### PR TITLE
fix: ensure default values are set

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -2151,6 +2151,19 @@ impl AttributeValue {
         Self::fetch_value_from_store(ctx, self.value).await
     }
 
+    pub async fn value_or_default(
+        &self,
+        ctx: &DalContext,
+        prop_id: PropId,
+    ) -> AttributeValueResult<serde_json::Value> {
+        match Self::fetch_value_from_store(ctx, self.value).await {
+            Ok(Some(value)) => Ok(value),
+            _ => Ok(Prop::default_value(ctx, prop_id)
+                .await?
+                .unwrap_or(Value::Null)),
+        }
+    }
+
     pub async fn unprocessed_value(
         &self,
         ctx: &DalContext,

--- a/lib/dal/src/property_editor/values.rs
+++ b/lib/dal/src/property_editor/values.rs
@@ -74,9 +74,8 @@ impl PropertyEditorValues {
                 prop_id: root_prop_id.into(),
                 key: None,
                 value: root_attribute_value
-                    .value(ctx)
-                    .await?
-                    .unwrap_or(Value::Null),
+                    .value_or_default(ctx, root_prop_id)
+                    .await?,
                 validation,
                 is_from_external_source: false,
                 can_be_set_by_socket: false,
@@ -192,9 +191,8 @@ impl PropertyEditorValues {
                     prop_id: prop_id_for_child_attribute_value.into(),
                     key,
                     value: child_attribute_value
-                        .value(ctx)
-                        .await?
-                        .unwrap_or(Value::Null),
+                        .value_or_default(ctx, prop_id_for_child_attribute_value)
+                        .await?,
                     validation,
                     can_be_set_by_socket: !sockets_for_av.is_empty(),
                     is_from_external_source,


### PR DESCRIPTION
If a an attribute does not exist, fallback to the prop default or null if one does not exist.

closes https://linear.app/system-initiative/issue/BUG-299/key-pair-default-key-type-is-rsa-but-it-does-not-select-as-default-in