### PR TITLE
fix(dal, sdf): Ensure update_asset works in all scenarios

### DIFF
--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -814,11 +814,10 @@ impl SchemaVariant {
         let leaf_item_prop_id =
             SchemaVariant::find_leaf_item_prop(ctx, schema_variant_id, leaf_kind).await?;
 
-        for (maybe_key, _proto) in Prop::prototypes_by_key(ctx, leaf_item_prop_id).await? {
-            if let Some(key) = maybe_key {
-                if let Some(func_id) = Func::find_by_name(ctx, key).await? {
-                    func_ids.push(func_id)
-                }
+        for (maybe_key, proto) in Prop::prototypes_by_key(ctx, leaf_item_prop_id).await? {
+            if maybe_key.is_some() {
+                let func_id = AttributePrototype::func_id(ctx, proto).await?;
+                func_ids.push(func_id);
             }
         }
 

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -316,7 +316,6 @@ impl VariantAuthoringClient {
             let mut thing_map = clone_and_import_funcs(ctx, pkg.funcs()?).await?;
             if let Some(new_schema_variant) = import_schema_variant(
                 ctx,
-                None,
                 &mut schema,
                 schema_spec.clone(),
                 variant_pkg_spec,
@@ -440,7 +439,6 @@ impl VariantAuthoringClient {
 
         if let Some(new_schema_variant) = import_schema_variant(
             ctx,
-            None,
             &mut schema,
             schema_spec.clone(),
             variant_pkg_spec,

--- a/lib/dal/tests/integration_test/module.rs
+++ b/lib/dal/tests/integration_test/module.rs
@@ -96,9 +96,6 @@ async fn module_export_simple(ctx: &mut DalContext) {
         Some(description.clone()),
         &user,
         vec![schema.id()],
-        ctx.get_workspace_default_change_set_id()
-            .await
-            .expect("unable to get default changeset id"),
     );
 
     let exported_pkg = exporter

--- a/lib/sdf-server/src/server/service/module/export_module.rs
+++ b/lib/sdf-server/src/server/service/module/export_module.rs
@@ -83,7 +83,6 @@ pub async fn export_module(
         request.description.as_ref(),
         &created_by_email,
         schema_ids,
-        ctx.get_workspace_default_change_set_id().await?,
     );
 
     let module_payload = exporter.export_as_bytes(&ctx).await?;


### PR DESCRIPTION
In order to support workspace level imports, the import code had a Changeset based thingmap. That thingmap was causing issues in variant export because some funcs were being added to the map with the incorrect changeset id

We no longer use the import_workspace code path so we only ever import a single changeset at a time

We have no rid the world of a Changeset scoped Thingmap and this means the update_variant is a happier world and we can now happily upgrade variants!