### PR TITLE
fix(web): fix type issue in theme switch

### DIFF
--- a/lib/vue-lib/src/design-system/utils/color_utils.ts
+++ b/lib/vue-lib/src/design-system/utils/color_utils.ts
@@ -87,9 +87,11 @@ export function getToneTextColorClass(tone: Tones) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const toneSettings = TONES[tone] as any;
 
-  if (theme.value === "dark")
-    return toneSettings.textColorClassDark || toneSettings.textColorClass;
-  return toneSettings.textColorClassLight || toneSettings.textColorClass;
+  if (theme?.value === "dark") {
+    return toneSettings?.textColorClassDark ?? toneSettings.textColorClass;
+  }
+
+  return toneSettings?.textColorClassLight ?? toneSettings.textColorClass;
 }
 
 export function getToneBorderColorClass(tone: Tones) {


### PR DESCRIPTION
Access of undefined `theme` causing crash in theme switch if no theme setting was already saved.