### PR TITLE
Return 409 on Conflict!

### DIFF
--- a/app/web/src/components/ApplyChangeSetButton.vue
+++ b/app/web/src/components/ApplyChangeSetButton.vue
@@ -392,13 +392,15 @@ const applyChangeSet = async () => {
   if (!route.name) return;
   applyModalRef.value?.close();
   await changeSetsStore.APPLY_CHANGE_SET(authStore.user?.email ?? "");
-  router.replace({
-    name: route.name,
-    params: {
-      ...route.params,
-      changeSetId: "head",
-    },
-  });
+  if (!applyChangeSetReqStatus.value.isError) {
+    router.replace({
+      name: route.name,
+      params: {
+        ...route.params,
+        changeSetId: "head",
+      },
+    });
+  }
 };
 
 const beginMergeApprovalReqStatus = changeSetsStore.getRequestStatus(

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -153,7 +153,7 @@ export function useChangeSetsStore() {
                 },
               });
             },
-            _delay: 1000,
+            _delay: 2000,
             onSuccess: (response) => {
               this.changeSetsById[response.changeSet.id] = response.changeSet;
               toast({
@@ -162,6 +162,9 @@ export function useChangeSetsStore() {
                   name: response.changeSet.name,
                 },
               });
+            },
+            onFail: () => {
+              // todo: show something!
             },
           });
         },

