### PR TITLE
Fix action associations when refresh mutating action funcs post failure

### DIFF
--- a/docs/LOCALSTACK.md
+++ b/docs/LOCALSTACK.md
@@ -1,0 +1,17 @@
+# LocalStack
+
+This document contains information related to using [LocalStack](https://github.com/localstack/localstack) when working on the System Initiative software.
+
+## How to Use with the "AWS Credential" Builtin `SchemaVariant`
+
+You can use the "AWS Credential" builtin `SchemaVariant` with LocalStack when running the System Initiative software with the following command:
+
+```shell
+buck2 run //dev:up
+```
+
+To use LocalStack with "AWS Credential", create a `Component` using the `SchemaVariant`.
+After that, create a `Secret` and use it in the property editor.
+The secret should have `http://0.0.0.0:4566` populated in the "Endpoint" field.
+
+Now, you can use LocalStack in your development setup.

--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -241,7 +241,7 @@ impl ActionPrototype {
         Ok(action_prototype_ids)
     }
 
-    async fn schema_variant_id(
+    pub async fn schema_variant_id(
         ctx: &DalContext,
         id: ActionPrototypeId,
     ) -> ActionPrototypeResult<SchemaVariantId> {


### PR DESCRIPTION
## Description

This commit fixes action associations during `save_func` by hardening the association logic. The fix not only aims to polish action association mutation logic as a whole, but fixes a user-level bug where mutating a refresh action func after a refresh action has failed causes the system to go into an unrecoverable state. There is likely another bug lurking there related to conflicts, updating, rebasing, etc., but this commit, at least, avoids the very bad times.

Additionally, this commit adds a developer document related to using LocalStack for local development with "AWS Credential".

<img src="https://media1.giphy.com/media/EukOAWKKs0QoW3ps7Z/giphy.gif"/>