### PR TITLE
Make from_base_change_set flag exist for SummaryDiagramComponent & SummaryDiagramEdge

### DIFF
--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -126,6 +126,7 @@ pub struct SummaryDiagramComponent {
     pub deleted_info: serde_json::Value,
     pub to_delete: bool,
     pub can_be_upgraded: bool,
+    pub from_base_change_set: bool,
 }
 
 impl SummaryDiagramComponent {
@@ -242,6 +243,7 @@ impl SummaryDiagramComponent {
             deleted_info: serde_json::Value::Null,
             to_delete: component.to_delete(),
             can_be_upgraded: default_schema_variant.id() != schema_variant.id(),
+            from_base_change_set: false,
         })
     }
 }
@@ -257,6 +259,7 @@ pub struct SummaryDiagramEdge {
     pub created_info: serde_json::Value,
     pub deleted_info: serde_json::Value,
     pub to_delete: bool,
+    pub from_base_change_set: bool,
 }
 
 impl SummaryDiagramEdge {
@@ -275,6 +278,7 @@ impl SummaryDiagramEdge {
             created_info: serde_json::to_value(incoming_connection.created_info)?,
             deleted_info: serde_json::to_value(incoming_connection.deleted_info)?,
             to_delete: from_component.to_delete() || to_component.to_delete(),
+            from_base_change_set: false,
         })
     }
 }


### PR DESCRIPTION
The logic to drive this flag will come later, but the idea is that when this flag is `true` it is letting the frontend know that this is a "virtual" Component/Edge, and doesn't actually exist in the current change set.