### PR TITLE
Do not dispatch Actions with pending dependent value updates

### DIFF
--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 
 use petgraph::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -11,6 +11,7 @@ use veritech_client::ResourceStatus;
 use crate::{
     action::dependency_graph::ActionDependencyGraph,
     action::prototype::{ActionKind, ActionPrototype, ActionPrototypeError},
+    attribute::value::{AttributeValueError, DependentValueGraph},
     func::backend::js_action::DeprecatedActionRunResult,
     func::execution::{FuncExecution, FuncExecutionError, FuncExecutionPk},
     id, implement_add_edge_to,
@@ -18,8 +19,8 @@ use crate::{
     workspace_snapshot::node_weight::{
         category_node_weight::CategoryNodeKind, ActionNodeWeight, NodeWeight, NodeWeightError,
     },
-    ChangeSetError, ChangeSetId, ComponentError, ComponentId, DalContext, EdgeWeightError,
-    EdgeWeightKind, EdgeWeightKindDiscriminants, HelperError, TransactionsError,
+    AttributeValue, ChangeSetError, ChangeSetId, ComponentError, ComponentId, DalContext,
+    EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants, HelperError, TransactionsError,
     WorkspaceSnapshotError, WsEvent, WsEventError, WsEventResult, WsPayload,
 };
 
@@ -31,6 +32,8 @@ pub mod prototype;
 pub enum ActionError {
     #[error("action prototype error: {0}")]
     ActionPrototype(#[from] ActionPrototypeError),
+    #[error("AttributeValue error: {0}")]
+    AttributeValue(#[from] AttributeValueError),
     #[error("Change Set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
     #[error("Component error: {0}")]
@@ -545,19 +548,57 @@ impl Action {
         Ok(resource)
     }
 
+    /// An Action is dispatchable if all of the following are true:
+    ///   * The action is in the state [`ActionState::Queued`](ActionState)
+    ///   * The graph of values for `DependentValuesUpdate` does *NOT* include
+    ///     *ANY* [`AttributeValue`s](AttributeValue) for the same
+    ///     [`Component`](crate::Component) as the [`Action`].
+    ///
+    /// This method **DOES NOT** check the `DependentValuesUpdate` graph. That
+    /// is done as part of [`Self::eligible_to_dispatch()`]
     pub fn is_eligible_to_dispatch(&self) -> bool {
         // Only Actions in the ActionState::Queued state are dispatchable.
         self.state() == ActionState::Queued
     }
 
+    /// An Action is dispatchable if all of the following are true:
+    ///   * The action is in the state [`ActionState::Queued`](ActionState)
+    ///   * The graph of values for `DependentValuesUpdate` does *NOT* include
+    ///     *ANY* [`AttributeValue`s](AttributeValue) for the same
+    ///     [`Component`](crate::Component) as the [`Action`].
     pub async fn eligible_to_dispatch(ctx: &DalContext) -> ActionResult<Vec<ActionId>> {
         let action_dependency_graph = ActionDependencyGraph::for_workspace(ctx).await?;
         let mut result = Vec::new();
+        let dependent_value_graph = DependentValueGraph::new(
+            ctx,
+            ctx.workspace_snapshot()?
+                .list_dependent_value_value_ids()
+                .await?,
+        )
+        .await?;
+
+        // Find the ComponentIds for all AttributeValues in the full dependency graph for the
+        // queued/running DependentValuesUpdate. We'll want to hold off on dispatching any Actions
+        // that would be operating on the same Component until after the DependentValuesUpdate has
+        // finished working with that Component.
+        let mut dvu_component_ids: HashSet<ComponentId> = HashSet::new();
+        for av_id in &dependent_value_graph.all_value_ids() {
+            dvu_component_ids.insert(AttributeValue::component_id(ctx, *av_id).await?);
+        }
 
         for possible_action_id in action_dependency_graph.independent_actions() {
             let action = Action::get_by_id(ctx, possible_action_id).await?;
 
             if action.is_eligible_to_dispatch() {
+                if let Some(action_component_id) = Action::component_id(ctx, action.id()).await? {
+                    if dvu_component_ids.contains(&action_component_id) {
+                        // This action is for a Component that currently involved in the queued
+                        // DependentValuesUpdate graph. We don't want to dispatch the Action until
+                        // the DependentValuesUpdate job has completely finished
+                        // processing/populating values that the Action might need to work with.
+                        continue;
+                    }
+                }
                 result.push(possible_action_id);
             }
         }

--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -482,6 +482,10 @@ impl DependentValueGraph {
         self.inner.independent_ids()
     }
 
+    pub fn all_value_ids(&self) -> Vec<AttributeValueId> {
+        self.inner.all_ids()
+    }
+
     /// Indicates whether the value needs to be processed. This is useful for determining when to
     /// filter or de-duplicate values when executing from their prototype functions. If the value is
     /// marked as needing to be processed, it likely needs to execute from its prototype function.

--- a/lib/dal/src/dependency_graph.rs
+++ b/lib/dal/src/dependency_graph.rs
@@ -105,4 +105,8 @@ impl<T: Copy + std::cmp::Eq + std::cmp::PartialEq + std::hash::Hash> DependencyG
     pub fn id_to_index_map(&self) -> &HashMap<T, NodeIndex> {
         &self.id_to_index_map
     }
+
+    pub fn all_ids(&self) -> Vec<T> {
+        self.graph.node_weights().copied().collect()
+    }
 }


### PR DESCRIPTION
While there are AttributeValues for any given Component that are still involved in a DependentValuesUpdate, we want to hold off on dispatching any Actions for those Components. This will let us make sure that the Action will be operating with the most up-to-date data possible in the model.

Now that we're tracking the root nodes for the DependentValuesUpdate graph of AttributeValues to update, we can directly check the Components that are involved in the pending DependentValuesUpdate to see if an Action would operate on an involved Component.