### PR TITLE
Fix secret attribute value containing an object instead of a string

### DIFF
--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -339,6 +339,9 @@ impl AttributePrototypeArgument {
                 NodeWeight::Prop(inner) => {
                     return Ok(Some(ValueSource::Prop(inner.id().into())));
                 }
+                NodeWeight::Secret(inner) => {
+                    return Ok(Some(ValueSource::Secret(inner.id().into())));
+                }
                 NodeWeight::Content(inner) => {
                     let discrim: ContentAddressDiscriminants = inner.content_address().into();
                     return Ok(Some(match discrim {
@@ -347,9 +350,6 @@ impl AttributePrototypeArgument {
                         }
                         ContentAddressDiscriminants::OutputSocket => {
                             ValueSource::OutputSocket(inner.id().into())
-                        }
-                        ContentAddressDiscriminants::Secret => {
-                            ValueSource::Secret(inner.id().into())
                         }
                         ContentAddressDiscriminants::StaticArgumentValue => {
                             ValueSource::StaticArgumentValue(inner.id().into())

--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -22,7 +22,7 @@ use crate::workspace_snapshot::node_weight::NodeWeightError;
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
     AttributePrototype, AttributePrototypeId, AttributeValue, AttributeValueId, Component,
-    ComponentError, DalContext, Func, FuncError, FuncId, Secret, SecretError,
+    ComponentError, DalContext, Func, FuncError, FuncId, SecretError,
 };
 
 type AttributePrototypeDebugViewResult<T> = Result<T, AttributePrototypeDebugViewError>;
@@ -54,6 +54,8 @@ pub enum AttributePrototypeDebugViewError {
     PropError(#[from] PropError),
     #[error("secret error: {0}")]
     SecretError(#[from] SecretError),
+    #[error("serde json error: {0}")]
+    SerdeJsonError(#[from] serde_json::Error),
     #[error("value source error: {0}")]
     ValueSourceError(#[from] ValueSourceError),
     #[error("workspace snapshot error: {0}")]
@@ -154,7 +156,9 @@ impl AttributePrototypeDebugView {
                 let values_for_arg = match value_source {
                     ValueSource::Secret(secret_id) => {
                         vec![FuncArgDebugView {
-                            value: Secret::payload_for_prototype_debug_view(secret_id)?,
+                            value: serde_json::to_value(format!(
+                                "[REDACTED KEY FOR SECRET (ID: {secret_id})]"
+                            ))?,
                             name: func_arg_name.clone(),
                             value_source: value_source.to_string(),
                             value_source_id: secret_id.into(),

--- a/lib/dal/src/layer_db_types/content_types.rs
+++ b/lib/dal/src/layer_db_types/content_types.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use si_events::{CasValue, ContentHash, EncryptedSecretKey};
+use si_events::{CasValue, ContentHash};
 use strum::EnumDiscriminants;
 
 use crate::validation::ValidationStatus;
@@ -370,8 +370,6 @@ pub enum SecretContent {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct SecretContentV1 {
-    pub key: EncryptedSecretKey,
-
     pub timestamp: Timestamp,
     pub created_by: Option<UserPk>,
     pub updated_by: Option<UserPk>,

--- a/lib/dal/src/secret/before_funcs.rs
+++ b/lib/dal/src/secret/before_funcs.rs
@@ -69,7 +69,7 @@ pub async fn before_funcs_for_component(
         .await?;
 
         let av_ids = Prop::attribute_values_for_prop_id(ctx, secret_prop_id).await?;
-        let mut maybe_payload = None;
+        let mut maybe_value = None;
         for av_id in av_ids {
             if AttributeValue::component_id(ctx, av_id).await? != component_id {
                 continue;
@@ -77,13 +77,12 @@ pub async fn before_funcs_for_component(
 
             let av = AttributeValue::get_by_id(ctx, av_id).await?;
 
-            maybe_payload = av.value(ctx).await?;
+            maybe_value = av.value(ctx).await?;
             break;
         }
 
-        if let Some(payload) = maybe_payload {
-            let key = Secret::key_from_payload(payload)?;
-
+        if let Some(value) = maybe_value {
+            let key = Secret::key_from_value_in_attribute_value(value)?;
             funcs_and_secrets.push((key, auth_funcs))
         }
     }

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -880,6 +880,10 @@ impl WorkspaceSnapshotGraph {
                     NodeWeight::Prop(prop_node_weight) => {
                         (format!("Prop\n{}", prop_node_weight.name()), "orange")
                     }
+                    NodeWeight::Secret(secret_node_weight) => (
+                        format!("Secret\n{}", secret_node_weight.encrypted_secret_key()),
+                        "black",
+                    ),
                 };
                 let color = color.to_string();
                 let id = node_weight.id();

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_events::{
     merkle_tree_hash::MerkleTreeHash,
+    EncryptedSecretKey,
     {ulid::Ulid, ContentHash},
 };
 use strum::EnumDiscriminants;
@@ -22,6 +23,7 @@ use crate::{
 use crate::{func::execution::FuncExecutionPk, EdgeWeightKindDiscriminants};
 
 use crate::func::FuncKind;
+use crate::workspace_snapshot::node_weight::secret_node_weight::SecretNodeWeight;
 pub use action_node_weight::ActionNodeWeight;
 pub use action_prototype_node_weight::ActionPrototypeNodeWeight;
 pub use attribute_prototype_argument_node_weight::ArgumentTargets;
@@ -48,6 +50,7 @@ pub mod func_argument_node_weight;
 pub mod func_node_weight;
 pub mod ordering_node_weight;
 pub mod prop_node_weight;
+pub mod secret_node_weight;
 
 #[remain::sorted]
 #[derive(Debug, Error)]
@@ -92,6 +95,7 @@ pub enum NodeWeight {
     FuncArgument(FuncArgumentNodeWeight),
     Ordering(OrderingNodeWeight),
     Prop(PropNodeWeight),
+    Secret(SecretNodeWeight),
 }
 
 impl NodeWeight {
@@ -108,6 +112,7 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.content_hash(),
             NodeWeight::Ordering(weight) => weight.content_hash(),
             NodeWeight::Prop(weight) => weight.content_hash(),
+            NodeWeight::Secret(weight) => weight.content_hash(),
         }
     }
 
@@ -124,6 +129,7 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.content_store_hashes(),
             NodeWeight::Ordering(weight) => weight.content_store_hashes(),
             NodeWeight::Prop(weight) => weight.content_store_hashes(),
+            NodeWeight::Secret(weight) => weight.content_store_hashes(),
         }
     }
 
@@ -139,7 +145,8 @@ impl NodeWeight {
             | NodeWeight::Func(_)
             | NodeWeight::FuncArgument(_)
             | NodeWeight::Ordering(_)
-            | NodeWeight::Prop(_) => None,
+            | NodeWeight::Prop(_)
+            | NodeWeight::Secret(_) => None,
         }
     }
 
@@ -156,6 +163,7 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.id(),
             NodeWeight::Ordering(weight) => weight.id(),
             NodeWeight::Prop(weight) => weight.id(),
+            NodeWeight::Secret(weight) => weight.id(),
         }
     }
 
@@ -174,6 +182,7 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.increment_vector_clock(change_set),
             NodeWeight::Ordering(weight) => weight.increment_vector_clock(change_set),
             NodeWeight::Prop(weight) => weight.increment_vector_clock(change_set),
+            NodeWeight::Secret(weight) => weight.increment_vector_clock(change_set),
         }
     }
 
@@ -190,6 +199,7 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.lineage_id(),
             NodeWeight::Ordering(weight) => weight.lineage_id(),
             NodeWeight::Prop(weight) => weight.lineage_id(),
+            NodeWeight::Secret(weight) => weight.lineage_id(),
         }
     }
 
@@ -208,6 +218,7 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.mark_seen_at(vector_clock_id, seen_at),
             NodeWeight::Ordering(weight) => weight.mark_seen_at(vector_clock_id, seen_at),
             NodeWeight::Prop(weight) => weight.mark_seen_at(vector_clock_id, seen_at),
+            NodeWeight::Secret(weight) => weight.mark_seen_at(vector_clock_id, seen_at),
         }
     }
 
@@ -252,6 +263,9 @@ impl NodeWeight {
             (NodeWeight::Prop(self_weight), NodeWeight::Prop(other_weight)) => {
                 self_weight.merge_clocks(change_set, other_weight)
             }
+            (NodeWeight::Secret(self_weight), NodeWeight::Secret(other_weight)) => {
+                self_weight.merge_clocks(change_set, other_weight)
+            }
             _ => Err(NodeWeightError::IncompatibleNodeWeightVariants),
         }
     }
@@ -269,6 +283,7 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.merkle_tree_hash(),
             NodeWeight::Ordering(weight) => weight.merkle_tree_hash(),
             NodeWeight::Prop(weight) => weight.merkle_tree_hash(),
+            NodeWeight::Secret(weight) => weight.merkle_tree_hash(),
         }
     }
 
@@ -279,6 +294,7 @@ impl NodeWeight {
             NodeWeight::Func(weight) => weight.new_content_hash(content_hash),
             NodeWeight::FuncArgument(weight) => weight.new_content_hash(content_hash),
             NodeWeight::Prop(weight) => weight.new_content_hash(content_hash),
+            NodeWeight::Secret(weight) => weight.new_content_hash(content_hash),
             NodeWeight::Action(_)
             | NodeWeight::ActionPrototype(_)
             | NodeWeight::AttributePrototypeArgument(_)
@@ -328,6 +344,9 @@ impl NodeWeight {
             NodeWeight::Prop(weight) => {
                 NodeWeight::Prop(weight.new_with_incremented_vector_clock(change_set)?)
             }
+            NodeWeight::Secret(weight) => {
+                NodeWeight::Secret(weight.new_with_incremented_vector_clock(change_set)?)
+            }
         };
 
         Ok(new_weight)
@@ -349,6 +368,7 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.node_hash(),
             NodeWeight::Ordering(weight) => weight.node_hash(),
             NodeWeight::Prop(weight) => weight.node_hash(),
+            NodeWeight::Secret(weight) => weight.node_hash(),
         }
     }
 
@@ -365,6 +385,7 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.set_merkle_tree_hash(new_hash),
             NodeWeight::Ordering(weight) => weight.set_merkle_tree_hash(new_hash),
             NodeWeight::Prop(weight) => weight.set_merkle_tree_hash(new_hash),
+            NodeWeight::Secret(weight) => weight.set_merkle_tree_hash(new_hash),
         }
     }
 
@@ -380,7 +401,8 @@ impl NodeWeight {
             | NodeWeight::Content(_)
             | NodeWeight::Func(_)
             | NodeWeight::FuncArgument(_)
-            | NodeWeight::Prop(_) => Err(NodeWeightError::CannotSetOrderOnKind),
+            | NodeWeight::Prop(_)
+            | NodeWeight::Secret(_) => Err(NodeWeightError::CannotSetOrderOnKind),
         }
     }
 
@@ -423,6 +445,9 @@ impl NodeWeight {
             NodeWeight::Prop(weight) => {
                 weight.set_vector_clock_recently_seen_to(change_set, new_val)
             }
+            NodeWeight::Secret(weight) => {
+                weight.set_vector_clock_recently_seen_to(change_set, new_val)
+            }
         }
     }
 
@@ -439,6 +464,7 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.vector_clock_first_seen(),
             NodeWeight::Ordering(weight) => weight.vector_clock_first_seen(),
             NodeWeight::Prop(weight) => weight.vector_clock_first_seen(),
+            NodeWeight::Secret(weight) => weight.vector_clock_first_seen(),
         }
     }
 
