### PR TITLE
feat(dal): check for cycles when connecting components

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1303,6 +1303,8 @@ impl Component {
         destination_component_id: ComponentId,
         destination_input_socket_id: InputSocketId,
     ) -> ComponentResult<Option<(AttributeValueId, AttributePrototypeArgumentId)>> {
+        let cycle_check_guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
+
         let destination_component = Component::get_by_id(ctx, destination_component_id).await?;
         for connection in destination_component.incoming_connections(ctx).await? {
             if connection.from_component_id == source_component_id
@@ -1348,6 +1350,8 @@ impl Component {
         .await?;
 
         AttributeValue::update_from_prototype_function(ctx, destination_attribute_value_id).await?;
+
+        drop(cycle_check_guard);
 
         Ok(Some((
             destination_attribute_value_id,

--- a/lib/dal/src/component/frame.rs
+++ b/lib/dal/src/component/frame.rs
@@ -75,9 +75,10 @@ impl Frame {
         parent_id: ComponentId,
         child_id: ComponentId,
     ) -> FrameResult<()> {
-        // detect cycles here?
+        let cycle_check_guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
         Component::add_edge_to_frame(ctx, parent_id, child_id, EdgeWeightKind::FrameContains)
             .await?;
+        drop(cycle_check_guard);
 
         // when detaching a child, need to rerun any attribute prototypes for those impacted sockets then queue up dvu!
 

--- a/lib/dal/tests/integration_test/cycle_check_guard.rs
+++ b/lib/dal/tests/integration_test/cycle_check_guard.rs
@@ -1,0 +1,14 @@
+use dal::DalContext;
+use dal_test::test;
+
+#[test]
+async fn cycle_check_guard_test(ctx: &DalContext) {
+    let snap = ctx.workspace_snapshot().expect("get snap");
+    let guard = snap.enable_cycle_check().await;
+
+    assert!(snap.cycle_check().await);
+
+    drop(guard);
+
+    assert!(!snap.cycle_check().await);
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -5,6 +5,7 @@ mod builtins;
 mod change_set;
 mod component;
 mod connection;
+mod cycle_check_guard;
 mod dependent_values_update;
 mod frame;
 mod func;


### PR DESCRIPTION
Ensures we check for graph cycles when connecting components (to prevent connecting components in a cycle), and when attaching children to parent frames.