### PR TITLE
chore(dal): refactor FuncRunner to support instrumentation

### DIFF
--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -40,7 +40,7 @@ async fn async_main() -> Result<()> {
             .service_namespace("si")
             .log_env_var_prefix("SI")
             .app_modules(vec!["pinga", "pinga_server"])
-            .interesting_modules(vec!["si_data_nats", "si_data_pg"])
+            .interesting_modules(vec!["dal", "si_data_nats", "si_data_pg", "si_layer_cache"])
             .build()?;
 
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -9,7 +9,7 @@ use si_events::{
 use si_layer_cache::LayerDbError;
 use telemetry::prelude::*;
 use thiserror::Error;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use veritech_client::{BeforeFunction, OutputStream, ResolverFunctionComponent};
 
 use crate::{
@@ -90,305 +90,697 @@ pub type FuncRunnerResult<T> = Result<T, FuncRunnerError>;
 
 pub type FuncRunnerValueChannel = tokio::sync::oneshot::Receiver<FuncRunnerResult<FuncRunValue>>;
 
-pub struct FuncRunner;
+pub struct FuncRunner {
+    func_run: Arc<FuncRun>,
+    func: Func,
+    args: serde_json::Value,
+    before: Vec<BeforeFunction>,
+}
 
 impl FuncRunner {
+    #[instrument(
+        name = "func_runner.run_test",
+        level = "debug",
+        skip_all,
+        fields(
+            job.id = Empty,
+            job.invoked_args = Empty,
+            // job.instance = metadata.job_instance,
+            job.invoked_name = func.name.as_str(),
+            // job.invoked_provider = metadata.job_invoked_provider,
+            otel.kind = SpanKind::Producer.as_str(),
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+            si.change_set.id = Empty,
+            si.component.id = Empty,
+            si.func_run.func.args = Empty,
+            si.func_run.func.backend_kind = func.backend_kind.as_ref(),
+            si.func_run.func.backend_response_type = func.backend_response_type.as_ref(),
+            si.func_run.func.id = Empty,
+            si.func_run.func.kind = func.kind.as_ref(),
+            si.func_run.func.name = func.name.as_str(),
+            si.func_run.id = Empty,
+            si.workspace.id = Empty,
+        )
+    )]
     pub async fn run_test(
         ctx: &DalContext,
         func: Func,
         args: serde_json::Value,
         component_id: ComponentId,
     ) -> FuncRunnerResult<(FuncRunId, FuncRunnerValueChannel)> {
-        let function_args: CasValue = args.clone().into();
-        let (function_args_cas_address, _) = ctx
-            .layer_db()
-            .cas()
-            .write(
-                Arc::new(function_args.into()),
-                None,
-                ctx.events_tenancy(),
-                ctx.events_actor(),
-            )
-            .await?;
-        let before = before_funcs_for_component(ctx, component_id).await?;
-
-        let func_run_create_time = Utc::now();
-        let func_run_inner = FuncRunBuilder::default()
-            .actor(ctx.events_actor())
-            .tenancy(ctx.events_tenancy())
-            .backend_kind(func.backend_kind.into())
-            .backend_response_type(func.backend_response_type.into())
-            .function_name(func.name.clone())
-            .function_kind(func.kind.into())
-            .function_display_name(func.display_name.clone())
-            .function_description(func.description.clone())
-            .function_link(func.link.clone())
-            .function_args_cas_address(function_args_cas_address)
-            .function_code_cas_address(func.code_blake3)
-            .attribute_value_id(None)
-            .component_id(Some(component_id.into()))
-            .created_at(func_run_create_time)
-            .updated_at(func_run_create_time)
-            .build()?;
-
-        let func_run = Arc::new(func_run_inner);
-
-        ctx.layer_db()
-            .func_run()
-            .write(
-                func_run.clone(),
-                None,
-                ctx.events_tenancy(),
-                ctx.events_actor(),
-            )
-            .await?;
-
-        let func_run_id = func_run.id();
-        let result_channel = FuncRunner::execute(ctx.clone(), func_run, func, args, before).await;
-
-        Ok((func_run_id, result_channel))
-    }
-
-    pub async fn run_asset_definition_func(
-        ctx: &DalContext,
-        func: &Func,
-    ) -> FuncRunnerResult<FuncRunnerValueChannel> {
-        let args = serde_json::Value::Null;
-
-        let function_args: CasValue = args.clone().into();
-
-        let (function_args_cas_address, _) = ctx
-            .layer_db()
-            .cas()
-            .write(
-                Arc::new(function_args.into()),
-                None,
-                ctx.events_tenancy(),
-                ctx.events_actor(),
-            )
-            .await?;
-
-        let code_cas_hash = if let Some(code) = func.code_base64.as_ref() {
-            let code_json_value: serde_json::Value = code.clone().into();
-            let code_cas_value: CasValue = code_json_value.into();
-            let (hash, _) = ctx
+        // Prepares the function for execution.
+        //
+        // Note: this function is internal so we can record early-returning errors in span metadata
+        // and in order to time the function's preparation vs. execution timings.
+        #[instrument(
+            name = "func_runner.run_test.prepare",
+            level = "debug",
+            skip_all,
+            fields()
+        )]
+        #[inline]
+        async fn prepare(
+            ctx: &DalContext,
+            func: Func,
+            args: serde_json::Value,
+            component_id: ComponentId,
+            span: &Span,
+        ) -> FuncRunnerResult<FuncRunner> {
+            let function_args: CasValue = args.clone().into();
+            let (function_args_cas_address, _) = ctx
                 .layer_db()
                 .cas()
                 .write(
-                    Arc::new(code_cas_value.into()),
+                    Arc::new(function_args.into()),
                     None,
                     ctx.events_tenancy(),
                     ctx.events_actor(),
                 )
                 .await?;
-            hash
-        } else {
-            // Why are we doing this? Because the struct gods demand it. I have feelings.
-            ContentHash::new("".as_bytes())
-        };
+            let before = before_funcs_for_component(ctx, component_id).await?;
 
-        let func_run_create_time = Utc::now();
-        let func_run_inner = FuncRunBuilder::default()
-            .actor(ctx.events_actor())
-            .tenancy(ctx.events_tenancy())
-            .backend_kind(func.backend_kind.into())
-            .backend_response_type(func.backend_response_type.into())
-            .function_name(func.name.clone())
-            .function_kind(func.kind.into())
-            .function_display_name(func.display_name.clone())
-            .function_description(func.description.clone())
-            .function_link(func.link.clone())
-            .function_args_cas_address(function_args_cas_address)
-            .function_code_cas_address(code_cas_hash)
-            .attribute_value_id(None)
-            .component_id(None)
-            .created_at(func_run_create_time)
-            .updated_at(func_run_create_time)
-            .build()?;
+            let component_id = component_id.into();
 
-        let func_run = Arc::new(func_run_inner);
+            let func_run_create_time = Utc::now();
+            let func_run_inner = FuncRunBuilder::default()
+                .actor(ctx.events_actor())
+                .tenancy(ctx.events_tenancy())
+                .backend_kind(func.backend_kind.into())
+                .backend_response_type(func.backend_response_type.into())
+                .function_name(func.name.clone())
+                .function_kind(func.kind.into())
+                .function_display_name(func.display_name.clone())
+                .function_description(func.description.clone())
+                .function_link(func.link.clone())
+                .function_args_cas_address(function_args_cas_address)
+                .function_code_cas_address(func.code_blake3)
+                .attribute_value_id(None)
+                .component_id(Some(component_id))
+                .created_at(func_run_create_time)
+                .updated_at(func_run_create_time)
+                .build()?;
 
-        ctx.layer_db()
-            .func_run()
-            .write(
-                func_run.clone(),
-                None,
-                ctx.events_tenancy(),
-                ctx.events_actor(),
-            )
-            .await?;
+            if !span.is_disabled() {
+                let mut id_buf = FuncRunId::array_to_str_buf();
 
-        let result_channel =
-            FuncRunner::execute(ctx.clone(), func_run, func.clone(), args, vec![]).await;
+                let id = func_run_inner.id().array_to_str(&mut id_buf);
+                span.record("job.id", &id);
+                span.record("si.func_run.id", &id);
+
+                let invoked_args = serde_json::to_string(&args)
+                    .unwrap_or_else(|_| "args failed to serialize".to_owned());
+                span.record("job.invoked_args", invoked_args.as_str());
+                span.record("si.func_run.func.args", invoked_args.as_str());
+
+                span.record("si.func_run.func.id", func.id.array_to_str(&mut id_buf));
+
+                span.record(
+                    "si.change_set.id",
+                    func_run_inner.change_set_id().array_to_str(&mut id_buf),
+                );
+                span.record("si.component.id", component_id.array_to_str(&mut id_buf));
+                span.record(
+                    "si.workspace.id",
+                    func_run_inner.workspace_pk().array_to_str(&mut id_buf),
+                );
+            }
+
+            let func_run = Arc::new(func_run_inner);
+
+            ctx.layer_db()
+                .func_run()
+                .write(
+                    func_run.clone(),
+                    None,
+                    ctx.events_tenancy(),
+                    ctx.events_actor(),
+                )
+                .await?;
+
+            Ok(FuncRunner {
+                func_run,
+                func,
+                args,
+                before,
+            })
+        }
+
+        let span = Span::current();
+
+        let runner = prepare(ctx, func, args, component_id, &span)
+            .await
+            .map_err(|err| span.record_err(err))?;
+
+        let func_run_id = runner.id();
+        let result_channel = runner.execute(ctx.clone(), span).await;
+
+        Ok((func_run_id, result_channel))
+    }
+
+    #[instrument(
+        name = "func_runner.run_asset_definition_func",
+        level = "debug",
+        skip_all,
+        fields(
+            job.id = Empty,
+            job.invoked_args = Empty,
+            // job.instance = metadata.job_instance,
+            job.invoked_name = func.name.as_str(),
+            // job.invoked_provider = metadata.job_invoked_provider,
+            otel.kind = SpanKind::Producer.as_str(),
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+            si.action.id = Empty,
+            si.action.kind = Empty,
+            si.change_set.id = Empty,
+            si.func_run.func.args = Empty,
+            si.func_run.func.backend_kind = func.backend_kind.as_ref(),
+            si.func_run.func.backend_response_type = func.backend_response_type.as_ref(),
+            si.func_run.func.id = Empty,
+            si.func_run.func.kind = func.kind.as_ref(),
+            si.func_run.func.name = func.name.as_str(),
+            si.func_run.id = Empty,
+            si.workspace.id = Empty,
+        )
+    )]
+    pub async fn run_asset_definition_func(
+        ctx: &DalContext,
+        func: &Func,
+    ) -> FuncRunnerResult<FuncRunnerValueChannel> {
+        // Prepares the function for execution.
+        //
+        // Note: this function is internal so we can record early-returning errors in span metadata
+        // and in order to time the function's preparation vs. execution timings.
+        #[instrument(
+            name = "func_runner.run_asset_definition_func.prepare",
+            level = "debug",
+            skip_all,
+            fields()
+        )]
+        #[inline]
+        async fn prepare(
+            ctx: &DalContext,
+            func: &Func,
+            span: &Span,
+        ) -> FuncRunnerResult<FuncRunner> {
+            let args = serde_json::Value::Null;
+
+            let function_args: CasValue = args.clone().into();
+
+            let (function_args_cas_address, _) = ctx
+                .layer_db()
+                .cas()
+                .write(
+                    Arc::new(function_args.into()),
+                    None,
+                    ctx.events_tenancy(),
+                    ctx.events_actor(),
+                )
+                .await?;
+
+            let code_cas_hash = if let Some(code) = func.code_base64.as_ref() {
+                let code_json_value: serde_json::Value = code.clone().into();
+                let code_cas_value: CasValue = code_json_value.into();
+                let (hash, _) = ctx
+                    .layer_db()
+                    .cas()
+                    .write(
+                        Arc::new(code_cas_value.into()),
+                        None,
+                        ctx.events_tenancy(),
+                        ctx.events_actor(),
+                    )
+                    .await?;
+                hash
+            } else {
+                // Why are we doing this? Because the struct gods demand it. I have feelings.
+                ContentHash::new("".as_bytes())
+            };
+
+            let func_run_create_time = Utc::now();
+            let func_run_inner = FuncRunBuilder::default()
+                .actor(ctx.events_actor())
+                .tenancy(ctx.events_tenancy())
+                .backend_kind(func.backend_kind.into())
+                .backend_response_type(func.backend_response_type.into())
+                .function_name(func.name.clone())
+                .function_kind(func.kind.into())
+                .function_display_name(func.display_name.clone())
+                .function_description(func.description.clone())
+                .function_link(func.link.clone())
+                .function_args_cas_address(function_args_cas_address)
+                .function_code_cas_address(code_cas_hash)
+                .attribute_value_id(None)
+                .component_id(None)
+                .created_at(func_run_create_time)
+                .updated_at(func_run_create_time)
+                .build()?;
+
+            if !span.is_disabled() {
+                let mut id_buf = FuncRunId::array_to_str_buf();
+
+                let id = func_run_inner.id().array_to_str(&mut id_buf);
+                span.record("job.id", &id);
+                span.record("si.func_run.id", &id);
+
+                let invoked_args = serde_json::to_string(&args)
+                    .unwrap_or_else(|_| "args failed to serialize".to_owned());
+                span.record("job.invoked_args", invoked_args.as_str());
+                span.record("si.func_run.func.args", invoked_args.as_str());
+
+                span.record("si.func_run.func.id", func.id.array_to_str(&mut id_buf));
+
+                span.record(
+                    "si.change_set.id",
+                    func_run_inner.change_set_id().array_to_str(&mut id_buf),
+                );
+                span.record(
+                    "si.workspace.id",
+                    func_run_inner.workspace_pk().array_to_str(&mut id_buf),
+                );
+            }
+
+            let func_run = Arc::new(func_run_inner);
+
+            ctx.layer_db()
+                .func_run()
+                .write(
+                    func_run.clone(),
+                    None,
+                    ctx.events_tenancy(),
+                    ctx.events_actor(),
+                )
+                .await?;
+
+            Ok(FuncRunner {
+                func_run,
+                func: func.clone(),
+                args,
+                before: vec![],
+            })
+        }
+
+        let span = Span::current();
+
+        let runner = prepare(ctx, func, &span)
+            .await
+            .map_err(|err| span.record_err(err))?;
+
+        let result_channel = runner.execute(ctx.clone(), span).await;
 
         Ok(result_channel)
     }
 
