### PR TITLE
feat(dal,rebaser-server): rebaser debounces dvu jobs

### DIFF
--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -544,6 +544,7 @@ impl ChangeSet {
             onto_workspace_snapshot_address,
             onto_vector_clock_id: self.vector_clock_id(),
             to_rebase_change_set_id,
+            dvu_values: None,
         };
 
         if let Some(conflicts) = ctx.do_rebase_request(rebase_request).await? {

--- a/lib/rebaser-server/src/change_set_requests.rs
+++ b/lib/rebaser-server/src/change_set_requests.rs
@@ -19,7 +19,7 @@ use telemetry::prelude::*;
 use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
 
-use crate::{ServerError as Error, ServerMetadata, ServerResult};
+use crate::{dvu_debouncer::DvuDebouncer, ServerError as Error, ServerMetadata, ServerResult};
 
 use self::app_state::AppState;
 
@@ -55,7 +55,13 @@ impl ChangeSetRequestsTask {
         ctx_builder: DalContextBuilder,
         shutdown_token: CancellationToken,
     ) -> Self {
-        let state = AppState::new(workspace_id, change_set_id, ctx_builder);
+        let dvu_debouncer = DvuDebouncer::new(
+            workspace_id,
+            change_set_id,
+            shutdown_token.clone(),
+            ctx_builder.clone(),
+        );
+        let state = AppState::new(workspace_id, change_set_id, ctx_builder, dvu_debouncer);
 
         let app = ServiceBuilder::new()
             .concurrency_limit(1)

--- a/lib/rebaser-server/src/change_set_requests/app_state.rs
+++ b/lib/rebaser-server/src/change_set_requests/app_state.rs
@@ -3,6 +3,8 @@
 use dal::DalContextBuilder;
 use si_events::{ChangeSetId, WorkspacePk};
 
+use crate::dvu_debouncer::DvuDebouncer;
+
 /// Application state.
 #[derive(Clone, Debug)]
 pub struct AppState {
@@ -12,6 +14,8 @@ pub struct AppState {
     pub change_set_id: ChangeSetId,
     /// DAL context builder for each processing request
     pub ctx_builder: DalContextBuilder,
+    /// The DVU debouncer
+    pub dvu_debouncer: DvuDebouncer,
 }
 
 impl AppState {
@@ -20,11 +24,13 @@ impl AppState {
         workspace_id: WorkspacePk,
         change_set_id: ChangeSetId,
         ctx_builder: DalContextBuilder,
+        dvu_debouncer: DvuDebouncer,
     ) -> Self {
         Self {
             workspace_id,
             change_set_id,
             ctx_builder,
+            dvu_debouncer,
         }
     }
 }

--- a/lib/rebaser-server/src/change_set_requests/handlers.rs
+++ b/lib/rebaser-server/src/change_set_requests/handlers.rs
@@ -71,7 +71,7 @@ pub async fn process_request(State(state): State<AppState>, msg: InnerMessage) -
         .activity()
         .rebase()
         .finished(
-            rebase_status,
+            rebase_status.clone(),
             message.payload.to_rebase_change_set_id,
             message.payload.onto_workspace_snapshot_address,
             message.metadata.clone(),
@@ -79,6 +79,13 @@ pub async fn process_request(State(state): State<AppState>, msg: InnerMessage) -
         )
         .await
         .map_err(HandlerError::SendRebaseFinished)?;
+
+    // only enqueue values if rebase succeeded. if it failed, there's no work to do
+    if let RebaseStatus::Success { .. } = rebase_status {
+        if let Some(values) = message.payload.dvu_values {
+            state.dvu_debouncer.enqueue_values(values);
+        }
+    }
 
     let mut event =
         WsEvent::change_set_written(&ctx, message.payload.to_rebase_change_set_id.into()).await?;

--- a/lib/rebaser-server/src/dvu_debouncer.rs
+++ b/lib/rebaser-server/src/dvu_debouncer.rs
@@ -1,0 +1,189 @@
+//! A per-changeset task to debounce dependent values updates
+
+use std::{collections::HashSet, sync::Arc};
+
+use dal::{DalContextBuilder, Tenancy, TransactionsError, Visibility};
+use si_events::{ChangeSetId, WorkspacePk};
+use telemetry::prelude::*;
+use thiserror::Error;
+use tokio::{
+    select,
+    sync::{
+        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+        Mutex,
+    },
+    time::{interval, Duration},
+};
+use tokio_util::sync::CancellationToken;
+use ulid::Ulid;
+
+const DVU_INTERVAL: Duration = Duration::from_secs(5);
+
+/// DvuDebouncer error type
+#[derive(Error, Debug)]
+pub enum DvuDebouncerError {
+    /// A transactions error
+    #[error("Transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
+}
+
+/// DvuDebouncer result type
+type DvuDebouncerResult<T> = Result<T, DvuDebouncerError>;
+
+/// Messages to the value management task
+#[derive(Debug)]
+enum ValueTaskMessage {
+    /// Enqueue values into the debouncer
+    EnqueueValues(Vec<Ulid>),
+}
+
+/// Messages to DVU spawner task
+#[derive(Debug)]
+enum DvuTaskMessage {
+    Dvu(Vec<Ulid>),
+}
+
+/// The DVU debouncer
+#[derive(Clone, Debug)]
+pub struct DvuDebouncer {
+    values: Arc<Mutex<HashSet<Ulid>>>,
+    value_tx: UnboundedSender<ValueTaskMessage>,
+    dvu_tx: UnboundedSender<DvuTaskMessage>,
+    cancellation_token: CancellationToken,
+    workspace_id: WorkspacePk,
+    change_set_id: ChangeSetId,
+    ctx_builder: DalContextBuilder,
+}
+
+impl DvuDebouncer {
+    /// Create a new DvuDebouncer. Spawns two long running tasks. One receives
+    /// and dedupes values, and enqueues jobs using the values on an interval.
+    /// The other processes the DVU job queue serially, as it receives messages.
+    pub fn new(
+        workspace_id: WorkspacePk,
+        change_set_id: ChangeSetId,
+        cancellation_token: CancellationToken,
+        ctx_builder: DalContextBuilder,
+    ) -> Self {
+        let values = Arc::new(Mutex::new(Default::default()));
+
+        let (value_tx, value_rx) = unbounded_channel();
+        let (dvu_tx, dvu_rx) = unbounded_channel();
+
+        let debouncer = Self {
+            values,
+            value_tx,
+            dvu_tx,
+            cancellation_token,
+            workspace_id,
+            change_set_id,
+            ctx_builder,
+        };
+
+        let debouncer_clone = debouncer.clone();
+        let debouncer_clone_2 = debouncer.clone();
+
+        tokio::task::spawn(async { dvu_task(debouncer_clone, dvu_rx).await });
+        tokio::task::spawn(async { debouncer_task(debouncer_clone_2, value_rx).await });
+
+        debouncer
+    }
+
+    /// Send a message to this debouncer's task
+    pub fn enqueue_values(&self, values: Vec<Ulid>) {
+        // Send only fails if the receiver end has gone away
+        if let Err(err) = self.value_tx.send(ValueTaskMessage::EnqueueValues(values)) {
+            error!(error = ?err, "Failed to enqueue values for dependent values update, receiver is closed");
+        }
+    }
+
+    async fn handle_enqueue_values(&self, new_values: &[Ulid]) {
+        let mut values = self.values.lock().await;
+        for value in new_values {
+            values.insert(*value);
+        }
+    }
+
+    async fn drain_values(&self) -> Option<Vec<Ulid>> {
+        let mut values = self.values.lock().await;
+        if values.is_empty() {
+            None
+        } else {
+            let current_values = values.clone();
+            *values = HashSet::new();
+            Some(current_values.into_iter().collect())
+        }
+    }
+
+    async fn enqueue_dependent_values_update(&self) {
+        if let Some(values) = self.drain_values().await {
+            if let Err(err) = self.dvu_tx.send(DvuTaskMessage::Dvu(values)) {
+                error!(error = ?err, "Failed to enqueue dependent values update, receiver is closed");
+            }
+        }
+    }
+
+    async fn handle_dependent_values_update(&self, values: Vec<Ulid>) -> DvuDebouncerResult<()> {
+        let mut ctx = self.ctx_builder.build_default().await?;
+
+        ctx.update_visibility_deprecated(Visibility::new(self.change_set_id.into_inner().into()));
+        ctx.update_tenancy(Tenancy::new(self.workspace_id.into_inner().into()));
+
+        ctx.enqueue_dependent_values_update(values.into_iter().collect())
+            .await?;
+
+        // the pinga job will do the rebase
+        ctx.blocking_commit_no_rebase().await?;
+
+        Ok(())
+    }
+}
+
+/// This task executes dependent values update jobs in serial
+async fn dvu_task(debouncer: DvuDebouncer, mut rx: UnboundedReceiver<DvuTaskMessage>) {
+    info!("booting dvu handler task for {}", &debouncer.change_set_id,);
+    loop {
+        select! {
+            _ = debouncer.cancellation_token.cancelled() => {
+                info!("DVU debouncer: DVU task received cancellation message");
+                return;
+            }
+            Some(message) = rx.recv() => {
+                match message {
+                    DvuTaskMessage::Dvu(values) => {
+                        info!("Enqueueing dependent values update job for {} values on change set {}", values.len(), debouncer.change_set_id);
+                        if let Err(err) = debouncer.handle_dependent_values_update(values).await {
+                            error!(error = ?err, "Attempt to enqueue dependent values update job failed");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn debouncer_task(debouncer: DvuDebouncer, mut rx: UnboundedReceiver<ValueTaskMessage>) {
+    info!("booting dvu values task for {}", &debouncer.change_set_id,);
+
+    let mut ticker = interval(DVU_INTERVAL);
+
+    loop {
+        select! {
+            _ = debouncer.cancellation_token.cancelled() => {
+                info!("DVU debouncer: value task received cancellation message");
+
+                return;
+            }
+            _ = ticker.tick() => {
+                debouncer.enqueue_dependent_values_update().await;
+            }
+            Some(message) = rx.recv() => {
+                match message {
+                    ValueTaskMessage::EnqueueValues(values) => {
+                        debouncer.handle_enqueue_values(&values).await;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lib/rebaser-server/src/lib.rs
+++ b/lib/rebaser-server/src/lib.rs
@@ -31,6 +31,7 @@ use thiserror::Error;
 
 pub mod change_set_requests;
 mod config;
+pub mod dvu_debouncer;
 mod rebase;
 mod server;
 

--- a/lib/si-events-rs/src/ulid.rs
+++ b/lib/si-events-rs/src/ulid.rs
@@ -1,5 +1,7 @@
 use ulid::Ulid as CoreUlid;
+pub use ulid::ULID_LEN;
 
+/// Size is the size in bytes, len is the string length
 const ULID_SIZE: usize = 16;
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, Default, PartialOrd, Ord)]

--- a/lib/si-layer-cache/src/activities/rebase.rs
+++ b/lib/si-layer-cache/src/activities/rebase.rs
@@ -13,7 +13,7 @@ use crate::activity_client::ActivityClient;
 use crate::{error::LayerDbResult, event::LayeredEventMetadata};
 
 /// The message that the server receives to perform a rebase.
-#[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct RebaseRequest {
     /// Corresponds to the change set whose pointer is to be updated.
     pub to_rebase_change_set_id: Ulid,
@@ -24,6 +24,9 @@ pub struct RebaseRequest {
     /// last change set before edits were made, or the change set that you are trying to rebase
     /// onto base.
     pub onto_vector_clock_id: Ulid,
+    /// A set of values that have changed, and need to have the impact of their
+    /// change reflected downstream of them by the dependent values update job
+    pub dvu_values: Option<Vec<Ulid>>,
 }
 
 impl RebaseRequest {
@@ -31,11 +34,13 @@ impl RebaseRequest {
         to_rebase_change_set_id: Ulid,
         onto_workspace_snapshot_address: WorkspaceSnapshotAddress,
         onto_vector_clock_id: Ulid,
+        dvu_values: Option<Vec<Ulid>>,
     ) -> RebaseRequest {
         RebaseRequest {
             to_rebase_change_set_id,
             onto_workspace_snapshot_address,
             onto_vector_clock_id,
+            dvu_values,
         }
     }
 }
@@ -113,12 +118,14 @@ impl<'a> ActivityRebase<'a> {
         to_rebase_change_set_id: Ulid,
         onto_workspace_snapshot_address: WorkspaceSnapshotAddress,
         onto_vector_clock_id: Ulid,
+        dvu_values: Option<Vec<Ulid>>,
         metadata: LayeredEventMetadata,
     ) -> LayerDbResult<Activity> {
         let payload = RebaseRequest::new(
             to_rebase_change_set_id,
             onto_workspace_snapshot_address,
             onto_vector_clock_id,
+            dvu_values,
         );
         let activity = Activity::rebase(payload, metadata);
         self.activity_base.publish(&activity).await?;
@@ -131,12 +138,14 @@ impl<'a> ActivityRebase<'a> {
         to_rebase_change_set_id: Ulid,
         onto_workspace_snapshot_address: WorkspaceSnapshotAddress,
         onto_vector_clock_id: Ulid,
+        dvu_values: Option<Vec<Ulid>>,
         metadata: LayeredEventMetadata,
     ) -> LayerDbResult<Activity> {
         let payload = RebaseRequest::new(
             to_rebase_change_set_id,
             onto_workspace_snapshot_address,
             onto_vector_clock_id,
+            dvu_values,
         );
         let activity = Activity::rebase(payload, metadata);
         // println!("trigger: sending rebase and waiting for response");

--- a/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
@@ -86,6 +86,7 @@ async fn subscribe_rebaser_requests_work_queue() {
             Ulid::new(),
             WorkspaceSnapshotAddress::new(b"poop"),
             Ulid::new(),
+            None,
             metadata.clone(),
         )
         .await
@@ -201,6 +202,7 @@ async fn rebase_and_wait() {
                 Ulid::new(),
                 WorkspaceSnapshotAddress::new(b"poop"),
                 Ulid::new(),
+                None,
                 metadata_for_task,
             )
             .await
@@ -337,6 +339,7 @@ async fn rebase_requests_work_queue_stress() {
                     Ulid::new(),
                     WorkspaceSnapshotAddress::new(b"poop"),
                     Ulid::new(),
+                    None,
                     send_meta.clone(),
                 )
                 .await
@@ -492,6 +495,7 @@ async fn rebase_and_wait_stress() {
                         Ulid::new(),
                         WorkspaceSnapshotAddress::new(b"poop"),
                         Ulid::new(),
+                        None,
                         mp,
                     )
                     .await;


### PR DESCRIPTION
Send the set of values we intend to run DependentValuesUpdate on along with the rebase request if a non-blocking commit is requested. If values appear in the rebase request, send them to a task which will dispatch DependentValuesUpdate jobs in 5 second intervals, blocking until they finish, so that they run serially for a change set.

Note, DalContext `commit` will no longer send DependentValuesUpdate jobs to pinga (no other job types are affected). Instead it sends them to the rebaser and the rebaser will send them to pinga. `blocking_commit` still processes the job queue the same way as before, since we expect this behavior in tests. Our tests should be restructured to not require the blocking commits.