### PR TITLE
feat(layerdb): support eviction for workspace snapshots

### DIFF
--- a/lib/si-layer-cache/src/db/cache_updates.rs
+++ b/lib/si-layer-cache/src/db/cache_updates.rs
@@ -168,6 +168,11 @@ where
                         .await?;
                 }
             }
+            crate::event::LayeredEventKind::SnapshotEvict => {
+                self.snapshot_cache
+                    .evict_from_cache_updates(event.key)
+                    .await?;
+            }
         }
         Ok(())
     }

--- a/lib/si-layer-cache/src/disk_cache.rs
+++ b/lib/si-layer-cache/src/disk_cache.rs
@@ -66,4 +66,9 @@ impl DiskCache {
             .await?;
         Ok(())
     }
+
+    pub async fn remove_from_disk(&self, event: Arc<LayeredEvent>) -> LayerDbResult<()> {
+        self.remove(event.payload.key.clone()).await?;
+        Ok(())
+    }
 }

--- a/lib/si-layer-cache/src/event.rs
+++ b/lib/si-layer-cache/src/event.rs
@@ -95,6 +95,7 @@ pub enum LayeredEventKind {
     CasInsertion,
     EncryptedSecretInsertion,
     Raw,
+    SnapshotEvict,
     SnapshotWrite,
 }
 

--- a/lib/si-layer-cache/src/layer_cache.rs
+++ b/lib/si-layer-cache/src/layer_cache.rs
@@ -185,4 +185,10 @@ where
         self.spawn_disk_cache_write_vec(key.clone(), serialize_value)
             .await
     }
+
+    pub async fn evict_from_cache_updates(&self, key: Arc<str>) -> LayerDbResult<()> {
+        self.memory_cache().remove(&key).await;
+        self.disk_cache().remove(key).await?;
+        Ok(())
+    }
 }

--- a/lib/si-layer-cache/tests/integration_test/db/mod.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/mod.rs
@@ -1,2 +1,3 @@
 mod cas;
 mod func_execution;
+mod workspace_snapshot;

