### PR TITLE
feat(dal,sdf): Close and Put On hold actions v2 endpoints

### DIFF
--- a/app/web/src/components/ActionV2Card.vue
+++ b/app/web/src/components/ActionV2Card.vue
@@ -1,0 +1,129 @@
+<template>
+  <div
+    class="flex flex-row gap-xs items-center text-sm relative p-xs min-w-0 w-full justify-end"
+    @click="addAction"
+  >
+    <StatusIndicatorIcon type="action" :status="action.kind" tone="shade" />
+    <div v-if="props.slim" class="flex flex-col overflow-hidden">
+      {{ actionName }}
+    </div>
+    <div v-else class="flex flex-col overflow-hidden">
+      <div class="">{{ actionName }}</div>
+      <div
+        :class="
+          clsx(
+            'truncate cursor-pointer ',
+            component?.displayName
+              ? 'dark:text-action-300 text-action-500 font-bold'
+              : 'text-neutral-500 dark:text-neutral-400',
+            isHover && 'underline',
+          )
+        "
+        @click="onClick"
+        @mouseenter="onHoverStart"
+        @mouseleave="onHoverEnd"
+      >
+        {{ component?.displayName ?? "unknown" }}
+      </div>
+      <!--
+      <div
+        v-if="hasActor"
+        class="text-neutral-500 dark:text-neutral-400 truncate"
+      >
+        By: {{ action.actor }}
+      </div>
+        -->
+    </div>
+    <VButton
+      v-if="props.action.id"
+      class="ml-auto"
+      size="xs"
+      tone="shade"
+      variant="transparent"
+      icon="x"
+      rounded
+      @click.stop="removeAction"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+import { VButton } from "@si/vue-lib/design-system";
+import clsx from "clsx";
+import { useComponentsStore } from "@/store/components.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
+import { ActionView } from "@/store/actions.store";
+import StatusIndicatorIcon from "./StatusIndicatorIcon.vue";
+
+const componentsStore = useComponentsStore();
+const changeSetStore = useChangeSetsStore();
+
+const props = defineProps<{
+  action: ActionView;
+  slim?: boolean;
+}>();
+
+const actionName = computed(() => {
+  const name = props.action.name.trim();
+  return name.length ? name.slice(0, 1).toUpperCase() + name.slice(1) : "";
+});
+
+// const hasActor = computed(() => props.action.actor);
+
+const component = computed(
+  () => componentsStore.componentsById[props.action.componentId ?? -1],
+);
+
+const addAction = (event: Event) => {
+  if (props.action.id || !changeSetStore.selectedChangeSet) return;
+  event.preventDefault();
+  event.stopPropagation();
+  emit("add");
+};
+const removeAction = () => {
+  if (!props.action.id || !changeSetStore.selectedChangeSet) return;
+  emit("remove");
+};
+
+const emit = defineEmits<{
+  (e: "add"): void;
+  (e: "remove"): void;
+}>();
+
+function onClick() {
+  if (
+    props.action.componentId &&
+    componentsStore.componentsById[props.action.componentId]
+  ) {
+    componentsStore.setSelectedComponentId(props.action.componentId);
+    componentsStore.eventBus.emit("panToComponent", {
+      componentId: props.action.componentId,
+      center: true,
+    });
+  }
+}
+
+const isHover = computed(
+  () => componentsStore.hoveredComponentId === props.action.componentId,
+);
+
+function onHoverStart() {
+  if (
+    props.action.componentId &&
+    componentsStore.componentsById[props.action.componentId]
+  ) {
+    componentsStore.setHoveredComponentId(props.action.componentId);
+  }
+}
+
+function onHoverEnd() {
+  if (
+    props.action.componentId &&
+    componentsStore.componentsById[props.action.componentId]
+  ) {
+    componentsStore.setHoveredComponentId(null);
+  }
+}
+</script>

--- a/app/web/src/components/ChangesPanel.vue
+++ b/app/web/src/components/ChangesPanel.vue
@@ -31,27 +31,52 @@
         </div>
       </div>
 
