### PR TITLE
feat: serialize ulids as bytes and compress layer db data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "arrayref"
@@ -1746,9 +1746,9 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -2925,6 +2925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3983,9 +3984,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -5145,6 +5146,7 @@ dependencies = [
  "criterion",
  "futures",
  "lazy_static",
+ "miniz_oxide",
  "moka",
  "postcard",
  "rand 0.8.5",
@@ -5281,6 +5283,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simdutf8"
@@ -5922,9 +5930,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "ef89ece63debf11bc32d1ed8d078ac870cbeb44da02afb02a9ff135ae7ca0582"
 dependencies = [
  "deranged",
  "itoa",
@@ -5943,9 +5951,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ jwt-simple = { version = "0.12.9", default-features = false, features = [
     "pure-rust",
 ] }
 lazy_static = "1.4.0"
+miniz_oxide = { version = "0.7.2", features = ["simd"] }
 moka = { version = "0.12.5", features = ["future"] }
 names = { version = "0.14.0", default-features = false }
 nix = { version = "0.27.1", features = ["process", "signal"] }

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -14,10 +14,10 @@ use std::sync::Arc;
 use content_node_weight::ContentNodeWeight;
 use petgraph::Direction;
 use serde::{Deserialize, Serialize};
+use si_events::ulid::Ulid;
 use si_layer_cache::LayerDbError;
 use telemetry::prelude::*;
 use thiserror::Error;
-use ulid::Ulid;
 
 use crate::attribute::prototype::argument::value_source::ValueSource;
 use crate::attribute::prototype::argument::AttributePrototypeArgument;

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -137,7 +137,7 @@ impl AttributePrototype {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let _node_index = workspace_snapshot.add_node(node_weight).await?;
 
-        let prototype = AttributePrototype::assemble(AttributePrototypeId::from(id), &content);
+        let prototype = AttributePrototype::assemble(id.into(), &content);
 
         Self::add_edge_to_func(ctx, prototype.id, func_id, EdgeWeightKind::new_use()).await?;
 

--- a/lib/dal/src/attribute/prototype/argument/static_value.rs
+++ b/lib/dal/src/attribute/prototype/argument/static_value.rs
@@ -72,7 +72,7 @@ impl StaticArgumentValue {
     ) -> AttributePrototypeArgumentResult<Self> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        let ulid: ulid::Ulid = id.into();
+        let ulid: si_events::ulid::Ulid = id.into();
         let node_index = workspace_snapshot.get_node_index_by_id(ulid).await?;
         let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
         let hash = node_weight.content_hash();

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -6,10 +6,10 @@ use std::sync::{Arc, Mutex};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use ulid::{Generator, Ulid};
+use ulid::Generator;
 
 use si_data_pg::{PgError, PgRow};
-use si_events::WorkspaceSnapshotAddress;
+use si_events::{ulid::Ulid, WorkspaceSnapshotAddress};
 use telemetry::prelude::*;
 
 use crate::context::RebaseRequest;
@@ -158,7 +158,7 @@ impl TryFrom<PgRow> for ChangeSet {
 impl ChangeSet {
     pub fn new_local() -> ChangeSetResult<Self> {
         let mut generator = Generator::new();
-        let id = generator.generate()?;
+        let id: Ulid = generator.generate()?.into();
 
         Ok(Self {
             id: id.into(),
@@ -255,6 +255,7 @@ impl ChangeSet {
             .lock()
             .map_err(|e| ChangeSetError::Mutex(e.to_string()))?
             .generate()
+            .map(Into::into)
             .map_err(Into::into)
     }
 

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -8,9 +8,8 @@ use std::sync::Arc;
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::sync::TryLockError;
-use ulid::Ulid;
 
-use si_events::ContentHash;
+use si_events::{ulid::Ulid, ContentHash};
 
 use crate::actor_view::ActorView;
 use crate::attribute::prototype::argument::value_source::ValueSource;

--- a/lib/dal/src/deprecated_action.rs
+++ b/lib/dal/src/deprecated_action.rs
@@ -187,7 +187,7 @@ impl DeprecatedAction {
 
     pub async fn get_by_id(ctx: &DalContext, id: ActionId) -> DeprecatedActionResult<Self> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
-        let ulid: ulid::Ulid = id.into();
+        let ulid: ::si_events::ulid::Ulid = id.into();
         let node_index = workspace_snapshot.get_node_index_by_id(ulid).await?;
         let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
         let hash: ContentHash = node_weight.content_hash();

--- a/lib/dal/src/deprecated_action/batch.rs
+++ b/lib/dal/src/deprecated_action/batch.rs
@@ -4,13 +4,12 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_data_pg::PgError;
-use si_events::ContentHash;
+use si_events::{ulid::Ulid, ContentHash};
 use si_layer_cache::LayerDbError;
 use std::collections::HashMap;
 use std::sync::Arc;
 use telemetry::prelude::*;
 use thiserror::Error;
-use ulid::Ulid;
 
 use crate::change_set::ChangeSetError;
 use crate::workspace_snapshot::content_address::{ContentAddress, ContentAddressDiscriminants};

--- a/lib/dal/src/deprecated_action/prototype.rs
+++ b/lib/dal/src/deprecated_action/prototype.rs
@@ -265,7 +265,7 @@ impl ActionPrototype {
 
     pub async fn get_by_id(ctx: &DalContext, id: ActionPrototypeId) -> ActionPrototypeResult<Self> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
-        let ulid: ulid::Ulid = id.into();
+        let ulid: ::si_events::ulid::Ulid = id.into();
         let node_index = workspace_snapshot.get_node_index_by_id(ulid).await?;
         let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
         let hash = node_weight.content_hash();

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -1,13 +1,12 @@
 use base64::{engine::general_purpose, Engine};
 use serde::{Deserialize, Serialize};
-use si_events::ContentHash;
+use si_events::{ulid::Ulid, ContentHash};
 use std::collections::HashMap;
 use std::string::FromUtf8Error;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 use telemetry::prelude::*;
 use thiserror::Error;
-use ulid::Ulid;
 
 use crate::change_set::ChangeSetError;
 use crate::func::argument::FuncArgumentId;

--- a/lib/dal/src/func/argument.rs
+++ b/lib/dal/src/func/argument.rs
@@ -1,13 +1,12 @@
 use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
-use si_events::ContentHash;
+use si_events::{ulid::Ulid, ContentHash};
 use si_pkg::FuncArgumentKind as PkgFuncArgumentKind;
 use std::collections::HashMap;
 use std::sync::Arc;
 use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
-use ulid::Ulid;
 
 use crate::change_set::ChangeSetError;
 use crate::layer_db_types::{FuncArgumentContent, FuncArgumentContentV1};
@@ -199,7 +198,7 @@ impl FuncArgument {
 
     pub async fn get_by_id(ctx: &DalContext, id: FuncArgumentId) -> FuncArgumentResult<Self> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
-        let id: ulid::Ulid = id.into();
+        let id: ::si_events::ulid::Ulid = id.into();
         let node_index = workspace_snapshot.get_node_index_by_id(id).await?;
         let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
         let hash = node_weight.content_hash();

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -127,6 +127,7 @@ pub use secret::SecretUpdatedPayload;
 pub use secret::SecretVersion;
 pub use secret::SecretView;
 pub use secret::SecretViewError;
+pub use si_events::ulid::Ulid;
 pub use socket::input::{InputSocket, InputSocketId};
 pub use socket::output::{OutputSocket, OutputSocketId};
 pub use socket::SocketArity;

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -1,14 +1,13 @@
 use petgraph::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use si_events::ContentHash;
+use si_events::{ulid::Ulid, ContentHash};
 use si_pkg::PropSpecKind;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
-use ulid::Ulid;
 
 use crate::attribute::prototype::argument::{
     AttributePrototypeArgument, AttributePrototypeArgumentError,
@@ -607,7 +606,7 @@ impl Prop {
 
     pub async fn get_by_id(ctx: &DalContext, id: PropId) -> PropResult<Self> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
-        let ulid: ulid::Ulid = id.into();
+        let ulid: ::si_events::ulid::Ulid = id.into();
         let node_index = workspace_snapshot.get_node_index_by_id(ulid).await?;
         let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
         let hash = node_weight.content_hash();

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -4,7 +4,7 @@
 use petgraph::{Direction, Incoming, Outgoing};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use si_events::ContentHash;
+use si_events::{ulid::Ulid, ContentHash};
 use si_layer_cache::LayerDbError;
 use si_pkg::{
     AttrFuncInputSpec, MapKeyFuncSpec, PropSpec, SchemaSpec, SchemaSpecData, SchemaVariantSpec,
@@ -15,7 +15,6 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use telemetry::prelude::*;
 use thiserror::Error;
-use ulid::Ulid;
 use url::ParseError;
 
 use crate::attribute::prototype::argument::{

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -29,8 +29,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use si_crypto::{SymmetricCryptoError, SymmetricCryptoService, SymmetricNonce};
 use si_data_pg::PgError;
-use si_events::ContentHash;
-use si_events::EncryptedSecretKey;
+use si_events::{ulid::Ulid, ContentHash, EncryptedSecretKey};
 use si_hash::Hash;
 use si_layer_cache::LayerDbError;
 use sodiumoxide::crypto::box_::{PublicKey, SecretKey};
@@ -39,7 +38,6 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 use thiserror::Error;
-use ulid::Ulid;
 use veritech_client::SensitiveContainer;
 
 use crate::key_pair::KeyPairPk;

--- a/lib/dal/src/standard_id.rs
+++ b/lib/dal/src/standard_id.rs
@@ -20,7 +20,7 @@ macro_rules! id {
             serde::Serialize,
             serde::Deserialize,
         )]
-        pub struct $name(ulid::Ulid);
+        pub struct $name(::ulid::Ulid);
 
         impl std::fmt::Debug for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -31,12 +31,30 @@ macro_rules! id {
         impl $name {
             /// Generates a new key which is virtually guaranteed to be unique.
             pub fn generate() -> Self {
-                Self(ulid::Ulid::new())
+                Self(::ulid::Ulid::new())
             }
 
             /// Converts type into inner [`Ulid`](::ulid::Ulid).
             pub fn into_inner(self) -> ::ulid::Ulid {
                 self.0
+            }
+        }
+
+        impl From<$name> for ::si_events::ulid::Ulid {
+            fn from(pk: $name) -> Self {
+                pk.0.into()
+            }
+        }
+
+        impl<'a> From<&'a $name> for ::si_events::ulid::Ulid {
+            fn from(pk: &'a $name) -> Self {
+                pk.0.into()
+            }
+        }
+
+        impl From<::si_events::ulid::Ulid> for $name {
+            fn from(ulid: ::si_events::ulid::Ulid) -> Self {
+                ulid.inner().into()
             }
         }
 
@@ -59,10 +77,10 @@ macro_rules! id {
         }
 
         impl std::str::FromStr for $name {
-            type Err = ulid::DecodeError;
+            type Err = ::ulid::DecodeError;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
-                Ok(Self(ulid::Ulid::from_string(s)?))
+                Ok(Self(::ulid::Ulid::from_string(s)?))
             }
         }
 
@@ -72,7 +90,7 @@ macro_rules! id {
                 raw: &'a [u8],
             ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
                 let id: String = postgres_types::FromSql::from_sql(ty, raw)?;
-                Ok(Self(ulid::Ulid::from_string(&id)?))
+                Ok(Self(::ulid::Ulid::from_string(&id)?))
             }
 
             fn accepts(ty: &postgres_types::Type) -> bool {

--- a/lib/dal/src/standard_pk.rs
+++ b/lib/dal/src/standard_pk.rs
@@ -35,7 +35,7 @@ macro_rules! pk {
 
         impl $name {
             /// An unset id value.
-            pub const NONE: Self = Self(ulid::Ulid::nil());
+            pub const NONE: Self = Self(::ulid::Ulid::nil());
 
             /// Returns `true` if id is set (i.e. not [`NONE`](Self::NONE)).
             pub fn is_some(&self) -> bool {
@@ -58,6 +58,12 @@ macro_rules! pk {
             }
         }
 
+        impl From<::si_events::ulid::Ulid> for $name {
+            fn from(events_ulid: ::si_events::ulid::Ulid) -> Self {
+                events_ulid.inner().into()
+            }
+        }
+
         impl From<Option<$name>> for $name {
             fn from(optional_pk: Option<$name>) -> Self {
                 match optional_pk {
@@ -73,9 +79,21 @@ macro_rules! pk {
             }
         }
 
-        impl<'a> From<&'a $name> for ulid::Ulid {
+        impl<'a> From<&'a $name> for ::ulid::Ulid {
             fn from(pk: &'a $name) -> Self {
                 pk.0
+            }
+        }
+
+        impl From<$name> for ::si_events::ulid::Ulid {
+            fn from(pk: $name) -> Self {
+                pk.0.into()
+            }
+        }
+
+        impl<'a> From<&'a $name> for ::si_events::ulid::Ulid {
+            fn from(pk: &'a $name) -> Self {
+                pk.0.into()
             }
         }
 

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -36,11 +36,9 @@ use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use petgraph::prelude::*;
 use si_data_pg::PgError;
-use si_events::ContentHash;
-use si_events::WorkspaceSnapshotAddress;
+use si_events::{ulid::Ulid, ContentHash, WorkspaceSnapshotAddress};
 use telemetry::prelude::*;
 use thiserror::Error;
-use ulid::Ulid;
 
 use crate::change_set::{ChangeSet, ChangeSetError, ChangeSetId};
 use crate::workspace_snapshot::conflict::Conflict;

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -10,9 +10,8 @@ pub use petgraph::Direction;
 use petgraph::{algo, prelude::*, visit::DfsEvent};
 use serde::{Deserialize, Serialize};
 use si_events::merkle_tree_hash::MerkleTreeHash;
-use si_events::ContentHash;
+use si_events::{ulid::Ulid, ContentHash};
 use thiserror::Error;
-use ulid::Ulid;
 
 use telemetry::prelude::*;
 

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -1015,7 +1015,7 @@ impl WorkspaceSnapshotGraph {
                 )
             },
         );
-        let filename_no_extension = format!("{}-{}", Ulid::new().to_string(), suffix);
+        let filename_no_extension = format!("{}-{}", Ulid::new(), suffix);
 
         let home_str = std::env::var("HOME").expect("could not find home directory via env");
         let home = std::path::Path::new(&home_str);

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -2,10 +2,12 @@ use std::num::TryFromIntError;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use si_events::{merkle_tree_hash::MerkleTreeHash, ContentHash};
+use si_events::{
+    merkle_tree_hash::MerkleTreeHash,
+    {ulid::Ulid, ContentHash},
+};
 use strum::EnumDiscriminants;
 use thiserror::Error;
-use ulid::Ulid;
 
 use crate::func::execution::FuncExecutionPk;
 use crate::workspace_snapshot::vector_clock::VectorClockId;

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
@@ -1,7 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use si_events::{merkle_tree_hash::MerkleTreeHash, ContentHash};
-use ulid::Ulid;
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::{
     change_set::ChangeSet,

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -1,7 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use si_events::{merkle_tree_hash::MerkleTreeHash, ContentHash};
-use ulid::Ulid;
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::{
     change_set::ChangeSet,

--- a/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
@@ -1,9 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use si_events::merkle_tree_hash::MerkleTreeHash;
-use si_events::ContentHash;
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 use strum::Display;
-use ulid::Ulid;
 
 use crate::change_set::ChangeSet;
 use crate::workspace_snapshot::vector_clock::VectorClockId;

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -1,7 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use si_events::{merkle_tree_hash::MerkleTreeHash, ContentHash};
-use ulid::Ulid;
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::{
     change_set::ChangeSet,

--- a/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
@@ -1,8 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_events::merkle_tree_hash::MerkleTreeHash;
-use si_events::ContentHash;
-use ulid::Ulid;
+use si_events::{ulid::Ulid, ContentHash};
 
 use crate::workspace_snapshot::vector_clock::VectorClockId;
 use crate::{

--- a/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
@@ -1,8 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use si_events::{merkle_tree_hash::MerkleTreeHash, ContentHash};
-
-use ulid::Ulid;
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::{
     change_set::ChangeSet,

--- a/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
@@ -1,8 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use si_events::merkle_tree_hash::MerkleTreeHash;
-use si_events::ContentHash;
-use ulid::Ulid;
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::func::FuncKind;
 use crate::workspace_snapshot::content_address::ContentAddressDiscriminants;

--- a/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
@@ -1,8 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use si_events::merkle_tree_hash::MerkleTreeHash;
-use si_events::ContentHash;
-use ulid::Ulid;
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use super::NodeWeightError;
 use crate::change_set::ChangeSet;

--- a/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
@@ -1,8 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use si_events::merkle_tree_hash::MerkleTreeHash;
-use si_events::ContentHash;
-use ulid::Ulid;
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::workspace_snapshot::content_address::ContentAddressDiscriminants;
 use crate::workspace_snapshot::vector_clock::VectorClockId;

--- a/lib/sdf-server/src/server/service/graphviz.rs
+++ b/lib/sdf-server/src/server/service/graphviz.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use axum::{extract::Query, response::Response, routing::get, Json, Router};
+use dal::Ulid;
 use dal::{
     attribute::value::AttributeValueError,
     schema::variant::SchemaVariantError,
@@ -15,7 +16,6 @@ use dal::{
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use ulid::Ulid;
 
 use crate::server::{
     extract::{AccessBuilder, HandlerContext},

--- a/lib/si-events-rs/BUCK
+++ b/lib/si-events-rs/BUCK
@@ -11,6 +11,7 @@ rust_library(
         "//lib/si-hash:si-hash",
         "//third-party/rust:blake3",
         "//third-party/rust:bytes",
+        "//third-party/rust:miniz_oxide",
         "//third-party/rust:paste",
         "//third-party/rust:postgres-types",
         "//third-party/rust:remain",

--- a/lib/si-events-rs/src/lib.rs
+++ b/lib/si-events-rs/src/lib.rs
@@ -7,6 +7,7 @@ mod actor;
 mod cas;
 mod encrypted_secret;
 mod tenancy;
+pub mod ulid;
 mod web_event;
 
 pub use crate::{

--- a/lib/si-events-rs/src/ulid.rs
+++ b/lib/si-events-rs/src/ulid.rs
@@ -1,0 +1,77 @@
+use ulid::Ulid as CoreUlid;
+
+const ULID_SIZE: usize = 16;
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, Default, PartialOrd, Ord)]
+pub struct Ulid(CoreUlid);
+
+impl Ulid {
+    pub fn new() -> Self {
+        Self(CoreUlid::new())
+    }
+
+    pub fn inner(&self) -> CoreUlid {
+        self.0
+    }
+}
+struct UlidVisitor;
+
+impl<'de> ::serde::de::Visitor<'de> for UlidVisitor {
+    type Value = Ulid;
+
+    fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        formatter.write_str("a 16 byte slice representing an xxh3 hash")
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: ::serde::de::Error,
+    {
+        if v.len() != ULID_SIZE {
+            return Err(E::custom(std::concat!(
+                "deserializer received wrong sized byte slice when attempting to deserialize a ",
+                stringify!($name)
+            )));
+        }
+
+        let mut ulid_bytes = [0u8; ULID_SIZE];
+        ulid_bytes.copy_from_slice(v);
+
+        Ok(Ulid(CoreUlid::from_bytes(ulid_bytes)))
+    }
+}
+
+impl<'de> ::serde::Deserialize<'de> for Ulid {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: ::serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_bytes(UlidVisitor)
+    }
+}
+impl ::serde::Serialize for Ulid {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ::serde::Serializer,
+    {
+        serializer.serialize_bytes(&self.0.to_bytes())
+    }
+}
+
+impl std::fmt::Display for Ulid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Ulid({})", self.0.to_string())
+    }
+}
+
+impl From<CoreUlid> for Ulid {
+    fn from(value: CoreUlid) -> Self {
+        Ulid(value)
+    }
+}
+
+impl From<Ulid> for CoreUlid {
+    fn from(value: Ulid) -> Self {
+        value.0
+    }
+}

--- a/lib/si-layer-cache/BUCK
+++ b/lib/si-layer-cache/BUCK
@@ -19,6 +19,7 @@ rust_library(
         "//third-party/rust:chrono",
         "//third-party/rust:futures",
         "//third-party/rust:lazy_static",
+        "//third-party/rust:miniz_oxide",
         "//third-party/rust:moka",
         "//third-party/rust:postcard",
         "//third-party/rust:refinery",

--- a/lib/si-layer-cache/Cargo.toml
+++ b/lib/si-layer-cache/Cargo.toml
@@ -13,6 +13,7 @@ cacache = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 lazy_static = { workspace = true }
+miniz_oxide = { workspace = true }
 moka = { workspace = true }
 postcard = { workspace = true }
 refinery = { workspace = true }

--- a/lib/si-layer-cache/src/db.rs
+++ b/lib/si-layer-cache/src/db.rs
@@ -21,6 +21,7 @@ use self::{cache_updates::CacheUpdatesTask, cas::CasDb, workspace_snapshot::Work
 mod cache_updates;
 pub mod cas;
 pub mod encrypted_secret;
+pub mod serialize;
 pub mod workspace_snapshot;
 
 #[derive(Debug, Clone)]

--- a/lib/si-layer-cache/src/db/cas.rs
+++ b/lib/si-layer-cache/src/db/cas.rs
@@ -12,6 +12,8 @@ use crate::{
     LayerDbError,
 };
 
+use super::serialize;
+
 pub const DBNAME: &str = "cas";
 pub const CACHE_NAME: &str = "cas";
 pub const PARTITION_KEY: &str = "cas";
@@ -43,7 +45,7 @@ where
         tenancy: Tenancy,
         actor: Actor,
     ) -> LayerDbResult<(ContentHash, PersisterStatusReader)> {
-        let postcard_value = postcard::to_stdvec(&value)?;
+        let postcard_value = serialize::to_vec(&value)?;
         let key = ContentHash::new(&postcard_value);
         let cache_key: Arc<str> = key.to_string().into();
 

--- a/lib/si-layer-cache/src/db/encrypted_secret.rs
+++ b/lib/si-layer-cache/src/db/encrypted_secret.rs
@@ -12,6 +12,8 @@ use crate::{
     LayerDbError,
 };
 
+use super::serialize;
+
 const KEYWORD_SINGULAR: &str = "encrypted_secret";
 const KEYWORD_PLURAL: &str = "encrypted_secrets";
 
@@ -48,7 +50,7 @@ where
         tenancy: Tenancy,
         actor: Actor,
     ) -> LayerDbResult<PersisterStatusReader> {
-        let postcard_value = postcard::to_stdvec(&value)?;
+        let postcard_value = serialize::to_vec(&value)?;
 
         let cache_key: Arc<str> = key.to_string().into();
 

--- a/lib/si-layer-cache/src/db/serialize.rs
+++ b/lib/si-layer-cache/src/db/serialize.rs
@@ -1,0 +1,26 @@
+use crate::error::LayerDbResult;
+use crate::LayerDbError;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+#[inline]
+pub fn to_vec<T>(value: &T) -> LayerDbResult<Vec<u8>>
+where
+    T: Serialize + ?Sized,
+{
+    let serialized = postcard::to_stdvec(value)?;
+    // 1 is the best speed, 6 is default, 9 is best compression but may be too slow
+    let compressed = miniz_oxide::deflate::compress_to_vec(&serialized, 1);
+
+    Ok(compressed)
+}
+
+#[inline]
+pub fn from_bytes<T>(bytes: &[u8]) -> LayerDbResult<T>
+where
+    T: DeserializeOwned,
+{
+    let uncompressed = miniz_oxide::inflate::decompress_to_vec(bytes)
+        .map_err(|e| LayerDbError::Decompress(e.to_string()))?;
+    Ok(postcard::from_bytes(&uncompressed)?)
+}

--- a/lib/si-layer-cache/src/db/workspace_snapshot.rs
+++ b/lib/si-layer-cache/src/db/workspace_snapshot.rs
@@ -10,6 +10,8 @@ use crate::{
     persister::{PersisterClient, PersisterStatusReader},
 };
 
+use super::serialize;
+
 pub const DBNAME: &str = "workspace_snapshots";
 pub const CACHE_NAME: &str = "workspace_snapshots";
 pub const PARTITION_KEY: &str = "workspace_snapshots";
@@ -41,8 +43,7 @@ where
         tenancy: Tenancy,
         actor: Actor,
     ) -> LayerDbResult<(WorkspaceSnapshotAddress, PersisterStatusReader)> {
-        let postcard_value = postcard::to_stdvec(&value)?;
-        dbg!(postcard_value.len());
+        let postcard_value = serialize::to_vec(&value)?;
         let key = WorkspaceSnapshotAddress::new(&postcard_value);
         let cache_key: Arc<str> = key.to_string().into();
 

--- a/lib/si-layer-cache/src/db/workspace_snapshot.rs
+++ b/lib/si-layer-cache/src/db/workspace_snapshot.rs
@@ -42,6 +42,7 @@ where
         actor: Actor,
     ) -> LayerDbResult<(WorkspaceSnapshotAddress, PersisterStatusReader)> {
         let postcard_value = postcard::to_stdvec(&value)?;
+        dbg!(postcard_value.len());
         let key = WorkspaceSnapshotAddress::new(&postcard_value);
         let cache_key: Arc<str> = key.to_string().into();
 

--- a/lib/si-layer-cache/src/error.rs
+++ b/lib/si-layer-cache/src/error.rs
@@ -42,6 +42,8 @@ pub enum LayerDbError {
     ContentConversion(String),
     #[error("could not convert to key from string")]
     CouldNotConvertToKeyFromString(String),
+    #[error("decompression error: {0}")]
+    Decompress(String),
     #[error("failed to parse content hash from str: {0}")]
     HashParse(#[from] ContentHashParseError),
     #[error("invalid cache name: {0}")]

--- a/lib/si-layer-cache/tests/integration_test/layer_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/layer_cache.rs
@@ -2,6 +2,7 @@ use rand::seq::SliceRandom;
 use rand::thread_rng;
 use std::sync::Arc;
 
+use si_layer_cache::db::serialize;
 use si_layer_cache::layer_cache::LayerCache;
 
 async fn make_layer_cache(db_name: &str) -> LayerCache<String> {
@@ -73,7 +74,7 @@ async fn get_inserts_to_memory() {
 
     let skid_row: Arc<str> = "skid row".into();
 
-    let postcard_serialized = postcard::to_stdvec("slave to the grind").expect("should serialize");
+    let postcard_serialized = serialize::to_vec("slave to the grind").expect("should serialize");
 
     layer_cache
         .disk_cache()

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -454,18 +454,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "anyhow-1.0.81.crate",
-    sha256 = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247",
-    strip_prefix = "anyhow-1.0.81",
-    urls = ["https://crates.io/api/v1/crates/anyhow/1.0.81/download"],
+    name = "anyhow-1.0.82.crate",
+    sha256 = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519",
+    strip_prefix = "anyhow-1.0.82",
+    urls = ["https://crates.io/api/v1/crates/anyhow/1.0.82/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "anyhow-1.0.81",
-    srcs = [":anyhow-1.0.81.crate"],
+    name = "anyhow-1.0.82",
+    srcs = [":anyhow-1.0.82.crate"],
     crate = "anyhow",
-    crate_root = "anyhow-1.0.81.crate/src/lib.rs",
+    crate_root = "anyhow-1.0.82.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -633,7 +633,7 @@ cargo.rust_library(
         ":serde_nanos-0.1.4",
         ":serde_repr-0.1.19",
         ":thiserror-1.0.58",
-        ":time-0.3.34",
+        ":time-0.3.35",
         ":tokio-1.37.0",
         ":tokio-rustls-0.25.0",
         ":tracing-0.1.40",
@@ -666,7 +666,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -711,7 +711,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -740,7 +740,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -871,7 +871,7 @@ cargo.rust_library(
         ":rust-ini-0.19.0",
         ":serde-1.0.197",
         ":thiserror-1.0.58",
-        ":time-0.3.34",
+        ":time-0.3.35",
         ":url-2.5.0",
     ],
 )
@@ -1000,7 +1000,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -2116,7 +2116,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.5.0",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -3317,7 +3317,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -3370,7 +3370,7 @@ cargo.rust_library(
         ":fnv-1.0.7",
         ":ident_case-1.0.1",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":strsim-0.10.0",
         ":syn-2.0.58",
     ],
@@ -3394,7 +3394,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":darling_core-0.20.8",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -3415,7 +3415,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":anyhow-1.0.81",
+        ":anyhow-1.0.82",
         ":html-escape-0.2.13",
         ":nom-7.1.3",
         ":ordered-float-2.10.1",
@@ -3608,7 +3608,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-1.0.109",
     ],
 )
@@ -3660,7 +3660,7 @@ cargo.rust_library(
     deps = [
         ":darling-0.20.8",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -3741,7 +3741,7 @@ cargo.rust_library(
     deps = [
         ":convert_case-0.4.0",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-1.0.109",
     ],
 )
@@ -4097,7 +4097,7 @@ cargo.rust_library(
     deps = [
         ":enum-ordinalize-4.3.0",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -4210,18 +4210,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "encoding_rs-0.8.33.crate",
-    sha256 = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1",
-    strip_prefix = "encoding_rs-0.8.33",
-    urls = ["https://crates.io/api/v1/crates/encoding_rs/0.8.33/download"],
+    name = "encoding_rs-0.8.34.crate",
+    sha256 = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59",
+    strip_prefix = "encoding_rs-0.8.34",
+    urls = ["https://crates.io/api/v1/crates/encoding_rs/0.8.34/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "encoding_rs-0.8.33",
-    srcs = [":encoding_rs-0.8.33.crate"],
+    name = "encoding_rs-0.8.34",
+    srcs = [":encoding_rs-0.8.34.crate"],
     crate = "encoding_rs",
-    crate_root = "encoding_rs-0.8.33.crate/src/lib.rs",
+    crate_root = "encoding_rs-0.8.34.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -4268,7 +4268,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -4880,7 +4880,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -6249,7 +6249,7 @@ cargo.rust_library(
     deps = [
         ":ignore-0.4.22",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":serde-1.0.197",
         ":syn-2.0.58",
         ":toml-0.8.12",
@@ -6445,7 +6445,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -6704,7 +6704,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":anyhow-1.0.81",
+        ":anyhow-1.0.82",
         ":binstring-0.1.1",
         ":blake2b_simd-1.0.2",
         ":coarsetime-0.1.34",
@@ -7491,7 +7491,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -7699,7 +7699,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -7780,6 +7780,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "miniz_oxide",
+    actual = ":miniz_oxide-0.7.2",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "miniz_oxide-0.7.2.crate",
     sha256 = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7",
@@ -7794,9 +7800,17 @@ cargo.rust_library(
     crate = "miniz_oxide",
     crate_root = "miniz_oxide-0.7.2.crate/src/lib.rs",
     edition = "2018",
-    features = ["with-alloc"],
+    features = [
+        "default",
+        "simd",
+        "simd-adler32",
+        "with-alloc",
+    ],
     visibility = [],
-    deps = [":adler-1.0.2"],
+    deps = [
+        ":adler-1.0.2",
+        ":simd-adler32-0.3.7",
+    ],
 )
 
 http_archive(
@@ -7910,7 +7924,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bytes-1.6.0",
-        ":encoding_rs-0.8.33",
+        ":encoding_rs-0.8.34",
         ":futures-util-0.3.30",
         ":http-0.2.12",
         ":httparse-1.8.0",
@@ -9039,7 +9053,7 @@ cargo.rust_library(
         ":heck-0.4.1",
         ":proc-macro-error-1.0.4",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -9066,7 +9080,7 @@ cargo.rust_library(
         ":itertools-0.12.1",
         ":proc-macro2-1.0.79",
         ":proc-macro2-diagnostics-0.10.1",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -9508,7 +9522,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-1.0.109",
     ],
 )
@@ -9531,7 +9545,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -9924,7 +9938,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -10134,7 +10148,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro-error-attr-1.0.4",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-1.0.109",
     ],
 )
@@ -10184,7 +10198,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
     ],
 )
 
@@ -10263,7 +10277,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
         ":yansi-1.0.1",
     ],
@@ -10312,10 +10326,10 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":anyhow-1.0.81",
+        ":anyhow-1.0.82",
         ":itertools-0.12.1",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -10405,23 +10419,23 @@ cargo.rust_library(
 
 alias(
     name = "quote",
-    actual = ":quote-1.0.35",
+    actual = ":quote-1.0.36",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "quote-1.0.35.crate",
-    sha256 = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef",
-    strip_prefix = "quote-1.0.35",
-    urls = ["https://crates.io/api/v1/crates/quote/1.0.35/download"],
+    name = "quote-1.0.36.crate",
+    sha256 = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7",
+    strip_prefix = "quote-1.0.36",
+    urls = ["https://crates.io/api/v1/crates/quote/1.0.36/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "quote-1.0.35",
-    srcs = [":quote-1.0.35.crate"],
+    name = "quote-1.0.36",
+    srcs = [":quote-1.0.36.crate"],
     crate = "quote",
-    crate_root = "quote-1.0.35.crate/src/lib.rs",
+    crate_root = "quote-1.0.36.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -10752,7 +10766,7 @@ cargo.rust_library(
         ":regex-1.10.4",
         ":siphasher-1.0.1",
         ":thiserror-1.0.58",
-        ":time-0.3.34",
+        ":time-0.3.35",
         ":tokio-1.37.0",
         ":tokio-postgres-0.7.10",
         ":url-2.5.0",
@@ -10779,7 +10793,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":refinery-core-0.8.14",
         ":regex-1.10.4",
         ":syn-2.0.58",
@@ -11018,7 +11032,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -12064,7 +12078,7 @@ cargo.rust_library(
         ":serde_json-1.0.115",
         ":sha2-0.10.8",
         ":thiserror-1.0.58",
-        ":time-0.3.34",
+        ":time-0.3.35",
         ":tokio-1.37.0",
         ":tokio-rustls-0.24.1",
         ":tokio-stream-0.1.15",
@@ -12700,7 +12714,7 @@ cargo.rust_library(
         ":heck-0.4.1",
         ":proc-macro-error-1.0.4",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -12767,7 +12781,7 @@ cargo.rust_library(
         ":sqlx-0.7.4",
         ":strum-0.25.0",
         ":thiserror-1.0.58",
-        ":time-0.3.34",
+        ":time-0.3.35",
         ":tracing-0.1.40",
         ":url-2.5.0",
         ":uuid-1.8.0",
@@ -12802,7 +12816,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
         ":unicode-ident-1.0.12",
     ],
@@ -12853,7 +12867,7 @@ cargo.rust_library(
         ":ordered-float-3.9.2",
         ":rust_decimal-1.35.0",
         ":serde_json-1.0.115",
-        ":time-0.3.34",
+        ":time-0.3.35",
         ":uuid-1.8.0",
     ],
 )
@@ -12898,7 +12912,7 @@ cargo.rust_library(
         ":sea-query-0.30.7",
         ":serde_json-1.0.115",
         ":sqlx-0.7.4",
-        ":time-0.3.34",
+        ":time-0.3.35",
         ":uuid-1.8.0",
     ],
 )
@@ -13188,7 +13202,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -13288,7 +13302,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -13392,7 +13406,7 @@ cargo.rust_library(
         "chrono_0_4": ":chrono-0.4.37",
         "indexmap_1": ":indexmap-1.9.3",
         "indexmap_2": ":indexmap-2.2.6",
-        "time_0_3": ":time-0.3.34",
+        "time_0_3": ":time-0.3.35",
     },
     visibility = [],
     deps = [
@@ -13424,7 +13438,7 @@ cargo.rust_library(
     deps = [
         ":darling-0.20.8",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -13754,6 +13768,23 @@ cargo.rust_library(
         ":digest-0.10.7",
         ":rand_core-0.6.4",
     ],
+)
+
+http_archive(
+    name = "simd-adler32-0.3.7.crate",
+    sha256 = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe",
+    strip_prefix = "simd-adler32-0.3.7",
+    urls = ["https://crates.io/api/v1/crates/simd-adler32/0.3.7/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "simd-adler32-0.3.7",
+    srcs = [":simd-adler32-0.3.7.crate"],
+    crate = "simd_adler32",
+    crate_root = "simd-adler32-0.3.7.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
 )
 
 http_archive(
@@ -14134,7 +14165,7 @@ cargo.rust_library(
         ":smallvec-1.13.2",
         ":sqlformat-0.2.3",
         ":thiserror-1.0.58",
-        ":time-0.3.34",
+        ":time-0.3.35",
         ":tokio-1.37.0",
         ":tokio-stream-0.1.15",
         ":tracing-0.1.40",
@@ -14209,7 +14240,7 @@ cargo.rust_library(
         ":sqlx-core-0.7.4",
         ":stringprep-0.1.4",
         ":thiserror-1.0.58",
-        ":time-0.3.34",
+        ":time-0.3.35",
         ":tracing-0.1.40",
         ":uuid-1.8.0",
         ":whoami-1.5.1",
@@ -14448,7 +14479,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":rustversion-1.0.15",
         ":syn-2.0.58",
     ],
@@ -14535,7 +14566,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":unicode-ident-1.0.12",
     ],
 )
@@ -14576,7 +14607,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":unicode-ident-1.0.12",
     ],
 )
@@ -14821,7 +14852,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -14876,6 +14907,7 @@ cargo.rust_binary(
         ":itertools-0.12.1",
         ":jwt-simple-0.12.9",
         ":lazy_static-1.4.0",
+        ":miniz_oxide-0.7.2",
         ":moka-0.12.5",
         ":names-0.14.0",
         ":nix-0.27.1",
@@ -14897,7 +14929,7 @@ cargo.rust_binary(
         ":postgres-types-0.2.6",
         ":pretty_assertions_sorted-1.2.3",
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":rand-0.8.5",
         ":refinery-0.8.12",
         ":regex-1.10.4",
@@ -14992,7 +15024,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -15019,18 +15051,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "time-0.3.34.crate",
-    sha256 = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749",
-    strip_prefix = "time-0.3.34",
-    urls = ["https://crates.io/api/v1/crates/time/0.3.34/download"],
+    name = "time-0.3.35.crate",
+    sha256 = "ef89ece63debf11bc32d1ed8d078ac870cbeb44da02afb02a9ff135ae7ca0582",
+    strip_prefix = "time-0.3.35",
+    urls = ["https://crates.io/api/v1/crates/time/0.3.35/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "time-0.3.34",
-    srcs = [":time-0.3.34.crate"],
+    name = "time-0.3.35",
+    srcs = [":time-0.3.35.crate"],
     crate = "time",
-    crate_root = "time-0.3.34.crate/src/lib.rs",
+    crate_root = "time-0.3.35.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -15050,7 +15082,7 @@ cargo.rust_library(
         ":powerfmt-0.2.0",
         ":serde-1.0.197",
         ":time-core-0.1.2",
-        ":time-macros-0.2.17",
+        ":time-macros-0.2.18",
     ],
 )
 
@@ -15072,18 +15104,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "time-macros-0.2.17.crate",
-    sha256 = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774",
-    strip_prefix = "time-macros-0.2.17",
-    urls = ["https://crates.io/api/v1/crates/time-macros/0.2.17/download"],
+    name = "time-macros-0.2.18.crate",
+    sha256 = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf",
+    strip_prefix = "time-macros-0.2.18",
+    urls = ["https://crates.io/api/v1/crates/time-macros/0.2.18/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "time-macros-0.2.17",
-    srcs = [":time-macros-0.2.17.crate"],
+    name = "time-macros-0.2.18",
+    srcs = [":time-macros-0.2.18.crate"],
     crate = "time_macros",
-    crate_root = "time-macros-0.2.17.crate/src/lib.rs",
+    crate_root = "time-macros-0.2.18.crate/src/lib.rs",
     edition = "2021",
     features = [
         "formatting",
@@ -15324,7 +15356,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -16043,7 +16075,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )
@@ -16914,7 +16946,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
     ],
 )
 
@@ -17806,7 +17838,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.79",
-        ":quote-1.0.35",
+        ":quote-1.0.36",
         ":syn-2.0.58",
     ],
 )

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "arrayref"
@@ -1614,9 +1614,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -2884,6 +2884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3831,9 +3832,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -4830,6 +4831,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5431,6 +5438,7 @@ dependencies = [
  "itertools 0.12.1",
  "jwt-simple",
  "lazy_static",
+ "miniz_oxide",
  "moka",
  "names",
  "nix 0.27.1",
@@ -5536,9 +5544,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "ef89ece63debf11bc32d1ed8d078ac870cbeb44da02afb02a9ff135ae7ca0582"
 dependencies = [
  "deranged",
  "itoa",
@@ -5557,9 +5565,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -78,6 +78,7 @@ jwt-simple = { version = "0.12.9", default-features = false, features = [
     "pure-rust",
 ] }
 lazy_static = "1.4.0"
+miniz_oxide = { version = "0.7.2", features = ["simd"] }
 moka = { version = "0.12.5", features = ["future"] }
 names = { version = "0.14.0", default-features = false }
 nix = { version = "0.27.1", features = ["process", "signal"] }


### PR DESCRIPTION
Shrinks the graph further, both by changing the Ulid serialization, and, at the expense of some extra compute, with compression, on the theory that the smaller it is, the faster we can move it through NATS.

The graph after imports is now 1,756,207 bytes vs 4,268,102 bytes on main.