### PR TITLE
fix(dal): ensure we merge the vector clocks of nodes in import subgraph

### DIFF
--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -1523,7 +1523,7 @@ impl WorkspaceSnapshotGraph {
     ) -> WorkspaceSnapshotGraphResult<()> {
         let mut dfs = petgraph::visit::DfsPostOrder::new(&other.graph, root_index);
         while let Some(node_index_to_copy) = dfs.next(&other.graph) {
-            let node_weight_to_copy = other.get_node_weight(node_index_to_copy)?.clone();
+            let mut node_weight_to_copy = other.get_node_weight(node_index_to_copy)?.clone();
             let node_weight_id = node_weight_to_copy.id();
             let node_weight_lineage_id = node_weight_to_copy.lineage_id();
 
@@ -1532,13 +1532,15 @@ impl WorkspaceSnapshotGraph {
             let node_index = if let Some(equivalent_node_index) =
                 self.find_equivalent_node(node_weight_id, node_weight_lineage_id)?
             {
-                let equivalent_node_weight = self.get_node_weight(equivalent_node_index)?;
+                let equivalent_node_weight = self.get_node_weight_mut(equivalent_node_index)?;
                 if equivalent_node_weight
                     .vector_clock_write()
                     .is_newer_than(node_weight_to_copy.vector_clock_write())
                 {
+                    equivalent_node_weight.merge_clocks(&node_weight_to_copy)?;
                     equivalent_node_index
                 } else {
+                    node_weight_to_copy.merge_clocks(equivalent_node_weight)?;
                     let new_node_index = self.add_node(node_weight_to_copy)?;
 
                     self.replace_references(equivalent_node_index)?;

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -228,54 +228,50 @@ impl NodeWeight {
         }
     }
 
-    pub fn merge_clocks(
-        &mut self,
-        change_set: &ChangeSet,
-        other: &NodeWeight,
-    ) -> NodeWeightResult<()> {
+    pub fn merge_clocks(&mut self, other: &NodeWeight) -> NodeWeightResult<()> {
         match (self, other) {
             (NodeWeight::Action(self_weight), NodeWeight::Action(other_weight)) => {
-                self_weight.merge_clocks(change_set, other_weight)
+                self_weight.merge_clocks(other_weight)
             }
             (
                 NodeWeight::ActionPrototype(self_weight),
                 NodeWeight::ActionPrototype(other_weight),
-            ) => self_weight.merge_clocks(change_set, other_weight),
+            ) => self_weight.merge_clocks(other_weight),
             (
                 NodeWeight::AttributePrototypeArgument(self_weight),
                 NodeWeight::AttributePrototypeArgument(other_weight),
-            ) => self_weight.merge_clocks(change_set, other_weight),
+            ) => self_weight.merge_clocks(other_weight),
             (NodeWeight::AttributeValue(self_weight), NodeWeight::AttributeValue(other_weight)) => {
-                self_weight.merge_clocks(change_set, other_weight)
+                self_weight.merge_clocks(other_weight)
             }
             (NodeWeight::Category(self_weight), NodeWeight::Category(other_weight)) => {
-                self_weight.merge_clocks(change_set, other_weight)
+                self_weight.merge_clocks(other_weight)
             }
             (NodeWeight::Component(self_weight), NodeWeight::Component(other_weight)) => {
-                self_weight.merge_clocks(change_set, other_weight)
+                self_weight.merge_clocks(other_weight)
             }
             (NodeWeight::Content(self_weight), NodeWeight::Content(other_weight)) => {
-                self_weight.merge_clocks(change_set, other_weight)
+                self_weight.merge_clocks(other_weight)
             }
             (NodeWeight::Func(self_weight), NodeWeight::Func(other_weight)) => {
-                self_weight.merge_clocks(change_set, other_weight)
+                self_weight.merge_clocks(other_weight)
             }
             (NodeWeight::FuncArgument(self_weight), NodeWeight::FuncArgument(other_weight)) => {
-                self_weight.merge_clocks(change_set, other_weight)
+                self_weight.merge_clocks(other_weight)
             }
             (NodeWeight::Ordering(self_weight), NodeWeight::Ordering(other_weight)) => {
-                self_weight.merge_clocks(change_set, other_weight)
+                self_weight.merge_clocks(other_weight)
             }
             (NodeWeight::Prop(self_weight), NodeWeight::Prop(other_weight)) => {
-                self_weight.merge_clocks(change_set, other_weight)
+                self_weight.merge_clocks(other_weight)
             }
             (NodeWeight::Secret(self_weight), NodeWeight::Secret(other_weight)) => {
-                self_weight.merge_clocks(change_set, other_weight)
+                self_weight.merge_clocks(other_weight)
             }
             (
                 NodeWeight::DependentValueRoot(self_weight),
                 NodeWeight::DependentValueRoot(other_weight),
-            ) => self_weight.merge_clocks(change_set, other_weight),
+            ) => self_weight.merge_clocks(other_weight),
             _ => Err(NodeWeightError::IncompatibleNodeWeightVariants),
         }
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
@@ -108,15 +108,12 @@ impl ActionNodeWeight {
         }
     }
 
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
+    pub fn merge_clocks(&mut self, other: &Self) -> NodeWeightResult<()> {
+        self.vector_clock_write.merge(&other.vector_clock_write)?;
         self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
+            .merge(&other.vector_clock_first_seen)?;
+        self.vector_clock_recently_seen
+            .merge(&other.vector_clock_recently_seen)?;
 
         Ok(())
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
@@ -102,15 +102,12 @@ impl ActionPrototypeNodeWeight {
         }
     }
 
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
+    pub fn merge_clocks(&mut self, other: &Self) -> NodeWeightResult<()> {
+        self.vector_clock_write.merge(&other.vector_clock_write)?;
         self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
+            .merge(&other.vector_clock_first_seen)?;
+        self.vector_clock_recently_seen
+            .merge(&other.vector_clock_recently_seen)?;
 
         Ok(())
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
@@ -105,15 +105,12 @@ impl AttributePrototypeArgumentNodeWeight {
         }
     }
 
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
+    pub fn merge_clocks(&mut self, other: &Self) -> NodeWeightResult<()> {
+        self.vector_clock_write.merge(&other.vector_clock_write)?;
         self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
+            .merge(&other.vector_clock_first_seen)?;
+        self.vector_clock_recently_seen
+            .merge(&other.vector_clock_recently_seen)?;
 
         Ok(())
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -121,15 +121,12 @@ impl AttributeValueNodeWeight {
         }
     }
 
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
+    pub fn merge_clocks(&mut self, other: &Self) -> NodeWeightResult<()> {
+        self.vector_clock_write.merge(&other.vector_clock_write)?;
         self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
+            .merge(&other.vector_clock_first_seen)?;
+        self.vector_clock_recently_seen
+            .merge(&other.vector_clock_recently_seen)?;
 
         Ok(())
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
@@ -86,17 +86,12 @@ impl CategoryNodeWeight {
         }
     }
 
-    pub fn merge_clocks(
-        &mut self,
-        change_set: &ChangeSet,
-        other: &CategoryNodeWeight,
-    ) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), other.vector_clock_write())?;
-        self.vector_clock_first_seen.merge(
-            change_set.vector_clock_id(),
-            other.vector_clock_first_seen(),
-        )?;
+    pub fn merge_clocks(&mut self, other: &CategoryNodeWeight) -> NodeWeightResult<()> {
+        self.vector_clock_write.merge(&other.vector_clock_write)?;
+        self.vector_clock_first_seen
+            .merge(&other.vector_clock_first_seen)?;
+        self.vector_clock_recently_seen
+            .merge(&other.vector_clock_recently_seen)?;
 
         Ok(())
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -87,15 +87,12 @@ impl ComponentNodeWeight {
         }
     }
 
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
+    pub fn merge_clocks(&mut self, other: &Self) -> NodeWeightResult<()> {
+        self.vector_clock_write.merge(&other.vector_clock_write)?;
         self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
+            .merge(&other.vector_clock_first_seen)?;
+        self.vector_clock_recently_seen
+            .merge(&other.vector_clock_recently_seen)?;
 
         Ok(())
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
@@ -104,15 +104,12 @@ impl ContentNodeWeight {
         }
     }
 
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
+    pub fn merge_clocks(&mut self, other: &Self) -> NodeWeightResult<()> {
+        self.vector_clock_write.merge(&other.vector_clock_write)?;
         self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
+            .merge(&other.vector_clock_first_seen)?;
+        self.vector_clock_recently_seen
+            .merge(&other.vector_clock_recently_seen)?;
 
         Ok(())
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/dependent_value_root_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/dependent_value_root_node_weight.rs
@@ -70,13 +70,12 @@ impl DependentValueRootNodeWeight {
         }
     }
 
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), other.vector_clock_write())?;
-        self.vector_clock_first_seen.merge(
-            change_set.vector_clock_id(),
-            other.vector_clock_first_seen(),
-        )?;
+    pub fn merge_clocks(&mut self, other: &Self) -> NodeWeightResult<()> {
+        self.vector_clock_write.merge(other.vector_clock_write())?;
+        self.vector_clock_first_seen
+            .merge(other.vector_clock_first_seen())?;
+        self.vector_clock_recently_seen
+            .merge(&other.vector_clock_recently_seen)?;
 
         Ok(())
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
@@ -86,15 +86,12 @@ impl FuncArgumentNodeWeight {
         }
     }
 
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
+    pub fn merge_clocks(&mut self, other: &Self) -> NodeWeightResult<()> {
+        self.vector_clock_write.merge(&other.vector_clock_write)?;
         self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
+            .merge(&other.vector_clock_first_seen)?;
+        self.vector_clock_recently_seen
+            .merge(&other.vector_clock_recently_seen)?;
 
         Ok(())
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
@@ -91,15 +91,12 @@ impl FuncNodeWeight {
         }
     }
 
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
+    pub fn merge_clocks(&mut self, other: &Self) -> NodeWeightResult<()> {
+        self.vector_clock_write.merge(&other.vector_clock_write)?;
         self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
+            .merge(&other.vector_clock_first_seen)?;
+        self.vector_clock_recently_seen
+            .merge(&other.vector_clock_recently_seen)?;
 
         Ok(())
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
@@ -64,17 +64,12 @@ impl OrderingNodeWeight {
         }
     }
 
