### PR TITLE
feat: add layer cache dbname to init container config

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
   pgbouncer:
     container_name: pgbouncer
     image: edoburu/pgbouncer:1.22.0-p0
-    profiles: [pinga, sdf]
+    profiles: [rebaser, pinga, sdf]
     ports:
       - 5432:5432
     volumes:

--- a/component/init/configs/pgbouncer.ini
+++ b/component/init/configs/pgbouncer.ini
@@ -1,5 +1,6 @@
 [databases]
 $SI_PG_DB=host=$SI_PG_HOST port=5432 dbname=$SI_PG_DB user=si
+$SI_LAYER_CACHE_DBNAME=host=$SI_PG_HOST port=5432 dbname=$SI_LAYER_CACHE_DBNAME user=si
 
 [pgbouncer]
 listen_addr = *

--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -1,4 +1,5 @@
 pkgs_path = "/tmp"
+layer_cache_pg_dbname = "$SI_LAYER_CACHE_DBNAME"
 
 [crypto]
 encryption_key_base64 = "$SI_ENCRYPTION_KEY_BASE64"


### PR DESCRIPTION
We need these values in place in order to set the layer cache db name in pgbouncer and the related services.

<img src="https://media1.giphy.com/media/snJ3SJJGDtwBDwzlr1/giphy.gif"/>