### PR TITLE
feat: added log aggregation in grafana for local services

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -7,17 +7,16 @@ config.define_bool("debug-no-rebaser-rustc-build-mode")
 cfg = config.parse()
 
 # Define groups of services
+
 groups = {
     "platform": [
-        "grafana",
-        "jaeger",
         "nats",
         "otelcol",
         "db",
-        "db-test",
         "postgres",
+        "db-test",
         "postgres-test",
-        "localstack",
+        "jaeger",
     ],
     "backend": [
         "pinga",
@@ -28,6 +27,15 @@ groups = {
     ],
     "frontend": [
         "web",
+    ],
+    "testing": [
+        "localstack",
+
+    ],
+    "telemetry": [
+        "promtail",
+        "grafana",
+        "loki",
     ],
 }
 
@@ -92,9 +100,15 @@ def _buck2_dep_inputs(target):
 # - https://docs.tilt.dev/api.html#api.allow_k8s_contexts
 allow_k8s_contexts(k8s_context())
 
+def find_group(name, groups):
+    for group, names in groups.items():
+        if name in names:
+            return group
+    return "all"
+
 # Use Docker Compose to provide the platform services
 docker_compose("./docker-compose.platform.yml")
-compose_services = ["jaeger", "nats", "otelcol", "postgres", "postgres-test", "db", "db-test", "grafana", "localstack"]
+compose_services = ["jaeger", "nats", "otelcol", "postgres", "postgres-test", "db", "db-test", "loki",  "grafana", "localstack", "promtail"]
 for service in compose_services:
     if service == "jaeger":
         links = [
@@ -104,24 +118,30 @@ for service in compose_services:
         links = [
             link("http://localhost:3000", "ui"),
         ]
+    elif service == "localstack":
+        links = [
+            link("http://localhost:4566", "localstack-api"),
+        ]
     else:
         links = []
-    dc_resource(service, links = links, labels = ["platform"])
+
+    dc_resource(service, links = links, labels = [find_group(service, groups)])
+
 
 # Locally build and run `rebaser-server`
 rebaser_target = "//bin/rebaser:rebaser"
 
 cmd = "buck2 build @//mode/release {}".format(rebaser_target)
-serve_cmd = "buck2 run @//mode/release {}".format(rebaser_target)
+serve_cmd = "buck2 run @//mode/release {} | tee /tmp/si-logs/rebaser".format(rebaser_target)
 if rustc_build_mode == 'standard':
     cmd = "buck2 build {}".format(rebaser_target)
     serve_cmd = "buck2 run {}".format(rebaser_target)
 elif debug_no_rebaser_rustc_build_mode:
     cmd = "buck2 build @//mode/release {}".format(rebaser_target)
-    serve_cmd = "buck2 run @//mode/release {}".format(rebaser_target)
+    serve_cmd = "buck2 run @//mode/release {} | tee /tmp/si-logs/rebaser".format(rebaser_target)
 elif rustc_build_mode == 'debug':
     cmd = "buck2 build @//mode/debug {}".format(rebaser_target)
-    serve_cmd = "buck2 run @//mode/debug {}".format(rebaser_target)
+    serve_cmd = "buck2 run @//mode/debug {} | tee /tmp/si-logs/rebaser".format(rebaser_target)
 
 local_resource(
     "rebaser",
@@ -171,7 +191,7 @@ local_resource(
 pinga_target = "//bin/pinga:pinga"
 
 cmd = "buck2 build @//mode/release {}".format(pinga_target)
-serve_cmd = "buck2 run @//mode/release {}".format(pinga_target)
+serve_cmd = "buck2 run @//mode/release {} | tee /tmp/si-logs/pinga".format(pinga_target)
 if rustc_build_mode == 'standard':
     cmd = "buck2 build {}".format(pinga_target)
     serve_cmd = "buck2 run {}".format(pinga_target)
@@ -199,7 +219,8 @@ local_resource(
 veritech_target = "//bin/veritech:veritech"
 
 cmd = "buck2 build @//mode/release {}".format(veritech_target)
-serve_cmd = "buck2 run @//mode/release {}".format(veritech_target)
+# Add something like this to then push it + consume the logs from prom tail
+serve_cmd = "buck2 run @//mode/release {} | tee /tmp/si-logs/veritech".format(veritech_target)
 if rustc_build_mode == 'standard':
     cmd = "buck2 build {}".format(veritech_target)
     serve_cmd = "buck2 run {}".format(veritech_target)
@@ -229,13 +250,13 @@ local_resource(
 sdf_target = "//bin/sdf:sdf"
 
 cmd = "buck2 build @//mode/release {}".format(sdf_target)
-serve_cmd = "buck2 run @//mode/release {}".format(sdf_target)
+serve_cmd = "buck2 run @//mode/release {} | tee /tmp/si-logs/sdf".format(sdf_target)
 if rustc_build_mode == 'standard':
     cmd = "buck2 build {}".format(sdf_target)
-    serve_cmd = "buck2 run {}".format(sdf_target)
+    serve_cmd = "buck2 run {} | tee /tmp/si-logs/sdf".format(sdf_target)
 elif rustc_build_mode == 'debug':
     cmd = "buck2 build @//mode/debug {}".format(sdf_target)
-    serve_cmd = "buck2 run @//mode/debug {}".format(sdf_target)
+    serve_cmd = "buck2 run @//mode/debug {} | tee /tmp/si-logs/sdf".format(sdf_target)
 
 local_resource(
     "sdf",

--- a/dev/datasources/datasources.yml
+++ b/dev/datasources/datasources.yml
@@ -8,3 +8,10 @@ datasources:
     access: proxy
     readOnly: false
     isDefault: true
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    jsonData:
+      timeout: 60
+      maxLines: 1000

--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -1,6 +1,20 @@
 ---
+# configures the system to use the loki docker driver
+# see https://grafana.com/docs/loki/latest/send-data/docker-driver/
+x-loki-logged-service: &loki-logged-service
+    logging:
+      driver: loki
+      options:
+        loki-url: "http://loki:3100/loki/api/v1/push"
+        loki-batch-size: "400"
+        loki-retries: "1"
+        max-file: "2"
+        max-size: "10m"
+
 services:
   db:
+    # uncomment below to get these logs in grafana
+    #<<: *loki-logged-service
     image: systeminit/postgres:stable
     environment:
       - "POSTGRES_PASSWORD=bugbear"
@@ -16,7 +30,27 @@ services:
       timeout: 10s
       retries: 5
 
+  promtail:
+    #<<: *loki-logged-service
+    image: grafana/promtail:latest
+    container_name: promtail
+    volumes:
+      - /tmp/si-logs:/logs
+      - ./promtail-config/config.yml:/etc/promtail/config.yml
+    command: -config.file=/etc/promtail/config.yml    
+
+  loki:
+    #<<: *loki-logged-service
+    image: grafana/loki
+    container_name: loki
+    volumes:
+      - ./loki-config/config.yml:/etc/loki/config.yml
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/config.yml
+
   db-test:
+    #<<: *loki-logged-service
     image: systeminit/postgres:stable
     environment:
       - "POSTGRES_PASSWORD=bugbear"
@@ -38,6 +72,7 @@ services:
       retries: 5
 
   postgres:
+    #<<: *loki-logged-service
     image: systeminit/pgbouncer:stable
     environment:
       - "DB_USER=si"
@@ -56,6 +91,7 @@ services:
       - db
 
   postgres-test:
+    #<<: *loki-logged-service
     image: systeminit/pgbouncer:stable
     environment:
       - "DB_USER=si_test"
@@ -74,6 +110,7 @@ services:
       - db-test
 
   nats:
+    #<<: *loki-logged-service
     image: systeminit/nats:stable
     command:
       - "--config"
@@ -88,12 +125,14 @@ services:
       - postgres
 
   jaeger:
+    #<<: *loki-logged-service
     image: systeminit/jaeger:stable
     ports:
       - "5317:4317"
       - "16686:16686"
 
   grafana:
+    #<<: *loki-logged-service
     image: grafana/grafana-enterprise
     container_name: grafana
     ports:
@@ -106,6 +145,7 @@ services:
       - "GF_AUTH_DISABLE_LOGIN_FORM=true"
 
   otelcol:
+    #<<: *loki-logged-service
     image: systeminit/otelcol:stable
     # If you'd like to ship to honeycomb from your local machine, you need these two variables in the otelcol
     #environment:
@@ -118,7 +158,7 @@ services:
       - jaeger
 
   localstack:
+    #<<: *loki-logged-service
     image: localstack/localstack
     ports:
       - "4566:4566"
-      - "4510-4559:4510-4559"

--- a/dev/loki-config/config.yml
+++ b/dev/loki-config/config.yml
@@ -1,0 +1,50 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+#analytics:
+#  reporting_enabled: false

--- a/dev/promtail-config/config.yml
+++ b/dev/promtail-config/config.yml
@@ -1,0 +1,34 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+  log_level: debug
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+positions:
+  filename: /tmp/positions.yaml
+
+scrape_configs:
+- job_name: system
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: veritech
+      __path__: /logs/veritech
+  - targets:
+      - localhost
+    labels:
+      job: sdf
+      __path__: /logs/sdf
+  - targets:
+      - localhost
+    labels:
+      job: pinga
+      __path__: /logs/pinga
+  - targets:
+      - localhost
+    labels:
+      job: rebaser
+      __path__: /logs/rebaser

--- a/prelude-si/tilt.bzl
+++ b/prelude-si/tilt.bzl
@@ -124,12 +124,16 @@ def _invoke_tilt(ctx: AnalysisContext, subcmd: str) -> list[[DefaultInfo, RunInf
         ctx.attrs.tiltfile,
     )
 
+    RunInfo(["rm", "-rf", "/tmp/si-logs"])
+    RunInfo(["mkdir", "-p", "/tmp/si-logs"])
+
     run_cmd_args = cmd_args([
         "tilt",
         subcmd,
         "--file",
         tiltfile,
     ])
+
     run_cmd_args.add(ctx.attrs.tilt_args)
     run_cmd_args.add("--")
     run_cmd_args.add(ctx.attrs.args)


### PR DESCRIPTION
Four main changes:
- Adds a `/tmp/si-logs/<service>` log file when running tilt. Deletes/Recreates this folder just before starting tilt. 
- `tees` the logs of the rust services into those files
- Adds promtail + loki so that the service logs for the rust services can be aggregated in local grafana.
- Sorts out the groupings of the services within the tiltfile

Kudos should be directed to my partner in crime @keeb 

<img src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExbWcwdzJ4cm5mOHcxcWozcHJmZnE0aTR4cjcweDM2OGN4aHN6bGg4bCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1oJRRiSteRVLHf7JKH/giphy.webp"/>