### PR TITLE
Build & use reverse component dependency graph for finding dependencies of Destroy Actions

### DIFF
--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -53,6 +53,8 @@ pub enum ActionError {
     PrototypeNotFoundForAction(ActionId),
     #[error("Transactions error: {0}")]
     Transactions(#[from] TransactionsError),
+    #[error("Unable to determine kind for action: {0}")]
+    UnableToGetKind(ActionId),
     #[error("Workspace Snapshot error: {0}")]
     WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
     #[error("ws event error: {0}")]


### PR DESCRIPTION
We need to ensure that things are destroyed in the reverse order of what we would have created them in.