### PR TITLE
Include node ID and kind in Conflict & Update records

### DIFF
--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -134,10 +134,11 @@ pub use timestamp::{Timestamp, TimestampError};
 pub use user::{User, UserClaim, UserError, UserPk, UserResult};
 pub use visibility::Visibility;
 pub use workspace::{Workspace, WorkspaceError, WorkspacePk, WorkspaceResult};
-pub use workspace_snapshot::edge_weight::{
-    EdgeWeight, EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
-};
 pub use workspace_snapshot::graph::WorkspaceSnapshotGraph;
+pub use workspace_snapshot::{
+    edge_weight::{EdgeWeight, EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants},
+    node_weight::NodeWeightDiscriminants,
+};
 pub use workspace_snapshot::{WorkspaceSnapshot, WorkspaceSnapshotError};
 pub use ws_event::{WsEvent, WsEventError, WsEventResult, WsPayload};
 

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -48,6 +48,7 @@ use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::action::{Action, ActionError};
 use crate::change_set::{ChangeSet, ChangeSetError, ChangeSetId};
+use crate::pk;
 use crate::workspace_snapshot::conflict::Conflict;
 use crate::workspace_snapshot::edge_weight::{
     EdgeWeight, EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
@@ -63,11 +64,12 @@ use crate::{
 
 use self::node_weight::{NodeWeightDiscriminants, OrderingNodeWeight};
 
+pk!(NodeId);
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NodeInformation {
     pub index: NodeIndex,
     pub node_weight_kind: NodeWeightDiscriminants,
-    pub id: Ulid,
+    pub id: NodeId,
 }
 
 #[remain::sorted]

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -38,6 +38,7 @@ use tokio::task::JoinError;
 
 use petgraph::prelude::*;
 pub use petgraph::Direction;
+use serde::{Deserialize, Serialize};
 use si_data_pg::PgError;
 use si_events::{ulid::Ulid, ContentHash, WorkspaceSnapshotAddress};
 use strum::IntoEnumIterator;
@@ -61,6 +62,13 @@ use crate::{
 };
 
 use self::node_weight::{NodeWeightDiscriminants, OrderingNodeWeight};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeInformation {
+    pub index: NodeIndex,
+    pub node_weight_kind: NodeWeightDiscriminants,
+    pub id: Ulid,
+}
 
 #[remain::sorted]
 #[derive(Error, Debug)]

--- a/lib/dal/src/workspace_snapshot/conflict.rs
+++ b/lib/dal/src/workspace_snapshot/conflict.rs
@@ -1,8 +1,6 @@
-use petgraph::stable_graph::NodeIndex;
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-use crate::EdgeWeightKindDiscriminants;
+use crate::{workspace_snapshot::NodeInformation, EdgeWeightKindDiscriminants};
 
 /// Describe the type of conflict between the given locations in a
 /// workspace graph.
@@ -10,30 +8,21 @@ use crate::EdgeWeightKindDiscriminants;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub enum Conflict {
     ChildOrder {
-        onto: NodeIndex,
-        to_rebase: NodeIndex,
+        onto: NodeInformation,
+        to_rebase: NodeInformation,
     },
     ExclusiveEdgeMismatch {
-        source: NodeIndex,
-        destination: NodeIndex,
+        source: NodeInformation,
+        destination: NodeInformation,
         edge_kind: EdgeWeightKindDiscriminants,
     },
-    ModifyRemovedItem(NodeIndex),
+    ModifyRemovedItem(NodeInformation),
     NodeContent {
-        onto: NodeIndex,
-        to_rebase: NodeIndex,
+        onto: NodeInformation,
+        to_rebase: NodeInformation,
     },
     RemoveModifiedItem {
-        container: NodeIndex,
-        removed_item: NodeIndex,
+        container: NodeInformation,
+        removed_item: NodeInformation,
     },
-}
-
-/// The [`NodeIndex`] of the location in the graph where a conflict occurs.
-#[derive(Debug, Copy, Clone)]
-pub struct ConflictLocation {
-    /// The location of the conflict in the "base" graph of the merge.
-    pub onto: NodeIndex,
-    /// The location of the conflict in the graph that is attempting to be merged into "base".
-    pub to_rebase: NodeIndex,
 }

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -633,12 +633,12 @@ impl WorkspaceSnapshotGraph {
                         {
                             let onto_node_information = NodeInformation {
                                 index: onto_node_index,
-                                id: onto_node_weight.id(),
+                                id: onto_node_weight.id().into(),
                                 node_weight_kind: onto_node_weight.clone().into(),
                             };
                             let to_rebase_node_information = NodeInformation {
                                 index: to_rebase_node_index,
-                                id: to_rebase_node_weight.id(),
+                                id: to_rebase_node_weight.id().into(),
                                 node_weight_kind: to_rebase_node_weight.clone().into(),
                             };
                             // `onto` has changes, but has already seen all of the changes in
@@ -691,12 +691,12 @@ impl WorkspaceSnapshotGraph {
                                 if common_onto_items != common_to_rebase_items {
                                     let to_rebase_node_information = NodeInformation {
                                         index: to_rebase_node_index,
-                                        id: to_rebase_node_weight.id(),
+                                        id: to_rebase_node_weight.id().into(),
                                         node_weight_kind: to_rebase_node_weight.into(),
                                     };
                                     let onto_node_information = NodeInformation {
                                         index: onto_node_index,
-                                        id: onto_node_weight.id(),
+                                        id: onto_node_weight.id().into(),
                                         node_weight_kind: onto_node_weight.into(),
                                     };
 
@@ -708,12 +708,12 @@ impl WorkspaceSnapshotGraph {
                             } else {
                                 let to_rebase_node_information = NodeInformation {
                                     index: to_rebase_node_index,
-                                    id: to_rebase_node_weight.id(),
+                                    id: to_rebase_node_weight.id().into(),
                                     node_weight_kind: to_rebase_node_weight.into(),
                                 };
                                 let onto_node_information = NodeInformation {
                                     index: onto_node_index,
-                                    id: onto_node_weight.id(),
+                                    id: onto_node_weight.id().into(),
                                     node_weight_kind: onto_node_weight.into(),
                                 };
 
@@ -1091,7 +1091,7 @@ impl WorkspaceSnapshotGraph {
                             // `onto` last saw `to_rebase`
                             let node_information = NodeInformation {
                                 index: only_to_rebase_edge_info.target_node_index,
-                                id: to_rebase_item_weight.id(),
+                                id: to_rebase_item_weight.id().into(),
                                 node_weight_kind: to_rebase_item_weight.into(),
                             };
                             conflicts.push(Conflict::ModifyRemovedItem(node_information))
@@ -1102,12 +1102,12 @@ impl WorkspaceSnapshotGraph {
                                 self.get_node_weight(only_to_rebase_edge_info.target_node_index)?;
                             let source_node_information = NodeInformation {
                                 index: only_to_rebase_edge_info.source_node_index,
-                                id: source_node_weight.id(),
+                                id: source_node_weight.id().into(),
                                 node_weight_kind: source_node_weight.into(),
                             };
                             let target_node_information = NodeInformation {
                                 index: only_to_rebase_edge_info.target_node_index,
-                                id: target_node_weight.id(),
+                                id: target_node_weight.id().into(),
                                 node_weight_kind: target_node_weight.into(),
                             };
                             updates.push(Update::RemoveEdge {
@@ -1127,12 +1127,12 @@ impl WorkspaceSnapshotGraph {
                                 self.get_node_weight(only_to_rebase_edge_info.target_node_index)?;
                             let source_node_information = NodeInformation {
                                 index: only_to_rebase_edge_info.source_node_index,
-                                id: source_node_weight.id(),
+                                id: source_node_weight.id().into(),
                                 node_weight_kind: source_node_weight.into(),
                             };
                             let destination_node_information = NodeInformation {
                                 index: only_to_rebase_edge_info.target_node_index,
-                                id: destination_node_weight.id(),
+                                id: destination_node_weight.id().into(),
                                 node_weight_kind: destination_node_weight.into(),
                             };
 
@@ -1192,12 +1192,12 @@ impl WorkspaceSnapshotGraph {
                                 onto.get_node_weight(only_onto_edge_info.target_node_index)?;
                             let container_node_information = NodeInformation {
                                 index: to_rebase_container_index,
-                                id: container_node_weight.id(),
+                                id: container_node_weight.id().into(),
                                 node_weight_kind: container_node_weight.into(),
                             };
                             let removed_item_node_information = NodeInformation {
                                 index: only_onto_edge_info.target_node_index,
-                                id: onto_node_weight.id(),
+                                id: onto_node_weight.id().into(),
                                 node_weight_kind: onto_node_weight.into(),
                             };
 
@@ -1213,12 +1213,12 @@ impl WorkspaceSnapshotGraph {
                             onto.get_node_weight(only_onto_edge_info.target_node_index)?;
                         let source_node_information = NodeInformation {
                             index: to_rebase_container_index,
-                            id: source_node_weight.id(),
+                            id: source_node_weight.id().into(),
                             node_weight_kind: source_node_weight.into(),
                         };
                         let destination_node_information = NodeInformation {
                             index: only_onto_edge_info.target_node_index,
-                            id: destination_node_weight.id(),
+                            id: destination_node_weight.id().into(),
                             node_weight_kind: destination_node_weight.into(),
                         };
 

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -26,6 +26,7 @@ use crate::workspace_snapshot::{
     edge_weight::{EdgeWeight, EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants},
     node_weight::{NodeWeight, NodeWeightError, OrderingNodeWeight},
     update::Update,
+    NodeInformation,
 };
 
 mod tests;
@@ -630,12 +631,22 @@ impl WorkspaceSnapshotGraph {
                             .vector_clock_write()
                             .is_newer_than(to_rebase_node_weight.vector_clock_write())
                         {
+                            let onto_node_information = NodeInformation {
+                                index: onto_node_index,
+                                id: onto_node_weight.id(),
+                                node_weight_kind: onto_node_weight.clone().into(),
+                            };
+                            let to_rebase_node_information = NodeInformation {
+                                index: to_rebase_node_index,
+                                id: to_rebase_node_weight.id(),
+                                node_weight_kind: to_rebase_node_weight.clone().into(),
+                            };
                             // `onto` has changes, but has already seen all of the changes in
                             // `to_rebase`. There is no conflict, and we should update to use the
                             // `onto` node.
                             updates.push(Update::ReplaceSubgraph {
-                                onto: onto_node_index,
-                                to_rebase: to_rebase_node_index,
+                                onto: onto_node_information,
+                                to_rebase: to_rebase_node_information,
                             });
                         } else {
                             // There are changes on both sides that have not
@@ -678,15 +689,37 @@ impl WorkspaceSnapshotGraph {
                                     items
                                 };
                                 if common_onto_items != common_to_rebase_items {
+                                    let to_rebase_node_information = NodeInformation {
+                                        index: to_rebase_node_index,
+                                        id: to_rebase_node_weight.id(),
+                                        node_weight_kind: to_rebase_node_weight.into(),
+                                    };
+                                    let onto_node_information = NodeInformation {
+                                        index: onto_node_index,
+                                        id: onto_node_weight.id(),
+                                        node_weight_kind: onto_node_weight.into(),
+                                    };
+
                                     conflicts.push(Conflict::ChildOrder {
-                                        to_rebase: to_rebase_node_index,
-                                        onto: onto_node_index,
+                                        to_rebase: to_rebase_node_information,
+                                        onto: onto_node_information,
                                     });
                                 }
                             } else {
+                                let to_rebase_node_information = NodeInformation {
+                                    index: to_rebase_node_index,
+                                    id: to_rebase_node_weight.id(),
+                                    node_weight_kind: to_rebase_node_weight.into(),
+                                };
+                                let onto_node_information = NodeInformation {
+                                    index: onto_node_index,
+                                    id: onto_node_weight.id(),
+                                    node_weight_kind: onto_node_weight.into(),
+                                };
+
                                 conflicts.push(Conflict::NodeContent {
-                                    to_rebase: to_rebase_node_index,
-                                    onto: onto_node_index,
+                                    to_rebase: to_rebase_node_information,
+                                    onto: onto_node_information,
                                 });
                             }
                         }
@@ -1056,13 +1089,30 @@ impl WorkspaceSnapshotGraph {
                         {
                             // Item has been modified in `to_rebase` since
                             // `onto` last saw `to_rebase`
-                            conflicts.push(Conflict::ModifyRemovedItem(
-                                only_to_rebase_edge_info.target_node_index,
-                            ))
+                            let node_information = NodeInformation {
+                                index: only_to_rebase_edge_info.target_node_index,
+                                id: to_rebase_item_weight.id(),
+                                node_weight_kind: to_rebase_item_weight.into(),
+                            };
+                            conflicts.push(Conflict::ModifyRemovedItem(node_information))
                         } else {
+                            let source_node_weight =
+                                self.get_node_weight(only_to_rebase_edge_info.source_node_index)?;
+                            let target_node_weight =
+                                self.get_node_weight(only_to_rebase_edge_info.target_node_index)?;
+                            let source_node_information = NodeInformation {
+                                index: only_to_rebase_edge_info.source_node_index,
+                                id: source_node_weight.id(),
+                                node_weight_kind: source_node_weight.into(),
+                            };
+                            let target_node_information = NodeInformation {
+                                index: only_to_rebase_edge_info.target_node_index,
+                                id: target_node_weight.id(),
+                                node_weight_kind: target_node_weight.into(),
+                            };
                             updates.push(Update::RemoveEdge {
-                                source: only_to_rebase_edge_info.source_node_index,
-                                destination: only_to_rebase_edge_info.target_node_index,
+                                source: source_node_information,
+                                destination: target_node_information,
                                 edge_kind: only_to_rebase_edge_info.edge_kind,
                             });
                         }
@@ -1071,9 +1121,24 @@ impl WorkspaceSnapshotGraph {
                         let container_weight = self.get_node_weight(to_rebase_container_index)?;
                         let edge_kind = only_to_rebase_edge_info.edge_kind;
                         if container_weight.is_exclusive_outgoing_edge(edge_kind) {
+                            let source_node_weight =
+                                self.get_node_weight(only_to_rebase_edge_info.source_node_index)?;
+                            let destination_node_weight =
+                                self.get_node_weight(only_to_rebase_edge_info.target_node_index)?;
+                            let source_node_information = NodeInformation {
+                                index: only_to_rebase_edge_info.source_node_index,
+                                id: source_node_weight.id(),
+                                node_weight_kind: source_node_weight.into(),
+                            };
+                            let destination_node_information = NodeInformation {
+                                index: only_to_rebase_edge_info.target_node_index,
+                                id: destination_node_weight.id(),
+                                node_weight_kind: destination_node_weight.into(),
+                            };
+
                             conflicts.push(Conflict::ExclusiveEdgeMismatch {
-                                source: only_to_rebase_edge_info.source_node_index,
-                                destination: only_to_rebase_edge_info.target_node_index,
+                                source: source_node_information,
+                                destination: destination_node_information,
                                 edge_kind,
                             });
                         }
@@ -1121,17 +1186,48 @@ impl WorkspaceSnapshotGraph {
                             .vector_clock_write()
                             .has_entries_newer_than(seen_by_to_rebase_at)
                         {
+                            let container_node_weight =
+                                self.get_node_weight(to_rebase_container_index)?;
+                            let onto_node_weight =
+                                onto.get_node_weight(only_onto_edge_info.target_node_index)?;
+                            let container_node_information = NodeInformation {
+                                index: to_rebase_container_index,
+                                id: container_node_weight.id(),
+                                node_weight_kind: container_node_weight.into(),
+                            };
+                            let removed_item_node_information = NodeInformation {
+                                index: only_onto_edge_info.target_node_index,
+                                id: onto_node_weight.id(),
+                                node_weight_kind: onto_node_weight.into(),
+                            };
+
                             conflicts.push(Conflict::RemoveModifiedItem {
-                                container: to_rebase_container_index,
-                                removed_item: only_onto_edge_info.target_node_index,
+                                container: container_node_information,
+                                removed_item: removed_item_node_information,
                             });
                         }
                     }
-                    None => updates.push(Update::NewEdge {
-                        source: to_rebase_container_index,
-                        destination: only_onto_edge_info.target_node_index,
-                        edge_weight: onto_edge_weight.clone(),
-                    }),
+                    None => {
+                        let source_node_weight = self.get_node_weight(to_rebase_container_index)?;
+                        let destination_node_weight =
+                            onto.get_node_weight(only_onto_edge_info.target_node_index)?;
+                        let source_node_information = NodeInformation {
+                            index: to_rebase_container_index,
+                            id: source_node_weight.id(),
+                            node_weight_kind: source_node_weight.into(),
+                        };
+                        let destination_node_information = NodeInformation {
+                            index: only_onto_edge_info.target_node_index,
+                            id: destination_node_weight.id(),
+                            node_weight_kind: destination_node_weight.into(),
+                        };
+
+                        updates.push(Update::NewEdge {
+                            source: source_node_information,
+                            destination: destination_node_information,
+                            edge_weight: onto_edge_weight.clone(),
+                        })
+                    }
                 }
             }
         }
@@ -1705,8 +1801,9 @@ impl WorkspaceSnapshotGraph {
                     destination,
                     edge_weight,
                 } => {
-                    let updated_source = self.get_latest_node_idx(*source)?;
-                    let destination = self.find_in_self_or_create_using_onto(*destination, onto)?;
+                    let updated_source = self.get_latest_node_idx(source.index)?;
+                    let destination =
+                        self.find_in_self_or_create_using_onto(destination.index, onto)?;
 
                     self.add_edge(updated_source, edge_weight.clone(), destination)?;
                 }
@@ -1715,8 +1812,8 @@ impl WorkspaceSnapshotGraph {
                     destination,
                     edge_kind,
                 } => {
-                    let updated_source = self.get_latest_node_idx(*source)?;
-                    let destination = self.get_latest_node_idx(*destination)?;
+                    let updated_source = self.get_latest_node_idx(source.index)?;
+                    let destination = self.get_latest_node_idx(destination.index)?;
                     self.remove_edge(
                         to_rebase_change_set,
                         updated_source,
@@ -1728,8 +1825,9 @@ impl WorkspaceSnapshotGraph {
                     onto: onto_subgraph_root,
                     to_rebase: to_rebase_subgraph_root,
                 } => {
-                    let updated_to_rebase = self.get_latest_node_idx(*to_rebase_subgraph_root)?;
-                    self.find_in_self_or_create_using_onto(*onto_subgraph_root, onto)?;
+                    let updated_to_rebase =
+                        self.get_latest_node_idx(to_rebase_subgraph_root.index)?;
+                    self.find_in_self_or_create_using_onto(onto_subgraph_root.index, onto)?;
                     self.replace_references(updated_to_rebase)?;
                 }
                 Update::MergeCategoryNodes {

--- a/lib/dal/src/workspace_snapshot/graph/tests/detect_conflicts_and_updates.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/detect_conflicts_and_updates.rs
@@ -671,14 +671,14 @@ mod test {
         assert_eq!(
             vec![Conflict::NodeContent {
                 onto: NodeInformation {
-                    id: component_id,
+                    id: component_id.into(),
                     index: base_graph
                         .get_node_index_by_id(component_id)
                         .expect("Unable to get component NodeIndex"),
                     node_weight_kind: NodeWeightDiscriminants::Content,
                 },
                 to_rebase: NodeInformation {
-                    id: component_id,
+                    id: component_id.into(),
                     index: new_graph
                         .get_node_index_by_id(component_id)
                         .expect("Unable to get component NodeIndex"),
@@ -828,7 +828,7 @@ mod test {
 
         assert_eq!(
             vec![Conflict::ModifyRemovedItem(NodeInformation {
-                id: component_id,
+                id: component_id.into(),
                 index: new_graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
@@ -1377,7 +1377,7 @@ mod test {
                 index: new_graph
                     .get_node_index_by_id(nginx_butane_component_id)
                     .expect("Unable to get component NodeIndex"),
-                id: nginx_butane_component_id,
+                id: nginx_butane_component_id.into(),
                 node_weight_kind: NodeWeightDiscriminants::Content,
             }),
             Conflict::NodeContent {
@@ -1385,14 +1385,14 @@ mod test {
                     index: base_graph
                         .get_node_index_by_id(docker_image_schema_variant_id)
                         .expect("Unable to get component NodeIndex"),
-                    id: docker_image_schema_variant_id,
+                    id: docker_image_schema_variant_id.into(),
                     node_weight_kind: NodeWeightDiscriminants::Content,
                 },
                 to_rebase: NodeInformation {
                     index: new_graph
                         .get_node_index_by_id(docker_image_schema_variant_id)
                         .expect("Unable to get component NodeIndex"),
-                    id: docker_image_schema_variant_id,
+                    id: docker_image_schema_variant_id.into(),
                     node_weight_kind: NodeWeightDiscriminants::Content,
                 },
             },
@@ -1402,14 +1402,14 @@ mod test {
                 index: base_graph
                     .get_node_index_by_id(docker_image_schema_id)
                     .expect("Unable to get NodeIndex"),
-                id: docker_image_schema_id,
+                id: docker_image_schema_id.into(),
                 node_weight_kind: NodeWeightDiscriminants::Content,
             },
             to_rebase: NodeInformation {
                 index: new_graph
                     .get_node_index_by_id(docker_image_schema_id)
                     .expect("Unable to get NodeIndex"),
-                id: docker_image_schema_id,
+                id: docker_image_schema_id.into(),
                 node_weight_kind: NodeWeightDiscriminants::Content,
             },
         }];
@@ -1956,14 +1956,14 @@ mod test {
                         index: new_graph
                             .get_node_index_by_id(container_prop_id)
                             .expect("Unable to get NodeIndex"),
-                        id: container_prop_id,
+                        id: container_prop_id.into(),
                         node_weight_kind: NodeWeightDiscriminants::Content,
                     },
                     destination: NodeInformation {
                         index: initial_graph
                             .get_node_index_by_id(ordered_prop_5_id)
                             .expect("Unable to get NodeIndex"),
-                        id: ordered_prop_5_id,
+                        id: ordered_prop_5_id.into(),
                         node_weight_kind: NodeWeightDiscriminants::Content,
                     },
                     edge_weight: new_edge_weight,
@@ -1971,12 +1971,12 @@ mod test {
                 Update::ReplaceSubgraph {
                     onto: NodeInformation {
                         index: initial_ordering_node_index_for_container,
-                        id: initial_ordering_node_weight_for_container.id(),
+                        id: initial_ordering_node_weight_for_container.id().into(),
                         node_weight_kind: NodeWeightDiscriminants::Ordering,
                     },
                     to_rebase: NodeInformation {
                         index: new_ordering_node_index_for_container,
-                        id: new_ordering_node_weight_for_container.id(),
+                        id: new_ordering_node_weight_for_container.id().into(),
                         node_weight_kind: NodeWeightDiscriminants::Ordering,
                     },
                 },
@@ -1985,14 +1985,14 @@ mod test {
                         index: new_graph
                             .get_node_index_by_id(source_node_id_for_ordinal_edge)
                             .expect("could not get node index by id"),
-                        id: source_node_id_for_ordinal_edge,
+                        id: source_node_id_for_ordinal_edge.into(),
                         node_weight_kind: NodeWeightDiscriminants::Ordering,
                     },
                     destination: NodeInformation {
                         index: initial_graph
                             .get_node_index_by_id(destination_node_id_for_ordinal_edge)
                             .expect("could not get node index by id"),
-                        id: destination_node_id_for_ordinal_edge,
+                        id: destination_node_id_for_ordinal_edge.into(),
                         node_weight_kind: NodeWeightDiscriminants::Content,
                     },
                     edge_weight: ordinal_edge_weight,
@@ -2297,7 +2297,8 @@ mod test {
                     id: initial_graph
                         .get_node_weight(initial_container_ordering_node_index)
                         .expect("Unable to get ordering node")
-                        .id(),
+                        .id()
+                        .into(),
                     node_weight_kind: NodeWeightDiscriminants::Ordering,
                 },
                 to_rebase: NodeInformation {
@@ -2305,7 +2306,8 @@ mod test {
                     id: new_graph
                         .get_node_weight(new_container_ordering_node_index)
                         .expect("Unable to get new ordering node")
-                        .id(),
+                        .id()
+                        .into(),
                     node_weight_kind: NodeWeightDiscriminants::Ordering,
                 },
             }],
@@ -2319,14 +2321,14 @@ mod test {
                         index: new_graph
                             .get_node_index_by_id(container_prop_id)
                             .expect("Unable to get new prop index"),
-                        id: container_prop_id,
+                        id: container_prop_id.into(),
                         node_weight_kind: NodeWeightDiscriminants::Content,
                     },
                     destination: NodeInformation {
                         index: initial_graph
                             .get_node_index_by_id(ordered_prop_5_id)
                             .expect("Unable to get ordered prop 5 index"),
-                        id: ordered_prop_5_id,
+                        id: ordered_prop_5_id.into(),
                         node_weight_kind: NodeWeightDiscriminants::Content,
                     },
                     edge_weight: new_edge_weight,
@@ -2336,14 +2338,14 @@ mod test {
                         index: new_graph
                             .get_node_index_by_id(source_node_id_for_ordinal_edge)
                             .expect("could not get node index by id"),
-                        id: source_node_id_for_ordinal_edge,
+                        id: source_node_id_for_ordinal_edge.into(),
                         node_weight_kind: NodeWeightDiscriminants::Ordering,
                     },
                     destination: NodeInformation {
                         index: initial_graph
                             .get_node_index_by_id(destination_node_id_for_ordinal_edge)
                             .expect("could not get node index by id"),
-                        id: destination_node_id_for_ordinal_edge,
+                        id: destination_node_id_for_ordinal_edge.into(),
                         node_weight_kind: NodeWeightDiscriminants::Content,
                     },
                     edge_weight: ordinal_edge_weight,
@@ -2652,14 +2654,14 @@ mod test {
                         index: new_graph
                             .get_node_index_by_id(container_prop_id)
                             .expect("Unable to get new_graph container NodeIndex"),
-                        id: container_prop_id,
+                        id: container_prop_id.into(),
                         node_weight_kind: NodeWeightDiscriminants::Content,
                     },
                     destination: NodeInformation {
                         index: initial_graph
                             .get_node_index_by_id(ordered_prop_5_id)
                             .expect("Unable to get ordered prop 5 NodeIndex"),
-                        id: ordered_prop_5_id,
+                        id: ordered_prop_5_id.into(),
                         node_weight_kind: NodeWeightDiscriminants::Content,
                     },
                     edge_weight: new_edge_weight,
@@ -2669,14 +2671,14 @@ mod test {
                         index: new_graph
                             .get_node_index_by_id(source_node_id_for_ordinal_edge)
                             .expect("could not get node index by id"),
-                        id: source_node_id_for_ordinal_edge,
+                        id: source_node_id_for_ordinal_edge.into(),
                         node_weight_kind: NodeWeightDiscriminants::Ordering,
                     },
                     destination: NodeInformation {
                         index: initial_graph
                             .get_node_index_by_id(destination_node_id_for_ordinal_edge)
                             .expect("could not get node index by id"),
-                        id: destination_node_id_for_ordinal_edge,
+                        id: destination_node_id_for_ordinal_edge.into(),
                         node_weight_kind: NodeWeightDiscriminants::Content,
                     },
                     edge_weight: ordinal_edge_weight,
@@ -2866,12 +2868,12 @@ mod test {
             vec![Update::RemoveEdge {
                 source: NodeInformation {
                     index: a_idx,
-                    id: a_id,
+                    id: a_id.into(),
                     node_weight_kind: NodeWeightDiscriminants::Prop,
                 },
                 destination: NodeInformation {
                     index: c_idx,
-                    id: c_id,
+                    id: c_id.into(),
                     node_weight_kind: NodeWeightDiscriminants::Prop,
                 },
                 edge_kind: EdgeWeightKindDiscriminants::Use,
@@ -2961,7 +2963,8 @@ mod test {
                     id: graph_a
                         .get_node_weight(a_q_node_idx)
                         .expect("Unable to get a_q node weight")
-                        .id(),
+                        .id()
+                        .into(),
                     node_weight_kind: NodeWeightDiscriminants::Prop,
                 },
                 destination: NodeInformation {
@@ -2969,7 +2972,8 @@ mod test {
                     id: graph_a
                         .get_node_weight(a_node_idx)
                         .expect("Unable to get a node weight")
-                        .id(),
+                        .id()
+                        .into(),
                     node_weight_kind: NodeWeightDiscriminants::Prop,
                 },
                 edge_kind: EdgeWeightKindDiscriminants::Use,
@@ -2992,7 +2996,8 @@ mod test {
                     id: graph_b
                         .get_node_weight(b_q_node_idx)
                         .expect("Unable to get b_q node_weight")
-                        .id(),
+                        .id()
+                        .into(),
                     node_weight_kind: NodeWeightDiscriminants::Prop,
                 },
                 destination: NodeInformation {
@@ -3000,7 +3005,8 @@ mod test {
                     id: graph_b
                         .get_node_weight(b_node_idx)
                         .expect("Unable to get b node_weight")
-                        .id(),
+                        .id()
+                        .into(),
                     node_weight_kind: NodeWeightDiscriminants::Prop,
                 },
                 edge_kind: EdgeWeightKindDiscriminants::Use,
@@ -3183,7 +3189,8 @@ mod test {
             id: to_rebase_graph
                 .get_node_weight(to_rebase_graph.root())
                 .expect("Unable to get root node")
-                .id(),
+                .id()
+                .into(),
             node_weight_kind: NodeWeightDiscriminants::Content,
         };
         let removed_index = onto_graph
@@ -3194,7 +3201,8 @@ mod test {
             id: onto_graph
                 .get_node_weight(removed_index)
                 .expect("Unable to get removed item node weight")
-                .id(),
+                .id()
+                .into(),
             node_weight_kind: NodeWeightDiscriminants::Content,
         };
         assert_eq!(

--- a/lib/dal/src/workspace_snapshot/update.rs
+++ b/lib/dal/src/workspace_snapshot/update.rs
@@ -1,29 +1,30 @@
-use petgraph::prelude::*;
 use si_events::ulid::Ulid;
 
-use super::edge_weight::{EdgeWeight, EdgeWeightKindDiscriminants};
 use serde::{Deserialize, Serialize};
+
+use super::edge_weight::{EdgeWeight, EdgeWeightKindDiscriminants};
+use crate::workspace_snapshot::NodeInformation;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub enum Update {
     NewEdge {
-        source: NodeIndex,
+        source: NodeInformation,
         // Check if already exists in "onto" (source). Grab node weight from "to_rebase"
         // (destination) and see if there is an equivalent node (id and lineage) in "onto".
         // If not, use "import_subgraph".
-        destination: NodeIndex,
+        destination: NodeInformation,
         edge_weight: EdgeWeight,
     },
     RemoveEdge {
-        source: NodeIndex,
-        destination: NodeIndex,
+        source: NodeInformation,
+        destination: NodeInformation,
         edge_kind: EdgeWeightKindDiscriminants,
     },
     ReplaceSubgraph {
-        onto: NodeIndex,
+        onto: NodeInformation,
         // Check if already exists in "onto". Grab node weight from "to_rebase" and see if there is
         // an equivalent node (id and lineage) in "onto". If not, use "import_subgraph".
-        to_rebase: NodeIndex,
+        to_rebase: NodeInformation,
     },
     MergeCategoryNodes {
         to_rebase_category_id: Ulid,

--- a/lib/si-events-rs/src/ulid.rs
+++ b/lib/si-events-rs/src/ulid.rs
@@ -4,7 +4,7 @@ pub use ulid::ULID_LEN;
 /// Size is the size in bytes, len is the string length
 const ULID_SIZE: usize = 16;
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, Default, PartialOrd, Ord)]
+#[derive(Eq, PartialEq, Copy, Clone, Hash, Default, PartialOrd, Ord)]
 pub struct Ulid(CoreUlid);
 
 impl Ulid {
@@ -63,6 +63,12 @@ impl ::serde::Serialize for Ulid {
 impl std::fmt::Display for Ulid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Ulid({})", self.0.to_string())
+    }
+}
+
+impl std::fmt::Debug for Ulid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Ulid").field(&self.0.to_string()).finish()
     }
 }
 


### PR DESCRIPTION
Previously, we were only including the (internal to the graph) `NodeIndex` in the structs for representing conflicts & updates. While this is all that's strictly necessary for performing the updates and (eventually) having SDF report what the conflicts are, having more contextual information such as the node weight kind, and the ID of the node makes things a bit easier for debugging issues when looking at spans & traces.