### PR TITLE
feat(sdf, dal): Restore get_resource endpoint to the system

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -129,6 +129,8 @@ pub enum ComponentError {
     Qualification(#[from] QualificationError),
     #[error("ordering node not found for qualifications map {0} and component {1}")]
     QualificationNoOrderingNode(AttributeValueId, ComponentId),
+    #[error("resource attribute value not found for component: {0}")]
+    ResourceAttributeValueNotFound(ComponentId),
     #[error("root attribute value not found for component: {0}")]
     RootAttributeValueNotFound(ComponentId),
     #[error("schema variant error: {0}")]

--- a/lib/sdf-server/src/server/service/component.rs
+++ b/lib/sdf-server/src/server/service/component.rs
@@ -15,16 +15,16 @@ use thiserror::Error;
 use crate::server::state::AppState;
 
 pub mod delete_property_editor_value;
+pub mod get_actions;
 pub mod get_diff;
 pub mod get_property_editor_schema;
 pub mod get_property_editor_validations;
 pub mod get_property_editor_values;
-pub mod update_property_editor_value;
-// pub mod get_resource;
-pub mod get_actions;
+pub mod get_resource;
 pub mod insert_property_editor_value;
 pub mod json;
 pub mod list_qualifications;
+pub mod update_property_editor_value;
 // pub mod list_resources;
 // pub mod refresh;
 // pub mod resource_domain_diff;
@@ -159,6 +159,7 @@ pub fn routes() -> Router<AppState> {
         )
         .route("/get_code", get(get_code::get_code))
         .route("/get_diff", get(get_diff::get_diff))
+        .route("/get_resource", get(get_resource::get_resource))
         .route(
             "/update_property_editor_value",
             post(update_property_editor_value::update_property_editor_value),

--- a/lib/sdf-server/src/server/service/component/get_resource.rs
+++ b/lib/sdf-server/src/server/service/component/get_resource.rs
@@ -1,5 +1,6 @@
 use axum::{extract::Query, Json};
-use dal::{ComponentId, ResourceView, Visibility};
+use dal::component::resource::ResourceView;
+use dal::{ComponentId, Visibility};
 use serde::{Deserialize, Serialize};
 
 use super::ComponentResult;
@@ -26,6 +27,6 @@ pub async fn get_resource(
 ) -> ComponentResult<Json<GetResourceResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let resource = ResourceView::get_by_component_id(&ctx, &request.component_id).await?;
+    let resource = ResourceView::get_by_component_id(&ctx, request.component_id).await?;
     Ok(Json(GetResourceResponse { resource }))
 }


### PR DESCRIPTION
This can't be merged yet  because refresh operations overwrite the /root/resource prop which means this will always return an empty resource to the UI