### PR TITLE
Fix: don't create pending components on head

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -765,6 +765,16 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                 ...visibilityParams,
               },
               optimistic: () => {
+                /**
+                 * NOTE: WsEvents are firing *BEFORE* the POST returns
+                 * And when a new changeset is created by the backend, we end up
+                 * re-creating componentStore, so the store for HEAD never runs onSuccess below
+                 * We end up with pending components on HEAD that never go away
+                 *
+                 * To fix: don't create pending components if we're on HEAD
+                 */
+                if (changeSetsStore.headSelected) return;
+
                 this.pendingInsertedComponents[tempInsertId] = {
                   tempId: tempInsertId,
                   position,


### PR DESCRIPTION
WsEvents are firing *BEFORE* the POST returns and when a new changeset is created by the backend, we end up re-creating componentStore, so the store for HEAD never runs onSuccess below and we end up with pending components on HEAD that never go away

To fix it; don't create pending components if we're on HEAD

<img src="https://media3.giphy.com/media/kCoIap1RrUqE1f0fKu/giphy.gif"/>