### PR TITLE
Perf: position and size are in the store, dont need to be passed as props

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramGroup.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroup.vue
@@ -367,7 +367,6 @@ import * as _ from "lodash-es";
 import tinycolor from "tinycolor2";
 
 import { KonvaEventObject } from "konva/lib/Node";
-import { Vector2d } from "konva/lib/types";
 import { getToneColorHex, useTheme } from "@si/vue-lib/design-system";
 import { useComponentsStore } from "@/store/components.store";
 import DiagramNodeSocket from "@/components/ModelingDiagram/DiagramNodeSocket.vue";
@@ -391,7 +390,6 @@ import {
   DiagramGroupData,
   DiagramSocketData,
   SideAndCornerIdentifiers,
-  Size2D,
 } from "./diagram_types";
 import { useDiagramContext } from "./ModelingDiagram.vue";
 import DiagramIcon from "./DiagramIcon.vue";
@@ -404,12 +402,6 @@ const props = defineProps({
   connectedEdges: {
     type: Object as PropType<DiagramEdgeData[]>,
     default: () => ({}),
-  },
-  tempPosition: {
-    type: Object as PropType<Vector2d>,
-  },
-  tempSize: {
-    type: Object as PropType<Size2D>,
   },
   drawEdgeState: {
     type: Object as PropType<DiagramDrawEdgeState>,
@@ -439,7 +431,9 @@ const titleTextRef = ref();
 const groupRef = ref();
 
 const size = computed(
-  () => props.tempSize || props.group.def.size || { width: 500, height: 500 },
+  () =>
+    componentsStore.resizedElementSizes[props.group.uniqueKey] ||
+    props.group.def.size || { width: 500, height: 500 },
 );
 
 const isDeleted = computed(
@@ -534,7 +528,11 @@ const nodeHeight = computed(
     nodeHeaderHeight.value + GROUP_HEADER_BOTTOM_MARGIN + nodeBodyHeight.value,
 );
 
-const position = computed(() => props.tempPosition || props.group.def.position);
+const position = computed(
+  () =>
+    componentsStore.movedElementPositions[props.group.uniqueKey] ||
+    props.group.def.position,
+);
 
 watch([nodeWidth, nodeHeight, position], () => {
   // we call on nextTick to let the component actually update itself on the stage first

--- a/app/web/src/components/ModelingDiagram/DiagramGroupOverlay.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroupOverlay.vue
@@ -47,20 +47,16 @@
 import { computed, nextTick, PropType, ref, watch } from "vue";
 import * as _ from "lodash-es";
 import { Tween } from "konva/lib/Tween";
-import { Vector2d } from "konva/lib/types";
 import { CORNER_RADIUS } from "@/components/ModelingDiagram/diagram_constants";
-import { DiagramGroupData, Size2D } from "./diagram_types";
+import { useComponentsStore } from "@/store/components.store";
+import { DiagramGroupData } from "./diagram_types";
+
+const componentsStore = useComponentsStore();
 
 const props = defineProps({
   group: {
     type: Object as PropType<DiagramGroupData>,
     required: true,
-  },
-  tempPosition: {
-    type: Object as PropType<Vector2d>,
-  },
-  tempSize: {
-    type: Object as PropType<Size2D>,
   },
   isHovered: Boolean,
   isSelected: Boolean,
@@ -70,7 +66,9 @@ const titleTextRef = ref();
 const groupRef = ref();
 
 const size = computed(
-  () => props.tempSize || props.group.def.size || { width: 500, height: 500 },
+  () =>
+    componentsStore.resizedElementSizes[props.group.uniqueKey] ||
+    props.group.def.size || { width: 500, height: 500 },
 );
 
 const nodeWidth = computed(() => size.value.width);
@@ -98,7 +96,11 @@ const nodeBodyHeight = computed(() => size.value.height);
 //     nodeHeaderHeight.value + GROUP_HEADER_BOTTOM_MARGIN + nodeBodyHeight.value,
 // );
 
-const position = computed(() => props.tempPosition || props.group.def.position);
+const position = computed(
+  () =>
+    componentsStore.movedElementPositions[props.group.uniqueKey] ||
+    props.group.def.position,
+);
 // const isDeleted = computed(() => props.group?.def.changeStatus === "deleted");
 // const deletedIconSize = computed(() =>
 //   Math.min(nodeHeight.value, nodeWidth.value, 300),

--- a/app/web/src/components/ModelingDiagram/DiagramNode.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramNode.vue
@@ -265,7 +265,6 @@ import tinycolor from "tinycolor2";
 
 import { KonvaEventObject } from "konva/lib/Node";
 import { Tween } from "konva/lib/Tween";
-import { Vector2d } from "konva/lib/types";
 import { getToneColorHex, useTheme } from "@si/vue-lib/design-system";
 import { useComponentsStore } from "@/store/components.store";
 import {
@@ -294,9 +293,6 @@ const props = defineProps({
   node: {
     type: Object as PropType<DiagramNodeData>,
     required: true,
-  },
-  tempPosition: {
-    type: Object as PropType<Vector2d>,
   },
   connectedEdges: {
     type: Object as PropType<DiagramEdgeData[]>,
@@ -433,7 +429,11 @@ const nodeHeight = computed(
 
 const parentComponentId = computed(() => props.node.def.parentId);
 
-const position = computed(() => props.tempPosition || props.node.def.position);
+const position = computed(
+  () =>
+    componentsStore.movedElementPositions[props.node.uniqueKey] ||
+    props.node.def.position,
+);
 
 watch([nodeWidth, nodeHeight, position], () => {
   // we call on nextTick to let the component actually update itself on the stage first

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -79,10 +79,6 @@ overflow hidden */
             :group="group"
             :isHovered="elementIsHovered(group)"
             :isSelected="elementIsSelected(group)"
-            :tempPosition="
-              componentsStore.movedElementPositions[group.uniqueKey]
-            "
-            :tempSize="componentsStore.resizedElementSizes[group.uniqueKey]"
             @resize="onNodeLayoutOrLocationChange(group)"
           />
           <template v-if="edgeDisplayMode === 'EDGES_UNDER'">
@@ -103,9 +99,6 @@ overflow hidden */
             :isHovered="elementIsHovered(node)"
             :isSelected="elementIsSelected(node)"
             :node="node"
-            :tempPosition="
-              componentsStore.movedElementPositions[node.uniqueKey]
-            "
             @resize="onNodeLayoutOrLocationChange(node)"
           />
           <DiagramCursor
@@ -128,10 +121,6 @@ overflow hidden */
             v-for="group in groups"
             :key="group.uniqueKey"
             :group="group"
-            :tempPosition="
-              componentsStore.movedElementPositions[group.uniqueKey]
-            "
-            :tempSize="componentsStore.resizedElementSizes[group.uniqueKey]"
             @resize="onNodeLayoutOrLocationChange(group)"
           />
 


### PR DESCRIPTION
Fewer re-renders is always better! We we're re-rendering every component that is being dragged, as its being dragged. Bad news bears.
<img src="https://media3.giphy.com/media/3NtY188QaxDdC/giphy.gif"/>