### PR TITLE
feat(dal): remove materialized views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ dependencies = [
  "futures",
  "hex",
  "iftree",
+ "indexmap 2.2.6",
  "itertools 0.12.1",
  "jwt-simple",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ hyperlocal = { version = "0.8.0", default-features = false, features = [
 ] } # todo: using the very latest of hyper client 1.x, we _may_ be able to phase this crate
 iftree = "1.0.5"
 indicatif = "0.17.8"
-indexmap = "2.2.6"
+indexmap = { version = "2.2.6", features = ["serde", "std"] }
 indoc = "2.0.5"
 inquire = "0.7.4"
 itertools = "0.12.1"

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -33,6 +33,7 @@ rust_library(
         "//third-party/rust:futures",
         "//third-party/rust:hex",
         "//third-party/rust:iftree",
+        "//third-party/rust:indexmap",
         "//third-party/rust:itertools",
         "//third-party/rust:jwt-simple",
         "//third-party/rust:lazy_static",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -34,6 +34,7 @@ dyn-clone = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 iftree = { workspace = true }
+indexmap = { workspace = true }
 itertools = { workspace = true }
 jwt-simple = { workspace = true }
 lazy_static = { workspace = true }

--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -174,13 +174,10 @@ impl AttributePrototypeDebugView {
                                 AttributeValue::get_by_id(ctx, attribute_value_id).await?;
                             let prop_path =
                                 AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
-                            let mat_view = attribute_value
-                                .materialized_view(ctx)
-                                .await?
-                                .unwrap_or(Value::Null);
-                            info!("Materialized View: {:?}", mat_view);
+                            let view = attribute_value.view(ctx).await?.unwrap_or(Value::Null);
+                            info!("View: {:?}", view);
                             let func_arg_debug = FuncArgDebugView {
-                                value: mat_view,
+                                value: view,
                                 name: func_arg_name.clone(),
                                 value_source: value_source.to_string(),
                                 value_source_id: prop_id.into(),
@@ -205,13 +202,11 @@ impl AttributePrototypeDebugView {
                             let attribute_value_path =
                                 AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
 
-                            let mat_view = attribute_value
-                                .materialized_view(ctx)
-                                .await?
-                                .unwrap_or(Value::Null);
-                            info!("Materialized View: {:?}", mat_view);
+                            let value_view =
+                                attribute_value.view(ctx).await?.unwrap_or(Value::Null);
+                            info!("Materialized View: {:?}", value_view);
                             let func_arg_debug = FuncArgDebugView {
-                                value: mat_view,
+                                value: value_view,
                                 name: func_arg_name.clone(),
                                 value_source: value_source.to_string(),
                                 value_source_id: input_socket_id.into(),
@@ -236,13 +231,11 @@ impl AttributePrototypeDebugView {
                             let attribute_value_path =
                                 AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
 
-                            let mat_view = attribute_value
-                                .materialized_view(ctx)
-                                .await?
-                                .unwrap_or(Value::Null);
-                            info!("Materialized View: {:?}", mat_view);
+                            let value_view =
+                                attribute_value.view(ctx).await?.unwrap_or(Value::Null);
+                            info!("Materialized View: {:?}", value_view);
                             let func_arg_debug = FuncArgDebugView {
-                                value: mat_view,
+                                value: value_view,
                                 name: func_arg_name.clone(),
                                 value_source: value_source.to_string(),
                                 value_source_id: output_socket_id.into(),
@@ -292,17 +285,14 @@ impl AttributePrototypeDebugView {
                         AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
                     let output_av =
                         AttributeValue::get_by_id(ctx, output_match.attribute_value_id).await?;
-                    let mat_view = output_av
-                        .materialized_view(ctx)
-                        .await?
-                        .unwrap_or(Value::Null);
+                    let value_view = output_av.view(ctx).await?.unwrap_or(Value::Null);
                     let input_func = AttributePrototype::func_id(ctx, prototype_id).await?;
                     if let Some(func_argument) =
                         FuncArgument::list_for_func(ctx, input_func).await?.pop()
                     {
                         let func_arg_name = func_argument.name.clone();
                         let func_arg_debug = FuncArgDebugView {
-                            value: mat_view,
+                            value: value_view,
                             name: func_argument.name,
                             value_source: "Output Socket".to_string(),
                             value_source_id: output_match.output_socket_id.into(),

--- a/lib/dal/src/attribute/value/debug.rs
+++ b/lib/dal/src/attribute/value/debug.rs
@@ -41,7 +41,7 @@ pub struct AttributeDebugView {
     pub func_args: HashMap<String, Vec<FuncArgDebugView>>,
     pub value: Option<serde_json::Value>,
     pub prop_kind: Option<PropKind>,
-    pub materialized_view: Option<serde_json::Value>,
+    pub view: Option<serde_json::Value>,
 }
 
 type AttributeDebugViewResult<T> = Result<T, AttributeDebugViewError>;
@@ -97,7 +97,7 @@ impl AttributeDebugView {
         let prop_opt: Option<Prop> = Some(prop);
         let attribute_prototype_debug_view =
             AttributePrototypeDebugView::new(ctx, attribute_value_id).await?;
-        let materialized_view = attribute_value.materialized_view(ctx).await?;
+        let value_view = attribute_value.view(ctx).await?;
         let prop_kind = prop_opt.clone().map(|prop| prop.kind);
         let value = match attribute_value.unprocessed_value(ctx).await? {
             Some(value) => Some(value),
@@ -118,7 +118,7 @@ impl AttributeDebugView {
             func_args: attribute_prototype_debug_view.func_args,
             value,
             prop_kind,
-            materialized_view,
+            view: value_view,
         };
         Ok(view)
     }

--- a/lib/dal/src/code_view.rs
+++ b/lib/dal/src/code_view.rs
@@ -82,7 +82,7 @@ impl CodeView {
             None => return Ok(None),
         };
 
-        let func_execution = match attribute_value.materialized_view(ctx).await? {
+        let func_execution = match attribute_value.view(ctx).await? {
             Some(func_execution) => func_execution,
             None => return Ok(None),
         };

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -285,10 +285,7 @@ impl Component {
         self.to_delete
     }
 
-    pub async fn materialized_view(
-        &self,
-        ctx: &DalContext,
-    ) -> ComponentResult<Option<serde_json::Value>> {
+    pub async fn view(&self, ctx: &DalContext) -> ComponentResult<Option<serde_json::Value>> {
         let schema_variant_id = Self::schema_variant_id(ctx, self.id()).await?;
         let root_prop_id =
             Prop::find_prop_id_by_path(ctx, schema_variant_id, &PropPath::new(["root"])).await?;
@@ -298,7 +295,7 @@ impl Component {
             let value_component_id = AttributeValue::component_id(ctx, value_id).await?;
             if value_component_id == self.id() {
                 let root_value = AttributeValue::get_by_id(ctx, value_id).await?;
-                return Ok(root_value.materialized_view(ctx).await?);
+                return Ok(root_value.view(ctx).await?);
             }
         }
 
@@ -1075,7 +1072,7 @@ impl Component {
 
         let av = AttributeValue::get_by_id(ctx, value_id).await?;
 
-        Ok(match av.materialized_view(ctx).await? {
+        Ok(match av.view(ctx).await? {
             Some(serde_value) => serde_json::from_value(serde_value)?,
             None => DeprecatedActionRunResult::default(),
         })
@@ -1091,7 +1088,7 @@ impl Component {
 
         let name_av = AttributeValue::get_by_id(ctx, name_value_id).await?;
 
-        Ok(match name_av.materialized_view(ctx).await? {
+        Ok(match name_av.view(ctx).await? {
             Some(serde_value) => serde_json::from_value(serde_value)?,
             None => "".into(),
         })
@@ -1107,7 +1104,7 @@ impl Component {
 
         let color_av = AttributeValue::get_by_id(ctx, color_value_id).await?;
 
-        Ok(match color_av.materialized_view(ctx).await? {
+        Ok(match color_av.view(ctx).await? {
             Some(serde_value) => Some(serde_json::from_value(serde_value)?),
             None => None,
         })
@@ -1125,7 +1122,7 @@ impl Component {
                 .ok_or(ComponentError::ComponentMissingTypeValue(component_id))?;
         let type_value = AttributeValue::get_by_id(ctx, type_value_id)
             .await?
-            .materialized_view(ctx)
+            .view(ctx)
             .await?
             .ok_or(ComponentError::ComponentMissingTypeValueMaterializedView(
                 component_id,

--- a/lib/dal/src/component/diff.rs
+++ b/lib/dal/src/component/diff.rs
@@ -33,8 +33,8 @@ impl Component {
     ) -> ComponentResult<ComponentDiff> {
         let component = Self::get_by_id(ctx, component_id).await?;
         let curr_json: String;
-        let materialized_view = component.materialized_view(ctx).await?;
-        if let Some(view) = materialized_view {
+        let view = component.view(ctx).await?;
+        if let Some(view) = view {
             let mut current_component_view = ComponentProperties::try_from(view)?;
             current_component_view.drop_private();
             curr_json = serde_json::to_string_pretty(&current_component_view)?;
@@ -58,8 +58,8 @@ impl Component {
         let head_component = Self::get_by_id(&head_ctx, component_id).await;
         match head_component {
             Ok(comp) => {
-                let materialized_view = comp.materialized_view(&head_ctx).await?;
-                if let Some(view) = materialized_view {
+                let view = comp.view(&head_ctx).await?;
+                if let Some(view) = view {
                     let mut head_component_view = ComponentProperties::try_from(view)?;
                     head_component_view.drop_private();
                     head_component_view.drop_private();
@@ -105,9 +105,9 @@ impl Component {
         component_id: ComponentId,
     ) -> ComponentResult<ComponentProperties> {
         let component = Self::get_by_id(ctx, component_id).await?;
-        let materialized_view = component.materialized_view(ctx).await?;
+        let view = component.view(ctx).await?;
 
-        if let Some(view) = materialized_view {
+        if let Some(view) = view {
             let properties = ComponentProperties::try_from(view)?;
             return Ok(properties);
         }

--- a/lib/dal/src/deprecated_action/prototype.rs
+++ b/lib/dal/src/deprecated_action/prototype.rs
@@ -344,7 +344,7 @@ impl DeprecatedActionPrototype {
         component_id: ComponentId,
     ) -> DeprecatedActionPrototypeResult<Option<DeprecatedActionRunResult>> {
         let component = Component::get_by_id(ctx, component_id).await?;
-        let component_view = component.materialized_view(ctx).await?;
+        let component_view = component.view(ctx).await?;
 
         let before = before_funcs_for_component(ctx, component_id).await?;
 

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -187,11 +187,10 @@ impl QualificationView {
             None => return Ok(None),
         };
 
-        let qualification_entry: QualificationEntry =
-            match attribute_value.materialized_view(ctx).await? {
-                Some(value) => serde_json::from_value(value)?,
-                None => return Ok(None),
-            };
+        let qualification_entry: QualificationEntry = match attribute_value.view(ctx).await? {
+            Some(value) => serde_json::from_value(value)?,
+            None => return Ok(None),
+        };
 
         let func = Func::get_by_id_or_error(ctx, *func_execution.func_id()).await?;
 

--- a/lib/dal/src/socket/debug.rs
+++ b/lib/dal/src/socket/debug.rs
@@ -34,7 +34,7 @@ pub struct SocketDebugView {
     pub func_name: String,
     pub func_args: HashMap<String, Vec<FuncArgDebugView>>,
     pub value: Option<serde_json::Value>,
-    pub materialized_view: Option<serde_json::Value>,
+    pub view: Option<serde_json::Value>,
     pub name: String,
     pub inferred_connections: Vec<Ulid>,
 }
@@ -84,7 +84,7 @@ impl SocketDebugView {
             None => String::new(),
         };
 
-        let materialized_view = attribute_value.materialized_view(ctx).await?;
+        let view = attribute_value.view(ctx).await?;
         let inferred_connections: Vec<Ulid> =
             AttributeValue::list_input_socket_sources_for_id(ctx, attribute_value_id)
                 .await?
@@ -102,7 +102,7 @@ impl SocketDebugView {
             connection_annotations,
             value: attribute_value.unprocessed_value(ctx).await?,
             path,
-            materialized_view,
+            view,
             name: output_socket.name().to_string(),
             inferred_connections,
         })
@@ -130,7 +130,7 @@ impl SocketDebugView {
             Some(path) => path,
             None => String::new(),
         };
-        let materialized_view = attribute_value.materialized_view(ctx).await?;
+        let value_view = attribute_value.view(ctx).await?;
         let inferred_connections =
             match Component::find_potential_inferred_connection_to_input_socket(
                 ctx,
@@ -153,7 +153,7 @@ impl SocketDebugView {
             connection_annotations,
             value: attribute_value.unprocessed_value(ctx).await?,
             path,
-            materialized_view,
+            view: value_view,
             name: input_socket.name().to_string(),
             inferred_connections,
         };

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -657,7 +657,6 @@ impl NodeWeight {
         attribute_value_id: Ulid,
         unprocessed_value: Option<ContentAddress>,
         value: Option<ContentAddress>,
-        materialized_view: Option<ContentAddress>,
         func_execution_pk: Option<FuncExecutionPk>,
     ) -> NodeWeightResult<Self> {
         Ok(NodeWeight::AttributeValue(AttributeValueNodeWeight::new(
@@ -665,7 +664,6 @@ impl NodeWeight {
             attribute_value_id,
             unprocessed_value,
             value,
-            materialized_view,
             func_execution_pk,
         )?))
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -29,8 +29,6 @@ pub struct AttributeValueNodeWeight {
     /// The processed return value.
     /// Example: empty array.
     value: Option<ContentAddress>,
-    /// A cached representation of this value and all of its child values.
-    materialized_view: Option<ContentAddress>,
     /// The id of the func execution that produced the values for this value
     func_execution_pk: Option<FuncExecutionPk>,
 }
@@ -41,7 +39,6 @@ impl AttributeValueNodeWeight {
         id: Ulid,
         unprocessed_value: Option<ContentAddress>,
         value: Option<ContentAddress>,
-        materialized_view: Option<ContentAddress>,
         func_execution_pk: Option<FuncExecutionPk>,
     ) -> NodeWeightResult<Self> {
         Ok(Self {
@@ -54,7 +51,6 @@ impl AttributeValueNodeWeight {
 
             unprocessed_value,
             value,
-            materialized_view,
             func_execution_pk,
         })
     }
@@ -66,9 +62,6 @@ impl AttributeValueNodeWeight {
             hashes.push(hash.content_hash());
         }
         if let Some(hash) = self.value {
-            hashes.push(hash.content_hash());
-        }
-        if let Some(hash) = self.materialized_view {
             hashes.push(hash.content_hash());
         }
 
@@ -93,14 +86,6 @@ impl AttributeValueNodeWeight {
 
     pub fn set_value(&mut self, value: Option<ContentAddress>) {
         self.value = value
-    }
-
-    pub fn materialized_view(&self) -> Option<ContentAddress> {
-        self.materialized_view
-    }
-
-    pub fn set_materialized_view(&mut self, materialized_view: Option<ContentAddress>) {
-        self.materialized_view = materialized_view
     }
 
     pub fn set_func_execution_pk(&mut self, func_execution_pk: Option<FuncExecutionPk>) {
@@ -171,7 +156,6 @@ impl AttributeValueNodeWeight {
         ContentHash::from(&serde_json::json![{
             "unprocessed_value": self.unprocessed_value,
             "value": self.value,
-            "materialized_view": self.materialized_view,
         }])
     }
 
@@ -217,7 +201,6 @@ impl std::fmt::Debug for AttributeValueNodeWeight {
             .field("lineage_id", &self.lineage_id.to_string())
             .field("value", &self.value)
             .field("unprocessed_value", &self.unprocessed_value)
-            .field("materialized_view", &self.materialized_view)
             .field("node_hash", &self.node_hash())
             .field("merkle_tree_hash", &self.merkle_tree_hash)
             .field("vector_clock_first_seen", &self.vector_clock_first_seen)

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -94,10 +94,7 @@ async fn update_and_insert_and_update(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    component
-        .materialized_view(ctx)
-        .await
-        .expect("materialized_view for component");
+    component.view(ctx).await.expect("view for component");
 
     // Confirm after rebase
     let property_values = PropertyEditorValues::assemble(ctx, component.id())
@@ -318,15 +315,15 @@ async fn through_the_wormholes(ctx: &mut DalContext) {
     .await
     .expect("able to set universe value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, rigid_designator_value_id)
+    let view = AttributeValue::get_by_id(ctx, rigid_designator_value_id)
         .await
         .expect("get av")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("get view")
         .expect("has a view");
 
-    assert_eq!(rigid_designation, materialized_view);
+    assert_eq!(rigid_designation, view);
 
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
@@ -335,9 +332,9 @@ async fn through_the_wormholes(ctx: &mut DalContext) {
     let naming_and_necessity_view = AttributeValue::get_by_id(ctx, naming_and_necessity_value_id)
         .await
         .expect("able to get attribute value for `naming_and_necessity_value_id`")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get materialized_view for `naming_and_necessity_value_id`")
+        .expect("able to get view for `naming_and_necessity_value_id`")
         .expect("naming and necessity has a value");
 
     // hesperus is phosphorus (the attr func on naming_and_necessity_value_id will return
@@ -360,10 +357,10 @@ async fn through_the_wormholes(ctx: &mut DalContext) {
         .expect("able to get the value for the root prop attriburte value id");
 
     let root_view = root_value
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to fetch materialized_view for root value")
-        .expect("there is a value for the root value materialized_view");
+        .expect("able to fetch view for root value")
+        .expect("there is a value for the root value view");
 
     assert_eq!(
         serde_json::json!({
@@ -487,15 +484,15 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
     .await
     .expect("able to set universe value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, possible_world_a_value_id)
+    let view = AttributeValue::get_by_id(ctx, possible_world_a_value_id)
         .await
         .expect("get av")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("get view")
         .expect("has a view");
 
-    assert_eq!(possible_world_a, materialized_view);
+    assert_eq!(possible_world_a, view);
 
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
@@ -504,9 +501,9 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
     let naming_and_necessity_view = AttributeValue::get_by_id(ctx, naming_and_necessity_value_id)
         .await
         .expect("able to get attribute value for `naming_and_necessity_value_id`")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get materialized_view for `naming_and_necessity_value_id`")
+        .expect("able to get view for `naming_and_necessity_value_id`")
         .expect("naming and necessity has a value");
 
     // hesperus is phosphorus (the attr func on naming_and_necessity_value_id will return
@@ -529,10 +526,10 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
         .expect("able to get the value for the root prop attriburte value id");
 
     let root_view = root_value
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to fetch materialized_view for root value")
-        .expect("there is a value for the root value materialized_view");
+        .expect("able to fetch view for root value")
+        .expect("there is a value for the root value view");
 
     assert_eq!(
         serde_json::json!({
@@ -608,29 +605,29 @@ async fn set_the_universe(ctx: &mut DalContext) {
         .await
         .expect("able to set universe value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, universe_value_id)
+    let view = AttributeValue::get_by_id(ctx, universe_value_id)
         .await
         .expect("get av")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("get view")
         .expect("has a view");
 
-    assert_eq!(universe_json, materialized_view);
+    assert_eq!(universe_json, view);
 
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, universe_value_id)
+    let view = AttributeValue::get_by_id(ctx, universe_value_id)
         .await
         .expect("get av")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("get view")
         .expect("has a view");
 
-    assert_eq!(universe_json, materialized_view);
+    assert_eq!(universe_json, view);
 }
 
 #[test]
@@ -741,15 +738,14 @@ async fn deletion_updates_downstream_components(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
-    let units_json_string =
-        serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
+        .expect("able to get units view")
+        .expect("units has a view");
+    let units_json_string = serde_json::to_string(&view).expect("Unable to stringify JSON");
     assert!(units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 
@@ -789,15 +785,14 @@ async fn deletion_updates_downstream_components(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
-    let units_json_string =
-        serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
+        .expect("able to get units view")
+        .expect("units has a view");
+    let units_json_string = serde_json::to_string(&view).expect("Unable to stringify JSON");
     assert!(!units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 }
@@ -910,15 +905,14 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
-    let units_json_string =
-        serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
+        .expect("able to get units view")
+        .expect("units has a view");
+    let units_json_string = serde_json::to_string(&view).expect("Unable to stringify JSON");
     assert!(units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 
@@ -958,15 +952,14 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
-    let units_json_string =
-        serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
+        .expect("able to get units view")
+        .expect("units has a view");
+    let units_json_string = serde_json::to_string(&view).expect("Unable to stringify JSON");
     assert!(!units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 
@@ -1007,15 +1000,15 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
-    let units_json_string =
-        serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
+        .expect("able to get units view")
+        .expect("units has a view");
+
+    let units_json_string = serde_json::to_string(&view).expect("Unable to stringify JSON");
     assert!(units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 
@@ -1037,15 +1030,15 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
-    let units_json_string =
-        serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
+        .expect("able to get units view")
+        .expect("units has a view");
+
+    let units_json_string = serde_json::to_string(&view).expect("Unable to stringify JSON");
     assert!(!units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 }
@@ -1097,7 +1090,7 @@ async fn paste_component(ctx: &mut DalContext) {
         .expect("could not commit and update snapshot to visibility");
 
     let mut view = pasted_pirate_component
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("unable to get materialized view of component")
         .expect("no view found");

--- a/lib/dal/tests/integration_test/component/get_diff.rs
+++ b/lib/dal/tests/integration_test/component/get_diff.rs
@@ -20,15 +20,17 @@ async fn get_diff_new_component(ctx: &mut DalContext) {
 
     assert_eq!(starfield_component.id(), diff.component_id);
     assert_eq!(
-        Some("{\n  \"si\": {\n    \"color\": \"#ffffff\",\n    \"name\": \"this is a new component\",\n    \"type\": \"component\"\n  },\n  \"domain\": {\n    \"name\": \"this is a new component\",\n    \"possible_world_a\": {\n      \"wormhole_1\": {\n        \"wormhole_2\": {\n          \"wormhole_3\": {}\n        }\n      }\n    },\n    \"possible_world_b\": {\n      \"wormhole_1\": {\n        \"wormhole_2\": {\n          \"wormhole_3\": {\n            \"naming_and_necessity\": \"not hesperus\"\n          }\n        }\n      }\n    },\n    \"universe\": {\n      \"galaxies\": []\n    }\n  }\n}".to_string()),
+        Some("{\n  \"si\": {\n    \"name\": \"this is a new component\",\n    \"type\": \"component\",\n    \"color\": \"#ffffff\"\n  },\n  \"domain\": {\n    \"name\": \"this is a new component\",\n    \"possible_world_a\": {\n      \"wormhole_1\": {\n        \"wormhole_2\": {\n          \"wormhole_3\": {}\n        }\n      }\n    },\n    \"possible_world_b\": {\n      \"wormhole_1\": {\n        \"wormhole_2\": {\n          \"wormhole_3\": {\n            \"naming_and_necessity\": \"not hesperus\"\n          }\n        }\n      }\n    },\n    \"universe\": {\n      \"galaxies\": []\n    }\n  }\n}".to_string()),
         diff.current.code
     );
     assert_eq!(CodeLanguage::Json, diff.current.language);
     assert_eq!(1, diff.diffs.len());
     let first_diff = diff.diffs.pop().expect("can't find a diff for the code");
     assert_eq!(CodeLanguage::Diff, first_diff.language);
-    assert_eq!(Some("+{\n+  \"si\": {\n+    \"color\": \"#ffffff\",\n+    \"name\": \"this is a new component\",\n+    \"type\": \"component\"\n+  },\n+  \"domain\": {\n+    \"name\": \"this is a new component\",\n+    \"possible_world_a\": {\n+      \"wormhole_1\": {\n+        \"wormhole_2\": {\n+          \"wormhole_3\": {}\n+        }\n+      }\n+    },\n+    \"possible_world_b\": {\n+      \"wormhole_1\": {\n+        \"wormhole_2\": {\n+          \"wormhole_3\": {\n+            \"naming_and_necessity\": \"not hesperus\"\n+          }\n+        }\n+      }\n+    },\n+    \"universe\": {\n+      \"galaxies\": []\n+    }\n+  }\n+}".to_string()),
-               first_diff.code);
+    assert_eq!(
+        Some("+{\n+  \"si\": {\n+    \"name\": \"this is a new component\",\n+    \"type\": \"component\",\n+    \"color\": \"#ffffff\"\n+  },\n+  \"domain\": {\n+    \"name\": \"this is a new component\",\n+    \"possible_world_a\": {\n+      \"wormhole_1\": {\n+        \"wormhole_2\": {\n+          \"wormhole_3\": {}\n+        }\n+      }\n+    },\n+    \"possible_world_b\": {\n+      \"wormhole_1\": {\n+        \"wormhole_2\": {\n+          \"wormhole_3\": {\n+            \"naming_and_necessity\": \"not hesperus\"\n+          }\n+        }\n+      }\n+    },\n+    \"universe\": {\n+      \"galaxies\": []\n+    }\n+  }\n+}".to_string()),
+        first_diff.code
+    );
 }
 
 #[test]
@@ -122,9 +124,11 @@ async fn get_diff_component_change_comp_type(ctx: &mut DalContext) {
     let first_diff = diff.diffs.pop().expect("can't find a diff for the code");
     assert_eq!(CodeLanguage::Diff, first_diff.language);
 
+    dbg!(&first_diff.code);
+
     // We expect there to be a diff as we have changed the componentType on this changeset but HEAD is a component
     assert_eq!(
-        Some(" {\n   \"si\": {\n     \"color\": \"#ffffff\",\n     \"name\": \"this is a new component\",\n-    \"type\": \"component\"\n+    \"type\": \"configurationFrameDown\"\n   },\n   \"domain\": {\n     \"name\": \"this is a new component\",\n     \"possible_world_a\": {\n       \"wormhole_1\": {\n         \"wormhole_2\": {\n           \"wormhole_3\": {}\n         }\n       }\n     },\n     \"possible_world_b\": {\n       \"wormhole_1\": {\n         \"wormhole_2\": {\n           \"wormhole_3\": {\n             \"naming_and_necessity\": \"not hesperus\"\n           }\n         }\n       }\n     },\n     \"universe\": {\n       \"galaxies\": []\n     }\n   }\n }".to_string()), // expected
+        Some(" {\n   \"si\": {\n     \"name\": \"this is a new component\",\n-    \"type\": \"component\",\n+    \"type\": \"configurationFrameDown\",\n     \"color\": \"#ffffff\"\n   },\n   \"domain\": {\n     \"name\": \"this is a new component\",\n     \"possible_world_a\": {\n       \"wormhole_1\": {\n         \"wormhole_2\": {\n           \"wormhole_3\": {}\n         }\n       }\n     },\n     \"possible_world_b\": {\n       \"wormhole_1\": {\n         \"wormhole_2\": {\n           \"wormhole_3\": {\n             \"naming_and_necessity\": \"not hesperus\"\n           }\n         }\n       }\n     },\n     \"universe\": {\n       \"galaxies\": []\n     }\n   }\n }".to_string()),
         first_diff.code // actual
     );
 }

--- a/lib/dal/tests/integration_test/connection.rs
+++ b/lib/dal/tests/integration_test/connection.rs
@@ -325,17 +325,17 @@ async fn connect_components(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
+        .expect("able to get units view")
+        .expect("units has a view");
 
-    assert!(matches!(materialized_view, serde_json::Value::Array(_)));
+    assert!(matches!(view, serde_json::Value::Array(_)));
 
-    if let serde_json::Value::Array(units_array) = materialized_view {
+    if let serde_json::Value::Array(units_array) = view {
         assert_eq!(2, units_array.len())
     }
 
@@ -508,17 +508,17 @@ async fn remove_connection(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
+        .expect("able to get units view")
+        .expect("units has a view");
 
-    assert!(matches!(materialized_view, serde_json::Value::Array(_)));
+    assert!(matches!(view, serde_json::Value::Array(_)));
 
-    if let serde_json::Value::Array(units_array) = materialized_view {
+    if let serde_json::Value::Array(units_array) = view {
         assert_eq!(2, units_array.len())
     }
 
@@ -545,17 +545,17 @@ async fn remove_connection(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
+        .expect("able to get units view")
+        .expect("units has a view");
 
-    assert!(matches!(materialized_view, serde_json::Value::Array(_)));
+    assert!(matches!(view, serde_json::Value::Array(_)));
 
-    if let serde_json::Value::Array(units_array) = materialized_view {
+    if let serde_json::Value::Array(units_array) = view {
         assert_eq!(1, units_array.len())
     }
 

--- a/lib/dal/tests/integration_test/dependent_values_update.rs
+++ b/lib/dal/tests/integration_test/dependent_values_update.rs
@@ -136,15 +136,15 @@ async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
-    let units_json_string =
-        serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
+        .expect("able to get units view")
+        .expect("units has a view");
+
+    let units_json_string = serde_json::to_string(&view).expect("Unable to stringify JSON");
     assert!(!units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 
@@ -181,15 +181,14 @@ async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
-    let units_json_string =
-        serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
+        .expect("able to get units view")
+        .expect("units has a view");
+    let units_json_string = serde_json::to_string(&view).expect("Unable to stringify JSON");
     assert!(!units_json_string.contains("docker.io/library/oysters on the floor\\n"));
     assert!(!units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
@@ -303,15 +302,14 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
-    let units_json_string =
-        serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
+        .expect("able to get units view")
+        .expect("units has a view");
+    let units_json_string = serde_json::to_string(&view).expect("Unable to stringify JSON");
     assert!(units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
 
     royel_component
@@ -350,15 +348,14 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
-    let units_json_string =
-        serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
+        .expect("able to get units view")
+        .expect("units has a view");
+    let units_json_string = serde_json::to_string(&view).expect("Unable to stringify JSON");
     assert!(units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
 
     // Modify normal component.
@@ -394,14 +391,13 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let materialized_view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
-        .expect("able to get units materialized_view")
-        .expect("units has a materialized_view");
-    let units_json_string =
-        serde_json::to_string(&materialized_view).expect("Unable to stringify JSON");
+        .expect("able to get units view")
+        .expect("units has a view");
+    let units_json_string = serde_json::to_string(&view).expect("Unable to stringify JSON");
     assert!(units_json_string.contains("docker.io/library/oysters on the floor\\n"));
 }

--- a/lib/dal/tests/integration_test/deprecated_action/with_secret.rs
+++ b/lib/dal/tests/integration_test/deprecated_action/with_secret.rs
@@ -156,7 +156,7 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
             },
         }], // expected
         source_component
-            .materialized_view(ctx)
+            .view(ctx)
             .await
             .expect("could not get materialized view")
             .expect("empty materialized view") // actual
@@ -171,7 +171,7 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
     let last_synced_value = AttributeValue::get_by_id(ctx, last_synced_av_id)
         .await
         .expect("should be able to get last synced av")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("should be able to get value for last synced av");
 
@@ -201,7 +201,7 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
             },
         }], // expected
         destination_component
-            .materialized_view(ctx)
+            .view(ctx)
             .await
             .expect("could not get materialized view")
             .expect("empty materialized view") // actual

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -448,7 +448,7 @@ async fn output_sockets_can_have_both(ctx: &mut DalContext) {
     let odd_component_1_mat_view = AttributeValue::get_by_id(ctx, odd_component_1_av)
         .await
         .expect("got av")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("got mat view")
         .expect("has value");
@@ -466,7 +466,7 @@ async fn output_sockets_can_have_both(ctx: &mut DalContext) {
     let odd_component_2_mat_view = AttributeValue::get_by_id(ctx, odd_component_2_av)
         .await
         .expect("got av")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("got mat view")
         .expect("has value");
@@ -520,7 +520,7 @@ async fn simple_down_frames_no_nesting(ctx: &mut DalContext) {
         .await
         .expect("could not get attribute value");
     let one_mat_view = one_av
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not get materialized view")
         .expect("is some");
@@ -544,7 +544,7 @@ async fn simple_down_frames_no_nesting(ctx: &mut DalContext) {
     let one_input_mat_view = AttributeValue::get_by_id(ctx, one_input_match.attribute_value_id)
         .await
         .expect("could not get attribute value")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not get materialized view")
         .expect("is some");
@@ -556,7 +556,7 @@ async fn simple_down_frames_no_nesting(ctx: &mut DalContext) {
     let one_input_mat_view = AttributeValue::get_by_id(ctx, one_input_match.attribute_value_id)
         .await
         .expect("could not get attribute value")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not get materialized view")
         .expect("is some");
@@ -624,7 +624,7 @@ async fn simple_down_frames_nesting(ctx: &mut DalContext) {
         .await
         .expect("could not get attribute value");
     let one_mat_view = one_av
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not get materialized view")
         .expect("is some");
@@ -652,7 +652,7 @@ async fn simple_down_frames_nesting(ctx: &mut DalContext) {
     let one_input_mat_view = AttributeValue::get_by_id(ctx, one_input_match.attribute_value_id)
         .await
         .expect("could not get attribute value")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not get materialized view")
         .expect("is some");
@@ -695,7 +695,7 @@ async fn simple_down_frames_nesting(ctx: &mut DalContext) {
         AttributeValue::get_by_id(ctx, one_input_match.attribute_value_id)
             .await
             .expect("could not get attribute value by id")
-            .materialized_view(ctx)
+            .view(ctx)
             .await
             .expect("could not get materialized view")
             .is_none()
@@ -736,7 +736,7 @@ async fn simple_down_frames_nesting(ctx: &mut DalContext) {
     let one_input_mat_view = AttributeValue::get_by_id(ctx, one_input_match.attribute_value_id)
         .await
         .expect("could not get av by id")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not get materialized view")
         .expect("is some");
@@ -789,7 +789,7 @@ async fn simple_down_frames_nesting(ctx: &mut DalContext) {
     let one_output_mat_view = AttributeValue::get_by_id(ctx, three_av_id.attribute_value_id)
         .await
         .expect("could not get attribute value")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not find materialized view")
         .expect("is some");
@@ -806,7 +806,7 @@ async fn simple_down_frames_nesting(ctx: &mut DalContext) {
     let one_input_mat_view = AttributeValue::get_by_id(ctx, one_input_match.attribute_value_id)
         .await
         .expect("could not get attribute value")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not get materialized view")
         .expect("is some");
@@ -861,7 +861,7 @@ async fn simple_up_frames_some_nesting(ctx: &mut DalContext) {
         .await
         .expect("could not get attribute value");
     let one_mat_view = one_av
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not get materialized view")
         .expect("is some");
@@ -889,7 +889,7 @@ async fn simple_up_frames_some_nesting(ctx: &mut DalContext) {
     let one_input_mat_view = AttributeValue::get_by_id(ctx, one_input_match.attribute_value_id)
         .await
         .expect("could not get attribute value")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not get materialized view")
         .expect("is some");
@@ -946,7 +946,7 @@ async fn simple_up_frames_some_nesting(ctx: &mut DalContext) {
         .await
         .expect("could not get attribute value");
     let one_mat_view = another_three_av
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not get materialized view")
         .expect("is some");
@@ -973,7 +973,7 @@ async fn simple_up_frames_some_nesting(ctx: &mut DalContext) {
     let one_input_mat_view = AttributeValue::get_by_id(ctx, one_input_match.attribute_value_id)
         .await
         .expect("could not get attribute value")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not get materialized view")
         .expect("is some");
@@ -1030,7 +1030,7 @@ async fn simple_up_frames_some_nesting(ctx: &mut DalContext) {
         .await
         .expect("could not get attribute value");
     let odd_two_mat_view = odd_two_av
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not get materialized view")
         .expect("is some");
@@ -1068,7 +1068,7 @@ async fn simple_up_frames_some_nesting(ctx: &mut DalContext) {
     let one_input_mat_view = AttributeValue::get_by_id(ctx, one_input_match.attribute_value_id)
         .await
         .expect("could not get attribute value")
-        .materialized_view(ctx)
+        .view(ctx)
         .await
         .expect("could not get materialized view")
         .expect("materialized view is some");


### PR DESCRIPTION
Views are now calculated on the fly by walking the attribute value tree for a given value. This should enable updates of sibling properties on a component without causing a conflict.