### PR TITLE
Fix Frames, a journey

### DIFF
--- a/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
@@ -40,7 +40,7 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
       cy.get('canvas').first().as('konvaStage');
 
       cy.intercept('POST', '/api/diagram/create_component').as('componentA');
-      let componentIDA, componentIDB, bearertoken;
+      let componentIDA, componentIDB;
 
       // drag to the canvas
       cy.dragTo('@awsRegion', '@konvaStage');
@@ -48,7 +48,7 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
         componentIDA = interception.response?.body.componentId;
       });
 
-      cy.wait(5000);
+      cy.wait(1000);
 
       cy.get('div[class="tree-node"]', { timeout: 30000 }).contains('EC2 Instance').as('awsEC2');
 
@@ -56,31 +56,10 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
       cy.dragTo('@awsEC2', '@konvaStage', 0, 75);
 
       cy.wait('@componentB', {timeout: 60000}).then(async (interception) => {
-        bearertoken = interception.request.headers.authorization;
         componentIDB = interception.response?.body.componentId;
       });
 
-      // WE CANNOT FORCE A HOVER STATE INSIDE CANVAS
-      // SO THE "PARENT" IS NOT SET DESPITE COMPONENT B BEING INSIDE THE FRAME
-      // HACK
-      cy.url().then(currentUrl => {
-        const parts = currentUrl.split('/');
-        parts.pop(); // c
-        const changeset = parts.pop();
-        cy.request({
-          method: 'POST',
-          url: '/api/diagram/connect_component_to_frame',
-          body: JSON.stringify({
-            childId: componentIDB,
-            parentId: componentIDA,
-            visibility_change_set_pk: changeset,
-            workspaceId: SI_WORKSPACE_ID
-          }),
-          headers: { Authorization: bearertoken, "Content-Type": 'application/json' }
-        });
-      });
-
-      cy.wait(2000);
+      cy.wait(1000);
 
       cy.url().then(currentUrl => {
         // Construct a new URL with desired query parameters for selecting 
@@ -95,7 +74,7 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
       });
 
       // Give the page a few seconds to load
-      cy.wait(2000);
+      cy.wait(1000);
 
       cy.intercept('POST', '/api/component/update_property_editor_value').as('updatePropertyEditorValue');
 
@@ -116,7 +95,7 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
       });
 
       // Wait for the values to propagate
-      cy.wait(1000);
+      cy.wait(3000);
 
       // Validate that the value has propagated through the system
       cy.get('.attributes-panel-item__input-wrap input.region')

--- a/app/web/src/components/ModelingDiagram/DiagramGroup.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroup.vue
@@ -428,7 +428,7 @@ const props = defineProps({
 const diagramContext = useDiagramContext();
 
 const componentId = computed(() => props.group.def.componentId);
-const parentComponentId = computed(() => _.last(props.group.def.ancestorIds));
+const parentComponentId = computed(() => props.group.def.parentId);
 
 const diffIconHover = ref(false);
 const statusIconHovers = ref(

--- a/app/web/src/components/ModelingDiagram/DiagramNode.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramNode.vue
@@ -420,7 +420,7 @@ const nodeHeight = computed(
   () => nodeHeaderHeight.value + nodeBodyHeight.value,
 );
 
-const parentComponentId = computed(() => _.last(props.node.def.ancestorIds));
+const parentComponentId = computed(() => props.node.def.parentId);
 
 const position = computed(() => props.tempPosition || props.node.def.position);
 

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -426,12 +426,11 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               ]);
 
               return {
-                ..._.omit(component, "parentId"),
+                ...component,
                 // swapping "id" to be node id and passing along component id separately for the diagram
                 // this is gross and needs to go, but will happen later
                 id: component.id,
                 componentId: component.id,
-                parentComponentId: component.parentId,
                 title: component.displayName,
                 subtitle: component.schemaName,
                 isLoading:
@@ -707,9 +706,6 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                 diagramKind: "configuration",
                 ...visibilityParams,
               },
-              onSuccess: (response) => {
-                // record position change rather than wait for re-fetch
-              },
             });
           },
 
@@ -725,6 +721,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
             schemaId: string,
             position: Vector2d,
             parentId?: string,
+            size?: Size2D,
           ) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
@@ -745,6 +742,8 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                 parentId,
                 x: position.x.toString(),
                 y: position.y.toString(),
