### PR TITLE
More Frames Fixes

### DIFF
--- a/app/web/src/components/Debug/AttributeDebugView.vue
+++ b/app/web/src/components/Debug/AttributeDebugView.vue
@@ -7,24 +7,19 @@
         :data="`${data.funcName} ${data.funcId}`"
         title="Set By Function"
       />
-      <DebugViewItem title="Input" :data="data.funcArgs ?? 'NULL'" />
-      <DebugViewItem title="Input sources">
-        <template #data>
-          <ul v-if="data.argSources && Object.keys(data.argSources).length">
-            <li v-for="[k, v] in Object.entries(data.argSources)" :key="k">
-              <strong>{{ k }}</strong>
-              : {{ v ?? "?" }}
-            </li>
-          </ul>
-          <p v-else>No input sources</p>
-        </template>
-      </DebugViewItem>
       <DebugViewItem title="Value" :data="data.value ?? 'NULL'" />
       <DebugViewItem title="Prototype Id" :data="data.prototypeId" />
       <DebugViewItem
         title="Materialized View"
         :data="data.materializedView ?? 'NULL'"
       />
+      <DebugViewItem title="Input Sources">
+        <template #data>
+          <ul v-if="data.funcArgs && Object.keys(data.funcArgs).length">
+            <AttributePrototypeDebugView :data="data.funcArgs" />
+          </ul>
+        </template>
+      </DebugViewItem>
     </dl>
   </div>
 </template>
@@ -32,6 +27,7 @@
 <script setup lang="ts">
 import { AttributeDebugView } from "@/store/components.store";
 import DebugViewItem from "./DebugViewItem.vue";
+import AttributePrototypeDebugView from "./AttributePrototypeDebugView.vue";
 
 defineProps<{ data: AttributeDebugView }>();
 </script>

--- a/app/web/src/components/Debug/AttributePrototypeDebugView.vue
+++ b/app/web/src/components/Debug/AttributePrototypeDebugView.vue
@@ -1,0 +1,42 @@
+<template>
+  <div>
+    <Collapsible
+      v-for="[funcArgName, funcArgViews] in Object.entries(data)"
+      :key="funcArgName"
+      :defaultOpen="false"
+      :label="funcArgName"
+      as="ul"
+      contentClasses="px-sm"
+      extraBorderAtBottomOfContent
+      xPadding="double"
+    >
+      <Collapsible
+        v-for="funcView in funcArgViews"
+        :key="funcView.valueSourceId"
+        :label="funcView.valueSource"
+      >
+        <DebugViewItem title="Argument Name" :data="funcView.name" />
+        <DebugViewItem title="Value Source" :data="funcView.valueSource" />
+        <DebugViewItem title="Value Source Id" :data="funcView.valueSourceId" />
+        <DebugViewItem title="Value" :data="funcView.value ?? 'NULL/None'" />
+        <DebugViewItem
+          title="Connection Kind"
+          :data="funcView.socketSourceKind ?? 'NULL'"
+        />
+        <DebugViewItem
+          title="Path To Attribute Value"
+          :data="funcView.path ?? 'NULL'"
+        />
+        <DebugViewItem title="Data Is Used" :data="funcView.isUsed" />
+      </Collapsible>
+    </Collapsible>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Collapsible } from "@si/vue-lib/design-system";
+import { FuncArgDebugView } from "@/store/components.store";
+import DebugViewItem from "./DebugViewItem.vue";
+
+defineProps<{ data: { [key: string]: FuncArgDebugView[] } }>();
+</script>

--- a/app/web/src/components/Debug/SocketDebugView.vue
+++ b/app/web/src/components/Debug/SocketDebugView.vue
@@ -7,18 +7,6 @@
         :data="`${data.funcName} ${data.funcId}`"
         title="Set By Function"
       />
-      <DebugViewItem title="Input" :data="data.funcArgs ?? 'NULL'" />
-      <DebugViewItem title="Input sources">
-        <template #data>
-          <ul v-if="data.argSources && Object.keys(data.argSources).length">
-            <li v-for="[k, v] in Object.entries(data.argSources)" :key="k">
-              <strong>{{ k }}</strong>
-              : {{ v ?? "?" }}
-            </li>
-          </ul>
-          <p v-else>No input sources</p>
-        </template>
-      </DebugViewItem>
       <DebugViewItem title="Value" :data="data.value ?? 'NULL'" />
       <DebugViewItem title="Prototype Id" :data="data.prototypeId" />
       <DebugViewItem title="Socket Id" :data="data.socketId" />
