### PR TITLE
fix: correcting node-exporter flags that blocked seeing sysd metrics

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -32,12 +32,17 @@ services:
     command:
       - --collector.systemd
       - --collector.systemd.unit-include=${SI_SERVICE}.service
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --path.rootfs=/rootfs
+      - --collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)
     ports:
       - 9100:9100
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /:/rootfs:ro
+      - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:ro
 
   pgbouncer:
     container_name: pgbouncer


### PR DESCRIPTION
I noticed that our node-exporter was having a bad time trying to ship a few metrics. This will ensure that it knows where to look for proc, sys, and the rootfs while also being able to pull metrics from systemd. Notably, we can get unit stats so we can tell if a service is thrashing.

```bash
[root@ip-12-0-10-253 ec2-user]# curl localhost:9100/metrics | grep rebaser
...
node_systemd_unit_state{name="rebaser.service",state="activating",type="exec"} 0
node_systemd_unit_state{name="rebaser.service",state="active",type="exec"} 1
node_systemd_unit_state{name="rebaser.service",state="deactivating",type="exec"} 0
node_systemd_unit_state{name="rebaser.service",state="failed",type="exec"} 0
node_systemd_unit_state{name="rebaser.service",state="inactive",type="exec"} 0
```

<img src="https://media1.giphy.com/media/MvbGrLlwvDNISEEF0v/giphy.gif"/>