### PR TITLE
feat: add port for node-exporter

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -32,6 +32,8 @@ services:
     command:
       - --collector.systemd
       - --collector.systemd.unit-include=${SI_SERVICE}.service
+    ports:
+      - 9100:9100
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro


### PR DESCRIPTION
Node exporter wasn't available on the nodes interfaces so that it could be consumed by prometheus.

This adds it onto the host interface so metrics can be pulled up the observability stack.