### PR TITLE
Add --layer-cache-disk-path arg to relevant services

### DIFF
--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -119,6 +119,10 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) concurrency: Option<u32>,
 
+    /// The path at which the layer db cache is created/used on disk [e.g. /banana/]
+    #[arg(long)]
+    pub(crate) layer_cache_disk_path: Option<String>,
+
     /// Instance ID [example: 01GWEAANW5BVFK5KDRVS6DEY0F"]
     ///
     /// And instance ID is used when tracking the execution of jobs in a way that can be traced
@@ -185,6 +189,9 @@ impl TryFrom<Args> for Config {
             }
             if let Some(concurrency) = args.concurrency {
                 config_map.set("concurrency_limit", i64::from(concurrency));
+            }
+            if let Some(layer_cache_disk_path) = args.layer_cache_disk_path {
+                config_map.set("layer_cache_disk_path", layer_cache_disk_path);
             }
             if let Some(instance_id) = args.instance_id {
                 config_map.set("instance_id", instance_id);

--- a/bin/rebaser/src/args.rs
+++ b/bin/rebaser/src/args.rs
@@ -118,6 +118,10 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) concurrency: Option<u32>,
 
+    /// The path at which the layer db cache is created/used on disk [e.g. /banana/]
+    #[arg(long)]
+    pub(crate) layer_cache_disk_path: Option<String>,
+
     /// Instance ID [example: 01GWEAANW5BVFK5KDRVS6DEY0F"]
     ///
     /// And instance ID is used when tracking the execution of jobs in a way that can be traced
@@ -181,6 +185,9 @@ impl TryFrom<Args> for Config {
                     "symmetric_crypto_service.active_key_base64",
                     secret_string.to_string(),
                 );
+            }
+            if let Some(layer_cache_disk_path) = args.layer_cache_disk_path {
+                config_map.set("layer_cache_disk_path", layer_cache_disk_path);
             }
             if let Some(concurrency) = args.concurrency {
                 config_map.set("concurrency_limit", i64::from(concurrency));

--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -123,6 +123,10 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) jwt_public_signing_key_base64: Option<SensitiveString>,
 
+    /// The path at which the layer db cache is created/used on disk [e.g. /banana/]
+    #[arg(long)]
+    pub(crate) layer_cache_disk_path: Option<String>,
+
     /// Generates cyclone secret key file (does not run server)
     ///
     /// Will error if set when `generate_cyclone_public_key_path` is not set
@@ -225,6 +229,9 @@ impl TryFrom<Args> for Config {
             }
             if let Some(jwt) = args.jwt_public_signing_key_base64 {
                 config_map.set("jwt_signing_public_key.key_base64", jwt.to_string());
+            }
+            if let Some(layer_cache_disk_path) = args.layer_cache_disk_path {
+                config_map.set("layer_cache_disk_path", layer_cache_disk_path);
             }
             if let Some(pkgs_path) = args.pkgs_path {
                 config_map.set("pkgs_path", pkgs_path);

--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -1,5 +1,6 @@
 pkgs_path = "/tmp"
 layer_cache_pg_dbname = "$SI_LAYER_CACHE_DBNAME"
+layer_cache_disk_path = "$SI_LAYER_CACHE_DISK_PATH"
 
 [crypto]
 encryption_key_base64 = "$SI_ENCRYPTION_KEY_BASE64"

--- a/lib/pinga-server/src/config.rs
+++ b/lib/pinga-server/src/config.rs
@@ -136,6 +136,8 @@ pub struct ConfigFile {
     concurrency_limit: usize,
     #[serde(default = "random_instance_id")]
     instance_id: String,
+    #[serde(default = "default_layer_cache_disk_path")]
+    layer_cache_disk_path: PathBuf,
     #[serde(default = "default_symmetric_crypto_config")]
     symmetric_crypto_service: SymmetricCryptoServiceConfigFile,
 }
@@ -149,6 +151,7 @@ impl Default for ConfigFile {
             concurrency_limit: default_concurrency_limit(),
             crypto: Default::default(),
             instance_id: random_instance_id(),
+            layer_cache_disk_path: default_layer_cache_disk_path(),
             symmetric_crypto_service: default_symmetric_crypto_config(),
         }
     }
@@ -172,8 +175,7 @@ impl TryFrom<ConfigFile> for Config {
         config.concurrency(value.concurrency_limit);
         config.instance_id(value.instance_id);
         config.symmetric_crypto_service(value.symmetric_crypto_service.try_into()?);
-        config.layer_cache_disk_path =
-            Some(si_layer_cache::default_cache_path_for_service("pinga"));
+        config.layer_cache_disk_path(value.layer_cache_disk_path);
         config.build().map_err(Into::into)
     }
 }
