### PR TITLE
Jhelwig/replace subgraph interaction with replace references

### DIFF
--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -735,6 +735,12 @@ impl WorkspaceSnapshotGraph {
                 if edge_kind_updates.additions.len()
                     > (edge_kind_updates.removals.len() + (1 - existing_outgoing_edges_of_kind))
                 {
+                    warn!(
+                        "ExclusiveEdgeMismatch: Found {} pre-existing edges. Requested {} removals, {} additions.",
+                        existing_outgoing_edges_of_kind,
+                        edge_kind_updates.removals.len(),
+                        edge_kind_updates.additions.len(),
+                    );
                     // The net count of outgoing edges of this kind is >1. Consider *ALL* of the
                     // additions to be in conflict.
                     for (

--- a/lib/dal/src/workspace_snapshot/update.rs
+++ b/lib/dal/src/workspace_snapshot/update.rs
@@ -21,6 +21,8 @@ pub enum Update {
         destination: NodeInformation,
         edge_kind: EdgeWeightKindDiscriminants,
     },
+    // This is not correctly named. We really only want to replace the single node, as we also
+    // generate Update entries to handle processing the rest of the subgraph.
     ReplaceSubgraph {
         onto: NodeInformation,
         // Check if already exists in "onto". Grab node weight from "to_rebase" and see if there is


### PR DESCRIPTION
# Commits
## Log how many pre-existing edges there are, and how many removals/additions were requested when an ExclusiveEdgeMismatch conflict is detected

## Make Update::ReplaceSubgraph only import a single node, instead of the entire subgraph

The problem with importing the entire subgraph is that we also still generate `Update` entries for things below the root of the `Update::ReplaceSubgraph`, and that `find_in_self_or_create_using_onto` + `replace_references` ends up with the uinion of the "child" nodes from   both `self` and `onto` as the child nodes in the resulting graph.

What  we want is either only the child nodes from `onto` with no further `Update` entries for things below the root of the `Update::ReplaceSubgraph`, or for only the specific node referenced in `Update::ReplaceSubgraph` to be replaced, to maintain the pre-existing child nodes in `self`, and to let the `Update` entries for things below the root specified in `Update::ReplaceSubgraph` to handle the rest of the subgraph update/import.
