### PR TITLE
Use ConflictsAndUpdates struct instead of tuple ordering for detect_conflicts_and_updates return value

### DIFF
--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -52,7 +52,6 @@ use tokio::task::JoinError;
 use crate::action::{Action, ActionError};
 use crate::change_set::{ChangeSet, ChangeSetError, ChangeSetId};
 use crate::pk;
-use crate::workspace_snapshot::conflict::Conflict;
 use crate::workspace_snapshot::edge_weight::{
     EdgeWeight, EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
 };
@@ -66,6 +65,7 @@ use crate::{
     DalContext, TransactionsError, WorkspaceSnapshotGraph,
 };
 
+use self::graph::ConflictsAndUpdates;
 use self::node_weight::{NodeWeightDiscriminants, OrderingNodeWeight};
 
 pk!(NodeId);
@@ -551,7 +551,7 @@ impl WorkspaceSnapshot {
         to_rebase_vector_clock_id: VectorClockId,
         onto_workspace_snapshot: &WorkspaceSnapshot,
         onto_vector_clock_id: VectorClockId,
-    ) -> WorkspaceSnapshotResult<(Vec<Conflict>, Vec<Update>)> {
+    ) -> WorkspaceSnapshotResult<ConflictsAndUpdates> {
         let self_clone = self.clone();
         let onto_clone = onto_workspace_snapshot.clone();
 

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -97,6 +97,12 @@ pub struct DeprecatedWorkspaceSnapshotGraph {
     root_index: NodeIndex,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ConflictsAndUpdates {
+    pub conflicts: Vec<Conflict>,
+    pub updates: Vec<Update>,
+}
+
 impl From<DeprecatedWorkspaceSnapshotGraph> for WorkspaceSnapshotGraph {
     fn from(deprecated_graph: DeprecatedWorkspaceSnapshotGraph) -> Self {
         let deprecated_graph_inner = &deprecated_graph.graph;
@@ -614,7 +620,7 @@ impl WorkspaceSnapshotGraph {
         to_rebase_vector_clock_id: VectorClockId,
         onto: &WorkspaceSnapshotGraph,
         onto_vector_clock_id: VectorClockId,
-    ) -> WorkspaceSnapshotGraphResult<(Vec<Conflict>, Vec<Update>)> {
+    ) -> WorkspaceSnapshotGraphResult<ConflictsAndUpdates> {
         let mut conflicts: Vec<Conflict> = Vec::new();
         let mut updates: Vec<Update> = Vec::new();
         if let Err(traversal_error) =
@@ -641,7 +647,7 @@ impl WorkspaceSnapshotGraph {
         // that the net result is that there is only one of that edge kind.
         conflicts.extend(self.detect_exclusive_edge_conflicts_in_updates(&updates)?);
 
-        Ok((conflicts, updates))
+        Ok(ConflictsAndUpdates { conflicts, updates })
     }
 
     fn detect_exclusive_edge_conflicts_in_updates(

--- a/lib/dal/src/workspace_snapshot/graph/tests.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests.rs
@@ -95,6 +95,7 @@ mod test {
     use crate::workspace_snapshot::edge_weight::{
         EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants,
     };
+    use crate::workspace_snapshot::graph::ConflictsAndUpdates;
     use crate::workspace_snapshot::node_weight::NodeWeight;
     use crate::workspace_snapshot::update::Update;
     use crate::WorkspaceSnapshotGraph;
@@ -1293,7 +1294,7 @@ mod test {
             .mark_graph_seen(new_change_set.vector_clock_id())
             .expect("Unable to mark new graph as seen");
 
-        let (conflicts, updates) = graph
+        let ConflictsAndUpdates { conflicts, updates } = graph
             .detect_conflicts_and_updates(
                 initial_change_set.vector_clock_id(),
                 &graph_with_deleted_edge,

--- a/lib/dal/src/workspace_snapshot/graph/tests/rebase.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/rebase.rs
@@ -8,6 +8,7 @@ mod test {
     use crate::func::FuncKind;
     use crate::workspace_snapshot::content_address::ContentAddress;
     use crate::workspace_snapshot::edge_weight::{EdgeWeight, EdgeWeightKind};
+    use crate::workspace_snapshot::graph::ConflictsAndUpdates;
     use crate::workspace_snapshot::node_weight::category_node_weight::CategoryNodeKind;
     use crate::workspace_snapshot::node_weight::NodeWeight;
     use crate::workspace_snapshot::node_weight::{ContentNodeWeight, FuncNodeWeight};
@@ -125,7 +126,10 @@ mod test {
         .expect("could not add edge");
 
         // Before cleanup, detect conflicts and updates.
-        let (before_cleanup_conflicts, before_cleanup_updates) = to_rebase
+        let ConflictsAndUpdates {
+            conflicts: before_cleanup_conflicts,
+            updates: before_cleanup_updates,
+        } = to_rebase
             .detect_conflicts_and_updates(
                 to_rebase_change_set.vector_clock_id(),
                 &onto,
@@ -142,7 +146,7 @@ mod test {
         );
 
         // Detect conflicts and updates. Ensure cleanup did not affect the results.
-        let (conflicts, updates) = to_rebase
+        let ConflictsAndUpdates { conflicts, updates } = to_rebase
             .detect_conflicts_and_updates(
                 to_rebase_change_set.vector_clock_id(),
                 &onto,


### PR DESCRIPTION
We had created a `ConflictsAndUpdates` struct for use as a convenience in some tests. This promotes it for general use, instead of relying on having to already know what the order of the tuple elements mean with `detect_conflicts_and_updates`.