### PR TITLE
Remove `PropParent` and fix `SchemaVariant::all_funcs`

### DIFF
--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -830,23 +830,6 @@ impl DalContext {
         Ok(is_in_our_tenancy)
     }
 
-    /// Copies every single row from `Self::builtin()` to our tenancy on head change-set
-    /// Needed to remove universal tenancy while packages aren't a thing
-    #[instrument(level = "debug", skip_all)]
-    pub async fn import_builtins(&self) -> Result<(), TransactionsError> {
-        // TODO(nick,zack,jacob): restore the ability to "import builtins" via the graph work.
-        // let source_workspace_pk = WorkspacePk::NONE;
-        // self.txns()
-        //     .await?
-        //     .pg()
-        //     .execute(
-        //         "SELECT import_builtins_v1($1, $2)",
-        //         &[self.tenancy(), &source_workspace_pk],
-        //     )
-        //     .await?;
-        Ok(())
-    }
-
     // NOTE(nick,zack,jacob): likely a temporary func to get the change set id from the visibility.
     pub fn change_set_id(&self) -> ChangeSetId {
         self.visibility.change_set_id

--- a/lib/dal/src/deprecated_action/prototype.rs
+++ b/lib/dal/src/deprecated_action/prototype.rs
@@ -290,10 +290,22 @@ impl DeprecatedActionPrototype {
         Ok(Self::assemble(id, inner))
     }
 
+    /// Finds the [`FuncId`](Func) for the [`DeprecatedActionPrototype`].
     pub async fn func_id(&self, ctx: &DalContext) -> DeprecatedActionPrototypeResult<FuncId> {
+        Self::func_id_by_id(ctx, self.id).await
+    }
+
+    /// Finds the [`FuncId`](Func) for a given [`ActionPrototypeId`](DeprecatedActionPrototype).
+    pub async fn func_id_by_id(
+        ctx: &DalContext,
+        action_prototype_id: ActionPrototypeId,
+    ) -> DeprecatedActionPrototypeResult<FuncId> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         for node_index in workspace_snapshot
-            .outgoing_targets_for_edge_weight_kind(self.id, EdgeWeightKindDiscriminants::Use)
+            .outgoing_targets_for_edge_weight_kind(
+                action_prototype_id,
+                EdgeWeightKindDiscriminants::Use,
+            )
             .await?
         {
             let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
@@ -303,7 +315,9 @@ impl DeprecatedActionPrototype {
             }
         }
 
-        Err(DeprecatedActionPrototypeError::MissingFunction(self.id))
+        Err(DeprecatedActionPrototypeError::MissingFunction(
+            action_prototype_id,
+        ))
     }
 
     pub async fn run(

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -330,19 +330,18 @@ impl Func {
     ///
     /// It's important to note that not all Intrinsic funcs are non-dynamic. Identity, for instance, is dynamic.
     pub fn is_dynamic_for_name_string(name: &str) -> bool {
-        if let Some(intrinsic) = IntrinsicFunc::maybe_from_str(name) {
-            ![
-                IntrinsicFunc::SetArray,
-                IntrinsicFunc::SetBoolean,
-                IntrinsicFunc::SetInteger,
-                IntrinsicFunc::SetMap,
-                IntrinsicFunc::SetObject,
-                IntrinsicFunc::SetString,
-                IntrinsicFunc::Unset,
-            ]
-            .contains(&intrinsic)
-        } else {
-            true
+        match IntrinsicFunc::maybe_from_str(name) {
+            Some(intrinsic) => match intrinsic {
+                IntrinsicFunc::SetArray
+                | IntrinsicFunc::SetBoolean
+                | IntrinsicFunc::SetInteger
+                | IntrinsicFunc::SetMap
+                | IntrinsicFunc::SetObject
+                | IntrinsicFunc::SetString
+                | IntrinsicFunc::Unset => false,
+                IntrinsicFunc::Identity | IntrinsicFunc::Validation => true,
+            },
+            None => true,
         }
     }
 

--- a/lib/dal/src/func/before.rs
+++ b/lib/dal/src/func/before.rs
@@ -151,7 +151,7 @@ async fn auth_funcs_for_secret_prop_id(
         }
 
         for auth_func_id in
-            SchemaVariant::list_auth_func_ids_for_schema_variant(ctx, secret_defining_sv_id).await?
+            SchemaVariant::list_auth_func_ids_for_id(ctx, secret_defining_sv_id).await?
         {
             auth_funcs.push(
                 Func::get_by_id_or_error(ctx, auth_func_id)

--- a/lib/dal/src/func/intrinsics.rs
+++ b/lib/dal/src/func/intrinsics.rs
@@ -191,8 +191,8 @@ impl IntrinsicFunc {
         }
     }
 
-    pub fn maybe_from_str(s: &str) -> Option<Self> {
-        Some(match s {
+    pub fn maybe_from_str(s: impl AsRef<str>) -> Option<Self> {
+        Some(match s.as_ref() {
             "si:identity" => Self::Identity,
             "si:setArray" => Self::SetArray,
             "si:setBoolean" => Self::SetBoolean,

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -3,7 +3,7 @@
 
 use strum::{AsRefStr, Display as EnumDisplay, EnumIter, EnumString};
 
-use crate::prop::{PropParent, PropPath};
+use crate::prop::PropPath;
 use crate::property_editor::schema::WidgetKind;
 use crate::schema::variant::leaves::LeafKind;
 use crate::schema::variant::SchemaVariantResult;
@@ -111,7 +111,7 @@ impl RootProp {
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
     ) -> SchemaVariantResult<Self> {
-        let root_prop = Prop::new(
+        let root_prop = Prop::new_root(
             ctx,
             "root",
             PropKind::Object,
@@ -119,7 +119,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::SchemaVariant(schema_variant_id),
+            schema_variant_id,
         )
         .await?;
         let root_prop_id = root_prop.id();
@@ -127,21 +127,11 @@ impl RootProp {
         // info!("setting up si, domain and secrets");
         let si_prop_id = Self::setup_si(ctx, root_prop_id).await?;
 
-        let domain_prop = Prop::new_without_ui_optionals(
-            ctx,
-            "domain",
-            PropKind::Object,
-            PropParent::OrderedProp(root_prop_id),
-        )
-        .await?;
+        let domain_prop =
+            Prop::new_without_ui_optionals(ctx, "domain", PropKind::Object, root_prop_id).await?;
 
-        let secrets_prop = Prop::new_without_ui_optionals(
-            ctx,
-            "secrets",
-            PropKind::Object,
-            PropParent::OrderedProp(root_prop_id),
-        )
-        .await?;
+        let secrets_prop =
+            Prop::new_without_ui_optionals(ctx, "secrets", PropKind::Object, root_prop_id).await?;
 
         // info!("setting up resource");
         let resource_prop_id = Self::setup_resource(ctx, root_prop_id).await?;
@@ -161,7 +151,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(root_prop_id),
+            root_prop_id,
         )
         .await?;
 
@@ -198,7 +188,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(root_prop_id),
+            root_prop_id,
         )
         .await?;
 
@@ -210,7 +200,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(leaf_prop.id()),
+            leaf_prop.id(),
         )
         .await?;
 
@@ -218,30 +208,16 @@ impl RootProp {
     }
 
     async fn setup_si(ctx: &DalContext, root_prop_id: PropId) -> SchemaVariantResult<PropId> {
-        let si_prop = Prop::new_without_ui_optionals(
-            ctx,
-            "si",
-            PropKind::Object,
-            PropParent::OrderedProp(root_prop_id),
-        )
-        .await?;
+        let si_prop =
+            Prop::new_without_ui_optionals(ctx, "si", PropKind::Object, root_prop_id).await?;
 
-        let _si_name_prop = Prop::new_without_ui_optionals(
-            ctx,
-            "name",
-            PropKind::String,
-            PropParent::OrderedProp(si_prop.id()),
-        )
-        .await?;
+        let _si_name_prop =
+            Prop::new_without_ui_optionals(ctx, "name", PropKind::String, si_prop.id()).await?;
 
         // The protected prop ensures a component cannot be deleted in the configuration diagram.
-        let _protected_prop = Prop::new_without_ui_optionals(
-            ctx,
-            "protected",
-            PropKind::Boolean,
-            PropParent::OrderedProp(si_prop.id()),
-        )
-        .await?;
+        let _protected_prop =
+            Prop::new_without_ui_optionals(ctx, "protected", PropKind::Boolean, si_prop.id())
+                .await?;
 
         // The type prop controls the type of the configuration node. The default type can be
         // determined by the schema variant author. The widget options correspond to the component
@@ -274,7 +250,7 @@ impl RootProp {
                 ])),
             )),
             None,
-            PropParent::OrderedProp(si_prop.id()),
+            si_prop.id(),
         )
         .await?;
 
@@ -287,7 +263,7 @@ impl RootProp {
             None,
             Some((WidgetKind::Color, None)),
             None,
-            PropParent::OrderedProp(si_prop.id()),
+            si_prop.id(),
         )
         .await?;
 
@@ -304,7 +280,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(root_prop_id),
+            root_prop_id,
         )
         .await?;
 
@@ -317,7 +293,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(resource_prop.id()),
+            resource_prop.id(),
         )
         .await?;
 
@@ -330,7 +306,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(resource_prop.id()),
+            resource_prop.id(),
         )
         .await?;
 
@@ -343,7 +319,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(resource_prop.id()),
+            resource_prop.id(),
         )
         .await?;
 
@@ -356,7 +332,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(resource_logs_prop.id()),
+            resource_logs_prop.id(),
         )
         .await?;
 
@@ -369,7 +345,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(resource_prop.id()),
+            resource_prop.id(),
         )
         .await?;
 
