### PR TITLE
fix(sdf, dal, web): Change Asset Panel to use schemaID

### DIFF
--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -72,6 +72,7 @@ export interface DetachedValidationPrototype {
 
 export interface ListedVariant {
   id: AssetId;
+  defaultSchemaVariantId: string;
   name: string;
   displayName?: string;
   category: string;
@@ -243,6 +244,7 @@ export const useAssetStore = () => {
         createNewAsset(): Asset {
           return {
             id: nilId(),
+            defaultSchemaVariantId: "",
             name: `new asset ${Math.floor(Math.random() * 10000)}`,
             code: "",
             color: this.generateMockColor(),

--- a/lib/dal/src/schema/variant/metadata_view.rs
+++ b/lib/dal/src/schema/variant/metadata_view.rs
@@ -1,12 +1,15 @@
 use serde::{Deserialize, Serialize};
 
 use crate::schema::variant::SchemaVariantResult;
-use crate::{ComponentType, DalContext, Schema, SchemaVariant, SchemaVariantId, Timestamp};
+use crate::{
+    ComponentType, DalContext, Schema, SchemaId, SchemaVariant, SchemaVariantId, Timestamp,
+};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaVariantMetadataView {
-    id: SchemaVariantId,
+    id: SchemaId,
+    default_schema_variant_id: SchemaVariantId,
     name: String,
     category: String,
     #[serde(alias = "display_name")]
@@ -28,7 +31,8 @@ impl SchemaVariantMetadataView {
             let default_schema_variant =
                 SchemaVariant::get_default_for_schema(ctx, schema.id()).await?;
             views.push(SchemaVariantMetadataView {
-                id: default_schema_variant.id,
+                id: schema.id,
+                default_schema_variant_id: default_schema_variant.id,
                 name: schema.name.to_owned(),
                 category: default_schema_variant.category.to_owned(),
                 color: default_schema_variant.get_color(ctx).await?,

--- a/lib/sdf-server/src/server/service/variant.rs
+++ b/lib/sdf-server/src/server/service/variant.rs
@@ -49,6 +49,8 @@ pub enum SchemaVariantError {
     Hyper(#[from] hyper::http::Error),
     #[error("no new asset was created")]
     NoAssetCreated,
+    #[error("no default schema variant found for schema")]
+    NoDefaultSchemaVariantFoundForSchema,
     #[error("pkg error: {0}")]
     Pkg(#[from] PkgError),
     #[error("schema error: {0}")]

--- a/lib/sdf-server/src/server/service/variant/clone_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/clone_variant.rs
@@ -1,16 +1,16 @@
 use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
 use crate::server::tracking::track;
-use crate::service::variant::SchemaVariantResult;
+use crate::service::variant::{SchemaVariantError, SchemaVariantResult};
 use axum::extract::OriginalUri;
 use axum::{response::IntoResponse, Json};
 use dal::schema::variant::authoring::VariantAuthoringClient;
-use dal::{ChangeSet, SchemaVariantId, Visibility, WsEvent};
+use dal::{ChangeSet, Schema, SchemaId, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CloneVariantRequest {
-    pub id: SchemaVariantId,
+    pub id: SchemaId,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -18,7 +18,7 @@ pub struct CloneVariantRequest {
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CloneVariantResponse {
-    pub id: SchemaVariantId,
+    pub id: SchemaId,
     pub success: bool,
 }
 
@@ -33,38 +33,43 @@ pub async fn clone_variant(
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
-    let (cloned_schema_variant, schema) =
-        VariantAuthoringClient::clone_variant(&ctx, request.id).await?;
+    let schema = Schema::get_by_id(&ctx, request.id).await?;
+    if let Some(default_schema_variant_id) = schema.get_default_schema_variant(&ctx).await? {
+        let (cloned_schema_variant, schema) =
+            VariantAuthoringClient::clone_variant(&ctx, default_schema_variant_id).await?;
 
-    track(
-        &posthog_client,
-        &ctx,
-        &original_uri,
-        "clone_variant",
-        serde_json::json!({
-            "variant_name": schema.name(),
-            "variant_category": cloned_schema_variant.category(),
-            "variant_menu_name": cloned_schema_variant.display_name(),
-            "variant_id": cloned_schema_variant.id(),
-            "variant_component_type": cloned_schema_variant.component_type(),
-        }),
-    );
+        track(
+            &posthog_client,
+            &ctx,
+            &original_uri,
+            "clone_variant",
+            serde_json::json!({
+                "variant_name": schema.name(),
+                "variant_category": cloned_schema_variant.category(),
+                "variant_menu_name": cloned_schema_variant.display_name(),
+                "variant_id": cloned_schema_variant.id(),
+                "variant_component_type": cloned_schema_variant.component_type(),
+            }),
+        );
 
-    WsEvent::schema_variant_cloned(&ctx, cloned_schema_variant.id())
-        .await?
-        .publish_on_commit(&ctx)
-        .await?;
+        WsEvent::schema_variant_cloned(&ctx, cloned_schema_variant.id())
+            .await?
+            .publish_on_commit(&ctx)
+            .await?;
 
-    ctx.commit().await?;
+        ctx.commit().await?;
 
-    let mut response = axum::response::Response::builder();
-    response = response.header("Content-Type", "application/json");
-    if let Some(force_change_set_id) = force_change_set_id {
-        response = response.header("force_change_set_id", force_change_set_id.to_string());
+        let mut response = axum::response::Response::builder();
+        response = response.header("Content-Type", "application/json");
+        if let Some(force_change_set_id) = force_change_set_id {
+            response = response.header("force_change_set_id", force_change_set_id.to_string());
+        }
+
+        Ok(response.body(serde_json::to_string(&CloneVariantResponse {
+            id: schema.id(),
+            success: true,
+        })?)?)
+    } else {
+        Err(SchemaVariantError::NoDefaultSchemaVariantFoundForSchema)
     }
-
-    Ok(response.body(serde_json::to_string(&CloneVariantResponse {
-        id: cloned_schema_variant.id(),
-        success: true,
-    })?)?)
 }

--- a/lib/sdf-server/src/server/service/variant/get_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/get_variant.rs
@@ -2,16 +2,19 @@ use axum::extract::OriginalUri;
 use axum::{extract::Query, Json};
 use dal::func::authoring::FuncAuthoringClient;
 use dal::func::summary::FuncSummary;
-use dal::{ComponentType, Func, SchemaVariant, SchemaVariantId, Timestamp, Visibility};
+use dal::{
+    ComponentType, Func, Schema, SchemaId, SchemaVariant, SchemaVariantId, Timestamp, Visibility,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
+use crate::server::tracking::track;
 use crate::service::variant::{SchemaVariantError, SchemaVariantResult};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct GetVariantRequest {
-    pub id: SchemaVariantId,
+    pub id: SchemaId,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -19,7 +22,8 @@ pub struct GetVariantRequest {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetVariantResponse {
-    pub id: SchemaVariantId,
+    pub id: SchemaId,
+    pub default_schema_variant_id: SchemaVariantId,
     pub name: String,
     pub menu_name: Option<String>,
     pub category: String,
@@ -38,64 +42,71 @@ pub struct GetVariantResponse {
 pub async fn get_variant(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
-    PosthogClient(_posthog_client): PosthogClient,
-    OriginalUri(_original_uri): OriginalUri,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
     Query(request): Query<GetVariantRequest>,
 ) -> SchemaVariantResult<Json<GetVariantResponse>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let variant = SchemaVariant::get_by_id(&ctx, request.id).await?;
-    let schema = variant.schema(&ctx).await?;
+    let schema = Schema::get_by_id(&ctx, request.id).await?;
+    if let Some(default_schema_variant_id) = schema.get_default_schema_variant(&ctx).await? {
+        let variant = SchemaVariant::get_by_id(&ctx, default_schema_variant_id).await?;
 
-    let mut response: GetVariantResponse = GetVariantResponse {
-        id: request.id,
-        name: schema.name().into(),
-        menu_name: variant.display_name(),
-        category: variant.category().into(),
-        color: variant.get_color(&ctx).await?,
-        link: variant.link(),
-        description: variant.description(),
-        component_type: variant.component_type(),
-        timestamp: variant.timestamp(),
-        // Will be set elsewhere
-        code: "".to_string(),
-        funcs: vec![],
-        types: "".to_string(),
-        has_components: false,
-    };
+        let mut response: GetVariantResponse = GetVariantResponse {
+            id: request.id,
+            default_schema_variant_id,
+            name: schema.name().into(),
+            menu_name: variant.display_name(),
+            category: variant.category().into(),
+            color: variant.get_color(&ctx).await?,
+            link: variant.link(),
+            description: variant.description(),
+            component_type: variant.component_type(),
+            timestamp: variant.timestamp(),
+            // Will be set elsewhere
+            code: "".to_string(),
+            funcs: vec![],
+            types: "".to_string(),
+            has_components: false,
+        };
 
-    if let Some(authoring_func) = variant.asset_func_id() {
-        let asset_func = Func::get_by_id_or_error(&ctx, authoring_func).await?;
+        if let Some(authoring_func) = variant.asset_func_id() {
+            let asset_func = Func::get_by_id_or_error(&ctx, authoring_func).await?;
 
-        response.code = asset_func
-            .code_plaintext()?
-            .ok_or(SchemaVariantError::FuncIsEmpty(asset_func.id))?;
+            response.code = asset_func
+                .code_plaintext()?
+                .ok_or(SchemaVariantError::FuncIsEmpty(asset_func.id))?;
 
-        response.types = FuncAuthoringClient::compile_return_types(
-            asset_func.backend_response_type,
-            asset_func.backend_kind,
-        )
-        .to_string();
+            response.types = FuncAuthoringClient::compile_return_types(
+                asset_func.backend_response_type,
+                asset_func.backend_kind,
+            )
+            .to_string();
+        }
+
+        // let has_components = is_variant_def_locked(&ctx, &variant_def).await?;
+        // response.has_components = has_components;
+
+        response.funcs =
+            FuncSummary::list_for_schema_variant_id(&ctx, default_schema_variant_id).await?;
+
+        track(
+            &posthog_client,
+            &ctx,
+            &original_uri,
+            "get_variant",
+            serde_json::json!({
+                        "variant_name": variant.name(),
+                        "variant_category": variant.category(),
+                        "variant_menu_name": variant.display_name(),
+                        "variant_id": variant.id(),
+                        "schema_id": schema.id(),
+                        "variant_component_type": variant.component_type(),
+            }),
+        );
+
+        Ok(Json(response))
+    } else {
+        Err(SchemaVariantError::NoDefaultSchemaVariantFoundForSchema)
     }
-
-    // let has_components = is_variant_def_locked(&ctx, &variant_def).await?;
-    // response.has_components = has_components;
-
-    response.funcs = FuncSummary::list_for_schema_variant_id(&ctx, request.id).await?;
-
-    // track(
-    //     &posthog_client,
-    //     &ctx,
-    //     &original_uri,
-    //     "get_variant",
-    //     serde_json::json!({
-    //                 "variant_name": variant.name(),
-    //                 "variant_category": variant.category(),
-    //                 "variant_menu_name": variant.menu_name(),
-    //                 "variant_id": variant.id(),
-    //                 "variant_component_type": variant.component_type(),
-    //     }),
-    // );
-
-    Ok(Json(response))
 }


### PR DESCRIPTION
We were using SchemaVariantId to load the Variant details. This meant when we needed to clone OR to create a new variant, the screen would have redirected

We are now going to use SchemaId as the identitifer and we will then load the default_schema_variant for the schema