### PR TITLE
Restore components & edges from base change set

### DIFF
--- a/app/web/src/api/sdf/dal/component.ts
+++ b/app/web/src/api/sdf/dal/component.ts
@@ -52,6 +52,7 @@ export interface RawComponent {
   updatedInfo: ActorAndTimestamp;
   toDelete: boolean;
   canBeUpgraded: boolean;
+  fromBaseChangeSet: boolean;
 }
 
 export type EdgeId = string;

--- a/app/web/src/components/ComponentCard.vue
+++ b/app/web/src/components/ComponentCard.vue
@@ -6,6 +6,7 @@
         'p-xs border-l-4 border relative',
         titleCard ? 'mb-xs' : 'rounded-md',
         component.toDelete && 'opacity-70',
+        component.fromBaseChangeSet && 'opacity-70',
       )
     "
     :style="{

--- a/app/web/src/components/DetailsPanelTimestamps.vue
+++ b/app/web/src/components/DetailsPanelTimestamps.vue
@@ -17,7 +17,7 @@
         class="shrink-0"
         tone="inherit"
       />
-      <div class="grow truncate">
+      <div v-if="created" class="grow truncate">
         {{ formatters.timeAgo(created.timestamp) }} by
         {{ created.actor.label }}
       </div>
@@ -42,7 +42,7 @@
         class="shrink-0"
         tone="inherit"
       />
-      <div class="grow truncate">
+      <div v-if="modified" class="grow truncate">
         {{ formatters.timeAgo(modified?.timestamp) }} by
         {{ modified?.actor.label }}
       </div>
@@ -58,7 +58,7 @@
         class="shrink-0"
         tone="inherit"
       />
-      <div class="grow truncate">
+      <div v-if="deleted" class="grow truncate">
         {{ formatters.timeAgo(deleted?.timestamp) }} by
         {{ deleted?.actor.label }}
       </div>

--- a/app/web/src/components/ModelingDiagram/DiagramGroup.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroup.vue
@@ -437,7 +437,10 @@ const size = computed(
 );
 
 const isDeleted = computed(
-  () => props.group.def.changeStatus === "deleted" || props.group.def.toDelete,
+  () =>
+    props.group.def.changeStatus === "deleted" ||
+    props.group.def.toDelete ||
+    props.group.def.fromBaseChangeSet,
 );
 const isModified = computed(() => props.group.def.changeStatus === "modified");
 const isAdded = computed(() => props.group.def.changeStatus === "added");

--- a/app/web/src/components/ModelingDiagram/DiagramNode.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramNode.vue
@@ -320,7 +320,10 @@ const diagramContext = useDiagramContext();
 const { edgeDisplayMode } = diagramContext;
 
 const isDeleted = computed(
-  () => props.node.def.changeStatus === "deleted" || props.node.def.toDelete,
+  () =>
+    props.node.def.changeStatus === "deleted" ||
+    props.node.def.toDelete ||
+    props.node.def.fromBaseChangeSet,
 );
 const isModified = computed(() => props.node.def.changeStatus === "modified");
 const isAdded = computed(() => props.node.def.changeStatus === "added");

--- a/app/web/src/components/ModelingDiagram/diagram_types.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_types.ts
@@ -213,6 +213,8 @@ export type DiagramNodeDef = {
   changeStatus?: ChangeStatus;
   /** component will be deleted after next action run */
   toDelete: boolean;
+  /** component is deleted in this changeset, but exists in base change set */
+  fromBaseChangeSet: boolean;
   /** can the component be upgraded */
   canBeUpgraded: boolean;
 };

