### PR TITLE
build(deps): update to Rust 1.78.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,15 @@ members = [
     "lib/veritech-server",
 ]
 
+[workspace.package]
+version = "0.1.0"
+authors = ["System Initiative Inc. <info@systeminit.com>"]
+license = "Apache-2.0"
+repository = "https://github.com/systeminit/si"
+edition = "2021"
+rust-version = "1.78"
+publish = false
+
 [workspace.dependencies]
 async-nats = { version = "0.34.0", features = ["service"] }
 async-recursion = "1.0.5"

--- a/bin/cyclone/Cargo.toml
+++ b/bin/cyclone/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "cyclone"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "cyclone"

--- a/bin/module-index/Cargo.toml
+++ b/bin/module-index/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "module-index"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "module-index"

--- a/bin/pinga/Cargo.toml
+++ b/bin/pinga/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "pinga"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "pinga"

--- a/bin/rebaser/Cargo.toml
+++ b/bin/rebaser/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "rebaser"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "rebaser"

--- a/bin/sdf/Cargo.toml
+++ b/bin/sdf/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "sdf"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "sdf"

--- a/bin/veritech/Cargo.toml
+++ b/bin/veritech/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "veritech"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "veritech"

--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702952173,
-        "narHash": "sha256-24kUnTZgXP5B/fs1/f61tJuHyFrJ8824rn1B/0hL1og=",
+        "lastModified": 1715221036,
+        "narHash": "sha256-81EKOdlmT/4hZpImRlvMVPgmCcJYZjwlWbJese/XqUw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "20fd62b0891707a1db8117d09fc3e65a1cd0f6d7",
+        "rev": "5c4bc8a0a70093a31a12509c5653c147f2310bd2",
         "type": "github"
       },
       "original": {

--- a/lib/auth-api-client/Cargo.toml
+++ b/lib/auth-api-client/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "auth-api-client"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.70"
-publish = false
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 chrono = { workspace = true }

--- a/lib/buck2-resources/Cargo.toml
+++ b/lib/buck2-resources/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "buck2-resources"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 serde_json = { workspace = true }

--- a/lib/bytes-lines-codec/Cargo.toml
+++ b/lib/bytes-lines-codec/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "bytes-lines-codec"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 bytes = { workspace = true }

--- a/lib/config-file/Cargo.toml
+++ b/lib/config-file/Cargo.toml
@@ -5,10 +5,13 @@
 
 [package]
 name = "config-file"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [features]
 default = []

--- a/lib/config-file/src/layered_load/ser.rs
+++ b/lib/config-file/src/layered_load/ser.rs
@@ -169,10 +169,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         self.serialize_unit()
     }
 
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok>
-    where
-        T: Serialize,
-    {
+    fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<Self::Ok> {
         value.serialize(self)
     }
 
@@ -193,23 +190,21 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         self.serialize_str(variant)
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
-    where
-        T: Serialize,
-    {
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok> {
         value.serialize(self)
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T: ?Sized + Serialize>(
         self,
         _name: &'static str,
         _variant_index: u32,
         _variant: &'static str,
         _value: &T,
-    ) -> Result<Self::Ok>
-    where
-        T: Serialize,
-    {
+    ) -> Result<Self::Ok> {
         todo!()
     }
 
@@ -267,10 +262,7 @@ impl<'a> ser::SerializeSeq for &'a mut Serializer {
     type Ok = ();
     type Error = SerializerError;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
-    where
-        T: Serialize,
-    {
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<()> {
         value.serialize(&mut **self)
     }
 
@@ -291,10 +283,7 @@ impl<'a> ser::SerializeTuple for &'a mut Serializer {
     type Ok = ();
     type Error = SerializerError;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
-    where
-        T: Serialize,
-    {
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<()> {
         ser::SerializeSeq::serialize_element(self, value)
     }
 
@@ -307,10 +296,7 @@ impl<'a> ser::SerializeTupleStruct for &'a mut Serializer {
     type Ok = ();
     type Error = SerializerError;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
-    where
-        T: Serialize,
-    {
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<()> {
         ser::SerializeSeq::serialize_element(self, value)
     }
 
@@ -323,10 +309,7 @@ impl<'a> ser::SerializeTupleVariant for &'a mut Serializer {
     type Ok = ();
     type Error = SerializerError;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
-    where
-        T: Serialize,
-    {
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<()> {
         ser::SerializeSeq::serialize_element(self, value)
     }
 
@@ -339,18 +322,12 @@ impl<'a> ser::SerializeMap for &'a mut Serializer {
     type Ok = ();
     type Error = SerializerError;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<()>
-    where
-        T: Serialize,
-    {
+    fn serialize_key<T: ?Sized + Serialize>(&mut self, key: &T) -> Result<()> {
         key.serialize(MapKeySerializer { ser: self })?;
         Ok(())
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<()>
-    where
-        T: Serialize,
-    {
+    fn serialize_value<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<()> {
         value.serialize(&mut **self)?;
         match self.key.rfind('.') {
             Some(at) => {
@@ -370,10 +347,11 @@ impl<'a> ser::SerializeStruct for &'a mut Serializer {
     type Ok = ();
     type Error = SerializerError;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
-    where
-        T: Serialize,
-    {
+    fn serialize_field<T: ?Sized + Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<()> {
         if !self.key.is_empty() {
             self.key.push('.');
         }
@@ -397,10 +375,11 @@ impl<'a> ser::SerializeStructVariant for &'a mut Serializer {
     type Ok = ();
     type Error = SerializerError;
 
-    fn serialize_field<T: ?Sized>(&mut self, _key: &'static str, _value: &T) -> Result<()>
-    where
-        T: Serialize,
-    {
+    fn serialize_field<T: ?Sized + Serialize>(
+        &mut self,
+        _key: &'static str,
+        _value: &T,
+    ) -> Result<()> {
         todo!()
     }
 
@@ -510,10 +489,7 @@ impl<'a> ser::Serializer for MapKeySerializer<'a> {
         Err(key_must_be_a_string())
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<()>
-    where
-        T: Serialize,
-    {
+    fn serialize_some<T: ?Sized + Serialize>(self, _value: &T) -> Result<()> {
         Err(key_must_be_a_string())
     }
 
@@ -534,23 +510,21 @@ impl<'a> ser::Serializer for MapKeySerializer<'a> {
         Err(key_must_be_a_string())
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, _value: &T) -> Result<()>
-    where
-        T: Serialize,
-    {
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<()> {
         Err(key_must_be_a_string())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T: ?Sized + Serialize>(
         self,
         _name: &'static str,
         _variant_index: u32,
         _variant: &'static str,
         _value: &T,
-    ) -> Result<()>
-    where
-        T: Serialize,
-    {
+    ) -> Result<()> {
         Err(key_must_be_a_string())
     }
 

--- a/lib/cyclone-client/Cargo.toml
+++ b/lib/cyclone-client/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "cyclone-client"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }

--- a/lib/cyclone-core/Cargo.toml
+++ b/lib/cyclone-core/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "cyclone-core"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 base64 = { workspace = true }

--- a/lib/cyclone-server/Cargo.toml
+++ b/lib/cyclone-server/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "cyclone-server"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }

--- a/lib/dal-test/Cargo.toml
+++ b/lib/dal-test/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "dal-test"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-recursion = { workspace = true }

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "dal"
-version = "0.1.0"
-authors = ["Adam Jacob <adam@systeminit.com>"]
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 nats-subscriber = { path = "../../lib/nats-subscriber" }

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1629,7 +1629,7 @@ impl AttributeValue {
             .await?
         {
             if let EdgeWeightKind::Contain(contain_key) = edge_weight.kind() {
-                key = contain_key.to_owned();
+                contain_key.clone_into(&mut key);
             }
         }
 

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -181,8 +181,8 @@ impl ChangeSet {
         new_local.base_change_set_id = self.base_change_set_id;
         new_local.workspace_snapshot_address = self.workspace_snapshot_address;
         new_local.workspace_id = self.workspace_id;
-        new_local.name = self.name.to_owned();
-        new_local.status = self.status.to_owned();
+        self.name.clone_into(&mut new_local.name);
+        self.status.clone_into(&mut new_local.status);
         Ok(new_local)
     }
 

--- a/lib/dal/src/dependency_graph.rs
+++ b/lib/dal/src/dependency_graph.rs
@@ -46,7 +46,7 @@ impl<T: Copy + std::cmp::Eq + std::cmp::PartialEq + std::hash::Hash> DependencyG
     }
 
     pub fn contains_id(&self, id: T) -> bool {
-        self.id_to_index_map.get(&id).is_some()
+        self.id_to_index_map.contains_key(&id)
     }
 
     pub fn direct_dependencies_of(&self, id: T) -> Vec<T> {

--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -234,9 +234,9 @@ impl FuncAuthoringClient {
         let func = Func::get_by_id_or_error(ctx, id).await?;
 
         Func::modify_by_id(ctx, func.id, |func| {
-            func.display_name = display_name.to_owned();
-            func.name = name.to_owned();
-            func.description = description.to_owned();
+            display_name.clone_into(&mut func.display_name);
+            name.clone_into(&mut func.name);
+            description.clone_into(&mut func.description);
             func.code_base64 = code
                 .as_ref()
                 .map(|code| general_purpose::STANDARD_NO_PAD.encode(code));

--- a/lib/dal/src/func/authoring/save.rs
+++ b/lib/dal/src/func/authoring/save.rs
@@ -368,7 +368,7 @@ async fn save_attr_func_arguments(
             func_argument.id
         } else {
             FuncArgument::modify_by_id(ctx, arg.id, |existing_arg| {
-                existing_arg.name = arg.name.to_owned();
+                arg.name.clone_into(&mut existing_arg.name);
                 existing_arg.kind = arg.kind;
                 existing_arg.element_kind = arg.element_kind;
 

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -116,7 +116,9 @@ impl PkgExporter {
                 if let Some(default_variant_id) = default_variant_id {
                     if variant.id() == default_variant_id {
                         category = variant_category;
-                        default_variant_unique_id = variant_spec.unique_id.to_owned();
+                        variant_spec
+                            .unique_id
+                            .clone_into(&mut default_variant_unique_id);
                     }
                 }
             }

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -311,7 +311,7 @@ async fn update_func(
 ) -> PkgResult<Func> {
     let func = func
         .modify(ctx, |func| {
-            func.name = func_spec_data.name().to_owned();
+            func_spec_data.name().clone_into(&mut func.name);
             func.backend_kind = func_spec_data.backend_kind().into();
             func.backend_response_type = func_spec_data.response_type().into();
             func.display_name = func_spec_data

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -299,17 +299,17 @@ impl VariantAuthoringClient {
             asset_func
                 .clone()
                 .modify(ctx, |func| {
-                    func.name = name.clone();
+                    func.name.clone_from(&name);
                     func.backend_kind = FuncBackendKind::JsSchemaVariantDefinition;
                     func.backend_response_type = FuncBackendResponseType::SchemaVariantDefinition;
                     func.display_name = menu_name
                         .clone()
                         .map(|display_name| display_name.to_owned());
                     func.code_base64 = Some(code_base64);
-                    func.description = description.clone();
+                    func.description.clone_from(&description);
                     func.handler = Some("main".to_string());
                     func.hidden = false;
-                    func.link = link.clone();
+                    func.link.clone_from(&link);
                     Ok(())
                 })
                 .await?;
@@ -368,7 +368,7 @@ impl VariantAuthoringClient {
             schema
                 .clone()
                 .modify(ctx, |s| {
-                    s.name = name.clone();
+                    s.name.clone_from(&name);
                     Ok(())
                 })
                 .await?;
@@ -402,9 +402,9 @@ impl VariantAuthoringClient {
                     .modify(ctx, |sv| {
                         sv.description = description;
                         sv.link = link;
-                        sv.category = category.clone();
+                        sv.category.clone_from(&category);
                         sv.component_type = component_type;
-                        sv.color = color.clone();
+                        sv.color.clone_from(&color);
                         sv.display_name = menu_name;
                         Ok(())
                     })
@@ -452,10 +452,10 @@ impl VariantAuthoringClient {
                     .clone()
                     .map(|display_name| display_name.to_owned());
                 func.code_base64 = Some(code_base64);
-                func.description = description.clone();
+                func.description.clone_from(&description);
                 func.handler = Some("main".to_string());
                 func.hidden = false;
-                func.link = link.clone();
+                func.link.clone_from(&link);
                 Ok(())
             })
             .await?;
@@ -517,7 +517,7 @@ impl VariantAuthoringClient {
         schema
             .clone()
             .modify(ctx, |s| {
-                s.name = name.clone();
+                s.name.clone_from(&name);
                 Ok(())
             })
             .await?;
@@ -573,10 +573,10 @@ impl VariantAuthoringClient {
                         .clone()
                         .map(|display_name| display_name.to_owned());
                     func.code_base64 = Some(code_base64);
-                    func.description = description.clone();
+                    func.description.clone_from(&description);
                     func.handler = Some("main".to_string());
                     func.hidden = false;
-                    func.link = link.clone();
+                    func.link.clone_from(&link);
                     Ok(())
                 })
                 .await?;

--- a/lib/module-index-client/Cargo.toml
+++ b/lib/module-index-client/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "module-index-client"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.69"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 chrono = { workspace = true }

--- a/lib/module-index-server/Cargo.toml
+++ b/lib/module-index-server/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "module-index-server"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 axum = { workspace = true }

--- a/lib/module-index-server/src/app_state.rs
+++ b/lib/module-index-server/src/app_state.rs
@@ -6,16 +6,13 @@ use s3::creds::Credentials as AwsCredentials;
 use sea_orm::DatabaseConnection;
 pub use si_posthog::PosthogClient;
 
-use tokio::sync::{broadcast, mpsc, Mutex};
+use tokio::sync::{mpsc, Mutex};
 
 use crate::{jwt_key::JwtPublicSigningKey, s3::S3Config};
 
 #[remain::sorted]
 #[derive(Debug, Eq, PartialEq)]
 pub enum ShutdownSource {}
-
-#[derive(Clone, Debug)]
-pub struct ShutdownBroadcast(broadcast::Sender<()>);
 
 #[derive(Clone, Debug, FromRef)]
 pub struct AppState {
@@ -26,8 +23,6 @@ pub struct AppState {
     aws_creds: AwsCredentials,
     s3_config: S3Config,
     token_emails: Arc<Mutex<HashMap<String, String>>>,
-
-    shutdown_broadcast: ShutdownBroadcast,
 
     // see notes in sdf AppState
     #[from_ref(skip)]
@@ -43,7 +38,6 @@ impl AppState {
         posthog_client: PosthogClient,
         aws_creds: AwsCredentials,
         s3_config: S3Config,
-        shutdown_broadcast_tx: broadcast::Sender<()>,
         tmp_shutdown_tx: mpsc::Sender<ShutdownSource>,
     ) -> Self {
         Self {
@@ -52,7 +46,6 @@ impl AppState {
             posthog_client,
             aws_creds,
             s3_config,
-            shutdown_broadcast: ShutdownBroadcast(shutdown_broadcast_tx),
             token_emails: Arc::new(Mutex::new(HashMap::new())),
             _tmp_shutdown_tx: Arc::new(tmp_shutdown_tx),
         }

--- a/lib/module-index-server/src/models/si_module.rs
+++ b/lib/module-index-server/src/models/si_module.rs
@@ -1,4 +1,4 @@
-use sea_orm::{entity::prelude::*, sea_query, DeriveIden, TryGetError};
+use sea_orm::{entity::prelude::*, sea_query, TryGetError};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use ulid::Ulid;
@@ -156,9 +156,6 @@ impl sea_orm::TryGetable for ModuleId {
         // serde_json::from_str(&json_str).map_err(|e| TryGetError::DbErr(DbErr::Json(e.to_string())))
     }
 }
-
-#[derive(DeriveIden, Clone, Copy)]
-struct UlidIdentType;
 
 impl sea_query::ValueType for ModuleId {
     fn try_from(v: Value) -> Result<Self, sea_query::ValueTypeErr> {

--- a/lib/module-index-server/src/server.rs
+++ b/lib/module-index-server/src/server.rs
@@ -232,7 +232,6 @@ pub fn build_service(
         posthog_client,
         aws_creds,
         s3_config,
-        shutdown_broadcast_tx.clone(),
         shutdown_tx,
     );
 

--- a/lib/nats-multiplexer-client/Cargo.toml
+++ b/lib/nats-multiplexer-client/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "nats-multiplexer-client"
-version = "0.1.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 nats-multiplexer-core = { path = "../../lib/nats-multiplexer-core" }

--- a/lib/nats-multiplexer-core/Cargo.toml
+++ b/lib/nats-multiplexer-core/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "nats-multiplexer-core"
-version = "0.1.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 si-data-nats = { path = "../../lib/si-data-nats" }

--- a/lib/nats-multiplexer/Cargo.toml
+++ b/lib/nats-multiplexer/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "nats-multiplexer"
-version = "0.1.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 nats-multiplexer-client = { path = "../../lib/nats-multiplexer-client" }

--- a/lib/nats-multiplexer/src/parsing.rs
+++ b/lib/nats-multiplexer/src/parsing.rs
@@ -46,7 +46,7 @@ pub(crate) fn keys_for_potential_receivers(subject: impl ToSubject) -> HashSet<S
         keys_for_potential_receivers.insert(format!("{current}.>"));
 
         // Before entering the next iteration, set the "previous" and "current'.
-        previous = current.clone();
+        previous.clone_from(&current);
         current = format!("{current}.{token}");
     }
 

--- a/lib/nats-subscriber/Cargo.toml
+++ b/lib/nats-subscriber/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "nats-subscriber"
-version = "0.1.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 futures = { workspace = true }

--- a/lib/naxum/Cargo.toml
+++ b/lib/naxum/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "naxum"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.70.0"
-authors = ["Fletcher Nichol <fnichol@nichol.ca>"]
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-nats = { workspace = true }

--- a/lib/naxum/src/extract/rejection.rs
+++ b/lib/naxum/src/extract/rejection.rs
@@ -26,7 +26,11 @@ impl IntoResponse for InvalidUtf8 {
 
 impl fmt::Display for InvalidUtf8 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "message payload didn't contain valid UTF-8")
+        write!(
+            f,
+            "message payload didn't contain valid UTF-8: {:?}",
+            self.0
+        )
     }
 }
 

--- a/lib/object-tree/Cargo.toml
+++ b/lib/object-tree/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "object-tree"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 si-hash = { path = "../../lib/si-hash" }

--- a/lib/object-tree/src/graph.rs
+++ b/lib/object-tree/src/graph.rs
@@ -107,25 +107,6 @@ pub trait WriteBytes {
     }
 }
 
-/// Trait for types which can compute and verify their own [`struct@Hash`] value.
-pub trait VerifyHash: WriteBytes {
-    /// Returns a pre-computed [`struct@Hash`] value for `self`.
-    fn hash(&self) -> &Hash;
-
-    /// Recomputes a [`struct@Hash`] value for `self` and confirms it matches the pre-computed Hash
-    /// value.
-    fn verify_hash(&self) -> Result<(), GraphError> {
-        let input = self.to_bytes()?;
-        let computed = Hash::new(&input);
-
-        if self.hash() == &computed {
-            Ok(())
-        } else {
-            Err(GraphError::Verify(*self.hash(), computed))
-        }
-    }
-}
-
 /// Trait for types that can deserialize its representation from bytes.
 pub trait ReadBytes {
     /// Reads a serialized version of `self` from a reader over bytes.
@@ -682,15 +663,6 @@ where
 {
     fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
         self.as_node_with_entries_ref().write_bytes(writer)
-    }
-}
-
-impl<T> VerifyHash for HashedNodeWithEntries<T>
-where
-    T: WriteBytes,
-{
-    fn hash(&self) -> &Hash {
-        &self.hash
     }
 }
 

--- a/lib/pinga-server/Cargo.toml
+++ b/lib/pinga-server/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "pinga-server"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 buck2-resources = { path = "../../lib/buck2-resources" }

--- a/lib/rebaser-core/Cargo.toml
+++ b/lib/rebaser-core/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "rebaser-core"
-version = "0.1.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 serde = { workspace = true }

--- a/lib/rebaser-server/Cargo.toml
+++ b/lib/rebaser-server/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "rebaser-server"
-version = "0.1.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 buck2-resources = { path = "../../lib/buck2-resources" }

--- a/lib/sdf-server/Cargo.toml
+++ b/lib/sdf-server/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "sdf-server"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }

--- a/lib/sdf-server/src/server/server.rs
+++ b/lib/sdf-server/src/server/server.rs
@@ -19,7 +19,6 @@ use si_data_nats::{NatsClient, NatsConfig, NatsError};
 use si_data_pg::{PgError, PgPool, PgPoolConfig, PgPoolError};
 use si_pkg::{SiPkg, SiPkgError};
 use si_posthog::{PosthogClient, PosthogConfig};
-use si_std::SensitiveString;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{io, net::SocketAddr, path::Path, path::PathBuf};
@@ -131,7 +130,6 @@ impl Server<(), ()> {
                 let (service, shutdown_rx, shutdown_broadcast_rx) = build_service(
                     services_context,
                     jwt_public_signing_key,
-                    config.signup_secret().clone(),
                     posthog_client,
                     ws_multiplexer_client,
                     crdt_multiplexer_client,
@@ -176,7 +174,6 @@ impl Server<(), ()> {
                 let (service, shutdown_rx, shutdown_broadcast_rx) = build_service(
                     services_context,
                     jwt_public_signing_key,
-                    config.signup_secret().clone(),
                     posthog_client,
                     ws_multiplexer_client,
                     crdt_multiplexer_client,
@@ -473,7 +470,6 @@ async fn fetch_builtin(
 pub fn build_service_for_tests(
     services_context: ServicesContext,
     jwt_public_signing_key: JwtPublicSigningKey,
-    signup_secret: SensitiveString,
     posthog_client: PosthogClient,
     ws_multiplexer_client: MultiplexerClient,
     crdt_multiplexer_client: MultiplexerClient,
@@ -481,7 +477,6 @@ pub fn build_service_for_tests(
     build_service_inner(
         services_context,
         jwt_public_signing_key,
-        signup_secret,
         posthog_client,
         true,
         ws_multiplexer_client,
@@ -492,7 +487,6 @@ pub fn build_service_for_tests(
 pub fn build_service(
     services_context: ServicesContext,
     jwt_public_signing_key: JwtPublicSigningKey,
-    signup_secret: SensitiveString,
     posthog_client: PosthogClient,
     ws_multiplexer_client: MultiplexerClient,
     crdt_multiplexer_client: MultiplexerClient,
@@ -500,7 +494,6 @@ pub fn build_service(
     build_service_inner(
         services_context,
         jwt_public_signing_key,
-        signup_secret,
         posthog_client,
         false,
         ws_multiplexer_client,
@@ -511,7 +504,6 @@ pub fn build_service(
 fn build_service_inner(
     services_context: ServicesContext,
     jwt_public_signing_key: JwtPublicSigningKey,
-    signup_secret: SensitiveString,
     posthog_client: PosthogClient,
     for_tests: bool,
     ws_multiplexer_client: MultiplexerClient,
@@ -522,7 +514,6 @@ fn build_service_inner(
 
     let state = AppState::new(
         services_context,
-        signup_secret,
         jwt_public_signing_key,
         posthog_client,
         shutdown_broadcast_tx.clone(),

--- a/lib/sdf-server/src/server/state.rs
+++ b/lib/sdf-server/src/server/state.rs
@@ -1,7 +1,6 @@
 use axum::extract::FromRef;
 use dal::JwtPublicSigningKey;
 use nats_multiplexer_client::MultiplexerClient;
-use si_std::SensitiveString;
 use std::{ops::Deref, sync::Arc};
 use tokio::sync::{broadcast, mpsc, Mutex};
 
@@ -12,7 +11,6 @@ use crate::server::service::ws::crdt::BroadcastGroups;
 #[derive(Clone, FromRef)]
 pub struct AppState {
     services_context: ServicesContext,
-    signup_secret: SignupSecret,
     broadcast_groups: BroadcastGroups,
     jwt_public_signing_key: JwtPublicSigningKey,
     posthog_client: PosthogClient,
@@ -30,7 +28,6 @@ impl AppState {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         services_context: impl Into<ServicesContext>,
-        signup_secret: impl Into<SignupSecret>,
         jwt_public_signing_key: impl Into<JwtPublicSigningKey>,
         posthog_client: impl Into<PosthogClient>,
         shutdown_broadcast_tx: broadcast::Sender<()>,
@@ -45,7 +42,6 @@ impl AppState {
         };
         Self {
             services_context: services_context.into(),
-            signup_secret: signup_secret.into(),
             jwt_public_signing_key: jwt_public_signing_key.into(),
             broadcast_groups: Default::default(),
             posthog_client: posthog_client.into(),
@@ -128,18 +124,6 @@ impl From<dal::ServicesContext> for ServicesContext {
 impl From<ServicesContext> for dal::ServicesContext {
     fn from(value: ServicesContext) -> Self {
         value.0
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct SignupSecret(Arc<SensitiveString>);
-
-impl<S> From<S> for SignupSecret
-where
-    S: Into<SensitiveString>,
-{
-    fn from(value: S) -> Self {
-        Self(Arc::new(value.into()))
     }
 }
 

--- a/lib/si-crypto/Cargo.toml
+++ b/lib/si-crypto/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "si-crypto"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 base64 = { workspace = true }

--- a/lib/si-data-nats/Cargo.toml
+++ b/lib/si-data-nats/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "si-data-nats"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-nats = { workspace = true }

--- a/lib/si-data-pg/Cargo.toml
+++ b/lib/si-data-pg/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "si-data-pg"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 base64 = { workspace = true }

--- a/lib/si-events-rs/Cargo.toml
+++ b/lib/si-events-rs/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "si-events"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 si-hash = { path = "../../lib/si-hash" }

--- a/lib/si-hash/Cargo.toml
+++ b/lib/si-hash/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "si-hash"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 blake3 = { workspace = true }

--- a/lib/si-layer-cache/Cargo.toml
+++ b/lib/si-layer-cache/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "si-layer-cache"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }

--- a/lib/si-pkg/Cargo.toml
+++ b/lib/si-pkg/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "si-pkg"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 base64.workspace = true

--- a/lib/si-pkg/src/lib.rs
+++ b/lib/si-pkg/src/lib.rs
@@ -128,7 +128,7 @@ mod tests {
         assert_eq!(2, leaf_funcs.len());
 
         for func in leaf_funcs {
-            assert!(funcs_by_unique_id.contains_key(&func.func_unique_id().to_string()));
+            assert!(funcs_by_unique_id.contains_key(func.func_unique_id()));
             match func.leaf_kind() {
                 LeafKind::Qualification => {
                     assert_eq!(

--- a/lib/si-pool-noodle/Cargo.toml
+++ b/lib/si-pool-noodle/Cargo.toml
@@ -1,13 +1,17 @@
 [package]
 name = "si-pool-noodle"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
 bollard = { workspace = true }
+buck2-resources = { path = "../buck2-resources" }
 crossbeam-queue = { workspace = true}
 cyclone-client = { path = "../cyclone-client" }
 cyclone-core = { path = "../cyclone-core" }
@@ -22,7 +26,6 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-buck2-resources = { path = "../buck2-resources" }
 
 [dev-dependencies]
 buck2-resources = { path = "../buck2-resources" }

--- a/lib/si-posthog-rs/Cargo.toml
+++ b/lib/si-posthog-rs/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "si-posthog"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 derive_builder = { workspace = true }

--- a/lib/si-service/Cargo.toml
+++ b/lib/si-service/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "si-service"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 color-eyre = { workspace = true }

--- a/lib/si-settings/Cargo.toml
+++ b/lib/si-settings/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "si-settings"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 config-file = { path = "../../lib/config-file", features = ["layered-toml"] }

--- a/lib/si-std/Cargo.toml
+++ b/lib/si-std/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "si-std"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 # NOTE: dependencies should be extremely minimal or very broadly re-used
 # amongst a potential large number of component crates

--- a/lib/si-test-macros/Cargo.toml
+++ b/lib/si-test-macros/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "si-test-macros"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [lib]
 proc-macro = true

--- a/lib/si-test-macros/src/dal_test.rs
+++ b/lib/si-test-macros/src/dal_test.rs
@@ -200,7 +200,6 @@ struct DalTestFnSetupExpander {
     test_context: Option<Rc<Ident>>,
     cancellation_token: Option<Rc<Ident>>,
     task_tracker: Option<Rc<Ident>>,
-    nats_subject_prefix: Option<Rc<Ident>>,
     pinga_server: Option<Rc<Ident>>,
     pinga_shutdown_handle: Option<Rc<Ident>>,
     start_pinga_server: Option<()>,
@@ -228,7 +227,6 @@ impl DalTestFnSetupExpander {
             test_context: None,
             cancellation_token: None,
             task_tracker: None,
-            nats_subject_prefix: None,
             pinga_server: None,
             pinga_shutdown_handle: None,
             start_pinga_server: None,
@@ -293,14 +291,6 @@ impl FnSetupExpander for DalTestFnSetupExpander {
 
     fn set_task_tracker(&mut self, value: Option<Rc<Ident>>) {
         self.task_tracker = value;
-    }
-
-    fn nats_subject_prefix(&self) -> Option<&Rc<Ident>> {
-        self.nats_subject_prefix.as_ref()
-    }
-
-    fn set_nats_subject_prefix(&mut self, value: Option<Rc<Ident>>) {
-        self.nats_subject_prefix = value;
     }
 
     fn pinga_server(&self) -> Option<&Rc<Ident>> {

--- a/lib/si-test-macros/src/expand.rs
+++ b/lib/si-test-macros/src/expand.rs
@@ -174,9 +174,6 @@ pub(crate) trait FnSetupExpander {
     fn task_tracker(&self) -> Option<&Rc<Ident>>;
     fn set_task_tracker(&mut self, value: Option<Rc<Ident>>);
 
-    fn nats_subject_prefix(&self) -> Option<&Rc<Ident>>;
-    fn set_nats_subject_prefix(&mut self, value: Option<Rc<Ident>>);
-
     fn pinga_server(&self) -> Option<&Rc<Ident>>;
     fn set_pinga_server(&mut self, value: Option<Rc<Ident>>);
 
@@ -271,20 +268,6 @@ pub(crate) trait FnSetupExpander {
         self.set_task_tracker(Some(Rc::new(var)));
 
         self.task_tracker().unwrap().clone()
-    }
-
-    fn setup_nats_subject_prefix(&mut self) -> Rc<Ident> {
-        if let Some(ident) = self.nats_subject_prefix() {
-            return ident.clone();
-        }
-
-        let var = Ident::new("nats_subject_prefix", Span::call_site());
-        self.code_extend(quote! {
-            let #var = ::dal_test::random_identifier_string();
-        });
-        self.set_nats_subject_prefix(Some(Rc::new(var)));
-
-        self.nats_subject_prefix().unwrap().clone()
     }
 
     fn setup_pinga_server(&mut self) -> Rc<Ident> {

--- a/lib/si-test-macros/src/sdf_test.rs
+++ b/lib/si-test-macros/src/sdf_test.rs
@@ -212,7 +212,6 @@ struct SdfTestFnSetupExpander {
     test_context: Option<Rc<Ident>>,
     cancellation_token: Option<Rc<Ident>>,
     task_tracker: Option<Rc<Ident>>,
-    nats_subject_prefix: Option<Rc<Ident>>,
     pinga_server: Option<Rc<Ident>>,
     pinga_shutdown_handle: Option<Rc<Ident>>,
     start_pinga_server: Option<()>,
@@ -231,7 +230,6 @@ struct SdfTestFnSetupExpander {
     dal_context_head_ref: Option<Rc<Ident>>,
     dal_context_head_mut_ref: Option<Rc<Ident>>,
     jwt_public_signing_key: Option<Rc<Ident>>,
-    signup_secret: Option<Rc<Ident>>,
     posthog_client: Option<Rc<Ident>>,
     ws_multiplexer_client: Option<Rc<Ident>>,
     crdt_multiplexer_client: Option<Rc<Ident>>,
@@ -248,7 +246,6 @@ impl SdfTestFnSetupExpander {
             test_context: None,
             cancellation_token: None,
             task_tracker: None,
-            nats_subject_prefix: None,
             pinga_server: None,
             pinga_shutdown_handle: None,
             start_pinga_server: None,
@@ -267,7 +264,6 @@ impl SdfTestFnSetupExpander {
             dal_context_head_ref: None,
             dal_context_head_mut_ref: None,
             jwt_public_signing_key: None,
-            signup_secret: None,
             posthog_client: None,
             ws_multiplexer_client: None,
             crdt_multiplexer_client: None,
@@ -293,20 +289,6 @@ impl SdfTestFnSetupExpander {
         self.jwt_public_signing_key = Some(Rc::new(var));
 
         self.jwt_public_signing_key.as_ref().unwrap().clone()
-    }
-
-    fn setup_signup_secret(&mut self) -> Rc<Ident> {
-        if let Some(ref ident) = self.signup_secret {
-            return ident.clone();
-        }
-
-        let var = Ident::new("signup_secret", Span::call_site());
-        self.code_extend(quote! {
-            let #var: ::si_std::SensitiveString = "sign-me-up".into();
-        });
-        self.signup_secret = Some(Rc::new(var));
-
-        self.signup_secret.as_ref().unwrap().clone()
     }
 
     fn setup_posthog_client(&mut self) -> Rc<Ident> {
@@ -381,8 +363,6 @@ impl SdfTestFnSetupExpander {
         let task_tracker = task_tracker.as_ref();
         let jwt_public_signing_key = self.setup_jwt_public_signing_key();
         let jwt_public_signing_key = jwt_public_signing_key.as_ref();
-        let signup_secret = self.setup_signup_secret();
-        let signup_secret = signup_secret.as_ref();
         let posthog_client = self.setup_posthog_client();
         let posthog_client = posthog_client.as_ref();
         let ws_multiplexer_client = self.setup_ws_multiplexer_client();
@@ -402,7 +382,6 @@ impl SdfTestFnSetupExpander {
                 let (service, _, _) = ::sdf_server::build_service_for_tests(
                     s_ctx,
                     #jwt_public_signing_key.clone(),
-                    #signup_secret.clone(),
                     #posthog_client,
                     #ws_multiplexer_client,
                     #crdt_multiplexer_client,
@@ -488,14 +467,6 @@ impl FnSetupExpander for SdfTestFnSetupExpander {
 
     fn set_test_context(&mut self, value: Option<Rc<Ident>>) {
         self.test_context = value;
-    }
-
-    fn nats_subject_prefix(&self) -> Option<&Rc<Ident>> {
-        self.nats_subject_prefix.as_ref()
-    }
-
-    fn set_nats_subject_prefix(&mut self, value: Option<Rc<Ident>>) {
-        self.nats_subject_prefix = value;
     }
 
     fn pinga_server(&self) -> Option<&Rc<Ident>> {

--- a/lib/telemetry-application-rs/Cargo.toml
+++ b/lib/telemetry-application-rs/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "telemetry-application"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 derive_builder = { workspace = true }

--- a/lib/telemetry-http-rs/Cargo.toml
+++ b/lib/telemetry-http-rs/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "telemetry-http"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 axum = { workspace = true }

--- a/lib/telemetry-nats-rs/Cargo.toml
+++ b/lib/telemetry-nats-rs/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "telemetry-nats"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 si-data-nats = { path = "../../lib/si-data-nats" }

--- a/lib/telemetry-rs/Cargo.toml
+++ b/lib/telemetry-rs/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "telemetry"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }

--- a/lib/veritech-client/Cargo.toml
+++ b/lib/veritech-client/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "veritech-client"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 cyclone-core = { path = "../../lib/cyclone-core" }

--- a/lib/veritech-core/Cargo.toml
+++ b/lib/veritech-core/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "veritech-core"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]

--- a/lib/veritech-server/Cargo.toml
+++ b/lib/veritech-server/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "veritech-server"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.64"
-publish = false
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
 buck2-resources = { path = "../../lib/buck2-resources" }

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -18,6 +18,15 @@ path = "top/main.rs"
 
 # BEGIN: DEPENDENCIES
 
+[workspace.package]
+version = "0.1.0"
+authors = ["System Initiative Inc. <info@systeminit.com>"]
+license = "Apache-2.0"
+repository = "https://github.com/systeminit/si"
+edition = "2021"
+rust-version = "1.78"
+publish = false
+
 [dependencies]
 async-nats = { version = "0.34.0", features = ["service"] }
 async-recursion = "1.0.5"


### PR DESCRIPTION
This change updates us to Rust 1.78.0 and addresses the associated updated lints (i.e. "cargo check" and Clippy). Home highlights of the changes:

- Use Cargo workspace package details so that every crate has the same metadata, updatable from the root Cargo.toml file. We have an increasingly old version of Rust specified as the `rust-version` and this refactoring makes future bumps of this value much easier (i.e. it is in one place).
- Address a lint related to combining trait bounds constraints in one location
- Remove several now-unused types
- Remove signup secret from SDF

<img src="https://media1.giphy.com/media/bMyW51TS3QVVIPulMG/giphy.gif"/>