### PR TITLE
Take new frames into account when tracking actions ordering

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1472,6 +1472,13 @@ impl Component {
                     .or_default()
                     .insert(incoming_connection.from_component_id);
             }
+
+            if let Some(parent_id) = component.parent(ctx).await? {
+                components_map
+                    .entry(component.id)
+                    .or_default()
+                    .insert(parent_id);
+            }
         }
 
         debug!("build graph took {:?}", total_start.elapsed());

--- a/lib/dal/src/deprecated_action.rs
+++ b/lib/dal/src/deprecated_action.rs
@@ -331,14 +331,6 @@ impl DeprecatedAction {
         for (id, parent_ids) in graph {
             let component = Component::get_by_id(ctx, id).await?;
 
-            // XXX: `is_destroyed` in the old engine should be "doesn't exist in the graph anymore"
-            // in the current/new engine, but we should double check that's what this was expecting
-            // to guard against.
-            //
-            // if component.is_destroyed() {
-            //     continue;
-            // }
-
             let actions = Self::for_component(ctx, id).await?;
             actions_by_component
                 .entry(id)


### PR DESCRIPTION
We defined actions ordering through regular component connections, now that frames don't create them, actions ordering was not taking frames into account.

Also fixes pasting components into a frame.