### PR TITLE
Ensure actions work with secrets and move apply change set logic to dal (ENG-2410)

### DIFF
--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -753,7 +753,7 @@ async fn migrate_local_builtins(
     schema::migrate_pkg(&ctx, SI_AWS_EC2_PKG, None).await?;
     schemas::migrate_test_exclusive_schema_starfield(&ctx).await?;
     schemas::migrate_test_exclusive_schema_fallout(&ctx).await?;
-    schemas::migrate_test_exclusive_schema_bethesda_secret(&ctx).await?;
+    schemas::migrate_test_exclusive_schema_dummy_secret(&ctx).await?;
     schemas::migrate_test_exclusive_schema_swifty(&ctx).await?;
     schemas::migrate_test_exclusive_schema_katy_perry(&ctx).await?;
     schemas::migrate_test_exclusive_schema_pirate(&ctx).await?;

--- a/lib/dal-test/src/schemas/mod.rs
+++ b/lib/dal-test/src/schemas/mod.rs
@@ -1,14 +1,17 @@
-pub use test_exclusive_schema_bethesda_secret::migrate_test_exclusive_schema_bethesda_secret;
 pub use test_exclusive_schema_category_pirate::migrate_test_exclusive_schema_pet_shop;
 pub use test_exclusive_schema_category_pirate::migrate_test_exclusive_schema_pirate;
+pub use test_exclusive_schema_dummy_secret::migrate_test_exclusive_schema_dummy_secret;
 pub use test_exclusive_schema_fallout::migrate_test_exclusive_schema_fallout;
 pub use test_exclusive_schema_katy_perry::migrate_test_exclusive_schema_katy_perry;
 pub use test_exclusive_schema_starfield::migrate_test_exclusive_schema_starfield;
 pub use test_exclusive_schema_swifty::migrate_test_exclusive_schema_swifty;
 
+const PKG_VERSION: &str = "2019-06-03";
+const PKG_CREATED_BY: &str = "System Initiative";
+
 mod schema_helpers;
-mod test_exclusive_schema_bethesda_secret;
 mod test_exclusive_schema_category_pirate;
+mod test_exclusive_schema_dummy_secret;
 mod test_exclusive_schema_fallout;
 mod test_exclusive_schema_katy_perry;
 mod test_exclusive_schema_starfield;

--- a/lib/dal-test/src/schemas/schema_helpers.rs
+++ b/lib/dal-test/src/schemas/schema_helpers.rs
@@ -1,17 +1,15 @@
 use dal::func::argument::FuncArgumentKind;
 use dal::func::intrinsics::IntrinsicFunc;
-use dal::BuiltinsError;
+use dal::{BuiltinsError, BuiltinsResult};
 use si_pkg::{
     FuncArgumentSpec, FuncSpec, FuncSpecBackendKind, FuncSpecBackendResponseType, FuncSpecData,
 };
 
-pub(crate) fn create_identity_func() -> FuncSpec {
-    IntrinsicFunc::Identity
-        .to_spec()
-        .expect("create identity func spec")
+pub(crate) fn create_identity_func() -> BuiltinsResult<FuncSpec> {
+    Ok(IntrinsicFunc::Identity.to_spec()?)
 }
 
-pub(crate) async fn build_resource_payload_to_value_func() -> Result<FuncSpec, BuiltinsError> {
+pub(crate) async fn build_resource_payload_to_value_func() -> BuiltinsResult<FuncSpec> {
     let resource_payload_to_value_func_code = "async function main(arg: Input): Promise<Output> {\
             return arg.payload ?? {};
         }";
@@ -60,10 +58,7 @@ pub(crate) async fn build_action_func(
     Ok(func)
 }
 
-pub(crate) async fn build_codegen_func(
-    code: &str,
-    fn_name: &str,
-) -> Result<FuncSpec, BuiltinsError> {
+pub(crate) async fn build_codegen_func(code: &str, fn_name: &str) -> BuiltinsResult<FuncSpec> {
     let func = FuncSpec::builder()
         .name(fn_name)
         .unique_id(fn_name)
@@ -87,7 +82,7 @@ pub(crate) async fn build_codegen_func(
     Ok(func)
 }
 
-pub(crate) async fn build_asset_func(fn_name: &str) -> Result<FuncSpec, BuiltinsError> {
+pub(crate) async fn build_asset_func(fn_name: &str) -> BuiltinsResult<FuncSpec> {
     let scaffold_func = "function main() {\
                 return new AssetBuilder().build();
             }";

--- a/lib/dal-test/src/schemas/test_exclusive_schema_category_pirate.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_category_pirate.rs
@@ -15,10 +15,10 @@ pub async fn migrate_test_exclusive_schema_pirate(ctx: &DalContext) -> BuiltinsR
 
     builder
         .name("pirate")
-        .version("2024-03-12")
-        .created_by("System Initiative");
+        .version(crate::schemas::PKG_VERSION)
+        .created_by(crate::schemas::PKG_CREATED_BY);
 
-    let identity_func_spec = create_identity_func();
+    let identity_func_spec = create_identity_func()?;
 
     // Create Scaffold Func
     let fn_name = "test:scaffoldPirateAsset";
@@ -137,10 +137,10 @@ pub async fn migrate_test_exclusive_schema_pet_shop(ctx: &DalContext) -> Builtin
 
     builder
         .name(schema_name)
-        .version("2024-03-21")
-        .created_by("System Initiative");
+        .version(crate::schemas::PKG_VERSION)
+        .created_by(crate::schemas::PKG_CREATED_BY);
 
-    let identity_func_spec = create_identity_func();
+    let identity_func_spec = create_identity_func()?;
 
     // Create Scaffold Func
     let fn_name = "test:scaffoldPetShopAsset";

--- a/lib/dal-test/src/schemas/test_exclusive_schema_dummy_secret.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_dummy_secret.rs
@@ -14,22 +14,22 @@ use si_pkg::{
     SchemaSpecData, SocketSpecArity,
 };
 
-pub async fn migrate_test_exclusive_schema_bethesda_secret(ctx: &DalContext) -> BuiltinsResult<()> {
-    let name = "bethesda-secret";
+pub async fn migrate_test_exclusive_schema_dummy_secret(ctx: &DalContext) -> BuiltinsResult<()> {
+    let name = "dummy-secret";
 
     let mut builder = PkgSpec::builder();
 
     builder
         .name(name)
-        .version("2024-03-01")
-        .created_by("System Initiative");
+        .version(crate::schemas::PKG_VERSION)
+        .created_by(crate::schemas::PKG_CREATED_BY);
 
     let identity_func_spec = IntrinsicFunc::Identity.to_spec()?;
 
     let scaffold_func = "function createAsset() {\
         return new AssetBuilder().build()
     }";
-    let fn_name = "test:scaffoldBethesdaSecretAsset";
+    let fn_name = "test:scaffoldDummySecretAsset";
     let authoring_schema_func = FuncSpec::builder()
         .name(fn_name)
         .unique_id(fn_name)
@@ -44,8 +44,8 @@ pub async fn migrate_test_exclusive_schema_bethesda_secret(ctx: &DalContext) -> 
         )
         .build()?;
 
-    let auth_func_code = "async function auth(secret: Input): Promise<Output> { requestStorage.setItem('fakeSecretString', secret.value); }";
-    let fn_name = "test:setFakeSecretString";
+    let auth_func_code = "async function auth(secret: Input): Promise<Output> { requestStorage.setItem('dummySecretString', secret.value); }";
+    let fn_name = "test:setDummySecretString";
     let auth_func = FuncSpec::builder()
         .name(fn_name)
         .unique_id(fn_name)
@@ -66,13 +66,13 @@ pub async fn migrate_test_exclusive_schema_bethesda_secret(ctx: &DalContext) -> 
         )
         .build()?;
 
-    let (fake_secret_definition_prop, fake_secret_prop, fake_secret_output_socket) =
-        assemble_secret_definition_fake(&identity_func_spec)?;
+    let (dummy_secret_definition_prop, dummy_secret_prop, dummy_secret_output_socket) =
+        assemble_secret_definition_dummy(&identity_func_spec)?;
 
     let (
-        qualification_fake_secret_value_is_todd_func,
-        qualification_fake_secret_value_is_todd_leaf,
-    ) = assemble_qualification_fake_secret_value_is_todd()?;
+        qualification_dummy_secret_value_is_todd_func,
+        qualification_dummy_secret_value_is_todd_leaf,
+    ) = assemble_qualification_dummy_secret_value_is_todd()?;
 
     let schema = SchemaSpec::builder()
         .name(name)
@@ -100,10 +100,10 @@ pub async fn migrate_test_exclusive_schema_bethesda_secret(ctx: &DalContext) -> 
                         .func_unique_id(&auth_func.unique_id)
                         .build()?,
                 )
-                .secret_prop(fake_secret_prop)
-                .secret_definition_prop(fake_secret_definition_prop)
-                .socket(fake_secret_output_socket)
-                .leaf_function(qualification_fake_secret_value_is_todd_leaf)
+                .secret_prop(dummy_secret_prop)
+                .secret_definition_prop(dummy_secret_definition_prop)
+                .socket(dummy_secret_output_socket)
+                .leaf_function(qualification_dummy_secret_value_is_todd_leaf)
                 .build()?,
         )
         .build()?;
@@ -112,7 +112,7 @@ pub async fn migrate_test_exclusive_schema_bethesda_secret(ctx: &DalContext) -> 
         .func(identity_func_spec)
         .func(authoring_schema_func)
         .func(auth_func)
-        .func(qualification_fake_secret_value_is_todd_func)
+        .func(qualification_dummy_secret_value_is_todd_func)
         .schema(schema)
         .build()?;
 
@@ -131,10 +131,10 @@ pub async fn migrate_test_exclusive_schema_bethesda_secret(ctx: &DalContext) -> 
 }
 
 // Mimics the "defineSecret" function in "asset_builder.ts".
-fn assemble_secret_definition_fake(
+fn assemble_secret_definition_dummy(
     identity_func_spec: &FuncSpec,
 ) -> BuiltinsResult<(PropSpec, PropSpec, SocketSpec)> {
-    let secret_definition_name = "fake";
+    let secret_definition_name = "dummy";
 
     // First, create the child of "/root/secret_definition" that defines our secret.
     let new_secret_definition_prop = PropSpec::builder()
@@ -188,30 +188,30 @@ fn assemble_secret_definition_fake(
     ))
 }
 
-fn assemble_qualification_fake_secret_value_is_todd() -> BuiltinsResult<(FuncSpec, LeafFunctionSpec)>
-{
+fn assemble_qualification_dummy_secret_value_is_todd(
+) -> BuiltinsResult<(FuncSpec, LeafFunctionSpec)> {
     let fn_code = "async function qualification(_component: Input): Promise<Output> {\
-        const authCheck = requestStorage.getItem('fakeSecretString');
+        const authCheck = requestStorage.getItem('dummySecretString');
         if (authCheck) {
             if (authCheck === 'todd') {
                 return {
                     result: 'success',
-                    message: 'fake secret string matches expected value'
+                    message: 'dummy secret string matches expected value'
                 };
             }
             return {
                 result: 'failure',
-                message: 'fake secret string does not match expected value'
+                message: 'dummy secret string does not match expected value'
             };
         } else {
             return {
                 result: 'failure',
-                message: 'fake secret string is empty'
+                message: 'dummy secret string is empty'
             };
         }
     }";
-    let fn_name = "test:qualificationFakeSecretStringIsTodd";
-    let qualification_fake_secret_value_is_todd_func = FuncSpec::builder()
+    let fn_name = "test:qualificationDummySecretStringIsTodd";
+    let qualification_dummy_secret_value_is_todd_func = FuncSpec::builder()
         .name(fn_name)
         .unique_id(fn_name)
         .data(
@@ -225,14 +225,14 @@ fn assemble_qualification_fake_secret_value_is_todd() -> BuiltinsResult<(FuncSpe
         )
         .build()?;
 
-    let qualification_fake_secret_value_is_todd_leaf = LeafFunctionSpec::builder()
-        .func_unique_id(&qualification_fake_secret_value_is_todd_func.unique_id)
+    let qualification_dummy_secret_value_is_todd_leaf = LeafFunctionSpec::builder()
+        .func_unique_id(&qualification_dummy_secret_value_is_todd_func.unique_id)
         .leaf_kind(LeafKind::Qualification)
         .inputs(vec![LeafInputLocation::Secrets])
         .build()?;
 
     Ok((
-        qualification_fake_secret_value_is_todd_func,
-        qualification_fake_secret_value_is_todd_leaf,
+        qualification_dummy_secret_value_is_todd_func,
+        qualification_dummy_secret_value_is_todd_leaf,
     ))
 }

--- a/lib/dal-test/src/schemas/test_exclusive_schema_katy_perry.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_katy_perry.rs
@@ -16,10 +16,10 @@ pub async fn migrate_test_exclusive_schema_katy_perry(ctx: &DalContext) -> Built
 
     kp_builder
         .name("katy perry")
-        .version("2024-03-12")
-        .created_by("System Initiative");
+        .version(crate::schemas::PKG_VERSION)
+        .created_by(crate::schemas::PKG_CREATED_BY);
 
-    let identity_func_spec = create_identity_func();
+    let identity_func_spec = create_identity_func()?;
 
     // Create Scaffold Func
     let fn_name = "test:scaffoldKatyPerryAsset";

--- a/lib/dal-test/src/schemas/test_exclusive_schema_starfield.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_starfield.rs
@@ -15,8 +15,8 @@ pub async fn migrate_test_exclusive_schema_starfield(ctx: &DalContext) -> Builti
 
     starfield_builder
         .name("starfield")
-        .version("2023-05-23")
-        .created_by("System Initiative");
+        .version(crate::schemas::PKG_VERSION)
+        .created_by(crate::schemas::PKG_CREATED_BY);
 
     let identity_func_spec = IntrinsicFunc::Identity
         .to_spec()

--- a/lib/dal-test/src/schemas/test_exclusive_schema_swifty.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_swifty.rs
@@ -17,10 +17,10 @@ pub async fn migrate_test_exclusive_schema_swifty(ctx: &DalContext) -> BuiltinsR
 
     swifty_builder
         .name("swifty")
-        .version("2024-03-06")
-        .created_by("System Initiative");
+        .version(crate::schemas::PKG_VERSION)
+        .created_by(crate::schemas::PKG_CREATED_BY);
 
-    let identity_func_spec = create_identity_func();
+    let identity_func_spec = create_identity_func()?;
 
     // Build Create Action Func
     let create_action_code = "async function main() {

--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -11,7 +11,7 @@ pub mod batch;
 pub mod prototype;
 pub mod runner;
 
-use crate::change_set_pointer::ChangeSetPointerError;
+use crate::change_set_pointer::ChangeSetError;
 use crate::layer_db_types::ComponentContent;
 use crate::workspace_snapshot::content_address::{ContentAddress, ContentAddressDiscriminants};
 use crate::workspace_snapshot::edge_weight::EdgeWeightKindDiscriminants;
@@ -34,7 +34,7 @@ pub enum ActionError {
     #[error("action prototype error: {0}")]
     ActionPrototype(#[from] ActionPrototypeError),
     #[error(transparent)]
-    ChangeSetPointer(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error(transparent)]
     Component(#[from] ComponentError),
     #[error("component not found for: {0}")]
@@ -294,6 +294,8 @@ impl Action {
         Ok(actions)
     }
 
+    /// A read-only method that assembles a flattened graph of [`Actions`] that will run when
+    /// the change set is applied to head.
     pub async fn build_graph(ctx: &DalContext) -> ActionResult<HashMap<ActionId, ActionBag>> {
         let mut actions_by_id: HashMap<ActionId, (Action, ComponentId)> = HashMap::new();
         let mut actions_by_component: HashMap<ComponentId, Vec<Action>> = HashMap::new();

--- a/lib/dal/src/action/batch.rs
+++ b/lib/dal/src/action/batch.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use telemetry::prelude::*;
 use thiserror::Error;
 
-use crate::change_set_pointer::ChangeSetPointerError;
+use crate::change_set_pointer::ChangeSetError;
 use crate::workspace_snapshot::content_address::{ContentAddress, ContentAddressDiscriminants};
 use crate::workspace_snapshot::edge_weight::{
     EdgeWeight, EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
@@ -39,7 +39,7 @@ pub enum ActionBatchError {
     #[error("cannot stamp batch as started since it already started")]
     AlreadyStarted,
     #[error(transparent)]
-    ChangeSetPointer(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error(transparent)]
     Component(#[from] ComponentError),
     #[error("edge weight error: {0}")]

--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use strum::{AsRefStr, Display};
 use thiserror::Error;
 
-use crate::change_set_pointer::ChangeSetPointerError;
+use crate::change_set_pointer::ChangeSetError;
 use crate::workspace_snapshot::content_address::ContentAddress;
 use crate::workspace_snapshot::edge_weight::EdgeWeightKindDiscriminants;
 use crate::workspace_snapshot::edge_weight::{EdgeWeight, EdgeWeightError, EdgeWeightKind};
@@ -64,7 +64,7 @@ pub enum ActionPrototypeError {
     #[error(transparent)]
     BeforeFunc(#[from] BeforeFuncError),
     #[error(transparent)]
-    ChangeSetPointer(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("component error: {0}")]
     Component(#[from] ComponentError),
     #[error("edge weight error: {0}")]

--- a/lib/dal/src/action/runner.rs
+++ b/lib/dal/src/action/runner.rs
@@ -13,7 +13,7 @@ use telemetry::prelude::*;
 use thiserror::Error;
 
 use crate::action::batch::ActionBatchId;
-use crate::change_set_pointer::ChangeSetPointerError;
+use crate::change_set_pointer::ChangeSetError;
 use crate::func::binding_return_value::FuncBindingReturnValueError;
 use crate::workspace_snapshot::content_address::ContentAddress;
 use crate::workspace_snapshot::edge_weight::EdgeWeightKindDiscriminants;
@@ -71,7 +71,7 @@ pub enum ActionRunnerError {
     #[error("cannot set action runner for {0}: batch ({1}) already started")]
     BatchAlreadyStarted(ActionRunnerId, ActionBatchId),
     #[error(transparent)]
-    ChangeSetPointer(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error(transparent)]
     Component(#[from] ComponentError),
     #[error(transparent)]

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 
 use crate::attribute::prototype::argument::value_source::ValueSource;
 use crate::attribute::prototype::argument::AttributePrototypeArgument;
-use crate::change_set_pointer::ChangeSetPointerError;
+use crate::change_set_pointer::ChangeSetError;
 use crate::layer_db_types::{AttributePrototypeContent, AttributePrototypeContentV1};
 use crate::workspace_snapshot::content_address::{ContentAddress, ContentAddressDiscriminants};
 use crate::workspace_snapshot::edge_weight::{
@@ -44,7 +44,7 @@ pub enum AttributePrototypeError {
     #[error("attribute prototype argument error: {0}")]
     AttributePrototypeArgument(String),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("edge weight error: {0}")]
     EdgeWeight(#[from] EdgeWeightError),
     #[error("layer db error: {0}")]

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use ulid::Ulid;
 
 use crate::{
-    change_set_pointer::ChangeSetPointerError,
+    change_set_pointer::ChangeSetError,
     func::argument::{FuncArgument, FuncArgumentError, FuncArgumentId},
     pk,
     socket::input::InputSocketId,
@@ -50,7 +50,7 @@ pub enum AttributePrototypeArgumentError {
     #[error("attribute value error: {0}")]
     AttributeValue(String),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("edge weight error: {0}")]
     EdgeWeight(#[from] EdgeWeightError),
     #[error("func argument error: {0}")]

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -52,7 +52,7 @@ use ulid::Ulid;
 pub use dependent_value_graph::DependentValueGraph;
 
 use crate::attribute::prototype::AttributePrototypeError;
-use crate::change_set_pointer::ChangeSetPointerError;
+use crate::change_set_pointer::ChangeSetError;
 use crate::func::argument::{FuncArgument, FuncArgumentError};
 use crate::func::before_funcs_for_component;
 use crate::func::binding::{FuncBinding, FuncBindingError};
@@ -114,7 +114,7 @@ pub enum AttributeValueError {
     #[error("cannot explicitly set the value of {0} because it is for an input or output socket")]
     CannotExplicitlySetSocketValues(AttributeValueId),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("component error: {0}")]
     Component(String),
     #[error("edge weight error: {0}")]

--- a/lib/dal/src/change_set_pointer.rs
+++ b/lib/dal/src/change_set_pointer.rs
@@ -1,5 +1,6 @@
 //! The sequel to [`ChangeSets`](crate::ChangeSet). Coming to an SI instance near you!
 
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, Utc};
@@ -10,20 +11,23 @@ use telemetry::prelude::*;
 use thiserror::Error;
 use ulid::{Generator, Ulid};
 
+use crate::action::ActionBag;
 use crate::context::RebaseRequest;
+use crate::job::definition::{ActionRunnerItem, ActionsJob};
 use crate::workspace_snapshot::vector_clock::VectorClockId;
 use crate::{
-    id, ChangeSetStatus, DalContext, HistoryEvent, HistoryEventError, TransactionsError, Workspace,
-    WorkspacePk, WsEvent, WsEventError,
+    id, Action, ActionBatch, ActionBatchError, ActionError, ActionId, ActionPrototypeId,
+    ActionRunner, ActionRunnerError, ActionRunnerId, ChangeSetStatus, Component, ComponentError,
+    DalContext, HistoryActor, HistoryEvent, HistoryEventError, TransactionsError, User, UserError,
+    UserPk, Workspace, WorkspacePk, WsEvent, WsEventError,
 };
 
 pub mod view;
 
+/// The primary error type for this module.
 #[remain::sorted]
 #[derive(Debug, Error)]
-pub enum ChangeSetPointerError {
-    #[error("change set not found")]
-    ChangeSetNotFound,
+pub enum ChangeSetError {
     #[error("could not find default change set: {0}")]
     DefaultChangeSetNotFound(ChangeSetId),
     #[error("default change set {0} has no workspace snapshot pointer")]
@@ -58,7 +62,41 @@ pub enum ChangeSetPointerError {
     WsEvent(#[from] WsEventError),
 }
 
-pub type ChangeSetPointerResult<T> = Result<T, ChangeSetPointerError>;
+/// The primary result type for this module.
+pub type ChangeSetResult<T> = Result<T, ChangeSetError>;
+
+/// A superset of [`ChangeSetError`] used when performing apply logic.
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ChangeSetApplyError {
+    #[error("action error: {0}")]
+    Action(#[from] ActionError),
+    #[error("action batch error: {0}")]
+    ActionBatch(#[from] ActionBatchError),
+    #[error("action prototype not found for id: {0}")]
+    ActionPrototypeNotFound(ActionId),
+    #[error("action runner error: {0}")]
+    ActionRunner(#[from] ActionRunnerError),
+    #[error("change set error: {0}")]
+    ChangeSet(#[from] ChangeSetError),
+    #[error("change set not found by id: {0}")]
+    ChangeSetNotFound(ChangeSetId),
+    #[error("component error: {0}")]
+    Component(#[from] ComponentError),
+    #[error("invalid user: {0}")]
+    InvalidUser(UserPk),
+    #[error("invalid user system init")]
+    InvalidUserSystemInit,
+    #[error("change set ({0}) does not have a base change set")]
+    NoBaseChangeSet(ChangeSetId),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
+    #[error("user error: {0}")]
+    User(#[from] UserError),
+}
+
+/// A superset of [`ChangeSetResult`] used when performing apply logic.
+pub type ChangeSetApplyResult<T> = Result<T, ChangeSetApplyError>;
 
 id!(ChangeSetId);
 
@@ -86,7 +124,7 @@ pub struct ChangeSetPointer {
 }
 
 impl TryFrom<PgRow> for ChangeSetPointer {
-    type Error = ChangeSetPointerError;
+    type Error = ChangeSetError;
 
     fn try_from(value: PgRow) -> Result<Self, Self::Error> {
         let status_string: String = value.try_get("status")?;
@@ -106,7 +144,7 @@ impl TryFrom<PgRow> for ChangeSetPointer {
 }
 
 impl ChangeSetPointer {
-    pub fn new_local() -> ChangeSetPointerResult<Self> {
+    pub fn new_local() -> ChangeSetResult<Self> {
         let mut generator = Generator::new();
         let id = generator.generate()?;
 
@@ -123,7 +161,7 @@ impl ChangeSetPointer {
         })
     }
 
-    pub fn editing_changeset(&self) -> ChangeSetPointerResult<Self> {
+    pub fn editing_changeset(&self) -> ChangeSetResult<Self> {
         let mut new_local = Self::new_local()?;
         new_local.base_change_set_id = self.base_change_set_id;
         new_local.workspace_snapshot_address = self.workspace_snapshot_address;
@@ -137,7 +175,7 @@ impl ChangeSetPointer {
         ctx: &DalContext,
         name: impl AsRef<str>,
         base_change_set_id: Option<ChangeSetId>,
-    ) -> ChangeSetPointerResult<Self> {
+    ) -> ChangeSetResult<Self> {
         let workspace_id = ctx.tenancy().workspace_pk();
         let name = name.as_ref();
         let row = ctx
@@ -160,24 +198,21 @@ impl ChangeSetPointer {
         Ok(change_set)
     }
 
-    pub async fn fork_head(
-        ctx: &DalContext,
-        name: impl AsRef<str>,
-    ) -> ChangeSetPointerResult<Self> {
+    pub async fn fork_head(ctx: &DalContext, name: impl AsRef<str>) -> ChangeSetResult<Self> {
         let workspace_pk = ctx
             .tenancy()
             .workspace_pk()
-            .ok_or(ChangeSetPointerError::NoTenancySet)?;
+            .ok_or(ChangeSetError::NoTenancySet)?;
 
         let workspace = Workspace::get_by_pk(ctx, &workspace_pk)
             .await
-            .map_err(|err| ChangeSetPointerError::Workspace(err.to_string()))?
-            .ok_or(ChangeSetPointerError::WorkspaceNotFound(workspace_pk))?;
+            .map_err(|err| ChangeSetError::Workspace(err.to_string()))?
+            .ok_or(ChangeSetError::WorkspaceNotFound(workspace_pk))?;
 
         let base_change_set_pointer =
             ChangeSetPointer::find(ctx, workspace.default_change_set_id())
                 .await?
-                .ok_or(ChangeSetPointerError::DefaultChangeSetNotFound(
+                .ok_or(ChangeSetError::DefaultChangeSetNotFound(
                     workspace.default_change_set_id(),
                 ))?;
 
@@ -188,7 +223,7 @@ impl ChangeSetPointer {
             .update_pointer(
                 ctx,
                 base_change_set_pointer.workspace_snapshot_address.ok_or(
-                    ChangeSetPointerError::DefaultChangeSetNoWorkspaceSnapshotPointer(
+                    ChangeSetError::DefaultChangeSetNoWorkspaceSnapshotPointer(
                         workspace.default_change_set_id(),
                     ),
                 )?,
@@ -203,10 +238,10 @@ impl ChangeSetPointer {
         VectorClockId::from(Ulid::from(self.id))
     }
 
-    pub fn generate_ulid(&self) -> ChangeSetPointerResult<Ulid> {
+    pub fn generate_ulid(&self) -> ChangeSetResult<Ulid> {
         self.generator
             .lock()
-            .map_err(|e| ChangeSetPointerError::Mutex(e.to_string()))?
+            .map_err(|e| ChangeSetError::Mutex(e.to_string()))?
             .generate()
             .map_err(Into::into)
     }
@@ -215,7 +250,7 @@ impl ChangeSetPointer {
         &mut self,
         ctx: &DalContext,
         workspace_id: WorkspacePk,
-    ) -> ChangeSetPointerResult<()> {
+    ) -> ChangeSetResult<()> {
         ctx.txns()
             .await?
             .pg()
@@ -234,7 +269,7 @@ impl ChangeSetPointer {
         &mut self,
         ctx: &DalContext,
         workspace_snapshot_address: WorkspaceSnapshotAddress,
-    ) -> ChangeSetPointerResult<()> {
+    ) -> ChangeSetResult<()> {
         ctx.txns()
             .await?
             .pg()
@@ -253,7 +288,7 @@ impl ChangeSetPointer {
         &mut self,
         ctx: &DalContext,
         status: ChangeSetStatus,
-    ) -> ChangeSetPointerResult<()> {
+    ) -> ChangeSetResult<()> {
         ctx.txns()
             .await?
             .pg()
@@ -272,7 +307,7 @@ impl ChangeSetPointer {
     pub async fn find(
         ctx: &DalContext,
         change_set_pointer_id: ChangeSetId,
-    ) -> ChangeSetPointerResult<Option<Self>> {
+    ) -> ChangeSetResult<Option<Self>> {
         let row = ctx
             .txns()
             .await?
@@ -289,7 +324,7 @@ impl ChangeSetPointer {
         }
     }
 
-    pub async fn list_open(ctx: &DalContext) -> ChangeSetPointerResult<Vec<Self>> {
+    pub async fn list_open(ctx: &DalContext) -> ChangeSetResult<Vec<Self>> {
         let mut result = vec![];
         let rows = ctx
             .txns()
@@ -311,16 +346,128 @@ impl ChangeSetPointer {
         Ok(result)
     }
 
+    /// Applies the current [`ChangeSetPointer`] in the provided [`DalContext`]. [`Actions`](Action)
+    /// are enqueued as needed and only done so if the base [`ChangeSetPointer`] is "HEAD" (i.e.
+    /// the default [`ChangeSetPointer`] of the [`Workspace`]).
     pub async fn apply_to_base_change_set(
-        &mut self,
-        ctx: &DalContext,
-    ) -> ChangeSetPointerResult<()> {
+        ctx: &mut DalContext,
+        allow_system_init_history_actor: bool,
+    ) -> ChangeSetApplyResult<ChangeSetPointer> {
+        // Gather actions to run, which should only be populated if we are applying to head.
+        let (actions_to_run, prototype_by_action_id) = Self::list_actions_to_run(ctx).await?;
+
+        // Apply to the base change with the current change set (non-editing) and commit.
+        let mut change_set_to_be_applied = Self::find(ctx, ctx.change_set_id())
+            .await?
+            .ok_or(ChangeSetApplyError::ChangeSetNotFound(ctx.change_set_id()))?;
+        ctx.update_visibility_and_snapshot_to_visibility_no_editing_change_set(ctx.change_set_id())
+            .await?;
+        change_set_to_be_applied
+            .apply_to_base_change_set_inner(ctx)
+            .await?;
+        ctx.blocking_commit().await?;
+        let change_set_that_was_applied = change_set_to_be_applied;
+
+        if !actions_to_run.is_empty() {
+            // Open an editing change set on head. We need it in order to update the resource trees
+            // for components on head.
+            let base_change_set_id = change_set_that_was_applied.base_change_set_id.ok_or(
+                ChangeSetApplyError::NoBaseChangeSet(change_set_that_was_applied.id),
+            )?;
+            ctx.update_visibility_and_snapshot_to_visibility(base_change_set_id)
+                .await?;
+
+            let author = match ctx.history_actor() {
+                HistoryActor::User(user_pk) => User::get_by_pk(ctx, *user_pk)
+                    .await?
+                    .ok_or(ChangeSetApplyError::InvalidUser(*user_pk))?
+                    .email()
+                    .to_string(),
+                HistoryActor::SystemInit => {
+                    if allow_system_init_history_actor {
+                        // TODO(nick): we need to ensure sdf cannot possibly hit this code path in
+                        // the future.
+                        ctx.history_actor().distinct_id()
+                    } else {
+                        return Err(ChangeSetApplyError::InvalidUserSystemInit);
+                    }
+                }
+            };
+
+            // TODO: restore actors of change-set concept
+            let actors_delimited_string = String::new();
+            let batch = ActionBatch::new(ctx, author, &actors_delimited_string).await?;
+            let mut runners: HashMap<ActionRunnerId, ActionRunnerItem> = HashMap::new();
+            let mut runners_by_action: HashMap<ActionId, ActionRunnerId> = HashMap::new();
+
+            let mut values: Vec<ActionBag> = actions_to_run.values().cloned().collect();
+            values.sort_by_key(|a| a.action.id);
+
+            let mut values: VecDeque<ActionBag> = values.into_iter().collect();
+
+            // Runners have to be created in the order we want to display them in the actions history panel
+            // So we do extra work here to ensure the order is the execution order
+            while let Some(bag) = values.pop_front() {
+                let prototype_id = *prototype_by_action_id
+                    .get(&bag.action.id)
+                    .ok_or(ChangeSetApplyError::ActionPrototypeNotFound(bag.action.id))?;
+
+                // Determine the parent runners for the given set of parents. If none are found, we
+                // need to process the bag in a future iteration.
+                let parents = match Self::determine_runners_for_parent_actions(
+                    bag.parents.as_slice(),
+                    &runners_by_action,
+                ) {
+                    Some(parents) => parents,
+                    None => {
+                        values.push_back(bag);
+                        continue;
+                    }
+                };
+
+                let component = Component::get_by_id(ctx, bag.component_id).await?;
+                let runner = ActionRunner::new(
+                    ctx,
+                    batch.id,
+                    bag.component_id,
+                    component.name(ctx).await?,
+                    prototype_id,
+                )
+                .await?;
+                runners_by_action.insert(bag.action.id, runner.id);
+
+                runners.insert(
+                    runner.id,
+                    ActionRunnerItem {
+                        id: runner.id,
+                        component_id: bag.component_id,
+                        action_prototype_id: prototype_id,
+                        parents,
+                    },
+                );
+            }
+
+            // With all the runners gathered, we can enqueue a new batch.
+            ctx.enqueue_actions(ActionsJob::new(ctx, runners, batch.id))
+                .await?;
+        }
+
+        Ok(change_set_that_was_applied)
+    }
+
+    /// Applies the current [`ChangeSetPointer`] in the provided [`DalContext`] to its base
+    /// [`ChangeSetPointer`]. This involves performing a rebase request and updating the status
+    /// of the [`ChangeSetPointer`] accordingly.
+    ///
+    /// This function neither changes the visibility nor the snapshot after performing the
+    /// aforementioned actions.
+    async fn apply_to_base_change_set_inner(&mut self, ctx: &DalContext) -> ChangeSetResult<()> {
         let to_rebase_change_set_id = self
             .base_change_set_id
-            .ok_or(ChangeSetPointerError::NoBaseChangeSet(self.id))?;
+            .ok_or(ChangeSetError::NoBaseChangeSet(self.id))?;
         let onto_workspace_snapshot_address = self
             .workspace_snapshot_address
-            .ok_or(ChangeSetPointerError::NoWorkspaceSnapshot(self.id))?;
+            .ok_or(ChangeSetError::NoWorkspaceSnapshot(self.id))?;
         let rebase_request = RebaseRequest {
             onto_workspace_snapshot_address,
             onto_vector_clock_id: self.vector_clock_id(),
@@ -333,7 +480,59 @@ impl ChangeSetPointer {
         Ok(())
     }
 
-    pub async fn force_new(ctx: &mut DalContext) -> ChangeSetPointerResult<Option<ChangeSetId>> {
+    async fn list_actions_to_run(
+        ctx: &DalContext,
+    ) -> ChangeSetApplyResult<(
+        HashMap<ActionId, ActionBag>,
+        HashMap<ActionId, ActionPrototypeId>,
+    )> {
+        let mut actions_graph = HashMap::new();
+        let mut prototype_by_action_id = HashMap::new();
+
+        // Before applying the change set, gather and write actions and corresponding prototypes if
+        // we are applying to head.
+        let applying_to_head = ctx.parent_is_head().await?;
+        if applying_to_head {
+            actions_graph = Action::build_graph(ctx).await?;
+            let mut at_least_one_deleted = false;
+
+            for bag in actions_graph.values() {
+                let prototype = bag.action.prototype(ctx).await?;
+                prototype_by_action_id.insert(bag.action.id, prototype.id);
+
+                // TODO(nick): assuming we want to continue to dynamically track actions on the
+                // graph, we should likely only remove the actions after they've successfully ran
+                // on head.
+                bag.action.clone().delete(ctx).await?;
+                at_least_one_deleted = true;
+            }
+
+            // TODO(nick): this code should be removed once we only remove actions that have
+            // succeeded.
+            if at_least_one_deleted {
+                ctx.blocking_commit().await?;
+            }
+        }
+
+        Ok((actions_graph, prototype_by_action_id))
+    }
+
+    fn determine_runners_for_parent_actions(
+        parent_ids: &[ActionId],
+        runners_by_action: &HashMap<ActionId, ActionRunnerId>,
+    ) -> Option<Vec<ActionRunnerId>> {
+        let mut parents = Vec::new();
+        for parent_id in parent_ids {
+            if let Some(parent_id) = runners_by_action.get(parent_id) {
+                parents.push(*parent_id);
+            } else {
+                return None;
+            }
+        }
+        Some(parents)
+    }
+
+    pub async fn force_new(ctx: &mut DalContext) -> ChangeSetResult<Option<ChangeSetId>> {
         let maybe_fake_pk =
             if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {
                 let change_set = Self::fork_head(ctx, Self::generate_name()).await?;

--- a/lib/dal/src/change_set_pointer/view.rs
+++ b/lib/dal/src/change_set_pointer/view.rs
@@ -1,9 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::change_set_pointer::{
-    ChangeSetId, ChangeSetPointer, ChangeSetPointerError, ChangeSetPointerResult,
-};
+use crate::change_set_pointer::{ChangeSetError, ChangeSetId, ChangeSetPointer, ChangeSetResult};
 use crate::{ChangeSetStatus, DalContext, UserPk};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
@@ -27,7 +25,7 @@ pub struct ChangeSetView {
 }
 
 impl OpenChangeSetsView {
-    pub async fn assemble(ctx: &DalContext) -> ChangeSetPointerResult<Self> {
+    pub async fn assemble(ctx: &DalContext) -> ChangeSetResult<Self> {
         // List all open change sets and assemble them into individual views.
         let open_change_sets = ChangeSetPointer::list_open(ctx).await?;
         let mut views = Vec::with_capacity(open_change_sets.len());
@@ -58,7 +56,7 @@ impl OpenChangeSetsView {
             .collect();
         if maybe_head_change_set_id.len() != 1 {
             return Err(
-                ChangeSetPointerError::UnexpectedNumberOfOpenChangeSetsMatchingDefaultChangeSet(
+                ChangeSetError::UnexpectedNumberOfOpenChangeSetsMatchingDefaultChangeSet(
                     maybe_head_change_set_id,
                 ),
             );

--- a/lib/dal/src/component/diff.rs
+++ b/lib/dal/src/component/diff.rs
@@ -42,8 +42,7 @@ impl Component {
             curr_json = serde_json::to_string_pretty(&json!(null))?;
         }
 
-        let head_ctx = ctx.clone_with_head().await?;
-        if ctx.change_set_id() == head_ctx.get_workspace_default_change_set_id().await? {
+        if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {
             // We are on HEAD and need to react as so!
             return Ok(ComponentDiff {
                 component_id,
@@ -51,6 +50,8 @@ impl Component {
                 diffs: vec![],
             });
         }
+
+        let head_ctx = ctx.clone_with_head().await?;
 
         let head_json: String;
         let mut is_new_comp = false;

--- a/lib/dal/src/component/qualification.rs
+++ b/lib/dal/src/component/qualification.rs
@@ -45,7 +45,12 @@ impl Component {
             .await?
         {
             Some(value_ids) => value_ids,
-            None => return Ok(vec![]), // should probably be an error
+            None => {
+                return Err(ComponentError::QualificationNoOrderingNode(
+                    qualification_map_value_id,
+                    component_id,
+                ))
+            }
         };
 
         for qualification_attribute_value_id in qualification_attribute_value_ids {

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -9,7 +9,7 @@ use telemetry::prelude::*;
 use thiserror::Error;
 use ulid::Ulid;
 
-use crate::change_set_pointer::ChangeSetPointerError;
+use crate::change_set_pointer::ChangeSetError;
 use crate::func::intrinsics::IntrinsicFunc;
 use crate::layer_db_types::{FuncContent, FuncContentV1};
 use crate::schema::variant::SchemaVariantResult;
@@ -43,7 +43,7 @@ pub enum FuncError {
     #[error("base64 decode error: {0}")]
     Base64Decode(#[from] base64::DecodeError),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("chrono parse error: {0}")]
     ChronoParse(#[from] chrono::ParseError),
     #[error("edge weight error: {0}")]

--- a/lib/dal/src/func/argument.rs
+++ b/lib/dal/src/func/argument.rs
@@ -9,7 +9,7 @@ use telemetry::prelude::*;
 use thiserror::Error;
 use ulid::Ulid;
 
-use crate::change_set_pointer::ChangeSetPointerError;
+use crate::change_set_pointer::ChangeSetError;
 use crate::layer_db_types::{FuncArgumentContent, FuncArgumentContentV1};
 use crate::workspace_snapshot::edge_weight::{
     EdgeWeight, EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
@@ -25,7 +25,7 @@ use crate::{
 #[derive(Debug, Error)]
 pub enum FuncArgumentError {
     #[error(transparent)]
-    ChangeSetPointer(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("edge weight error: {0}")]
     EdgeWeight(#[from] EdgeWeightError),
     #[error("history event error: {0}")]

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -85,7 +85,8 @@ pub use attribute::{
 };
 pub use builtins::{BuiltinsError, BuiltinsResult};
 pub use change_set::ChangeSetStatus;
-pub use change_set_pointer::{ChangeSetId, ChangeSetPointer, ChangeSetPointerError};
+pub use change_set_pointer::ChangeSetApplyError;
+pub use change_set_pointer::{ChangeSetError, ChangeSetId, ChangeSetPointer};
 pub use component::Component;
 pub use component::ComponentError;
 pub use component::ComponentId;

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -7,7 +7,7 @@ use crate::attribute::prototype::argument::AttributePrototypeArgumentError;
 use crate::attribute::prototype::AttributePrototypeError;
 use crate::schema::variant::SchemaVariantError;
 use crate::{
-    change_set_pointer::ChangeSetPointerError,
+    change_set_pointer::ChangeSetError,
     func::{argument::FuncArgumentError, FuncError},
     installed_pkg::InstalledPkgError,
     prop::PropError,
@@ -40,7 +40,7 @@ pub enum PkgError {
     #[error("attrbute prototype argument error: {0}")]
     AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
     #[error(transparent)]
-    ChangeSetPointer(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error(transparent)]
     ConnectionAnnotation(#[from] ConnectionAnnotationError),
     #[error("expected data on an SiPkg node, but none found: {0}")]

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -14,7 +14,7 @@ use crate::attribute::prototype::argument::{
     AttributePrototypeArgument, AttributePrototypeArgumentError,
 };
 use crate::attribute::prototype::AttributePrototypeError;
-use crate::change_set_pointer::ChangeSetPointerError;
+use crate::change_set_pointer::ChangeSetError;
 use crate::func::argument::{FuncArgument, FuncArgumentError};
 use crate::func::intrinsics::IntrinsicFunc;
 use crate::func::FuncError;
@@ -41,7 +41,7 @@ pub enum PropError {
     #[error("attribute prototype argument error: {0}")]
     AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("child prop of {0:?} not found by name: {1}")]
     ChildPropNotFoundByName(NodeIndex, String),
     #[error("edge weight error: {0}")]

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -9,7 +9,7 @@ use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::sync::TryLockError;
 
-use crate::change_set_pointer::ChangeSetPointerError;
+use crate::change_set_pointer::ChangeSetError;
 use crate::layer_db_types::{SchemaContent, SchemaContentDiscriminants, SchemaContentV1};
 use crate::workspace_snapshot::content_address::{ContentAddress, ContentAddressDiscriminants};
 use crate::workspace_snapshot::edge_weight::{
@@ -31,7 +31,7 @@ pub const SCHEMA_VERSION: SchemaContentDiscriminants = SchemaContentDiscriminant
 #[derive(Error, Debug)]
 pub enum SchemaError {
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("edge weight error: {0}")]
     EdgeWeight(#[from] EdgeWeightError),
     #[error("layer db error: {0}")]

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -22,7 +22,7 @@ use crate::attribute::prototype::argument::{
     AttributePrototypeArgument, AttributePrototypeArgumentError,
 };
 use crate::attribute::prototype::AttributePrototypeError;
-use crate::change_set_pointer::ChangeSetPointerError;
+use crate::change_set_pointer::ChangeSetError;
 use crate::func::argument::{FuncArgument, FuncArgumentError};
 use crate::func::intrinsics::IntrinsicFunc;
 use crate::func::{FuncError, FuncKind};
@@ -74,7 +74,7 @@ pub enum SchemaVariantError {
     #[error("attribute argument prototype error: {0}")]
     AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("default schema variant not found for schema: {0}")]
     DefaultSchemaVariantNotFound(SchemaId),
     #[error("default variant not found: {0}")]

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -55,7 +55,7 @@ use crate::workspace_snapshot::node_weight::category_node_weight::CategoryNodeKi
 use crate::workspace_snapshot::node_weight::{NodeWeight, NodeWeightError};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
-    id, ChangeSetPointerError, DalContext, HistoryActor, HistoryEventError, KeyPair, KeyPairError,
+    id, ChangeSetError, DalContext, HistoryActor, HistoryEventError, KeyPair, KeyPairError,
     SchemaVariantError, StandardModelError, Timestamp, TransactionsError, UserPk,
 };
 
@@ -78,8 +78,8 @@ pub use view::SecretViewResult;
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum SecretError {
-    #[error("change set pointer error: {0}")]
-    ChangeSetPointer(#[from] ChangeSetPointerError),
+    #[error("change set error: {0}")]
+    ChangeSet(#[from] ChangeSetError),
     #[error("error when decrypting crypted secret")]
     DecryptionFailed,
     #[error("error deserializing message: {0}")]

--- a/lib/dal/src/socket/input.rs
+++ b/lib/dal/src/socket/input.rs
@@ -7,7 +7,7 @@ use telemetry::prelude::*;
 use thiserror::Error;
 
 use crate::attribute::prototype::AttributePrototypeError;
-use crate::change_set_pointer::ChangeSetPointerError;
+use crate::change_set_pointer::ChangeSetError;
 use crate::func::FuncError;
 use crate::layer_db_types::{InputSocketContent, InputSocketContentV1};
 use crate::socket::{SocketArity, SocketKind};
@@ -30,7 +30,7 @@ pub enum InputSocketError {
     #[error("attribute prototype error: {0}")]
     AttributePrototype(#[from] AttributePrototypeError),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error(transparent)]
     ConnectionAnnotation(#[from] ConnectionAnnotationError),
     #[error("edge weight error: {0}")]

--- a/lib/dal/src/socket/output.rs
+++ b/lib/dal/src/socket/output.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use crate::attribute::prototype::argument::AttributePrototypeArgumentId;
 use crate::attribute::prototype::AttributePrototypeError;
-use crate::change_set_pointer::ChangeSetPointerError;
+use crate::change_set_pointer::ChangeSetError;
 use crate::layer_db_types::{OutputSocketContent, OutputSocketContentV1};
 use crate::socket::{SocketArity, SocketKind};
 use crate::workspace_snapshot::content_address::{ContentAddress, ContentAddressDiscriminants};
@@ -30,7 +30,7 @@ pub enum OutputSocketError {
     #[error("attribute prototype error: {0}")]
     AttributePrototype(#[from] AttributePrototypeError),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error(transparent)]
     ConnectionAnnotation(#[from] ConnectionAnnotationError),
     #[error("edge weight error: {0}")]

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -5,7 +5,7 @@ use si_data_pg::{PgError, PgRow};
 use telemetry::prelude::*;
 use thiserror::Error;
 
-use crate::change_set_pointer::{ChangeSetId, ChangeSetPointer, ChangeSetPointerError};
+use crate::change_set_pointer::{ChangeSetError, ChangeSetId, ChangeSetPointer};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
     pk, standard_model, standard_model_accessor_ro, DalContext, HistoryActor, HistoryEvent,
@@ -24,7 +24,7 @@ const DEFAULT_CHANGE_SET_NAME: &str = "HEAD";
 #[derive(Error, Debug)]
 pub enum WorkspaceError {
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("change set not found by id: {0}")]
     ChangeSetNotFound(ChangeSetId),
     #[error(transparent)]

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -42,7 +42,7 @@ use telemetry::prelude::*;
 use thiserror::Error;
 use ulid::Ulid;
 
-use crate::change_set_pointer::{ChangeSetId, ChangeSetPointer, ChangeSetPointerError};
+use crate::change_set_pointer::{ChangeSetError, ChangeSetId, ChangeSetPointer};
 use crate::workspace_snapshot::conflict::Conflict;
 use crate::workspace_snapshot::edge_weight::{
     EdgeWeight, EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
@@ -61,8 +61,8 @@ use self::node_weight::{NodeWeightDiscriminants, OrderingNodeWeight};
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum WorkspaceSnapshotError {
-    #[error("change set pointer error: {0}")]
-    ChangeSetPointer(#[from] ChangeSetPointerError),
+    #[error("change set error: {0}")]
+    ChangeSet(#[from] ChangeSetError),
     #[error("change set pointer {0} has no workspace snapshot address")]
     ChangeSetPointerMissingWorkspaceSnapshotAddress(ChangeSetId),
     #[error("edge weight error: {0}")]

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -15,7 +15,7 @@ use ulid::Ulid;
 
 use telemetry::prelude::*;
 
-use crate::change_set_pointer::{ChangeSetPointer, ChangeSetPointerError};
+use crate::change_set_pointer::{ChangeSetError, ChangeSetPointer};
 use crate::workspace_snapshot::content_address::ContentAddressDiscriminants;
 use crate::workspace_snapshot::node_weight::category_node_weight::CategoryNodeKind;
 use crate::workspace_snapshot::node_weight::{CategoryNodeWeight, NodeWeightDiscriminants};
@@ -41,7 +41,7 @@ pub enum WorkspaceSnapshotGraphError {
     #[error("could not find category node used by node with index {0:?}")]
     CategoryNodeNotFound(NodeIndex),
     #[error("ChangeSet error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("Unable to retrieve content for ContentHash")]
     ContentMissingForContentHash,
     #[error("Action would create a graph cycle")]

--- a/lib/dal/src/workspace_snapshot/lamport_clock.rs
+++ b/lib/dal/src/workspace_snapshot/lamport_clock.rs
@@ -4,12 +4,12 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::workspace_snapshot::ChangeSetPointerError;
+use crate::workspace_snapshot::ChangeSetError;
 
 #[derive(Debug, Error)]
 pub enum LamportClockError {
     #[error("Change Set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
 }
 
 pub type LamportClockResult<T> = Result<T, LamportClockError>;

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -8,7 +8,7 @@ use ulid::Ulid;
 use crate::func::execution::FuncExecutionPk;
 use crate::workspace_snapshot::vector_clock::VectorClockId;
 use crate::{
-    change_set_pointer::{ChangeSetPointer, ChangeSetPointerError},
+    change_set_pointer::{ChangeSetError, ChangeSetPointer},
     workspace_snapshot::{
         content_address::ContentAddress,
         vector_clock::{VectorClock, VectorClockError},
@@ -49,7 +49,7 @@ pub enum NodeWeightError {
     #[error("Cannot update root node's content hash")]
     CannotUpdateRootNodeContentHash,
     #[error("ChangeSet error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("Incompatible node weights")]
     IncompatibleNodeWeightVariants,
     #[error("Invalid ContentAddress variant ({0}) for NodeWeight variant ({1})")]

--- a/lib/dal/tests/integration_test/action.rs
+++ b/lib/dal/tests/integration_test/action.rs
@@ -1,5 +1,6 @@
 mod batch;
 mod runner;
+mod with_secret;
 
 use dal::{Action, ActionKind, ActionPrototype, Component, DalContext, InputSocket, OutputSocket};
 use dal_test::test;

--- a/lib/dal/tests/integration_test/action/with_secret.rs
+++ b/lib/dal/tests/integration_test/action/with_secret.rs
@@ -1,0 +1,208 @@
+use dal::prop::PropPath;
+use dal::property_editor::values::PropertyEditorValues;
+use dal::qualification::QualificationSubCheckStatus;
+use dal::{
+    Action, ActionKind, AttributeValue, ChangeSetPointer, Component, DalContext, InputSocket,
+    OutputSocket, Prop, Secret,
+};
+use dal_test::test_harness::{create_component_for_schema_name, encrypt_message};
+use dal_test::{test, WorkspaceSignup};
+
+#[test]
+async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) {
+    let source_component = create_component_for_schema_name(ctx, "dummy-secret", "source").await;
+    let source_schema_variant_id = Component::schema_variant_id(ctx, source_component.id())
+        .await
+        .expect("could not get schema variant id for component");
+
+    let destination_component =
+        create_component_for_schema_name(ctx, "fallout", "destination").await;
+    let destination_schema_variant_id =
+        Component::schema_variant_id(ctx, destination_component.id())
+            .await
+            .expect("could not get schema variant id for component");
+
+    // This is the name of the secret definition from the test exclusive schema.
+    let secret_definition_name = "dummy";
+
+    // Cache the prop we need for attribute value update.
+    let reference_to_secret_prop = Prop::find_prop_by_path(
+        ctx,
+        source_schema_variant_id,
+        &PropPath::new(["root", "secrets", secret_definition_name]),
+    )
+    .await
+    .expect("could not find prop by path");
+
+    // Connect the two components to propagate the secret value.
+    let source_output_socket = OutputSocket::find_with_name(ctx, "dummy", source_schema_variant_id)
+        .await
+        .expect("could not perform find with name")
+        .expect("output socket not found by name");
+    let destination_input_socket =
+        InputSocket::find_with_name(ctx, "dummy", destination_schema_variant_id)
+            .await
+            .expect("could not perform find with name")
+            .expect("input socket not found by name");
+    Component::connect(
+        ctx,
+        source_component.id(),
+        source_output_socket.id(),
+        destination_component.id(),
+        destination_input_socket.id(),
+    )
+    .await
+    .expect("could not connect");
+
+    // Create the secret and commit.
+    let secret = Secret::new(
+        ctx,
+        "johnqt",
+        secret_definition_name.to_string(),
+        None,
+        &encrypt_message(ctx, nw.key_pair.pk(), &serde_json::json![{"value": "todd"}]).await,
+        nw.key_pair.pk(),
+        Default::default(),
+        Default::default(),
+    )
+    .await
+    .expect("cannot create secret");
+    let conflicts = ctx.blocking_commit().await.expect("unable to commit");
+    assert!(conflicts.is_none());
+    ctx.update_snapshot_to_visibility()
+        .await
+        .expect("unable to update snapshot to visibility");
+
+    // Use the secret in the source component and commit.
+    let property_values = PropertyEditorValues::assemble(ctx, source_component.id())
+        .await
+        .expect("unable to list prop values");
+    let reference_to_secret_attribute_value_id = property_values
+        .find_by_prop_id(reference_to_secret_prop.id)
+        .expect("could not find attribute value");
+    AttributeValue::update(
+        ctx,
+        reference_to_secret_attribute_value_id,
+        Some(serde_json::json!(secret.id().to_string())),
+    )
+    .await
+    .expect("unable to perform attribute value update");
+    let conflicts = ctx.blocking_commit().await.expect("unable to commit");
+    assert!(conflicts.is_none());
+    ctx.update_snapshot_to_visibility()
+        .await
+        .expect("unable to update snapshot to visibility");
+
+    // Ensure that the qualification is successful on the source component.
+    let qualifications = Component::list_qualifications(ctx, source_component.id())
+        .await
+        .expect("could not list qualifications");
+    let qualification = qualifications
+        .into_iter()
+        .find(|q| q.qualification_name == "test:qualificationDummySecretStringIsTodd")
+        .expect("could not find qualification");
+    assert_eq!(
+        QualificationSubCheckStatus::Success, // expected
+        qualification.result.expect("no result found").status  // actual
+    );
+
+    // Ensure we have our create action on the destination component.
+    let mut actions = Action::for_component(ctx, destination_component.id())
+        .await
+        .expect("unable to list actions for component");
+    assert_eq!(
+        1,             // expected
+        actions.len()  // actual
+    );
+    let create_action = actions.pop().expect("no actions found");
+    let create_action_prototype = create_action
+        .prototype(ctx)
+        .await
+        .expect("could not get action prototype for action");
+    assert_eq!(
+        ActionKind::Create,           // expected
+        create_action_prototype.kind, // actual
+    );
+
+    // Ensure that the parent is head so that the "create" action will execute by default.
+    // Technically, this primarily validates the test setup rather than the system itself, but it
+    // serves a secondary function of ensuring no prior functions cause this assertion to fail.
+    assert!(ctx
+        .parent_is_head()
+        .await
+        .expect("could not perform parent is head"));
+
+    // Apply to the base change set and commit.
+    let applied_change_set = ChangeSetPointer::apply_to_base_change_set(ctx, true)
+        .await
+        .expect("could apply to base change set");
+    let conflicts = ctx.blocking_commit().await.expect("unable to commit");
+    assert!(conflicts.is_none());
+
+    // Observe that the "create" action on the destination component succeeded. We'll use the base
+    // change set id to do so.
+    ctx.update_visibility_and_snapshot_to_visibility_no_editing_change_set(
+        applied_change_set
+            .base_change_set_id
+            .expect("base change set not found"),
+    )
+    .await
+    .expect("could not update visibility and snapshot to visibility");
+
+    assert_eq!(
+        serde_json::json![{
+            "qualification": {
+                "test:qualificationDummySecretStringIsTodd": {
+                    "message": "dummy secret string matches expected value",
+                    "result": "success",
+                },
+            },
+            "resource": {},
+            "resource_value": {},
+            "secret_definition": {},
+            "secrets": {
+                "dummy": secret.id().to_string(),
+            },
+            "si": {
+                "color": "#ffffff",
+                "name": "source",
+                "type": "component",
+            },
+        }], // expected
+        source_component
+            .materialized_view(ctx)
+            .await
+            .expect("could not get materialized view")
+            .expect("empty materialized view") // actual
+    );
+    assert_eq!(
+        serde_json::json![{
+            "domain": {
+                "active": true,
+                "name": "destination",
+            },
+            "resource": {
+                "logs": [
+                    "Setting dummySecretString to requestStorage",
+                     "Output: {\n  \"protocol\": \"result\",\n  \"status\": \"success\",\n  \"executionId\": \"ayrtonsennajscommand\",\n  \"payload\": {\n    \"poop\": true\n  },\n  \"health\": \"ok\"\n}",
+                ],
+                "payload": "{\"poop\":true}",
+                "status": "ok",
+            },
+            "resource_value": {},
+            "secrets": {
+                "dummy": secret.id().to_string(),
+            },
+            "si": {
+                "color": "#ffffff",
+                "name": "destination",
+                "type": "component",
+            },
+        }], // expected
+        destination_component
+            .materialized_view(ctx)
+            .await
+            .expect("could not get materialized view")
+            .expect("empty materialized view") // actual
+    );
+}

--- a/lib/dal/tests/integration_test/before_funcs.rs
+++ b/lib/dal/tests/integration_test/before_funcs.rs
@@ -6,17 +6,13 @@ use dal_test::test_harness::create_component_for_schema_name;
 use dal_test::test_harness::encrypt_message;
 use dal_test::{test, WorkspaceSignup};
 
-/// Run with the following environment variable:
-/// ```
-/// SI_TEST_BUILTIN_SCHEMAS=test
-/// ```
 #[test]
 async fn secret_definition_works_with_dummy_qualification(
     ctx: &mut DalContext,
     nw: &WorkspaceSignup,
 ) {
     let secret_definition_component =
-        create_component_for_schema_name(ctx, "bethesda-secret", "secret-definition").await;
+        create_component_for_schema_name(ctx, "dummy-secret", "secret-definition").await;
 
     let secret_definition_schema_variant_id =
         Component::schema_variant_id(ctx, secret_definition_component.id())
@@ -25,8 +21,8 @@ async fn secret_definition_works_with_dummy_qualification(
 
     let secret_definition_component_id = secret_definition_component.id();
 
-    // This is the name of the secret definition from the "BethesdaSecret" test exclusive schema.
-    let secret_definition_name = "fake";
+    // This is the name of the secret definition from the test exclusive schema.
+    let secret_definition_name = "dummy";
 
     // Cache the output socket that will contain the secret id.
     let output_socket = OutputSocket::find_with_name(
@@ -125,10 +121,9 @@ async fn secret_definition_works_with_dummy_qualification(
             .await
             .expect("could not list qualifications");
         let qualification = qualifications
-            .iter()
-            .find(|q| q.qualification_name == "test:qualificationFakeSecretStringIsTodd")
-            .expect("qualification not found")
-            .to_owned();
+            .into_iter()
+            .find(|q| q.qualification_name == "test:qualificationDummySecretStringIsTodd")
+            .expect("could not find qualification");
         assert_eq!(
             QualificationSubCheckStatus::Failure, // expected
             qualification.result.expect("no result found").status  // actual
@@ -209,10 +204,9 @@ async fn secret_definition_works_with_dummy_qualification(
             .await
             .expect("could not list qualifications");
         let qualification = qualifications
-            .iter()
-            .find(|q| q.qualification_name == "test:qualificationFakeSecretStringIsTodd")
-            .expect("no qualifications found")
-            .to_owned();
+            .into_iter()
+            .find(|q| q.qualification_name == "test:qualificationDummySecretStringIsTodd")
+            .expect("could not find qualification");
         assert_eq!(
             QualificationSubCheckStatus::Success, // expected
             qualification.result.expect("no result found").status  // actual

--- a/lib/dal/tests/integration_test/change_set.rs
+++ b/lib/dal/tests/integration_test/change_set.rs
@@ -39,14 +39,9 @@ async fn open_change_sets(ctx: &mut DalContext) {
     );
 
     // Apply the change set and perform a blocking commit.
-    let mut change_set = ChangeSetPointer::find(ctx, ctx.change_set_id())
+    ChangeSetPointer::apply_to_base_change_set(ctx, true)
         .await
-        .expect("could not perform find change set")
-        .expect("no change set found");
-    change_set
-        .apply_to_base_change_set(ctx)
-        .await
-        .expect("could not apply to base change set");
+        .expect("could not apply to base");
     let conflicts = ctx
         .blocking_commit()
         .await

--- a/lib/dal/tests/integration_test/component/get_diff.rs
+++ b/lib/dal/tests/integration_test/component/get_diff.rs
@@ -3,6 +3,7 @@ use dal::{ChangeSetPointer, Component, ComponentType, DalContext};
 use dal_test::test;
 use dal_test::test_harness::{commit_and_update_snapshot, create_component_for_schema_name};
 use pretty_assertions_sorted::assert_eq;
+use serde_json::Value;
 
 #[test]
 async fn get_diff_new_component(ctx: &mut DalContext) {
@@ -40,18 +41,12 @@ async fn get_diff_component_no_changes_from_head(ctx: &mut DalContext) {
         create_component_for_schema_name(ctx, "starfield", "this is a new component").await;
     let conflicts = ctx.blocking_commit().await.expect("unable to commit");
     assert!(conflicts.is_none());
-
     ctx.update_snapshot_to_visibility()
         .await
         .expect("unable to update snapshot to visiblity");
 
     // Apply the change set and perform a blocking commit.
-    let mut change_set = ChangeSetPointer::find(ctx, ctx.change_set_id())
-        .await
-        .expect("could not perform find change set")
-        .expect("no change set found");
-    change_set
-        .apply_to_base_change_set(ctx)
+    let applied_change_set = ChangeSetPointer::apply_to_base_change_set(ctx, true)
         .await
         .expect("could not apply to base change set");
     let conflicts = ctx
@@ -60,17 +55,54 @@ async fn get_diff_component_no_changes_from_head(ctx: &mut DalContext) {
         .expect("could not perform commit");
     assert!(conflicts.is_none());
 
-    let mut diff = Component::get_diff(ctx, starfield_component.id())
+    // Ensure the diff looks as expected on head.
+    ctx.update_visibility_and_snapshot_to_visibility_no_editing_change_set(
+        applied_change_set
+            .base_change_set_id
+            .expect("base change set not found"),
+    )
+    .await
+    .expect("could not update visibility and snapshot to visibility");
+    let diff = Component::get_diff(ctx, starfield_component.id())
         .await
         .expect("unable to get diff");
 
     assert_eq!(starfield_component.id(), diff.component_id);
-    assert_eq!(1, diff.diffs.len());
-    let first_diff = diff.diffs.pop().expect("can't find a diff for the code");
-    assert_eq!(CodeLanguage::Diff, first_diff.language);
+    assert!(diff.diffs.is_empty());
+    let code = diff.current.code.expect("code not found");
     // We expect there to be no marked diffs as the component is the same on HEAD
-    assert_eq!(Some(" {\n   \"si\": {\n     \"color\": \"#ffffff\",\n     \"name\": \"this is a new component\",\n     \"type\": \"component\"\n   },\n   \"domain\": {\n     \"name\": \"this is a new component\",\n     \"possible_world_a\": {\n       \"wormhole_1\": {\n         \"wormhole_2\": {\n           \"wormhole_3\": {}\n         }\n       }\n     },\n     \"possible_world_b\": {\n       \"wormhole_1\": {\n         \"wormhole_2\": {\n           \"wormhole_3\": {\n             \"naming_and_necessity\": \"not hesperus\"\n           }\n         }\n       }\n     },\n     \"universe\": {\n       \"galaxies\": []\n     }\n   }\n }".to_string()),
-               first_diff.code);
+    assert_eq!(
+        serde_json::json![{
+            "si": {
+                "color": "#ffffff",
+                "name": "this is a new component",
+                "type": "component"
+            },
+            "domain": {
+                "name": "this is a new component",
+                "possible_world_a": {
+                    "wormhole_1": {
+                        "wormhole_2": {
+                            "wormhole_3": {}
+                        }
+                    }
+                },
+                "possible_world_b": {
+                    "wormhole_1": {
+                        "wormhole_2": {
+                            "wormhole_3": {
+                                "naming_and_necessity": "not hesperus"
+                            }
+                        }
+                    }
+                },
+                "universe": {
+                    "galaxies": []
+                },
+            }
+        }], // expected
+        serde_json::from_str::<Value>(code.as_str()).expect("could not deserialize") // actual
+    );
 }
 
 #[test]
@@ -81,15 +113,7 @@ async fn get_diff_component_change_comp_type(ctx: &mut DalContext) {
     assert!(conflicts.is_none());
 
     // Apply the change set and perform a blocking commit.
-    let mut change_set = ChangeSetPointer::find(ctx, ctx.change_set_id())
-        .await
-        .expect("could not perform find change set")
-        .expect("no change set found");
-    ctx.update_visibility_and_snapshot_to_visibility_no_editing_change_set(change_set.id)
-        .await
-        .expect("Unable to set no editing changeset");
-    change_set
-        .apply_to_base_change_set(ctx)
+    ChangeSetPointer::apply_to_base_change_set(ctx, true)
         .await
         .expect("could not apply to base change set");
     let conflicts = ctx
@@ -124,6 +148,8 @@ async fn get_diff_component_change_comp_type(ctx: &mut DalContext) {
     let first_diff = diff.diffs.pop().expect("can't find a diff for the code");
     assert_eq!(CodeLanguage::Diff, first_diff.language);
     // We there to be a diff as we have changed the componentType on this changeset but HEAD is a component
-    assert_eq!(Some(" {\n   \"si\": {\n     \"color\": \"#ffffff\",\n     \"name\": \"this is a new component\",\n-    \"type\": \"component\"\n+    \"type\": \"configurationFrameDown\"\n   },\n   \"domain\": {\n     \"name\": \"this is a new component\",\n     \"possible_world_a\": {\n       \"wormhole_1\": {\n         \"wormhole_2\": {\n           \"wormhole_3\": {}\n         }\n       }\n     },\n     \"possible_world_b\": {\n       \"wormhole_1\": {\n         \"wormhole_2\": {\n           \"wormhole_3\": {\n             \"naming_and_necessity\": \"not hesperus\"\n           }\n         }\n       }\n     },\n     \"universe\": {\n       \"galaxies\": []\n     }\n   }\n }".to_string()),
-               first_diff.code);
+    assert_eq!(
+        Some("{\n  \"si\": {\n    \"color\": \"#ffffff\",\n    \"name\": \"this is a new component\",\n    \"type\": \"component\"\n  },\n  \"domain\": {\n    \"name\": \"this is a new component\",\n    \"possible_world_a\": {\n      \"wormhole_1\": {\n        \"wormhole_2\": {\n          \"wormhole_3\": {}\n        }\n      }\n    },\n    \"possible_world_b\": {\n      \"wormhole_1\": {\n        \"wormhole_2\": {\n          \"wormhole_3\": {\n            \"naming_and_necessity\": \"not hesperus\"\n          }\n        }\n      }\n    },\n    \"universe\": {\n      \"galaxies\": []\n    }\n  }\n}".to_string()), // expected
+        first_diff.code // actual
+    );
 }

--- a/lib/rebaser-server/src/server/rebase.rs
+++ b/lib/rebaser-server/src/server/rebase.rs
@@ -1,4 +1,4 @@
-use dal::change_set_pointer::{ChangeSetId, ChangeSetPointer, ChangeSetPointerError};
+use dal::change_set_pointer::{ChangeSetError, ChangeSetId, ChangeSetPointer};
 use dal::workspace_snapshot::vector_clock::VectorClockId;
 use dal::workspace_snapshot::WorkspaceSnapshotError;
 use dal::{
@@ -16,7 +16,7 @@ use ulid::Ulid;
 #[derive(Debug, Error)]
 pub(crate) enum RebaseError {
     #[error("workspace snapshot error: {0}")]
-    ChangeSetPointer(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("missing change set pointer")]
     MissingChangeSetPointer(ChangeSetId),
     #[error("missing workspace snapshot for change set ({0}) (the change set likely isn't pointing at a workspace snapshot)")]

--- a/lib/sdf-server/src/server/service/change_set.rs
+++ b/lib/sdf-server/src/server/service/change_set.rs
@@ -5,12 +5,11 @@ use axum::{
     Json, Router,
 };
 use dal::{
-    ActionBatchError, ActionError, ActionPrototypeError, ActionRunnerError, ChangeSetId,
-    ChangeSetPointerError as DalChangeSetPointerError, ComponentError, FuncError,
-    StandardModelError, TransactionsError, UserError, UserPk, WorkspaceError, WorkspacePk,
-    WsEventError,
+    ActionError, ActionPrototypeError, ChangeSetApplyError as DalChangeSetApplyError,
+    ChangeSetError as DalChangeSetError, ComponentError, FuncError, StandardModelError,
+    TransactionsError, WsEventError,
 };
-use module_index_client::IndexClientError;
+
 use telemetry::prelude::*;
 use thiserror::Error;
 
@@ -31,67 +30,27 @@ pub mod remove_action;
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum ChangeSetError {
-    #[error(transparent)]
+    #[error("action error: {0}")]
     Action(#[from] ActionError),
-    #[error(transparent)]
-    ActionBatch(#[from] ActionBatchError),
-    #[error(transparent)]
+    #[error("action prototype error: {0}")]
     ActionPrototype(#[from] ActionPrototypeError),
-    #[error(transparent)]
-    ActionRunner(#[from] ActionRunnerError),
-    // #[error("action {0} not found")]
-    // ActionNotFound(ActionId),
-    #[error("base change set not found for change set: {0}")]
-    BaseChangeSetNotFound(ChangeSetId),
     #[error("change set not found")]
     ChangeSetNotFound,
     #[error("component error: {0}")]
     Component(#[from] ComponentError),
-    // #[error(transparent)]
-    // ChangeStatusError(#[from] ChangeStatusError),
-    // #[error(transparent)]
-    // Component(#[from] DalComponentError),
-    #[error(transparent)]
-    ContextError(#[from] TransactionsError),
     #[error("dal change set error: {0}")]
-    DalChangeSet(#[from] DalChangeSetPointerError),
-    #[error("could not find default change set: {0}")]
-    DefaultChangeSetNotFound(ChangeSetId),
-    #[error("default change set {0} has no workspace snapshot pointer")]
-    DefaultChangeSetNoWorkspaceSnapshotPointer(ChangeSetId),
-    #[error(transparent)]
+    DalChangeSet(#[from] DalChangeSetError),
+    #[error("dal change set apply error: {0}")]
+    DalChangeSetApply(#[from] DalChangeSetApplyError),
+    #[error("func error: {0}")]
     Func(#[from] FuncError),
-    // #[error(transparent)]
-    // DalPkg(#[from] dal::pkg::PkgError),
-    // #[error(transparent)]
-    // Fix(#[from] FixError),
     #[error("invalid header name {0}")]
     Hyper(#[from] hyper::http::Error),
-    #[error(transparent)]
-    IndexClient(#[from] IndexClientError),
-    #[error("invalid user {0}")]
-    InvalidUser(UserPk),
-    #[error("invalid user system init")]
-    InvalidUserSystemInit,
-    #[error(transparent)]
-    Nats(#[from] si_data_nats::NatsError),
-    #[error("no tenancy set in context")]
-    NoTenancySet,
-    #[error(transparent)]
-    Pg(#[from] si_data_pg::PgError),
-    // #[error(transparent)]
-    // PkgService(#[from] PkgError),
-    #[error(transparent)]
+    #[error("standard model error: {0}")]
     StandardModel(#[from] StandardModelError),
-    #[error(transparent)]
-    UrlParse(#[from] url::ParseError),
-    #[error(transparent)]
-    User(#[from] UserError),
-    #[error("workspace error: {0}")]
-    Workspace(#[from] WorkspaceError),
-    #[error("workspace not found: {0}")]
-    WorkspaceNotFound(WorkspacePk),
-    #[error(transparent)]
+    #[error("transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
+    #[error("ws event error: {0}")]
     WsEvent(#[from] WsEventError),
 }
 

--- a/lib/sdf-server/src/server/service/change_set/apply_change_set.rs
+++ b/lib/sdf-server/src/server/service/change_set/apply_change_set.rs
@@ -1,18 +1,12 @@
-use super::ChangeSetResult;
-use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
-use crate::server::service::change_set::ChangeSetError;
-use crate::server::tracking::track;
 use axum::extract::OriginalUri;
 use axum::Json;
 use dal::change_set_pointer::ChangeSetPointer;
-use dal::{
-    action::ActionBag,
-    job::definition::{ActionRunnerItem, ActionsJob},
-    Action, ActionBatch, ActionError, ActionId, ActionRunner, ActionRunnerId, Component,
-    HistoryActor, User, Visibility,
-};
+use dal::Visibility;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, VecDeque};
+
+use super::ChangeSetResult;
+use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
+use crate::server::tracking::track;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -36,26 +30,7 @@ pub async fn apply_change_set(
 ) -> ChangeSetResult<Json<ApplyChangeSetResponse>> {
     let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let actions = Action::build_graph(&ctx).await?;
-    let mut prototype_by_action_id = HashMap::new();
-
-    let applying_to_head = ctx.parent_is_head().await?;
-    if applying_to_head {
-        for bag in actions.values() {
-            prototype_by_action_id.insert(bag.action.id, bag.action.prototype(&ctx).await?.id);
-            bag.action.clone().delete(&ctx).await?;
-        }
-    }
-
-    ctx.blocking_commit().await?;
-
-    let mut change_set = ChangeSetPointer::find(&ctx, request.visibility.change_set_id)
-        .await?
-        .ok_or(ChangeSetError::ChangeSetNotFound)?;
-    ctx.update_visibility_and_snapshot_to_visibility_no_editing_change_set(change_set.id)
-        .await?;
-    change_set.apply_to_base_change_set(&ctx).await?;
-    ctx.blocking_commit().await?;
+    let change_set = ChangeSetPointer::apply_to_base_change_set(&mut ctx, false).await?;
 
     track(
         &posthog_client,
@@ -67,101 +42,15 @@ pub async fn apply_change_set(
         }),
     );
 
-    // If head and there are actions to apply
-    if applying_to_head && !actions.is_empty() {
-        let base_change_set_id = change_set
-            .base_change_set_id
-            .ok_or(ChangeSetError::BaseChangeSetNotFound(change_set.id))?;
-        let head = ChangeSetPointer::find(&ctx, base_change_set_id)
-            .await?
-            .ok_or(ChangeSetError::ChangeSetNotFound)?;
-        ctx.update_visibility_and_snapshot_to_visibility(head.id)
-            .await?;
+    // // If anything fails with uploading the workspace backup module, just log it. We shouldn't
+    // // have the change set apply itself fail because of this.
+    // tokio::task::spawn(
+    //     super::upload_workspace_backup_module(ctx, raw_access_token)
+    //         .instrument(info_span!("Workspace backup module upload")),
+    // );
 
-        let user = match ctx.history_actor() {
-            HistoryActor::User(user_pk) => User::get_by_pk(&ctx, *user_pk)
-                .await?
-                .ok_or(ChangeSetError::InvalidUser(*user_pk))?,
+    ctx.commit().await?;
 
-            HistoryActor::SystemInit => return Err(ChangeSetError::InvalidUserSystemInit),
-        };
-
-        // TODO: restore actors of change-set concept
-        let actors_delimited_string = String::new();
-        let batch = ActionBatch::new(&ctx, user.email(), &actors_delimited_string).await?;
-        let mut runners: HashMap<ActionRunnerId, ActionRunnerItem> = HashMap::new();
-        let mut runners_by_action: HashMap<ActionId, ActionRunnerId> = HashMap::new();
-
-        let mut values: Vec<ActionBag> = actions.values().cloned().collect();
-        values.sort_by_key(|a| a.action.id);
-
-        let mut values: VecDeque<ActionBag> = values.into_iter().collect();
-
-        // Runners have to be created in the order we want to display them in the actions history panel
-        // So we do extra work here to ensure the order is the execution order
-        'outer: while let Some(bag) = values.pop_front() {
-            let prototype_id = *prototype_by_action_id
-                .get(&bag.action.id)
-                .ok_or(ActionError::PrototypeNotFoundFor(bag.action.id))?;
-
-            let mut parents = Vec::new();
-            for parent_id in bag.parents.clone() {
-                if let Some(parent_id) = runners_by_action.get(&parent_id) {
-                    parents.push(*parent_id);
-                } else {
-                    values.push_back(bag);
-                    continue 'outer;
-                }
-            }
-
-            let component = Component::get_by_id(&ctx, bag.component_id).await?;
-            let runner = ActionRunner::new(
-                &ctx,
-                batch.id,
-                bag.component_id,
-                component.name(&ctx).await?,
-                prototype_id,
-            )
-            .await?;
-            runners_by_action.insert(bag.action.id, runner.id);
-
-            runners.insert(
-                runner.id,
-                ActionRunnerItem {
-                    id: runner.id,
-                    component_id: bag.component_id,
-                    action_prototype_id: prototype_id,
-                    parents,
-                },
-            );
-        }
-
-        track(
-            &posthog_client,
-            &ctx,
-            &original_uri,
-            "apply_fix",
-            serde_json::json!({
-                "fix_batch_id": batch.id,
-                "number_of_action_runners_in_batch": runners.len(),
-                "action_runners_applied": runners,
-            }),
-        );
-
-        ctx.enqueue_actions(ActionsJob::new(&ctx, runners, batch.id))
-            .await?;
-
-        ctx.commit().await?;
-    }
-
-    // If anything fails with uploading the workspace backup module, just log it. We shouldn't
-    // have the change set apply itself fail because of this.
-    /*
-    tokio::task::spawn(
-        super::upload_workspace_backup_module(ctx, raw_access_token)
-            .instrument(info_span!("Workspace backup module upload")),
-    );
-    */
     Ok(Json(ApplyChangeSetResponse {
         change_set: change_set.to_owned(),
     }))

--- a/lib/sdf-server/src/server/service/component.rs
+++ b/lib/sdf-server/src/server/service/component.rs
@@ -9,7 +9,7 @@ use dal::component::ComponentId;
 use dal::property_editor::PropertyEditorError;
 use dal::validation::resolver::ValidationResolverError;
 use dal::{ActionPrototypeError, ComponentError as DalComponentError, StandardModelError};
-use dal::{ChangeSetPointerError, TransactionsError};
+use dal::{ChangeSetError, TransactionsError};
 use thiserror::Error;
 
 use crate::server::state::AppState;
@@ -51,7 +51,7 @@ pub enum ComponentError {
     // #[error("attribute value not found")]
     // AttributeValueNotFound,
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     // #[error("change status error: {0}")]
     // ChangeStatus(#[from] ChangeStatusError),
     // #[error("component debug view error: {0}")]

--- a/lib/sdf-server/src/server/service/diagram.rs
+++ b/lib/sdf-server/src/server/service/diagram.rs
@@ -12,7 +12,7 @@ use dal::socket::output::OutputSocketError;
 use dal::workspace_snapshot::WorkspaceSnapshotError;
 use dal::WsEventError;
 use dal::{
-    ActionError, ActionPrototypeError, ChangeSetPointerError, SchemaVariantId, StandardModelError,
+    ActionError, ActionPrototypeError, ChangeSetError, SchemaVariantId, StandardModelError,
     TransactionsError,
 };
 use thiserror::Error;
@@ -47,7 +47,7 @@ pub enum DiagramError {
     #[error("attribute value error: {0}")]
     AttributeValue(#[from] AttributeValueError),
     #[error("changeset error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("change set not found")]
     ChangeSetNotFound,
     #[error("component error: {0}")]

--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -10,7 +10,7 @@ use dal::{
     workspace_snapshot::WorkspaceSnapshotError, DalContext, Func, FuncBackendKind,
     FuncBackendResponseType, FuncId, SchemaVariantId, TransactionsError,
 };
-use dal::{ChangeSetPointerError, WsEventError};
+use dal::{ChangeSetError, WsEventError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -64,7 +64,7 @@ pub enum FuncError {
     //     #[error("attribute value missing")]
     //     AttributeValueMissing,
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     //     #[error("component error: {0}")]
     //     Component(#[from] ComponentError),
     //     #[error("component missing schema variant")]

--- a/lib/sdf-server/src/server/service/pkg.rs
+++ b/lib/sdf-server/src/server/service/pkg.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use convert_case::{Case, Casing};
 use dal::{
-    installed_pkg::InstalledPkgError, pkg::PkgError as DalPkgError, ChangeSetPointerError,
+    installed_pkg::InstalledPkgError, pkg::PkgError as DalPkgError, ChangeSetError,
     DalContextBuilder, SchemaVariantError, SchemaVariantId, StandardModelError, TenancyError,
     TransactionsError, UserError, UserPk, WorkspaceError, WorkspacePk, WsEventError,
 };
@@ -37,7 +37,7 @@ pub enum PkgError {
     #[error("Could not canononicalize path: {0}")]
     Canononicalize(#[from] CanonicalFileError),
     #[error(transparent)]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error(transparent)]
     ContextTransaction(#[from] TransactionsError),
     #[error(transparent)]

--- a/lib/sdf-server/src/server/service/secret.rs
+++ b/lib/sdf-server/src/server/service/secret.rs
@@ -6,8 +6,8 @@ use axum::{
     Json, Router,
 };
 use dal::{
-    ChangeSetPointerError, KeyPairError, SecretId, StandardModelError, TransactionsError,
-    UserError, WorkspacePk, WsEventError,
+    ChangeSetError, KeyPairError, SecretId, StandardModelError, TransactionsError, UserError,
+    WorkspacePk, WsEventError,
 };
 use thiserror::Error;
 
@@ -22,7 +22,7 @@ pub mod update_secret;
 #[derive(Debug, Error)]
 pub enum SecretError {
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     #[error("context transactions error: {0}")]
     ContextTransactions(#[from] TransactionsError),
     #[error("dal secret error: {0}")]

--- a/lib/sdf-server/src/server/service/variant.rs
+++ b/lib/sdf-server/src/server/service/variant.rs
@@ -6,9 +6,7 @@ use chrono::Utc;
 use convert_case::{Case, Casing};
 use dal::func::binding::FuncBindingError;
 use dal::pkg::PkgError;
-use dal::{
-    ChangeSetPointerError, FuncError, FuncId, SchemaError, SchemaVariantId, TransactionsError,
-};
+use dal::{ChangeSetError, FuncError, FuncId, SchemaError, SchemaVariantId, TransactionsError};
 use si_pkg::{SiPkgError, SpecError};
 use thiserror::Error;
 
@@ -39,7 +37,7 @@ pub enum SchemaVariantError {
     //     #[error(transparent)]
     //     AuthenticationPrototype(#[from] AuthenticationPrototypeError),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetPointerError),
+    ChangeSet(#[from] ChangeSetError),
     //     #[error(transparent)]
     //     ContextTransaction(#[from] TransactionsError),
     //     #[error("error creating schema variant from definition: {0}")]


### PR DESCRIPTION
## Description

This PR adds an integration test for ensuring that actions work with secrets. For both testing and for code reuse, the apply logic has been moved to the dal.

<img src="https://media3.giphy.com/media/EDd9ER1ixrCzMprljW/giphy.gif"/>

## Additional Changes

- Move the upsertion of "create" actions to `Component::new`
- Rename `ChangeSetPointerError` to `ChangeSetError` and `ChangeSetPointerResult` to `ChangeSetResult` for two reasons
  - First reason: this is part of the ongoing refactor to replace the new change set concept with the old one
  - Second reason: to avoid confusion with the introduction of the `ChangeSetApplyError` and `ChangeSetApplyResult` types
- Reduce and refactor sdf change set service errors
- Standardize package version string for test exclusive schemas
- Standardize package "created by" string for test exclusive schemas
- Make the secret defining test exclusive schema more generic and rename "fake" to "dummy" (the previous name was confusing given the name of the sockets for the fallout and starfield schemas)
- Return an error when a qualification map attribute value does not have an ordering node