### PR TITLE
fix(dal): don't break custom name functions on component creation

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -918,9 +918,19 @@ impl Component {
         Ok(Self::assemble(&node_weight, content))
     }
 
-    pub async fn set_name(&self, ctx: &DalContext, name: &str) -> ComponentResult<()> {
+    // Set the name of the component. Should only be used during component creation
+    async fn set_name(&self, ctx: &DalContext, name: &str) -> ComponentResult<()> {
+        let path = ["root", "si", "name"];
+        let sv_id = Self::schema_variant_id(ctx, self.id).await?;
+        let name_prop_id = Prop::find_prop_id_by_path(ctx, sv_id, &PropPath::new(path)).await?;
+        // If the name prop is controlled by an identity or other function,
+        // don't override the prototype here
+        if Prop::is_set_by_dependent_function(ctx, name_prop_id).await? {
+            return Ok(());
+        }
+
         let av_for_name = self
-            .attribute_values_for_prop(ctx, &["root", "si", "name"])
+            .attribute_values_for_prop(ctx, &path)
             .await?
             .into_iter()
             .next()

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -828,6 +828,20 @@ impl Prop {
         Ok(AttributePrototype::list_input_socket_sources_for_id(ctx, prototype_id).await?)
     }
 
+    /// Is this prop set by a function that takes another prop (or socket) as an input?
+    pub async fn is_set_by_dependent_function(
+        ctx: &DalContext,
+        prop_id: PropId,
+    ) -> PropResult<bool> {
+        let prototype_id = Self::prototype_id(ctx, prop_id).await?;
+        let prototype_func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
+
+        Ok(Func::get_by_id(ctx, prototype_func_id)
+            .await?
+            .map(|f| f.is_dynamic())
+            .unwrap_or(false))
+    }
+
     pub async fn set_default_value<T: Serialize>(
         ctx: &DalContext,
         prop_id: PropId,


### PR DESCRIPTION
This fixes the bug that broke the `region` frame. We were manually setting the name on component creation, overriding the prototype that makes the region prop control the root/si/name prop for that component.