### PR TITLE
Basic multiplayer experience for moving and resizing elements on the diagram

### DIFF
--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -211,12 +211,14 @@ import tinycolor from "tinycolor2";
 import { LoadingMessage, getToneColorHex } from "@si/vue-lib/design-system";
 import { connectionAnnotationFitsReference } from "@si/ts-lib/src/connection-annotations";
 import { windowListenerManager } from "@si/vue-lib";
+import { el } from "date-fns/locale";
 import { useCustomFontsLoaded } from "@/utils/useFontLoaded";
 import DiagramGroup from "@/components/ModelingDiagram/DiagramGroup.vue";
 import {
   ComponentId,
   EdgeId,
   useComponentsStore,
+  FullComponent,
 } from "@/store/components.store";
 import DiagramGroupOverlay from "@/components/ModelingDiagram/DiagramGroupOverlay.vue";
 import { DiagramCursorDef, usePresenceStore } from "@/store/presence.store";
@@ -477,32 +479,24 @@ const onResize: ResizeObserverCallback = (entries) => {
 const debouncedOnResize = _.debounce(onResize, 50);
 const resizeObserver = new ResizeObserver(debouncedOnResize);
 
-// the movedElementPositions and resizedElementSizes are undefined until something is moved or resized
-// lets define them here, so we always can use them
-// i tried this onBeforeMounted and onMounted but the store data was empty, which was unexpected
-// but watching also makes sense, b/c as new components come onto the stage, we need to fill them in here
+// fill both movedElementPositions and resizedElementSizes from data-loading
+// and watch for new components entering the stage, fill them in here
 watch(
   () => Object.keys(componentsStore.componentsById),
   () => {
     Object.values(componentsStore.componentsById).forEach((n) => {
-      const uniqueKey = n.isGroup
-        ? DiagramGroupData.generateUniqueKey(n.id)
-        : DiagramNodeData.generateUniqueKey(n.id);
+      const elm = diagramDataFromNodeDef(n);
 
       // don't overwrite existing values (this causes elements to return to previous positions)
-      if (!movedElementPositions[uniqueKey]) {
-        movedElementPositions[uniqueKey] = {
-          x: n.position.x,
-          y: n.position.y,
-        };
-      }
+      const e: updateElementPositionAndSizeArgs = {
+        uniqueKey: elm.uniqueKey,
+        position: { x: n.position.x, y: n.position.y } as Vector2d,
+      };
       if (n.isGroup && n.size?.height && n.size.width) {
-        if (!resizedElementSizes[uniqueKey]) {
-          resizedElementSizes[uniqueKey] = {
-            width: n.size.width,
-            height: n.size.height,
-          };
-        }
+        e.size = { width: n.size.width, height: n.size.height } as Size2D;
+      }
+      if (!movedElementPositions[elm.uniqueKey]) {
+        updateElementPositionAndSize(e); // and don't save or broadcast
       }
     });
   },
@@ -575,15 +569,22 @@ watch(
             if (changeSetId !== changeSetsStore.selectedChangeSetId) return;
             if (userPk === authStore.userPk) return;
 
-            const gKey = `g-${componentId}`;
-            const nKey = `n-${componentId}`;
+            const gKey = DiagramGroupData.generateUniqueKey(componentId);
+            const nKey = DiagramNodeData.generateUniqueKey(componentId);
             if (movedElementPositions[gKey]) {
-              movedElementPositions[gKey] = { x, y };
-              if (resizedElementSizes[gKey] && width && height) {
-                resizedElementSizes[gKey] = { width, height };
+              const e = {
+                uniqueKey: gKey,
+                position: { x, y },
+              } as updateElementPositionAndSizeArgs;
+              if (width && height) {
+                e.size = { width, height };
               }
+              updateElementPositionAndSize(e);
             } else if (movedElementPositions[nKey]) {
-              movedElementPositions[nKey] = { x, y };
+              updateElementPositionAndSize({
+                uniqueKey: nKey,
+                position: { x, y },
+              });
             }
           },
         },
@@ -1252,7 +1253,12 @@ function endDragSelect(doSelection = true) {
   if (doSelection) setSelectionByKey(dragSelectPreviewKeys.value);
 }
 
-// MOVING DIAGRAM ELEMENTS (nodes/groups/annotations/etc) ///////////////////////////////////////
+/*
+ * MOVING DIAGRAM ELEMENTS (nodes/groups/annotations/etc) ///////////////////////////////////////
+ *
+ * `movedElementPositions` and `resizedElementSizes` should only be SET via the updateElementPositionAndSize fn
+ * You can read from those reactive dictionaries w/o issue
+ */
 const movedElementPositions = reactive<
   Record<DiagramElementUniqueKey, Vector2d>
 >({});
@@ -1281,25 +1287,61 @@ const draggedElementsPositionsPreDrag = ref<
 >({});
 const totalScrolledDuringDrag = ref<Vector2d>({ x: 0, y: 0 });
 
+interface updateElementPositionAndSizeArgs {
+  uniqueKey: DiagramElementUniqueKey;
+  position?: Vector2d;
+  size?: Size2D; // only frames have a size
+  writeToChangeSet?: boolean;
+  broadcastToClients?: boolean;
+}
+function updateElementPositionAndSize(e: updateElementPositionAndSizeArgs) {
+  /*
+    Replaces most common uses of `sendMovedElementPosition`
+    Nearly every instance of `send...` also mutated these two dictionaries, encapsulating that logic
+    It will also call `send...`, optionally
+  */
+  if (e.position) {
+    movedElementPositions[e.uniqueKey] = { ...e.position };
+  }
+  if (e.size) {
+    resizedElementSizes[e.uniqueKey] = { ...e.size };
+  }
+
+  // for convience
+  if (e.writeToChangeSet || e.broadcastToClients) {
+    sendMovedElementPosition({ ...e });
+  }
+}
+
 function sendMovedElementPosition(e: {
-  element: DiagramElementData;
-  position: Vector2d;
-  size?: Size2D;
-  isFinal: boolean;
+  // used to send the already existing elements position and size
+  uniqueKey: DiagramElementUniqueKey;
+  writeToChangeSet?: boolean;
+  broadcastToClients?: boolean;
 }) {
-  // this gets called many times during a move, with e.isFinal telling you if the drag is in progress or complete
-  // eventually we will want to send those to the backend for realtime multiplayer
-  // But for now we just send off the final position
-  if (!e.isFinal) return;
-  if (
-    e.element instanceof DiagramNodeData ||
-    e.element instanceof DiagramGroupData
-  ) {
-    componentsStore.SET_COMPONENT_DIAGRAM_POSITION(
-      e.element.def.id,
-      e.position,
-      e.size,
-    );
+  if (!e.writeToChangeSet && !e.broadcastToClients) return;
+
+  const position = movedElementPositions[e.uniqueKey];
+  const size = resizedElementSizes[e.uniqueKey];
+  const componentId = DiagramNodeData.componentIdFromUniqueKey(
+    DiagramGroupData.componentIdFromUniqueKey(e.uniqueKey),
+  );
+
+  // should always be true
+  if (position) {
+    if (e.writeToChangeSet) {
+      componentsStore.SET_COMPONENT_DIAGRAM_POSITION(
+        componentId,
+        position,
+        size,
+      );
+    }
+
+    if (e.broadcastToClients) {
+      // TODO
+    }
+  } else {
+    throw Error(`${e.uniqueKey} has no position`);
   }
 }
 
@@ -1354,8 +1396,6 @@ function endDragElements() {
       }
     }
 
-    // move the element itself
-    const movedElementPosition = movedElementPositions[el.uniqueKey];
     // only resize if my parent *currently* has zero children, and i have no children
     // otherwise let the human deal witht it
     if (el.def.childIds?.length === 0 && fitWithinParent) {
@@ -1363,19 +1403,16 @@ function endDragElements() {
         fitWithinParent.position,
         fitWithinParent.size,
       );
-      movedElementPositions[el.uniqueKey] = { ...position };
-      resizedElementSizes[el.uniqueKey] = { ...size };
-      sendMovedElementPosition({
-        element: el,
+      updateElementPositionAndSize({
+        uniqueKey: el.uniqueKey,
         position,
         size,
-        isFinal: true,
+        writeToChangeSet: true,
       });
-    } else if (movedElementPosition) {
+    } else {
       sendMovedElementPosition({
-        element: el,
-        position: movedElementPosition,
-        isFinal: true,
+        uniqueKey: el.uniqueKey,
+        writeToChangeSet: true,
       });
     }
 
@@ -1385,11 +1422,8 @@ function endDragElements() {
       // for now only dealing with nodes... will be fixed later
       _.each(childEls, (childEl) => {
         sendMovedElementPosition({
-          element: childEl,
-          // Again, not sure how we should handle a possible missing element
-          // position
-          position: movedElementPositions[childEl.uniqueKey] ?? { x: 0, y: 0 },
-          isFinal: true,
+          uniqueKey: childEl.uniqueKey,
+          writeToChangeSet: true,
         });
       });
     }
@@ -1511,21 +1545,19 @@ function onDragElementsMove() {
         );
 
         // track the position locally, so we don't need to rely on parent to store the temporary position
-        movedElementPositions[childEl.uniqueKey] = newChildPosition;
-        sendMovedElementPosition({
-          element: childEl,
+        updateElementPositionAndSize({
+          uniqueKey: childEl.uniqueKey,
           position: newChildPosition,
-          isFinal: false,
+          writeToChangeSet: false,
         });
       });
     }
 
     // track the position locally, so we don't need to rely on parent to store the temporary position
-    movedElementPositions[el.uniqueKey] = newPosition;
-    sendMovedElementPosition({
-      element: el,
+    updateElementPositionAndSize({
+      uniqueKey: el.uniqueKey,
       position: newPosition,
-      isFinal: false,
+      writeToChangeSet: false,
     });
   });
 
@@ -1626,11 +1658,10 @@ function alignSelection(direction: Direction) {
       x: alignedX === undefined ? el.def.position.x : alignedX,
       y: alignedY === undefined ? el.def.position.y : alignedY,
     };
-    movedElementPositions[el.uniqueKey] = newPosition;
-    sendMovedElementPosition({
-      element: el,
+    updateElementPositionAndSize({
+      uniqueKey: el.uniqueKey,
       position: newPosition,
-      isFinal: true,
+      writeToChangeSet: true,
     });
   });
   // TODO: move viewport to show selection
@@ -1661,9 +1692,8 @@ const debounceTracker: Record<
 const debounceNudge = () => {
   return _.debounce((el, newPos) => {
     sendMovedElementPosition({
-      element: el,
-      position: newPos,
-      isFinal: true,
+      uniqueKey: el.uniqueKey,
+      writeToChangeSet: true,
     });
   }, 300);
 };
@@ -1676,8 +1706,14 @@ const nudgeOneNode = (
     movedElementPositions[el.uniqueKey] || el.def.position,
     nudgeVector,
   );
-  movedElementPositions[el.uniqueKey] = newPosition;
-  // we have to debounce *each* element, not one debounce for all elements
+  // this call updates myself, and other clients through WS
+  updateElementPositionAndSize({
+    uniqueKey: el.uniqueKey,
+    position: newPosition,
+    broadcastToClients: true,
+  });
+
+  // we have to debounce the save for *each* element, not one debounce for all elements
   if (!debounceTracker[el.uniqueKey]) {
     debounceTracker[el.uniqueKey] = debounceNudge();
   }
@@ -2129,9 +2165,11 @@ function onResizeMove() {
     newNodeSize.height = newNodeRect.height;
   }
 
-  resizedElementSizes[resizeTargetKey] = newNodeSize;
-  movedElementPositions[resizeTargetKey] = newNodePosition;
-  // TODO: send updates to backend while dragging for multiplayer?
+  updateElementPositionAndSize({
+    uniqueKey: resizeElement.value.uniqueKey,
+    position: newNodePosition,
+    size: newNodeSize,
+  });
 }
 
 // DRAWING EDGES ///////////////////////////////////////////////////////////////////////
@@ -2453,6 +2491,17 @@ function onNodeLayoutOrLocationChange(el: DiagramNodeData | DiagramGroupData) {
 }
 
 // DIAGRAM CONTENTS HELPERS //////////////////////////////////////////////////
+
+// TODO: DiagramNodeDef and FullComponent are almost identical. We don't need both.
+function diagramDataFromNodeDef(
+  nodeDef: DiagramNodeDef | FullComponent,
+): DiagramNodeData | DiagramGroupData {
+  const Cls =
+    nodeDef.componentType === ComponentType.Component
+      ? DiagramNodeData
+      : DiagramGroupData;
+  return new Cls(nodeDef as DiagramNodeDef);
+}
 
 const nodes = computed(() =>
   _.map(

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -211,7 +211,6 @@ import tinycolor from "tinycolor2";
 import { LoadingMessage, getToneColorHex } from "@si/vue-lib/design-system";
 import { connectionAnnotationFitsReference } from "@si/ts-lib/src/connection-annotations";
 import { windowListenerManager } from "@si/vue-lib";
-import { el } from "date-fns/locale";
 import { useCustomFontsLoaded } from "@/utils/useFontLoaded";
 import DiagramGroup from "@/components/ModelingDiagram/DiagramGroup.vue";
 import {
@@ -1337,8 +1336,24 @@ function sendMovedElementPosition(e: {
       );
     }
 
-    if (e.broadcastToClients) {
-      // TODO
+    if (
+      e.broadcastToClients &&
+      changeSetsStore.selectedChangeSetId &&
+      componentId &&
+      authStore.userPk
+    ) {
+      realtimeStore.sendMessage({
+        kind: "ComponentSetPosition",
+        data: {
+          userPk: authStore.userPk,
+          componentId,
+          changeSetId: changeSetsStore.selectedChangeSetId,
+          x: position.x,
+          y: position.y,
+          width: size?.width || null,
+          height: size?.height || null,
+        },
+      });
     }
   } else {
     throw Error(`${e.uniqueKey} has no position`);
@@ -1549,6 +1564,7 @@ function onDragElementsMove() {
           uniqueKey: childEl.uniqueKey,
           position: newChildPosition,
           writeToChangeSet: false,
+          broadcastToClients: true,
         });
       });
     }
@@ -1558,6 +1574,7 @@ function onDragElementsMove() {
       uniqueKey: el.uniqueKey,
       position: newPosition,
       writeToChangeSet: false,
+      broadcastToClients: true,
     });
   });
 
