### PR TITLE
Add Function Execution DB 

### DIFF
--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 use crate::{EncryptedSecret, Workspace};
 
-pub type DalLayerDb = LayerDb<ContentTypes, EncryptedSecret, WorkspaceSnapshotGraph>;
+pub type DalLayerDb = LayerDb<ContentTypes, EncryptedSecret, String, WorkspaceSnapshotGraph>;
 
 /// A context type which contains handles to common core service dependencies.
 ///

--- a/lib/si-events-rs/src/function_execution.rs
+++ b/lib/si-events-rs/src/function_execution.rs
@@ -1,0 +1,30 @@
+use std::str::FromStr;
+
+use ulid::Ulid;
+
+#[derive(Eq, PartialEq, Hash, Clone, Debug)]
+pub struct FunctionExecutionKey {
+    value: String,
+}
+
+impl FunctionExecutionKey {
+    pub fn new(component_id: Ulid, prototype_id: Ulid, action_id: Ulid) -> Self {
+        Self {
+            value: format!("{}{}{}", component_id, prototype_id, action_id),
+        }
+    }
+
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+impl FromStr for FunctionExecutionKey {
+    type Err = ulid::DecodeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self {
+            value: String::from(s),
+        })
+    }
+}

--- a/lib/si-events-rs/src/function_execution.rs
+++ b/lib/si-events-rs/src/function_execution.rs
@@ -1,8 +1,8 @@
-use std::str::FromStr;
+use std::{str::FromStr, string::ParseError};
 
 use ulid::Ulid;
 
-#[derive(Eq, PartialEq, Hash, Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct FunctionExecutionKey {
     value: String,
 }
