### PR TITLE
Fix: dont confetti unless on head

### DIFF
--- a/app/web/src/store/actions.store.ts
+++ b/app/web/src/store/actions.store.ts
@@ -302,7 +302,11 @@ export const useActionsStore = () => {
                 visibility_change_set_pk: changeSetId,
               },
               onSuccess: (response) => {
-                if (this.actions.length > 0 && response.length === 0)
+                if (
+                  this.actions.length > 0 &&
+                  response.length === 0 &&
+                  changeSetsStore.headSelected
+                )
                   jsConfetti.addConfetti(_.sample(confettis));
 
                 this.actions = response;


### PR DESCRIPTION
Confetti was firing on a changeset when deleting a component that was added in the changeset. 