+    #[instrument(
+        name = "func_runner.run_validation_format",
+        level = "debug",
+        skip_all,
+        fields(
+            job.id = Empty,
+            job.invoked_args = Empty,
+            // job.instance = metadata.job_instance,
+            job.invoked_name = Empty,
+            // job.invoked_provider = metadata.job_invoked_provider,
+            otel.kind = SpanKind::Producer.as_str(),
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+            si.attribute_value.id = Empty,
+            si.change_set.id = Empty,
+            si.component.id = Empty,
+            si.func_run.func.args = Empty,
+            si.func_run.func.backend_kind = Empty,
+            si.func_run.func.backend_response_type = Empty,
+            si.func_run.func.id = Empty,
+            si.func_run.func.kind = Empty,
+            si.func_run.func.name = Empty,
+            si.func_run.id = Empty,
+            si.workspace.id = Empty,
+        )
+    )]
     pub async fn run_validation_format(
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
         value: Option<serde_json::Value>,
         validation_format: String,
     ) -> FuncRunnerResult<FuncRunnerValueChannel> {
-        let func_id =
-            Func::find_intrinsic(ctx, super::intrinsics::IntrinsicFunc::Validation).await?;
-        let func = Func::get_by_id(ctx, func_id)
-            .await?
-            .ok_or(FuncRunnerError::FuncIntrinsicValidationMissing)?;
+        // Prepares the function for execution.
+        //
+        // Note: this function is internal so we can record early-returning errors in span metadata
+        // and in order to time the function's preparation vs. execution timings.
+        #[instrument(
+            name = "func_runner.run_validation_format.prepare",
+            level = "debug",
+            skip_all,
+            fields()
+        )]
+        #[inline]
+        async fn prepare(
+            ctx: &DalContext,
+            attribute_value_id: AttributeValueId,
+            value: Option<serde_json::Value>,
+            validation_format: String,
+            span: &Span,
+        ) -> FuncRunnerResult<FuncRunner> {
+            let func_id =
+                Func::find_intrinsic(ctx, super::intrinsics::IntrinsicFunc::Validation).await?;
+            let func = Func::get_by_id(ctx, func_id)
+                .await?
+                .ok_or(FuncRunnerError::FuncIntrinsicValidationMissing)?;
 
-        let args = serde_json::json!({
-            "value": value,
-            "validation_format": validation_format,
-        });
+            let args = serde_json::json!({
+                "value": value,
+                "validation_format": validation_format,
+            });
 
-        let function_args: CasValue = args.clone().into();
+            let function_args: CasValue = args.clone().into();
 
-        let (function_args_cas_address, _) = ctx
-            .layer_db()
-            .cas()
-            .write(
-                Arc::new(function_args.into()),
-                None,
-                ctx.events_tenancy(),
-                ctx.events_actor(),
-            )
-            .await?;
-
-        let code_cas_hash = if let Some(code) = func.code_base64.as_ref() {
-            let code_json_value: serde_json::Value = code.clone().into();
-            let code_cas_value: CasValue = code_json_value.into();
-            let (hash, _) = ctx
+            let (function_args_cas_address, _) = ctx
                 .layer_db()
                 .cas()
                 .write(
-                    Arc::new(code_cas_value.into()),
+                    Arc::new(function_args.into()),
                     None,
                     ctx.events_tenancy(),
                     ctx.events_actor(),
                 )
                 .await?;
-            hash
-        } else {
-            // Why are we doing this? Because the struct gods demand it. I have feelings.
-            ContentHash::new("".as_bytes())
-        };
 
-        let component_id = AttributeValue::component_id(ctx, attribute_value_id).await?;
+            let code_cas_hash = if let Some(code) = func.code_base64.as_ref() {
+                let code_json_value: serde_json::Value = code.clone().into();
+                let code_cas_value: CasValue = code_json_value.into();
+                let (hash, _) = ctx
+                    .layer_db()
+                    .cas()
+                    .write(
+                        Arc::new(code_cas_value.into()),
+                        None,
+                        ctx.events_tenancy(),
+                        ctx.events_actor(),
+                    )
+                    .await?;
+                hash
+            } else {
+                // Why are we doing this? Because the struct gods demand it. I have feelings.
+                ContentHash::new("".as_bytes())
+            };
 
-        let func_run_create_time = Utc::now();
-        let func_run_inner = FuncRunBuilder::default()
-            .actor(ctx.events_actor())
-            .tenancy(ctx.events_tenancy())
-            .backend_kind(func.backend_kind.into())
-            .backend_response_type(func.backend_response_type.into())
-            .function_name(func.name.clone())
-            .function_kind(func.kind.into())
-            .function_display_name(func.display_name.clone())
-            .function_description(func.description.clone())
-            .function_link(func.link.clone())
-            .function_args_cas_address(function_args_cas_address)
-            .function_code_cas_address(code_cas_hash)
-            .attribute_value_id(Some(attribute_value_id.into()))
-            .component_id(Some(component_id.into()))
-            .created_at(func_run_create_time)
-            .updated_at(func_run_create_time)
-            .build()?;
+            let component_id = AttributeValue::component_id(ctx, attribute_value_id).await?;
+            let component_id = component_id.into();
+            let attribute_value_id = attribute_value_id.into();
 
-        let func_run = Arc::new(func_run_inner);
+            let func_run_create_time = Utc::now();
+            let func_run_inner = FuncRunBuilder::default()
+                .actor(ctx.events_actor())
+                .tenancy(ctx.events_tenancy())
+                .backend_kind(func.backend_kind.into())
+                .backend_response_type(func.backend_response_type.into())
+                .function_name(func.name.clone())
+                .function_kind(func.kind.into())
+                .function_display_name(func.display_name.clone())
+                .function_description(func.description.clone())
+                .function_link(func.link.clone())
+                .function_args_cas_address(function_args_cas_address)
+                .function_code_cas_address(code_cas_hash)
+                .attribute_value_id(Some(attribute_value_id))
+                .component_id(Some(component_id))
+                .created_at(func_run_create_time)
+                .updated_at(func_run_create_time)
+                .build()?;
 
-        ctx.layer_db()
-            .func_run()
-            .write(
-                func_run.clone(),
-                None,
-                ctx.events_tenancy(),
-                ctx.events_actor(),
-            )
-            .await?;
+            if !span.is_disabled() {
+                let mut id_buf = FuncRunId::array_to_str_buf();
 
-        let result_channel = FuncRunner::execute(ctx.clone(), func_run, func, args, vec![]).await;
+                let id = func_run_inner.id().array_to_str(&mut id_buf);
+                span.record("job.id", &id);
+                span.record("si.func_run.id", &id);
+
+                let invoked_args = serde_json::to_string(&args)
+                    .unwrap_or_else(|_| "args failed to serialize".to_owned());
+                span.record("job.invoked_args", invoked_args.as_str());
+                span.record("si.func_run.func.args", invoked_args.as_str());
+
+                span.record("job.invoked_name", func.name.as_str());
+                span.record("si.func_run.func.name", func.name.as_str());
+
+                span.record("si.func_run.func.backend_kind", func.backend_kind.as_ref());
+                span.record(
+                    "si.func_run.func.backend_response_type",
+                    func.backend_response_type.as_ref(),
+                );
+                span.record("si.func_run.func.id", func.id.array_to_str(&mut id_buf));
+                span.record("si.func_run.func.kind", func.kind.as_ref());
+
+                span.record(
+                    "si.attribute_value.id",
+                    attribute_value_id.array_to_str(&mut id_buf),
+                );
+                span.record(
+                    "si.change_set.id",
+                    func_run_inner.change_set_id().array_to_str(&mut id_buf),
+                );
+                span.record("si.component.id", component_id.array_to_str(&mut id_buf));
+                span.record(
+                    "si.workspace.id",
+                    func_run_inner.workspace_pk().array_to_str(&mut id_buf),
+                );
+            }
+
+            let func_run = Arc::new(func_run_inner);
+
+            ctx.layer_db()
+                .func_run()
+                .write(
+                    func_run.clone(),
+                    None,
+                    ctx.events_tenancy(),
+                    ctx.events_actor(),
+                )
+                .await?;
+
+            Ok(FuncRunner {
+                func_run,
+                func,
+                args,
+                before: vec![],
+            })
+        }
+
+        let span = Span::current();
+
+        let runner = prepare(ctx, attribute_value_id, value, validation_format, &span)
+            .await
+            .map_err(|err| span.record_err(err))?;
+
+        let result_channel = runner.execute(ctx.clone(), span).await;
 
         Ok(result_channel)
     }
 
