### PR TITLE
fix(dal): recalculate merkle tree hash in import_subgraph

### DIFF
--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -1243,6 +1243,8 @@ impl WorkspaceSnapshotGraph {
                 self.graph
                     .update_edge(node_index, latest_target, edge.weight().clone());
             }
+
+            self.update_merkle_tree_hash(node_index)?;
         }
 
         Ok(())


### PR DESCRIPTION
If import_subgraph cannot find an equivalent node in to_rebase, it will add the node from onto directly to the graph, and then call update_edge to add the edges. However, update_edge does not recalculate the merkle tree hash, and so the node added via add_node will have the merkle tree hash of node with no children. Add a call to update_merkle_tree_hash at the end of import subgraph to ensure the hash is updated properly.