### PR TITLE
fix(web): Don't show that a root prop has a value overridden

### DIFF
--- a/app/web/src/components/AttributesPanel/AttributesPanel.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanel.vue
@@ -44,10 +44,12 @@
       <AttributesPanelItem
         v-if="domainTree && domainTree.children.length"
         :attributeDef="domainTree"
+        isRootProp
       />
       <AttributesPanelItem
         v-if="secretsTree && secretsTree.children.length"
         :attributeDef="secretsTree"
+        isRootProp
       />
     </div>
 

--- a/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
@@ -101,7 +101,7 @@
             </div>
           </div>
           <SourceIconWithTooltip
-            v-if="!(widgetKind === 'secret')"
+            v-if="!(widgetKind === 'secret') && !props.isRootProp"
             :icon="sourceIcon"
             :overridden="sourceOverridden"
             :tooltipText="sourceTooltip"
@@ -382,7 +382,9 @@
             @blur="onBlur"
             @change="updateValue"
             @focus="onFocus"
-            @input="(e) => newValueBoolean = (e.target as HTMLInputElement)?.checked"
+            @input="
+              (e) => (newValueBoolean = (e.target as HTMLInputElement)?.checked)
+            "
           />
           <div class="attributes-panel-item__input-value">
             <Icon
@@ -608,6 +610,7 @@ const props = defineProps({
   startCollapsed: { type: Boolean },
   // number of prop keys to show while collapsed
   numPreviewProps: { type: Number, default: 3 },
+  isRootProp: { type: Boolean, default: false },
 });
 
 const headerMainLabelRef = ref();


### PR DESCRIPTION
Domain and Secrets are props attached to the root and are not set directly, therefore, we were telling a user they had overridden them which was misleading

![Screenshot 2024-05-20 at 20 06 04](https://github.com/systeminit/si/assets/227823/4b7d33b5-c1ae-4d9d-a064-68d16e405981)

No icons in place for props directly connected to the root
