### PR TITLE
feat(binary): move nix-invoked buck build to use release mode by default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
         pkgName,
         extraBuildInputs ? [],
         stdBuildPhase ? ''
-          buck2 build "$buck2_target" --verbose 8 --out "build/$name-$system"
+          buck2 build @//mode/release "$buck2_target" --verbose 8 --out "build/$name-$system"
         '',
         extraBuildPhase ? "",
         installPhase,


### PR DESCRIPTION
Docker build and omnibus use nix-invoked builds to create the binaries/packages.

This moves those publishable Artifacts to use release build by default.