### PR TITLE
fix: run actions serially

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1061,20 +1061,13 @@ impl AttributeValue {
             )
             .await?
         {
-            let current_node_index = workspace_snapshot
-                .get_node_index_by_id(attribute_value_id)
-                .await?;
-            let current_target_idx = workspace_snapshot
-                .get_latest_node_index(attribute_value_target)
-                .await?;
+            let current_target_id = workspace_snapshot
+                .get_node_weight(attribute_value_target)
+                .await?
+                .id();
 
             workspace_snapshot
-                .remove_edge(
-                    ctx.change_set()?,
-                    current_node_index,
-                    current_target_idx,
-                    EdgeWeightKindDiscriminants::Contain,
-                )
+                .remove_node_by_id(ctx.change_set()?, current_target_id)
                 .await?;
         }
 

--- a/lib/dal/tests/integration_test/action/with_update.rs
+++ b/lib/dal/tests/integration_test/action/with_update.rs
@@ -5,6 +5,7 @@ use dal::{
 };
 use dal_test::test;
 use dal_test::test_harness::{commit_and_update_snapshot, create_component_for_schema_name};
+use pretty_assertions_sorted::assert_eq;
 
 #[test]
 async fn update_action(ctx: &mut DalContext) {
@@ -40,6 +41,7 @@ async fn update_action(ctx: &mut DalContext) {
     let applied_change_set = ChangeSet::apply_to_base_change_set(ctx, true)
         .await
         .expect("could apply to base change set");
+
     let conflicts = ctx.blocking_commit().await.expect("unable to commit");
     assert!(conflicts.is_none());
 
@@ -136,4 +138,13 @@ async fn update_action(ctx: &mut DalContext) {
     } else {
         panic!("No resource data found for the component after update action");
     }
+
+    assert_eq!(
+        1,
+        ms_swift
+            .attribute_values_for_prop(ctx, &["root", "resource", "last_synced"])
+            .await
+            .expect("should be able to get values")
+            .len()
+    );
 }


### PR DESCRIPTION
Running actions concurrently produces some race condition behavior with the current implementation (also we were rebasing at least 3 times per action, too much!). Actions will have to be refactored to support concurrent execution similar to the way we synchronize function execution in the dependent value update. For now, running them serially will produce correct results.