### PR TITLE
feat: set moka max_size to 12gb to ensure we don't starve the host

### DIFF
--- a/lib/si-layer-cache/src/memory_cache.rs
+++ b/lib/si-layer-cache/src/memory_cache.rs
@@ -25,8 +25,10 @@ where
     V: Serialize + DeserializeOwned + Clone + Send + Sync + Clone + 'static,
 {
     pub fn new() -> Self {
+        // hardcoding max cache size to 12gb as a hammer to ensure we don't starve the OS
+        // TODO(scott): make this dynamic based on the the total memory set
         Self {
-            cache: Cache::new(u64::MAX),
+            cache: Cache::new(12 * 1024 * 1024 * 1024),
         }
     }
 


### PR DESCRIPTION
We should be smarter about this, but this should work for now to ensure we don't starve the VMs in AWS. We'll want this to get the max memory from the machine and set to some ratio of that. 