### PR TITLE
Move check for Conflict::ExclusiveEdgeMismatch to operate on the net changes for the outgoing edges

### DIFF
--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -69,7 +69,7 @@ use crate::{
 use self::node_weight::{NodeWeightDiscriminants, OrderingNodeWeight};
 
 pk!(NodeId);
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NodeInformation {
     pub index: NodeIndex,
     pub node_weight_kind: NodeWeightDiscriminants,

--- a/lib/dal/src/workspace_snapshot/conflict.rs
+++ b/lib/dal/src/workspace_snapshot/conflict.rs
@@ -5,7 +5,7 @@ use crate::{workspace_snapshot::NodeInformation, EdgeWeightKindDiscriminants};
 /// Describe the type of conflict between the given locations in a
 /// workspace graph.
 #[remain::sorted]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Hash)]
 pub enum Conflict {
     ChildOrder {
         onto: NodeInformation,

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -18,7 +18,7 @@ pub type EdgeWeightResult<T> = Result<T, EdgeWeightError>;
 
 #[remain::sorted]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, EnumDiscriminants)]
-#[strum_discriminants(derive(Serialize, Deserialize))]
+#[strum_discriminants(derive(Hash, Serialize, Deserialize))]
 pub enum EdgeWeightKind {
     Action,
     /// A function used by a [`SchemaVariant`] to perform an action that affects its resource

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -80,7 +80,7 @@ pub enum NodeWeightError {
 pub type NodeWeightResult<T> = Result<T, NodeWeightError>;
 
 #[derive(Debug, Serialize, Deserialize, Clone, EnumDiscriminants)]
-#[strum_discriminants(derive(strum::Display, Serialize, Deserialize))]
+#[strum_discriminants(derive(strum::Display, Hash, Serialize, Deserialize))]
 pub enum NodeWeight {
     Action(ActionNodeWeight),
     ActionPrototype(ActionPrototypeNodeWeight),

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -186,7 +186,6 @@ impl AttributeValueNodeWeight {
 
     pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
         &[
-            EdgeWeightKindDiscriminants::Contain,
             EdgeWeightKindDiscriminants::Prototype,
             EdgeWeightKindDiscriminants::Prop,
             EdgeWeightKindDiscriminants::Socket,

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -174,7 +174,6 @@ impl ComponentNodeWeight {
     pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
         &[
             EdgeWeightKindDiscriminants::Use,
-            EdgeWeightKindDiscriminants::FrameContains,
             EdgeWeightKindDiscriminants::Root,
             EdgeWeightKindDiscriminants::SocketValue,
         ]

--- a/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
@@ -186,7 +186,7 @@ impl FuncNodeWeight {
     }
 
     pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
-        &[EdgeWeightKindDiscriminants::Use]
+        &[]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
@@ -186,10 +186,7 @@ impl PropNodeWeight {
     }
 
     pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
-        &[
-            EdgeWeightKindDiscriminants::Prototype,
-            EdgeWeightKindDiscriminants::Use,
-        ]
+        &[]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/update.rs
+++ b/lib/dal/src/workspace_snapshot/update.rs
@@ -1,11 +1,12 @@
 use si_events::ulid::Ulid;
 
 use serde::{Deserialize, Serialize};
+use strum::EnumDiscriminants;
 
 use super::edge_weight::{EdgeWeight, EdgeWeightKindDiscriminants};
 use crate::workspace_snapshot::NodeInformation;
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, EnumDiscriminants)]
 pub enum Update {
     NewEdge {
         source: NodeInformation,

--- a/lib/dal/tests/integration_test/rebaser.rs
+++ b/lib/dal/tests/integration_test/rebaser.rs
@@ -201,6 +201,8 @@ async fn func_node_with_arguments(ctx: &mut DalContext) {
     );
 }
 
+/// This can't be checked for until we have more fully-featured semantic conflict detection.
+#[ignore]
 #[test]
 async fn func_node_with_arguments_conflict(ctx: &mut DalContext) {
     let code_base64 = general_purpose::STANDARD_NO_PAD.encode("this is code");

--- a/lib/dal/tests/integration_test/rebaser.rs
+++ b/lib/dal/tests/integration_test/rebaser.rs
@@ -1,8 +1,13 @@
 use base64::{engine::general_purpose, Engine};
 use dal::func::argument::{FuncArgument, FuncArgumentKind};
 use dal::workspace_snapshot::conflict::Conflict;
-use dal::{ChangeSet, DalContext, Func, FuncBackendKind, FuncBackendResponseType};
-use dal_test::helpers::{ChangeSetTestHelpers, ChangeSetTestHelpersError};
+use dal::{
+    AttributeValue, ChangeSet, Component, DalContext, Func, FuncBackendKind,
+    FuncBackendResponseType,
+};
+use dal_test::helpers::{
+    create_component_for_schema_name, ChangeSetTestHelpers, ChangeSetTestHelpersError,
+};
 use dal_test::test;
 use pretty_assertions_sorted::assert_eq;
 
@@ -353,4 +358,131 @@ async fn delete_func_node(ctx: &mut DalContext) {
 
     let result = Func::get_by_id_or_error(ctx, func.id).await;
     assert!(result.is_err());
+}
+
+#[test]
+async fn correctly_detect_unrelated_unmodified_data(ctx: &mut DalContext) {
+    let shared_component_id =
+        create_component_for_schema_name(ctx, "Docker Image", "Shared component")
+            .await
+            .id();
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("Unable to commit_and_update_snapshot_to_visibility");
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx)
+        .await
+        .expect("Unable to merge to base change set");
+
+    let change_set_a =
+        ChangeSetTestHelpers::fork_from_head_change_set_with_name(ctx, "Change set A")
+            .await
+            .expect("Unable to create change set A");
+    let change_set_b =
+        ChangeSetTestHelpers::fork_from_head_change_set_with_name(ctx, "Change set B")
+            .await
+            .expect("Unable to create change set B");
+
+    // Modify the shared component in change set A.
+    ctx.update_visibility_and_snapshot_to_visibility(change_set_a.id)
+        .await
+        .expect("Unable to switch to change set A");
+    let cs_a_name_av_id = {
+        let component = Component::get_by_id(ctx, shared_component_id)
+            .await
+            .expect("Unable to get shared component in change set A");
+        component
+            .attribute_values_for_prop(ctx, &["root", "si", "name"])
+            .await
+            .expect("Unable to get attribute values for si.name")
+            .first()
+            .copied()
+            .expect("si.name attribute value not found")
+    };
+    AttributeValue::update(
+        ctx,
+        cs_a_name_av_id,
+        Some(serde_json::json!("Modified in change set A")),
+    )
+    .await
+    .expect("Unable to update shared component name in change set A");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("Unable to commit_and_update_snapshot_to_visibility for change set A");
+
+    // Create a new component in change set B.
+    ctx.update_visibility_and_snapshot_to_visibility(change_set_b.id)
+        .await
+        .expect("Unable to switch to change set B");
+    let _change_set_b_component_id =
+        create_component_for_schema_name(ctx, "Docker Image", "Change Set B Component")
+            .await
+            .id();
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("Unable to commit_and_update_snapshot_to_visibility for change set B");
+
+    // Merge change set A to head.
+    ctx.update_visibility_and_snapshot_to_visibility(change_set_a.id)
+        .await
+        .expect("Unable to switch to change set A");
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx)
+        .await
+        .expect("Unable to merge change set A");
+
+    // Make sure the shared component looks as we'd expect.
+    let expected_qualification_item_count = 1;
+    let shared_component = Component::get_by_id(ctx, shared_component_id)
+        .await
+        .expect("Unable to get shared component in change set A");
+    let av_ids = shared_component
+        .attribute_values_for_prop(ctx, &["root", "si", "name"])
+        .await
+        .expect("Unable to get attribute values for si.name");
+    assert_eq!(av_ids.len(), 1, "Found more than one AV for si.name");
+    let av_ids = shared_component
+        .attribute_values_for_prop(ctx, &["root", "domain", "image"])
+        .await
+        .expect("Unable to get attribute values for domain.image");
+    assert_eq!(av_ids.len(), 1, "Found more than one AV for domain.image");
+    let av_ids = shared_component
+        .attribute_values_for_prop(ctx, &["root", "qualification", "qualificationItem"])
+        .await
+        .expect("Unable to get attribute values for qualification.qualificationItem");
+    assert_eq!(
+        av_ids.len(),
+        expected_qualification_item_count,
+        "Found more than one AV for qualification.qualificationItem"
+    );
+
+    // Merge change set B to head.
+    ctx.update_visibility_and_snapshot_to_visibility(change_set_b.id)
+        .await
+        .expect("Unable to switch to change set B");
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx)
+        .await
+        .expect("Unable to merge change set B");
+
+    // Make sure merging change set B didn't affect anything it didn't touch.
+    let shared_component = Component::get_by_id(ctx, shared_component_id)
+        .await
+        .expect("Unable to get shared component in change set A");
+    let av_ids = shared_component
+        .attribute_values_for_prop(ctx, &["root", "si", "name"])
+        .await
+        .expect("Unable to get attribute values for si.name");
+    assert_eq!(av_ids.len(), 1, "Found more than one AV for si.name");
+    let av_ids = shared_component
+        .attribute_values_for_prop(ctx, &["root", "domain", "image"])
+        .await
+        .expect("Unable to get attribute values for domain.image");
+    assert_eq!(av_ids.len(), 1, "Found more than one AV for domain.image");
+    let av_ids = shared_component
+        .attribute_values_for_prop(ctx, &["root", "qualification", "qualificationItem"])
+        .await
+        .expect("Unable to get attribute values for qualification.qualificationItem");
+    assert_eq!(
+        av_ids.len(),
+        expected_qualification_item_count,
+        "Found more than one AV for qualification.qualificationItem"
+    );
 }


### PR DESCRIPTION
Previously, the check was not taking into account that while there may be an `Update::NewEdge` that is creating an outgoing edge of the same `EdgeWeightKind` as an existing edge, there might also be an `Update::RemoveEdge` that is removing that pre-existing edge.

We now check to make sure that after all additions & removals of outgoing edges for a specific `EdgeWeightKind`, the net result is that we have no more than a single edge.

The following exclusive edge mismatch conditions have been removed as they are more nuanced than "Node X can have at most 1 of edge kind Y", and will be addressed at a later date.

* `AttributeValue` - `Contain`: `AttributeValue`s can have multiple outgoing `Contain` edges. The restriction on whether or not a specific `Contain` edge is a semantic conflict with another depends on information about the `Prop` tree structure, and looking at the `key` portion of the `Contain` edge weight.
* `Component` - `FrameContains`: The exclusivity of the `FrameContains` edge is that a `Component` can only have one *incoming* `FrameContains` edge. An arbitrary number of *outgoing* `FrameContains` are allowed.
* `Func` - `Use`: A `Func` can have multiple outgoing `Use` edges, and is a requirement for any `Func` that has multiple `FuncArgument`s.
* `Prop` - `Prototype`: As with `AttributeValue` and `Contain`, this requires looking at the prop tree structure, and taking into consideration the `key` portion of the `Prototype` edge weight.
* `Prop` - `Use`: As with `FrameContains`, the direction of the exclusivity is on *incoming* edges, not on the number of *outgoing* edges.