### PR TITLE
BUG-142 debounce & batch prop edits at 1 second

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -39,6 +39,7 @@
     "@codemirror/view": "^6.7.1",
     "@headlessui/vue": "^1.7.10",
     "@lezer/highlight": "^1.1.3",
+    "@pinia/plugin-debounce": "^1.0.1",
     "@replit/codemirror-vim": "^6.0.11",
     "@si/ts-lib": "workspace:*",
     "@si/vue-lib": "workspace:*",

--- a/app/web/src/components/AttributesPanel/AttributesPanel.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanel.vue
@@ -171,7 +171,7 @@ function updateSiProp(key: keyof typeof siValues) {
   const prop = siProps.value?.[key as string];
   if (!prop) return;
 
-  attributesStore.UPDATE_PROPERTY_VALUE({
+  attributesStore.addPropertyToBatch({
     update: {
       attributeValueId: prop.valueId,
       parentAttributeValueId: prop.parentValueId,

--- a/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
@@ -962,17 +962,13 @@ function updateValue() {
     return;
   }
 
-<<<<<<< HEAD
   // If we are explicitly setting a secret, we need to inform SDF so that dependent values update
   // will trigger when the secret's encrypted contents change.
   if (widgetKind.value === "secret") {
     isForSecret = true;
   }
 
-  attributesStore.UPDATE_PROPERTY_VALUE({
-=======
   attributesStore.addPropertyToBatch({
->>>>>>> d23cff5ea (BUG-142 debounce & batch prop edits at 1 second)
     update: {
       attributeValueId: props.attributeDef.valueId,
       parentAttributeValueId: props.attributeDef.parentValueId,

--- a/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
@@ -802,7 +802,7 @@ const setSource = (source: AttributeValueSource) => {
   if (source === AttributeValueSource.Manual) {
     const value = props.attributeDef.value?.value ?? null;
 
-    attributesStore.UPDATE_PROPERTY_VALUE({
+    attributesStore.addPropertyToBatch({
       update: {
         attributeValueId: props.attributeDef.valueId,
         parentAttributeValueId: props.attributeDef.parentValueId,
@@ -911,7 +911,7 @@ function addChildHandler() {
     return;
   }
 
-  attributesStore.UPDATE_PROPERTY_VALUE({
+  attributesStore.addPropertyToBatch({
     insert: {
       parentAttributeValueId: props.attributeDef.valueId,
       propId: props.attributeDef.propId,
@@ -962,6 +962,7 @@ function updateValue() {
     return;
   }
 
+<<<<<<< HEAD
   // If we are explicitly setting a secret, we need to inform SDF so that dependent values update
   // will trigger when the secret's encrypted contents change.
   if (widgetKind.value === "secret") {
@@ -969,6 +970,9 @@ function updateValue() {
   }
 
   attributesStore.UPDATE_PROPERTY_VALUE({
+=======
+  attributesStore.addPropertyToBatch({
+>>>>>>> d23cff5ea (BUG-142 debounce & batch prop edits at 1 second)
     update: {
       attributeValueId: props.attributeDef.valueId,
       parentAttributeValueId: props.attributeDef.parentValueId,

--- a/app/web/src/store/index.ts
+++ b/app/web/src/store/index.ts
@@ -1,10 +1,12 @@
 import { createPinia } from "pinia";
 
+import * as _ from "lodash-es";
 import {
   piniaHooksPlugin,
   initPiniaApiToolkitPlugin,
   registerApi,
 } from "@si/vue-lib/pinia";
+import { PiniaDebounce } from "@pinia/plugin-debounce";
 import {
   sdfApiInstance,
   authApiInstance,
@@ -25,5 +27,6 @@ export const ModuleIndexApiRequest = registerApi(moduleIndexApiInstance);
 
 pinia.use(piniaApiToolkitPlugin);
 pinia.use(piniaHooksPlugin);
+pinia.use(PiniaDebounce(_.debounce));
 
 export default pinia;

--- a/lib/sdf-server/src/server/service/component.rs
+++ b/lib/sdf-server/src/server/service/component.rs
@@ -120,12 +120,8 @@ pub fn routes() -> Router<AppState> {
         .route("/get_diff", get(get_diff::get_diff))
         .route("/get_resource", get(get_resource::get_resource))
         .route(
-            "/update_property_editor_value",
-            post(update_property_editor_value::update_property_editor_value),
-        )
-        .route(
-            "/insert_property_editor_value",
-            post(insert_property_editor_value::insert_property_editor_value),
+            "/upsert_property_editor_value",
+            post(update_property_editor_value::upsert_property_editor_value),
         )
         .route(
             "/delete_property_editor_value",

--- a/lib/sdf-server/src/server/service/component/update_property_editor_value.rs
+++ b/lib/sdf-server/src/server/service/component/update_property_editor_value.rs
@@ -56,17 +56,17 @@ pub async fn upsert_property_editor_value(
     for update in request.updates {
         // Determine how to update the value based on whether it corresponds to a secret. The vast
         // majority of the time, the request will not be for a secret.
-        if request.is_for_secret {
-            if let Some(value) = request.value.as_ref() {
+        if update.is_for_secret {
+            if let Some(value) = update.value.as_ref() {
                 let secret_id: SecretId = serde_json::from_value(value.to_owned())?;
                 Secret::attach_for_attribute_value(
                     &ctx,
-                    request.attribute_value_id,
+                    update.attribute_value_id,
                     Some(secret_id),
                 )
                 .await?;
             } else {
-                Secret::attach_for_attribute_value(&ctx, request.attribute_value_id, None).await?;
+                Secret::attach_for_attribute_value(&ctx, update.attribute_value_id, None).await?;
             }
         } else {
             AttributeValue::update(&ctx, update.attribute_value_id, update.value).await?;

--- a/lib/sdf-server/src/server/service/component/update_property_editor_value.rs
+++ b/lib/sdf-server/src/server/service/component/update_property_editor_value.rs
@@ -16,48 +16,66 @@ pub struct UpdatePropertyEditorValueRequest {
     pub attribute_value_id: AttributeValueId,
     pub parent_attribute_value_id: Option<AttributeValueId>,
     pub prop_id: PropId,
-    pub component_id: ComponentId,
     pub value: Option<serde_json::Value>,
     pub key: Option<String>,
     pub is_for_secret: bool,
-    #[serde(flatten)]
-    pub visibility: Visibility,
 }
 
-pub async fn update_property_editor_value(
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct InsertPropertyEditorValueRequest {
+    pub parent_attribute_value_id: AttributeValueId,
+    pub prop_id: PropId,
+    pub value: Option<serde_json::Value>,
+    pub key: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PropertyEditorValueRequests {
+    pub component_id: ComponentId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+    pub inserts: Vec<InsertPropertyEditorValueRequest>,
+    pub updates: Vec<UpdatePropertyEditorValueRequest>,
+}
+
+pub async fn upsert_property_editor_value(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
     PosthogClient(posthog_client): PosthogClient,
     OriginalUri(original_uri): OriginalUri,
-    Json(request): Json<UpdatePropertyEditorValueRequest>,
+    Json(request): Json<PropertyEditorValueRequests>,
 ) -> ComponentResult<impl IntoResponse> {
     let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
-    // Determine how to update the value based on whether it corresponds to a secret. The vast
-    // majority of the time, the request will not be for a secret.
-    if request.is_for_secret {
-        if let Some(value) = request.value.as_ref() {
-            let secret_id: SecretId = serde_json::from_value(value.to_owned())?;
-            Secret::attach_for_attribute_value(&ctx, request.attribute_value_id, Some(secret_id))
+    let mut prop_detail: Vec<serde_json::Value> = vec![];
+
+    for update in request.updates {
+        // Determine how to update the value based on whether it corresponds to a secret. The vast
+        // majority of the time, the request will not be for a secret.
+        if request.is_for_secret {
+            if let Some(value) = request.value.as_ref() {
+                let secret_id: SecretId = serde_json::from_value(value.to_owned())?;
+                Secret::attach_for_attribute_value(
+                    &ctx,
+                    request.attribute_value_id,
+                    Some(secret_id),
+                )
                 .await?;
+            } else {
+                Secret::attach_for_attribute_value(&ctx, request.attribute_value_id, None).await?;
+            }
         } else {
-            Secret::attach_for_attribute_value(&ctx, request.attribute_value_id, None).await?;
+            AttributeValue::update(&ctx, update.attribute_value_id, update.value).await?;
         }
-    } else {
-        AttributeValue::update(&ctx, request.attribute_value_id, request.value).await?;
-    }
 
-    // Track
-    {
-        let component = Component::get_by_id(&ctx, request.component_id).await?;
-
-        let component_schema = component.schema(&ctx).await?;
-        let prop = Prop::get_by_id_or_error(&ctx, request.prop_id).await?;
+        let prop = Prop::get_by_id_or_error(&ctx, update.prop_id).await?;
 
         // In this context, there will always be a parent attribute value id
-        let parent_prop = if let Some(att_val_id) = request.parent_attribute_value_id {
+        let parent_prop = if let Some(att_val_id) = update.parent_attribute_value_id {
             if let Some(prop_id) = AttributeValue::prop_id_for_id(&ctx, att_val_id).await? {
                 Some(Prop::get_by_id_or_error(&ctx, prop_id).await?)
             } else {
@@ -66,6 +84,48 @@ pub async fn update_property_editor_value(
         } else {
             None
         };
+
+        prop_detail.push(serde_json::json!({
+            "prop_id": prop.id,
+            "prop_name": prop.name,
+            "parent_prop_id": parent_prop.as_ref().map(|prop| prop.id),
+            "parent_prop_name": parent_prop.as_ref().map(|prop| prop.name.clone()),
+        }));
+    }
+
+    for insert in request.inserts {
+        let _ = AttributeValue::insert(
+            &ctx,
+            insert.parent_attribute_value_id,
+            insert.value,
+            insert.key,
+        )
+        .await?;
+
+        let prop = Prop::get_by_id_or_error(&ctx, insert.prop_id).await?;
+
+        // In this context, there will always be a parent attribute value id
+        let parent_prop = if let Some(prop_id) =
+            AttributeValue::prop_id_for_id(&ctx, insert.parent_attribute_value_id).await?
+        {
+            Some(Prop::get_by_id_or_error(&ctx, prop_id).await?)
+        } else {
+            None
+        };
+
+        prop_detail.push(serde_json::json!({
+            "prop_id": prop.id,
+            "prop_name": prop.name,
+            "parent_prop_id": parent_prop.as_ref().map(|prop| prop.id),
+            "parent_prop_name": parent_prop.as_ref().map(|prop| prop.name.clone()),
+        }));
+    }
+
+    // Track
+    {
+        let component = Component::get_by_id(&ctx, request.component_id).await?;
+
+        let component_schema = component.schema(&ctx).await?;
 
         track(
             &posthog_client,
@@ -76,11 +136,8 @@ pub async fn update_property_editor_value(
                 "how": "/component/property_value_updated",
                 "component_id": component.id(),
                 "component_schema_name": component_schema.name(),
-                "prop_id": prop.id,
-                "prop_name": prop.name,
-                "parent_prop_id": parent_prop.as_ref().map(|prop| prop.id),
-                "parent_prop_name": parent_prop.as_ref().map(|prop| prop.name.clone()),
                 "change_set_id": ctx.change_set_id(),
+                "prop_details": prop_detail,
             }),
         );
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@lezer/highlight':
         specifier: ^1.1.3
         version: 1.1.3
+      '@pinia/plugin-debounce':
+        specifier: ^1.0.1
+        version: 1.0.1
       '@replit/codemirror-vim':
         specifier: ^6.0.11
         version: 6.0.11(@codemirror/commands@6.1.2)(@codemirror/language@6.3.1)(@codemirror/search@6.3.0)(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)
@@ -3074,6 +3077,10 @@ packages:
 
   /@one-ini/wasm@0.1.1:
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+    dev: false
+
+  /@pinia/plugin-debounce@1.0.1:
+    resolution: {integrity: sha512-/ITYpdvEk8CvUWs/0zpI3eBQkSOoLI/hgTr+WaULxMHdKP9IWBEM+yY2+aqEMa0e48K4y+uVMFYCM9lcv8g/cQ==}
     dev: false
 
   /@pkgjs/parseargs@0.11.0:


### PR DESCRIPTION
We probably don't need this if we can avoid using materialized view which generates conflicts and Adam's "send WsEvent after rebaser commits" is completed.
<img src="https://media2.giphy.com/media/e9naycep2pz7OHQ4n0/giphy.gif"/>