### PR TITLE
Up Frames can connect to multiple child components and fix data propagation on attach/detach/delete

### DIFF
--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -8,8 +8,8 @@ use dal::property_editor::schema::{
 use dal::property_editor::values::{PropertyEditorValue, PropertyEditorValues};
 use dal::property_editor::{PropertyEditorPropId, PropertyEditorValueId};
 use dal::{
-    Component, ComponentId, DalContext, InputSocket, KeyPair, OutputSocket, Prop, Schema,
-    SchemaVariant, SchemaVariantId, User, UserClaim, UserPk,
+    AttributeValue, Component, ComponentId, DalContext, InputSocket, KeyPair, OutputSocket, Prop,
+    Schema, SchemaVariant, SchemaVariantId, User, UserClaim, UserPk,
 };
 use itertools::enumerate;
 use jwt_simple::algorithms::RSAKeyPairLike;
@@ -156,6 +156,85 @@ pub async fn connect_components_with_socket_names(
     )
     .await
     .expect("could not connect components");
+}
+
+/// Gets the [`Value`] for a specific [`Component`]'s [`InputSocket`] by the [`InputSocket`] name
+pub async fn get_component_input_socket_value(
+    ctx: &DalContext,
+    component_id: ComponentId,
+    input_socket_name: impl AsRef<str>,
+) -> Option<serde_json::Value> {
+    let schema_variant_id = Component::schema_variant_id(ctx, component_id)
+        .await
+        .expect("got schema variant id");
+    let component = Component::get_by_id(ctx, component_id)
+        .await
+        .expect("got component");
+    let component_input_sockets = component
+        .input_socket_attribute_values(ctx)
+        .await
+        .expect("got attribute values");
+    let input_socket = InputSocket::find_with_name(ctx, input_socket_name, schema_variant_id)
+        .await
+        .expect("got input socket")
+        .expect("has value");
+    let input_socket_match = component_input_sockets
+        .get(&input_socket.id())
+        .expect("got input socket av");
+    let input_socket_av = AttributeValue::get_by_id(ctx, input_socket_match.attribute_value_id)
+        .await
+        .expect("got input av");
+    input_socket_av.view(ctx).await.expect("got view")
+}
+
+/// Gets the [`Value`] for a specific [`Component`]'s [`OutputSocket`] by the [`OutputSocket`] name
+pub async fn get_component_output_socket_value(
+    ctx: &DalContext,
+    component_id: ComponentId,
+    output_socket_name: impl AsRef<str>,
+) -> Option<serde_json::Value> {
+    let schema_variant_id = Component::schema_variant_id(ctx, component_id)
+        .await
+        .expect("got schema variant id");
+    let component = Component::get_by_id(ctx, component_id)
+        .await
+        .expect("got component");
+    let component_output_sockets = component
+        .output_socket_attribute_values(ctx)
+        .await
+        .expect("got attribute values");
+    let output_socket = OutputSocket::find_with_name(ctx, output_socket_name, schema_variant_id)
+        .await
+        .expect("got output socket")
+        .expect("has value");
+    let output_socket_match = component_output_sockets
+        .get(&output_socket.id())
+        .expect("got output socket av");
+    let output_socket_av = AttributeValue::get_by_id(ctx, output_socket_match.attribute_value_id)
+        .await
+        .expect("got output av");
+    output_socket_av.view(ctx).await.expect("got view")
+}
+/// Update the [`Value`] for a specific [`AttributeValue`] for the given [`Component`](ComponentId) by the [`PropPath`]
+pub async fn update_attribute_value_for_component(
+    ctx: &DalContext,
+    component_id: ComponentId,
+    prop_path: &[&str],
+    value: serde_json::Value,
+) {
+    let component = Component::get_by_id(ctx, component_id)
+        .await
+        .expect("got component");
+    let attribute_value_id = component
+        .attribute_values_for_prop(ctx, prop_path)
+        .await
+        .expect("found attribute values for prop")
+        .into_iter()
+        .next()
+        .expect("got attribute value id");
+    AttributeValue::update(ctx, attribute_value_id, Some(value))
+        .await
+        .expect("updated attribute value");
 }
 
 /// Encrypts a message with a given [`KeyPairPk`](KeyPair).

