### PR TITLE
feat(dal): support children of "dynamic" objects as inputs to other functions

### DIFF
--- a/app/web/src/components/Debug/AttributeDebugView.vue
+++ b/app/web/src/components/Debug/AttributeDebugView.vue
@@ -13,10 +13,7 @@
         title="Prototype Is Component Specific"
         :data="data.prototypeIsComponentSpecific"
       />
-      <DebugViewItem
-        title="Materialized View"
-        :data="data.materializedView ?? 'NULL'"
-      />
+      <DebugViewItem title="Materialized View" :data="data.view ?? 'NULL'" />
       <DebugViewItem title="Input Sources">
         <template #data>
           <ul v-if="data.funcArgs && Object.keys(data.funcArgs).length">

--- a/app/web/src/components/Debug/SocketDebugView.vue
+++ b/app/web/src/components/Debug/SocketDebugView.vue
@@ -44,10 +44,7 @@
           <p v-else>No inferred connections</p>
         </template>
       </DebugViewItem>
-      <DebugViewItem
-        title="Materialized View"
-        :data="data.materializedView ?? 'NULL'"
-      />
+      <DebugViewItem title="Materialized View" :data="data.view ?? 'NULL'" />
       <DebugViewItem title="Input Sources">
         <template #data>
           <ul v-if="data.funcArgs && Object.keys(data.funcArgs).length">

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -154,7 +154,7 @@ export interface AttributeDebugView {
   prototypeId: string;
   prototypeIsComponentSpecific: boolean;
   kind: string;
-  materializedView?: string;
+  view?: string;
 }
 export interface FuncArgDebugView {
   value: object | string | number | boolean | null;

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -791,6 +791,8 @@ async fn migrate_local_builtins(
     schema::migrate_pkg(&ctx, SI_COREOS_PKG, None).await?;
     schema::migrate_pkg(&ctx, SI_AWS_EC2_PKG, None).await?;
     schemas::migrate_test_exclusive_schema_starfield(&ctx).await?;
+    schemas::migrate_test_exclusive_schema_etoiles(&ctx).await?;
+    schemas::migrate_test_exclusive_schema_morningstar(&ctx).await?;
     schemas::migrate_test_exclusive_schema_fallout(&ctx).await?;
     schemas::migrate_test_exclusive_schema_dummy_secret(&ctx).await?;
     schemas::migrate_test_exclusive_schema_swifty(&ctx).await?;

--- a/lib/dal-test/src/schemas/mod.rs
+++ b/lib/dal-test/src/schemas/mod.rs
@@ -12,6 +12,8 @@ pub(crate) use test_exclusive_schema_lego_medium::migrate_test_exclusive_schema_
 pub(crate) use test_exclusive_schema_lego_medium::migrate_test_exclusive_schema_medium_odd_lego;
 pub(crate) use test_exclusive_schema_lego_small::migrate_test_exclusive_schema_small_even_lego;
 pub(crate) use test_exclusive_schema_lego_small::migrate_test_exclusive_schema_small_odd_lego;
+pub(crate) use test_exclusive_schema_starfield::migrate_test_exclusive_schema_etoiles;
+pub(crate) use test_exclusive_schema_starfield::migrate_test_exclusive_schema_morningstar;
 pub(crate) use test_exclusive_schema_starfield::migrate_test_exclusive_schema_starfield;
 pub(crate) use test_exclusive_schema_swifty::migrate_test_exclusive_schema_swifty;
 

--- a/lib/dal/tests/integration_test/module.rs
+++ b/lib/dal/tests/integration_test/module.rs
@@ -13,19 +13,19 @@ async fn list_modules(ctx: &DalContext) {
     let mut module_names: Vec<String> = modules.iter().map(|m| m.name().to_string()).collect();
     module_names.sort();
 
-    assert_eq!(20, modules.len());
-
     let expected_installed_module_names = vec![
         "BadValidations".to_string(),
         "ValidatedInput".to_string(),
         "ValidatedOutput".to_string(),
         "dummy-secret".to_string(),
+        "etoiles".to_string(),
         "fallout".to_string(),
         "katy perry".to_string(),
         "large even lego".to_string(),
         "large odd lego".to_string(),
         "medium even lego".to_string(),
         "medium odd lego".to_string(),
+        "morningstar".to_string(),
         "pet_shop".to_string(),
         "pirate".to_string(),
         "si-aws-ec2-2023-09-26-2".to_string(),


### PR DESCRIPTION
This makes it possible to take the children of an object set by a custom function as the input to another function. It ensures we do not place the child values directly onto the dependent value graph, but instead we place the "controlling" attribute value onto the graph if one is discovered (we will resolve the input to the correct child value in function execution).

Many of our assets depend on this, since they take children of the resource_value tree as inputs to other functions.

Closes BUG-135