### PR TITLE
fix(dal): Ensure that we don't allow changing a func to an existing kind

### DIFF
--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -44,7 +44,7 @@ use telemetry::prelude::*;
 use thiserror::Error;
 use veritech_client::OutputStream;
 
-use crate::action::prototype::ActionPrototypeError;
+use crate::action::prototype::{ActionKind, ActionPrototypeError};
 use crate::attribute::prototype::argument::{
     AttributePrototypeArgumentError, AttributePrototypeArgumentId,
 };
@@ -115,6 +115,8 @@ pub enum FuncAuthoringError {
     InvalidFuncAssociationsForFunc(FuncAssociations, FuncId, FuncKind),
     #[error("invalid func kind for creation: {0}")]
     InvalidFuncKindForCreation(FuncKind),
+    #[error("can't use func kind '{0}' as it already exists")]
+    KindAlreadyExists(ActionKind),
     #[error("no input location given for attribute prototype id ({0}) and func argument id ({1})")]
     NoInputLocationGiven(AttributePrototypeId, FuncArgumentId),
     #[error("no output location given for func: {0}")]

--- a/lib/dal/src/func/authoring/save.rs
+++ b/lib/dal/src/func/authoring/save.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use telemetry::prelude::*;
 
-use crate::action::prototype::ActionPrototype;
+use crate::action::prototype::{ActionKind, ActionPrototype};
 use crate::attribute::prototype::argument::{
     AttributePrototypeArgument, AttributePrototypeArgumentId,
 };
@@ -12,9 +12,10 @@ use crate::func::{AttributePrototypeArgumentBag, AttributePrototypeBag, FuncKind
 use crate::schema::variant::leaves::{LeafInputLocation, LeafKind};
 use crate::workspace_snapshot::graph::WorkspaceSnapshotGraphError;
 use crate::{
-    AttributePrototype, AttributePrototypeId, AttributeValue, Component, ComponentId, DalContext,
-    DeprecatedActionKind, DeprecatedActionPrototype, EdgeWeightKind, Func, FuncBackendResponseType,
-    FuncId, OutputSocket, Prop, SchemaVariant, SchemaVariantId, WorkspaceSnapshotError,
+    ActionPrototypeId, AttributePrototype, AttributePrototypeId, AttributeValue, Component,
+    ComponentId, DalContext, DeprecatedActionKind, DeprecatedActionPrototype, EdgeWeightKind, Func,
+    FuncBackendResponseType, FuncId, OutputSocket, Prop, SchemaVariant, SchemaVariantId,
+    WorkspaceSnapshotError,
 };
 
 #[instrument(
@@ -119,21 +120,58 @@ async fn update_action_associations(
     kind: DeprecatedActionKind,
     schema_variant_ids: Vec<SchemaVariantId>,
 ) -> FuncAuthoringResult<()> {
-    // Clean up existing prototypes for all variants that use it.
+    let mut deprecated_prototypes_to_remove: Vec<ActionPrototypeId> = vec![];
+    let mut prototyes_to_remove: Vec<ActionPrototypeId> = vec![];
 
     for schema_variant_id in SchemaVariant::list_ids(ctx).await? {
-        for prototype in DeprecatedActionPrototype::for_variant(ctx, schema_variant_id).await? {
+        let current_deprecated_prototypes =
+            DeprecatedActionPrototype::for_variant(ctx, schema_variant_id).await?;
+        for prototype in current_deprecated_prototypes.clone() {
             let prototype_func_id = prototype.func_id(ctx).await?;
             if func.id == prototype_func_id {
-                DeprecatedActionPrototype::remove(ctx, prototype.id).await?;
+                if prototype.kind != kind && kind != DeprecatedActionKind::Other {
+                    let existing_kind = current_deprecated_prototypes
+                        .clone()
+                        .into_iter()
+                        .find(|ap| ap.kind == kind);
+                    if existing_kind.is_some() {
+                        return Err(FuncAuthoringError::KindAlreadyExists(ActionKind::from(
+                            kind,
+                        )));
+                    }
+                }
+                deprecated_prototypes_to_remove.push(prototype.id);
             }
         }
-        for prototype in ActionPrototype::for_variant(ctx, schema_variant_id).await? {
+        let new_action_protypes_for_schema_variant =
+            ActionPrototype::for_variant(ctx, schema_variant_id).await?;
+        for prototype in new_action_protypes_for_schema_variant.clone() {
             let prototype_func_id = ActionPrototype::func_id(ctx, prototype.id()).await?;
             if func.id == prototype_func_id {
-                ActionPrototype::remove(ctx, prototype.id()).await?;
+                if prototype.kind != ActionKind::from(kind)
+                    && ActionKind::from(kind) != ActionKind::Manual
+                {
+                    let existing_kind = new_action_protypes_for_schema_variant
+                        .clone()
+                        .into_iter()
+                        .find(|ap| ap.kind == ActionKind::from(kind));
+                    if existing_kind.is_some() {
+                        return Err(FuncAuthoringError::KindAlreadyExists(ActionKind::from(
+                            kind,
+                        )));
+                    }
+                }
+                prototyes_to_remove.push(prototype.id());
             }
         }
+    }
+
+    for removal_id in deprecated_prototypes_to_remove {
+        DeprecatedActionPrototype::remove(ctx, removal_id).await?;
+    }
+
+    for removal_id in prototyes_to_remove {
+        ActionPrototype::remove(ctx, removal_id).await?;
     }
 
     // Create or re-create the prototype for the schema variant ids passed in.


### PR DESCRIPTION
If you have a Create func for an asset type, and we change a func type to be Create, then we want to error on save of the func because it's not allowed to have 2 different funcs of the same type for a schema variant