### PR TITLE
fix(dal): debug view should not assume all values have executed

### DIFF
--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -329,8 +329,7 @@ impl AttributePrototypeDebugView {
         let attribute_values = AttributePrototype::attribute_value_ids(ctx, prototype_id).await?;
         let func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
 
-        let func_execution =
-            Some(FuncExecution::get_latest_execution_by_func_id(ctx, &func_id).await?);
+        let func_execution = FuncExecution::get_latest_execution_by_func_id(ctx, &func_id).await?;
         let func_name = Func::get_by_id_or_error(ctx, func_id).await?.name;
         let view = AttributePrototypeDebugView {
             func_args: func_binding_args,

--- a/lib/dal/src/func/execution.rs
+++ b/lib/dal/src/func/execution.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use tokio::sync::mpsc::Receiver;
 use veritech_client::{FunctionResultFailure, OutputStream};
 
-use crate::standard_model::object_from_row;
+use crate::standard_model::object_option_from_row_option;
 use crate::{
     pk, DalContext, Func, FuncBackendKind, FuncBackendResponseType, HistoryEventError,
     StandardModel, StandardModelError, Timestamp,
@@ -256,17 +256,17 @@ impl FuncExecution {
     pub async fn get_latest_execution_by_func_id(
         ctx: &DalContext,
         func_id: &FuncId,
-    ) -> FuncExecutionResult<Self> {
+    ) -> FuncExecutionResult<Option<Self>> {
         let row = ctx
             .txns()
             .await?
             .pg()
-            .query_one(
+            .query_opt(
                 "SELECT row_to_json(fe.*) as object FROM func_executions fe WHERE func_id = $1 ORDER BY updated_at LIMIT 1",
                 &[func_id],
             )
             .await?;
-        Ok(object_from_row(row)?)
+        Ok(object_option_from_row_option(row)?)
     }
 
     pub fn func_binding_return_value_id(&self) -> Option<FuncBindingReturnValueId> {


### PR DESCRIPTION
We no longer execute all functions for all values on component creation, so we can't assume every value's prototype function has in fact executed.