### PR TITLE
feat: wait for cloudfront to invalidate before deploying services

### DIFF
--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -28,7 +28,15 @@ jobs:
           aws-region: us-east-1
       - name: Invalidate Artifacts Cache
         run: |
-          aws cloudfront create-invalidation --distribution-id E2HW6000JEVIPB --paths "/*"
+          DIST_ID=E2HW6000JEVIPB
+          # Create a CloudFront invalidation for all objects (/*)
+          invalidation_id=$(aws cloudfront create-invalidation --distribution-id $DIST_ID --paths "/*" --query 'Invalidation.Id' --output text)
+          # Check the status of the invalidation until it's completed
+          while [[ "$(aws cloudfront get-invalidation --distribution-id $DIST_ID --id $invalidation_id --query 'Invalidation.Status' --output text)" != "Completed" ]]; do
+              echo "Invalidation is still in progress. Waiting..."
+              sleep 5
+          done
+          echo "Invalidation is complete."
 
       - name: Configure AWS credentials for tools-prod
         uses: aws-actions/configure-aws-credentials@v2


### PR DESCRIPTION
Cloudfront invalidations can take 5 seconds or 5 minutes depending on gamma rays and such. This ensures that we wait until the invalidation completes before we deploy our services to ensure we are always getting latest.

<img src="https://media2.giphy.com/media/uPpF0kb37JWruaYYDc/giphy.gif"/>