### PR TITLE
Make func test selector placeholder refer to bindings

### DIFF
--- a/app/web/src/components/FuncEditor/FuncTestSelector.vue
+++ b/app/web/src/components/FuncEditor/FuncTestSelector.vue
@@ -14,7 +14,7 @@
       v-model="selectedPrototypeId"
       class="flex-grow"
       type="dropdown"
-      placeholder="no prototype selected"
+      placeholder="no binding selected"
       noLabel
       :disabled="!selectedComponentId"
       :options="prototypeAttributeOptions"


### PR DESCRIPTION
This commit makes the func test selector placeholder for attribute funcs refer to bindings. The word "prototype" does not appear in this user domain and should not be used here.