### PR TITLE
fix: remove unnecessary gerneric bounds for func execution

### DIFF
--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 use crate::{EncryptedSecret, Workspace};
 
-pub type DalLayerDb = LayerDb<ContentTypes, EncryptedSecret, String, WorkspaceSnapshotGraph>;
+pub type DalLayerDb = LayerDb<ContentTypes, EncryptedSecret, WorkspaceSnapshotGraph>;
 
 /// A context type which contains handles to common core service dependencies.
 ///

--- a/lib/si-layer-cache/tests/integration_test/activities.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities.rs
@@ -11,7 +11,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::integration_test::{disk_cache_path, setup_nats_client, setup_pg_db};
 
-type TestLayerDb = LayerDb<Arc<String>, Arc<String>, String, String>;
+type TestLayerDb = LayerDb<Arc<String>, Arc<String>, String>;
 
 #[tokio::test]
 async fn activities() {

--- a/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
@@ -10,7 +10,7 @@ use ulid::Ulid;
 
 use crate::integration_test::{disk_cache_path, setup_nats_client, setup_pg_db};
 
-type TestLayerDb = LayerDb<Arc<String>, Arc<String>, String, String>;
+type TestLayerDb = LayerDb<Arc<String>, Arc<String>, String>;
 
 #[tokio::test]
 async fn subscribe_rebaser_requests_work_queue() {

--- a/lib/si-layer-cache/tests/integration_test/db/cas.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/cas.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::integration_test::{disk_cache_path, setup_nats_client, setup_pg_db};
 
-type TestLayerDb = LayerDb<CasValue, String, String, String>;
+type TestLayerDb = LayerDb<CasValue, String, String>;
 
 #[tokio::test]
 async fn write_to_db() {

--- a/lib/si-layer-cache/tests/integration_test/db/func_execution.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/func_execution.rs
@@ -7,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::integration_test::{disk_cache_path, setup_nats_client, setup_pg_db};
 
-type TestLayerDb = LayerDb<CasValue, String, FuncExecution, String>;
+type TestLayerDb = LayerDb<CasValue, String, String>;
 
 #[tokio::test]
 async fn write() {
@@ -29,7 +29,7 @@ async fn write() {
     let value = FuncExecution::new("funky".to_string(), FuncExecutionState::Create);
     key = ldb
         .func_execution()
-        .write(key.clone(), value.clone())
+        .write(key.clone(), value.clone().into())
         .await
         .expect("failed to write to layerdb");
     assert!(key.func_execution_id().is_some());
@@ -64,7 +64,7 @@ async fn write_with_message() {
     let value = FuncExecution::new("funky".to_string(), FuncExecutionState::Create);
     key = ldb
         .func_execution()
-        .write(key.clone(), value.clone())
+        .write(key.clone(), value.clone().into())
         .await
         .expect("failed to write to layerdb");
     assert!(key.func_execution_id().is_some());
@@ -130,7 +130,7 @@ async fn write_and_read_many() {
         let mut key = FuncExecutionKey::new(Ulid::new(), Ulid::new(), Ulid::new(), Ulid::new());
         key = ldb
             .func_execution()
-            .write(key.clone(), value.clone())
+            .write(key.clone(), value.clone().into())
             .await
             .expect("failed to write to layerdb");
 
@@ -190,7 +190,7 @@ async fn read_by_component_id() {
         let mut key = FuncExecutionKey::new(Ulid::new(), Ulid::new(), component_id, Ulid::new());
         key = ldb
             .func_execution()
-            .write(key.clone(), value.clone())
+            .write(key.clone(), value.clone().into())
             .await
             .expect("failed to write to layerdb");
 
@@ -210,7 +210,7 @@ async fn read_by_component_id() {
     let key = FuncExecutionKey::new(Ulid::new(), Ulid::new(), Ulid::new(), Ulid::new());
     let value = FuncExecution::new("no oath, no spell".to_string(), FuncExecutionState::Create);
     ldb.func_execution()
-        .write(key.clone(), value.clone())
+        .write(key.clone(), value.clone().into())
         .await
         .expect("failed to write to layerdb");
 
@@ -259,7 +259,7 @@ async fn read_by_prototype_id() {
         let mut key = FuncExecutionKey::new(Ulid::new(), Ulid::new(), Ulid::new(), prototype_id);
         key = ldb
             .func_execution()
-            .write(key.clone(), value.clone())
+            .write(key.clone(), value.clone().into())
             .await
             .expect("failed to write to layerdb");
 
@@ -279,7 +279,7 @@ async fn read_by_prototype_id() {
     let key = FuncExecutionKey::new(Ulid::new(), Ulid::new(), Ulid::new(), Ulid::new());
     let value = FuncExecution::new("no oath, no spell".to_string(), FuncExecutionState::Create);
     ldb.func_execution()
-        .write(key.clone(), value.clone())
+        .write(key.clone(), value.clone().into())
         .await
         .expect("failed to write to layerdb");
     let read_values = ldb
@@ -328,7 +328,7 @@ async fn read_by_component_id_and_prototype_id() {
         let mut key = FuncExecutionKey::new(Ulid::new(), Ulid::new(), component_id, prototype_id);
         key = ldb
             .func_execution()
-            .write(key.clone(), value.clone())
+            .write(key.clone(), value.clone().into())
             .await
             .expect("failed to write to layerdb");
 
@@ -348,7 +348,7 @@ async fn read_by_component_id_and_prototype_id() {
     let key = FuncExecutionKey::new(Ulid::new(), Ulid::new(), Ulid::new(), prototype_id);
     let value = FuncExecution::new("no oath, no spell".to_string(), FuncExecutionState::Create);
     ldb.func_execution()
-        .write(key.clone(), value.clone())
+        .write(key.clone(), value.clone().into())
         .await
         .expect("failed to write to layerdb");
 


### PR DESCRIPTION
We don't actually need the bounds around the func execution db to be generic as we know the type we want to use and we don't interact with the DB layers that need it. 

<img src="https://media0.giphy.com/media/xTiTnxjqbg2qfwFaiA/giphy.gif"/>