--- a/lib/dal/src/action/dependency_graph.rs
+++ b/lib/dal/src/action/dependency_graph.rs
@@ -64,7 +64,7 @@ impl ActionDependencyGraph {
                     .or_default()
                     .insert(incoming_connection.from_component_id);
             }
-            for inferred_connection in component.inferred_connections(ctx).await? {
+            for inferred_connection in component.inferred_incoming_connections(ctx).await? {
                 if inferred_connection.to_component_id != component_id {
                     continue;
                 }

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -614,6 +614,7 @@ impl AttributePrototypeArgument {
         ctx.workspace_snapshot()?
             .remove_node_by_id(ctx.change_set()?, self.id)
             .await?;
+
         // Enqueue a dependent values update with the destination attribute values
         ctx.enqueue_dependent_values_update(avs_to_update).await?;
 

--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -285,12 +285,11 @@ impl AttributePrototypeDebugView {
             {
                 info!("Input socket match: {:?}", input_socket_match);
                 // now get inferred func binding args and values!
-                if let Some(output_match) =
-                    Component::find_potential_inferred_connection_to_input_socket(
-                        ctx,
-                        input_socket_match,
-                    )
-                    .await?
+                for output_match in Component::find_available_inferred_connections_to_input_socket(
+                    ctx,
+                    input_socket_match,
+                )
+                .await?
                 {
                     info!("output socket match: {:?}", output_match);
                     let arg_used = Component::should_data_flow_between_components(

--- a/lib/dal/src/component/frame.rs
+++ b/lib/dal/src/component/frame.rs
@@ -1,3 +1,6 @@
+use std::collections::HashSet;
+
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use telemetry::prelude::*;
 use thiserror::Error;
@@ -7,7 +10,7 @@ use crate::socket::input::InputSocketError;
 use crate::workspace_snapshot::edge_weight::{EdgeWeightError, EdgeWeightKind};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
-    Component, ComponentError, ComponentId, ComponentType, DalContext, InputSocket,
+    AttributeValueId, Component, ComponentError, ComponentId, ComponentType, DalContext,
     TransactionsError,
 };
 
@@ -32,6 +35,11 @@ pub enum FrameError {
     Transactions(#[from] TransactionsError),
     #[error("workspace snapshot error: {0}")]
     WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+}
+#[derive(Eq, Hash, PartialEq, Copy, Clone)]
+struct SocketAttributeValuePair {
+    input_attribute_value_id: AttributeValueId,
+    output_attribute_value_id: AttributeValueId,
 }
 
 pub type FrameResult<T> = Result<T, FrameError>;
@@ -64,7 +72,6 @@ impl Frame {
 
         match Component::get_type_by_id(ctx, new_parent_id).await? {
             ComponentType::ConfigurationFrameDown | ComponentType::ConfigurationFrameUp => {
-                Self::orphan_child(ctx, child_id).await?;
                 Self::attach_child_to_parent_inner(ctx, new_parent_id, child_id).await?;
             }
             ComponentType::Component => {
@@ -82,49 +89,43 @@ impl Frame {
         parent_id: ComponentId,
         child_id: ComponentId,
     ) -> FrameResult<()> {
+        // is the current child already connected to a parent?
+        let mut cached_impacted_values: HashSet<SocketAttributeValuePair> = HashSet::new();
+        if let Some(current_parent_id) = Component::get_parent_by_id(ctx, child_id).await? {
+            // cache input sockets impacted by the child component
+            let before_remove_edge_input_sockets =
+                Self::get_impacted_connections(ctx, child_id).await?;
+
+            cached_impacted_values.extend(before_remove_edge_input_sockets);
+            //remove the edge
+            Component::remove_edge_from_frame(ctx, current_parent_id, child_id).await?;
+        }
+
         let cycle_check_guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
         Component::add_edge_to_frame(ctx, parent_id, child_id, EdgeWeightKind::FrameContains)
             .await?;
         drop(cycle_check_guard);
+        let mut values_to_run: HashSet<SocketAttributeValuePair> = HashSet::new();
+        let current_impacted_values = Self::get_impacted_connections(ctx, child_id).await?;
+        // if an input socket + output socket is in both sets, we don't need to rerun it
+        values_to_run.extend(
+            cached_impacted_values
+                .difference(&current_impacted_values)
+                .copied(),
+        );
 
-        // when attaching a child, need to rerun any attribute prototypes for those impacted sockets then queue up dvu!
-
-        let values_rerun = match Component::get_type_by_id(ctx, child_id).await? {
-            ComponentType::Component
-            | ComponentType::ConfigurationFrameDown
-            | ComponentType::ConfigurationFrameUp => {
-                let mut updated_avs = vec![];
-                for (_, input_socket_match) in
-                    Component::input_socket_attribute_values_for_component_id(ctx, child_id).await?
-                {
-                    if !InputSocket::is_manually_configured(ctx, input_socket_match).await? {
-                        updated_avs.push(input_socket_match.attribute_value_id);
-                    }
-                }
-                let mut work_queue = vec![parent_id];
-                while let Some(parent) = work_queue.pop() {
-                    if Component::get_type_by_id(ctx, parent).await?
-                        == ComponentType::ConfigurationFrameUp
-                    {
-                        for (_, input_socket_match) in
-                            Component::input_socket_attribute_values_for_component_id(ctx, child_id)
-                                .await?
-                        {
-                            if !InputSocket::is_manually_configured(ctx, input_socket_match).await?
-                            {
-                                updated_avs.push(input_socket_match.attribute_value_id);
-                            }
-                        }
-                    }
-                    if let Some(next_parent) = Component::get_parent_by_id(ctx, parent).await? {
-                        work_queue.push(next_parent);
-                    }
-                }
-                updated_avs
-            }
-            ComponentType::AggregationFrame => vec![],
-        };
-        ctx.enqueue_dependent_values_update(values_rerun).await?;
+        values_to_run.extend(
+            current_impacted_values
+                .difference(&cached_impacted_values)
+                .copied(),
+        );
+        ctx.enqueue_dependent_values_update(
+            values_to_run
+                .into_iter()
+                .map(|values| values.input_attribute_value_id)
+                .collect_vec(),
+        )
+        .await?;
 
         Ok(())
     }
@@ -133,47 +134,53 @@ impl Frame {
         parent_id: ComponentId,
         child_id: ComponentId,
     ) -> FrameResult<()> {
-        //when detaching a child, need to re-run any attribute prototypes for those impacted input sockets then queue up dvu!
-
-        let values_rerun = match Component::get_type_by_id(ctx, child_id).await? {
-            ComponentType::Component
-            | ComponentType::ConfigurationFrameDown
-            | ComponentType::ConfigurationFrameUp => {
-                let mut updated_avs = vec![];
-                for (_, input_socket_match) in
-                    Component::input_socket_attribute_values_for_component_id(ctx, child_id).await?
-                {
-                    if !InputSocket::is_manually_configured(ctx, input_socket_match).await? {
-                        updated_avs.push(input_socket_match.attribute_value_id);
-                    }
-                }
-                let mut work_queue = vec![parent_id];
-                while let Some(parent) = work_queue.pop() {
-                    if Component::get_type_by_id(ctx, parent).await?
-                        == ComponentType::ConfigurationFrameUp
-                    {
-                        for (_, input_socket_match) in
-                            Component::input_socket_attribute_values_for_component_id(ctx, child_id)
-                                .await?
-                        {
-                            if !InputSocket::is_manually_configured(ctx, input_socket_match).await?
-                            {
-                                updated_avs.push(input_socket_match.attribute_value_id);
-                            }
-                        }
-                    }
-                    if let Some(next_parent) = Component::get_parent_by_id(ctx, parent).await? {
-                        work_queue.push(next_parent);
-                    }
-                }
-                updated_avs
-            }
-            ComponentType::AggregationFrame => vec![],
-        };
-
+        let before_change_impacted_input_sockets: HashSet<SocketAttributeValuePair> =
+            Self::get_impacted_connections(ctx, child_id).await?;
+        //when detaching a child, need to re-run any attribute value functions for those impacted input sockets then queue up dvu!
         Component::remove_edge_from_frame(ctx, parent_id, child_id).await?;
-        ctx.enqueue_dependent_values_update(values_rerun).await?;
+
+        ctx.enqueue_dependent_values_update(
+            before_change_impacted_input_sockets
+                .into_iter()
+                .map(|values| values.input_attribute_value_id)
+                .collect_vec(),
+        )
+        .await?;
         Ok(())
+    }
+
+    /// For a given component, get all of the input sockets
+    /// that have an inferred connection and for every output socket, get all
+    /// downstream input sockets that have an inferred connection to it
+    async fn get_impacted_connections(
+        ctx: &DalContext,
+        child_id: ComponentId,
+    ) -> FrameResult<HashSet<SocketAttributeValuePair>> {
+        let input_map =
+            Component::build_map_for_component_id_inferred_incoming_connections(ctx, child_id)
+                .await?;
+        let output_map =
+            Component::build_map_for_component_id_inferred_outgoing_connections(ctx, child_id)
+                .await?;
+
+        let mut impacted_connections = HashSet::new();
+        for (input_socket, output_sockets) in input_map.into_iter() {
+            for output_socket in output_sockets {
+                impacted_connections.insert(SocketAttributeValuePair {
+                    input_attribute_value_id: input_socket.attribute_value_id,
+                    output_attribute_value_id: output_socket.attribute_value_id,
+                });
+            }
+        }
+        for (output_socket, input_sockets) in output_map.into_iter() {
+            for input_socket in input_sockets {
+                impacted_connections.insert(SocketAttributeValuePair {
+                    input_attribute_value_id: input_socket.attribute_value_id,
+                    output_attribute_value_id: output_socket.attribute_value_id,
+                });
+            }
+        }
+        Ok(impacted_connections)
     }
 }
 

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -382,7 +382,8 @@ impl Diagram {
                 )?);
             }
 
-            for inferred_incoming_connection in component.inferred_connections(ctx).await? {
+            for inferred_incoming_connection in component.inferred_incoming_connections(ctx).await?
+            {
                 diagram_inferred_edges.push(SummaryDiagramInferredEdge::assemble(
                     inferred_incoming_connection,
                 )?)

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -144,6 +144,7 @@ impl FuncBinding {
     /// Use this function if you would like to receive the
     /// [`FuncBindingReturnValue`](crate::FuncBindingReturnValue) for a given
     /// [`FuncId`](crate::Func) and [`args`](serde_json::Value).
+    #[instrument(level = "info", skip(ctx))]
     pub async fn create_and_execute(
         ctx: &DalContext,
         args: serde_json::Value,

--- a/lib/dal/src/property_editor/values.rs
+++ b/lib/dal/src/property_editor/values.rs
@@ -43,7 +43,7 @@ impl PropertyEditorValues {
             .map(|c| c.to_input_socket_id)
             .collect();
         let inferred_sockets_on_components: HashSet<InputSocketId> = component
-            .inferred_connections(ctx)
+            .inferred_incoming_connections(ctx)
             .await?
             .iter()
             .map(|c| c.to_input_socket_id)

--- a/lib/dal/src/socket/debug.rs
+++ b/lib/dal/src/socket/debug.rs
@@ -132,16 +132,11 @@ impl SocketDebugView {
         };
         let value_view = attribute_value.view(ctx).await?;
         let inferred_connections =
-            match Component::find_potential_inferred_connection_to_input_socket(
-                ctx,
-                input_socket_match,
-            )
-            .await?
-            .map(|output_socket| Ulid::from(output_socket.attribute_value_id))
-            {
-                Some(output_id) => vec![output_id],
-                None => vec![],
-            };
+            Component::find_available_inferred_connections_to_input_socket(ctx, input_socket_match)
+                .await?
+                .into_iter()
+                .map(|output_socket| Ulid::from(output_socket.attribute_value_id))
+                .collect();
         let view = SocketDebugView {
             prototype_id,
             func_name: prototype_debug_view.func_name,

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -549,7 +549,6 @@ impl WorkspaceSnapshotGraph {
 
         Ok((conflicts, updates))
     }
-    #[instrument(level = "info", skip_all)]
     fn detect_conflicts_and_updates_process_dfs_event(
         &self,
         to_rebase_vector_clock_id: VectorClockId,

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -678,7 +678,9 @@ async fn through_the_wormholes_dynamic_child_value_reactivity(ctx: &mut DalConte
     let stars_value = AttributeValue::get_by_id(ctx, stars_value_id)
         .await
         .expect("able to get av by id");
-
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
     assert_eq!(
         Some(serde_json::to_value("phosphorus").expect("able to make phosphorus value")),
         stars_value.view(ctx).await.expect("get stars value")
@@ -691,10 +693,6 @@ async fn set_the_universe(ctx: &mut DalContext) {
     let variant_id = Component::schema_variant_id(ctx, component.id())
         .await
         .expect("find variant id for component");
-
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
-        .await
-        .expect("could not commit and update snapshot to visibility");
 
     let universe_prop_id = Prop::find_prop_id_by_path(
         ctx,
@@ -1042,6 +1040,9 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .expect("able to get units view")
         .expect("units has a view");
     let units_json_string = serde_json::to_string(&view).expect("Unable to stringify JSON");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
     assert!(units_json_string.contains("docker.io/library/oysters in my pocket\\n"));
     assert!(units_json_string.contains("docker.io/library/were saving for lunch\\n"));
 

--- a/lib/dal/tests/integration_test/connection.rs
+++ b/lib/dal/tests/integration_test/connection.rs
@@ -336,6 +336,10 @@ async fn connect_and_disconnect_components_explicit_connection(ctx: &mut DalCont
 
     assert!(matches!(view, serde_json::Value::Array(_)));
 
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
     if let serde_json::Value::Array(units_array) = view {
         assert_eq!(2, units_array.len())
     }

--- a/lib/si-layer-cache/src/activities/rebase.rs
+++ b/lib/si-layer-cache/src/activities/rebase.rs
@@ -134,7 +134,7 @@ impl<'a> ActivityRebase<'a> {
         Ok(activity)
     }
 
-    #[instrument(name = "activity::rebase::rebase_and_wait", level = "info")]
+    #[instrument(name = "activity::rebase::rebase_and_wait", level = "info", skip(self))]
     pub async fn rebase_and_wait(
         &self,
         to_rebase_change_set_id: Ulid,
@@ -182,7 +182,7 @@ impl<'a> ActivityRebase<'a> {
             .await
     }
 
-    #[instrument(name = "activity::rebase::rebase_finished", level = "info")]
+    #[instrument(name = "activity::rebase::rebase_finished", level = "info", skip(self))]
     pub async fn finished(
         &self,
         status: RebaseStatus,


### PR DESCRIPTION
Frames are a bit messy, but functional! I will be refactoring this into modules in another pass this week, but I want to get this out there for now. 

This PR includes the following changes: 

- Up Frames can now take inputs from multiple children (for example, when turning a Butane Component into an Up Frame and dropping multiple Docker Images inside) 
- When you attach a component to a parent, we will now run queue up only those input socket's Attribute Values for Dependent Values Update that have different inputs as a result of the attachment (this fixes a bug where we were not always re-running the right functions, which was the original bug)
- When you orphan a component, we first cache the current impacted input sockets so we can rerun them after we remove the FrameContains edge (another bug, as we were rerunning funcs THEN removing the edge, womp womp)
- Note: This takes significant advantage of the latest change to Dependent Values Update as any Input Socket's Attribute Value that gets queued for DVU will probably (always?) have a dynamic function that sets the value, meaning it will run during the next DVU job
- When we remove the Component on delete (because it doesn't have a resource), we also orphan it, making sure that any impacted input sockets are queued up for DVU
- Add a complex test for multiple components as children of an Up Frame, with nesting, moves, and deletes, making sure the data flows as expected
- Added some test helpers to make it faster to write tests for frames as we continue to cover the various permutations. 
- Add some tracing for the rebaser loop so we can see the count of updates and conflicts better in Jaeger and Honeycomb. I needed this to debug an issue while I was working on this and left it in as this will be valuable for us in the short term (and more valuable as we enrich the metadata we return)


<div><img src="https://media3.giphy.com/media/IgdrPBTDxRBi0tK6FH/giphy.gif?cid=5a38a5a2x11b4u13ls942avbd8kz4g6dznuei6a74h2lk627&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:173px;width:300px"/><br/>via <a href="https://giphy.com/election2020/">Election 2020</a> on <a href="https://giphy.com/gifs/2020-iowa-democratic-party-liberty-and-justice-celebration-IgdrPBTDxRBi0tK6FH">GIPHY</a></div>