@@ -20,7 +20,7 @@ impl FunctionExecutionKey {
 }
 
 impl FromStr for FunctionExecutionKey {
-    type Err = ulid::DecodeError;
+    type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self {

--- a/lib/si-events-rs/src/lib.rs
+++ b/lib/si-events-rs/src/lib.rs
@@ -6,13 +6,14 @@ pub mod xxhash_type;
 mod actor;
 mod cas;
 mod encrypted_secret;
+mod function_execution;
 mod tenancy;
 pub mod ulid;
 mod web_event;
 
 pub use crate::{
     actor::Actor, actor::UserPk, cas::CasValue, content_hash::ContentHash,
-    encrypted_secret::EncryptedSecretKey, tenancy::ChangeSetId, tenancy::Tenancy,
-    tenancy::WorkspacePk, web_event::WebEvent,
+    encrypted_secret::EncryptedSecretKey, function_execution::FunctionExecutionKey,
+    tenancy::ChangeSetId, tenancy::Tenancy, tenancy::WorkspacePk, web_event::WebEvent,
     workspace_snapshot_address::WorkspaceSnapshotAddress,
 };

--- a/lib/si-layer-cache/src/db.rs
+++ b/lib/si-layer-cache/src/db.rs
@@ -24,8 +24,8 @@ use self::{
 mod cache_updates;
 pub mod cas;
 pub mod encrypted_secret;
-pub mod serialize;
 pub mod function_execution;
+pub mod serialize;
 pub mod workspace_snapshot;
 
 #[derive(Debug, Clone)]

--- a/lib/si-layer-cache/src/db.rs
+++ b/lib/si-layer-cache/src/db.rs
@@ -16,23 +16,29 @@ use crate::{
     persister::{PersisterClient, PersisterTask},
 };
 
-use self::{cache_updates::CacheUpdatesTask, cas::CasDb, workspace_snapshot::WorkspaceSnapshotDb};
+use self::{
+    cache_updates::CacheUpdatesTask, cas::CasDb, function_execution::FunctionExecutionDb,
+    workspace_snapshot::WorkspaceSnapshotDb,
+};
 
 mod cache_updates;
 pub mod cas;
 pub mod encrypted_secret;
 pub mod serialize;
+pub mod function_execution;
 pub mod workspace_snapshot;
 
 #[derive(Debug, Clone)]
-pub struct LayerDb<CasValue, EncryptedSecretValue, WorkspaceSnapshotValue>
+pub struct LayerDb<CasValue, EncryptedSecretValue, FunctionExecutionValue, WorkspaceSnapshotValue>
 where
     CasValue: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     EncryptedSecretValue: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
+    FunctionExecutionValue: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     WorkspaceSnapshotValue: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
 {
     cas: CasDb<CasValue>,
     encrypted_secret: EncryptedSecretDb<EncryptedSecretValue>,
+    function_execution: FunctionExecutionDb<FunctionExecutionValue>,
     workspace_snapshot: WorkspaceSnapshotDb<WorkspaceSnapshotValue>,
     pg_pool: PgPool,
     nats_client: NatsClient,
@@ -41,11 +47,12 @@ where
     instance_id: Ulid,
 }
 
-impl<CasValue, EncryptedSecretValue, WorkspaceSnapshotValue>
-    LayerDb<CasValue, EncryptedSecretValue, WorkspaceSnapshotValue>
+impl<CasValue, EncryptedSecretValue, FunctionExecutionValue, WorkspaceSnapshotValue>
+    LayerDb<CasValue, EncryptedSecretValue, FunctionExecutionValue, WorkspaceSnapshotValue>
 where
     CasValue: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     EncryptedSecretValue: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
+    FunctionExecutionValue: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     WorkspaceSnapshotValue: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
 {
     pub async fn initialize(
@@ -68,6 +75,9 @@ where
 
         let encrypted_secret_cache: LayerCache<Arc<EncryptedSecretValue>> =
             LayerCache::new(encrypted_secret::CACHE_NAME, disk_path, pg_pool.clone())?;
+
+        let function_execution_cache: LayerCache<Arc<FunctionExecutionValue>> =
+            LayerCache::new(function_execution::CACHE_NAME, disk_path, pg_pool.clone())?;
 
         let snapshot_cache: LayerCache<Arc<WorkspaceSnapshotValue>> =
             LayerCache::new(workspace_snapshot::CACHE_NAME, disk_path, pg_pool.clone())?;
@@ -97,6 +107,7 @@ where
         let cas = CasDb::new(cas_cache, persister_client.clone());
         let encrypted_secret =
             EncryptedSecretDb::new(encrypted_secret_cache, persister_client.clone());
+        let function_execution = FunctionExecutionDb::new(function_execution_cache);
         let workspace_snapshot = WorkspaceSnapshotDb::new(snapshot_cache, persister_client.clone());
 
         let activity = ActivityClient::new(instance_id, nats_client.clone(), token.clone());
@@ -106,6 +117,7 @@ where
             activity,
             cas,
             encrypted_secret,
+            function_execution,
             workspace_snapshot,
             pg_pool,
             persister_client,
@@ -134,6 +146,10 @@ where
 
     pub fn encrypted_secret(&self) -> &EncryptedSecretDb<EncryptedSecretValue> {
         &self.encrypted_secret
+    }
+
+    pub fn function_execution(&self) -> &FunctionExecutionDb<FunctionExecutionValue> {
+        &self.function_execution
     }
 
     pub fn workspace_snapshot(&self) -> &WorkspaceSnapshotDb<WorkspaceSnapshotValue> {

--- a/lib/si-layer-cache/src/db/function_execution.rs
+++ b/lib/si-layer-cache/src/db/function_execution.rs
@@ -1,0 +1,91 @@
+use std::sync::Arc;
+use std::{collections::HashMap, fmt::Display};
+
+use serde::{de::DeserializeOwned, Serialize};
+use si_events::FunctionExecutionKey;
+
+use crate::{error::LayerDbResult, layer_cache::LayerCache, LayerDbError};
+
+const KEYWORD_SINGULAR: &str = "function_execution";
+const KEYWORD_PLURAL: &str = "function_executions";
+
+pub const PARTITION_KEY: &str = KEYWORD_PLURAL;
+pub const DBNAME: &str = KEYWORD_PLURAL;
+pub const CACHE_NAME: &str = KEYWORD_PLURAL;
+pub const SORT_KEY: &str = KEYWORD_SINGULAR;
+
+#[derive(Debug, Clone)]
+pub struct FunctionExecutionDb<V>
+where
+    V: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
+{
+    pub cache: LayerCache<Arc<V>>,
+}
+
+impl<V> FunctionExecutionDb<V>
+where
+    V: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
+{
+    pub fn new(cache: LayerCache<Arc<V>>) -> Self {
+        FunctionExecutionDb { cache }
+    }
+
+    pub async fn write(&self, key: FunctionExecutionKey, value: Arc<V>) -> LayerDbResult<()> {
+        let postcard_value = postcard::to_stdvec(&value)?;
+
+        self.cache
+            .pg()
+            .insert(key.value(), SORT_KEY, &postcard_value)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn read(&self, key: &FunctionExecutionKey) -> LayerDbResult<Option<Arc<V>>> {
+        match self.cache.pg().get(key.value()).await? {
+            Some(value) => {
+                let deserialized: V = postcard::from_bytes(&value)?;
+                Ok(Some(deserialized.into()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// We often need to extract the value from the arc by cloning it (although
+    /// this should be avoided for large values). This will do that, and also
+    /// helpfully convert the value to the type we want to deal with
+    pub async fn try_read_as<T>(&self, key: &FunctionExecutionKey) -> LayerDbResult<Option<T>>
+    where
+        V: TryInto<T>,
+        <V as TryInto<T>>::Error: Display,
+    {
+        Ok(match self.read(key).await? {
+            None => None,
+            Some(arc_v) => Some(
+                arc_v
+                    .as_ref()
+                    .clone()
+                    .try_into()
+                    .map_err(|err| LayerDbError::ContentConversion(err.to_string()))?,
+            ),
+        })
+    }
+
+    pub async fn read_many(
+        &self,
+        keys: &[Arc<FunctionExecutionKey>],
+    ) -> LayerDbResult<HashMap<FunctionExecutionKey, Arc<V>>> {
+        let mut formatted_keys = vec![];
+        for key in keys {
+            let key_str: Arc<str> = key.value().to_string().into();
+            formatted_keys.push(key_str);
+        }
+        let mut values: HashMap<FunctionExecutionKey, Arc<V>> = HashMap::new();
+        if let Some(found) = self.cache.pg().get_many(&formatted_keys).await? {
+            for (k, v) in found {
+                values.insert(k.parse().unwrap(), postcard::from_bytes(&v)?);
+            }
+        }
+        Ok(values)
+    }
+}

--- a/lib/si-layer-cache/src/migrations/U0004__function_executions.sql
+++ b/lib/si-layer-cache/src/migrations/U0004__function_executions.sql
@@ -1,0 +1,10 @@
+CREATE TABLE function_executions
+(
+    key               text                     NOT NULL PRIMARY KEY,
+    sort_key          text                     NOT NULL,
+    created_at        timestamp with time zone NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    value             bytea                    NOT NULL,
+    serialization_lib text                     NOT NULL DEFAULT 'postcard'
+);
+
+CREATE INDEX IF NOT EXISTS function_executions_sort_key ON function_executions (sort_key);

--- a/lib/si-layer-cache/tests/integration_test/activities.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities.rs
@@ -11,7 +11,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::integration_test::{disk_cache_path, setup_nats_client, setup_pg_db};
 
-type TestLayerDb = LayerDb<Arc<String>, Arc<String>, String>;
+type TestLayerDb = LayerDb<Arc<String>, Arc<String>, String, String>;
 
 #[tokio::test]
 async fn activities() {

--- a/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
@@ -10,7 +10,7 @@ use ulid::Ulid;
 
 use crate::integration_test::{disk_cache_path, setup_nats_client, setup_pg_db};
 
-type TestLayerDb = LayerDb<Arc<String>, Arc<String>, String>;
+type TestLayerDb = LayerDb<Arc<String>, Arc<String>, String, String>;
 
 #[tokio::test]
 async fn subscribe_rebaser_requests_work_queue() {

--- a/lib/si-layer-cache/tests/integration_test/db/cas.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/cas.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::integration_test::{disk_cache_path, setup_nats_client, setup_pg_db};
 
-type TestLayerDb = LayerDb<CasValue, String, String>;
+type TestLayerDb = LayerDb<CasValue, String, String, String>;
 
 #[tokio::test]
 async fn write_to_db() {

--- a/lib/si-layer-cache/tests/integration_test/db/function_execution.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/function_execution.rs
@@ -1,0 +1,91 @@
+use std::sync::Arc;
+
+use si_events::{CasValue, FunctionExecutionKey};
+use si_layer_cache::LayerDb;
+use tokio_util::sync::CancellationToken;
+use ulid::Ulid;
+
+use crate::integration_test::{disk_cache_path, setup_nats_client, setup_pg_db};
+
+type TestLayerDb = LayerDb<CasValue, String, String, String>;
+
+#[tokio::test]
+async fn write_to_db() {
+    let token = CancellationToken::new();
+
+    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
+    let dbfile = disk_cache_path(&tempdir, "mbd");
+    let (ldb, _): (TestLayerDb, _) = LayerDb::initialize(
+        dbfile,
+        setup_pg_db("fe_write_to_db").await,
+        setup_nats_client(Some("fe_write_to_db".to_string())).await,
+        token,
+    )
+    .await
+    .expect("cannot create layerdb");
+    ldb.pg_migrate().await.expect("migrate layer db");
+
+    let key = FunctionExecutionKey::new(Ulid::new(), Ulid::new(), Ulid::new());
+    let value: Arc<String> = Arc::new("go to the light".to_string());
+    ldb.function_execution()
+        .write(key.clone(), value.clone())
+        .await
+        .expect("failed to write to layerdb");
+
+    // Are we in pg?
+    let in_pg = ldb
+        .function_execution()
+        .read(&key)
+        .await
+        .expect("error getting data from pg")
+        .expect("no fe object in pg");
+    assert_eq!(value.as_ref(), in_pg.as_ref());
+}
+
+#[tokio::test]
+async fn write_and_read_many() {
+    let token = CancellationToken::new();
+
+    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
+
+    let dbfile = disk_cache_path(&tempdir, "mbd");
+
+    let (ldb, _): (TestLayerDb, _) = LayerDb::initialize(
+        dbfile,
+        setup_pg_db("fe_write_and_read_many").await,
+        setup_nats_client(Some("fe_write_and_read_many".to_string())).await,
+        token,
+    )
+    .await
+    .expect("cannot create layerdb");
+    ldb.pg_migrate().await.expect("migrate ldb");
+
+    let values: Vec<Arc<String>> = vec![
+        Arc::new("spring break 1989".to_string()),
+        Arc::new("comin home".to_string()),
+        Arc::new("lost river".to_string()),
+        Arc::new("foxglove".to_string()),
+    ];
+
+    let mut keys = vec![];
+
+    for value in &values {
+        let key = FunctionExecutionKey::new(Ulid::new(), Ulid::new(), Ulid::new());
+        keys.push(Arc::new(key.clone()));
+        ldb.function_execution()
+            .write(key.clone(), value.clone())
+            .await
+            .expect("failed to write to layerdb");
+    }
+
+    let read_values = ldb
+        .function_execution()
+        .read_many(keys.as_slice())
+        .await
+        .expect("should be able to read");
+
+    assert_eq!(&read_values.len(), &values.len());
+    for value in read_values.values().collect::<Vec<_>>() {
+        assert!(values.contains(value));
+    }
+}

--- a/lib/si-layer-cache/tests/integration_test/db/mod.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/mod.rs
@@ -1,1 +1,2 @@
 mod cas;
+mod function_execution;

--- a/lib/si-layer-cache/tests/integration_test/layer_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/layer_cache.rs
@@ -157,3 +157,32 @@ async fn get_bulk_from_db() {
         }
     }
 }
+
+#[tokio::test]
+async fn get_last_four_from_database() {
+    let layer_cache = make_layer_cache("get_last_four_from_database").await;
+
+    let values: [Arc<str>; 5] = [
+        "skid row".into(),
+        "kid scrow".into(),
+        "march for macragge".into(),
+        "magnus did nothing wrong".into(),
+        "steppa pig".into(),
+    ];
+
+    for value in &values {
+        let _ = layer_cache
+            .pg()
+            .insert(value, "gettin'", value.as_ref().as_bytes())
+            .await;
+    }
+
+    let get_values = layer_cache
+        .pg()
+        .get_most_recent(4)
+        .await
+        .expect("should get")
+        .expect("should have results");
+
+    assert_eq!(get_values.len(), 4);
+}


### PR DESCRIPTION
This yet another db inside of layer db. What's special about this one is that it only interacts with postgres and does not use the in-memory or on-disk layers at all (so no NATs bits either).  Also, I'm attempting to use an ugly version of a composite key to ensure we can look these executions up from a few different angles. Currently, the key is `component_id + prototype_id + action_id` . This allows us to do lookups for specific actions and lookups for all action executions that ever happened for a given component/prototype. I _think_ there is a cleaner way to do this, so I'm all ears if anyone has thoughts.

Note that this doesn't implement the actual struct that will be stored. That will come next. 

<img src="https://media3.giphy.com/media/Zefws0y8TVoa4JXvbv/giphy.gif"/>