@@ -455,6 +481,7 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.vector_clock_recently_seen(),
             NodeWeight::Ordering(weight) => weight.vector_clock_recently_seen(),
             NodeWeight::Prop(weight) => weight.vector_clock_recently_seen(),
+            NodeWeight::Secret(weight) => weight.vector_clock_recently_seen(),
         }
     }
 
@@ -471,6 +498,7 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.vector_clock_write(),
             NodeWeight::Ordering(weight) => weight.vector_clock_write(),
             NodeWeight::Prop(weight) => weight.vector_clock_write(),
+            NodeWeight::Secret(weight) => weight.vector_clock_write(),
         }
     }
 
@@ -497,6 +525,7 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.exclusive_outgoing_edges(),
             NodeWeight::Ordering(weight) => weight.exclusive_outgoing_edges(),
             NodeWeight::Prop(weight) => weight.exclusive_outgoing_edges(),
+            NodeWeight::Secret(weight) => weight.exclusive_outgoing_edges(),
         }
     }
 
@@ -581,6 +610,16 @@ impl NodeWeight {
             NodeWeight::FuncArgument(inner) => Ok(inner.to_owned()),
             other => Err(NodeWeightError::UnexpectedNodeWeightVariant(
                 NodeWeightDiscriminants::FuncArgument,
+                other.into(),
+            )),
+        }
+    }
+
+    pub fn get_secret_node_weight(&self) -> NodeWeightResult<SecretNodeWeight> {
+        match self {
+            NodeWeight::Secret(inner) => Ok(inner.to_owned()),
+            other => Err(NodeWeightError::UnexpectedNodeWeightVariant(
+                NodeWeightDiscriminants::Secret,
                 other.into(),
             )),
         }
@@ -755,5 +794,19 @@ impl NodeWeight {
                 targets,
             )?,
         ))
