### PR TITLE
Drop ActionKind from ActionPrototype edge (ENG-2434)

### DIFF
--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -133,7 +133,6 @@ impl Action {
         let change_set = ctx.change_set()?;
         let id = change_set.generate_ulid()?;
         let node_weight = NodeWeight::new_content(change_set, id, ContentAddress::Action(hash))?;
-        let action_prototype = ActionPrototype::get_by_id(ctx, prototype_id).await?;
 
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
@@ -142,10 +141,7 @@ impl Action {
         workspace_snapshot
             .add_edge(
                 id,
-                EdgeWeight::new(
-                    change_set,
-                    EdgeWeightKind::ActionPrototype(action_prototype.kind),
-                )?,
+                EdgeWeight::new(change_set, EdgeWeightKind::ActionPrototype)?,
                 prototype_id,
             )
             .await?;

--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -196,7 +196,7 @@ impl ActionPrototype {
         workspace_snapshot
             .add_edge(
                 schema_variant_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::ActionPrototype(kind))?,
+                EdgeWeight::new(change_set, EdgeWeightKind::ActionPrototype)?,
                 id,
             )
             .await?;

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -7,7 +7,6 @@ use thiserror::Error;
 
 use crate::change_set::ChangeSet;
 use crate::workspace_snapshot::vector_clock::{VectorClock, VectorClockError, VectorClockId};
-use crate::ActionKind;
 
 #[derive(Debug, Error)]
 pub enum EdgeWeightError {
@@ -23,7 +22,7 @@ pub type EdgeWeightResult<T> = Result<T, EdgeWeightError>;
 pub enum EdgeWeightKind {
     Action,
     /// A function used by a [`SchemaVariant`] to perform an action that affects its resource
-    ActionPrototype(ActionKind),
+    ActionPrototype,
     /// A function defined for a secret defining [`SchemaVariant`] to be executed before funcs on
     /// components that have a secret of that kind
     AuthenticationPrototype,

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -1696,11 +1696,6 @@ impl WorkspaceSnapshotGraph {
                     // This is the key for an entry in a map.
                     EdgeWeightKind::Contain(Some(key)) => hasher.update(key.as_bytes()),
 
-                    // This is the kind of the action.
-                    EdgeWeightKind::ActionPrototype(kind) => {
-                        hasher.update(kind.to_string().as_bytes())
-                    }
-
                     EdgeWeightKind::Use { is_default } => {
                         hasher.update(is_default.to_string().as_bytes())
                     }
@@ -1713,6 +1708,7 @@ impl WorkspaceSnapshotGraph {
                     // in the edge itself.
                     EdgeWeightKind::AuthenticationPrototype
                     | EdgeWeightKind::Action
+                    | EdgeWeightKind::ActionPrototype
                     | EdgeWeightKind::Contain(None)
                     | EdgeWeightKind::FrameContains
                     | EdgeWeightKind::PrototypeArgument


### PR DESCRIPTION
## Description

This PR drops `ActionKind` from the `ActionPrototype` variant within `EdgeWeightKind`. This information is available within the `ActionPrototype` node and we should not store duplicate information unless strictly necessary.

<img src="https://media4.giphy.com/media/v8ysebDNM6jRnlBw8u/giphy.gif"/>