### PR TITLE
experiment(web): Remove component spinner on update

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramGroup.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroup.vue
@@ -334,15 +334,8 @@
           x: 0,
           y: 0,
           cornerRadius: [0, 0, CORNER_RADIUS, CORNER_RADIUS],
-          fill: 'rgba(255,255,255,0.70)',
+          fill: 'rgba(255,255,255,0.30)',
         }"
-      />
-      <DiagramIcon
-        icon="loader"
-        :color="getToneColorHex('info')"
-        :size="overlayIconSize"
-        :x="halfWidth"
-        :y="nodeBodyHeight / 2"
       />
     </v-group>
 
@@ -468,8 +461,6 @@ const childCount = computed(() => {
 
   return undeletedChildren.length;
 });
-
-const overlayIconSize = computed(() => nodeWidth.value / 3);
 
 const nodeWidth = computed(() => size.value.width);
 const halfWidth = computed(() => nodeWidth.value / 2);

--- a/app/web/src/components/ModelingDiagram/DiagramGroupOverlay.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroupOverlay.vue
@@ -26,15 +26,8 @@
           x: 0,
           y: 0,
           cornerRadius: [0, 0, CORNER_RADIUS, CORNER_RADIUS],
-          fill: 'rgba(255,255,255,0.70)',
+          fill: 'rgba(255,255,255,0.30)',
         }"
-      />
-      <DiagramIcon
-        icon="loader"
-        :color="getToneColorHex('info')"
-        :size="overlayIconSize"
-        :x="halfWidth"
-        :y="nodeBodyHeight / 2"
       />
     </v-group>
 
@@ -86,8 +79,6 @@ const size = computed(
 
 const nodeWidth = computed(() => size.value.width);
 const halfWidth = computed(() => nodeWidth.value / 2);
-
-const overlayIconSize = computed(() => nodeWidth.value / 3);
 
 const headerTextHeight = ref(20);
 watch(

--- a/app/web/src/components/ModelingDiagram/DiagramNode.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramNode.vue
@@ -105,14 +105,15 @@
           y: nodeHeight - 2,
         }"
       >
-        HERE
         <DiagramIcon
           v-for="(statusIcon, i) in _.reverse(_.slice(node.def.statusIcons))"
           :key="`status-icon-${i}`"
           :icon="statusIcon.icon"
-          :color="statusIcon.color || statusIcon.tone
-            ? getToneColorHex(statusIcon.tone!)
-            : getToneColorHex('neutral')"
+          :color="
+            statusIcon.color || statusIcon.tone
+              ? getToneColorHex(statusIcon.tone!)
+              : getToneColorHex('neutral')
+          "
           :size="24 + (statusIconHovers[i] ? 4 : 0)"
           :x="i * -26 + (statusIconHovers[i] ? 2 : 0)"
           :y="statusIconHovers[i] ? 2 : 0"
@@ -141,15 +142,8 @@
             x: 0,
             y: 0,
             cornerRadius: [0, 0, CORNER_RADIUS, CORNER_RADIUS],
-            fill: 'rgba(255,255,255,0.70)',
+            fill: 'rgba(255,255,255,0.30)',
           }"
-        />
-        <DiagramIcon
-          icon="loader"
-          :color="getToneColorHex('info')"
-          :size="overlayIconSize"
-          :x="halfWidth"
-          :y="nodeBodyHeight / 2"
         />
       </v-group>
 
@@ -391,8 +385,6 @@ const truncatedNodeTitle = computed(() => {
 
 const nodeWidth = computed(() => NODE_WIDTH);
 const halfWidth = computed(() => nodeWidth.value / 2);
-
-const overlayIconSize = computed(() => nodeWidth.value / 3);
 
 const headerTextHeight = ref(20);
 const subtitleTextHeight = ref(0);


### PR DESCRIPTION
We are experimenting with the removal of the spinner icon for component upgrades and changing the colour and opacity of the component