### PR TITLE
Fix test executions for attribute funcs and missing payload value

### DIFF
--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -32,12 +32,7 @@
           <Stack class="p-2 border-b dark:border-neutral-600" spacing="xs">
             <div class="flex gap-1 flex-wrap">
               <VButton
-                v-if="
-                  testPanelEnabled &&
-                  funcStore.selectedFuncDetails &&
-                  funcStore.selectedFuncDetails?.associations?.type !==
-                    'authentication'
-                "
+                v-if="enableTestPanel"
                 class="--tone-action"
                 icon="save"
                 size="md"
@@ -229,15 +224,7 @@
         />
       </TabGroupItem>
 
-      <TabGroupItem
-        v-if="
-          testPanelEnabled &&
-          funcStore.selectedFuncDetails &&
-          funcStore.selectedFuncDetails?.associations?.type !== 'authentication'
-        "
-        label="Test"
-        slug="test"
-      >
+      <TabGroupItem v-if="enableTestPanel" label="Test" slug="test">
         <FuncTest />
       </TabGroupItem>
     </TabGroup>
@@ -280,7 +267,7 @@ const props = defineProps<{
   funcId?: FuncId;
   schemaVariantId?: string;
   singleModelScreen?: boolean;
-  testPanelEnabled?: boolean;
+  allowTestPanel?: boolean;
 }>();
 
 const funcDetailsTabGroupRef = ref();
@@ -420,15 +407,14 @@ const expandTestPanel = (selectedTabSlug: string | undefined) => {
   }
 };
 
-// const getExecutionReqStatus = funcStore.getRequestStatus(
-//   "GET_FUNC_LAST_EXECUTION",
-//   funcId,
-// );
-// function getLastExecution() {
-//   if (!funcId.value) return;
-//   funcStore.GET_FUNC_LAST_EXECUTION(funcId.value);
-// }
-// const lastExecutionLog = computed(
-//   () => funcStore.lastFuncExecutionLogByFuncId[funcId?.value || ""],
-// );
+// The parent component can allow the test panel to be enabled, but we need to dynamically enable
+// it based on the func kind.
+const enableTestPanel = computed((): boolean => {
+  return (
+    props.allowTestPanel &&
+    (funcStore.selectedFuncDetails?.associations?.type === "attribute" ||
+      funcStore.selectedFuncDetails?.associations?.type === "codeGeneration" ||
+      funcStore.selectedFuncDetails?.associations?.type === "qualification")
+  );
+});
 </script>