+    }
+
+    pub fn new_secret(
+        change_set: &ChangeSet,
+        secret_id: Ulid,
+        encrypted_secret_key: EncryptedSecretKey,
+        content_hash: ContentHash,
+    ) -> NodeWeightResult<Self> {
+        Ok(NodeWeight::Secret(SecretNodeWeight::new(
+            change_set,
+            secret_id,
+            ContentAddress::Secret(content_hash),
+            encrypted_secret_key,
+        )?))
     }
 }

--- a/lib/dal/tests/integration_test/connection.rs
+++ b/lib/dal/tests/integration_test/connection.rs
@@ -386,7 +386,7 @@ async fn connect_and_disconnect_components_explicit_connection(ctx: &mut DalCont
     assert_eq!(
         "were-saving-for-lunch.service",
         units
-            .get(0)
+            .first()
             .map(|unit| unit.name.to_owned())
             .expect("has the first unit")
     );

--- a/lib/dal/tests/integration_test/secret/bench.rs
+++ b/lib/dal/tests/integration_test/secret/bench.rs
@@ -1,0 +1,50 @@
+use dal::{DalContext, Secret};
+use dal_test::{test, WorkspaceSignup};
+use std::time::Duration;
+
+#[test]
+async fn list_ids_by_key_bench(ctx: &mut DalContext, nw: &WorkspaceSignup) {
+    let secrets_count = 1000;
+    let key_pair_pk = nw.key_pair.pk();
+
+    // Populate the graph with many secrets.
+    let secret_creation_instant = tokio::time::Instant::now();
+    for count in 0..secrets_count {
+        if count % 100 == 0 {
+            println!(
+                "creating secret {count} of {secrets_count} ({:?})",
+                secret_creation_instant.elapsed()
+            );
+        }
+        Secret::new(
+            ctx,
+            count.to_string(),
+            count.to_string(),
+            None,
+            &[],
+            key_pair_pk,
+            Default::default(),
+            Default::default(),
+        )
+        .await
+        .expect("could not create secret");
+    }
+    println!(
+        "creating {secrets_count} secrets took: {:?}",
+        secret_creation_instant.elapsed()
+    );
+
+    // Now that we have a graph with many secrets, let's run the function and cache the result.
+    let list_ids_by_key_instant = tokio::time::Instant::now();
+    let _map = Secret::list_ids_by_key(ctx)
+        .await
+        .expect("could not list ids by key");
+    let list_ids_by_key_instant_elapsed = list_ids_by_key_instant.elapsed();
+
+    // Ensure that the result meets our expectations for wall clock time.
+    assert!(Duration::from_millis(10) > list_ids_by_key_instant_elapsed);
+    println!(
+        "list ids by key for {secrets_count} secrets took: {:?}",
+        list_ids_by_key_instant_elapsed
+    );
+}

--- a/lib/dal/tests/integration_test/secret/with_actions.rs
+++ b/lib/dal/tests/integration_test/secret/with_actions.rs
@@ -149,10 +149,7 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
                 "type": "component",
             },
             "secrets": {
-                "dummy": {
-                    "encrypted_secret_key": secret.key(),
-                    "secret_id": secret.id()
-                }
+                "dummy": secret.encrypted_secret_key().to_string()
             },
             "resource": {},
             "resource_value": {},
