### PR TITLE
Spike: Front end conflicts

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -79,6 +79,7 @@
     "sigma": "3.0.0-beta.5",
     "tinycolor2": "^1.4.2",
     "typescript": "^4.9.5",
+    "ulid": "^2.3.0",
     "util-browser": "^0.0.2",
     "validator": "^13.7.0",
     "vanilla-picker": "^2.12.1",

--- a/app/web/src/components/StatusBar/StatusBar.vue
+++ b/app/web/src/components/StatusBar/StatusBar.vue
@@ -10,10 +10,7 @@
     <div class="flex text-sm items-center pl-xs mr-lg w-full">
       System&nbsp;Initiative
     </div>
-    <div
-      v-if="statusStore.conflicts.length > 0"
-      class="border-l border-shade-100"
-    >
+    <div class="border-l border-shade-100">
       <StatusBarConflictSummary />
     </div>
     <div class="border-l border-shade-100">
@@ -34,7 +31,6 @@ import * as _ from "lodash-es";
 import clsx from "clsx";
 import { useChangeSetsStore } from "@/store/change_sets.store";
 
-import { useStatusStore } from "@/store/status.store";
 import StatusBarConflictSummary from "./StatusBarConflictSummary.vue";
 import StatusBarDiffSummary from "./StatusBarDiffSummary.vue";
 import StatusBarResourceSummary from "./StatusBarResourceSummary.vue";
@@ -43,7 +39,6 @@ import StatusBarQualificationSummary from "./StatusBarQualificationSummary.vue";
 // override theme to be always dark within status bar
 
 const changeSetStore = useChangeSetsStore();
-const statusStore = useStatusStore();
 </script>
 
 <style scoped></style>

--- a/app/web/src/components/StatusBar/StatusBarConflictSummary.vue
+++ b/app/web/src/components/StatusBar/StatusBarConflictSummary.vue
@@ -1,8 +1,8 @@
 <template>
   <StatusBarTab
-    class="cursor-pointer"
+    :class="clsx(numConflicts > 0 ? 'animate-bounce cursor-pointer' : '')"
     :selected="props.selected"
-    :click="openModal"
+    :click="() => numConflicts > 0 && openModal()"
   >
     <template #icon>
       <Icon class="text-destructive-700" name="read-only" />
@@ -10,10 +10,11 @@
     <template #name>Conflicts</template>
     <template #summary>
       <StatusBarTabPill
-        v-if="statusStore.conflicts.length > 0"
         class="bg-destructive-100 text-destructive-700 font-bold"
       >
-        <div @click="openModal">{{ statusStore.conflicts.length }}</div>
+        <div @click="() => numConflicts > 0 && openModal()">
+          {{ numConflicts }}
+        </div>
       </StatusBarTabPill>
       <Modal ref="modalRef" title="Conflicts" noExit>
         <div>
@@ -23,32 +24,35 @@
               class="text-warning-600 content-center ml-md"
               size="lg"
             />
-            <p class="grow py-md">
-              There are {{ statusStore.conflicts.length }} conflict(s) in this
-              change set ({{ changeSetsStore.selectedChangeSet?.name }}) that
-              need to be resolved before you can apply.
+            <p v-if="numConflicts > 0" class="grow py-md">
+              Your changes have produced
+              {{ numConflicts }} conflict(s). Retry them below:
             </p>
+            <p v-else>No more conflicts!</p>
           </div>
-          <div
-            v-show="show"
+          <ol
+            v-if="numConflicts > 0"
             class="max-h-[50vh] overflow-hidden overflow-y-auto"
           >
-            <pre
-              v-for="conflict in statusStore.conflicts"
-              :key="conflict"
-              class="text-sm"
-              >{{ conflict }}</pre
+            <li
+              v-for="conflict in conflictDisplay"
+              :key="conflict.requestUlid"
+              class="text-sm py-sm border-b-2 border-neutral-200 dark:border-neutral-600 flex flex-col"
             >
-            >
-          </div>
-          <div class="flex flex-row gap-sm items-center">
-            <VButton
-              label="View conflict message"
-              tone="empty"
-              variant="solid"
-              class="grow text-action-300 dark:hover:text-white hover:text-black hover:underline"
-              @click="() => (show = !show)"
-            ></VButton>
+              <span class="capitalize self-center"
+                >{{ conflict.actionName }}:</span
+              >
+              <pre class="text-xs">{{ conflict.payload }}</pre>
+              <VButton
+                class="self-end"
+                label="Retry Change"
+                size="md"
+                tone="action"
+                @click="retry(conflict.requestUlid)"
+              ></VButton>
+            </li>
+          </ol>
+          <div class="flex flex-row gap-sm items-center mt-sm">
             <VButton
               class="grow text-action-300 dark:hover:text-white hover:text-black hover:underline"
               label="Close"
