### PR TITLE
Fix attribute bindings not appearing in the asset screen

### DIFF
--- a/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
+++ b/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
@@ -49,7 +49,7 @@
         <FuncDetails
           v-if="assetStore.selectedFuncId"
           :funcId="assetStore.selectedFuncId"
-          :schemaVariantId="assetStore.selectedAsset?.id"
+          :schemaVariantId="assetStore.selectedAsset?.defaultSchemaVariantId"
           singleModelScreen
           testPanelEnabled
           @detached="onDetach"


### PR DESCRIPTION
## Description

This PR fixes attribute bindings not appearing in the asset screen by using the schema variant id instead of the schema id.

<img width="1008" alt="Screenshot 2024-04-30 at 4 36 48 PM" src="https://github.com/systeminit/si/assets/39320683/d533b953-dfdf-4bd2-b87f-a52bb7332f8b">
