### PR TITLE
feat(dal): add exclusive outgoing edge conflicts to rebase

### DIFF
--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -170,6 +170,14 @@ impl AttributePrototypeArgument {
         result: AttributePrototypeArgumentResult,
     );
 
+    implement_add_edge_to!(
+        source_id: AttributePrototypeArgumentId,
+        destination_id: Ulid,
+        add_fn: add_edge_to_value,
+        discriminant: EdgeWeightKindDiscriminants::PrototypeArgumentValue,
+        result: AttributePrototypeArgumentResult,
+    );
+
     pub async fn get_by_id(
         ctx: &DalContext,
         id: AttributePrototypeArgumentId,
@@ -400,14 +408,6 @@ impl AttributePrototypeArgument {
 
         Ok(self)
     }
-
-    implement_add_edge_to!(
-        source_id: AttributePrototypeArgumentId,
-        destination_id: Ulid,
-        add_fn: add_edge_to_value,
-        discriminant: EdgeWeightKindDiscriminants::PrototypeArgumentValue,
-        result: AttributePrototypeArgumentResult,
-    );
 
     pub async fn prototype_id_for_argument_id(
         ctx: &DalContext,

--- a/lib/dal/src/workspace_snapshot/conflict.rs
+++ b/lib/dal/src/workspace_snapshot/conflict.rs
@@ -2,6 +2,8 @@ use petgraph::stable_graph::NodeIndex;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::EdgeWeightKindDiscriminants;
+
 /// Describe the type of conflict between the given locations in a
 /// workspace graph.
 #[remain::sorted]
@@ -10,6 +12,11 @@ pub enum Conflict {
     ChildOrder {
         onto: NodeIndex,
         to_rebase: NodeIndex,
+    },
+    ExclusiveEdgeMismatch {
+        source: NodeIndex,
+        destination: NodeIndex,
+        edge_kind: EdgeWeightKindDiscriminants,
     },
     ModifyRemovedItem(NodeIndex),
     NodeContent {

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -434,167 +434,6 @@ impl WorkspaceSnapshotGraph {
         Ok(source)
     }
 
-    // pub async fn attribute_value_view(
-    //     &self,
-    //     content_store: &mut impl Store,
-    //     root_index: NodeIndex,
-    // ) -> WorkspaceSnapshotGraphResult<serde_json::Value> {
-    //     let mut view = serde_json::json![{}];
-    //     let mut nodes_to_add = VecDeque::from([(root_index, "".to_string())]);
-
-    //     while let Some((current_node_index, write_location)) = nodes_to_add.pop_front() {
-    //         let current_node_weight = self.get_node_weight(current_node_index)?;
-    //         let current_node_content: serde_json::Value = content_store
-    //             .get(&current_node_weight.content_hash())
-    //             .await?
-    //             .ok_or(WorkspaceSnapshotGraphError::ContentMissingForContentHash)?;
-    //         // We don't need to care what kind the prop is, since assigning a value via
-    //         // `pointer_mut` completely overwrites the existing value, regardless of any
-    //         // pre-existing data types.
-    //         let view_pointer = match view.pointer_mut(&write_location) {
-    //             Some(pointer) => {
-    //                 *pointer = current_node_content.clone();
-    //                 pointer
-    //             }
-    //             None => {
-    //                 // This is an error, and really shouldn't ever happen.
-    //                 dbg!(view, write_location, current_node_content);
-    //                 todo!();
-    //             }
-    //         };
-
-    //         if current_node_content.is_null() {
-    //             // If the value we just inserted is "null", then there shouldn't be any child
-    //             // values, so don't bother looking for them in the graph to be able to add
-    //             // them to the work queue.
-    //             continue;
-    //         }
-
-    //         // Find the ordering if there is one, so we can add the children in the proper order.
-    //         if let Some(child_ordering) = self.ordered_children_for_node(current_node_index)? {
-    //             for (child_position_index, &child_node_index) in child_ordering.iter().enumerate() {
-    //                 // `.enumerate()` gives us 1-indexed, but we need 0-indexed.
-
-    //                 // We insert a JSON `Null` as a "place holder" for the write location. We need
-    //                 // it to exist to be able to get a `pointer_mut` to it on the next time around,
-    //                 // but we don't really care what it is, since we're going to completely
-    //                 // overwrite it anyway.
-    //                 for edge in self
-    //                     .graph
-    //                     .edges_connecting(current_node_index, child_node_index)
-    //                 {
-    //                     let child_position = match edge.weight().kind() {
-    //                         EdgeWeightKind::Contain(Some(key)) => {
-    //                             view_pointer
-    //                                 .as_object_mut()
-    //                                 .ok_or(WorkspaceSnapshotGraphError::InvalidValueGraph)?
-    //                                 .insert(key.clone(), serde_json::json![null]);
-    //                             key.clone()
-    //                         }
-    //                         EdgeWeightKind::Contain(None) => {
-    //                             if current_node_content.is_array() {
-    //                                 view_pointer
-    //                                     .as_array_mut()
-    //                                     .ok_or(WorkspaceSnapshotGraphError::InvalidValueGraph)?
-    //                                     .push(serde_json::json![null]);
-    //                                 child_position_index.to_string()
-    //                             } else {
-    //                                 // Get prop name
-    //                                 if let NodeWeight::Prop(prop_weight) = self.get_node_weight(
-    //                                     self.prop_node_index_for_node_index(child_node_index)?
-    //                                         .ok_or(WorkspaceSnapshotGraphError::NoPropFound(
-    //                                             child_node_index,
-    //                                         ))?,
-    //                                 )? {
-    //                                     view_pointer
-    //                                         .as_object_mut()
-    //                                         .ok_or(WorkspaceSnapshotGraphError::InvalidValueGraph)?
-    //                                         .insert(
-    //                                             prop_weight.name().to_string(),
-    //                                             serde_json::json![null],
-    //                                         );
-    //                                     prop_weight.name().to_string()
-    //                                 } else {
-    //                                     return Err(WorkspaceSnapshotGraphError::InvalidValueGraph);
-    //                                 }
-    //                             }
-    //                         }
-    //                         _ => continue,
-    //                     };
-    //                     let child_write_location = format!("{}/{}", write_location, child_position);
-    //                     nodes_to_add.push_back((child_node_index, child_write_location));
-    //                 }
-    //             }
-    //         } else {
-    //             // The child nodes aren't explicitly ordered, so we'll need to come up with one of
-    //             // our own. We'll sort the nodes by their `NodeIndex`, which means that when a
-    //             // write last happened to them (or anywhere further towards the leaves) will
-    //             // determine their sorting in oldest to most recent order.
-    //             let mut child_index_to_position = HashMap::new();
-    //             let mut child_indexes = Vec::new();
-    //             let outgoing_edges = self.graph.edges_directed(current_node_index, Outgoing);
-    //             for edge_ref in outgoing_edges {
-    //                 match edge_ref.weight().kind() {
-    //                     EdgeWeightKind::Contain(Some(key)) => {
-    //                         view_pointer
-    //                             .as_object_mut()
-    //                             .ok_or(WorkspaceSnapshotGraphError::InvalidValueGraph)?
-    //                             .insert(key.clone(), serde_json::json![null]);
-    //                         child_index_to_position.insert(edge_ref.target(), key.clone());
-    //                         child_indexes.push(edge_ref.target());
-    //                     }
-    //                     EdgeWeightKind::Contain(None) => {
-    //                         child_indexes.push(edge_ref.target());
-    //                         if current_node_content.is_array() {
-    //                             view_pointer
-    //                                 .as_array_mut()
-    //                                 .ok_or(WorkspaceSnapshotGraphError::InvalidValueGraph)?
-    //                                 .push(serde_json::json![null]);
-    //                         } else {
-    //                             // Get prop name
-    //                             if let NodeWeight::Prop(prop_weight) = self.get_node_weight(
-    //                                 self.prop_node_index_for_node_index(edge_ref.target())?
-    //                                     .ok_or(WorkspaceSnapshotGraphError::NoPropFound(
-    //                                         edge_ref.target(),
-    //                                     ))?,
-    //                             )? {
-    //                                 view_pointer
-    //                                     .as_object_mut()
-    //                                     .ok_or(WorkspaceSnapshotGraphError::InvalidValueGraph)?
-    //                                     .insert(
-    //                                         prop_weight.name().to_string(),
-    //                                         serde_json::json![null],
-    //                                     );
-    //                                 child_index_to_position
-    //                                     .insert(edge_ref.target(), prop_weight.name().to_string());
-    //                                 child_indexes.push(edge_ref.target());
-    //                             } else {
-    //                                 return Err(WorkspaceSnapshotGraphError::InvalidValueGraph);
-    //                             }
-    //                         }
-    //                     }
-    //                     _ => continue,
-    //                 }
-    //             }
-    //             child_indexes.sort();
-
-    //             for (child_position_index, child_node_index) in child_indexes.iter().enumerate() {
-    //                 if let Some(key) = child_index_to_position.get(child_node_index) {
-    //                     nodes_to_add
-    //                         .push_back((*child_node_index, format!("{}/{}", write_location, key)));
-    //                 } else {
-    //                     nodes_to_add.push_back((
-    //                         *child_node_index,
-    //                         format!("{}/{}", write_location, child_position_index),
-    //                     ));
-    //                 }
-    //             }
-    //         }
-    //     }
-
-    //     Ok(view)
-    // }
-
     pub fn cleanup(&mut self) {
         let start = tokio::time::Instant::now();
 
@@ -1197,8 +1036,14 @@ impl WorkspaceSnapshotGraph {
                     });
                 }
             } else {
-                debug!(
-                    "edge weight entry for to rebase vector clock id {:?} is older than onto last saw {:?}", to_rebase_edge_weight.vector_clock_first_seen().entry_for(to_rebase_vector_clock_id), onto_last_saw_to_rebase);
+                let edge_kind = only_to_rebase_edge_info.edge_kind;
+                if to_rebase_item_weight.is_exclusive_outgoing_edge(edge_kind) {
+                    conflicts.push(Conflict::ExclusiveEdgeMismatch {
+                        source: only_to_rebase_edge_info.source_node_index,
+                        destination: only_to_rebase_edge_info.target_node_index,
+                        edge_kind,
+                    });
+                }
             }
         }
 

--- a/lib/dal/src/workspace_snapshot/graph/tests/detect_conflicts_and_updates.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/detect_conflicts_and_updates.rs
@@ -13,6 +13,7 @@ mod test {
     use crate::workspace_snapshot::edge_weight::{
         EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants,
     };
+    use crate::workspace_snapshot::graph::tests::{add_edges, add_prop_nodes_to_graph};
     use crate::workspace_snapshot::node_weight::NodeWeight;
     use crate::workspace_snapshot::update::Update;
     use crate::{PropKind, WorkspaceSnapshotGraph};
@@ -2593,6 +2594,106 @@ mod test {
                 edge_kind: EdgeWeightKindDiscriminants::Use,
             }],
             updates
+        );
+    }
+
+    #[test]
+    fn detect_exclusive_edge_conflict() {
+        let base_nodes = ["r", "q"];
+        let base_edges = [(None, "r"), (Some("r"), "q")];
+
+        let base_change_set = ChangeSet::new_local().expect("unable to create change set");
+        let base_change_set = &base_change_set;
+        let mut base_graph =
+            WorkspaceSnapshotGraph::new(base_change_set).expect("unable to make base graph");
+
+        let mut node_id_map =
+            add_prop_nodes_to_graph(&mut base_graph, base_change_set, &base_nodes);
+        add_edges(&mut base_graph, &node_id_map, base_change_set, &base_edges);
+        base_graph.cleanup();
+        base_graph
+            .mark_graph_seen(base_change_set.vector_clock_id())
+            .expect("unable to mark seen");
+
+        let a_new_nodes = ["a"];
+        let a_edges = [(Some("q"), "a")];
+
+        let change_set_a = ChangeSet::new_local().expect("unable to create change set");
+        let change_set_a = &change_set_a;
+        let mut graph_a = base_graph.clone();
+        node_id_map.extend(add_prop_nodes_to_graph(
+            &mut graph_a,
+            change_set_a,
+            &a_new_nodes,
+        ));
+        add_edges(&mut graph_a, &node_id_map, change_set_a, &a_edges);
+        graph_a.cleanup();
+        graph_a
+            .mark_graph_seen(change_set_a.vector_clock_id())
+            .expect("unable to mark seen");
+
+        let b_new_nodes = ["b"];
+        let b_edges = [(Some("q"), "b")];
+
+        let change_set_b = ChangeSet::new_local().expect("unable to create change set");
+        let change_set_b = &change_set_b;
+        let mut graph_b = base_graph.clone();
+        node_id_map.extend(add_prop_nodes_to_graph(
+            &mut graph_b,
+            change_set_b,
+            &b_new_nodes,
+        ));
+        add_edges(&mut graph_b, &node_id_map, change_set_b, &b_edges);
+        graph_b.cleanup();
+        graph_b
+            .mark_graph_seen(change_set_b.vector_clock_id())
+            .expect("unable to mark seen");
+
+        let (conflicts, _) = graph_a
+            .detect_conflicts_and_updates(
+                change_set_a.vector_clock_id(),
+                &graph_b,
+                change_set_b.vector_clock_id(),
+            )
+            .expect("able to detect conflicts and updates");
+
+        let a_q_node_idx = graph_a
+            .get_node_index_by_id(*node_id_map.get("q").expect("should have an id for 'q'"))
+            .expect("able to get q node index");
+        let b_q_node_idx = graph_b
+            .get_node_index_by_id(*node_id_map.get("q").expect("should have an id for 'q'"))
+            .expect("able to get q node index");
+        let a_node_idx = graph_a
+            .get_node_index_by_id(*node_id_map.get("a").expect("should have an id for 'a'"))
+            .expect("able to get a node index");
+        let b_node_idx = graph_b
+            .get_node_index_by_id(*node_id_map.get("b").expect("should have an id for 'b'"))
+            .expect("able to get b node index");
+
+        assert_eq!(
+            vec![Conflict::ExclusiveEdgeMismatch {
+                source: a_q_node_idx,
+                destination: a_node_idx,
+                edge_kind: EdgeWeightKindDiscriminants::Use,
+            }],
+            conflicts
+        );
+
+        let (conflicts, _) = graph_b
+            .detect_conflicts_and_updates(
+                change_set_b.vector_clock_id(),
+                &graph_a,
+                change_set_a.vector_clock_id(),
+            )
+            .expect("able to detect conflicts and updates");
+
+        assert_eq!(
+            vec![Conflict::ExclusiveEdgeMismatch {
+                source: b_q_node_idx,
+                destination: b_node_idx,
+                edge_kind: EdgeWeightKindDiscriminants::Use,
+            }],
+            conflicts
         );
     }
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
@@ -8,7 +8,7 @@ use crate::{
         graph::LineageId,
         vector_clock::{VectorClock, VectorClockId},
     },
