### PR TITLE
Forbid editing functions on head

### DIFF
--- a/app/web/src/components/AssetEditor.vue
+++ b/app/web/src/components/AssetEditor.vue
@@ -30,7 +30,11 @@
     </template>
 
     <CodeEditor
-      :id="`asset-${assetId}`"
+      :id="
+        changeSetsStore.headChangeSetId === changeSetsStore.selectedChangeSetId
+          ? undefined
+          : `asset-${assetId}`
+      "
       v-model="editingAsset"
       :typescript="selectedAsset?.types"
       :disabled="isReadOnly"
@@ -52,8 +56,11 @@ import {
 } from "@si/vue-lib/design-system";
 import { useAssetStore, assetDisplayName } from "@/store/asset.store";
 import SiChip from "@/components/SiChip.vue";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 import CodeEditor from "./CodeEditor.vue";
 import NodeSkeleton from "./NodeSkeleton.vue";
+
+const changeSetsStore = useChangeSetsStore();
 
 const props = defineProps<{
   assetId?: string;
@@ -85,10 +92,24 @@ watch(
   { immediate: true },
 );
 
+const updatedHead = ref(false);
+watch(
+  () => changeSetsStore.selectedChangeSetId,
+  () => {
+    updatedHead.value = false;
+  },
+);
+
 const onChange = () => {
-  if (!selectedAsset.value || selectedAsset.value.code === editingAsset.value) {
+  if (
+    !selectedAsset.value ||
+    selectedAsset.value.code === editingAsset.value ||
+    updatedHead.value
+  ) {
     return;
   }
+  updatedHead.value =
+    changeSetsStore.selectedChangeSetId === changeSetsStore.headChangeSetId;
   assetStore.enqueueAssetSave({
     ...selectedAsset.value,
     code: editingAsset.value,

--- a/app/web/src/components/FuncEditor/FuncEditor.vue
+++ b/app/web/src/components/FuncEditor/FuncEditor.vue
@@ -16,7 +16,12 @@
       "
     >
       <CodeEditor
-        :id="selectedFuncDetails ? `func-${selectedFuncDetails.id}` : undefined"
+        :id="
+          changeSetsStore.headChangeSetId !==
+            changeSetsStore.selectedChangeSetId && selectedFuncDetails
+            ? `func-${selectedFuncDetails.id}`
+            : undefined
+        "
         v-model="editingFunc"
         :typescript="selectedFuncDetails?.types"
         @change="updateFuncCode"
@@ -36,7 +41,10 @@ import { PropType, ref, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { LoadingMessage, ErrorMessage } from "@si/vue-lib/design-system";
 import { FuncId, useFuncStore } from "@/store/func/funcs.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 import CodeEditor from "@/components/CodeEditor.vue";
+
+const changeSetsStore = useChangeSetsStore();
 
 const props = defineProps({
   funcId: { type: String as PropType<FuncId>, required: true },
@@ -72,7 +80,18 @@ watch(
   { immediate: true },
 );
 
+const updatedHead = ref(false);
+watch(
+  () => changeSetsStore.selectedChangeSetId,
+  () => {
+    updatedHead.value = false;
+  },
+);
 const updateFuncCode = (code: string) => {
+  if (updatedHead.value) return;
+
+  updatedHead.value =
+    changeSetsStore.selectedChangeSetId === changeSetsStore.headChangeSetId;
   funcStore.updateFuncCode(props.funcId, code);
 };
 


### PR DESCRIPTION
- No CRDT on head, since it should be set from an apply
- Stop creating two change-sets (saving on the edit and then on unmount)
- Create new change-set with the updated func, leaving head untouched