### PR TITLE
feat(dal): retry dependent values update jobs on conflict

### DIFF
--- a/lib/dal/src/job/definition/compute_validation.rs
+++ b/lib/dal/src/job/definition/compute_validation.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use telemetry::prelude::*;
 
+use crate::job::consumer::JobCompletionState;
 use crate::validation::{ValidationOutput, ValidationOutputNode};
 use crate::{
     job::consumer::{
@@ -81,7 +82,7 @@ impl JobConsumer for ComputeValidation {
             attribute_values = ?self.attribute_values,
         )
     )]
-    async fn run(&self, ctx: &mut DalContext) -> JobConsumerResult<()> {
+    async fn run(&self, ctx: &mut DalContext) -> JobConsumerResult<JobCompletionState> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         for &av_id in &self.attribute_values {
@@ -118,7 +119,7 @@ impl JobConsumer for ComputeValidation {
 
         ctx.commit().await?;
 
-        Ok(())
+        Ok(JobCompletionState::Done)
     }
 }
 

--- a/lib/dal/src/job/definition/refresh.rs
+++ b/lib/dal/src/job/definition/refresh.rs
@@ -7,7 +7,8 @@ use telemetry::prelude::*;
 use crate::{
     job::{
         consumer::{
-            JobConsumer, JobConsumerError, JobConsumerMetadata, JobConsumerResult, JobInfo,
+            JobCompletionState, JobConsumer, JobConsumerError, JobConsumerMetadata,
+            JobConsumerResult, JobInfo,
         },
         producer::{JobProducer, JobProducerResult},
     },
@@ -81,7 +82,7 @@ impl JobConsumer for RefreshJob {
             component_ids = ?self.component_ids,
         )
     )]
-    async fn run(&self, ctx: &mut DalContext) -> JobConsumerResult<()> {
+    async fn run(&self, ctx: &mut DalContext) -> JobConsumerResult<JobCompletionState> {
         for component_id in &self.component_ids {
             let variant = Component::schema_variant_for_component_id(ctx, *component_id).await?;
             for prototype in DeprecatedActionPrototype::for_variant(ctx, variant.id()).await? {
@@ -99,7 +100,7 @@ impl JobConsumer for RefreshJob {
             ctx.commit().await?;
         }
 
-        Ok(())
+        Ok(JobCompletionState::Done)
     }
 }
 


### PR DESCRIPTION
Adds retry logic to the job consumer. Jobs can request retry and specify a retry policy (immediate, or exponential backoff), as well as the retry limit. Uses this to make the `DependentValuesUpdate` job retry on conflict.