### PR TITLE
Add standard and debug rustc build modes for tilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ Every service should eventually have a green checkmark next to them, which ensur
 
 _Please note: database migrations may take some time to complete._
 
-If you would like to learn more on what's running, check out the [Architecture](./docs/ARCHITECTURE.md) section.
+If you would like to learn more on what's running, check out our [ARCHITECTURE](./docs/ARCHITECTURE.md) documentation.
+If you would like to learn more about running the stack locally, check out our [DEVELOPMENT_ENVIRONMENT](./docs/DEVELOPMENT_ENVIRONMENT.md) and [RUNNING_THE_STACK_LOCALLY](./docs/RUNNING_THE_STACK_LOCALLY.md) documentation.
 
 ### (6) Troubleshooting in Tilt
 

--- a/dev/BUCK
+++ b/dev/BUCK
@@ -20,9 +20,25 @@ alias(
     actual = ":up",
 )
 
-# Bring up the full set of services for development
+# Bring up the full set of services for development (defaults to release build optimizations)
 tilt_up(
     name = "up",
+)
+
+# Bring up the full set of services for development with standard build optimizations
+tilt_up(
+    name = "up-standard",
+    args = [
+        "--standard-rustc-build-mode"
+    ]
+)
+
+# Bring up the full set of services for development with debug build optimizations
+tilt_up(
+    name = "up-debug",
+    args = [
+        "--debug-rustc-build-mode"
+    ]
 )
 
 # Bring up only platform services such as PostgreSQL, NATS, etc.

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -1,4 +1,8 @@
+# Set args to "True" if we want to allow positional arguments
 config.define_string_list("to-run", args = True)
+config.define_bool("standard-rustc-build-mode")
+config.define_bool("debug-rustc-build-mode")
+
 cfg = config.parse()
 
 # Define groups of services
@@ -37,6 +41,21 @@ for arg in cfg.get("to-run", []):
     else:
         enabled_resources.append(arg)
 config.set_enabled_resources(enabled_resources)
+
+# Parse the CLI args to get the rustc build mode or default to release
+standard_rustc_build_mode = cfg.get('standard-rustc-build-mode', False)
+debug_rustc_build_mode = cfg.get('debug-rustc-build-mode', False)
+rustc_build_mode = 'release'
+
+# TODO(nick): the bzl logic for writing arguments out does not know how
+# to group string ("config.define_string") arguments with the argument
+# call (i.e. it thinks "--foo bar" is one argument rather than having
+# argument "--foo" be passed value "bar"). Thus, we use two booleans to
+# get around this. If we get both, greedily choose the standard mode.
+if standard_rustc_build_mode:
+    rustc_build_mode = 'standard'
+elif debug_rustc_build_mode:
+    rustc_build_mode = 'debug'
 
 # Default trigger mode to manual so that (importantly) backend services don't rebuild/restart
 # automatically. This is opt-in in the Tilt UI in the `Mode` column
@@ -79,11 +98,21 @@ for service in compose_services:
 
 # Locally build and run `rebaser-server`
 rebaser_target = "//bin/rebaser:rebaser"
