### PR TITLE
bug(*): need change set written after all

### DIFF
--- a/app/web/src/store/component_attributes.store.ts
+++ b/app/web/src/store/component_attributes.store.ts
@@ -362,6 +362,16 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
               },
             },
           ]);
+          realtimeStore.subscribe(this.$id, `changeset/${changeSetId}`, [
+            {
+              eventType: "ChangeSetWritten",
+              debounce: true,
+              callback: (writtenChangeSetId) => {
+                if (writtenChangeSetId !== changeSetId) return;
+                this.reloadPropertyEditorData();
+              },
+            },
+          ]);
 
           return () => {
             realtimeStore.unsubscribe(this.$id);

--- a/lib/dal/src/change_set/event.rs
+++ b/lib/dal/src/change_set/event.rs
@@ -3,6 +3,13 @@ use serde::{Deserialize, Serialize};
 use crate::{ChangeSetId, DalContext, UserPk, WsEvent, WsEventResult, WsPayload};
 
 impl WsEvent {
+    pub async fn change_set_written(
+        ctx: &DalContext,
+        change_set_id: ChangeSetId,
+    ) -> WsEventResult<Self> {
+        WsEvent::new(ctx, WsPayload::ChangeSetWritten(change_set_id)).await
+    }
+
     pub async fn change_set_created(
         ctx: &DalContext,
         change_set_id: ChangeSetId,

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -60,6 +60,7 @@ pub enum WsPayload {
     ChangeSetCanceled(ChangeSetId),
     ChangeSetCreated(ChangeSetId),
     ChangeSetMergeVote(ChangeSetMergeVotePayload),
+    ChangeSetWritten(ChangeSetId),
     CheckedQualifications(QualificationCheckPayload),
     ComponentCreated(ComponentCreatedPayload),
     ComponentUpdated(ComponentUpdatedPayload),
@@ -131,6 +132,10 @@ impl WsEvent {
 
     pub fn workspace_pk(&self) -> WorkspacePk {
         self.workspace_pk
+    }
+
+    pub fn set_workspace_pk(&mut self, workspace_pk: WorkspacePk) {
+        self.workspace_pk = workspace_pk;
     }
 
     fn workspace_subject(&self) -> String {


### PR DESCRIPTION
This restores the change set written event, which it turns out we do need - the rebaser still handles when data is "committed", and therefore when it is visible in different parts of the UI. Long term, it would be great to figure out how to thread more specific events through, so that we don't have a cascade of calls that are needless from the frontend. But for now, this will work.