-    ChangeSet, ChangeSetId,
+    ChangeSet, ChangeSetId, EdgeWeightKindDiscriminants,
 };
 
 use super::NodeWeightResult;
@@ -139,5 +139,9 @@ impl ActionNodeWeight {
 
     pub fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
+    }
+
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[EdgeWeightKindDiscriminants::Use]
     }
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
@@ -8,7 +8,7 @@ use crate::{
         graph::LineageId,
         vector_clock::{VectorClock, VectorClockId},
     },
-    ChangeSet,
+    ChangeSet, EdgeWeightKindDiscriminants,
 };
 
 use super::NodeWeightResult;
@@ -157,5 +157,9 @@ impl ActionPrototypeNodeWeight {
 
     pub fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
+    }
+
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[EdgeWeightKindDiscriminants::Use]
     }
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
@@ -7,7 +7,7 @@ use crate::{
     workspace_snapshot::{
         graph::LineageId, node_weight::NodeWeightResult, vector_clock::VectorClock,
     },
-    ComponentId, Timestamp,
+    ComponentId, EdgeWeightKindDiscriminants, Timestamp,
 };
 
 use crate::workspace_snapshot::vector_clock::VectorClockId;
@@ -155,6 +155,13 @@ impl AttributePrototypeArgumentNodeWeight {
 
     pub fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
+    }
+
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[
+            EdgeWeightKindDiscriminants::Use,
+            EdgeWeightKindDiscriminants::PrototypeArgumentValue,
+        ]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -11,6 +11,7 @@ use crate::{
         node_weight::NodeWeightResult,
         vector_clock::{VectorClock, VectorClockId},
     },
