### PR TITLE
fix check for preventing edits

### DIFF
--- a/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
@@ -830,6 +830,7 @@ const sourceOverridden = computed(() => props.attributeDef.value?.overridden);
 const propIsEditable = computed(
   () =>
     sourceOverridden.value ||
+    editOverride.value ||
     (!propPopulatedBySocket.value && !propSetByDynamicFunc.value),
 );
 


### PR DESCRIPTION
When the user confirms they want to override, we need to remove the overlay so the value populated by a socket can be manually edited

<div><img src="https://media2.giphy.com/media/a6O5pzQ8pAPTCoeagK/giphy.gif?cid=5a38a5a2wgh3yyda3qlum5z8ufhmz0jgfz86q8t8052pcrzq&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/latenightseth/">Late Night with Seth Meyers</a> on <a href="https://giphy.com/gifs/latenightseth-seth-meyers-lnsm-a6O5pzQ8pAPTCoeagK">GIPHY</a></div>