--- a/lib/si-layer-cache/tests/integration_test/db/workspace_snapshot.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/workspace_snapshot.rs
@@ -1,0 +1,359 @@
+use si_layer_cache::memory_cache::MemoryCacheConfig;
+use std::{sync::Arc, time::Duration};
+
+use si_events::{Actor, ChangeSetId, Tenancy, UserPk, WorkspacePk};
+use si_layer_cache::db::serialize;
+use si_layer_cache::{persister::PersistStatus, LayerDb};
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+use crate::integration_test::{disk_cache_path, setup_nats_client, setup_pg_db};
+
+type TestLayerDb = LayerDb<String, String, String>;
+
+#[tokio::test]
+async fn write_to_db() {
+    let token = CancellationToken::new();
+
+    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
+    let dbfile = disk_cache_path(&tempdir, "slash");
+    let (ldb, _): (TestLayerDb, _) = LayerDb::from_services(
+        dbfile,
+        setup_pg_db("workspace_snapshot_write_to_db").await,
+        setup_nats_client(Some("workspace_snapshot_write_to_db".to_string())).await,
+        MemoryCacheConfig::default(),
+        token,
+    )
+    .await
+    .expect("cannot create layerdb");
+    ldb.pg_migrate().await.expect("migrate layer db");
+
+    let value: Arc<String> = Arc::new("pantera".into());
+    let (key, status) = ldb
+        .workspace_snapshot()
+        .write(
+            value.clone(),
+            None,
+            Tenancy::new(WorkspacePk::new(), ChangeSetId::new()),
+            Actor::User(UserPk::new()),
+        )
+        .await
+        .expect("failed to write to layerdb");
+
+    match status.get_status().await.expect("failed to get status") {
+        PersistStatus::Finished => {}
+        PersistStatus::Error(e) => panic!("Write failed; {e}"),
+    }
+
+    let key_str: Arc<str> = key.to_string().into();
+
+    // Are we in memory?
+    let in_memory = ldb
+        .workspace_snapshot()
+        .cache
+        .memory_cache()
+        .get(&key_str)
+        .await;
+    assert_eq!(Some(value.clone()), in_memory);
+
+    // Are we on disk?
+    let on_disk_postcard = ldb
+        .workspace_snapshot()
+        .cache
+        .disk_cache()
+        .get(key_str.clone())
+        .await
+        .expect("cannot get from disk cache");
+    let on_disk: String =
+        serialize::from_bytes(&on_disk_postcard[..]).expect("cannot deserialize data");
+    assert_eq!(value.as_ref(), &on_disk);
+
+    // Are we in pg?
+    let in_pg_postcard = ldb
+        .workspace_snapshot()
+        .cache
+        .pg()
+        .get(&key_str)
+        .await
+        .expect("error getting data from pg")
+        .expect("no cas object in pg");
+    let in_pg: String =
+        serialize::from_bytes(&in_pg_postcard[..]).expect("cannot deserialize data");
+    assert_eq!(value.as_ref(), &in_pg);
+}
+
+#[tokio::test]
+async fn evict_from_db() {
+    let token = CancellationToken::new();
+
+    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
+    let dbfile = disk_cache_path(&tempdir, "slash");
+    let (ldb, _): (TestLayerDb, _) = LayerDb::from_services(
+        dbfile,
+        setup_pg_db("workspace_snapshot_evict_from_db").await,
+        setup_nats_client(Some("workspace_snapshot_evict_from_db".to_string())).await,
+        MemoryCacheConfig::default(),
+        token,
+    )
+    .await
+    .expect("cannot create layerdb");
+    ldb.pg_migrate().await.expect("migrate layer db");
+
+    let value: Arc<String> = Arc::new("pantera".into());
+    let (key, status) = ldb
+        .workspace_snapshot()
+        .write(
+            value.clone(),
+            None,
+            Tenancy::new(WorkspacePk::new(), ChangeSetId::new()),
+            Actor::User(UserPk::new()),
+        )
+        .await
+        .expect("failed to write to layerdb");
+
+    match status.get_status().await.expect("failed to get status") {
+        PersistStatus::Finished => {}
+        PersistStatus::Error(e) => panic!("Write failed; {e}"),
+    }
+
+    let key_str: Arc<str> = key.to_string().into();
+
+    let status = ldb
+        .workspace_snapshot()
+        .evict(
+            &key,
+            Tenancy::new(WorkspacePk::new(), ChangeSetId::new()),
+            Actor::System,
+        )
+        .await
+        .expect("cannot evict local data");
+    match status.get_status().await.expect("failed to get status") {
+        PersistStatus::Finished => {}
+        PersistStatus::Error(e) => panic!("Eviction failed; {e}"),
+    }
+
+    // Are we in memory?
+    let in_memory = ldb
+        .workspace_snapshot()
+        .cache
+        .memory_cache()
+        .get(&key_str)
+        .await;
+    assert_ne!(Some(value.clone()), in_memory);
+
+    // Are we on disk?
+    assert!(
+        ldb.workspace_snapshot()
+            .cache
+            .disk_cache()
+            .get(key_str.clone())
+            .await
+            .is_err(),
+        "found item on disk when it should have been evicted"
+    );
+
+    // Are we in pg?
+    assert!(
+        ldb.workspace_snapshot()
+            .cache
+            .pg()
+            .get(&key_str)
+            .await
+            .expect("error getting data from pg")
+            .is_none(),
+        "found item in database when it should have been evicted"
+    );
+}
+
+#[tokio::test]
+async fn evictions_are_gossiped() {
+    let token = CancellationToken::new();
+
+    let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
+
+    let tempdir_slash = disk_cache_path(&tempdir, "slash");
+    let tempdir_axl = disk_cache_path(&tempdir, "axl");
+
+    let db = setup_pg_db("workspace_snapshot_evictions_are_gossiped").await;
+
+    // First, we need a layerdb for slash
+    let (ldb_slash, _): (TestLayerDb, _) = LayerDb::from_services(
+        tempdir_slash,
+        db.clone(),
+        setup_nats_client(Some(
+            "workspace_snapshot_evictions_are_gossiped".to_string(),
+        ))
+        .await,
+        MemoryCacheConfig::default(),
+        token.clone(),
+    )
+    .await
+    .expect("cannot create layerdb");
+    ldb_slash.pg_migrate().await.expect("migrate layerdb");
+
+    // Then, we need a layerdb for axl
+    let (ldb_axl, _): (TestLayerDb, _) = LayerDb::from_services(
+        tempdir_axl,
+        db,
+        setup_nats_client(Some(
+            "workspace_snapshot_evictions_are_gossiped".to_string(),
+        ))
+        .await,
+        MemoryCacheConfig::default(),
+        token,
+    )
+    .await
+    .expect("cannot create layerdb");
+    ldb_axl.pg_migrate().await.expect("migrate layerdb");
+
+    let value: Arc<String> = Arc::new("pantera".into());
+    let (key, status) = ldb_slash
+        .workspace_snapshot()
+        .write(
+            value.clone(),
+            None,
+            Tenancy::new(WorkspacePk::new(), ChangeSetId::new()),
+            Actor::User(UserPk::new()),
+        )
+        .await
+        .expect("failed to write to layerdb");
+    assert!(
+        matches!(
+            status.get_status().await.expect("failed to get status"),
+            PersistStatus::Finished
+        ),
+        "persister failed"
+    );
+
+    let pk_str: Arc<str> = key.to_string().into();
+
+    let max_check_count = 10;
+
+    let mut memory_check_count = 0;
+    while memory_check_count <= max_check_count {
+        let in_memory = ldb_axl
+            .workspace_snapshot()
+            .cache
+            .memory_cache()
+            .get(&pk_str)
+            .await;
+        match in_memory {
+            Some(value) => {
+                assert_eq!(value.clone(), value);
+                break;
+            }
+            None => {
+                memory_check_count += 1;
+                tokio::time::sleep_until(Instant::now() + Duration::from_millis(1)).await;
+            }
+        }
+    }
+    assert_ne!(
+        max_check_count, memory_check_count,
+        "value did not arrive in the remote memory cache within 10ms"
+    );
+
+    // Are we on disk?
+    let mut disk_check_count = 0;
+    while disk_check_count <= max_check_count {
+        match ldb_axl
+            .workspace_snapshot()
+            .cache
+            .disk_cache()
+            .get(pk_str.clone())
+            .await
+        {
+            Ok(on_disk_postcard) => {
+                let on_disk: String =
+                    serialize::from_bytes(&on_disk_postcard[..]).expect("cannot deserialize data");
+                assert_eq!(value.as_ref(), &on_disk);
+                break;
+            }
+            Err(_e) => {
+                disk_check_count += 1;
+                tokio::time::sleep_until(Instant::now() + Duration::from_millis(1)).await;
+            }
+        }
+    }
+    assert_ne!(
+        max_check_count, memory_check_count,
+        "value did not arrive in the remote disk cache within 10ms"
+    );
+
+    // Are we in pg?
+    let in_pg_postcard = ldb_axl
+        .workspace_snapshot()
+        .cache
+        .pg()
+        .get(&pk_str)
+        .await
+        .expect("error getting data from pg")
+        .expect("no cas object in pg");
+    let in_pg: String =
+        serialize::from_bytes(&in_pg_postcard[..]).expect("cannot deserialize data");
+    assert_eq!(value.as_ref(), &in_pg);
+
+    // Evict!
+    let status = ldb_slash
+        .workspace_snapshot()
+        .evict(
+            &key,
+            Tenancy::new(WorkspacePk::new(), ChangeSetId::new()),
+            Actor::System,
+        )
+        .await
+        .expect("cannot evict local data");
+    match status.get_status().await.expect("failed to get status") {
+        PersistStatus::Finished => {}
+        PersistStatus::Error(e) => panic!("Eviction failed; {e}"),
+    }
+
+    let max_check_count = 10;
+
+    let mut memory_check_count = 0;
+    while memory_check_count < max_check_count {
+        let in_memory = ldb_axl
+            .workspace_snapshot()
+            .cache
+            .memory_cache()
+            .get(&pk_str)
+            .await;
+        match in_memory {
+            Some(_value) => {
+                memory_check_count += 1;
+                tokio::time::sleep_until(Instant::now() + Duration::from_millis(1)).await;
+            }
+            None => {
+                break;
+            }
+        }
+    }
+    assert_ne!(
+        max_check_count, memory_check_count,
+        "value did not evict from the remote memory cache within 10ms"
+    );
+
+    // Are we on disk?
+    let mut disk_check_count = 0;
+    while disk_check_count < max_check_count {
+        match ldb_axl
+            .workspace_snapshot()
+            .cache
+            .disk_cache()
+            .get(pk_str.clone())
+            .await
+        {
+            Ok(_on_disk_postcard) => {
+                disk_check_count += 1;
+                tokio::time::sleep_until(Instant::now() + Duration::from_millis(1)).await;
+            }
+            Err(_e) => {
+                break;
+            }
+        }
+    }
+    assert_ne!(
+        max_check_count, disk_check_count,
+        "value did not evict from the remote disk cache within 10ms"
+    );
+}