@@ -53,13 +41,20 @@
               {{ connection }}
             </li>
           </ul>
-          <p v-else>No input sources</p>
+          <p v-else>No inferred connections</p>
         </template>
       </DebugViewItem>
       <DebugViewItem
         title="Materialized View"
         :data="data.materializedView ?? 'NULL'"
       />
+      <DebugViewItem title="Input Sources">
+        <template #data>
+          <ul v-if="data.funcArgs && Object.keys(data.funcArgs).length">
+            <AttributePrototypeDebugView :data="data.funcArgs" />
+          </ul>
+        </template>
+      </DebugViewItem>
     </dl>
   </div>
 </template>
@@ -67,6 +62,7 @@
 <script setup lang="ts">
 import { SocketDebugView } from "@/store/components.store";
 import DebugViewItem from "./DebugViewItem.vue";
+import AttributePrototypeDebugView from "./AttributePrototypeDebugView.vue";
 
 defineProps<{ data: SocketDebugView }>();
 </script>

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -142,8 +142,7 @@ export interface AttributeDebugView {
   proxyFor?: string | null;
   funcName: string;
   funcId: string;
-  funcArgs: object;
-  argSources: { [key: string]: string | null } | null;
+  funcArgs: { [key: string]: FuncArgDebugView[] } | null;
   visibility: {
     visibility_change_set_pk: string;
     visibility_deleted_at: Date | undefined | null;
@@ -152,6 +151,15 @@ export interface AttributeDebugView {
   prototypeId: string;
   kind: string;
   materializedView?: string;
+}
+export interface FuncArgDebugView {
+  value: object | string | number | boolean | null;
+  name: string;
+  valueSource: string;
+  valueSourceId: string;
+  socketSourceKind: string | null;
+  path: string | null;
+  isUsed: boolean;
 }
 export interface SocketDebugView extends AttributeDebugView {
   socketId: string;
@@ -1403,6 +1411,8 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                 // don't update
                 if (data.changeSetId !== changeSetId) return;
                 this.FETCH_DIAGRAM_DATA();
+                if (this.selectedComponentId === data.componentId)
+                  this.FETCH_COMPONENT_DEBUG_VIEW(data.componentId);
               },
             },
             {

--- a/lib/dal/src/attribute/prototype/argument/value_source.rs
+++ b/lib/dal/src/attribute/prototype/argument/value_source.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use thiserror::Error;
 
 use crate::{
@@ -75,5 +77,15 @@ impl ValueSource {
         }
 
         Ok(result)
+    }
+}
+impl fmt::Display for ValueSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ValueSource::InputSocket(_) => write!(f, "Input Socket"),
+            ValueSource::OutputSocket(_) => write!(f, "Output Socket"),
+            ValueSource::Prop(_) => write!(f, "Prop"),
+            ValueSource::StaticArgumentValue(_) => write!(f, "Static Argument"),
+        }
     }
 }

--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use telemetry::prelude::*;
 use thiserror::Error;