+                height: size?.height.toString(),
+                width: size?.width.toString(),
                 ...visibilityParams,
               },
               optimistic: () => {

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -56,6 +56,16 @@ export type WsEventPayloadMap = {
   ChangeSetWritten: string;
   ChangeSetCancelled: string;
 
+  SetComponentPosition: {
+    changeSetId: ChangeSetId;
+    componentId: ComponentId;
+    userPk: UserId;
+    x: number;
+    y: number;
+    width: number | undefined;
+    height: number | undefined;
+  };
+
   ChangeSetBeginApprovalProcess: {
     changeSetId: ChangeSetId;
     userPk: UserId;

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
         pkgName,
         extraBuildInputs ? [],
         stdBuildPhase ? ''
-          buck2 build "$buck2_target" --verbose 8 --out "build/$name-$system"
+          buck2 build @//mode/release "$buck2_target" --verbose 8 --out "build/$name-$system"
         '',
         extraBuildPhase ? "",
         installPhase,

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -676,7 +676,7 @@ impl ChangeSet {
         Ok(())
     }
 
-    async fn extract_userid_from_context(ctx: &DalContext) -> Option<UserPk> {
+    pub async fn extract_userid_from_context(ctx: &DalContext) -> Option<UserPk> {
         let user_id = match ctx.history_actor() {
             HistoryActor::User(user_pk) => {
                 let maybe_user = User::get_by_pk(ctx, *user_pk).await;

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -292,7 +292,7 @@ impl Diagram {
                 y: component.y().parse::<f64>()?.round() as isize,
             };
             let size = match (component.width(), component.height()) {
-                (Some(h), Some(w)) => Size2D {
+                (Some(w), Some(h)) => Size2D {
                     height: h.parse()?,
                     width: w.parse()?,
                 },

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -1,3 +1,5 @@
+use std::num::ParseIntError;
+
 use serde::{Deserialize, Serialize};
 use si_data_nats::NatsError;
 use si_data_pg::PgError;
@@ -5,7 +7,9 @@ use thiserror::Error;
 use ulid::Ulid;
 
 use crate::change_set::event::{ChangeSetActorPayload, ChangeSetMergeVotePayload};
-use crate::component::{ComponentCreatedPayload, ComponentUpdatedPayload};
+use crate::component::{
+    ComponentCreatedPayload, ComponentSetPositionPayload, ComponentUpdatedPayload,
+};
 use crate::qualification::QualificationCheckPayload;
 use crate::schema::variant::SchemaVariantCreatedPayload;
 use crate::status::StatusUpdate;
@@ -32,6 +36,8 @@ pub enum WsEventError {
     NoUserInContext,
     #[error("no workspace in tenancy")]
     NoWorkspaceInTenancy,
+    #[error("number parse string error: {0}")]
+    ParseIntError(#[from] ParseIntError),
     #[error(transparent)]
     Pg(#[from] PgError),
     #[error("error serializing/deserializing json: {0}")]
@@ -82,6 +88,7 @@ pub enum WsPayload {
     // SchemaVariantSaved(SchemaVariantSavedPayload),
     SecretCreated(SecretCreatedPayload),
     SecretUpdated(SecretUpdatedPayload),
+    SetComponentPosition(ComponentSetPositionPayload),
     StatusUpdate(StatusUpdate),
     // WorkspaceExported(WorkspaceExportPayload),
     // WorkspaceImportBeginApprovalProcess(WorkspaceImportApprovalActorPayload),

--- a/lib/sdf-server/src/server/service/diagram/create_component.rs
+++ b/lib/sdf-server/src/server/service/diagram/create_component.rs
@@ -19,6 +19,8 @@ pub struct CreateComponentRequest {
     pub parent_id: Option<ComponentId>,
     pub x: String,
     pub y: String,
+    pub height: Option<String>,
+    pub width: Option<String>,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -64,8 +66,12 @@ pub async fn create_component(
             &ctx,
             request.x.clone(),
             request.y.clone(),
-            Some(DEFAULT_COMPONENT_WIDTH),
-            Some(DEFAULT_COMPONENT_HEIGHT),
+            request
+                .width
+                .or_else(|| Some(DEFAULT_COMPONENT_WIDTH.to_string())),
+            request
+                .height
+                .or_else(|| Some(DEFAULT_COMPONENT_HEIGHT.to_string())),
         )
         .await?;
 


### PR DESCRIPTION
1. do not rely on browser hover when dropping components into frame. perform the math to see what we are inside.
2. this lets us remove the hack in cypress tests
3. fix to missing parentId (was renamed to parentComponentId)
4. `set_component_position` endpoint needed to change for the new engine
5. fixed a swap of width & height bug on resizing
6. send a web event from the `set_component_position` endpoint
7. frame movement now supports deeply nested children
8. nudging is debounced now, so we don't flood the system with changes
9. creating or attaching a component inside a frame expands the child to the available size and fully bounded by the parent
10. so long as there are no other children, in that case, it makes the frame smaller and does not attempt a "best fit".
![Art Frame GIF by Mowgli420](https://github.com/systeminit/si/assets/69541/e8da5175-7e44-4def-beb0-7e2a811ab799)
