### PR TITLE
feat: add config struct for layerdb and the memory cache

### DIFF
--- a/bin/rebaser/src/args.rs
+++ b/bin/rebaser/src/args.rs
@@ -60,7 +60,7 @@ pub(crate) struct Args {
 
     /// PostgreSQL connection pool dbname for layer_db [example: melons]
     #[arg(long)]
-    pub(crate) layer_cache_pg_dbname: Option<String>,
+    pub(crate) layer_db_pg_dbname: Option<String>,
 
     /// PostgreSQL connection pool hostname [example: prod.db.example.com]
     #[arg(long)]
@@ -120,7 +120,11 @@ pub(crate) struct Args {
 
     /// The path at which the layer db cache is created/used on disk [e.g. /banana/]
     #[arg(long)]
-    pub(crate) layer_cache_disk_path: Option<String>,
+    pub(crate) layer_db_disk_path: Option<String>,
+
+    /// The time to idle for items in the layercache
+    #[arg(long)]
+    pub(crate) layer_db_seconds_to_idle: Option<u64>,
 
     /// Instance ID [example: 01GWEAANW5BVFK5KDRVS6DEY0F"]
     ///
@@ -138,35 +142,59 @@ impl TryFrom<Args> for Config {
             if let Some(dbname) = args.pg_dbname {
                 config_map.set("pg.dbname", dbname);
             }
+            if let Some(layer_cache_pg_dbname) = args.layer_db_pg_dbname {
+                config_map.set(
+                    "layer_db_config.pg_pool_config.dbname",
+                    layer_cache_pg_dbname,
+                );
+            }
             if let Some(hostname) = args.pg_hostname {
-                config_map.set("pg.hostname", hostname);
+                config_map.set("pg.hostname", hostname.clone());
+                config_map.set("layer_db_config.pg_pool_config.hostname", hostname);
             }
             if let Some(pool_max_size) = args.pg_pool_max_size {
                 config_map.set("pg.pool_max_size", i64::from(pool_max_size));
+                config_map.set(
+                    "layer_db_config.pg_pool_config.pool_max_size",
+                    i64::from(pool_max_size),
+                );
             }
             if let Some(port) = args.pg_port {
                 config_map.set("pg.port", i64::from(port));
+                config_map.set("layer_db_config.pg_pool_config.port", i64::from(port));
             }
             if let Some(user) = args.pg_user {
-                config_map.set("pg.user", user);
+                config_map.set("pg.user", user.clone());
+                config_map.set("layer_db_config.pg_pool_config.user", user);
             }
             if let Some(cert_path) = args.pg_cert_path {
                 config_map.set("pg.certificate_path", cert_path.display().to_string());
+                config_map.set(
+                    "layer_db_config.pg_pool_config.certificate_path",
+                    cert_path.display().to_string(),
+                );
             }
             if let Some(cert) = args.pg_cert_base64 {
                 config_map.set("pg.certificate_base64", cert.to_string());
-            }
-            if let Some(layer_cache_pg_dbname) = args.layer_cache_pg_dbname {
-                config_map.set("layer_cache_pg_dbname", layer_cache_pg_dbname);
+                config_map.set(
+                    "layer_db_config.pg_pool_config.certificate_base64",
+                    cert.to_string(),
+                );
             }
             if let Some(url) = args.nats_url {
-                config_map.set("nats.url", url);
+                config_map.set("nats.url", url.clone());
+                config_map.set("layer_db_config.nats_config.url", url);
             }
             if let Some(creds) = args.nats_creds {
                 config_map.set("nats.creds", creds.to_string());
+                config_map.set("layer_db_config.nats_config.creds", creds.to_string());
             }
             if let Some(creds_path) = args.nats_creds_path {
                 config_map.set("nats.creds_file", creds_path.display().to_string());
+                config_map.set(
+                    "layer_db_config.nats_config.creds_file",
+                    creds_path.display().to_string(),
+                );
             }
             if let Some(cyclone_encryption_key_file) = args.cyclone_encryption_key_path {
                 config_map.set(
@@ -186,17 +214,25 @@ impl TryFrom<Args> for Config {
                     secret_string.to_string(),
                 );
             }
-            if let Some(layer_cache_disk_path) = args.layer_cache_disk_path {
-                config_map.set("layer_cache_disk_path", layer_cache_disk_path);
-            }
             if let Some(concurrency) = args.concurrency {
                 config_map.set("concurrency_limit", i64::from(concurrency));
+            }
+            if let Some(layer_cache_disk_path) = args.layer_db_disk_path {
+                config_map.set("layer_db_config.disk_path", layer_cache_disk_path);
+            }
+            if let Some(layer_cache_seconds_to_idle) = args.layer_db_seconds_to_idle {
+                config_map.set(
+                    "layer_db_config.memory_cache_config.seconds_to_idle",
+                    layer_cache_seconds_to_idle,
+                );
             }
             if let Some(instance_id) = args.instance_id {
                 config_map.set("instance_id", instance_id);
             }
-
+            config_map.set("nats.connection_name", NAME);
             config_map.set("pg.application_name", NAME);
+            config_map.set("layer_db_config.pg_pool_config.application_name", NAME);
+            config_map.set("layer_db_config.nats_config.connection_name", NAME);
         })?
         .try_into()
     }

--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -1,6 +1,4 @@
 pkgs_path = "/tmp"
-layer_cache_pg_dbname = "$SI_LAYER_CACHE_DBNAME"
-layer_cache_disk_path = "$SI_LAYER_CACHE_DISK_PATH"
 
 [crypto]
 encryption_key_base64 = "$SI_ENCRYPTION_KEY_BASE64"
@@ -34,3 +32,24 @@ port = 5156
 
 [symmetric_crypto_service]
 active_key_base64 = "$SI_ACTIVE_KEY_BASE64"
+
+[layer_db_config]
+disk_path = "$SI_LAYER_CACHE_DISK_PATH"
+
+[layer_db_config.pg_pool_config]
+user = "si"
+password = "$SI_PG_PASSWORD"
+dbname = "$SI_LAYER_CACHE_DBNAME"
+application_name = "$SI_SERVICE"
+hostname = "localhost"
+port = 5432
+pool_max_size = 500
+
+[layer_db_config.nats_config]
+creds = """
+$SI_NATS_CREDS
+"""
+url = "$SI_NATS_URL"
+
+[layer_db_config.memory_cache_config]
+seconds_to_idle = 900

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -35,6 +35,7 @@ use si_crypto::{
 };
 use si_data_nats::{NatsClient, NatsConfig};
 use si_data_pg::{PgPool, PgPoolConfig};
+use si_layer_cache::memory_cache::MemoryCacheConfig;
 use si_layer_cache::CaCacheTempFile;
 use si_std::ResultExt;
 use std::{
@@ -320,6 +321,7 @@ impl TestContext {
             self.layer_db_cache_path.tempdir.path(),
             self.layer_db_pg_pool.clone(),
             self.nats_conn.clone(),
+            MemoryCacheConfig::default(),
             token,
         )
         .await

--- a/lib/pinga-server/src/server.rs
+++ b/lib/pinga-server/src/server.rs
@@ -120,16 +120,8 @@ impl Server {
         let symmetric_crypto_service =
             Self::create_symmetric_crypto_service(config.symmetric_crypto_service()).await?;
 
-        let mut pg_layer_db_pool = config.pg_pool().clone();
-        pg_layer_db_pool.dbname = config.layer_cache_pg_dbname().to_string();
-
-        let (layer_db, layer_db_graceful_shutdown) = LayerDb::initialize(
-            config.layer_cache_disk_path(),
-            PgPool::new(&pg_layer_db_pool).await?,
-            nats.clone(),
-            token,
-        )
-        .await?;
+        let (layer_db, layer_db_graceful_shutdown) =
+            LayerDb::from_config(config.layer_db_config().clone(), token).await?;
         tracker.spawn(layer_db_graceful_shutdown.into_future());
 
         let services_context = ServicesContext::new(

--- a/lib/rebaser-server/src/server.rs
+++ b/lib/rebaser-server/src/server.rs
@@ -95,16 +95,8 @@ impl Server {
         let symmetric_crypto_service =
             Self::create_symmetric_crypto_service(config.symmetric_crypto_service()).await?;
 
-        let mut pg_layer_db_pool = config.pg_pool().clone();
-        pg_layer_db_pool.dbname = config.layer_cache_pg_dbname().to_string();
-
-        let (layer_db, layer_db_graceful_shutdown) = DalLayerDb::initialize(
-            config.layer_cache_disk_path(),
-            PgPool::new(&pg_layer_db_pool).await?,
-            nats.clone(),
-            token,
-        )
-        .await?;
+        let (layer_db, layer_db_graceful_shutdown) =
+            DalLayerDb::from_config(config.layer_db_config().clone(), token).await?;
         tracker.spawn(layer_db_graceful_shutdown.into_future());
 
         Self::from_services(

--- a/lib/si-layer-cache/src/db.rs
+++ b/lib/si-layer-cache/src/db.rs
@@ -1,7 +1,11 @@
+use serde::Deserialize;
+use si_data_pg::PgPoolConfig;
+use std::path::PathBuf;
+use std::str::FromStr;
 use std::{future::IntoFuture, io, path::Path, sync::Arc};
 
 use serde::{de::DeserializeOwned, Serialize};
-use si_data_nats::NatsClient;
+use si_data_nats::{NatsClient, NatsConfig};
 use si_data_pg::PgPool;
 use si_events::FuncExecution;
 use telemetry::prelude::*;
@@ -10,6 +14,7 @@ use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use ulid::Ulid;
 
 use crate::db::encrypted_secret::EncryptedSecretDb;
+use crate::memory_cache::MemoryCacheConfig;
 use crate::{
     activity_client::ActivityClient,
     error::LayerDbResult,
@@ -54,10 +59,27 @@ where
     EncryptedSecretValue: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     WorkspaceSnapshotValue: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
 {
+    pub async fn from_config(
+        config: LayerDbConfig,
+        token: CancellationToken,
+    ) -> LayerDbResult<(Self, LayerDbGracefulShutdown)> {
+        let pg_pool = PgPool::new(&config.pg_pool_config).await?;
+        let nats_client = NatsClient::new(&config.nats_config).await?;
+        Self::initialize(
+            config.disk_path,
+            pg_pool,
+            nats_client,
+            config.memory_cache_config,
+            token,
+        )
+        .await
+    }
+
     pub async fn initialize(
         disk_path: impl AsRef<Path>,
         pg_pool: PgPool,
         nats_client: NatsClient,
+        memory_cache_config: MemoryCacheConfig,
         token: CancellationToken,
     ) -> LayerDbResult<(Self, LayerDbGracefulShutdown)> {
         let instance_id = Ulid::new();
@@ -69,17 +91,33 @@ where
         let (tx, rx) = mpsc::unbounded_channel();
         let persister_client = PersisterClient::new(tx);
 
-        let cas_cache: LayerCache<Arc<CasValue>> =
-            LayerCache::new(cas::CACHE_NAME, disk_path, pg_pool.clone())?;
+        let cas_cache: LayerCache<Arc<CasValue>> = LayerCache::new(
+            cas::CACHE_NAME,
+            disk_path,
+            pg_pool.clone(),
+            memory_cache_config.clone(),
+        )?;
 
-        let encrypted_secret_cache: LayerCache<Arc<EncryptedSecretValue>> =
-            LayerCache::new(encrypted_secret::CACHE_NAME, disk_path, pg_pool.clone())?;
+        let encrypted_secret_cache: LayerCache<Arc<EncryptedSecretValue>> = LayerCache::new(
+            encrypted_secret::CACHE_NAME,
+            disk_path,
+            pg_pool.clone(),
+            memory_cache_config.clone(),
+        )?;
 
-        let func_execution_cache: LayerCache<Arc<FuncExecution>> =
-            LayerCache::new(func_execution::CACHE_NAME, disk_path, pg_pool.clone())?;
+        let func_execution_cache: LayerCache<Arc<FuncExecution>> = LayerCache::new(
+            func_execution::CACHE_NAME,
+            disk_path,
+            pg_pool.clone(),
+            memory_cache_config.clone(),
+        )?;
 
-        let snapshot_cache: LayerCache<Arc<WorkspaceSnapshotValue>> =
-            LayerCache::new(workspace_snapshot::CACHE_NAME, disk_path, pg_pool.clone())?;
+        let snapshot_cache: LayerCache<Arc<WorkspaceSnapshotValue>> = LayerCache::new(
+            workspace_snapshot::CACHE_NAME,
+            disk_path,
+            pg_pool.clone(),
+            memory_cache_config.clone(),
+        )?;
 
         let cache_updates_task = CacheUpdatesTask::create(
             instance_id,
@@ -227,6 +265,27 @@ mod private {
     impl fmt::Debug for GracefulShutdownFuture {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("ShutdownFuture").finish_non_exhaustive()
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct LayerDbConfig {
+    pub disk_path: PathBuf,
+    pub pg_pool_config: PgPoolConfig,
+    pub nats_config: NatsConfig,
+    pub memory_cache_config: MemoryCacheConfig,
+}
+
+impl LayerDbConfig {
+    pub fn default_for_service(service: impl AsRef<str>) -> Self {
+        let service = service.as_ref();
+        Self {
+            disk_path: PathBuf::from_str(&format!("/tmp/layerdb-{service}-cacache"))
+                .expect("paths from strings is infallible"),
+            pg_pool_config: Default::default(),
+            nats_config: Default::default(),
+            memory_cache_config: Default::default(),
         }
     }
 }

--- a/lib/si-layer-cache/src/disk_cache.rs
+++ b/lib/si-layer-cache/src/disk_cache.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use std::path::PathBuf;
 
@@ -21,12 +21,6 @@ impl CaCacheTempFile {
 pub fn default_cacache_path() -> LayerDbResult<CaCacheTempFile> {
     let tempdir = tempfile::tempdir()?;
     Ok(CaCacheTempFile::new(tempdir))
-}
-
-pub fn default_cache_path_for_service(service: impl AsRef<str>) -> PathBuf {
-    let service = service.as_ref();
-    PathBuf::from_str(&format!("/tmp/layerdb-{service}-cacache"))
-        .expect("paths from strings is infallible")
 }
 
 #[derive(Clone, Debug)]

--- a/lib/si-layer-cache/src/error.rs
+++ b/lib/si-layer-cache/src/error.rs
@@ -62,6 +62,8 @@ pub enum LayerDbError {
     NatsAck(#[source] si_data_nats::async_nats::Error),
     #[error("raw ack error: {0}")]
     NatsAckRaw(String),
+    #[error("nats client: {0}")]
+    NatsClient(#[from] si_data_nats::Error),
     #[error("stream consumer error: {0}")]
     NatsConsumer(#[from] jetstream::stream::ConsumerError),
     #[error("error while fetching or creating a nats jetsream: {0}")]

--- a/lib/si-layer-cache/src/lib.rs
+++ b/lib/si-layer-cache/src/lib.rs
@@ -36,6 +36,6 @@ pub mod persister;
 pub mod pg;
 
 pub use db::LayerDb;
-pub use disk_cache::{default_cacache_path, default_cache_path_for_service, CaCacheTempFile};
+pub use disk_cache::{default_cacache_path, CaCacheTempFile};
 pub use error::LayerDbError;
 pub use pg::{default_pg_pool_config, APPLICATION_NAME, DBNAME};

--- a/lib/si-layer-cache/tests/integration_test/activities.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use futures::StreamExt;
 use si_events::{Actor, ChangeSetId, Tenancy, WorkspacePk};
 use si_layer_cache::{
-    activities::ActivityPayloadDiscriminants, event::LayeredEventMetadata, LayerDb,
+    activities::ActivityPayloadDiscriminants, event::LayeredEventMetadata,
+    memory_cache::MemoryCacheConfig, LayerDb,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -29,6 +30,7 @@ async fn activities() {
         tempdir_slash,
         db.clone(),
         setup_nats_client(Some("activities".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -40,6 +42,7 @@ async fn activities() {
         tempdir_axl,
         db,
         setup_nats_client(Some("activities".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -89,6 +92,7 @@ async fn activities_subscribe_partial() {
         tempdir_slash,
         db.clone(),
         setup_nats_client(Some("activities_subscribe_partial".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -100,6 +104,7 @@ async fn activities_subscribe_partial() {
         tempdir_axl,
         db,
         setup_nats_client(Some("activities_subscribe_partial".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await

--- a/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
@@ -4,7 +4,9 @@ use std::sync::{
 };
 
 use si_events::{Actor, ChangeSetId, Tenancy, WorkspacePk, WorkspaceSnapshotAddress};
-use si_layer_cache::{activities::ActivityId, event::LayeredEventMetadata, LayerDb};
+use si_layer_cache::{
+    activities::ActivityId, event::LayeredEventMetadata, memory_cache::MemoryCacheConfig, LayerDb,
+};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use ulid::Ulid;
 
@@ -28,6 +30,7 @@ async fn subscribe_rebaser_requests_work_queue() {
         tempdir_slash,
         db.clone(),
         setup_nats_client(Some("subscribe_rebaser_requests_work_queue".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -39,6 +42,7 @@ async fn subscribe_rebaser_requests_work_queue() {
         tempdir_axl,
         db.clone(),
         setup_nats_client(Some("subscribe_rebaser_requests_work_queue".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -50,6 +54,7 @@ async fn subscribe_rebaser_requests_work_queue() {
         tempdir_duff,
         db,
         setup_nats_client(Some("subscribe_rebaser_requests_work_queue".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -156,6 +161,7 @@ async fn rebase_and_wait() {
         tempdir_slash,
         db.clone(),
         setup_nats_client(Some("rebase_and_wait".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -167,6 +173,7 @@ async fn rebase_and_wait() {
         tempdir_axl,
         db.clone(),
         setup_nats_client(Some("rebase_and_wait".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -244,6 +251,7 @@ async fn rebase_requests_work_queue_stress() {
         tempdir_slash,
         db.clone(),
         setup_nats_client(Some("rebase_requests_work_queue_stress".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -255,6 +263,7 @@ async fn rebase_requests_work_queue_stress() {
         tempdir_axl,
         db.clone(),
         setup_nats_client(Some("rebase_requests_work_queue_stress".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -266,6 +275,7 @@ async fn rebase_requests_work_queue_stress() {
         tempdir_duff,
         db,
         setup_nats_client(Some("rebase_requests_work_queue_stress".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -405,6 +415,7 @@ async fn rebase_and_wait_stress() {
         tempdir_slash,
         db.clone(),
         setup_nats_client(Some("rebase_and_wait_stress".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -416,6 +427,7 @@ async fn rebase_and_wait_stress() {
         tempdir_axl,
         db.clone(),
         setup_nats_client(Some("rebase_and_wait_stress".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await

--- a/lib/si-layer-cache/tests/integration_test/db/cas.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/cas.rs
@@ -1,3 +1,4 @@
+use si_layer_cache::memory_cache::MemoryCacheConfig;
 use std::{sync::Arc, time::Duration};
 
 use si_events::{Actor, CasValue, ChangeSetId, ContentHash, Tenancy, UserPk, WorkspacePk};
@@ -20,6 +21,7 @@ async fn write_to_db() {
         dbfile,
         setup_pg_db("cas_write_to_db").await,
         setup_nats_client(Some("cas_write_to_db".to_string())).await,
+        MemoryCacheConfig::default(),
         token,
     )
     .await
@@ -87,6 +89,7 @@ async fn write_and_read_many() {
         dbfile,
         setup_pg_db("cas_write_and_read_many").await,
         setup_nats_client(Some("cas_write_and_read_many".to_string())).await,
+        MemoryCacheConfig::default(),
         token,
     )
     .await
@@ -142,6 +145,7 @@ async fn cold_read_from_db() {
         dbfile,
         setup_pg_db("cas_cold_read_from_db").await,
         setup_nats_client(Some("cas_cold_read_from_db".to_string())).await,
+        MemoryCacheConfig::default(),
         token,
     )
     .await
@@ -236,6 +240,7 @@ async fn writes_are_gossiped() {
         tempdir_slash,
         db.clone(),
         setup_nats_client(Some("cas_writes_are_gossiped".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -247,6 +252,7 @@ async fn writes_are_gossiped() {
         tempdir_axl,
         db,
         setup_nats_client(Some("cas_write_to_db".to_string())).await,
+        MemoryCacheConfig::default(),
         token,
     )
     .await
@@ -353,6 +359,7 @@ async fn stress_test() {
         tempdir_slash,
         db.clone(),
         setup_nats_client(Some("stress_test".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await
@@ -366,6 +373,7 @@ async fn stress_test() {
         tempdir_axl,
         db,
         setup_nats_client(Some("stress_test".to_string())).await,
+        MemoryCacheConfig::default(),
         token.clone(),
     )
     .await

--- a/lib/si-layer-cache/tests/integration_test/db/func_execution.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/func_execution.rs
@@ -2,6 +2,7 @@ use si_events::ulid::Ulid;
 use si_events::{
     CasValue, FuncExecution, FuncExecutionKey, FuncExecutionMessage, FuncExecutionState,
 };
+use si_layer_cache::memory_cache::MemoryCacheConfig;
 use si_layer_cache::LayerDb;
 use tokio_util::sync::CancellationToken;
 
@@ -19,6 +20,7 @@ async fn write() {
         dbfile,
         setup_pg_db("fe_write").await,
         setup_nats_client(Some("fe_write".to_string())).await,
+        MemoryCacheConfig::default(),
         token,
     )
     .await
@@ -54,6 +56,7 @@ async fn write_with_message() {
         dbfile,
         setup_pg_db("fe_write_with_maessage").await,
         setup_nats_client(Some("fe_write_with_message".to_string())).await,
+        MemoryCacheConfig::default(),
         token,
     )
     .await
@@ -112,6 +115,7 @@ async fn write_and_read_many() {
         dbfile,
         setup_pg_db("fe_write_and_read_many").await,
         setup_nats_client(Some("fe_write_and_read_many".to_string())).await,
+        MemoryCacheConfig::default(),
         token,
     )
     .await
@@ -171,6 +175,7 @@ async fn read_by_component_id() {
         dbfile,
         setup_pg_db("fe_by_component_id").await,
         setup_nats_client(Some("fe_by_component_id".to_string())).await,
+        MemoryCacheConfig::default(),
         token,
     )
     .await
@@ -240,6 +245,7 @@ async fn read_by_prototype_id() {
         dbfile,
         setup_pg_db("fe_by_prototype_id").await,
         setup_nats_client(Some("fe_by_prototype_id".to_string())).await,
+        MemoryCacheConfig::default(),
         token,
     )
     .await
@@ -307,6 +313,7 @@ async fn read_by_component_id_and_prototype_id() {
         dbfile,
         setup_pg_db("fe_by_component_id_and_prototype_id").await,
         setup_nats_client(Some("fe_by_component_id_and_prototype_id".to_string())).await,
+        MemoryCacheConfig::default(),
         token,
     )
     .await

--- a/lib/si-layer-cache/tests/integration_test/layer_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/layer_cache.rs
@@ -1,5 +1,6 @@
 use rand::seq::SliceRandom;
 use rand::thread_rng;
+use si_layer_cache::memory_cache::MemoryCacheConfig;
 use std::sync::Arc;
 
 use si_layer_cache::db::serialize;
@@ -8,8 +9,13 @@ use si_layer_cache::layer_cache::LayerCache;
 async fn make_layer_cache(db_name: &str) -> LayerCache<String> {
     let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
 
-    let layer_cache = LayerCache::new("cas", tempdir.path(), super::setup_pg_db(db_name).await)
-        .expect("cannot create layer cache");
+    let layer_cache = LayerCache::new(
+        "cas",
+        tempdir.path(),
+        super::setup_pg_db(db_name).await,
+        MemoryCacheConfig::default(),
+    )
+    .expect("cannot create layer cache");
     layer_cache.pg().migrate().await.expect("migrate");
 
     layer_cache


### PR DESCRIPTION
This adds the ability to configure the idle time of items in the memory portion of the layerdb. It defaults to 10 minutes. It does this by adding configuration structs for the memory cache and layerdb itself. This helps us on the front end for these settings as it makes it easier to turn args and config values into a normalized structure that we can pass through to app startup. Should make it much easier to add more settings as we go.

The pgpool and nats bits are shared in the args (except for the layerdb dbname), but you can configure the settings separately in the config file, which is what we use in prod.

<img src="https://media1.giphy.com/media/5zh1j8sUfLUJGI5T5d/giphy.gif"/>

```toml 
[nats]
creds = """
$SI_NATS_CREDS
"""
url = "$SI_NATS_URL"
[pg]
user = "si"
password = "$SI_PG_PASSWORD"
dbname = "$SI_PG_DB"
application_name = "$SI_SERVICE"
hostname = "localhost"
port = 5432
pool_max_size = 500
[service]
port = 5156

[symmetric_crypto_service]
active_key_base64 = "$SI_ACTIVE_KEY_BASE64"

[layer_db_config]
disk_path = "$SI_LAYER_CACHE_DISK_PATH"

[layer_db_config.pg_pool_config]
user = "si"
password = "$SI_PG_PASSWORD"
dbname = "$SI_LAYER_CACHE_DBNAME"
application_name = "$SI_SERVICE"
hostname = "localhost"
port = 5432
pool_max_size = 500

[layer_db_config.nats_config]
creds = """
$SI_NATS_CREDS
"""
url = "$SI_NATS_URL"

[layer_db_config.memory_cache_config]
seconds_to_idle = 900
```