### PR TITLE
chore(si-service,cyclone): quiet some noisy info messages

### DIFF
--- a/lib/cyclone-server/src/watch.rs
+++ b/lib/cyclone-server/src/watch.rs
@@ -64,7 +64,7 @@ pub async fn watch_timeout_task(
             }
             Ok(None) | Err(_) => {
                 // Timeout has elapsed
-                info!("watch_timeout_task timeout elapsed");
+                debug!("watch_timeout_task timeout elapsed");
                 if shutdown_tx
                     .send(ShutdownSource::WatchTimeout)
                     .await

--- a/lib/si-service/src/startup.rs
+++ b/lib/si-service/src/startup.rs
@@ -45,7 +45,7 @@ pub async fn startup(service: &str) -> Result<(), std::io::Error> {
         .components()
         .any(|path| Component::Normal("buck-out".as_ref()) == path)
     {
-        info!(
+        debug!(
             "development build (buck) detected for {}, no metadata can be reported",
             service
         );


### PR DESCRIPTION
Both of these `info!` messages are very noisy when running tests