### PR TITLE
chore(dal, sdf): Refactoring the Asset Authoring experience behind a client

### DIFF
--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -52,6 +52,8 @@ mod metadata_view;
 pub mod root_prop;
 mod value_from;
 
+pub mod authoring;
+
 pub use json::SchemaVariantJson;
 pub use json::SchemaVariantMetadataJson;
 pub use metadata_view::SchemaVariantMetadataView;

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -1,0 +1,294 @@
+use std::collections::HashMap;
+
+use base64::engine::general_purpose;
+use base64::Engine;
+use chrono::Utc;
+use convert_case::{Case, Casing};
+use thiserror::Error;
+
+use si_pkg::{
+    FuncSpec, FuncSpecBackendKind, FuncSpecBackendResponseType, FuncSpecData, PkgSpec, SiPkg,
+    SiPkgError, SpecError,
+};
+use telemetry::prelude::*;
+
+use crate::func::binding::{FuncBinding, FuncBindingError};
+use crate::func::intrinsics::IntrinsicFunc;
+use crate::pkg::{import_pkg_from_pkg, PkgError};
+use crate::schema::variant::{SchemaVariantJson, SchemaVariantMetadataJson};
+use crate::{
+    generate_unique_id, pkg, ComponentType, DalContext, Func, FuncBackendKind,
+    FuncBackendResponseType, FuncError, FuncId, Schema, SchemaError, SchemaVariant,
+    SchemaVariantError, SchemaVariantId,
+};
+
+#[allow(missing_docs)]
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum VariantAuthoringError {
+    #[error("func error: {0}")]
+    Func(#[from] FuncError),
+    #[error("func binding error: {0}")]
+    FuncBinding(#[from] FuncBindingError),
+    #[error("func execution error: {0}")]
+    FuncExecution(FuncId),
+    #[error("func execution failure error: {0}")]
+    FuncExecutionFailure(String),
+    #[error("no new asset was created")]
+    NoAssetCreated,
+    #[error("pkg error: {0}")]
+    Pkg(#[from] PkgError),
+    #[error("schema error: {0}")]
+    Schema(#[from] SchemaError),
+    #[error("schema variant error: {0}")]
+    SchemaVariant(#[from] SchemaVariantError),
+    #[error("schema variant asset func not found: {0}")]
+    SchemaVariantAssetNotFound(SchemaVariantId),
+    #[error("json serialization error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("si pkg error: {0}")]
+    SiPkg(#[from] SiPkgError),
+    #[error("spec error: {0}")]
+    Spec(#[from] SpecError),
+}
+
+type VariantAuthoringResult<T> = Result<T, VariantAuthoringError>;
+
+const DEFAULT_ASSET_CODE: &str = r#"function main() {
+  return new AssetBuilder().build()
+}"#;
+
+#[derive(Debug)]
+pub struct VariantAuthoringClient;
+
+impl VariantAuthoringClient {
+    /// Creates a [`SchemaVariant`] and returns the [result](SchemaVariant).
+    #[instrument(name = "variant.authoring.create_variant", level = "info", skip_all)]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_variant(
+        ctx: &DalContext,
+        name: String,
+        display_name: Option<String>,
+        description: Option<String>,
+        link: Option<String>,
+        category: String,
+        color: String,
+    ) -> VariantAuthoringResult<SchemaVariant> {
+        let code_base64 = general_purpose::STANDARD_NO_PAD.encode(DEFAULT_ASSET_CODE);
+        let asset_func = Func::new(
+            ctx,
+            generate_scaffold_func_name(name.clone()),
+            display_name.clone(),
+            description.clone(),
+            link.clone(),
+            false,
+            false,
+            FuncBackendKind::JsSchemaVariantDefinition,
+            FuncBackendResponseType::SchemaVariantDefinition,
+            Some("main"),
+            Some(code_base64),
+        )
+        .await?;
+
+        let asset_func_spec = build_asset_func_spec(&asset_func)?;
+        let definition = execute_asset_func(ctx, &asset_func).await?;
+
+        let metadata = SchemaVariantMetadataJson {
+            name: name.clone(),
+            menu_name: display_name.clone(),
+            category,
+            color,
+            component_type: ComponentType::Component,
+            link: link.clone(),
+            description: description.clone(),
+        };
+
+        //TODO @stack72 - figure out how we get the current user in this!
+        let pkg_spec = build_pkg_spec_for_variant(
+            definition,
+            &asset_func_spec,
+            &metadata,
+            "sally@systeminit.com",
+        )?;
+
+        let pkg = SiPkg::load_from_spec(pkg_spec.clone())?;
+
+        let (_, schema_variant_ids, _) = import_pkg_from_pkg(
+            ctx,
+            &pkg,
+            Some(pkg::ImportOptions {
+                schemas: None,
+                skip_import_funcs: Some(HashMap::from_iter([(
+                    asset_func_spec.unique_id.to_owned(),
+                    asset_func.clone(),
+                )])),
+                no_record: true,
+                is_builtin: false,
+            }),
+        )
+        .await?;
+
+        let schema_variant_id = schema_variant_ids
+            .first()
+            .copied()
+            .ok_or(VariantAuthoringError::NoAssetCreated)?;
+
+        Ok(SchemaVariant::get_by_id(ctx, schema_variant_id).await?)
+    }
+
+    #[instrument(name = "variant.authoring.clone_variant", level = "info", skip_all)]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn clone_variant(
+        ctx: &DalContext,
+        schema_variant_id: SchemaVariantId,
+    ) -> VariantAuthoringResult<(SchemaVariant, Schema)> {
+        let variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
+        let schema = variant.schema(ctx).await?;
+
+        let new_name = format!("{} Clone {}", schema.name(), generate_unique_id(4));
+        let menu_name = variant.display_name().map(|mn| format!("{mn} Clone"));
+
+        if let Some(asset_func_id) = variant.asset_func_id() {
+            let old_func = Func::get_by_id_or_error(ctx, asset_func_id).await?;
+
+            let cloned_func = old_func.duplicate(ctx, new_name.clone()).await?;
+            let cloned_func_spec = build_asset_func_spec(&cloned_func)?;
+            let definition = execute_asset_func(ctx, &cloned_func).await?;
+            let metadata = SchemaVariantMetadataJson {
+                name: new_name.clone(),
+                menu_name: menu_name.clone(),
+                category: variant.category().to_string(),
+                color: variant.get_color(ctx).await?,
+                component_type: variant.component_type(),
+                link: variant.link().clone(),
+                description: variant.description().clone(),
+            };
+            //TODO @stack72 - figure out how we get the current user in this!
+            let pkg_spec = build_pkg_spec_for_variant(
+                definition,
+                &cloned_func_spec,
+                &metadata,
+                "sally@systeminit.com",
+            )?;
+
+            let pkg = SiPkg::load_from_spec(pkg_spec.clone())?;
+
+            let (_, schema_variant_ids, _) = import_pkg_from_pkg(
+                ctx,
+                &pkg,
+                Some(pkg::ImportOptions {
+                    schemas: None,
+                    skip_import_funcs: Some(HashMap::from_iter([(
+                        cloned_func_spec.unique_id.to_owned(),
+                        cloned_func.clone(),
+                    )])),
+                    no_record: true,
+                    is_builtin: false,
+                }),
+            )
+            .await?;
+
+            let new_schema_variant_id = schema_variant_ids
+                .first()
+                .copied()
+                .ok_or(VariantAuthoringError::NoAssetCreated)?;
+
+            Ok((
+                SchemaVariant::get_by_id(ctx, new_schema_variant_id).await?,
+                schema,
+            ))
+        } else {
+            return Err(VariantAuthoringError::SchemaVariantAssetNotFound(
+                schema_variant_id,
+            ));
+        }
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn build_asset_func_spec(asset_func: &Func) -> VariantAuthoringResult<FuncSpec> {
+    let mut schema_variant_func_spec = FuncSpec::builder();
+    schema_variant_func_spec.name(asset_func.name.clone());
+    schema_variant_func_spec.unique_id(asset_func.id.to_string());
+    let mut func_spec_data_builder = FuncSpecData::builder();
+    func_spec_data_builder
+        .name(asset_func.name.clone())
+        .backend_kind(FuncSpecBackendKind::JsSchemaVariantDefinition)
+        .response_type(FuncSpecBackendResponseType::SchemaVariantDefinition)
+        .hidden(asset_func.hidden);
+    if let Some(code) = asset_func.code_plaintext()? {
+        func_spec_data_builder.code_plaintext(code);
+    }
+    if let Some(handler) = asset_func.handler.clone() {
+        func_spec_data_builder.handler(handler.to_string());
+    }
+    if let Some(description) = asset_func.description.clone() {
+        func_spec_data_builder.description(description.to_string());
+    }
+    if let Some(display_name) = asset_func.display_name.clone() {
+        func_spec_data_builder.display_name(display_name.to_string());
+    }
+    Ok(schema_variant_func_spec
+        .data(func_spec_data_builder.build()?)
+        .build()?)
+}
+async fn execute_asset_func(
+    ctx: &DalContext,
+    asset_func: &Func,
+) -> VariantAuthoringResult<SchemaVariantJson> {
+    let (_, return_value) =
+        FuncBinding::create_and_execute(ctx, serde_json::Value::Null, asset_func.id, vec![])
+            .await?;
+    if let Some(error) = return_value
+        .value()
+        .ok_or(VariantAuthoringError::FuncExecution(asset_func.id))?
+        .as_object()
+        .ok_or(VariantAuthoringError::FuncExecution(asset_func.id))?
+        .get("error")
+        .and_then(|e| e.as_str())
+    {
+        return Err(VariantAuthoringError::FuncExecutionFailure(
+            error.to_owned(),
+        ));
+    }
+    let func_resp = return_value
+        .value()
+        .ok_or(VariantAuthoringError::FuncExecution(asset_func.id))?
+        .as_object()
+        .ok_or(VariantAuthoringError::FuncExecution(asset_func.id))?
+        .get("definition")
+        .ok_or(VariantAuthoringError::FuncExecution(asset_func.id))?;
+    Ok(serde_json::from_value::<SchemaVariantJson>(
+        func_resp.to_owned(),
+    )?)
+}
+#[allow(clippy::result_large_err)]
+fn build_pkg_spec_for_variant(
+    definition: SchemaVariantJson,
+    asset_func_spec: &FuncSpec,
+    metadata: &SchemaVariantMetadataJson,
+    user_email: &str,
+) -> VariantAuthoringResult<PkgSpec> {
+    // we need to change this to use the PkgImport
+    let identity_func_spec = IntrinsicFunc::Identity.to_spec()?;
+    let variant_spec = definition.to_spec(
+        metadata.clone(),
+        &identity_func_spec.unique_id,
+        &asset_func_spec.unique_id,
+    )?;
+    let schema_spec = metadata.to_spec(variant_spec)?;
+    Ok(PkgSpec::builder()
+        .name(metadata.clone().name)
+        .created_by(user_email)
+        .func(identity_func_spec)
+        .func(asset_func_spec.clone())
+        .schema(schema_spec)
+        .version("0.0.1")
+        .build()?)
+}
+
+fn generate_scaffold_func_name(name: String) -> String {
+    let version = Utc::now().format("%Y%m%d%H%M").to_string();
+    let generated_name = format!("{}Scaffold_{}", name.to_case(Case::Camel), version);
+    generated_name
+}

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -6,6 +6,7 @@ use dal::{
 use dal_test::{test, test_harness::create_schema};
 use pretty_assertions_sorted::assert_eq;
 
+mod authoring;
 mod view;
 
 #[test]

--- a/lib/dal/tests/integration_test/schema/variant/authoring.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring.rs
@@ -1,1 +1,2 @@
+mod clone_variant;
 mod create_variant;

--- a/lib/dal/tests/integration_test/schema/variant/authoring.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring.rs
@@ -1,0 +1,1 @@
+mod create_variant;

--- a/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
@@ -1,0 +1,60 @@
+use dal::schema::variant::authoring::VariantAuthoringClient;
+use dal::{ChangeSet, DalContext, Schema, SchemaVariant};
+use dal_test::test;
+
+#[test]
+async fn clone_variant(ctx: &mut DalContext) {
+    let new_change_set = ChangeSet::fork_head(ctx, "new change set")
+        .await
+        .expect("could not create new change set");
+    ctx.update_visibility_and_snapshot_to_visibility(new_change_set.id)
+        .await
+        .expect("could not update visibility");
+
+    let schema = Schema::find_by_name(ctx, "dummy-secret")
+        .await
+        .expect("unable to get schema")
+        .expect("schema not found");
+
+    let default_schema_variant = schema
+        .get_default_schema_variant(ctx)
+        .await
+        .expect("Unable to find the default schema variant id");
+    let existing_schema = SchemaVariant::get_by_id(
+        ctx,
+        default_schema_variant.expect("unable to unwrap schema variant id"),
+    )
+    .await
+    .expect("unable to lookup the default schema variant");
+
+    assert!(default_schema_variant.is_some());
+
+    let (new_schema_variant, _) = VariantAuthoringClient::clone_variant(
+        ctx,
+        default_schema_variant.expect("unable to get the schema variant id from the option"),
+    )
+    .await
+    .expect("unable to clone the schema variant");
+
+    assert_eq!(new_schema_variant.category(), existing_schema.category());
+    assert_eq!(
+        new_schema_variant.display_name(),
+        Some("dummy-secret Clone".to_string())
+    );
+    assert_eq!(
+        new_schema_variant
+            .get_color(ctx)
+            .await
+            .expect("unable to get color"),
+        new_schema_variant
+            .get_color(ctx)
+            .await
+            .expect("unable to get color")
+    );
+    assert!(new_schema_variant.asset_func_id().is_some());
+
+    assert_ne!(
+        new_schema_variant.id(),
+        default_schema_variant.expect("unable to unwrap default schema variant id")
+    );
+}

--- a/lib/dal/tests/integration_test/schema/variant/authoring/create_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/create_variant.rs
@@ -1,0 +1,72 @@
+use dal::func::FuncKind;
+use dal::schema::variant::authoring::VariantAuthoringClient;
+use dal::{ChangeSet, DalContext, Func, FuncBackendResponseType};
+use dal_test::test;
+
+#[test]
+async fn create_variant(ctx: &mut DalContext) {
+    let new_change_set = ChangeSet::fork_head(ctx, "new change set")
+        .await
+        .expect("could not create new change set");
+    ctx.update_visibility_and_snapshot_to_visibility(new_change_set.id)
+        .await
+        .expect("could not update visibility");
+
+    let asset_name = "paulsTestAsset".to_string();
+    let display_name = None;
+    let description = None;
+    let link = None;
+    let category = "Integration Tests".to_string();
+    let color = "#00b0b0".to_string();
+    let variant = VariantAuthoringClient::create_variant(
+        ctx,
+        asset_name.clone(),
+        display_name.clone(),
+        description.clone(),
+        link.clone(),
+        category.clone(),
+        color.clone(),
+    )
+    .await
+    .expect("Unable to create new asset");
+
+    let new_schema = variant
+        .schema(ctx)
+        .await
+        .expect("Unable to get the schema for the variant");
+
+    assert_eq!(variant.category(), category.clone());
+    assert_eq!(new_schema.name(), asset_name.clone());
+    assert_eq!(variant.display_name(), display_name.clone());
+    assert_eq!(
+        variant.get_color(ctx).await.expect("unable to get color"),
+        color.clone()
+    );
+    assert!(variant.asset_func_id().is_some());
+
+    let maybe_func = Func::get_by_id(
+        ctx,
+        variant
+            .asset_func_id()
+            .expect("unable to get asset func id from variant"),
+    )
+    .await
+    .expect("unable to get asset authoring func");
+
+    assert!(maybe_func.is_some());
+
+    let func = maybe_func.unwrap();
+
+    let scaffold_func_name = format!("{}Scaffold_", asset_name);
+    assert!(func.name.contains(&scaffold_func_name));
+    assert_eq!(func.kind, FuncKind::SchemaVariantDefinition);
+    assert_eq!(
+        func.backend_response_type,
+        FuncBackendResponseType::SchemaVariantDefinition
+    );
+    assert_eq!(Some("main".to_string()), func.handler);
+    assert_eq!(
+        Some("function main() {\n  return new AssetBuilder().build()\n}".to_string()),
+        func.code_plaintext().expect("Unable to get code plaintext")
+    );
+}

--- a/lib/sdf-server/src/server/service/variant/clone_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/clone_variant.rs
@@ -1,19 +1,11 @@
 use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
 use crate::server::tracking::track;
-use crate::service::variant::{
-    build_asset_func_spec, build_pkg_spec_for_variant, execute_asset_func, SchemaVariantError,
-    SchemaVariantResult,
-};
+use crate::service::variant::SchemaVariantResult;
 use axum::extract::OriginalUri;
 use axum::{response::IntoResponse, Json};
-use dal::pkg::import_pkg_from_pkg;
-use dal::schema::variant::SchemaVariantMetadataJson;
-use dal::{
-    generate_unique_id, ChangeSet, Func, SchemaVariant, SchemaVariantId, Visibility, WsEvent,
-};
+use dal::schema::variant::authoring::VariantAuthoringClient;
+use dal::{ChangeSet, SchemaVariantId, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
-use si_pkg::SiPkg;
-use std::collections::HashMap;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -41,60 +33,8 @@ pub async fn clone_variant(
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
-    let variant_def = dbg!(SchemaVariant::get_by_id(&ctx, request.id).await)?;
-    let schema = variant_def.schema(&ctx).await?;
-
-    let new_name = format!("{} Clone {}", schema.name(), generate_unique_id(4));
-    let menu_name = variant_def.display_name().map(|mn| format!("{mn} Clone"));
-
-    if let Some(asset_func_id) = variant_def.asset_func_id() {
-        let old_func = Func::get_by_id_or_error(&ctx, asset_func_id).await?;
-
-        let cloned_func = old_func.duplicate(&ctx, new_name.clone()).await?;
-        let cloned_func_spec = build_asset_func_spec(&cloned_func)?;
-        let definition = execute_asset_func(&ctx, &cloned_func).await?;
-        let metadata = SchemaVariantMetadataJson {
-            name: new_name.clone(),
-            menu_name: menu_name.clone(),
-            category: variant_def.category().to_string(),
-            color: variant_def.get_color(&ctx).await?,
-            component_type: variant_def.component_type(),
-            link: variant_def.link().clone(),
-            description: variant_def.description().clone(),
-        };
-
-        //TODO @stack72 - figure out how we get the current user in this!
-        let pkg_spec = build_pkg_spec_for_variant(
-            definition,
-            &cloned_func_spec,
-            &metadata,
-            "sally@systeminit.com",
-        )?;
-
-        let pkg = SiPkg::load_from_spec(pkg_spec.clone())?;
-
-        let (_, schema_variant_ids, _) = import_pkg_from_pkg(
-            &ctx,
-            &pkg,
-            Some(dal::pkg::ImportOptions {
-                schemas: None,
-                skip_import_funcs: Some(HashMap::from_iter([(
-                    cloned_func_spec.unique_id.to_owned(),
-                    cloned_func.clone(),
-                )])),
-                no_record: true,
-                is_builtin: false,
-            }),
-        )
-        .await?;
-
-        let _schema_variant_id = schema_variant_ids
-            .first()
-            .copied()
-            .ok_or(SchemaVariantError::NoAssetCreated)?;
-    } else {
-        return Err(SchemaVariantError::SchemaVariantAssetNotFound(request.id));
-    }
+    let (cloned_schema_variant, schema) =
+        VariantAuthoringClient::clone_variant(&ctx, request.id).await?;
 
     track(
         &posthog_client,
@@ -103,14 +43,14 @@ pub async fn clone_variant(
         "clone_variant",
         serde_json::json!({
             "variant_name": schema.name(),
-            "variant_category": variant_def.category(),
-            "variant_menu_name": variant_def.display_name(),
-            "variant_id": variant_def.id(),
-            "variant_component_type": variant_def.component_type(),
+            "variant_category": cloned_schema_variant.category(),
+            "variant_menu_name": cloned_schema_variant.display_name(),
+            "variant_id": cloned_schema_variant.id(),
+            "variant_component_type": cloned_schema_variant.component_type(),
         }),
     );
 
-    WsEvent::schema_variant_cloned(&ctx, variant_def.id())
+    WsEvent::schema_variant_cloned(&ctx, cloned_schema_variant.id())
         .await?
         .publish_on_commit(&ctx)
         .await?;
@@ -124,7 +64,7 @@ pub async fn clone_variant(
     }
 
     Ok(response.body(serde_json::to_string(&CloneVariantResponse {
-        id: variant_def.id(),
+        id: cloned_schema_variant.id(),
         success: true,
     })?)?)
 }

--- a/lib/sdf-server/src/server/service/variant/create_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/create_variant.rs
@@ -1,29 +1,13 @@
-use std::collections::HashMap;
-
 use axum::extract::OriginalUri;
 use axum::{response::IntoResponse, Json};
-use base64::engine::general_purpose;
-use base64::Engine;
 use serde::{Deserialize, Serialize};
 
-use dal::pkg::import_pkg_from_pkg;
-use dal::schema::variant::SchemaVariantMetadataJson;
-use dal::{
-    ChangeSet, ComponentType, Func, FuncBackendKind, FuncBackendResponseType, SchemaVariantId,
-    Visibility, WsEvent,
-};
-use si_pkg::SiPkg;
+use dal::schema::variant::authoring::VariantAuthoringClient;
+use dal::{ChangeSet, SchemaVariantId, Visibility, WsEvent};
 
 use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
 use crate::server::tracking::track;
-use crate::service::variant::{
-    build_asset_func_spec, build_pkg_spec_for_variant, execute_asset_func,
-    generate_scaffold_func_name, SchemaVariantError, SchemaVariantResult,
-};
-
-const DEFAULT_ASSET_CODE: &str = r#"function main() {
-  return new AssetBuilder().build()
-}"#;
+use crate::service::variant::SchemaVariantResult;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -56,64 +40,16 @@ pub async fn create_variant(
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
-    let code_base64 = general_purpose::STANDARD_NO_PAD.encode(DEFAULT_ASSET_CODE);
-    let asset_func = Func::new(
+    let created_schema_variant = VariantAuthoringClient::create_variant(
         &ctx,
-        generate_scaffold_func_name(request.name.clone()),
+        request.name.clone(),
         request.display_name.clone(),
         request.description.clone(),
         request.link.clone(),
-        false,
-        false,
-        FuncBackendKind::JsSchemaVariantDefinition,
-        FuncBackendResponseType::SchemaVariantDefinition,
-        Some("main"),
-        Some(code_base64),
+        request.category.clone(),
+        request.color.clone(),
     )
     .await?;
-
-    let asset_func_spec = build_asset_func_spec(&asset_func)?;
-    let definition = execute_asset_func(&ctx, &asset_func).await?;
-
-    let metadata = SchemaVariantMetadataJson {
-        name: request.name.clone(),
-        menu_name: request.display_name.clone(),
-        category: request.category.clone(),
-        color: request.color,
-        component_type: ComponentType::Component,
-        link: request.link.clone(),
-        description: request.description.clone(),
-    };
-
-    //TODO @stack72 - figure out how we get the current user in this!
-    let pkg_spec = build_pkg_spec_for_variant(
-        definition,
-        &asset_func_spec,
-        &metadata,
-        "sally@systeminit.com",
-    )?;
-
-    let pkg = SiPkg::load_from_spec(pkg_spec.clone())?;
-
-    let (_, schema_variant_ids, _) = import_pkg_from_pkg(
-        &ctx,
-        &pkg,
-        Some(dal::pkg::ImportOptions {
-            schemas: None,
-            skip_import_funcs: Some(HashMap::from_iter([(
-                asset_func_spec.unique_id.to_owned(),
-                asset_func.clone(),
-            )])),
-            no_record: true,
-            is_builtin: false,
-        }),
-    )
-    .await?;
-
-    let schema_variant_id = schema_variant_ids
-        .first()
-        .copied()
-        .ok_or(SchemaVariantError::NoAssetCreated)?;
 
     track(
         &posthog_client,
@@ -124,11 +60,11 @@ pub async fn create_variant(
             "variant_name": request.name.clone(),
             "variant_category": request.category.clone(),
             "variant_menu_name": request.display_name.clone(),
-            "variant_id": schema_variant_id.clone(),
+            "variant_id": created_schema_variant.id().clone(),
         }),
     );
 
-    WsEvent::schema_variant_created(&ctx, schema_variant_id)
+    WsEvent::schema_variant_created(&ctx, created_schema_variant.id())
         .await?
         .publish_on_commit(&ctx)
         .await?;
@@ -141,7 +77,7 @@ pub async fn create_variant(
         response = response.header("force_change_set_id", force_change_set_id.to_string());
     }
     Ok(response.body(serde_json::to_string(&CreateVariantResponse {
-        id: schema_variant_id,
+        id: created_schema_variant.id(),
         success: true,
     })?)?)
 }


### PR DESCRIPTION
This keeps it inline with Func Authoring and will allow us to test the pieces in isolation rather than needing to go through SDF for testing