+    EdgeWeightKindDiscriminants,
 };
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -181,6 +182,15 @@ impl AttributeValueNodeWeight {
 
     pub fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
+    }
+
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[
+            EdgeWeightKindDiscriminants::Contain,
+            EdgeWeightKindDiscriminants::Prototype,
+            EdgeWeightKindDiscriminants::Prop,
+            EdgeWeightKindDiscriminants::Socket,
+        ]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
@@ -6,6 +6,7 @@ use strum::Display;
 use crate::change_set::ChangeSet;
 use crate::workspace_snapshot::vector_clock::VectorClockId;
 use crate::workspace_snapshot::{node_weight::NodeWeightResult, vector_clock::VectorClock};
+use crate::EdgeWeightKindDiscriminants;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Display)]
 pub enum CategoryNodeKind {
@@ -142,6 +143,10 @@ impl CategoryNodeWeight {
 
     pub fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
+    }
+
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -9,6 +9,7 @@ use crate::{
         graph::LineageId,
         vector_clock::{VectorClock, VectorClockId},
     },
+    EdgeWeightKindDiscriminants,
 };
 
 use super::{NodeWeightError, NodeWeightResult};
@@ -164,5 +165,14 @@ impl ComponentNodeWeight {
 
     pub fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
+    }
+
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[
+            EdgeWeightKindDiscriminants::Use,
+            EdgeWeightKindDiscriminants::FrameContains,
+            EdgeWeightKindDiscriminants::Root,
+            EdgeWeightKindDiscriminants::SocketValue,
+        ]
     }
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
@@ -4,6 +4,7 @@ use si_events::merkle_tree_hash::MerkleTreeHash;
 use si_events::{ulid::Ulid, ContentHash};
 
 use crate::workspace_snapshot::vector_clock::VectorClockId;
