### PR TITLE
fix(dal): use correct logic in detect_conflicts_and_updates

### DIFF
--- a/lib/dal-test/src/expand_helpers.rs
+++ b/lib/dal-test/src/expand_helpers.rs
@@ -20,18 +20,17 @@ pub async fn create_change_set_and_update_ctx(
         .await
         .expect("could not perform find change set")
         .expect("no change set found");
-    let mut change_set = ChangeSet::new(ctx, generate_fake_name(), Some(base_change_set_id))
-        .await
-        .expect("could not create change set");
-    change_set
-        .update_pointer(
-            ctx,
-            base_change_set
-                .workspace_snapshot_address
-                .expect("no workspace snapshot set on base change set"),
-        )
-        .await
-        .expect("could not update pointer");
+    let workspace_snapshot_address = base_change_set
+        .workspace_snapshot_address
+        .expect("no workspace snapshot set on base change set");
+    let change_set = ChangeSet::new(
+        ctx,
+        generate_fake_name(),
+        Some(base_change_set_id),
+        workspace_snapshot_address,
+    )
+    .await
+    .expect("could not create change set");
     ctx.update_visibility_and_snapshot_to_visibility(change_set.id)
         .await
         .expect("could not update visibility and snapshot");


### PR DESCRIPTION
Our logic in `detect_conflicts_and_updates` was incorrect. A big reason for this was that we were not marking changesets as seen in the tests, and we were also not marking forked / new change sets as *seen by themselves*. Since they had no vector clock entry for the change set itself, we could not reliably detect all the times that onto saw to_rebase or to_rebase saw onto.

For example, if I open up change set B, and make changes to it, in the rebase the changes I make will be the "onto" changeset and the not-yet-modified snapshot pointed to by B will be the "to rebase" changeset. Since onto was forked from to_rebase, onto should have a vector clock entry for to rebase (B). But we were not marking the snapshot for B as "seen" by B when we forked B from the base change set. Thus, we had no way of reliably knowing what things in the "to rebase" were there when we started editing it to produce the "onto", so we couldn't accurately produce the right conflicts and updates.

Note that this means that all currently open changesets are broken, since they don't have a vector clock entry for the change set that they are on. Before we merge this we should decide if we want to try and fix open changesets in prod/tools-prod, or if they can be abandoned. Newly forked changesets will be correct.