### PR TITLE
fix(dal): give dvu 10000 second interval in tests

### DIFF
--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -599,6 +599,8 @@ pub fn rebaser_server(
         config.instance_id(),
         services_context,
         shutdown_token,
+        // a huge interval, to prevent dvu debouncer from running dvus in tests
+        std::time::Duration::from_secs(10000),
     )
     .wrap_err("failed to create Rebaser server")?;
 

--- a/lib/rebaser-server/src/change_set_requests.rs
+++ b/lib/rebaser-server/src/change_set_requests.rs
@@ -6,6 +6,7 @@ use std::{
     future::{Future, IntoFuture},
     io,
     sync::Arc,
+    time::Duration,
 };
 
 use dal::DalContextBuilder;
@@ -54,12 +55,14 @@ impl ChangeSetRequestsTask {
         incoming: jetstream::consumer::pull::Stream,
         ctx_builder: DalContextBuilder,
         shutdown_token: CancellationToken,
+        dvu_interval: Duration,
     ) -> Self {
         let dvu_debouncer = DvuDebouncer::new(
             workspace_id,
             change_set_id,
             shutdown_token.clone(),
             ctx_builder.clone(),
+            dvu_interval,
         );
         let state = AppState::new(workspace_id, change_set_id, ctx_builder, dvu_debouncer);
 

--- a/lib/rebaser-server/src/config.rs
+++ b/lib/rebaser-server/src/config.rs
@@ -65,6 +65,9 @@ pub struct Config {
 
     #[builder(default = "random_instance_id()")]
     instance_id: String,
+
+    #[builder(default = "5000")]
+    dvu_interval_millis: u64,
 }
 
 impl StandardConfig for Config {
@@ -114,6 +117,11 @@ impl Config {
     /// Gets the config's instance ID.
     pub fn instance_id(&self) -> &str {
         self.instance_id.as_ref()
+    }
+
+    /// Gets the duration of the dvu interval
+    pub fn dvu_interval(&self) -> std::time::Duration {
+        std::time::Duration::from_millis(self.dvu_interval_millis)
     }
 }
 

--- a/lib/rebaser-server/src/server.rs
+++ b/lib/rebaser-server/src/server.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{HashMap, HashSet},
     future::IntoFuture,
     sync::Arc,
+    time::Duration,
 };
 
 use dal::feature_flags::FeatureFlagService;
@@ -52,6 +53,7 @@ pub struct Server {
     ctx_builder: DalContextBuilder,
     change_set_tasks: HashMap<ChangeSetId, RunningTask>,
     shutdown_token: CancellationToken,
+    dvu_interval: Duration,
 }
 
 impl Server {
@@ -94,6 +96,7 @@ impl Server {
             config.instance_id().to_string(),
             services_context,
             shutdown_token,
+            config.dvu_interval(),
         )
     }
 
@@ -103,6 +106,7 @@ impl Server {
         instance_id: impl Into<String>,
         services_context: ServicesContext,
         shutdown_token: CancellationToken,
+        dvu_interval: Duration,
     ) -> ServerResult<Self> {
         dal::init()?;
 
@@ -117,6 +121,7 @@ impl Server {
             ctx_builder,
             change_set_tasks: HashMap::default(),
             shutdown_token,
+            dvu_interval,
         })
     }
 
@@ -282,6 +287,7 @@ impl Server {
             incoming,
             self.ctx_builder.clone(),
             token.clone(),
+            self.dvu_interval,
         );
         let handle = tokio::spawn(task.run());
         let running_task = RunningTask { handle, token };


### PR DESCRIPTION
To prevent DVU debouncer from racing with blocking_commit jobs in tests, increase tick interval in tests to 10000 seconds, so it will never run (unless an individual test takes several hours (unless an individual test takes several hours). This is a stop gap until we implement a way to wait on the completion of the debounced dvus.