### PR TITLE
fix: module export no longer ignores component type

### DIFF
--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -1076,7 +1076,7 @@ pub async fn get_component_type(
         .pop()
     {
         let av = AttributeValue::get_by_id(ctx, av_id).await?;
-        if let Some(type_value) = av.value(ctx).await? {
+        if let Some(type_value) = av.view(ctx).await? {
             let component_type: ComponentType = serde_json::from_value(type_value)?;
             return Ok(component_type.into());
         }


### PR DESCRIPTION
The value here was always coming back as null, so all modules were exported as `components` regardless of their type. The materialized view is being generated correctly, so switching to that ensures we export the module correctly. The Region module is fixed with this change. 

Closes https://linear.app/system-initiative/issue/BUG-292/region-prop-is-default-to-component-not-frame

<img src="https://media3.giphy.com/media/5DrceevwkOIbS/giphy.gif"/>