### PR TITLE
feat: display error message and remove timeout for 500s

### DIFF
--- a/app/web/src/components/toasts/FiveHundredError.vue
+++ b/app/web/src/components/toasts/FiveHundredError.vue
@@ -8,36 +8,38 @@
       />
       <p class="grow py-md">
         The server encountered an error and could not complete your request.
+        Please reach out on Discord if you need some help! <br />
+        <br />
+        Request to
+        <span class="font-bold">{{ requestUrl }}</span> returned:
       </p>
     </div>
-    <div v-show="show">
-      <ol>
-        <li>Try again</li>
-        <li>Reload the page</li>
-        <li>Reach out to us on Discord</li>
-      </ol>
-    </div>
+    <ErrorMessage class="mx-1" icon="alert-triangle" tone="warning">
+      {{ message }}
+    </ErrorMessage>
     <div class="flex flex-row gap-sm items-center">
       <VButton
-        label="What can I do?"
+        class="grow text-action-300 dark:hover:text-white hover:text-black hover:bg-action-400 hover:underline"
+        label="Close"
         tone="empty"
         variant="solid"
-        class="grow text-action-300 dark:hover:text-white hover:text-black hover:bg-action-400 hover:underline"
-        @click="() => (show = !show)"
+        @click="$emit('close-toast')"
       ></VButton>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
-import { VButton, Icon } from "@si/vue-lib/design-system";
+import { VButton, Icon, ErrorMessage } from "@si/vue-lib/design-system";
 
 const emit = defineEmits<{
   (e: "close-toast"): void;
 }>();
 
-const show = ref(false);
+const props = defineProps({
+  requestUrl: { type: String, required: false },
+  message: { type: String, required: false },
+});
 </script>
 
 <style lang="less">

--- a/app/web/src/store/apis.ts
+++ b/app/web/src/store/apis.ts
@@ -82,9 +82,18 @@ async function handleConflictsFound(error: AxiosError) {
 async function handle500(error: AxiosError) {
   const toast = useToast();
   if (error?.response?.status === 500) {
-    toast({
-      component: FiveHundredError,
-    });
+    toast(
+      {
+        component: FiveHundredError,
+        props: {
+          requestUrl: error?.config?.url,
+          message: error?.response?.data,
+        },
+      },
+      {
+        timeout: false,
+      },
+    );
   }
   return Promise.reject(error);
 }


### PR DESCRIPTION
Okay, re-removing the timeout for 500s so we count them as bugs and address them. I also added the error and the route to the toast. My styling here is not so great, so maybe @jobelenus or @wendybujalski can school me at some point.

<img width="542" alt="image" src="https://github.com/systeminit/si/assets/3621657/7f75765b-7a22-4a96-8246-734c8effe3cc">
