### PR TITLE
Detect ChangeStatus::Added for Components in summary diagram

### DIFF
--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -11,6 +11,7 @@ use veritech_client::ActionRunResultSuccess;
 
 use crate::{
     action::ResourceStatus,
+    change_status::ChangeStatus,
     component::ComponentUpdatedPayload,
     diagram::{DiagramError, SummaryDiagramComponent},
     func::{
@@ -345,14 +346,24 @@ impl ActionPrototype {
                         .set_resource(ctx, run_result.clone().into())
                         .await?;
 
-                    let payload = SummaryDiagramComponent::assemble(ctx, &component).await?;
+                    let payload = SummaryDiagramComponent::assemble(
+                        ctx,
+                        &component,
+                        ChangeStatus::Unmodified,
+                    )
+                    .await?;
                     WsEvent::resource_refreshed(ctx, payload)
                         .await?
                         .publish_on_commit(ctx)
                         .await?;
                 } else if run_result.status == ResourceStatus::Ok {
                     component.clear_resource(ctx).await?;
-                    let payload = SummaryDiagramComponent::assemble(ctx, &component).await?;
+                    let payload = SummaryDiagramComponent::assemble(
+                        ctx,
+                        &component,
+                        ChangeStatus::Unmodified,
+                    )
+                    .await?;
                     WsEvent::resource_refreshed(ctx, payload)
                         .await?
                         .publish_on_commit(ctx)

--- a/lib/sdf-server/src/server/service/component/delete_property_editor_value.rs
+++ b/lib/sdf-server/src/server/service/component/delete_property_editor_value.rs
@@ -2,6 +2,7 @@ use crate::server::extract::{AccessBuilder, HandlerContext};
 use crate::service::component::ComponentResult;
 use axum::response::IntoResponse;
 use axum::Json;
+use dal::change_status::ChangeStatus;
 use dal::diagram::SummaryDiagramComponent;
 use dal::{
     AttributeValue, AttributeValueId, ChangeSet, Component, ComponentId, PropId, Visibility,
@@ -33,7 +34,7 @@ pub async fn delete_property_editor_value(
 
     let component = Component::get_by_id(&ctx, request.component_id).await?;
     let payload: SummaryDiagramComponent =
-        SummaryDiagramComponent::assemble(&ctx, &component).await?;
+        SummaryDiagramComponent::assemble(&ctx, &component, ChangeStatus::Unmodified).await?;
     WsEvent::component_updated(&ctx, payload)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/component/insert_property_editor_value.rs
+++ b/lib/sdf-server/src/server/service/component/insert_property_editor_value.rs
@@ -2,8 +2,8 @@ use axum::{response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
 use dal::{
-    diagram::SummaryDiagramComponent, AttributeValue, AttributeValueId, ChangeSet, Component,
-    ComponentId, PropId, Visibility, WsEvent,
+    change_status::ChangeStatus, diagram::SummaryDiagramComponent, AttributeValue,
+    AttributeValueId, ChangeSet, Component, ComponentId, PropId, Visibility, WsEvent,
 };
 
 use crate::server::extract::{AccessBuilder, HandlerContext};
@@ -41,7 +41,7 @@ pub async fn insert_property_editor_value(
 
     let component: Component = Component::get_by_id(&ctx, request.component_id).await?;
     let payload: SummaryDiagramComponent =
-        SummaryDiagramComponent::assemble(&ctx, &component).await?;
+        SummaryDiagramComponent::assemble(&ctx, &component, ChangeStatus::Unmodified).await?;
     WsEvent::component_updated(&ctx, payload)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/component/set_type.rs
+++ b/lib/sdf-server/src/server/service/component/set_type.rs
@@ -1,6 +1,7 @@
 use axum::extract::OriginalUri;
 use axum::{response::IntoResponse, Json};
 
+use dal::change_status::ChangeStatus;
 use dal::component::ComponentGeometry;
 use dal::diagram::SummaryDiagramComponent;
 use dal::{ChangeSet, Component, ComponentId, ComponentType, Visibility, WsEvent};
@@ -52,8 +53,10 @@ pub async fn set_type(
     }
 
     let component = Component::get_by_id(&ctx, component_id).await?;
+    // TODO: We'll want to figure out whether this component is Added/Modified, depending on
+    // whether it existed in the base change set already or not.
     let payload: SummaryDiagramComponent =
-        SummaryDiagramComponent::assemble(&ctx, &component).await?;
+        SummaryDiagramComponent::assemble(&ctx, &component, ChangeStatus::Unmodified).await?;
     WsEvent::component_updated(&ctx, payload)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/component/update_property_editor_value.rs
+++ b/lib/sdf-server/src/server/service/component/update_property_editor_value.rs
@@ -1,5 +1,6 @@
 use axum::extract::OriginalUri;
 use axum::{response::IntoResponse, Json};
+use dal::change_status::ChangeStatus;
 use dal::diagram::SummaryDiagramComponent;
 use dal::{
     AttributeValue, AttributeValueId, ChangeSet, Component, ComponentId, Prop, PropId, Secret,
@@ -86,7 +87,7 @@ pub async fn update_property_editor_value(
     }
 
     let payload: SummaryDiagramComponent =
-        SummaryDiagramComponent::assemble(&ctx, &component).await?;
+        SummaryDiagramComponent::assemble(&ctx, &component, ChangeStatus::Unmodified).await?;
     WsEvent::component_updated(&ctx, payload)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/component/upgrade.rs
+++ b/lib/sdf-server/src/server/service/component/upgrade.rs
@@ -5,6 +5,7 @@ use axum::extract::OriginalUri;
 use axum::response::IntoResponse;
 use axum::Json;
 use dal::action::{Action, ActionState};
+use dal::change_status::ChangeStatus;
 use dal::diagram::SummaryDiagramComponent;
 use dal::{ChangeSet, Component, ComponentId, SchemaVariant, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
@@ -68,7 +69,8 @@ pub async fn upgrade(
     );
 
     let payload: SummaryDiagramComponent =
-        SummaryDiagramComponent::assemble(&ctx, &upgraded_component).await?;
+        SummaryDiagramComponent::assemble(&ctx, &upgraded_component, ChangeStatus::Unmodified)
+            .await?;
     WsEvent::component_upgraded(&ctx, payload, request.component_id)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/diagram/delete_component.rs
+++ b/lib/sdf-server/src/server/service/diagram/delete_component.rs
@@ -1,5 +1,6 @@
 use axum::{extract::OriginalUri, http::uri::Uri};
 use axum::{response::IntoResponse, Json};
+use dal::change_status::ChangeStatus;
 use dal::diagram::SummaryDiagramComponent;
 use dal::{ChangeSet, Component, ComponentId, DalContext, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
@@ -70,7 +71,7 @@ pub async fn delete_components(
             // to_delete=True
             let component: Component = Component::get_by_id(&ctx, maybe.id()).await?;
             let payload: SummaryDiagramComponent =
-                SummaryDiagramComponent::assemble(&ctx, &component).await?;
+                SummaryDiagramComponent::assemble(&ctx, &component, ChangeStatus::Deleted).await?;
             WsEvent::component_updated(&ctx, payload)
                 .await?
                 .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/diagram/set_component_position.rs
+++ b/lib/sdf-server/src/server/service/diagram/set_component_position.rs
@@ -1,4 +1,5 @@
 use axum::{response::IntoResponse, Json};
+use dal::change_status::ChangeStatus;
 use dal::component::ComponentGeometry;
 use dal::{
     component::frame::Frame,
@@ -45,7 +46,8 @@ pub async fn set_component_position(
         if update.detach {
             Frame::orphan_child(&ctx, component.id()).await?;
             let payload: SummaryDiagramComponent =
-                SummaryDiagramComponent::assemble(&ctx, &component).await?;
+                SummaryDiagramComponent::assemble(&ctx, &component, ChangeStatus::Unmodified)
+                    .await?;
             WsEvent::component_updated(&ctx, payload)
                 .await?
                 .publish_on_commit(&ctx)
@@ -53,7 +55,8 @@ pub async fn set_component_position(
         } else if let Some(new_parent) = update.new_parent {
             Frame::upsert_parent(&ctx, component.id(), new_parent).await?;
             let payload: SummaryDiagramComponent =
-                SummaryDiagramComponent::assemble(&ctx, &component).await?;
+                SummaryDiagramComponent::assemble(&ctx, &component, ChangeStatus::Unmodified)
+                    .await?;
             WsEvent::component_updated(&ctx, payload)
                 .await?
                 .publish_on_commit(&ctx)


### PR DESCRIPTION
Rather than reporting that all Components are `ChangeStatus::Added`, we now detect whether the Component would be added to the base change set, if we were to merge this change set into it. If we are looking at the default change set for a Workspace, then we consider it to not have a base change set, even though it is possible to have one defined.

This does not detect `ChangeStatus::Modified`, or the `ChangeStatus` for Edges yet.