### PR TITLE
chore(dal): Adding a test for setting an update action

### DIFF
--- a/lib/dal-test/src/schemas/test_exclusive_schema_swifty.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_swifty.rs
@@ -32,11 +32,17 @@ pub async fn migrate_test_exclusive_schema_swifty(ctx: &DalContext) -> BuiltinsR
 
     // Build Refresh Action Func
     let refresh_action_code = "async function main(component: Input): Promise<Output> {
-              return { payload: { \"poop\": true }, status: \"ok\" };
+              return { payload: JSON.parse(component.properties.resource?.payload) || { \"poop\": true } , status: \"ok\" };
             }";
 
     let fn_name = "test:refreshActionSwifty";
     let refresh_action_func = build_action_func(refresh_action_code, fn_name).await?;
+
+    let update_action_code = "async function main(component: Input): Promise<Output> {
+              return { payload: { \"poonami\": true }, status: \"ok\" };
+            }";
+    let fn_name = "test:updateActionSwifty";
+    let update_action_func = build_action_func(update_action_code, fn_name).await?;
 
     // Create Scaffold Func
     let fn_name = "test:scaffoldSwiftyAsset";
@@ -116,6 +122,12 @@ pub async fn migrate_test_exclusive_schema_swifty(ctx: &DalContext) -> BuiltinsR
                         .func_unique_id(&refresh_action_func.unique_id)
                         .build()?,
                 )
+                .action_func(
+                    ActionFuncSpec::builder()
+                        .kind(&ActionKind::Other)
+                        .func_unique_id(&update_action_func.unique_id)
+                        .build()?,
+                )
                 .leaf_function(
                     LeafFunctionSpec::builder()
                         .func_unique_id(codegen_fn_name)
@@ -131,6 +143,7 @@ pub async fn migrate_test_exclusive_schema_swifty(ctx: &DalContext) -> BuiltinsR
         .func(identity_func_spec)
         .func(refresh_action_func)
         .func(create_action_func)
+        .func(update_action_func)
         .func(swifty_authoring_schema_func)
         .func(resource_payload_to_value_func)
         .func(code_gen_func)

--- a/lib/dal/tests/integration_test/action.rs
+++ b/lib/dal/tests/integration_test/action.rs
@@ -1,6 +1,7 @@
 mod batch;
 mod runner;
 mod with_secret;
+mod with_update;
 
 use dal::{Action, ActionKind, ActionPrototype, Component, DalContext, InputSocket, OutputSocket};
 use dal_test::test;

--- a/lib/dal/tests/integration_test/action/with_update.rs
+++ b/lib/dal/tests/integration_test/action/with_update.rs
@@ -1,0 +1,136 @@
+use dal::component::resource::ResourceView;
+use dal::{Action, ActionKind, ActionPrototype, ChangeSet, Component, DalContext};
+use dal_test::test;
+use dal_test::test_harness::{commit_and_update_snapshot, create_component_for_schema_name};
+
+#[test]
+async fn update_action(ctx: &mut DalContext) {
+    let ms_swift = create_component_for_schema_name(ctx, "swifty", "ms swift").await;
+    let swift_schema_variant_id = Component::schema_variant_id(ctx, ms_swift.id())
+        .await
+        .expect("Unable to get schema variant for component");
+
+    commit_and_update_snapshot(ctx).await;
+
+    let mut actions = Action::for_component(ctx, ms_swift.id())
+        .await
+        .expect("unable to list actions for component");
+    pretty_assertions_sorted::assert_eq!(
+        1,             // expected
+        actions.len()  // actual
+    );
+    let create_action = actions.pop().expect("no actions found");
+    let create_action_prototype = create_action
+        .prototype(ctx)
+        .await
+        .expect("could not get action prototype for action");
+    pretty_assertions_sorted::assert_eq!(
+        ActionKind::Create,           // expected
+        create_action_prototype.kind, // actual
+    );
+
+    assert!(ctx
+        .parent_is_head()
+        .await
+        .expect("could not perform parent is head"));
+
+    let applied_change_set = ChangeSet::apply_to_base_change_set(ctx, true)
+        .await
+        .expect("could apply to base change set");
+    let conflicts = ctx.blocking_commit().await.expect("unable to commit");
+    assert!(conflicts.is_none());
+
+    ctx.update_visibility_and_snapshot_to_visibility_no_editing_change_set(
+        applied_change_set
+            .base_change_set_id
+            .expect("base change set not found"),
+    )
+    .await
+    .expect("could not update visibility and snapshot to visibility");
+
+    let resource = ResourceView::get_by_component_id(ctx, ms_swift.id())
+        .await
+        .expect("unable to get the Resource view");
+
+    if let Some(payload) = resource.data {
+        pretty_assertions_sorted::assert_eq!(serde_json::json![{"poop":true}], payload);
+    } else {
+        panic!("No resource data found for the component after create action");
+    }
+
+    let new_change_set = ChangeSet::fork_head(ctx, "new change set")
+        .await
+        .expect("could not create new change set");
+    ctx.update_visibility_and_snapshot_to_visibility(new_change_set.id)
+        .await
+        .expect("could not update visibility");
+
+    let actions_available = ActionPrototype::for_variant(ctx, swift_schema_variant_id)
+        .await
+        .expect("Unable to get action prototypes");
+
+    assert_eq!(3, actions_available.len());
+
+    let mut update_actions: Vec<&ActionPrototype> = actions_available
+        .iter()
+        .filter(|a| a.kind == ActionKind::Other)
+        .collect();
+    assert_eq!(1, update_actions.len());
+
+    let action = update_actions.pop().expect("Unable to get the action");
+
+    Action::upsert(ctx, action.id, ms_swift.id())
+        .await
+        .expect("Unable to insert an action");
+
+    let mut queued_actions = Action::for_component(ctx, ms_swift.id())
+        .await
+        .expect("unable to list actions for component");
+    pretty_assertions_sorted::assert_eq!(
+        1,                    // expected
+        queued_actions.len()  // actual
+    );
+    let action_detail = queued_actions.pop().expect("no actions found");
+    let action_prototype = action_detail
+        .prototype(ctx)
+        .await
+        .expect("could not get action prototype for action");
+    pretty_assertions_sorted::assert_eq!(
+        ActionKind::Other,     // expected
+        action_prototype.kind, // actual
+    );
+
+    commit_and_update_snapshot(ctx).await;
+
+    // Apply to the base change set and commit.
+    let applied_change_set = ChangeSet::apply_to_base_change_set(ctx, true)
+        .await
+        .expect("could apply to base change set");
+    let conflicts = ctx.blocking_commit().await.expect("unable to commit");
+    assert!(conflicts.is_none());
+
+    ctx.update_visibility_and_snapshot_to_visibility_no_editing_change_set(
+        applied_change_set
+            .base_change_set_id
+            .expect("base change set not found"),
+    )
+    .await
+    .expect("could not update visibility and snapshot to visibility");
+
+    let queued_actions = Action::for_component(ctx, ms_swift.id())
+        .await
+        .expect("unable to list actions for component");
+    assert!(queued_actions.is_empty());
+
+    commit_and_update_snapshot(ctx).await;
+
+    let resource = ResourceView::get_by_component_id(ctx, ms_swift.id())
+        .await
+        .expect("unable to get the Resource view");
+
+    if let Some(payload) = resource.data {
+        pretty_assertions_sorted::assert_eq!(serde_json::json![{"poonami":true}], payload);
+    } else {
+        panic!("No resource data found for the component after update action");
+    }
+}

--- a/lib/dal/tests/integration_test/schema/variant/view.rs
+++ b/lib/dal/tests/integration_test/schema/variant/view.rs
@@ -43,7 +43,7 @@ async fn get_schema_variant(ctx: &DalContext) {
         .await
         .expect("Unable to get all schema variant funcs");
 
-    assert_eq!(4, sv_funcs.len());
+    assert_eq!(5, sv_funcs.len());
 
     let mut func_names: Vec<String> = sv_funcs.iter().map(|f| f.name.clone()).collect();
     func_names.sort();
@@ -52,6 +52,7 @@ async fn get_schema_variant(ctx: &DalContext) {
         "test:createActionSwifty".to_string(),
         "test:generateCode".to_string(),
         "test:refreshActionSwifty".to_string(),
+        "test:updateActionSwifty".to_string(),
     ];
     assert_eq!(expected, func_names);
 }


### PR DESCRIPTION
Fixes ENG-2432

This test creates a component, merges to head, sees the create action happen, forks head, queues an update action, merged to head then checks the component resource view