### PR TITLE
Support authoring for Actions V2

### DIFF
--- a/lib/dal/src/deprecated_action/prototype.rs
+++ b/lib/dal/src/deprecated_action/prototype.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use strum::{AsRefStr, Display};
 use thiserror::Error;
 
+use crate::action::prototype::ActionKind;
 use crate::attribute::prototype::AttributePrototypeResult;
 use crate::change_set::ChangeSetError;
 use crate::workspace_snapshot::content_address::ContentAddress;
@@ -112,6 +113,29 @@ impl From<&DeprecatedActionKind> for ActionFuncSpecKind {
             DeprecatedActionKind::Other => ActionFuncSpecKind::Other,
             DeprecatedActionKind::Delete => ActionFuncSpecKind::Delete,
             DeprecatedActionKind::Update => ActionFuncSpecKind::Update,
+        }
+    }
+}
+impl From<DeprecatedActionKind> for ActionKind {
+    fn from(value: DeprecatedActionKind) -> Self {
+        match value {
+            DeprecatedActionKind::Create => ActionKind::Create,
+            DeprecatedActionKind::Delete => ActionKind::Destroy,
+            DeprecatedActionKind::Other => ActionKind::Manual,
+            DeprecatedActionKind::Refresh => ActionKind::Refresh,
+            DeprecatedActionKind::Update => ActionKind::Update,
+        }
+    }
+}
+
+impl From<ActionKind> for DeprecatedActionKind {
+    fn from(value: ActionKind) -> Self {
+        match value {
+            ActionKind::Create => DeprecatedActionKind::Create,
+            ActionKind::Destroy => DeprecatedActionKind::Delete,
+            ActionKind::Manual => DeprecatedActionKind::Other,
+            ActionKind::Refresh => DeprecatedActionKind::Refresh,
+            ActionKind::Update => DeprecatedActionKind::Update,
         }
     }
 }

--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -44,6 +44,7 @@ use telemetry::prelude::*;
 use thiserror::Error;
 use veritech_client::OutputStream;
 
+use crate::action::prototype::ActionPrototypeError;
 use crate::attribute::prototype::argument::{
     AttributePrototypeArgumentError, AttributePrototypeArgumentId,
 };
@@ -74,8 +75,10 @@ mod ts_types;
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum FuncAuthoringError {
+    #[error("action kind already exists for schema variant")]
+    ActionKindAlreadyExists(SchemaVariantId),
     #[error("action prototype error: {0}")]
-    ActionPrototype(#[from] DeprecatedActionPrototypeError),
+    ActionPrototype(#[from] ActionPrototypeError),
     #[error("attribute prototype error: {0}")]
     AttributePrototype(#[from] AttributePrototypeError),
     #[error("attribute prototype already set by func (id: {0}) (name: {1})")]
@@ -88,6 +91,8 @@ pub enum FuncAuthoringError {
     BeforeFunc(#[from] BeforeFuncError),
     #[error("component error: {0}")]
     Component(#[from] ComponentError),
+    #[error("deprecated action prototype error: {0}")]
+    DeprecatedActionPrototype(#[from] DeprecatedActionPrototypeError),
     #[error("func error: {0}")]
     Func(#[from] FuncError),
     #[error("func argument error: {0}")]

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -120,6 +120,8 @@ pub enum PkgError {
     WorkspaceExportNotSupported(),
     #[error("Workspace not found: {0}")]
     WorkspaceNotFound(WorkspacePk),
+    #[error("workspace pk not found on context")]
+    WorkspacePkNone,
     #[error(transparent)]
     WorkspaceSnaphot(#[from] WorkspaceSnapshotError),
 }

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -13,6 +13,7 @@ use si_pkg::{
 };
 use telemetry::prelude::*;
 
+use crate::action::prototype::ActionPrototype;
 use crate::attribute::prototype::argument::{
     AttributePrototypeArgument, AttributePrototypeArgumentId,
 };
@@ -483,25 +484,54 @@ impl PkgExporter {
         schema_variant_id: SchemaVariantId,
     ) -> PkgResult<Vec<ActionFuncSpec>> {
         let mut specs = vec![];
+        // only export 1 of the Action Func Versions if there are both
+        let workspace_pk = ctx
+            .tenancy()
+            .workspace_pk()
+            .ok_or(PkgError::WorkspacePkNone)?;
 
-        let action_prototypes =
-            DeprecatedActionPrototype::for_variant(ctx, schema_variant_id).await?;
+        let workspace = Workspace::get_by_pk_or_error(ctx, &workspace_pk).await?;
 
-        for action_proto in action_prototypes {
-            let key = &action_proto.func_id(ctx).await?;
-            let func_spec = self
-                .func_map
-                .get(key)
-                .ok_or(PkgError::MissingExportedFunc(*key))?;
+        if workspace.uses_actions_v2() {
+            let action_prototypes = ActionPrototype::for_variant(ctx, schema_variant_id).await?;
 
-            let mut builder = ActionFuncSpec::builder();
+            for action_proto in action_prototypes {
+                let key = ActionPrototype::func_id(ctx, action_proto.id()).await?;
 
-            specs.push(
-                builder
-                    .kind(&action_proto.kind)
-                    .func_unique_id(&func_spec.unique_id)
-                    .build()?,
-            )
+                let func_spec = self
+                    .func_map
+                    .get(&key)
+                    .ok_or(PkgError::MissingExportedFunc(key))?;
+
+                let mut builder = ActionFuncSpec::builder();
+
+                specs.push(
+                    builder
+                        .kind(action_proto.kind)
+                        .func_unique_id(&func_spec.unique_id)
+                        .build()?,
+                )
+            }
+        } else {
+            let action_prototypes =
+                DeprecatedActionPrototype::for_variant(ctx, schema_variant_id).await?;
+
+            for action_proto in action_prototypes {
+                let key = &action_proto.func_id(ctx).await?;
+                let func_spec = self
+                    .func_map
+                    .get(key)
+                    .ok_or(PkgError::MissingExportedFunc(*key))?;
+
+                let mut builder = ActionFuncSpec::builder();
+
+                specs.push(
+                    builder
+                        .kind(&action_proto.kind)
+                        .func_unique_id(&func_spec.unique_id)
+                        .build()?,
+                )
+            }
         }
 
         Ok(specs)


### PR DESCRIPTION
This PR does the following things: 

- Create both types of action funcs (regardless of flag, this way new actions funcs are on the graph in the v2 flavor for tools prod)
- Only export v1 or v2 action funcs based on the flag (no need to duplicate what's exported as we can import either kind) 
- Fixes a bug with authoring action funcs where changing the action kind results in duplicate prototypes
- prevents users from creating duplicate action func kinds for a given schema variant 