### PR TITLE
chore(db): add pgbouncer to our dev setup

### DIFF
--- a/.ci/DEV.md
+++ b/.ci/DEV.md
@@ -1,0 +1,38 @@
+# How to run the CI stack locally
+
+First, you need to prepare a local copy of the code you want to test.
+
+```
+$ cp ./si ./si-fixme
+$ chown -R 2000:2000 ./si-fixme
+```
+
+This is to create a working copy of the source that is owned by the same user
+as the internal 'ci' user.
+
+## Run the CI platform
+
+```
+$ docker-compose -f .ci/docker-compose.test-integration.yml up
+```
+
+This will start all the services, but the 'app' service will fail. This is
+expected. You can run this from the `si` or `si-fixme` copy, it doesn't matter.
+
+## Run the app service as a container
+
+From your `si-fixme` root directory, you can start the app container:
+
+```
+$ docker-compose -f .ci/docker-compose.test-integration.yml run --entrypoint /bin/bash --volume $(pwd):/workdir app
+```
+
+That will give you a shell with your current code mounted as /workdir.
+
+To develop:
+
+```
+$ nix develop
+```
+
+You can now run buck2 as normal and debug the containers in a CI-like environment.

--- a/.ci/docker-compose.test-integration.yml
+++ b/.ci/docker-compose.test-integration.yml
@@ -3,7 +3,8 @@ services:
   app:
     image: systeminit/ci-base:stable
     environment:
-      - "SI_TEST_PG_HOSTNAME=postgres"
+      - "USE_CI_PG_SETUP=true"
+      - "SI_TEST_PG_HOSTNAME=postgres-test"
       # NOTE: We want to set this to the default postgres port as the tests run
       # in *this* container and we're accessing postgres in a peer container
       # and not using the external port mapping.
@@ -11,16 +12,33 @@ services:
       - "SI_TEST_NATS_URL=nats"
       - "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317"
     depends_on:
-      - postgres
+      - postgres-test
       - nats
       - jaeger
       - otelcol
 
-  # NOTE: this db is the same configuration as `postgres-test` under
+  # This is the same as the pgbouncer test setup in our dev environment
+  postgres-test:
+    image: systeminit/pgbouncer:stable
+    environment:
+      - "DB_USER=si_test"
+      - "DB_PASSWORD=bugbear"
+      - "DB_HOST=db-test"
+      - "ADMIN_USERS=postgres,dbuser,si_test"
+      - "AUTH_TYPE=scram-sha-256"
+      - "MAX_CLIENT_CONN=100000"
+      - "DEFAULT_POOL_SIZE=10"
+      - "SERVER_IDLE_TIMEOUT=10"
+      - "POOL_MODE=transaction"
+      - "MAX_PREPARED_STATEMENTS=10000"
+    depends_on:
+      - db-test
+
+  # NOTE: this db is the same configuration as `db-test` under
   # `dev/docker-compose.platform.yml`. In the CI environment, there should be
   # *no* need for the `postgres` service as we aren't running the full service
   # stack.
-  postgres:
+  db-test:
     image: systeminit/postgres:stable
     environment:
       - "POSTGRES_PASSWORD=bugbear"

--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
 
   pgbouncer:
     container_name: pgbouncer
-    image: edoburu/pgbouncer:1.22.0-p0
+    image: systeminit/pgbouncer:stable
     profiles: [rebaser, pinga, sdf]
     ports:
       - 5432:5432

--- a/component/pgbouncer/BUCK
+++ b/component/pgbouncer/BUCK
@@ -1,0 +1,15 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "docker_image",
+)
+
+docker_image(
+    name = "pgbouncer",
+    build_args = {
+        "BASE_VERSION": "1.22.1-p0",
+    },
+    run_docker_args = [
+        "--publish",
+        "5432:5432",
+    ],
+)

--- a/component/pgbouncer/Dockerfile
+++ b/component/pgbouncer/Dockerfile
@@ -1,0 +1,2 @@
+ARG BASE_VERSION
+FROM edoburu/pgbouncer:${BASE_VERSION}

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,5 @@
+# What are minica.pem and minica-key.pem?
+
+They are the certificate authority records for our fake development
+certificates. In particular, they are used to generate the postgres
+certificates, and embedded in our dev builds as valid CAs.

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -7,6 +7,8 @@ groups = {
         "jaeger",
         "nats",
         "otelcol",
+        "db",
+        "db-test",
         "postgres",
         "postgres-test",
     ],
