### PR TITLE
chore(dal): Simplify test migrations

### DIFF
--- a/lib/dal-test/src/schemas/test_exclusive_schema_category_pirate.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_category_pirate.rs
@@ -1,6 +1,6 @@
 use crate::schemas::schema_helpers::{build_asset_func, create_identity_func};
 use dal::pkg::import_pkg_from_pkg;
-use dal::{pkg, prop::PropPath, ComponentType};
+use dal::{prop::PropPath, ComponentType};
 use dal::{BuiltinsResult, DalContext, PropKind};
 use si_pkg::{
     AttrFuncInputSpec, AttrFuncInputSpecKind, PkgSpec, PropSpec, SchemaSpec, SchemaVariantSpec,
@@ -13,8 +13,10 @@ const CATEGORY: &str = "pirate";
 pub async fn migrate_test_exclusive_schema_pirate(ctx: &DalContext) -> BuiltinsResult<()> {
     let mut builder = PkgSpec::builder();
 
+    let schema_name = "pirate";
+
     builder
-        .name("pirate")
+        .name(schema_name)
         .version(crate::schemas::PKG_VERSION)
         .created_by(crate::schemas::PKG_CREATED_BY);
 
@@ -25,10 +27,10 @@ pub async fn migrate_test_exclusive_schema_pirate(ctx: &DalContext) -> BuiltinsR
     let authoring_schema_func = build_asset_func(fn_name).await?;
 
     let schema = SchemaSpec::builder()
-        .name("pirate")
+        .name(schema_name)
         .data(
             SchemaSpecData::builder()
-                .name("pirate")
+                .name(schema_name)
                 .category("test exclusive")
                 .category_name(CATEGORY)
                 .build()
@@ -124,15 +126,7 @@ pub async fn migrate_test_exclusive_schema_pirate(ctx: &DalContext) -> BuiltinsR
         .build()?;
 
     let pkg = SiPkg::load_from_spec(spec)?;
-    import_pkg_from_pkg(
-        ctx,
-        &pkg,
-        Some(pkg::ImportOptions {
-            schemas: Some(vec!["pirate".into()]),
-            ..Default::default()
-        }),
-    )
-    .await?;
+    import_pkg_from_pkg(ctx, &pkg, None).await?;
 
     Ok(())
 }
@@ -220,15 +214,7 @@ pub async fn migrate_test_exclusive_schema_pet_shop(ctx: &DalContext) -> Builtin
         .build()?;
 
     let pkg = SiPkg::load_from_spec(spec)?;
-    import_pkg_from_pkg(
-        ctx,
-        &pkg,
-        Some(pkg::ImportOptions {
-            schemas: Some(vec![schema_name.into()]),
-            ..Default::default()
-        }),
-    )
-    .await?;
+    import_pkg_from_pkg(ctx, &pkg, None).await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/schemas/test_exclusive_schema_dummy_secret.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_dummy_secret.rs
@@ -1,8 +1,8 @@
 use dal::func::argument::FuncArgumentKind;
 use dal::func::intrinsics::IntrinsicFunc;
 use dal::pkg::import_pkg_from_pkg;
+use dal::prop::PropPath;
 use dal::schema::variant::leaves::LeafKind;
-use dal::{pkg, prop::PropPath};
 use dal::{BuiltinsResult, DalContext};
 use si_pkg::{
     AttrFuncInputSpec, AttrFuncInputSpecKind, FuncArgumentSpec, FuncSpec, FuncSpecBackendKind,
@@ -117,15 +117,7 @@ pub async fn migrate_test_exclusive_schema_dummy_secret(ctx: &DalContext) -> Bui
         .build()?;
 
     let pkg = SiPkg::load_from_spec(spec)?;
-    import_pkg_from_pkg(
-        ctx,
-        &pkg,
-        Some(pkg::ImportOptions {
-            schemas: Some(vec![name.into()]),
-            ..Default::default()
-        }),
-    )
-    .await?;
+    import_pkg_from_pkg(ctx, &pkg, None).await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/schemas/test_exclusive_schema_fallout.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_fallout.rs
@@ -1,5 +1,5 @@
 use dal::pkg::import_pkg_from_pkg;
-use dal::{pkg, prop::PropPath, ActionKind};
+use dal::{prop::PropPath, ActionKind};
 use dal::{BuiltinsResult, DalContext, PropKind};
 use si_pkg::{
     ActionFuncSpec, AttrFuncInputSpec, AttrFuncInputSpecKind, FuncSpec, FuncSpecBackendKind,
@@ -16,8 +16,10 @@ use crate::schemas::schema_helpers::{
 pub async fn migrate_test_exclusive_schema_fallout(ctx: &DalContext) -> BuiltinsResult<()> {
     let mut fallout_builder = PkgSpec::builder();
 
+    let schema_name = "fallout";
+
     fallout_builder
-        .name("fallout")
+        .name(schema_name)
         .version(crate::schemas::PKG_VERSION)
         .created_by(crate::schemas::PKG_CREATED_BY);
 
@@ -72,12 +74,12 @@ pub async fn migrate_test_exclusive_schema_fallout(ctx: &DalContext) -> Builtins
         assemble_dummy_secret_socket_and_prop(&identity_func_spec)?;
 
     let fallout_schema = SchemaSpec::builder()
-        .name("fallout")
+        .name(schema_name)
         .data(
             SchemaSpecData::builder()
-                .name("fallout")
+                .name(schema_name)
                 .category("test exclusive")
-                .category_name("fallout")
+                .category_name(schema_name)
                 .build()
                 .expect("build schema spec data"),
         )
@@ -188,16 +190,8 @@ pub async fn migrate_test_exclusive_schema_fallout(ctx: &DalContext) -> Builtins
         .schema(fallout_schema)
         .build()?;
 
-    let fallout_pkg = SiPkg::load_from_spec(fallout_spec)?;
-    import_pkg_from_pkg(
-        ctx,
-        &fallout_pkg,
-        Some(pkg::ImportOptions {
-            schemas: Some(vec!["fallout".into()]),
-            ..Default::default()
-        }),
-    )
-    .await?;
+    let pkg = SiPkg::load_from_spec(fallout_spec)?;
+    import_pkg_from_pkg(ctx, &pkg, None).await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/schemas/test_exclusive_schema_katy_perry.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_katy_perry.rs
@@ -3,7 +3,7 @@ use crate::schemas::schema_helpers::{
     create_identity_func,
 };
 use dal::pkg::import_pkg_from_pkg;
-use dal::{pkg, prop::PropPath, ComponentType};
+use dal::{prop::PropPath, ComponentType};
 use dal::{BuiltinsResult, DalContext, PropKind};
 use si_pkg::{
     AttrFuncInputSpec, AttrFuncInputSpecKind, LeafInputLocation, LeafKind, PkgSpec, PropSpec,
@@ -14,8 +14,10 @@ use si_pkg::{LeafFunctionSpec, SchemaSpecData};
 pub async fn migrate_test_exclusive_schema_katy_perry(ctx: &DalContext) -> BuiltinsResult<()> {
     let mut kp_builder = PkgSpec::builder();
 
+    let schema_name = "katy perry";
+
     kp_builder
-        .name("katy perry")
+        .name(schema_name)
         .version(crate::schemas::PKG_VERSION)
         .created_by(crate::schemas::PKG_CREATED_BY);
 
@@ -51,12 +53,12 @@ pub async fn migrate_test_exclusive_schema_katy_perry(ctx: &DalContext) -> Built
         build_codegen_func(string_codegen_func_code, string_codegen_fn_name).await?;
 
     let kp_schema = SchemaSpec::builder()
-        .name("katy perry")
+        .name(schema_name)
         .data(
             SchemaSpecData::builder()
-                .name("katy perry")
+                .name(schema_name)
                 .category("test exclusive")
-                .category_name("katy perry")
+                .category_name(schema_name)
                 .build()
                 .expect("schema spec data build"),
         )
@@ -114,16 +116,8 @@ pub async fn migrate_test_exclusive_schema_katy_perry(ctx: &DalContext) -> Built
         .schema(kp_schema)
         .build()?;
 
-    let kp_pkg = SiPkg::load_from_spec(kp_spec)?;
-    import_pkg_from_pkg(
-        ctx,
-        &kp_pkg,
-        Some(pkg::ImportOptions {
-            schemas: Some(vec!["katy perry".into()]),
-            ..Default::default()
-        }),
-    )
-    .await?;
+    let pkg = SiPkg::load_from_spec(kp_spec)?;
+    import_pkg_from_pkg(ctx, &pkg, None).await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/schemas/test_exclusive_schema_starfield.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_starfield.rs
@@ -1,7 +1,7 @@
 use dal::func::argument::FuncArgumentKind;
 use dal::func::intrinsics::IntrinsicFunc;
 use dal::pkg::import_pkg_from_pkg;
-use dal::{pkg, prop::PropPath, ActionKind};
+use dal::{prop::PropPath, ActionKind};
 use dal::{BuiltinsResult, DalContext, PropKind};
 use si_pkg::SchemaSpecData;
 use si_pkg::{
@@ -13,8 +13,10 @@ use si_pkg::{
 pub async fn migrate_test_exclusive_schema_starfield(ctx: &DalContext) -> BuiltinsResult<()> {
     let mut starfield_builder = PkgSpec::builder();
 
+    let schema_name = "starfield";
+
     starfield_builder
-        .name("starfield")
+        .name(schema_name)
         .version(crate::schemas::PKG_VERSION)
         .created_by(crate::schemas::PKG_CREATED_BY);
 
@@ -176,12 +178,12 @@ pub async fn migrate_test_exclusive_schema_starfield(ctx: &DalContext) -> Builti
         .build()?;
 
     let starfield_schema = SchemaSpec::builder()
-        .name("starfield")
+        .name(schema_name)
         .data(
             SchemaSpecData::builder()
-                .name("starfield")
+                .name(schema_name)
                 .category("test exclusive")
-                .category_name("starfield")
+                .category_name(schema_name)
                 .build()
                 .expect("schema spec data build"),
         )
@@ -408,15 +410,7 @@ pub async fn migrate_test_exclusive_schema_starfield(ctx: &DalContext) -> Builti
         .build()?;
 
     let starfield_pkg = SiPkg::load_from_spec(starfield_spec)?;
-    import_pkg_from_pkg(
-        ctx,
-        &starfield_pkg,
-        Some(pkg::ImportOptions {
-            schemas: Some(vec!["starfield".into()]),
-            ..Default::default()
-        }),
-    )
-    .await?;
+    import_pkg_from_pkg(ctx, &starfield_pkg, None).await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/schemas/test_exclusive_schema_swifty.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_swifty.rs
@@ -3,7 +3,7 @@ use crate::schemas::schema_helpers::{
     create_identity_func,
 };
 use dal::pkg::import_pkg_from_pkg;
-use dal::{pkg, prop::PropPath, ActionKind, ComponentType};
+use dal::{prop::PropPath, ActionKind, ComponentType};
 use dal::{BuiltinsResult, DalContext, PropKind};
 use si_pkg::{
     ActionFuncSpec, AttrFuncInputSpec, AttrFuncInputSpecKind, LeafInputLocation, LeafKind, PkgSpec,
@@ -15,8 +15,10 @@ use si_pkg::{LeafFunctionSpec, SchemaSpecData};
 pub async fn migrate_test_exclusive_schema_swifty(ctx: &DalContext) -> BuiltinsResult<()> {
     let mut swifty_builder = PkgSpec::builder();
 
+    let schema_name = "swifty";
+
     swifty_builder
-        .name("swifty")
+        .name(schema_name)
         .version(crate::schemas::PKG_VERSION)
         .created_by(crate::schemas::PKG_CREATED_BY);
 
@@ -62,12 +64,12 @@ pub async fn migrate_test_exclusive_schema_swifty(ctx: &DalContext) -> BuiltinsR
     let code_gen_func = build_codegen_func(codegen_func_code, codegen_fn_name).await?;
 
     let swifty_schema = SchemaSpec::builder()
-        .name("swifty")
+        .name(schema_name)
         .data(
             SchemaSpecData::builder()
-                .name("swifty")
+                .name(schema_name)
                 .category("test exclusive")
-                .category_name("swifty")
+                .category_name(schema_name)
                 .build()
                 .expect("schema spec data build"),
         )
@@ -151,15 +153,7 @@ pub async fn migrate_test_exclusive_schema_swifty(ctx: &DalContext) -> BuiltinsR
         .build()?;
 
     let swifty_pkg = SiPkg::load_from_spec(swifty_spec)?;
-    import_pkg_from_pkg(
-        ctx,
-        &swifty_pkg,
-        Some(pkg::ImportOptions {
-            schemas: Some(vec!["swifty".into()]),
-            ..Default::default()
-        }),
-    )
-    .await?;
+    import_pkg_from_pkg(ctx, &swifty_pkg, None).await?;
 
     Ok(())
 }

--- a/lib/sdf-server/src/server/job_processor.rs
+++ b/lib/sdf-server/src/server/job_processor.rs
@@ -34,7 +34,6 @@ impl JobProcessorConnector for NatsProcessor {
         config: &Config,
     ) -> Result<(Self::Client, Box<dyn JobQueueProcessor + Send + Sync>), ServerError> {
         let job_client = Server::connect_to_nats(config.nats()).await?;
-        dbg!(&job_client);
         let job_processor = Box::new(NatsProcessor::new(job_client.clone()))
             as Box<dyn JobQueueProcessor + Send + Sync>;
         Ok((job_client, job_processor))


### PR DESCRIPTION
import_pkg by default will import all schemas in pkg if the list is not passed, so we can get away with passing the default import options on tests.

<img src="https://media0.giphy.com/media/gxUX91yk9FJfpkZq60/giphy-downsized-medium.gif"/>