### PR TITLE
feat(dal, sdf): Reinstate get_pkg using the Modules on the graph

### DIFF
--- a/lib/dal/tests/integration_test/pkgs.rs
+++ b/lib/dal/tests/integration_test/pkgs.rs
@@ -29,3 +29,34 @@ async fn list_pkgs(ctx: &DalContext) {
 
     assert_eq!(expected_installed_module_names, module_names);
 }
+
+#[test]
+async fn get_fallout_pkg(ctx: &DalContext) {
+    let modules = Module::list_installed(ctx)
+        .await
+        .expect("unable to get installed modules");
+
+    let mut filtered_modules: Vec<Module> = modules
+        .into_iter()
+        .filter(|m| m.name() == "fallout")
+        .collect();
+
+    assert_eq!(1, filtered_modules.len());
+
+    if let Some(fallout_module) = filtered_modules.pop() {
+        let associated_funcs = fallout_module
+            .list_associated_funcs(ctx)
+            .await
+            .expect("Unable to get association funcs");
+        let associated_schemas = fallout_module
+            .list_associated_schemas(ctx)
+            .await
+            .expect("Unable to get association schemas");
+
+        assert_eq!("fallout", fallout_module.name());
+        assert_eq!("System Initiative", fallout_module.created_by_email());
+        assert_eq!("2019-06-03", fallout_module.version());
+        assert_eq!(3, associated_funcs.len());
+        assert_eq!(1, associated_schemas.len());
+    }
+}

--- a/lib/sdf-server/src/server/service/pkg.rs
+++ b/lib/sdf-server/src/server/service/pkg.rs
@@ -21,7 +21,7 @@ const MAX_NAME_SEARCH_ATTEMPTS: usize = 100;
 // pub mod builtin_module_spec;
 // pub mod export_pkg;
 // pub mod export_workspace;
-// pub mod get_pkg;
+pub mod get_pkg;
 // pub mod import_workspace_vote;
 // pub mod install_pkg;
 pub mod list_pkgs;
@@ -205,7 +205,7 @@ pub fn routes() -> Router<AppState> {
         //     "/export_workspace",
         //     post(export_workspace::export_workspace),
         // )
-        // .route("/get_module_by_hash", get(get_pkg::get_module_by_hash))
+        .route("/get_module_by_hash", get(get_pkg::get_module_by_hash))
         // .route("/install_pkg", post(install_pkg::install_pkg))
         .route("/list_pkgs", get(list_pkgs::list_pkgs))
         .route(


### PR DESCRIPTION
This used to load the package from disk and we don't need to do that anymore now that we have all the details on the graph