### PR TITLE
Add regression test for qualification views

### DIFF
--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -13,6 +13,7 @@ mod input_sources;
 mod module;
 mod prop;
 mod property_editor;
+mod qualifications;
 mod rebaser;
 mod schema;
 mod secret;

--- a/lib/dal/tests/integration_test/qualifications.rs
+++ b/lib/dal/tests/integration_test/qualifications.rs
@@ -1,0 +1,88 @@
+use dal::qualification::{
+    QualificationOutputStreamView, QualificationResult, QualificationSubCheck,
+    QualificationSubCheckStatus, QualificationView,
+};
+use dal::{Component, DalContext};
+use dal_test::helpers::{create_component_for_schema_name, ChangeSetTestHelpers};
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn list_qualifications(ctx: &mut DalContext) {
+    let component = create_component_for_schema_name(
+        ctx,
+        "dummy-secret",
+        "deserializing serde json value null into an option results in None and that's insane",
+    )
+    .await;
+
+    // Prepare expected qualification views.
+    let expected_prop_validations_qualification_view = QualificationView {
+        title: "Prop Validations".to_string(),
+        output: vec![],
+        description: None,
+        link: None,
+        result: Some(QualificationResult {
+            status: QualificationSubCheckStatus::Success,
+            title: None,
+            link: None,
+            sub_checks: vec![QualificationSubCheck {
+                description: "Component has 0 invalid value(s).".to_string(),
+                status: QualificationSubCheckStatus::Success,
+            }],
+        }),
+        qualification_name: "validations".to_string(),
+    };
+    let expected_additional_qualification_view_name =
+        "test:qualificationDummySecretStringIsTodd".to_string();
+    let expected_additional_qualification_view = QualificationView {
+        title: expected_additional_qualification_view_name.to_owned(),
+        output: vec![
+            QualificationOutputStreamView {
+                stream: "output".to_string(),
+                line: "Output: {\n  \"protocol\": \"result\",\n  \"status\": \"success\",\n  \"executionId\": \"tomcruise\",\n  \"data\": {\n    \"result\": \"failure\",\n    \"message\": \"dummy secret string is empty\"\n  },\n  \"unset\": false\n}".to_string(),
+                level: "info".to_string(),
+            }
+        ],
+        description: None,
+        link: None,
+        result: Some(QualificationResult {
+            status: QualificationSubCheckStatus::Failure,
+            title: Some( expected_additional_qualification_view_name.to_owned()),
+            link: None,
+            sub_checks: vec![QualificationSubCheck {
+                description: "dummy secret string is empty".to_string(),
+                status: QualificationSubCheckStatus::Failure,
+            }],
+        }),
+        qualification_name:  expected_additional_qualification_view_name.to_owned(),
+    };
+
+    // Check qualifications before committing and running dependent values update.
+    let qualifications = Component::list_qualifications(ctx, component.id())
+        .await
+        .expect("could not list qualifications");
+    assert_eq!(
+        vec![expected_prop_validations_qualification_view.clone()], // expected
+        qualifications                                              // actual
+    );
+
+    // Commit and check qualifications again. We should see the populated map with all
+    // qualifications.
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+    let qualifications = Component::list_qualifications(ctx, component.id())
+        .await
+        .expect("could not list qualifications");
+
+    // NOTE(nick): at the time of writing this test, we receive the qualifications sorted, so we
+    // neither need to perform an additional sort nor use something like a hash set.
+    assert_eq!(
+        vec![
+            expected_prop_validations_qualification_view,
+            expected_additional_qualification_view
+        ], // expected
+        qualifications // actual
+    );
+}


### PR DESCRIPTION
This was found during func execution refactoring (#3825) since other tests rely on qualification view generation working.