### PR TITLE
Feat/max bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4104,6 +4104,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "rebaser-server",
+ "si-std",
  "telemetry-application",
  "tokio",
  "tokio-util",

--- a/app/web/Dockerfile
+++ b/app/web/Dockerfile
@@ -1,5 +1,5 @@
 # hadolint ignore=DL3007
-FROM nixos/nix:latest AS builder
+FROM nixos/nix:2.21.2 AS builder
 ARG APP=web
 
 COPY . /workdir

--- a/bin/cyclone/Dockerfile
+++ b/bin/cyclone/Dockerfile
@@ -2,7 +2,7 @@
 # Builder Stage: cyclone
 ###########################################################################
 # hadolint ignore=DL3007
-FROM nixos/nix:latest AS builder-cyclone
+FROM nixos/nix:2.21.2 AS builder-cyclone
 ARG BIN=cyclone
 
 COPY . /workdir
@@ -30,7 +30,7 @@ RUN set -eux; \
 # Builder Stage: lang-js
 ###########################################################################
 # hadolint ignore=DL3007
-FROM nixos/nix:latest AS builder-lang-js
+FROM nixos/nix:2.21.2 AS builder-lang-js
 ARG BIN=lang-js
 
 COPY . /workdir

--- a/bin/module-index/Dockerfile
+++ b/bin/module-index/Dockerfile
@@ -1,5 +1,5 @@
 # hadolint ignore=DL3007
-FROM nixos/nix:latest AS builder
+FROM nixos/nix:2.21.2 AS builder
 ARG BIN=module-index
 
 COPY . /workdir

--- a/bin/pinga/Dockerfile
+++ b/bin/pinga/Dockerfile
@@ -1,5 +1,5 @@
 # hadolint ignore=DL3007
-FROM nixos/nix:latest AS builder
+FROM nixos/nix:2.21.2 AS builder
 ARG BIN=pinga
 
 COPY . /workdir

