### PR TITLE
Fix the (not so) Mysterious Up Frame Bug

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -2701,6 +2701,7 @@ impl Component {
         Ok(maybe_target_sockets)
     }
 
+    #[instrument(level = "info", skip(ctx))]
     pub async fn remove_connection(
         ctx: &DalContext,
         source_component_id: ComponentId,

--- a/lib/dal/src/component/frame.rs
+++ b/lib/dal/src/component/frame.rs
@@ -57,7 +57,7 @@ impl Frame {
         Ok(())
     }
     /// Provides the ability to attach or replace a child [`Component`]'s parent
-    #[instrument(level = "info", skip_all)]
+    #[instrument(level = "info", skip(ctx))]
     pub async fn upsert_parent(
         ctx: &DalContext,
         child_id: ComponentId,


### PR DESCRIPTION
When we execute an attribute's function, we gather up any inferred inputs by walking the graph and finding inferred connections.  

As input sockets share prototypes across components, if there are multiple instances of the component on the graph, where one has an explicit edge drawn and one is supposed to take an inferred input, the existence of prototype arguments as a result of the edge being drawn meant we were never getting inferred inputs for the second component.  

This fixes the logic, such that we look to find inferred inputs only after we haven't found any explicit inputs for that attribute value. 

<div><img src="https://media3.giphy.com/media/l0IykOsxLECVejOzm/giphy.gif?cid=5a38a5a2lrni10a5rlt5y3e435tvu6gibi9hj3invwk89u4n&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:191px;width:300px"/><br/>via <a href="https://giphy.com/gifs/fx-charlie-always-sunny-l0IykOsxLECVejOzm">GIPHY</a></div>