### PR TITLE
fix(layer-cache): Prevent jetstream consumers from exceeding their inactivity threshold

### DIFF
--- a/lib/si-layer-cache/src/activities.rs
+++ b/lib/si-layer-cache/src/activities.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use std::{collections::HashMap, fmt, str::FromStr, sync::Arc};
 
 use futures::StreamExt;
@@ -365,6 +366,7 @@ impl ActivityStream {
             description: Some(description),
             deliver_policy: jetstream::consumer::DeliverPolicy::All,
             max_bytes: MAX_BYTES,
+            inactive_threshold: Duration::from_secs(180),
             ..Default::default()
         };
 

--- a/lib/si-layer-cache/src/event.rs
+++ b/lib/si-layer-cache/src/event.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use std::{
     collections::{hash_map::Entry, HashMap},
     sync::Arc,
@@ -397,6 +398,7 @@ impl LayeredEventServer {
             description: Some(description),
             deliver_policy: DeliverPolicy::New,
             max_bytes: MAX_BYTES,
+            inactive_threshold: Duration::from_secs(180),
             ..Default::default()
         }
     }


### PR DESCRIPTION
The default timeout was 5 seconds so we want to prevent any slowness of instances causing a disconnect