### PR TITLE
Component position & parentage need to be sent together for rebaser. Send WsEvents to populate components & edges appropriately.

### DIFF
--- a/app/web/src/api/sdf/dal/component.ts
+++ b/app/web/src/api/sdf/dal/component.ts
@@ -53,3 +53,24 @@ export interface RawComponent {
   toDelete: boolean;
   canBeUpgraded: boolean;
 }
+
+export type EdgeId = string;
+export type SocketId = string;
+
+export type RawEdge = {
+  fromComponentId: ComponentId;
+  fromSocketId: SocketId;
+  toComponentId: ComponentId;
+  toSocketId: SocketId;
+  toDelete: boolean;
+  /** change status of edge in relation to head */
+  changeStatus?: ChangeStatus;
+  createdInfo: ActorAndTimestamp;
+  // updatedInfo?: ActorAndTimestamp; // currently we dont ever update an edge...
+  deletedInfo?: ActorAndTimestamp;
+};
+
+export type Edge = RawEdge & {
+  id: EdgeId;
+  isInferred: boolean;
+};

--- a/app/web/src/components/EdgeCard.vue
+++ b/app/web/src/components/EdgeCard.vue
@@ -14,7 +14,8 @@
 <script lang="ts" setup>
 import * as _ from "lodash-es";
 import { computed, PropType } from "vue";
