### PR TITLE
Revert "feat: set moka max_size to 12gb to ensure we don't starve the host"

### DIFF
--- a/lib/si-layer-cache/src/memory_cache.rs
+++ b/lib/si-layer-cache/src/memory_cache.rs
@@ -25,10 +25,8 @@ where
     V: Serialize + DeserializeOwned + Clone + Send + Sync + Clone + 'static,
 {
     pub fn new() -> Self {
-        // hardcoding max cache size to 12gb as a hammer to ensure we don't starve the OS
-        // TODO(scott): make this dynamic based on the the total memory set
         Self {
-            cache: Cache::new(12 * 1024 * 1024 * 1024),
+            cache: Cache::new(u64::MAX),
         }
     }
 


### PR DESCRIPTION
This was not considered well enough. We actually make 4 distinct caches, so collectively we are setting the total memory to 48gb. Reverting so we can do this properly.

This reverts commit f108aec47d5cc32be89e0404d84339b349d69e6e.