### PR TITLE
Restore func associations for attribute funcs, fix eventual parent logic and finish wiping provider concept from `app/web`

### DIFF
--- a/app/web/src/api/sdf/dal/diagram.ts
+++ b/app/web/src/api/sdf/dal/diagram.ts
@@ -2,8 +2,6 @@ import * as _ from "lodash-es";
 
 export type DiagramKind = "configuration";
 
-export type DiagramProviderMetadata = string;
-
 export interface DiagramOutputSocket {
   id: string;
   name: string;

--- a/app/web/src/components/AssetFuncAttachModal.vue
+++ b/app/web/src/components/AssetFuncAttachModal.vue
@@ -216,10 +216,10 @@ const attributeOutputLocationParsed = computed<
         type: "prop",
         propId: parsed.propId,
       };
-    } else if ("externalProviderId" in parsed && parsed.externalProviderId) {
+    } else if ("outputSocketId" in parsed && parsed.outputSocketId) {
       return {
         type: "outputSocket",
-        externalProviderId: parsed.externalProviderId,
+        outputSocketId: parsed.outputSocketId,
       };
     }
   }
@@ -349,9 +349,9 @@ const attachToAttributeFunction = (
     {
       id: nilId(),
       propId: "propId" in outputLocation ? outputLocation.propId : undefined,
-      externalProviderId:
-        "externalProviderId" in outputLocation
-          ? outputLocation.externalProviderId
+      outputSocketId:
+        "outputSocketId" in outputLocation
+          ? outputLocation.outputSocketId
           : undefined,
       prototypeArguments: [],
       componentId: undefined,

--- a/app/web/src/components/FuncEditor/AttributeBindings.vue
+++ b/app/web/src/components/FuncEditor/AttributeBindings.vue
@@ -200,9 +200,8 @@ const prototypeViews = computed(() =>
 
       const args = proto.prototypeArguments.map((arg) => ({
         name: funcArgumentsIdMap?.value[arg.funcArgumentId]?.name ?? "none",
-        prop: arg.internalProviderId
-          ? funcStore.internalProviderIdToSourceName(arg.internalProviderId) ??
-            "none"
+        prop: arg.inputSocketId
+          ? funcStore.inputSocketIdToSourceName(arg.inputSocketId) ?? "none"
           : "none",
       }));
 

--- a/app/web/src/components/FuncEditor/AttributeBindingsModal.vue
+++ b/app/web/src/components/FuncEditor/AttributeBindingsModal.vue
@@ -132,15 +132,15 @@ const editedPrototype = computed(() => ({
     "propId" in selectedOutputLocation.value.value
       ? selectedOutputLocation.value.value.propId
       : undefined,
-  externalProviderId:
-    "externalProviderId" in selectedOutputLocation.value.value
-      ? selectedOutputLocation.value.value.externalProviderId
+  outputSocketId:
+    "outputSocketId" in selectedOutputLocation.value.value
+      ? selectedOutputLocation.value.value.outputSocketId
       : undefined,
   prototypeArguments: editableBindings.value.map(
     ({ id, funcArgumentId, binding }) => ({
       id: id ?? nilId(),
       funcArgumentId: funcArgumentId ?? nilId(),
-      internalProviderId: binding.value as string,
+      inputSocketId: binding.value as string,
     }),
   ),
 }));
@@ -176,21 +176,21 @@ const inputSourceOptions = computed<Option[]>(() => {
   const socketOptions =
     funcStore.inputSourceSockets[selectedVariantId]?.map((socket) => ({
       label: `Input Socket: ${socket.name}`,
-      value: socket.internalProviderId,
+      value: socket.inputSocketId,
     })) ?? [];
 
   const propOptions =
     funcStore.inputSourceProps[selectedVariantId]
       ?.filter(
         (prop) =>
-          prop.internalProviderId &&
+          prop.inputSocketId &&
           ("propId" in selectedOutputLocation.value.value
             ? prop.propId !== selectedOutputLocation.value.value.propId
             : true),
       )
       .map((prop) => ({
         label: `Attribute: ${prop.path}${prop.name}`,
-        value: prop.internalProviderId ?? nilId(),
+        value: prop.inputSocketId ?? nilId(),
       })) ?? [];
 
   return socketOptions.concat(propOptions);
@@ -214,9 +214,9 @@ watch(selectedVariant, (selectedVariant) => {
         "propId" in selectedOutputLocation.value.value
           ? selectedOutputLocation.value.value.propId
           : undefined,
-      externalProviderId:
-        "externalProviderId" in selectedOutputLocation.value.value
-          ? selectedOutputLocation.value.value.externalProviderId
+      outputSocketId:
+        "outputSocketId" in selectedOutputLocation.value.value
+          ? selectedOutputLocation.value.value.outputSocketId
           : undefined,
     },
   );
@@ -264,19 +264,18 @@ const open = (prototype: AttributePrototypeView) => {
     outputLocationOptions.value.find(
       (loc) =>
         ("propId" in loc.value && loc.value.propId === prototype.propId) ||
-        ("externalProviderId" in loc.value &&
-          loc.value.externalProviderId === prototype.externalProviderId),
+        ("outputSocketId" in loc.value &&
+          loc.value.outputSocketId === prototype.outputSocketId),
     ) ?? noneOutputLocation;
 
   editableBindings.value =
     prototype?.prototypeArguments.map(
-      ({ id, funcArgumentId, internalProviderId }) => ({
+      ({ id, funcArgumentId, inputSocketId }) => ({
         id: id ?? undefined,
         funcArgumentId,
         binding:
-          inputSourceOptions.value.find(
-            (opt) => opt.value === internalProviderId,
-          ) ?? noneSource,
+          inputSourceOptions.value.find((opt) => opt.value === inputSocketId) ??
+          noneSource,
       }),
     ) ?? [];
 

--- a/app/web/src/components/FuncEditor/FuncTest.vue
+++ b/app/web/src/components/FuncEditor/FuncTest.vue
@@ -369,9 +369,7 @@ const prepareTest = async () => {
     const getJsonPath = () => {
       for (const prototype of prototypes) {
         for (const arg of prototype.prototypeArguments) {
-          const prop = funcStore.propForInternalProviderId(
-            arg.internalProviderId ?? "",
-          );
+          const prop = funcStore.proprForInputSocketId(arg.inputSocketId ?? "");
 
           if (prop) {
             return `${prop.path}${prop.name}`;
@@ -411,40 +409,6 @@ const prepareTest = async () => {
       string,
       unknown
     >;
-
-    testInputCode.value = JSON.stringify(properties, null, 2);
-    testInputProperties.value = properties;
-  } else if (selectedFunc?.associations?.type === "validation") {
-    const prototypes = selectedFunc.associations.prototypes;
-
-    const getJsonPath = () => {
-      for (const prototype of prototypes) {
-        const prop = funcStore.propForId(prototype.propId);
-
-        if (prop) {
-          return `${prop.path}${prop.name}`;
-        }
-      }
-    };
-    const jsonPath = getJsonPath();
-    if (!jsonPath) {
-      // TODO(Wendy) - handle a failure properly instead of just bailing!
-      return;
-    }
-    // We remove the first two strings because they will always be an empty string and "root"
-    const jsonPathArray = jsonPath.split("/").splice(2);
-    let properties: Record<string, unknown> | null = json as Record<
-      string,
-      unknown
-    >;
-
-    for (const key of jsonPathArray) {
-      if (!properties[key]) {
-        properties = null;
-        break;
-      }
-      properties = properties[key] as Record<string, unknown>;
-    }
 
     testInputCode.value = JSON.stringify(properties, null, 2);
     testInputProperties.value = properties;
@@ -520,9 +484,7 @@ const startTest = async () => {
   funcTestTabsRef.value.selectTab("logs");
 
   let args = testInputProperties.value;
-  if (funcStore.selectedFuncDetails.associations?.type === "validation") {
-    args = { value: args };
-  } else if (funcStore.selectedFuncDetails.associations?.type === "action") {
+  if (funcStore.selectedFuncDetails.associations?.type === "action") {
     args = { kind: "standard", properties: args };
   }
 

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -35,20 +35,20 @@ export interface InstalledPkgAssetView {
 
 export type DetachedAttributePrototypeKind =
   | {
-      type: "ExternalProviderSocket";
+      type: "OutputSocketSocket";
       data: {
         name: string;
         kind: "ConfigurationInput" | "ConfigurationOutput";
       };
     }
   | {
-      type: "InternalProviderSocket";
+      type: "InputSocketSocket";
       data: {
         name: string;
         kind: "ConfigurationInput" | "ConfigurationOutput";
       };
     }
-  | { type: "InternalProviderProp"; data: { path: string; kind: PropKind } }
+  | { type: "InputSocketProp"; data: { path: string; kind: PropKind } }
   | { type: "Prop"; data: { path: string; kind: PropKind } };
 
 export interface DetachedAttributePrototype {
@@ -484,8 +484,8 @@ export const useAssetStore = () => {
 
                 for (const detached of detachedAttributePrototypes) {
                   if (
-                    detached.context.type === "ExternalProviderSocket" ||
-                    detached.context.type === "InternalProviderSocket"
+                    detached.context.type === "OutputSocketSocket" ||
+                    detached.context.type === "InputSocketSocket"
                   ) {
                     this.detachmentWarnings.push({
                       funcId: detached.funcId,
@@ -493,7 +493,7 @@ export const useAssetStore = () => {
                       message: `Attribute ${detached.funcName} detached from asset because the property associated to it changed. Socket=${detached.context.data.name} of Kind=${detached.context.data.kind}`,
                     });
                   } else if (
-                    detached.context.type === "InternalProviderProp" ||
+                    detached.context.type === "InputSocketProp" ||
                     detached.context.type === "Prop"
                   ) {
                     this.detachmentWarnings.push({

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -150,12 +150,12 @@ export const useFuncStore = () => {
             return undefined;
           },
 
-        propForInternalProviderId:
+        proprForInputSocketId:
           (state) =>
-          (internalProviderId: string): InputSourceProp | undefined => {
+          (inputSocketId: string): InputSourceProp | undefined => {
             for (const props of Object.values(state.inputSourceProps)) {
               const inputSourceProp = props.find(
-                (prop) => prop.internalProviderId === internalProviderId,
+                (prop) => prop.inputSocketId === inputSocketId,
               );
               if (inputSourceProp) {
                 return inputSourceProp;
@@ -164,12 +164,12 @@ export const useFuncStore = () => {
             return undefined;
           },
 
-        inputSocketForInternalProviderId:
+        inputSocketForInputSocketId:
           (state) =>
-          (internalProviderId: string): InputSourceSocket | undefined => {
+          (inputSocketId: string): InputSourceSocket | undefined => {
             for (const sockets of Object.values(state.inputSourceSockets)) {
               const inputSourceSocket = sockets.find(
-                (socket) => socket.internalProviderId === internalProviderId,
+                (socket) => socket.inputSocketId === inputSocketId,
               );
               if (inputSourceSocket) {
                 return inputSourceSocket;
@@ -180,10 +180,10 @@ export const useFuncStore = () => {
 
         outputSocketForId:
           (state) =>
-          (externalProviderId: string): OutputSocket | undefined => {
+          (outputSocketId: string): OutputSocket | undefined => {
             for (const sockets of Object.values(state.outputSockets)) {
               const outputSocket = sockets.find(
-                (socket) => socket.externalProviderId === externalProviderId,
+                (socket) => socket.outputSocketId === outputSocketId,
               );
               if (outputSocket) {
                 return outputSocket;
@@ -222,14 +222,13 @@ export const useFuncStore = () => {
       },
 
       actions: {
-        internalProviderIdToSourceName(internalProviderId: string) {
-          const socket =
-            this.inputSocketForInternalProviderId(internalProviderId);
+        inputSocketIdToSourceName(inputSocketId: string) {
+          const socket = this.inputSocketForInputSocketId(inputSocketId);
           if (socket) {
             return `Input Socket: ${socket.name}`;
           }
 
-          const prop = this.propForInternalProviderId(internalProviderId);
+          const prop = this.proprForInputSocketId(inputSocketId);
           if (prop) {
             return `Attribute: ${prop.path}${prop.name}`;
           }
@@ -244,8 +243,8 @@ export const useFuncStore = () => {
           }
         },
 
-        externalProviderIdToSourceName(externalProviderId: string) {
-          const outputSocket = this.outputSocketForId(externalProviderId);
+        outputSocketIdToSourceName(outputSocketId: string) {
+          const outputSocket = this.outputSocketForId(outputSocketId);
           if (outputSocket) {
             return `Output Socket: ${outputSocket.name}`;
           }
@@ -259,8 +258,8 @@ export const useFuncStore = () => {
             return this.propForId(prototype.propId)?.schemaVariantId;
           }
 
-          if (prototype.externalProviderId) {
-            return this.outputSocketForId(prototype.externalProviderId)
+          if (prototype.outputSocketId) {
+            return this.outputSocketForId(prototype.outputSocketId)
               ?.schemaVariantId;
           }
         },
@@ -275,13 +274,12 @@ export const useFuncStore = () => {
             };
           }
 
-          if (prototype.externalProviderId) {
+          if (prototype.outputSocketId) {
             return {
               label:
-                this.externalProviderIdToSourceName(
-                  prototype.externalProviderId,
-                ) ?? "none",
-              externalProviderId: prototype.externalProviderId,
+                this.outputSocketIdToSourceName(prototype.outputSocketId) ??
+                "none",
+              outputSocketId: prototype.outputSocketId,
             };
           }
 
@@ -312,14 +310,13 @@ export const useFuncStore = () => {
               : this.outputSockets[schemaVariantId]
             )?.map((socket) => {
               const label =
-                this.externalProviderIdToSourceName(
-                  socket.externalProviderId,
-                ) ?? "none";
+                this.outputSocketIdToSourceName(socket.outputSocketId) ??
+                "none";
               return {
                 label,
                 value: {
                   label,
-                  externalProviderId: socket.externalProviderId,
+                  outputSocketId: socket.outputSocketId,
                 },
               };
             }) ?? [];

--- a/app/web/src/store/func/types.ts
+++ b/app/web/src/store/func/types.ts
@@ -34,27 +34,18 @@ export interface QualificationAssociations {
   inputs: LeafInputLocation[];
 }
 
-export interface ValidationAssociations {
-  type: "validation";
-  prototypes: ValidationPrototypeView[];
-}
-
-export interface ValidationPrototypeView {
-  schemaVariantId: string;
-  propId: string;
-}
-
 export interface AttributePrototypeArgumentView {
   funcArgumentId: string;
   id?: string;
-  internalProviderId?: string;
+  inputSocketId?: string;
 }
 
 export interface AttributePrototypeView {
   id: string;
   componentId?: string;
+  schemaVariantId?: string;
   propId?: string;
-  externalProviderId?: string;
+  outputSocketId?: string;
   prototypeArguments: AttributePrototypeArgumentView[];
 }
 
@@ -69,18 +60,17 @@ export type FuncAssociations =
   | ActionAssociations
   | AttributeAssociations
   | CodeGenerationAssociations
-  | QualificationAssociations
-  | ValidationAssociations;
+  | QualificationAssociations;
 
 export interface InputSourceSocket {
   schemaVariantId: string;
-  internalProviderId: string;
+  inputSocketId: string;
   name: string;
 }
 
 export interface OutputSocket {
   schemaVariantId: string;
-  externalProviderId: string;
+  outputSocketId: string;
   name: string;
 }
 
@@ -88,7 +78,7 @@ export interface InputSourceProp {
   propId: string;
   kind: PropKind;
   schemaVariantId: string;
-  internalProviderId?: string;
+  inputSocketId?: string;
   path: string;
   name: string;
 }
@@ -100,7 +90,7 @@ export interface OutputLocationProp {
 
 export interface OutputLocationOutputSocket {
   label: string;
-  externalProviderId: string;
+  outputSocketId: string;
 }
 
 export type OutputLocation = OutputLocationProp | OutputLocationOutputSocket;
@@ -112,7 +102,7 @@ export interface CreateFuncAttributeOutputLocationProp {
 
 export interface CreateFuncAttributeOutputLocationOutputSocket {
   type: "outputSocket";
-  externalProviderId: string;
+  outputSocketId: string;
 }
 
 export type CreateFuncOutputLocation =
@@ -128,12 +118,6 @@ export interface CreateFuncAttributeOptions {
   type: "attributeOptions";
   schemaVariantId: string;
   outputLocation: CreateFuncOutputLocation;
-}
-
-export interface CreateFuncValidationOptions {
-  type: "validationOptions";
-  schemaVariantId: string;
-  propToValidate: string;
 }
 
 export interface CreateFuncActionOptions {
@@ -157,5 +141,4 @@ export type CreateFuncOptions =
   | CreateFuncActionOptions
   | CreateFuncAttributeOptions
   | CreateFuncCodeGenerationOptions
-  | CreateFuncQualificationOptions
-  | CreateFuncValidationOptions;
+  | CreateFuncQualificationOptions;

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -13,7 +13,7 @@ use ulid::Ulid;
 use crate::{
     change_set::ChangeSetError,
     func::argument::{FuncArgument, FuncArgumentError, FuncArgumentId},
-    implement_add_edge_to, pk,
+    id, implement_add_edge_to,
     socket::input::InputSocketId,
     workspace_snapshot::{
         content_address::ContentAddressDiscriminants,
@@ -40,7 +40,7 @@ use super::AttributePrototypeError;
 pub mod static_value;
 pub mod value_source;
 
-pk!(AttributePrototypeArgumentId);
+id!(AttributePrototypeArgumentId);
 
 #[remain::sorted]
 #[derive(Error, Debug)]

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -19,7 +19,7 @@ use crate::workspace_snapshot::graph::WorkspaceSnapshotGraphError;
 use crate::workspace_snapshot::node_weight::category_node_weight::CategoryNodeKind;
 use crate::workspace_snapshot::node_weight::{FuncNodeWeight, NodeWeight, NodeWeightError};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
-use crate::{implement_add_edge_to, pk, DalContext, HelperError, Timestamp, TransactionsError};
+use crate::{id, implement_add_edge_to, DalContext, HelperError, Timestamp, TransactionsError};
 
 use self::backend::{FuncBackendKind, FuncBackendResponseType};
 
@@ -35,6 +35,7 @@ mod associations;
 mod before;
 mod kind;
 
+pub use associations::AttributePrototypeArgumentView;
 pub use associations::AttributePrototypeView;
 pub use associations::FuncAssociations;
 pub use before::before_funcs_for_component;
@@ -104,10 +105,10 @@ pub struct FuncMetadataView {
 }
 
 pub fn is_intrinsic(name: &str) -> bool {
-    intrinsics::IntrinsicFunc::iter().any(|intrinsic| intrinsic.name() == name)
+    IntrinsicFunc::iter().any(|intrinsic| intrinsic.name() == name)
 }
 
-pk!(FuncId);
+id!(FuncId);
 
 /// A `Func` is the declaration of the existence of a function. It has a name,
 /// and corresponds to a given function backend (and its associated return types).

--- a/lib/dal/src/func/argument.rs
+++ b/lib/dal/src/func/argument.rs
@@ -14,7 +14,7 @@ use crate::workspace_snapshot::edge_weight::{EdgeWeightError, EdgeWeightKindDisc
 use crate::workspace_snapshot::node_weight::{FuncArgumentNodeWeight, NodeWeight, NodeWeightError};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
-    pk, DalContext, EdgeWeightKind, Func, FuncError, FuncId, HistoryEventError, PropKind,
+    id, DalContext, EdgeWeightKind, Func, FuncError, FuncId, HistoryEventError, PropKind,
     StandardModelError, Timestamp, TransactionsError,
 };
 
@@ -120,8 +120,7 @@ impl From<FuncArgumentKind> for PkgFuncArgumentKind {
     }
 }
 
-pk!(FuncArgumentPk);
-pk!(FuncArgumentId);
+id!(FuncArgumentId);
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct FuncArgument {

--- a/lib/dal/src/func/authoring/save.rs
+++ b/lib/dal/src/func/authoring/save.rs
@@ -51,18 +51,18 @@ pub(crate) async fn save_func(
             }) = associations
             {
                 debug!(?prototypes, ?arguments, "saving for attribute func kind");
-                //     let backend_response_type = save_attr_func_prototypes(
-                //         ctx,
-                //         &func,
-                //         prototypes,
-                //         RemovedPrototypeOp::Reset,
-                //         None,
-                //     )
-                //     .await?;
-                //     save_attr_func_arguments(ctx, &func, arguments).await?;
+                // let backend_response_type = save_attr_func_prototypes(
+                //     ctx,
+                //     &func,
+                //     prototypes,
+                //     RemovedPrototypeOp::Reset,
+                //     None,
+                // )
+                // .await?;
+                // save_attr_func_arguments(ctx, &func, arguments).await?;
                 //
-                //     func.set_backend_response_type(ctx, backend_response_type)
-                //         .await?;
+                // func.set_backend_response_type(ctx, backend_response_type)
+                //     .await?;
             }
         }
         FuncKind::Authentication => {

--- a/lib/dal/tests/integration_test/func/associations.rs
+++ b/lib/dal/tests/integration_test/func/associations.rs
@@ -1,8 +1,10 @@
+use dal::attribute::prototype::argument::AttributePrototypeArgument;
 use dal::func::argument::{FuncArgument, FuncArgumentKind};
 use dal::func::view::FuncArgumentView;
-use dal::func::FuncAssociations;
+use dal::func::{AttributePrototypeArgumentView, AttributePrototypeView, FuncAssociations};
+use dal::prop::PropPath;
 use dal::schema::variant::leaves::LeafInputLocation;
-use dal::{DalContext, Func, Schema};
+use dal::{AttributePrototype, DalContext, Func, Prop, Schema};
 use dal_test::test;
 use pretty_assertions_sorted::assert_eq;
 
@@ -39,6 +41,16 @@ async fn for_action(ctx: &mut DalContext) {
 
 #[test]
 async fn for_attribute(ctx: &mut DalContext) {
+    let schema = Schema::find_by_name(ctx, "starfield")
+        .await
+        .expect("could not perform find by name")
+        .expect("no schema found");
+    let schema_variant_id = schema
+        .get_default_schema_variant(ctx)
+        .await
+        .expect("could not perform get default schema variant")
+        .expect("default schema variant not found");
+
     let func_id = Func::find_by_name(ctx, "test:falloutEntriesToGalaxies")
         .await
         .expect("could not perform find func by name")
@@ -59,9 +71,56 @@ async fn for_attribute(ctx: &mut DalContext) {
         .expect("func argument ids are empty");
     assert!(func_argument_ids.is_empty());
 
+    // Find the sole attribute prototype  id. Ensure there is only one.
+    let mut attribute_prototype_ids = AttributePrototype::list_ids_for_func_id(ctx, func_id)
+        .await
+        .expect("could not list attribute prototype ids");
+    let attribute_prototype_id = attribute_prototype_ids
+        .pop()
+        .expect("attribute prototype ids are empty");
+    assert!(attribute_prototype_ids.is_empty());
+
+    // Find the sole attribute prototype argument id. Ensure there is only one.
+    let mut attribute_prototype_argument_ids =
+        AttributePrototypeArgument::list_ids_for_prototype(ctx, attribute_prototype_id)
+            .await
+            .expect("could not list attribute prototype argument ids");
+    let attribute_prototype_argument_id = attribute_prototype_argument_ids
+        .pop()
+        .expect("attribute prototype argument ids are empty");
+    assert!(attribute_prototype_argument_ids.is_empty());
+
+    // Find the sole input socket id. Ensure there is only one.
+    let mut input_socket_ids =
+        AttributePrototype::list_input_socket_sources_for_id(ctx, attribute_prototype_id)
+            .await
+            .expect("could not list input socket ids");
+    let input_socket_id = input_socket_ids.pop().expect("input socket ids are empty");
+    assert!(input_socket_ids.is_empty());
+
+    // Find the prop for the prototype.
+    let prop = Prop::find_prop_by_path(
+        ctx,
+        schema_variant_id,
+        &PropPath::new(["root", "domain", "universe", "galaxies"]),
+    )
+    .await
+    .expect("could not find prop by path");
+
     assert_eq!(
         FuncAssociations::Attribute {
-            prototypes: vec![],
+            prototypes: vec![AttributePrototypeView {
+                id: attribute_prototype_id,
+                component_id: None,
+                schema_variant_id: Some(schema_variant_id),
+                prop_id: Some(prop.id),
+                output_socket_id: None,
+                prototype_arguments: vec![AttributePrototypeArgumentView {
+                    func_argument_id,
+                    id: attribute_prototype_argument_id,
+                    input_socket_id: Some(input_socket_id),
+                }],
+            }],
             arguments: vec![FuncArgumentView {
                 id: func_argument_id,
                 name: "entries".to_string(),


### PR DESCRIPTION
## Description

This PR restores func associations for attribute funcs. It also fixes how components and schema variants are derived from attribute prototypes via the new "eventual parent" concept. Now, we enforce that there must be one and only one eventual parent for a given attribute prototype.

<img src="https://media3.giphy.com/media/SUhZ7TTf32aWamJwxj/giphy-downsized-medium.gif"/>

## Misc Changes

- `ExternalProviders` and `InternalProviders` are completely scrubbed from `app/web`
- Simplify code gen and qualification func association logic
- Replaces some `pk` macro usages with the newer `id` macro