### PR TITLE
Added to_delete to inferred connections and ensure output sockets can drive inferred and manual connections simultaneously

### DIFF
--- a/lib/dal/src/component/frame.rs
+++ b/lib/dal/src/component/frame.rs
@@ -55,6 +55,13 @@ impl Frame {
         child_id: ComponentId,
         new_parent_id: ComponentId,
     ) -> FrameResult<()> {
+        // let's see if we need to even do anything
+        if let Some(current_parent_id) = Component::get_parent_by_id(ctx, child_id).await? {
+            if current_parent_id == new_parent_id {
+                return Ok(());
+            }
+        }
+
         match Component::get_type_by_id(ctx, new_parent_id).await? {
             ComponentType::ConfigurationFrameDown | ComponentType::ConfigurationFrameUp => {
                 Self::orphan_child(ctx, child_id).await?;
@@ -80,7 +87,7 @@ impl Frame {
             .await?;
         drop(cycle_check_guard);
 
-        // when detaching a child, need to rerun any attribute prototypes for those impacted sockets then queue up dvu!
+        // when attaching a child, need to rerun any attribute prototypes for those impacted sockets then queue up dvu!
 
         let values_rerun = match Component::get_type_by_id(ctx, child_id).await? {
             ComponentType::Component

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -1160,7 +1160,10 @@ async fn rebase(
         )
         .await?;
     info!("got response from rebaser: {:?}", start.elapsed());
-
+    info!(
+        "rebaser response payload: {:?}",
+        rebase_finished_activity.payload
+    );
     match rebase_finished_activity.payload {
         ActivityPayload::RebaseFinished(rebase_finished) => match rebase_finished.status() {
             RebaseStatus::Success { .. } => Ok(None),

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -152,6 +152,8 @@ pub struct SummaryDiagramInferredEdge {
     pub from_socket_id: OutputSocketId,
     pub to_component_id: ComponentId,
     pub to_socket_id: InputSocketId,
+    // this is inferred by if either the to or from component is marked to_delete
+    pub to_delete: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
@@ -251,6 +253,7 @@ impl Diagram {
                     from_socket_id: inferred_incoming_connection.from_output_socket_id,
                     to_component_id: inferred_incoming_connection.to_component_id,
                     to_socket_id: inferred_incoming_connection.to_input_socket_id,
+                    to_delete: inferred_incoming_connection.to_delete,
                 })
             }
 
@@ -364,7 +367,6 @@ impl Diagram {
             component_views.push(component_view);
         }
 
-        // TODO(nick): restore the ability to show edges.
         Ok(Self {
             edges: diagram_edges,
             components: component_views,

--- a/lib/dal/src/socket/debug.rs
+++ b/lib/dal/src/socket/debug.rs
@@ -135,20 +135,21 @@ impl SocketDebugView {
             None => String::new(),
         };
         let materialized_view = attribute_value.materialized_view(ctx).await?;
-        let inferred_connections = match Component::find_inferred_connection_to_input_socket(
-            ctx,
-            InputSocketMatch {
-                component_id,
-                input_socket_id,
-                attribute_value_id,
-            },
-        )
-        .await?
-        .map(|output_socket| Ulid::from(output_socket.attribute_value_id))
-        {
-            Some(output_id) => vec![output_id],
-            None => vec![],
-        };
+        let inferred_connections =
+            match Component::find_potential_inferred_connection_to_input_socket(
+                ctx,
+                InputSocketMatch {
+                    component_id,
+                    input_socket_id,
+                    attribute_value_id,
+                },
+            )
+            .await?
+            .map(|output_socket| Ulid::from(output_socket.attribute_value_id))
+            {
+                Some(output_id) => vec![output_id],
+                None => vec![],
+            };
 
         Ok(SocketDebugView {
             prototype_id,

--- a/lib/dal/src/socket/input.rs
+++ b/lib/dal/src/socket/input.rs
@@ -403,7 +403,7 @@ impl InputSocket {
 
         Ok(maybe_input_socket)
     }
-
+    #[instrument(level = "debug", skip(ctx))]
     pub async fn is_manually_configured(
         ctx: &DalContext,
         input_socket_match: InputSocketMatch,
@@ -421,12 +421,7 @@ impl InputSocket {
             let maybe_apa =
                 AttributePrototypeArgument::list_ids_for_prototype(ctx, maybe_attribute_prototype)
                     .await?;
-            info!("maybe attribute prototype args: {:?}", maybe_apa);
             if !maybe_apa.is_empty() {
-                info!(
-                    "attribute prototype argument found for input socket {:?}, no implicit inputs here.",
-                    input_socket_match
-                );
                 return Ok(true);
             }
         }


### PR DESCRIPTION
This PR moves around the check for deletes so we can pass the flag appropriately on inferred connections. I also added a test to make sure output sockets can pass values to children and manually connected components

<div><img src="https://media1.giphy.com/media/xzDIIZCozVXI4/giphy.gif?cid=5a38a5a2n5clqtpghj9isgn611f6ft41825b4aftiw62k7tq&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:225px;width:300px"/><br/>via <a href="https://giphy.com/channel/tkyle/">T. Kyle</a> on <a href="https://giphy.com/gifs/realitytvgifs-rhonj-danielle-staub-tgif-xzDIIZCozVXI4">GIPHY</a></div>