### PR TITLE
ENG-2508 update edge logic

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramEdge.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramEdge.vue
@@ -28,7 +28,7 @@
         stroke: strokeColor,
         strokeWidth: 2,
         hitStrokeWidth: 10,
-        listening: !edge.def.isInvisible,
+        listening: !edge.def.isInferred,
         opacity: mainLineOpacity,
         dash: [10, 10],
         dashEnabled: isDeleted,
@@ -43,7 +43,7 @@
 
     <v-group
       v-if="
-        !edge.def.isInvisible &&
+        !edge.def.isInferred &&
         (isAdded || isDeleted || willDeleteIfPendingEdgeCreated)
       "
       :config="{
@@ -134,7 +134,7 @@ const defaultStrokeColor = computed(() =>
 );
 
 const strokeColor = computed(() => {
-  if (isDevMode && props.edge.def.isInvisible) {
+  if (isDevMode && props.edge.def.isInferred) {
     return "rgba(100,50,255,0.1)";
   }
 
@@ -199,7 +199,7 @@ function onMouseDown(_e: KonvaEventObject<MouseEvent>) {
 }
 
 const shouldDraw = computed(() =>
-  isDevMode ? true : !props.edge.def.isInvisible,
+  isDevMode ? true : !props.edge.def.isInferred,
 );
 
 // defineExpose({ recalculatePoints });

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -2331,31 +2331,16 @@ async function endDrawEdge() {
   const toComponentId = adjustedTo.parent.def.id;
   const toSocketId = adjustedTo.def.id;
 
-  const equivalentEdge = _.find(
-    edges.value,
-    (e) =>
-      e.def.fromComponentId === fromComponentId &&
-      e.def.fromSocketId === fromSocketId &&
-      e.def.toComponentId === toComponentId &&
-      e.def.toSocketId === toSocketId,
+  await componentsStore.CREATE_COMPONENT_CONNECTION(
+    {
+      componentId: fromComponentId,
+      socketId: fromSocketId,
+    },
+    {
+      componentId: toComponentId,
+      socketId: toSocketId,
+    },
   );
-
-  // TODO: probably move this to the store?
-  // and the backend should probably handle it correctly on the create edge route
-  if (equivalentEdge) {
-    await componentsStore.RESTORE_EDGE(equivalentEdge.def.id);
-  } else {
-    await componentsStore.CREATE_COMPONENT_CONNECTION(
-      {
-        componentId: fromComponentId,
-        socketId: fromSocketId,
-      },
-      {
-        componentId: toComponentId,
-        socketId: toSocketId,
-      },
-    );
-  }
 }
 
 const pasteElementsActive = computed(() => {

--- a/app/web/src/components/ModelingDiagram/diagram_types.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_types.ts
@@ -247,7 +247,7 @@ export type DiagramEdgeDef = {
   toComponentId: DiagramElementId;
   toSocketId: DiagramElementId;
   isBidirectional?: boolean;
-  isInvisible?: boolean;
+  isInferred?: boolean;
   /** change status of edge in relation to head */
   changeStatus?: ChangeStatus;
   createdAt?: Date;

--- a/app/web/src/components/ModelingView/DeleteSelectionModal.vue
+++ b/app/web/src/components/ModelingView/DeleteSelectionModal.vue
@@ -121,8 +121,18 @@ function open() {
 
 async function onConfirmDelete() {
   close();
-  if (componentsStore.selectedEdgeId) {
-    await componentsStore.DELETE_EDGE(componentsStore.selectedEdgeId);
+  if (
+    componentsStore.selectedEdgeId &&
+    componentsStore.selectedEdge?.toSocketId &&
+    componentsStore.selectedEdge?.fromSocketId
+  ) {
+    await componentsStore.DELETE_EDGE(
+      componentsStore.selectedEdgeId,
+      componentsStore.selectedEdge?.toSocketId,
+      componentsStore.selectedEdge?.fromSocketId,
+      componentsStore.selectedEdge?.toComponentId,
+      componentsStore.selectedEdge?.fromComponentId,
+    );
   } else if (componentsStore.selectedComponentIds) {
     await componentsStore.DELETE_COMPONENTS(
       componentsStore.selectedComponentIds,

--- a/app/web/src/components/ModelingView/RestoreSelectionModal.vue
+++ b/app/web/src/components/ModelingView/RestoreSelectionModal.vue
@@ -77,9 +77,7 @@ function open() {
 }
 
 async function onConfirmRestore() {
-  if (componentsStore.selectedEdgeId) {
-    await componentsStore.RESTORE_EDGE(componentsStore.selectedEdgeId);
-  } else if (componentsStore.selectedComponentIds) {
+  if (componentsStore.selectedComponentIds) {
     await componentsStore.RESTORE_COMPONENTS(
       componentsStore.selectedComponentIds,
     );

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -4,7 +4,6 @@ use std::collections::{hash_map, HashMap};
 use std::num::{ParseFloatError, ParseIntError};
 use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
-use telemetry::tracing::instrument;
 use thiserror::Error;
 
 use crate::actor_view::ActorView;
@@ -132,8 +131,6 @@ pub struct SummaryDiagramComponent {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct SummaryDiagramEdge {
-    pub id: EdgeId,
-    pub edge_id: EdgeId,
     pub from_component_id: ComponentId,
     pub from_socket_id: OutputSocketId,
     pub to_component_id: ComponentId,
@@ -233,8 +230,6 @@ impl Diagram {
                 let from_component =
                     Component::get_by_id(ctx, incoming_connection.from_component_id).await?;
                 diagram_edges.push(SummaryDiagramEdge {
-                    id: incoming_connection.attribute_prototype_argument_id,
-                    edge_id: incoming_connection.attribute_prototype_argument_id,
                     from_component_id: incoming_connection.from_component_id,
                     from_socket_id: incoming_connection.from_output_socket_id,
                     to_component_id: incoming_connection.to_component_id,

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -211,7 +211,7 @@ pub enum DiagramSocketNodeSide {
 pub struct Diagram {
     pub components: Vec<SummaryDiagramComponent>,
     pub edges: Vec<SummaryDiagramEdge>,
-    pub implicit_edges: Vec<SummaryDiagramInferredEdge>,
+    pub inferred_edges: Vec<SummaryDiagramInferredEdge>,
 }
 
 impl Diagram {
@@ -221,7 +221,7 @@ impl Diagram {
     pub async fn assemble(ctx: &DalContext) -> DiagramResult<Self> {
         let mut diagram_sockets: HashMap<SchemaVariantId, serde_json::Value> = HashMap::new();
         let mut diagram_edges: Vec<SummaryDiagramEdge> = vec![];
-        let mut diagram_implicit_edges: Vec<SummaryDiagramInferredEdge> = vec![];
+        let mut diagram_inferred_edges: Vec<SummaryDiagramInferredEdge> = vec![];
         let components = Component::list(ctx).await?;
 
         let mut component_views = Vec::with_capacity(components.len());
@@ -242,7 +242,7 @@ impl Diagram {
             }
 
             for inferred_incoming_connection in component.inferred_connections(ctx).await? {
-                diagram_implicit_edges.push(SummaryDiagramInferredEdge {
+                diagram_inferred_edges.push(SummaryDiagramInferredEdge {
                     from_component_id: inferred_incoming_connection.from_component_id,
                     from_socket_id: inferred_incoming_connection.from_output_socket_id,
                     to_component_id: inferred_incoming_connection.to_component_id,
@@ -368,7 +368,7 @@ impl Diagram {
         Ok(Self {
             edges: diagram_edges,
             components: component_views,
-            implicit_edges: diagram_implicit_edges,
+            inferred_edges: diagram_inferred_edges,
         })
     }
 }

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -6,6 +6,7 @@ use dal::{ComponentType, InputSocket, OutputSocket};
 use dal_test::helpers::ChangeSetTestHelpers;
 use dal_test::helpers::{connect_components_with_socket_names, create_component_for_schema_name};
 use dal_test::test;
+use petgraph::graph::Edge;
 use pretty_assertions_sorted::assert_eq;
 use std::collections::HashMap;
 
@@ -1462,7 +1463,7 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
 
 struct DiagramByKey {
     pub components: HashMap<String, (SummaryDiagramComponent, Vec<SummaryDiagramInferredEdge>)>,
-    pub edges: HashMap<EdgeId, SummaryDiagramEdge>,
+    pub edges: HashMap<String, SummaryDiagramEdge>,
 }
 
 impl DiagramByKey {
@@ -1485,7 +1486,10 @@ impl DiagramByKey {
 
         let mut edges = HashMap::new();
         for edge in &diagram.edges {
-            edges.insert(edge.edge_id, edge.to_owned());
+            edges.insert(
+                "{edge.to_socket_id}_{edge.from_socket_id}".to_string(),
+                edge.to_owned(),
+            );
         }
 
         Ok(Self { components, edges })

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -290,7 +290,7 @@ async fn simple_frames(ctx: &mut DalContext) {
         .expect("found one");
         assert!(!maybe_ins.is_empty());
         assert_eq!(maybe_ins.len(), 1);
-        assert_eq!(diagram.get_all_implicit_edges().len(), 1);
+        assert_eq!(diagram.get_all_inferred_edges().len(), 1);
     }
     // scenario 3 - detach and make sure nothing implicit passes
 
@@ -376,7 +376,7 @@ async fn simple_frames(ctx: &mut DalContext) {
         .await
         .expect("could not find inferred values");
         assert!(maybe_ins.is_empty());
-        assert_eq!(diagram.get_all_implicit_edges().len(), 0);
+        assert_eq!(diagram.get_all_inferred_edges().len(), 0);
     }
 }
 
@@ -433,7 +433,7 @@ async fn output_sockets_can_have_both(ctx: &mut DalContext) {
     );
     assert_eq!(
         3,                                      // expected
-        diagram.get_all_implicit_edges().len()  // actual
+        diagram.get_all_inferred_edges().len()  // actual
     );
     let odd_component = Component::get_by_id(ctx, odd_component.id())
         .await
@@ -1152,7 +1152,7 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
 
         assert_eq!(
             1,                                      // expected
-            diagram.get_all_implicit_edges().len()  // actual
+            diagram.get_all_inferred_edges().len()  // actual
         );
 
         let new_era_taylor_swift_assembled = diagram
@@ -1202,7 +1202,7 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
         );
         assert_eq!(
             1,                                      // expected
-            diagram.get_all_implicit_edges().len()  // actual
+            diagram.get_all_inferred_edges().len()  // actual
         );
 
         let new_era_taylor_swift_assembled = diagram
@@ -1263,7 +1263,7 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
         );
         assert_eq!(
             2,                                      // expected
-            diagram.get_all_implicit_edges().len()  // actual
+            diagram.get_all_inferred_edges().len()  // actual
         );
 
         let new_era_taylor_swift_assembled = diagram
@@ -1334,7 +1334,7 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
         );
         assert_eq!(
             2,                                      // expected
-            diagram.get_all_implicit_edges().len()  // actual
+            diagram.get_all_inferred_edges().len()  // actual
         );
 
         let new_era_taylor_swift_assembled = diagram
@@ -1405,7 +1405,7 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
         );
         assert_eq!(
             2,                                      // expected
-            diagram.get_all_implicit_edges().len()  // actual
+            diagram.get_all_inferred_edges().len()  // actual
         );
 
         let new_era_taylor_swift_assembled = diagram
@@ -1471,15 +1471,15 @@ impl DiagramByKey {
 
         let mut components = HashMap::new();
         for component in &diagram.components {
-            let mut implicit_edges = vec![];
-            for implicit_edge in &diagram.implicit_edges {
-                if implicit_edge.to_component_id == component.id {
-                    implicit_edges.push(implicit_edge.to_owned());
+            let mut inferred_edges = vec![];
+            for inferred_edge in &diagram.inferred_edges {
+                if inferred_edge.to_component_id == component.id {
+                    inferred_edges.push(inferred_edge.to_owned());
                 }
             }
             components.insert(
                 component.display_name.clone(),
-                (component.to_owned(), implicit_edges.to_owned()),
+                (component.to_owned(), inferred_edges.to_owned()),
             );
         }
 
@@ -1493,7 +1493,7 @@ impl DiagramByKey {
 
         Ok(Self { components, edges })
     }
-    pub fn get_all_implicit_edges(&self) -> Vec<SummaryDiagramInferredEdge> {
+    pub fn get_all_inferred_edges(&self) -> Vec<SummaryDiagramInferredEdge> {
         let mut all = vec![];
         for component in self.components.values() {
             for edge in component.1.clone() {

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -1,12 +1,11 @@
 use dal::component::frame::{Frame, FrameError};
 use dal::diagram::SummaryDiagramInferredEdge;
-use dal::diagram::{Diagram, DiagramResult, EdgeId, SummaryDiagramComponent, SummaryDiagramEdge};
+use dal::diagram::{Diagram, DiagramResult, SummaryDiagramComponent, SummaryDiagramEdge};
 use dal::{AttributeValue, Component, DalContext, Schema, SchemaVariant};
 use dal::{ComponentType, InputSocket, OutputSocket};
 use dal_test::helpers::ChangeSetTestHelpers;
 use dal_test::helpers::{connect_components_with_socket_names, create_component_for_schema_name};
 use dal_test::test;
-use petgraph::graph::Edge;
 use pretty_assertions_sorted::assert_eq;
 use std::collections::HashMap;
 

--- a/lib/sdf-server/src/server/service/diagram/delete_connection.rs
+++ b/lib/sdf-server/src/server/service/diagram/delete_connection.rs
@@ -1,14 +1,8 @@
 use axum::extract::OriginalUri;
 use axum::{response::IntoResponse, Json};
-use dal::attribute::prototype::argument::value_source::ValueSource;
-use dal::attribute::prototype::argument::{
-    AttributePrototypeArgument, AttributePrototypeArgumentError, AttributePrototypeArgumentId,
-};
-use dal::attribute::prototype::AttributePrototypeError;
-use dal::attribute::value::ValueIsFor;
-use dal::workspace_snapshot::node_weight::NodeWeightDiscriminants;
 use dal::{
-    AttributePrototype, AttributeValue, ChangeSet, Component, InputSocket, OutputSocket, Visibility,
+    ChangeSet, Component, ComponentId, InputSocket, InputSocketId, OutputSocket, OutputSocketId,
+    Visibility,
 };
 use serde::{Deserialize, Serialize};
 
@@ -20,7 +14,10 @@ use crate::server::tracking::track;
 #[serde(rename_all = "camelCase")]
 
 pub struct DeleteConnectionRequest {
-    pub edge_id: AttributePrototypeArgumentId,
+    pub from_socket_id: OutputSocketId,
+    pub from_component_id: ComponentId,
+    pub to_component_id: ComponentId,
+    pub to_socket_id: InputSocketId,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -36,76 +33,23 @@ pub async fn delete_connection(
     let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
+    Component::remove_connection(
+        &ctx,
+        request.to_socket_id,
+        request.from_socket_id,
+        request.to_component_id,
+        request.from_component_id,
+    )
+    .await?;
 
-    let attribute_prototype_argument =
-        AttributePrototypeArgument::get_by_id(&ctx, request.edge_id).await?;
-    let targets = attribute_prototype_argument.targets().ok_or(
-        AttributePrototypeArgumentError::NoTargets(attribute_prototype_argument.id()),
-    )?;
-    let output_socket_id = match attribute_prototype_argument
-        .value_source(&ctx)
-        .await?
-        .ok_or(AttributePrototypeArgumentError::MissingSource(
-            attribute_prototype_argument.id(),
-        ))? {
-        ValueSource::OutputSocket(source_id) => source_id,
+    let from_component_schema =
+        Component::schema_for_component_id(&ctx, request.from_component_id).await?;
 
-        // Any other source should be considered an error, as connections on the diagram
-        // are only from output sockets to input sockets.
-        ValueSource::Prop(_) => {
-            return Err(AttributePrototypeArgumentError::UnexpectedValueSourceNode(
-                attribute_prototype_argument.id(),
-                NodeWeightDiscriminants::Prop,
-            )
-            .into());
-        }
-        ValueSource::InputSocket(_) | ValueSource::StaticArgumentValue(_) => {
-            return Err(AttributePrototypeArgumentError::UnexpectedValueSourceNode(
-                attribute_prototype_argument.id(),
-                NodeWeightDiscriminants::Content,
-            )
-            .into());
-        }
-    };
-    let prototype_id = attribute_prototype_argument.prototype_id(&ctx).await?;
-    let value_id = AttributePrototype::attribute_value_ids(&ctx, prototype_id)
-        .await?
-        .first()
-        .copied()
-        .ok_or(AttributePrototypeError::NoAttributeValues(prototype_id))?;
-    let input_socket_id = match AttributeValue::is_for(&ctx, value_id).await? {
-        ValueIsFor::InputSocket(socket_id) => socket_id,
+    let to_component_schema =
+        Component::schema_for_component_id(&ctx, request.to_component_id).await?;
 
-        // Any other destination should be considered an error, as connections on the diagram
-        // are only from output sockets to input sockets.
-        ValueIsFor::Prop(_) => {
-            return Err(AttributePrototypeArgumentError::UnexpectedValueSourceNode(
-                attribute_prototype_argument.id(),
-                NodeWeightDiscriminants::Prop,
-            )
-            .into());
-        }
-        ValueIsFor::OutputSocket(_) => {
-            return Err(AttributePrototypeArgumentError::UnexpectedValueSourceNode(
-                attribute_prototype_argument.id(),
-                NodeWeightDiscriminants::Content,
-            )
-            .into());
-        }
-    };
-
-    let from_component_schema = Component::get_by_id(&ctx, targets.source_component_id)
-        .await?
-        .schema(&ctx)
-        .await?;
-    let to_component_schema = Component::get_by_id(&ctx, targets.destination_component_id)
-        .await?
-        .schema(&ctx)
-        .await?;
-    let output_socket = OutputSocket::get_by_id(&ctx, output_socket_id).await?;
-    let input_socket = InputSocket::get_by_id(&ctx, input_socket_id).await?;
-
-    AttributePrototypeArgument::remove(&ctx, attribute_prototype_argument.id()).await?;
+    let output_socket = OutputSocket::get_by_id(&ctx, request.from_socket_id).await?;
+    let input_socket = InputSocket::get_by_id(&ctx, request.to_socket_id).await?;
 
     track(
         &posthog_client,
@@ -114,13 +58,13 @@ pub async fn delete_connection(
         "delete_connection",
         serde_json::json!({
             "how": "/diagram/delete_connection",
-            "from_component_id": targets.source_component_id,
+            "from_component_id": request.from_component_id,
             "from_component_schema_name": from_component_schema.name(),
-            "from_socket_id": output_socket_id,
+            "from_socket_id": request.from_socket_id,
             "from_socket_name": &output_socket.name(),
-            "to_component_id": targets.destination_component_id,
+            "to_component_id": request.to_component_id,
             "to_component_schema_name": to_component_schema.name(),
-            "to_socket_id": input_socket_id,
+            "to_socket_id": request.to_socket_id,
             "to_socket_name":  &input_socket.name(),
             "change_set_id": ctx.change_set_id(),
         }),


### PR DESCRIPTION
Edges no longer have an inherent ID. They are defined by what they connect. Diagram::assemble now returns edges and inferredEdges and we need to reconcile both of those in the UI.

1. Change Vue to use edgeId that is a compound key made up by {to_socket_ulid}_{from_socket_ulid} for all edges
2. Change SDF to remove id  and edgeId from Diagram::assemble
3. In Vue add inferred edges to the store edgesById where the rest of the edges live.
4. Change SDF to accept two params {to_socket_ulid} and {from_socket_ulid} to delete an edge and to restore an edge
5. On detach component from parent remove inferred edges between the two components.
6. On attach component to parent fire the component updated WsEvent (which fires the big hammer).
7. isInvisible should reflect whether an edge is inferred or not.

![knife_fingers](https://github.com/systeminit/si/assets/69541/91424985-020e-4e13-adbc-2c98973e01e1)
