### PR TITLE
Allow new attribute funcs for output locations with dynamic funcs

### DIFF
--- a/app/web/src/components/AssetEditorTabs.vue
+++ b/app/web/src/components/AssetEditorTabs.vue
@@ -121,7 +121,7 @@ const closeTab = (slug: string) => {
 };
 
 const loadFuncDetailsReqStatus = funcStore.getRequestStatus(
-  "FETCH_FUNC_DETAILS",
+  "FETCH_FUNC",
   assetStore.urlSelectedFuncId,
 );
 

--- a/app/web/src/components/AssetFuncAttachModal.vue
+++ b/app/web/src/components/AssetFuncAttachModal.vue
@@ -200,10 +200,7 @@ const selectedExistingFuncId = ref<FuncId | undefined>();
 const selectedFuncCode = ref<string>("");
 const loadFuncDetailsReq = computed(() =>
   selectedExistingFuncId.value
-    ? funcStore.getRequestStatus(
-        "FETCH_FUNC_DETAILS",
-        selectedExistingFuncId.value,
-      )
+    ? funcStore.getRequestStatus("FETCH_FUNC", selectedExistingFuncId.value)
     : undefined,
 );
 
@@ -215,7 +212,7 @@ watch(
         !funcStore.funcDetailsById[funcId] ||
         !funcStore.funcArgumentsByFuncId[funcId]
       ) {
-        const result = await funcStore.FETCH_FUNC_DETAILS(funcId);
+        const result = await funcStore.FETCH_FUNC(funcId);
         if (result.result.success) {
           selectedFuncCode.value = result.result.data.code;
           if (result.result.data.associations?.type === "attribute") {
@@ -369,7 +366,6 @@ const newFuncOptions = (
         return {
           type: "attributeOptions",
           outputLocation: attributeOutputLocationParsed.value,
-          ...baseOptions,
         };
       }
       throw new Error(

--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -320,7 +320,7 @@ const detachRef = ref<DetachType>();
 const funcId = computed(() => props.funcId);
 
 const loadFuncDetailsReqStatus = funcStore.getRequestStatus(
-  "FETCH_FUNC_DETAILS",
+  "FETCH_FUNC",
   funcId,
 );
 const updateFuncReqStatus = funcStore.getRequestStatus("UPDATE_FUNC", funcId);

--- a/app/web/src/components/FuncEditor/FuncEditor.vue
+++ b/app/web/src/components/FuncEditor/FuncEditor.vue
@@ -56,7 +56,7 @@ const { selectedFuncSummary, selectedFuncDetails } = storeToRefs(funcStore);
 const editingFunc = ref<string>(selectedFuncDetails.value?.code ?? "");
 
 const loadFuncDetailsReq = funcStore.getRequestStatus(
-  "FETCH_FUNC_DETAILS",
+  "FETCH_FUNC",
   props.funcId,
 );
 

--- a/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
+++ b/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
@@ -138,7 +138,7 @@ watch(
       }
 
       if (assetStore.urlSelectedFuncId && !assetStore.selectedFunc) {
-        await funcStore.FETCH_FUNC_DETAILS(assetStore.urlSelectedFuncId);
+        await funcStore.FETCH_FUNC(assetStore.urlSelectedFuncId);
       }
 
       if (assetStore.selectedAssetId && assetStore.selectedFuncId) {

--- a/app/web/src/store/func/types.ts
+++ b/app/web/src/store/func/types.ts
@@ -114,7 +114,6 @@ export interface CreateFuncAuthenticationOptions {
 
 export interface CreateFuncAttributeOptions {
   type: "attributeOptions";
-  schemaVariantId: string;
   outputLocation: CreateFuncOutputLocation;
 }
 

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -85,10 +85,10 @@ pub type AttributePrototypeResult<T> = Result<T, AttributePrototypeError>;
 /// Indicates the _one and only one_ eventual parent of a corresponding [`AttributePrototype`].
 ///
 /// - If an [`AttributePrototype`] is used by an [`AttributeValue`], its eventual parent is a
-///   [`SchemaVariant`].
+///   [`Component`](crate::Component).
 /// - If an [`AttributePrototype`] is used by a [`Prop`](crate::Prop), an
 ///   [`InputSocket`](crate::InputSocket), or an [`OutputSocket`](crate::OutputSocket), its eventual
-///   parent is a [`Component`](crate::Component).
+///   parent is a [`SchemaVariant`].
 #[remain::sorted]
 #[derive(Debug, Clone, Copy, EnumDiscriminants)]
 pub enum AttributePrototypeEventualParent {
@@ -244,6 +244,7 @@ impl AttributePrototype {
 
         Ok(None)
     }
+
     pub async fn find_for_input_socket(
         ctx: &DalContext,
         input_socket_id: InputSocketId,

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -221,6 +221,7 @@ impl AttributePrototypeArgument {
 
         Ok(argument)
     }
+
     #[instrument(level = "info", skip(ctx))]
     pub async fn new_inter_component(
         ctx: &DalContext,

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -555,8 +555,6 @@ impl AttributeValue {
             Self::prepare_arguments_for_prototype_function_execution(ctx, attribute_value_id)
                 .await?;
 
-        //drop(read_guard);
-
         let result_channel = FuncRunner::run_attribute_value(
             ctx,
             attribute_value_id,
@@ -577,8 +575,8 @@ impl AttributeValue {
 
         // If the value is for a prop, we need to make sure container-type props are initialized
         // properly when the unprocessed value is populated.
-        match value_is_for {
-            ValueIsFor::Prop(prop_id) => match func_values.unprocessed_value() {
+        if let ValueIsFor::Prop(prop_id) = value_is_for {
+            match func_values.unprocessed_value() {
                 Some(unprocessed_value) => {
                     let prop = Prop::get_by_id_or_error(ctx, prop_id).await?;
                     match prop.kind {
@@ -592,21 +590,6 @@ impl AttributeValue {
                     }
                 }
                 None => func_values.set_processed_value(None),
-            },
-            _v => {
-                // TODO: Maybe we should do somethign herE? who khnows
-                //let func = Func::get_by_id(ctx, prototype_func_id)
-                //    .await?
-                //    .expect("oh shit!");
-                //dbg!(
-                //    &v,
-                //    &func.name,
-                //    &func.backend_kind,
-                //    &func.backend_response_type,
-                //    &func.kind,
-                //    &prepared_args,
-                //    &func_values
-                //);
             }
         };
 

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -11,7 +11,6 @@ use thiserror::Error;
 
 use crate::change_set::ChangeSetError;
 use crate::func::argument::FuncArgumentId;
-use crate::func::associations::FuncAssociationsError;
 use crate::func::intrinsics::IntrinsicFunc;
 use crate::layer_db_types::{FuncContent, FuncContentV1};
 use crate::workspace_snapshot::edge_weight::{
@@ -42,6 +41,7 @@ mod kind;
 pub use associations::AttributePrototypeArgumentBag;
 pub use associations::AttributePrototypeBag;
 pub use associations::FuncAssociations;
+pub use associations::FuncAssociationsError;
 pub use kind::FuncKind;
 
 #[remain::sorted]

--- a/lib/sdf-server/src/server/service/func.rs
+++ b/lib/sdf-server/src/server/service/func.rs
@@ -6,6 +6,7 @@ use axum::{
 use dal::func::authoring::FuncAuthoringError;
 use dal::func::summary::FuncSummaryError;
 use dal::func::view::FuncViewError;
+use dal::func::FuncAssociationsError;
 use dal::input_sources::InputSourcesError;
 use dal::schema::variant::SchemaVariantError;
 use dal::{attribute::prototype::AttributePrototypeError, func::argument::FuncArgumentError};
@@ -22,6 +23,7 @@ pub mod create_func_argument;
 pub mod delete_func;
 pub mod delete_func_argument;
 pub mod get_func;
+pub mod get_func_associations;
 pub mod get_func_run;
 pub mod list_func_arguments;
 pub mod list_funcs;
@@ -44,6 +46,8 @@ pub enum FuncError {
     Func(#[from] dal::func::FuncError),
     #[error("func argument error: {0}")]
     FuncArgument(#[from] FuncArgumentError),
+    #[error("func associations error: {0}")]
+    FuncAssociations(#[from] FuncAssociationsError),
     #[error("func authoring error: {0}")]
     FuncAuthoring(#[from] FuncAuthoringError),
     #[error("func {0} cannot be converted to frontend variant")]
@@ -93,6 +97,10 @@ pub fn routes() -> Router<AppState> {
             post(delete_func_argument::delete_func_argument),
         )
         .route("/get_func", get(get_func::get_func))
+        .route(
+            "/get_func_associations",
+            get(get_func_associations::get_func_associations),
+        )
         .route("/get_func_run", get(get_func_run::get_func_run))
         .route(
             "/list_func_arguments",

--- a/lib/sdf-server/src/server/service/func/get_func_associations.rs
+++ b/lib/sdf-server/src/server/service/func/get_func_associations.rs
@@ -1,0 +1,51 @@
+use axum::extract::OriginalUri;
+use axum::{extract::Query, Json};
+use serde::{Deserialize, Serialize};
+
+use dal::func::FuncAssociations;
+use dal::{Func, FuncId, Visibility};
+
+use super::FuncResult;
+use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
+use crate::server::tracking::track;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetFuncAssociationsRequest {
+    pub id: FuncId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetFuncAssociationsResponse {
+    pub associations: Option<FuncAssociations>,
+}
+
+pub async fn get_func_associations(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Query(request): Query<GetFuncAssociationsRequest>,
+) -> FuncResult<Json<GetFuncAssociationsResponse>> {
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let func = Func::get_by_id_or_error(&ctx, request.id).await?;
+    let (associations, _input_type) = FuncAssociations::from_func(&ctx, &func).await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        "get_func_associations",
+        serde_json::json!({
+            "how": "/func/get_func_associations",
+            "func_id": func.id,
+            "func_name": func.name
+        }),
+    );
+
+    Ok(Json(GetFuncAssociationsResponse { associations }))
+}


### PR DESCRIPTION
## Description

This PR allows for new attribute funcs to be bound to output locations with pre-existing dynamic funcs, including the identity func.

Here's why this is important: you can neither edit nor remove binding for `si:identity` since we do not allow authoring for intrinsics in the frontend. While going down the path to allowing overwriting `si:identity` usages when creating new funcs for a selected asset (schema with a default schema variant), we realized that we could also allow it for all dynamic functions. This requires existing attribute prototype arguments to be drained as well as enqueing all affected attribute values for a dependent values update job.

<img src="https://media1.giphy.com/media/l46CkwNP2mNz65tyU/giphy.gif"/>

## Additional Changes

- Remove duplicate data in create func options for attribute funcs
- Restore and polish tests related to this functionality
- Fix doc comment related to the eventual parents for attribute prototypes
- Only fetch associations if currently editing a func so that we do not overwrite user's mutations in flight (i.e. prevent screen flashing when editing attribute funcs, but also ensuring new associations are populated properly)
- Rename `FETCH_FUNC_DETAILS` to `FETCH_FUNC` and add additional route for fetching associations
- Clarify purpose of reset attribute prototype by its name (though it is still very unclear)