--- a/app/web/src/components/FuncEditor/FuncTestSelector.vue
+++ b/app/web/src/components/FuncEditor/FuncTestSelector.vue
@@ -1,0 +1,162 @@
+<template>
+  <div class="flex flex-row items-center gap-sm">
+    <VormInput
+      v-model="selectedComponentId"
+      class="flex-grow"
+      type="dropdown"
+      placeholder="no component selected"
+      noLabel
+      :options="componentAttributeOptions"
+      @update:model-value="loadInputIfNotAttributeFunc"
+    />
+    <VormInput
+      v-if="isAttributeFunc"
+      v-model="selectedPrototypeId"
+      class="flex-grow"
+      type="dropdown"
+      placeholder="no prototype selected"
+      noLabel
+      :disabled="!selectedComponentId"
+      :options="prototypeAttributeOptions"
+      @update:model-value="emit('loadInput')"
+    />
+    <VButton
+      label="Run Test"
+      size="sm"
+      :loading="testStatus === 'running'"
+      loadingText="Running"
+      loadingIcon="loader"
+      icon="play"
+      :disabled="disableTestButton"
+      @click="emit('startTest')"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { VButton, VormInput } from "@si/vue-lib/design-system";
+import { PropType, computed, ref } from "vue";
+import { useComponentsStore } from "@/store/components.store";
+import { useFuncStore } from "@/store/func/funcs.store";
+import { AttributePrototypeBag } from "@/store/func/types";
+import { TestStatus } from "./FuncTest.vue";
+
+const componentsStore = useComponentsStore();
+const funcStore = useFuncStore();
+
+const props = defineProps({
+  testStatus: { type: String as PropType<TestStatus>, required: true },
+  schemaVariantId: { type: String, required: true },
+  readyToTest: { type: Boolean, required: true },
+  isAttributeFunc: { type: Boolean, required: true },
+});
+
+const selectedComponentId = ref<string | undefined>(undefined);
+const selectedPrototypeId = ref<string | undefined>(undefined);
+
+const componentAttributeOptions = computed(() => {
+  return componentsForSchemaVariantId.value.map((c) => {
+    return { value: c.id, label: c.displayName };
+  });
+});
+const componentsForSchemaVariantId = computed(() => {
+  return componentsStore.allComponents.filter(
+    (c) => c.schemaVariantId === props.schemaVariantId,
+  );
+});
+
+const disableTestButton = computed(
+  (): boolean =>
+    !selectedComponentId.value ||
+    !props.readyToTest ||
+    (props.isAttributeFunc && !selectedPrototypeId.value),
+);
+
+const prototypeIsForSelectedComponent = (
+  prototype: AttributePrototypeBag,
+): boolean => {
+  // First, we need to ensure the component and its asset have been selected . If not, we need to bail.
+  if (!selectedComponentId.value) {
+    return false;
+  }
+
+  // Default to checking if the prototype belongs to the component first. If it doesn't, we need to check
+  // if it belongs its schema variant. If the prototype belongs to neither, it has been orphaned and we need to
+  // error (this should not be possible, but we still want to check).
+  if (prototype.componentId) {
+    return prototype.componentId === selectedComponentId.value;
+  } else if (prototype.schemaVariantId) {
+    return prototype.schemaVariantId === props.schemaVariantId;
+  } else {
+    throw new Error(
+      "prototype has been orphaned: it neither belongs to a component nor a schema variant",
+    );
+  }
+};
+
+// Only for attribute funcs, assemble prototypes that belong to the selected component.
+const prototypeAttributeOptions = computed(
+  (): {
+    label: string;
+    value: string;
+  }[] => {
+    const options = [];
+
+    // Despite the fact that we can compile prototype options for _all_ components, we should wait until
+    // the user selects a _single_ component.
+    if (!funcStore.selectedFuncId || !selectedComponentId.value) return [];
+    const selectedFunc = funcStore.selectedFuncDetails;
+
+    if (selectedFunc?.associations?.type === "attribute") {
+      const attributeAssociations = selectedFunc.associations;
+
+      for (const prototype of attributeAssociations.prototypes) {
+        if (prototypeIsForSelectedComponent(prototype)) {
+          // Once we know the prototype belongs to either the selected component or its schema variant,
+          // we assemble the option based on what output location the prototype is bound to. If it is
+          // bound to nowhere, we need to error (this should not be possible, but we still want to check).
+          if (prototype.propId) {
+            options.push({
+              label:
+                funcStore.propIdToSourceName(prototype.propId) ??
+                `Attribute: ${prototype.propId}`,
+              value: prototype.id,
+            });
+          } else if (prototype.outputSocketId) {
+            options.push({
+              label:
+                funcStore.outputSocketIdToSourceName(
+                  prototype.outputSocketId,
+                ) ?? `Output Socket: ${prototype.outputSocketId}`,
+              value: prototype.id,
+            });
+          } else {
+            throw new Error(
+              "prototype to test is not bound to an output location",
+            );
+          }
+        }
+      }
+      return options;
+    } else {
+      // If the selected func is not an attribute func, there are no options to assemble.
+      return [];
+    }
+  },
+);
+
+// We need the user to select a prototype after selecting a component if its an attribute func.
+const loadInputIfNotAttributeFunc = () => {
+  if (props.isAttributeFunc) {
+    return;
+  }
+  emit("loadInput");
+};
+
+defineExpose({ selectedComponentId, selectedPrototypeId });
+
+const emit = defineEmits<{
+  (e: "startTest"): void;
+  (e: "loadInput"): void;
+}>();
+</script>

--- a/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
+++ b/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
@@ -51,7 +51,7 @@
           :funcId="assetStore.selectedFuncId"
           :schemaVariantId="assetStore.selectedAsset?.defaultSchemaVariantId"
           singleModelScreen
-          testPanelEnabled
+          allowTestPanel
           @detached="onDetach"
           @expand-panel="rightResizablePanelRef?.maximize()"
         />

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -406,7 +406,6 @@ export const useFuncStore = () => {
             },
           });
         },
-
         async SAVE_AND_EXEC_FUNC(funcId: FuncId) {
           const func = this.funcById(funcId);
           if (func) {
@@ -434,17 +433,6 @@ export const useFuncStore = () => {
             },
           });
         },
