### PR TITLE
feat: increase otel batch size so we don't drop traces

### DIFF
--- a/lib/telemetry-application-rs/src/lib.rs
+++ b/lib/telemetry-application-rs/src/lib.rs
@@ -392,6 +392,11 @@ fn otel_tracer(config: &TelemetryConfig) -> result::Result<Tracer, TraceError> {
         .tracing()
         .with_exporter(opentelemetry_otlp::new_exporter().tonic())
         .with_trace_config(trace::config().with_resource(telemetry_resource(config)))
+        .with_batch_config(
+            trace::BatchConfigBuilder::default()
+                .with_max_queue_size(4096)
+                .build(),
+        )
         .install_batch(runtime::Tokio)
 }
 


### PR DESCRIPTION
We've been dropping spans in tools-prod. We should turn down the noise on some of the services, but we also want to make sure that we are capturing valuable trace data. We have plenty of headroom on the ec2 nodes to handle the extra memory/cpu consumption here. This doubles us from the default of `2048`.

<img src="https://media2.giphy.com/media/dgBAeipxgzbvV99aCW/giphy.gif"/>