### PR TITLE
ENG-2502 edge set response id

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -802,6 +802,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                 if (this.edgesById[tempId]) {
                   const edge = this.edgesById[tempId];
                   if (edge) {
+                    edge.id = response.id;
                     this.edgesById[response.id] = edge;
                     delete this.edgesById[tempId];
                   }


### PR DESCRIPTION
`componentStore.selectedEdge` fails without saving over the tempID.