### PR TITLE
commit more often to reduce the chance that the background job races …

### DIFF
--- a/lib/dal-test/src/helpers/change_set.rs
+++ b/lib/dal-test/src/helpers/change_set.rs
@@ -67,7 +67,7 @@ impl ChangeSetTestHelpers {
         let mut count = 0;
         while count < total_count {
             ctx.update_snapshot_to_visibility().await?;
-            let mut still_active = ctx
+            let still_active = ctx
                 .workspace_snapshot()?
                 .has_dependent_value_roots()
                 .await?;

--- a/lib/dal/tests/integration_test/validations.rs
+++ b/lib/dal/tests/integration_test/validations.rs
@@ -141,7 +141,9 @@ async fn validation_on_dependent_value(ctx: &mut DalContext) {
         "number",
     )
     .await;
-
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
     let prop_path = &["root", "domain", "a_number"];
     let av_id = output_component
         .attribute_values_for_prop(ctx, prop_path)

--- a/lib/dal/tests/integration_test/validations.rs
+++ b/lib/dal/tests/integration_test/validations.rs
@@ -127,6 +127,9 @@ async fn prop_editor_validation(ctx: &mut DalContext) {
 #[test]
 async fn validation_on_dependent_value(ctx: &mut DalContext) {
     let output_component = create_component_for_schema_name(ctx, "ValidatedOutput", "Output").await;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
     let input_component = create_component_for_schema_name(ctx, "ValidatedInput", "Input").await;
 
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
@@ -155,7 +158,8 @@ async fn validation_on_dependent_value(ctx: &mut DalContext) {
     AttributeValue::update(ctx, av_id, Some(json!(1)))
         .await
         .expect("override attribute value");
-
+    let conflicts = ctx.blocking_commit().await.expect("could commit");
+    assert!(conflicts.is_none());
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update snapshot to visibility");
@@ -187,7 +191,8 @@ async fn validation_on_dependent_value(ctx: &mut DalContext) {
     AttributeValue::update(ctx, av_id, Some(json!(3)))
         .await
         .expect("override attribute value");
-
+    let conflicts = ctx.blocking_commit().await.expect("could commit");
+    assert!(conflicts.is_none());
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update snapshot to visibility");


### PR DESCRIPTION
…our blocking_commit