### PR TITLE
Ignore deleted values in DVU

### DIFF
--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -1,5 +1,6 @@
 use petgraph::prelude::*;
 use std::collections::{hash_map::Entry, HashMap, VecDeque};
+use telemetry::prelude::*;
 use tokio::{fs::File, io::AsyncWriteExt};
 use ulid::Ulid;
 
@@ -51,8 +52,24 @@ impl DependentValueGraph {
         > = HashMap::new();
         let mut dependent_value_graph = Self::new();
 
+        let workspace_snapshot = ctx.workspace_snapshot()?;
+
         let mut work_queue = VecDeque::from_iter(values);
         while let Some(current_attribute_value_id) = work_queue.pop_front() {
+            // It's possible that one or more of the initial AttributeValueIds provided by the enqueued DependentValuesUpdate job
+            // may have been removed from the snapshot between when the DVU job was created and when we're processing
+            // things now. This could happen if there are other modifications to the snapshot before the DVU job starts
+            // executing, as the job always operates on the current state of the change set's snapshot, not the state at the time
+            // the job was created.
+            if workspace_snapshot
+                .try_get_node_index_by_id(current_attribute_value_id)
+                .await?
+                .is_none()
+            {
+                debug!("Attribute Value {current_attribute_value_id} missing, skipping it in DependentValueGraph");
+                continue;
+            }
+
             let current_component_id =
                 AttributeValue::component_id(ctx, current_attribute_value_id).await?;
 

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -521,6 +521,14 @@ impl WorkspaceSnapshot {
     }
 
     #[instrument(level = "debug", skip_all)]
+    pub async fn try_get_node_index_by_id(
+        &self,
+        id: impl Into<Ulid>,
+    ) -> WorkspaceSnapshotResult<Option<NodeIndex>> {
+        Ok(self.working_copy().await.try_get_node_index_by_id(id)?)
+    }
+
+    #[instrument(level = "debug", skip_all)]
     pub async fn get_latest_node_index(
         &self,
         node_index: NodeIndex,

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -1227,6 +1227,16 @@ impl WorkspaceSnapshotGraph {
             .ok_or(WorkspaceSnapshotGraphError::NodeWithIdNotFound(id))
     }
 
+    #[inline(always)]
+    pub(crate) fn try_get_node_index_by_id(
+        &self,
+        id: impl Into<Ulid>,
+    ) -> WorkspaceSnapshotGraphResult<Option<NodeIndex>> {
+        let id = id.into();
+
+        Ok(self.node_index_by_id.get(&id).copied())
+    }
+
     fn get_node_index_by_lineage(&self, lineage_id: Ulid) -> HashSet<NodeIndex> {
         self.node_indices_by_lineage_id
             .get(&lineage_id)


### PR DESCRIPTION
Ideally we should be dequeueing values that don't exist, but that's a can of worms since we can't ensure it will happen, as removing some edge may delete something because it gets garbage collected.

This should be ok, and not hide any bugs, and the warning is there so we can be informed of further consequence. Right now it will pretty much only happen in tests and copy pasting.

If the warning gets too verbose, we can remove it, or downgrade to a debug statement, but let's see how it behaves first.