-      <div
-        v-for="action in actionsStore.proposedActions"
-        :key="action.id"
-        :class="
-          clsx(
-            'border-b',
-            themeClasses('border-neutral-200', 'border-neutral-600'),
-          )
-        "
-      >
-        <ActionCard
-          :action="action"
-          @remove="actionsStore.REMOVE_ACTION(action.id)"
-        />
-      </div>
-      <div
-        v-if="!actionsStore.proposedActions.length"
-        class="p-4 italic !delay-0 !duration-0 hidden first:block"
-      >
-        <div class="pb-sm">No actions were chosen at this time.</div>
-      </div>
+      <template v-if="featureFlagsStore.IS_ACTIONS_V2">
+        <div
+          v-for="action in actionsStore.actionsV2"
+          :key="action.id"
+          :class="
+            clsx(
+              'border-b',
+              themeClasses('border-neutral-200', 'border-neutral-600'),
+            )
+          "
+        >
+          <ActionV2Card
+            :action="action"
+            @remove="actionsStore.CANCEL(action.id)"
+          />
+        </div>
+        <div
+          v-if="!actionsStore.proposedActions.length"
+          class="p-4 italic !delay-0 !duration-0 hidden first:block"
+        >
+          <div class="pb-sm">No actions were chosen at this time.</div>
+        </div>
+      </template>
+      <template v-else>
+        <div
+          v-for="action in actionsStore.proposedActions"
+          :key="action.id"
+          :class="
+            clsx(
+              'border-b',
+              themeClasses('border-neutral-200', 'border-neutral-600'),
+            )
+          "
+        >
+          <ActionCard
+            :action="action"
+            @remove="actionsStore.REMOVE_ACTION(action.id)"
+          />
+        </div>
+        <div
+          v-if="!actionsStore.proposedActions.length"
+          class="p-4 italic !delay-0 !duration-0 hidden first:block"
+        >
+          <div class="pb-sm">No actions were chosen at this time.</div>
+        </div>
+      </template>
     </TabGroupItem>
 
     <TabGroupItem label="Applied Changes" slug="actions_applied">
