### PR TITLE
Restore func associations for actions

### DIFF
--- a/lib/dal-test/src/test_harness.rs
+++ b/lib/dal-test/src/test_harness.rs
@@ -10,8 +10,8 @@ use dal::{
     InputSocket, KeyPair, OutputSocket, Schema, SchemaVariant, SchemaVariantId, User, UserPk,
 };
 use itertools::enumerate;
-use jwt_simple::prelude::{Deserialize, Serialize};
 use names::{Generator, Name};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 

--- a/lib/dal/src/deprecated_action/prototype.rs
+++ b/lib/dal/src/deprecated_action/prototype.rs
@@ -263,7 +263,10 @@ impl ActionPrototype {
         Ok(prototypes)
     }
 
-    pub async fn get_by_id(ctx: &DalContext, id: ActionPrototypeId) -> ActionPrototypeResult<Self> {
+    pub async fn get_by_id_or_error(
+        ctx: &DalContext,
+        id: ActionPrototypeId,
+    ) -> ActionPrototypeResult<Self> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let ulid: ::si_events::ulid::Ulid = id.into();
         let node_index = workspace_snapshot.get_node_index_by_id(ulid).await?;

--- a/lib/dal/src/deprecated_action/runner.rs
+++ b/lib/dal/src/deprecated_action/runner.rs
@@ -207,7 +207,7 @@ impl DeprecatedActionRunner {
         let timestamp = Timestamp::now();
 
         let component = Component::get_by_id(ctx, component_id).await?;
-        let prototype = ActionPrototype::get_by_id(ctx, action_prototype_id).await?;
+        let prototype = ActionPrototype::get_by_id_or_error(ctx, action_prototype_id).await?;
         let func = Func::get_by_id_or_error(ctx, prototype.func_id(ctx).await?).await?;
         let func_name = func
             .display_name
@@ -291,7 +291,8 @@ impl DeprecatedActionRunner {
         // Stamp started and run the workflow.
         self.stamp_started(ctx).await?;
 
-        let action_prototype = ActionPrototype::get_by_id(ctx, self.action_prototype_id).await?;
+        let action_prototype =
+            ActionPrototype::get_by_id_or_error(ctx, self.action_prototype_id).await?;
 
         Ok(match action_prototype.run(ctx, self.component_id).await {
             Ok(Some(run_result)) => {

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -12,7 +12,6 @@ use crate::change_set::ChangeSetError;
 use crate::func::argument::FuncArgumentId;
 use crate::func::intrinsics::IntrinsicFunc;
 use crate::layer_db_types::{FuncContent, FuncContentV1};
-use crate::schema::variant::SchemaVariantResult;
 use crate::workspace_snapshot::edge_weight::{
     EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
 };
@@ -20,10 +19,7 @@ use crate::workspace_snapshot::graph::WorkspaceSnapshotGraphError;
 use crate::workspace_snapshot::node_weight::category_node_weight::CategoryNodeKind;
 use crate::workspace_snapshot::node_weight::{FuncNodeWeight, NodeWeight, NodeWeightError};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
-use crate::{
-    implement_add_edge_to, pk, DalContext, HelperError, SchemaVariantId, Timestamp,
-    TransactionsError,
-};
+use crate::{implement_add_edge_to, pk, DalContext, HelperError, Timestamp, TransactionsError};
 
 use self::backend::{FuncBackendKind, FuncBackendResponseType};
 
@@ -526,33 +522,6 @@ impl Func {
         }
 
         Ok(funcs)
-    }
-
-    pub async fn list_schema_variants_for_auth_func(
-        ctx: &DalContext,
-        func_id: FuncId,
-    ) -> SchemaVariantResult<Vec<SchemaVariantId>> {
-        let workspace_snapshot = ctx.workspace_snapshot()?;
-
-        let mut schema_variant_ids = vec![];
-
-        for node_id in workspace_snapshot
-            .incoming_sources_for_edge_weight_kind(
-                func_id,
-                EdgeWeightKindDiscriminants::AuthenticationPrototype,
-            )
-            .await?
-        {
-            schema_variant_ids.push(
-                workspace_snapshot
-                    .get_node_weight(node_id)
-                    .await?
-                    .id()
-                    .into(),
-            )
-        }
-
-        Ok(schema_variant_ids)
     }
 
     /// Checks if the [`Func`] is "revertible".

--- a/lib/dal/src/func/variant.rs
+++ b/lib/dal/src/func/variant.rs
@@ -3,7 +3,7 @@
 //! since some JsAttribute functions are a special case (Qualification, CodeGeneration etc.)
 
 use crate::{Func, FuncBackendKind, FuncBackendResponseType, FuncError};
-use jwt_simple::prelude::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 #[remain::sorted]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Copy)]

--- a/lib/dal/src/history_event/metadata.rs
+++ b/lib/dal/src/history_event/metadata.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use jwt_simple::prelude::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::diagram::DiagramResult;
 use crate::{ActorView, DalContext, HistoryActorTimestamp};

--- a/lib/dal/src/job/definition/action.rs
+++ b/lib/dal/src/job/definition/action.rs
@@ -451,7 +451,8 @@ async fn process_failed_action_inner(
                 .await?;
         }
 
-        let prototype = ActionPrototype::get_by_id(ctx, action.action_prototype_id).await?;
+        let prototype =
+            ActionPrototype::get_by_id_or_error(ctx, action.action_prototype_id).await?;
 
         WsEvent::action_return(
             ctx,

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -1,16 +1,10 @@
-//! This module contains [`SchemaVariant`](crate::SchemaVariant), which is t/he "class" of a
-//! [`Component`](crate::Component).
+//! This module contains [`SchemaVariant`](SchemaVariant), which is the "class" of a [`Component`](crate::Component).
 
 use petgraph::{Direction, Incoming, Outgoing};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use si_events::{ulid::Ulid, ContentHash};
 use si_layer_cache::LayerDbError;
-use si_pkg::{
-    AttrFuncInputSpec, MapKeyFuncSpec, PropSpec, SchemaSpec, SchemaSpecData, SchemaVariantSpec,
-    SchemaVariantSpecData, SiPropFuncSpec, SiPropFuncSpecKind, SocketSpec, SocketSpecArity,
-    SocketSpecData, SocketSpecKind, SpecError,
-};
+use si_pkg::SpecError;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use telemetry::prelude::*;
@@ -26,8 +20,7 @@ use crate::func::argument::{FuncArgument, FuncArgumentError};
 use crate::func::intrinsics::IntrinsicFunc;
 use crate::func::{FuncError, FuncKind};
 use crate::layer_db_types::{
-    InputSocketContent, OutputSocketContent, SchemaVariantContent,
-    SchemaVariantContentDiscriminants, SchemaVariantContentV1,
+    InputSocketContent, OutputSocketContent, SchemaVariantContent, SchemaVariantContentV1,
 };
 use crate::prop::{PropError, PropPath};
 use crate::schema::variant::root_prop::RootProp;
@@ -38,8 +31,6 @@ use crate::workspace_snapshot::edge_weight::{
     EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
 };
 use crate::workspace_snapshot::graph::NodeIndex;
-
-use crate::property_editor::schema::WidgetKind;
 use crate::workspace_snapshot::node_weight::{NodeWeight, NodeWeightError, PropNodeWeight};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
@@ -47,21 +38,27 @@ use crate::{
     schema::variant::leaves::{LeafInput, LeafInputLocation, LeafKind},
     ActionPrototype, ActionPrototypeId, AttributePrototype, AttributePrototypeId, ChangeSetId,
     ComponentId, ComponentType, DalContext, Func, FuncId, HelperError, InputSocket, OutputSocket,
-    OutputSocketId, Prop, PropId, PropKind, Schema, SchemaError, SchemaId, SocketArity, Timestamp,
+    OutputSocketId, Prop, PropId, PropKind, Schema, SchemaError, SchemaId, Timestamp,
     TransactionsError, WsEvent, WsEventResult, WsPayload,
 };
 use crate::{FuncBackendResponseType, InputSocketId};
 
 use self::root_prop::RootPropChild;
 
+mod json;
 pub mod leaves;
+mod metadata_view;
 pub mod root_prop;
+mod value_from;
+
+pub use json::SchemaVariantJson;
+pub use json::SchemaVariantMetadataJson;
+pub use metadata_view::SchemaVariantMetadataView;
+pub use value_from::ValueFrom;
 
 // FIXME(nick,theo): colors should be required for all schema variants.
 // There should be no default in the backend as there should always be a color.
 pub const DEFAULT_SCHEMA_VARIANT_COLOR: &str = "#00b0bc";
-pub const SCHEMA_VARIANT_VERSION: SchemaVariantContentDiscriminants =
-    SchemaVariantContentDiscriminants::V1;
 
 #[remain::sorted]
 #[derive(Error, Debug)]
@@ -155,6 +152,29 @@ pub struct SchemaVariant {
     description: Option<String>,
     asset_func_id: Option<FuncId>,
     finalized_once: bool,
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaVariantCreatedPayload {
+    schema_variant_id: SchemaVariantId,
+    change_set_id: ChangeSetId,
+}
+
+impl WsEvent {
+    pub async fn schema_variant_created(
+        ctx: &DalContext,
+        schema_variant_id: SchemaVariantId,
+    ) -> WsEventResult<Self> {
+        WsEvent::new(
+            ctx,
+            WsPayload::SchemaVariantCreated(SchemaVariantCreatedPayload {
+                schema_variant_id,
+                change_set_id: ctx.change_set_id(),
+            }),
+        )
+        .await
+    }
 }
 
 impl SchemaVariant {
@@ -1171,7 +1191,7 @@ impl SchemaVariant {
             let weight = workspace_snapshot
                 .get_node_weight(action_prototype_node)
                 .await?;
-            let ap = ActionPrototype::get_by_id(ctx, weight.id().into())
+            let ap = ActionPrototype::get_by_id_or_error(ctx, weight.id().into())
                 .await
                 .map_err(|e| SchemaVariantError::ActionPrototype(e.to_string()))?;
             let func = Func::get_by_id_or_error(
@@ -1306,480 +1326,79 @@ impl SchemaVariant {
             output_socket_id,
         ))
     }
-}
 
-#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct SchemaVariantCreatedPayload {
-    schema_variant_id: SchemaVariantId,
-    change_set_id: ChangeSetId,
-}
-
-impl WsEvent {
-    pub async fn schema_variant_created(
+    /// List all [`SchemaVariantIds`](SchemaVariant) for the provided
+    /// [authentication](FuncKind::Authentication) [`Func`].
+    pub async fn list_for_auth_func(
         ctx: &DalContext,
-        schema_variant_id: SchemaVariantId,
-    ) -> WsEventResult<Self> {
-        WsEvent::new(
-            ctx,
-            WsPayload::SchemaVariantCreated(SchemaVariantCreatedPayload {
-                schema_variant_id,
-                change_set_id: ctx.change_set_id(),
-            }),
-        )
-        .await
-    }
-}
+        func_id: FuncId,
+    ) -> SchemaVariantResult<Vec<SchemaVariantId>> {
+        let workspace_snapshot = ctx.workspace_snapshot()?;
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SchemaVariantMetadataJson {
-    /// Name for this variant. Actually, this is the name for this [`Schema`](crate::Schema), we're
-    /// punting on the issue of multiple variants for the moment.
-    pub name: String,
-    /// Override for the UI name for this schema
-    #[serde(alias = "menu_name")]
-    pub menu_name: Option<String>,
-    /// The category this schema variant belongs to
-    pub category: String,
-    /// The color for the component on the component diagram as a hex string
-    pub color: String,
-    #[serde(alias = "component_type")]
-    pub component_type: ComponentType,
-    pub link: Option<String>,
-    pub description: Option<String>,
-}
+        let mut schema_variant_ids = vec![];
 
-impl SchemaVariantMetadataJson {
-    pub fn to_spec(&self, variant: SchemaVariantSpec) -> SchemaVariantResult<SchemaSpec> {
-        let mut builder = SchemaSpec::builder();
-        builder.name(&self.name);
-        let mut data_builder = SchemaSpecData::builder();
-        data_builder.name(&self.name);
-        data_builder.category(&self.category);
-        if let Some(menu_name) = &self.menu_name {
-            data_builder.category_name(menu_name.as_str());
-        }
-        builder.data(data_builder.build()?);
-        builder.variant(variant);
-
-        Ok(builder.build()?)
-    }
-}
-
-/// The json definition for a [`SchemaVariant`](crate::SchemaVariant)'s [`Prop`](crate::Prop) tree (and
-/// more in the future).
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SchemaVariantJson {
-    /// The immediate child [`Props`](crate::Prop) underneath "/root/domain".
-    #[serde(default)]
-    pub props: Vec<PropDefinition>,
-    /// The immediate child [`Props`](crate::Prop) underneath "/root/secrets".
-    #[serde(default)]
-    pub secret_props: Vec<PropDefinition>,
-    /// The immediate child [`Props`](crate::Prop) underneath "/root/secretsDefinition".
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub secret_definition: Option<Vec<PropDefinition>>,
-    /// The immediate child [`Props`](crate::Prop) underneath "/root/resource_value".
-    #[serde(default)]
-    pub resource_props: Vec<PropDefinition>,
-    /// Identity relationships for [`Props`](crate::Prop) underneath "/root/si".
-    #[serde(default)]
-    pub si_prop_value_froms: Vec<SiPropValueFrom>,
-
-    /// The input [`Sockets`](crate::Socket) and created for the [`variant`](crate::SchemaVariant).
-    #[serde(default)]
-    pub input_sockets: Vec<SocketDefinition>,
-    /// The output [`Sockets`](crate::Socket) and created for the [`variant`](crate::SchemaVariant).
-    #[serde(default)]
-    pub output_sockets: Vec<SocketDefinition>,
-    /// A map of documentation links to reference. To reference links (values) specify the key via
-    /// the "doc_link_ref" field for a [`PropDefinition`].
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub doc_links: Option<HashMap<String, String>>,
-}
-
-impl SchemaVariantJson {
-    pub fn to_spec(
-        &self,
-        metadata: SchemaVariantMetadataJson,
-        identity_func_unique_id: &str,
-        asset_func_spec_unique_id: &str,
-    ) -> SchemaVariantResult<SchemaVariantSpec> {
-        let mut builder = SchemaVariantSpec::builder();
-        let name = "v0";
-        builder.name(name);
-
-        let mut data_builder = SchemaVariantSpecData::builder();
-
-        data_builder.name(name);
-        data_builder.color(metadata.color);
-        data_builder.component_type(metadata.component_type);
-        if let Some(link) = metadata.link {
-            data_builder.try_link(link.as_str())?;
-        }
-
-        data_builder.func_unique_id(asset_func_spec_unique_id);
-        builder.data(data_builder.build()?);
-
-        for si_prop_value_from in &self.si_prop_value_froms {
-            builder.si_prop_func(si_prop_value_from.to_spec(identity_func_unique_id));
-        }
-        for prop in &self.props {
-            builder.domain_prop(prop.to_spec(identity_func_unique_id)?);
-        }
-        for prop in &self.secret_props {
-            builder.secret_prop(prop.to_spec(identity_func_unique_id)?);
-        }
-        if let Some(props) = &self.secret_definition {
-            for prop in props {
-                builder.secret_definition_prop(prop.to_spec(identity_func_unique_id)?);
-            }
-        }
-        for resource_prop in &self.resource_props {
-            builder.resource_value_prop(resource_prop.to_spec(identity_func_unique_id)?);
-        }
-        for input_socket in &self.input_sockets {
-            builder.socket(input_socket.to_spec(true, identity_func_unique_id)?);
-        }
-        for output_socket in &self.output_sockets {
-            builder.socket(output_socket.to_spec(false, identity_func_unique_id)?);
-        }
-
-        Ok(builder.build()?)
-    }
-
-    pub fn metadata_from_spec(
-        schema_spec: SchemaSpec,
-    ) -> SchemaVariantResult<SchemaVariantMetadataJson> {
-        let schema_data = schema_spec.data.unwrap_or(SchemaSpecData {
-            name: schema_spec.name.to_owned(),
-            default_schema_variant: None,
-            category: "".into(),
-            category_name: None,
-            ui_hidden: false,
-        });
-
-        let default_variant_spec = match schema_data.default_schema_variant {
-            Some(default_variant_unique_id) => schema_spec
-                .variants
-                .iter()
-                .find(|variant| variant.unique_id.as_deref() == Some(&default_variant_unique_id))
-                .ok_or(SchemaVariantError::DefaultVariantNotFound(
-                    default_variant_unique_id,
-                ))?,
-            None => schema_spec
-                .variants
-                .last()
-                .ok_or(SchemaVariantError::NoVariants)?,
-        };
-
-        let variant_spec_data =
-            default_variant_spec
-                .data
-                .to_owned()
-                .unwrap_or(SchemaVariantSpecData {
-                    name: "v0".into(),
-                    color: None,
-                    link: None,
-                    component_type: si_pkg::SchemaVariantSpecComponentType::Component,
-                    func_unique_id: "0".into(),
-                });
-
-        let metadata = SchemaVariantMetadataJson {
-            name: schema_spec.name,
-            menu_name: schema_data.category_name,
-            category: schema_data.category,
-            color: variant_spec_data
-                .color
-                .to_owned()
-                .unwrap_or(DEFAULT_SCHEMA_VARIANT_COLOR.into()),
-            component_type: variant_spec_data.component_type.into(),
-            link: variant_spec_data.link.as_ref().map(|l| l.to_string()),
-            description: None, // XXX - does this exist?
-        };
-
-        Ok(metadata)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PropWidgetDefinition {
-    /// The [`kind`](crate::property_editor::schema::WidgetKind) of the [`Prop`](crate::Prop) to be created.
-    kind: WidgetKind,
-    /// The `Option<Value>` of the [`kind`](crate::property_editor::schema::WidgetKind) to be created.
-    #[serde(default)]
-    options: Option<Value>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MapKeyFunc {
-    pub key: String,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value_from: Option<ValueFrom>,
-}
-
-impl MapKeyFunc {
-    pub fn to_spec(&self, identity_func_unique_id: &str) -> SchemaVariantResult<MapKeyFuncSpec> {
-        let mut builder = MapKeyFuncSpec::builder();
-        builder.func_unique_id(identity_func_unique_id);
-        builder.key(&self.key);
-        if let Some(value_from) = &self.value_from {
-            builder.input(value_from.to_spec());
-        };
-        Ok(builder.build()?)
-    }
-}
-
-/// The definition for a [`Prop`](crate::Prop) in a [`SchemaVariant`](crate::SchemaVariant).
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PropDefinition {
-    /// The name of the [`Prop`](crate::Prop) to be created.
-    pub name: String,
-    /// The [`kind`](crate::PropKind) of the [`Prop`](crate::Prop) to be created.
-    pub kind: PropKind,
-    /// An optional reference to a documentation link in the "doc_links" field for the
-    /// [`SchemaVariantJson`] for the [`Prop`](crate::Prop) to be created.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub doc_link_ref: Option<String>,
-    /// An optional documentation link for the [`Prop`](crate::Prop) to be created.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub doc_link: Option<String>,
-    /// An optional set of inline documentation for the [`Prop`](crate::Prop) to be created.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub documentation: Option<String>,
-    /// If our [`kind`](crate::PropKind) is [`Object`](crate::PropKind::Object), specify the
-    /// child definition(s).
-    #[serde(default)]
-    pub children: Vec<PropDefinition>,
-    /// If our [`kind`](crate::PropKind) is [`Array`](crate::PropKind::Array), specify the entry
-    /// definition.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub entry: Option<Box<PropDefinition>>,
-    /// The [`WidgetDefinition`](crate::schema::variant::definition::PropWidgetDefinition) of the
-    /// [`Prop`](crate::Prop) to be created.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub widget: Option<PropWidgetDefinition>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    // The source of the information for the prop
-    pub value_from: Option<ValueFrom>,
-    // Whether the prop is hidden from the UI
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub hidden: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub validation_format: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub default_value: Option<serde_json::Value>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub map_key_funcs: Option<Vec<MapKeyFunc>>,
-}
-
-impl PropDefinition {
-    pub fn to_spec(&self, identity_func_unique_id: &str) -> SchemaVariantResult<PropSpec> {
-        let mut builder = PropSpec::builder();
-        builder.name(&self.name);
-        builder.kind(self.kind);
-        builder.has_data(true);
-        if let Some(doc_url) = &self.doc_link {
-            builder.try_doc_link(doc_url.as_str())?;
-        }
-        if let Some(docs) = &self.documentation {
-            builder.documentation(docs);
-        }
-        if let Some(default_value) = &self.default_value {
-            builder.default_value(default_value.to_owned());
-        }
-        match self.kind {
-            PropKind::Array | PropKind::Map => {
-                if let Some(entry) = &self.entry {
-                    builder.type_prop(entry.to_spec(identity_func_unique_id)?);
-                }
-            }
-            PropKind::Object => {
-                for child in &self.children {
-                    builder.entry(child.to_spec(identity_func_unique_id)?);
-                }
-            }
-            _ => {}
-        }
-        if let Some(widget) = &self.widget {
-            builder.widget_kind(widget.kind);
-            if let Some(widget_options) = &widget.options {
-                builder.widget_options(widget_options.to_owned());
-            }
-        }
-        if let Some(value_from) = &self.value_from {
-            builder.func_unique_id(identity_func_unique_id);
-            builder.input(value_from.to_spec());
-        }
-        if let Some(hidden) = self.hidden {
-            builder.hidden(hidden);
-        }
-        if let Some(map_key_funcs) = &self.map_key_funcs {
-            for map_key_func in map_key_funcs {
-                builder.map_key_func(map_key_func.to_spec(identity_func_unique_id)?);
-            }
-        }
-
-        Ok(builder.build()?)
-    }
-}
-
-/// The definition for a [`Socket`](crate::Socket) in a [`SchemaVariant`](crate::SchemaVariant).
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SocketDefinition {
-    /// The name of the [`Socket`](crate::Socket) to be created.
-    pub name: String,
-    /// The type identifier of the [`Socket`](crate::Socket) to be created.
-    pub connection_annotations: String,
-    /// The [`arity`](https://en.wikipedia.org/wiki/Arity) of the [`Socket`](crate::Socket).
-    /// Defaults to [`SocketArity::Many`](crate::SocketArity::Many) if nothing is provided.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub arity: Option<SocketArity>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ui_hidden: Option<bool>,
-    // The source of the information for the socket
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value_from: Option<ValueFrom>,
-}
-
-impl SocketDefinition {
-    pub fn to_spec(
-        &self,
-        is_input: bool,
-        identity_func_unique_id: &str,
-    ) -> SchemaVariantResult<SocketSpec> {
-        let mut builder = SocketSpec::builder();
-        let mut data_builder = SocketSpecData::builder();
-        builder.name(&self.name);
-        data_builder.name(&self.name);
-        data_builder.connection_annotations(&self.connection_annotations);
-        if is_input {
-            data_builder.kind(SocketSpecKind::Input);
-        } else {
-            data_builder.kind(SocketSpecKind::Output);
-        }
-
-        if let Some(arity) = &self.arity {
-            data_builder.arity(arity);
-        } else {
-            data_builder.arity(SocketSpecArity::Many);
-        }
-        if let Some(hidden) = &self.ui_hidden {
-            data_builder.ui_hidden(*hidden);
-        } else {
-            data_builder.ui_hidden(false);
-        }
-        if let Some(value_from) = &self.value_from {
-            data_builder.func_unique_id(identity_func_unique_id);
-            builder.input(value_from.to_spec());
-        }
-        builder.data(data_builder.build()?);
-
-        Ok(builder.build()?)
-    }
-}
-
-/// The definition for the source of the information for a prop or a socket in a [`SchemaVariant`](crate::SchemaVariant).
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(tag = "kind", rename_all = "camelCase")]
-pub enum ValueFrom {
-    InputSocket { socket_name: String },
-    OutputSocket { socket_name: String },
-    Prop { prop_path: Vec<String> },
-}
-
-impl ValueFrom {
-    fn to_spec(&self) -> AttrFuncInputSpec {
-        match self {
-            ValueFrom::InputSocket { socket_name } => AttrFuncInputSpec::InputSocket {
-                name: "identity".to_string(),
-                socket_name: socket_name.to_owned(),
-                unique_id: None,
-                deleted: false,
-            },
-            ValueFrom::Prop { prop_path } => AttrFuncInputSpec::Prop {
-                name: "identity".to_string(),
-                prop_path: PropPath::new(prop_path).into(),
-                unique_id: None,
-                deleted: false,
-            },
-            ValueFrom::OutputSocket { socket_name } => AttrFuncInputSpec::OutputSocket {
-                name: "identity".to_string(),
-                socket_name: socket_name.to_owned(),
-                unique_id: None,
-                deleted: false,
-            },
-        }
-    }
-}
-
-/// The definition for the source of the data for prop under "/root/"si" in a [`SchemaVariant`](crate::SchemaVariant).
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SiPropValueFrom {
-    kind: SiPropFuncSpecKind,
-    value_from: ValueFrom,
-}
-
-impl SiPropValueFrom {
-    fn to_spec(&self, identity_func_unique_id: &str) -> SiPropFuncSpec {
-        SiPropFuncSpec {
-            kind: self.kind,
-            func_unique_id: identity_func_unique_id.to_owned(),
-            inputs: vec![self.value_from.to_spec()],
-            unique_id: None,
-            deleted: false,
-        }
-    }
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct SchemaVariantMetadataView {
-    id: SchemaVariantId,
-    name: String,
-    category: String,
-    #[serde(alias = "display_name")]
-    display_name: Option<String>,
-    color: String,
-    component_type: ComponentType,
-    link: Option<String>,
-    description: Option<String>,
-    #[serde(flatten)]
-    timestamp: Timestamp,
-}
-
-impl SchemaVariantMetadataView {
-    pub async fn list(ctx: &DalContext) -> SchemaVariantResult<Vec<Self>> {
-        let mut views = Vec::new();
-
-        let schemas = Schema::list(ctx).await?;
-        for schema in schemas {
-            let default_schema_variant =
-                SchemaVariant::get_default_for_schema(ctx, schema.id()).await?;
-            views.push(SchemaVariantMetadataView {
-                id: default_schema_variant.id,
-                name: schema.name.to_owned(),
-                category: default_schema_variant.category.to_owned(),
-                color: default_schema_variant.get_color(ctx).await?,
-                timestamp: default_schema_variant.timestamp.to_owned(),
-                component_type: default_schema_variant
-                    .get_type(ctx)
+        for node_id in workspace_snapshot
+            .incoming_sources_for_edge_weight_kind(
+                func_id,
+                EdgeWeightKindDiscriminants::AuthenticationPrototype,
+            )
+            .await?
+        {
+            schema_variant_ids.push(
+                workspace_snapshot
+                    .get_node_weight(node_id)
                     .await?
-                    .unwrap_or(ComponentType::Component),
-                link: default_schema_variant.link.to_owned(),
-                description: default_schema_variant.description,
-                display_name: default_schema_variant.display_name,
-            })
+                    .id()
+                    .into(),
+            )
         }
 
-        Ok(views)
+        Ok(schema_variant_ids)
+    }
+
+    /// List all [`SchemaVariantIds`](SchemaVariant) for the provided [action](FuncKind::Action)
+    /// [`Func`].
+    pub async fn list_for_action_func(
+        ctx: &DalContext,
+        func_id: FuncId,
+    ) -> SchemaVariantResult<Vec<SchemaVariantId>> {
+        let workspace_snapshot = ctx.workspace_snapshot()?;
+
+        // First, collect all the action prototypes using the func.
+        let mut action_prototype_raw_ids = Vec::new();
+        for node_index in workspace_snapshot
+            .incoming_sources_for_edge_weight_kind(func_id, EdgeWeightKindDiscriminants::Use)
+            .await?
+        {
+            let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
+
+            if let Some(ContentAddressDiscriminants::ActionPrototype) =
+                node_weight.content_address_discriminants()
+            {
+                action_prototype_raw_ids.push(node_weight.id());
+            }
+        }
+
+        // Second, collect all the schema variants using the action prototype.
+        let mut schema_variant_ids = Vec::new();
+        for action_prototype_raw_id in action_prototype_raw_ids {
+            for node_index in workspace_snapshot
+                .incoming_sources_for_edge_weight_kind(
+                    action_prototype_raw_id,
+                    EdgeWeightKindDiscriminants::ActionPrototype,
+                )
+                .await?
+            {
+                let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
+
+                if let Some(ContentAddressDiscriminants::SchemaVariant) =
+                    node_weight.content_address_discriminants()
+                {
+                    schema_variant_ids.push(node_weight.id().into());
+                }
+            }
+        }
+
+        Ok(schema_variant_ids)
     }
 }

--- a/lib/dal/src/schema/variant/json.rs
+++ b/lib/dal/src/schema/variant/json.rs
@@ -1,0 +1,367 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use si_pkg::{
+    MapKeyFuncSpec, PropSpec, SchemaSpec, SchemaSpecData, SchemaVariantSpec, SchemaVariantSpecData,
+    SocketSpec, SocketSpecArity, SocketSpecData, SocketSpecKind,
+};
+use std::collections::HashMap;
+
+use crate::property_editor::schema::WidgetKind;
+use crate::schema::variant::value_from::SiPropValueFrom;
+use crate::schema::variant::{SchemaVariantResult, ValueFrom, DEFAULT_SCHEMA_VARIANT_COLOR};
+use crate::{ComponentType, PropKind, SchemaVariantError, SocketArity};
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaVariantMetadataJson {
+    /// Name for this variant. Actually, this is the name for this [`Schema`](crate::Schema), we're
+    /// punting on the issue of multiple variants for the moment.
+    pub name: String,
+    /// Override for the UI name for this schema
+    #[serde(alias = "menu_name")]
+    pub menu_name: Option<String>,
+    /// The category this schema variant belongs to
+    pub category: String,
+    /// The color for the component on the component diagram as a hex string
+    pub color: String,
+    #[serde(alias = "component_type")]
+    pub component_type: ComponentType,
+    pub link: Option<String>,
+    pub description: Option<String>,
+}
+
+impl SchemaVariantMetadataJson {
+    pub fn to_spec(&self, variant: SchemaVariantSpec) -> SchemaVariantResult<SchemaSpec> {
+        let mut builder = SchemaSpec::builder();
+        builder.name(&self.name);
+        let mut data_builder = SchemaSpecData::builder();
+        data_builder.name(&self.name);
+        data_builder.category(&self.category);
+        if let Some(menu_name) = &self.menu_name {
+            data_builder.category_name(menu_name.as_str());
+        }
+        builder.data(data_builder.build()?);
+        builder.variant(variant);
+
+        Ok(builder.build()?)
+    }
+}
+
+/// The json definition for a [`SchemaVariant`](crate::SchemaVariant)'s [`Prop`](crate::Prop) tree (and
+/// more in the future).
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaVariantJson {
+    /// The immediate child [`Props`](crate::Prop) underneath "/root/domain".
+    #[serde(default)]
+    pub props: Vec<PropDefinition>,
+    /// The immediate child [`Props`](crate::Prop) underneath "/root/secrets".
+    #[serde(default)]
+    pub secret_props: Vec<PropDefinition>,
+    /// The immediate child [`Props`](crate::Prop) underneath "/root/secretsDefinition".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret_definition: Option<Vec<PropDefinition>>,
+    /// The immediate child [`Props`](crate::Prop) underneath "/root/resource_value".
+    #[serde(default)]
+    pub resource_props: Vec<PropDefinition>,
+    /// Identity relationships for [`Props`](crate::Prop) underneath "/root/si".
+    #[serde(default)]
+    pub si_prop_value_froms: Vec<SiPropValueFrom>,
+
+    /// The input [`Sockets`](crate::Socket) and created for the [`variant`](crate::SchemaVariant).
+    #[serde(default)]
+    pub input_sockets: Vec<SocketDefinition>,
+    /// The output [`Sockets`](crate::Socket) and created for the [`variant`](crate::SchemaVariant).
+    #[serde(default)]
+    pub output_sockets: Vec<SocketDefinition>,
+    /// A map of documentation links to reference. To reference links (values) specify the key via
+    /// the "doc_link_ref" field for a [`PropDefinition`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doc_links: Option<HashMap<String, String>>,
+}
+
+impl SchemaVariantJson {
+    pub fn to_spec(
+        &self,
+        metadata: SchemaVariantMetadataJson,
+        identity_func_unique_id: &str,
+        asset_func_spec_unique_id: &str,
+    ) -> SchemaVariantResult<SchemaVariantSpec> {
+        let mut builder = SchemaVariantSpec::builder();
+        let name = "v0";
+        builder.name(name);
+
+        let mut data_builder = SchemaVariantSpecData::builder();
+
+        data_builder.name(name);
+        data_builder.color(metadata.color);
+        data_builder.component_type(metadata.component_type);
+        if let Some(link) = metadata.link {
+            data_builder.try_link(link.as_str())?;
+        }
+
+        data_builder.func_unique_id(asset_func_spec_unique_id);
+        builder.data(data_builder.build()?);
+
+        for si_prop_value_from in &self.si_prop_value_froms {
+            builder.si_prop_func(si_prop_value_from.to_spec(identity_func_unique_id));
+        }
+        for prop in &self.props {
+            builder.domain_prop(prop.to_spec(identity_func_unique_id)?);
+        }
+        for prop in &self.secret_props {
+            builder.secret_prop(prop.to_spec(identity_func_unique_id)?);
+        }
+        if let Some(props) = &self.secret_definition {
+            for prop in props {
+                builder.secret_definition_prop(prop.to_spec(identity_func_unique_id)?);
+            }
+        }
+        for resource_prop in &self.resource_props {
+            builder.resource_value_prop(resource_prop.to_spec(identity_func_unique_id)?);
+        }
+        for input_socket in &self.input_sockets {
+            builder.socket(input_socket.to_spec(true, identity_func_unique_id)?);
+        }
+        for output_socket in &self.output_sockets {
+            builder.socket(output_socket.to_spec(false, identity_func_unique_id)?);
+        }
+
+        Ok(builder.build()?)
+    }
+
+    pub fn metadata_from_spec(
+        schema_spec: SchemaSpec,
+    ) -> SchemaVariantResult<SchemaVariantMetadataJson> {
+        let schema_data = schema_spec.data.unwrap_or(SchemaSpecData {
+            name: schema_spec.name.to_owned(),
+            default_schema_variant: None,
+            category: "".into(),
+            category_name: None,
+            ui_hidden: false,
+        });
+
+        let default_variant_spec = match schema_data.default_schema_variant {
+            Some(default_variant_unique_id) => schema_spec
+                .variants
+                .iter()
+                .find(|variant| variant.unique_id.as_deref() == Some(&default_variant_unique_id))
+                .ok_or(SchemaVariantError::DefaultVariantNotFound(
+                    default_variant_unique_id,
+                ))?,
+            None => schema_spec
+                .variants
+                .last()
+                .ok_or(SchemaVariantError::NoVariants)?,
+        };
+
+        let variant_spec_data =
+            default_variant_spec
+                .data
+                .to_owned()
+                .unwrap_or(SchemaVariantSpecData {
+                    name: "v0".into(),
+                    color: None,
+                    link: None,
+                    component_type: si_pkg::SchemaVariantSpecComponentType::Component,
+                    func_unique_id: "0".into(),
+                });
+
+        let metadata = SchemaVariantMetadataJson {
+            name: schema_spec.name,
+            menu_name: schema_data.category_name,
+            category: schema_data.category,
+            color: variant_spec_data
+                .color
+                .to_owned()
+                .unwrap_or(DEFAULT_SCHEMA_VARIANT_COLOR.into()),
+            component_type: variant_spec_data.component_type.into(),
+            link: variant_spec_data.link.as_ref().map(|l| l.to_string()),
+            description: None, // XXX - does this exist?
+        };
+
+        Ok(metadata)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PropWidgetDefinition {
+    /// The [`kind`](crate::property_editor::schema::WidgetKind) of the [`Prop`](crate::Prop) to be created.
+    kind: WidgetKind,
+    /// The `Option<Value>` of the [`kind`](crate::property_editor::schema::WidgetKind) to be created.
+    #[serde(default)]
+    options: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MapKeyFunc {
+    pub key: String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value_from: Option<ValueFrom>,
+}
+
+impl MapKeyFunc {
+    pub fn to_spec(&self, identity_func_unique_id: &str) -> SchemaVariantResult<MapKeyFuncSpec> {
+        let mut builder = MapKeyFuncSpec::builder();
+        builder.func_unique_id(identity_func_unique_id);
+        builder.key(&self.key);
+        if let Some(value_from) = &self.value_from {
+            builder.input(value_from.to_spec());
+        };
+        Ok(builder.build()?)
+    }
+}
+
+/// The definition for a [`Prop`](crate::Prop) in a [`SchemaVariant`](crate::SchemaVariant).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PropDefinition {
+    /// The name of the [`Prop`](crate::Prop) to be created.
+    pub name: String,
+    /// The [`kind`](crate::PropKind) of the [`Prop`](crate::Prop) to be created.
+    pub kind: PropKind,
+    /// An optional reference to a documentation link in the "doc_links" field for the
+    /// [`SchemaVariantJson`] for the [`Prop`](crate::Prop) to be created.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doc_link_ref: Option<String>,
+    /// An optional documentation link for the [`Prop`](crate::Prop) to be created.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doc_link: Option<String>,
+    /// An optional set of inline documentation for the [`Prop`](crate::Prop) to be created.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub documentation: Option<String>,
+    /// If our [`kind`](crate::PropKind) is [`Object`](crate::PropKind::Object), specify the
+    /// child definition(s).
+    #[serde(default)]
+    pub children: Vec<PropDefinition>,
+    /// If our [`kind`](crate::PropKind) is [`Array`](crate::PropKind::Array), specify the entry
+    /// definition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entry: Option<Box<PropDefinition>>,
+    /// The [`WidgetDefinition`](crate::schema::variant::json::PropWidgetDefinition) of the
+    /// [`Prop`](crate::Prop) to be created.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub widget: Option<PropWidgetDefinition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    // The source of the information for the prop
+    pub value_from: Option<ValueFrom>,
+    // Whether the prop is hidden from the UI
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hidden: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation_format: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_value: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub map_key_funcs: Option<Vec<MapKeyFunc>>,
+}
+
+impl PropDefinition {
+    pub fn to_spec(&self, identity_func_unique_id: &str) -> SchemaVariantResult<PropSpec> {
+        let mut builder = PropSpec::builder();
+        builder.name(&self.name);
+        builder.kind(self.kind);
+        builder.has_data(true);
+        if let Some(doc_url) = &self.doc_link {
+            builder.try_doc_link(doc_url.as_str())?;
+        }
+        if let Some(docs) = &self.documentation {
+            builder.documentation(docs);
+        }
+        if let Some(default_value) = &self.default_value {
+            builder.default_value(default_value.to_owned());
+        }
+        match self.kind {
+            PropKind::Array | PropKind::Map => {
+                if let Some(entry) = &self.entry {
+                    builder.type_prop(entry.to_spec(identity_func_unique_id)?);
+                }
+            }
+            PropKind::Object => {
+                for child in &self.children {
+                    builder.entry(child.to_spec(identity_func_unique_id)?);
+                }
+            }
+            _ => {}
+        }
+        if let Some(widget) = &self.widget {
+            builder.widget_kind(widget.kind);
+            if let Some(widget_options) = &widget.options {
+                builder.widget_options(widget_options.to_owned());
+            }
+        }
+        if let Some(value_from) = &self.value_from {
+            builder.func_unique_id(identity_func_unique_id);
+            builder.input(value_from.to_spec());
+        }
+        if let Some(hidden) = self.hidden {
+            builder.hidden(hidden);
+        }
+        if let Some(map_key_funcs) = &self.map_key_funcs {
+            for map_key_func in map_key_funcs {
+                builder.map_key_func(map_key_func.to_spec(identity_func_unique_id)?);
+            }
+        }
+
+        Ok(builder.build()?)
+    }
+}
+
+/// The definition for a [`Socket`](crate::Socket) in a [`SchemaVariant`](crate::SchemaVariant).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SocketDefinition {
+    /// The name of the [`Socket`](crate::Socket) to be created.
+    pub name: String,
+    /// The type identifier of the [`Socket`](crate::Socket) to be created.
+    pub connection_annotations: String,
+    /// The [`arity`](https://en.wikipedia.org/wiki/Arity) of the [`Socket`](crate::Socket).
+    /// Defaults to [`SocketArity::Many`](crate::SocketArity::Many) if nothing is provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arity: Option<SocketArity>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ui_hidden: Option<bool>,
+    // The source of the information for the socket
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value_from: Option<ValueFrom>,
+}
+
+impl SocketDefinition {
+    pub fn to_spec(
+        &self,
+        is_input: bool,
+        identity_func_unique_id: &str,
+    ) -> SchemaVariantResult<SocketSpec> {
+        let mut builder = SocketSpec::builder();
+        let mut data_builder = SocketSpecData::builder();
+        builder.name(&self.name);
+        data_builder.name(&self.name);
+        data_builder.connection_annotations(&self.connection_annotations);
+        if is_input {
+            data_builder.kind(SocketSpecKind::Input);
+        } else {
+            data_builder.kind(SocketSpecKind::Output);
+        }
+
+        if let Some(arity) = &self.arity {
+            data_builder.arity(arity);
+        } else {
+            data_builder.arity(SocketSpecArity::Many);
+        }
+        if let Some(hidden) = &self.ui_hidden {
+            data_builder.ui_hidden(*hidden);
+        } else {
+            data_builder.ui_hidden(false);
+        }
+        if let Some(value_from) = &self.value_from {
+            data_builder.func_unique_id(identity_func_unique_id);
+            builder.input(value_from.to_spec());
+        }
+        builder.data(data_builder.build()?);
+
+        Ok(builder.build()?)
+    }
+}

--- a/lib/dal/src/schema/variant/metadata_view.rs
+++ b/lib/dal/src/schema/variant/metadata_view.rs
@@ -1,0 +1,48 @@
+use serde::{Deserialize, Serialize};
+
+use crate::schema::variant::SchemaVariantResult;
+use crate::{ComponentType, DalContext, Schema, SchemaVariant, SchemaVariantId, Timestamp};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaVariantMetadataView {
+    id: SchemaVariantId,
+    name: String,
+    category: String,
+    #[serde(alias = "display_name")]
+    display_name: Option<String>,
+    color: String,
+    component_type: ComponentType,
+    link: Option<String>,
+    description: Option<String>,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+}
+
+impl SchemaVariantMetadataView {
+    pub async fn list(ctx: &DalContext) -> SchemaVariantResult<Vec<Self>> {
+        let mut views = Vec::new();
+
+        let schemas = Schema::list(ctx).await?;
+        for schema in schemas {
+            let default_schema_variant =
+                SchemaVariant::get_default_for_schema(ctx, schema.id()).await?;
+            views.push(SchemaVariantMetadataView {
+                id: default_schema_variant.id,
+                name: schema.name.to_owned(),
+                category: default_schema_variant.category.to_owned(),
+                color: default_schema_variant.get_color(ctx).await?,
+                timestamp: default_schema_variant.timestamp.to_owned(),
+                component_type: default_schema_variant
+                    .get_type(ctx)
+                    .await?
+                    .unwrap_or(ComponentType::Component),
+                link: default_schema_variant.link.to_owned(),
+                description: default_schema_variant.description,
+                display_name: default_schema_variant.display_name,
+            })
+        }
+
+        Ok(views)
+    }
+}

--- a/lib/dal/src/schema/variant/value_from.rs
+++ b/lib/dal/src/schema/variant/value_from.rs
@@ -1,0 +1,58 @@
+use serde::{Deserialize, Serialize};
+use si_pkg::{AttrFuncInputSpec, SiPropFuncSpec, SiPropFuncSpecKind};
+
+use crate::prop::PropPath;
+
+/// The definition for the source of the information for a prop or a socket in a [`SchemaVariant`](crate::SchemaVariant).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ValueFrom {
+    InputSocket { socket_name: String },
+    OutputSocket { socket_name: String },
+    Prop { prop_path: Vec<String> },
+}
+
+impl ValueFrom {
+    pub fn to_spec(&self) -> AttrFuncInputSpec {
+        match self {
+            ValueFrom::InputSocket { socket_name } => AttrFuncInputSpec::InputSocket {
+                name: "identity".to_string(),
+                socket_name: socket_name.to_owned(),
+                unique_id: None,
+                deleted: false,
+            },
+            ValueFrom::Prop { prop_path } => AttrFuncInputSpec::Prop {
+                name: "identity".to_string(),
+                prop_path: PropPath::new(prop_path).into(),
+                unique_id: None,
+                deleted: false,
+            },
+            ValueFrom::OutputSocket { socket_name } => AttrFuncInputSpec::OutputSocket {
+                name: "identity".to_string(),
+                socket_name: socket_name.to_owned(),
+                unique_id: None,
+                deleted: false,
+            },
+        }
+    }
+}
+
+/// The definition for the source of the data for prop under "/root/"si" in a [`SchemaVariant`](crate::SchemaVariant).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SiPropValueFrom {
+    kind: SiPropFuncSpecKind,
+    value_from: ValueFrom,
+}
+
+impl SiPropValueFrom {
+    pub fn to_spec(&self, identity_func_unique_id: &str) -> SiPropFuncSpec {
+        SiPropFuncSpec {
+            kind: self.kind,
+            func_unique_id: identity_func_unique_id.to_owned(),
+            inputs: vec![self.value_from.to_spec()],
+            unique_id: None,
+            deleted: false,
+        }
+    }
+}

--- a/lib/dal/tests/integration_test/func/associations.rs
+++ b/lib/dal/tests/integration_test/func/associations.rs
@@ -1,8 +1,141 @@
+use dal::func::argument::{FuncArgument, FuncArgumentKind};
+use dal::func::view::FuncArgumentView;
 use dal::func::FuncAssociations;
 use dal::schema::variant::leaves::LeafInputLocation;
 use dal::{DalContext, Func, Schema};
 use dal_test::test;
 use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn for_action(ctx: &mut DalContext) {
+    let schema = Schema::find_by_name(ctx, "swifty")
+        .await
+        .expect("could not perform find by name")
+        .expect("no schema found");
+    let schema_variant_id = schema
+        .get_default_schema_variant(ctx)
+        .await
+        .expect("could not perform get default schema variant")
+        .expect("default schema variant not found");
+
+    let func_id = Func::find_by_name(ctx, "test:createActionSwifty")
+        .await
+        .expect("could not perform find func by name")
+        .expect("func not found");
+    let func = Func::get_by_id_or_error(ctx, func_id)
+        .await
+        .expect("could not get func by id");
+    let (associations, _input_type) = FuncAssociations::from_func(ctx, &func)
+        .await
+        .expect("could not get associations");
+
+    assert_eq!(
+        FuncAssociations::Action {
+            schema_variant_ids: vec![schema_variant_id],
+        }, // expected
+        associations.expect("no associations found") // actual
+    );
+}
+
+#[test]
+async fn for_attribute(ctx: &mut DalContext) {
+    let func_id = Func::find_by_name(ctx, "test:falloutEntriesToGalaxies")
+        .await
+        .expect("could not perform find func by name")
+        .expect("func not found");
+    let func = Func::get_by_id_or_error(ctx, func_id)
+        .await
+        .expect("could not get func by id");
+    let (associations, _input_type) = FuncAssociations::from_func(ctx, &func)
+        .await
+        .expect("could not get associations");
+
+    // Find the sole func argument id. Ensure there is only one.
+    let mut func_argument_ids = FuncArgument::list_ids_for_func(ctx, func_id)
+        .await
+        .expect("could not list func argument ids");
+    let func_argument_id = func_argument_ids
+        .pop()
+        .expect("func argument ids are empty");
+    assert!(func_argument_ids.is_empty());
+
+    assert_eq!(
+        FuncAssociations::Attribute {
+            prototypes: vec![],
+            arguments: vec![FuncArgumentView {
+                id: func_argument_id,
+                name: "entries".to_string(),
+                kind: FuncArgumentKind::Array,
+                element_kind: Some(FuncArgumentKind::Object),
+            }],
+        }, // expected
+        associations.expect("no associations found") // actual
+    );
+}
+
+#[test]
+async fn for_authentication(ctx: &mut DalContext) {
+    let schema = Schema::find_by_name(ctx, "dummy-secret")
+        .await
+        .expect("could not perform find by name")
+        .expect("no schema found");
+    let schema_variant_id = schema
+        .get_default_schema_variant(ctx)
+        .await
+        .expect("could not perform get default schema variant")
+        .expect("default schema variant not found");
+
+    let func_id = Func::find_by_name(ctx, "test:setDummySecretString")
+        .await
+        .expect("could not perform find func by name")
+        .expect("func not found");
+    let func = Func::get_by_id_or_error(ctx, func_id)
+        .await
+        .expect("could not get func by id");
+    let (associations, _input_type) = FuncAssociations::from_func(ctx, &func)
+        .await
+        .expect("could not get associations");
+
+    assert_eq!(
+        FuncAssociations::Authentication {
+            schema_variant_ids: vec![schema_variant_id],
+        }, // expected
+        associations.expect("no associations found") // actual
+    );
+}
+
+#[test]
+async fn for_code_generation(ctx: &mut DalContext) {
+    let schema = Schema::find_by_name(ctx, "katy perry")
+        .await
+        .expect("could not perform find by name")
+        .expect("no schema found");
+    let schema_variant_id = schema
+        .get_default_schema_variant(ctx)
+        .await
+        .expect("could not perform get default schema variant")
+        .expect("default schema variant not found");
+
+    let func_id = Func::find_by_name(ctx, "test:generateStringCode")
+        .await
+        .expect("could not perform find func by name")
+        .expect("func not found");
+    let func = Func::get_by_id_or_error(ctx, func_id)
+        .await
+        .expect("could not get func by id");
+    let (associations, _input_type) = FuncAssociations::from_func(ctx, &func)
+        .await
+        .expect("could not get associations");
+
+    assert_eq!(
+        FuncAssociations::CodeGeneration {
+            schema_variant_ids: vec![schema_variant_id],
+            component_ids: vec![],
+            inputs: vec![LeafInputLocation::Domain]
+        }, // expected
+        associations.expect("no associations found") // actual
+    );
+}
 
 #[test]
 async fn for_qualification(ctx: &mut DalContext) {


### PR DESCRIPTION
## Description

This PR restores func associations for actions. In addition, it refactors the schema variant domain to make the core module easier to navigate. That was fueled by listing schema variants for auth funcs moving to the `SchemaVariant` impl as well as the addition of a new function to list schema variants for action funcs.

This PR also includes an integration test for each association. They're non-comprehensive, but are a step in the right direction.

<img src="https://media4.giphy.com/media/6rdMX8uL9NaawLhX96/giphy.gif"/>