### PR TITLE
feat(dal,sdf,web): Make components not grow across parent borders on type change

### DIFF
--- a/app/web/src/components/AttributesPanel/AttributesPanel.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanel.vue
@@ -1,21 +1,21 @@
 <template>
   <div
     ref="rootRef"
-    class="attributes-panel"
     :class="{
       '--show-section-toggles': showSectionToggles,
     }"
-    @pointermove="onMouseMove"
+    class="attributes-panel"
     @mouseleave="onMouseLeave"
+    @pointermove="onMouseMove"
   >
     <!-- custom inputs for SI props (name, color, etc) -->
     <div class="attributes-panel__si-settings">
       <div
         :id="`color-picker-${componentId}`"
         ref="colorPickerMountRef"
+        :style="{ backgroundColor: siValues.color }"
         :title="siValues.color"
         class="attributes-panel__color-swatch"
-        :style="{ backgroundColor: siValues.color }"
         @click="openColorPicker"
       />
       <input
@@ -27,9 +27,11 @@
       />
       <div class="attributes-panel__type-dropdown">
         <select v-model="siValues.type" @change="updateComponentType()">
-          <option value="component">Component</option>
-          <option value="configurationFrameUp">Configuration Frame (Up)</option>
-          <option value="configurationFrameDown">
+          <option :value="ComponentType.Component">Component</option>
+          <option :value="ComponentType.ConfigurationFrameUp">
+            Configuration Frame (Up)
+          </option>
+          <option :value="ComponentType.ConfigurationFrameUp">
             Configuration Frame (Down)
           </option>
         </select>
@@ -88,7 +90,7 @@ export function useAttributesPanelContext() {
 </script>
 
 <!-- eslint-disable vue/component-tags-order,import/first -->
-<script setup lang="ts">
+<script lang="ts" setup>
 import Picker from "vanilla-picker";
 import * as _ from "lodash-es";
 import {
@@ -113,6 +115,7 @@ import {
 import { useComponentsStore } from "@/store/components.store";
 import { useComponentAttributesStore } from "@/store/component_attributes.store";
 
+import { ComponentType } from "@/api/sdf/dal/diagram";
 import AttributesPanelItem from "./AttributesPanelItem.vue";
 
 const props = defineProps({
@@ -149,7 +152,8 @@ const siValuesFromStore = computed(() => ({
   name: (siProps.value?.name?.value?.value as string) || component.displayName,
   color: (siProps.value?.color?.value?.value as string) || component.color,
   type:
-    (siProps.value?.type?.value?.value as string) || component?.componentType,
+    (siProps.value?.type?.value?.value as ComponentType) ||
+    component?.componentType,
 }));
 const siValues = reactive(_.cloneDeep(siValuesFromStore.value));
 
@@ -189,14 +193,15 @@ function updateSiProp(key: keyof typeof siValues) {
   }
 }
 
-// color picker
-const colorPickerMountRef = ref<HTMLElement>();
 function updateComponentType() {
   attributesStore.SET_COMPONENT_TYPE({
     componentId: component.id,
-    value: siValues.type,
+    componentType: siValues.type,
   });
 }
+
+// color picker
+const colorPickerMountRef = ref<HTMLElement>();
 
 let picker: Picker | undefined;
 function openColorPicker() {
@@ -330,7 +335,6 @@ provide(AttributesPanelContextInjectionKey, {
       border-color: var(--input-focus-border-color);
 
       z-index: 2;
-      border-color: var(--input-focus-border-color);
     }
   }
 }

--- a/app/web/src/components/ModelingDiagram/diagram_constants.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_constants.ts
@@ -14,6 +14,7 @@ export const DRAG_EDGE_TRIGGER_SCROLL_WIDTH = 15;
 
 // Default Width for Node
 export const NODE_WIDTH = 200;
+export const MIN_NODE_DIMENSION = NODE_WIDTH + 20 * 2;
 
 // spacing between sockets
 export const SOCKET_GAP = 22;
@@ -28,7 +29,10 @@ export const GROUP_TITLE_FONT_SIZE = 14;
 export const GROUP_INTERNAL_PADDING = 20;
 export const GROUP_RESIZE_HANDLE_SIZE = 20;
 export const GROUP_HEADER_ICON_SIZE = 35;
+// We need an extra bottom padding to account for the status icons
 export const GROUP_BOTTOM_INTERNAL_PADDING = 35;
+export const GROUP_DEFAULT_WIDTH = 35;
+export const GROUP_DEFAULT_HEIGHT = 35;
 
 // corner radius used on nodes (maybe other things later?)
 export const CORNER_RADIUS = 3;

--- a/app/web/src/components/ModelingDiagram/diagram_types.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_types.ts
@@ -201,6 +201,8 @@ export type DiagramNodeDef = {
   typeIcon?: string | null;
   /** type of node - define if this is a simple component or a type of frame */
   componentType: ComponentType;
+  /** type of node - define if this is a simple component or a type of frame */
+  isGroup: boolean;
   /** array of icons (slug and colors) to show statuses */
   statusIcons?: DiagramStatusIcon[];
   /** if true, node shows the `loading` overlay */

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -4,7 +4,7 @@
 import { FuncId } from "@/store/func/funcs.store";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import { ComponentId, RawComponent, RawEdge } from "@/api/sdf/dal/component";
-import { ComponentPositions } from "../components.store";
+import { ComponentGeometry } from "../components.store";
 import { WorkspacePk } from "../workspaces.store";
 import { ActionId } from "../actions.store";
 import { StatusUpdate } from "../status.store";
@@ -46,7 +46,7 @@ export interface ComponentPositionRequest {
   data: {
     userPk: UserId;
     changeSetId: string | null;
-    positions: ComponentPositions[];
+    positions: ComponentGeometry[];
   };
 }
 

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -92,10 +92,6 @@ async fn async_main() -> Result<()> {
     }
 
     let config = Config::try_from(args)?;
-    dbg!(config.boot_feature_flags());
-    // TODO Create Feature Flags Service in Service Context
-    // TODO Push Boot feature flags into it
-    // TODO Read FFs  back from actions endpoints
 
     let encryption_key = Server::load_encryption_key(config.crypto().clone()).await?;
     let jwt_public_signing_key =

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -261,6 +261,15 @@ impl From<Component> for ComponentContentV1 {
     }
 }
 
+// Used to transfer the size and position of a component
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ComponentGeometry {
+    pub x: String,
+    pub y: String,
+    pub width: Option<String>,
+    pub height: Option<String>,
+}
+
 #[derive(Copy, Clone)]
 pub struct ControllingFuncData {
     pub func_id: FuncId,


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/fo84j6rpbL0yui7qBd/giphy.gif"/>

Also fixes:
- moving children alongside group
- detaching/reparenting multiple components in a single call