### PR TITLE
Ensure updated encrypted secrets trigger dependent values update

### DIFF
--- a/app/web/src/components/AttributesPanel/AttributesPanel.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanel.vue
@@ -178,6 +178,7 @@ function updateSiProp(key: keyof typeof siValues) {
       propId: prop.propId,
       componentId: component.id,
       value: newVal,
+      isForSecret: false,
     },
   });
 }

--- a/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
@@ -809,6 +809,7 @@ const setSource = (source: AttributeValueSource) => {
         propId: props.attributeDef.propId,
         componentId,
         value,
+        isForSecret: false,
       },
     });
   } else {
@@ -930,6 +931,8 @@ function unsetHandler() {
 function updateValue() {
   let newVal;
   let skipUpdate = false;
+  let isForSecret = false;
+
   if (widgetKind.value === "checkbox") {
     newVal = newValueBoolean.value;
     // special handling for empty value + false
@@ -953,6 +956,12 @@ function updateValue() {
     return;
   }
 
+  // If we are explicitly setting a secret, we need to inform SDF so that dependent values update
+  // will trigger when the secret's encrypted contents change.
+  if (widgetKind.value === "secret") {
+    isForSecret = true;
+  }
+
   attributesStore.UPDATE_PROPERTY_VALUE({
     update: {
       attributeValueId: props.attributeDef.valueId,
@@ -960,6 +969,7 @@ function updateValue() {
       propId: props.attributeDef.propId,
       componentId,
       value: newVal,
+      isForSecret,
     },
   });
 }

--- a/app/web/src/store/component_attributes.store.ts
+++ b/app/web/src/store/component_attributes.store.ts
@@ -21,6 +21,7 @@ export interface UpdatePropertyEditorValueArgs {
   componentId: string;
   value?: unknown;
   key?: string;
+  isForSecret: boolean;
 }
 
 export interface InsertPropertyEditorValueArgs {

--- a/lib/dal/tests/integration_test/action/with_secret.rs
+++ b/lib/dal/tests/integration_test/action/with_secret.rs
@@ -81,10 +81,10 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
     let reference_to_secret_attribute_value_id = property_values
         .find_by_prop_id(reference_to_secret_prop.id)
         .expect("could not find attribute value");
-    AttributeValue::update(
+    AttributeValue::update_for_secret(
         ctx,
         reference_to_secret_attribute_value_id,
-        Some(serde_json::json!(secret.id().to_string())),
+        Some(secret.id()),
     )
     .await
     .expect("unable to perform attribute value update");

--- a/lib/dal/tests/integration_test/before_funcs.rs
+++ b/lib/dal/tests/integration_test/before_funcs.rs
@@ -79,13 +79,10 @@ async fn secret_definition_works_with_dummy_qualification(
         let reference_to_secret_attribute_value_id = property_values
             .find_by_prop_id(reference_to_secret_prop.id)
             .expect("unable to find attribute value");
-
-        let fail_value =
-            serde_json::json!(secret_that_will_fail_the_qualification.id().to_string());
-        AttributeValue::update(
+        AttributeValue::update_for_secret(
             ctx,
             reference_to_secret_attribute_value_id,
-            Some(fail_value.clone()),
+            Some(secret_that_will_fail_the_qualification.id()),
         )
         .await
         .expect("unable to perform attribute value update");
@@ -114,7 +111,10 @@ async fn secret_definition_works_with_dummy_qualification(
                 .await
                 .expect("could not get value")
                 .expect("no value found");
-        assert_eq!(fail_value, output_socket_attribute_value);
+        assert_eq!(
+            serde_json::json!(secret_that_will_fail_the_qualification.id().to_string()), // expected
+            output_socket_attribute_value                                                // actual
+        );
 
         // Check that the qualification fails.
         let qualifications = Component::list_qualifications(ctx, secret_definition_component_id)
@@ -162,13 +162,10 @@ async fn secret_definition_works_with_dummy_qualification(
         let reference_to_secret_attribute_value_id = property_values
             .find_by_prop_id(reference_to_secret_prop.id)
             .expect("could not find attribute value");
-
-        let success_value =
-            serde_json::json!(secret_that_will_pass_the_qualification.id().to_string());
-        AttributeValue::update(
+        AttributeValue::update_for_secret(
             ctx,
             reference_to_secret_attribute_value_id,
-            Some(success_value.clone()),
+            Some(secret_that_will_pass_the_qualification.id()),
         )
         .await
         .expect("unable to perform attribute value update");
@@ -197,7 +194,10 @@ async fn secret_definition_works_with_dummy_qualification(
                 .await
                 .expect("could not get value")
                 .expect("no value found");
-        assert_eq!(success_value, output_socket_attribute_value);
+        assert_eq!(
+            serde_json::json!(secret_that_will_pass_the_qualification.id().to_string()), // expected
+            output_socket_attribute_value                                                // actual
+        );
 
         // Check that the qualification passes.
         let qualifications = Component::list_qualifications(ctx, secret_definition_component_id)


### PR DESCRIPTION
## Description

Currently, if we update the encrypted contents of a secret (or any contents of a secret), all `AttributeValues` dependent on the source `AttributeValue` containing the corresponding `SecretId` will not be updated. Example: a qualification that ensures credentials are valid may depend on the `AttributeValue` in the `"/root/secrets"` tree corresponding to a specific `Secret`. If you update the `Secret`, the `SecretId` contained within the `AttributeValue` stays the same, so the qualification is not re-ran.

With this PR, only `AttributeValues` that _directly_ contain the `SecretId` for a given `Secret` have an outgoing edge to that `Secret`. This creates an interesting "one off" design where updating property editor values for a Secret results in a slightly different backend call. Given that `Secrets` already exhibit divergent behavior in the frontend based on the `Prop`'s widget, this behavior was trivial to sandbox.

<img src="https://media1.giphy.com/media/Fn7EouKtFLHXhWKgFI/giphy.gif"/>

## Accepted Risk

As mentioned above, this is a "one off" scenario for updating property editor values where SDF has to know to call `AttributeValue::update_for_secret` instead of `AttributeValue::update`.

Why do we need this? The following must be true with the current `Secrets` design in the new engine: if we want updating encrypted contents to trigger dependent values update for relevant values, **_there must be an edge that connects the `Secret` to  the directly set `AttributeValue` or to a uniquely identifying node for that `AttributeValue` (e.g. its `AttributePrototype`)_**.

Thus, the solution in this PR accepts the risk of having two update calls since `AttributeValues` for `Secrets` must have different treatment _somewhere_ in the system given the aforementioned constraint.