### PR TITLE
dev: add grafana to our platform stack

### DIFF
--- a/component/grafana/docker-compose.yaml
+++ b/component/grafana/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: "3.8"
+services:
+  grafana:
+    image: grafana/grafana-enterprise
+    container_name: grafana
+    ports:
+      - "3000:3000"

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -9,6 +9,7 @@ cfg = config.parse()
 # Define groups of services
 groups = {
     "platform": [
+        "grafana",
         "jaeger",
         "nats",
         "otelcol",
@@ -92,11 +93,15 @@ allow_k8s_contexts(k8s_context())
 
 # Use Docker Compose to provide the platform services
 docker_compose("./docker-compose.platform.yml")
-compose_services = ["jaeger", "nats", "otelcol", "postgres", "postgres-test", "db", "db-test"]
+compose_services = ["jaeger", "nats", "otelcol", "postgres", "postgres-test", "db", "db-test", "grafana"]
 for service in compose_services:
     if service == "jaeger":
         links = [
             link("http://localhost:16686", "ui"),
+        ]
+    elif service == "grafana":
+        links = [
+            link("http://localhost:3000", "ui"),
         ]
     else:
         links = []

--- a/dev/datasources/datasources.yml
+++ b/dev/datasources/datasources.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Jaeger
+    type: jaeger
+    url: http://dev-jaeger-1:16686
+    basicAuth: false
+    access: proxy
+    readOnly: false
+    isDefault: true

--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -93,6 +93,18 @@ services:
       - "5317:4317"
       - "16686:16686"
 
+  grafana:
+    image: grafana/grafana-enterprise
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./datasources:/etc/grafana/provisioning/datasources
+    environment:
+      - "GF_AUTH_ANONYMOUS_ENABLED=true"
+      - "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin"
+      - "GF_AUTH_DISABLE_LOGIN_FORM=true"
+
   otelcol:
     image: systeminit/otelcol:stable
     # If you'd like to ship to honeycomb from your local machine, you need these two variables in the otelcol


### PR DESCRIPTION
This adds grafana to our platform stack and allows grafana to automatically use the trace data from Jaeger as a datasource

Hit localhost:3000 in your browser after bring up the tiltstack and log right in!