### PR TITLE
feat: verify disk_path values for layerdb on startup

### DIFF
--- a/lib/si-layer-cache/src/db.rs
+++ b/lib/si-layer-cache/src/db.rs
@@ -1,7 +1,6 @@
 use serde::Deserialize;
 use si_data_pg::PgPoolConfig;
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::{future::IntoFuture, io, path::Path, sync::Arc};
 
 use serde::{de::DeserializeOwned, Serialize};
@@ -278,11 +277,11 @@ pub struct LayerDbConfig {
 }
 
 impl LayerDbConfig {
-    pub fn default_for_service(service: impl AsRef<str>) -> Self {
-        let service = service.as_ref();
+    pub fn default_for_service(service: &str) -> Self {
         Self {
-            disk_path: PathBuf::from_str(&format!("/tmp/layerdb-{service}-cacache"))
-                .expect("paths from strings is infallible"),
+            disk_path: tempfile::TempDir::with_prefix(format!("{service}-cache-"))
+                .expect("unable to create tmp dir for layerdb")
+                .into_path(),
             pg_pool_config: Default::default(),
             nats_config: Default::default(),
             memory_cache_config: Default::default(),


### PR DESCRIPTION
Use the tempdir() methods to ensure the path is actually created.
<img src="https://media4.giphy.com/media/L0O3TQpp0WnSXmxV8p/giphy.gif"/>