### PR TITLE
bug(rebaser): only rebase one request at a time per change set

### DIFF
--- a/lib/rebaser-server/src/server/core_loop.rs
+++ b/lib/rebaser-server/src/server/core_loop.rs
@@ -10,12 +10,16 @@ use si_data_pg::PgPool;
 use si_layer_cache::activities::rebase::RebaseStatus;
 use si_layer_cache::activities::ActivityRebaseRequest;
 use si_layer_cache::LayerDbError;
+
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
+use tokio_util::task::TaskTracker;
+use ulid::Ulid;
 
 use telemetry::prelude::*;
 use thiserror::Error;
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 
 use crate::server::rebase::perform_rebase;
@@ -71,24 +75,27 @@ pub(crate) async fn setup_and_run_core_loop(
     let stream = layer_db.activity().rebase().subscribe_work_queue().await?;
 
     info!("setup complete, entering core loop");
-    core_loop_infallible(ctx_builder, stream, shutdown_watch_rx).await;
+    run_me(ctx_builder, stream, shutdown_watch_rx).await;
     info!("exited core loop");
 
     Ok(())
 }
 
-async fn core_loop_infallible(
+async fn run_me(
     ctx_builder: DalContextBuilder,
-    mut rebase_activity_channel: UnboundedReceiver<ActivityRebaseRequest>,
+    rebase_activity_channel: UnboundedReceiver<ActivityRebaseRequest>,
     shutdown_watch_rx: oneshot::Receiver<()>,
 ) {
-    let run_core_handle = tokio::spawn(async move {
-        while let Some(message) = rebase_activity_channel.recv().await {
-            let ctx_builder = ctx_builder.clone();
-            tokio::spawn(async move {
-                perform_rebase_and_reply_infallible(ctx_builder, &message).await;
-            });
-        }
+    let tracker = TaskTracker::new();
+
+    let change_set_distributor_tracker = tracker.clone();
+    let distributor_handle = tracker.spawn(async move {
+        change_set_distributor(
+            ctx_builder,
+            change_set_distributor_tracker,
+            rebase_activity_channel,
+        )
+        .await
     });
     let watch_handle = tokio::spawn(async move {
         match shutdown_watch_rx.await {
@@ -97,12 +104,67 @@ async fn core_loop_infallible(
         }
     });
     tokio::select! {
-        _ = run_core_handle => {
-           info!("core rebase loop has exited");
+        _ = distributor_handle => {
+           info!("rebase change set distributor has exited");
         },
         _ = watch_handle => {
+            tracker.close();
            info!("graceful shutdown");
         }
+    }
+}
+
+// Hey, you. Yes, you. The one trying to figure out: "hey, self, why is it that the rebaser has so
+// many tokio tasks and is running out of memory?". Well, here is why. If you actually try and use
+// it in the current state, you're going to get a worker per change set id, which then serializes
+// all the work. That's great, because it's how the rebaser is supposed to work. It's bad, because
+// we never garbage collect them.
+//
+// Fletcher is in the middle of making this work permanently, but for now - this will work. If it's
+// getting weird in resource utilization, you can always reboot the rebaser. :)
+async fn change_set_distributor(
+    ctx_builder: DalContextBuilder,
+    tracker: TaskTracker,
+    mut rebase_activity_channel: UnboundedReceiver<ActivityRebaseRequest>,
+) -> CoreLoopSetupResult<()> {
+    let mut change_set_channels: HashMap<Ulid, UnboundedSender<ActivityRebaseRequest>> =
+        HashMap::new();
+    while let Some(message) = rebase_activity_channel.recv().await {
+        let rebase_change_set_id = message.payload.to_rebase_change_set_id;
+        if change_set_channels.contains_key(&message.payload.to_rebase_change_set_id) {
+            if let Some(channel) = change_set_channels.get(&message.payload.to_rebase_change_set_id)
+            {
+                if let Err(_error) = channel.send(message) {
+                    info!(
+                        "Worker for {} has closed its channel; removing worker",
+                        &rebase_change_set_id
+                    );
+                    change_set_channels.remove(&rebase_change_set_id);
+                }
+            }
+        } else {
+            let (tx, rx) = unbounded_channel();
+            if let Err(error) = tx.send(message) {
+                error!(
+                    ?error,
+                    "Couldn't publish to a change set channel we just created; bug!"
+                );
+            }
+            change_set_channels.insert(rebase_change_set_id, tx);
+            let change_set_ctx_builder = ctx_builder.clone();
+            tracker.spawn(async move { core_loop_change_set(change_set_ctx_builder, rx).await });
+        }
+    }
+    Ok(())
+}
+
+async fn core_loop_change_set(
+    ctx_builder: DalContextBuilder,
+    mut rebase_activity_channel: UnboundedReceiver<ActivityRebaseRequest>,
+) {
+    while let Some(message) = rebase_activity_channel.recv().await {
+        let ctx_builder = ctx_builder.clone();
+        perform_rebase_and_reply_infallible(ctx_builder, &message).await;
     }
 }
 


### PR DESCRIPTION
This PR fixes the issue where the rebaser would rebase things as fast as it possibly could. Instead, it creates a queue for every change set ID it sees, and only processes one message at a time for each change set.

It currently doesn't support removing those queues - once we see it, the worker will stay resident forever. That's probably not a big deal, given that we mostly have single users and the proliferation of change sets isn't so high. But it's obviously not the optimal solution for long.

This is a stop-gap PR while Fletcher works on the long term solution, which likely involves some clever use of Jetstream's tuning options to ensure only one message can be in flight at a time, and that those messages get replayed if needed.

<img src="https://media4.giphy.com/media/EzcbZZUyfWSqGKvdQo/giphy.gif"/>