### PR TITLE
Dispatch Actions V2 after successful rebase of default change set for workspace

### DIFF
--- a/lib/si-layer-cache/src/activities/rebase.rs
+++ b/lib/si-layer-cache/src/activities/rebase.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use strum::EnumDiscriminants;
 
 use si_events::WorkspaceSnapshotAddress;
 use telemetry::prelude::*;
@@ -75,7 +76,8 @@ impl RebaseFinished {
 
 // NOTE: We're basically smashing the data in here, and we really do have to figure out what we
 // actually want when things work / or don't work.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, EnumDiscriminants)]
+#[strum_discriminants(derive(strum::Display, Serialize, Deserialize))]
 pub enum RebaseStatus {
     /// Processing the request and performing updates were both successful. Additionally, no conflicts were found.
     Success {


### PR DESCRIPTION
Whenever we have successfully rebased the default change set for a workspace, we need to dispatch any eligible Actions (and mark them as dispatched). By checking which Actions are eligible to dispatch on successful rebase, we ensure that any changes to the default change set (typically `HEAD`, or `main`) will automatically cause relevant Actions to run, such as an Action being removed from the graph because it succeeded, or new Actions being queued from merging a change set into the default change set.