### PR TITLE
fix: increase cyclone_pool get timeout to ten minutes

### DIFF
--- a/lib/si-pool-noodle/src/pool_noodle.rs
+++ b/lib/si-pool-noodle/src/pool_noodle.rs
@@ -220,7 +220,7 @@ where
     pub async fn get(&mut self) -> Result<LifeGuard<I>> {
         let me = Arc::clone(&self.0);
 
-        let max_retries = 300; // Set the maximum number of retries
+        let max_retries = 6000; // Set the maximum number of retries
         let mut retries = 0;
         loop {
             if retries >= max_retries {
@@ -254,7 +254,7 @@ where
                     "Failed to get from pool, retry ({} of {})",
                     retries, max_retries
                 );
-                sleep(Duration::from_millis(500)).await;
+                sleep(Duration::from_millis(100)).await;
             }
         }
     }


### PR DESCRIPTION
This will cause pool_noodle to attempt gets more frequently and set the over all timeout to 10 minutes, which seems like more than enough time to finish work :crossed_fingers: 

