### PR TITLE
chore(sdf): remove `v2` request fields post-actions v2 merging

### DIFF
--- a/app/web/src/store/actions.store.ts
+++ b/app/web/src/store/actions.store.ts
@@ -9,7 +9,6 @@ import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import { ComponentId } from "@/api/sdf/dal/component";
 import { useChangeSetsStore } from "./change_sets.store";
 import { useRealtimeStore } from "./realtime/realtime.store";
-import { useFeatureFlagsStore } from "./feature_flags.store";
 
 export type DeprecatedActionStatus =
   | "success"
@@ -138,8 +137,6 @@ export const useActionsStore = () => {
 
   const changeSetsStore = useChangeSetsStore();
   const changeSetId = changeSetsStore.selectedChangeSetId;
-
-  const featureFlagsStore = useFeatureFlagsStore();
 
   return addStoreHooks(
     defineStore(
@@ -274,7 +271,6 @@ export const useActionsStore = () => {
               params: {
                 prototypeId: actionPrototypeId,
                 componentId,
-                v2: featureFlagsStore.IS_ACTIONS_V2,
                 visibility_change_set_pk: changeSetId,
               },
             });
@@ -285,7 +281,6 @@ export const useActionsStore = () => {
               keyRequestStatusBy: componentId,
               params: {
                 componentId,
-                v2: featureFlagsStore.IS_ACTIONS_V2,
                 visibility_change_set_pk: changeSetId,
               },
               onSuccess: (response) => {

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -12,7 +12,6 @@ import router from "@/router";
 import { UserId } from "@/store/auth.store";
 import IncomingChangesMerging from "@/components/toasts/IncomingChangesMerging.vue";
 import ChangesMerged from "@/components/toasts/ChangesMerged.vue";
-import { useFeatureFlagsStore } from "./feature_flags.store";
 import { useWorkspacesStore } from "./workspaces.store";
 import { useRealtimeStore } from "./realtime/realtime.store";
 import { useRouterStore } from "./router.store";
@@ -27,8 +26,6 @@ export interface OpenChangeSetsView {
 export function useChangeSetsStore() {
   const workspacesStore = useWorkspacesStore();
   const workspacePk = workspacesStore.selectedWorkspacePk;
-
-  const featureFlagsStore = useFeatureFlagsStore();
 
   return addStoreHooks(
     defineStore(`w${workspacePk || "NONE"}/change-sets`, {
@@ -142,7 +139,6 @@ export function useChangeSetsStore() {
             method: "post",
             url: "change_set/apply_change_set",
             params: {
-              v2: featureFlagsStore.IS_ACTIONS_V2,
               visibility_change_set_pk: this.selectedChangeSet.id,
             },
             optimistic: () => {

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -41,7 +41,6 @@ import { Resource } from "@/api/sdf/dal/resource";
 import { CodeView } from "@/api/sdf/dal/code_view";
 import ComponentUpgrading from "@/components/toasts/ComponentUpgrading.vue";
 import { useChangeSetsStore } from "./change_sets.store";
-import { useFeatureFlagsStore } from "./feature_flags.store";
 import { useRealtimeStore } from "./realtime/realtime.store";
 import {
   QualificationStatus,
@@ -218,7 +217,6 @@ const edgeFromRawEdge =
 export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
   const workspacesStore = useWorkspacesStore();
   const workspaceId = workspacesStore.selectedWorkspacePk;
-  const featureFlagsStore = useFeatureFlagsStore();
 
   const changeSetsStore = useChangeSetsStore();
 
@@ -1400,7 +1398,6 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               url: "component/refresh",
               params: {
                 componentId,
-                v2: featureFlagsStore.IS_ACTIONS_V2,
                 workspaceId: visibilityParams.workspaceId,
                 visibility_change_set_pk: changeSetsStore.headChangeSetId,
               },

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -7,7 +7,6 @@ import { posthog } from "@/utils/posthog";
 const FLAG_MAPPING = {
   // STORE_FLAG_NAME: "posthogFlagName",
   MODULES_TAB: "modules_tab",
-  IS_ACTIONS_V2: "is_actions_v2",
 };
 
 type FeatureFlags = keyof typeof FLAG_MAPPING;
@@ -32,9 +31,6 @@ export function useFeatureFlagsStore() {
           });
         });
         // You can override feature flags while working on a feature by setting them to true here
-
-        this.IS_ACTIONS_V2 = true; // TODO -  THIS SHOULD BE REMOVED ONCE ACTIONS V1 IS GONE
-        // Make sure to remove the override before committing your code!
       },
     }),
   )();

--- a/lib/sdf-server/src/server/service/change_set/add_action.rs
+++ b/lib/sdf-server/src/server/service/change_set/add_action.rs
@@ -15,8 +15,6 @@ use serde::{Deserialize, Serialize};
 pub struct AddActionRequest {
     pub prototype_id: ActionPrototypeId,
     pub component_id: ComponentId,
-    // TODO(fnichol): I THINK THIS GETS DELETED NOW
-    pub v2: bool,
     #[serde(flatten)]
     pub visibility: Visibility,
 }

--- a/lib/sdf-server/src/server/service/change_set/apply_change_set.rs
+++ b/lib/sdf-server/src/server/service/change_set/apply_change_set.rs
@@ -11,8 +11,6 @@ use crate::server::tracking::track;
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ApplyChangeSetRequest {
-    // TODO(fnichol): I THINK THIS GETS DELETED NOW
-    pub v2: bool,
     #[serde(flatten)]
     pub visibility: Visibility,
 }

--- a/lib/sdf-server/src/server/service/component/get_actions.rs
+++ b/lib/sdf-server/src/server/service/component/get_actions.rs
@@ -45,8 +45,6 @@ pub struct GetActionsResponse {
 #[serde(rename_all = "camelCase")]
 pub struct GetActionsRequest {
     pub component_id: ComponentId,
-    // TODO(fnichol): I THINK THIS GETS DELETED NOW
-    pub v2: bool,
     #[serde(flatten)]
     pub visibility: Visibility,
 }

--- a/lib/sdf-server/src/server/service/component/refresh.rs
+++ b/lib/sdf-server/src/server/service/component/refresh.rs
@@ -15,8 +15,6 @@ use crate::server::tracking::track;
 #[serde(rename_all = "camelCase")]
 pub struct RefreshRequest {
     pub component_id: ComponentId,
-    // TODO(fnichol): I THINK THIS GETS DELETED NOW
-    pub v2: bool,
     #[serde(flatten)]
     pub visibility: Visibility,
 }


### PR DESCRIPTION
Remove the `v2` request fields on front and back end now that we are post-actions v2 merging.

<img src="https://media2.giphy.com/media/zaq11oczHA6be/giphy.gif"/>