@@ -70,9 +95,12 @@ import {
 import clsx from "clsx";
 import { useActionsStore } from "@/store/actions.store";
 import { useChangeSetsStore } from "@/store/change_sets.store";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import ApplyHistory from "./ApplyHistory.vue";
 import ActionCard from "./ActionCard.vue";
+import ActionV2Card from "./ActionV2Card.vue";
 
 const changeSetStore = useChangeSetsStore();
 const actionsStore = useActionsStore();
+const featureFlagsStore = useFeatureFlagsStore();
 </script>

--- a/app/web/src/store/actions.store.ts
+++ b/app/web/src/store/actions.store.ts
@@ -325,7 +325,7 @@ export const useActionsStore = () => {
           // Actions V2 Actions
           async LOAD_ACTIONS() {
             return new ApiRequest<Array<ActionView>>({
-              url: "/action/load_queued",
+              url: "/action/list",
               headers: { accept: "application/json" },
               params: {
                 visibility_change_set_pk: changeSetId,

--- a/app/web/src/store/actions.store.ts
+++ b/app/web/src/store/actions.store.ts
@@ -104,6 +104,7 @@ export enum ActionKind {
 export interface ActionView {
   id: ActionId;
   prototypeId: ActionPrototypeId;
+  componentId: ComponentId | null;
   name: string;
   description?: string;
   kind: ActionKind;

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -7,7 +7,7 @@ import { posthog } from "@/utils/posthog";
 const FLAG_MAPPING = {
   // STORE_FLAG_NAME: "posthogFlagName",
   MODULES_TAB: "modules_tab",
-  IS_ACTIONS_V2: "actions_v2", // TODO - THIS SHOULD BE REMOVED ONCE ACTIONS V1 IS GONE
+  IS_ACTIONS_V2: "is_actions_v2",
 };
 
 type FeatureFlags = keyof typeof FLAG_MAPPING;
@@ -32,8 +32,6 @@ export function useFeatureFlagsStore() {
           });
         });
         // You can override feature flags while working on a feature by setting them to true here
-
-        this.IS_ACTIONS_V2 = false; // TODO -  THIS SHOULD BE REMOVED ONCE ACTIONS V1 IS GONE
 
         // Make sure to remove the override before committing your code!
       },

--- a/lib/dal-test/src/schemas/test_exclusive_schema_swifty.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_swifty.rs
@@ -153,12 +153,6 @@ pub(crate) async fn migrate_test_exclusive_schema_swifty(ctx: &DalContext) -> Bu
                 )
                 .action_func(
                     ActionFuncSpec::builder()
-                        .kind(&DeprecatedActionKind::Other)
-                        .func_unique_id(&update_action_func.unique_id)
-                        .build()?,
-                )
-                .action_func(
-                    ActionFuncSpec::builder()
                         .kind(&DeprecatedActionKind::Update)
                         .func_unique_id(&update_action_func.unique_id)
                         .build()?,

--- a/lib/dal-test/src/schemas/test_exclusive_schema_swifty.rs
+++ b/lib/dal-test/src/schemas/test_exclusive_schema_swifty.rs
@@ -32,6 +32,13 @@ pub(crate) async fn migrate_test_exclusive_schema_swifty(ctx: &DalContext) -> Bu
     let fn_name = "test:createActionSwifty";
     let create_action_func = build_action_func(create_action_code, fn_name).await?;
 
+    // Build Update Action Func
+    let update_action_code = "async function main(component: Input): Promise<Output> {
+              return { payload: { \"poonami\": true }, status: \"ok\" };
+            }";
+    let fn_name = "test:updateActionSwifty";
+    let update_action_func = build_action_func(update_action_code, fn_name).await?;
+
     // Build Delete Action Func
     let delete_action_code = "async function main() {
                 return { payload: undefined, status: \"ok\" };
@@ -47,12 +54,6 @@ pub(crate) async fn migrate_test_exclusive_schema_swifty(ctx: &DalContext) -> Bu
 
     let fn_name = "test:refreshActionSwifty";
     let refresh_action_func = build_action_func(refresh_action_code, fn_name).await?;
-
-    let update_action_code = "async function main(component: Input): Promise<Output> {
-              return { payload: { \"poonami\": true }, status: \"ok\" };
-            }";
-    let fn_name = "test:updateActionSwifty";
-    let update_action_func = build_action_func(update_action_code, fn_name).await?;
 
     // Create Scaffold Func
     let fn_name = "test:scaffoldSwiftyAsset";
@@ -153,6 +154,12 @@ pub(crate) async fn migrate_test_exclusive_schema_swifty(ctx: &DalContext) -> Bu
                 .action_func(
                     ActionFuncSpec::builder()
                         .kind(&DeprecatedActionKind::Other)
+                        .func_unique_id(&update_action_func.unique_id)
+                        .build()?,
+                )
+                .action_func(
+                    ActionFuncSpec::builder()
+                        .kind(&DeprecatedActionKind::Update)
                         .func_unique_id(&update_action_func.unique_id)
                         .build()?,
                 )

--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -257,7 +257,16 @@ impl Action {
         Ok(new_action)
     }
 
-    pub async fn remove(
+    pub async fn remove_by_id(ctx: &DalContext, action_id: ActionId) -> ActionResult<()> {
+        let change_set = ctx.change_set()?;
+
+        ctx.workspace_snapshot()?
+            .remove_node_by_id(change_set, action_id)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn remove_by_prototype_and_component(
         ctx: &DalContext,
         action_prototype_id: ActionPrototypeId,
         maybe_component_id: Option<ComponentId>,
@@ -268,8 +277,7 @@ impl Action {
         if let Some(action_id) =
             Self::find_equivalent(ctx, action_prototype_id, maybe_component_id).await?
         {
-            let action_ulid: Ulid = action_id.into();
-            snap.remove_node_by_id(change_set, action_ulid).await?;
+            snap.remove_node_by_id(change_set, action_id).await?;
         }
         Ok(())
     }

--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -71,6 +71,18 @@ pub enum ActionKind {
     Update,
 }
 
+impl From<ActionFuncSpecKind> for ActionKind {
+    fn from(value: ActionFuncSpecKind) -> Self {
+        match value {
+            ActionFuncSpecKind::Create => ActionKind::Create,
+            ActionFuncSpecKind::Refresh => ActionKind::Refresh,
+            ActionFuncSpecKind::Other => ActionKind::Manual,
+            ActionFuncSpecKind::Delete => ActionKind::Destroy,
+            ActionFuncSpecKind::Update => ActionKind::Update,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ActionPrototype {
     pub id: ActionPrototypeId,
@@ -252,17 +264,5 @@ impl ActionPrototype {
         }
 
         Ok(prototypes)
-    }
-}
-
-impl From<ActionFuncSpecKind> for ActionKind {
-    fn from(value: ActionFuncSpecKind) -> Self {
-        match value {
-            ActionFuncSpecKind::Create => ActionKind::Create,
-            ActionFuncSpecKind::Refresh => ActionKind::Refresh,
-            ActionFuncSpecKind::Other => ActionKind::Manual,
-            ActionFuncSpecKind::Delete => ActionKind::Destroy,
-            ActionFuncSpecKind::Update => ActionKind::Update,
-        }
     }
 }

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1745,7 +1745,7 @@ impl Component {
             )
             .await?
             {
-                Action::remove(ctx, prototype_id, Some(component.id))
+                Action::remove_by_prototype_and_component(ctx, prototype_id, Some(component.id))
                     .await
                     .map_err(|err| ComponentError::Action(err.to_string()))?;
             }
@@ -1833,13 +1833,15 @@ impl Component {
         if to_delete {
             // Enqueue delete actions for component
             if workspace.uses_actions_v2() {
-                for prototype_id in SchemaVariant::find_action_prototypes_by_kind(
-                    ctx,
-                    schema_variant_id,
-                    ActionKind::Destroy,
-                )
-                .await?
-                {
+                println!("actionsv2");
+                for prototype_id in dbg!(
+                    SchemaVariant::find_action_prototypes_by_kind(
+                        ctx,
+                        schema_variant_id,
+                        ActionKind::Destroy,
+                    )
+                    .await?
+                ) {
                     Action::new(ctx, prototype_id, Some(component_id))
                         .await
                         .map_err(|err| ComponentError::Action(err.to_string()))?;
@@ -1870,9 +1872,13 @@ impl Component {
                 )
                 .await?
                 {
-                    Action::remove(ctx, prototype_id, Some(component_id))
-                        .await
-                        .map_err(|err| ComponentError::Action(err.to_string()))?;
+                    Action::remove_by_prototype_and_component(
+                        ctx,
+                        prototype_id,
+                        Some(component_id),
+                    )
+                    .await
+                    .map_err(|err| ComponentError::Action(err.to_string()))?;
                 }
             } else {
                 let actions = DeprecatedAction::build_graph(ctx)

--- a/lib/dal/src/deprecated_action.rs
+++ b/lib/dal/src/deprecated_action.rs
@@ -422,6 +422,8 @@ impl DeprecatedAction {
                                 .2
                                 .extend(ids);
                         }
+                        // Variant Added just for compatibility, no prototype should have this in the wild
+                        DeprecatedActionKind::Update => unreachable!(),
                     }
                 }
             }
@@ -546,7 +548,7 @@ impl WsEvent {
             }
         }
 
-        // Super inneficient, but traversing the graph is required to get the parents
+        // Super inefficient, but traversing the graph is required to get the parents
         let parents = if let Some(action_bag) = DeprecatedAction::build_graph(ctx)
             .await
             .map_err(Box::new)?
@@ -563,8 +565,8 @@ impl WsEvent {
             name: display_name.unwrap_or_else(|| match prototype.kind {
                 DeprecatedActionKind::Create => "create".to_owned(),
                 DeprecatedActionKind::Delete => "delete".to_owned(),
-                DeprecatedActionKind::Other => "other".to_owned(),
                 DeprecatedActionKind::Refresh => "refresh".to_owned(),
+                DeprecatedActionKind::Other | DeprecatedActionKind::Update => "other".to_owned(),
             }),
             component_id: action.component(ctx).await.map_err(Box::new)?.id(),
             actor: actor_email,

--- a/lib/dal/src/deprecated_action/prototype.rs
+++ b/lib/dal/src/deprecated_action/prototype.rs
@@ -88,6 +88,8 @@ pub enum DeprecatedActionKind {
     Other,
     /// The [`action`](ActionPrototype) that refreshes an existing "resource".
     Refresh,
+    /// Unused - added so we can create actions v2 forward compatible schemas
+    Update,
 }
 
 impl From<ActionFuncSpecKind> for DeprecatedActionKind {
@@ -109,6 +111,7 @@ impl From<&DeprecatedActionKind> for ActionFuncSpecKind {
             DeprecatedActionKind::Refresh => ActionFuncSpecKind::Refresh,
             DeprecatedActionKind::Other => ActionFuncSpecKind::Other,
             DeprecatedActionKind::Delete => ActionFuncSpecKind::Delete,
+            DeprecatedActionKind::Update => ActionFuncSpecKind::Update,
         }
     }
 }

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -723,7 +723,7 @@ async fn import_socket(
     Ok(())
 }
 
-async fn create_action_protoype(
+async fn create_action_prototype(
     ctx: &DalContext,
     action_func_spec: &SiPkgActionFunc<'_>,
     func_id: FuncId,
@@ -771,7 +771,7 @@ async fn import_action_func(
                                 (None, None)
                             } else {
                                 let (deprecated_action_prototype, action_prototype) =
-                                    create_action_protoype(
+                                    create_action_prototype(
                                         ctx,
                                         action_func_spec,
                                         func_id,
@@ -784,7 +784,7 @@ async fn import_action_func(
                     }
                 } else {
                     let (deprecated_action_prototype, action_prototype) =
-                        create_action_protoype(ctx, action_func_spec, func_id, schema_variant_id)
+                        create_action_prototype(ctx, action_func_spec, func_id, schema_variant_id)
                             .await?;
                     (Some(deprecated_action_prototype), Some(action_prototype))
                 }

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -101,6 +101,8 @@ pub enum WorkspaceSnapshotError {
     WorkspaceSnapshotGraphMissing(WorkspaceSnapshotAddress),
     #[error("no workspace snapshot was fetched for this dal context")]
     WorkspaceSnapshotNotFetched,
+    #[error("Unable to write workspace snapshot")]
+    WorkspaceSnapshotNotWritten,
 }
 
 pub type WorkspaceSnapshotResult<T> = Result<T, WorkspaceSnapshotError>;

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -1266,13 +1266,16 @@ impl WorkspaceSnapshot {
         Ok(None)
     }
 
-    pub async fn dispatch_actions(ctx: &DalContext) -> WorkspaceSnapshotResult<()> {
+    /// Returns whether or not any Actions were dispatched.
+    pub async fn dispatch_actions(ctx: &DalContext) -> WorkspaceSnapshotResult<bool> {
+        let mut did_dispatch = false;
         for dispatchable_ation_id in Action::eligible_to_dispatch(ctx).await.map_err(Box::new)? {
             Action::dispatch_action(ctx, dispatchable_ation_id)
                 .await
                 .map_err(Box::new)?;
+            did_dispatch = true;
         }
 
-        Ok(())
+        Ok(did_dispatch)
     }
 }

--- a/lib/rebaser-server/src/change_set_requests/handlers.rs
+++ b/lib/rebaser-server/src/change_set_requests/handlers.rs
@@ -3,8 +3,8 @@
 use std::result;
 
 use dal::{
-    HistoryActor, RequestContext, Tenancy, Visibility, Workspace, WorkspaceError,
-    WorkspaceSnapshot, WorkspaceSnapshotError, WsEvent,
+    ChangeSet, ChangeSetError, HistoryActor, RequestContext, Tenancy, Visibility, Workspace,
+    WorkspaceError, WorkspaceSnapshot, WorkspaceSnapshotError, WsEvent,
 };
 use naxum::{
     extract::State,
@@ -22,7 +22,7 @@ use telemetry::prelude::*;
 use thiserror::Error;
 use ulid::Ulid;
 
-use crate::rebase::perform_rebase;
+use crate::rebase::{perform_rebase, RebaseError};
 
 use super::app_state::AppState;
 
@@ -30,12 +30,18 @@ use super::app_state::AppState;
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum HandlerError {
+    /// Failures related to ChangeSets
+    #[error("Change set error: {0}")]
+    ChangeSet(#[from] ChangeSetError),
     /// When failing to create a DAL context
     #[error("error creating a dal ctx: {0}")]
     DalTransactions(#[from] dal::TransactionsError),
     /// When failing to deserialize a message from bytes
     #[error("failed to deserialize message from bytes: {0}")]
     Deserialize(#[source] si_layer_cache::LayerDbError),
+    /// Failures related to rebasing/updating a snapshot or change set pointer.
+    #[error("Rebase error: {0}")]
+    Rebase(#[from] RebaseError),
     /// When failing to successfully send a "rebase finished" message
     #[error("failed to send rebase finished activity: {0}")]
     SendRebaseFinished(#[source] si_layer_cache::LayerDbError),
@@ -88,10 +94,21 @@ pub async fn process_request(State(state): State<AppState>, msg: InnerMessage) -
     if RebaseStatusDiscriminants::Success == rebase_status.clone().into() {
         if let Some(workspace) = Workspace::get_by_pk(&ctx, &workspace_pk.into()).await? {
             if workspace.default_change_set_id() == ctx.visibility().change_set_id {
+                let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+                    .await?
+                    .ok_or(RebaseError::MissingChangeSet(
+                        ctx.visibility().change_set_id,
+                    ))?;
                 WorkspaceSnapshot::dispatch_actions(&ctx).await?;
-                // Disable until we fix the issue of commiting inside the rebaser
-                // Without this commit the dispatch is never persisted (or enqueued to pinga)
-                // ctx.commit().await?;
+                // Write out the snapshot to get the new address/id.
+                let new_snapshot_id = ctx
+                    .write_snapshot()
+                    .await?
+                    .ok_or(WorkspaceSnapshotError::WorkspaceSnapshotNotWritten)?;
+                // Manually update the pointer to the new address/id that reflects the new Action states.
+                change_set.update_pointer(&ctx, new_snapshot_id).await?;
+                // No need to send the request over to the rebaser as we are the rebaser.
+                ctx.commit_no_rebase().await?;
             }
         }
     }

--- a/lib/rebaser-server/src/rebase.rs
+++ b/lib/rebaser-server/src/rebase.rs
@@ -10,7 +10,7 @@ use tokio::time::Instant;
 
 #[remain::sorted]
 #[derive(Debug, Error)]
-pub(crate) enum RebaseError {
+pub enum RebaseError {
     #[error("workspace snapshot error: {0}")]
     ChangeSet(#[from] ChangeSetError),
     #[error("missing change set")]

--- a/lib/sdf-server/src/server/service/action/cancel.rs
+++ b/lib/sdf-server/src/server/service/action/cancel.rs
@@ -1,0 +1,37 @@
+use axum::extract::Query;
+use dal::action::{Action, ActionState};
+use dal::{ActionId, Visibility};
+use serde::{Deserialize, Serialize};
+
+use super::ActionResult;
+use crate::server::extract::{AccessBuilder, HandlerContext};
+use crate::service::action::ActionError;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PutOnHoldRequest {
+    id: ActionId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+pub async fn cancel(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Query(request): Query<PutOnHoldRequest>,
+) -> ActionResult<()> {
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let action = Action::get_by_id(&ctx, request.id).await?;
+
+    match action.state() {
+        ActionState::Running | ActionState::Dispatched => {
+            return Err(ActionError::InvalidActionCancellation(request.id))
+        }
+        ActionState::Failed | ActionState::OnHold | ActionState::Queued => {}
+    }
+
+    Action::set_state(&ctx, action.id(), ActionState::OnHold).await?;
+
+    Ok(())
+}

--- a/lib/sdf-server/src/server/service/action/list_actions.rs
+++ b/lib/sdf-server/src/server/service/action/list_actions.rs
@@ -2,7 +2,7 @@ use axum::extract::Query;
 use axum::Json;
 use dal::action::prototype::{ActionKind, ActionPrototype};
 use dal::action::{Action, ActionState};
-use dal::{ActionId, ActionPrototypeId, ChangeSetId, Visibility};
+use dal::{ActionId, ActionPrototypeId, ChangeSetId, ComponentId, Visibility};
 use serde::{Deserialize, Serialize};
 
 use super::ActionResult;
@@ -13,6 +13,7 @@ use crate::server::extract::{AccessBuilder, HandlerContext};
 pub struct ActionView {
     pub id: ActionId,
     pub prototype_id: ActionPrototypeId,
+    pub component_id: Option<ComponentId>,
     pub name: String,
     pub description: Option<String>,
     pub kind: ActionKind,
@@ -49,6 +50,7 @@ pub async fn list_actions(
             id: action_id,
             prototype_id: prototype.id(),
             name: prototype.name().clone(),
+            component_id: Action::component_id(&ctx, action_id).await?,
             description: prototype.description().clone(),
             kind: prototype.kind,
             state: action.state(),

--- a/lib/sdf-server/src/server/service/action/list_actions.rs
+++ b/lib/sdf-server/src/server/service/action/list_actions.rs
@@ -29,7 +29,7 @@ pub struct LoadQueuedRequest {
 
 pub type LoadQueuedResponse = Vec<ActionView>;
 
-pub async fn load_queued(
+pub async fn list_actions(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
     Query(request): Query<LoadQueuedRequest>,
@@ -42,21 +42,19 @@ pub async fn load_queued(
 
     for action_id in action_ids {
         let action = Action::get_by_id(&ctx, action_id).await?;
-        if action.state() == ActionState::Queued {
-            let prototype_id = Action::prototype_id(&ctx, action_id).await?;
-            let prototype = ActionPrototype::get_by_id(&ctx, prototype_id).await?;
+        let prototype_id = Action::prototype_id(&ctx, action_id).await?;
+        let prototype = ActionPrototype::get_by_id(&ctx, prototype_id).await?;
 
-            let action_view = ActionView {
-                id: action_id,
-                prototype_id: prototype.id(),
-                name: prototype.name().clone(),
-                description: prototype.description().clone(),
-                kind: prototype.kind,
-                state: action.state(),
-                originating_changeset_id: action.originating_changeset_id(),
-            };
-            queued.push(action_view);
-        }
+        let action_view = ActionView {
+            id: action_id,
+            prototype_id: prototype.id(),
+            name: prototype.name().clone(),
+            description: prototype.description().clone(),
+            kind: prototype.kind,
+            state: action.state(),
+            originating_changeset_id: action.originating_changeset_id(),
+        };
+        queued.push(action_view);
     }
 
     Ok(Json(queued))

--- a/lib/sdf-server/src/server/service/action/put_on_hold.rs
+++ b/lib/sdf-server/src/server/service/action/put_on_hold.rs
@@ -1,0 +1,38 @@
+use axum::extract::Query;
+use dal::action::{Action, ActionState};
+use dal::{ActionId, Visibility};
+use serde::{Deserialize, Serialize};
+
+use super::ActionResult;
+use crate::server::extract::{AccessBuilder, HandlerContext};
+use crate::service::action::ActionError;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PutOnHoldRequest {
+    id: ActionId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+pub async fn put_on_hold(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Query(request): Query<PutOnHoldRequest>,
+) -> ActionResult<()> {
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let action = Action::get_by_id(&ctx, request.id).await?;
+
+    match action.state() {
+        ActionState::Running
+        | ActionState::Dispatched
+        | ActionState::Failed
+        | ActionState::OnHold => return Err(ActionError::InvalidOnHoldTransition(request.id)),
+        ActionState::Queued => {}
+    }
+
+    Action::remove_by_id(&ctx, action.id()).await?;
+
+    Ok(())
+}

--- a/lib/sdf-server/src/server/service/action/put_on_hold.rs
+++ b/lib/sdf-server/src/server/service/action/put_on_hold.rs
@@ -25,11 +25,10 @@ pub async fn put_on_hold(
     let action = Action::get_by_id(&ctx, request.id).await?;
 
     match action.state() {
-        ActionState::Running
-        | ActionState::Dispatched
-        | ActionState::Failed
-        | ActionState::OnHold => return Err(ActionError::InvalidOnHoldTransition(request.id)),
-        ActionState::Queued => {}
+        ActionState::Running | ActionState::Dispatched | ActionState::OnHold => {
+            return Err(ActionError::InvalidOnHoldTransition(request.id))
+        }
+        ActionState::Queued | ActionState::Failed => {}
     }
 
     Action::remove_by_id(&ctx, action.id()).await?;

--- a/lib/sdf-server/src/server/service/action/put_on_hold.rs
+++ b/lib/sdf-server/src/server/service/action/put_on_hold.rs
@@ -31,7 +31,9 @@ pub async fn put_on_hold(
         ActionState::Queued | ActionState::Failed => {}
     }
 
-    Action::remove_by_id(&ctx, action.id()).await?;
+    Action::set_state(&ctx, action.id(), ActionState::OnHold).await?;
+
+    ctx.commit().await?;
 
     Ok(())
 }

--- a/lib/sdf-server/src/server/service/change_set.rs
+++ b/lib/sdf-server/src/server/service/change_set.rs
@@ -8,7 +8,7 @@ use dal::{
     action::prototype::ActionPrototypeError, action::ActionError,
     ChangeSetApplyError as DalChangeSetApplyError, ChangeSetError as DalChangeSetError,
     ComponentError, DeprecatedActionError, DeprecatedActionPrototypeError, FuncError,
-    StandardModelError, TransactionsError, WorkspaceError, WsEventError,
+    StandardModelError, TransactionsError, WorkspaceError, WorkspaceSnapshotError, WsEventError,
 };
 
 use telemetry::prelude::*;
@@ -57,6 +57,8 @@ pub enum ChangeSetError {
     Transactions(#[from] TransactionsError),
     #[error("workspace error: {0}")]
     Workspace(#[from] WorkspaceError),
+    #[error("workspace snapshot error: {0}")]
+    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
     #[error("ws event error: {0}")]
     WsEvent(#[from] WsEventError),
 }

--- a/lib/sdf-server/src/server/service/change_set/list_queued_actions.rs
+++ b/lib/sdf-server/src/server/service/change_set/list_queued_actions.rs
@@ -76,6 +76,7 @@ pub async fn list_queued_actions(
                     DeprecatedActionKind::Delete => "delete".to_owned(),
                     DeprecatedActionKind::Other => "other".to_owned(),
                     DeprecatedActionKind::Refresh => "refresh".to_owned(),
+                    DeprecatedActionKind::Update => "other".to_owned(),
                 }),
                 component_id,
                 actor: actor_email,

--- a/lib/sdf-server/src/server/service/component/get_actions.rs
+++ b/lib/sdf-server/src/server/service/component/get_actions.rs
@@ -47,7 +47,9 @@ impl ActionPrototypeView {
                 || match prototype.kind {
                     DeprecatedActionKind::Create => "create".to_owned(),
                     DeprecatedActionKind::Delete => "delete".to_owned(),
-                    DeprecatedActionKind::Other => "other".to_owned(),
+                    DeprecatedActionKind::Update | DeprecatedActionKind::Other => {
+                        "other".to_owned()
+                    }
                     DeprecatedActionKind::Refresh => "refresh".to_owned(),
                 },
                 ToOwned::to_owned,

--- a/lib/si-events-rs/src/tenancy.rs
+++ b/lib/si-events-rs/src/tenancy.rs
@@ -20,6 +20,12 @@ impl WorkspacePk {
     }
 }
 
+impl From<WorkspacePk> for Ulid {
+    fn from(id: WorkspacePk) -> Self {
+        id.0
+    }
+}
+
 impl Default for WorkspacePk {
     fn default() -> Self {
         Self::new()
@@ -60,6 +66,12 @@ impl ChangeSetId {
 
     pub fn into_inner(self) -> Ulid {
         self.0
+    }
+}
+
+impl From<ChangeSetId> for Ulid {
+    fn from(id: ChangeSetId) -> Self {
+        id.0
     }
 }
 


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/Kg3AMWiK3Zohf2lUU0/giphy.gif"/>

- Close actions by deleting them from the graph
- put actions on hold by updating the status
- send all actions to frontend instead of just enqueued ones
- fix some issues in the actions_v2 tests