### PR TITLE
Fix detach for attribute and code gen

### DIFF
--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -177,6 +177,7 @@
               editingFunc.associations &&
               editingFunc.associations.type === 'codeGeneration'
             "
+            ref="detachRef"
             v-model="editingFunc.associations"
             :schemaVariantId="schemaVariantId"
             @change="updateFunc"

--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -84,8 +84,6 @@ pub enum FuncAuthoringError {
     AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
     #[error("attribute value error: {0}")]
     AttributeValue(#[from] AttributeValueError),
-    #[error("attribute value not found for attribute prototype: {0}")]
-    AttributeValueNotFoundForAttributePrototype(AttributePrototypeId),
     #[error("before func error: {0}")]
     BeforeFunc(#[from] BeforeFuncError),
     #[error("component error: {0}")]
@@ -335,19 +333,4 @@ pub struct TestExecuteFuncResult {
     pub execution_key: String,
     /// The logs corresponding to the output stream of the test execution.
     pub logs: Vec<OutputStream>,
-}
-
-/// Determines what we should do with the [`AttributePrototype`](dal::AttributePrototype) and
-/// [`AttributeValues`](dal::AttributeValue) that are currently associated with a function but
-/// that are having their association removed.
-///
-/// `RemovedPrototypeOp::Reset` takes the currenty value and resets the prototype to set it to that
-/// value using a builtin value function, like `si:setString`, etc.
-///
-/// `RemovedPrototypeOp::Delete` deletes the prototype and its values.
-#[remain::sorted]
-#[derive(Debug, Copy, Clone)]
-enum RemovedPrototypeOp {
-    Delete,
-    Reset,
 }

--- a/lib/dal/tests/integration_test/func/authoring/save_func.rs
+++ b/lib/dal/tests/integration_test/func/authoring/save_func.rs
@@ -7,6 +7,7 @@ use pretty_assertions_sorted::assert_eq;
 
 mod attach;
 mod attribute;
+mod detach;
 
 #[test]
 async fn action(ctx: &mut DalContext) {

--- a/lib/dal/tests/integration_test/func/authoring/save_func/detach.rs
+++ b/lib/dal/tests/integration_test/func/authoring/save_func/detach.rs
@@ -1,0 +1,72 @@
+use dal::func::authoring::FuncAuthoringClient;
+use dal::func::summary::FuncSummary;
+use dal::func::view::FuncView;
+use dal::func::FuncAssociations;
+use dal::{DalContext, Func, Schema, SchemaVariant};
+use dal_test::helpers::ChangeSetTestHelpers;
+use dal_test::test;
+
+#[test]
+async fn detach_attribute_func(ctx: &mut DalContext) {
+    let schema = Schema::find_by_name(ctx, "starfield")
+        .await
+        .expect("unable to find by name")
+        .expect("no schema found");
+    let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+        .await
+        .expect("unable to get default schema variant");
+
+    // Cache the total number of funcs before continuing.
+    let funcs = FuncSummary::list_for_schema_variant_id(ctx, schema_variant_id)
+        .await
+        .expect("unable to get the funcs for a schema variant");
+    let total_funcs = funcs.len();
+
+    // Detach one action func to the schema variant and commit.
+    let func_id = Func::find_by_name(ctx, "test:falloutEntriesToGalaxies")
+        .await
+        .expect("unable to find the func")
+        .expect("no func found");
+    let func = Func::get_by_id_or_error(ctx, func_id)
+        .await
+        .expect("unable to get func by id");
+    let func_view = FuncView::assemble(ctx, &func)
+        .await
+        .expect("unable to assemble a func view");
+    let (prototypes, arguments) = func_view
+        .associations
+        .expect("empty associations")
+        .get_attribute_internals()
+        .expect("could not get internals");
+    let prototypes = prototypes
+        .into_iter()
+        .filter(|p| p.schema_variant_id != Some(schema_variant_id))
+        .collect();
+    FuncAuthoringClient::save_func(
+        ctx,
+        func_view.id,
+        func_view.display_name,
+        func_view.name,
+        func_view.description,
+        func_view.code,
+        Some(FuncAssociations::Attribute {
+            prototypes,
+            arguments,
+        }),
+    )
+    .await
+    .expect("unable to save the func");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Now, let's list all funcs and see what's left.
+    let funcs = FuncSummary::list_for_schema_variant_id(ctx, schema_variant_id)
+        .await
+        .expect("unable to get the funcs for a schema variant");
+    assert_eq!(
+        total_funcs - 1, // expected
+        funcs.len()      // actual
+    );
+    assert!(!funcs.iter().any(|summary| summary.id == func_id));
+}

--- a/lib/dal/tests/integration_test/secret/bench.rs
+++ b/lib/dal/tests/integration_test/secret/bench.rs
@@ -35,16 +35,22 @@ async fn list_ids_by_key_bench(ctx: &mut DalContext, nw: &WorkspaceSignup) {
     );
 
     // Now that we have a graph with many secrets, let's run the function and cache the result.
+    // Ensure that the result meets our expectations for wall clock time.
     let list_ids_by_key_instant = tokio::time::Instant::now();
-    let _map = Secret::list_ids_by_key(ctx)
+    let ids_by_key = Secret::list_ids_by_key(ctx)
         .await
         .expect("could not list ids by key");
     let list_ids_by_key_instant_elapsed = list_ids_by_key_instant.elapsed();
-
-    // Ensure that the result meets our expectations for wall clock time.
     assert!(Duration::from_millis(10) > list_ids_by_key_instant_elapsed);
     println!(
         "list ids by key for {secrets_count} secrets took: {:?}",
         list_ids_by_key_instant_elapsed
+    );
+
+    // Check the number of keys in the map. Their length should be the same as the number of secrets
+    // created.
+    assert_eq!(
+        secrets_count,           // expected
+        ids_by_key.keys().len(), // actual
     );
 }


### PR DESCRIPTION
## Description

This commit fixes detaching for attribute and code generation funcs.

For attribute funcs, we needed fallback to removing the prototype at the schema variant level if an attribute prototype could not be found at the component level (i.e. the prototype did not correspond to an attribute value). There is now an integration test tracking this behavior.

For code generation funcs, we needed to ensure that we were using the detach ref. No new integration tests were added for this behavior because the bug was purely a frontend usage bug.

<img src="https://media4.giphy.com/media/FDPxw3QVL8Anb84Hia/giphy.gif"/>