### PR TITLE
chore: enable debug symbols and clean up chatty output

### DIFF
--- a/lib/cyclone-server/src/server.rs
+++ b/lib/cyclone-server/src/server.rs
@@ -116,7 +116,7 @@ impl Server {
                 let inner =
                     axum::Server::builder(UdsIncomingStream::create(path).await?).serve(service);
                 let socket = path.clone();
-                info!(socket = %socket.display(), "unix domain server serving");
+                debug!(socket = %socket.display(), "unix domain server serving");
 
                 Ok(Self {
                     inner: Box::new(InnerServer { inner, shutdown_rx }),

--- a/lib/telemetry-application-rs/src/lib.rs
+++ b/lib/telemetry-application-rs/src/lib.rs
@@ -244,7 +244,7 @@ pub fn init(
     let (subscriber, handles) = tracing_subscriber(&config, &tracing_level, span_events_fmt)?;
     subscriber.try_init()?;
 
-    info!(
+    debug!(
         ?config,
         directives = TracingDirectives::from(&tracing_level).as_str(),
         "telemetry configuration"
@@ -668,7 +668,7 @@ impl TelemetryUpdateTask {
 
         let timeout = Duration::from_secs(5);
         match time::timeout(timeout, wait_on_shutdown).await {
-            Ok(Ok(_)) => info!(
+            Ok(Ok(_)) => debug!(
                 time_ns = (Instant::now() - started_at).as_nanos(),
                 "opentelemetry shutdown"
             ),

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -64,7 +64,14 @@ system_rust_toolchain(
     name = "rust_debug",
     default_edition = "2021",
     clippy_toml = "root//:clippy.toml",
-    visibility = ["PUBLIC"]
+    visibility = ["PUBLIC"],
+    rustc_flags = [
+        "-Copt-level=0",
+        "-Cdebuginfo=full",
+        "-Ccodegen-units=256",
+        "-Cdebug-assertions=true",
+        "-Coverflow-checks=true",
+    ]
 )
 
 toolchain_alias(


### PR DESCRIPTION
This PR tweaks the compilation profile for our "default" debug builds so that they actually include debug symbols. This helps when you want to use rust-gdb on a buck2 build binary or running process (they work perfectly now, including source lines!)

I also turned down the level for two chatty lines in the cyclone server and the raw telemetry settings, which make the test output usable again.