--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -105,7 +105,7 @@ pub(crate) struct Args {
 
     /// Cyclone encryption key file location [default: /run/pinga/cyclone_encryption.key]
     #[arg(long)]
-    pub(crate) cyclone_encryption_key_path: Option<PathBuf>,
+    pub(crate) cyclone_encryption_key_path: Option<String>,
 
     /// Cyclone encryption key file contents as a base64 encoded string
     #[arg(long)]
@@ -168,7 +168,7 @@ impl TryFrom<Args> for Config {
             if let Some(cyclone_encryption_key_file) = args.cyclone_encryption_key_path {
                 config_map.set(
                     "crypto.encryption_key_file",
-                    cyclone_encryption_key_file.display().to_string(),
+                    cyclone_encryption_key_file.to_string(),
                 );
             }
             if let Some(cyclone_encryption_key_base64) = args.cyclone_encryption_key_base64 {

--- a/bin/rebaser/BUCK
+++ b/bin/rebaser/BUCK
@@ -9,6 +9,7 @@ rust_binary(
     name = "rebaser",
     deps = [
         "//lib/rebaser-server:rebaser-server",
+        "//lib/si-std:si-std",
         "//lib/telemetry-application-rs:telemetry-application",
         "//third-party/rust:clap",
         "//third-party/rust:color-eyre",

--- a/bin/rebaser/Cargo.toml
+++ b/bin/rebaser/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 clap = { workspace = true }
 color-eyre = { workspace = true }
 rebaser-server = { path = "../../lib/rebaser-server" }
+si-std = { path = "../../lib/si-std" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/bin/rebaser/Dockerfile
+++ b/bin/rebaser/Dockerfile
@@ -1,5 +1,5 @@
 # hadolint ignore=DL3007
-FROM nixos/nix:latest AS builder
+FROM nixos/nix:2.21.2 AS builder
 ARG BIN=rebaser
 
 COPY . /workdir

--- a/bin/sdf/Dockerfile
+++ b/bin/sdf/Dockerfile
@@ -1,5 +1,5 @@
 # hadolint ignore=DL3007
-FROM nixos/nix:latest AS builder
+FROM nixos/nix:2.21.2 AS builder
 ARG BIN=sdf
 
 COPY . /workdir

--- a/bin/veritech/Dockerfile
+++ b/bin/veritech/Dockerfile
@@ -2,7 +2,7 @@
 # Builder Stage: veritech
 ###########################################################################
 # hadolint ignore=DL3007
-FROM nixos/nix:latest AS builder-veritech
+FROM nixos/nix:2.21.2 AS builder-veritech
 ARG BIN=veritech
 
 COPY . /workdir
@@ -30,7 +30,7 @@ RUN set -eux; \
 # Builder Stage: cyclone
 ###########################################################################
 # hadolint ignore=DL3007
-FROM nixos/nix:latest AS builder-cyclone
+FROM nixos/nix:2.21.2 AS builder-cyclone
 ARG BIN=cyclone
 
 COPY . /workdir
@@ -53,7 +53,7 @@ RUN ln -snf $(nix-store --query result/)/bin/* /tmp/local-bin/
 # Builder Stage: lang-js
 ###########################################################################
 # hadolint ignore=DL3007
-FROM nixos/nix:latest AS builder-lang-js
+FROM nixos/nix:2.21.2 AS builder-lang-js
 ARG BIN=lang-js
 
 COPY . /workdir

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -84,6 +84,7 @@ local_resource(
     labels = ["backend"],
     cmd = "buck2 build @//mode/release {}".format(rebaser_target),
     serve_cmd = "buck2 run @//mode/release {}".format(rebaser_target),
+    serve_env = {"SI_FORCE_COLOR": "true"},
     allow_parallel = True,
     resource_deps = [
         "nats",

--- a/lib/si-data-nats/src/jetstream/context.rs
+++ b/lib/si-data-nats/src/jetstream/context.rs
@@ -11,6 +11,7 @@ use crate::HeaderName;
 pub static REPLY_SUBJECT_HEADER_NAME: HeaderName = HeaderName::from_static("X-Reply-Subject");
 
 const DEFAULT_MAX_MESSAGES: i64 = 10_000;
+const MAX_BYTES: i64 = 5 * 1024 * 1024 * 1024; // mirrors settings in Synadia NATs
 
 /// A wrapper around [`jetstream::Context`].
 #[derive(Debug)]
@@ -49,6 +50,7 @@ impl Context {
                 name,
                 subjects,
                 max_messages: DEFAULT_MAX_MESSAGES,
+                max_bytes: MAX_BYTES,
                 retention: RetentionPolicy::WorkQueue,
                 ..Default::default()
             })
@@ -91,6 +93,7 @@ impl Context {
                 name.as_str(),
                 jetstream::consumer::pull::Config {
                     durable_name: Some(name.clone()),
+                    max_bytes: MAX_BYTES,
                     ..Default::default()
                 },
             )

--- a/lib/si-data-nats/src/jetstream/context.rs
+++ b/lib/si-data-nats/src/jetstream/context.rs
@@ -11,7 +11,7 @@ use crate::HeaderName;
 pub static REPLY_SUBJECT_HEADER_NAME: HeaderName = HeaderName::from_static("X-Reply-Subject");
 
 const DEFAULT_MAX_MESSAGES: i64 = 10_000;
-const MAX_BYTES: i64 = 5 * 1024 * 1024 * 1024; // mirrors settings in Synadia NATs
+const MAX_BYTES: i64 = 1024 * 1024; // mirrors settings in Synadia NATs
 
 /// A wrapper around [`jetstream::Context`].
 #[derive(Debug)]

--- a/lib/si-layer-cache/src/activities.rs
+++ b/lib/si-layer-cache/src/activities.rs
@@ -42,7 +42,7 @@ pub mod test;
 //pub static RECV_NATS_COUNTER: AtomicI32 = AtomicI32::new(0);
 //pub static SENT_BROADCAST_COUNTER: AtomicI32 = AtomicI32::new(0);
 //pub static SENT_BROADCAST_ERROR_COUNTER: AtomicI32 = AtomicI32::new(0);
-const MAX_BYTES: i64 = 5 * 1024 * 1024 * 1024; // mirrors settings in Synadia NATs
+const MAX_BYTES: i64 = 1024 * 1024; // mirrors settings in Synadia NATs
 
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct ActivityId(Ulid);

--- a/lib/si-layer-cache/src/activities.rs
+++ b/lib/si-layer-cache/src/activities.rs
@@ -42,6 +42,7 @@ pub mod test;
 //pub static RECV_NATS_COUNTER: AtomicI32 = AtomicI32::new(0);
 //pub static SENT_BROADCAST_COUNTER: AtomicI32 = AtomicI32::new(0);
 //pub static SENT_BROADCAST_ERROR_COUNTER: AtomicI32 = AtomicI32::new(0);
+const MAX_BYTES: i64 = 5 * 1024 * 1024 * 1024; // mirrors settings in Synadia NATs
 
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct ActivityId(Ulid);
@@ -368,6 +369,7 @@ impl ActivityStream {
             name: Some(name),
             description: Some(description),
             deliver_policy: jetstream::consumer::DeliverPolicy::New,
+            max_bytes: MAX_BYTES,
             ..Default::default()
         };
 
@@ -502,6 +504,7 @@ impl RebaserRequestWorkQueue {
         jetstream::consumer::pull::Config {
             durable_name: Some(Self::CONSUMER_NAME.to_string()),
             description: Some("rebaser requests consumer".to_string()),
+            max_bytes: MAX_BYTES,
             ..Default::default()
         }
     }

--- a/lib/si-layer-cache/src/event.rs
+++ b/lib/si-layer-cache/src/event.rs
@@ -36,7 +36,7 @@ use crate::nats::NATS_HEADER_KEY;
 use crate::LayerDbError;
 
 const DEFAULT_CHUNK_SIZE: usize = 128 * 1024;
-const MAX_BYTES: i64 = 5 * 1024 * 1024 * 1024; // mirrors settings in Synadia NATs
+const MAX_BYTES: i64 = 1024 * 1024; // mirrors settings in Synadia NATs
 
 const HEADER_EVENT_ID: &str = "X-EVENT-ID";
 const HEADER_CHECKSUM: &str = "X-CHECKSUM";

--- a/lib/si-layer-cache/src/event.rs
+++ b/lib/si-layer-cache/src/event.rs
@@ -36,6 +36,7 @@ use crate::nats::NATS_HEADER_KEY;
 use crate::LayerDbError;
 
 const DEFAULT_CHUNK_SIZE: usize = 128 * 1024;
+const MAX_BYTES: i64 = 5 * 1024 * 1024 * 1024; // mirrors settings in Synadia NATs
 
 const HEADER_EVENT_ID: &str = "X-EVENT-ID";
 const HEADER_CHECKSUM: &str = "X-CHECKSUM";
@@ -404,6 +405,7 @@ impl LayeredEventServer {
             name: Some(name),
             description: Some(description),
             deliver_policy: DeliverPolicy::New,
+            max_bytes: MAX_BYTES,
             ..Default::default()
         }
     }

--- a/lib/si-layer-cache/src/nats.rs
+++ b/lib/si-layer-cache/src/nats.rs
@@ -18,6 +18,7 @@ const NATS_ACTIVITIES_STREAM_NAME: &str = "LAYERDB_ACTIVITIES";
 const NATS_ACTIVITIES_STREAM_SUBJECTS: &[&str] = &["si.layerdb.activities.>"];
 
 const NATS_REBASER_REQUESTS_WORK_QUEUE_STREAM_NAME: &str = "REBASER_REQUESTS";
+const MAX_BYTES: i64 = 5 * 1024 * 1024 * 1024; // mirrors settings in Synadia NATs
 
 /// Returns a Jetstream Stream and creates it if it doesn't yet exist.
 pub async fn layerdb_events_stream(
@@ -63,6 +64,7 @@ pub async fn layerdb_activities_stream(
             discard: jetstream::stream::DiscardPolicy::Old,
             // TODO(fnichol): this likely needs tuning
             max_age: Duration::from_secs(60 * 60 * 6),
+            max_bytes: MAX_BYTES,
             ..Default::default()
         })
         .await?;
@@ -91,6 +93,7 @@ pub async fn rebaser_requests_work_queue_stream(
             description: Some("Rebaser requests work queue".to_owned()),
             retention: jetstream::stream::RetentionPolicy::WorkQueue,
             sources: Some(vec![source]),
+            max_bytes: MAX_BYTES,
             ..Default::default()
         })
         .await?;

--- a/lib/si-layer-cache/src/nats.rs
+++ b/lib/si-layer-cache/src/nats.rs
@@ -18,7 +18,7 @@ const NATS_ACTIVITIES_STREAM_NAME: &str = "LAYERDB_ACTIVITIES";
 const NATS_ACTIVITIES_STREAM_SUBJECTS: &[&str] = &["si.layerdb.activities.>"];
 
 const NATS_REBASER_REQUESTS_WORK_QUEUE_STREAM_NAME: &str = "REBASER_REQUESTS";
-const MAX_BYTES: i64 = 5 * 1024 * 1024 * 1024; // mirrors settings in Synadia NATs
+const MAX_BYTES: i64 = 1024 * 1024; // mirrors settings in Synadia NATs
 
 /// Returns a Jetstream Stream and creates it if it doesn't yet exist.
 pub async fn layerdb_events_stream(


### PR DESCRIPTION
This normalizes the rebaser config to match how pinga is configured today. We shouldn't be doing this an instead should be removing all of the bits the rebaser doesn't use, but it's a bigger lift to refactor how we create the services context. This also adds the `max_bytes` setting wherever we use jetstream. It is currently set to 1mb, but this is easily tuneable.

<img src="https://media0.giphy.com/media/KxbhQdZQ8Pvo47Hnti/giphy.gif"/>