+use ulid::Ulid;
 
 use crate::attribute::prototype::argument::{
     static_value::StaticArgumentValue,
@@ -14,14 +15,14 @@ use crate::attribute::value::{AttributeValueError, ValueIsFor};
 use crate::func::argument::FuncArgument;
 use crate::func::argument::FuncArgumentError;
 use crate::func::execution::{FuncExecution, FuncExecutionError};
-use crate::prop::{PropError, PropPath};
+use crate::prop::PropError;
 use crate::socket::input::InputSocketError;
 use crate::socket::output::OutputSocketError;
 use crate::workspace_snapshot::node_weight::NodeWeightError;
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
     AttributePrototype, AttributePrototypeId, AttributeValue, AttributeValueId, Component,
-    ComponentError, DalContext, Func, FuncError, FuncId, InputSocket, Prop,
+    ComponentError, DalContext, Func, FuncError, FuncId,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -31,9 +32,25 @@ pub struct AttributePrototypeDebugView {
     pub func_execution: Option<FuncExecution>,
     pub id: AttributePrototypeId,
     pub func_name: String,
-    pub func_args: HashMap<String, Vec<serde_json::Value>>,
-    pub arg_sources: HashMap<String, Option<String>>,
+    pub func_args: HashMap<String, Vec<FuncArgDebugView>>,
     pub attribute_values: Vec<AttributeValueId>,
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FuncArgDebugView {
+    pub value: serde_json::Value,
+    pub name: String,
+    pub value_source: String,
+    pub value_source_id: Ulid,
+    pub socket_source_kind: Option<SocketSourceKind>,
+    pub path: Option<String>,
+    pub is_used: bool,
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SocketSourceKind {
+    Inferred,
+    Manual,
 }
 
 type AttributePrototypeDebugViewResult<T> = Result<T, AttributePrototypeDebugViewError>;
@@ -70,112 +87,165 @@ pub enum AttributePrototypeDebugViewError {
 }
 
 impl AttributePrototypeDebugView {
-    #[instrument(level = "debug", skip_all)]
-    pub async fn assemble(
+    #[instrument(level = "info", skip_all)]
+    pub async fn new(
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
     ) -> AttributePrototypeDebugViewResult<AttributePrototypeDebugView> {
         let prototype_id = AttributeValue::prototype_id(ctx, attribute_value_id).await?;
-
         let destination_component_id =
             AttributeValue::component_id(ctx, attribute_value_id).await?;
-
-        let mut func_binding_args: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
-        let mut arg_sources: HashMap<String, Option<String>> = HashMap::new();
-
-        let attribute_prototype_ids =
+        let mut func_binding_args: HashMap<String, Vec<FuncArgDebugView>> = HashMap::new();
+        let attribute_prototype_arg_ids =
             AttributePrototypeArgument::list_ids_for_prototype(ctx, prototype_id).await?;
-        for attribute_prototype_id in attribute_prototype_ids {
+        info!("attribute prototype ids: {:?}", attribute_prototype_arg_ids);
+        for attribute_prototype_arg_id in attribute_prototype_arg_ids {
             let attribute_prototype_argument =
-                AttributePrototypeArgument::get_by_id(ctx, attribute_prototype_id).await?;
+                AttributePrototypeArgument::get_by_id(ctx, attribute_prototype_arg_id).await?;
+            info!(
+                "Attribute Prototype Argument: {:?}",
+                attribute_prototype_argument
+            );
+            let targets = attribute_prototype_argument.targets();
+            info!("targets: {:?}", targets);
             let expected_source_component_id = attribute_prototype_argument
                 .targets()
                 .map(|targets| targets.source_component_id)
                 .unwrap_or(destination_component_id);
-
+            info!("expected source id: {}", expected_source_component_id);
             if attribute_prototype_argument
                 .targets()
                 .map_or(true, |targets| {
                     targets.destination_component_id == destination_component_id
                 })
             {
-                // If the "source" Component is marked for deletion, and we (the destination) are
-                // *NOT*, then we should ignore the argument as data should not flow from things
-                // that are marked for deletion to ones that are not.
-                let destination_component = Component::get_by_id(ctx, destination_component_id)
-                    .await
-                    .map_err(|e| AttributeValueError::Component(Box::new(e)))?;
-
-                let source_component = Component::get_by_id(ctx, expected_source_component_id)
-                    .await
-                    .map_err(|e| AttributeValueError::Component(Box::new(e)))?;
-
-                if source_component.to_delete() && !destination_component.to_delete() {
-                    continue;
-                }
-
-                let func_arg_id =
-                    AttributePrototypeArgument::func_argument_id_by_id(ctx, attribute_prototype_id)
-                        .await?;
-                let func_arg_name = FuncArgument::get_name_by_id(ctx, func_arg_id).await?;
-
-                let values_for_arg = match AttributePrototypeArgument::value_source_by_id(
+                let arg_used = Component::should_data_flow_between_components(
                     ctx,
-                    attribute_prototype_id,
+                    destination_component_id,
+                    expected_source_component_id,
                 )
-                .await?
-                .ok_or(
-                    AttributeValueError::AttributePrototypeArgumentMissingValueSource(
-                        attribute_prototype_id,
-                    ),
-                )? {
+                .await?;
+
+                let func_arg_id = AttributePrototypeArgument::func_argument_id_by_id(
+                    ctx,
+                    attribute_prototype_arg_id,
+                )
+                .await?;
+                info!("func arg id: {:?}", func_arg_id);
+
+                let func_arg_name = FuncArgument::get_name_by_id(ctx, func_arg_id).await?;
+                let value_source =
+                    AttributePrototypeArgument::value_source_by_id(ctx, attribute_prototype_arg_id)
+                        .await?
+                        .ok_or(
+                            AttributeValueError::AttributePrototypeArgumentMissingValueSource(
+                                attribute_prototype_arg_id,
+                            ),
+                        )?;
+                let values_for_arg = match value_source {
                     ValueSource::StaticArgumentValue(static_argument_value_id) => {
                         let val = StaticArgumentValue::get_by_id(ctx, static_argument_value_id)
                             .await?
                             .value;
-                        arg_sources.insert(
-                            func_arg_name.clone(),
-                            Some(PropPath::new(["Static Value"]).to_string()),
-                        );
-                        vec![val]
+                        vec![FuncArgDebugView {
+                            value: val,
+                            name: func_arg_name.clone(),
+                            value_source: value_source.to_string(),
+                            value_source_id: static_argument_value_id.into(),
+                            path: None,
+                            socket_source_kind: None,
+                            is_used: arg_used,
+                        }]
                     }
-                    other_source => {
+
+                    ValueSource::Prop(prop_id) => {
                         let mut values = vec![];
 
-                        for attribute_value_id in other_source
+                        for attribute_value_id in value_source
                             .attribute_values_for_component_id(ctx, expected_source_component_id)
                             .await?
                         {
                             let attribute_value =
                                 AttributeValue::get_by_id(ctx, attribute_value_id).await?;
-
-                            let attribute_value_name =
-                                AttributeValue::is_for(ctx, attribute_value_id).await?;
-                            let prop_path: PropPath = match attribute_value_name {
-                                ValueIsFor::InputSocket(id) => {
-                                    let inputsock = InputSocket::get_by_id(ctx, id).await?;
-                                    PropPath::new(["Input Socket", inputsock.name()])
-                                }
-                                ValueIsFor::Prop(_) => {
-                                    let prop_id = AttributeValue::prop_id_for_id_or_error(
-                                        ctx,
-                                        attribute_value.id(),
-                                    )
-                                    .await?;
-                                    Prop::path_by_id(ctx, prop_id).await?
-                                }
-                                ValueIsFor::OutputSocket(_) => continue,
+                            let prop_path =
+                                AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
+                            let mat_view = attribute_value
+                                .materialized_view(ctx)
+                                .await?
+                                .unwrap_or(Value::Null);
+                            info!("Materialized View: {:?}", mat_view);
+                            let func_arg_debug = FuncArgDebugView {
+                                value: mat_view,
+                                name: func_arg_name.clone(),
+                                value_source: value_source.to_string(),
+                                value_source_id: prop_id.into(),
+                                socket_source_kind: None,
+                                path: prop_path,
+                                is_used: arg_used,
                             };
-                            arg_sources.insert(
-                                func_arg_name.clone(),
-                                Some(prop_path.with_replaced_sep("/")),
-                            );
-                            values.push(
-                                attribute_value
-                                    .materialized_view(ctx)
-                                    .await?
-                                    .unwrap_or(Value::Null),
-                            );
+                            values.push(func_arg_debug);
+                        }
+
+                        values
+                    }
+                    ValueSource::InputSocket(input_socket_id) => {
+                        let mut values = vec![];
+
+                        for attribute_value_id in value_source
+                            .attribute_values_for_component_id(ctx, expected_source_component_id)
+                            .await?
+                        {
+                            let attribute_value =
+                                AttributeValue::get_by_id(ctx, attribute_value_id).await?;
+                            let attribute_value_path =
+                                AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
+
+                            let mat_view = attribute_value
+                                .materialized_view(ctx)
+                                .await?
+                                .unwrap_or(Value::Null);
+                            info!("Materialized View: {:?}", mat_view);
+                            let func_arg_debug = FuncArgDebugView {
+                                value: mat_view,
+                                name: func_arg_name.clone(),
+                                value_source: value_source.to_string(),
+                                value_source_id: input_socket_id.into(),
+                                socket_source_kind: Some(SocketSourceKind::Manual),
+                                path: attribute_value_path,
+                                is_used: arg_used,
+                            };
+                            values.push(func_arg_debug);
+                        }
+
+                        values
+                    }
+                    ValueSource::OutputSocket(output_socket_id) => {
+                        let mut values = vec![];
+
+                        for attribute_value_id in value_source
+                            .attribute_values_for_component_id(ctx, expected_source_component_id)
+                            .await?
+                        {
+                            let attribute_value =
+                                AttributeValue::get_by_id(ctx, attribute_value_id).await?;
+                            let attribute_value_path =
+                                AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
+
+                            let mat_view = attribute_value
+                                .materialized_view(ctx)
+                                .await?
+                                .unwrap_or(Value::Null);
+                            info!("Materialized View: {:?}", mat_view);
+                            let func_arg_debug = FuncArgDebugView {
+                                value: mat_view,
+                                name: func_arg_name.clone(),
+                                value_source: value_source.to_string(),
+                                value_source_id: output_socket_id.into(),
+                                socket_source_kind: Some(SocketSourceKind::Manual),
+                                path: attribute_value_path,
+                                is_used: arg_used,
+                            };
+                            values.push(func_arg_debug);
                         }
 
                         values
@@ -188,21 +258,77 @@ impl AttributePrototypeDebugView {
                     .or_insert(values_for_arg);
             }
         }
+        // if this attribute value is for an input socket, need to also get any inferred inputs if they exist!
+        if let ValueIsFor::InputSocket(input_socket_id) =
+            AttributeValue::is_for(ctx, attribute_value_id).await?
+        {
+            info!("value is for input socket!");
+            if let Some(input_socket_match) =
+                Component::input_socket_match(ctx, destination_component_id, input_socket_id)
+                    .await?
+            {
+                info!("Input socket match: {:?}", input_socket_match);
+                // now get inferred func binding args and values!
+                if let Some(output_match) =
+                    Component::find_potential_inferred_connection_to_input_socket(
+                        ctx,
+                        input_socket_match,
+                    )
+                    .await?
+                {
+                    info!("output socket match: {:?}", output_match);
+                    let arg_used = Component::should_data_flow_between_components(
+                        ctx,
+                        input_socket_match.component_id,
+                        output_match.component_id,
+                    )
+                    .await?;
+                    let attribute_value_path =
+                        AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
+                    let output_av =
+                        AttributeValue::get_by_id(ctx, output_match.attribute_value_id).await?;
+                    let mat_view = output_av
+                        .materialized_view(ctx)
+                        .await?
+                        .unwrap_or(Value::Null);
+                    let input_func = AttributePrototype::func_id(ctx, prototype_id).await?;
+                    if let Some(func_argument) =
+                        FuncArgument::list_for_func(ctx, input_func).await?.pop()
+                    {
+                        let func_arg_name = func_argument.name.clone();
+                        let func_arg_debug = FuncArgDebugView {
+                            value: mat_view,
+                            name: func_argument.name,
+                            value_source: "Output Socket".to_string(),
+                            value_source_id: output_match.output_socket_id.into(),
+                            socket_source_kind: Some(SocketSourceKind::Inferred),
+                            path: attribute_value_path,
+                            is_used: arg_used,
+                        };
+                        func_binding_args
+                            .entry(func_arg_name)
+                            .and_modify(|values| values.push(func_arg_debug.clone()))
+                            .or_insert(vec![func_arg_debug]);
+                    }
+                }
+            }
+        }
+
         let attribute_values = AttributePrototype::attribute_value_ids(ctx, prototype_id).await?;
         let func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
 
         let func_execution =
             Some(FuncExecution::get_latest_execution_by_func_id(ctx, &func_id).await?);
         let func_name = Func::get_by_id_or_error(ctx, func_id).await?.name;
-
-        Ok(AttributePrototypeDebugView {
+        let view = AttributePrototypeDebugView {
             func_args: func_binding_args,
             func_id,
             func_name,
             func_execution,
-            arg_sources,
             id: prototype_id,
             attribute_values,
-        })
+        };
+        info!("AttributePrototype Debug View: {:?}", view);
+        Ok(view)
     }
 }

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -2233,7 +2233,7 @@ impl AttributeValue {
     /// Get the moral equivalent of the [`PropPath`]for a given [`AttributeValueId`].
     /// This includes the key/index in the path, unlike the [`PropPath`] which doesn't
     /// include the key/index
-    #[instrument(level = "info", skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn get_path_for_id(
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,

--- a/lib/dal/src/attribute/value/debug.rs
+++ b/lib/dal/src/attribute/value/debug.rs
@@ -5,7 +5,7 @@ use telemetry::prelude::*;
 use thiserror::Error;
 
 use crate::attribute::prototype::debug::{
-    AttributePrototypeDebugView, AttributePrototypeDebugViewError,
+    AttributePrototypeDebugView, AttributePrototypeDebugViewError, FuncArgDebugView,
 };
 use crate::attribute::prototype::{
     argument::{value_source::ValueSourceError, AttributePrototypeArgumentError},
@@ -37,8 +37,7 @@ pub struct AttributeDebugView {
     pub prototype_id: Option<AttributePrototypeId>,
     pub key: Option<String>,
     pub func_name: String,
-    pub func_args: HashMap<String, Vec<serde_json::Value>>,
-    pub arg_sources: HashMap<String, Option<String>>,
+    pub func_args: HashMap<String, Vec<FuncArgDebugView>>,
     pub value: Option<serde_json::Value>,
     pub prop_kind: Option<PropKind>,
     pub materialized_view: Option<serde_json::Value>,
@@ -96,7 +95,7 @@ impl AttributeDebugView {
             .unwrap_or_else(String::new);
         let prop_opt: Option<Prop> = Some(prop);
         let attribute_prototype_debug_view =
-            AttributePrototypeDebugView::assemble(ctx, attribute_value_id).await?;
+            AttributePrototypeDebugView::new(ctx, attribute_value_id).await?;
         let materialized_view = attribute_value.materialized_view(ctx).await?;
         let prop_kind = prop_opt.clone().map(|prop| prop.kind);
         let value = match attribute_value.unprocessed_value(ctx).await? {
@@ -115,7 +114,6 @@ impl AttributeDebugView {
             value_is_for,
             func_name: attribute_prototype_debug_view.func_name,
             func_args: attribute_prototype_debug_view.func_args,
-            arg_sources: attribute_prototype_debug_view.arg_sources,
             value,
             prop_kind,
             materialized_view,

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1850,7 +1850,7 @@ impl Component {
     /// and finds the closest matching [`OutputSocket`]
     ///
     /// Note: this does not check for whether data should actually flow between components
-    #[instrument(level = "debug", skip(ctx))]
+    #[instrument(level = "info", skip(ctx))]
     pub async fn find_potential_inferred_connection_to_input_socket(
         ctx: &DalContext,
         input_socket_match: InputSocketMatch,
@@ -1858,7 +1858,7 @@ impl Component {
         if InputSocket::is_manually_configured(ctx, input_socket_match).await? {
             //if the input socket is being manually driven (the user has drawn an edge)
             // there will be no inferred connections to it
-            debug!("input socket is manually configured");
+            info!("input socket is manually configured");
             return Ok(None);
         }
         let maybe_source_socket =
@@ -1890,7 +1890,7 @@ impl Component {
                 }
                 ComponentType::AggregationFrame => None,
             };
-        debug!(
+        info!(
             "Source socket for input socket {:?} is: {:?}",
             input_socket_match, maybe_source_socket
         );

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -3,6 +3,8 @@ use si_data_pg::PgError;
 use std::collections::{hash_map, HashMap};
 use std::num::{ParseFloatError, ParseIntError};
 use strum::{AsRefStr, Display, EnumIter, EnumString};
+use telemetry::prelude::*;
+use telemetry::tracing::instrument;
 use thiserror::Error;
 
 use crate::actor_view::ActorView;
@@ -218,6 +220,7 @@ pub struct Diagram {
 impl Diagram {
     /// Assemble a [`Diagram`](Self) based on existing [`Nodes`](crate::Node) and
     /// [`Connections`](crate::Connection).
+    #[instrument(level = "debug", skip(ctx))]
     pub async fn assemble(ctx: &DalContext) -> DiagramResult<Self> {
         let mut diagram_sockets: HashMap<SchemaVariantId, serde_json::Value> = HashMap::new();
         let mut diagram_edges: Vec<SummaryDiagramEdge> = vec![];

--- a/lib/dal/src/socket/debug.rs
+++ b/lib/dal/src/socket/debug.rs
@@ -8,15 +8,17 @@ use super::{input::InputSocketError, output::OutputSocketError};
 use crate::{
     attribute::{
         prototype::{
-            debug::{AttributePrototypeDebugView, AttributePrototypeDebugViewError},
+            debug::{
+                AttributePrototypeDebugView, AttributePrototypeDebugViewError, FuncArgDebugView,
+            },
             AttributePrototypeError,
         },
         value::AttributeValueError,
     },
-    component::InputSocketMatch,
+    component::{InputSocketMatch, OutputSocketMatch},
     func::execution::FuncExecution,
     AttributePrototype, AttributePrototypeId, AttributeValue, AttributeValueId, Component,
-    ComponentError, DalContext, FuncId, InputSocket, InputSocketId, OutputSocket, OutputSocketId,
+    ComponentError, DalContext, FuncId, InputSocket, OutputSocket,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -30,8 +32,7 @@ pub struct SocketDebugView {
     pub prototype_id: Option<AttributePrototypeId>,
     pub connection_annotations: Vec<String>,
     pub func_name: String,
-    pub func_args: HashMap<String, Vec<serde_json::Value>>,
-    pub arg_sources: HashMap<String, Option<String>>,
+    pub func_args: HashMap<String, Vec<FuncArgDebugView>>,
     pub value: Option<serde_json::Value>,
     pub materialized_view: Option<serde_json::Value>,
     pub name: String,
@@ -60,21 +61,19 @@ impl SocketDebugView {
     #[instrument(level = "info", skip_all)]
     pub async fn new_for_output_socket(
         ctx: &DalContext,
-        output_socket_id: OutputSocketId,
+        output_socket_match: OutputSocketMatch,
     ) -> SocketDebugViewResult<SocketDebugView> {
         let prototype_id =
-            AttributePrototype::find_for_output_socket(ctx, output_socket_id).await?;
+            AttributePrototype::find_for_output_socket(ctx, output_socket_match.output_socket_id)
+                .await?;
 
-        let attribute_value_id =
-            OutputSocket::attribute_values_for_output_socket_id(ctx, output_socket_id)
-                .await?
-                .pop()
-                .expect("should have attribute value id");
+        let attribute_value_id = output_socket_match.attribute_value_id;
 
         let prototype_debug_view =
-            AttributePrototypeDebugView::assemble(ctx, attribute_value_id).await?;
+            AttributePrototypeDebugView::new(ctx, attribute_value_id).await?;
         let attribute_value = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
-        let output_socket = OutputSocket::get_by_id(ctx, output_socket_id).await?;
+        let output_socket =
+            OutputSocket::get_by_id(ctx, output_socket_match.output_socket_id).await?;
         let connection_annotations = output_socket
             .connection_annotations()
             .into_iter()
@@ -96,9 +95,8 @@ impl SocketDebugView {
             prototype_id,
             func_name: prototype_debug_view.func_name,
             func_args: prototype_debug_view.func_args,
-            arg_sources: prototype_debug_view.arg_sources,
             attribute_value_id,
-            socket_id: output_socket_id.into(),
+            socket_id: output_socket_match.output_socket_id.into(),
             func_id: prototype_debug_view.func_id,
             func_execution: prototype_debug_view.func_execution,
             connection_annotations,
@@ -112,19 +110,17 @@ impl SocketDebugView {
     #[instrument(level = "info", skip_all)]
     pub async fn new_for_input_socket(
         ctx: &DalContext,
-        input_socket_id: InputSocketId,
+        input_socket_match: InputSocketMatch,
     ) -> SocketDebugViewResult<SocketDebugView> {
-        let prototype_id = AttributePrototype::find_for_input_socket(ctx, input_socket_id).await?;
-        let attribute_value_id =
-            InputSocket::attribute_values_for_input_socket_id(ctx, input_socket_id)
-                .await?
-                .pop()
-                .expect("should have attribute value id");
+        let prototype_id =
+            AttributePrototype::find_for_input_socket(ctx, input_socket_match.input_socket_id)
+                .await?;
+        let attribute_value_id = input_socket_match.attribute_value_id;
         let prototype_debug_view =
-            AttributePrototypeDebugView::assemble(ctx, attribute_value_id).await?;
+            AttributePrototypeDebugView::new(ctx, input_socket_match.attribute_value_id).await?;
+        info!("prototype_debug_view: {:?}", prototype_debug_view);
         let attribute_value = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
-        let component_id = AttributeValue::component_id(ctx, attribute_value_id).await?;
-        let input_socket = InputSocket::get_by_id(ctx, input_socket_id).await?;
+        let input_socket = InputSocket::get_by_id(ctx, input_socket_match.input_socket_id).await?;
         let connection_annotations = input_socket
             .connection_annotations()
             .into_iter()
@@ -138,11 +134,7 @@ impl SocketDebugView {
         let inferred_connections =
             match Component::find_potential_inferred_connection_to_input_socket(
                 ctx,
-                InputSocketMatch {
-                    component_id,
-                    input_socket_id,
-                    attribute_value_id,
-                },
+                input_socket_match,
             )
             .await?
             .map(|output_socket| Ulid::from(output_socket.attribute_value_id))
@@ -150,14 +142,12 @@ impl SocketDebugView {
                 Some(output_id) => vec![output_id],
                 None => vec![],
             };
-
-        Ok(SocketDebugView {
+        let view = SocketDebugView {
             prototype_id,
             func_name: prototype_debug_view.func_name,
             func_args: prototype_debug_view.func_args,
-            arg_sources: prototype_debug_view.arg_sources,
             attribute_value_id,
-            socket_id: input_socket_id.into(),
+            socket_id: input_socket_match.input_socket_id.into(),
             func_id: prototype_debug_view.func_id,
             func_execution: prototype_debug_view.func_execution,
             connection_annotations,
@@ -166,6 +156,8 @@ impl SocketDebugView {
             materialized_view,
             name: input_socket.name().to_string(),
             inferred_connections,
-        })
+        };
+        info!("Socket Debug View: {:?}", view);
+        Ok(view)
     }
 }

--- a/lib/dal/src/socket/input.rs
+++ b/lib/dal/src/socket/input.rs
@@ -418,9 +418,12 @@ impl InputSocket {
             // if this socket has an attribute prototype argument,
             //that means it has an explicit connection and we should not
             // look for implicits
-            let maybe_apa =
-                AttributePrototypeArgument::list_ids_for_prototype(ctx, maybe_attribute_prototype)
-                    .await?;
+            let maybe_apa = AttributePrototypeArgument::list_ids_for_prototype_and_destination(
+                ctx,
+                maybe_attribute_prototype,
+                input_socket_match.component_id,
+            )
+            .await?;
             if !maybe_apa.is_empty() {
                 return Ok(true);
             }

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -432,7 +432,7 @@ async fn output_sockets_can_have_both(ctx: &mut DalContext) {
         diagram.edges.len()  // actual
     );
     assert_eq!(
-        2,                                      // expected
+        3,                                      // expected
         diagram.get_all_implicit_edges().len()  // actual
     );
     let odd_component = Component::get_by_id(ctx, odd_component.id())
@@ -1494,6 +1494,7 @@ impl DiagramByKey {
         let mut all = vec![];
         for component in self.components.values() {
             for edge in component.1.clone() {
+                dbg!(&edge);
                 all.push(edge);
             }
         }


### PR DESCRIPTION
This PR contains the following fixes: 

- accurately infer if an input socket is manually configured or not (I was previously not filtering correctly by destination component)
- grab the correct Attribute Prototype Argument when showing inputs in the debug panel
- Display more helpful info in the debug panel. I added the value source, value id source, whether or not the data should pass through, and I now include inferred inputs to attribute prototypes (which matters only for input sockets) 
- Fixed a false positive integration test, that was falsely passing due to the above bug on inferring whether an input socket is manually inferred