--- a/app/web/src/components/ModelingView/RestoreSelectionModal.vue
+++ b/app/web/src/components/ModelingView/RestoreSelectionModal.vue
@@ -78,12 +78,26 @@ function open() {
 }
 
 async function onConfirmRestore() {
-  if (componentsStore.selectedComponentIds) {
+  if (
+    componentsStore.selectedComponentIds &&
+    componentsStore.selectedComponentIds.length > 0
+  ) {
     const data = {} as Record<ComponentId, boolean>;
     componentsStore.selectedComponentIds.forEach((cId) => {
       data[cId] = !!componentsStore.componentsById[cId]?.fromBaseChangeSet;
     });
     await componentsStore.RESTORE_COMPONENTS(data);
+  } else if (componentsStore.selectedEdge) {
+    await componentsStore.CREATE_COMPONENT_CONNECTION(
+      {
+        componentId: componentsStore.selectedEdge.fromComponentId,
+        socketId: componentsStore.selectedEdge.fromSocketId,
+      },
+      {
+        componentId: componentsStore.selectedEdge.toComponentId,
+        socketId: componentsStore.selectedEdge.toSocketId,
+      },
+    );
   }
   componentsStore.setSelectedComponentId(null);
   close();

--- a/app/web/src/components/ModelingView/RestoreSelectionModal.vue
+++ b/app/web/src/components/ModelingView/RestoreSelectionModal.vue
@@ -32,6 +32,7 @@ import {
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 
 import { useComponentsStore } from "@/store/components.store";
+import { ComponentId } from "@/api/sdf/dal/component";
 
 const componentsStore = useComponentsStore();
 const selectedEdge = computed(() => componentsStore.selectedEdge);
@@ -78,9 +79,11 @@ function open() {
 
 async function onConfirmRestore() {
   if (componentsStore.selectedComponentIds) {
-    await componentsStore.RESTORE_COMPONENTS(
-      componentsStore.selectedComponentIds,
-    );
+    const data = {} as Record<ComponentId, boolean>;
+    componentsStore.selectedComponentIds.forEach((cId) => {
+      data[cId] = !!componentsStore.componentsById[cId]?.fromBaseChangeSet;
+    });
+    await componentsStore.RESTORE_COMPONENTS(data);
   }
   componentsStore.setSelectedComponentId(null);
   close();

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -1499,28 +1499,33 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
             });
           },
 
-          async RESTORE_COMPONENTS(componentIds: ComponentId[]) {
+          async RESTORE_COMPONENTS(components: Record<ComponentId, boolean>) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
             if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
+            const payload = [];
+            for (const [key, value] of Object.entries(components)) {
+              payload.push({ componentId: key, fromBaseChangeSet: value });
+            }
             return new ApiRequest({
               method: "post",
               url: "diagram/remove_delete_intent",
-              keyRequestStatusBy: componentIds,
+              keyRequestStatusBy: Object.keys(components),
               params: {
-                componentIds,
+                components: payload,
                 ...visibilityParams,
               },
               onSuccess: () => {
-                for (const componentId of componentIds) {
+                for (const componentId of Object.keys(components)) {
                   const component = this.rawComponentsById[componentId];
                   if (component) {
                     this.rawComponentsById[componentId] = {
                       ...component,
                       changeStatus: "unmodified",
                       toDelete: false,
+                      fromBaseChangeSet: false,
                       deletedInfo: undefined,
                     };
                   }

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1237,6 +1237,7 @@ impl Component {
 
         Ok(incoming_edges)
     }
+
     pub async fn get_children_for_id(
         ctx: &DalContext,
         component_id: ComponentId,
@@ -1261,6 +1262,7 @@ impl Component {
 
         Ok(children)
     }
+
     #[instrument(level = "debug" skip(ctx))]
     pub async fn get_parent_by_id(
         ctx: &DalContext,
@@ -1290,6 +1292,7 @@ impl Component {
         };
         Ok(maybe_parent)
     }
+
     pub async fn parent(&self, ctx: &DalContext) -> ComponentResult<Option<ComponentId>> {
         Self::get_parent_by_id(ctx, self.id).await
     }
@@ -1587,6 +1590,7 @@ impl Component {
             None => None,
         })
     }
+
     #[instrument(level="debug" skip(ctx))]
     pub async fn get_type_by_id(
         ctx: &DalContext,
@@ -1773,6 +1777,7 @@ impl Component {
 
         Ok(socket_values)
     }
+
     #[instrument(level="debug" skip_all)]
     pub async fn input_socket_match(
         ctx: &DalContext,
@@ -1783,6 +1788,7 @@ impl Component {
             Self::input_socket_attribute_values_for_component_id(ctx, component_id).await?;
         Ok(all_input_sockets.get(&input_socket_id).cloned())
     }
+
     pub async fn output_socket_match(
         ctx: &DalContext,
         component_id: ComponentId,
@@ -1832,6 +1838,7 @@ impl Component {
     ) -> ComponentResult<HashMap<InputSocketId, InputSocketMatch>> {
         Self::input_socket_attribute_values_for_component_id(ctx, self.id()).await
     }
+
     #[instrument(level = "info", skip(ctx))]
     async fn connect_inner(
         ctx: &DalContext,
@@ -1931,6 +1938,7 @@ impl Component {
             attribute_prototype_argument.id(),
         )))
     }
+
     pub async fn remove_edge_from_frame(
         ctx: &DalContext,
         parent_id: ComponentId,
@@ -2101,6 +2109,7 @@ impl Component {
 
         Ok(result)
     }
+
     /// Checks the destination and source component to determine if data flow between them
     /// Both "deleted" and not deleted Components can feed data into
     /// "deleted" Components. **ONLY** not deleted Components can feed
@@ -2122,6 +2131,7 @@ impl Component {
             },
         )
     }
+
     /// Simply gets the to_delete status for a component via the Node Weight
     async fn is_set_to_delete(
         ctx: &DalContext,
@@ -2143,6 +2153,7 @@ impl Component {
             None => Ok(None),
         }
     }
+
     async fn modify<L>(self, ctx: &DalContext, lambda: L) -> ComponentResult<Self>
     where
         L: FnOnce(&mut Self) -> ComponentResult<()>,
@@ -2575,6 +2586,7 @@ impl Component {
         pasted_comp.clone_attributes_from(ctx, self.id()).await?;
         Ok(pasted_comp)
     }
+
     /// For a given [`ComponentId`], map each input socket to the inferred output sockets
     /// it is connected to. Inferred socket connections are determined by following
     /// the ancestry line of FrameContains edges and matching the relevant input to output sockets.
@@ -3558,6 +3570,7 @@ impl Component {
             format!("{} - Copy", name)
         }
     }
+
     /// This method finds the [`AttributeValueId`](crate::AttributeValue) corresponding to either  "/root/code" or
     /// "/root/qualification" for the given [`ComponentId`](Component) and ['LeafKind'](LeafKind).
     pub async fn find_map_attribute_value_for_leaf_kind(
@@ -3574,6 +3587,23 @@ impl Component {
             }
         };
         Ok(attribute_value_id)
+    }
+
+    pub async fn restore_from_base_change_set(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<()> {
+        let base_change_set_ctx = ctx.clone_with_base().await?;
+
+        ctx.workspace_snapshot()?
+            .import_component_subgraph(
+                ctx.change_set()?.vector_clock_id(),
+                &*base_change_set_ctx.workspace_snapshot()?,
+                component_id,
+            )
+            .await?;
+
+        Ok(())
     }
 }
 

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use crate::actor_view::ActorView;
 use crate::attribute::prototype::argument::{
-    AttributePrototypeArgumentError, AttributePrototypeArgumentId,
+    AttributePrototypeArgument, AttributePrototypeArgumentError, AttributePrototypeArgumentId,
 };
 use crate::attribute::value::AttributeValueError;
 use crate::change_status::ChangeStatus;
@@ -385,6 +385,8 @@ impl Diagram {
         let mut diagram_edges: Vec<SummaryDiagramEdge> = vec![];
         let mut diagram_inferred_edges: Vec<SummaryDiagramInferredEdge> = vec![];
         let components = Component::list(ctx).await?;
+        let mut virtual_and_real_components_by_id: HashMap<ComponentId, Component> =
+            components.iter().cloned().map(|c| (c.id(), c)).collect();
         let mut component_views = Vec::with_capacity(components.len());
         let new_component_ids: HashSet<ComponentId> = ctx
             .workspace_snapshot()?
@@ -467,8 +469,8 @@ impl Diagram {
             // We now need to retrieve these Components from the base change set, and build
             // SummaryDiagramComponents for them with from_base_change_set true, and change_status
             // ChangeStatus::Removed
-            let base_snapshot_ctx = ctx.clone_with_base().await?;
-            let base_snapshot_ctx = &base_snapshot_ctx;
+            let base_change_set_ctx = ctx.clone_with_base().await?;
+            let base_change_set_ctx = &base_change_set_ctx;
 
             for removed_component_id in removed_component_ids {
                 // We don't need to worry about these duplicating SummaryDiagramComponents that
@@ -476,24 +478,89 @@ impl Diagram {
                 // still in the change set's snapshot, while the list of Component IDs we're
                 // working on here are explicitly ones that do not exist in that snapshot anymore.
                 let base_change_set_component =
-                    Component::get_by_id(base_snapshot_ctx, removed_component_id).await?;
+                    Component::get_by_id(base_change_set_ctx, removed_component_id).await?;
                 let mut summary_diagram_component = SummaryDiagramComponent::assemble(
-                    base_snapshot_ctx,
+                    base_change_set_ctx,
                     &base_change_set_component,
                     ChangeStatus::Deleted,
                 )
                 .await?;
                 summary_diagram_component.from_base_change_set = true;
+                virtual_and_real_components_by_id
+                    .insert(removed_component_id, base_change_set_component);
 
                 component_views.push(summary_diagram_component);
             }
 
-            // We need to bring in any AttributePrototypeArguments for incoming & outgoing connections.
+            // We need to bring in any AttributePrototypeArguments for incoming & outgoing
+            // connections that have been removed.
+            let removed_attribute_prototype_argument_ids = ctx
+                .workspace_snapshot()?
+                .socket_edges_removed_relative_to_base(ctx)
+                .await?;
+            let mut incoming_connections_by_component_id: HashMap<
+                ComponentId,
+                Vec<IncomingConnection>,
+            > = HashMap::new();
 
-            // let removed_attribute_prototype_aguments = ctx
-            //     .workspace_snapshot()?
-            //     .socket_edges_removed_relative_to_base(ctx)
-            //     .await?;
+            for removed_attribute_prototype_argument_id in &removed_attribute_prototype_argument_ids
+            {
+                let attribute_prototype_argument = AttributePrototypeArgument::get_by_id(
+                    base_change_set_ctx,
+                    *removed_attribute_prototype_argument_id,
+                )
+                .await?;
+
+                // This should always be Some as
+                // `WorkspaceSnapshot::socket_edges_removed_relative_to_base` only returns the
+                // IDs of arguments that have targets.
+                if let Some(targets) = attribute_prototype_argument.targets() {
+                    if let hash_map::Entry::Vacant(vacant_entry) =
+                        incoming_connections_by_component_id.entry(targets.destination_component_id)
+                    {
+                        let removed_component = Component::get_by_id(
+                            base_change_set_ctx,
+                            targets.destination_component_id,
+                        )
+                        .await?;
+                        let mut incoming_connections = removed_component
+                            .incoming_connections(base_change_set_ctx)
+                            .await?;
+                        // We only care about connections going to the Component in the base that
+                        // are *ALSO* ones that we are considered to have removed.
+                        incoming_connections.retain(|connection| {
+                            removed_attribute_prototype_argument_ids
+                                .contains(&connection.attribute_prototype_argument_id)
+                        });
+                        vacant_entry.insert(incoming_connections);
+                    }
+                }
+            }
+
+            for incoming_connections in incoming_connections_by_component_id.values() {
+                for incoming_connection in incoming_connections {
+                    let from_component = virtual_and_real_components_by_id
+                        .get(&incoming_connection.from_component_id)
+                        .cloned()
+                        .ok_or(ComponentError::NotFound(
+                            incoming_connection.from_component_id,
+                        ))?;
+                    let to_component = virtual_and_real_components_by_id
+                        .get(&incoming_connection.to_component_id)
+                        .ok_or(ComponentError::NotFound(
+                            incoming_connection.to_component_id,
+                        ))?;
+                    let mut summary_diagram_edge = SummaryDiagramEdge::assemble(
+                        incoming_connection.clone(),
+                        from_component,
+                        to_component,
+                        ChangeStatus::Deleted,
+                    )?;
+                    summary_diagram_edge.from_base_change_set = true;
+
+                    diagram_edges.push(summary_diagram_edge);
+                }
+            }
         }
 
         Ok(Self {

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -619,7 +619,7 @@ impl WorkspaceSnapshot {
         let component_node_index = other.read_only_graph.get_node_index_by_id(component_id)?;
         Ok(self.working_copy_mut().await.import_component_subgraph(
             vector_clock_id,
-            &*other.read_only_graph,
+            &other.read_only_graph,
             component_node_index,
         )?)
     }

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -606,20 +606,22 @@ impl WorkspaceSnapshot {
     }
 
     #[instrument(
-        name = "workspace_snapshot.import_subgraph",
+        name = "workspace_snapshot.import_component_subgraph",
         level = "debug",
-        skip_all,
-        fields()
+        skip_all
     )]
-    pub async fn import_subgraph(
+    pub async fn import_component_subgraph(
         &self,
-        other: &mut Self,
-        root_index: NodeIndex,
+        vector_clock_id: VectorClockId,
+        other: &Self,
+        component_id: ComponentId,
     ) -> WorkspaceSnapshotResult<()> {
-        Ok(self
-            .working_copy_mut()
-            .await
-            .import_subgraph(&*other.working_copy().await, root_index)?)
+        let component_node_index = other.read_only_graph.get_node_index_by_id(component_id)?;
+        Ok(self.working_copy_mut().await.import_component_subgraph(
+            vector_clock_id,
+            &*other.read_only_graph,
+            component_node_index,
+        )?)
     }
 
     /// Calls [`WorkspaceSnapshotGraph::replace_references()`]

--- a/lib/dal/tests/integration_test/diagram.rs
+++ b/lib/dal/tests/integration_test/diagram.rs
@@ -7,9 +7,13 @@ use dal_test::{
 #[test]
 async fn components_removed_from_snapshot_have_virtual_diagram_entries(ctx: &mut DalContext) {
     let component_to_remove =
-        create_component_for_schema_name(ctx, "Docker Image", "Removed in sub-change set").await;
+        create_component_for_schema_name(ctx, "Docker Image", "Removed in sub-change set")
+            .await
+            .expect("Unable to create component.");
     let _component_still_in_change_set =
-        create_component_for_schema_name(ctx, "Docker Image", "Still here").await;
+        create_component_for_schema_name(ctx, "Docker Image", "Still here")
+            .await
+            .expect("Unable to create component.");
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("Unable to commit");

--- a/lib/dal/tests/integration_test/diagram.rs
+++ b/lib/dal/tests/integration_test/diagram.rs
@@ -1,0 +1,53 @@
+use dal::{change_status::ChangeStatus, diagram::Diagram, Component, DalContext};
+use dal_test::{
+    helpers::{create_component_for_schema_name, ChangeSetTestHelpers},
+    test,
+};
+
+#[test]
+async fn components_removed_from_snapshot_have_virtual_diagram_entries(ctx: &mut DalContext) {
+    let component_to_remove =
+        create_component_for_schema_name(ctx, "Docker Image", "Removed in sub-change set").await;
+    let _component_still_in_change_set =
+        create_component_for_schema_name(ctx, "Docker Image", "Still here").await;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("Unable to commit");
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx)
+        .await
+        .expect("Unable to merge setup to HEAD");
+
+    ChangeSetTestHelpers::fork_from_head_change_set(ctx)
+        .await
+        .expect("Unable to create forked change set");
+
+    let removed_component = Component::get_by_id(ctx, component_to_remove.id())
+        .await
+        .expect("Unable to get component to remove");
+    removed_component
+        .delete(ctx)
+        .await
+        .expect("Unable to remove component");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("Unable to commit");
+
+    assert!(Component::get_by_id(ctx, component_to_remove.id())
+        .await
+        .is_err());
+
+    let summary_diagram = Diagram::assemble(ctx)
+        .await
+        .expect("Unable to assemble summary diagram");
+
+    let removed_component_summary = summary_diagram
+        .components
+        .iter()
+        .find(|comp| comp.id == component_to_remove.id())
+        .expect("Removed Component not found in summary diagram");
+    assert!(removed_component_summary.from_base_change_set);
+    assert_eq!(
+        ChangeStatus::Deleted,
+        removed_component_summary.change_status
+    );
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -6,6 +6,7 @@ mod component;
 mod connection;
 mod cycle_check_guard;
 mod dependent_values_update;
+mod diagram;
 mod frame;
 mod func;
 mod input_sources;


### PR DESCRIPTION
# Back end

## Include Components only in the base change set that would be actively removed by a change set when building the summary diagram

We now look at the series of updates that would be applied if we were to merge a change set into its base, and include "virtual" summary diagram component entries for any Components that would be removed and that only exist in the base change set. These virtual entries will have `from_base_change_set` set to true to signal that they don't actually exist in the snapshot for the change set.

## List edges from base change set that would be actively removed on merge

## Allow importing a Component from another snapshot graph

This allows us to "undelete"/"restore" a Component from the base change set if we've removed it from the current change set, and change our mind.

## Restore Component->Component connections from base changeset whenever possible

Rather than creating a new API endpoint & method for attempting to restore a `Component -> Component` (`Output Socket -> Input Socket`) connection, `Component::connect` (and by extension `diagram/create_connection`) will now check the base change set to see if an equivalent connection exists there. If it does, then we import that pre-existing connection into the current change set. If it does not, then we'll create the connection as a brand new one.

This means that if you remove a connection, decide you didn’t actually want to do that, and re-draw it instead of clicking the “restore connection” button, we’ll do the right thing and restore it, so you don’t end up seeing a remove+add of the “same” connection, and should generally help reduce the potential churn in looking at diffs.

## Only try to create Component -> Component connections when both are in the current change set

Since we display "virtual" Components of some things that aren't actually in the current change set, we need to make sure that we don't try to create a connection to them as that would effectively be a dangling pointer.