### PR TITLE
fix(ci-base): adds better deps structure + more cypress deps into the…

### DIFF
--- a/component/ci-base/Dockerfile
+++ b/component/ci-base/Dockerfile
@@ -32,15 +32,29 @@ RUN set -eux; \
         containerd.io \
         docker-buildx-plugin \
         docker-compose-plugin \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Cypress Dependencies
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends \
         xvfb \
         libgtk2.0-0 \
         libnss3 \
         libatk-bridge2.0-0 \
         libgtk-3-0 \
         libgdm-dev \
+        libgbm1 \
+        libwayland-server0 \
         libasound2 \
     ; \
     rm -rf /var/lib/apt/lists/*
+
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable libxss1 \
+      --no-install-recommends \
 
 RUN set -eux; \
     useradd --create-home --shell /bin/bash --uid "${USER_UID}" ci; \


### PR DESCRIPTION
Installs the remainder of the cypress deps into the ci-base image, all of these should be satisfied locally on dev machines already, so this is a ci-specific fix.

Locally I get (using the ci-base off this branch):
```
ci@45ae3dd1610a:/workdir/app/web$ npx cypress run --spec ./cypress/e2e/authentication/login.cy.ts 
It looks like this is your first time using Cypress: 13.7.1

✔  Verified Cypress! /home/ci/.cache/Cypress/13.7.1/Cypress

Opening Cypress...

DevTools listening on ws://127.0.0.1:44311/devtools/browser/00cc15de-63a8-4e8f-b0b7-04b3af451aee
Your configFile is invalid: /workdir/app/web/cypress.config.ts

It threw an error when required, check the stack trace below:

TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /workdir/app/web/cypress.config.ts
```

Which I believe should be a non-issue in CI/a real .nix flake 