@@ -382,7 +358,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(resource_prop.id()),
+            resource_prop.id(),
         )
         .await?;
 
@@ -401,7 +377,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(root_prop_id),
+            root_prop_id,
         )
         .await?;
 
@@ -420,7 +396,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(code_map_item_prop_id),
+            code_map_item_prop_id,
         )
         .await?;
 
@@ -432,7 +408,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(code_map_item_prop_id),
+            code_map_item_prop_id,
         )
         .await?;
 
@@ -454,7 +430,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(qualification_map_item_prop_id),
+            qualification_map_item_prop_id,
         )
         .await?;
 
@@ -466,7 +442,7 @@ impl RootProp {
             None,
             None,
             None,
-            PropParent::OrderedProp(qualification_map_item_prop_id),
+            qualification_map_item_prop_id,
         )
         .await?;
 

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -268,8 +268,6 @@ impl Workspace {
             None => Workspace::new(ctx, workspace_pk, workspace_name).await?,
         };
 
-        ctx.import_builtins().await?;
-
         Ok(workspace)
     }
 

--- a/lib/dal/tests/integration_test/attribute.rs
+++ b/lib/dal/tests/integration_test/attribute.rs
@@ -1,0 +1,1 @@
+mod prototype;

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -1,0 +1,49 @@
+use dal::prop::PropPath;
+use dal::{AttributePrototype, DalContext, Func, Prop, Schema};
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn find_for_prop(ctx: &mut DalContext) {
+    let schema = Schema::find_by_name(ctx, "swifty")
+        .await
+        .expect("unable to get schema")
+        .expect("schema not found");
+    let schema_variant_id = schema
+        .get_default_schema_variant(ctx)
+        .await
+        .expect("unable to get schema variant")
+        .expect("schema variant not found");
+    let func_name = "test:generateCode";
+
+    // Find the sole attribute prototype via its func. Ensure that we find one and only one.
+    let func_id = Func::find_by_name(ctx, func_name)
+        .await
+        .expect("could not perform find by name")
+        .expect("func not found");
+    let mut attribute_prototype_ids = AttributePrototype::list_ids_for_func_id(ctx, func_id)
+        .await
+        .expect("could not list attribute prototype ids for func id");
+    let attribute_prototype_id = attribute_prototype_ids
+        .pop()
+        .expect("empty attribute prototype ids");
+    assert!(attribute_prototype_ids.is_empty());
+
+    // Ensure that find for prop works with a key.
+    let prop_id = Prop::find_prop_id_by_path(
+        ctx,
+        schema_variant_id,
+        &PropPath::new(["root", "code", "codeItem"]),
+    )
+    .await
+    .expect("could not find prop by path");
+    let found_attribute_prototype_id =
+        AttributePrototype::find_for_prop(ctx, prop_id, &Some(func_name.to_owned()))
+            .await
+            .expect("could not perform find for prop")
+            .expect("no attribute prototype found");
+    assert_eq!(
+        attribute_prototype_id,       // expected
+        found_attribute_prototype_id  // actual
+    );
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -1,4 +1,5 @@
 mod action;
+mod attribute;
 mod before_funcs;
 mod builtins;
 mod change_set;

--- a/lib/rebaser-server/src/server.rs
+++ b/lib/rebaser-server/src/server.rs
@@ -199,7 +199,6 @@ impl Server {
 
     #[instrument(name = "rebaser.init.create_pg_pool", skip_all)]
     async fn create_pg_pool(pg_pool_config: &PgPoolConfig) -> ServerResult<PgPool> {
-        dbg!(&pg_pool_config);
         let pool = PgPool::new(pg_pool_config).await?;
         debug!("successfully started pg pool (note that not all connections may be healthy)");
         Ok(pool)

--- a/lib/sdf-server/src/server/service/session/auth_connect.rs
+++ b/lib/sdf-server/src/server/service/session/auth_connect.rs
@@ -105,7 +105,6 @@ async fn find_or_create_user_and_workspace(
             )
             .await?;
             let _key_pair = KeyPair::new(&ctx, "default").await?;
-            ctx.import_builtins().await?;
             workspace
         }
     };


### PR DESCRIPTION
## Description

This PR removes the `PropParent` enum and replaces it with explicit methods. In addition, `Props` can now only have "ordered" `Prop` parents, which has been the only way we've created `Props` anyway.

This commit also fixes `SchemaVariant::all_funcs` to account for sockets. The method has been optimized it to batch load funcs after all `FuncIds` have been collected.

<img src="https://media3.giphy.com/media/GBSj8zQtylzOgzkfw9/giphy.gif"/>

## Misc Changes

- Remove unneeded `dbg!` from the rebaser
- Remove unused `import_builtins` method from the old engine
- Allow `AsRef<str>` parameter for `IntrinsicFunc::maybe_from_str`
- Tweak ergonomics for downstream methods related to `SchemaVariant::all_funcs`
- Replace remaining references to providers in import logic
- Add `find_for_prop` integration test for `AttributePrototype` in addition to tests related to `SchemaVariant::all_funcs`