@@ -196,10 +193,7 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
                 "active": true
             },
             "secrets": {
-                "dummy": {
-                    "encrypted_secret_key": secret.key(),
-                    "secret_id": secret.id()
-                }
+                "dummy": secret.encrypted_secret_key().to_string()
             },
             "resource": {
                 "status": "ok",

--- a/lib/si-events-rs/src/encrypted_secret.rs
+++ b/lib/si-events-rs/src/encrypted_secret.rs
@@ -1,3 +1,3 @@
-/// This key uses a [`blake3::Hash`] wrapper, [`si_hash::Hash`], in order to get de/ser and display
-/// implementation benefits.
-pub type EncryptedSecretKey = si_hash::Hash;
+use crate::create_xxhash_type;
+
+create_xxhash_type!(EncryptedSecretKey);

--- a/lib/si-events-rs/src/lib.rs
+++ b/lib/si-events-rs/src/lib.rs
@@ -1,14 +1,14 @@
 pub mod content_hash;
+pub mod encrypted_secret;
 pub mod merkle_tree_hash;
+pub mod ulid;
 pub mod workspace_snapshot_address;
 pub mod xxhash_type;
 
 mod actor;
 mod cas;
-mod encrypted_secret;
 mod func_execution;
 mod tenancy;
-pub mod ulid;
 mod web_event;
 
 pub use crate::{


### PR DESCRIPTION
## Description

This PR is a follow-up to #3694 and fixes the attribute values corresponding to individual secrets containing an object instead of a string.

The encrypted secret key is now passed through the attribute subsystem alone. Since the property editor still needs to reference which encrypted secret key belongs to which secret, we determine the origin secret dynamically when assembling the property editor (~3.8ms wall clock time for 1000 secrets with a 3970X system on `Pop!_OS 22.04 LTS` with Linux kernel `6.8.0`).

As a result of these changes, we were able to remove intermediary types with a lot of footguns as well as move the encrypted secret key to the new `SecretNodeWeight` kind. Overall performance and consistency in results should be net positive.

<img src="https://media4.giphy.com/media/iq2azxZAGIlMpXkYPm/giphy.gif"/>

## Other Changes

Another change this PR brings is the inclusion of our first integration test... "bench". We want to ensure that looking up which secret an encrypted secret key is derived from is fast, so the new test will fail if the function takes too long. We may want to use this logic to create tests where similar performance scrutiny is needed.

Finally, we are now using the `create_xxhash_type` macro to ensure that the `EncryptedSecretKey` works with `si-layer-cache`.

## Q&A

Let's talk!

### Why now? Doesn't this already work from #3694?

Passing around object types as strings has potential to break or result in dropped or mangled values in dependent values update. Not only that, but the footguns working with transitory structs are greater than just passing the key as a string downstream and then deriving the secrets from the keys since there is a one-to-one relationship between each secret and key.

### Are you worried about performance?

Secrets collections have the potential to be multitudinous in nature. This PR adds a performance-baseline "bench" for ensuring that finding the secret for the corresponding key happens in an acceptable timeframe.

### Does this break existing users?

If all `Secrets` are deleted in all `ChangeSets` for all `Workspaces`, then re-using a database from a deployment of latest `main` should work. However, we do not yet guarantee backwards compatibility with recent `main`, though that will likely change shortly.