@@ -196,6 +198,10 @@ fn default_layer_cache_dbname() -> String {
 
 fn default_concurrency_limit() -> usize {
     DEFAULT_CONCURRENCY_LIMIT
+}
+
+fn default_layer_cache_disk_path() -> PathBuf {
+    si_layer_cache::default_cache_path_for_service("pinga")
 }
 
 #[allow(clippy::disallowed_methods)] // Used to determine if running in development

--- a/lib/rebaser-server/src/config.rs
+++ b/lib/rebaser-server/src/config.rs
@@ -62,6 +62,7 @@ pub struct Config {
     #[builder(default = "default_layer_cache_dbname()")]
     layer_cache_pg_dbname: String,
 
+    #[builder(default = "si_layer_cache::default_cache_path_for_service(\"rebaser\")")]
     layer_cache_disk_path: PathBuf,
 }
 
@@ -129,6 +130,8 @@ pub struct ConfigFile {
     crypto: CryptoConfig,
     #[serde(default = "default_symmetric_crypto_config")]
     symmetric_crypto_service: SymmetricCryptoServiceConfigFile,
+    #[serde(default = "default_layer_cache_disk_path")]
+    layer_cache_disk_path: PathBuf,
     #[serde(default)]
     messaging_config: RebaserMessagingConfig,
 }
@@ -141,6 +144,7 @@ impl Default for ConfigFile {
             nats: Default::default(),
             crypto: Default::default(),
             symmetric_crypto_service: default_symmetric_crypto_config(),
+            layer_cache_disk_path: default_layer_cache_disk_path(),
             messaging_config: Default::default(),
         }
     }
@@ -162,8 +166,7 @@ impl TryFrom<ConfigFile> for Config {
         config.nats(value.nats);
         config.crypto(value.crypto);
         config.symmetric_crypto_service(value.symmetric_crypto_service.try_into()?);
-        config.layer_cache_disk_path =
-            Some(si_layer_cache::default_cache_path_for_service("rebaser"));
+        config.layer_cache_disk_path(value.layer_cache_disk_path);
         config.build().map_err(Into::into)
     }
 }
@@ -178,6 +181,10 @@ fn default_symmetric_crypto_config() -> SymmetricCryptoServiceConfigFile {
 
 fn default_layer_cache_dbname() -> String {
     "si_layer_db".to_string()
+}
+
+fn default_layer_cache_disk_path() -> PathBuf {
+    si_layer_cache::default_cache_path_for_service("rebaser")
 }
 
 /// This function is used to determine the development environment and update the [`ConfigFile`]

--- a/lib/sdf-server/src/server/config.rs
+++ b/lib/sdf-server/src/server/config.rs
@@ -84,6 +84,7 @@ pub struct Config {
     #[builder(default = "default_layer_cache_dbname()")]
     layer_cache_pg_dbname: String,
 
+    #[builder(default = "si_layer_cache::default_cache_path_for_service(\"sdf\")")]
     layer_cache_disk_path: PathBuf,
 
     signup_secret: SensitiveString,
@@ -198,6 +199,8 @@ pub struct ConfigFile {
     pub signup_secret: SensitiveString,
     #[serde(default = "default_pkgs_path")]
     pub pkgs_path: String,
+    #[serde(default = "default_layer_cache_disk_path")]
+    layer_cache_disk_path: PathBuf,
     #[serde(default)]
     pub posthog: PosthogConfig,
     #[serde(default)]
@@ -217,6 +220,7 @@ impl Default for ConfigFile {
             crypto: Default::default(),
             signup_secret: default_signup_secret(),
             pkgs_path: default_pkgs_path(),
+            layer_cache_disk_path: default_layer_cache_disk_path(),
             posthog: Default::default(),
             module_index_url: default_module_index_url(),
             symmetric_crypto_service: default_symmetric_crypto_config(),
@@ -246,7 +250,7 @@ impl TryFrom<ConfigFile> for Config {
         config.posthog(value.posthog);
         config.module_index_url(value.module_index_url);
         config.symmetric_crypto_service(value.symmetric_crypto_service.try_into()?);
-        config.layer_cache_disk_path = Some(si_layer_cache::default_cache_path_for_service("sdf"));
+        config.layer_cache_disk_path(value.layer_cache_disk_path);
         config.build().map_err(Into::into)
     }
 }
@@ -298,6 +302,10 @@ fn default_symmetric_crypto_config() -> SymmetricCryptoServiceConfigFile {
 
 fn default_layer_cache_dbname() -> String {
     "si_layer_db".to_string()
+}
+
+fn default_layer_cache_disk_path() -> PathBuf {
+    si_layer_cache::default_cache_path_for_service("sdf")
 }
 
 fn default_module_index_url() -> String {


### PR DESCRIPTION
Adds a `--layer-cache-disk-path` arg to rebaser, pinga and sdf to allow us to specify a non /tmp/ path when running in Production/Tools Production.

This should let us monitor + work with the services more easily.