### PR TITLE
feat(dal,rebaser): store pending dvu values on snapshot

### DIFF
--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -143,7 +143,7 @@ impl Action {
         let mut actions = vec![];
         let snap = ctx.workspace_snapshot()?;
         let action_category_id = snap
-            .get_category_node(None, CategoryNodeKind::Action)
+            .get_category_node_or_err(None, CategoryNodeKind::Action)
             .await?;
 
         for action_idx in snap
@@ -219,7 +219,7 @@ impl Action {
     ) -> ActionResult<Option<ActionId>> {
         let snap = ctx.workspace_snapshot()?;
         let action_category_id = snap
-            .get_category_node(None, CategoryNodeKind::Action)
+            .get_category_node_or_err(None, CategoryNodeKind::Action)
             .await?;
 
         for action_idx in snap
@@ -308,7 +308,7 @@ impl Action {
 
         let action_category_id = ctx
             .workspace_snapshot()?
-            .get_category_node(None, CategoryNodeKind::Action)
+            .get_category_node_or_err(None, CategoryNodeKind::Action)
             .await?;
         Self::add_incoming_category_edge(
             ctx,
@@ -453,7 +453,7 @@ impl Action {
 
         let action_category_node_index = ctx
             .workspace_snapshot()?
-            .get_category_node(None, CategoryNodeKind::Action)
+            .get_category_node_or_err(None, CategoryNodeKind::Action)
             .await?;
         for (_, _, action_node_index) in ctx
             .workspace_snapshot()?

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -616,7 +616,7 @@ impl AttributePrototypeArgument {
             .await?;
 
         // Enqueue a dependent values update with the destination attribute values
-        ctx.enqueue_dependent_values_update(avs_to_update).await?;
+        ctx.add_dependent_values_and_enqueue(avs_to_update).await?;
 
         Ok(())
     }

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -462,7 +462,7 @@ impl AttributeValue {
         Self::set_value(ctx, attribute_value_id, value.clone()).await?;
         Self::populate_nested_values(ctx, attribute_value_id, value).await?;
 
-        ctx.enqueue_dependent_values_update(vec![attribute_value_id])
+        ctx.add_dependent_values_and_enqueue(vec![attribute_value_id])
             .await?;
 
         Ok(())
@@ -1829,7 +1829,7 @@ impl AttributeValue {
         if !AttributeValue::is_set_by_dependent_function(ctx, attribute_value_id).await? {
             AttributeValue::update_from_prototype_function(ctx, attribute_value_id).await?;
         }
-        ctx.enqueue_dependent_values_update(vec![attribute_value_id])
+        ctx.add_dependent_values_and_enqueue(vec![attribute_value_id])
             .await?;
 
         Ok(())
@@ -2247,8 +2247,11 @@ impl AttributeValue {
         ctx.workspace_snapshot()?
             .remove_node_by_id(ctx.change_set()?, id)
             .await?;
+        ctx.workspace_snapshot()?
+            .remove_dependent_value_root(ctx.change_set()?, id)
+            .await?;
 
-        ctx.enqueue_dependent_values_update(vec![parent_av_id])
+        ctx.add_dependent_values_and_enqueue(vec![parent_av_id])
             .await?;
         Ok(())
     }

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -560,7 +560,6 @@ impl ChangeSet {
             onto_workspace_snapshot_address,
             onto_vector_clock_id: self.vector_clock_id(),
             to_rebase_change_set_id,
-            dvu_values: None,
         };
 
         if let Some(conflicts) = ctx.do_rebase_request(rebase_request).await? {

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -406,7 +406,7 @@ impl Component {
 
         // Root --> Component Category --> Component (this)
         let component_category_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::Component)
+            .get_category_node_or_err(None, CategoryNodeKind::Component)
             .await?;
         Self::add_category_edge(
             ctx,
@@ -519,7 +519,7 @@ impl Component {
 
         let component_graph = DependentValueGraph::new(ctx, attribute_values).await?;
         let leaf_value_ids = component_graph.independent_values();
-        ctx.enqueue_dependent_values_update(leaf_value_ids).await?;
+        ctx.add_dependent_values_and_enqueue(leaf_value_ids).await?;
 
         // Find all create action prototypes for the variant and create actions for them.
         for prototype_id in SchemaVariant::find_action_prototypes_by_kind(
@@ -971,7 +971,7 @@ impl Component {
 
         let mut components = vec![];
         let component_category_node_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::Component)
+            .get_category_node_or_err(None, CategoryNodeKind::Component)
             .await?;
 
         let component_node_indices = workspace_snapshot
@@ -1573,7 +1573,7 @@ impl Component {
         .await?;
 
         if let Some((destination_attribute_value_id, attribute_prototype_argument_id)) = maybe {
-            ctx.enqueue_dependent_values_update(vec![destination_attribute_value_id])
+            ctx.add_dependent_values_and_enqueue(vec![destination_attribute_value_id])
                 .await?;
 
             Ok(Some(attribute_prototype_argument_id))
@@ -1904,7 +1904,7 @@ impl Component {
             .cloned()
             .collect();
 
-        ctx.enqueue_dependent_values_update(input_av_ids).await?;
+        ctx.add_dependent_values_and_enqueue(input_av_ids).await?;
 
         // We always want to make sure that everything "downstream" of us reacts appropriately
         // regardless of whether we're setting, or clearing the `to_delete` flag.
@@ -1916,7 +1916,7 @@ impl Component {
 
         let downstream_av_ids = modified.downstream_attribute_value_ids(ctx).await?;
 
-        ctx.enqueue_dependent_values_update(downstream_av_ids)
+        ctx.add_dependent_values_and_enqueue(downstream_av_ids)
             .await?;
 
         // Deal with deletion actions
@@ -2788,7 +2788,7 @@ impl Component {
                                        ),
                                    )?;
 
-                                ctx.enqueue_dependent_values_update(vec![
+                                ctx.add_dependent_values_and_enqueue(vec![
                                     destination_attribute_value_id,
                                 ])
                                 .await?;

--- a/lib/dal/src/component/frame.rs
+++ b/lib/dal/src/component/frame.rs
@@ -146,7 +146,7 @@ impl Frame {
                 .difference(&cached_impacted_values)
                 .copied(),
         );
-        ctx.enqueue_dependent_values_update(
+        ctx.add_dependent_values_and_enqueue(
             values_to_run
                 .into_iter()
                 .map(|values| values.input_socket_match.attribute_value_id)
@@ -181,7 +181,7 @@ impl Frame {
             .publish_on_commit(ctx)
             .await?;
 
-        ctx.enqueue_dependent_values_update(
+        ctx.add_dependent_values_and_enqueue(
             before_change_impacted_input_sockets
                 .into_iter()
                 .map(|values| values.input_socket_match.attribute_value_id)

--- a/lib/dal/src/deprecated_action/batch.rs
+++ b/lib/dal/src/deprecated_action/batch.rs
@@ -183,7 +183,7 @@ impl DeprecatedActionBatch {
 
         // Root --> ActionBatch Category --> Component (this)
         let category_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::DeprecatedActionBatch)
+            .get_category_node_or_err(None, CategoryNodeKind::DeprecatedActionBatch)
             .await?;
         Self::add_category_edge(ctx, category_id, id.into(), EdgeWeightKind::new_use()).await?;
 
@@ -217,7 +217,7 @@ impl DeprecatedActionBatch {
 
         let mut action_batches = vec![];
         let action_batch_category_node_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::DeprecatedActionBatch)
+            .get_category_node_or_err(None, CategoryNodeKind::DeprecatedActionBatch)
             .await?;
 
         let action_batch_node_indices = workspace_snapshot

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -239,7 +239,7 @@ impl Func {
         workspace_snapshot.add_node(node_weight.clone()).await?;
 
         let func_category_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::Func)
+            .get_category_node_or_err(None, CategoryNodeKind::Func)
             .await?;
         Self::add_category_edge(ctx, func_category_id, id.into(), EdgeWeightKind::new_use())
             .await?;
@@ -301,7 +301,7 @@ impl Func {
     ) -> FuncResult<Option<FuncId>> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let func_category_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::Func)
+            .get_category_node_or_err(None, CategoryNodeKind::Func)
             .await?;
         let func_indices = workspace_snapshot
             .outgoing_targets_for_edge_weight_kind(
@@ -509,7 +509,7 @@ impl Func {
 
         let mut funcs = vec![];
         let func_category_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::Func)
+            .get_category_node_or_err(None, CategoryNodeKind::Func)
             .await?;
 
         let func_node_indexes = workspace_snapshot

--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -62,7 +62,7 @@ use crate::{
     AttributePrototypeId, ComponentError, ComponentId, DalContext, DeprecatedActionKind,
     DeprecatedActionPrototypeError, Func, FuncBackendKind, FuncBackendResponseType, FuncError,
     FuncId, OutputSocketId, PropId, SchemaVariantError, SchemaVariantId, TransactionsError,
-    WsEventError,
+    WorkspaceSnapshotError, WsEventError,
 };
 
 mod create;
@@ -133,6 +133,8 @@ pub enum FuncAuthoringError {
     Transactions(#[from] TransactionsError),
     #[error("unexpected func kind ({0}) creating attribute func")]
     UnexpectedFuncKindCreatingAttributeFunc(FuncKind),
+    #[error("workspace snapshot error: {0}")]
+    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
     #[error("ws event error: {0}")]
     WsEvent(#[from] WsEventError),
 }

--- a/lib/dal/src/func/authoring/execute.rs
+++ b/lib/dal/src/func/authoring/execute.rs
@@ -27,7 +27,7 @@ pub(crate) async fn execute_attribute_func(
             AttributeValue::update_from_prototype_function(ctx, *attribute_value_id).await?;
         }
 
-        ctx.enqueue_dependent_values_update(attribute_value_ids)
+        ctx.add_dependent_values_and_enqueue(attribute_value_ids)
             .await?;
     }
 

--- a/lib/dal/src/func/authoring/save.rs
+++ b/lib/dal/src/func/authoring/save.rs
@@ -523,7 +523,7 @@ async fn create_new_attribute_prototype(
     }
 
     if !affected_attribute_value_ids.is_empty() {
-        ctx.enqueue_dependent_values_update(affected_attribute_value_ids)
+        ctx.add_dependent_values_and_enqueue(affected_attribute_value_ids)
             .await?;
     }
 

--- a/lib/dal/src/job/queue.rs
+++ b/lib/dal/src/job/queue.rs
@@ -107,11 +107,7 @@ impl JobQueue {
             // in the job definitions module, but this works.
             return Some(match job_kind {
                 AttributeValueBasedJobIdentifier::DependentValuesUpdate => {
-                    DependentValuesUpdate::new(
-                        access_builder,
-                        Visibility::new(change_set_id),
-                        ids.into_iter().collect(),
-                    )
+                    DependentValuesUpdate::new(access_builder, Visibility::new(change_set_id))
                 }
                 AttributeValueBasedJobIdentifier::ComputeValidation => ComputeValidation::new(
                     access_builder,

--- a/lib/dal/src/module.rs
+++ b/lib/dal/src/module.rs
@@ -143,7 +143,7 @@ impl Module {
         workspace_snapshot.add_node(node_weight).await?;
 
         let schema_module_index_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::Module)
+            .get_category_node_or_err(None, CategoryNodeKind::Module)
             .await?;
         workspace_snapshot
             .add_edge(
@@ -183,7 +183,7 @@ impl Module {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let module_node_indices = {
             let module_category_index_id = workspace_snapshot
-                .get_category_node(None, CategoryNodeKind::Module)
+                .get_category_node_or_err(None, CategoryNodeKind::Module)
                 .await?;
             workspace_snapshot
                 .outgoing_targets_for_edge_weight_kind(
@@ -285,7 +285,7 @@ impl Module {
 
         let mut modules = vec![];
         let module_category_index_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::Module)
+            .get_category_node_or_err(None, CategoryNodeKind::Module)
             .await?;
 
         let module_node_indices = workspace_snapshot

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -133,7 +133,7 @@ impl Schema {
         workspace_snapshot.add_node(node_weight).await?;
 
         let schema_category_index_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::Schema)
+            .get_category_node_or_err(None, CategoryNodeKind::Schema)
             .await?;
         workspace_snapshot
             .add_edge(
@@ -315,7 +315,7 @@ impl Schema {
 
         let mut schemas = vec![];
         let schema_category_index_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::Schema)
+            .get_category_node_or_err(None, CategoryNodeKind::Schema)
             .await?;
 
         let schema_node_indices = workspace_snapshot
@@ -364,7 +364,7 @@ impl Schema {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let schema_category_index_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::Schema)
+            .get_category_node_or_err(None, CategoryNodeKind::Schema)
             .await?;
         let schema_node_indices = workspace_snapshot
             .outgoing_targets_for_edge_weight_kind(
@@ -390,7 +390,7 @@ impl Schema {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let schema_node_indices = {
             let schema_category_index_id = workspace_snapshot
-                .get_category_node(None, CategoryNodeKind::Schema)
+                .get_category_node_or_err(None, CategoryNodeKind::Schema)
                 .await?;
             workspace_snapshot
                 .outgoing_targets_for_edge_weight_kind(

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -263,7 +263,7 @@ impl Secret {
 
         // Root --> Secret Category --> Secret (this)
         let secret_category_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::Secret)
+            .get_category_node_or_err(None, CategoryNodeKind::Secret)
             .await?;
         Self::add_category_edge(
             ctx,
@@ -382,7 +382,8 @@ impl Secret {
             .await?
             .set_value_from_secret_id(ctx, secret_id)
             .await?;
-        ctx.enqueue_dependent_values_update(vec![secret_id]).await?;
+        ctx.add_dependent_values_and_enqueue(vec![secret_id])
+            .await?;
 
         Ok(())
     }
@@ -499,7 +500,7 @@ impl Secret {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let secret_category_node_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::Secret)
+            .get_category_node_or_err(None, CategoryNodeKind::Secret)
             .await?;
 
         let indices = workspace_snapshot
@@ -530,7 +531,7 @@ impl Secret {
 
         let mut secrets = vec![];
         let secret_category_node_id = workspace_snapshot
-            .get_category_node(None, CategoryNodeKind::Secret)
+            .get_category_node_or_err(None, CategoryNodeKind::Secret)
             .await?;
 
         let secret_node_indices = workspace_snapshot
@@ -607,7 +608,7 @@ impl Secret {
 
         // Since we are updating encrypted contents, we have a new key and need to enqueue ourselves
         // into dependent values update.
-        ctx.enqueue_dependent_values_update(vec![self.id]).await?;
+        ctx.add_dependent_values_and_enqueue(vec![self.id]).await?;
 
         self.modify(ctx, |s| {
             s.encrypted_secret_key = new_key;

--- a/lib/dal/src/workspace_snapshot/update.rs
+++ b/lib/dal/src/workspace_snapshot/update.rs
@@ -1,9 +1,9 @@
 use petgraph::prelude::*;
+use si_events::ulid::Ulid;
 
 use super::edge_weight::{EdgeWeight, EdgeWeightKindDiscriminants};
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub enum Update {
     NewEdge {
@@ -24,5 +24,9 @@ pub enum Update {
         // Check if already exists in "onto". Grab node weight from "to_rebase" and see if there is
         // an equivalent node (id and lineage) in "onto". If not, use "import_subgraph".
         to_rebase: NodeIndex,
+    },
+    MergeCategoryNodes {
+        to_rebase_category_id: Ulid,
+        onto_category_id: Ulid,
     },
 }

--- a/lib/rebaser-server/src/change_set_requests/handlers.rs
+++ b/lib/rebaser-server/src/change_set_requests/handlers.rs
@@ -128,13 +128,6 @@ pub async fn process_request(State(state): State<AppState>, msg: InnerMessage) -
         .await
         .map_err(HandlerError::SendRebaseFinished)?;
 
-    // only enqueue values if rebase succeeded. if it failed, there's no work to do
-    if let RebaseStatus::Success { .. } = rebase_status {
-        if let Some(values) = message.payload.dvu_values {
-            state.dvu_debouncer.enqueue_values(values);
-        }
-    }
-
     let mut event =
         WsEvent::change_set_written(&ctx, message.payload.to_rebase_change_set_id.into()).await?;
     event.set_workspace_pk(message.metadata.tenancy.workspace_pk.into_inner().into());

--- a/lib/rebaser-server/src/dvu_debouncer.rs
+++ b/lib/rebaser-server/src/dvu_debouncer.rs
@@ -1,21 +1,14 @@
 //! A per-changeset task to debounce dependent values updates
 
-use std::{collections::HashSet, sync::Arc};
-
-use dal::{DalContextBuilder, Tenancy, TransactionsError, Visibility};
+use dal::{DalContextBuilder, Tenancy, TransactionsError, Visibility, WorkspaceSnapshotError};
 use si_events::{ChangeSetId, WorkspacePk};
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::{
     select,
-    sync::{
-        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
-        Mutex,
-    },
     time::{interval, Duration},
 };
 use tokio_util::sync::CancellationToken;
-use ulid::Ulid;
 
 const DVU_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -25,30 +18,17 @@ pub enum DvuDebouncerError {
     /// A transactions error
     #[error("Transactions error: {0}")]
     Transactions(#[from] TransactionsError),
+    /// Workspace Snapshot Error
+    #[error("workspace snapshot: {0}")]
+    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
 }
 
 /// DvuDebouncer result type
 type DvuDebouncerResult<T> = Result<T, DvuDebouncerError>;
 
-/// Messages to the value management task
-#[derive(Debug)]
-enum ValueTaskMessage {
-    /// Enqueue values into the debouncer
-    EnqueueValues(Vec<Ulid>),
-}
-
-/// Messages to DVU spawner task
-#[derive(Debug)]
-enum DvuTaskMessage {
-    Dvu(Vec<Ulid>),
-}
-
 /// The DVU debouncer
 #[derive(Clone, Debug)]
 pub struct DvuDebouncer {
-    values: Arc<Mutex<HashSet<Ulid>>>,
-    value_tx: UnboundedSender<ValueTaskMessage>,
-    dvu_tx: UnboundedSender<DvuTaskMessage>,
     cancellation_token: CancellationToken,
     workspace_id: WorkspacePk,
     change_set_id: ChangeSetId,
@@ -56,24 +36,14 @@ pub struct DvuDebouncer {
 }
 
 impl DvuDebouncer {
-    /// Create a new DvuDebouncer. Spawns two long running tasks. One receives
-    /// and dedupes values, and enqueues jobs using the values on an interval.
-    /// The other processes the DVU job queue serially, as it receives messages.
+    /// Create a new dvu debouncer task
     pub fn new(
         workspace_id: WorkspacePk,
         change_set_id: ChangeSetId,
         cancellation_token: CancellationToken,
         ctx_builder: DalContextBuilder,
     ) -> Self {
-        let values = Arc::new(Mutex::new(Default::default()));
-
-        let (value_tx, value_rx) = unbounded_channel();
-        let (dvu_tx, dvu_rx) = unbounded_channel();
-
         let debouncer = Self {
-            values,
-            value_tx,
-            dvu_tx,
             cancellation_token,
             workspace_id,
             change_set_id,
@@ -81,89 +51,37 @@ impl DvuDebouncer {
         };
 
         let debouncer_clone = debouncer.clone();
-        let debouncer_clone_2 = debouncer.clone();
 
-        tokio::task::spawn(async { dvu_task(debouncer_clone, dvu_rx).await });
-        tokio::task::spawn(async { debouncer_task(debouncer_clone_2, value_rx).await });
+        tokio::task::spawn(async { ticker(debouncer_clone).await });
 
         debouncer
     }
 
-    /// Send a message to this debouncer's task
-    pub fn enqueue_values(&self, values: Vec<Ulid>) {
-        // Send only fails if the receiver end has gone away
-        if let Err(err) = self.value_tx.send(ValueTaskMessage::EnqueueValues(values)) {
-            error!(error = ?err, "Failed to enqueue values for dependent values update, receiver is closed");
-        }
-    }
-
-    async fn handle_enqueue_values(&self, new_values: &[Ulid]) {
-        let mut values = self.values.lock().await;
-        for value in new_values {
-            values.insert(*value);
-        }
-    }
-
-    async fn drain_values(&self) -> Option<Vec<Ulid>> {
-        let mut values = self.values.lock().await;
-        if values.is_empty() {
-            None
-        } else {
-            let current_values = values.clone();
-            *values = HashSet::new();
-            Some(current_values.into_iter().collect())
-        }
-    }
-
-    async fn enqueue_dependent_values_update(&self) {
-        if let Some(values) = self.drain_values().await {
-            if let Err(err) = self.dvu_tx.send(DvuTaskMessage::Dvu(values)) {
-                error!(error = ?err, "Failed to enqueue dependent values update, receiver is closed");
-            }
-        }
-    }
-
-    async fn handle_dependent_values_update(&self, values: Vec<Ulid>) -> DvuDebouncerResult<()> {
+    async fn run_dvu_if_values_pending(&self) -> DvuDebouncerResult<()> {
         let mut ctx = self.ctx_builder.build_default().await?;
 
         ctx.update_visibility_deprecated(Visibility::new(self.change_set_id.into_inner().into()));
         ctx.update_tenancy(Tenancy::new(self.workspace_id.into_inner().into()));
-
-        ctx.enqueue_dependent_values_update(values.into_iter().collect())
-            .await?;
-
-        // the pinga job will do the rebase
-        ctx.blocking_commit_no_rebase().await?;
+        ctx.update_snapshot_to_visibility().await?;
+        if ctx
+            .workspace_snapshot()?
+            .has_dependent_value_roots()
+            .await?
+        {
+            info!(
+                "enqueuing dependent_values_update for {}",
+                self.change_set_id
+            );
+            ctx.enqueue_dependent_values_update().await?;
+            ctx.blocking_commit_no_rebase().await?;
+        }
 
         Ok(())
     }
 }
 
-/// This task executes dependent values update jobs in serial
-async fn dvu_task(debouncer: DvuDebouncer, mut rx: UnboundedReceiver<DvuTaskMessage>) {
-    info!("booting dvu handler task for {}", &debouncer.change_set_id,);
-    loop {
-        select! {
-            _ = debouncer.cancellation_token.cancelled() => {
-                info!("DVU debouncer: DVU task received cancellation message");
-                return;
-            }
-            Some(message) = rx.recv() => {
-                match message {
-                    DvuTaskMessage::Dvu(values) => {
-                        info!("Enqueueing dependent values update job for {} values on change set {}", values.len(), debouncer.change_set_id);
-                        if let Err(err) = debouncer.handle_dependent_values_update(values).await {
-                            error!(error = ?err, "Attempt to enqueue dependent values update job failed");
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-async fn debouncer_task(debouncer: DvuDebouncer, mut rx: UnboundedReceiver<ValueTaskMessage>) {
-    info!("booting dvu values task for {}", &debouncer.change_set_id,);
+async fn ticker(debouncer: DvuDebouncer) {
+    info!("booting dvu task for {}", &debouncer.change_set_id,);
 
     let mut ticker = interval(DVU_INTERVAL);
 
@@ -175,13 +93,9 @@ async fn debouncer_task(debouncer: DvuDebouncer, mut rx: UnboundedReceiver<Value
                 return;
             }
             _ = ticker.tick() => {
-                debouncer.enqueue_dependent_values_update().await;
-            }
-            Some(message) = rx.recv() => {
-                match message {
-                    ValueTaskMessage::EnqueueValues(values) => {
-                        debouncer.handle_enqueue_values(&values).await;
-                    }
+                // This will block, in which case we'll just run again on the next tick
+                if let Err(err) = debouncer.run_dvu_if_values_pending().await {
+                    error!(error = ?err, "Attempt to run dependent values update job failed for changeset {}", debouncer.change_set_id);
                 }
             }
         }

--- a/lib/si-layer-cache/src/activities/rebase.rs
+++ b/lib/si-layer-cache/src/activities/rebase.rs
@@ -25,8 +25,7 @@ pub struct RebaseRequest {
     /// last change set before edits were made, or the change set that you are trying to rebase
     /// onto base.
     pub onto_vector_clock_id: Ulid,
-    /// A set of values that have changed, and need to have the impact of their
-    /// change reflected downstream of them by the dependent values update job
+    /// DEPRECATED: We have to hang on to this to ensure we can deserialize this message
     pub dvu_values: Option<Vec<Ulid>>,
 }
 
@@ -35,13 +34,12 @@ impl RebaseRequest {
         to_rebase_change_set_id: Ulid,
         onto_workspace_snapshot_address: WorkspaceSnapshotAddress,
         onto_vector_clock_id: Ulid,
-        dvu_values: Option<Vec<Ulid>>,
     ) -> RebaseRequest {
         RebaseRequest {
             to_rebase_change_set_id,
             onto_workspace_snapshot_address,
             onto_vector_clock_id,
-            dvu_values,
+            dvu_values: None,
         }
     }
 }
@@ -120,14 +118,12 @@ impl<'a> ActivityRebase<'a> {
         to_rebase_change_set_id: Ulid,
         onto_workspace_snapshot_address: WorkspaceSnapshotAddress,
         onto_vector_clock_id: Ulid,
-        dvu_values: Option<Vec<Ulid>>,
         metadata: LayeredEventMetadata,
     ) -> LayerDbResult<Activity> {
         let payload = RebaseRequest::new(
             to_rebase_change_set_id,
             onto_workspace_snapshot_address,
             onto_vector_clock_id,
-            dvu_values,
         );
         let activity = Activity::rebase(payload, metadata);
         self.activity_base.publish(&activity).await?;
@@ -140,14 +136,12 @@ impl<'a> ActivityRebase<'a> {
         to_rebase_change_set_id: Ulid,
         onto_workspace_snapshot_address: WorkspaceSnapshotAddress,
         onto_vector_clock_id: Ulid,
-        dvu_values: Option<Vec<Ulid>>,
         metadata: LayeredEventMetadata,
     ) -> LayerDbResult<Activity> {
         let payload = RebaseRequest::new(
             to_rebase_change_set_id,
             onto_workspace_snapshot_address,
             onto_vector_clock_id,
-            dvu_values,
         );
         let activity = Activity::rebase(payload, metadata);
         // println!("trigger: sending rebase and waiting for response");

--- a/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
@@ -86,7 +86,6 @@ async fn subscribe_rebaser_requests_work_queue() {
             Ulid::new(),
             WorkspaceSnapshotAddress::new(b"poop"),
             Ulid::new(),
-            None,
             metadata.clone(),
         )
         .await
@@ -202,7 +201,6 @@ async fn rebase_and_wait() {
                 Ulid::new(),
                 WorkspaceSnapshotAddress::new(b"poop"),
                 Ulid::new(),
-                None,
                 metadata_for_task,
             )
             .await
@@ -339,7 +337,6 @@ async fn rebase_requests_work_queue_stress() {
                     Ulid::new(),
                     WorkspaceSnapshotAddress::new(b"poop"),
                     Ulid::new(),
-                    None,
                     send_meta.clone(),
                 )
                 .await
@@ -495,7 +492,6 @@ async fn rebase_and_wait_stress() {
                         Ulid::new(),
                         WorkspaceSnapshotAddress::new(b"poop"),
                         Ulid::new(),
-                        None,
                         mp,
                     )
                     .await;


### PR DESCRIPTION
Instead of sending the set of values to use as the starting point for calculating the dependent value graph in the DependentValuesUpdate job, place those values on the graph off a new category node. Then, when the job executes them, remove them from the graph.