+    #[instrument(
+        name = "func_runner.run_attribute_value",
+        level = "debug",
+        skip_all,
+        fields(
+            job.id = Empty,
+            job.invoked_args = Empty,
+            // job.instance = metadata.job_instance,
+            job.invoked_name = Empty,
+            // job.invoked_provider = metadata.job_invoked_provider,
+            otel.kind = SpanKind::Producer.as_str(),
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+            si.attribute_value.id = Empty,
+            si.change_set.id = Empty,
+            si.component.id = Empty,
+            si.func_run.func.args = Empty,
+            si.func_run.func.backend_kind = Empty,
+            si.func_run.func.backend_response_type = Empty,
+            si.func_run.func.id = Empty,
+            si.func_run.func.kind = Empty,
+            si.func_run.func.name = Empty,
+            si.func_run.id = Empty,
+            si.workspace.id = Empty,
+        )
+    )]
     pub async fn run_attribute_value(
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
         func_id: FuncId,
         args: serde_json::Value,
     ) -> FuncRunnerResult<FuncRunnerValueChannel> {
-        let func = Func::get_by_id_or_error(ctx, func_id).await?;
+        // Prepares the function for execution.
+        //
+        // Note: this function is internal so we can record early-returning errors in span metadata
+        // and in order to time the function's preparation vs. execution timings.
+        #[instrument(
+            name = "func_runner.run_attribute_value.prepare",
+            level = "debug",
+            skip_all,
+            fields()
+        )]
+        #[inline]
+        async fn prepare(
+            ctx: &DalContext,
+            attribute_value_id: AttributeValueId,
+            func_id: FuncId,
+            args: serde_json::Value,
+            parent_span: &Span,
+        ) -> FuncRunnerResult<FuncRunner> {
+            let func = Func::get_by_id_or_error(ctx, func_id).await?;
 
-        let function_args: CasValue = args.clone().into();
-        let (function_args_cas_address, _) = ctx
-            .layer_db()
-            .cas()
-            .write(
-                Arc::new(function_args.into()),
-                None,
-                ctx.events_tenancy(),
-                ctx.events_actor(),
-            )
-            .await?;
-
-        let code_cas_hash = if let Some(code) = func.code_base64.as_ref() {
-            let code_json_value: serde_json::Value = code.clone().into();
-            let code_cas_value: CasValue = code_json_value.into();
-            let (hash, _) = ctx
+            let function_args: CasValue = args.clone().into();
+            let (function_args_cas_address, _) = ctx
                 .layer_db()
                 .cas()
                 .write(
-                    Arc::new(code_cas_value.into()),
+                    Arc::new(function_args.into()),
                     None,
                     ctx.events_tenancy(),
                     ctx.events_actor(),
                 )
                 .await?;
-            hash
-        } else {
-            // Why are we doing this? Because the struct gods demand it. I have feelings.
-            ContentHash::new("".as_bytes())
-        };
 
-        let component_id = AttributeValue::component_id(ctx, attribute_value_id).await?;
-        let before = before_funcs_for_component(ctx, component_id).await?;
+            let code_cas_hash = if let Some(code) = func.code_base64.as_ref() {
+                let code_json_value: serde_json::Value = code.clone().into();
+                let code_cas_value: CasValue = code_json_value.into();
+                let (hash, _) = ctx
+                    .layer_db()
+                    .cas()
+                    .write(
+                        Arc::new(code_cas_value.into()),
+                        None,
+                        ctx.events_tenancy(),
+                        ctx.events_actor(),
+                    )
+                    .await?;
+                hash
+            } else {
+                // Why are we doing this? Because the struct gods demand it. I have feelings.
+                ContentHash::new("".as_bytes())
+            };
 
-        let func_run_create_time = Utc::now();
-        let func_run_inner = FuncRunBuilder::default()
-            .actor(ctx.events_actor())
-            .tenancy(ctx.events_tenancy())
-            .backend_kind(func.backend_kind.into())
-            .backend_response_type(func.backend_response_type.into())
-            .function_name(func.name.clone())
-            .function_kind(func.kind.into())
-            .function_display_name(func.display_name.clone())
-            .function_description(func.description.clone())
-            .function_link(func.link.clone())
-            .function_args_cas_address(function_args_cas_address)
-            .function_code_cas_address(code_cas_hash)
-            .attribute_value_id(Some(attribute_value_id.into()))
-            .component_id(Some(component_id.into()))
-            .created_at(func_run_create_time)
-            .updated_at(func_run_create_time)
-            .build()?;
+            let component_id = AttributeValue::component_id(ctx, attribute_value_id).await?;
+            let before = before_funcs_for_component(ctx, component_id).await?;
 
-        let func_run = Arc::new(func_run_inner);
+            let component_id = component_id.into();
+            let attribute_value_id = attribute_value_id.into();
 
-        ctx.layer_db()
-            .func_run()
-            .write(
-                func_run.clone(),
-                None,
-                ctx.events_tenancy(),
-                ctx.events_actor(),
-            )
-            .await?;
+            let func_run_create_time = Utc::now();
+            let func_run_inner = FuncRunBuilder::default()
+                .actor(ctx.events_actor())
+                .tenancy(ctx.events_tenancy())
+                .backend_kind(func.backend_kind.into())
+                .backend_response_type(func.backend_response_type.into())
+                .function_name(func.name.clone())
+                .function_kind(func.kind.into())
+                .function_display_name(func.display_name.clone())
+                .function_description(func.description.clone())
+                .function_link(func.link.clone())
+                .function_args_cas_address(function_args_cas_address)
+                .function_code_cas_address(code_cas_hash)
+                .attribute_value_id(Some(attribute_value_id))
+                .component_id(Some(component_id))
+                .created_at(func_run_create_time)
+                .updated_at(func_run_create_time)
+                .build()?;
 
-        let result_channel = FuncRunner::execute(ctx.clone(), func_run, func, args, before).await;
+            if !parent_span.is_disabled() {
+                let mut id_buf = FuncRunId::array_to_str_buf();
+
+                let id = func_run_inner.id().array_to_str(&mut id_buf);
+                parent_span.record("job.id", &id);
+                parent_span.record("si.func_run.id", &id);
+
+                let invoked_args = serde_json::to_string(&args)
+                    .unwrap_or_else(|_| "args failed to serialize".to_owned());
+                parent_span.record("job.invoked_args", invoked_args.as_str());
+                parent_span.record("si.func_run.func.args", invoked_args.as_str());
+
+                parent_span.record("job.invoked_name", func.name.as_str());
+                parent_span.record("si.func_run.func.name", func.name.as_str());
+
+                parent_span.record("si.func_run.func.backend_kind", func.backend_kind.as_ref());
+                parent_span.record(
+                    "si.func_run.func.backend_response_type",
+                    func.backend_response_type.as_ref(),
+                );
+                parent_span.record("si.func_run.func.id", func.id.array_to_str(&mut id_buf));
+                parent_span.record("si.func_run.func.kind", func.kind.as_ref());
+
+                parent_span.record(
+                    "si.attribute_value.id",
+                    attribute_value_id.array_to_str(&mut id_buf),
+                );
+                parent_span.record(
+                    "si.change_set.id",
+                    func_run_inner.change_set_id().array_to_str(&mut id_buf),
+                );
+                parent_span.record("si.component.id", component_id.array_to_str(&mut id_buf));
+                parent_span.record(
+                    "si.workspace.id",
+                    func_run_inner.workspace_pk().array_to_str(&mut id_buf),
+                );
+            }
+
+            let func_run = Arc::new(func_run_inner);
+
+            ctx.layer_db()
+                .func_run()
+                .write(
+                    func_run.clone(),
+                    None,
+                    ctx.events_tenancy(),
+                    ctx.events_actor(),
+                )
+                .await?;
+
+            Ok(FuncRunner {
+                func_run,
+                func,
+                args,
+                before,
+            })
+        }
+
+        let span = Span::current();
+
+        let runner = prepare(ctx, attribute_value_id, func_id, args, &span)
+            .await
+            .map_err(|err| span.record_err(err))?;
+
+        let result_channel = runner.execute(ctx.clone(), span).await;
 
         Ok(result_channel)
     }
 
