### PR TITLE
feat: upgrade instead of duplicate on import

### DIFF
--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -86,10 +86,7 @@ async fn import_change_set(
         // This is a hack because the hash of the intrinsics has changed from the version in the
         // packages. We also apply this to si:resourcePayloadToValue since it should be an
         // intrinsic but is only in our packages
-        if func::is_intrinsic(func_spec.name())
-            || SPECIAL_CASE_FUNCS.contains(&func_spec.name())
-            || func_spec.is_from_builtin().unwrap_or(false)
-        {
+        if func::is_intrinsic(func_spec.name()) || SPECIAL_CASE_FUNCS.contains(&func_spec.name()) {
             if let Some(func_id) = Func::find_by_name(ctx, func_spec.name()).await? {
                 let func = Func::get_by_id_or_error(ctx, func_id).await?;
 
@@ -430,8 +427,8 @@ async fn import_schema(
 ) -> PkgResult<(Option<SchemaId>, Vec<SchemaVariantId>)> {
     let schema_and_category = {
         let mut existing_schema: Option<Schema> = None;
-        if let Some(installed_pkg) = installed_module.clone() {
-            let associated_schemas = installed_pkg.list_associated_schemas(ctx).await?;
+        if installed_module.is_some() {
+            let associated_schemas = Schema::list(ctx).await?;
             let mut maybe_matching_schema: Vec<Schema> = associated_schemas
                 .into_iter()
                 .filter(|s| s.name.clone() == schema_spec.name())

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -10,6 +10,7 @@ mod frame;
 mod func;
 mod input_sources;
 mod module;
+mod pkg;
 mod prop;
 mod property_editor;
 mod qualifications;

--- a/lib/dal/tests/integration_test/pkg/mod.rs
+++ b/lib/dal/tests/integration_test/pkg/mod.rs
@@ -1,0 +1,107 @@
+use dal::pkg::export::PkgExporter;
+use dal::pkg::import_pkg_from_pkg;
+use dal::schema::variant::authoring::VariantAuthoringClient;
+use dal::{DalContext, FuncBackendKind, FuncBackendResponseType};
+use dal_test::test;
+use si_pkg::{FuncSpec, FuncSpecData, PkgSpec, SchemaSpec, SchemaSpecData, SiPkg};
+
+#[test]
+async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) {
+    // Let's create a new asset
+    let asset_name = "imanasset".to_string();
+    let display_name = None;
+    let description = None;
+    let link = None;
+    let category = "Integration Tests".to_string();
+    let color = "#00b0b0".to_string();
+    let variant = VariantAuthoringClient::create_variant(
+        ctx,
+        asset_name.clone(),
+        display_name.clone(),
+        description.clone(),
+        link.clone(),
+        category.clone(),
+        color.clone(),
+    )
+    .await
+    .expect("Unable to create new asset");
+
+    let schema = variant
+        .schema(ctx)
+        .await
+        .expect("Unable to get the schema for the variant");
+
+    let default_schema_variant = schema
+        .get_default_schema_variant_id(ctx)
+        .await
+        .expect("unable to get the default schema variant id");
+
+    assert!(default_schema_variant.is_some());
+    assert_eq!(default_schema_variant, Some(variant.id()));
+
+    // now lets create a pkg from the asset and import it
+    let (variant_spec, variant_funcs) = PkgExporter::export_variant_standalone(ctx, &variant)
+        .await
+        .expect("should go to spec");
+
+    let schema_spec = SchemaSpec::builder()
+        .name(schema.name())
+        .unique_id(schema.id())
+        .variant(variant_spec)
+        .data(
+            SchemaSpecData::builder()
+                .name(schema.name())
+                .category(category.clone())
+                .default_schema_variant(variant.id())
+                .build()
+                .expect("should build data"),
+        )
+        .build()
+        .expect("should build spec");
+
+    let func_spec = FuncSpec::builder()
+        .name(asset_name.clone())
+        .unique_id(schema.id())
+        .data(
+            FuncSpecData::builder()
+                .name(asset_name.clone())
+                .backend_kind(FuncBackendKind::JsSchemaVariantDefinition)
+                .response_type(FuncBackendResponseType::SchemaVariantDefinition)
+                .handler("main")
+                .code_plaintext("I am code")
+                .build()
+                .expect("should build data"),
+        )
+        .build()
+        .expect("should make new func spec");
+
+    let pkg_spec = PkgSpec::builder()
+        .name(asset_name)
+        .created_by("sally@systeminit.com")
+        .funcs(variant_funcs)
+        .func(func_spec)
+        .schemas([schema_spec].to_vec())
+        .version("0")
+        .build()
+        .expect("should build");
+
+    let pkg = SiPkg::load_from_spec(pkg_spec).expect("should load from spec");
+
+    // import and get add variants
+    let (_, mut variants, _) = import_pkg_from_pkg(ctx, &pkg, None)
+        .await
+        .expect("should import");
+    assert!(variants.len() == 1);
+
+    let default_schema_variant = schema
+        .get_default_schema_variant_id(ctx)
+        .await
+        .expect("unable to get the default schema variant id");
+
+    // the new default variant should be the one we just added
+    assert!(default_schema_variant.is_some());
+    assert_eq!(
+        default_schema_variant,
+        Some(variants.pop().expect("should pop"))
+    );
+}


### PR DESCRIPTION
Okay, this feels too easy which makes me think I am missing something obvious. Instead of looking at associated schemas, we list all schemas and match by name. If a match is found, we add a schema variant and set it as the default. We also no longer check if the funcs we are importing are marked as a builtin as otherwise we were stomping over the schema variant def func.
<img src="https://media4.giphy.com/media/oVkhNmBp2odlCpkI2j/giphy.gif"/>