@@ -67,7 +69,7 @@ allow_k8s_contexts(k8s_context())
 
 # Use Docker Compose to provide the platform services
 docker_compose("./docker-compose.platform.yml")
-compose_services = ["jaeger", "nats", "otelcol", "postgres", "postgres-test"]
+compose_services = ["jaeger", "nats", "otelcol", "postgres", "postgres-test", "db", "db-test"]
 for service in compose_services:
     if service == "jaeger":
         links = [

--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -1,6 +1,6 @@
 ---
 services:
-  postgres:
+  db:
     image: systeminit/postgres:stable
     environment:
       - "POSTGRES_PASSWORD=bugbear"
@@ -9,14 +9,14 @@ services:
       - "POSTGRES_DB=si"
       - "POSTGRES_MULTIPLE_DBS=si_layer_db,si_auth,si_module_index"
     ports:
-      - "5432:5432"
+      - "7432:5432"
     healthcheck:
       test: ["CMD-SHELL", "[ -f /tmp/ready ]"]
       interval: 5s
       timeout: 10s
       retries: 5
 
-  postgres-test:
+  db-test:
     image: systeminit/postgres:stable
     environment:
       - "POSTGRES_PASSWORD=bugbear"
@@ -30,12 +30,48 @@ services:
       - "-c"
       - "full_page_writes=off"
     ports:
-      - "6432:5432"
+      - "8432:5432"
     healthcheck:
       test: ["CMD-SHELL", "[ -f /tmp/ready ]"]
       interval: 5s
       timeout: 10s
       retries: 5
+
+  postgres:
+    image: systeminit/pgbouncer:stable
+    environment:
+      - "DB_USER=si"
+      - "DB_PASSWORD=bugbear"
+      - "DB_HOST=db"
+      - "ADMIN_USERS=postgres,dbuser,si"
+      - "AUTH_TYPE=scram-sha-256"
+      - "MAX_CLIENT_CONN=100000"
+      - "MAX_PREPARED_STATEMENTS=10000"
+      - "DEFAULT_POOL_SIZE=250"
+      - "MIN_POOL_SIZE=200"
+      - "POOL_MODE=transaction"
+    ports:
+      - "5432:5432"
+    depends_on:
+      - db
+
+  postgres-test:
+    image: systeminit/pgbouncer:stable
+    environment:
+      - "DB_USER=si_test"
+      - "DB_PASSWORD=bugbear"
+      - "DB_HOST=db-test"
+      - "ADMIN_USERS=postgres,dbuser,si_test"
+      - "AUTH_TYPE=scram-sha-256"
+      - "MAX_CLIENT_CONN=100000"
+      - "DEFAULT_POOL_SIZE=10"
+      - "SERVER_IDLE_TIMEOUT=10"
+      - "POOL_MODE=transaction"
+      - "MAX_PREPARED_STATEMENTS=10000"
+    ports:
+      - "6432:5432"
+    depends_on:
+      - db-test
 
   nats:
     image: systeminit/nats:stable


### PR DESCRIPTION
This PR adds pgbouncer to our dev setup. It moves the "real" postgres instances to 7432 (si) and 8432 (si-test) respectively, replacing them with two different pgbouncers. This change is primarily to ensure that we avoid any threat of pool exhaustion in the test suite, but has the added benefit of making the dev stack closer to our production deployment (which would also include pgbouncer.)

PgBouncer configures a pool per hostname+database. Since each of our dal integration tests creates its own database, it thereby also creates its own pool. To manage this, we create a pool size of 10 per hostname+database tuple, which we will then reap after 10 idle seconds. The result is that the current test suite peaks somewhere around 300 tests, but very rapidly shrinks. We should have plenty of headroom.

The only tricky thing here is that we alter the migration paths for tests, as we migrate with the underlying database connection directly. When we do, we must forcibly disconnect the bouncer - so if you happen to be logged in to postgres, get ready to be logged out when we need to make the original template database for tests.

<img src="https://media1.giphy.com/media/etn52ENYVnpxqMaXiT/giphy.gif"/>