### PR TITLE
Re-introduce saving attribute funcs in the new engine

### DIFF
--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -34,7 +34,7 @@ use crate::workspace_snapshot::node_weight::{
 };
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
-    attribute::prototype::argument::AttributePrototypeArgumentId, id, implement_add_edge_to,
+    attribute::prototype::argument::AttributePrototypeArgumentId, implement_add_edge_to, pk,
     AttributeValue, AttributeValueId, ComponentId, DalContext, FuncId, HelperError, InputSocketId,
     OutputSocketId, PropId, SchemaVariant, SchemaVariantError, SchemaVariantId, Timestamp,
     TransactionsError,
@@ -98,7 +98,9 @@ pub enum AttributePrototypeEventualParent {
     SchemaVariantFromProp(SchemaVariantId, PropId),
 }
 
-id!(AttributePrototypeId);
+// TODO(nick): switch to the "id!" macro once the frontend doesn't use the old nil id to indicate
+// that the argument is a new one.
+pk!(AttributePrototypeId);
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct AttributePrototype {

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -570,6 +570,7 @@ impl ChangeSet {
         Some(parents)
     }
 
+    /// Returns a new [`ChangeSetId`](ChangeSet) if a new [`ChangeSet`] was created.
     pub async fn force_new(ctx: &mut DalContext) -> ChangeSetResult<Option<ChangeSetId>> {
         let maybe_fake_pk =
             if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {

--- a/lib/dal/src/func/associations/view.rs
+++ b/lib/dal/src/func/associations/view.rs
@@ -1,0 +1,106 @@
+use serde::{Deserialize, Serialize};
+
+use crate::attribute::prototype::argument::value_source::ValueSource;
+use crate::attribute::prototype::argument::{
+    AttributePrototypeArgument, AttributePrototypeArgumentId,
+};
+use crate::attribute::prototype::AttributePrototypeEventualParent;
+use crate::func::argument::FuncArgumentId;
+use crate::func::associations::FuncAssociationsResult;
+use crate::{
+    AttributePrototype, AttributePrototypeId, ComponentId, DalContext, InputSocketId,
+    OutputSocketId, PropId, SchemaVariantId,
+};
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributePrototypeArgumentView {
+    pub func_argument_id: FuncArgumentId,
+    pub id: AttributePrototypeArgumentId,
+    pub input_socket_id: Option<InputSocketId>,
+}
+
+impl AttributePrototypeArgumentView {
+    pub async fn assemble(
+        ctx: &DalContext,
+        id: AttributePrototypeArgumentId,
+    ) -> FuncAssociationsResult<Self> {
+        let attribute_prototype_argument = AttributePrototypeArgument::get_by_id(ctx, id).await?;
+
+        let input_socket_id =
+            if let Some(value_source) = attribute_prototype_argument.value_source(ctx).await? {
+                match value_source {
+                    ValueSource::InputSocket(input_socket_id) => Some(input_socket_id),
+                    ValueSource::OutputSocket(_)
+                    | ValueSource::Prop(_)
+                    | ValueSource::StaticArgumentValue(_) => None,
+                }
+            } else {
+                None
+            };
+
+        let func_argument_id = AttributePrototypeArgument::func_argument_id_by_id(ctx, id).await?;
+
+        Ok(Self {
+            func_argument_id,
+            id,
+            input_socket_id,
+        })
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributePrototypeView {
+    pub id: AttributePrototypeId,
+    pub component_id: Option<ComponentId>,
+    pub schema_variant_id: Option<SchemaVariantId>,
+    pub prop_id: Option<PropId>,
+    pub output_socket_id: Option<OutputSocketId>,
+    pub prototype_arguments: Vec<AttributePrototypeArgumentView>,
+}
+
+impl AttributePrototypeView {
+    pub async fn assemble(
+        ctx: &DalContext,
+        id: AttributePrototypeId,
+    ) -> FuncAssociationsResult<Self> {
+        let attribute_prototype_argument_ids =
+            AttributePrototypeArgument::list_ids_for_prototype(ctx, id).await?;
+
+        let eventual_parent = AttributePrototype::eventual_parent(ctx, id).await?;
+        let (component_id, schema_variant_id, prop_id, output_socket_id) = match eventual_parent {
+            AttributePrototypeEventualParent::Component(component_id) => {
+                (Some(component_id), None, None, None)
+            }
+            AttributePrototypeEventualParent::SchemaVariantFromInputSocket(
+                schema_variant_id,
+                _,
+            ) => (None, Some(schema_variant_id), None, None),
+            AttributePrototypeEventualParent::SchemaVariantFromOutputSocket(
+                schema_variant_id,
+                output_socket_id,
+            ) => (None, Some(schema_variant_id), None, Some(output_socket_id)),
+            AttributePrototypeEventualParent::SchemaVariantFromProp(schema_variant_id, prop_id) => {
+                (None, Some(schema_variant_id), Some(prop_id), None)
+            }
+        };
+
+        let mut prototype_arguments = Vec::new();
+        for attribute_prototype_argument_id in attribute_prototype_argument_ids {
+            prototype_arguments.push(
+                AttributePrototypeArgumentView::assemble(ctx, attribute_prototype_argument_id)
+                    .await?,
+            );
+        }
+
+        Ok(Self {
+            id,
+            component_id,
+            schema_variant_id,
+            prop_id,
+            output_socket_id,
+            prototype_arguments,
+        })
+    }
+}

--- a/lib/dal/src/func/authoring/create.rs
+++ b/lib/dal/src/func/authoring/create.rs
@@ -210,7 +210,7 @@ async fn create_attribute_func(
                     if let Some(func) = Func::get_by_id(ctx, func_id).await? {
                         if Func::is_dynamic_for_name_string(func.name.as_str()) {
                             return Err(FuncAuthoringError::AttributePrototypeAlreadySetByFunc(
-                                kind.to_string(),
+                                func_id, func.name,
                             ));
                         }
                     }

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -175,10 +175,9 @@ impl Schema {
     ) -> SchemaResult<()> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        info!(
-            "Setting {} as the default schema variant for {}",
-            schema_variant_id.clone(),
-            self.id.clone()
+        debug!(
+            %schema_variant_id, "setting the default schema variant for schema: {}",
+            self.id
         );
 
         // Our system will have edges as follows:

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -4,6 +4,7 @@ use dal_test::test;
 use dal_test::test_harness::create_empty_action_func;
 use pretty_assertions_sorted::assert_eq;
 
+mod argument;
 mod associations;
 mod authoring;
 

--- a/lib/dal/tests/integration_test/func/argument.rs
+++ b/lib/dal/tests/integration_test/func/argument.rs
@@ -1,0 +1,41 @@
+use dal::attribute::prototype::argument::AttributePrototypeArgument;
+use dal::func::argument::FuncArgument;
+use dal::{AttributePrototype, DalContext, Func};
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn list_attribute_prototype_argument_ids(ctx: &mut DalContext) {
+    let func_id = Func::find_by_name(ctx, "test:falloutEntriesToGalaxies")
+        .await
+        .expect("could not perform find by name")
+        .expect("no func found");
+    let func_argument = FuncArgument::find_by_name_for_func(ctx, "entries", func_id)
+        .await
+        .expect("could not perform find by name")
+        .expect("no func argument found");
+    let mut attribute_prototype_argument_ids =
+        FuncArgument::list_attribute_prototype_argument_ids(ctx, func_argument.id)
+            .await
+            .expect("could not list attribute prototype argument ids");
+
+    // Ensure that the attribute prototype argument is what we expect and that it leads back to the
+    // original func.
+    let attribute_prototype_argument_id = attribute_prototype_argument_ids
+        .pop()
+        .expect("empty attribute prototype argument ids");
+    assert!(attribute_prototype_argument_ids.is_empty());
+    let attribute_prototype_id = AttributePrototypeArgument::prototype_id_for_argument_id(
+        ctx,
+        attribute_prototype_argument_id,
+    )
+    .await
+    .expect("could not get attribute prototype id");
+    let found_func_id = AttributePrototype::func_id(ctx, attribute_prototype_id)
+        .await
+        .expect("could not get func id");
+    assert_eq!(
+        func_id,       // expected
+        found_func_id  // actual
+    );
+}

--- a/lib/dal/tests/integration_test/func/associations.rs
+++ b/lib/dal/tests/integration_test/func/associations.rs
@@ -4,7 +4,7 @@ use dal::func::view::FuncArgumentView;
 use dal::func::{AttributePrototypeArgumentView, AttributePrototypeView, FuncAssociations};
 use dal::prop::PropPath;
 use dal::schema::variant::leaves::LeafInputLocation;
-use dal::{AttributePrototype, DalContext, Func, Prop, Schema};
+use dal::{AttributePrototype, DalContext, DeprecatedActionKind, Func, Prop, Schema};
 use dal_test::test;
 use pretty_assertions_sorted::assert_eq;
 
@@ -33,6 +33,7 @@ async fn for_action(ctx: &mut DalContext) {
 
     assert_eq!(
         FuncAssociations::Action {
+            kind: DeprecatedActionKind::Create,
             schema_variant_ids: vec![schema_variant_id],
         }, // expected
         associations.expect("no associations found") // actual

--- a/lib/dal/tests/integration_test/func/authoring.rs
+++ b/lib/dal/tests/integration_test/func/authoring.rs
@@ -1,1 +1,2 @@
 mod create_func;
+mod save_func;

--- a/lib/dal/tests/integration_test/func/authoring/save_func.rs
+++ b/lib/dal/tests/integration_test/func/authoring/save_func.rs
@@ -1,0 +1,161 @@
+use dal::func::argument::{FuncArgument, FuncArgumentId};
+use dal::func::authoring::{FuncAuthoringClient, SavedFunc};
+use dal::func::view::FuncView;
+use dal::func::FuncAssociations;
+use dal::{AttributePrototype, AttributePrototypeId, DalContext, Func, FuncId};
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn save_action_func(ctx: &mut DalContext) {
+    let (_func_id, _saved_func) = setup(ctx, "test:createActionStarfield").await;
+}
+
+#[test]
+async fn save_authentication_func(ctx: &mut DalContext) {
+    let (_func_id, _saved_func) = setup(ctx, "test:setDummySecretString").await;
+}
+
+#[test]
+async fn save_attribute_func(ctx: &mut DalContext) {
+    let (func_id, saved_func) = setup(ctx, "test:falloutEntriesToGalaxies").await;
+
+    // Find the associations.
+    let (prototypes, arguments) = saved_func
+        .associations
+        .expect("could not get associations")
+        .get_attribute_internals()
+        .expect("could not get internals");
+
+    // Ensure the prototypes look as we expect.
+    let attribute_prototype_ids = AttributePrototype::list_ids_for_func_id(ctx, func_id)
+        .await
+        .expect("could not list ids for func id");
+    assert_eq!(
+        attribute_prototype_ids, // expected
+        prototypes
+            .iter()
+            .map(|v| v.id)
+            .collect::<Vec<AttributePrototypeId>>()  // actual
+    );
+
+    // Ensure the arguments look as we expect.
+    let func_argument_ids = FuncArgument::list_ids_for_func(ctx, func_id)
+        .await
+        .expect("could not list ids for func");
+    assert_eq!(
+        func_argument_ids, // expected
+        arguments
+            .iter()
+            .map(|v| v.id)
+            .collect::<Vec<FuncArgumentId>>()  // actual
+    );
+
+    // Let's delete the func argument and update some metadata.
+    let func = Func::get_by_id_or_error(ctx, func_id)
+        .await
+        .expect("could not get func by id");
+    let func_view = FuncView::assemble(ctx, &func)
+        .await
+        .expect("could not assemble func view");
+    let (prototypes, _arguments) = func_view
+        .associations
+        .expect("could not get associations")
+        .get_attribute_internals()
+        .expect("could not get internals");
+    let saved_func = FuncAuthoringClient::save_func(
+        ctx,
+        func_view.id,
+        Some("updated-display-name".to_string()),
+        func_view.name,
+        func_view.description,
+        func_view.code,
+        Some(FuncAssociations::Attribute {
+            prototypes,
+            arguments: Vec::new(),
+        }),
+    )
+    .await
+    .expect("unable to create func");
+
+    // Ensure the updated func looks as we expect.
+    let func = Func::get_by_id_or_error(ctx, func_id)
+        .await
+        .expect("could not get func by id");
+    let func_view = FuncView::assemble(ctx, &func)
+        .await
+        .expect("could not assemble func view");
+    assert_eq!(
+        saved_func.associations, // expected
+        func_view.associations   // actual
+    );
+    assert_eq!(
+        func_id,      // expected
+        func_view.id  // actual
+    );
+
+    let (mut prototypes, arguments) = func_view
+        .associations
+        .expect("could not get associations")
+        .get_attribute_internals()
+        .expect("could not get internals");
+    assert!(arguments.is_empty());
+    let prototype = prototypes.pop().expect("empty prototypes");
+    assert!(prototypes.is_empty());
+    assert!(prototype.prototype_arguments.is_empty());
+}
+
+#[test]
+async fn save_code_generation_func(ctx: &mut DalContext) {
+    let (_func_id, _saved_func) = setup(ctx, "test:generateCode").await;
+}
+
+#[test]
+async fn save_qualification_func(ctx: &mut DalContext) {
+    let (_func_id, _saved_func) = setup(ctx, "test:qualificationDummySecretStringIsTodd").await;
+}
+
+// Sets up the tests within the module. Find the func to be saved by name and then save it
+// immediately when found. This is the basic "does it work in place" check.
+async fn setup(ctx: &mut DalContext, func_name: impl AsRef<str>) -> (FuncId, SavedFunc) {
+    let func_id = Func::find_by_name(ctx, func_name)
+        .await
+        .expect("could not perform find func by name")
+        .expect("no func found");
+
+    // Save the func immediately when found.
+    let func = Func::get_by_id_or_error(ctx, func_id)
+        .await
+        .expect("could not get func by id");
+    let func_view = FuncView::assemble(ctx, &func)
+        .await
+        .expect("could not assemble func view");
+    let saved_func = FuncAuthoringClient::save_func(
+        ctx,
+        func_view.id,
+        func_view.display_name,
+        func_view.name,
+        func_view.description,
+        func_view.code,
+        func_view.associations.clone(),
+    )
+    .await
+    .expect("unable to create func");
+
+    // We know it is successful and revertible because it should work immediately and the test
+    // runs in a new change set.
+    assert!(saved_func.success);
+    assert!(saved_func.is_revertible);
+
+    // Perform all other assertions before getting started.
+    assert_eq!(
+        func_id,      // expected
+        func_view.id  // actual
+    );
+    assert_eq!(
+        func_view.types,  // expected
+        saved_func.types, // actual
+    );
+
+    (func_id, saved_func)
+}

--- a/lib/sdf-server/src/server/service/func/save_func.rs
+++ b/lib/sdf-server/src/server/service/func/save_func.rs
@@ -35,7 +35,7 @@ pub async fn save_func(
 
     let request_id = request.id;
 
-    let (save_response, _) = FuncAuthoringClient::save_func(
+    let save_response = FuncAuthoringClient::save_func(
         &ctx,
         request.id,
         request.display_name,


### PR DESCRIPTION
## Description

Currently, `save_func` works in the new engine. However, we need it to work for attribute funcs and advanced use cases. This commit is a step in that direction with the goal of ensuring of collecting and saving func associations works when saving an attribute func.

<img src="https://media2.giphy.com/media/U7DIuNUkkEjGoHiszu/giphy.gif"/>

## Relevant Changes

- Fix func argument mutation, removal and additional procedures when working with attribute funcs
- Fix action kind selection in the authoring screen
- Add integration tests for all func saving scenarios (with attribute funcs getting a full-length test)
- Fix code gen and qualification input checkboxes

## Misc Changes

- Convert stdout lines to logs when importing packages
- Make errors clearer when importing packages
- Replace default schema variant log with debug log

## Known Issues

- Changing the type of a func argument for an attribute func does not work
- Changing "run on assets of type" and similar values does not work
- Using the attribute bindings panel for attribute funcs may not work as intended
- Changing builtin funcs is allowed