### PR TITLE
fix: refresh asset pinia store with new variant id

### DIFF
--- a/app/web/src/components/ComponentCard.vue
+++ b/app/web/src/components/ComponentCard.vue
@@ -102,6 +102,7 @@ const componentNameTooltip = computed(() => {
 });
 
 const upgradeComponent = async () => {
+  componentsStore.setSelectedComponentId(null);
   await componentsStore.UPGRADE_COMPONENT(
     props.componentId,
     component.value?.displayName || "",

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -425,6 +425,11 @@ export const useAssetStore = () => {
             eventType: "SchemaVariantUpdateFinished",
             callback: (data) => {
               if (data.changeSetId !== changeSetId) return;
+              for (const asset of Object.values(this.assetsById)) {
+                if (asset.defaultSchemaVariantId === data.oldSchemaVariantId) {
+                  asset.defaultSchemaVariantId = data.newSchemaVariantId;
+                }
+              }
               this.LOAD_ASSET_LIST();
             },
           },

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -258,7 +258,8 @@ export type WsEventPayloadMap = {
   };
   SchemaVariantUpdateFinished: {
     changeSetId: string;
-    schemaVariantId: string;
+    oldSchemaVariantId: string;
+    newSchemaVariantId: string;
   };
   SchemaVariantSaved: {
     schemaVariantId: string;

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -184,7 +184,8 @@ pub struct SchemaVariantClonedPayload {
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaVariantUpdatedPayload {
-    schema_variant_id: SchemaVariantId,
+    old_schema_variant_id: SchemaVariantId,
+    new_schema_variant_id: SchemaVariantId,
     change_set_id: ChangeSetId,
 }
 
@@ -240,12 +241,14 @@ impl WsEvent {
 
     pub async fn schema_variant_update_finished(
         ctx: &DalContext,
-        schema_variant_id: SchemaVariantId,
+        old_schema_variant_id: SchemaVariantId,
+        new_schema_variant_id: SchemaVariantId,
     ) -> WsEventResult<Self> {
         WsEvent::new(
             ctx,
             WsPayload::SchemaVariantUpdateFinished(SchemaVariantUpdatedPayload {
-                schema_variant_id,
+                old_schema_variant_id,
+                new_schema_variant_id,
                 change_set_id: ctx.change_set_id(),
             }),
         )

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -725,7 +725,7 @@ fn build_pkg_spec_for_variant(
 }
 
 fn generate_scaffold_func_name(name: String) -> String {
-    let version = Utc::now().format("%Y%m%d%H%M").to_string();
+    let version = Utc::now().format("%Y%m%d%H%M%S%f").to_string();
     let generated_name = format!("{}Scaffold_{}", name.to_case(Case::Camel), version);
     generated_name
 }

--- a/lib/sdf-server/src/server/service/variant/update_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/update_variant.rs
@@ -70,7 +70,7 @@ pub async fn update_variant(
         }),
     );
 
-    WsEvent::schema_variant_update_finished(&ctx, updated_sv_id)
+    WsEvent::schema_variant_update_finished(&ctx, request.default_schema_variant_id, updated_sv_id)
         .await?
         .publish_on_commit(&ctx)
         .await?;


### PR DESCRIPTION
The asset pinia store was not updating with the newly generated schema variant id, so subsequent updates were all being done on the old version.

Closes https://linear.app/system-initiative/issue/BUG-275/cannot-upgrade-an-asset-twice
<img src="https://media2.giphy.com/media/O9kCzQTSyPcTLlQ20b/giphy.gif"/>