### PR TITLE
feat: add logging of version/author/metadata during startup for all binaries running in Production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,6 +1208,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "cyclone-server",
+ "si-service",
  "telemetry-application",
  "tokio",
  "tokio-util",
@@ -3650,6 +3651,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "pinga-server",
+ "si-service",
  "si-std",
  "telemetry-application",
  "tokio",
@@ -4105,6 +4107,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "rebaser-server",
+ "si-service",
  "si-std",
  "telemetry-application",
  "tokio",
@@ -4646,6 +4649,7 @@ dependencies = [
  "color-eyre",
  "nats-multiplexer",
  "sdf-server",
+ "si-service",
  "si-std",
  "telemetry-application",
  "tokio",
@@ -5204,6 +5208,7 @@ name = "si-service"
 version = "0.1.0"
 dependencies = [
  "color-eyre",
+ "glob",
  "telemetry",
  "telemetry-application",
  "thiserror",
@@ -6590,6 +6595,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "color-eyre",
+ "si-service",
  "si-std",
  "telemetry-application",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ dyn-clone = "1.0.17"
 flate2 = "1.0.28"
 futures = "0.3.30"
 futures-lite = "2.3.0"
+glob = "0.3.1"
 hex = "0.4.3"
 http = "0.2.12" # todo: upgrade this alongside hyper/axum/tokio-tungstenite/tower-http
 hyper = { version = "0.14.28", features = [

--- a/bin/cyclone/BUCK
+++ b/bin/cyclone/BUCK
@@ -31,6 +31,7 @@ rust_binary(
     name = "cyclone",
     deps = [
         "//lib/cyclone-server:cyclone-server",
+        "//lib/si-service:si-service",
         "//lib/telemetry-application-rs:telemetry-application",
         "//third-party/rust:clap",
         "//third-party/rust:color-eyre",

--- a/bin/cyclone/Cargo.toml
+++ b/bin/cyclone/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 clap = { workspace = true }
 color-eyre = { workspace = true }
 cyclone-server = { path = "../../lib/cyclone-server" }
+si-service = { path = "../../lib/si-service" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -1,5 +1,6 @@
 use color_eyre::Result;
 use cyclone_server::{Config, Runnable as _, Server};
+use si_service::startup;
 use telemetry_application::prelude::*;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
@@ -30,6 +31,8 @@ async fn main() -> Result<()> {
 
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
     };
+
+    startup::startup("cyclone").await?;
 
     if args.verbose > 0 {
         telemetry

--- a/bin/pinga/BUCK
+++ b/bin/pinga/BUCK
@@ -9,6 +9,7 @@ rust_binary(
     name = "pinga",
     deps = [
         "//lib/pinga-server:pinga-server",
+        "//lib/si-service:si-service",
         "//lib/si-std:si-std",
         "//lib/telemetry-application-rs:telemetry-application",
         "//third-party/rust:clap",

--- a/bin/pinga/Cargo.toml
+++ b/bin/pinga/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 clap = { workspace = true }
 color-eyre = { workspace = true }
 pinga-server = { path = "../../lib/pinga-server" }
+si-service = { path = "../../lib/si-service" }
 si-std = { path = "../../lib/si-std" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -1,5 +1,6 @@
 use color_eyre::Result;
 use pinga_server::{Config, Server};
+use si_service::startup;
 use telemetry_application::prelude::*;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
@@ -44,6 +45,8 @@ async fn async_main() -> Result<()> {
 
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
     };
+
+    startup::startup("pinga").await?;
 
     if args.verbose > 0 {
         telemetry

--- a/bin/rebaser/BUCK
+++ b/bin/rebaser/BUCK
@@ -9,6 +9,7 @@ rust_binary(
     name = "rebaser",
     deps = [
         "//lib/rebaser-server:rebaser-server",
+        "//lib/si-service:si-service",
         "//lib/si-std:si-std",
         "//lib/telemetry-application-rs:telemetry-application",
         "//third-party/rust:clap",

--- a/bin/rebaser/Cargo.toml
+++ b/bin/rebaser/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 clap = { workspace = true }
 color-eyre = { workspace = true }
 rebaser-server = { path = "../../lib/rebaser-server" }
+si-service = { path = "../../lib/si-service" }
 si-std = { path = "../../lib/si-std" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }

--- a/bin/rebaser/src/main.rs
+++ b/bin/rebaser/src/main.rs
@@ -1,8 +1,8 @@
 use color_eyre::Result;
 use rebaser_server::{Config, Server};
+use si_service::startup;
 use telemetry_application::prelude::*;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
-
 mod args;
 
 const RT_DEFAULT_THREAD_STACK_SIZE: usize = 2 * 1024 * 1024 * 3;
@@ -45,6 +45,8 @@ async fn async_main() -> Result<()> {
 
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
     };
+
+    startup::startup("rebaser").await?;
 
     if args.verbose > 0 {
         telemetry

--- a/bin/sdf/BUCK
+++ b/bin/sdf/BUCK
@@ -10,6 +10,7 @@ rust_binary(
     deps = [
         "//lib/nats-multiplexer:nats-multiplexer",
         "//lib/sdf-server:sdf-server",
+        "//lib/si-service:si-service",
         "//lib/si-std:si-std",
         "//lib/telemetry-application-rs:telemetry-application",
         "//third-party/rust:clap",

--- a/bin/sdf/Cargo.toml
+++ b/bin/sdf/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [dependencies]
 nats-multiplexer = { path = "../../lib/nats-multiplexer" }
 sdf-server = { path = "../../lib/sdf-server" }
+si-service = { path = "../../lib/si-service" }
 si-std = { path = "../../lib/si-std" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -10,6 +10,7 @@ use sdf_server::{
     Config, IncomingStream, JobProcessorClientCloser, JobProcessorConnector, MigrationMode, Server,
     ServicesContext,
 };
+use si_service::startup;
 use telemetry_application::prelude::*;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
@@ -56,6 +57,8 @@ async fn async_main() -> Result<()> {
 
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
     };
+
+    startup::startup("sdf").await?;
 
     if args.verbose > 0 {
         telemetry

--- a/bin/veritech/BUCK
+++ b/bin/veritech/BUCK
@@ -31,6 +31,7 @@ rust_binary(
     edition = "2021",
     deps = [
         "//lib/si-std:si-std",
+        "//lib/si-service:si-service",
         "//lib/telemetry-application-rs:telemetry-application",
         "//lib/veritech-server:veritech-server",
         "//third-party/rust:clap",

--- a/bin/veritech/Cargo.toml
+++ b/bin/veritech/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 color-eyre = { workspace = true }
+si-service = { path = "../../lib/si-service" }
 si-std = { path = "../../lib/si-std" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }

--- a/bin/veritech/src/main.rs
+++ b/bin/veritech/src/main.rs
@@ -1,4 +1,5 @@
 use color_eyre::Result;
+use si_service::startup;
 use telemetry_application::prelude::*;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use veritech_server::{Config, CycloneSpec, Server};
@@ -30,6 +31,8 @@ async fn main() -> Result<()> {
 
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
     };
+
+    startup::startup("veritech").await?;
 
     if args.verbose > 0 {
         telemetry

--- a/lib/si-service/BUCK
+++ b/lib/si-service/BUCK
@@ -6,6 +6,7 @@ rust_library(
         "//lib/telemetry-application-rs:telemetry-application",
         "//lib/telemetry-rs:telemetry",
         "//third-party/rust:color-eyre",
+        "//third-party/rust:glob",
         "//third-party/rust:thiserror",
         "//third-party/rust:tokio",
         "//third-party/rust:tokio-util",

--- a/lib/si-service/Cargo.toml
+++ b/lib/si-service/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 color-eyre = { workspace = true }
+glob = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 thiserror = { workspace = true }

--- a/lib/si-service/src/lib.rs
+++ b/lib/si-service/src/lib.rs
@@ -18,6 +18,7 @@
 
 pub mod rt;
 pub mod shutdown;
+pub mod startup;
 
 pub use color_eyre::{self, eyre::Error, Result};
 pub use telemetry_application;

--- a/lib/si-service/src/startup.rs
+++ b/lib/si-service/src/startup.rs
@@ -1,0 +1,112 @@
+//! Service/server start pre-processing for establishing/reigstering service:
+//! - Health [to come]
+//! - Version
+//! - Anything else to do async or sync during service startup
+
+use glob::glob;
+use std::env;
+use std::io;
+use std::path::Component;
+use telemetry::prelude::*;
+use thiserror::Error;
+use tokio::{fs::File, io::AsyncReadExt};
+
+/// An error that can be returned when starting the process for the binary
+#[derive(Debug, Error)]
+pub enum StartupError {
+    /// When the version could not be established
+    #[error("Failed to establish version: {0}")]
+    Signal(#[source] io::Error),
+}
+
+/// Gracefully start a service and conduct pre-processing of service handler
+pub async fn startup(service: &str) -> Result<(), std::io::Error> {
+    let executable_path = match env::current_exe() {
+        Ok(exe_path) => exe_path,
+        Err(_) => {
+            info!(
+                "could not establish running executable path for {}",
+                service
+            );
+            return Ok(());
+        }
+    };
+
+    let executable_path = match executable_path.canonicalize() {
+        Ok(exe_path) => exe_path,
+        Err(_) => {
+            info!("could not canonicalize executable path for {}", service);
+            return Ok(());
+        }
+    };
+
+    // Check if it's a dev build (i.e. running from buck-out)
+    if executable_path
+        .components()
+        .any(|path| Component::Normal("buck-out".as_ref()) == path)
+    {
+        info!(
+            "development build (buck) detected for {}, no metadata can be reported",
+            service
+        );
+        return Ok(());
+    }
+
+    let metadata_candidates = match glob(&format!("/etc/nix-omnibus/{}/*/metadata.json", service)) {
+        Ok(iter) => iter,
+        Err(_) => {
+            info!("metadata candidates could not be found for {}", service);
+            return Ok(());
+        }
+    };
+
+    let mut metadata_candidates = match metadata_candidates.collect::<Result<Vec<_>, _>>() {
+        Ok(vec) => vec,
+        Err(_) => {
+            info!(
+                "could not collect PathBufs from metadata_candidates for {}",
+                service
+            );
+            return Ok(());
+        }
+    };
+
+    // Sort them lexically so that the latest (if there is more than one) is at the bottom
+    // There is a minor issue here if we `downgrade` a single running server/host there is the potential
+    // that this reports the newer version, rather than the rollback version due to how we are
+    // lexically sorting. At the time of writing there was no viable method to determine which exact
+    // metadata file should be referenced.
+    metadata_candidates.sort();
+
+    // Take the last one (the latest)
+    let metadata_file_path = match metadata_candidates.pop() {
+        Some(file_path) => file_path,
+        None => {
+            info!(
+                "could not read appropriate metadata files for {} to determine version",
+                service
+            );
+            return Ok(());
+        }
+    };
+
+    // Read contents of metadata file
+    let mut metadata_file_handler = match File::open(&metadata_file_path).await {
+        Ok(metadata_file_handler) => metadata_file_handler,
+        Err(_) => {
+            info!("metadata file could not be read for {}", service);
+            return Ok(());
+        }
+    };
+
+    let mut file_contents = String::new();
+    metadata_file_handler
+        .read_to_string(&mut file_contents)
+        .await?;
+
+    let metadata_file_path_str = metadata_file_path.as_path().display().to_string();
+
+    info!(file_contents, metadata_file_path_str, "metadata contents:");
+
+    Ok(())
+}

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -244,18 +244,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "allocator-api2-0.2.16.crate",
-    sha256 = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5",
-    strip_prefix = "allocator-api2-0.2.16",
-    urls = ["https://crates.io/api/v1/crates/allocator-api2/0.2.16/download"],
+    name = "allocator-api2-0.2.18.crate",
+    sha256 = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f",
+    strip_prefix = "allocator-api2-0.2.18",
+    urls = ["https://crates.io/api/v1/crates/allocator-api2/0.2.18/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "allocator-api2-0.2.16",
-    srcs = [":allocator-api2-0.2.16.crate"],
+    name = "allocator-api2-0.2.18",
+    srcs = [":allocator-api2-0.2.18.crate"],
     crate = "allocator_api2",
-    crate_root = "allocator-api2-0.2.16.crate/src/lib.rs",
+    crate_root = "allocator-api2-0.2.18.crate/src/lib.rs",
     edition = "2018",
     features = ["alloc"],
     visibility = [],
@@ -527,18 +527,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "async-compression-0.4.8.crate",
-    sha256 = "07dbbf24db18d609b1462965249abdf49129ccad073ec257da372adc83259c60",
-    strip_prefix = "async-compression-0.4.8",
-    urls = ["https://crates.io/api/v1/crates/async-compression/0.4.8/download"],
+    name = "async-compression-0.4.9.crate",
+    sha256 = "4e9eabd7a98fe442131a17c316bd9349c43695e49e730c3c8e12cfb5f4da2693",
+    strip_prefix = "async-compression-0.4.9",
+    urls = ["https://crates.io/api/v1/crates/async-compression/0.4.9/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-compression-0.4.8",
-    srcs = [":async-compression-0.4.8.crate"],
+    name = "async-compression-0.4.9",
+    srcs = [":async-compression-0.4.9.crate"],
     crate = "async_compression",
-    crate_root = "async-compression-0.4.8.crate/src/lib.rs",
+    crate_root = "async-compression-0.4.9.crate/src/lib.rs",
     edition = "2018",
     features = [
         "brotli",
@@ -549,8 +549,8 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":brotli-4.0.0",
-        ":flate2-1.0.28",
+        ":brotli-5.0.0",
+        ":flate2-1.0.30",
         ":futures-core-0.3.30",
         ":memchr-2.7.2",
         ":pin-project-lite-0.2.14",
@@ -559,21 +559,29 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "async-lock-2.8.0.crate",
-    sha256 = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b",
-    strip_prefix = "async-lock-2.8.0",
-    urls = ["https://crates.io/api/v1/crates/async-lock/2.8.0/download"],
+    name = "async-lock-3.3.0.crate",
+    sha256 = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b",
+    strip_prefix = "async-lock-3.3.0",
+    urls = ["https://crates.io/api/v1/crates/async-lock/3.3.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-lock-2.8.0",
-    srcs = [":async-lock-2.8.0.crate"],
+    name = "async-lock-3.3.0",
+    srcs = [":async-lock-3.3.0.crate"],
     crate = "async_lock",
-    crate_root = "async-lock-2.8.0.crate/src/lib.rs",
-    edition = "2018",
+    crate_root = "async-lock-3.3.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "std",
+    ],
     visibility = [],
-    deps = [":event-listener-2.5.3"],
+    deps = [
+        ":event-listener-4.0.3",
+        ":event-listener-strategy-0.4.0",
+        ":pin-project-lite-0.2.14",
+    ],
 )
 
 alias(
@@ -614,11 +622,11 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":base64-0.22.0",
+        ":base64-0.22.1",
         ":bytes-1.6.0",
         ":futures-0.3.30",
         ":memchr-2.7.2",
-        ":nkeys-0.4.0",
+        ":nkeys-0.4.1",
         ":nuid-0.5.0",
         ":once_cell-1.19.0",
         ":portable-atomic-1.6.0",
@@ -627,13 +635,13 @@ cargo.rust_library(
         ":ring-0.17.5",
         ":rustls-native-certs-0.7.0",
         ":rustls-pemfile-2.1.2",
-        ":rustls-webpki-0.102.2",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":rustls-webpki-0.102.3",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
         ":serde_nanos-0.1.4",
         ":serde_repr-0.1.19",
-        ":thiserror-1.0.58",
-        ":time-0.3.35",
+        ":thiserror-1.0.59",
+        ":time-0.3.36",
         ":tokio-1.37.0",
         ":tokio-rustls-0.25.0",
         ":tracing-0.1.40",
@@ -644,30 +652,30 @@ cargo.rust_library(
 
 alias(
     name = "async-recursion",
-    actual = ":async-recursion-1.1.0",
+    actual = ":async-recursion-1.1.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "async-recursion-1.1.0.crate",
-    sha256 = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5",
-    strip_prefix = "async-recursion-1.1.0",
-    urls = ["https://crates.io/api/v1/crates/async-recursion/1.1.0/download"],
+    name = "async-recursion-1.1.1.crate",
+    sha256 = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11",
+    strip_prefix = "async-recursion-1.1.1",
+    urls = ["https://crates.io/api/v1/crates/async-recursion/1.1.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-recursion-1.1.0",
-    srcs = [":async-recursion-1.1.0.crate"],
+    name = "async-recursion-1.1.1",
+    srcs = [":async-recursion-1.1.1.crate"],
     crate = "async_recursion",
-    crate_root = "async-recursion-1.1.0.crate/src/lib.rs",
+    crate_root = "async-recursion-1.1.1.crate/src/lib.rs",
     edition = "2018",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -710,38 +718,38 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
 alias(
     name = "async-trait",
-    actual = ":async-trait-0.1.79",
+    actual = ":async-trait-0.1.80",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "async-trait-0.1.79.crate",
-    sha256 = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681",
-    strip_prefix = "async-trait-0.1.79",
-    urls = ["https://crates.io/api/v1/crates/async-trait/0.1.79/download"],
+    name = "async-trait-0.1.80.crate",
+    sha256 = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca",
+    strip_prefix = "async-trait-0.1.80",
+    urls = ["https://crates.io/api/v1/crates/async-trait/0.1.80/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-trait-0.1.79",
-    srcs = [":async-trait-0.1.79.crate"],
+    name = "async-trait-0.1.80",
+    srcs = [":async-trait-0.1.80.crate"],
     crate = "async_trait",
-    crate_root = "async-trait-0.1.79.crate/src/lib.rs",
+    crate_root = "async-trait-0.1.80.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -821,14 +829,14 @@ cargo.rust_library(
         "webpki-roots",
     ],
     named_deps = {
-        "rustls_opt_dep": ":rustls-0.21.10",
+        "rustls_opt_dep": ":rustls-0.21.12",
     },
     visibility = [],
     deps = [
         ":http-0.2.12",
         ":log-0.4.21",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
         ":url-2.5.0",
         ":webpki-roots-0.25.4",
     ],
@@ -869,9 +877,9 @@ cargo.rust_library(
         ":log-0.4.21",
         ":quick-xml-0.30.0",
         ":rust-ini-0.19.0",
-        ":serde-1.0.197",
-        ":thiserror-1.0.58",
-        ":time-0.3.35",
+        ":serde-1.0.200",
+        ":thiserror-1.0.59",
+        ":time-0.3.36",
         ":url-2.5.0",
     ],
 )
@@ -883,7 +891,7 @@ cargo.rust_library(
     crate_root = "rust-s3-61c54947c717d042/aws-region/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":thiserror-1.0.58"],
+    deps = [":thiserror-1.0.59"],
 )
 
 alias(
@@ -922,7 +930,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.79",
+        ":async-trait-0.1.80",
         ":axum-core-0.3.4",
         ":axum-macros-0.3.8",
         ":base64-0.21.7",
@@ -939,8 +947,8 @@ cargo.rust_library(
         ":multer-2.1.0",
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.14",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
         ":serde_path_to_error-0.1.16",
         ":serde_urlencoded-0.7.1",
         ":sha1-0.10.6",
@@ -969,7 +977,7 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":async-trait-0.1.79",
+        ":async-trait-0.1.80",
         ":bytes-1.6.0",
         ":futures-util-0.3.30",
         ":http-0.2.12",
@@ -999,9 +1007,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -1028,7 +1036,7 @@ cargo.rust_library(
         "linux-arm64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":miniz_oxide-0.7.2",
                 ":object-0.32.2",
             ],
@@ -1036,7 +1044,7 @@ cargo.rust_library(
         "linux-x86_64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":miniz_oxide-0.7.2",
                 ":object-0.32.2",
             ],
@@ -1044,7 +1052,7 @@ cargo.rust_library(
         "macos-arm64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":miniz_oxide-0.7.2",
                 ":object-0.32.2",
             ],
@@ -1052,7 +1060,7 @@ cargo.rust_library(
         "macos-x86_64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":miniz_oxide-0.7.2",
                 ":object-0.32.2",
             ],
@@ -1060,7 +1068,7 @@ cargo.rust_library(
         "windows-gnu": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":miniz_oxide-0.7.2",
                 ":object-0.32.2",
             ],
@@ -1136,23 +1144,23 @@ cargo.rust_library(
 
 alias(
     name = "base64",
-    actual = ":base64-0.22.0",
+    actual = ":base64-0.22.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "base64-0.22.0.crate",
-    sha256 = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51",
-    strip_prefix = "base64-0.22.0",
-    urls = ["https://crates.io/api/v1/crates/base64/0.22.0/download"],
+    name = "base64-0.22.1.crate",
+    sha256 = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6",
+    strip_prefix = "base64-0.22.1",
+    urls = ["https://crates.io/api/v1/crates/base64/0.22.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "base64-0.22.0",
-    srcs = [":base64-0.22.0.crate"],
+    name = "base64-0.22.1",
+    srcs = [":base64-0.22.1.crate"],
     crate = "base64",
-    crate_root = "base64-0.22.0.crate/src/lib.rs",
+    crate_root = "base64-0.22.1.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -1277,7 +1285,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde-1.0.197"],
+    deps = [":serde-1.0.200"],
 )
 
 http_archive(
@@ -1571,7 +1579,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":base64-0.22.0",
+        ":base64-0.22.1",
         ":bollard-stubs-1.44.0-rc.2",
         ":bytes-1.6.0",
         ":futures-core-0.3.30",
@@ -1579,16 +1587,16 @@ cargo.rust_library(
         ":hex-0.4.3",
         ":http-1.1.0",
         ":http-body-util-0.1.1",
-        ":hyper-1.2.0",
+        ":hyper-1.3.1",
         ":hyper-util-0.1.3",
         ":log-0.4.21",
         ":pin-project-lite-0.2.14",
-        ":serde-1.0.197",
-        ":serde_derive-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_derive-1.0.200",
+        ":serde_json-1.0.116",
         ":serde_repr-0.1.19",
         ":serde_urlencoded-0.7.1",
-        ":thiserror-1.0.58",
+        ":thiserror-1.0.59",
         ":tokio-1.37.0",
         ":tokio-util-0.7.10",
         ":url-2.5.0",
@@ -1611,51 +1619,52 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":serde-1.0.197",
+        ":serde-1.0.200",
         ":serde_repr-0.1.19",
-        ":serde_with-3.7.0",
+        ":serde_with-3.8.1",
     ],
 )
 
 http_archive(
-    name = "brotli-4.0.0.crate",
-    sha256 = "125740193d7fee5cc63ab9e16c2fdc4e07c74ba755cc53b327d6ea029e9fc569",
-    strip_prefix = "brotli-4.0.0",
-    urls = ["https://crates.io/api/v1/crates/brotli/4.0.0/download"],
+    name = "brotli-5.0.0.crate",
+    sha256 = "19483b140a7ac7174d34b5a581b406c64f84da5409d3e09cf4fff604f9270e67",
+    strip_prefix = "brotli-5.0.0",
+    urls = ["https://crates.io/api/v1/crates/brotli/5.0.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "brotli-4.0.0",
-    srcs = [":brotli-4.0.0.crate"],
+    name = "brotli-5.0.0",
+    srcs = [":brotli-5.0.0.crate"],
     crate = "brotli",
-    crate_root = "brotli-4.0.0.crate/src/lib.rs",
+    crate_root = "brotli-5.0.0.crate/src/lib.rs",
     edition = "2015",
     features = [
         "alloc-stdlib",
+        "default",
         "std",
     ],
     visibility = [],
     deps = [
         ":alloc-no-stdlib-2.0.4",
         ":alloc-stdlib-0.2.2",
-        ":brotli-decompressor-3.0.0",
+        ":brotli-decompressor-4.0.0",
     ],
 )
 
 http_archive(
-    name = "brotli-decompressor-3.0.0.crate",
-    sha256 = "65622a320492e09b5e0ac436b14c54ff68199bac392d0e89a6832c4518eea525",
-    strip_prefix = "brotli-decompressor-3.0.0",
-    urls = ["https://crates.io/api/v1/crates/brotli-decompressor/3.0.0/download"],
+    name = "brotli-decompressor-4.0.0.crate",
+    sha256 = "e6221fe77a248b9117d431ad93761222e1cf8ff282d9d1d5d9f53d6299a1cf76",
+    strip_prefix = "brotli-decompressor-4.0.0",
+    urls = ["https://crates.io/api/v1/crates/brotli-decompressor/4.0.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "brotli-decompressor-3.0.0",
-    srcs = [":brotli-decompressor-3.0.0.crate"],
+    name = "brotli-decompressor-4.0.0",
+    srcs = [":brotli-decompressor-4.0.0.crate"],
     crate = "brotli_decompressor",
-    crate_root = "brotli-decompressor-3.0.0.crate/src/lib.rs",
+    crate_root = "brotli-decompressor-4.0.0.crate/src/lib.rs",
     edition = "2015",
     features = [
         "alloc-stdlib",
@@ -1689,7 +1698,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":memchr-2.7.2",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -1761,7 +1770,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde-1.0.197"],
+    deps = [":serde-1.0.200"],
 )
 
 alias(
@@ -1806,29 +1815,29 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
     },
     visibility = [],
     deps = [
         ":digest-0.10.7",
-        ":either-1.10.0",
+        ":either-1.11.0",
         ":futures-0.3.30",
         ":hex-0.4.3",
         ":memmap2-0.5.10",
         ":miette-5.10.0",
-        ":reflink-copy-0.1.15",
-        ":serde-1.0.197",
-        ":serde_derive-1.0.197",
-        ":serde_json-1.0.115",
+        ":reflink-copy-0.1.17",
+        ":serde-1.0.200",
+        ":serde_derive-1.0.200",
+        ":serde_json-1.0.116",
         ":sha1-0.10.6",
         ":sha2-0.10.8",
         ":ssri-9.2.0",
         ":tempfile-3.10.1",
-        ":thiserror-1.0.58",
+        ":thiserror-1.0.59",
         ":tokio-1.37.0",
         ":tokio-stream-0.1.15",
         ":walkdir-2.5.0",
@@ -1853,18 +1862,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "cc-1.0.92.crate",
-    sha256 = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41",
-    strip_prefix = "cc-1.0.92",
-    urls = ["https://crates.io/api/v1/crates/cc/1.0.92/download"],
+    name = "cc-1.0.96.crate",
+    sha256 = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd",
+    strip_prefix = "cc-1.0.96",
+    urls = ["https://crates.io/api/v1/crates/cc/1.0.96/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "cc-1.0.92",
-    srcs = [":cc-1.0.92.crate"],
+    name = "cc-1.0.96",
+    srcs = [":cc-1.0.96.crate"],
     crate = "cc",
-    crate_root = "cc-1.0.92.crate/src/lib.rs",
+    crate_root = "cc-1.0.96.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
 )
@@ -1888,23 +1897,23 @@ cargo.rust_library(
 
 alias(
     name = "chrono",
-    actual = ":chrono-0.4.37",
+    actual = ":chrono-0.4.38",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "chrono-0.4.37.crate",
-    sha256 = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e",
-    strip_prefix = "chrono-0.4.37",
-    urls = ["https://crates.io/api/v1/crates/chrono/0.4.37/download"],
+    name = "chrono-0.4.38.crate",
+    sha256 = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401",
+    strip_prefix = "chrono-0.4.38",
+    urls = ["https://crates.io/api/v1/crates/chrono/0.4.38/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "chrono-0.4.37",
-    srcs = [":chrono-0.4.37.crate"],
+    name = "chrono-0.4.38",
+    srcs = [":chrono-0.4.38.crate"],
     crate = "chrono",
-    crate_root = "chrono-0.4.37.crate/src/lib.rs",
+    crate_root = "chrono-0.4.38.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -1936,16 +1945,16 @@ cargo.rust_library(
             deps = [":iana-time-zone-0.1.60"],
         ),
         "windows-gnu": dict(
-            deps = [":windows-targets-0.52.4"],
+            deps = [":windows-targets-0.52.5"],
         ),
         "windows-msvc": dict(
-            deps = [":windows-targets-0.52.4"],
+            deps = [":windows-targets-0.52.5"],
         ),
     },
     visibility = [],
     deps = [
         ":num-traits-0.2.18",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -1977,7 +1986,7 @@ cargo.rust_library(
     deps = [
         ":ciborium-io-0.2.2",
         ":ciborium-ll-0.2.2",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -2115,9 +2124,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.5.0",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -2154,22 +2163,22 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "windows-gnu": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "windows-msvc": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
     },
     visibility = [],
@@ -2357,8 +2366,27 @@ cargo.rust_library(
         ":console-0.15.8",
         ":strum-0.26.2",
         ":strum_macros-0.26.2",
-        ":unicode-width-0.1.11",
+        ":unicode-width-0.1.12",
     ],
+)
+
+http_archive(
+    name = "concurrent-queue-2.5.0.crate",
+    sha256 = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973",
+    strip_prefix = "concurrent-queue-2.5.0",
+    urls = ["https://crates.io/api/v1/crates/concurrent-queue/2.5.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "concurrent-queue-2.5.0",
+    srcs = [":concurrent-queue-2.5.0.crate"],
+    crate = "concurrent_queue",
+    crate_root = "concurrent-queue-2.5.0.crate/src/lib.rs",
+    edition = "2021",
+    features = ["std"],
+    visibility = [],
+    deps = [":crossbeam-utils-0.8.19"],
 )
 
 alias(
@@ -2387,7 +2415,7 @@ cargo.rust_library(
         ":lazy_static-1.4.0",
         ":nom-7.1.3",
         ":pathdiff-0.2.1",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
         ":toml-0.8.12",
     ],
 )
@@ -2434,8 +2462,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":lazy_static-1.4.0",
-        ":libc-0.2.153",
-        ":unicode-width-0.1.11",
+        ":libc-0.2.154",
+        ":unicode-width-0.1.12",
     ],
 )
 
@@ -2548,8 +2576,8 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":chrono-0.4.37",
-        ":flate2-1.0.28",
+        ":chrono-0.4.38",
+        ":flate2-1.0.30",
         ":futures-util-0.3.30",
         ":http-0.2.12",
         ":hyper-0.14.28",
@@ -2557,10 +2585,10 @@ cargo.rust_library(
         ":mime-0.3.17",
         ":paste-1.0.14",
         ":pin-project-1.1.5",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
         ":tar-0.4.40",
-        ":thiserror-1.0.58",
+        ":thiserror-1.0.59",
         ":tokio-1.37.0",
         ":url-2.5.0",
     ],
@@ -2628,7 +2656,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":core-foundation-sys-0.8.6",
-        ":libc-0.2.153",
+        ":libc-0.2.154",
     ],
 )
 
@@ -2669,10 +2697,10 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
     },
     visibility = [],
@@ -2792,9 +2820,9 @@ cargo.rust_library(
         ":plotters-0.3.5",
         ":rayon-1.10.0",
         ":regex-1.10.4",
-        ":serde-1.0.197",
-        ":serde_derive-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_derive-1.0.200",
+        ":serde_json-1.0.116",
         ":tinytemplate-1.2.1",
         ":tokio-1.37.0",
         ":walkdir-2.5.0",
@@ -2985,7 +3013,7 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":mio-0.8.11",
                 ":signal-hook-0.3.17",
                 ":signal-hook-mio-0.2.3",
@@ -2993,7 +3021,7 @@ cargo.rust_library(
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":mio-0.8.11",
                 ":signal-hook-0.3.17",
                 ":signal-hook-mio-0.2.3",
@@ -3001,7 +3029,7 @@ cargo.rust_library(
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":mio-0.8.11",
                 ":signal-hook-0.3.17",
                 ":signal-hook-mio-0.2.3",
@@ -3009,7 +3037,7 @@ cargo.rust_library(
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":mio-0.8.11",
                 ":signal-hook-0.3.17",
                 ":signal-hook-mio-0.2.3",
@@ -3031,7 +3059,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bitflags-1.3.2",
-        ":parking_lot-0.12.1",
+        ":parking_lot-0.12.2",
     ],
 )
 
@@ -3052,16 +3080,16 @@ cargo.rust_library(
     features = ["windows"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "windows-gnu": dict(
             deps = [
@@ -3079,7 +3107,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bitflags-2.5.0",
-        ":parking_lot-0.12.1",
+        ":parking_lot-0.12.2",
     ],
 )
 
@@ -3316,9 +3344,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -3369,10 +3397,10 @@ cargo.rust_library(
     deps = [
         ":fnv-1.0.7",
         ":ident_case-1.0.1",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
         ":strsim-0.10.0",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -3395,7 +3423,7 @@ cargo.rust_library(
     deps = [
         ":darling_core-0.20.8",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -3423,18 +3451,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "data-encoding-2.5.0.crate",
-    sha256 = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5",
-    strip_prefix = "data-encoding-2.5.0",
-    urls = ["https://crates.io/api/v1/crates/data-encoding/2.5.0/download"],
+    name = "data-encoding-2.6.0.crate",
+    sha256 = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2",
+    strip_prefix = "data-encoding-2.6.0",
+    urls = ["https://crates.io/api/v1/crates/data-encoding/2.6.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "data-encoding-2.5.0",
-    srcs = [":data-encoding-2.5.0.crate"],
+    name = "data-encoding-2.6.0",
+    srcs = [":data-encoding-2.6.0.crate"],
     crate = "data_encoding",
-    crate_root = "data-encoding-2.5.0.crate/src/lib.rs",
+    crate_root = "data-encoding-2.6.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -3473,7 +3501,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.79",
+        ":async-trait-0.1.80",
         ":deadpool-runtime-0.1.3",
         ":num_cpus-1.16.0",
         ":tokio-1.37.0",
@@ -3586,7 +3614,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":powerfmt-0.2.0",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -3607,7 +3635,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
         ":syn-1.0.109",
     ],
@@ -3659,9 +3687,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":darling-0.20.8",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -3684,7 +3712,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":derive_builder_core-0.20.0",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -3740,7 +3768,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":convert_case-0.4.0",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
         ":syn-1.0.109",
     ],
@@ -3843,16 +3871,16 @@ cargo.rust_library(
     edition = "2015",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.48.0"],
@@ -4096,25 +4124,25 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":enum-ordinalize-4.3.0",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
 http_archive(
-    name = "either-1.10.0.crate",
-    sha256 = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a",
-    strip_prefix = "either-1.10.0",
-    urls = ["https://crates.io/api/v1/crates/either/1.10.0/download"],
+    name = "either-1.11.0.crate",
+    sha256 = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2",
+    strip_prefix = "either-1.11.0",
+    urls = ["https://crates.io/api/v1/crates/either/1.11.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "either-1.10.0",
-    srcs = [":either-1.10.0.crate"],
+    name = "either-1.11.0",
+    srcs = [":either-1.11.0.crate"],
     crate = "either",
-    crate_root = "either-1.10.0.crate/src/lib.rs",
+    crate_root = "either-1.11.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -4122,7 +4150,7 @@ cargo.rust_library(
         "use_std",
     ],
     visibility = [],
-    deps = [":serde-1.0.197"],
+    deps = [":serde-1.0.200"],
 )
 
 http_archive(
@@ -4267,9 +4295,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -4307,16 +4335,16 @@ cargo.rust_library(
     features = ["std"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -4372,6 +4400,119 @@ cargo.rust_library(
     crate_root = "event-listener-2.5.3.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
+)
+
+http_archive(
+    name = "event-listener-4.0.3.crate",
+    sha256 = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e",
+    strip_prefix = "event-listener-4.0.3",
+    urls = ["https://crates.io/api/v1/crates/event-listener/4.0.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "event-listener-4.0.3",
+    srcs = [":event-listener-4.0.3.crate"],
+    crate = "event_listener",
+    crate_root = "event-listener-4.0.3.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "parking",
+        "std",
+    ],
+    platform = {
+        "linux-arm64": dict(
+            deps = [":parking-2.2.0"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":parking-2.2.0"],
+        ),
+        "macos-arm64": dict(
+            deps = [":parking-2.2.0"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":parking-2.2.0"],
+        ),
+        "windows-gnu": dict(
+            deps = [":parking-2.2.0"],
+        ),
+        "windows-msvc": dict(
+            deps = [":parking-2.2.0"],
+        ),
+    },
+    visibility = [],
+    deps = [
+        ":concurrent-queue-2.5.0",
+        ":pin-project-lite-0.2.14",
+    ],
+)
+
+http_archive(
+    name = "event-listener-5.3.0.crate",
+    sha256 = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24",
+    strip_prefix = "event-listener-5.3.0",
+    urls = ["https://crates.io/api/v1/crates/event-listener/5.3.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "event-listener-5.3.0",
+    srcs = [":event-listener-5.3.0.crate"],
+    crate = "event_listener",
+    crate_root = "event-listener-5.3.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "parking",
+        "std",
+    ],
+    platform = {
+        "linux-arm64": dict(
+            deps = [":parking-2.2.0"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":parking-2.2.0"],
+        ),
+        "macos-arm64": dict(
+            deps = [":parking-2.2.0"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":parking-2.2.0"],
+        ),
+        "windows-gnu": dict(
+            deps = [":parking-2.2.0"],
+        ),
+        "windows-msvc": dict(
+            deps = [":parking-2.2.0"],
+        ),
+    },
+    visibility = [],
+    deps = [
+        ":concurrent-queue-2.5.0",
+        ":pin-project-lite-0.2.14",
+    ],
+)
+
+http_archive(
+    name = "event-listener-strategy-0.4.0.crate",
+    sha256 = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3",
+    strip_prefix = "event-listener-strategy-0.4.0",
+    urls = ["https://crates.io/api/v1/crates/event-listener-strategy/0.4.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "event-listener-strategy-0.4.0",
+    srcs = [":event-listener-strategy-0.4.0.crate"],
+    crate = "event_listener_strategy",
+    crate_root = "event-listener-strategy-0.4.0.crate/src/lib.rs",
+    edition = "2018",
+    features = ["std"],
+    visibility = [],
+    deps = [
+        ":event-listener-4.0.3",
+        ":pin-project-lite-0.2.14",
+    ],
 )
 
 http_archive(
@@ -4439,18 +4580,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "fastrand-2.0.2.crate",
-    sha256 = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984",
-    strip_prefix = "fastrand-2.0.2",
-    urls = ["https://crates.io/api/v1/crates/fastrand/2.0.2/download"],
+    name = "fastrand-2.1.0.crate",
+    sha256 = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a",
+    strip_prefix = "fastrand-2.1.0",
+    urls = ["https://crates.io/api/v1/crates/fastrand/2.1.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "fastrand-2.0.2",
-    srcs = [":fastrand-2.0.2.crate"],
+    name = "fastrand-2.1.0",
+    srcs = [":fastrand-2.1.0.crate"],
     crate = "fastrand",
-    crate_root = "fastrand-2.0.2.crate/src/lib.rs",
+    crate_root = "fastrand-2.1.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -4498,16 +4639,16 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -4561,23 +4702,23 @@ cargo.rust_library(
 
 alias(
     name = "flate2",
-    actual = ":flate2-1.0.28",
+    actual = ":flate2-1.0.30",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "flate2-1.0.28.crate",
-    sha256 = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e",
-    strip_prefix = "flate2-1.0.28",
-    urls = ["https://crates.io/api/v1/crates/flate2/1.0.28/download"],
+    name = "flate2-1.0.30.crate",
+    sha256 = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae",
+    strip_prefix = "flate2-1.0.30",
+    urls = ["https://crates.io/api/v1/crates/flate2/1.0.30/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "flate2-1.0.28",
-    srcs = [":flate2-1.0.28.crate"],
+    name = "flate2-1.0.30",
+    srcs = [":flate2-1.0.30.crate"],
     crate = "flate2",
-    crate_root = "flate2-1.0.28.crate/src/lib.rs",
+    crate_root = "flate2-1.0.30.crate/src/lib.rs",
     edition = "2018",
     features = [
         "any_impl",
@@ -4797,8 +4938,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":futures-core-0.3.30",
-        ":lock_api-0.4.11",
-        ":parking_lot-0.12.1",
+        ":lock_api-0.4.12",
+        ":parking_lot-0.12.2",
     ],
 )
 
@@ -4854,7 +4995,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":fastrand-2.0.2",
+        ":fastrand-2.1.0",
         ":futures-core-0.3.30",
         ":futures-io-0.3.30",
         ":parking-2.2.0",
@@ -4879,9 +5020,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -5102,16 +5243,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
     },
     visibility = [],
@@ -5141,16 +5282,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
     },
     visibility = [],
@@ -5176,6 +5317,12 @@ cargo.rust_library(
         "read-core",
     ],
     visibility = [],
+)
+
+alias(
+    name = "glob",
+    actual = ":glob-0.3.1",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -5354,18 +5501,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "hashbrown-0.14.3.crate",
-    sha256 = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604",
-    strip_prefix = "hashbrown-0.14.3",
-    urls = ["https://crates.io/api/v1/crates/hashbrown/0.14.3/download"],
+    name = "hashbrown-0.14.5.crate",
+    sha256 = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1",
+    strip_prefix = "hashbrown-0.14.5",
+    urls = ["https://crates.io/api/v1/crates/hashbrown/0.14.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "hashbrown-0.14.3",
-    srcs = [":hashbrown-0.14.3.crate"],
+    name = "hashbrown-0.14.5",
+    srcs = [":hashbrown-0.14.5.crate"],
     crate = "hashbrown",
-    crate_root = "hashbrown-0.14.3.crate/src/lib.rs",
+    crate_root = "hashbrown-0.14.5.crate/src/lib.rs",
     edition = "2021",
     features = [
         "ahash",
@@ -5377,7 +5524,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":ahash-0.8.11",
-        ":allocator-api2-0.2.16",
+        ":allocator-api2-0.2.18",
     ],
 )
 
@@ -5396,7 +5543,7 @@ cargo.rust_library(
     crate_root = "hashlink-0.8.4.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":hashbrown-0.14.3"],
+    deps = [":hashbrown-0.14.5"],
 )
 
 http_archive(
@@ -5456,7 +5603,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hash32-0.2.1",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
         ":stable_deref_trait-1.2.0",
     ],
 )
@@ -5904,7 +6051,7 @@ cargo.rust_library(
         ":httpdate-1.0.3",
         ":itoa-1.0.11",
         ":pin-project-lite-0.2.14",
-        ":socket2-0.5.6",
+        ":socket2-0.5.7",
         ":tokio-1.37.0",
         ":tower-service-0.3.2",
         ":tracing-0.1.40",
@@ -5913,18 +6060,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "hyper-1.2.0.crate",
-    sha256 = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a",
-    strip_prefix = "hyper-1.2.0",
-    urls = ["https://crates.io/api/v1/crates/hyper/1.2.0/download"],
+    name = "hyper-1.3.1.crate",
+    sha256 = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d",
+    strip_prefix = "hyper-1.3.1",
+    urls = ["https://crates.io/api/v1/crates/hyper/1.3.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "hyper-1.2.0",
-    srcs = [":hyper-1.2.0.crate"],
+    name = "hyper-1.3.1",
+    srcs = [":hyper-1.3.1.crate"],
     crate = "hyper",
-    crate_root = "hyper-1.2.0.crate/src/lib.rs",
+    crate_root = "hyper-1.3.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "client",
@@ -5964,7 +6111,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hex-0.4.3",
-        ":hyper-1.2.0",
+        ":hyper-1.3.1",
         ":hyper-util-0.1.3",
         ":pin-project-lite-0.2.14",
         ":tokio-1.37.0",
@@ -5992,7 +6139,7 @@ cargo.rust_library(
         ":futures-util-0.3.30",
         ":http-0.2.12",
         ":hyper-0.14.28",
-        ":rustls-0.21.10",
+        ":rustls-0.21.12",
         ":tokio-1.37.0",
         ":tokio-rustls-0.24.1",
     ],
@@ -6013,15 +6160,15 @@ cargo.rust_library(
     crate_root = "hyper-rustls-0.26.0.crate/src/lib.rs",
     edition = "2021",
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.4.1",
+        "pki_types": ":rustls-pki-types-1.5.0",
     },
     visibility = [],
     deps = [
         ":futures-util-0.3.30",
         ":http-1.1.0",
-        ":hyper-1.2.0",
+        ":hyper-1.3.1",
         ":hyper-util-0.1.3",
-        ":rustls-0.22.3",
+        ":rustls-0.22.4",
         ":tokio-1.37.0",
         ":tokio-rustls-0.25.0",
         ":tower-service-0.3.2",
@@ -6079,9 +6226,9 @@ cargo.rust_library(
         ":futures-util-0.3.30",
         ":http-1.1.0",
         ":http-body-1.0.0",
-        ":hyper-1.2.0",
+        ":hyper-1.3.1",
         ":pin-project-lite-0.2.14",
-        ":socket2-0.5.6",
+        ":socket2-0.5.7",
         ":tokio-1.37.0",
         ":tower-0.4.13",
         ":tower-service-0.3.2",
@@ -6141,7 +6288,7 @@ cargo.rust_library(
     deps = [
         ":hex-0.4.3",
         ":http-body-util-0.1.1",
-        ":hyper-1.2.0",
+        ":hyper-1.3.1",
         ":hyper-util-0.1.3",
         ":pin-project-lite-0.2.14",
         ":tokio-1.37.0",
@@ -6248,10 +6395,10 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":ignore-0.4.22",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":serde-1.0.197",
-        ":syn-2.0.58",
+        ":serde-1.0.200",
+        ":syn-2.0.60",
         ":toml-0.8.12",
         ":unicode-xid-0.2.4",
     ],
@@ -6273,10 +6420,10 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "windows-gnu": dict(
-            deps = [":winapi-util-0.1.6"],
+            deps = [":winapi-util-0.1.8"],
         ),
         "windows-msvc": dict(
-            deps = [":winapi-util-0.1.6"],
+            deps = [":winapi-util-0.1.8"],
         ),
     },
     visibility = [],
@@ -6332,7 +6479,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hashbrown-0.12.3",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -6365,8 +6512,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":equivalent-1.0.1",
-        ":hashbrown-0.14.3",
-        ":serde-1.0.197",
+        ":hashbrown-0.14.5",
+        ":serde-1.0.200",
     ],
 )
 
@@ -6399,7 +6546,7 @@ cargo.rust_library(
         ":console-0.15.8",
         ":number_prefix-0.4.0",
         ":portable-atomic-1.6.0",
-        ":unicode-width-0.1.11",
+        ":unicode-width-0.1.12",
     ],
 )
 
@@ -6444,31 +6591,31 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
 alias(
     name = "inquire",
-    actual = ":inquire-0.7.4",
+    actual = ":inquire-0.7.5",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "inquire-0.7.4.crate",
-    sha256 = "fe95f33091b9b7b517a5849bce4dce1b550b430fc20d58059fcaa319ed895d8b",
-    strip_prefix = "inquire-0.7.4",
-    urls = ["https://crates.io/api/v1/crates/inquire/0.7.4/download"],
+    name = "inquire-0.7.5.crate",
+    sha256 = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a",
+    strip_prefix = "inquire-0.7.5",
+    urls = ["https://crates.io/api/v1/crates/inquire/0.7.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "inquire-0.7.4",
-    srcs = [":inquire-0.7.4.crate"],
+    name = "inquire-0.7.5",
+    srcs = [":inquire-0.7.5.crate"],
     crate = "inquire",
-    crate_root = "inquire-0.7.4.crate/src/lib.rs",
+    crate_root = "inquire-0.7.5.crate/src/lib.rs",
     edition = "2018",
     features = [
         "crossterm",
@@ -6488,7 +6635,7 @@ cargo.rust_library(
         ":newline-converter-0.3.0",
         ":once_cell-1.19.0",
         ":unicode-segmentation-1.11.0",
-        ":unicode-width-0.1.11",
+        ":unicode-width-0.1.12",
     ],
 )
 
@@ -6547,16 +6694,16 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -6609,7 +6756,7 @@ cargo.rust_library(
         "use_std",
     ],
     visibility = [],
-    deps = [":either-1.10.0"],
+    deps = [":either-1.11.0"],
 )
 
 alias(
@@ -6638,7 +6785,7 @@ cargo.rust_library(
         "use_std",
     ],
     visibility = [],
-    deps = [":either-1.10.0"],
+    deps = [":either-1.11.0"],
 )
 
 http_archive(
@@ -6717,9 +6864,9 @@ cargo.rust_library(
         ":p256-0.13.2",
         ":p384-0.13.0",
         ":rand-0.8.5",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
-        ":thiserror-1.0.58",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
+        ":thiserror-1.0.59",
         ":zeroize-1.7.0",
     ],
 )
@@ -6797,33 +6944,33 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "libc-0.2.153.crate",
-    sha256 = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd",
-    strip_prefix = "libc-0.2.153",
-    urls = ["https://crates.io/api/v1/crates/libc/0.2.153/download"],
+    name = "libc-0.2.154.crate",
+    sha256 = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346",
+    strip_prefix = "libc-0.2.154",
+    urls = ["https://crates.io/api/v1/crates/libc/0.2.154/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "libc-0.2.153",
-    srcs = [":libc-0.2.153.crate"],
+    name = "libc-0.2.154",
+    srcs = [":libc-0.2.154.crate"],
     crate = "libc",
-    crate_root = "libc-0.2.153.crate/src/lib.rs",
+    crate_root = "libc-0.2.154.crate/src/lib.rs",
     edition = "2015",
     features = [
         "default",
         "extra_traits",
         "std",
     ],
-    rustc_flags = ["@$(location :libc-0.2.153-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :libc-0.2.154-build-script-run[rustc_flags])"],
     visibility = [],
 )
 
 cargo.rust_binary(
-    name = "libc-0.2.153-build-script-build",
-    srcs = [":libc-0.2.153.crate"],
+    name = "libc-0.2.154-build-script-build",
+    srcs = [":libc-0.2.154.crate"],
     crate = "build_script_build",
-    crate_root = "libc-0.2.153.crate/build.rs",
+    crate_root = "libc-0.2.154.crate/build.rs",
     edition = "2015",
     features = [
         "default",
@@ -6834,15 +6981,15 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "libc-0.2.153-build-script-run",
+    name = "libc-0.2.154-build-script-run",
     package_name = "libc",
-    buildscript_rule = ":libc-0.2.153-build-script-build",
+    buildscript_rule = ":libc-0.2.154-build-script-build",
     features = [
         "default",
         "extra_traits",
         "std",
     ],
-    version = "0.2.153",
+    version = "0.2.154",
 )
 
 http_archive(
@@ -7116,7 +7263,7 @@ cargo.rust_library(
     edition = "2015",
     visibility = [],
     deps = [
-        ":libc-0.2.153",
+        ":libc-0.2.154",
         ":libsodium-sys-0.2.7-libsodium",
     ],
 )
@@ -7397,19 +7544,19 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "lock_api-0.4.11.crate",
-    sha256 = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45",
-    strip_prefix = "lock_api-0.4.11",
-    urls = ["https://crates.io/api/v1/crates/lock_api/0.4.11/download"],
+    name = "lock_api-0.4.12.crate",
+    sha256 = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17",
+    strip_prefix = "lock_api-0.4.12",
+    urls = ["https://crates.io/api/v1/crates/lock_api/0.4.12/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "lock_api-0.4.11",
-    srcs = [":lock_api-0.4.11.crate"],
+    name = "lock_api-0.4.12",
+    srcs = [":lock_api-0.4.12.crate"],
     crate = "lock_api",
-    crate_root = "lock_api-0.4.11.crate/src/lib.rs",
-    edition = "2018",
+    crate_root = "lock_api-0.4.12.crate/src/lib.rs",
+    edition = "2021",
     features = [
         "atomic_usize",
         "default",
@@ -7490,9 +7637,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -7580,16 +7727,16 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
     },
     visibility = [],
@@ -7612,16 +7759,16 @@ cargo.rust_library(
     features = ["stable_deref_trait"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
     },
     visibility = [],
@@ -7676,8 +7823,8 @@ cargo.rust_library(
     deps = [
         ":miette-derive-5.10.0",
         ":once_cell-1.19.0",
-        ":thiserror-1.0.58",
-        ":unicode-width-0.1.11",
+        ":thiserror-1.0.59",
+        ":unicode-width-0.1.12",
     ],
 )
 
@@ -7698,9 +7845,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -7836,16 +7983,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.48.0"],
@@ -7860,47 +8007,49 @@ cargo.rust_library(
 
 alias(
     name = "moka",
-    actual = ":moka-0.12.5",
+    actual = ":moka-0.12.7",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "moka-0.12.5.crate",
-    sha256 = "b1911e88d5831f748a4097a43862d129e3c6fca831eecac9b8db6d01d93c9de2",
-    strip_prefix = "moka-0.12.5",
-    urls = ["https://crates.io/api/v1/crates/moka/0.12.5/download"],
+    name = "moka-0.12.7.crate",
+    sha256 = "9e0d88686dc561d743b40de8269b26eaf0dc58781bde087b0984646602021d08",
+    strip_prefix = "moka-0.12.7",
+    urls = ["https://crates.io/api/v1/crates/moka/0.12.7/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "moka-0.12.5",
-    srcs = [":moka-0.12.5.crate"],
+    name = "moka-0.12.7",
+    srcs = [":moka-0.12.7.crate"],
     crate = "moka",
-    crate_root = "moka-0.12.5.crate/src/lib.rs",
+    crate_root = "moka-0.12.7.crate/src/lib.rs",
     edition = "2021",
     features = [
         "async-lock",
         "async-trait",
         "atomic64",
         "default",
+        "event-listener",
         "future",
         "futures-util",
         "quanta",
     ],
     visibility = [],
     deps = [
-        ":async-lock-2.8.0",
-        ":async-trait-0.1.79",
+        ":async-lock-3.3.0",
+        ":async-trait-0.1.80",
         ":crossbeam-channel-0.5.12",
         ":crossbeam-epoch-0.9.18",
         ":crossbeam-utils-0.8.19",
+        ":event-listener-5.3.0",
         ":futures-util-0.3.30",
         ":once_cell-1.19.0",
-        ":parking_lot-0.12.1",
+        ":parking_lot-0.12.2",
         ":quanta-0.12.3",
         ":smallvec-1.13.2",
         ":tagptr-0.2.0",
-        ":thiserror-1.0.58",
+        ":thiserror-1.0.59",
         ":triomphe-0.1.11",
         ":uuid-1.8.0",
     ],
@@ -8092,7 +8241,7 @@ cargo.rust_library(
     deps = [
         ":bitflags-1.3.2",
         ":cfg-if-1.0.0",
-        ":libc-0.2.153",
+        ":libc-0.2.154",
     ],
 )
 
@@ -8125,34 +8274,33 @@ cargo.rust_library(
     deps = [
         ":bitflags-2.5.0",
         ":cfg-if-1.0.0",
-        ":libc-0.2.153",
+        ":libc-0.2.154",
     ],
 )
 
 alias(
     name = "nkeys",
-    actual = ":nkeys-0.4.0",
+    actual = ":nkeys-0.4.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "nkeys-0.4.0.crate",
-    sha256 = "6eafe79aeb8066a6f1f84dc44c03ae97403013e946bf0b13626468e0d5e26c6f",
-    strip_prefix = "nkeys-0.4.0",
-    urls = ["https://crates.io/api/v1/crates/nkeys/0.4.0/download"],
+    name = "nkeys-0.4.1.crate",
+    sha256 = "bc522a19199a0795776406619aa6aa78e1e55690fbeb3181b8db5265fd0e89ce",
+    strip_prefix = "nkeys-0.4.1",
+    urls = ["https://crates.io/api/v1/crates/nkeys/0.4.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "nkeys-0.4.0",
-    srcs = [":nkeys-0.4.0.crate"],
+    name = "nkeys-0.4.1",
+    srcs = [":nkeys-0.4.1.crate"],
     crate = "nkeys",
-    crate_root = "nkeys-0.4.0.crate/src/lib.rs",
+    crate_root = "nkeys-0.4.1.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [
-        ":byteorder-1.5.0",
-        ":data-encoding-2.5.0",
+        ":data-encoding-2.6.0",
         ":ed25519-2.2.3",
         ":ed25519-dalek-2.1.1",
         ":log-0.4.21",
@@ -8488,16 +8636,16 @@ cargo.rust_library(
     edition = "2015",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
     },
     visibility = [],
@@ -8622,26 +8770,26 @@ cargo.rust_library(
         "linux-arm64": dict(
             deps = [
                 ":is-wsl-0.4.0",
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":pathdiff-0.2.1",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
                 ":is-wsl-0.4.0",
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":pathdiff-0.2.1",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":pathdiff-0.2.1",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":pathdiff-0.2.1",
             ],
         ),
@@ -8698,7 +8846,7 @@ cargo.rust_library(
         ":futures-sink-0.3.30",
         ":once_cell-1.19.0",
         ":pin-project-lite-0.2.14",
-        ":thiserror-1.0.58",
+        ":thiserror-1.0.59",
         ":urlencoding-2.1.3",
     ],
 )
@@ -8745,7 +8893,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.79",
+        ":async-trait-0.1.80",
         ":futures-core-0.3.30",
         ":http-0.2.12",
         ":opentelemetry-0.22.0",
@@ -8753,7 +8901,7 @@ cargo.rust_library(
         ":opentelemetry-semantic-conventions-0.14.0",
         ":opentelemetry_sdk-0.22.1",
         ":prost-0.12.4",
-        ":thiserror-1.0.58",
+        ":thiserror-1.0.59",
         ":tokio-1.37.0",
         ":tonic-0.11.0",
     ],
@@ -8858,7 +9006,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.79",
+        ":async-trait-0.1.80",
         ":crossbeam-channel-0.5.12",
         ":futures-channel-0.3.30",
         ":futures-executor-0.3.30",
@@ -8869,7 +9017,7 @@ cargo.rust_library(
         ":ordered-float-4.2.0",
         ":percent-encoding-2.3.1",
         ":rand-0.8.5",
-        ":thiserror-1.0.58",
+        ":thiserror-1.0.59",
         ":tokio-1.37.0",
         ":tokio-stream-0.1.15",
     ],
@@ -9052,9 +9200,9 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro-error-1.0.4",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -9078,10 +9226,10 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":itertools-0.12.1",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":proc-macro2-diagnostics-0.10.1",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -9214,59 +9362,59 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "parking_lot-0.12.1.crate",
-    sha256 = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f",
-    strip_prefix = "parking_lot-0.12.1",
-    urls = ["https://crates.io/api/v1/crates/parking_lot/0.12.1/download"],
+    name = "parking_lot-0.12.2.crate",
+    sha256 = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb",
+    strip_prefix = "parking_lot-0.12.2",
+    urls = ["https://crates.io/api/v1/crates/parking_lot/0.12.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "parking_lot-0.12.1",
-    srcs = [":parking_lot-0.12.1.crate"],
+    name = "parking_lot-0.12.2",
+    srcs = [":parking_lot-0.12.2.crate"],
     crate = "parking_lot",
-    crate_root = "parking_lot-0.12.1.crate/src/lib.rs",
-    edition = "2018",
+    crate_root = "parking_lot-0.12.2.crate/src/lib.rs",
+    edition = "2021",
     features = ["default"],
     visibility = [],
     deps = [
-        ":lock_api-0.4.11",
-        ":parking_lot_core-0.9.9",
+        ":lock_api-0.4.12",
+        ":parking_lot_core-0.9.10",
     ],
 )
 
 http_archive(
-    name = "parking_lot_core-0.9.9.crate",
-    sha256 = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e",
-    strip_prefix = "parking_lot_core-0.9.9",
-    urls = ["https://crates.io/api/v1/crates/parking_lot_core/0.9.9/download"],
+    name = "parking_lot_core-0.9.10.crate",
+    sha256 = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8",
+    strip_prefix = "parking_lot_core-0.9.10",
+    urls = ["https://crates.io/api/v1/crates/parking_lot_core/0.9.10/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "parking_lot_core-0.9.9",
-    srcs = [":parking_lot_core-0.9.9.crate"],
+    name = "parking_lot_core-0.9.10",
+    srcs = [":parking_lot_core-0.9.10.crate"],
     crate = "parking_lot_core",
-    crate_root = "parking_lot_core-0.9.9.crate/src/lib.rs",
-    edition = "2018",
+    crate_root = "parking_lot_core-0.9.10.crate/src/lib.rs",
+    edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "windows-gnu": dict(
-            deps = [":windows-targets-0.48.5"],
+            deps = [":windows-targets-0.52.5"],
         ),
         "windows-msvc": dict(
-            deps = [":windows-targets-0.48.5"],
+            deps = [":windows-targets-0.52.5"],
         ),
     },
     visibility = [],
@@ -9343,8 +9491,8 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":base64-0.22.0",
-        ":serde-1.0.197",
+        ":base64-0.22.1",
+        ":serde-1.0.200",
     ],
 )
 
@@ -9422,8 +9570,8 @@ cargo.rust_library(
     deps = [
         ":fixedbitset-0.4.2",
         ":indexmap-2.2.6",
-        ":serde-1.0.197",
-        ":serde_derive-1.0.197",
+        ":serde-1.0.200",
+        ":serde_derive-1.0.200",
     ],
 )
 
@@ -9521,7 +9669,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
         ":syn-1.0.109",
     ],
@@ -9544,9 +9692,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -9775,18 +9923,18 @@ cargo.rust_library(
         ":base64-0.13.1",
         ":byteorder-1.5.0",
         ":bytes-1.6.0",
-        ":chrono-0.4.37",
+        ":chrono-0.4.38",
         ":containers-api-0.8.0",
-        ":flate2-1.0.28",
+        ":flate2-1.0.30",
         ":futures-util-0.3.30",
         ":futures_codec-0.4.1",
         ":log-0.4.21",
         ":paste-1.0.14",
         ":podman-api-stubs-0.9.0",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
         ":tar-0.4.40",
-        ":thiserror-1.0.58",
+        ":thiserror-1.0.59",
         ":tokio-1.37.0",
         ":url-2.5.0",
     ],
@@ -9808,9 +9956,9 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":chrono-0.4.37",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":chrono-0.4.38",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
     ],
 )
 
@@ -9915,7 +10063,7 @@ cargo.rust_library(
         ":cobs-0.2.3",
         ":embedded-io-0.4.0",
         ":heapless-0.7.17",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -9937,9 +10085,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -10003,9 +10151,9 @@ cargo.rust_library(
         "with-serde_json-1",
     ],
     named_deps = {
-        "chrono_04": ":chrono-0.4.37",
-        "serde_1": ":serde-1.0.197",
-        "serde_json_1": ":serde_json-1.0.115",
+        "chrono_04": ":chrono-0.4.38",
+        "serde_1": ":serde-1.0.200",
+        "serde_json_1": ":serde_json-1.0.116",
     },
     visibility = [],
     deps = [
@@ -10147,7 +10295,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro-error-attr-1.0.4",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
         ":syn-1.0.109",
     ],
@@ -10197,45 +10345,45 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
     ],
 )
 
 alias(
     name = "proc-macro2",
-    actual = ":proc-macro2-1.0.79",
+    actual = ":proc-macro2-1.0.81",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "proc-macro2-1.0.79.crate",
-    sha256 = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e",
-    strip_prefix = "proc-macro2-1.0.79",
-    urls = ["https://crates.io/api/v1/crates/proc-macro2/1.0.79/download"],
+    name = "proc-macro2-1.0.81.crate",
+    sha256 = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba",
+    strip_prefix = "proc-macro2-1.0.81",
+    urls = ["https://crates.io/api/v1/crates/proc-macro2/1.0.81/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "proc-macro2-1.0.79",
-    srcs = [":proc-macro2-1.0.79.crate"],
+    name = "proc-macro2-1.0.81",
+    srcs = [":proc-macro2-1.0.81.crate"],
     crate = "proc_macro2",
-    crate_root = "proc-macro2-1.0.79.crate/src/lib.rs",
+    crate_root = "proc-macro2-1.0.81.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
         "proc-macro",
     ],
-    rustc_flags = ["@$(location :proc-macro2-1.0.79-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :proc-macro2-1.0.81-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [":unicode-ident-1.0.12"],
 )
 
 cargo.rust_binary(
-    name = "proc-macro2-1.0.79-build-script-build",
-    srcs = [":proc-macro2-1.0.79.crate"],
+    name = "proc-macro2-1.0.81-build-script-build",
+    srcs = [":proc-macro2-1.0.81.crate"],
     crate = "build_script_build",
-    crate_root = "proc-macro2-1.0.79.crate/build.rs",
+    crate_root = "proc-macro2-1.0.81.crate/build.rs",
     edition = "2021",
     features = [
         "default",
@@ -10245,14 +10393,14 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "proc-macro2-1.0.79-build-script-run",
+    name = "proc-macro2-1.0.81-build-script-run",
     package_name = "proc-macro2",
-    buildscript_rule = ":proc-macro2-1.0.79-build-script-build",
+    buildscript_rule = ":proc-macro2-1.0.81-build-script-build",
     features = [
         "default",
         "proc-macro",
     ],
-    version = "1.0.79",
+    version = "1.0.81",
 )
 
 http_archive(
@@ -10276,9 +10424,9 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
         ":yansi-1.0.1",
     ],
 )
@@ -10328,9 +10476,9 @@ cargo.rust_library(
     deps = [
         ":anyhow-1.0.82",
         ":itertools-0.12.1",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -10354,32 +10502,32 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.153",
-                ":raw-cpuid-11.0.1",
+                ":libc-0.2.154",
+                ":raw-cpuid-11.0.2",
             ],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.153",
-                ":raw-cpuid-11.0.1",
+                ":libc-0.2.154",
+                ":raw-cpuid-11.0.2",
             ],
         ),
         "windows-gnu": dict(
             deps = [
-                ":raw-cpuid-11.0.1",
+                ":raw-cpuid-11.0.2",
                 ":winapi-0.3.9",
             ],
         ),
         "windows-msvc": dict(
             deps = [
-                ":raw-cpuid-11.0.1",
+                ":raw-cpuid-11.0.2",
                 ":winapi-0.3.9",
             ],
         ),
@@ -10413,7 +10561,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":memchr-2.7.2",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -10442,7 +10590,7 @@ cargo.rust_library(
         "proc-macro",
     ],
     visibility = [],
-    deps = [":proc-macro2-1.0.79"],
+    deps = [":proc-macro2-1.0.81"],
 )
 
 http_archive(
@@ -10474,25 +10622,25 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":rand_chacha-0.2.2",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":rand_chacha-0.2.2",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":rand_chacha-0.2.2",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":rand_chacha-0.2.2",
             ],
         ),
@@ -10539,16 +10687,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
     },
     visibility = [],
@@ -10649,18 +10797,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "raw-cpuid-11.0.1.crate",
-    sha256 = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1",
-    strip_prefix = "raw-cpuid-11.0.1",
-    urls = ["https://crates.io/api/v1/crates/raw-cpuid/11.0.1/download"],
+    name = "raw-cpuid-11.0.2.crate",
+    sha256 = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd",
+    strip_prefix = "raw-cpuid-11.0.2",
+    urls = ["https://crates.io/api/v1/crates/raw-cpuid/11.0.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "raw-cpuid-11.0.1",
-    srcs = [":raw-cpuid-11.0.1.crate"],
+    name = "raw-cpuid-11.0.2",
+    srcs = [":raw-cpuid-11.0.2.crate"],
     crate = "raw_cpuid",
-    crate_root = "raw-cpuid-11.0.1.crate/src/lib.rs",
+    crate_root = "raw-cpuid-11.0.2.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
     deps = [":bitflags-2.5.0"],
@@ -10682,7 +10830,7 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":either-1.10.0",
+        ":either-1.11.0",
         ":rayon-core-1.12.1",
     ],
 )
@@ -10760,13 +10908,13 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.79",
+        ":async-trait-0.1.80",
         ":cfg-if-1.0.0",
         ":log-0.4.21",
         ":regex-1.10.4",
         ":siphasher-1.0.1",
-        ":thiserror-1.0.58",
-        ":time-0.3.35",
+        ":thiserror-1.0.59",
+        ":time-0.3.36",
         ":tokio-1.37.0",
         ":tokio-postgres-0.7.10",
         ":url-2.5.0",
@@ -10792,40 +10940,40 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
         ":refinery-core-0.8.14",
         ":regex-1.10.4",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
 http_archive(
-    name = "reflink-copy-0.1.15.crate",
-    sha256 = "52b1349400e2ffd64a9fb5ed9008e33c0b8ef86bd5bae8f73080839c7082f1d5",
-    strip_prefix = "reflink-copy-0.1.15",
-    urls = ["https://crates.io/api/v1/crates/reflink-copy/0.1.15/download"],
+    name = "reflink-copy-0.1.17.crate",
+    sha256 = "7c3138c30c59ed9b8572f82bed97ea591ecd7e45012566046cc39e72679cff22",
+    strip_prefix = "reflink-copy-0.1.17",
+    urls = ["https://crates.io/api/v1/crates/reflink-copy/0.1.17/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "reflink-copy-0.1.15",
-    srcs = [":reflink-copy-0.1.15.crate"],
+    name = "reflink-copy-0.1.17",
+    srcs = [":reflink-copy-0.1.17.crate"],
     crate = "reflink_copy",
-    crate_root = "reflink-copy-0.1.15.crate/src/lib.rs",
+    crate_root = "reflink-copy-0.1.17.crate/src/lib.rs",
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":rustix-0.38.32"],
+            deps = [":rustix-0.38.34"],
         ),
         "linux-x86_64": dict(
-            deps = [":rustix-0.38.32"],
+            deps = [":rustix-0.38.34"],
         ),
         "windows-gnu": dict(
-            deps = [":windows-0.54.0"],
+            deps = [":windows-0.56.0"],
         ),
         "windows-msvc": dict(
-            deps = [":windows-0.54.0"],
+            deps = [":windows-0.56.0"],
         ),
     },
     visibility = [],
@@ -11031,31 +11179,31 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
 alias(
     name = "reqwest",
-    actual = ":reqwest-0.12.3",
+    actual = ":reqwest-0.12.4",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "reqwest-0.12.3.crate",
-    sha256 = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19",
-    strip_prefix = "reqwest-0.12.3",
-    urls = ["https://crates.io/api/v1/crates/reqwest/0.12.3/download"],
+    name = "reqwest-0.12.4.crate",
+    sha256 = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10",
+    strip_prefix = "reqwest-0.12.4",
+    urls = ["https://crates.io/api/v1/crates/reqwest/0.12.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "reqwest-0.12.3",
-    srcs = [":reqwest-0.12.3.crate"],
+    name = "reqwest-0.12.4",
+    srcs = [":reqwest-0.12.4.crate"],
     crate = "reqwest",
-    crate_root = "reqwest-0.12.3.crate/src/lib.rs",
+    crate_root = "reqwest-0.12.4.crate/src/lib.rs",
     edition = "2021",
     features = [
         "__rustls",
@@ -11071,7 +11219,7 @@ cargo.rust_library(
             deps = [
                 ":http-body-1.0.0",
                 ":http-body-util-0.1.1",
-                ":hyper-1.2.0",
+                ":hyper-1.3.1",
                 ":hyper-rustls-0.26.0",
                 ":hyper-util-0.1.3",
                 ":ipnet-2.9.0",
@@ -11080,9 +11228,9 @@ cargo.rust_library(
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
-                ":rustls-0.22.3",
+                ":rustls-0.22.4",
                 ":rustls-pemfile-2.1.2",
-                ":rustls-pki-types-1.4.1",
+                ":rustls-pki-types-1.5.0",
                 ":tokio-1.37.0",
                 ":tokio-rustls-0.25.0",
                 ":webpki-roots-0.26.1",
@@ -11092,7 +11240,7 @@ cargo.rust_library(
             deps = [
                 ":http-body-1.0.0",
                 ":http-body-util-0.1.1",
-                ":hyper-1.2.0",
+                ":hyper-1.3.1",
                 ":hyper-rustls-0.26.0",
                 ":hyper-util-0.1.3",
                 ":ipnet-2.9.0",
@@ -11101,9 +11249,9 @@ cargo.rust_library(
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
-                ":rustls-0.22.3",
+                ":rustls-0.22.4",
                 ":rustls-pemfile-2.1.2",
-                ":rustls-pki-types-1.4.1",
+                ":rustls-pki-types-1.5.0",
                 ":tokio-1.37.0",
                 ":tokio-rustls-0.25.0",
                 ":webpki-roots-0.26.1",
@@ -11113,7 +11261,7 @@ cargo.rust_library(
             deps = [
                 ":http-body-1.0.0",
                 ":http-body-util-0.1.1",
-                ":hyper-1.2.0",
+                ":hyper-1.3.1",
                 ":hyper-rustls-0.26.0",
                 ":hyper-util-0.1.3",
                 ":ipnet-2.9.0",
@@ -11122,9 +11270,9 @@ cargo.rust_library(
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
-                ":rustls-0.22.3",
+                ":rustls-0.22.4",
                 ":rustls-pemfile-2.1.2",
-                ":rustls-pki-types-1.4.1",
+                ":rustls-pki-types-1.5.0",
                 ":tokio-1.37.0",
                 ":tokio-rustls-0.25.0",
                 ":webpki-roots-0.26.1",
@@ -11134,7 +11282,7 @@ cargo.rust_library(
             deps = [
                 ":http-body-1.0.0",
                 ":http-body-util-0.1.1",
-                ":hyper-1.2.0",
+                ":hyper-1.3.1",
                 ":hyper-rustls-0.26.0",
                 ":hyper-util-0.1.3",
                 ":ipnet-2.9.0",
@@ -11143,9 +11291,9 @@ cargo.rust_library(
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
-                ":rustls-0.22.3",
+                ":rustls-0.22.4",
                 ":rustls-pemfile-2.1.2",
-                ":rustls-pki-types-1.4.1",
+                ":rustls-pki-types-1.5.0",
                 ":tokio-1.37.0",
                 ":tokio-rustls-0.25.0",
                 ":webpki-roots-0.26.1",
@@ -11155,7 +11303,7 @@ cargo.rust_library(
             deps = [
                 ":http-body-1.0.0",
                 ":http-body-util-0.1.1",
-                ":hyper-1.2.0",
+                ":hyper-1.3.1",
                 ":hyper-rustls-0.26.0",
                 ":hyper-util-0.1.3",
                 ":ipnet-2.9.0",
@@ -11164,9 +11312,9 @@ cargo.rust_library(
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
-                ":rustls-0.22.3",
+                ":rustls-0.22.4",
                 ":rustls-pemfile-2.1.2",
-                ":rustls-pki-types-1.4.1",
+                ":rustls-pki-types-1.5.0",
                 ":tokio-1.37.0",
                 ":tokio-rustls-0.25.0",
                 ":webpki-roots-0.26.1",
@@ -11177,7 +11325,7 @@ cargo.rust_library(
             deps = [
                 ":http-body-1.0.0",
                 ":http-body-util-0.1.1",
-                ":hyper-1.2.0",
+                ":hyper-1.3.1",
                 ":hyper-rustls-0.26.0",
                 ":hyper-util-0.1.3",
                 ":ipnet-2.9.0",
@@ -11186,9 +11334,9 @@ cargo.rust_library(
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
-                ":rustls-0.22.3",
+                ":rustls-0.22.4",
                 ":rustls-pemfile-2.1.2",
-                ":rustls-pki-types-1.4.1",
+                ":rustls-pki-types-1.5.0",
                 ":tokio-1.37.0",
                 ":tokio-rustls-0.25.0",
                 ":webpki-roots-0.26.1",
@@ -11198,14 +11346,14 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":base64-0.22.0",
+        ":base64-0.22.1",
         ":bytes-1.6.0",
         ":futures-core-0.3.30",
         ":futures-util-0.3.30",
         ":http-1.1.0",
         ":mime_guess-2.0.4",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
         ":serde_urlencoded-0.7.1",
         ":sync_wrapper-0.1.2",
         ":tower-service-0.3.2",
@@ -11382,7 +11530,7 @@ cargo.rust_library(
                 "RING_CORE_PREFIX": "ring_core_0_17_5_",
             },
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":ring-0.17.5-ring-c-asm-elf-aarch64",
                 ":ring-0.17.5-ring-c-asm-elf-aarch64",
                 ":spin-0.9.8",
@@ -11393,7 +11541,7 @@ cargo.rust_library(
                 "RING_CORE_PREFIX": "ring_core_0_17_5_",
             },
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":ring-0.17.5-ring-c-asm-elf-x86_84",
                 ":ring-0.17.5-ring-c-asm-elf-x86_84",
                 ":spin-0.9.8",
@@ -12054,7 +12202,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.79",
+        ":async-trait-0.1.80",
         ":aws-creds-0.36.0",
         ":aws-region-0.25.4",
         ":base64-0.21.7",
@@ -12071,14 +12219,14 @@ cargo.rust_library(
         ":md5-0.7.0",
         ":percent-encoding-2.3.1",
         ":quick-xml-0.30.0",
-        ":rustls-0.21.10",
+        ":rustls-0.21.12",
         ":rustls-native-certs-0.6.3",
-        ":serde-1.0.197",
-        ":serde_derive-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_derive-1.0.200",
+        ":serde_json-1.0.116",
         ":sha2-0.10.8",
-        ":thiserror-1.0.58",
-        ":time-0.3.35",
+        ":thiserror-1.0.59",
+        ":time-0.3.36",
         ":tokio-1.37.0",
         ":tokio-rustls-0.24.1",
         ":tokio-stream-0.1.15",
@@ -12113,7 +12261,7 @@ cargo.rust_library(
     deps = [
         ":arrayvec-0.7.4",
         ":num-traits-0.2.18",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -12181,23 +12329,24 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "rustix-0.38.32.crate",
-    sha256 = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89",
-    strip_prefix = "rustix-0.38.32",
-    urls = ["https://crates.io/api/v1/crates/rustix/0.38.32/download"],
+    name = "rustix-0.38.34.crate",
+    sha256 = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f",
+    strip_prefix = "rustix-0.38.34",
+    urls = ["https://crates.io/api/v1/crates/rustix/0.38.34/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustix-0.38.32",
-    srcs = [":rustix-0.38.32.crate"],
+    name = "rustix-0.38.34",
+    srcs = [":rustix-0.38.34.crate"],
     crate = "rustix",
-    crate_root = "rustix-0.38.32.crate/src/lib.rs",
+    crate_root = "rustix-0.38.34.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
         "default",
         "fs",
+        "libc-extra-traits",
         "std",
         "termios",
         "use-libc-auxv",
@@ -12208,7 +12357,7 @@ cargo.rust_library(
                 "libc_errno": ":errno-0.3.8",
             },
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":linux-raw-sys-0.4.13",
             ],
         ),
@@ -12217,7 +12366,7 @@ cargo.rust_library(
                 "libc_errno": ":errno-0.3.8",
             },
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":linux-raw-sys-0.4.13",
             ],
         ),
@@ -12225,13 +12374,13 @@ cargo.rust_library(
             named_deps = {
                 "libc_errno": ":errno-0.3.8",
             },
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
             named_deps = {
                 "libc_errno": ":errno-0.3.8",
             },
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "windows-gnu": dict(
             named_deps = {
@@ -12246,21 +12395,22 @@ cargo.rust_library(
             deps = [":windows-sys-0.52.0"],
         ),
     },
-    rustc_flags = ["@$(location :rustix-0.38.32-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :rustix-0.38.34-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [":bitflags-2.5.0"],
 )
 
 cargo.rust_binary(
-    name = "rustix-0.38.32-build-script-build",
-    srcs = [":rustix-0.38.32.crate"],
+    name = "rustix-0.38.34-build-script-build",
+    srcs = [":rustix-0.38.34.crate"],
     crate = "build_script_build",
-    crate_root = "rustix-0.38.32.crate/build.rs",
+    crate_root = "rustix-0.38.34.crate/build.rs",
     edition = "2021",
     features = [
         "alloc",
         "default",
         "fs",
+        "libc-extra-traits",
         "std",
         "termios",
         "use-libc-auxv",
@@ -12269,33 +12419,34 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "rustix-0.38.32-build-script-run",
+    name = "rustix-0.38.34-build-script-run",
     package_name = "rustix",
-    buildscript_rule = ":rustix-0.38.32-build-script-build",
+    buildscript_rule = ":rustix-0.38.34-build-script-build",
     features = [
         "alloc",
         "default",
         "fs",
+        "libc-extra-traits",
         "std",
         "termios",
         "use-libc-auxv",
     ],
-    version = "0.38.32",
+    version = "0.38.34",
 )
 
 http_archive(
-    name = "rustls-0.21.10.crate",
-    sha256 = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba",
-    strip_prefix = "rustls-0.21.10",
-    urls = ["https://crates.io/api/v1/crates/rustls/0.21.10/download"],
+    name = "rustls-0.21.12.crate",
+    sha256 = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e",
+    strip_prefix = "rustls-0.21.12",
+    urls = ["https://crates.io/api/v1/crates/rustls/0.21.12/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-0.21.10",
-    srcs = [":rustls-0.21.10.crate"],
+    name = "rustls-0.21.12",
+    srcs = [":rustls-0.21.12.crate"],
     crate = "rustls",
-    crate_root = "rustls-0.21.10.crate/src/lib.rs",
+    crate_root = "rustls-0.21.12.crate/src/lib.rs",
     edition = "2021",
     features = [
         "dangerous_configuration",
@@ -12315,23 +12466,23 @@ cargo.rust_library(
 
 alias(
     name = "rustls",
-    actual = ":rustls-0.22.3",
+    actual = ":rustls-0.22.4",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "rustls-0.22.3.crate",
-    sha256 = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c",
-    strip_prefix = "rustls-0.22.3",
-    urls = ["https://crates.io/api/v1/crates/rustls/0.22.3/download"],
+    name = "rustls-0.22.4.crate",
+    sha256 = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432",
+    strip_prefix = "rustls-0.22.4",
+    urls = ["https://crates.io/api/v1/crates/rustls/0.22.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-0.22.3",
-    srcs = [":rustls-0.22.3.crate"],
+    name = "rustls-0.22.4",
+    srcs = [":rustls-0.22.4.crate"],
     crate = "rustls",
-    crate_root = "rustls-0.22.3.crate/src/lib.rs",
+    crate_root = "rustls-0.22.4.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -12341,13 +12492,13 @@ cargo.rust_library(
         "tls12",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.4.1",
+        "pki_types": ":rustls-pki-types-1.5.0",
     },
     visibility = [],
     deps = [
         ":log-0.4.21",
         ":ring-0.17.5",
-        ":rustls-webpki-0.102.2",
+        ":rustls-webpki-0.102.3",
         ":subtle-2.5.0",
         ":zeroize-1.7.0",
     ],
@@ -12406,7 +12557,7 @@ cargo.rust_library(
     crate_root = "rustls-native-certs-0.7.0.crate/src/lib.rs",
     edition = "2021",
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.4.1",
+        "pki_types": ":rustls-pki-types-1.5.0",
     },
     platform = {
         "linux-arm64": dict(
@@ -12475,25 +12626,25 @@ cargo.rust_library(
         "std",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.4.1",
+        "pki_types": ":rustls-pki-types-1.5.0",
     },
     visibility = [],
-    deps = [":base64-0.22.0"],
+    deps = [":base64-0.22.1"],
 )
 
 http_archive(
-    name = "rustls-pki-types-1.4.1.crate",
-    sha256 = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247",
-    strip_prefix = "rustls-pki-types-1.4.1",
-    urls = ["https://crates.io/api/v1/crates/rustls-pki-types/1.4.1/download"],
+    name = "rustls-pki-types-1.5.0.crate",
+    sha256 = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54",
+    strip_prefix = "rustls-pki-types-1.5.0",
+    urls = ["https://crates.io/api/v1/crates/rustls-pki-types/1.5.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-pki-types-1.4.1",
-    srcs = [":rustls-pki-types-1.4.1.crate"],
+    name = "rustls-pki-types-1.5.0",
+    srcs = [":rustls-pki-types-1.5.0.crate"],
     crate = "rustls_pki_types",
-    crate_root = "rustls-pki-types-1.4.1.crate/src/lib.rs",
+    crate_root = "rustls-pki-types-1.5.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -12530,18 +12681,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "rustls-webpki-0.102.2.crate",
-    sha256 = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610",
-    strip_prefix = "rustls-webpki-0.102.2",
-    urls = ["https://crates.io/api/v1/crates/rustls-webpki/0.102.2/download"],
+    name = "rustls-webpki-0.102.3.crate",
+    sha256 = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf",
+    strip_prefix = "rustls-webpki-0.102.3",
+    urls = ["https://crates.io/api/v1/crates/rustls-webpki/0.102.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-webpki-0.102.2",
-    srcs = [":rustls-webpki-0.102.2.crate"],
+    name = "rustls-webpki-0.102.3",
+    srcs = [":rustls-webpki-0.102.3.crate"],
     crate = "webpki",
-    crate_root = "rustls-webpki-0.102.2.crate/src/lib.rs",
+    crate_root = "rustls-webpki-0.102.3.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -12550,7 +12701,7 @@ cargo.rust_library(
         "std",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.4.1",
+        "pki_types": ":rustls-pki-types-1.5.0",
     },
     visibility = [],
     deps = [
@@ -12629,10 +12780,10 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "windows-gnu": dict(
-            deps = [":winapi-util-0.1.6"],
+            deps = [":winapi-util-0.1.8"],
         ),
         "windows-msvc": dict(
-            deps = [":winapi-util-0.1.6"],
+            deps = [":winapi-util-0.1.8"],
         ),
     },
     visibility = [],
@@ -12713,9 +12864,9 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro-error-1.0.4",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -12766,9 +12917,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-stream-0.3.5",
-        ":async-trait-0.1.79",
+        ":async-trait-0.1.80",
         ":bigdecimal-0.3.1",
-        ":chrono-0.4.37",
+        ":chrono-0.4.38",
         ":futures-0.3.30",
         ":log-0.4.21",
         ":ouroboros-0.17.2",
@@ -12776,12 +12927,12 @@ cargo.rust_library(
         ":sea-orm-macros-0.12.15",
         ":sea-query-0.30.7",
         ":sea-query-binder-0.5.0",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
         ":sqlx-0.7.4",
         ":strum-0.25.0",
-        ":thiserror-1.0.58",
-        ":time-0.3.35",
+        ":thiserror-1.0.59",
+        ":time-0.3.36",
         ":tracing-0.1.40",
         ":url-2.5.0",
         ":uuid-1.8.0",
@@ -12815,9 +12966,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
         ":unicode-ident-1.0.12",
     ],
 )
@@ -12861,13 +13012,13 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bigdecimal-0.3.1",
-        ":chrono-0.4.37",
+        ":chrono-0.4.38",
         ":derivative-2.2.0",
         ":inherent-1.0.11",
         ":ordered-float-3.9.2",
         ":rust_decimal-1.35.0",
-        ":serde_json-1.0.115",
-        ":time-0.3.35",
+        ":serde_json-1.0.116",
+        ":time-0.3.36",
         ":uuid-1.8.0",
     ],
 )
@@ -12907,12 +13058,12 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bigdecimal-0.3.1",
-        ":chrono-0.4.37",
+        ":chrono-0.4.38",
         ":rust_decimal-1.35.0",
         ":sea-query-0.30.7",
-        ":serde_json-1.0.115",
+        ":serde_json-1.0.116",
         ":sqlx-0.7.4",
-        ":time-0.3.35",
+        ":time-0.3.36",
         ":uuid-1.8.0",
     ],
 )
@@ -12978,7 +13129,7 @@ cargo.rust_library(
         ":bitflags-1.3.2",
         ":core-foundation-0.9.4",
         ":core-foundation-sys-0.8.6",
-        ":libc-0.2.153",
+        ":libc-0.2.154",
         ":security-framework-sys-2.10.0",
     ],
 )
@@ -13005,7 +13156,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":core-foundation-sys-0.8.6",
-        ":libc-0.2.153",
+        ":libc-0.2.154",
     ],
 )
 
@@ -13074,12 +13225,10 @@ cargo.rust_library(
     },
     features = [
         "default",
-        "serde",
         "std",
     ],
     rustc_flags = ["@$(location :semver-1.0.22-build-script-run[rustc_flags])"],
     visibility = [],
-    deps = [":serde-1.0.197"],
 )
 
 cargo.rust_binary(
@@ -13101,7 +13250,6 @@ cargo.rust_binary(
     },
     features = [
         "default",
-        "serde",
         "std",
     ],
     visibility = [],
@@ -13113,7 +13261,6 @@ buildscript_run(
     buildscript_rule = ":semver-1.0.22-build-script-build",
     features = [
         "default",
-        "serde",
         "std",
     ],
     version = "1.0.22",
@@ -13121,23 +13268,23 @@ buildscript_run(
 
 alias(
     name = "serde",
-    actual = ":serde-1.0.197",
+    actual = ":serde-1.0.200",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde-1.0.197.crate",
-    sha256 = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2",
-    strip_prefix = "serde-1.0.197",
-    urls = ["https://crates.io/api/v1/crates/serde/1.0.197/download"],
+    name = "serde-1.0.200.crate",
+    sha256 = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f",
+    strip_prefix = "serde-1.0.200",
+    urls = ["https://crates.io/api/v1/crates/serde/1.0.200/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde-1.0.197",
-    srcs = [":serde-1.0.197.crate"],
+    name = "serde-1.0.200",
+    srcs = [":serde-1.0.200.crate"],
     crate = "serde",
-    crate_root = "serde-1.0.197.crate/src/lib.rs",
+    crate_root = "serde-1.0.200.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -13148,7 +13295,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde_derive-1.0.197"],
+    deps = [":serde_derive-1.0.200"],
 )
 
 alias(
@@ -13177,55 +13324,55 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":chrono-0.4.37",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":chrono-0.4.38",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
     ],
 )
 
 http_archive(
-    name = "serde_derive-1.0.197.crate",
-    sha256 = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b",
-    strip_prefix = "serde_derive-1.0.197",
-    urls = ["https://crates.io/api/v1/crates/serde_derive/1.0.197/download"],
+    name = "serde_derive-1.0.200.crate",
+    sha256 = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb",
+    strip_prefix = "serde_derive-1.0.200",
+    urls = ["https://crates.io/api/v1/crates/serde_derive/1.0.200/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_derive-1.0.197",
-    srcs = [":serde_derive-1.0.197.crate"],
+    name = "serde_derive-1.0.200",
+    srcs = [":serde_derive-1.0.200.crate"],
     crate = "serde_derive",
-    crate_root = "serde_derive-1.0.197.crate/src/lib.rs",
+    crate_root = "serde_derive-1.0.200.crate/src/lib.rs",
     edition = "2015",
     features = ["default"],
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
 alias(
     name = "serde_json",
-    actual = ":serde_json-1.0.115",
+    actual = ":serde_json-1.0.116",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde_json-1.0.115.crate",
-    sha256 = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd",
-    strip_prefix = "serde_json-1.0.115",
-    urls = ["https://crates.io/api/v1/crates/serde_json/1.0.115/download"],
+    name = "serde_json-1.0.116.crate",
+    sha256 = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813",
+    strip_prefix = "serde_json-1.0.116",
+    urls = ["https://crates.io/api/v1/crates/serde_json/1.0.116/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_json-1.0.115",
-    srcs = [":serde_json-1.0.115.crate"],
+    name = "serde_json-1.0.116",
+    srcs = [":serde_json-1.0.116.crate"],
     crate = "serde_json",
-    crate_root = "serde_json-1.0.115.crate/src/lib.rs",
+    crate_root = "serde_json-1.0.116.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -13234,14 +13381,13 @@ cargo.rust_library(
         "preserve_order",
         "raw_value",
         "std",
-        "unbounded_depth",
     ],
     visibility = [],
     deps = [
         ":indexmap-2.2.6",
         ":itoa-1.0.11",
         ":ryu-1.0.17",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -13260,7 +13406,7 @@ cargo.rust_library(
     crate_root = "serde_nanos-0.1.4.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":serde-1.0.197"],
+    deps = [":serde-1.0.200"],
 )
 
 http_archive(
@@ -13280,7 +13426,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":itoa-1.0.11",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -13301,9 +13447,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -13323,7 +13469,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["serde"],
     visibility = [],
-    deps = [":serde-1.0.197"],
+    deps = [":serde-1.0.200"],
 )
 
 alias(
@@ -13348,7 +13494,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":serde-1.0.197",
+        ":serde-1.0.200",
         ":url-2.5.0",
     ],
 )
@@ -13372,29 +13518,29 @@ cargo.rust_library(
         ":form_urlencoded-1.2.1",
         ":itoa-1.0.11",
         ":ryu-1.0.17",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
 alias(
     name = "serde_with",
-    actual = ":serde_with-3.7.0",
+    actual = ":serde_with-3.8.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde_with-3.7.0.crate",
-    sha256 = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a",
-    strip_prefix = "serde_with-3.7.0",
-    urls = ["https://crates.io/api/v1/crates/serde_with/3.7.0/download"],
+    name = "serde_with-3.8.1.crate",
+    sha256 = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20",
+    strip_prefix = "serde_with-3.8.1",
+    urls = ["https://crates.io/api/v1/crates/serde_with/3.8.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_with-3.7.0",
-    srcs = [":serde_with-3.7.0.crate"],
+    name = "serde_with-3.8.1",
+    srcs = [":serde_with-3.8.1.crate"],
     crate = "serde_with",
-    crate_root = "serde_with-3.7.0.crate/src/lib.rs",
+    crate_root = "serde_with-3.8.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -13403,43 +13549,43 @@ cargo.rust_library(
         "std",
     ],
     named_deps = {
-        "chrono_0_4": ":chrono-0.4.37",
+        "chrono_0_4": ":chrono-0.4.38",
         "indexmap_1": ":indexmap-1.9.3",
         "indexmap_2": ":indexmap-2.2.6",
-        "time_0_3": ":time-0.3.35",
+        "time_0_3": ":time-0.3.36",
     },
     visibility = [],
     deps = [
-        ":base64-0.21.7",
+        ":base64-0.22.1",
         ":hex-0.4.3",
-        ":serde-1.0.197",
-        ":serde_derive-1.0.197",
-        ":serde_json-1.0.115",
-        ":serde_with_macros-3.7.0",
+        ":serde-1.0.200",
+        ":serde_derive-1.0.200",
+        ":serde_json-1.0.116",
+        ":serde_with_macros-3.8.1",
     ],
 )
 
 http_archive(
-    name = "serde_with_macros-3.7.0.crate",
-    sha256 = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655",
-    strip_prefix = "serde_with_macros-3.7.0",
-    urls = ["https://crates.io/api/v1/crates/serde_with_macros/3.7.0/download"],
+    name = "serde_with_macros-3.8.1.crate",
+    sha256 = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2",
+    strip_prefix = "serde_with_macros-3.8.1",
+    urls = ["https://crates.io/api/v1/crates/serde_with_macros/3.8.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_with_macros-3.7.0",
-    srcs = [":serde_with_macros-3.7.0.crate"],
+    name = "serde_with_macros-3.8.1",
+    srcs = [":serde_with_macros-3.8.1.crate"],
     crate = "serde_with_macros",
-    crate_root = "serde_with_macros-3.7.0.crate/src/lib.rs",
+    crate_root = "serde_with_macros-3.8.1.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
         ":darling-0.20.8",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -13468,7 +13614,7 @@ cargo.rust_library(
         ":indexmap-2.2.6",
         ":itoa-1.0.11",
         ":ryu-1.0.17",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
         ":unsafe-libyaml-0.2.11",
     ],
 )
@@ -13648,8 +13794,8 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":libc-0.2.153",
-        ":signal-hook-registry-1.4.1",
+        ":libc-0.2.154",
+        ":signal-hook-registry-1.4.2",
     ],
 )
 
@@ -13676,27 +13822,27 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":libc-0.2.153",
+        ":libc-0.2.154",
         ":signal-hook-0.3.17",
     ],
 )
 
 http_archive(
-    name = "signal-hook-registry-1.4.1.crate",
-    sha256 = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1",
-    strip_prefix = "signal-hook-registry-1.4.1",
-    urls = ["https://crates.io/api/v1/crates/signal-hook-registry/1.4.1/download"],
+    name = "signal-hook-registry-1.4.2.crate",
+    sha256 = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1",
+    strip_prefix = "signal-hook-registry-1.4.2",
+    urls = ["https://crates.io/api/v1/crates/signal-hook-registry/1.4.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "signal-hook-registry-1.4.1",
-    srcs = [":signal-hook-registry-1.4.1.crate"],
+    name = "signal-hook-registry-1.4.2",
+    srcs = [":signal-hook-registry-1.4.2.crate"],
     crate = "signal_hook_registry",
-    crate_root = "signal-hook-registry-1.4.1.crate/src/lib.rs",
+    crate_root = "signal-hook-registry-1.4.2.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
-    deps = [":libc-0.2.153"],
+    deps = [":libc-0.2.154"],
 )
 
 http_archive(
@@ -13892,32 +14038,32 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "socket2-0.5.6.crate",
-    sha256 = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871",
-    strip_prefix = "socket2-0.5.6",
-    urls = ["https://crates.io/api/v1/crates/socket2/0.5.6/download"],
+    name = "socket2-0.5.7.crate",
+    sha256 = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c",
+    strip_prefix = "socket2-0.5.7",
+    urls = ["https://crates.io/api/v1/crates/socket2/0.5.7/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "socket2-0.5.6",
-    srcs = [":socket2-0.5.6.crate"],
+    name = "socket2-0.5.7",
+    srcs = [":socket2-0.5.7.crate"],
     crate = "socket2",
-    crate_root = "socket2-0.5.6.crate/src/lib.rs",
+    crate_root = "socket2-0.5.7.crate/src/lib.rs",
     edition = "2021",
     features = ["all"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.153"],
+            deps = [":libc-0.2.154"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -13957,9 +14103,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":ed25519-1.5.3",
-        ":libc-0.2.153",
+        ":libc-0.2.154",
         ":libsodium-sys-0.2.7",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -14006,7 +14152,7 @@ cargo.rust_library(
         "spin_mutex",
     ],
     named_deps = {
-        "lock_api_crate": ":lock_api-0.4.11",
+        "lock_api_crate": ":lock_api-0.4.12",
     },
     visibility = [],
 )
@@ -14138,10 +14284,10 @@ cargo.rust_library(
         ":bigdecimal-0.3.1",
         ":byteorder-1.5.0",
         ":bytes-1.6.0",
-        ":chrono-0.4.37",
+        ":chrono-0.4.38",
         ":crc-3.2.1",
         ":crossbeam-queue-0.3.11",
-        ":either-1.10.0",
+        ":either-1.11.0",
         ":event-listener-2.5.3",
         ":futures-channel-0.3.30",
         ":futures-core-0.3.30",
@@ -14157,15 +14303,15 @@ cargo.rust_library(
         ":paste-1.0.14",
         ":percent-encoding-2.3.1",
         ":rust_decimal-1.35.0",
-        ":rustls-0.21.10",
+        ":rustls-0.21.12",
         ":rustls-pemfile-1.0.4",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
         ":sha2-0.10.8",
         ":smallvec-1.13.2",
         ":sqlformat-0.2.3",
-        ":thiserror-1.0.58",
-        ":time-0.3.35",
+        ":thiserror-1.0.59",
+        ":time-0.3.36",
         ":tokio-1.37.0",
         ":tokio-stream-0.1.15",
         ":tracing-0.1.40",
@@ -14214,7 +14360,7 @@ cargo.rust_library(
         ":bigdecimal-0.3.1",
         ":bitflags-2.5.0",
         ":byteorder-1.5.0",
-        ":chrono-0.4.37",
+        ":chrono-0.4.38",
         ":crc-3.2.1",
         ":dotenvy-0.15.7",
         ":futures-channel-0.3.30",
@@ -14233,14 +14379,14 @@ cargo.rust_library(
         ":once_cell-1.19.0",
         ":rand-0.8.5",
         ":rust_decimal-1.35.0",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
         ":sha2-0.10.8",
         ":smallvec-1.13.2",
         ":sqlx-core-0.7.4",
         ":stringprep-0.1.4",
-        ":thiserror-1.0.58",
-        ":time-0.3.35",
+        ":thiserror-1.0.59",
+        ":time-0.3.36",
         ":tracing-0.1.40",
         ":uuid-1.8.0",
         ":whoami-1.5.1",
@@ -14282,10 +14428,10 @@ cargo.rust_library(
         ":digest-0.10.7",
         ":hex-0.4.3",
         ":miette-5.10.0",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
         ":sha-1-0.10.1",
         ":sha2-0.10.8",
-        ":thiserror-1.0.58",
+        ":thiserror-1.0.59",
         ":xxhash-rust-0.8.10",
     ],
 )
@@ -14478,10 +14624,10 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
         ":rustversion-1.0.15",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -14565,7 +14711,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
         ":unicode-ident-1.0.12",
     ],
@@ -14573,23 +14719,23 @@ cargo.rust_library(
 
 alias(
     name = "syn",
-    actual = ":syn-2.0.58",
+    actual = ":syn-2.0.60",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "syn-2.0.58.crate",
-    sha256 = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687",
-    strip_prefix = "syn-2.0.58",
-    urls = ["https://crates.io/api/v1/crates/syn/2.0.58/download"],
+    name = "syn-2.0.60.crate",
+    sha256 = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3",
+    strip_prefix = "syn-2.0.60",
+    urls = ["https://crates.io/api/v1/crates/syn/2.0.60/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "syn-2.0.58",
-    srcs = [":syn-2.0.58.crate"],
+    name = "syn-2.0.60",
+    srcs = [":syn-2.0.60.crate"],
     crate = "syn",
-    crate_root = "syn-2.0.58.crate/src/lib.rs",
+    crate_root = "syn-2.0.60.crate/src/lib.rs",
     edition = "2021",
     features = [
         "clone-impls",
@@ -14606,7 +14752,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
         ":unicode-ident-1.0.12",
     ],
@@ -14673,25 +14819,25 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":xattr-1.3.1",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":xattr-1.3.1",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":xattr-1.3.1",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.153",
+                ":libc-0.2.154",
                 ":xattr-1.3.1",
             ],
         ),
@@ -14740,16 +14886,16 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":rustix-0.38.32"],
+            deps = [":rustix-0.38.34"],
         ),
         "linux-x86_64": dict(
-            deps = [":rustix-0.38.32"],
+            deps = [":rustix-0.38.34"],
         ),
         "macos-arm64": dict(
-            deps = [":rustix-0.38.32"],
+            deps = [":rustix-0.38.34"],
         ),
         "macos-x86_64": dict(
-            deps = [":rustix-0.38.32"],
+            deps = [":rustix-0.38.34"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -14761,7 +14907,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":cfg-if-1.0.0",
-        ":fastrand-2.0.2",
+        ":fastrand-2.1.0",
     ],
 )
 
@@ -14781,16 +14927,16 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":rustix-0.38.32"],
+            deps = [":rustix-0.38.34"],
         ),
         "linux-x86_64": dict(
-            deps = [":rustix-0.38.32"],
+            deps = [":rustix-0.38.34"],
         ),
         "macos-arm64": dict(
-            deps = [":rustix-0.38.32"],
+            deps = [":rustix-0.38.34"],
         ),
         "macos-x86_64": dict(
-            deps = [":rustix-0.38.32"],
+            deps = [":rustix-0.38.34"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.48.0"],
@@ -14804,56 +14950,53 @@ cargo.rust_library(
 
 alias(
     name = "test-log",
-    actual = ":test-log-0.2.15",
+    actual = ":test-log-0.2.16",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "test-log-0.2.15.crate",
-    sha256 = "7b319995299c65d522680decf80f2c108d85b861d81dfe340a10d16cee29d9e6",
-    strip_prefix = "test-log-0.2.15",
-    urls = ["https://crates.io/api/v1/crates/test-log/0.2.15/download"],
+    name = "test-log-0.2.16.crate",
+    sha256 = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93",
+    strip_prefix = "test-log-0.2.16",
+    urls = ["https://crates.io/api/v1/crates/test-log/0.2.16/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "test-log-0.2.15",
-    srcs = [":test-log-0.2.15.crate"],
+    name = "test-log-0.2.16",
+    srcs = [":test-log-0.2.16.crate"],
     crate = "test_log",
-    crate_root = "test-log-0.2.15.crate/src/lib.rs",
+    crate_root = "test-log-0.2.16.crate/src/lib.rs",
     edition = "2021",
-    features = [
-        "trace",
-        "tracing-subscriber",
-    ],
+    features = ["trace"],
     visibility = [],
     deps = [
-        ":test-log-macros-0.2.15",
+        ":test-log-macros-0.2.16",
         ":tracing-subscriber-0.3.18",
     ],
 )
 
 http_archive(
-    name = "test-log-macros-0.2.15.crate",
-    sha256 = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107",
-    strip_prefix = "test-log-macros-0.2.15",
-    urls = ["https://crates.io/api/v1/crates/test-log-macros/0.2.15/download"],
+    name = "test-log-macros-0.2.16.crate",
+    sha256 = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5",
+    strip_prefix = "test-log-macros-0.2.16",
+    urls = ["https://crates.io/api/v1/crates/test-log-macros/0.2.16/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "test-log-macros-0.2.15",
-    srcs = [":test-log-macros-0.2.15.crate"],
+    name = "test-log-macros-0.2.16",
+    srcs = [":test-log-macros-0.2.16.crate"],
     crate = "test_log_macros",
-    crate_root = "test-log-macros-0.2.15.crate/src/lib.rs",
+    crate_root = "test-log-macros-0.2.16.crate/src/lib.rs",
     edition = "2021",
     features = ["trace"],
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -14866,15 +15009,15 @@ cargo.rust_binary(
     visibility = [],
     deps = [
         ":async-nats-0.34.0",
-        ":async-recursion-1.1.0",
-        ":async-trait-0.1.79",
+        ":async-recursion-1.1.1",
+        ":async-trait-0.1.80",
         ":axum-0.6.20",
-        ":base64-0.22.0",
+        ":base64-0.22.1",
         ":blake3-1.5.1",
         ":bollard-0.16.1",
         ":bytes-1.6.0",
         ":cacache-13.0.0",
-        ":chrono-0.4.37",
+        ":chrono-0.4.38",
         ":ciborium-0.2.2",
         ":clap-4.5.4",
         ":color-eyre-0.6.3",
@@ -14892,9 +15035,10 @@ cargo.rust_binary(
         ":diff-0.1.13",
         ":directories-5.0.1",
         ":dyn-clone-1.0.17",
-        ":flate2-1.0.28",
+        ":flate2-1.0.30",
         ":futures-0.3.30",
         ":futures-lite-2.3.0",
+        ":glob-0.3.1",
         ":hex-0.4.3",
         ":http-0.2.12",
         ":hyper-0.14.28",
@@ -14903,15 +15047,15 @@ cargo.rust_binary(
         ":indexmap-2.2.6",
         ":indicatif-0.17.8",
         ":indoc-2.0.5",
-        ":inquire-0.7.4",
+        ":inquire-0.7.5",
         ":itertools-0.12.1",
         ":jwt-simple-0.12.9",
         ":lazy_static-1.4.0",
         ":miniz_oxide-0.7.2",
-        ":moka-0.12.5",
+        ":moka-0.12.7",
         ":names-0.14.0",
         ":nix-0.27.1",
-        ":nkeys-0.4.0",
+        ":nkeys-0.4.1",
         ":num_cpus-1.16.0",
         ":once_cell-1.19.0",
         ":open-5.1.2",
@@ -14928,33 +15072,33 @@ cargo.rust_binary(
         ":postcard-1.0.8",
         ":postgres-types-0.2.6",
         ":pretty_assertions_sorted-1.2.3",
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
         ":rand-0.8.5",
         ":refinery-0.8.12",
         ":regex-1.10.4",
         ":remain-0.2.13",
-        ":reqwest-0.12.3",
+        ":reqwest-0.12.4",
         ":ring-0.17.5",
         ":rust-s3-0.34.0-rc4",
-        ":rustls-0.22.3",
+        ":rustls-0.22.4",
         ":rustls-pemfile-2.1.2",
         ":sea-orm-0.12.15",
         ":self-replace-1.3.7",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
         ":serde-aux-4.5.0",
-        ":serde_json-1.0.115",
+        ":serde_json-1.0.116",
         ":serde_url_params-0.2.1",
-        ":serde_with-3.7.0",
+        ":serde_with-3.8.1",
         ":serde_yaml-0.9.34+deprecated",
         ":sodiumoxide-0.2.7",
         ":stream-cancel-0.8.2",
         ":strum-0.26.2",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
         ":tar-0.4.40",
         ":tempfile-3.10.1",
-        ":test-log-0.2.15",
-        ":thiserror-1.0.58",
+        ":test-log-0.2.16",
+        ":thiserror-1.0.59",
         ":tokio-1.37.0",
         ":tokio-postgres-0.7.10",
         ":tokio-postgres-rustls-0.11.1",
@@ -14984,48 +15128,48 @@ cargo.rust_binary(
 
 alias(
     name = "thiserror",
-    actual = ":thiserror-1.0.58",
+    actual = ":thiserror-1.0.59",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "thiserror-1.0.58.crate",
-    sha256 = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297",
-    strip_prefix = "thiserror-1.0.58",
-    urls = ["https://crates.io/api/v1/crates/thiserror/1.0.58/download"],
+    name = "thiserror-1.0.59.crate",
+    sha256 = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa",
+    strip_prefix = "thiserror-1.0.59",
+    urls = ["https://crates.io/api/v1/crates/thiserror/1.0.59/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "thiserror-1.0.58",
-    srcs = [":thiserror-1.0.58.crate"],
+    name = "thiserror-1.0.59",
+    srcs = [":thiserror-1.0.59.crate"],
     crate = "thiserror",
-    crate_root = "thiserror-1.0.58.crate/src/lib.rs",
+    crate_root = "thiserror-1.0.59.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":thiserror-impl-1.0.58"],
+    deps = [":thiserror-impl-1.0.59"],
 )
 
 http_archive(
-    name = "thiserror-impl-1.0.58.crate",
-    sha256 = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7",
-    strip_prefix = "thiserror-impl-1.0.58",
-    urls = ["https://crates.io/api/v1/crates/thiserror-impl/1.0.58/download"],
+    name = "thiserror-impl-1.0.59.crate",
+    sha256 = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66",
+    strip_prefix = "thiserror-impl-1.0.59",
+    urls = ["https://crates.io/api/v1/crates/thiserror-impl/1.0.59/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "thiserror-impl-1.0.58",
-    srcs = [":thiserror-impl-1.0.58.crate"],
+    name = "thiserror-impl-1.0.59",
+    srcs = [":thiserror-impl-1.0.59.crate"],
     crate = "thiserror_impl",
-    crate_root = "thiserror-impl-1.0.58.crate/src/lib.rs",
+    crate_root = "thiserror-impl-1.0.59.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -15051,18 +15195,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "time-0.3.35.crate",
-    sha256 = "ef89ece63debf11bc32d1ed8d078ac870cbeb44da02afb02a9ff135ae7ca0582",
-    strip_prefix = "time-0.3.35",
-    urls = ["https://crates.io/api/v1/crates/time/0.3.35/download"],
+    name = "time-0.3.36.crate",
+    sha256 = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885",
+    strip_prefix = "time-0.3.36",
+    urls = ["https://crates.io/api/v1/crates/time/0.3.36/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "time-0.3.35",
-    srcs = [":time-0.3.35.crate"],
+    name = "time-0.3.36",
+    srcs = [":time-0.3.36.crate"],
     crate = "time",
-    crate_root = "time-0.3.35.crate/src/lib.rs",
+    crate_root = "time-0.3.36.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -15080,7 +15224,7 @@ cargo.rust_library(
         ":itoa-1.0.11",
         ":num-conv-0.1.0",
         ":powerfmt-0.2.0",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
         ":time-core-0.1.2",
         ":time-macros-0.2.18",
     ],
@@ -15168,8 +15312,8 @@ cargo.rust_library(
     edition = "2015",
     visibility = [],
     deps = [
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
     ],
 )
 
@@ -15262,41 +15406,41 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.153",
-                ":signal-hook-registry-1.4.1",
-                ":socket2-0.5.6",
+                ":libc-0.2.154",
+                ":signal-hook-registry-1.4.2",
+                ":socket2-0.5.7",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.153",
-                ":signal-hook-registry-1.4.1",
-                ":socket2-0.5.6",
+                ":libc-0.2.154",
+                ":signal-hook-registry-1.4.2",
+                ":socket2-0.5.7",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.153",
-                ":signal-hook-registry-1.4.1",
-                ":socket2-0.5.6",
+                ":libc-0.2.154",
+                ":signal-hook-registry-1.4.2",
+                ":socket2-0.5.7",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.153",
-                ":signal-hook-registry-1.4.1",
-                ":socket2-0.5.6",
+                ":libc-0.2.154",
+                ":signal-hook-registry-1.4.2",
+                ":socket2-0.5.7",
             ],
         ),
         "windows-gnu": dict(
             deps = [
-                ":socket2-0.5.6",
+                ":socket2-0.5.7",
                 ":windows-sys-0.48.0",
             ],
         ),
         "windows-msvc": dict(
             deps = [
-                ":socket2-0.5.6",
+                ":socket2-0.5.7",
                 ":windows-sys-0.48.0",
             ],
         ),
@@ -15310,7 +15454,7 @@ cargo.rust_library(
         ":bytes-1.6.0",
         ":mio-0.8.11",
         ":num_cpus-1.16.0",
-        ":parking_lot-0.12.1",
+        ":parking_lot-0.12.2",
         ":pin-project-lite-0.2.14",
         ":tokio-macros-2.2.0",
         ":tracing",
@@ -15355,9 +15499,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -15389,34 +15533,34 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":socket2-0.5.6"],
+            deps = [":socket2-0.5.7"],
         ),
         "linux-x86_64": dict(
-            deps = [":socket2-0.5.6"],
+            deps = [":socket2-0.5.7"],
         ),
         "macos-arm64": dict(
-            deps = [":socket2-0.5.6"],
+            deps = [":socket2-0.5.7"],
         ),
         "macos-x86_64": dict(
-            deps = [":socket2-0.5.6"],
+            deps = [":socket2-0.5.7"],
         ),
         "windows-gnu": dict(
-            deps = [":socket2-0.5.6"],
+            deps = [":socket2-0.5.7"],
         ),
         "windows-msvc": dict(
-            deps = [":socket2-0.5.6"],
+            deps = [":socket2-0.5.7"],
         ),
     },
     visibility = [],
     deps = [
-        ":async-trait-0.1.79",
+        ":async-trait-0.1.80",
         ":byteorder-1.5.0",
         ":bytes-1.6.0",
         ":fallible-iterator-0.2.0",
         ":futures-channel-0.3.30",
         ":futures-util-0.3.30",
         ":log-0.4.21",
-        ":parking_lot-0.12.1",
+        ":parking_lot-0.12.2",
         ":percent-encoding-2.3.1",
         ":phf-0.11.2",
         ":pin-project-lite-0.2.14",
@@ -15453,7 +15597,7 @@ cargo.rust_library(
     deps = [
         ":futures-0.3.30",
         ":ring-0.17.5",
-        ":rustls-0.22.3",
+        ":rustls-0.22.4",
         ":tokio-1.37.0",
         ":tokio-postgres-0.7.10",
         ":tokio-rustls-0.25.0",
@@ -15482,7 +15626,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":rustls-0.21.10",
+        ":rustls-0.21.12",
         ":tokio-1.37.0",
     ],
 )
@@ -15508,11 +15652,11 @@ cargo.rust_library(
         "tls12",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.4.1",
+        "pki_types": ":rustls-pki-types-1.5.0",
     },
     visibility = [],
     deps = [
-        ":rustls-0.22.3",
+        ":rustls-0.22.4",
         ":tokio-1.37.0",
     ],
 )
@@ -15550,8 +15694,8 @@ cargo.rust_library(
         ":futures-core-0.3.30",
         ":futures-sink-0.3.30",
         ":pin-project-1.1.5",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
     ],
 )
 
@@ -15722,7 +15866,7 @@ cargo.rust_library(
     deps = [
         ":bytes-1.6.0",
         ":futures-0.3.30",
-        ":libc-0.2.153",
+        ":libc-0.2.154",
         ":tokio-1.37.0",
         ":vsock-0.3.0",
     ],
@@ -15755,10 +15899,10 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":serde-1.0.197",
+        ":serde-1.0.200",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
-        ":toml_edit-0.22.9",
+        ":toml_edit-0.22.12",
     ],
 )
 
@@ -15778,22 +15922,22 @@ cargo.rust_library(
     edition = "2021",
     features = ["serde"],
     visibility = [],
-    deps = [":serde-1.0.197"],
+    deps = [":serde-1.0.200"],
 )
 
 http_archive(
-    name = "toml_edit-0.22.9.crate",
-    sha256 = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4",
-    strip_prefix = "toml_edit-0.22.9",
-    urls = ["https://crates.io/api/v1/crates/toml_edit/0.22.9/download"],
+    name = "toml_edit-0.22.12.crate",
+    sha256 = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef",
+    strip_prefix = "toml_edit-0.22.12",
+    urls = ["https://crates.io/api/v1/crates/toml_edit/0.22.12/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "toml_edit-0.22.9",
-    srcs = [":toml_edit-0.22.9.crate"],
+    name = "toml_edit-0.22.12",
+    srcs = [":toml_edit-0.22.12.crate"],
     crate = "toml_edit",
-    crate_root = "toml_edit-0.22.9.crate/src/lib.rs",
+    crate_root = "toml_edit-0.22.12.crate/src/lib.rs",
     edition = "2021",
     features = [
         "display",
@@ -15803,10 +15947,10 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":indexmap-2.2.6",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
         ":serde_spanned-0.6.5",
         ":toml_datetime-0.6.5",
-        ":winnow-0.6.5",
+        ":winnow-0.6.7",
     ],
 )
 
@@ -15844,7 +15988,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-stream-0.3.5",
-        ":async-trait-0.1.79",
+        ":async-trait-0.1.80",
         ":axum-0.6.20",
         ":base64-0.21.7",
         ":bytes-1.6.0",
@@ -15970,7 +16114,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-compression-0.4.8",
+        ":async-compression-0.4.9",
         ":bitflags-2.5.0",
         ":bytes-1.6.0",
         ":futures-core-0.3.30",
@@ -16074,9 +16218,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )
 
@@ -16221,7 +16365,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":serde-1.0.197",
+        ":serde-1.0.200",
         ":tracing-core-0.1.32",
     ],
 )
@@ -16274,8 +16418,8 @@ cargo.rust_library(
         ":nu-ansi-term-0.46.0",
         ":once_cell-1.19.0",
         ":regex-1.10.4",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
         ":sharded-slab-0.1.7",
         ":smallvec-1.13.2",
         ":thread_local-1.1.8",
@@ -16368,13 +16512,13 @@ cargo.rust_library(
     deps = [
         ":byteorder-1.5.0",
         ":bytes-1.6.0",
-        ":data-encoding-2.5.0",
+        ":data-encoding-2.6.0",
         ":http-0.2.12",
         ":httparse-1.8.0",
         ":log-0.4.21",
         ":rand-0.8.5",
         ":sha1-0.10.6",
-        ":thiserror-1.0.58",
+        ":thiserror-1.0.59",
         ":url-2.5.0",
         ":utf-8-0.7.6",
     ],
@@ -16448,7 +16592,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rand-0.8.5",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -16567,19 +16711,19 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "unicode-width-0.1.11.crate",
-    sha256 = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85",
-    strip_prefix = "unicode-width-0.1.11",
-    urls = ["https://crates.io/api/v1/crates/unicode-width/0.1.11/download"],
+    name = "unicode-width-0.1.12.crate",
+    sha256 = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6",
+    strip_prefix = "unicode-width-0.1.12",
+    urls = ["https://crates.io/api/v1/crates/unicode-width/0.1.12/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "unicode-width-0.1.11",
-    srcs = [":unicode-width-0.1.11.crate"],
+    name = "unicode-width-0.1.12",
+    srcs = [":unicode-width-0.1.12.crate"],
     crate = "unicode_width",
-    crate_root = "unicode-width-0.1.11.crate/src/lib.rs",
-    edition = "2015",
+    crate_root = "unicode-width-0.1.12.crate/src/lib.rs",
+    edition = "2021",
     features = ["default"],
     visibility = [],
 )
@@ -16682,7 +16826,7 @@ cargo.rust_library(
         ":form_urlencoded-1.2.1",
         ":idna-0.5.0",
         ":percent-encoding-2.3.1",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -16785,7 +16929,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":getrandom-0.2.14",
-        ":serde-1.0.197",
+        ":serde-1.0.200",
     ],
 )
 
@@ -16896,7 +17040,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":libc-0.2.153",
+        ":libc-0.2.154",
         ":nix-0.24.3",
     ],
 )
@@ -16945,7 +17089,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
     ],
 )
@@ -16966,10 +17110,10 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "windows-gnu": dict(
-            deps = [":winapi-util-0.1.6"],
+            deps = [":winapi-util-0.1.8"],
         ),
         "windows-msvc": dict(
-            deps = [":winapi-util-0.1.6"],
+            deps = [":winapi-util-0.1.8"],
         ),
     },
     visibility = [],
@@ -17032,7 +17176,7 @@ cargo.rust_library(
     crate_root = "webpki-roots-0.26.1.crate/src/lib.rs",
     edition = "2018",
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.4.1",
+        "pki_types": ":rustls-pki-types-1.5.0",
     },
     visibility = [],
 )
@@ -17079,16 +17223,11 @@ cargo.rust_library(
         "fileapi",
         "handleapi",
         "impl-default",
-        "minwindef",
         "processenv",
         "profileapi",
-        "std",
         "synchapi",
-        "sysinfoapi",
         "winbase",
-        "wincon",
         "winerror",
-        "winnt",
         "winuser",
     ],
     platform = {
@@ -17115,16 +17254,11 @@ cargo.rust_binary(
         "fileapi",
         "handleapi",
         "impl-default",
-        "minwindef",
         "processenv",
         "profileapi",
-        "std",
         "synchapi",
-        "sysinfoapi",
         "winbase",
-        "wincon",
         "winerror",
-        "winnt",
         "winuser",
     ],
     visibility = [],
@@ -17140,41 +17274,36 @@ buildscript_run(
         "fileapi",
         "handleapi",
         "impl-default",
-        "minwindef",
         "processenv",
         "profileapi",
-        "std",
         "synchapi",
-        "sysinfoapi",
         "winbase",
-        "wincon",
         "winerror",
-        "winnt",
         "winuser",
     ],
     version = "0.3.9",
 )
 
 http_archive(
-    name = "winapi-util-0.1.6.crate",
-    sha256 = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596",
-    strip_prefix = "winapi-util-0.1.6",
-    urls = ["https://crates.io/api/v1/crates/winapi-util/0.1.6/download"],
+    name = "winapi-util-0.1.8.crate",
+    sha256 = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b",
+    strip_prefix = "winapi-util-0.1.8",
+    urls = ["https://crates.io/api/v1/crates/winapi-util/0.1.8/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "winapi-util-0.1.6",
-    srcs = [":winapi-util-0.1.6.crate"],
+    name = "winapi-util-0.1.8",
+    srcs = [":winapi-util-0.1.8.crate"],
     crate = "winapi_util",
-    crate_root = "winapi-util-0.1.6.crate/src/lib.rs",
+    crate_root = "winapi-util-0.1.8.crate/src/lib.rs",
     edition = "2021",
     platform = {
         "windows-gnu": dict(
-            deps = [":winapi-0.3.9"],
+            deps = [":windows-sys-0.52.0"],
         ),
         "windows-msvc": dict(
-            deps = [":winapi-0.3.9"],
+            deps = [":windows-sys-0.52.0"],
         ),
     },
     visibility = [],
@@ -17228,18 +17357,18 @@ third_party_rust_prebuilt_cxx_library(
 )
 
 http_archive(
-    name = "windows-0.54.0.crate",
-    sha256 = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49",
-    strip_prefix = "windows-0.54.0",
-    urls = ["https://crates.io/api/v1/crates/windows/0.54.0/download"],
+    name = "windows-0.56.0.crate",
+    sha256 = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132",
+    strip_prefix = "windows-0.56.0",
+    urls = ["https://crates.io/api/v1/crates/windows/0.56.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "windows-0.54.0",
-    srcs = [":windows-0.54.0.crate"],
+    name = "windows-0.56.0",
+    srcs = [":windows-0.56.0.crate"],
     crate = "windows",
-    crate_root = "windows-0.54.0.crate/src/lib.rs",
+    crate_root = "windows-0.56.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "Win32",
@@ -17254,8 +17383,8 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":windows-core-0.54.0",
-        ":windows-targets-0.52.4",
+        ":windows-core-0.56.0",
+        ":windows-targets-0.52.5",
     ],
 )
 
@@ -17275,47 +17404,94 @@ cargo.rust_library(
     edition = "2021",
     features = ["default"],
     visibility = [],
-    deps = [":windows-targets-0.52.4"],
+    deps = [":windows-targets-0.52.5"],
 )
 
 http_archive(
-    name = "windows-core-0.54.0.crate",
-    sha256 = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65",
-    strip_prefix = "windows-core-0.54.0",
-    urls = ["https://crates.io/api/v1/crates/windows-core/0.54.0/download"],
+    name = "windows-core-0.56.0.crate",
+    sha256 = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6",
+    strip_prefix = "windows-core-0.56.0",
+    urls = ["https://crates.io/api/v1/crates/windows-core/0.56.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "windows-core-0.54.0",
-    srcs = [":windows-core-0.54.0.crate"],
+    name = "windows-core-0.56.0",
+    srcs = [":windows-core-0.56.0.crate"],
     crate = "windows_core",
-    crate_root = "windows-core-0.54.0.crate/src/lib.rs",
+    crate_root = "windows-core-0.56.0.crate/src/lib.rs",
     edition = "2021",
-    features = ["default"],
     visibility = [],
     deps = [
-        ":windows-result-0.1.0",
-        ":windows-targets-0.52.4",
+        ":windows-implement-0.56.0",
+        ":windows-interface-0.56.0",
+        ":windows-result-0.1.1",
+        ":windows-targets-0.52.5",
     ],
 )
 
 http_archive(
-    name = "windows-result-0.1.0.crate",
-    sha256 = "cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64",
-    strip_prefix = "windows-result-0.1.0",
-    urls = ["https://crates.io/api/v1/crates/windows-result/0.1.0/download"],
+    name = "windows-implement-0.56.0.crate",
+    sha256 = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b",
+    strip_prefix = "windows-implement-0.56.0",
+    urls = ["https://crates.io/api/v1/crates/windows-implement/0.56.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "windows-result-0.1.0",
-    srcs = [":windows-result-0.1.0.crate"],
+    name = "windows-implement-0.56.0",
+    srcs = [":windows-implement-0.56.0.crate"],
+    crate = "windows_implement",
+    crate_root = "windows-implement-0.56.0.crate/src/lib.rs",
+    edition = "2021",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.81",
+        ":quote-1.0.36",
+        ":syn-2.0.60",
+    ],
+)
+
+http_archive(
+    name = "windows-interface-0.56.0.crate",
+    sha256 = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc",
+    strip_prefix = "windows-interface-0.56.0",
+    urls = ["https://crates.io/api/v1/crates/windows-interface/0.56.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-interface-0.56.0",
+    srcs = [":windows-interface-0.56.0.crate"],
+    crate = "windows_interface",
+    crate_root = "windows-interface-0.56.0.crate/src/lib.rs",
+    edition = "2021",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.81",
+        ":quote-1.0.36",
+        ":syn-2.0.60",
+    ],
+)
+
+http_archive(
+    name = "windows-result-0.1.1.crate",
+    sha256 = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b",
+    strip_prefix = "windows-result-0.1.1",
+    urls = ["https://crates.io/api/v1/crates/windows-result/0.1.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-result-0.1.1",
+    srcs = [":windows-result-0.1.1.crate"],
     crate = "windows_result",
-    crate_root = "windows-result-0.1.0.crate/src/lib.rs",
+    crate_root = "windows-result-0.1.1.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":windows-targets-0.52.4"],
+    deps = [":windows-targets-0.52.5"],
 )
 
 http_archive(
@@ -17399,6 +17575,7 @@ cargo.rust_library(
         "Win32_System_Diagnostics_Debug",
         "Win32_System_IO",
         "Win32_System_Memory",
+        "Win32_System_SystemInformation",
         "Win32_System_Threading",
         "Win32_System_WindowsProgramming",
         "Win32_UI",
@@ -17408,7 +17585,7 @@ cargo.rust_library(
         "default",
     ],
     visibility = [],
-    deps = [":windows-targets-0.52.4"],
+    deps = [":windows-targets-0.52.5"],
 )
 
 http_archive(
@@ -17440,28 +17617,28 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "windows-targets-0.52.4.crate",
-    sha256 = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b",
-    strip_prefix = "windows-targets-0.52.4",
-    urls = ["https://crates.io/api/v1/crates/windows-targets/0.52.4/download"],
+    name = "windows-targets-0.52.5.crate",
+    sha256 = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb",
+    strip_prefix = "windows-targets-0.52.5",
+    urls = ["https://crates.io/api/v1/crates/windows-targets/0.52.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "windows-targets-0.52.4",
-    srcs = [":windows-targets-0.52.4.crate"],
+    name = "windows-targets-0.52.5",
+    srcs = [":windows-targets-0.52.5.crate"],
     crate = "windows_targets",
-    crate_root = "windows-targets-0.52.4.crate/src/lib.rs",
+    crate_root = "windows-targets-0.52.5.crate/src/lib.rs",
     edition = "2021",
     platform = {
         "linux-x86_64": dict(
-            deps = [":windows_x86_64_gnu-0.52.4"],
+            deps = [":windows_x86_64_gnu-0.52.5"],
         ),
         "windows-gnu": dict(
-            deps = [":windows_x86_64_gnu-0.52.4"],
+            deps = [":windows_x86_64_gnu-0.52.5"],
         ),
         "windows-msvc": dict(
-            deps = [":windows_x86_64_msvc-0.52.4"],
+            deps = [":windows_x86_64_msvc-0.52.5"],
         ),
     },
     visibility = [],
@@ -17485,18 +17662,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "windows_x86_64_gnu-0.52.4.crate",
-    sha256 = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03",
-    strip_prefix = "windows_x86_64_gnu-0.52.4",
-    urls = ["https://crates.io/api/v1/crates/windows_x86_64_gnu/0.52.4/download"],
+    name = "windows_x86_64_gnu-0.52.5.crate",
+    sha256 = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9",
+    strip_prefix = "windows_x86_64_gnu-0.52.5",
+    urls = ["https://crates.io/api/v1/crates/windows_x86_64_gnu/0.52.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "windows_x86_64_gnu-0.52.4",
-    srcs = [":windows_x86_64_gnu-0.52.4.crate"],
+    name = "windows_x86_64_gnu-0.52.5",
+    srcs = [":windows_x86_64_gnu-0.52.5.crate"],
     crate = "windows_x86_64_gnu",
-    crate_root = "windows_x86_64_gnu-0.52.4.crate/src/lib.rs",
+    crate_root = "windows_x86_64_gnu-0.52.5.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
 )
@@ -17519,35 +17696,35 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "windows_x86_64_msvc-0.52.4.crate",
-    sha256 = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8",
-    strip_prefix = "windows_x86_64_msvc-0.52.4",
-    urls = ["https://crates.io/api/v1/crates/windows_x86_64_msvc/0.52.4/download"],
+    name = "windows_x86_64_msvc-0.52.5.crate",
+    sha256 = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0",
+    strip_prefix = "windows_x86_64_msvc-0.52.5",
+    urls = ["https://crates.io/api/v1/crates/windows_x86_64_msvc/0.52.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "windows_x86_64_msvc-0.52.4",
-    srcs = [":windows_x86_64_msvc-0.52.4.crate"],
+    name = "windows_x86_64_msvc-0.52.5",
+    srcs = [":windows_x86_64_msvc-0.52.5.crate"],
     crate = "windows_x86_64_msvc",
-    crate_root = "windows_x86_64_msvc-0.52.4.crate/src/lib.rs",
+    crate_root = "windows_x86_64_msvc-0.52.5.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
 )
 
 http_archive(
-    name = "winnow-0.6.5.crate",
-    sha256 = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8",
-    strip_prefix = "winnow-0.6.5",
-    urls = ["https://crates.io/api/v1/crates/winnow/0.6.5/download"],
+    name = "winnow-0.6.7.crate",
+    sha256 = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578",
+    strip_prefix = "winnow-0.6.7",
+    urls = ["https://crates.io/api/v1/crates/winnow/0.6.7/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "winnow-0.6.5",
-    srcs = [":winnow-0.6.5.crate"],
+    name = "winnow-0.6.7",
+    srcs = [":winnow-0.6.7.crate"],
     crate = "winnow",
-    crate_root = "winnow-0.6.5.crate/src/lib.rs",
+    crate_root = "winnow-0.6.7.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -17597,14 +17774,14 @@ cargo.rust_library(
     deps = [
         ":bcder-0.7.4",
         ":bytes-1.6.0",
-        ":chrono-0.4.37",
+        ":chrono-0.4.38",
         ":der-0.7.9",
         ":hex-0.4.3",
         ":pem-3.0.4",
         ":ring-0.17.5",
         ":signature-2.2.0",
         ":spki-0.7.3",
-        ":thiserror-1.0.58",
+        ":thiserror-1.0.59",
         ":zeroize-1.7.0",
     ],
 )
@@ -17636,7 +17813,7 @@ cargo.rust_library(
         ),
     },
     visibility = [],
-    deps = [":rustix-0.38.32"],
+    deps = [":rustix-0.38.34"],
 )
 
 alias(
@@ -17690,7 +17867,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":futures-util-0.3.30",
-        ":thiserror-1.0.58",
+        ":thiserror-1.0.59",
         ":tokio-1.37.0",
         ":yrs-0.17.4",
     ],
@@ -17759,11 +17936,11 @@ cargo.rust_library(
     deps = [
         ":atomic_refcell-0.1.13",
         ":rand-0.7.3",
-        ":serde-1.0.197",
-        ":serde_json-1.0.115",
+        ":serde-1.0.200",
+        ":serde_json-1.0.116",
         ":smallstr-0.3.0",
         ":smallvec-1.13.2",
-        ":thiserror-1.0.58",
+        ":thiserror-1.0.59",
     ],
 )
 
@@ -17837,8 +18014,8 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.79",
+        ":proc-macro2-1.0.81",
         ":quote-1.0.36",
-        ":syn-2.0.58",
+        ":syn-2.0.60",
     ],
 )

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -191,9 +191,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-compression"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dbbf24db18d609b1462965249abdf49129ccad073ec257da372adc83259c60"
+checksum = "4e9eabd7a98fe442131a17c316bd9349c43695e49e730c3c8e12cfb5f4da2693"
 dependencies = [
  "brotli",
  "flate2",
@@ -205,11 +205,13 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.8.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
- "event-listener",
+ "event-listener 4.0.3",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -218,7 +220,7 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eea7b126ebfa4db78e9e788b2a792b6329f35b4f2fdd56dbc646dedc2beec7a5"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes 1.6.0",
  "futures",
  "memchr",
@@ -231,7 +233,7 @@ dependencies = [
  "ring",
  "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.2",
- "rustls-webpki 0.102.2",
+ "rustls-webpki 0.102.3",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -247,13 +249,13 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -275,18 +277,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.79"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -321,7 +323,7 @@ checksum = "0f77d243921b0979fbbd728dd2d5162e68ac8252976797c24eb5b3a6af9090dc"
 dependencies = [
  "http 0.2.12",
  "log",
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "serde",
  "serde_json",
  "url",
@@ -421,7 +423,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -459,9 +461,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -562,7 +564,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "bollard-stubs",
  "bytes 1.6.0",
  "futures-core",
@@ -570,7 +572,7 @@ dependencies = [
  "hex",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "hyper-named-pipe",
  "hyper-util",
  "hyperlocal-next",
@@ -602,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0901fc8eb0aca4c83be0106d6f2db17d86a08dfc2c25f0e84464bf381158add6"
+checksum = "dbe5b10e214954177fb1dc9fbd20a1a2608fe99e6c832033bdc7cea287a20d77"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -612,23 +614,23 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51670c3aa053938b0ee3bd67c3817e471e626151131b934038e83c5bf8de48f5"
+checksum = "d7a8646f94ab393e43e8b35a2558b1624bed28b97ee09c5d15456e3c9463f46d"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "syn_derive",
 ]
 
 [[package]]
 name = "brotli"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125740193d7fee5cc63ab9e16c2fdc4e07c74ba755cc53b327d6ea029e9fc569"
+checksum = "19483b140a7ac7174d34b5a581b406c64f84da5409d3e09cf4fff604f9270e67"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -637,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65622a320492e09b5e0ac436b14c54ff68199bac392d0e89a6832c4518eea525"
+checksum = "e6221fe77a248b9117d431ad93761222e1cf8ff282d9d1d5d9f53d6299a1cf76"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -682,12 +684,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "bytecount"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "byteorder"
@@ -738,37 +734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,9 +741,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.92"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 
 [[package]]
 name = "cfg-if"
@@ -794,9 +759,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -804,7 +769,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -866,7 +831,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -947,6 +912,15 @@ dependencies = [
  "strum 0.26.2",
  "strum_macros",
  "unicode-width",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1278,7 +1252,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1302,7 +1276,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1313,7 +1287,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1330,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "deadpool"
@@ -1417,7 +1391,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1427,7 +1401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1567,14 +1541,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 dependencies = [
  "serde",
 ]
@@ -1638,7 +1612,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1658,15 +1632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +1647,38 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.3",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "eyre"
@@ -1710,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "ff"
@@ -1726,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
 
 [[package]]
 name = "filetime"
@@ -1738,7 +1735,7 @@ checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "windows-sys 0.52.0",
 ]
 
@@ -1756,9 +1753,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1861,7 +1858,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -1876,7 +1873,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2067,9 +2064,9 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
@@ -2081,7 +2078,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2295,9 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
 dependencies = [
  "bytes 1.6.0",
  "futures-channel",
@@ -2319,7 +2316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2336,7 +2333,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.28",
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -2349,9 +2346,9 @@ checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "hyper-util",
- "rustls 0.22.3",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -2381,7 +2378,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2410,7 +2407,7 @@ checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2466,7 +2463,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.58",
+ "syn 2.0.60",
  "toml",
  "unicode-xid",
 ]
@@ -2511,7 +2508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -2542,14 +2539,14 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "inquire"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe95f33091b9b7b517a5849bce4dce1b550b430fc20d58059fcaa319ed895d8b"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
 dependencies = [
  "bitflags 2.5.0",
  "crossterm 0.25.0",
@@ -2691,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libm"
@@ -2742,9 +2739,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2779,7 +2776,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2852,7 +2849,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2901,21 +2898,21 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1911e88d5831f748a4097a43862d129e3c6fca831eecac9b8db6d01d93c9de2"
+checksum = "9e0d88686dc561d743b40de8269b26eaf0dc58781bde087b0984646602021d08"
 dependencies = [
  "async-lock",
  "async-trait",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
+ "event-listener 5.3.0",
  "futures-util",
  "once_cell",
  "parking_lot",
  "quanta",
  "rustc_version",
- "skeptic",
  "smallvec",
  "tagptr",
  "thiserror",
@@ -2984,11 +2981,10 @@ dependencies = [
 
 [[package]]
 name = "nkeys"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafe79aeb8066a6f1f84dc44c03ae97403013e946bf0b13626468e0d5e26c6f"
+checksum = "bc522a19199a0795776406619aa6aa78e1e55690fbeb3181b8db5265fd0e89ce"
 dependencies = [
- "byteorder",
  "data-encoding",
  "ed25519 2.2.3",
  "ed25519-dalek",
@@ -3294,7 +3290,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3308,7 +3304,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3355,9 +3351,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -3365,15 +3361,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.1",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -3394,7 +3390,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -3480,7 +3476,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3619,7 +3615,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3731,9 +3727,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -3746,7 +3742,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "version_check",
  "yansi 1.0.1",
 ]
@@ -3771,7 +3767,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3792,17 +3788,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
-dependencies = [
- "bitflags 2.5.0",
- "memchr",
- "unicase",
 ]
 
 [[package]]
@@ -3918,9 +3903,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.0.1"
+version = "11.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
+checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -3952,6 +3937,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -4005,14 +3999,14 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b1349400e2ffd64a9fb5ed9008e33c0b8ef86bd5bae8f73080839c7082f1d5"
+checksum = "7c3138c30c59ed9b8572f82bed97ea591ecd7e45012566046cc39e72679cff22"
 dependencies = [
  "cfg-if",
  "rustix",
@@ -4071,7 +4065,7 @@ checksum = "ad9f2390298a947ee0aa6073d440e221c0726188cfbcdf9604addb6ee393eb4a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4085,18 +4079,18 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes 1.6.0",
  "futures-core",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "hyper-rustls 0.26.0",
  "hyper-util",
  "ipnet",
@@ -4107,7 +4101,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.3",
+ "rustls 0.22.4",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -4231,7 +4225,7 @@ dependencies = [
  "md5",
  "percent-encoding",
  "quick-xml",
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
  "serde",
  "serde_derive",
@@ -4278,9 +4272,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -4291,9 +4285,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
@@ -4303,14 +4297,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki 0.102.3",
  "subtle",
  "zeroize",
 ]
@@ -4355,15 +4349,15 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
 
 [[package]]
 name = "rustls-webpki"
@@ -4377,9 +4371,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4442,7 +4436,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4483,7 +4477,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.58",
+ "syn 2.0.60",
  "unicode-ident",
 ]
 
@@ -4579,15 +4573,12 @@ name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
@@ -4605,20 +4596,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -4653,7 +4644,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4689,11 +4680,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.7.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4707,14 +4698,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.7.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4795,9 +4786,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -4855,21 +4846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
-name = "skeptic"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
-dependencies = [
- "bytecount",
- "cargo_metadata",
- "error-chain",
- "glob",
- "pulldown-cmark",
- "tempfile",
- "walkdir",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4895,9 +4871,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4979,7 +4955,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-channel",
  "futures-core",
  "futures-intrusive",
@@ -4994,7 +4970,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rust_decimal",
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -5255,7 +5231,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5290,9 +5266,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5308,7 +5284,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5356,7 +5332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -5373,9 +5349,9 @@ dependencies = [
 
 [[package]]
 name = "test-log"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b319995299c65d522680decf80f2c108d85b861d81dfe340a10d16cee29d9e6"
+checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
 dependencies = [
  "test-log-macros",
  "tracing-subscriber",
@@ -5383,13 +5359,13 @@ dependencies = [
 
 [[package]]
 name = "test-log-macros"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
+checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5400,7 +5376,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "axum",
- "base64 0.22.0",
+ "base64 0.22.1",
  "blake3",
  "bollard",
  "bytes 1.6.0",
@@ -5426,6 +5402,7 @@ dependencies = [
  "flate2",
  "futures",
  "futures-lite",
+ "glob",
  "hex",
  "http 0.2.12",
  "hyper 0.14.28",
@@ -5468,7 +5445,7 @@ dependencies = [
  "reqwest",
  "ring",
  "rust-s3",
- "rustls 0.22.3",
+ "rustls 0.22.4",
  "rustls-pemfile 2.1.2",
  "sea-orm",
  "self-replace",
@@ -5481,7 +5458,7 @@ dependencies = [
  "sodiumoxide",
  "stream-cancel",
  "strum 0.26.2",
- "syn 2.0.58",
+ "syn 2.0.60",
  "tar",
  "tempfile",
  "test-log",
@@ -5514,22 +5491,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5544,9 +5521,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef89ece63debf11bc32d1ed8d078ac870cbeb44da02afb02a9ff135ae7ca0582"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -5644,7 +5621,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5681,7 +5658,7 @@ checksum = "0ea13f22eda7127c827983bdaf0d7fff9df21c8817bab02815ac277a21143677"
 dependencies = [
  "futures",
  "ring",
- "rustls 0.22.3",
+ "rustls 0.22.4",
  "tokio",
  "tokio-postgres",
  "tokio-rustls 0.25.0",
@@ -5694,7 +5671,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -5704,7 +5681,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.3",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
 ]
@@ -5771,7 +5748,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -5799,7 +5776,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.9",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -5824,15 +5801,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.5",
+ "winnow 0.6.7",
 ]
 
 [[package]]
@@ -5937,7 +5914,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6118,9 +6095,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-xid"
@@ -6335,7 +6312,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -6369,7 +6346,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6421,7 +6398,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
 dependencies = [
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "wasite",
  "web-sys",
 ]
@@ -6444,11 +6421,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6459,12 +6436,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.54.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.4",
+ "windows-core 0.56.0",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -6473,26 +6450,50 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.54.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
+ "windows-implement",
+ "windows-interface",
  "windows-result",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64"
+checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -6510,7 +6511,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -6530,17 +6531,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -6551,9 +6553,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6563,9 +6565,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6575,9 +6577,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6587,9 +6595,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6599,9 +6607,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6611,9 +6619,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6623,9 +6631,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
@@ -6638,9 +6646,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
 dependencies = [
  "memchr",
 ]
@@ -6756,7 +6764,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6776,7 +6784,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[patch.unused]]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -57,6 +57,7 @@ dyn-clone = "1.0.17"
 flate2 = "1.0.28"
 futures = "0.3.30"
 futures-lite = "2.3.0"
+glob = "0.3.1"
 hex = "0.4.3"
 http = "0.2.12" # todo: upgrade this alongside hyper/axum/tokio-tungstenite/tower-http
 hyper = { version = "0.14.28", features = [


### PR DESCRIPTION
For production deployments, the binaries all now log out the metadata file associated with the build via the omnibus package so we can see exactly what version is running on any host.

```
{"architecture": "x86_64", "author": "The System Initiative <dev@systeminit.com>", "binaries": ["/nix/store/1gm83plfdmxcs4c03s5hakwfmmw7iyk7-rebaser/bin/rebaser"], "commit": "4412718b378360cc60d2822d2be471c57e9d9356", "license": "Apache-2.0", "name": "rebaser", "nix_closure": ["/nix/store/08n25j4vxyjidjf93fyc15icxwrxm2p8-libidn2-2.3.4", "/nix/store/1gm83plfdmxcs4c03s5hakwfmmw7iyk7-rebaser", "/nix/store/lmidwx4id2q87f4z9aj79xwb03gsmq5j-xgcc-12.3.0-libgcc", "/nix/store/qn3ggz5sf3hkjs2c797xf7nan3amdxmp-glibc-2.38-27", "/nix/store/s2f1sqfsdi4pmh23nfnrh42v17zsvi5y-libunistring-1.1"], "os": "linux", "source_url": "http://github.com/systeminit/si.git", "version": "20240501.204726.0-sha.4412718b3"}
```

This leverages the metadata.json which is stored somewhere like `/etc/nix-omnibus/rebaser/20240501.204726.0-sha.4412718b3/metadata.json` on the host. 

Locally, it just says metadata cannot be established as it's running vis buck/in buck-out directly.

<hr/>

This PR doesn't include the change, but now that the version can be established, the binary should be able to:
- Push the version/startup marker(s) into Honeycomb on startup
- Include the version in traces/telemetry

This introduces the use of the si-service library (dormant in the repository as is) which can be extended out for various things we may need to do during the application lifecycle like catching signals, handling the internalised health endpoint and various other pieces of functionality to do with managing the binary during it's running lifecycle. 