### PR TITLE
Actions V2 Fixes

### DIFF
--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -274,10 +274,6 @@ impl ActionPrototype {
                     .publish_on_commit(ctx)
                     .await?;
 
-                if component.to_delete() && run_result.payload.is_none() {
-                    Component::remove(ctx, component.id()).await?;
-                }
-
                 Some(run_result)
             }
             None => None,

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1866,11 +1866,31 @@ impl AttributeValue {
                 IntrinsicFunc::from(prop_node.kind())
             }
         };
-
+        let associated_component_id = AttributeValue::component_id(ctx, attribute_value_id).await?;
         let func_id = Func::find_intrinsic(ctx, intrinsic_func).await?;
-        let prototype = AttributePrototype::new(ctx, func_id).await?;
+        // find existing component-specific prototype if it exists, if it does exist, prune the arguments (which will be re-added later)
+        // if it doesn't exist, create a new one and set it as the component specific prototype
+        let prototype_id = if let Some(existing_prototype) =
+            AttributeValue::component_prototype_id(ctx, attribute_value_id).await?
+        {
+            // prune existing arguments
+            let existing_arguments =
+                AttributePrototypeArgument::list_ids_for_prototype_and_destination(
+                    ctx,
+                    existing_prototype,
+                    associated_component_id,
+                )
+                .await?;
+            for existing_argument in existing_arguments {
+                AttributePrototypeArgument::remove_or_no_op(ctx, existing_argument).await?;
+            }
+            existing_prototype
+        } else {
+            let prototype = AttributePrototype::new(ctx, func_id).await?;
 
-        Self::set_component_prototype_id(ctx, attribute_value_id, prototype.id()).await?;
+            Self::set_component_prototype_id(ctx, attribute_value_id, prototype.id()).await?;
+            prototype.id()
+        };
 
         let func_binding_args = match value.to_owned() {
             Some(value) => {
@@ -1891,7 +1911,7 @@ impl AttributeValue {
                         .to_owned()
                 };
 
-                AttributePrototypeArgument::new(ctx, prototype.id(), func_arg_id)
+                AttributePrototypeArgument::new(ctx, prototype_id, func_arg_id)
                     .await?
                     .set_value_from_static_value(ctx, value.to_owned())
                     .await?;
@@ -1901,7 +1921,6 @@ impl AttributeValue {
             None => serde_json::Value::Null,
         };
 
-        let associated_component_id = AttributeValue::component_id(ctx, attribute_value_id).await?;
         let before = before_funcs_for_component(ctx, associated_component_id)
             .await
             .map_err(|e| AttributeValueError::BeforeFunc(e.to_string()))?;


### PR DESCRIPTION
Fixed 2 bugs in this PR: 
- an issue with removing delete actions from the graph on successful action run (due to a race in removing all existing actions when removing a component, and the surgical 'remove this action because it finished') 
- when we set attribute values, (for example setting the resource), we were always deleting and recreating the Attribute Prototype. With this change we will first check if there's a component specific attribute prototype and if so, wipe the Arguments and repopulate them. Then, create one if it doesn't already exist. 

<div><img src="https://media1.giphy.com/media/EukOAWKKs0QoW3ps7Z/200.gif?cid=5a38a5a20ofneit8i6drtwh1shbm3p9v7l2ph4w4szu4n2ke&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:170px;width:300px"/><br/>via <a href="https://giphy.com/nickelodeon/">Nickelodeon</a> on <a href="https://giphy.com/gifs/nickelodeon-theatre-the-loud-house-and-action-EukOAWKKs0QoW3ps7Z">GIPHY</a></div>