### PR TITLE
Restore Detatch Component

### DIFF
--- a/app/web/src/components/Debug/ComponentDebugDetails.vue
+++ b/app/web/src/components/Debug/ComponentDebugDetails.vue
@@ -23,6 +23,10 @@
               :data="debugData.schemaVariantId"
               title="Variant Id"
             />
+            <DebugViewItem
+              :data="debugData.parentId ?? 'NULL'"
+              title="Parent Id?"
+            />
           </dl>
         </Collapsible>
 

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -1238,7 +1238,7 @@ function endDragElements() {
     // dragging onto root - ie detach from all parents
     if (!cursorWithinGroupKey.value) {
       if (el.def.parentId) {
-        componentsStore.DETACH_COMPONENT(el.def.componentId);
+        componentsStore.DETACH_COMPONENT(el.def.componentId, [el.def.parentId]);
       }
     } else {
       const newParent = allElementsByKey.value[

--- a/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
+++ b/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
@@ -147,7 +147,7 @@ const rightClickMenuItems = computed(() => {
       onSelect: () => {
         // TODO: we likely want an endpoint that handles multiple?
         _.each(selectedComponentIds.value, (id) => {
-          componentsStore.DETACH_COMPONENT(id);
+          componentsStore.DETACH_COMPONENT(id, []);
         });
       },
       disabled,

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -164,6 +164,7 @@ export interface ComponentDebugView {
   attributes: AttributeDebugView[];
   inputSockets: SocketDebugView[];
   outputSockets: SocketDebugView[];
+  parentId?: string | null;
 }
 
 type EventBusEvents = {
@@ -857,7 +858,10 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               },
             });
           },
-          async DETACH_COMPONENT(componentId: ComponentId) {
+          async DETACH_COMPONENT(
+            componentId: ComponentId,
+            parentIds: ComponentId[],
+          ) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
             if (changeSetId === changeSetsStore.headChangeSetId)
@@ -868,6 +872,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               url: "diagram/detach_component",
               params: {
                 componentId,
+                parentIds,
                 ...visibilityParams,
               },
               optimistic: () => {

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -405,6 +405,74 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
             mama_kelce_assembled.parent_id.expect("no parent node id")  // actual
         );
     }
+    //Scenario 7?! No more Country Era Swift, she wants to break freeeeeee
+    Frame::detach_child_from_parents(
+        ctx,
+        vec![new_era_taylor_swift.id()],
+        country_era_taylor_swift.id(),
+    )
+    .await
+    .expect("could not detach child to parent");
+    {
+        let diagram = DiagramByKey::assemble(ctx)
+            .await
+            .expect("could not assemble diagram");
+        assert_eq!(
+            4,                        // expected
+            diagram.components.len()  // actual
+        );
+        assert_eq!(
+            2,                   // expected
+            diagram.edges.len()  // actual
+        );
+
+        let new_era_taylor_swift_assembled = diagram
+            .components
+            .get(new_era_taylor_swift_name)
+            .expect("could not get component by name");
+        let travis_kelce_assembled = diagram
+            .components
+            .get(travis_kelce_component_name)
+            .expect("could not get component by name");
+        let country_era_taylor_swift_assembled = diagram
+            .components
+            .get(country_era_taylor_swift_name)
+            .expect("could not get component by name");
+        let mama_kelce_assembled = diagram
+            .components
+            .get(mama_kelce_name)
+            .expect("could not get component by name");
+
+        assert_eq!(
+            new_era_taylor_swift.id(),                   // expected
+            new_era_taylor_swift_assembled.component_id  // actual
+        );
+        assert_eq!(
+            travis_kelce_component.id(),         // expected
+            travis_kelce_assembled.component_id  // actual
+        );
+        assert_eq!(
+            country_era_taylor_swift.id(),                   // expected
+            country_era_taylor_swift_assembled.component_id  // actual
+        );
+        assert_eq!(
+            mama_kelce.id(),                   // expected
+            mama_kelce_assembled.component_id  // actual
+        );
+
+        assert!(new_era_taylor_swift_assembled.parent_id.is_none());
+        dbg!(country_era_taylor_swift_assembled.parent_id);
+        assert!(country_era_taylor_swift_assembled.parent_id.is_none());
+
+        assert_eq!(
+            new_era_taylor_swift.id(),                                    // expected
+            travis_kelce_assembled.parent_id.expect("no parent node id")  // actual
+        );
+        assert_eq!(
+            country_era_taylor_swift.id(),                              // expected
+            mama_kelce_assembled.parent_id.expect("no parent node id")  // actual
+        );
+    }
 }
 
 struct DiagramByKey {

--- a/lib/sdf-server/src/server/service/diagram.rs
+++ b/lib/sdf-server/src/server/service/diagram.rs
@@ -22,6 +22,7 @@ use crate::server::state::AppState;
 mod connect_component_to_frame;
 pub mod create_component;
 pub mod create_connection;
+pub mod detach_component_from_frame;
 pub mod get_diagram;
 pub mod list_schemas;
 pub mod set_component_position;
@@ -150,4 +151,8 @@ pub fn routes() -> Router<AppState> {
         )
         .route("/get_diagram", get(get_diagram::get_diagram))
         .route("/list_schemas", get(list_schemas::list_schemas))
+        .route(
+            "/detach_component",
+            post(detach_component_from_frame::detach_component_from_frame),
+        )
 }

--- a/lib/sdf-server/src/server/service/diagram/detach_component_from_frame.rs
+++ b/lib/sdf-server/src/server/service/diagram/detach_component_from_frame.rs
@@ -1,16 +1,17 @@
 use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
-use crate::server::tracking::track;
 use crate::service::diagram::DiagramResult;
 use axum::extract::OriginalUri;
 use axum::response::IntoResponse;
 use axum::Json;
-use dal::{ChangeSet, ComponentId, Edge, Visibility};
+use dal::component::frame::Frame;
+use dal::{ChangeSet, ComponentId, Visibility};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DetachComponentRequest {
     pub component_id: ComponentId,
+    pub parent_ids: Vec<ComponentId>,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -18,26 +19,25 @@ pub struct DetachComponentRequest {
 pub async fn detach_component_from_frame(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
-    PosthogClient(posthog_client): PosthogClient,
-    OriginalUri(original_uri): OriginalUri,
+    PosthogClient(_posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
     Json(request): Json<DetachComponentRequest>,
 ) -> DiagramResult<impl IntoResponse> {
     let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
+    Frame::detach_child_from_parents(&ctx, request.parent_ids, request.component_id).await?;
 
-    let detached_parent_id = Edge::detach_component_from_parent(&ctx, request.component_id).await?;
-
-    track(
-        &posthog_client,
-        &ctx,
-        &original_uri,
-        "detach_component_from_frame",
-        serde_json::json!({
-            "child_component_id": &request.component_id,
-            "parent_component_id": detached_parent_id,
-        }),
-    );
+    // track(
+    //     &posthog_client,
+    //     &ctx,
+    //     &original_uri,
+    //     "detach_component_from_frame",
+    //     serde_json::json!({
+    //         "child_component_id": &request.component_id,
+    //         "parent_component_ids": &request.parent_ids,
+    //     }),
+    // );
 
     ctx.commit().await?;
 


### PR DESCRIPTION
This PR restores the route to detach components from frames. The route takes a list of parent ids, so we can detach from many frames at once if needed. If no parent is passed in, we'll attempt to detach from the direct parent for that component. 

Follow up PR will include WS Events for these and adjustment to attachment to handle nested frames