-        async GET_FUNC_LAST_EXECUTION(funcId: FuncId) {
-          return new ApiRequest({
-            method: "get",
-            url: "func/get_func_last_execution",
-            params: { id: funcId, ...visibility },
-            onSuccess: (response) => {
-              this.lastFuncExecutionLogByFuncId[funcId] = response;
-            },
-          });
-        },
-
         async TEST_EXECUTE(executeRequest: {
           id: FuncId;
           args: unknown;
@@ -477,7 +465,6 @@ export const useFuncStore = () => {
             params: { ...executeRequest, ...visibility },
           });
         },
-
         async CREATE_FUNC(createFuncRequest: {
           kind: FuncKind;
           name?: string;
@@ -497,7 +484,6 @@ export const useFuncStore = () => {
             },
           });
         },
-
         async FETCH_INPUT_SOURCE_LIST(schemaVariantId?: string) {
           return new ApiRequest<{
             inputSockets: InputSocketView[];
@@ -540,6 +526,17 @@ export const useFuncStore = () => {
               }
               this.outputSockets = outputSockets;
             },
+          });
+        },
+        async FETCH_PROTOTYPE_ARGUMENTS(
+          propId?: string,
+          outputSocketId?: string,
+        ) {
+          return new ApiRequest<{
+            preparedArguments: Record<string, unknown>;
+          }>({
+            url: "attribute/get_prototype_arguments",
+            params: { propId, outputSocketId, ...visibility },
           });
         },
 

