### PR TITLE
Frame fixes, and support up frames with many children

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -233,7 +233,7 @@ const edgeFromRawEdge =
   (isInferred: boolean) =>
   (e: RawEdge): Edge => {
     const edge = structuredClone(e) as Edge;
-    edge.id = `${edge.toSocketId}_${edge.fromSocketId}`;
+    edge.id = `${edge.toComponentId}_${edge.toSocketId}_${edge.fromSocketId}_${edge.fromComponentId}`;
     edge.isInferred = isInferred;
     return edge;
   };

--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -281,12 +281,11 @@ impl AttributePrototypeDebugView {
             {
                 info!("Input socket match: {:?}", input_socket_match);
                 // now get inferred func binding args and values!
-                if let Some(output_match) =
-                    Component::find_potential_inferred_connection_to_input_socket(
-                        ctx,
-                        input_socket_match,
-                    )
-                    .await?
+                for output_match in Component::find_potential_inferred_connections_to_input_socket(
+                    ctx,
+                    input_socket_match,
+                )
+                .await?
                 {
                     info!("output socket match: {:?}", output_match);
                     let arg_used = Component::should_data_flow_between_components(

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -628,19 +628,13 @@ impl AttributeValue {
         let mut func_binding_args: HashMap<String, Vec<Value>> = HashMap::new();
         let apa_ids = AttributePrototypeArgument::list_ids_for_prototype(ctx, prototype_id).await?;
         if apa_ids.is_empty() {
-            if let Some(implicit_input) =
-                Self::get_inferred_input_value(ctx, attribute_value_id).await?
-            {
+            let inferred_inputs = Self::get_inferred_input_values(ctx, attribute_value_id).await?;
+            if !inferred_inputs.is_empty() {
                 let input_func = AttributePrototype::func_id(ctx, prototype_id).await?;
-
-                match Func::get_by_id(ctx, input_func).await? {
-                    Some(_) => match FuncArgument::list_for_func(ctx, input_func).await?.pop() {
-                        Some(id) => func_binding_args.insert(id.name, vec![implicit_input]),
-                        None => None,
-                    },
-                    None => None,
-                };
-            };
+                if let Some(func_arg) = FuncArgument::list_for_func(ctx, input_func).await?.pop() {
+                    func_binding_args.insert(func_arg.name, inferred_inputs);
+                }
+            }
         } else {
             for apa_id in apa_ids {
                 let apa = AttributePrototypeArgument::get_by_id(ctx, apa_id).await?;
@@ -757,10 +751,10 @@ impl AttributeValue {
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn get_inferred_input_value(
+    async fn get_inferred_input_values(
         ctx: &DalContext,
         input_attribute_value_id: AttributeValueId,
-    ) -> AttributeValueResult<Option<Value>> {
+    ) -> AttributeValueResult<Vec<Value>> {
         // let mut maybe_result: Option<Value> = None;
         let maybe_input_socket_id =
             match AttributeValue::is_for(ctx, input_attribute_value_id).await? {
@@ -769,7 +763,7 @@ impl AttributeValue {
             };
 
         let Some(input_socket_id) = maybe_input_socket_id else {
-            return Ok(None);
+            return Ok(vec![]);
         };
 
         let component_id = Self::component_id(ctx, input_attribute_value_id).await?;
@@ -778,38 +772,36 @@ impl AttributeValue {
             input_socket_id,
             attribute_value_id: input_attribute_value_id,
         };
-        Ok(
-            match Component::find_potential_inferred_connection_to_input_socket(
-                ctx,
-                input_socket_match,
-            )
-            .await
-            {
-                Ok(Some(output_match)) => {
-                    // Both deleted and non deleted components can feed data into deleted components.
-                    // ** ONLY ** non-deleted components can feed data into non-deleted components
-                    if !Component::should_data_flow_between_components(
-                        ctx,
-                        input_socket_match.component_id,
-                        output_match.component_id,
-                    )
-                    .await
-                    .map_err(|e| AttributeValueError::Component(Box::new(e)))?
-                    {
-                        return Ok(None);
-                    }
-
-                    // XXX: We need to properly handle the difference between "there is
-                    // XXX: no value" vs "the value is null", but right now we collapse
-                    // XXX: the two to just be "null" when passing these to a function.
-                    let output_av =
-                        AttributeValue::get_by_id(ctx, output_match.attribute_value_id).await?;
-                    let view = output_av.view(ctx).await?.unwrap_or(Value::Null);
-                    Some(view)
+        let mut inputs = vec![];
+        if let Ok(maybe_matches) =
+            Component::find_potential_inferred_connections_to_input_socket(ctx, input_socket_match)
+                .await
+                .map_err(|e| AttributeValueError::Component(Box::new(e)))
+        {
+            for output_match in maybe_matches {
+                // Both deleted and non deleted components can feed data into deleted components.
+                // ** ONLY ** non-deleted components can feed data into non-deleted components
+                if !Component::should_data_flow_between_components(
+                    ctx,
+                    input_socket_match.component_id,
+                    output_match.component_id,
+                )
+                .await
+                .map_err(|e| AttributeValueError::Component(Box::new(e)))?
+                {
+                    return Ok(vec![]);
                 }
-                _ => None,
-            },
-        )
+                // XXX: We need to properly handle the difference between "there is
+                // XXX: no value" vs "the value is null", but right now we collapse
+                // XXX: the two to just be "null" when passing these to a function.
+                let output_av =
+                    AttributeValue::get_by_id(ctx, output_match.attribute_value_id).await?;
+                let view = output_av.view(ctx).await?.unwrap_or(Value::Null);
+                inputs.push(view);
+            }
+        };
+
+        Ok(inputs)
     }
 
     pub async fn prototype_func(

--- a/lib/dal/src/component/frame.rs
+++ b/lib/dal/src/component/frame.rs
@@ -112,7 +112,7 @@ impl Frame {
                         == ComponentType::ConfigurationFrameUp
                     {
                         for (_, input_socket_match) in
-                            Component::input_socket_attribute_values_for_component_id(ctx, child_id)
+                            Component::input_socket_attribute_values_for_component_id(ctx, parent)
                                 .await?
                         {
                             if !InputSocket::is_manually_configured(ctx, input_socket_match).await?
@@ -144,6 +144,7 @@ impl Frame {
         child_id: ComponentId,
     ) -> FrameResult<()> {
         //when detaching a child, need to re-run any attribute prototypes for those impacted input sockets then queue up dvu!
+        Component::remove_edge_from_frame(ctx, parent_id, child_id).await?;
 
         let values_rerun = match Component::get_type_by_id(ctx, child_id).await? {
             ComponentType::Component
@@ -168,7 +169,7 @@ impl Frame {
                         == ComponentType::ConfigurationFrameUp
                     {
                         for (_, input_socket_match) in
-                            Component::input_socket_attribute_values_for_component_id(ctx, child_id)
+                            Component::input_socket_attribute_values_for_component_id(ctx, parent)
                                 .await?
                         {
                             if !InputSocket::is_manually_configured(ctx, input_socket_match).await?
@@ -191,7 +192,6 @@ impl Frame {
             ComponentType::AggregationFrame => vec![],
         };
 
-        Component::remove_edge_from_frame(ctx, parent_id, child_id).await?;
         ctx.enqueue_dependent_values_update(values_rerun).await?;
         Ok(())
     }

--- a/lib/dal/src/socket/debug.rs
+++ b/lib/dal/src/socket/debug.rs
@@ -132,16 +132,11 @@ impl SocketDebugView {
         };
         let value_view = attribute_value.view(ctx).await?;
         let inferred_connections =
-            match Component::find_potential_inferred_connection_to_input_socket(
-                ctx,
-                input_socket_match,
-            )
-            .await?
-            .map(|output_socket| Ulid::from(output_socket.attribute_value_id))
-            {
-                Some(output_id) => vec![output_id],
-                None => vec![],
-            };
+            Component::find_potential_inferred_connections_to_input_socket(ctx, input_socket_match)
+                .await?
+                .into_iter()
+                .map(|output_socket| Ulid::from(output_socket.attribute_value_id))
+                .collect();
         let view = SocketDebugView {
             prototype_id,
             func_name: prototype_debug_view.func_name,

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -255,14 +255,15 @@ async fn simple_frames(ctx: &mut DalContext) {
             .expect("couldn't get input sockets")
         {
             if input_socket_id == swifty_input.id() {
-                let possible_match = Component::find_potential_inferred_connection_to_input_socket(
-                    ctx,
-                    input_socket_match,
-                )
-                .await
-                .expect("couldn't find implicit inputs");
-                assert!(possible_match.is_some());
-                let travis_output_match = possible_match.expect("has a value");
+                let mut possible_match =
+                    Component::find_potential_inferred_connections_to_input_socket(
+                        ctx,
+                        input_socket_match,
+                    )
+                    .await
+                    .expect("couldn't find implicit inputs");
+                assert!(!possible_match.is_empty());
+                let travis_output_match = possible_match.pop().expect("has a value");
                 //maybe_travis_output_socket = Some(travis_output);
                 assert_eq!(
                     travis_output_match.component_id,
@@ -348,13 +349,14 @@ async fn simple_frames(ctx: &mut DalContext) {
             .expect("couldn't get input sockets")
         {
             if input_socket_id == swifty_input.id() {
-                let possible_match = Component::find_potential_inferred_connection_to_input_socket(
-                    ctx,
-                    input_socket_match,
-                )
-                .await
-                .expect("couldn't find implicit inputs");
-                assert!(possible_match.is_none());
+                let possible_match =
+                    Component::find_potential_inferred_connections_to_input_socket(
+                        ctx,
+                        input_socket_match,
+                    )
+                    .await
+                    .expect("couldn't find implicit inputs");
+                assert!(possible_match.is_empty());
             }
         }
         //make sure travis output socket can find swifty input socket
@@ -795,10 +797,11 @@ async fn simple_down_frames_nesting(ctx: &mut DalContext) {
         .expect("is some");
     assert_eq!(one_output_mat_view, serde_json::json!("4"));
     let maybe_match =
-        Component::find_potential_inferred_connection_to_input_socket(ctx, one_input_match)
+        Component::find_potential_inferred_connections_to_input_socket(ctx, one_input_match)
             .await
             .expect("could not find inferred input socket")
-            .expect("is some");
+            .pop()
+            .expect("has one");
     assert_eq!(
         maybe_match.attribute_value_id,
         three_av_id.attribute_value_id
@@ -1059,9 +1062,10 @@ async fn simple_up_frames_some_nesting(ctx: &mut DalContext) {
         .expect("could not get input socket");
 
     let output_match =
-        Component::find_potential_inferred_connection_to_input_socket(ctx, *one_input_match)
+        Component::find_potential_inferred_connections_to_input_socket(ctx, *one_input_match)
             .await
             .expect("could not get inferred connection")
+            .pop()
             .expect("inferred connection is some");
     assert_eq!(odd_up_frame_output_av, output_match.attribute_value_id);
 

--- a/lib/deadpool-cyclone/src/pool_noodle/pool_noodle.rs
+++ b/lib/deadpool-cyclone/src/pool_noodle/pool_noodle.rs
@@ -387,8 +387,11 @@ where
                             item: Some(item),
                         });
                     }
-                    Err(_) => {
-                        debug!("PoolNoodle: not healthy, cleaning up and getting a new one.");
+                    Err(err) => {
+                        debug!(
+                            "PoolNoodle: not healthy, cleaning up and getting a new one: {}",
+                            err
+                        );
                         // Item will be dropped, we need to try again
                     }
                 }


### PR DESCRIPTION
Fixes include: 
- make edge ids unique in the web so they don't disappear 
- remove the Frame Contains edge before updating the attribute value for the impacted input socket

Lastly, we (once again) support Up Frames inferring their inputs from multiple children, if and only if each child with matching output sockets only has one match. 

<div><img src="https://media3.giphy.com/media/IgdrPBTDxRBi0tK6FH/giphy.gif?cid=5a38a5a23jqkvisc9ypnqb4ij0vgsynayks7vz0rdvbowmuj&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:173px;width:300px"/><br/>via <a href="https://giphy.com/election2020/">Election 2020</a> on <a href="https://giphy.com/gifs/2020-iowa-democratic-party-liberty-and-justice-celebration-IgdrPBTDxRBi0tK6FH">GIPHY</a></div>