### PR TITLE
Find func associations for code generation and qualification funcs

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1700,8 +1700,8 @@ impl AttributeValue {
         let maybe_existing_prototype_id =
             Self::component_prototype_id(ctx, attribute_value_id).await?;
 
-        if let Some(exsiting_prototype_id) = maybe_existing_prototype_id {
-            AttributePrototype::remove(ctx, exsiting_prototype_id).await?;
+        if let Some(existing_prototype_id) = maybe_existing_prototype_id {
+            AttributePrototype::remove(ctx, existing_prototype_id).await?;
         }
 
         Self::add_edge_to_attribute_prototype(

--- a/lib/dal/src/func/associations.rs
+++ b/lib/dal/src/func/associations.rs
@@ -1,8 +1,29 @@
 use serde::{Deserialize, Serialize};
+use telemetry::prelude::*;
+use thiserror::Error;
 
+use crate::attribute::prototype::AttributePrototypeError;
+use crate::func::argument::{FuncArgument, FuncArgumentError};
 use crate::func::view::FuncArgumentView;
+use crate::func::FuncKind;
 use crate::schema::variant::leaves::LeafInputLocation;
-use crate::{ActionKind, ComponentId, SchemaVariantId};
+use crate::{
+    ActionKind, AttributePrototype, ComponentId, DalContext, Func, FuncBackendResponseType, FuncId,
+    SchemaVariantError, SchemaVariantId,
+};
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum FuncAssociationsError {
+    #[error("attribute prototype error: {0}")]
+    AttributePrototype(#[from] AttributePrototypeError),
+    #[error("func argument error: {0}")]
+    FuncArgument(#[from] FuncArgumentError),
+    #[error("schema variant error: {0}")]
+    SchemaVariant(#[from] SchemaVariantError),
+}
+
+type FuncAssociationsResult<T> = Result<T, FuncAssociationsError>;
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -40,4 +61,163 @@ pub enum FuncAssociations {
         component_ids: Vec<ComponentId>,
         inputs: Vec<LeafInputLocation>,
     },
+}
+
+impl FuncAssociations {
+    #[instrument(name = "func.associations.from_func", level = "debug", skip_all)]
+    pub async fn from_func(
+        ctx: &DalContext,
+        func: &Func,
+    ) -> FuncAssociationsResult<(Option<Self>, String)> {
+        let arguments = FuncArgument::list_for_func(ctx, func.id).await?;
+
+        let (associations, input_type) = match func.kind {
+            FuncKind::Action => {
+                // TODO(nick): do something similar to authentications
+                (None::<FuncAssociations>, String::new())
+            }
+            FuncKind::Attribute => {
+                // TODO(nick): get prototype views and types
+                (
+                    Some(Self::Attribute {
+                        prototypes: vec![],
+                        arguments: arguments
+                            .iter()
+                            .map(|arg| FuncArgumentView {
+                                id: arg.id,
+                                name: arg.name.to_owned(),
+                                kind: arg.kind,
+                                element_kind: arg.element_kind.to_owned(),
+                            })
+                            .collect(),
+                    }),
+                    "type Input = any".into(),
+                )
+            }
+            FuncKind::Authentication => {
+                let schema_variant_ids =
+                    Func::list_schema_variants_for_auth_func(ctx, func.id).await?;
+
+                (
+                    Some(Self::Authentication { schema_variant_ids }),
+                    concat!(
+                        "type Input = Record<string, unknown>;\n",
+                        "\n",
+                        "declare namespace requestStorage {\n",
+                        "    function setEnv(key: string, value: any);\n",
+                        "    function setItem(key: string, value: any);\n",
+                        "    function deleteEnv(key: string);\n",
+                        "    function deleteItem(key: string);\n",
+                        "}",
+                    )
+                    .to_owned(),
+                )
+            }
+            FuncKind::CodeGeneration | FuncKind::Qualification => {
+                let attribute_prototype_ids =
+                    AttributePrototype::list_ids_for_func_id(ctx, func.id).await?;
+
+                let mut schema_variant_ids = Vec::new();
+                let mut component_ids = Vec::new();
+
+                for attribute_prototype_id in attribute_prototype_ids {
+                    let (
+                        schema_variant_ids_for_attribute_prototype,
+                        component_ids_for_attribute_prototype,
+                    ) = AttributePrototype::schema_variants_and_components(
+                        ctx,
+                        attribute_prototype_id,
+                    )
+                    .await?;
+                    schema_variant_ids.extend(schema_variant_ids_for_attribute_prototype);
+                    component_ids.extend(component_ids_for_attribute_prototype);
+                }
+
+                let inputs = Self::list_leaf_function_inputs(ctx, func.id).await?;
+
+                // TODO(nick): restore the ability to compile func input types.
+                let input_type = "".to_string();
+                // compile_leaf_function_input_types(ctx, &schema_variant_ids, &inputs).await?;
+
+                (
+                    Some(match func.backend_response_type {
+                        FuncBackendResponseType::CodeGeneration => Self::CodeGeneration {
+                            schema_variant_ids,
+                            component_ids,
+                            inputs,
+                        },
+
+                        FuncBackendResponseType::Qualification => Self::Qualification {
+                            schema_variant_ids,
+                            component_ids,
+                            inputs: Self::list_leaf_function_inputs(ctx, func.id).await?,
+                        },
+                        _ => unreachable!("the match above ensures this is unreachable"),
+                    }),
+                    input_type,
+                )
+            }
+            FuncKind::Intrinsic | FuncKind::SchemaVariantDefinition | FuncKind::Unknown => {
+                debug!(?func.kind, "no associations or input type needed for func kind");
+                (None::<FuncAssociations>, String::new())
+            }
+        };
+
+        Ok((associations, input_type))
+    }
+
+    async fn list_leaf_function_inputs(
+        ctx: &DalContext,
+        func_id: FuncId,
+    ) -> FuncAssociationsResult<Vec<LeafInputLocation>> {
+        Ok(FuncArgument::list_for_func(ctx, func_id)
+            .await?
+            .iter()
+            .filter_map(|arg| LeafInputLocation::maybe_from_arg_name(&arg.name))
+            .collect())
+    }
+
+    // async fn compile_leaf_function_input_types(
+    //     ctx: &DalContext,
+    //     schema_variant_ids: &[SchemaVariantId],
+    //     inputs: &[LeafInputLocation],
+    // ) -> FuncViewResult<String> {
+    //     let mut ts_type = "type Input = {\n".to_string();
+    //
+    //     for input_location in inputs {
+    //         let input_property = format!(
+    //             "{}?: {} | null;\n",
+    //             input_location.arg_name(),
+    //             Self::get_per_variant_types_for_prop_path(
+    //                 ctx,
+    //                 schema_variant_ids,
+    //                 &input_location.prop_path(),
+    //             )
+    //             .await?
+    //         );
+    //         ts_type.push_str(&input_property);
+    //     }
+    //     ts_type.push_str("};");
+    //
+    //     Ok(ts_type)
+    // }
+    //
+    // async fn get_per_variant_types_for_prop_path(
+    //     ctx: &DalContext,
+    //     variant_ids: &[SchemaVariantId],
+    //     path: &PropPath,
+    // ) -> FuncViewResult<String> {
+    //     let mut per_variant_types = vec![];
+    //
+    //     for variant_id in variant_ids {
+    //         let prop = Prop::find_prop_by_path(ctx, *variant_id, path).await?;
+    //         let ts_type = prop.ts_type(ctx).await?;
+    //
+    //         if !per_variant_types.contains(&ts_type) {
+    //             per_variant_types.push(ts_type);
+    //         }
+    //     }
+    //
+    //     Ok(per_variant_types.join(" | "))
+    // }
 }

--- a/lib/dal/src/func/view.rs
+++ b/lib/dal/src/func/view.rs
@@ -1,16 +1,11 @@
 use serde::{Deserialize, Serialize};
-use telemetry::prelude::debug;
 use thiserror::Error;
 
-use crate::func::argument::{FuncArgument, FuncArgumentError, FuncArgumentId, FuncArgumentKind};
-use crate::func::associations::FuncAssociations;
+use crate::func::argument::{FuncArgumentId, FuncArgumentKind};
+use crate::func::associations::{FuncAssociations, FuncAssociationsError};
 use crate::func::authoring::FuncAuthoringClient;
 use crate::func::FuncKind;
-use crate::schema::variant::leaves::LeafInputLocation;
-use crate::{
-    DalContext, Func, FuncBackendKind, FuncBackendResponseType, FuncError, FuncId,
-    SchemaVariantError,
-};
+use crate::{DalContext, Func, FuncError, FuncId, SchemaVariantError};
 
 pub mod summary;
 
@@ -19,8 +14,8 @@ pub mod summary;
 pub enum FuncViewError {
     #[error("func error: {0}")]
     Func(#[from] FuncError),
-    #[error("func argument error: {0}")]
-    FuncArgument(#[from] FuncArgumentError),
+    #[error("func associations error: {0}")]
+    FuncAssociations(#[from] FuncAssociationsError),
     #[error("schema variant error: {0}")]
     SchemaVariant(#[from] SchemaVariantError),
 }
@@ -53,138 +48,7 @@ pub struct FuncView {
 
 impl FuncView {
     pub async fn assemble(ctx: &DalContext, func: &Func) -> FuncViewResult<Self> {
-        let arguments = FuncArgument::list_for_func(ctx, func.id).await?;
-
-        let (_associations, _input_type) = match func.kind {
-            FuncKind::Action => (None::<FuncAssociations>, String::new()),
-            FuncKind::Attribute => (None::<FuncAssociations>, String::new()),
-            FuncKind::Authentication => (None::<FuncAssociations>, String::new()),
-            FuncKind::CodeGeneration | FuncKind::Qualification => {
-                // let (schema_variant_ids, component_ids) =
-                //     attribute_prototypes_into_schema_variants_and_components(ctx, *func.id())
-                //         .await?;
-                //
-                // let inputs = Self::list_leaf_function_inputs(ctx, *func.id()).await?;
-                //
-                // // TODO(nick): restore the ability to compile func input types.
-                // let input_type = "".to_string();
-                // // compile_leaf_function_input_types(ctx, &schema_variant_ids, &inputs).await?;
-                //
-                // (
-                //     Some(match func.backend_response_type() {
-                //         FuncBackendResponseType::CodeGeneration => {
-                //             FuncAssociations::CodeGeneration {
-                //                 schema_variant_ids,
-                //                 component_ids,
-                //                 inputs,
-                //             }
-                //         }
-                //
-                //         FuncBackendResponseType::Qualification => FuncAssociations::Qualification {
-                //             schema_variant_ids,
-                //             component_ids,
-                //             inputs: Self::list_leaf_function_inputs(ctx, *func.id()).await?,
-                //         },
-                //         _ => unreachable!("the match above ensures this is unreachable"),
-                //     }),
-                //     input_type,
-                // )
-                (None::<FuncAssociations>, String::new())
-            }
-            FuncKind::Intrinsic | FuncKind::SchemaVariantDefinition | FuncKind::Unknown => {
-                debug!(?func.kind, "no associations or input type needed for func kind");
-                (None::<FuncAssociations>, String::new())
-            }
-        };
-
-        let (associations, input_type) = match &func.backend_kind {
-            FuncBackendKind::JsAttribute => {
-                let (associations, input_type) = match &func.backend_response_type {
-                    FuncBackendResponseType::CodeGeneration
-                    | FuncBackendResponseType::Qualification => (None, "".into()),
-                    _ => {
-                        // let protos = AttributePrototype::find_for_func(ctx, func.id()).await?;
-
-                        //                         let mut prototypes = Vec::with_capacity(protos.len());
-                        //                         for proto in &protos {
-                        //                             prototypes.push(
-                        //                                 prototype_view_for_attribute_prototype(ctx, *func.id(), proto).await?,
-                        //                             );
-                        //                         }
-
-                        // let ts_types = compile_attribute_function_types(ctx, &prototypes).await?;
-
-                        (
-                            Some(FuncAssociations::Attribute {
-                                prototypes: vec![],
-                                arguments: arguments
-                                    .iter()
-                                    .map(|arg| FuncArgumentView {
-                                        id: arg.id,
-                                        name: arg.name.to_owned(),
-                                        kind: arg.kind,
-                                        element_kind: arg.element_kind.to_owned(),
-                                    })
-                                    .collect(),
-                            }),
-                            "type Input = any".into(),
-                        )
-                    }
-                };
-                (associations, input_type)
-            }
-            //         FuncBackendKind::JsAction => {
-            //             let (kind, schema_variant_ids) =
-            //                 action_prototypes_into_schema_variants_and_components(ctx, *func.id()).await?;
-            //
-            //             let ts_types = compile_action_types(ctx, &schema_variant_ids).await?;
-            //
-            //             let associations = Some(FuncAssociations::Action {
-            //                 schema_variant_ids,
-            //                 kind,
-            //             });
-            //
-            //             (associations, ts_types)
-            //         }
-            //         FuncBackendKind::JsReconciliation => {
-            //             return Err(FuncError::EditingReconciliationFuncsNotImplemented);
-            //         }
-            //         FuncBackendKind::JsValidation => {
-            //             let protos = ValidationPrototype::list_for_func(ctx, *func.id()).await?;
-            //             let input_type = compile_validation_types(ctx, &protos).await?;
-            //
-            //             let associations = Some(FuncAssociations::Validation {
-            //                 prototypes: protos
-            //                     .iter()
-            //                     .map(|proto| ValidationPrototypeView {
-            //                         schema_variant_id: proto.context().schema_variant_id(),
-            //                         prop_id: proto.context().prop_id(),
-            //                     })
-            //                     .collect(),
-            //             });
-            //             (associations, input_type)
-            //         }
-            FuncBackendKind::JsAuthentication => {
-                let schema_variant_ids =
-                    Func::list_schema_variants_for_auth_func(ctx, func.id).await?;
-
-                (
-                    Some(FuncAssociations::Authentication { schema_variant_ids }),
-                    concat!(
-                        "type Input = Record<string, unknown>;\n",
-                        "\n",
-                        "declare namespace requestStorage {\n",
-                        "    function setEnv(key: string, value: any);\n",
-                        "    function setItem(key: string, value: any);\n",
-                        "    function deleteEnv(key: string);\n",
-                        "    function deleteItem(key: string);\n",
-                        "}",
-                    )
-                    .to_owned(),
-                )
-            }
-            _ => (None, String::new()),
-        };
+        let (associations, input_type) = FuncAssociations::from_func(ctx, func).await?;
 
         let types = [
             FuncAuthoringClient::compile_return_types(
@@ -208,17 +72,5 @@ impl FuncView {
             associations,
             types,
         })
-    }
-
-    #[allow(dead_code)]
-    async fn list_leaf_function_inputs(
-        ctx: &DalContext,
-        func_id: FuncId,
-    ) -> FuncViewResult<Vec<LeafInputLocation>> {
-        Ok(FuncArgument::list_for_func(ctx, func_id)
-            .await?
-            .iter()
-            .filter_map(|arg| LeafInputLocation::maybe_from_arg_name(&arg.name))
-            .collect())
     }
 }

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -351,10 +351,13 @@ impl Prop {
         self.id
     }
 
+    /// Returns `Some` with the parent [`PropId`](Prop) or returns `None` if the parent is a
+    /// [`SchemaVariant`].
     pub async fn parent_prop_id_by_id(
         ctx: &DalContext,
         prop_id: PropId,
     ) -> PropResult<Option<PropId>> {
+        dbg!(Self::get_by_id(ctx, prop_id).await?.name);
         let workspace_snapshot = ctx.workspace_snapshot()?;
         match workspace_snapshot
             .incoming_sources_for_edge_weight_kind(prop_id, EdgeWeightKindDiscriminants::Use)
@@ -375,7 +378,7 @@ impl Prop {
                     _ => return Err(PropError::PropParentInvalid(prop_id)),
                 },
             ),
-            None => Ok(None),
+            None => Err(PropError::PropIsOrphan(prop_id)),
         }
     }
 

--- a/lib/dal/src/schema/variant/leaves.rs
+++ b/lib/dal/src/schema/variant/leaves.rs
@@ -15,6 +15,7 @@ use crate::{
 use si_pkg::{LeafInputLocation as PkgLeafInputLocation, LeafKind as PkgLeafKind};
 
 use crate::func::argument::{FuncArgumentId, FuncArgumentKind};
+use crate::prop::PropPath;
 use crate::schema::variant::root_prop::RootPropChild;
 
 use super::{SchemaVariantError, SchemaVariantResult};
@@ -132,8 +133,8 @@ impl LeafInputLocation {
         }
     }
 
-    pub fn prop_path(&self) -> Vec<&'static str> {
-        vec!["root", self.arg_name()]
+    pub fn prop_path(&self) -> PropPath {
+        PropPath::new(["root", self.arg_name()])
     }
 
     pub fn maybe_from_arg_name(arg_name: impl AsRef<str>) -> Option<Self> {

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -4,6 +4,8 @@ use dal_test::test;
 use dal_test::test_harness::create_empty_action_func;
 use pretty_assertions_sorted::assert_eq;
 
+mod associations;
+
 #[test]
 async fn summary(ctx: &mut DalContext) {
     let schema = Schema::find_by_name(ctx, "starfield")

--- a/lib/dal/tests/integration_test/func/associations.rs
+++ b/lib/dal/tests/integration_test/func/associations.rs
@@ -1,0 +1,38 @@
+use dal::func::FuncAssociations;
+use dal::schema::variant::leaves::LeafInputLocation;
+use dal::{DalContext, Func, Schema};
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn for_qualification(ctx: &mut DalContext) {
+    let schema = Schema::find_by_name(ctx, "dummy-secret")
+        .await
+        .expect("could not perform find by name")
+        .expect("no schema found");
+    let schema_variant_id = schema
+        .get_default_schema_variant(ctx)
+        .await
+        .expect("could not perform get default schema variant")
+        .expect("default schema variant not found");
+
+    let func_id = Func::find_by_name(ctx, "test:qualificationDummySecretStringIsTodd")
+        .await
+        .expect("could not perform find func by name")
+        .expect("func not found");
+    let func = Func::get_by_id_or_error(ctx, func_id)
+        .await
+        .expect("could not get func by id");
+    let (associations, _input_type) = FuncAssociations::from_func(ctx, &func)
+        .await
+        .expect("could not get associations");
+
+    assert_eq!(
+        FuncAssociations::Qualification {
+            schema_variant_ids: vec![schema_variant_id],
+            component_ids: vec![],
+            inputs: vec![LeafInputLocation::Secrets]
+        }, // expected
+        associations.expect("no associations found") // actual
+    );
+}


### PR DESCRIPTION
## Description

This PR adds the ability to find func associations for code generation and qualification funcs. It may have also done it for attribute funcs, but that remains to be seen.

There's one integration test added as part of this commit, but it's hardly enough for the authoring domain. Baby steps.

<img src="https://media2.giphy.com/media/3o6Mb7xfYE0y9UN4eQ/giphy.gif"/>