### PR TITLE
chore(test): remove dbg and println

### DIFF
--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -495,7 +495,7 @@ impl TestContextBuilder {
         // (or displayed) during tests, while `println!(...)` will be captured the same as
         // "normal" test output, meaning it respects --nocapture and being displayed for
         // failing tests.
-        println!("Test database: {}", &dbname);
+        info!("Test database: {}", &dbname);
 
         // Return new PG pool that uess the new datatbase
         new_pg_pool_config.dbname = dbname;

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -1815,7 +1815,6 @@ pub async fn attach_resource_payload_to_value(
 
     match rv_input_apa_id {
         Some(apa_id) => {
-            dbg!("existing apa");
             if !{
                 if let Some(ValueSource::Prop(prop_id)) =
                     AttributePrototypeArgument::value_source_by_id(ctx, apa_id).await?

--- a/lib/dal/src/workspace_snapshot/graph/tests.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests.rs
@@ -1298,7 +1298,6 @@ mod test {
             .expect("Failed to detect conflicts and updates");
 
         assert!(conflicts.is_empty());
-        dbg!(&updates);
         assert_eq!(1, updates.len());
 
         assert!(matches!(

--- a/lib/dal/src/workspace_snapshot/graph/tests/detect_conflicts_and_updates.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/detect_conflicts_and_updates.rs
@@ -184,7 +184,6 @@ mod test {
             )
             .expect("Unable to add schema -> schema variant edge");
 
-        println!("Initial base graph (Root {:?}):", base_graph.root_index);
         base_graph.dot();
 
         let new_change_set = ChangeSet::new_local().expect("Unable to create ChangeSet");
@@ -225,7 +224,6 @@ mod test {
             )
             .expect("Unable to add component -> schema variant edge");
 
-        println!("Updated base graph (Root: {:?}):", base_graph.root_index);
         base_graph.dot();
 
         let (conflicts, updates) = new_graph
@@ -285,7 +283,6 @@ mod test {
             .expect("Unable to add root -> component edge");
 
         base_graph.cleanup();
-        println!("Initial base graph (Root {:?}):", base_graph.root_index);
         base_graph.dot();
 
         let new_change_set = ChangeSet::new_local().expect("Unable to create ChangeSet");
@@ -315,7 +312,6 @@ mod test {
             .expect("Unable to add root -> component edge");
 
         new_graph.cleanup();
-        println!("Updated new graph (Root: {:?}):", new_graph.root_index);
         new_graph.dot();
 
         let (conflicts, updates) = new_graph
@@ -406,7 +402,6 @@ mod test {
             )
             .expect("Unable to add schema -> schema variant edge");
 
-        println!("Initial base graph (Root {:?}):", base_graph.root_index);
         base_graph.dot();
 
         let new_change_set = ChangeSet::new_local().expect("Unable to create ChangeSet");
@@ -447,7 +442,6 @@ mod test {
             )
             .expect("Unable to add component -> schema variant edge");
 
-        println!("new graph (Root {:?}):", new_graph.root_index);
         new_graph.dot();
 
         let new_onto_component_id = base_change_set
@@ -484,7 +478,6 @@ mod test {
             )
             .expect("Unable to add component -> schema variant edge");
 
-        println!("Updated base graph (Root: {:?}):", base_graph.root_index);
         base_graph.dot();
 
         let (conflicts, updates) = new_graph
@@ -602,7 +595,6 @@ mod test {
             .expect("Unable to add component -> schema variant edge");
 
         base_graph.cleanup();
-        println!("Initial base graph (Root {:?}):", base_graph.root_index);
         base_graph.dot();
 
         let new_change_set = ChangeSet::new_local().expect("Unable to create ChangeSet");
@@ -618,7 +610,6 @@ mod test {
             .expect("Unable to update Component A");
 
         new_graph.cleanup();
-        println!("new graph (Root {:?}):", new_graph.root_index);
         new_graph.dot();
 
         base_graph
@@ -630,7 +621,6 @@ mod test {
             .expect("Unable to update Component A");
 
         base_graph.cleanup();
-        println!("Updated base graph (Root: {:?}):", base_graph.root_index);
         base_graph.dot();
 
         let (conflicts, updates) = new_graph
@@ -743,7 +733,6 @@ mod test {
             .expect("Unable to add component -> schema variant edge");
 
         base_graph.cleanup();
-        println!("Initial base graph (Root {:?}):", base_graph.root_index);
         base_graph.dot();
 
         let new_change_set = ChangeSet::new_local().expect("Unable to create ChangeSet");
@@ -762,7 +751,6 @@ mod test {
             .expect("Unable to remove Component A");
 
         base_graph.cleanup();
-        println!("Updated base graph (Root: {:?}):", base_graph.root_index);
         base_graph.dot();
 
         new_graph
@@ -774,7 +762,6 @@ mod test {
             .expect("Unable to update Component A");
 
         new_graph.cleanup();
-        println!("new graph (Root {:?}):", new_graph.root_index);
         new_graph.dot();
 
         let (conflicts, updates) = new_graph
@@ -1181,7 +1168,6 @@ mod test {
             .expect("Unable to add component -> schema variant edge");
 
         base_graph.cleanup();
-        println!("Initial base graph (Root {:?}):", base_graph.root_index);
         base_graph.dot();
 
         // Create a new change set to cause some problems!
@@ -1241,9 +1227,7 @@ mod test {
             )
             .expect("Unable to detect conflicts and updates");
 
-        println!("base graph current root: {:?}", base_graph.root_index);
         base_graph.dot();
-        println!("new graph current root: {:?}", new_graph.root_index);
         new_graph.dot();
 
         let expected_conflicts = vec![

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -571,8 +571,6 @@ async fn deletion_updates_downstream_components(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    //dbg!(royel_component.incoming_connections(ctx).await.expect("ok"));
-
     // Verify data.
     let units_value_id = royel_component
         .attribute_values_for_prop(ctx, &["root", "domain", "systemd", "units"])
@@ -591,7 +589,6 @@ async fn deletion_updates_downstream_components(ctx: &mut DalContext) {
         .expect("units has a materialized_view");
     let units_json_string =
         serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
-    dbg!(materialized_view);
     assert!(units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 
@@ -612,12 +609,11 @@ async fn deletion_updates_downstream_components(ctx: &mut DalContext) {
         .expect("unable to ser resource");
 
     // Delete component.
-    let oysters_component = oysters_component
+    let _oysters_component = oysters_component
         .delete(ctx)
         .await
         .expect("Unable to delete oysters component")
         .expect("component fully deleted");
-    dbg!(oysters_component);
 
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
@@ -641,7 +637,6 @@ async fn deletion_updates_downstream_components(ctx: &mut DalContext) {
         .expect("units has a materialized_view");
     let units_json_string =
         serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
-    dbg!(materialized_view);
     assert!(!units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 }
@@ -745,8 +740,6 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    //dbg!(royel_component.incoming_connections(ctx).await.expect("ok"));
-
     // Verify data.
     let units_value_id = royel_component
         .attribute_values_for_prop(ctx, &["root", "domain", "systemd", "units"])
@@ -765,7 +758,6 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .expect("units has a materialized_view");
     let units_json_string =
         serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
-    dbg!(materialized_view);
     assert!(units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 
@@ -786,12 +778,11 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .expect("unable to ser resource");
 
     // Delete component.
-    let oysters_component = oysters_component
+    let _oysters_component = oysters_component
         .delete(ctx)
         .await
         .expect("Unable to delete oysters component")
         .expect("component fully deleted");
-    dbg!(oysters_component);
 
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
@@ -815,7 +806,6 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .expect("units has a materialized_view");
     let units_json_string =
         serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
-    dbg!(materialized_view);
     assert!(!units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 
@@ -865,7 +855,6 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .expect("units has a materialized_view");
     let units_json_string =
         serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
-    dbg!(materialized_view);
     assert!(units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 
@@ -896,7 +885,6 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .expect("units has a materialized_view");
     let units_json_string =
         serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
-    dbg!(materialized_view);
     assert!(!units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 }
@@ -953,7 +941,9 @@ async fn paste_component(ctx: &mut DalContext) {
         .expect("unable to get materialized view of component")
         .expect("no view found");
 
-    *view.pointer_mut("/resource/last_synced").expect("no last synced found") = serde_json::Value::Null;
+    *view
+        .pointer_mut("/resource/last_synced")
+        .expect("no last synced found") = serde_json::Value::Null;
     assert_eq!(
         view,
         serde_json::json!({

--- a/lib/dal/tests/integration_test/component/get_diff.rs
+++ b/lib/dal/tests/integration_test/component/get_diff.rs
@@ -18,8 +18,6 @@ async fn get_diff_new_component(ctx: &mut DalContext) {
         .await
         .expect("unable to get diff");
 
-    dbg!(&diff);
-
     assert_eq!(starfield_component.id(), diff.component_id);
     assert_eq!(
         Some("{\n  \"si\": {\n    \"color\": \"#ffffff\",\n    \"name\": \"this is a new component\",\n    \"type\": \"component\"\n  },\n  \"domain\": {\n    \"name\": \"this is a new component\",\n    \"possible_world_a\": {\n      \"wormhole_1\": {\n        \"wormhole_2\": {\n          \"wormhole_3\": {}\n        }\n      }\n    },\n    \"possible_world_b\": {\n      \"wormhole_1\": {\n        \"wormhole_2\": {\n          \"wormhole_3\": {\n            \"naming_and_necessity\": \"not hesperus\"\n          }\n        }\n      }\n    },\n    \"universe\": {\n      \"galaxies\": []\n    }\n  }\n}".to_string()),

--- a/lib/dal/tests/integration_test/connection.rs
+++ b/lib/dal/tests/integration_test/connection.rs
@@ -317,8 +317,6 @@ async fn connect_components(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    //dbg!(royel_component.incoming_connections(ctx).await.expect("ok"));
-
     let units_value_id = royel_component
         .attribute_values_for_prop(ctx, &["root", "domain", "systemd", "units"])
         .await
@@ -334,11 +332,6 @@ async fn connect_components(ctx: &mut DalContext) {
         .await
         .expect("able to get units materialized_view")
         .expect("units has a materialized_view");
-
-    dbg!(lunch_component
-        .materialized_view(ctx)
-        .await
-        .expect("get docker image materialized_view"));
 
     assert!(matches!(materialized_view, serde_json::Value::Array(_)));
 
@@ -507,8 +500,6 @@ async fn remove_connection(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    //dbg!(royel_component.incoming_connections(ctx).await.expect("ok"));
-
     let units_value_id = royel_component
         .attribute_values_for_prop(ctx, &["root", "domain", "systemd", "units"])
         .await
@@ -524,11 +515,6 @@ async fn remove_connection(ctx: &mut DalContext) {
         .await
         .expect("able to get units materialized_view")
         .expect("units has a materialized_view");
-
-    dbg!(lunch_component
-        .materialized_view(ctx)
-        .await
-        .expect("get docker image materialized_view"));
 
     assert!(matches!(materialized_view, serde_json::Value::Array(_)));
 
@@ -566,11 +552,6 @@ async fn remove_connection(ctx: &mut DalContext) {
         .await
         .expect("able to get units materialized_view")
         .expect("units has a materialized_view");
-
-    dbg!(lunch_component
-        .materialized_view(ctx)
-        .await
-        .expect("get docker image materialized_view"));
 
     assert!(matches!(materialized_view, serde_json::Value::Array(_)));
 

--- a/lib/dal/tests/integration_test/dependent_values_update.rs
+++ b/lib/dal/tests/integration_test/dependent_values_update.rs
@@ -127,8 +127,6 @@ async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    //dbg!(royel_component.incoming_connections(ctx).await.expect("ok"));
-
     // Verify data.
     let units_value_id = royel_component
         .attribute_values_for_prop(ctx, &["root", "domain", "systemd", "units"])
@@ -147,7 +145,6 @@ async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
         .expect("units has a materialized_view");
     let units_json_string =
         serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
-    dbg!(materialized_view);
     assert!(!units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 
@@ -193,7 +190,6 @@ async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
         .expect("units has a materialized_view");
     let units_json_string =
         serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
-    dbg!(materialized_view);
     assert!(!units_json_string.contains("docker.io/library/oysters on the floor\\n"));
     assert!(!units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
@@ -297,7 +293,6 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update snapshot to visibility");
-    //dbg!(royel_component.incoming_connections(ctx).await.expect("ok"));
 
     // Verify pre-delete data.
     let units_value_id = royel_component
@@ -408,6 +403,5 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
         .expect("units has a materialized_view");
     let units_json_string =
         serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
-    dbg!(materialized_view);
     assert!(units_json_string.contains("docker.io/library/oysters on the floor\\n"));
 }

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -1443,7 +1443,6 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
         );
 
         assert!(new_era_taylor_swift_assembled.0.parent_id.is_none());
-        dbg!(country_era_taylor_swift_assembled.0.parent_id);
         assert!(country_era_taylor_swift_assembled.0.parent_id.is_none());
 
         assert_eq!(
@@ -1497,7 +1496,6 @@ impl DiagramByKey {
         let mut all = vec![];
         for component in self.components.values() {
             for edge in component.1.clone() {
-                dbg!(&edge);
                 all.push(edge);
             }
         }

--- a/lib/dal/tests/integration_test/func/authoring/create_func.rs
+++ b/lib/dal/tests/integration_test/func/authoring/create_func.rs
@@ -325,7 +325,6 @@ async fn create_attribute_with_socket(ctx: &mut DalContext) {
     let (output, _input) = SchemaVariant::list_all_sockets(ctx, sv_id)
         .await
         .expect("Unable to get the Sockets for the Schema Variant");
-    dbg!(&output);
 
     assert!(!output.is_empty());
 

--- a/lib/si-layer-cache/src/persister.rs
+++ b/lib/si-layer-cache/src/persister.rs
@@ -210,7 +210,6 @@ impl PersistEventTask {
         match self.try_write_layers(event).await {
             Ok(_) => status_tx.send(PersistStatus::Finished),
             Err(e) => {
-                println!("wtf: {:?}", e);
                 status_tx.send(PersistStatus::Error(e));
             }
         }


### PR DESCRIPTION
This PR removes dbg and println statements from the test suites, as they were mostly just generating noise (in particular in CI). Let's try and keep this tidy in the future :)

<img src="https://media1.giphy.com/media/hor7W22LilvnttSTAl/giphy.gif"/>