### PR TITLE
fix(dal): do less work in replace references

### DIFF
--- a/lib/dal/src/workspace_snapshot/graph/tests.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests.rs
@@ -218,7 +218,11 @@ mod test {
                 source.unwrap_or("root"),
                 target
             );
+
+            assert!(graph.has_path_to_root(source_idx));
+            assert!(graph.has_path_to_root(target_idx));
         }
+        assert!(graph.is_acyclic_directed());
 
         for (_, id) in node_id_map.iter() {
             let idx_for_node = graph


### PR DESCRIPTION
Replace references was doing too much work. This restores it to almost its original logic, without breaking the multiply parented nodes tests (or any others). I believe the issue fixed by the more complicated logic was actually out of date node indexes, and the extra walks were just duplicating work.