### PR TITLE
feat(web): Removal of SiChip to denote if something is builtin or not

### DIFF
--- a/app/web/src/components/SiFuncListItem.vue
+++ b/app/web/src/components/SiFuncListItem.vue
@@ -18,11 +18,6 @@
         <div class="truncate">
           {{ func.name }}
         </div>
-        <SiChip
-          :text="func.isBuiltin ? 'builtin' : 'custom'"
-          :variant="func.isBuiltin ? 'warning' : 'neutral'"
-          class="flex-none"
-        />
       </div>
       <!-- <div
                 class="italic text-xs text-neutral-500 dark:text-neutral-400"
@@ -40,7 +35,6 @@ import { TreeNode } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { useFuncStore, FuncSummary } from "@/store/func/funcs.store";
 import { trackEvent } from "@/utils/tracking";
-import SiChip from "./SiChip.vue";
 
 const props = defineProps<{
   color?: string;


### PR DESCRIPTION
This is a controversial one - TL;DR, I don't believe a user cares about something being builtin or not. All a builtin is, is something we give a user at application startup time. It was more important in the old engine where there was no concept of lineage

In this new engine, we can allow editing of all builtins EXCEPT the intrinsics because they are important to the system. This feels less confusing to me, as a user now

![Screenshot 2024-05-02 at 23 20 01](https://github.com/systeminit/si/assets/227823/3a412d3c-7055-4adc-9362-a821e265d1a8)
