### PR TITLE
fix(dal): add recently seen clocks to edge weights

### DIFF
--- a/lib/dal/src/workspace_snapshot/vector_clock.rs
+++ b/lib/dal/src/workspace_snapshot/vector_clock.rs
@@ -34,6 +34,12 @@ impl VectorClock {
         Ok(VectorClock { entries })
     }
 
+    pub fn empty() -> Self {
+        Self {
+            entries: HashMap::new(),
+        }
+    }
+
     pub fn entry_for(&self, vector_clock_id: VectorClockId) -> Option<LamportClock> {
         self.entries.get(&vector_clock_id).copied()
     }

--- a/lib/si-events-rs/src/workspace_snapshot_address.rs
+++ b/lib/si-events-rs/src/workspace_snapshot_address.rs
@@ -7,7 +7,7 @@ use serde::{
 use std::{fmt, str::FromStr};
 use thiserror::Error;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct WorkspaceSnapshotAddress(blake3::Hash);
 
 impl WorkspaceSnapshotAddress {

--- a/lib/si-layer-cache/src/layer_cache.rs
+++ b/lib/si-layer-cache/src/layer_cache.rs
@@ -93,6 +93,24 @@ where
         })
     }
 
+    #[instrument(
+        name = "layer_cache.get_bytes_from_durable_storage",
+        level = "debug",
+        skip_all,
+        fields(
+            si.layer_cache.key = key.as_ref(),
+        ),
+    )]
+    pub async fn get_bytes_from_durable_storage(
+        &self,
+        key: Arc<str>,
+    ) -> LayerDbResult<Option<Vec<u8>>> {
+        Ok(match self.disk_cache.get(key.clone()).await {
+            Ok(bytes) => Some(bytes),
+            Err(_) => self.pg.get(&key).await?,
+        })
+    }
+
     pub async fn get_bulk<K>(&self, keys: &[K]) -> LayerDbResult<HashMap<K, V>>
     where
         K: Clone + Display + Eq + std::hash::Hash + std::str::FromStr,


### PR DESCRIPTION
EdgeWeights had no "recently seen" vector clocks. This lead to situations where we produced a conflict but should not have, because we only had the "first seen" clock to work with. This adds the recently seen vector clock to the graph. However, this cannot be done without a new version of the WorkspaceSnapshotGraph, so migration logic has been implemented to automatically migrate the snapshot on first read.