### PR TITLE
feat(dal): only run update_from_prototype_function in DVU

### DIFF
--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -614,12 +614,6 @@ impl AttributePrototypeArgument {
         ctx.workspace_snapshot()?
             .remove_node_by_id(ctx.change_set()?, self.id)
             .await?;
-        // Update the destination attribute values
-        for av_id_to_update in &avs_to_update {
-            AttributeValue::update_from_prototype_function(ctx, *av_id_to_update)
-                .await
-                .map_err(|e| AttributePrototypeArgumentError::AttributeValue(e.to_string()))?;
-        }
         // Enqueue a dependent values update with the destination attribute values
         ctx.enqueue_dependent_values_update(avs_to_update).await?;
 

--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -99,7 +99,15 @@ impl DependentValueGraph {
 
             match node_weight.into() {
                 NodeWeightDiscriminants::AttributeValue => {
-                    values.push(WorkQueueValue::Initial(initial_id.into()));
+                    let initial_attribute_value_id: AttributeValueId = initial_id.into();
+                    if AttributeValue::is_set_by_dependent_function(ctx, initial_attribute_value_id)
+                        .await?
+                    {
+                        self.values_that_need_to_execute_from_prototype_function
+                            .insert(initial_attribute_value_id);
+                    }
+
+                    values.push(WorkQueueValue::Initial(initial_attribute_value_id));
                 }
                 NodeWeightDiscriminants::Secret => {
                     // If we are processing a secret, we don't want to add the secret itself. We

--- a/lib/dal/src/component/frame.rs
+++ b/lib/dal/src/component/frame.rs
@@ -7,7 +7,7 @@ use crate::socket::input::InputSocketError;
 use crate::workspace_snapshot::edge_weight::{EdgeWeightError, EdgeWeightKind};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
-    AttributeValue, Component, ComponentError, ComponentId, ComponentType, DalContext, InputSocket,
+    Component, ComponentError, ComponentId, ComponentType, DalContext, InputSocket,
     TransactionsError,
 };
 
@@ -98,11 +98,6 @@ impl Frame {
                     Component::input_socket_attribute_values_for_component_id(ctx, child_id).await?
                 {
                     if !InputSocket::is_manually_configured(ctx, input_socket_match).await? {
-                        AttributeValue::update_from_prototype_function(
-                            ctx,
-                            input_socket_match.attribute_value_id,
-                        )
-                        .await?;
                         updated_avs.push(input_socket_match.attribute_value_id);
                     }
                 }
@@ -117,11 +112,6 @@ impl Frame {
                         {
                             if !InputSocket::is_manually_configured(ctx, input_socket_match).await?
                             {
-                                AttributeValue::update_from_prototype_function(
-                                    ctx,
-                                    input_socket_match.attribute_value_id,
-                                )
-                                .await?;
                                 updated_avs.push(input_socket_match.attribute_value_id);
                             }
                         }
@@ -154,11 +144,6 @@ impl Frame {
                     Component::input_socket_attribute_values_for_component_id(ctx, child_id).await?
                 {
                     if !InputSocket::is_manually_configured(ctx, input_socket_match).await? {
-                        AttributeValue::update_from_prototype_function(
-                            ctx,
-                            input_socket_match.attribute_value_id,
-                        )
-                        .await?;
                         updated_avs.push(input_socket_match.attribute_value_id);
                     }
                 }
@@ -173,11 +158,6 @@ impl Frame {
                         {
                             if !InputSocket::is_manually_configured(ctx, input_socket_match).await?
                             {
-                                AttributeValue::update_from_prototype_function(
-                                    ctx,
-                                    input_socket_match.attribute_value_id,
-                                )
-                                .await?;
                                 updated_avs.push(input_socket_match.attribute_value_id);
                             }
                         }

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -365,7 +365,6 @@ async fn through_the_wormholes(ctx: &mut DalContext) {
     assert_eq!(
         serde_json::json!({
                 "si": { "name": name, "color": "#ffffff", "type": "component" },
-                "resource": {},
                 "resource_value": {},
                 "domain": {
                     "name": name,
@@ -534,7 +533,6 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
     assert_eq!(
         serde_json::json!({
                 "si": { "name": name, "color": "#ffffff", "type": "component" },
-                "resource": {},
                 "resource_value": {},
                 "domain": {
                     "name": name,

--- a/lib/dal/tests/integration_test/component/get_diff.rs
+++ b/lib/dal/tests/integration_test/component/get_diff.rs
@@ -19,18 +19,18 @@ async fn get_diff_new_component(ctx: &mut DalContext) {
         .expect("unable to get diff");
 
     assert_eq!(starfield_component.id(), diff.component_id);
-    assert_eq!(
-        Some("{\n  \"si\": {\n    \"name\": \"this is a new component\",\n    \"type\": \"component\",\n    \"color\": \"#ffffff\"\n  },\n  \"domain\": {\n    \"name\": \"this is a new component\",\n    \"possible_world_a\": {\n      \"wormhole_1\": {\n        \"wormhole_2\": {\n          \"wormhole_3\": {}\n        }\n      }\n    },\n    \"possible_world_b\": {\n      \"wormhole_1\": {\n        \"wormhole_2\": {\n          \"wormhole_3\": {\n            \"naming_and_necessity\": \"not hesperus\"\n          }\n        }\n      }\n    },\n    \"universe\": {\n      \"galaxies\": []\n    }\n  }\n}".to_string()),
-        diff.current.code
+    let expected = Some(
+        "{\n  \"si\": {\n    \"name\": \"this is a new component\",\n    \"type\": \"component\",\n    \"color\": \"#ffffff\"\n  },\n  \"domain\": {\n    \"name\": \"this is a new component\",\n    \"possible_world_b\": {\n      \"wormhole_1\": {\n        \"wormhole_2\": {\n          \"wormhole_3\": {\n            \"naming_and_necessity\": \"not hesperus\"\n          }\n        }\n      }\n    },\n    \"universe\": {\n      \"galaxies\": []\n    }\n  }\n}".to_string(),
     );
+    assert_eq!(expected, diff.current.code);
     assert_eq!(CodeLanguage::Json, diff.current.language);
     assert_eq!(1, diff.diffs.len());
     let first_diff = diff.diffs.pop().expect("can't find a diff for the code");
     assert_eq!(CodeLanguage::Diff, first_diff.language);
-    assert_eq!(
-        Some("+{\n+  \"si\": {\n+    \"name\": \"this is a new component\",\n+    \"type\": \"component\",\n+    \"color\": \"#ffffff\"\n+  },\n+  \"domain\": {\n+    \"name\": \"this is a new component\",\n+    \"possible_world_a\": {\n+      \"wormhole_1\": {\n+        \"wormhole_2\": {\n+          \"wormhole_3\": {}\n+        }\n+      }\n+    },\n+    \"possible_world_b\": {\n+      \"wormhole_1\": {\n+        \"wormhole_2\": {\n+          \"wormhole_3\": {\n+            \"naming_and_necessity\": \"not hesperus\"\n+          }\n+        }\n+      }\n+    },\n+    \"universe\": {\n+      \"galaxies\": []\n+    }\n+  }\n+}".to_string()),
-        first_diff.code
+    let expected = Some(
+        "+{\n+  \"si\": {\n+    \"name\": \"this is a new component\",\n+    \"type\": \"component\",\n+    \"color\": \"#ffffff\"\n+  },\n+  \"domain\": {\n+    \"name\": \"this is a new component\",\n+    \"possible_world_b\": {\n+      \"wormhole_1\": {\n+        \"wormhole_2\": {\n+          \"wormhole_3\": {\n+            \"naming_and_necessity\": \"not hesperus\"\n+          }\n+        }\n+      }\n+    },\n+    \"universe\": {\n+      \"galaxies\": []\n+    }\n+  }\n+}".to_string(),
     );
+    assert_eq!(expected, first_diff.code);
 }
 
 #[test]
@@ -64,13 +64,6 @@ async fn get_diff_component_no_changes_from_head(ctx: &mut DalContext) {
             },
             "domain": {
                 "name": "this is a new component",
-                "possible_world_a": {
-                    "wormhole_1": {
-                        "wormhole_2": {
-                            "wormhole_3": {}
-                        }
-                    }
-                },
                 "possible_world_b": {
                     "wormhole_1": {
                         "wormhole_2": {
@@ -124,11 +117,13 @@ async fn get_diff_component_change_comp_type(ctx: &mut DalContext) {
     let first_diff = diff.diffs.pop().expect("can't find a diff for the code");
     assert_eq!(CodeLanguage::Diff, first_diff.language);
 
-    dbg!(&first_diff.code);
+    let expected = Some(
+        " {\n   \"si\": {\n     \"name\": \"this is a new component\",\n-    \"type\": \"component\",\n+    \"type\": \"configurationFrameDown\",\n     \"color\": \"#ffffff\"\n   },\n   \"domain\": {\n     \"name\": \"this is a new component\",\n     \"possible_world_b\": {\n       \"wormhole_1\": {\n         \"wormhole_2\": {\n           \"wormhole_3\": {\n             \"naming_and_necessity\": \"not hesperus\"\n           }\n         }\n       }\n     },\n     \"universe\": {\n       \"galaxies\": []\n     }\n   }\n }".to_string(),
+    );
 
     // We expect there to be a diff as we have changed the componentType on this changeset but HEAD is a component
     assert_eq!(
-        Some(" {\n   \"si\": {\n     \"name\": \"this is a new component\",\n-    \"type\": \"component\",\n+    \"type\": \"configurationFrameDown\",\n     \"color\": \"#ffffff\"\n   },\n   \"domain\": {\n     \"name\": \"this is a new component\",\n     \"possible_world_a\": {\n       \"wormhole_1\": {\n         \"wormhole_2\": {\n           \"wormhole_3\": {}\n         }\n       }\n     },\n     \"possible_world_b\": {\n       \"wormhole_1\": {\n         \"wormhole_2\": {\n           \"wormhole_3\": {\n             \"naming_and_necessity\": \"not hesperus\"\n           }\n         }\n       }\n     },\n     \"universe\": {\n       \"galaxies\": []\n     }\n   }\n }".to_string()),
+        expected,
         first_diff.code // actual
     );
 }

--- a/lib/dal/tests/integration_test/secret/with_actions.rs
+++ b/lib/dal/tests/integration_test/secret/with_actions.rs
@@ -151,7 +151,6 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
             "secrets": {
                 "dummy": secret.encrypted_secret_key().to_string()
             },
-            "resource": {},
             "resource_value": {},
             "qualification": {
                 "test:qualificationDummySecretStringIsTodd": {
@@ -159,7 +158,6 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
                     "message": "dummy secret string matches expected value"
                 },
             },
-            "secret_definition": {},
         }], // expected
         source_component
             .view(ctx)


### PR DESCRIPTION
To reduce more chances of conflict, remove all calls to update_from_prototype_function for dependent functions, restricting their use to the DependentValuesUpdate job (except in the case of the function execution call on the customize screen, which we have to decide how best to handle).