### PR TITLE
chore(dal): remove `Debug` implementation on `DalContext`

### DIFF
--- a/lib/sdf-server/src/server/state.rs
+++ b/lib/sdf-server/src/server/state.rs
@@ -1,6 +1,7 @@
 use axum::extract::FromRef;
 use dal::JwtPublicSigningKey;
 use nats_multiplexer_client::MultiplexerClient;
+use std::fmt;
 use std::{ops::Deref, sync::Arc};
 use tokio::sync::{broadcast, mpsc, Mutex};
 
@@ -98,8 +99,14 @@ impl From<PosthogClient> for si_posthog::PosthogClient {
     }
 }
 
-#[derive(Clone, Debug, FromRef)]
+#[derive(Clone, FromRef)]
 pub struct ServicesContext(dal::ServicesContext);
+
+impl fmt::Debug for ServicesContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ServicesContext").finish_non_exhaustive()
+    }
+}
 
 impl ServicesContext {
     pub fn into_inner(self) -> dal::ServicesContext {


### PR DESCRIPTION
This change removes the automatically derived `Debug` implementation from the `DalContext` type.

At present, this type is incredibly complex, with many complex parts. A developer who wishes to "debug" this type will not be helped by calling `dbg!(ctx)` as the output may grow into the megabytes/gigabytes. Furthermore this type can be accidentally debugged when using a tracing `#[instrument()]` call. For any function or method, the `instrument` macro has an implicit "register all function parameters" behavior, meaning that:

```rust
fn do_something(ctx: &DalContext) {}
```

will create a span called `do_something` with a field called `ctx`. The `ctx` field would contain the contents of the `impl std::fmt::Debug for DalContext` output. Removing the `Debug` implementation on `DalContext` makes this accidental behavior not possible as it results in a Rust compilation failure.

<img src="https://media4.giphy.com/media/U7isUDZ6VPWJW/giphy.gif"/>