@@ -64,15 +68,19 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, computed, reactive, watch, WatchStopHandle } from "vue";
+import { Store } from "pinia";
+import clsx from "clsx";
+import { RequestUlid, ConflictsForRetry, ApiRequest } from "@si/vue-lib/pinia";
 import { Icon, Modal, VButton } from "@si/vue-lib/design-system";
-import { useStatusStore } from "@/store/status.store";
-import { useChangeSetsStore } from "@/store/change_sets.store";
+import { useComponentAttributesStore } from "@/store/component_attributes.store";
+import { useActionsStore } from "@/store/actions.store";
+import { useAssetStore } from "@/store/asset.store";
+import { useComponentsStore } from "@/store/components.store";
 import StatusBarTabPill from "./StatusBarTabPill.vue";
 import StatusBarTab from "./StatusBarTab.vue";
 
 const modalRef = ref();
-const show = ref(false);
 
 const openModal = () => {
   modalRef.value.open();
@@ -82,8 +90,85 @@ const props = defineProps({
   selected: Boolean,
 });
 
-const statusStore = useStatusStore();
-const changeSetsStore = useChangeSetsStore();
+const assetStore = useAssetStore();
+const actionsStore = useActionsStore();
+const componentsStore = useComponentsStore();
+
+let attributesStore: Store | null;
+const conflicts = reactive({} as ConflictsForRetry);
+let unwatch: WatchStopHandle | undefined;
+
+watch(
+  () => componentsStore.selectedComponentId,
+  () => {
+    if (componentsStore.selectedComponentId) {
+      attributesStore = useComponentAttributesStore(
+        componentsStore.selectedComponentId,
+      );
+      if (unwatch) unwatch();
+      unwatch = watch(attributesStore.availableRetries, () => {
+        Object.assign(conflicts, attributesStore?.availableRetries);
+      });
+    } else {
+      attributesStore = null;
+      if (unwatch) unwatch();
+    }
+  },
+  { immediate: true },
+);
+
+watch(componentsStore.availableRetries, () =>
+  Object.assign(conflicts, componentsStore.availableRetries),
+);
+watch(assetStore.availableRetries, () =>
+  Object.assign(conflicts, assetStore.availableRetries),
+);
+watch(actionsStore.availableRetries, () =>
+  Object.assign(conflicts, actionsStore.availableRetries),
+);
+
+const numConflicts = computed(() => Object.keys(conflicts).length);
+
+type ConflictDisplay = {
+  requestUlid: RequestUlid;
+  actionName: string;
+  payload: Record<string, unknown> | undefined;
+};
+
+const retry = (requestUlid: RequestUlid) => {
+  let p;
+  if (Object.keys(componentsStore.availableRetries).includes(requestUlid))
+    p = componentsStore.RETRY_CONFLICT(requestUlid);
+  else if (Object.keys(assetStore.availableRetries).includes(requestUlid))
+    p = assetStore.RETRY_CONFLICT(requestUlid);
+  else if (Object.keys(actionsStore.availableRetries).includes(requestUlid))
+    p = actionsStore.RETRY_CONFLICT(requestUlid);
+  else if (
+    attributesStore &&
+    Object.keys(attributesStore.availableRetries).includes(requestUlid)
+  )
+    p = attributesStore.RETRY_CONFLICT(requestUlid);
+
+  if (p) delete conflicts[requestUlid];
+  else throw Error("Retry not found");
+};
+
+const conflictDisplay = computed(() => {
+  const display = [] as ConflictDisplay[];
+  for (const requestUlid of Object.keys(conflicts)) {
+    const details = conflicts[requestUlid];
+    const actionName =
+      details?.[0].replaceAll("_", " ").toLowerCase() || "Unknown";
+    const apiRequest = details?.[1] as ApiRequest;
+    const payload = apiRequest?.requestSpec.params;
+    display.push({
+      requestUlid,
+      actionName,
+      payload,
+    });
+  }
+  return display;
+});
 </script>
 
 <style type="less">

--- a/app/web/src/components/toasts/Conflict.vue
+++ b/app/web/src/components/toasts/Conflict.vue
@@ -35,7 +35,7 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
-import { Icon } from "@si/vue-lib/design-system";
+import { Icon, VButton } from "@si/vue-lib/design-system";
 import { Conflict } from "@/store/status.store";
 
 const emit = defineEmits<{

--- a/app/web/src/store/apis.ts
+++ b/app/web/src/store/apis.ts
@@ -7,7 +7,6 @@ import Axios, {
 import { useToast } from "vue-toastification";
 import { useAuthStore } from "@/store/auth.store";
 import { useChangeSetsStore } from "@/store/change_sets.store";
-import { useStatusStore } from "@/store/status.store";
 import { trackEvent } from "@/utils/tracking";
 import FiveHundredError from "@/components/toasts/FiveHundredError.vue";
 
@@ -71,14 +70,6 @@ async function handleProxyTimeouts(response: AxiosResponse) {
   return response;
 }
 
-async function handleConflictsFound(error: AxiosError) {
-  if (error?.response?.status === 409) {
-    const statusStore = useStatusStore();
-    statusStore.addConflictFromHttp(JSON.stringify(error?.response?.data));
-  }
-  return Promise.reject(error);
-}
-
 async function handle500(error: AxiosError) {
   const toast = useToast();
   if (error?.response?.status === 500) {
@@ -99,10 +90,7 @@ async function handle500(error: AxiosError) {
 }
 
 sdfApiInstance.interceptors.response.use(handleProxyTimeouts, handle500);
-sdfApiInstance.interceptors.response.use(
-  handleForcedChangesetRedirection,
-  handleConflictsFound,
-);
+sdfApiInstance.interceptors.response.use(handleForcedChangesetRedirection);
 
 export const authApiInstance = Axios.create({
   headers: {

--- a/lib/sdf-server/src/server/service/diagram/set_component_position.rs
+++ b/lib/sdf-server/src/server/service/diagram/set_component_position.rs
@@ -7,6 +7,7 @@ use dal::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use ulid::Ulid;
 
 use super::DiagramResult;
 use crate::server::extract::{AccessBuilder, HandlerContext};
@@ -25,6 +26,13 @@ pub struct SetComponentPositionRequest {
     #[serde(flatten)]
     pub visibility: Visibility,
     pub data_by_component_id: HashMap<ComponentId, SingleComponentGeometryUpdate>,
+    pub request_ulid: Ulid,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SetComponentPositionResponse {
+    pub request_ulid: Ulid,
 }
 
 pub async fn set_component_position(
@@ -124,5 +132,9 @@ pub async fn set_component_position(
         response = response.header("force_change_set_id", force_change_set_id.to_string());
     }
 
-    Ok(response.body(axum::body::Empty::new())?)
+    Ok(
+        response.body(serde_json::to_string(&SetComponentPositionResponse {
+            request_ulid: request.request_ulid,
+        })?)?,
+    )
 }

--- a/lib/vue-lib/package.json
+++ b/lib/vue-lib/package.json
@@ -58,6 +58,7 @@
     "pinia": "^2.1.7",
     "posthog-js": "^1.51.4",
     "tailwindcss-capsize": "^3.0.3",
+    "ulid": "^2.3.0",
     "vue": "^3.4.15",
     "vue-router": "^4.2.5",
     "vue-safe-teleport": "^0.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,9 @@ importers:
       typescript:
         specifier: ^4.9.5
         version: 4.9.5
+      ulid:
+        specifier: ^2.3.0
+        version: 2.3.0
       util-browser:
         specifier: ^0.0.2
         version: 0.0.2
@@ -746,6 +749,9 @@ importers:
       tailwindcss-capsize:
         specifier: ^3.0.3
         version: 3.0.3(tailwindcss@3.2.2)
+      ulid:
+        specifier: ^2.3.0
+        version: 2.3.0
       vue:
         specifier: ^3.4.15
         version: 3.4.15(typescript@4.9.5)
@@ -18093,7 +18099,6 @@ packages:
   /ulid@2.3.0:
     resolution: {integrity: sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==}
     hasBin: true
-    dev: true
 
   /ulidx@0.5.0:
     resolution: {integrity: sha512-fZFAVMxsp3QSwOpIta6uqc3ZjHfRe4m3GllM+HO4MNQMXlzcUhWihHKWuBxFcDYATsuyxjBwCH0MqVsj/D/how==}


### PR DESCRIPTION
Retry set_component_position with most current data for components that are not in flight. No toasts for this endpoint. For most cases, the exact components that are conflicting are also in flight, which is a no-op, and we swallow the conflict.

Implemented generic retry! The bottom bar bounces!
![image](https://github.com/systeminit/si/assets/69541/ba2a235b-3954-4c07-b9a6-39bfd006ed89)

You can see the conflicts and retry:
![image](https://github.com/systeminit/si/assets/69541/0fed07b8-386f-410e-990b-1adc14999f6f)

TADA!
![image](https://github.com/systeminit/si/assets/69541/08b8d76f-783a-45ea-82f0-bfe68d985985)


<img src="https://media1.giphy.com/media/11o5fBqY66IciQ/giphy.gif"/>