### PR TITLE
bug(layerdb): race to create broadcast channels

### DIFF
--- a/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
@@ -384,3 +384,159 @@ async fn rebase_requests_work_queue_stress() {
         _ => panic!("I dunno what happened"),
     }
 }
+
+// This test ensures that the multiplexer behavior for activities is working correctly. It
+// simulates sending thousands of rebase requests and responses, ensuring that multiple blocking
+// waits all receive their replies.
+#[tokio::test(flavor = "multi_thread")]
+async fn rebase_and_wait_stress() {
+    let token = CancellationToken::new();
+    let tracker = TaskTracker::new();
+
+    let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
+
+    let tempdir_slash = disk_cache_path(&tempdir, "slash");
+    let tempdir_axl = disk_cache_path(&tempdir, "axl");
+
+    let db = setup_pg_db("rebase_and_wait_stress").await;
+
+    // we need a layerdb for slash, who will send the rebase request
+    let (ldb_slash, _): (TestLayerDb, _) = LayerDb::initialize(
+        tempdir_slash,
+        db.clone(),
+        setup_nats_client(Some("rebase_and_wait_stress".to_string())).await,
+        token.clone(),
+    )
+    .await
+    .expect("cannot create layerdb");
+    ldb_slash.pg_migrate().await.expect("migrate layerdb");
+
+    // we need a layerdb for axl, who will send the reply
+    let (ldb_axl, _): (TestLayerDb, _) = LayerDb::initialize(
+        tempdir_axl,
+        db.clone(),
+        setup_nats_client(Some("rebase_and_wait_stress".to_string())).await,
+        token.clone(),
+    )
+    .await
+    .expect("cannot create layerdb");
+    ldb_axl.pg_migrate().await.expect("migrate layerdb");
+
+    let rebase_activities = 5_000;
+    static SENT_REQUEST_COUNTER: AtomicI32 = AtomicI32::new(0);
+    static SENT_REPLY_COUNTER: AtomicI32 = AtomicI32::new(0);
+    static RECV_REPLY_COUNTER: AtomicI32 = AtomicI32::new(0);
+
+    let tenancy = Tenancy::new(WorkspacePk::new(), ChangeSetId::new());
+    let actor = Actor::System;
+    let metadata = LayeredEventMetadata::new(tenancy, actor);
+    let metadata_for_processor = metadata.clone();
+
+    // Set up a processor, rouhgly equivalent to a rebaser
+    let processor_handle = tracker.spawn(async move {
+        // Subscribe to a work queue of rebase activities on axl
+        let mut axl_work_queue = ldb_axl
+            .activity()
+            .rebase()
+            .subscribe_work_queue()
+            .await
+            .expect("cannot retrieve a work queue");
+        while let Some(rebase_request) = axl_work_queue.recv().await {
+            let mp = metadata_for_processor.clone();
+            let _rebase_finished_activity = ldb_axl
+                .activity()
+                .rebase()
+                .finished(
+                    si_layer_cache::activities::rebase::RebaseStatus::Error {
+                        message: "poop".to_string(),
+                    },
+                    Ulid::new(),
+                    WorkspaceSnapshotAddress::new(b"skid row"),
+                    mp,
+                    rebase_request.id,
+                )
+                .await
+                .expect("cannot send rebase finished");
+            SENT_REPLY_COUNTER.fetch_add(1, Ordering::Relaxed);
+            //if SENT_REPLY_COUNTER.load(Ordering::SeqCst) == rebase_activities {
+            //    break;
+            //}
+            //dbg!("recv reply {}", count);
+        }
+    });
+
+    let mut rebase_waiter_handles = Vec::new();
+    for _i in 0..11 {
+        let metadata_for_sender = metadata.clone();
+        let ldb_slash_clone = ldb_slash.clone();
+        let rebase_waiter_handle = tracker.spawn(async move {
+            loop {
+                SENT_REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+                let mp = metadata_for_sender.clone();
+                let _response = ldb_slash_clone
+                    .activity()
+                    .rebase()
+                    .rebase_and_wait(
+                        Ulid::new(),
+                        WorkspaceSnapshotAddress::new(b"poop"),
+                        Ulid::new(),
+                        mp,
+                    )
+                    .await;
+                RECV_REPLY_COUNTER.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+        rebase_waiter_handles.push(rebase_waiter_handle);
+    }
+
+    let check_token = token.clone();
+    let all_messages_processed_stream = tracker.spawn(async move {
+        loop {
+            let recv_reply_count = RECV_REPLY_COUNTER.load(Ordering::SeqCst);
+            if recv_reply_count >= rebase_activities {
+                break;
+            }
+            if check_token.is_cancelled() {
+                break;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+    });
+
+    let timeout_handle = tracker.spawn(async move {
+        tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+    });
+    tracker.close();
+
+    let result = tokio::select!(
+        e = processor_handle => {
+           println!("processor exited: {:?}", e);
+            token.cancel();
+          "processor".to_string()
+        },
+        e = futures::future::select_all(rebase_waiter_handles) => {
+           println!("rebase_waiter exited: {:?}", e);
+            token.cancel();
+          "rebase_waiter".to_string()
+        },
+        _e = all_messages_processed_stream => {
+            token.cancel();
+           "finished".to_string()
+        }
+        _ = timeout_handle => {
+            token.cancel();
+           "deadline".to_string()
+        },
+        () = token.cancelled() => {
+           "finished".to_string()
+        }
+    );
+
+    match result.as_ref() {
+        "processor" => panic!("Processing task has paniced"),
+        "rebase_waiter" => panic!("Rebase send/wait task has paniced"),
+        "finished" => {}
+        "deadline" => panic!("test took longer than 10 seconds to complete"),
+        _ => panic!("wtf"),
+    }
+}


### PR DESCRIPTION
We were using the wrong kind of lock a (RwLock rather than a Mutex) around the creation of broadcast channels in the activity multiplexer. When we went to create a new subscription, we would acquire a Read lock when checking for the existence of the broadcast channel, and if it didn't exist, continue on to create a new one by acquiring a Write lock later in the function.

This, of course, was racy - multiple consumers could acquire a failing Read lock condition, and then pass through to the critical section where we create a new broadcast channel - the result being multiple consumers of the underlying NATS jetstream would be created, only one of which was actually sending the messages we wanted.

I believe this is the source of the occasional deadline misses in rebase finished requests - at the very least, this code was easy to trigger with the test coverage in this PR, which leads me to believe it was also the source of our other issues.

Let's see how it goes. :)

<img src="https://media2.giphy.com/media/xT5LMwXc8C0a7cJdbG/giphy.gif"/>