--- a/lib/dal/tests/integration_test/rebaser.rs
+++ b/lib/dal/tests/integration_test/rebaser.rs
@@ -3,7 +3,7 @@ use dal::func::argument::{FuncArgument, FuncArgumentKind};
 use dal::workspace_snapshot::conflict::Conflict;
 use dal::{
     AttributeValue, ChangeSet, Component, DalContext, Func, FuncBackendKind,
-    FuncBackendResponseType,
+    FuncBackendResponseType, TransactionsError,
 };
 use dal_test::helpers::{
     create_component_for_schema_name, ChangeSetTestHelpers, ChangeSetTestHelpersError,
@@ -297,10 +297,13 @@ async fn func_node_with_arguments_conflict(ctx: &mut DalContext) {
     let result = ChangeSetTestHelpers::apply_change_set_to_base(ctx).await;
     assert!(matches!(
         result,
-        Err(ChangeSetTestHelpersError::ConflictsFoundAfterApply(_))
+        Err(ChangeSetTestHelpersError::ChangeSetApply(_))
     ));
 
-    if let Err(ChangeSetTestHelpersError::ConflictsFoundAfterApply(conflicts)) = result {
+    if let Err(ChangeSetTestHelpersError::Transactions(TransactionsError::ConflictsOccurred(
+        conflicts,
+    ))) = result
+    {
         assert_eq!(1, conflicts.conflicts_found.len());
         let conflict = conflicts
             .conflicts_found

--- a/lib/dal/tests/integration_test/validations.rs
+++ b/lib/dal/tests/integration_test/validations.rs
@@ -129,6 +129,10 @@ async fn validation_on_dependent_value(ctx: &mut DalContext) {
     let output_component = create_component_for_schema_name(ctx, "ValidatedOutput", "Output").await;
     let input_component = create_component_for_schema_name(ctx, "ValidatedInput", "Input").await;
 
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
     connect_components_with_socket_names(
         ctx,
         output_component.id(),

--- a/lib/sdf-server/src/server.rs
+++ b/lib/sdf-server/src/server.rs
@@ -29,7 +29,10 @@ macro_rules! impl_default_error_into_response {
     ) => {
         impl axum::response::IntoResponse for $error_type {
             fn into_response(self) -> Response {
-                let (status, error_message) = (axum::http::StatusCode::INTERNAL_SERVER_ERROR, self.to_string());
+                let (status, error_message) = match self {
+                   $error_type::Transactions(TransactionsError::ConflictsOccurred(_)) => (axum::http::StatusCode::CONFLICT, self.to_string()),
+                  _ => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+                };
 
                 let body = Json(
                     serde_json::json!({ "error": { "message": error_message, "code": 42, "statusCode": status.as_u16() } }),

--- a/lib/sdf-server/src/server/service/action.rs
+++ b/lib/sdf-server/src/server/service/action.rs
@@ -1,10 +1,5 @@
 use axum::routing::post;
-use axum::{
-    http::StatusCode,
-    response::{IntoResponse, Response},
-    routing::get,
-    Json, Router,
-};
+use axum::{response::Response, routing::get, Json, Router};
 use dal::WsEventError;
 use si_layer_cache::LayerDbError;
 use thiserror::Error;
@@ -15,7 +10,7 @@ use dal::{
 };
 use dal::{ComponentError, ComponentId, StandardModelError, TransactionsError, UserError, UserPk};
 
-use crate::server::state::AppState;
+use crate::server::{impl_default_error_into_response, state::AppState};
 
 mod cancel;
 mod history;
@@ -64,17 +59,7 @@ pub enum ActionError {
 
 pub type ActionResult<T> = std::result::Result<T, ActionError>;
 
-impl IntoResponse for ActionError {
-    fn into_response(self) -> Response {
-        let (status, error_message) = (StatusCode::INTERNAL_SERVER_ERROR, self.to_string());
-
-        let body = Json(
-            serde_json::json!({ "error": { "message": error_message, "code": 42, "statusCode": status.as_u16() } }),
-        );
-
-        (status, body).into_response()
-    }
-}
+impl_default_error_into_response!(ActionError);
 
 pub fn routes() -> Router<AppState> {
     Router::new()

--- a/lib/sdf-server/src/server/service/attribute.rs
+++ b/lib/sdf-server/src/server/service/attribute.rs
@@ -14,8 +14,6 @@ pub mod get_prototype_arguments;
 pub enum AttributeError {
     #[error("attribute value error: {0}")]
     AttributeValue(#[from] AttributeValueError),
-    #[error("context transaction error: {0}")]
-    ContextTransaction(#[from] TransactionsError),
     #[error("multiple attribute values ({0:?}) found for output socket ({1})")]
     MultipleAttributeValuesForOutputSocket(Vec<AttributeValueId>, OutputSocketId),
     #[error("multiple attribute values ({0:?}) found for prop ({1})")]
@@ -32,6 +30,8 @@ pub enum AttributeError {
     OutputSocket(#[from] OutputSocketError),
     #[error("prop error: {0}")]
     Prop(#[from] PropError),
+    #[error("transaction error: {0}")]
+    Transactions(#[from] TransactionsError),
 }
 
 pub type AttributeResult<T> = Result<T, AttributeError>;

--- a/lib/sdf-server/src/server/service/change_set.rs
+++ b/lib/sdf-server/src/server/service/change_set.rs
@@ -65,6 +65,10 @@ impl IntoResponse for ChangeSetError {
     fn into_response(self) -> Response {
         let (status, error_message) = match self {
             ChangeSetError::ChangeSetNotFound => (StatusCode::NOT_FOUND, self.to_string()),
+            ChangeSetError::Transactions(TransactionsError::ConflictsOccurred(_)) => {
+                (StatusCode::CONFLICT, self.to_string())
+            }
+            ChangeSetError::DalChangeSetApply(_) => (StatusCode::CONFLICT, self.to_string()),
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 

--- a/lib/sdf-server/src/server/service/component.rs
+++ b/lib/sdf-server/src/server/service/component.rs
@@ -106,6 +106,9 @@ impl IntoResponse for ComponentError {
         let (status, error_message) = match self {
             ComponentError::SchemaNotFound => (StatusCode::NOT_FOUND, self.to_string()),
             ComponentError::InvalidVisibility => (StatusCode::NOT_FOUND, self.to_string()),
+            ComponentError::Transactions(TransactionsError::ConflictsOccurred(_)) => {
+                (StatusCode::CONFLICT, self.to_string())
+            }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 

--- a/lib/sdf-server/src/server/service/diagram.rs
+++ b/lib/sdf-server/src/server/service/diagram.rs
@@ -103,6 +103,9 @@ impl IntoResponse for DiagramError {
     fn into_response(self) -> Response {
         let (status, error_message) = match self {
             DiagramError::SchemaNotFound => (StatusCode::NOT_FOUND, self.to_string()),
+            DiagramError::ContextTransaction(TransactionsError::ConflictsOccurred(_)) => {
+                (StatusCode::CONFLICT, self.to_string())
+            }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 

--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -31,8 +31,6 @@ pub mod test_execute;
 pub enum FuncError {
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
-    #[error("context transaction error: {0}")]
-    ContextTransaction(#[from] TransactionsError),
     #[error("dal func error: {0}")]
     Func(#[from] dal::func::FuncError),
     #[error("func argument error: {0}")]
@@ -57,6 +55,8 @@ pub enum FuncError {
     SchemaVariant(#[from] SchemaVariantError),
     #[error("json serialization error: {0}")]
     SerdeJson(#[from] serde_json::Error),
+    #[error("transaction error: {0}")]
+    Transactions(#[from] TransactionsError),
     #[error("workspace snapshot error: {0}")]
     WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
     #[error("could not publish websocket event: {0}")]

--- a/lib/sdf-server/src/server/service/graphviz.rs
+++ b/lib/sdf-server/src/server/service/graphviz.rs
@@ -30,14 +30,14 @@ pub enum GraphVizError {
     AttributeValueError(#[from] AttributeValueError),
     #[error(transparent)]
     Component(#[from] ComponentError),
-    #[error(transparent)]
-    ContextTransaction(#[from] TransactionsError),
     #[error("graph did not have a root node, although this is an unreachable state")]
     NoRootNode,
     #[error(transparent)]
     SchemaVariant(#[from] SchemaVariantError),
     #[error("serde json: {0}")]
     SerdeJson(#[from] serde_json::Error),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
     #[error("could not acquire lock: {0}")]
     TryLock(#[from] tokio::sync::TryLockError),
     #[error("workspace snapshot error")]

--- a/lib/sdf-server/src/server/service/module.rs
+++ b/lib/sdf-server/src/server/service/module.rs
@@ -18,7 +18,6 @@ use si_std::CanonicalFileError;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tokio::fs::read_dir;
-
 const PKG_EXTENSION: &str = "sipkg";
 const MAX_NAME_SEARCH_ATTEMPTS: usize = 100;
 
@@ -43,8 +42,7 @@ pub enum ModuleError {
     ChangeSet(#[from] ChangeSetError),
     #[error("Changeset not found: {0}")]
     ChangeSetNotFound(ChangeSetId),
-    #[error(transparent)]
-    ContextTransaction(#[from] TransactionsError),
+
     #[error(transparent)]
     DalPkg(#[from] DalPkgError),
     #[error("Trying to export from/import into root tenancy")]
@@ -103,6 +101,8 @@ pub enum ModuleError {
     StandardModel(#[from] StandardModelError),
     #[error("tenancy error: {0}")]
     Tenancy(#[from] TenancyError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
     #[error(transparent)]
     UlidDecode(#[from] ulid::DecodeError),
     #[error("Unable to parse URL: {0}")]


### PR DESCRIPTION
Return errors when conflicts happen on commit and blocking_commit, transform errors to 409 responses from SDF, basic front end handling of conflicts when trying to apply

![image](https://github.com/systeminit/si/assets/77113647/681ec5d8-5803-4b62-bd10-2efe9ea9b2e9)