@@ -2169,6 +2186,7 @@ function onResizeMove() {
     uniqueKey: resizeElement.value.uniqueKey,
     position: newNodePosition,
     size: newNodeSize,
+    broadcastToClients: true,
   });
 }
 

--- a/app/web/src/components/ModelingDiagram/diagram_types.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_types.ts
@@ -41,6 +41,10 @@ export class DiagramNodeData extends DiagramElementData {
   static generateUniqueKey(id: string | number) {
     return `n-${id}`;
   }
+
+  static componentIdFromUniqueKey(uniqueKey: string): string {
+    return uniqueKey.replace("n-", "");
+  }
 }
 
 export class DiagramGroupData extends DiagramElementData {
@@ -58,6 +62,10 @@ export class DiagramGroupData extends DiagramElementData {
 
   static generateUniqueKey(id: string | number) {
     return `g-${id}`;
+  }
+
+  static componentIdFromUniqueKey(uniqueKey: string): string {
+    return uniqueKey.replace("g-", "");
   }
 }
 

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -12,7 +12,10 @@ import { CursorContainerKind } from "../presence.store";
 import { UserId } from "../auth.store";
 import { SecretId } from "../secrets.store";
 
-export type WebsocketRequest = CursorRequest | OnlineRequest;
+export type WebsocketRequest =
+  | CursorRequest
+  | OnlineRequest
+  | ComponentPositionRequest;
 
 export interface CursorRequest {
   kind: "Cursor";
@@ -35,6 +38,19 @@ export interface OnlineRequest {
     pictureUrl: string | null;
     idle: boolean;
     changeSetId: string | null;
+  };
+}
+
+export interface ComponentPositionRequest {
+  kind: "ComponentSetPosition";
+  data: {
+    userPk: UserId;
+    componentId: ComponentId;
+    changeSetId: string | null;
+    x: number;
+    y: number;
+    width: number | null;
+    height: number | null;
   };
 }
 

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -44,8 +44,8 @@ use crate::{
     DeprecatedAction, DeprecatedActionError, DeprecatedActionKind, DeprecatedActionPrototype,
     DeprecatedActionPrototypeError, Func, FuncError, FuncId, HelperError, InputSocket,
     InputSocketId, OutputSocket, OutputSocketId, Prop, PropId, PropKind, Schema, SchemaVariant,
-    SchemaVariantId, StandardModelError, Timestamp, TransactionsError, UserPk, WsEvent,
-    WsEventError, WsEventResult, WsPayload,
+    SchemaVariantId, StandardModelError, Timestamp, TransactionsError, UserPk, WorkspacePk,
+    WsEvent, WsEventError, WsEventResult, WsPayload,
 };
 
 pub mod code;
@@ -2159,7 +2159,26 @@ pub struct ComponentSetPositionPayload {
     user_pk: Option<UserPk>,
 }
 
+impl ComponentSetPositionPayload {
+    pub fn change_set_id(&self) -> ChangeSetId {
+        self.change_set_id
+    }
+}
+
 impl WsEvent {
+    pub async fn reflect_component_position(
+        workspace_pk: WorkspacePk,
+        change_set_id: ChangeSetId,
+        payload: ComponentSetPositionPayload,
+    ) -> WsEventResult<Self> {
+        WsEvent::new_raw(
+            workspace_pk,
+            Some(change_set_id),
+            WsPayload::SetComponentPosition(payload),
+        )
+        .await
+    }
+
     pub async fn set_component_position(
         ctx: &DalContext,
         change_set_id: ChangeSetId,


### PR DESCRIPTION
The changes include:
1. Make sure all changes to position and size runs through a single function. That refactor is most of the diff. Nearly every single position change also had a line of code to POST the same position. We can encapsulate that logic to prevent errors and introduce clarity.
2. Adding a new receiver for WsEvents in SDF that reflects the payload back out to all clients.
3. Sending websocket messages onDragMove and onResize events.
![multiplayer](https://github.com/systeminit/si/assets/69541/51d99a07-0a25-4b45-8d06-ff918e673aef)
