### PR TITLE
Replace FuncVariant with FuncKind and consolidate list func logic

### DIFF
--- a/app/web/src/api/sdf/dal/func.ts
+++ b/app/web/src/api/sdf/dal/func.ts
@@ -1,35 +1,68 @@
-export enum FuncVariant {
-  Attribute = "Attribute",
-  CodeGeneration = "CodeGeneration",
+export enum FuncKind {
   Action = "Action",
-  Qualification = "Qualification",
+  Attribute = "Attribute",
   Authentication = "Authentication",
+  CodeGeneration = "CodeGeneration",
+  Intrinsic = "Intrinsic",
+  Qualification = "Qualification",
+  SchemaVariantDefinition = "SchemaVariantDefinition",
+  Unknwon = "Unknown",
+}
+
+export enum CustomizableFuncKind {
+  Action = "Action",
+  Attribute = "Attribute",
+  Authentication = "Authentication",
+  CodeGeneration = "CodeGeneration",
+  Qualification = "Qualification",
+}
+
+// TODO(nick,wendy): this is ugly to use in some places. We probably need to think of a better interface. Blame me, not Wendy.
+export function customizableFuncKindToFuncKind(
+  customizableFuncKind: CustomizableFuncKind,
+): FuncKind {
+  switch (customizableFuncKind) {
+    case CustomizableFuncKind.Action:
+      return FuncKind.Action;
+    case CustomizableFuncKind.Attribute:
+      return FuncKind.Attribute;
+    case CustomizableFuncKind.Authentication:
+      return FuncKind.Authentication;
+    case CustomizableFuncKind.CodeGeneration:
+      return FuncKind.CodeGeneration;
+    case CustomizableFuncKind.Qualification:
+      return FuncKind.Qualification;
+    default:
+      throw new Error(
+        "this should not be possible since CustomizableFuncKind is a subset of FuncKind",
+      );
+  }
 }
 
 export const CUSTOMIZABLE_FUNC_TYPES = {
-  [FuncVariant.Action]: {
+  [CustomizableFuncKind.Action]: {
     pluralLabel: "Actions",
     singularLabel: "Action",
   },
-  [FuncVariant.Attribute]: {
+  [CustomizableFuncKind.Attribute]: {
     pluralLabel: "Attributes",
     singularLabel: "Attribute",
   },
-  [FuncVariant.Authentication]: {
+  [CustomizableFuncKind.Authentication]: {
     pluralLabel: "Authentications",
     singularLabel: "Authentication",
   },
-  [FuncVariant.CodeGeneration]: {
+  [CustomizableFuncKind.CodeGeneration]: {
     pluralLabel: "Code Generations",
     singularLabel: "Code Generation",
   },
-  [FuncVariant.Qualification]: {
+  [CustomizableFuncKind.Qualification]: {
     pluralLabel: "Qualifications",
     singularLabel: "Qualification",
   },
 };
 
-export const isCustomizableFuncKind = (f: FuncVariant) =>
+export const isCustomizableFuncKind = (f: FuncKind) =>
   f in CUSTOMIZABLE_FUNC_TYPES;
 
 export enum FuncArgumentKind {

--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -34,7 +34,7 @@
           v-for="(warning, index) in assetStore.detachmentWarnings"
           :key="warning.message"
           class="mx-1"
-          :class="{ 'cursor-pointer': !!warning.variant }"
+          :class="{ 'cursor-pointer': !!warning.kind }"
           icon="alert-triangle"
           tone="warning"
           @click="openAttachModal(warning)"
@@ -172,7 +172,7 @@ import {
 } from "@si/vue-lib/design-system";
 import * as _ from "lodash-es";
 import { storeToRefs } from "pinia";
-import { FuncVariant } from "@/api/sdf/dal/func";
+import { FuncKind } from "@/api/sdf/dal/func";
 import { useAssetStore } from "@/store/asset.store";
 import { FuncId } from "@/store/func/funcs.store";
 import { ComponentType } from "@/components/ModelingDiagram/diagram_types";
@@ -190,12 +190,9 @@ const loadAssetReqStatus = assetStore.getRequestStatus(
 );
 const executeAssetModalRef = ref();
 
-const openAttachModal = (warning: {
-  variant?: FuncVariant;
-  funcId?: FuncId;
-}) => {
-  if (!warning.variant) return;
-  attachModalRef.value?.open(true, warning.variant, warning.funcId);
+const openAttachModal = (warning: { kind?: FuncKind; funcId?: FuncId }) => {
+  if (!warning.kind) return;
+  attachModalRef.value?.open(true, warning.kind, warning.funcId);
 };
 
 const componentTypeOptions = [

--- a/app/web/src/components/AssetFuncAttachModal.vue
+++ b/app/web/src/components/AssetFuncAttachModal.vue
@@ -11,10 +11,10 @@
         "
       >
         <VormInput
-          v-model="funcVariant"
+          v-model="funcKind"
           label="Kind"
           type="dropdown"
-          :options="funcVariantOptions"
+          :options="funcKindOptions"
         />
         <VormInput
           v-if="!attachExisting"
@@ -31,7 +31,7 @@
           required
           :options="existingFuncOptions"
         />
-        <template v-if="funcVariant === FuncVariant.Action && !attachExisting">
+        <template v-if="funcKind === FuncKind.Action && !attachExisting">
           <h2 class="pt-4 text-neutral-700 type-bold-sm dark:text-neutral-50">
             <SiCheckBox
               id="create"
@@ -58,7 +58,7 @@
           </h2>
         </template>
         <VormInput
-          v-if="funcVariant === FuncVariant.Attribute"
+          v-if="funcKind === FuncKind.Attribute"
           v-model="attributeOutputLocation"
           label="Output Location"
           type="dropdown"
@@ -121,7 +121,11 @@ import clsx from "clsx";
 import * as _ from "lodash-es";
 import { ActionKind } from "@/store/actions.store";
 import SiCheckBox from "@/components/SiCheckBox.vue";
-import { CUSTOMIZABLE_FUNC_TYPES, FuncVariant } from "@/api/sdf/dal/func";
+import {
+  CUSTOMIZABLE_FUNC_TYPES,
+  CustomizableFuncKind,
+  FuncKind,
+} from "@/api/sdf/dal/func";
 import { FuncId, useFuncStore } from "@/store/func/funcs.store";
 import { useAssetStore } from "@/store/asset.store";
 import {
@@ -153,17 +157,15 @@ const showLoading = computed(
     createFuncReqStatus.value.isPending || loadAssetsReqStatus.value.isPending,
 );
 
-const funcVariantOptions = Object.keys(CUSTOMIZABLE_FUNC_TYPES).map(
-  (variant) => ({
-    label: CUSTOMIZABLE_FUNC_TYPES[variant as FuncVariant]?.singularLabel,
-    value: variant as string,
-  }),
-);
+const funcKindOptions = Object.keys(CUSTOMIZABLE_FUNC_TYPES).map((kind) => ({
+  label: CUSTOMIZABLE_FUNC_TYPES[kind as CustomizableFuncKind]?.singularLabel,
+  value: kind as string,
+}));
 
 const attachExisting = ref(false);
 
 const name = ref("");
-const funcVariant = ref(FuncVariant.Action);
+const funcKind = ref(FuncKind.Action);
 
 const selectedExistingFuncId = ref<FuncId | undefined>();
 const selectedFuncCode = ref<string>("");
@@ -191,7 +193,7 @@ watch(selectedExistingFuncId, async (funcId) => {
 
 const existingFuncOptions = computed(() =>
   Object.values(funcStore.funcsById)
-    .filter((func) => func.variant === funcVariant.value)
+    .filter((func) => func.kind === funcKind.value)
     .map((func) => ({
       label: func.name,
       value: func.id,
@@ -250,7 +252,7 @@ const attachEnabled = computed(() => {
   const nameIsSet =
     attachExisting.value || !!(name.value && name.value.length > 0);
   const hasOutput =
-    funcVariant.value !== FuncVariant.Attribute ||
+    funcKind.value !== FuncKind.Attribute ||
     !!attributeOutputLocationParsed.value;
   const existingSelected =
     !attachExisting.value || !!selectedExistingFuncId.value;
@@ -258,11 +260,11 @@ const attachEnabled = computed(() => {
   return nameIsSet && hasOutput && existingSelected;
 });
 
-const open = (existing?: boolean, variant?: FuncVariant, funcId?: FuncId) => {
+const open = (existing?: boolean, variant?: FuncKind, funcId?: FuncId) => {
   attachExisting.value = existing ?? false;
 
   name.value = "";
-  funcVariant.value = variant ?? FuncVariant.Action;
+  funcKind.value = variant ?? FuncKind.Action;
   isCreate.value = false;
   isDelete.value = false;
   isRefresh.value = false;
@@ -287,7 +289,7 @@ const open = (existing?: boolean, variant?: FuncVariant, funcId?: FuncId) => {
 };
 
 const newFuncOptions = (
-  funcVariant: FuncVariant,
+  funcKind: FuncKind,
   schemaVariantId: string,
 ): CreateFuncOptions => {
   const baseOptions = {
@@ -295,13 +297,13 @@ const newFuncOptions = (
   };
 
   let kind = ActionKind.Other;
-  switch (funcVariant) {
-    case FuncVariant.Authentication:
+  switch (funcKind) {
+    case FuncKind.Authentication:
       return {
         type: "authenticationOptions",
         ...baseOptions,
       };
-    case FuncVariant.Action:
+    case FuncKind.Action:
       if (isCreate.value) kind = ActionKind.Create;
       if (isDelete.value) kind = ActionKind.Delete;
       if (isRefresh.value) kind = ActionKind.Refresh;
@@ -311,7 +313,7 @@ const newFuncOptions = (
         actionKind: kind,
         ...baseOptions,
       };
-    case FuncVariant.Attribute:
+    case FuncKind.Attribute:
       if (attributeOutputLocationParsed.value) {
         return {
           type: "attributeOptions",
@@ -323,18 +325,18 @@ const newFuncOptions = (
         `attributeOutputLocationParsed not defined for Attribute`,
       );
 
-    case FuncVariant.CodeGeneration:
+    case FuncKind.CodeGeneration:
       return {
         type: "codeGenerationOptions",
         ...baseOptions,
       };
-    case FuncVariant.Qualification:
+    case FuncKind.Qualification:
       return {
         type: "qualificationOptions",
         ...baseOptions,
       };
     default:
-      throw new Error(`newFuncOptions not defined for ${funcVariant}`);
+      throw new Error(`newFuncOptions not defined for ${funcKind}`);
   }
 };
 
@@ -416,9 +418,9 @@ const attachExistingFunc = async () => {
 
 const attachNewFunc = async () => {
   if (props.schemaVariantId) {
-    const options = newFuncOptions(funcVariant.value, props.schemaVariantId);
+    const options = newFuncOptions(funcKind.value, props.schemaVariantId);
     const result = await funcStore.CREATE_FUNC({
-      variant: funcVariant.value,
+      kind: funcKind.value,
       name: name.value,
       options,
     });

--- a/app/web/src/components/AssetFuncListPanel.vue
+++ b/app/web/src/components/AssetFuncListPanel.vue
@@ -27,8 +27,8 @@
         class="overflow-y-auto min-h-[200px]"
       >
         <Collapsible
-          v-for="(label, variant) in CUSTOMIZABLE_FUNC_TYPES"
-          :key="variant"
+          v-for="(label, kind) in CUSTOMIZABLE_FUNC_TYPES"
+          :key="kind"
           as="li"
           class="w-full"
           contentAs="ul"
@@ -42,7 +42,12 @@
           </template>
 
           <template #default>
-            <li v-for="func in funcsByVariant[variant] ?? []" :key="func.id">
+            <li
+              v-for="func in funcsByKind[
+                customizableFuncKindToFuncKind(kind)
+              ] ?? []"
+              :key="func.id"
+            >
               <SiFuncListItem
                 :func="func"
                 color="#921ed6"
@@ -69,7 +74,10 @@ import {
   RequestStatusMessage,
   ScrollArea,
 } from "@si/vue-lib/design-system";
-import { CUSTOMIZABLE_FUNC_TYPES } from "@/api/sdf/dal/func";
+import {
+  CUSTOMIZABLE_FUNC_TYPES,
+  customizableFuncKindToFuncKind,
+} from "@/api/sdf/dal/func";
 import { useAssetStore } from "@/store/asset.store";
 import SiFuncListItem from "@/components/SiFuncListItem.vue";
 import SidebarSubpanelTitle from "@/components/SidebarSubpanelTitle.vue";
@@ -81,12 +89,9 @@ const props = defineProps<{ assetId?: string }>();
 
 const assetStore = useAssetStore();
 
-const funcsByVariant = computed(() =>
+const funcsByKind = computed(() =>
   props.assetId
-    ? groupBy(
-        assetStore.assetsById[props.assetId]?.funcs ?? [],
-        (f) => f.variant,
-      )
+    ? groupBy(assetStore.assetsById[props.assetId]?.funcs ?? [], (f) => f.kind)
     : {},
 );
 

--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -191,7 +191,7 @@
           />
 
           <Collapsible
-            v-if="editingFunc.variant === FuncVariant.Attribute"
+            v-if="editingFunc.kind === FuncKind.Attribute"
             label="Arguments"
             defaultOpen
           >
@@ -206,9 +206,7 @@
           </Collapsible>
 
           <Collapsible
-            v-if="
-              editingFunc.variant === FuncVariant.Attribute && schemaVariantId
-            "
+            v-if="editingFunc.kind === FuncKind.Attribute && schemaVariantId"
             label="Binding"
             defaultOpen
           >
@@ -227,7 +225,7 @@
       </TabGroupItem>
 
       <TabGroupItem
-        v-if="editingFunc.variant === FuncVariant.Attribute && !schemaVariantId"
+        v-if="editingFunc.kind === FuncKind.Attribute && !schemaVariantId"
         label="Bindings"
         slug="bindings"
       >
@@ -280,7 +278,7 @@ import {
   VormInput,
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
-import { FuncArgument, FuncVariant } from "@/api/sdf/dal/func";
+import { FuncArgument, FuncKind } from "@/api/sdf/dal/func";
 import { FuncId, useFuncStore } from "@/store/func/funcs.store";
 import AuthenticationDetails from "@/components/FuncEditor/AuthenticationDetails.vue";
 import FuncArguments from "./FuncArguments.vue";

--- a/app/web/src/components/FuncEditor/FuncListPanel.vue
+++ b/app/web/src/components/FuncEditor/FuncListPanel.vue
@@ -13,7 +13,7 @@
           <NewFuncDropdown
             label="Function"
             :fnTypes="CREATE_OPTIONS"
-            @selected-func-variant="createNewFunc"
+            @selected-func-kind="createNewFunc"
           />
         </div>
         <ErrorMessage
@@ -34,8 +34,8 @@
 
       <ul class="overflow-y-auto min-h-[200px]">
         <Collapsible
-          v-for="(label, variant) in CUSTOMIZABLE_FUNC_TYPES"
-          :key="variant"
+          v-for="(label, kind) in CUSTOMIZABLE_FUNC_TYPES"
+          :key="kind"
           as="li"
           class="w-full"
           contentAs="ul"
@@ -48,7 +48,12 @@
             </div>
           </template>
           <template #default>
-            <li v-for="func in funcsByVariant[variant] ?? []" :key="func.id">
+            <li
+              v-for="func in funcsByKind[
+                customizableFuncKindToFuncKind(kind)
+              ] ?? []"
+              :key="func.id"
+            >
               <SiFuncListItem
                 :func="func"
                 color="#921ed6"
@@ -74,7 +79,11 @@ import {
 } from "@si/vue-lib/design-system";
 import SiFuncListItem from "@/components/SiFuncListItem.vue";
 import SiSearch from "@/components/SiSearch.vue";
-import { CUSTOMIZABLE_FUNC_TYPES, FuncVariant } from "@/api/sdf/dal/func";
+import {
+  CUSTOMIZABLE_FUNC_TYPES,
+  CustomizableFuncKind,
+  customizableFuncKindToFuncKind,
+} from "@/api/sdf/dal/func";
 import NewFuncDropdown from "@/components/NewFuncDropdown.vue";
 import { useFuncStore } from "@/store/func/funcs.store";
 import { useRouteToFunc } from "@/utils/useRouteToFunc";
@@ -100,14 +109,16 @@ const filteredList = computed(() => {
   );
 });
 
-const funcsByVariant = computed(() =>
-  _.groupBy(filteredList.value, (f) => f.variant),
+const funcsByKind = computed(() =>
+  _.groupBy(filteredList.value, (f) => f.kind),
 );
 
 const createFuncReqStatus = funcStore.getRequestStatus("CREATE_FUNC");
 
-async function createNewFunc(variant: FuncVariant) {
-  const createReq = await funcStore.CREATE_FUNC({ variant });
+async function createNewFunc(kind: CustomizableFuncKind) {
+  const createReq = await funcStore.CREATE_FUNC({
+    kind: customizableFuncKindToFuncKind(kind),
+  });
   if (createReq.result.success) {
     routeToFunc(createReq.result.data.id);
   }

--- a/app/web/src/components/FuncEditor/FuncTest.vue
+++ b/app/web/src/components/FuncEditor/FuncTest.vue
@@ -7,7 +7,7 @@
         <div
           class="font-bold text-xl text-center overflow-hidden text-ellipsis flex-grow"
         >
-          Test {{ funcStore.selectedFuncDetails?.variant + " " || "" }}Function
+          Test {{ funcStore.selectedFuncDetails?.kind + " " || "" }}Function
           <span class="italic">{{ editingFunc?.name }}</span>
         </div>
         <StatusIndicatorIcon
@@ -238,7 +238,7 @@ import { useAssetStore } from "@/store/asset.store";
 import { useComponentsStore } from "@/store/components.store";
 import { useRealtimeStore } from "@/store/realtime/realtime.store";
 import { useChangeSetsStore } from "@/store/change_sets.store";
-import { FuncVariant } from "@/api/sdf/dal/func";
+import { FuncKind } from "@/api/sdf/dal/func";
 import CodeViewer from "../CodeViewer.vue";
 import StatusIndicatorIcon, { Status } from "../StatusIndicatorIcon.vue";
 
@@ -267,7 +267,7 @@ const runningTest = ref(false);
 const dryRunConfig = computed(() => {
   // TODO(Wendy) - which function variants allow for a choice of dry run? which are always dry and which are always wet?
   // Note(Paulo): We only support dry run when testing functions
-  if (funcStore.selectedFuncDetails?.variant === FuncVariant.Attribute) {
+  if (funcStore.selectedFuncDetails?.kind === FuncKind.Attribute) {
     return "dry";
     // eslint-disable-next-line no-constant-condition
   } else if (false) {

--- a/app/web/src/components/NewFuncDropdown.vue
+++ b/app/web/src/components/NewFuncDropdown.vue
@@ -12,9 +12,9 @@
     {{ label }}
     <DropdownMenu ref="menuRef">
       <DropdownMenuItem
-        v-for="(fnLabel, fnVariant) in CUSTOMIZABLE_FUNC_TYPES"
-        :key="fnVariant"
-        @select="emit('selectedFuncVariant', fnVariant)"
+        v-for="(fnLabel, fnKind) in CUSTOMIZABLE_FUNC_TYPES"
+        :key="fnKind"
+        @select="emit('selectedFuncKind', fnKind)"
       >
         <template #icon><FuncSkeleton /></template>
         {{ fnLabel.singularLabel }}
@@ -32,7 +32,10 @@ import {
   VButton,
 } from "@si/vue-lib/design-system";
 import FuncSkeleton from "@/components/FuncSkeleton.vue";
-import { FuncVariant, CUSTOMIZABLE_FUNC_TYPES } from "@/api/sdf/dal/func";
+import {
+  CUSTOMIZABLE_FUNC_TYPES,
+  CustomizableFuncKind,
+} from "@/api/sdf/dal/func";
 
 defineProps({
   label: { type: String, required: true },
@@ -40,7 +43,7 @@ defineProps({
 });
 
 const emit = defineEmits<{
-  (e: "selectedFuncVariant", kind: FuncVariant): void;
+  (e: "selectedFuncKind", kind: CustomizableFuncKind): void;
 }>();
 
 const menuRef = ref<InstanceType<typeof DropdownMenu>>();

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -3,7 +3,7 @@ import * as _ from "lodash-es";
 import { addStoreHooks, ApiRequest } from "@si/vue-lib/pinia";
 import storage from "local-storage-fallback"; // drop-in storage polyfill which falls back to cookies/memory
 import { useWorkspacesStore } from "@/store/workspaces.store";
-import { FuncVariant } from "@/api/sdf/dal/func";
+import { FuncKind } from "@/api/sdf/dal/func";
 import { Visibility } from "@/api/sdf/dal/visibility";
 import { nilId } from "@/utils/nilId";
 import keyedDebouncer from "@/utils/keyedDebouncer";
@@ -56,7 +56,7 @@ export interface DetachedAttributePrototype {
   funcId: FuncId;
   funcName: string;
   key: string | null;
-  variant: FuncVariant;
+  kind: FuncKind;
   context: DetachedAttributePrototypeKind;
 }
 
@@ -135,7 +135,7 @@ export const useAssetStore = () => {
         detachmentWarnings: [] as {
           message: string;
           funcId: FuncId;
-          variant?: FuncVariant;
+          kind?: FuncKind;
         }[],
       }),
       getters: {
@@ -495,7 +495,7 @@ export const useAssetStore = () => {
                   ) {
                     this.detachmentWarnings.push({
                       funcId: detached.funcId,
-                      variant: detached.variant ?? undefined,
+                      kind: detached.kind ?? undefined,
                       message: `Attribute ${detached.funcName} detached from asset because the property associated to it changed. Socket=${detached.context.data.name} of Kind=${detached.context.data.kind}`,
                     });
                   } else if (
@@ -504,7 +504,7 @@ export const useAssetStore = () => {
                   ) {
                     this.detachmentWarnings.push({
                       funcId: detached.funcId,
-                      variant: detached.variant ?? undefined,
+                      kind: detached.kind ?? undefined,
                       message: `Attribute ${detached.funcName} detached from asset because the property associated to it changed. Path=${detached.context.data.path} of Kind=${detached.context.data.kind}`,
                     });
                   }

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -5,7 +5,7 @@ import { addStoreHooks, ApiRequest } from "@si/vue-lib/pinia";
 
 import storage from "local-storage-fallback"; // drop-in storage polyfill which falls back to cookies/memory
 import { Visibility } from "@/api/sdf/dal/visibility";
-import { FuncVariant } from "@/api/sdf/dal/func";
+import { FuncKind } from "@/api/sdf/dal/func";
 
 import { nilId } from "@/utils/nilId";
 import { trackEvent } from "@/utils/tracking";
@@ -31,12 +31,13 @@ export type FuncId = string;
 
 export type FuncSummary = {
   id: string;
-  variant: FuncVariant;
+  kind: FuncKind;
   name: string;
   displayName?: string;
   description?: string;
   isBuiltin: boolean;
 };
+
 export type FuncWithDetails = FuncSummary & {
   code: string;
   types: string;
@@ -524,7 +525,7 @@ export const useFuncStore = () => {
         },
 
         async CREATE_FUNC(createFuncRequest: {
-          variant: FuncVariant;
+          kind: FuncKind;
           name?: string;
           options?: CreateFuncOptions;
         }) {

--- a/lib/dal-test/src/test_harness.rs
+++ b/lib/dal-test/src/test_harness.rs
@@ -123,10 +123,10 @@ pub async fn create_schema(ctx: &DalContext) -> Schema {
 
 pub async fn create_component_for_schema_name(
     ctx: &DalContext,
-    schema_variant_name: impl AsRef<str>,
+    schema_name: impl AsRef<str>,
     name: impl AsRef<str>,
 ) -> Component {
-    let schema = Schema::find_by_name(ctx, schema_variant_name)
+    let schema = Schema::find_by_name(ctx, schema_name)
         .await
         .expect("could not find schema")
         .expect("schema not found");

--- a/lib/dal/src/func/kind.rs
+++ b/lib/dal/src/func/kind.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+use strum::{AsRefStr, Display};
+use telemetry::prelude::warn;
+
+use crate::func::FuncResult;
+use crate::{FuncBackendKind, FuncBackendResponseType, FuncError};
+
+/// Describes the kind of [`Func`](crate::Func).
+#[remain::sorted]
+#[derive(AsRefStr, Deserialize, Display, Serialize, Debug, Eq, PartialEq, Clone, Copy, Hash)]
+pub enum FuncKind {
+    Action,
+    Attribute,
+    Authentication,
+    CodeGeneration,
+    Intrinsic,
+    Qualification,
+    SchemaVariantDefinition,
+    Unknown,
+}
+
+impl FuncKind {
+    pub fn new(
+        func_backend_kind: FuncBackendKind,
+        func_backend_response_type: FuncBackendResponseType,
+    ) -> FuncResult<FuncKind> {
+        match func_backend_kind {
+            FuncBackendKind::JsAttribute => match func_backend_response_type {
+                FuncBackendResponseType::CodeGeneration => Ok(FuncKind::CodeGeneration),
+                FuncBackendResponseType::Qualification => Ok(FuncKind::Qualification),
+                _ => Ok(FuncKind::Attribute),
+            },
+            FuncBackendKind::JsAction => Ok(FuncKind::Action),
+            FuncBackendKind::JsAuthentication => Ok(FuncKind::Authentication),
+            FuncBackendKind::JsSchemaVariantDefinition => Ok(FuncKind::SchemaVariantDefinition),
+            FuncBackendKind::JsValidation => {
+                warn!(
+                    ?func_backend_kind,
+                    ?func_backend_response_type,
+                    "found JsValidation func backend kind, marking as unknown"
+                );
+                Ok(FuncKind::Unknown)
+            }
+            FuncBackendKind::Array
+            | FuncBackendKind::Boolean
+            | FuncBackendKind::Diff
+            | FuncBackendKind::Identity
+            | FuncBackendKind::Integer
+            | FuncBackendKind::Map
+            | FuncBackendKind::Object
+            | FuncBackendKind::String
+            | FuncBackendKind::Unset
+            | FuncBackendKind::Validation => Ok(FuncKind::Intrinsic),
+            _ => Err(FuncError::UnknownFunctionType(
+                func_backend_kind,
+                func_backend_response_type,
+            )),
+        }
+    }
+}

--- a/lib/dal/src/func/view.rs
+++ b/lib/dal/src/func/view.rs
@@ -1,0 +1,4 @@
+mod list;
+
+pub use list::FuncSummary;
+pub use list::FuncSummaryError;

--- a/lib/dal/src/func/view/list.rs
+++ b/lib/dal/src/func/view/list.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::func::FuncKind;
+use crate::{
+    DalContext, Func, FuncError, FuncId, SchemaVariant, SchemaVariantError, SchemaVariantId,
+};
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum FuncSummaryError {
+    #[error("func error: {0}")]
+    Func(#[from] FuncError),
+    #[error("schema variant error: {0}")]
+    SchemaVariant(#[from] SchemaVariantError),
+}
+
+type FuncSummaryResult<T> = Result<T, FuncSummaryError>;
+
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FuncSummary {
+    id: FuncId,
+    handler: Option<String>,
+    kind: FuncKind,
+    name: String,
+    display_name: Option<String>,
+    is_builtin: bool,
+}
+
+impl FuncSummary {
+    /// By default, this returns a list of [`Func`] [summaries](FuncSummary) for the entire
+    /// workspace. If a [`SchemaVariantId`](SchemaVariant) is passed in, it will only return
+    /// [summaries](FuncSummary) that are associated with the [variant](SchemaVariant).
+    pub async fn list(
+        ctx: &DalContext,
+        schema_variant_id: Option<SchemaVariantId>,
+    ) -> FuncSummaryResult<Vec<Self>> {
+        let funcs = match schema_variant_id {
+            Some(provided_schema_variant_id) => {
+                SchemaVariant::all_funcs(ctx, provided_schema_variant_id).await?
+            }
+            None => Func::list(ctx).await?,
+        };
+
+        let customizable_kinds = [
+            FuncKind::Action,
+            FuncKind::Attribute,
+            FuncKind::Authentication,
+            FuncKind::CodeGeneration,
+            FuncKind::Qualification,
+        ];
+
+        let mut func_summaries: Vec<FuncSummary> = funcs
+            .iter()
+            .filter(|f| {
+                if f.hidden {
+                    false
+                } else {
+                    customizable_kinds.contains(&f.kind)
+                }
+            })
+            .map(|func| Self {
+                id: func.id,
+                handler: func.handler.to_owned().map(|handler| handler.to_owned()),
+                kind: func.kind,
+                name: func.name.to_owned(),
+                display_name: func.display_name.to_owned().map(Into::into),
+                is_builtin: func.builtin,
+            })
+            .collect();
+
+        func_summaries.sort_by(|a, b| a.name.cmp(&b.name));
+
+        Ok(func_summaries)
+    }
+
+    pub fn name(&self) -> String {
+        self.name.to_owned()
+    }
+}

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -130,10 +130,18 @@ impl Schema {
         &self,
         ctx: &DalContext,
     ) -> SchemaResult<Option<SchemaVariantId>> {
+        Self::get_default_schema_variant_by_id(ctx, self.id).await
+    }
+
+    pub async fn get_default_schema_variant_by_id(
+        ctx: &DalContext,
+        schema_id: SchemaId,
+    ) -> SchemaResult<Option<SchemaVariantId>> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        let default_schema_variant_node_indicies =
-            workspace_snapshot.edges_directed(self.id, Outgoing).await?;
+        let default_schema_variant_node_indicies = workspace_snapshot
+            .edges_directed(schema_id, Outgoing)
+            .await?;
 
         for (edge_weight, _, target_index) in default_schema_variant_node_indicies {
             if *edge_weight.kind() == EdgeWeightKind::new_use_default() {

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -363,15 +363,22 @@ impl SchemaVariant {
         ctx: &DalContext,
         schema_id: SchemaId,
     ) -> SchemaVariantResult<Self> {
-        let schema = Schema::get_by_id(ctx, schema_id).await?;
-        let default_schema_variant_id = schema
-            .get_default_schema_variant(ctx)
+        let default_schema_variant_id = Schema::get_default_schema_variant_by_id(ctx, schema_id)
             .await?
             .ok_or(SchemaVariantError::DefaultSchemaVariantNotFound(schema_id))?;
 
         Self::get_by_id(ctx, default_schema_variant_id).await
     }
 
+    pub async fn get_default_id_for_schema(
+        ctx: &DalContext,
+        schema_id: SchemaId,
+    ) -> SchemaVariantResult<SchemaVariantId> {
+        let default_schema_variant_id = Schema::get_default_schema_variant_by_id(ctx, schema_id)
+            .await?
+            .ok_or(SchemaVariantError::DefaultSchemaVariantNotFound(schema_id))?;
+        Ok(default_schema_variant_id)
+    }
     pub async fn list_for_schema(
         ctx: &DalContext,
         schema_id: SchemaId,

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -1,0 +1,35 @@
+use dal::func::view::FuncSummary;
+use dal::{DalContext, Schema, SchemaVariant};
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn summary(ctx: &mut DalContext) {
+    let schema = Schema::find_by_name(ctx, "starfield")
+        .await
+        .expect("could not find schema")
+        .expect("schema not found");
+    let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+        .await
+        .expect("no schema variant found");
+
+    // Ensure that the same func can be found within its schema variant and for all funcs in the workspace.
+    let funcs_for_schema_variant = FuncSummary::list(ctx, Some(schema_variant_id))
+        .await
+        .expect("could not list func summaries");
+    let all_funcs = FuncSummary::list(ctx, None)
+        .await
+        .expect("could not list func summaries");
+
+    let func_name = "test:createActionStarfield".to_string();
+    let found_func_for_all = all_funcs
+        .iter()
+        .find(|f| f.name() == func_name)
+        .expect("could not find func");
+    let found_func_for_schema_variant = funcs_for_schema_variant
+        .iter()
+        .find(|f| f.name() == func_name)
+        .expect("could not find func");
+
+    assert_eq!(found_func_for_all, found_func_for_schema_variant);
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -6,6 +6,7 @@ mod component;
 mod connection;
 mod dependent_values_update;
 mod frame;
+mod func;
 mod prop;
 mod property_editor;
 mod rebaser;

--- a/lib/sdf-server/src/server/service/func/get_func.rs
+++ b/lib/sdf-server/src/server/service/func/get_func.rs
@@ -1,9 +1,10 @@
 use axum::{extract::Query, Json};
 use serde::{Deserialize, Serialize};
 
+use dal::func::FuncKind;
 use dal::{Func, FuncId, Visibility};
 
-use super::{FuncAssociations, FuncResult, FuncVariant};
+use super::{FuncAssociations, FuncResult};
 use crate::server::extract::{AccessBuilder, HandlerContext};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -36,7 +37,7 @@ pub struct GetFuncRequest {
 #[serde(rename_all = "camelCase")]
 pub struct GetFuncResponse {
     pub id: FuncId,
-    pub variant: FuncVariant,
+    pub kind: FuncKind,
     pub name: String,
     pub display_name: Option<String>,
     pub description: Option<String>,

--- a/lib/sdf-server/src/server/service/variant.rs
+++ b/lib/sdf-server/src/server/service/variant.rs
@@ -5,6 +5,7 @@ use axum::{routing::get, Json, Router};
 use chrono::Utc;
 use convert_case::{Case, Casing};
 use dal::func::binding::FuncBindingError;
+use dal::func::view::FuncSummaryError;
 use dal::pkg::PkgError;
 use dal::{ChangeSetError, FuncError, FuncId, SchemaError, SchemaVariantId, TransactionsError};
 use si_pkg::{SiPkgError, SpecError};
@@ -22,109 +23,41 @@ pub mod list_variants;
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum SchemaVariantError {
-    //     #[error(transparent)]
-    //     ActionPrototype(#[from] ActionPrototypeError),
-    //     #[error(transparent)]
-    //     AttributeContext(#[from] AttributeContextError),
-    //     #[error(transparent)]
-    //     AttributeContextBuilder(#[from] AttributeContextBuilderError),
-    //     #[error(transparent)]
-    //     AttributePrototype(#[from] AttributePrototypeError),
-    //     #[error(transparent)]
-    //     AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
-    //     #[error(transparent)]
-    //     AttributeValue(#[from] AttributeValueError),
-    //     #[error(transparent)]
-    //     AuthenticationPrototype(#[from] AuthenticationPrototypeError),
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
-    //     #[error(transparent)]
-    //     ContextTransaction(#[from] TransactionsError),
-    //     #[error("error creating schema variant from definition: {0}")]
-    //     CouldNotCreateSchemaVariantFromDefinition(String),
-    //     #[error("component error: {0}")]
-    //     DalComponent(#[from] DalComponentError),
-    //     #[error(transparent)]
-    //     ExternalProvider(#[from] ExternalProviderError),
-    //     #[error("external provider not found for socket: {0}")]
-    //     ExternalProviderNotFoundForSocket(SocketId),
+    #[error("dal schema variant error: {0}")]
+    DalSchemaVariant(#[from] dal::schema::variant::SchemaVariantError),
     #[error("func error: {0}")]
     Func(#[from] FuncError),
-    //     #[error(transparent)]
-    //     FuncArgument(#[from] FuncArgumentError),
-    //     #[error("func argument not found: {0}")]
-    //     FuncArgumentNotFound(FuncArgumentId),
-    #[error(transparent)]
+    #[error("func binding error: {0}")]
     FuncBinding(#[from] FuncBindingError),
     #[error("func execution error: {0}")]
     FuncExecution(FuncId),
     #[error("func execution failure error: {0}")]
     FuncExecutionFailure(String),
-    //     #[error("func has no handler: {0}")]
-    //     FuncHasNoHandler(FuncId),
     #[error("func is empty: {0}")]
     FuncIsEmpty(FuncId),
-    #[error("Func {0} not found")]
+    #[error("func not found: {0}")]
     FuncNotFound(FuncId),
-    #[error(transparent)]
+    #[error("func summary error: {0}")]
+    FuncSummary(#[from] FuncSummaryError),
+    #[error("hyper error: {0}")]
     Hyper(#[from] hyper::http::Error),
-    //     #[error(transparent)]
-    //     InstalledPkg(#[from] InstalledPkgError),
-    //     #[error(transparent)]
-    //     InternalProvider(#[from] InternalProviderError),
-    //     #[error("internal provider not found for socket: {0}")]
-    //     InternalProviderNotFoundForSocket(SocketId),
-    //     #[error("updating the schema variant found an invalid state: {0}")]
-    //     InvalidState(String),
-    #[error("No new asset was created")]
+    #[error("no new asset was created")]
     NoAssetCreated,
-    //     #[error(transparent)]
-    //     Pg(#[from] si_data_pg::PgError),
-    //     #[error(transparent)]
-    //     PgPool(#[from] si_data_pg::PgPoolError),
-    #[error(transparent)]
+    #[error("pkg error: {0}")]
     Pkg(#[from] PkgError),
-    //     #[error("constructed package has no schema node")]
-    //     PkgMissingSchema,
-    //     #[error("constructed package has no schema variant node")]
-    //     PkgMissingSchemaVariant,
-    //     #[error(transparent)]
-    //     Prop(#[from] PropError),
-    #[error(transparent)]
+    #[error("schema error: {0}")]
     Schema(#[from] SchemaError),
-    //     #[error("could not find schema connected to variant definition {0}")]
-    //     SchemaNotFound(SchemaVariantDefinitionId),
-    //     #[error("could not find schema connected to variant {0}")]
-    //     SchemaNotFoundForVariant(SchemaVariantId),
-    #[error(transparent)]
-    SchemaVariant(#[from] dal::schema::variant::SchemaVariantError),
-    //     #[error("could not find schema variant {0} connected to variant definition {1}")]
-    //     SchemaVariantNotFound(SchemaVariantId, SchemaVariantDefinitionId),
-    //     #[error(transparent)]
-    //     SdfFunc(#[from] SdfFuncError),
     #[error("json serialization error: {0}")]
     SerdeJson(#[from] serde_json::Error),
-    #[error(transparent)]
+    #[error("si pkg error: {0}")]
     SiPkg(#[from] SiPkgError),
-    //     #[error(transparent)]
-    //     Socket(#[from] SocketError),
-    #[error(transparent)]
+    #[error("spec error: {0}")]
     Spec(#[from] SpecError),
-    //     #[error(transparent)]
-    //     StandardModel(#[from] StandardModelError),
-    //     #[error("summary diagram error: {0}")]
-    //     SummaryDiagram(#[from] dal::diagram::SummaryDiagramError),
-    //     #[error("tenancy error: {0}")]
-    //     Tenancy(#[from] TenancyError),
-    //     #[error("transparent")]
-    //     User(#[from] UserError),
-    //     #[error("Cannot update asset structure while in use by components, attribute functions, or validations")]
-    //     VariantInUse,
-    //     #[error("could not publish websocket event: {0}")]
-    //     WsEvent(#[from] WsEventError),
     #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),
-    #[error("Schema Variant {0} not found")]
+    #[error("schema variant not found: {0}")]
     VariantNotFound(SchemaVariantId),
 }
 

--- a/lib/sdf-server/src/server/service/variant/create_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/create_variant.rs
@@ -169,7 +169,7 @@ pub async fn create_variant(
     .await?;
 
     let schema_variant_id = schema_variant_ids
-        .get(0)
+        .first()
         .copied()
         .ok_or(SchemaVariantError::NoAssetCreated)?;
 


### PR DESCRIPTION
## Description

This PR replaces `FuncVariant` with `FuncKind`. `FuncKind` is being used in the new engine and `FuncVariant` is a very similar, but leftover, enum from the func authoring experience in the old engine. These changes do not guarantee that creating funcs will work, but listing and getting funcs in the frontend should continue to work.

This PR also consolidates the `"list_func"` route logic into one location in the dal. It is backed with an integration test as a result.

<img src="https://media3.giphy.com/media/vhQjXuLGDz1W8DV8gN/giphy-downsized-medium.gif"/>

## Miscellaneous Changes

- Add "kind" to the `Func` struct since it is already on the node weight
- Move `FuncKind` to its own submodule
- Remove unnecessary conversions of `FuncBackendKind <> FuncVariant` and hardcode `FuncBackendKind` in relevant routes
- Separate `FuncKind` and `CustomizableFuncKind` in the frontend (the latter is a subset of the former)
- Add ability to get default `SchemaVariantId` without fetching the entire `Schema` or `SchemaVariant`
- Replace usages of "transparent" in error types with populated fields as well as generally clean up error types
- Fix usage of `schema_name` in dal test helper