### PR TITLE
fix: defaults in rebaser config overwrite local settings

### DIFF
--- a/lib/rebaser-server/src/config.rs
+++ b/lib/rebaser-server/src/config.rs
@@ -53,6 +53,7 @@ pub struct Config {
     #[builder(default = "CryptoConfig::default()")]
     crypto: CryptoConfig,
 
+    #[builder(default = "SymmetricCryptoServiceConfig::default()")]
     symmetric_crypto_service: SymmetricCryptoServiceConfig,
 
     #[builder(default)]
@@ -169,7 +170,7 @@ impl TryFrom<ConfigFile> for Config {
 
 fn default_symmetric_crypto_config() -> SymmetricCryptoServiceConfigFile {
     SymmetricCryptoServiceConfigFile {
-        active_key: Some("/run/rebaser/donkey.key".to_owned()),
+        active_key: None,
         active_key_base64: None,
         extra_keys: vec![],
     }


### PR DESCRIPTION
Missed some defaults in my earlier PR for the rebase config.

<img src="https://media1.giphy.com/media/4gjChPhgF6Q3IRh5Aj/giphy.gif"/>