-    pub fn merge_clocks(
-        &mut self,
-        change_set: &ChangeSet,
-        other: &OrderingNodeWeight,
-    ) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), other.vector_clock_write())?;
-        self.vector_clock_first_seen.merge(
-            change_set.vector_clock_id(),
-            other.vector_clock_first_seen(),
-        )?;
+    pub fn merge_clocks(&mut self, other: &OrderingNodeWeight) -> NodeWeightResult<()> {
+        self.vector_clock_write.merge(other.vector_clock_write())?;
+        self.vector_clock_recently_seen
+            .merge(other.vector_clock_recently_seen())?;
+        self.vector_clock_first_seen
+            .merge(other.vector_clock_first_seen())?;
 
         Ok(())
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
@@ -105,15 +105,12 @@ impl PropNodeWeight {
         }
     }
 
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
+    pub fn merge_clocks(&mut self, other: &Self) -> NodeWeightResult<()> {
+        self.vector_clock_write.merge(&other.vector_clock_write)?;
         self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
+            .merge(&other.vector_clock_first_seen)?;
+        self.vector_clock_recently_seen
+            .merge(&other.vector_clock_recently_seen)?;
 
         Ok(())
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
@@ -87,15 +87,12 @@ impl SecretNodeWeight {
         }
     }
 
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
+    pub fn merge_clocks(&mut self, other: &Self) -> NodeWeightResult<()> {
+        self.vector_clock_write.merge(&other.vector_clock_write)?;
         self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
+            .merge(&other.vector_clock_first_seen)?;
+        self.vector_clock_recently_seen
+            .merge(&other.vector_clock_recently_seen)?;
 
         Ok(())
     }

