### PR TITLE
feat: Enable begin approval and abandon approval process routes

### DIFF
--- a/app/web/src/components/ApplyChangeSetButton.vue
+++ b/app/web/src/components/ApplyChangeSetButton.vue
@@ -360,7 +360,8 @@ const applyChangeSetReqStatus =
 const applyChangeSet = async () => {
   if (!route.name) return;
   applyModalRef.value?.close();
-  await changeSetsStore.APPLY_CHANGE_SET();
+  // don't await
+  changeSetsStore.APPLY_CHANGE_SET();
   window.localStorage.setItem("applied-changes", "true");
   router.replace({
     name: route.name,
@@ -459,14 +460,24 @@ watch(
   },
 );
 
+/* FUTURE: we have a hole here (we need storage on the backend to resolve)
+Person 1 & 2 are on a changeset
+Person 1 starts the vote
+Person 3 joins the changeset
+  they missed the "please vote WS Event"
+We now expect 3 votes
+Person 1 will be forced to hit override to move forward
+
+We can now look at "are you looking at a changeset that needs approval?"
+And show them the vote prompt
+*/
 watch(
   () => changeSetsStore.changeSetApprovals,
   () => {
     if (!appliedByYou.value) return;
     if (
       _.values(changeSetsStore.changeSetApprovals).length !==
-      usersInChangeset.value.length + 1
-      // This is the number of other users + the person who triggered the merge
+      usersInChangeset.value.length // This is the number of other users (without the person who triggered the merge)
     )
       return;
     if (

--- a/app/web/src/components/layout/navbar/ChangeSetPanel.vue
+++ b/app/web/src/components/layout/navbar/ChangeSetPanel.vue
@@ -418,6 +418,13 @@ function onSelectChangeSet(newVal: string) {
   if (newVal && route.name) {
     if (newVal === changeSetsStore.headChangeSetId) newVal = "head";
 
+    // do not allow people to navigate to a changeset that NeedsApproval
+    if (
+      changeSetsStore.changeSetsById[newVal]?.status !== ChangeSetStatus.Open
+    ) {
+      return;
+    }
+
     // keep everything in the current route except the change set id
     // note - we use push here, so there is a new browser history entry
     router.push({

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import * as _ from "lodash-es";
 import { watch } from "vue";
 import { ApiRequest, addStoreHooks } from "@si/vue-lib/pinia";
+import { useRoute } from "vue-router";
 import {
   ChangeSet,
   ChangeSetId,
@@ -19,6 +20,7 @@ export interface OpenChangeSetsView {
 }
 
 export function useChangeSetsStore() {
+  const route = useRoute();
   const workspacesStore = useWorkspacesStore();
   const workspacePk = workspacesStore.selectedWorkspacePk;
 
@@ -314,6 +316,23 @@ export function useChangeSetsStore() {
                   this.postApplyActor = userPk;
                 }
                 this.changeSetsById[changeSetId] = changeSet;
+                // whenever the changeset is applied move us to head
+              }
+              // `list_open_change_sets` gets called prior on voters
+              // which means the changeset is gone, so always move
+              if (
+                !this.selectedChangeSetId ||
+                this.selectedChangeSetId === changeSetId
+              ) {
+                if (route.name) {
+                  router.push({
+                    name: route.name,
+                    params: {
+                      ...route.params,
+                      changeSetId: "head",
+                    },
+                  });
+                }
               }
             },
           },

--- a/lib/dal/src/change_set/event.rs
+++ b/lib/dal/src/change_set/event.rs
@@ -54,7 +54,7 @@ impl WsEvent {
     pub async fn change_set_merge_vote(
         ctx: &DalContext,
         change_set_id: ChangeSetId,
-        user_pk: UserPk,
+        user_pk: Option<UserPk>,
         vote: String,
     ) -> WsEventResult<Self> {
         WsEvent::new(
@@ -101,7 +101,7 @@ impl WsEvent {
     pub async fn change_set_abandon_vote(
         ctx: &DalContext,
         change_set_id: ChangeSetId,
-        user_pk: UserPk,
+        user_pk: Option<UserPk>,
         vote: String,
     ) -> WsEventResult<Self> {
         WsEvent::new(
@@ -157,6 +157,6 @@ pub struct ChangeSetActorPayload {
 #[serde(rename_all = "camelCase")]
 pub struct ChangeSetMergeVotePayload {
     change_set_id: ChangeSetId,
-    user_pk: UserPk,
+    user_pk: Option<UserPk>,
     vote: String,
 }

--- a/lib/sdf-server/src/server/service/change_set.rs
+++ b/lib/sdf-server/src/server/service/change_set.rs
@@ -16,15 +16,15 @@ use thiserror::Error;
 use crate::server::state::AppState;
 
 pub mod abandon_change_set;
-// mod abandon_vote;
+mod abandon_vote;
 pub mod add_action;
 pub mod apply_change_set;
-// mod begin_abandon_approval_process;
-// mod begin_approval_process;
+mod begin_abandon_approval_process;
+mod begin_approval_process;
 pub mod create_change_set;
 pub mod list_open_change_sets;
 pub mod list_queued_actions;
-// mod merge_vote;
+mod merge_vote;
 pub mod remove_action;
 
 #[remain::sorted]
@@ -95,22 +95,22 @@ pub fn routes() -> Router<AppState> {
             "/abandon_change_set",
             post(abandon_change_set::abandon_change_set),
         )
-    // .route(
-    //     "/begin_approval_process",
-    //     post(begin_approval_process::begin_approval_process),
-    // )
-    // .route(
-    //     "/cancel_approval_process",
-    //     post(begin_approval_process::cancel_approval_process),
-    // )
-    // .route("/merge_vote", post(merge_vote::merge_vote))
-    // .route(
-    //     "/begin_abandon_approval_process",
-    //     post(begin_abandon_approval_process::begin_abandon_approval_process),
-    // )
-    // .route(
-    //     "/cancel_abandon_approval_process",
-    //     post(begin_abandon_approval_process::cancel_abandon_approval_process),
-    // )
-    // .route("/abandon_vote", post(abandon_vote::abandon_vote))
+        .route(
+            "/begin_approval_process",
+            post(begin_approval_process::begin_approval_process),
+        )
+        .route(
+            "/cancel_approval_process",
+            post(begin_approval_process::cancel_approval_process),
+        )
+        .route("/merge_vote", post(merge_vote::merge_vote))
+        .route(
+            "/begin_abandon_approval_process",
+            post(begin_abandon_approval_process::begin_abandon_approval_process),
+        )
+        .route(
+            "/cancel_abandon_approval_process",
+            post(begin_abandon_approval_process::cancel_abandon_approval_process),
+        )
+        .route("/abandon_vote", post(abandon_vote::abandon_vote))
 }

--- a/lib/sdf-server/src/server/service/change_set/begin_abandon_approval_process.rs
+++ b/lib/sdf-server/src/server/service/change_set/begin_abandon_approval_process.rs
@@ -3,7 +3,7 @@ use crate::server::tracking::track;
 use crate::service::change_set::{ChangeSetError, ChangeSetResult};
 use axum::extract::OriginalUri;
 use axum::Json;
-use dal::{ChangeSet, HistoryActor, User, Visibility, WsEvent};
+use dal::{ChangeSet, Visibility};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -27,24 +27,12 @@ pub async fn begin_abandon_approval_process(
     AccessBuilder(request_ctx): AccessBuilder,
     Json(request): Json<BeginAbandonFlow>,
 ) -> ChangeSetResult<Json<()>> {
-    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
-
-    let mut change_set = ChangeSet::get_by_pk(&ctx, &ctx.visibility().change_set_pk)
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
         .await?
         .ok_or(ChangeSetError::ChangeSetNotFound)?;
-    change_set.begin_abandon_approval_flow(&mut ctx).await?;
 
-    let user_pk = match ctx.history_actor() {
-        HistoryActor::User(user_pk) => {
-            let user = User::get_by_pk(&ctx, *user_pk)
-                .await?
-                .ok_or(ChangeSetError::InvalidUser(*user_pk))?;
-
-            Some(user.pk())
-        }
-
-        HistoryActor::SystemInit => None,
-    };
+    change_set.begin_abandon_approval_flow(&ctx).await?;
 
     track(
         &posthog_client,
@@ -53,31 +41,10 @@ pub async fn begin_abandon_approval_process(
         "begin_abandon_approval_process",
         serde_json::json!({
             "how": "/change_set/begin_abandon_approval_process",
-            "change_set_pk": ctx.visibility().change_set_pk,
+            "change_set_pk": ctx.visibility().change_set_id,
         }),
     );
-
-    WsEvent::change_set_begin_abandon_approval_process(
-        &ctx,
-        ctx.visibility().change_set_pk,
-        user_pk,
-    )
-    .await?
-    .publish_on_commit(&ctx)
-    .await?;
-
-    WsEvent::change_set_abandon_vote(
-        &ctx,
-        ctx.visibility().change_set_pk,
-        user_pk.expect("A user was definitely found as per above"),
-        "Approve".to_string(),
-    )
-    .await?
-    .publish_on_commit(&ctx)
-    .await?;
-
-    ctx.commit().await?;
-
+    ctx.commit_no_rebase().await?;
     Ok(Json(()))
 }
 
@@ -88,24 +55,12 @@ pub async fn cancel_abandon_approval_process(
     AccessBuilder(request_ctx): AccessBuilder,
     Json(request): Json<CancelAbandonFlow>,
 ) -> ChangeSetResult<Json<()>> {
-    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let mut change_set = ChangeSet::get_by_pk(&ctx, &ctx.visibility().change_set_pk)
+    let mut change_set = ChangeSet::find(&ctx, ctx.change_set_id())
         .await?
         .ok_or(ChangeSetError::ChangeSetNotFound)?;
-    change_set.cancel_abandon_approval_flow(&mut ctx).await?;
-
-    let user_pk = match ctx.history_actor() {
-        HistoryActor::User(user_pk) => {
-            let user = User::get_by_pk(&ctx, *user_pk)
-                .await?
-                .ok_or(ChangeSetError::InvalidUser(*user_pk))?;
-
-            Some(user.pk())
-        }
-
-        HistoryActor::SystemInit => None,
-    };
+    change_set.cancel_abandon_approval_flow(&ctx).await?;
 
     track(
         &posthog_client,
@@ -114,20 +69,11 @@ pub async fn cancel_abandon_approval_process(
         "cancel_abandon_approval_process",
         serde_json::json!({
             "how": "/change_set/cancel_abandon_approval_process",
-            "change_set_pk": ctx.visibility().change_set_pk,
+            "change_set_pk": ctx.visibility().change_set_id,
         }),
     );
 
-    WsEvent::change_set_cancel_abandon_approval_process(
-        &ctx,
-        ctx.visibility().change_set_pk,
-        user_pk,
-    )
-    .await?
-    .publish_on_commit(&ctx)
-    .await?;
-
-    ctx.commit().await?;
+    ctx.commit_no_rebase().await?;
 
     Ok(Json(()))
 }

--- a/lib/sdf-server/src/server/service/change_set/begin_approval_process.rs
+++ b/lib/sdf-server/src/server/service/change_set/begin_approval_process.rs
@@ -1,9 +1,8 @@
 use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
-use crate::server::tracking::track;
 use crate::service::change_set::{ChangeSetError, ChangeSetResult};
 use axum::extract::OriginalUri;
 use axum::Json;
-use dal::{ChangeSet, HistoryActor, User, Visibility, WsEvent};
+use dal::{ChangeSet, Visibility};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -21,105 +20,61 @@ pub struct CancelMergeFlow {
 }
 
 pub async fn begin_approval_process(
-    OriginalUri(original_uri): OriginalUri,
-    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    PosthogClient(_posthog_client): PosthogClient,
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
     Json(request): Json<BeginMergeFlow>,
 ) -> ChangeSetResult<Json<()>> {
-    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let mut change_set = ChangeSet::get_by_pk(&ctx, &ctx.visibility().change_set_pk)
+    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
         .await?
         .ok_or(ChangeSetError::ChangeSetNotFound)?;
-    change_set.begin_approval_flow(&mut ctx).await?;
+    change_set.begin_approval_flow(&ctx).await?;
 
-    let user_pk = match ctx.history_actor() {
-        HistoryActor::User(user_pk) => {
-            let user = User::get_by_pk(&ctx, *user_pk)
-                .await?
-                .ok_or(ChangeSetError::InvalidUser(*user_pk))?;
+    // track(
+    //     &posthog_client,
+    //     &ctx,
+    //     &original_uri,
+    //     "begin_approval_process",
+    //     serde_json::json!({
+    //         "how": "/change_set/begin_approval_process",
+    //         "change_set_pk": ctx.visibility().change_set_pk,
+    //     }),
+    // );
 
-            Some(user.pk())
-        }
-
-        HistoryActor::SystemInit => None,
-    };
-
-    track(
-        &posthog_client,
-        &ctx,
-        &original_uri,
-        "begin_approval_process",
-        serde_json::json!({
-            "how": "/change_set/begin_approval_process",
-            "change_set_pk": ctx.visibility().change_set_pk,
-        }),
-    );
-
-    WsEvent::change_set_begin_approval_process(&ctx, ctx.visibility().change_set_pk, user_pk)
-        .await?
-        .publish_on_commit(&ctx)
-        .await?;
-
-    WsEvent::change_set_merge_vote(
-        &ctx,
-        ctx.visibility().change_set_pk,
-        user_pk.expect("A user was definitely found as per above"),
-        "Approve".to_string(),
-    )
-    .await?
-    .publish_on_commit(&ctx)
-    .await?;
-
-    ctx.commit().await?;
+    ctx.commit_no_rebase().await?;
 
     Ok(Json(()))
 }
 
 pub async fn cancel_approval_process(
-    OriginalUri(original_uri): OriginalUri,
-    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    PosthogClient(_posthog_client): PosthogClient,
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
     Json(request): Json<CancelMergeFlow>,
 ) -> ChangeSetResult<Json<()>> {
-    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let mut change_set = ChangeSet::get_by_pk(&ctx, &ctx.visibility().change_set_pk)
+    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
         .await?
         .ok_or(ChangeSetError::ChangeSetNotFound)?;
-    change_set.cancel_approval_flow(&mut ctx).await?;
+    change_set.cancel_approval_flow(&ctx).await?;
 
-    let user_pk = match ctx.history_actor() {
-        HistoryActor::User(user_pk) => {
-            let user = User::get_by_pk(&ctx, *user_pk)
-                .await?
-                .ok_or(ChangeSetError::InvalidUser(*user_pk))?;
+    // track(
+    //     &posthog_client,
+    //     &ctx,
+    //     &original_uri,
+    //     "cancel_approval_process",
+    //     serde_json::json!({
+    //         "how": "/change_set/cancel_approval_process",
+    //         "change_set_pk": ctx.visibility().change_set_pk,
+    //     }),
+    // );
 
-            Some(user.pk())
-        }
-
-        HistoryActor::SystemInit => None,
-    };
-
-    track(
-        &posthog_client,
-        &ctx,
-        &original_uri,
-        "cancel_approval_process",
-        serde_json::json!({
-            "how": "/change_set/cancel_approval_process",
-            "change_set_pk": ctx.visibility().change_set_pk,
-        }),
-    );
-
-    WsEvent::change_set_cancel_approval_process(&ctx, ctx.visibility().change_set_pk, user_pk)
-        .await?
-        .publish_on_commit(&ctx)
-        .await?;
-
-    ctx.commit().await?;
+    ctx.commit_no_rebase().await?;
 
     Ok(Json(()))
 }

--- a/lib/sdf-server/src/server/service/change_set/merge_vote.rs
+++ b/lib/sdf-server/src/server/service/change_set/merge_vote.rs
@@ -1,9 +1,9 @@
 use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
-use crate::server::tracking::track;
-use crate::service::change_set::{ChangeSetError, ChangeSetResult};
+use crate::service::change_set::ChangeSetError;
+use crate::service::change_set::ChangeSetResult;
 use axum::extract::OriginalUri;
 use axum::Json;
-use dal::{HistoryActor, User, Visibility, WsEvent};
+use dal::{ChangeSet, Visibility};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -15,46 +15,33 @@ pub struct MergeVoteRequest {
 }
 
 pub async fn merge_vote(
-    OriginalUri(original_uri): OriginalUri,
-    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    PosthogClient(_posthog_client): PosthogClient,
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
     Json(request): Json<MergeVoteRequest>,
 ) -> ChangeSetResult<Json<()>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let user = match ctx.history_actor() {
-        HistoryActor::User(user_pk) => User::get_by_pk(&ctx, *user_pk)
-            .await?
-            .ok_or(ChangeSetError::InvalidUser(*user_pk))?,
+    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+        .await?
+        .ok_or(ChangeSetError::ChangeSetNotFound)?;
+    change_set.merge_vote(&ctx, request.vote).await?;
 
-        HistoryActor::SystemInit => return Err(ChangeSetError::InvalidUserSystemInit),
-    };
+    // track(
+    //     &posthog_client,
+    //     &ctx,
+    //     &original_uri,
+    //     "merge_vote",
+    //     serde_json::json!({
+    //         "how": "/change_set/merge_vote",
+    //         "change_set_pk": ctx.visibility().change_set_pk,
+    //         "user_pk": user.pk(),
+    //         "vote": request.vote,
+    //     }),
+    // );
 
-    track(
-        &posthog_client,
-        &ctx,
-        &original_uri,
-        "merge_vote",
-        serde_json::json!({
-            "how": "/change_set/merge_vote",
-            "change_set_pk": ctx.visibility().change_set_pk,
-            "user_pk": user.pk(),
-            "vote": request.vote,
-        }),
-    );
-
-    WsEvent::change_set_merge_vote(
-        &ctx,
-        ctx.visibility().change_set_pk,
-        user.pk(),
-        request.vote,
-    )
-    .await?
-    .publish_on_commit(&ctx)
-    .await?;
-
-    ctx.commit().await?;
+    ctx.commit_no_rebase().await?;
 
     Ok(Json(()))
 }


### PR DESCRIPTION
Enable the routes for beginning the approval and abandon approval processes.
This change allows users to start the approval flow for change sets.

In-App flow is functioning with parity.