### PR TITLE
bug(layerdb): spawn those writes after all

### DIFF
--- a/lib/si-layer-cache/src/persister.rs
+++ b/lib/si-layer-cache/src/persister.rs
@@ -172,7 +172,7 @@ impl PersisterTask {
                         self.pg_pool.clone(),
                         self.layered_event_client.clone(),
                     );
-                    task.write_layers(event, status_tx).await;
+                    self.tracker.spawn(task.write_layers(event, status_tx));
                 }
             }
         }


### PR DESCRIPTION
We saw an error last week where some snapshots we expected weren't appearing in the database. Our theory was that perhaps we were doing some out-of-order writes. That might have been true, but the fix was that we stopped spawning tasks for each persister request - which slowed down the processing of those writes to a degree that, unless you had a very fast machine, would mean that the snapshot write hadn't been distributed by the time the rebaser hit its two second limit (and the write hadn't committed to postgres yet).

This would then cause the SDF instance running the migration to panic, which would destroy the remaining persister tasks, which would ensure the data never arrives.

This brings back spawning the write tasks in the persister, which lets us sail through the writes.