--- a/lib/dal/src/component/properties.rs
+++ b/lib/dal/src/component/properties.rs
@@ -29,9 +29,9 @@ pub struct ResourceProperties {
     #[serde(skip_serializing_if = "Option::is_none")]
     logs: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    value: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     last_synced: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payload: Option<serde_json::Value>,
 }
 
 impl ComponentProperties {

--- a/lib/dal/tests/integration_test/attribute.rs
+++ b/lib/dal/tests/integration_test/attribute.rs
@@ -1,1 +1,2 @@
 mod prototype;
+mod value;

--- a/lib/dal/tests/integration_test/attribute/value.rs
+++ b/lib/dal/tests/integration_test/attribute/value.rs
@@ -1,0 +1,56 @@
+use dal::prop::PropPath;
+use dal::{AttributeValue, Component, DalContext, Prop, Schema};
+use dal_test::helpers::ChangeSetTestHelpers;
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn arguments_for_prototype_function_execution(ctx: &mut DalContext) {
+    let schema = Schema::find_by_name(ctx, "swifty")
+        .await
+        .expect("could not perform find by name")
+        .expect("schema not found");
+    let schema_variant_id = schema
+        .get_default_schema_variant_id(ctx)
+        .await
+        .expect("could not perform get default schema variant")
+        .expect("schema variant not found");
+
+    // Create a component and commit. For context, the test exclusive schema has the identity
+    // function set on "/root/domain/name" with an input from "/root/si/name". We need to ensure
+    // that the value of "/root/si/name" comes in, as expected. The name is set when creating a
+    // component, so we do not need to do additional setup.
+    let expected = "you should see this name in the arguments";
+    let _component = Component::new(ctx, expected, schema_variant_id)
+        .await
+        .expect("could not create component");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Ensure that the arguments look as we expect.
+    let prop_id = Prop::find_prop_id_by_path(
+        ctx,
+        schema_variant_id,
+        &PropPath::new(["root", "domain", "name"]),
+    )
+    .await
+    .expect("could not find prop id by path");
+    let mut attribute_value_ids = Prop::attribute_values_for_prop_id(ctx, prop_id)
+        .await
+        .expect("could not list attribute value ids for prop id");
+    let attribute_value_id = attribute_value_ids
+        .pop()
+        .expect("empty attribute value ids");
+    assert!(attribute_value_ids.is_empty());
+    let (_, arguments) =
+        AttributeValue::prepare_arguments_for_prototype_function_execution(ctx, attribute_value_id)
+            .await
+            .expect("could not prepare arguments");
+    assert_eq!(
+        serde_json::json![{
+            "identity": expected
+        }], // expected
+        arguments // actual
+    );
+}

--- a/lib/sdf-server/src/server/routes.rs
+++ b/lib/sdf-server/src/server/routes.rs
@@ -25,6 +25,10 @@ pub fn routes(state: AppState) -> Router {
         )
         .nest("/api/action", crate::server::service::action::routes())
         .nest(
+            "/api/attribute",
+            crate::server::service::attribute::routes(),
+        )
+        .nest(
             "/api/change_set",
             crate::server::service::change_set::routes(),
         )

--- a/lib/sdf-server/src/server/service.rs
+++ b/lib/sdf-server/src/server/service.rs
@@ -1,5 +1,6 @@
 pub mod action;
 pub mod async_route;
+pub mod attribute;
 pub mod change_set;
 pub mod component;
 pub mod diagram;

--- a/lib/sdf-server/src/server/service/attribute.rs
+++ b/lib/sdf-server/src/server/service/attribute.rs
@@ -1,0 +1,46 @@
+use axum::{response::Response, routing::get, Json, Router};
+use dal::attribute::value::AttributeValueError;
+use dal::prop::PropError;
+use dal::socket::output::OutputSocketError;
+use dal::{AttributeValueId, OutputSocketId, PropId, TransactionsError};
+use thiserror::Error;
+
+use crate::server::{impl_default_error_into_response, state::AppState};
+
+pub mod get_prototype_arguments;
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum AttributeError {
+    #[error("attribute value error: {0}")]
+    AttributeValue(#[from] AttributeValueError),
+    #[error("context transaction error: {0}")]
+    ContextTransaction(#[from] TransactionsError),
+    #[error("multiple attribute values ({0:?}) found for output socket ({1})")]
+    MultipleAttributeValuesForOutputSocket(Vec<AttributeValueId>, OutputSocketId),
+    #[error("multiple attribute values ({0:?}) found for prop ({1})")]
+    MultipleAttributeValuesForProp(Vec<AttributeValueId>, PropId),
+    #[error("multiple output locations provided: prop id ({0}) and output socket id ({1})")]
+    MultipleOutputLocationsProvided(PropId, OutputSocketId),
+    #[error("no attribute values found for output socket: {0}")]
+    NoAttributeValuesFoundForOutputSocket(OutputSocketId),
+    #[error("no attribute values found for ou: {0}")]
+    NoAttributeValuesFoundForProp(PropId),
+    #[error("no output locations provided")]
+    NoOutputLocationsProvided,
+    #[error("output socket error: {0}")]
+    OutputSocket(#[from] OutputSocketError),
+    #[error("prop error: {0}")]
+    Prop(#[from] PropError),
+}
+
+pub type AttributeResult<T> = Result<T, AttributeError>;
+
+impl_default_error_into_response!(AttributeError);
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route(
+        "/get_prototype_arguments",
+        get(get_prototype_arguments::get_prototype_arguments),
+    )
+}

--- a/lib/sdf-server/src/server/service/attribute/get_prototype_arguments.rs
+++ b/lib/sdf-server/src/server/service/attribute/get_prototype_arguments.rs
@@ -1,0 +1,92 @@
+use axum::extract::OriginalUri;
+use axum::{extract::Query, Json};
+use dal::{AttributeValue, OutputSocket, OutputSocketId, Prop, PropId, Visibility};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::AttributeResult;
+use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
+use crate::server::tracking::track;
+use crate::service::attribute::AttributeError;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetPrototypeArgumentsRequest {
+    pub prop_id: Option<PropId>,
+    pub output_socket_id: Option<OutputSocketId>,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetPrototypeArgumentsResponse {
+    pub prepared_arguments: Value,
+}
+
+pub async fn get_prototype_arguments(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Query(request): Query<GetPrototypeArgumentsRequest>,
+) -> AttributeResult<Json<GetPrototypeArgumentsResponse>> {
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    // Find the attribute values for the provided output location corresponding to the attribute
+    // prototype. There should only be one.
+    let attribute_value_id = match (request.prop_id, request.output_socket_id) {
+        (Some(prop_id), None) => {
+            let attribute_value_ids = Prop::attribute_values_for_prop_id(&ctx, prop_id).await?;
+            if attribute_value_ids.len() > 1 {
+                return Err(AttributeError::MultipleAttributeValuesForProp(
+                    attribute_value_ids.to_owned(),
+                    prop_id,
+                ));
+            }
+            *attribute_value_ids
+                .first()
+                .ok_or(AttributeError::NoAttributeValuesFoundForProp(prop_id))?
+        }
+        (None, Some(output_socket_id)) => {
+            let attribute_value_ids =
+                OutputSocket::attribute_values_for_output_socket_id(&ctx, output_socket_id).await?;
+            if attribute_value_ids.len() > 1 {
+                return Err(AttributeError::MultipleAttributeValuesForOutputSocket(
+                    attribute_value_ids.to_owned(),
+                    output_socket_id,
+                ));
+            }
+            *attribute_value_ids.first().ok_or(
+                AttributeError::NoAttributeValuesFoundForOutputSocket(output_socket_id),
+            )?
+        }
+        (None, None) => return Err(AttributeError::NoOutputLocationsProvided),
+        (Some(prop_id), Some(ouput_socket_id)) => {
+            return Err(AttributeError::MultipleOutputLocationsProvided(
+                prop_id,
+                ouput_socket_id,
+            ))
+        }
+    };
+
+    let (_, prepared_arguments) =
+        AttributeValue::prepare_arguments_for_prototype_function_execution(
+            &ctx,
+            attribute_value_id,
+        )
+        .await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        "get_prototype_arguments",
+        serde_json::json!({
+            "how": "/attribute/get_prototype_arguments",
+            "prop_id": request.prop_id,
+            "output_socket_id": request.output_socket_id,
+        }),
+    );
+
+    Ok(Json(GetPrototypeArgumentsResponse { prepared_arguments }))
+}

--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -77,7 +77,7 @@ pub fn routes() -> Router<AppState> {
         )
         .route("/save_and_exec", post(save_and_exec::save_and_exec))
         .route("/save_func", post(save_func::save_func))
-        .route("/test_execute", post(test_execute::execute))
+        .route("/test_execute", post(test_execute::test_execute))
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/lib/sdf-server/src/server/service/func/get_func.rs
+++ b/lib/sdf-server/src/server/service/func/get_func.rs
@@ -17,16 +17,6 @@ pub struct GetLatestFuncExecutionRequest {
     pub visibility: Visibility,
 }
 
-// #[derive(Deserialize, Serialize, Debug)]
-// #[serde(rename_all = "camelCase")]
-// pub struct GetLatestFuncExecutionResponse {
-//     pub id: FuncId,
-//     pub state: FuncExecutionState,
-//     pub value: Option<serde_json::Value>,
-//     pub output_stream: Option<Vec<OutputStream>>,
-//     pub function_failure: Option<FunctionResultFailure>,
-// }
-
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct GetFuncRequest {
@@ -63,22 +53,3 @@ pub async fn get_func(
 
     Ok(Json(view))
 }
-
-// pub async fn get_latest_func_execution(
-//     HandlerContext(builder): HandlerContext,
-//     AccessBuilder(request_ctx): AccessBuilder,
-//     Query(request): Query<GetLatestFuncExecutionRequest>,
-// ) -> FuncResult<Json<GetLatestFuncExecutionResponse>> {
-//     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
-
-//     let func_execution_result =
-//         FuncExecution::get_latest_execution_by_func_id(&ctx, &request.id).await?;
-
-//     Ok(Json(GetLatestFuncExecutionResponse {
-//         id: *func_execution_result.func_id(),
-//         state: func_execution_result.state(),
-//         value: func_execution_result.value().cloned(),
-//         output_stream: func_execution_result.output_stream().cloned(),
-//         function_failure: func_execution_result.function_failure().clone(),
-//     }))
-// }

--- a/lib/sdf-server/src/server/service/func/test_execute.rs
+++ b/lib/sdf-server/src/server/service/func/test_execute.rs
@@ -10,7 +10,7 @@ use crate::server::tracking::track;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct ExecuteRequest {
+pub struct TestExecuteFuncRequest {
     pub id: FuncId,
     pub args: serde_json::Value,
     pub execution_key: String,
@@ -20,15 +20,15 @@ pub struct ExecuteRequest {
     pub visibility: Visibility,
 }
 
-pub type ExecuteResponse = TestExecuteFuncResult;
+pub type TestExecuteFuncResponse = TestExecuteFuncResult;
 
-pub async fn execute(
+pub async fn test_execute(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
     PosthogClient(posthog_client): PosthogClient,
     OriginalUri(original_uri): OriginalUri,
-    Json(req): Json<ExecuteRequest>,
-) -> FuncResult<Json<ExecuteResponse>> {
+    Json(req): Json<TestExecuteFuncRequest>,
+) -> FuncResult<Json<TestExecuteFuncResponse>> {
     let ctx = builder.build(request_ctx.build(req.visibility)).await?;
 
     let response = FuncAuthoringClient::test_execute_func(

--- a/lib/vue-lib/src/design-system/forms/VormInput.vue
+++ b/lib/vue-lib/src/design-system/forms/VormInput.vue
@@ -775,8 +775,12 @@ defineExpose({
     background-repeat: no-repeat;
 
     &.--placeholder-selected {
-      color: white;
+      color: @colors-neutral-400;
       font-style: italic;
+
+      &.--theme-dark {
+        color: @colors-neutral-500;
+      }
     }
 
     &:-moz-focusring {


### PR DESCRIPTION
## Description

This PR fixes test executions for attribute funcs. It also scopes test execution abilities to solely attribute, code generation and qualification funcs.

The existing code assumes that there was only one binding for attribute funcs. Attribute funcs may have multiple bindings, which means that they can have different input sources (`AttributePrototypeArguments`) for the same `FuncArguments`. For example: if you have a `FuncArgument` that takes in a string called `toddhoward`, it is possible for one binding to get that value from `/root/si/name` and another binding to get that value from an input socket who provides a string.

The existing code also assumed that there was only one `FuncArgument`. Now, we derive the arguments from the backend and avoid walking the result of `component/json` (as well as assuming that the `FuncArgument` name will match the name of a given `Prop`).

This PR also fixes a bug where `/root/resource/payload` would not be returned from the `component/json` route due to a dropped field during de/serialization.

<img src="https://media4.giphy.com/media/3orieTN9KzSeh6MxOw/giphy.gif"/>

## Additional Fixes
- Placeholder text colors for `VormInput` now work in both light and dark mode
- Split selector details out into a new component: `FuncTestSelector`
- Split argument preparation for prototype execution into its own method with a corresponding integration test
- Removed unused code related to fetching latest func executions
- Add new `/attribute` endpoint and alongside a route to provide prototype arguments

## Screenshots: Attribute Func Test (Light Mode)

![image](https://github.com/systeminit/si/assets/39320683/9706f52e-a59f-48c1-a81e-2057beaf7cde)

---

![image](https://github.com/systeminit/si/assets/39320683/f2214bbd-ff88-4c48-b309-801af6f7e2e3)

---

![image](https://github.com/systeminit/si/assets/39320683/434eda31-5e4c-4be8-a40c-9adcdc714fd9)

## Screenshots: Attribute Func Test (Dark Mode)

![image](https://github.com/systeminit/si/assets/39320683/bdcbae18-5535-4b3f-993c-609b2acdc4a1)

---

![image](https://github.com/systeminit/si/assets/39320683/21b55b9b-d7cd-4f35-8d3f-4b084a5edb32)

---

![image](https://github.com/systeminit/si/assets/39320683/56381e45-33a0-4823-ae55-b24d31386326)

## Screenshots: Post Test Execution of an Attribute Func (Dark Mode)

![image](https://github.com/systeminit/si/assets/39320683/ac31f83e-7ed4-44a6-b395-7b01861c2fb3)

## Screenshots: Code Generation Func Test with Execution (Light Mode)

![image](https://github.com/systeminit/si/assets/39320683/5c790abf-9896-4f73-a6d5-21be76af7140)

---

![image](https://github.com/systeminit/si/assets/39320683/ed7a2552-54b1-4bf5-8f5e-982d1f72fada)

---

![image](https://github.com/systeminit/si/assets/39320683/1a0aa34d-45aa-40a1-8847-0fe5a3018781)

## Screenshots: Qualification Func Test with Execution (Dark Mode)

![image](https://github.com/systeminit/si/assets/39320683/880f95c9-cf70-41d6-a88f-cba7eeb43de1)

---

![image](https://github.com/systeminit/si/assets/39320683/48631629-b893-4147-8fab-ebafe5cc2922)

---

![image](https://github.com/systeminit/si/assets/39320683/f129fc5f-5eb3-4b65-9852-27368f901de5)

## Screenshots: No Func Test Tab for Action or Authentication Funcs (Light Mode)

![image](https://github.com/systeminit/si/assets/39320683/efc04f96-f386-4dac-93c3-84b6db9a00ce)

---

![image](https://github.com/systeminit/si/assets/39320683/ae438e7f-97f1-436f-a0f4-a94215db61fd)