-import { EdgeId, useComponentsStore } from "@/store/components.store";
+import { useComponentsStore } from "@/store/components.store";
+import { EdgeId } from "@/api/sdf/dal/component";
 import ComponentCard from "./ComponentCard.vue";
 
 const props = defineProps({

--- a/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
+++ b/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
@@ -24,7 +24,6 @@ const {
   selectedComponentId,
   selectedComponentIds,
   selectedComponent,
-  selectedComponents,
   deletableSelectedComponents,
   restorableSelectedComponents,
   selectedEdgeId,
@@ -133,21 +132,6 @@ const rightClickMenuItems = computed(() => {
     }
   }
 
-  if (
-    selectedComponents.value.length > 0 &&
-    _.every(selectedComponents.value, (c) => (c.ancestorIds?.length || 0) > 0)
-  ) {
-    items.push({
-      label: "Detach from parent(s)",
-      icon: "frame",
-      onSelect: () => {
-        _.each(selectedComponentIds.value, (id) => {
-          componentsStore.DETACH_COMPONENT([id]);
-        });
-      },
-      disabled,
-    });
-  }
   if (
     selectedComponent.value?.hasResource &&
     changeSetsStore.selectedChangeSetId === changeSetsStore.headChangeSetId

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -4,7 +4,7 @@
 import { FuncId } from "@/store/func/funcs.store";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import { Resource } from "@/api/sdf/dal/resource";
-import { ComponentId, RawComponent } from "@/api/sdf/dal/component";
+import { ComponentId, RawComponent, RawEdge } from "@/api/sdf/dal/component";
 import { ComponentPositions } from "../components.store";
 import { WorkspacePk } from "../workspaces.store";
 import {
@@ -195,6 +195,14 @@ export type WsEventPayloadMap = {
     component: RawComponent;
     originalComponentId: ComponentId;
     changeSetId: string;
+  };
+  InferredEdgeUpsert: {
+    changeSetId: string;
+    edges: RawEdge[];
+  };
+  InferredEdgeRemove: {
+    changeSetId: string;
+    edges: RawEdge[];
   };
   ConnectionCreated: {
     fromComponentId: string;

--- a/app/web/src/store/status.store.ts
+++ b/app/web/src/store/status.store.ts
@@ -5,12 +5,12 @@ import { POSITION, useToast } from "vue-toastification";
 import { watch } from "vue";
 import { useWorkspacesStore } from "@/store/workspaces.store";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
-import { ComponentId } from "@/api/sdf/dal/component";
+import { ComponentId, SocketId } from "@/api/sdf/dal/component";
 import { useChangeSetsStore } from "./change_sets.store";
 import { useRealtimeStore } from "./realtime/realtime.store";
 import UpdatingModel from "../components/toasts/UpdatingModel.vue";
 
-import { SocketId, useComponentsStore } from "./components.store";
+import { useComponentsStore } from "./components.store";
 
 const GLOBAL_STATUS_TOAST_TIMEOUT = 1000;
 const GLOBAL_STATUS_TOAST_DEBOUNCE = 300;

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -10,7 +10,7 @@ use crate::change_set::event::{ChangeSetActorPayload, ChangeSetMergeVotePayload}
 use crate::component::{
     ComponentCreatedPayload, ComponentDeletedPayload, ComponentSetPositionPayload,
     ComponentUpdatedPayload, ComponentUpgradedPayload, ConnectionCreatedPayload,
-    ConnectionDeletedPayload,
+    ConnectionDeletedPayload, InferredEdgeRemovePayload, InferredEdgeUpsertPayload,
 };
 use crate::func::FuncWsEventPayload;
 use crate::pkg::{
@@ -101,6 +101,8 @@ pub enum WsPayload {
     FuncDeleted(FuncWsEventPayload),
     FuncSaved(FuncWsEventPayload),
     ImportWorkspaceVote(ImportWorkspaceVotePayload),
+    InferredEdgeRemove(InferredEdgeRemovePayload),
+    InferredEdgeUpsert(InferredEdgeUpsertPayload),
     LogLine(LogLinePayload),
     ModuleImported(ModuleImportedPayload),
     Online(OnlinePayload),

--- a/lib/sdf-server/src/server/service/diagram.rs
+++ b/lib/sdf-server/src/server/service/diagram.rs
@@ -143,10 +143,10 @@ pub fn routes() -> Router<AppState> {
             "/connect_component_to_frame",
             post(connect_component_to_frame::connect_component_to_frame),
         )
-        .route(
+        /*.route(
             "/create_connection",
             post(create_connection::create_connection),
-        )
+        )*/
         .route(
             "/create_component",
             post(create_component::create_component),
@@ -157,8 +157,8 @@ pub fn routes() -> Router<AppState> {
         )
         .route("/get_diagram", get(get_diagram::get_diagram))
         .route("/list_schemas", get(list_schemas::list_schemas))
-        .route(
-            "/detach_component",
-            post(detach_component_from_frame::detach_component_from_frame),
-        )
+    /*.route(
+        "/detach_component",
+        post(detach_component_from_frame::detach_component_from_frame),
+    )*/
 }

--- a/lib/sdf-server/src/server/service/diagram/set_component_position.rs
+++ b/lib/sdf-server/src/server/service/diagram/set_component_position.rs
@@ -1,5 +1,9 @@
 use axum::Json;
-use dal::{ChangeSet, Component, ComponentId, ComponentType, Visibility, WsEvent};
+use dal::{
+    component::frame::Frame,
+    diagram::{SummaryDiagramComponent, SummaryDiagramInferredEdge},
+    ChangeSet, Component, ComponentId, ComponentType, Visibility, WsEvent,
+};
 use serde::{Deserialize, Serialize};
 
 use super::DiagramResult;
@@ -20,6 +24,8 @@ pub struct SetComponentPositionRequest {
     #[serde(flatten)]
     pub visibility: Visibility,
     pub positions: Vec<ElementPositions>,
+    pub detach: bool,
+    pub new_parent: Option<ComponentId>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -38,6 +44,24 @@ pub async fn set_component_position(
     let mut components: Vec<Component> = vec![];
     for element in request.positions {
         let mut component = Component::get_by_id(&ctx, element.component_id).await?;
+
+        if request.detach {
+            Frame::orphan_child(&ctx, component.id()).await?;
+            let payload: SummaryDiagramComponent =
+                SummaryDiagramComponent::assemble(&ctx, &component).await?;
+            WsEvent::component_updated(&ctx, payload)
+                .await?
+                .publish_on_commit(&ctx)
+                .await?;
+        } else if let Some(new_parent) = request.new_parent {
+            Frame::upsert_parent(&ctx, component.id(), new_parent).await?;
+            let payload: SummaryDiagramComponent =
+                SummaryDiagramComponent::assemble(&ctx, &component).await?;
+            WsEvent::component_updated(&ctx, payload)
+                .await?
+                .publish_on_commit(&ctx)
+                .await?;
+        }
 
         let (width, height) = {
             let mut size = (None, None);
@@ -65,10 +89,30 @@ pub async fn set_component_position(
     }
     let user_id = ChangeSet::extract_userid_from_context(&ctx).await;
 
-    WsEvent::set_component_position(&ctx, ctx.change_set_id(), &components, user_id)
+    WsEvent::set_component_position(&ctx, ctx.change_set_id(), components, user_id)
         .await?
         .publish_on_commit(&ctx)
         .await?;
+
+    if let Some(new_parent) = request.new_parent {
+        let component = Component::get_by_id(&ctx, new_parent).await?;
+        let mut diagram_inferred_edges: Vec<SummaryDiagramInferredEdge> = vec![];
+        for inferred_incoming_connection in component.inferred_incoming_connections(&ctx).await? {
+            diagram_inferred_edges.push(SummaryDiagramInferredEdge::assemble(
+                inferred_incoming_connection,
+            )?)
+        }
+        for inferred_outgoing_connection in component.inferred_outgoing_connections(&ctx).await? {
+            diagram_inferred_edges.push(SummaryDiagramInferredEdge::assemble(
+                inferred_outgoing_connection,
+            )?)
+        }
+
+        WsEvent::upsert_inferred_edges(&ctx, diagram_inferred_edges)
+            .await?
+            .publish_on_commit(&ctx)
+            .await?;
+    }
 
     ctx.commit().await?;
 


### PR DESCRIPTION
OK—the front end now has all the info required to display sockets correctly through attach & detach. And the conflicts that happen when position and parentage are sent in separate rebases is avoided. This is the way.

<img src="https://media3.giphy.com/media/6UFgdU9hirj1pAOJyN/giphy.gif"/>