+    #[instrument(
+        name = "func_runner.run_action",
+        level = "debug",
+        skip_all,
+        fields(
+            job.id = Empty,
+            job.invoked_args = Empty,
+            // job.instance = metadata.job_instance,
+            job.invoked_name = Empty,
+            // job.invoked_provider = metadata.job_invoked_provider,
+            otel.kind = SpanKind::Producer.as_str(),
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+            si.action.id = Empty,
+            si.action.kind = Empty,
+            si.change_set.id = Empty,
+            si.component.id = Empty,
+            si.func_run.func.args = Empty,
+            si.func_run.func.backend_kind = Empty,
+            si.func_run.func.backend_response_type = Empty,
+            si.func_run.func.id = Empty,
+            si.func_run.func.kind = Empty,
+            si.func_run.func.name = Empty,
+            si.func_run.id = Empty,
+            si.workspace.id = Empty,
+        )
+    )]
     pub async fn run_action(
         ctx: &DalContext,
         action_prototype_id: ActionPrototypeId,
@@ -396,409 +788,517 @@ impl FuncRunner {
         func_id: FuncId,
         args: serde_json::Value,
     ) -> FuncRunnerResult<FuncRunnerValueChannel> {
-        let func = Func::get_by_id_or_error(ctx, func_id).await?;
-        let prototype = ActionPrototype::get_by_id(ctx, action_prototype_id)
-            .await
-            .map_err(Box::new)?;
-        let maybe_action_id = Action::find_equivalent(ctx, action_prototype_id, Some(component_id))
-            .await
-            .map_err(Box::new)?;
-        let maybe_action_originating_change_set_id = match maybe_action_id {
-            Some(action_id) => {
-                let action = Action::get_by_id(ctx, action_id).await.map_err(Box::new)?;
-                Some(action.originating_changeset_id())
-            }
-            None => None,
-        };
-        let maybe_action_originating_change_set_name = if let Some(
-            action_originating_change_set_id,
-        ) = maybe_action_originating_change_set_id
-        {
-            if let Some(original_change_set) =
-                ChangeSet::find(ctx, action_originating_change_set_id).await?
-            {
-                Some(original_change_set.name)
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+        // Prepares the function for execution.
+        //
+        // Note: this function is internal so we can record early-returning errors in span metadata
+        // and in order to time the function's preparation vs. execution timings.
+        #[instrument(
+            name = "func_runner.run_action.prepare",
+            level = "debug",
+            skip_all,
+            fields()
+        )]
+        #[inline]
+        async fn prepare(
+            ctx: &DalContext,
+            action_prototype_id: ActionPrototypeId,
+            component_id: ComponentId,
+            func_id: FuncId,
+            args: serde_json::Value,
+            span: &Span,
+        ) -> FuncRunnerResult<FuncRunner> {
+            let func = Func::get_by_id_or_error(ctx, func_id).await?;
+            let prototype = ActionPrototype::get_by_id(ctx, action_prototype_id)
+                .await
+                .map_err(Box::new)?;
+            let maybe_action_id =
+                Action::find_equivalent(ctx, action_prototype_id, Some(component_id))
+                    .await
+                    .map_err(Box::new)?;
+            let maybe_action_originating_change_set_id = match maybe_action_id {
+                Some(action_id) => {
+                    let action = Action::get_by_id(ctx, action_id).await.map_err(Box::new)?;
+                    Some(action.originating_changeset_id())
+                }
+                None => None,
+            };
+            let maybe_action_originating_change_set_name =
+                if let Some(action_originating_change_set_id) =
+                    maybe_action_originating_change_set_id
+                {
+                    if let Some(original_change_set) =
+                        ChangeSet::find(ctx, action_originating_change_set_id).await?
+                    {
+                        Some(original_change_set.name)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
 
-        let function_args: CasValue = args.clone().into();
-        let (function_args_cas_address, _) = ctx
-            .layer_db()
-            .cas()
-            .write(
-                Arc::new(function_args.into()),
-                None,
-                ctx.events_tenancy(),
-                ctx.events_actor(),
-            )
-            .await?;
-
-        let code_cas_hash = if let Some(code) = func.code_base64.as_ref() {
-            let code_json_value: serde_json::Value = code.clone().into();
-            let code_cas_value: CasValue = code_json_value.into();
-            let (hash, _) = ctx
+            let function_args: CasValue = args.clone().into();
+            let (function_args_cas_address, _) = ctx
                 .layer_db()
                 .cas()
                 .write(
-                    Arc::new(code_cas_value.into()),
+                    Arc::new(function_args.into()),
                     None,
                     ctx.events_tenancy(),
                     ctx.events_actor(),
                 )
                 .await?;
-            hash
-        } else {
-            // Why are we doing this? Because the struct gods demand it. I have feelings.
-            ContentHash::new("".as_bytes())
-        };
 
-        let before = before_funcs_for_component(ctx, component_id).await?;
-        let component = Component::get_by_id(ctx, component_id).await?;
-        let component_name = component.name(ctx).await?;
-        let schema_name = component.schema(ctx).await?.name;
-
-        let func_run_create_time = Utc::now();
-        let func_run_inner = FuncRunBuilder::default()
-            .actor(ctx.events_actor())
-            .tenancy(ctx.events_tenancy())
-            .backend_kind(func.backend_kind.into())
-            .backend_response_type(func.backend_response_type.into())
-            .function_name(func.name.clone())
-            .function_kind(func.kind.into())
-            .function_display_name(func.display_name.clone())
-            .function_description(func.description.clone())
-            .function_link(func.link.clone())
-            .function_args_cas_address(function_args_cas_address)
-            .function_code_cas_address(code_cas_hash)
-            .action_id(maybe_action_id.map(|a| a.into()))
-            .action_prototype_id(Some(action_prototype_id.into()))
-            .action_kind(Some(prototype.kind.into()))
-            .action_display_name(Some(prototype.name().clone()))
-            .action_originating_change_set_id(
-                maybe_action_originating_change_set_id.map(|a| a.into()),
-            )
-            .action_originating_change_set_name(maybe_action_originating_change_set_name)
-            .action_result_state(Some(ActionResultState::Unknown))
-            .attribute_value_id(None)
-            .component_id(Some(component_id.into()))
-            .component_name(Some(component_name))
-            .schema_name(Some(schema_name))
-            .created_at(func_run_create_time)
-            .updated_at(func_run_create_time)
-            .build()?;
-
-        let func_run = Arc::new(func_run_inner);
-
-        ctx.layer_db()
-            .func_run()
-            .write(
-                func_run.clone(),
-                None,
-                ctx.events_tenancy(),
-                ctx.events_actor(),
-            )
-            .await?;
-
-        let result_channel = FuncRunner::execute(ctx.clone(), func_run, func, args, before).await;
-
-        Ok(result_channel)
-    }
-
-    async fn execute(
-        ctx: DalContext,
-        func_run: Arc<FuncRun>,
-        func: Func,
-        args: serde_json::Value,
-        before: Vec<BeforeFunction>,
-    ) -> FuncRunnerValueChannel {
-        let (tx, rx) = tokio::sync::oneshot::channel();
-
-        // This probably needs a tracker, if we're being honest - but one thing at a time.
-        tokio::spawn(async move {
-            if let Err(error) = run_function_on_backend(tx, ctx, func_run, func, args, before).await
-            {
-                error!(?error, "Function Runner had an error during dispatch!");
-            }
-
-            async fn run_function_on_backend(
-                tx: tokio::sync::oneshot::Sender<FuncRunnerResult<FuncRunValue>>,
-                ctx: DalContext,
-                func_run: Arc<FuncRun>,
-                func: Func,
-                args: serde_json::Value,
-                before: Vec<BeforeFunction>,
-            ) -> FuncRunnerResult<()> {
-                let (func_dispatch_context, output_stream_rx) = FuncDispatchContext::new(&ctx);
-                let func_run_id = func_run.id();
-
-                // NOTE(nick): multi-track cloning! Bad idea? We'll see!
-                let logs_ctx = ctx.clone();
-
-                tokio::spawn(async move {
-                    if let Err(error) = record_logs_from_running_function_on_backend(
-                        logs_ctx,
-                        func_run_id,
-                        output_stream_rx,
-                    )
-                    .await
-                    {
-                        error!(
-                            ?error,
-                            "Function Runner had an error while recording logs from output stream!"
-                        );
-                    }
-
-                    async fn record_logs_from_running_function_on_backend(
-                        ctx: DalContext,
-                        func_run_id: FuncRunId,
-                        mut output_stream_rx: mpsc::Receiver<OutputStream>,
-                    ) -> FuncRunnerResult<()> {
-                        let mut func_run_log = FuncRunLog::new(func_run_id, ctx.events_tenancy());
-                        while let Some(item) = output_stream_rx.recv().await {
-                            func_run_log.push_log(si_events::OutputLine {
-                                stream: item.stream,
-                                execution_id: item.execution_id,
-                                level: item.level,
-                                group: item.group,
-                                message: item.message,
-                                timestamp: item.timestamp,
-                            });
-
-                            WsEvent::func_run_log_updated(
-                                &ctx,
-                                func_run_log.func_run_id(),
-                                func_run_log.id(),
-                            )
-                            .await?
-                            .publish_immediately(&ctx)
-                            .await?;
-
-                            ctx.layer_db()
-                                .func_run_log()
-                                .write(
-                                    Arc::new(func_run_log.clone()),
-                                    None,
-                                    ctx.events_tenancy(),
-                                    ctx.events_actor(),
-                                )
-                                .await?;
-                        }
-
-                        // Now that all `OutputStream` messages have been received, we will never
-                        // see any further lines so we know we've reached the end. Marking the
-                        // `FuncRunLog` as finalized can signal to other observers that this value
-                        // is now effectively immutable and will not change going forward. (hint:
-                        // this could be used to synchronize/wait on the final accumulation of all
-                        // logs from a function execution, even if this task takes far longer than
-                        // the execution time of the function).
-                        func_run_log.set_finalized();
-                        ctx.layer_db()
-                            .func_run_log()
-                            .write(
-                                Arc::new(func_run_log.clone()),
-                                None,
-                                ctx.events_tenancy(),
-                                ctx.events_actor(),
-                            )
-                            .await?;
-
-                        Ok(())
-                    }
-                });
-
-                let mut running_state_func_run_inner = Arc::unwrap_or_clone(func_run.clone());
-                running_state_func_run_inner.set_state_to_running();
-                let running_state_func_run = Arc::new(running_state_func_run_inner);
-                ctx.layer_db()
-                    .func_run()
+            let code_cas_hash = if let Some(code) = func.code_base64.as_ref() {
+                let code_json_value: serde_json::Value = code.clone().into();
+                let code_cas_value: CasValue = code_json_value.into();
+                let (hash, _) = ctx
+                    .layer_db()
+                    .cas()
                     .write(
-                        running_state_func_run.clone(),
+                        Arc::new(code_cas_value.into()),
                         None,
                         ctx.events_tenancy(),
                         ctx.events_actor(),
                     )
                     .await?;
+                hash
+            } else {
+                // Why are we doing this? Because the struct gods demand it. I have feelings.
+                ContentHash::new("".as_bytes())
+            };
 
-                let execution_result = match func_run.backend_kind().into() {
-                    FuncBackendKind::JsAction => {
-                        FuncBackendJsAction::create_and_execute(
-                            func_dispatch_context,
-                            &func,
-                            &args,
-                            before,
-                        )
-                        .await
-                    }
-                    FuncBackendKind::JsReconciliation => {
-                        FuncBackendJsReconciliation::create_and_execute(
-                            func_dispatch_context,
-                            &func,
-                            &args,
-                            before,
-                        )
-                        .await
-                    }
-                    FuncBackendKind::JsAttribute => {
-                        let args = FuncBackendJsAttributeArgs {
-                            component: ResolverFunctionComponent {
-                                data: veritech_client::ComponentView {
-                                    properties: args.to_owned(),
-                                    ..Default::default()
-                                },
-                                parents: Vec::new(),
-                            },
-                            response_type: func.backend_response_type.try_into()?,
-                        };
-                        FuncBackendJsAttribute::create_and_execute(
-                            func_dispatch_context,
-                            &func,
-                            &serde_json::to_value(args)?,
-                            before,
-                        )
-                        .await
-                    }
-                    FuncBackendKind::JsSchemaVariantDefinition => {
-                        FuncBackendJsSchemaVariantDefinition::create_and_execute(
-                            func_dispatch_context,
-                            &func,
-                            &serde_json::Value::Null,
-                            before,
-                        )
-                        .await
-                    }
-                    FuncBackendKind::Json => FuncBackendJson::create_and_execute(&args).await,
-                    FuncBackendKind::Array => FuncBackendArray::create_and_execute(&args).await,
-                    FuncBackendKind::Boolean => FuncBackendBoolean::create_and_execute(&args).await,
-                    FuncBackendKind::Identity => {
-                        FuncBackendIdentity::create_and_execute(&args).await
-                    }
-                    FuncBackendKind::Diff => FuncBackendDiff::create_and_execute(&args).await,
-                    FuncBackendKind::Integer => FuncBackendInteger::create_and_execute(&args).await,
-                    FuncBackendKind::Map => FuncBackendMap::create_and_execute(&args).await,
-                    FuncBackendKind::Object => FuncBackendObject::create_and_execute(&args).await,
-                    FuncBackendKind::String => FuncBackendString::create_and_execute(&args).await,
-                    FuncBackendKind::Unset => Ok((None, None)),
-                    FuncBackendKind::Validation => {
-                        FuncBackendValidation::create_and_execute(
-                            func_dispatch_context,
-                            &func,
-                            &args,
-                            before,
-                        )
-                        .await
-                    }
-                    FuncBackendKind::JsValidation => {
-                        return Err(FuncRunnerError::DirectValidationFuncsNoLongerSupported(
-                            func.id,
-                        ))
-                    }
-                    FuncBackendKind::JsAuthentication => {
-                        return Err(
-                            FuncRunnerError::DirectAuthenticationFuncExecutionUnsupported(func.id),
-                        )
-                    }
-                };
+            let before = before_funcs_for_component(ctx, component_id).await?;
+            let component = Component::get_by_id(ctx, component_id).await?;
+            let component_name = component.name(ctx).await?;
+            let schema_name = component.schema(ctx).await?.name;
 
-                // if func.name.as_str() != "si:setObject" {
-                //     dbg!(&func.name, &func.kind, &args, &execution_result);
-                // }
+            let component_id = component_id.into();
+            let action_kind = prototype.kind.into();
 
-                match execution_result {
-                    Ok((mut unprocessed_value, mut value)) => {
-                        // We so sorry - this is the way that the old code
-                        // worked. Basically, we were serializing
-                        // serde_json::Value::Null into the database when we
-                        // executed functions, and then when you read it
-                        // back out, it was as an Option<serde_json::Value>,
-                        // which Serde would helpfuly translate into
-                        // None, rather than Some(serde_json::Value::Null).
-                        //
-                        // Unfortunately, that means that there is a whole bunch
-                        // of code that relies on basically never being able
-                        // to read serde_json::Value::Null. So that's what
-                        // we are going to do.
-                        //
-                        // Love,
-                        // Adam, Fletcher, and Nick. :)
+            let func_run_create_time = Utc::now();
+            let func_run_inner = FuncRunBuilder::default()
+                .actor(ctx.events_actor())
+                .tenancy(ctx.events_tenancy())
+                .backend_kind(func.backend_kind.into())
+                .backend_response_type(func.backend_response_type.into())
+                .function_name(func.name.clone())
+                .function_kind(func.kind.into())
+                .function_display_name(func.display_name.clone())
+                .function_description(func.description.clone())
+                .function_link(func.link.clone())
+                .function_args_cas_address(function_args_cas_address)
+                .function_code_cas_address(code_cas_hash)
+                .action_id(maybe_action_id.map(|a| a.into()))
+                .action_prototype_id(Some(action_prototype_id.into()))
+                .action_kind(Some(action_kind))
+                .action_display_name(Some(prototype.name().clone()))
+                .action_originating_change_set_id(
+                    maybe_action_originating_change_set_id.map(|a| a.into()),
+                )
+                .action_originating_change_set_name(maybe_action_originating_change_set_name)
+                .action_result_state(Some(ActionResultState::Unknown))
+                .attribute_value_id(None)
+                .component_id(Some(component_id))
+                .component_name(Some(component_name))
+                .schema_name(Some(schema_name))
+                .created_at(func_run_create_time)
+                .updated_at(func_run_create_time)
+                .build()?;
 
-                        if unprocessed_value == Some(serde_json::Value::Null) {
-                            unprocessed_value = None;
-                        }
+            if !span.is_disabled() {
+                let mut id_buf = FuncRunId::array_to_str_buf();
 
-                        if value == Some(serde_json::Value::Null) {
-                            value = None;
-                        }
+                let id = func_run_inner.id().array_to_str(&mut id_buf);
+                span.record("job.id", &id);
+                span.record("si.func_run.id", &id);
 
-                        let mut next_state_inner =
-                            Arc::unwrap_or_clone(running_state_func_run.clone());
-                        next_state_inner.set_state_to_post_processing();
-                        let next_state = Arc::new(next_state_inner);
-                        ctx.layer_db()
-                            .func_run()
-                            .write(
-                                next_state.clone(),
-                                None,
-                                ctx.events_tenancy(),
-                                ctx.events_actor(),
-                            )
-                            .await?;
-                        let _ = tx.send(Ok(FuncRunValue::new(
-                            next_state.id(),
-                            unprocessed_value,
-                            value,
-                        )));
-                    }
-                    Err(FuncBackendError::ResultFailure {
-                        kind,
-                        message,
-                        backend,
-                    }) => {
-                        let mut next_state_inner =
-                            Arc::unwrap_or_clone(running_state_func_run.clone());
-                        next_state_inner.set_state_to_failure();
-                        let next_state = Arc::new(next_state_inner);
-                        ctx.layer_db()
-                            .func_run()
-                            .write(
-                                next_state.clone(),
-                                None,
-                                ctx.events_tenancy(),
-                                ctx.events_actor(),
-                            )
-                            .await?;
+                let invoked_args = serde_json::to_string(&args)
+                    .unwrap_or_else(|_| "args failed to serialize".to_owned());
+                span.record("job.invoked_args", invoked_args.as_str());
+                span.record("si.func_run.func.args", invoked_args.as_str());
 
-                        let _ = tx.send(Err(FuncRunnerError::ResultFailure {
-                            kind,
-                            message,
-                            backend,
-                        }));
-                    }
-                    Err(err) => {
-                        let mut next_state_inner =
-                            Arc::unwrap_or_clone(running_state_func_run.clone());
-                        next_state_inner.set_state_to_failure();
-                        let next_state = Arc::new(next_state_inner);
-                        ctx.layer_db()
-                            .func_run()
-                            .write(
-                                next_state.clone(),
-                                None,
-                                ctx.events_tenancy(),
-                                ctx.events_actor(),
-                            )
-                            .await?;
-                        let _ = tx.send(Err(err.into()));
-                    }
+                span.record("job.invoked_name", func.name.as_str());
+                span.record("si.func_run.func.name", func.name.as_str());
+
+                if let Some(action_id) = maybe_action_id {
+                    span.record("si.action.id", action_id.array_to_str(&mut id_buf));
                 }
-                Ok(())
-            }
-        });
+                span.record("si.action.kind", action_kind.as_ref());
+                span.record("si.func_run.func.backend_kind", func.backend_kind.as_ref());
+                span.record(
+                    "si.func_run.func.backend_response_type",
+                    func.backend_response_type.as_ref(),
+                );
+                span.record("si.func_run.func.id", func.id.array_to_str(&mut id_buf));
+                span.record("si.func_run.func.kind", func.kind.as_ref());
 
-        rx
+                span.record(
+                    "si.change_set.id",
+                    func_run_inner.change_set_id().array_to_str(&mut id_buf),
+                );
+                span.record("si.component.id", component_id.array_to_str(&mut id_buf));
+                span.record(
+                    "si.workspace.id",
+                    func_run_inner.workspace_pk().array_to_str(&mut id_buf),
+                );
+            }
+
+            let func_run = Arc::new(func_run_inner);
+
+            ctx.layer_db()
+                .func_run()
+                .write(
+                    func_run.clone(),
+                    None,
+                    ctx.events_tenancy(),
+                    ctx.events_actor(),
+                )
+                .await?;
+
+            Ok(FuncRunner {
+                func_run,
+                func,
+                args,
+                before,
+            })
+        }
+
+        let span = Span::current();
+
+        let runner = prepare(ctx, action_prototype_id, component_id, func_id, args, &span)
+            .await
+            .map_err(|err| span.record_err(err))?;
+
+        let result_channel = runner.execute(ctx.clone(), span).await;
+
+        Ok(result_channel)
+    }
+
+    fn id(&self) -> FuncRunId {
+        self.func_run.id()
+    }
+
+    async fn execute(self, ctx: DalContext, execution_parent_span: Span) -> FuncRunnerValueChannel {
+        let func_run_id = self.func_run.id();
+        let (func_dispatch_context, output_stream_rx) = FuncDispatchContext::new(&ctx);
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
+        let logs_task = FuncRunnerLogsTask {
+            ctx: ctx.clone(),
+            func_run_id,
+            output_stream_rx,
+        };
+
+        let execution_task = FuncRunnerExecutionTask {
+            result_tx,
+            ctx,
+            func_dispatch_context,
+            func_run: self.func_run,
+            func: self.func,
+            args: self.args,
+            before: self.before,
+            parent_span: execution_parent_span,
+        };
+
+        // This probably needs a tracker, if we're being honest - but one thing at a time.
+        tokio::spawn(logs_task.run());
+        tokio::spawn(execution_task.run());
+
+        result_rx
+    }
+}
+
+struct FuncRunnerLogsTask {
+    ctx: DalContext,
+    func_run_id: FuncRunId,
+    output_stream_rx: mpsc::Receiver<OutputStream>,
+}
+
+impl FuncRunnerLogsTask {
+    const NAME: &'static str = "Dal::FuncRunnerLogsTask";
+
+    async fn run(self) {
+        if let Err(err) = self.try_run().await {
+            error!(task = Self::NAME, error = ?err, "error while processing function logs");
+        }
+    }
+
+    async fn try_run(mut self) -> FuncRunnerResult<()> {
+        let mut func_run_log = FuncRunLog::new(self.func_run_id, self.ctx.events_tenancy());
+        while let Some(item) = self.output_stream_rx.recv().await {
+            func_run_log.push_log(si_events::OutputLine {
+                stream: item.stream,
+                execution_id: item.execution_id,
+                level: item.level,
+                group: item.group,
+                message: item.message,
+                timestamp: item.timestamp,
+            });
+
+            WsEvent::func_run_log_updated(&self.ctx, func_run_log.func_run_id(), func_run_log.id())
+                .await?
+                .publish_immediately(&self.ctx)
+                .await?;
+
+            self.ctx
+                .layer_db()
+                .func_run_log()
+                .write(
+                    Arc::new(func_run_log.clone()),
+                    None,
+                    self.ctx.events_tenancy(),
+                    self.ctx.events_actor(),
+                )
+                .await?;
+        }
+
+        // Now that all `OutputStream` messages have been received, we will never
+        // see any further lines so we know we've reached the end. Marking the
+        // `FuncRunLog` as finalized can signal to other observers that this value
+        // is now effectively immutable and will not change going forward. (hint:
+        // this could be used to synchronize/wait on the final accumulation of all
+        // logs from a function execution, even if this task takes far longer than
+        // the execution time of the function).
+        func_run_log.set_finalized();
+        self.ctx
+            .layer_db()
+            .func_run_log()
+            .write(
+                Arc::new(func_run_log.clone()),
+                None,
+                self.ctx.events_tenancy(),
+                self.ctx.events_actor(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+struct FuncRunnerExecutionTask {
+    result_tx: oneshot::Sender<FuncRunnerResult<FuncRunValue>>,
+    ctx: DalContext,
+    func_dispatch_context: FuncDispatchContext,
+    func_run: Arc<FuncRun>,
+    func: Func,
+    args: serde_json::Value,
+    before: Vec<BeforeFunction>,
+    parent_span: Span,
+}
+
+impl FuncRunnerExecutionTask {
+    const NAME: &'static str = "Dal::FuncRunnerExecutionTask";
+
+    #[instrument(
+        name = "func_runner.execution_task.run",
+        level = "debug",
+        parent = &self.parent_span,
+        skip_all,
+        fields()
+    )]
+    async fn run(self) {
+        let span = Span::current();
+        let parent_span = self.parent_span.clone();
+
+        if let Err(err) = self
+            .try_run()
+            .await
+            .inspect(|_| {
+                span.record_ok();
+                parent_span.record_ok()
+            })
+            .map_err(|err| {
+                let err = span.record_err(err);
+                parent_span.record_err(err)
+            })
+        {
+            error!(task = Self::NAME, error = ?err, "error while dispatching and running function");
+        }
+    }
+
+    async fn try_run(self) -> FuncRunnerResult<()> {
+        let mut running_state_func_run_inner = Arc::unwrap_or_clone(self.func_run.clone());
+        running_state_func_run_inner.set_state_to_running();
+        let running_state_func_run = Arc::new(running_state_func_run_inner);
+        self.ctx
+            .layer_db()
+            .func_run()
+            .write(
+                running_state_func_run.clone(),
+                None,
+                self.ctx.events_tenancy(),
+                self.ctx.events_actor(),
+            )
+            .await?;
+
+        let execution_result = match self.func_run.backend_kind().into() {
+            FuncBackendKind::JsAction => {
+                FuncBackendJsAction::create_and_execute(
+                    self.func_dispatch_context,
+                    &self.func,
+                    &self.args,
+                    self.before,
+                )
+                .await
+            }
+            FuncBackendKind::JsReconciliation => {
+                FuncBackendJsReconciliation::create_and_execute(
+                    self.func_dispatch_context,
+                    &self.func,
+                    &self.args,
+                    self.before,
+                )
+                .await
+            }
+            FuncBackendKind::JsAttribute => {
+                let args = FuncBackendJsAttributeArgs {
+                    component: ResolverFunctionComponent {
+                        data: veritech_client::ComponentView {
+                            properties: self.args.to_owned(),
+                            ..Default::default()
+                        },
+                        parents: Vec::new(),
+                    },
+                    response_type: self.func.backend_response_type.try_into()?,
+                };
+                FuncBackendJsAttribute::create_and_execute(
+                    self.func_dispatch_context,
+                    &self.func,
+                    &serde_json::to_value(args)?,
+                    self.before,
+                )
+                .await
+            }
+            FuncBackendKind::JsSchemaVariantDefinition => {
+                FuncBackendJsSchemaVariantDefinition::create_and_execute(
+                    self.func_dispatch_context,
+                    &self.func,
+                    &serde_json::Value::Null,
+                    self.before,
+                )
+                .await
+            }
+            FuncBackendKind::Json => FuncBackendJson::create_and_execute(&self.args).await,
+            FuncBackendKind::Array => FuncBackendArray::create_and_execute(&self.args).await,
+            FuncBackendKind::Boolean => FuncBackendBoolean::create_and_execute(&self.args).await,
+            FuncBackendKind::Identity => FuncBackendIdentity::create_and_execute(&self.args).await,
+            FuncBackendKind::Diff => FuncBackendDiff::create_and_execute(&self.args).await,
+            FuncBackendKind::Integer => FuncBackendInteger::create_and_execute(&self.args).await,
+            FuncBackendKind::Map => FuncBackendMap::create_and_execute(&self.args).await,
+            FuncBackendKind::Object => FuncBackendObject::create_and_execute(&self.args).await,
+            FuncBackendKind::String => FuncBackendString::create_and_execute(&self.args).await,
+            FuncBackendKind::Unset => Ok((None, None)),
+            FuncBackendKind::Validation => {
+                FuncBackendValidation::create_and_execute(
+                    self.func_dispatch_context,
+                    &self.func,
+                    &self.args,
+                    self.before,
+                )
+                .await
+            }
+            FuncBackendKind::JsValidation => {
+                return Err(FuncRunnerError::DirectValidationFuncsNoLongerSupported(
+                    self.func.id,
+                ))
+            }
+            FuncBackendKind::JsAuthentication => {
+                return Err(
+                    FuncRunnerError::DirectAuthenticationFuncExecutionUnsupported(self.func.id),
+                )
+            }
+        };
+
+        match execution_result {
+            Ok((mut unprocessed_value, mut value)) => {
+                // We so sorry - this is the way that the old code
+                // worked. Basically, we were serializing
+                // serde_json::Value::Null into the database when we
+                // executed functions, and then when you read it
+                // back out, it was as an Option<serde_json::Value>,
+                // which Serde would helpfuly translate into
+                // None, rather than Some(serde_json::Value::Null).
+                //
+                // Unfortunately, that means that there is a whole bunch
+                // of code that relies on basically never being able
+                // to read serde_json::Value::Null. So that's what
+                // we are going to do.
+                //
+                // Love,
+                // Adam, Fletcher, and Nick. :)
+
+                if unprocessed_value == Some(serde_json::Value::Null) {
+                    unprocessed_value = None;
+                }
+
+                if value == Some(serde_json::Value::Null) {
+                    value = None;
+                }
+
+                let mut next_state_inner = Arc::unwrap_or_clone(running_state_func_run.clone());
+                next_state_inner.set_state_to_post_processing();
+                let next_state = Arc::new(next_state_inner);
+                self.ctx
+                    .layer_db()
+                    .func_run()
+                    .write(
+                        next_state.clone(),
+                        None,
+                        self.ctx.events_tenancy(),
+                        self.ctx.events_actor(),
+                    )
+                    .await?;
+                let _ = self.result_tx.send(Ok(FuncRunValue::new(
+                    next_state.id(),
+                    unprocessed_value,
+                    value,
+                )));
+            }
+            Err(FuncBackendError::ResultFailure {
+                kind,
+                message,
+                backend,
+            }) => {
+                let mut next_state_inner = Arc::unwrap_or_clone(running_state_func_run.clone());
+                next_state_inner.set_state_to_failure();
+                let next_state = Arc::new(next_state_inner);
+                self.ctx
+                    .layer_db()
+                    .func_run()
+                    .write(
+                        next_state.clone(),
+                        None,
+                        self.ctx.events_tenancy(),
+                        self.ctx.events_actor(),
+                    )
+                    .await?;
+
+                let _ = self.result_tx.send(Err(FuncRunnerError::ResultFailure {
+                    kind,
+                    message,
+                    backend,
+                }));
+            }
+            Err(err) => {
+                let mut next_state_inner = Arc::unwrap_or_clone(running_state_func_run.clone());
+                next_state_inner.set_state_to_failure();
+                let next_state = Arc::new(next_state_inner);
+                self.ctx
+                    .layer_db()
+                    .func_run()
+                    .write(
+                        next_state.clone(),
+                        None,
+                        self.ctx.events_tenancy(),
+                        self.ctx.events_actor(),
+                    )
+                    .await?;
+                let _ = self.result_tx.send(Err(err.into()));
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/lib/dal/src/standard_id.rs
+++ b/lib/dal/src/standard_id.rs
@@ -38,6 +38,11 @@ macro_rules! id {
             pub fn into_inner(self) -> ::ulid::Ulid {
                 self.0
             }
+
+            /// Creates a Crockford Base32 encoded string that represents this Ulid.
+            pub fn array_to_str<'buf>(&self, buf: &'buf mut [u8; ::ulid::ULID_LEN]) -> &'buf mut str {
+                self.0.array_to_str(buf)
+            }
         }
 
         impl From<$name> for ::si_events::ulid::Ulid {

--- a/lib/si-events-rs/src/func_run.rs
+++ b/lib/si-events-rs/src/func_run.rs
@@ -3,7 +3,7 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display, EnumIter, EnumString};
 
-use crate::{id, Actor, ChangeSetId, ContentHash, Tenancy};
+use crate::{id, Actor, ChangeSetId, ContentHash, Tenancy, WorkspacePk};
 
 id!(FuncRunId);
 id!(ComponentId);
@@ -106,7 +106,7 @@ pub enum FuncBackendResponseType {
 }
 
 #[remain::sorted]
-#[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq, Eq, Display)]
+#[derive(AsRefStr, Debug, Copy, Clone, Deserialize, Serialize, PartialEq, Eq, Display)]
 pub enum ActionKind {
     /// Create the "outside world" version of the modeled object.
     Create,
@@ -239,6 +239,14 @@ impl FuncRun {
 
     pub fn tenancy(&self) -> &Tenancy {
         &self.tenancy
+    }
+
+    pub fn workspace_pk(&self) -> WorkspacePk {
+        self.tenancy.workspace_pk
+    }
+
+    pub fn change_set_id(&self) -> ChangeSetId {
+        self.tenancy.change_set_id
     }
 
     pub fn component_id(&self) -> Option<ComponentId> {

--- a/lib/si-events-rs/src/lib.rs
+++ b/lib/si-events-rs/src/lib.rs
@@ -78,6 +78,10 @@ macro_rules! id {
                 self.0.array_to_str(buf)
             }
 
+            pub fn array_to_str_buf() -> [u8; ::ulid::ULID_LEN] {
+                [0; ::ulid::ULID_LEN]
+            }
+
             /// Converts type into inner [`Ulid`](::ulid::Ulid).
             pub fn into_inner(self) -> ::ulid::Ulid {
                 self.0


### PR DESCRIPTION
This change adds rather extensive instrumentation coverage around all
function execution types. As this code lives in the DAL, we have access
to data such as change set and workspace identifiers so this is a very
nice location to attach this relevant data.

The largest refactoring step was to take the 2 spawned activities and
split them into explicit types to make future tracking and cancelling
easier.

<img src="https://media4.giphy.com/media/iFGhsoee2xTOM/giphy.gif"/>