--- a/lib/si-layer-cache/tests/integration_test/disk_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/disk_cache.rs
@@ -23,3 +23,34 @@ async fn insert_and_get() {
         .expect("cannot get object from disk");
     assert_eq!(&result[..], b"slave to the grind");
 }
+
+#[tokio::test]
+async fn insert_and_remove() {
+    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
+    let disk_cache: DiskCache =
+        DiskCache::new(tempdir.path(), "random?").expect("cannot create disk cache");
+
+    disk_cache
+        .insert("skid row".into(), b"slave to the grind".to_vec())
+        .await
+        .expect("cannot insert object");
+    disk_cache
+        .get("skid row".into())
+        .await
+        .expect("cannot get object from disk");
+    disk_cache
+        .remove("skid row".into())
+        .await
+        .expect("cannot remove object from disk");
+}
+
+#[tokio::test]
+async fn remove_never_inserted_object() {
+    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
+    let disk_cache: DiskCache =
+        DiskCache::new(tempdir.path(), "random?").expect("cannot create disk cache");
+    disk_cache
+        .remove("skid row".into())
+        .await
+        .expect("cannot remove object from disk");
+}


### PR DESCRIPTION
This adds workspace snapshot eviction. The layerdb instance that calls evict will delete the entry from memory, disk, and postgres, and send an eviction event to all other layerdb instances. Those instances will then evict from memory and disk.

If we find ourselves adding a lot more eviction style calls, we need to refactor the layered event structure - right now, it always expects a value, and it's theoretically type safe to pass the wrong kind of layeredevent between eviction and writing. (It may be type safe, but it would be very hard to do in practice, since you never assemble these things directly anyway)

<img src="https://media4.giphy.com/media/3o6Mb6MYhk1fShAzx6/giphy.gif"/>