### PR TITLE
fix: flakiness in firecracker jail management

### DIFF
--- a/bin/veritech/scripts/stop.sh
+++ b/bin/veritech/scripts/stop.sh
@@ -2,32 +2,30 @@
 
 set -euo pipefail
 
-SB_ID="${1:-null}"
+SB_ID="${1:-0}"
 
 # Kill the firecracker process if it exists
-FIRECRACKER_PID=$(pgrep -f "firecracker --id $SB_ID") || true
-if [ -n "${FIRECRACKER_PID}" ]; then
-  kill -9 $FIRECRACKER_PID
-fi
+pkill -f "firecracker --id $SB_ID" || true
 
 # Remove directories and files
-DISK="/srv/jailer/firecracker/$SB_ID/root/rootfs.ext4"
-OVERLAY="rootfs-overlay-$SB_ID"
+JAIL="/srv/jailer/firecracker/${SB_ID}/root"
+DISK="${JAIL}/rootfs.ext4"
+OVERLAY="rootfs-overlay-${SB_ID}"
+OVERLAY_FILE="${JAIL}/rootfs-overlay-${SB_ID}"
 
-until ! $(mount | grep -q $DISK); do
+# Unmount disk if mounted
+while mountpoint -q "$DISK"; do
   umount -dl "$DISK"
 done
 
-until ! dmsetup status "$OVERLAY" &> /dev/null; do
-  dmsetup remove --force --retry $OVERLAY
+# Remove device mapper overlay
+while dmsetup info "$OVERLAY" &> /dev/null; do
+  dmsetup remove --force --retry "$OVERLAY"
 done
 
-# We are not currently creating these.
-# umount /srv/jailer/firecracker/$SB_ID/root/image-kernel.bin || true
-# dmsetup remove kernel-overlay-$SB_ID || true
-
-# TODO(scott): figure out a better way to do this.
-# this will only detach devices removed from device-mapper
-# but it still feels bad
-losetup --detach-all
-rm -rf /srv/jailer/firecracker/$SB_ID
+# Detach loop devices related to the specific SB_ID
+# Note the ) at the end to ensure we don't match -1 with -10
+if losetup -a | grep "$OVERLAY)" &> /dev/null; then
+  losetup -d $(losetup -j "$OVERLAY_FILE" -O NAME | sed -n 2p)
+fi
+rm -rf "/srv/jailer/firecracker/$SB_ID"

--- a/lib/cyclone-core/src/process.rs
+++ b/lib/cyclone-core/src/process.rs
@@ -44,7 +44,7 @@ pub async fn child_shutdown(
         Ok(wait_result) => {
             let exit_status = wait_result.map_err(ShutdownError::ChildWait)?;
             if !exit_status.success() {
-                warn!("child process had a nonzero exit; code={}", exit_status);
+                debug!("child process had a nonzero exit; code={}", exit_status);
             }
 
             Ok(exit_status)
@@ -53,7 +53,7 @@ pub async fn child_shutdown(
             child.start_kill().map_err(ShutdownError::StartKill)?;
             let exit_status = child.wait().await.map_err(ShutdownError::ChildWait)?;
             if !exit_status.success() {
-                warn!("child process had a nonzero exit; code={}", exit_status);
+                debug!("child process had a nonzero exit; code={}", exit_status);
             }
 
             Ok(exit_status)


### PR DESCRIPTION
This does a handful of things:

* modify stop script to match better and be more specific about cleanup tasks. This *should* allow it to be more reliable
* change some warnings to debug as they are needlessly chatty
* move initial jail cleaning to pool noodle instead of startup script
* capture the output of scripts runs and throw if they do not succeed
* remove the drop channel in favor of another drop arrayqueue. I'm pretty sure that there were issues in receiving drop messages causing us to not handle cleanup correctly. This is the likely cause of the pool leakage
* bubble up errors when interacting with the arrayqueues, just in case
* keep track of both the number of active and dropped instances
* emit pool stats on debug so we can better understand issues where we think the pool is in a bad shape

the overall result here should be no more leaking in the pool and just better resiliency overall. There will be follow-on work to refactor some of the script bits into a dedicated library so I can start teasing them into rust analogues, but that's mostly side work

<img src="https://media1.giphy.com/media/MXvDhlmD0eB5qNvvjZ/giphy.gif"/>