### PR TITLE
Fix: send correct change_set_id back in WsEvent::ChangeSetWritten

### DIFF
--- a/lib/rebaser-server/src/change_set_requests/handlers.rs
+++ b/lib/rebaser-server/src/change_set_requests/handlers.rs
@@ -83,6 +83,7 @@ pub async fn process_request(State(state): State<AppState>, msg: InnerMessage) -
     let mut event =
         WsEvent::change_set_written(&ctx, message.payload.to_rebase_change_set_id.into()).await?;
     event.set_workspace_pk(message.metadata.tenancy.workspace_pk.into_inner().into());
+    event.set_change_set_id(Some(message.payload.to_rebase_change_set_id.into()));
     event.publish_immediately(&ctx).await?;
 
     Ok(())


### PR DESCRIPTION
<img src="https://media0.giphy.com/media/gAHcN03H0C9m11K9Yc/giphy.gif"/>