### PR TITLE
feat: adding timeouts to all toasts, removing ack buttons where relevant

### DIFF
--- a/app/web/src/components/toasts/FiveHundredError.vue
+++ b/app/web/src/components/toasts/FiveHundredError.vue
@@ -25,13 +25,6 @@
         class="grow text-action-300 dark:hover:text-white hover:text-black hover:bg-action-400 hover:underline"
         @click="() => (show = !show)"
       ></VButton>
-      <VButton
-        class="grow text-action-300 dark:hover:text-white hover:text-black hover:bg-action-400 hover:underline"
-        label="Close"
-        tone="empty"
-        variant="solid"
-        @click="$emit('close-toast')"
-      ></VButton>
     </div>
   </div>
 </template>

--- a/app/web/src/components/toasts/MovedToHead.vue
+++ b/app/web/src/components/toasts/MovedToHead.vue
@@ -9,18 +9,11 @@
       </div>
       <div>You are now on HEAD.</div>
     </div>
-    <VButton
-      label="Ok"
-      size="sm"
-      variant="solid"
-      tone="empty"
-      class="self-stretch text-action-300 dark:hover:text-white hover:text-black hover:bg-action-400 hover:underline"
-    />
   </div>
 </template>
 
 <script lang="ts" setup>
-import { Icon, IconNames, VButton } from "@si/vue-lib/design-system";
+import { Icon, IconNames } from "@si/vue-lib/design-system";
 import { PropType, computed } from "vue";
 
 const props = defineProps({

--- a/app/web/src/store/apis.ts
+++ b/app/web/src/store/apis.ts
@@ -82,14 +82,9 @@ async function handleConflictsFound(error: AxiosError) {
 async function handle500(error: AxiosError) {
   const toast = useToast();
   if (error?.response?.status === 500) {
-    toast(
-      {
-        component: FiveHundredError,
-      },
-      {
-        timeout: false,
-      },
-    );
+    toast({
+      component: FiveHundredError,
+    });
   }
   return Promise.reject(error);
 }

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -284,19 +284,14 @@ export function useChangeSetsStore() {
               if (data.changeSetId === this.selectedChangeSetId) {
                 if (this.headChangeSetId) {
                   await this.setActiveChangeset(this.headChangeSetId);
-                  toast(
-                    {
-                      component: MovedToHead,
-                      props: {
-                        icon: "trash",
-                        changeSetName: this.selectedChangeSet?.name,
-                        action: "abandoned",
-                      },
+                  toast({
+                    component: MovedToHead,
+                    props: {
+                      icon: "trash",
+                      changeSetName: this.selectedChangeSet?.name,
+                      action: "abandoned",
                     },
-                    {
-                      timeout: false,
-                    },
-                  );
+                  });
                 }
               }
               await this.FETCH_CHANGE_SETS();
@@ -355,19 +350,14 @@ export function useChangeSetsStore() {
                       changeSetId: "head",
                     },
                   });
-                  toast(
-                    {
-                      component: MovedToHead,
-                      props: {
-                        icon: "tools",
-                        changeSetName: this.selectedChangeSet?.name,
-                        action: "merged",
-                      },
+                  toast({
+                    component: MovedToHead,
+                    props: {
+                      icon: "tools",
+                      changeSetName: this.selectedChangeSet?.name,
+                      action: "merged",
                     },
-                    {
-                      timeout: false,
-                    },
-                  );
+                  });
                 }
               }
             },

--- a/app/web/src/store/status.store.ts
+++ b/app/web/src/store/status.store.ts
@@ -273,17 +273,12 @@ export const useStatusStore = (forceChangeSetId?: ChangeSetId) => {
         actions: {
           addConflictFromHttp(conflict: Conflict): void {
             this.rawConflicts.push(conflict);
-            toast(
-              {
-                component: ConflictToast,
-                props: {
-                  conflict,
-                },
+            toast({
+              component: ConflictToast,
+              props: {
+                conflict,
               },
-              {
-                timeout: false,
-              },
-            );
+            });
           },
         },
         onActivated() {


### PR DESCRIPTION
Some of the toasts hangout without a timeout. This turns out to be undesirable in regular use. I enabled the timeouts for moving back to head on apply/abandon, conflicts, and 500s. I also removed the OK button as it doesn't seem relevant anymore.

closes https://linear.app/system-initiative/issue/BUG-293/toast-doesnt-get-automatically-dismissed-after-migrating-away-from

<img src="https://media0.giphy.com/media/3oaPtHC37Vx0Q/giphy.gif"/>