### PR TITLE
fix(dal): Ensure that we copy Socket data on export schema variant

### DIFF
--- a/lib/si-pkg/src/pkg/variant.rs
+++ b/lib/si-pkg/src/pkg/variant.rs
@@ -239,6 +239,7 @@ impl<'a> SiPkgSchemaVariant<'a> {
                         node,
                         PkgNode::SchemaVariantChild(SchemaVariantChildNode::ResourceValue)
                     ),
+                    SchemaVariantSpecPropRoot::Resource => false,
                     SchemaVariantSpecPropRoot::Secrets => matches!(
                         node,
                         PkgNode::SchemaVariantChild(SchemaVariantChildNode::Secrets)
@@ -257,19 +258,19 @@ impl<'a> SiPkgSchemaVariant<'a> {
         if maybe_node_index.is_some() || prop_root == SchemaVariantSpecPropRoot::Secrets {
             Ok(maybe_node_index)
         } else {
-            Err(SiPkgError::SchemaVariantChildNotFound(
-                match prop_root {
-                    SchemaVariantSpecPropRoot::Domain => SchemaVariantChildNode::Domain,
-                    SchemaVariantSpecPropRoot::ResourceValue => {
-                        SchemaVariantChildNode::ResourceValue
-                    }
-                    SchemaVariantSpecPropRoot::Secrets => SchemaVariantChildNode::Secrets,
-                    SchemaVariantSpecPropRoot::SecretDefinition => {
-                        SchemaVariantChildNode::SecretDefinition
-                    }
+            let maybe_kind = match prop_root {
+                SchemaVariantSpecPropRoot::Domain => SchemaVariantChildNode::Domain.kind_str(),
+                SchemaVariantSpecPropRoot::ResourceValue => {
+                    SchemaVariantChildNode::ResourceValue.kind_str()
                 }
-                .kind_str(),
-            ))
+                SchemaVariantSpecPropRoot::Secrets => SchemaVariantChildNode::Secrets.kind_str(),
+                SchemaVariantSpecPropRoot::SecretDefinition => {
+                    SchemaVariantChildNode::SecretDefinition.kind_str()
+                }
+                _ => "resource",
+            };
+
+            Err(SiPkgError::SchemaVariantChildNotFound(maybe_kind))
         }
     }
 

--- a/lib/si-pkg/src/spec/socket.rs
+++ b/lib/si-pkg/src/spec/socket.rs
@@ -102,4 +102,32 @@ impl SocketSpec {
     pub fn kind(&self) -> Option<SocketSpecKind> {
         self.data.as_ref().map(|data| data.kind)
     }
+
+    pub fn merge_socket_spec(&self, old_socket: &SocketSpec) -> SocketSpecBuilder {
+        let mut builder = SocketSpec::builder();
+        builder.name(self.clone().name);
+
+        if let Some(new_data) = self.clone().data {
+            let mut spec_data = new_data.clone();
+            if new_data.func_unique_id.is_none() {
+                if let Some(old_data) = old_socket.clone().data {
+                    if old_data.func_unique_id.is_some() {
+                        spec_data.func_unique_id = old_data.func_unique_id;
+                    }
+                }
+            }
+
+            builder.data(spec_data);
+        }
+
+        if self.clone().inputs.is_empty() && !old_socket.inputs.is_empty() {
+            builder.inputs(old_socket.clone().inputs);
+        }
+
+        if old_socket.unique_id.is_some() && self.clone().unique_id.is_none() {
+            builder.unique_id(old_socket.clone().unique_id);
+        }
+
+        builder
+    }
 }


### PR DESCRIPTION
We were not merging the socket data when exporting a schema variant and thus dropping all of the export details