### PR TITLE
dev: Adding Localstack to our devstack

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -17,6 +17,7 @@ groups = {
         "db-test",
         "postgres",
         "postgres-test",
+        "localstack",
     ],
     "backend": [
         "pinga",
@@ -93,7 +94,7 @@ allow_k8s_contexts(k8s_context())
 
 # Use Docker Compose to provide the platform services
 docker_compose("./docker-compose.platform.yml")
-compose_services = ["jaeger", "nats", "otelcol", "postgres", "postgres-test", "db", "db-test", "grafana"]
+compose_services = ["jaeger", "nats", "otelcol", "postgres", "postgres-test", "db", "db-test", "grafana", "localstack"]
 for service in compose_services:
     if service == "jaeger":
         links = [

--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -116,3 +116,9 @@ services:
       - "55679:55679"
     depends_on:
       - jaeger
+
+  localstack:
+    image: localstack/localstack
+    ports:
+      - "4566:4566"
+      - "4510-4559:4510-4559"


### PR DESCRIPTION
We no longer need AWS credentials to be able to use the system - we can use the AWS_ENDPOINT http://0.0.0.0:4566 and we are good to go!