### PR TITLE
feat(dal, sdf): Add ability to create a note on the diagram

### DIFF
--- a/lib/dal/src/layer_db_types/content_types.rs
+++ b/lib/dal/src/layer_db_types/content_types.rs
@@ -34,6 +34,7 @@ pub enum ContentTypes {
     FuncArgument(FuncArgumentContent),
     InputSocket(InputSocketContent),
     Module(ModuleContent),
+    Note(NoteContent),
     Prop(PropContent),
     Schema(SchemaContent),
     SchemaVariant(SchemaVariantContent),
@@ -89,6 +90,7 @@ impl_into_content_types!(FuncArgument);
 impl_into_content_types!(InputSocket);
 impl_into_content_types!(OutputSocket);
 impl_into_content_types!(Module);
+impl_into_content_types!(Note);
 impl_into_content_types!(Prop);
 impl_into_content_types!(Schema);
 impl_into_content_types!(SchemaVariant);
@@ -277,6 +279,20 @@ pub struct ModuleContentV1 {
     pub description: String,
     pub created_by_email: String,
     pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, EnumDiscriminants, Serialize, Deserialize, PartialEq)]
+pub enum NoteContent {
+    V1(NoteContentV1),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct NoteContentV1 {
+    pub timestamp: Timestamp,
+    pub note: String,
+    pub x: String,
+    pub y: String,
+    pub created_by_email: String,
 }
 
 #[derive(Debug, Clone, EnumDiscriminants, Serialize, Deserialize, PartialEq)]

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -43,6 +43,7 @@ pub mod key_pair;
 pub mod label_list;
 pub mod layer_db_types;
 pub mod module;
+pub mod note;
 pub mod pkg;
 pub mod prop;
 pub mod property_editor;

--- a/lib/dal/src/note.rs
+++ b/lib/dal/src/note.rs
@@ -1,0 +1,207 @@
+use std::{collections::HashMap, sync::Arc};
+
+use serde::{Deserialize, Serialize};
+use si_events::ContentHash;
+use thiserror::Error;
+
+use crate::{
+    layer_db_types::{NoteContent, NoteContentV1},
+    pk,
+    workspace_snapshot::{
+        content_address::{ContentAddress, ContentAddressDiscriminants},
+        node_weight::{category_node_weight::CategoryNodeKind, NodeWeight, NodeWeightError},
+    },
+    ChangeSetError, DalContext, EdgeWeight, EdgeWeightError, EdgeWeightKind,
+    EdgeWeightKindDiscriminants, Timestamp, TransactionsError, WorkspaceSnapshotError,
+};
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum NoteError {
+    #[error("change set error: {0}")]
+    ChangeSet(#[from] ChangeSetError),
+    #[error("edge weight error: {0}")]
+    EdgeWeight(#[from] EdgeWeightError),
+    #[error("layer db error: {0}")]
+    LayerDb(#[from] si_layer_cache::LayerDbError),
+    #[error("node weight error: {0}")]
+    NodeWeight(#[from] NodeWeightError),
+    #[error("serde json error: {0}")]
+    Serde(#[from] serde_json::Error),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
+    #[error("could not acquire lock: {0}")]
+    TryLock(#[from] tokio::sync::TryLockError),
+    #[error("workspace snapshot error: {0}")]
+    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+}
+
+pub type NoteResult<T> = Result<T, NoteError>;
+
+pk!(NoteId);
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct Note {
+    id: NoteId,
+    #[serde(flatten)]
+    timestamp: Timestamp,
+    x: String,
+    y: String,
+    created_by_email: String,
+    note: String,
+}
+
+impl Note {
+    pub fn assemble(id: NoteId, inner: NoteContentV1) -> Self {
+        Self {
+            id,
+            timestamp: inner.timestamp,
+            x: inner.x,
+            y: inner.y,
+            created_by_email: inner.created_by_email,
+            note: inner.note,
+        }
+    }
+
+    pub fn id(&self) -> NoteId {
+        self.id
+    }
+
+    pub fn note(&self) -> String {
+        self.note.clone()
+    }
+
+    pub fn x(&self) -> String {
+        self.x.clone()
+    }
+
+    pub fn y(&self) -> String {
+        self.y.clone()
+    }
+
+    pub async fn new(
+        ctx: &DalContext,
+        x: String,
+        y: String,
+        note: String,
+        created_by_email: String,
+    ) -> NoteResult<Self> {
+        let timestamp = Timestamp::now();
+        let content = NoteContentV1 {
+            timestamp,
+            note,
+            x,
+            y,
+            created_by_email,
+        };
+
+        let (hash, _) = ctx
+            .layer_db()
+            .cas()
+            .write(
+                Arc::new(NoteContent::V1(content.clone()).into()),
+                None,
+                ctx.events_tenancy(),
+                ctx.events_actor(),
+            )
+            .await?;
+
+        let change_set = ctx.change_set()?;
+        let id = change_set.generate_ulid()?;
+        let node_weight = NodeWeight::new_content(change_set, id, ContentAddress::Note(hash))?;
+
+        let workspace_snapshot = ctx.workspace_snapshot()?;
+        workspace_snapshot.add_node(node_weight).await?;
+
+        let note_index_id = workspace_snapshot
+            .get_category_node(None, CategoryNodeKind::Note)
+            .await?;
+        workspace_snapshot
+            .add_edge(
+                note_index_id,
+                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
+                id,
+            )
+            .await?;
+
+        Ok(Note::assemble(id.into(), content))
+    }
+
+    pub async fn get_by_id(ctx: &DalContext, id: NoteId) -> NoteResult<Self> {
+        let workspace_snapshot = ctx.workspace_snapshot()?;
+
+        let ulid: si_events::ulid::Ulid = id.into();
+        let node_index = workspace_snapshot.get_node_index_by_id(ulid).await?;
+        let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
+        let hash = node_weight.content_hash();
+
+        let content: NoteContent = ctx
+            .layer_db()
+            .cas()
+            .try_read_as(&hash)
+            .await?
+            .ok_or(WorkspaceSnapshotError::MissingContentFromStore(ulid))?;
+
+        // If we had a v2, then there would be migration logic here.
+        let NoteContent::V1(inner) = content;
+
+        Ok(Note::assemble(id, inner))
+    }
+
+    pub async fn delete_by_id(ctx: &DalContext, id: NoteId) -> NoteResult<()> {
+        let workspace_snapshot = ctx.workspace_snapshot()?;
+        let change_set = ctx.change_set()?;
+        workspace_snapshot.remove_node_by_id(change_set, id).await?;
+
+        Ok(())
+    }
+
+    pub async fn list(ctx: &DalContext) -> NoteResult<Vec<Self>> {
+        let workspace_snapshot = ctx.workspace_snapshot()?;
+
+        let mut notes = vec![];
+        let note_category_index_id = workspace_snapshot
+            .get_category_node(None, CategoryNodeKind::Note)
+            .await?;
+
+        let note_node_indicies = workspace_snapshot
+            .outgoing_targets_for_edge_weight_kind(
+                note_category_index_id,
+                EdgeWeightKindDiscriminants::Use,
+            )
+            .await?;
+
+        let mut node_weights = vec![];
+        let mut content_hashes = vec![];
+
+        for note_index in note_node_indicies {
+            let node_weight = workspace_snapshot
+                .get_node_weight(note_index)
+                .await?
+                .get_content_node_weight_of_kind(ContentAddressDiscriminants::Note)?;
+            content_hashes.push(node_weight.content_hash());
+            node_weights.push(node_weight);
+        }
+
+        let content_map: HashMap<ContentHash, NoteContent> = ctx
+            .layer_db()
+            .cas()
+            .try_read_many_as(content_hashes.as_slice())
+            .await?;
+
+        for node_weight in node_weights {
+            match content_map.get(&node_weight.content_hash()) {
+                Some(note_content) => {
+                    let NoteContent::V1(inner) = note_content;
+
+                    notes.push(Self::assemble(node_weight.id().into(), inner.to_owned()))
+                }
+                None => Err(WorkspaceSnapshotError::MissingContentFromStore(
+                    node_weight.id(),
+                ))?,
+            }
+        }
+
+        Ok(notes)
+    }
+}

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -245,6 +245,7 @@ impl WorkspaceSnapshot {
         let secret_node_index = graph.add_category_node(change_set, CategoryNodeKind::Secret)?;
         let module_node_index = graph.add_category_node(change_set, CategoryNodeKind::Module)?;
         let action_node_index = graph.add_category_node(change_set, CategoryNodeKind::Action)?;
+        let notes_node_index = graph.add_category_node(change_set, CategoryNodeKind::Note)?;
 
         // Connect them to root.
         graph.add_edge(
@@ -281,6 +282,11 @@ impl WorkspaceSnapshot {
             graph.root(),
             EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
             action_node_index,
+        )?;
+        graph.add_edge(
+            graph.root(),
+            EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
+            notes_node_index,
         )?;
 
         // We do not care about any field other than "working_copy" because "write" will populate

--- a/lib/dal/src/workspace_snapshot/content_address.rs
+++ b/lib/dal/src/workspace_snapshot/content_address.rs
@@ -21,6 +21,7 @@ pub enum ContentAddress {
     InputSocket(ContentHash),
     JsonValue(ContentHash),
     Module(ContentHash),
+    Note(ContentHash),
     OutputSocket(ContentHash),
     Prop(ContentHash),
     Root,
@@ -48,6 +49,7 @@ impl ContentAddress {
             | ContentAddress::InputSocket(id)
             | ContentAddress::JsonValue(id)
             | ContentAddress::Module(id)
+            | ContentAddress::Note(id)
             | ContentAddress::Prop(id)
             | ContentAddress::Schema(id)
             | ContentAddress::SchemaVariant(id)

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -820,6 +820,7 @@ impl WorkspaceSnapshotGraph {
                             ContentAddressDiscriminants::InputSocket => "red",
                             ContentAddressDiscriminants::JsonValue => "fuchsia",
                             ContentAddressDiscriminants::Module => "yellow",
+                            ContentAddressDiscriminants::Note => "black",
                             ContentAddressDiscriminants::Prop => "orange",
                             ContentAddressDiscriminants::Root => "black",
                             ContentAddressDiscriminants::Schema => "black",
@@ -857,6 +858,7 @@ impl WorkspaceSnapshotGraph {
                         CategoryNodeKind::Schema => ("Schemas (Category)".to_string(), "black"),
                         CategoryNodeKind::Secret => ("Secrets (Category)".to_string(), "black"),
                         CategoryNodeKind::Module => ("Modules (Category)".to_string(), "black"),
+                        CategoryNodeKind::Note => ("Notes (Category)".to_string(), "black"),
                     },
                     NodeWeight::Component(component) => (
                         "Component".to_string(),

--- a/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
@@ -15,6 +15,7 @@ pub enum CategoryNodeKind {
     DeprecatedActionBatch,
     Func,
     Module,
+    Note,
     Schema,
     Secret,
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
@@ -141,6 +141,7 @@ impl ContentNodeWeight {
             ContentAddress::InputSocket(_) => ContentAddress::InputSocket(content_hash),
             ContentAddress::JsonValue(_) => ContentAddress::JsonValue(content_hash),
             ContentAddress::Module(_) => ContentAddress::Module(content_hash),
+            ContentAddress::Note(_) => ContentAddress::Note(content_hash),
             ContentAddress::Prop(_) => {
                 return Err(NodeWeightError::InvalidContentAddressForWeightKind(
                     "Prop".to_string(),

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -11,6 +11,7 @@ mod frame;
 mod func;
 mod input_sources;
 mod module;
+mod notes;
 mod prop;
 mod property_editor;
 mod rebaser;

--- a/lib/dal/tests/integration_test/notes.rs
+++ b/lib/dal/tests/integration_test/notes.rs
@@ -1,0 +1,29 @@
+use dal::{note::Note, DalContext};
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn note(ctx: &DalContext) {
+    let note_contents = "This is a demo note".to_string();
+    let x_coord = "100".to_string();
+    let y_coord = "100".to_string();
+    let created_by = "sally@systeminit.com".to_string();
+
+    let note = Note::new(
+        ctx,
+        x_coord.clone(),
+        y_coord.clone(),
+        note_contents.clone(),
+        created_by,
+    )
+    .await
+    .expect("unable to create note");
+
+    assert_eq!(note_contents, note.note());
+    assert_eq!(x_coord, note.x());
+    assert_eq!(y_coord, note.y());
+
+    let notes_in_changeset = Note::list(ctx).await.expect("Unable to list notes");
+
+    assert_eq!(1, notes_in_changeset.len());
+}

--- a/lib/sdf-server/src/server/service/diagram.rs
+++ b/lib/sdf-server/src/server/service/diagram.rs
@@ -7,6 +7,7 @@ use dal::attribute::prototype::argument::AttributePrototypeArgumentError;
 use dal::attribute::prototype::AttributePrototypeError;
 use dal::attribute::value::AttributeValueError;
 use dal::component::ComponentError;
+use dal::note::NoteError;
 use dal::socket::input::InputSocketError;
 use dal::socket::output::OutputSocketError;
 use dal::workspace_snapshot::WorkspaceSnapshotError;
@@ -28,6 +29,7 @@ pub mod set_component_position;
 
 pub mod delete_component;
 pub mod delete_connection;
+pub mod notes;
 pub mod paste_component;
 pub mod remove_delete_intent;
 
@@ -80,6 +82,8 @@ pub enum DiagramError {
     Nats(#[from] si_data_nats::NatsError),
     #[error("not authorized")]
     NotAuthorized,
+    #[error("note error: {0}")]
+    Note(#[from] NoteError),
     #[error("output socket error: {0}")]
     OutputSocket(#[from] OutputSocketError),
     #[error("parse float error: {0}")]
@@ -144,6 +148,8 @@ pub fn routes() -> Router<AppState> {
             "/create_component",
             post(create_component::create_component),
         )
+        .route("/create_note", post(notes::create_note))
+        .route("/delete_note", post(notes::delete_note))
         .route(
             "/set_component_position",
             post(set_component_position::set_component_position),

--- a/lib/sdf-server/src/server/service/diagram/notes.rs
+++ b/lib/sdf-server/src/server/service/diagram/notes.rs
@@ -1,0 +1,87 @@
+use axum::{extract::OriginalUri, response::IntoResponse, Json};
+use dal::{
+    note::{Note, NoteId},
+    ChangeSet, Visibility,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
+
+use super::DiagramResult;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateNoteRequest {
+    pub x: String,
+    pub y: String,
+    pub note: String,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateNoteResponse {
+    pub note_id: NoteId,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteNoteRequest {
+    pub id: NoteId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+pub async fn create_note(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(_posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    Json(request): Json<CreateNoteRequest>,
+) -> DiagramResult<impl IntoResponse> {
+    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
+
+    let note = Note::new(
+        &ctx,
+        request.x,
+        request.y,
+        request.note,
+        "sally@systeminit.com".to_string(),
+    )
+    .await?;
+
+    ctx.commit().await?;
+
+    let mut response = axum::response::Response::builder();
+    if let Some(force_change_set_id) = force_change_set_id {
+        response = response.header("force_change_set_id", force_change_set_id.to_string());
+    }
+    response = response.header("content-type", "application/json");
+    Ok(response.body(serde_json::to_string(&CreateNoteResponse {
+        note_id: note.id(),
+    })?)?)
+}
+
+pub async fn delete_note(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(_posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    Json(request): Json<DeleteNoteRequest>,
+) -> DiagramResult<impl IntoResponse> {
+    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
+
+    Note::delete_by_id(&ctx, request.id).await?;
+    ctx.commit().await?;
+
+    let mut response = axum::response::Response::builder();
+    if let Some(force_change_set_id) = force_change_set_id {
+        response = response.header("force_change_set_id", force_change_set_id.to_string());
+    }
+    Ok(response.body(axum::body::Empty::new())?)
+}


### PR DESCRIPTION
This creates a content node on the snapshot for the changeset and it can be merged to HEAD

There is absolutely no UI implemention for this yet - it's purely an idea that we can explore. But my imagination is that we can right click on the diagram and add a note - a note has a string for it's conents and a position - nothing more at this time and there is no connection between a note and a component at this time