### PR TITLE
fix(web): don't inject route outside of createStore

### DIFF
--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -2,7 +2,6 @@ import { defineStore } from "pinia";
 import * as _ from "lodash-es";
 import { watch } from "vue";
 import { ApiRequest, addStoreHooks } from "@si/vue-lib/pinia";
-import { useRoute } from "vue-router";
 import { useToast } from "vue-toastification";
 import {
   ChangeSet,
@@ -25,7 +24,6 @@ export interface OpenChangeSetsView {
 }
 
 export function useChangeSetsStore() {
-  const route = useRoute();
   const workspacesStore = useWorkspacesStore();
   const workspacePk = workspacesStore.selectedWorkspacePk;
 
@@ -337,7 +335,9 @@ export function useChangeSetsStore() {
                 !this.selectedChangeSetId ||
                 this.selectedChangeSetId === changeSetId
               ) {
-                if (route.name) {
+                const route = useRouterStore().currentRoute;
+
+                if (route?.name) {
                   router.push({
                     name: route.name,
                     params: {


### PR DESCRIPTION
`useRoute` cannot be used outside of a Vue component (it's enough to put it inside of the createStore). Quiet the warning about inject in the wrong context.