### PR TITLE
BUG-138 diagram outliner fix recursion

### DIFF
--- a/app/web/src/components/DiagramOutline/DiagramOutline.vue
+++ b/app/web/src/components/DiagramOutline/DiagramOutline.vue
@@ -205,18 +205,22 @@ const filterComponentArrayBySearchString = (components: FullComponent[]) => {
 const filterComponentArrayBySearchStringAndFilters = (
   components: FullComponent[],
 ) => {
-  let filteredComponents = filterComponentArrayBySearchString(components);
+  let _filteredComponents = filterComponentArrayBySearchString(components);
 
   if (searchRef.value?.filteringActive) {
-    searchFiltersWithCounts.value.forEach((filter, index) => {
+    for (
+      let index = 0;
+      index < searchRef.value?.activeFilters.length;
+      index++
+    ) {
       if (searchRef.value?.activeFilters[index]) {
-        filteredComponents = _.filter(filteredComponents, (component) =>
+        _filteredComponents = _.filter(_filteredComponents, (component) =>
           filterArrays[index]?.value.includes(component),
         ) as FullComponent[];
       }
-    });
+    }
   }
-  return filteredComponents;
+  return _filteredComponents;
 };
 
 const filteredComponents = computed(() => {


### PR DESCRIPTION
The problem is that the computed `searchFiltersWithCounts` uses the fn `filterComponentArrayBySearchStringAndFilters` and that fn uses `searchFiltersWithCounts` within it. So I found a way to remove the reference from within the fn.
<img src="https://media2.giphy.com/media/pJmnk86fXFNmrUb8LB/giphy.gif"/>