### PR TITLE
Make links between documents easier to read

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Every service should eventually have a green checkmark next to them, which ensur
 
 _Please note: database migrations may take some time to complete._
 
-If you would like to learn more on what's running, check out our [ARCHITECTURE](./docs/ARCHITECTURE.md) documentation.
-If you would like to learn more about running the stack locally, check out our [DEVELOPMENT_ENVIRONMENT](./docs/DEVELOPMENT_ENVIRONMENT.md) and [RUNNING_THE_STACK_LOCALLY](./docs/RUNNING_THE_STACK_LOCALLY.md) documentation.
+If you would like to learn more on what's running, check out the [architecture](./docs/ARCHITECTURE.md) documentation.
+If you would like to learn more about running the stack locally, check out the [development environment documentation](./docs/DEVELOPMENT_ENVIRONMENT.md) and the [documentation for running the stack locally](./docs/RUNNING_THE_STACK_LOCALLY.md).
 
 ### (6) Troubleshooting in Tilt
 

--- a/docs/BUCK2.md
+++ b/docs/BUCK2.md
@@ -106,7 +106,7 @@ For complex introspection and interaction with graphs, `bxl` files are Starlark 
 
 ## How do I run Rust tests with `buck2`?
 
-Check out the [RUNNING_RUST_TESTS](./RUNNING_RUST_TESTS.md) guide!
+Check out the [guide for running rust tests](./RUNNING_RUST_TESTS.md)!
 Essentially, you'll use the following pattern:
 
 ```shell

--- a/docs/EDITORS_AND_IDES.md
+++ b/docs/EDITORS_AND_IDES.md
@@ -4,4 +4,4 @@ This document contains information related to using editors and IDEs when develo
 
 ## Direnv
 
-For notes on using plugins with `direnv`, see [`DEVELOPMENT_ENVIRONMENT`](./DEVELOPMENT_ENVIRONMENT.md).
+For notes on using plugins with `direnv`, see the [development environment documentation](./DEVELOPMENT_ENVIRONMENT.md).

--- a/docs/LEARNING_ABOUT_SI_CONCEPTS.md
+++ b/docs/LEARNING_ABOUT_SI_CONCEPTS.md
@@ -1,6 +1,6 @@
 # Learning About SI Concepts
 
-As referenced in [CODE_DOCUMENTATION](./CODE_DOCUMENTATION.md), the `rustdoc` static webpages are an entrypoint
+As referenced in [our code documentation guide](./CODE_DOCUMENTATION.md), the `rustdoc` static webpages are an entrypoint
 into learning about the Rust modules and structs that back many SI concepts.
 
 Let's say you want to learn about what a `Component` is.

--- a/docs/RUNNING_THE_STACK_LOCALLY.md
+++ b/docs/RUNNING_THE_STACK_LOCALLY.md
@@ -1,7 +1,7 @@
 # Running the Stack Locally
 
 This document provides additional information on running the System Initiative software stack locally.
-Readers should first refer to the [README](../README.md) and [DEVELOPMENT_ENVIRONMENT](./DEVELOPMENT_ENVIRONMENT.md) before reading this document.
+Readers should first refer to the [README](../README.md) and [the development environment documentation](./DEVELOPMENT_ENVIRONMENT.md) before reading this document.
 
 ## Advanced Options
 


### PR DESCRIPTION
## Description

This PR makes links between documents easier to read by using naturally flowing sentences rather than hard references by file names.

<img src="https://media0.giphy.com/media/8dYmJ6Buo3lYY/giphy.gif"/>