### PR TITLE
fix(dal): Ensure that CodeGen and Qualifications can be executed

### DIFF
--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -212,7 +212,9 @@ impl FuncAuthoringClient {
         let func = Func::get_by_id_or_error(ctx, id).await?;
 
         match func.kind {
-            FuncKind::Attribute => execute::execute_attribute_func(ctx, &func).await?,
+            FuncKind::Qualification | FuncKind::CodeGeneration | FuncKind::Attribute => {
+                execute::execute_attribute_func(ctx, &func).await?
+            }
             FuncKind::Action => {
                 // TODO(nick): fully restore or wait for actions v2. Essentially, we need to run
                 // every prototype using the func id for every component.


### PR DESCRIPTION
We were making the asusmption that executable func types were limited to Attribute funcs when it was infact FuncBackendKind::JsAttribute which includes codegen and qualifications

The logic doesn't need to filter the runs to components on the graph, our DVU enqueue will do that for us as the attribute_value_ids for the prototype will find all the values across all components for that proto