### PR TITLE
First Pass Actions Endpoints

### DIFF
--- a/app/web/src/store/actions.store.ts
+++ b/app/web/src/store/actions.store.ts
@@ -342,7 +342,7 @@ export const useActionsStore = () => {
               url: "action/put_on_hold",
               keyRequestStatusBy: id,
               params: {
-                id,
+                ids: [id],
                 visibility_change_set_pk: changeSetId,
               },
             });
@@ -353,7 +353,7 @@ export const useActionsStore = () => {
               url: "action/cancel",
               keyRequestStatusBy: id,
               params: {
-                id,
+                ids: [id],
                 visibility_change_set_pk: changeSetId,
               },
             });

--- a/lib/dal/src/dependency_graph.rs
+++ b/lib/dal/src/dependency_graph.rs
@@ -60,6 +60,17 @@ impl<T: Copy + std::cmp::Eq + std::cmp::PartialEq + std::hash::Hash> DependencyG
         }
     }
 
+    pub fn direct_reverse_dependencies_of(&self, id: T) -> Vec<T> {
+        match self.id_to_index_map.get(&id) {
+            None => vec![],
+            Some(value_idx) => self
+                .graph
+                .edges_directed(*value_idx, Incoming)
+                .filter_map(|edge_ref| self.graph.node_weight(edge_ref.source()).copied())
+                .collect(),
+        }
+    }
+
     pub fn remove_id(&mut self, id: T) {
         if let Some(node_idx) = self.id_to_index_map.remove(&id) {
             self.graph.remove_node(node_idx);

--- a/lib/sdf-server/src/server/service/action/cancel.rs
+++ b/lib/sdf-server/src/server/service/action/cancel.rs
@@ -10,28 +10,30 @@ use crate::service::action::ActionError;
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct PutOnHoldRequest {
-    id: ActionId,
+    pub ids: Vec<ActionId>,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
-
+// batched
 pub async fn cancel(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
     Json(request): Json<PutOnHoldRequest>,
 ) -> ActionResult<()> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+    for action_id in request.ids {
+        let action = Action::get_by_id(&ctx, action_id).await?;
 
-    let action = Action::get_by_id(&ctx, request.id).await?;
-
-    match action.state() {
-        ActionState::Running | ActionState::Dispatched => {
-            return Err(ActionError::InvalidActionCancellation(request.id))
+        match action.state() {
+            ActionState::Running | ActionState::Dispatched => {
+                return Err(ActionError::InvalidActionCancellation(action_id))
+            }
+            ActionState::Failed | ActionState::OnHold | ActionState::Queued => {}
         }
-        ActionState::Failed | ActionState::OnHold | ActionState::Queued => {}
-    }
 
-    Action::remove_by_id(&ctx, action.id()).await?;
+        Action::remove_by_id(&ctx, action.id()).await?;
+        // todo add wsevent here
+    }
 
     ctx.commit().await?;
 

--- a/lib/sdf-server/src/server/service/change_set/add_action.rs
+++ b/lib/sdf-server/src/server/service/change_set/add_action.rs
@@ -53,6 +53,7 @@ pub async fn add_action(
                 "change_set_id": ctx.change_set_id(),
             }),
         );
+        // todo add ws event here
     } else {
         let action =
             DeprecatedAction::upsert(&ctx, request.prototype_id, request.component_id).await?;


### PR DESCRIPTION
Allow on_hold and cancel to be passed multiple ActionIds, hydrate ActionView to include dependents, dependencies, and the list of actions influencing this status.

<div><img src="https://media0.giphy.com/media/26DOMQa5Ib2SmaRZm/giphy.gif?cid=5a38a5a2p4b32t6xmeqpp33mmven2igvg1vr22jfh9b3x6al&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:207px;width:300px"/><br/>via <a href="https://giphy.com/alexanderirl/">Alexander IRL</a> on <a href="https://giphy.com/gifs/alexanderirl-alexander-irl-26DOMQa5Ib2SmaRZm">GIPHY</a></div>