### PR TITLE
fix: UID range too low for AML 2023

### DIFF
--- a/bin/veritech/scripts/prepare_jailer.sh
+++ b/bin/veritech/scripts/prepare_jailer.sh
@@ -44,7 +44,7 @@ JAILER_NS="jailer-$SB_ID"
 
 # Create a user and group to run the execution via for one micro-vm
 function user_prep() {
-  useradd -M -u 30$SB_ID $JAILER_NS
+  useradd -M -u 300$SB_ID $JAILER_NS
   usermod -L $JAILER_NS
 
   # This group was created earlier on the machine provisioning
@@ -53,7 +53,7 @@ function user_prep() {
   usermod -a -G kvm $JAILER_NS
 }
 
-if ! id 30$SB_ID >/dev/null 2>&1; then
+if ! id 300$SB_ID >/dev/null 2>&1; then
   retry user_prep
 fi
 

--- a/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
+++ b/lib/deadpool-cyclone/src/instance/cyclone/local_uds.rs
@@ -842,7 +842,7 @@ impl LocalFirecrackerRuntime {
             .arg("--exec-file")
             .arg("/usr/bin/firecracker")
             .arg("--uid")
-            .arg(format!("30{}", vm_id))
+            .arg(format!("300{}", vm_id))
             .arg("--gid")
             .arg("10000")
             .arg("--netns")


### PR DESCRIPTION
The default UID range on AML 2023 is 1000-60000. We set the pool size to 100 right now. This means that we were creating pools with UIDs of 300-3099, meaning the first 10 jails would fail to prepare and cause poolnoodle to thrash when it hit those ranges. This will put us in the 3000-30099 range, which should be more reliable.

I would really love to spend some cycles reintroducing the poolnoodle changes I attempted to make before and to rethink some of these bits. The flakiness here is always bothersome. 

<img src="https://media3.giphy.com/media/dW6sHDZIRnEvwPPmkj/giphy.gif"/>