### PR TITLE
fix: increase func editor debouce to avoid rebaser conflicts

### DIFF
--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -300,7 +300,7 @@ export const useAssetStore = () => {
               const a = this.assetsById[id];
               if (!a) return;
               this.SAVE_ASSET(a);
-            }, 500);
+            }, 1000);
           }
           const assetSaveFunc = assetSaveDebouncer(asset.id);
           if (assetSaveFunc) {


### PR DESCRIPTION
Increase func editor save debounce to avoid rebaser conflicts. This is obviously a band aid, but in practice I no longer got any conflicts while editing and I did not lose any changes when navigating around. Verified scenarios pass.

<img src="https://media0.giphy.com/media/3oEdv8tIvUB0LZpC7e/giphy.gif"/>