--- a/lib/dal/src/workspace_snapshot/vector_clock.rs
+++ b/lib/dal/src/workspace_snapshot/vector_clock.rs
@@ -15,7 +15,7 @@ pub enum VectorClockError {
     LamportClock(#[from] LamportClockError),
 }
 
-const CLOCKS_TO_RETAIN: usize = 10;
+const CLOCKS_TO_RETAIN: usize = 7;
 
 pub type VectorClockResult<T> = Result<T, VectorClockError>;
 
@@ -81,13 +81,8 @@ impl VectorClock {
     }
 
     /// Add all entries in `other` to `self`, taking the most recent value if the entry already
-    /// exists in `self`, then increment the entry for [`VectorClockId`] (adding one if it is not
-    /// already there).
-    pub fn merge(
-        &mut self,
-        vector_clock_id: VectorClockId,
-        other: &VectorClock,
-    ) -> VectorClockResult<()> {
+    /// exists in `self`.
+    pub fn merge(&mut self, other: &VectorClock) -> VectorClockResult<()> {
         for (other_vector_clock_id, other_lamport_clock) in other.entries.iter() {
             if let Some(lamport_clock) = self.entries.get_mut(other_vector_clock_id) {
                 lamport_clock.merge(other_lamport_clock);
@@ -96,7 +91,6 @@ impl VectorClock {
                     .insert(*other_vector_clock_id, *other_lamport_clock);
             }
         }
-        self.inc(vector_clock_id)?;
 
         Ok(())
     }


### PR DESCRIPTION
This ensures we merge the vector clocks of nodes we are copying from onto into to_rebase, and vice versa. This gets us closer to being able to drop more vector clocks from the graph.