+
+cmd = "buck2 build @//mode/release {}".format(rebaser_target)
+serve_cmd = "buck2 run @//mode/release {}".format(rebaser_target)
+if rustc_build_mode == 'standard':
+    cmd = "buck2 build {}".format(rebaser_target)
+    serve_cmd = "buck2 run {}".format(rebaser_target)
+elif rustc_build_mode == 'debug':
+    cmd = "buck2 build @//mode/debug {}".format(rebaser_target)
+    serve_cmd = "buck2 run @//mode/debug {}".format(rebaser_target)
+
 local_resource(
     "rebaser",
     labels = ["backend"],
-    cmd = "buck2 build @//mode/release {}".format(rebaser_target),
-    serve_cmd = "buck2 run @//mode/release {}".format(rebaser_target),
+    cmd = cmd,
+    serve_cmd = serve_cmd,
     serve_env = {"SI_FORCE_COLOR": "true"},
     allow_parallel = True,
     resource_deps = [
@@ -97,11 +126,21 @@ local_resource(
 
 # Locally build and run `module-index`
 module_index_target = "//bin/module-index:module-index"
+
+cmd = "buck2 build @//mode/release {}".format(module_index_target)
+serve_cmd = "buck2 run @//mode/release {}".format(module_index_target)
+if rustc_build_mode == 'standard':
+    cmd = "buck2 build {}".format(module_index_target)
+    serve_cmd = "buck2 run {}".format(module_index_target)
+elif rustc_build_mode == 'debug':
+    cmd = "buck2 build @//mode/debug {}".format(module_index_target)
+    serve_cmd = "buck2 run @//mode/debug {}".format(module_index_target)
+
 local_resource(
     "module-index",
     labels = ["backend"],
-    cmd = "buck2 build {}".format(module_index_target),
-    serve_cmd = "buck2 run {}".format(module_index_target),
+    cmd = cmd,
+    serve_cmd = serve_cmd,
     serve_env = {"SI_FORCE_COLOR": "true"},
     allow_parallel = True,
     auto_init = False,
@@ -115,11 +154,21 @@ local_resource(
 
 # Locally build and run `pinga`
 pinga_target = "//bin/pinga:pinga"
+
+cmd = "buck2 build @//mode/release {}".format(pinga_target)
+serve_cmd = "buck2 run @//mode/release {}".format(pinga_target)
+if rustc_build_mode == 'standard':
+    cmd = "buck2 build {}".format(pinga_target)
+    serve_cmd = "buck2 run {}".format(pinga_target)
+elif rustc_build_mode == 'debug':
+    cmd = "buck2 build @//mode/debug {}".format(pinga_target)
+    serve_cmd = "buck2 run @//mode/debug {}".format(pinga_target)
+
 local_resource(
     "pinga",
     labels = ["backend"],
-    cmd = "buck2 build @//mode/release {}".format(pinga_target),
-    serve_cmd = "buck2 run @//mode/release {}".format(pinga_target),
+    cmd = cmd,
+    serve_cmd = serve_cmd,
     serve_env = {"SI_FORCE_COLOR": "true"},
     allow_parallel = True,
     resource_deps = [
@@ -133,11 +182,21 @@ local_resource(
 
 # Locally build and run `veritech`
 veritech_target = "//bin/veritech:veritech"
+
+cmd = "buck2 build @//mode/release {}".format(veritech_target)
+serve_cmd = "buck2 run @//mode/release {}".format(veritech_target)
+if rustc_build_mode == 'standard':
+    cmd = "buck2 build {}".format(veritech_target)
+    serve_cmd = "buck2 run {}".format(veritech_target)
+elif rustc_build_mode == 'debug':
+    cmd = "buck2 build @//mode/debug {}".format(veritech_target)
+    serve_cmd = "buck2 run @//mode/debug {}".format(veritech_target)
+
 local_resource(
     "veritech",
     labels = ["backend"],
-    cmd = "buck2 build @//mode/release {}".format(veritech_target),
-    serve_cmd = "SI_LOG=debug buck2 run @//mode/release {}".format(veritech_target),
+    cmd = cmd,
+    serve_cmd = serve_cmd,
     serve_env = {"SI_FORCE_COLOR": "true"},
     # This is the serve command you might need if you want to execute on firecracker for 10 functione executions.
     # NB: BUCK2 MUST RUN AS ROOT OR THIS WILL NOT WORK
@@ -153,11 +212,21 @@ local_resource(
 
 # Locally build and run `sdf`
 sdf_target = "//bin/sdf:sdf"
+
+cmd = "buck2 build @//mode/release {}".format(sdf_target)
+serve_cmd = "buck2 run @//mode/release {}".format(sdf_target)
+if rustc_build_mode == 'standard':
+    cmd = "buck2 build {}".format(sdf_target)
+    serve_cmd = "buck2 run {}".format(sdf_target)
+elif rustc_build_mode == 'debug':
+    cmd = "buck2 build @//mode/debug {}".format(sdf_target)
+    serve_cmd = "buck2 run @//mode/debug {}".format(sdf_target)
+
 local_resource(
     "sdf",
     labels = ["backend"],
-    cmd = "buck2 build @//mode/release {}".format(sdf_target),
-    serve_cmd = "buck2 run @//mode/release {}".format(sdf_target),
+    cmd = cmd,
+    serve_cmd = serve_cmd,
     serve_env = {"SI_FORCE_COLOR": "true"},
     allow_parallel = True,
     resource_deps = [

--- a/docs/RUNNING_THE_STACK_LOCALLY.md
+++ b/docs/RUNNING_THE_STACK_LOCALLY.md
@@ -1,0 +1,18 @@
+# Running the Stack Locally
+
+This document provides additional information on running the System Initiative software stack locally.
+Readers should first refer to the [README](../README.md) and [DEVELOPMENT_ENVIRONMENT](./DEVELOPMENT_ENVIRONMENT.md) before reading this document.
+
+## Advanced Options
+
+While the [README](../README.md) covers using `buck2 run dev:up`, there are two other ways to run the full stack locally:
+
+- `buck2 run dev:up-standard`: run with `rustc` default build optimizations
+- `buck2 run dev:up-debug`: run with `rustc` debug build optimizations
+
+By default, the stack will run with `rustc` release build optimizations, which is what users and testers of the System Initiative software will want to use.
+It runs the software in its intended state.
+However, if you are a contributor seeking build times suitable for rapid iteration, you may want to use one of the aforementioned options.
+
+_Warning: contributors should test your changes with integration tests and with release optimizations when running the full stack._
+_The aforementioned options are solely recommended for rapid iteration._


### PR DESCRIPTION
## Description

This PR adds standard and debug rustc build modes when building and running the full stack via tilt. The "standard" rustc build mode is what the upstream prelude builds with by default. The "debug" rustc build mode explicitly uses debug build optimizations.

<img src="https://media0.giphy.com/media/YXp9LRRkSjbvVTa0B0/giphy.gif"/>

## Usage

Debug optimizations...

```shell
buck2 run dev:up-debug
```

Standard optimizations...

```shell
buck2 run dev:up-standard
```