### PR TITLE
fix(dal): None values for container props should remove child values

### DIFF
--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -266,8 +266,12 @@ pub enum PropKind {
 }
 
 impl PropKind {
-    pub fn ordered(&self) -> bool {
+    pub fn is_container(&self) -> bool {
         matches!(self, PropKind::Array | PropKind::Map | PropKind::Object)
+    }
+
+    pub fn ordered(&self) -> bool {
+        self.is_container()
     }
 
     pub fn empty_value(&self) -> Option<serde_json::Value> {

--- a/lib/sdf-server/src/server/service/diagram/delete_connection.rs
+++ b/lib/sdf-server/src/server/service/diagram/delete_connection.rs
@@ -35,10 +35,10 @@ pub async fn delete_connection(
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
     Component::remove_connection(
         &ctx,
-        request.to_socket_id,
+        request.from_component_id,
         request.from_socket_id,
         request.to_component_id,
-        request.from_component_id,
+        request.to_socket_id,
     )
     .await?;
 


### PR DESCRIPTION
If we receive a None value from executing a function and the value being set is a container (object, map, array), we should still populate nested since otherwise we will not clear out the child values.