### PR TITLE
Action Prototypes Have Edges!

### DIFF
--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -178,13 +178,16 @@ impl ActionPrototype {
         first_action: ActionPrototypeId,
         second_action: ActionPrototypeId,
     ) -> ActionPrototypeResult<()> {
-        Ok(Self::add_edge_to_after_action(
+        let cycle_check_guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
+        let edge_added = Self::add_edge_to_after_action(
             ctx,
             first_action,
             second_action,
             EdgeWeightKind::ActionRunsAfter,
         )
-        .await?)
+        .await?;
+        drop(cycle_check_guard);
+        Ok(())
     }
     pub async fn get_next_actions(
         ctx: &DalContext,

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -1128,6 +1128,8 @@ pub(crate) async fn import_schema_variant(
             for socket in variant_spec.sockets()? {
                 import_socket(ctx, socket, schema_variant.id(), thing_map).await?;
             }
+            let mut create_prototype_id = None;
+            let mut refresh_prototype_id = None;
 
             for action_func in &variant_spec.action_funcs()? {
                 let (deprecated_prototype, prototype) =
@@ -1145,6 +1147,10 @@ pub(crate) async fn import_schema_variant(
                 if let (Some(prototype), Some(unique_id)) = (prototype, action_func.unique_id()) {
                     thing_map.insert(unique_id.to_owned(), Thing::ActionPrototype(prototype));
                 }
+            }
+            if let (Some(create_id), Some(refresh_id)) = (create_prototype_id, refresh_prototype_id)
+            {
+                ActionPrototype::action_runs_after(ctx, create_id, refresh_id).await?;
             }
 
             for auth_func in &variant_spec.auth_funcs()? {

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -23,6 +23,11 @@ pub enum EdgeWeightKind {
     Action,
     /// A function used by a [`SchemaVariant`] to perform an action that affects its resource
     ActionPrototype,
+    /// Used to indicate that an [`ActionPrototype`] should always run
+    /// after a successful action run
+    ///
+    /// For example, we currently always run a refresh action after a successful create
+    ActionRunsAfter,
     /// A function defined for a secret defining [`SchemaVariant`] to be executed before funcs on
     /// components that have a secret of that kind
     AuthenticationPrototype,

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -769,6 +769,7 @@ impl WorkspaceSnapshotGraph {
                 let color = match discrim {
                     EdgeWeightKindDiscriminants::Action => "black",
                     EdgeWeightKindDiscriminants::ActionPrototype => "black",
+                    EdgeWeightKindDiscriminants::ActionRunsAfter => "blue",
                     EdgeWeightKindDiscriminants::AuthenticationPrototype => "black",
                     EdgeWeightKindDiscriminants::Contain => "blue",
                     EdgeWeightKindDiscriminants::FrameContains => "black",
@@ -1602,6 +1603,7 @@ impl WorkspaceSnapshotGraph {
                     EdgeWeightKind::AuthenticationPrototype
                     | EdgeWeightKind::Action
                     | EdgeWeightKind::ActionPrototype
+                    | EdgeWeightKind::ActionRunsAfter
                     | EdgeWeightKind::Contain(None)
                     | EdgeWeightKind::FrameContains
                     | EdgeWeightKind::PrototypeArgument


### PR DESCRIPTION
When importing action functions, if there's a refresh and create function imported, we create an edge FROM the `ActionPrototype` for Create TO the `ActionPrototype` for Refresh. 

This allows us to enqueue the refresh function after the create successfully runs without special casing it. 

Todo: Any existing workspace will not have this edge created, so we'll need to talk about how to ensure we're backwards compatible. 

Todo 2: TESTS!