### PR TITLE
feat(dal): Add an edge from Module to package contents on import

### DIFF
--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -11,6 +11,7 @@ use si_pkg::{SiPkgError, SpecError};
 
 use crate::func::FuncError;
 use crate::installed_pkg::InstalledPkgError;
+use crate::module::ModuleError;
 use crate::pkg::PkgError;
 use crate::{AttributeValueId, PropId, SchemaVariantId, StandardModelError, TransactionsError};
 
@@ -41,6 +42,8 @@ pub enum BuiltinsError {
     MissingAttributePrototypeForAttributeValue,
     #[error("no packages path configured")]
     MissingPkgsPath,
+    #[error(transparent)]
+    Module(#[from] ModuleError),
     #[error(transparent)]
     Pkg(#[from] PkgError),
     #[error("prop cache not found: {0}")]

--- a/lib/dal/src/builtins/func.rs
+++ b/lib/dal/src/builtins/func.rs
@@ -1,8 +1,8 @@
 use si_pkg::SiPkg;
 
+use crate::module::Module;
 use crate::{
-    func::intrinsics::IntrinsicFunc, installed_pkg::InstalledPkg, pkg::import_pkg_from_pkg,
-    BuiltinsResult, DalContext,
+    func::intrinsics::IntrinsicFunc, pkg::import_pkg_from_pkg, BuiltinsResult, DalContext,
 };
 
 // #[derive(Deserialize, Serialize, Debug)]
@@ -51,7 +51,7 @@ pub async fn migrate_intrinsics(ctx: &DalContext) -> BuiltinsResult<()> {
     let _name = intrinsics_pkg_spec.name.to_owned();
     let intrinsics_pkg = SiPkg::load_from_spec(intrinsics_pkg_spec)?;
 
-    if InstalledPkg::find_by_hash(ctx, &intrinsics_pkg.hash()?.to_string())
+    if Module::find_by_root_hash(ctx, &intrinsics_pkg.hash()?.to_string())
         .await?
         .is_none()
     {


### PR DESCRIPTION
This will allow us to be able to understand what makes up a package at import time - we are creating connections to funcs, schemas and schema variants

There are still some TODOs in this PR:

* Before we import funcs, schemas or schema variants, we need to check the graph to see if there's already an edge to them

That will be followed up with as it doesn't change the way that the import_pkg works