+use crate::EdgeWeightKindDiscriminants;
 use crate::{
     change_set::ChangeSet,
     workspace_snapshot::{
@@ -201,6 +202,10 @@ impl ContentNodeWeight {
 
     pub fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
+    }
+
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
@@ -5,13 +5,13 @@ use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 use crate::{
     change_set::ChangeSet,
     workspace_snapshot::{
-        content_address::ContentAddress,
-        content_address::ContentAddressDiscriminants,
+        content_address::{ContentAddress, ContentAddressDiscriminants},
         graph::LineageId,
         node_weight::NodeWeightResult,
         vector_clock::{VectorClock, VectorClockId},
         NodeWeightError,
     },
+    EdgeWeightKindDiscriminants,
 };
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -164,6 +164,10 @@ impl FuncArgumentNodeWeight {
 
     pub fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
+    }
+
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
@@ -5,6 +5,7 @@ use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 use crate::func::FuncKind;
 use crate::workspace_snapshot::content_address::ContentAddressDiscriminants;
 use crate::workspace_snapshot::vector_clock::VectorClockId;
+use crate::EdgeWeightKindDiscriminants;
 use crate::{
     change_set::ChangeSet,
     workspace_snapshot::{
@@ -178,6 +179,10 @@ impl FuncNodeWeight {
 
     pub fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
+    }
+
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[EdgeWeightKindDiscriminants::Use]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
@@ -6,6 +6,7 @@ use super::NodeWeightError;
 use crate::change_set::ChangeSet;
 use crate::workspace_snapshot::vector_clock::VectorClockId;
 use crate::workspace_snapshot::{node_weight::NodeWeightResult, vector_clock::VectorClock};
+use crate::EdgeWeightKindDiscriminants;
 
 #[derive(Clone, Serialize, Deserialize, Default)]
 pub struct OrderingNodeWeight {
@@ -181,6 +182,10 @@ impl OrderingNodeWeight {
             .ok_or(NodeWeightError::MissingKeytForChildEntry(id))?;
         let ret: i64 = index.try_into().map_err(NodeWeightError::TryFromIntError)?;
         Ok(ret)
+    }
+
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
@@ -4,6 +4,7 @@ use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::workspace_snapshot::content_address::ContentAddressDiscriminants;
 use crate::workspace_snapshot::vector_clock::VectorClockId;
+use crate::EdgeWeightKindDiscriminants;
 use crate::{
     change_set::ChangeSet,
     workspace_snapshot::{
@@ -178,6 +179,13 @@ impl PropNodeWeight {
 
     pub fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
+    }
+
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[
+            EdgeWeightKindDiscriminants::Prototype,
+            EdgeWeightKindDiscriminants::Use,
+        ]
     }
 }
 


### PR DESCRIPTION
Many nodes assume complete control of their direct, outgoing neighbors, and allowing them to be silently merged with other neighbors from another changeset would create an incorrect graph. For example, an AttributeValue should only ever have one outgoing Prototype edge defining the "component specific" prototype for that value. If another user merges in a changeset with an updated prototype edge that we have never seen in our change set, that should be considered a conflict, since otherwise the result of the rebase would be an AttributeValue with *two* Prototype edges, an incorrect state. The same applies for "Contains" edges and many others. This change will produce an `ExclusiveEdgeMismatch` conflict when the snapshot being rebased (the `to_rebase`) has a container with edges not seen by the `onto`, *if* that container defines the edge kinds as exclusive edges. Be sure to add these exclusions the node weight when adding a new edge kind, if it makes sense to do so.