### PR TITLE
feat(si-generator): Add support for setting missingResource refresh settings

### DIFF
--- a/bin/si-generator/src/render.ts
+++ b/bin/si-generator/src/render.ts
@@ -61,7 +61,10 @@ export async function fmt(ts: string): Promise<string> {
   }
 }
 
-export async function renderAsset(props: Array<Prop>, provider: RenderProvider): Promise<string> {
+export async function renderAsset(
+  props: Array<Prop>,
+  provider: RenderProvider,
+): Promise<string> {
   const eta = useEta();
   const assetDefinition = eta.render("@assetMain", { props, provider });
   return await fmt(assetDefinition);
@@ -74,7 +77,7 @@ export async function renderCodeGen(provider: RenderProvider): Promise<string> {
 }
 
 export interface RenderCreateBase {
-  provider: RenderProvider
+  provider: RenderProvider;
 }
 
 export interface RenderCreateAws extends RenderCreateBase {
@@ -85,7 +88,9 @@ export interface RenderCreateAws extends RenderCreateBase {
 
 export type RenderCreateOptions = RenderCreateAws;
 
-export async function renderCreate(options: RenderCreateOptions): Promise<string> {
+export async function renderCreate(
+  options: RenderCreateOptions,
+): Promise<string> {
   const eta = useEta();
   const create = eta.render("@createMain", { options });
   return await fmt(create);
@@ -96,10 +101,13 @@ export interface RenderRefreshOptions {
   awsService: string;
   awsCommand: string;
   inputs: Array<ArgInput>;
+  missingResources: Array<String>;
   outputs: Array<ArgOutput>;
-};
+}
 
-export async function renderRefresh(options: RenderRefreshOptions): Promise<string> {
+export async function renderRefresh(
+  options: RenderRefreshOptions,
+): Promise<string> {
   const eta = useEta();
   const refresh = eta.render("@refreshMain", options);
   return await fmt(refresh);
@@ -114,13 +122,17 @@ export interface RenderDeleteOptions {
 
 export type RenderActionOptions = RenderDeleteOptions;
 
-export async function renderDelete(options: RenderDeleteOptions): Promise<string> {
+export async function renderDelete(
+  options: RenderDeleteOptions,
+): Promise<string> {
   const eta = useEta();
   const deletetemp = eta.render("@deleteMain", options);
   return await fmt(deletetemp);
 }
 
-export async function renderAction(options: RenderActionOptions): Promise<string> {
+export async function renderAction(
+  options: RenderActionOptions,
+): Promise<string> {
   const eta = useEta();
   const actiontemp = eta.render("@actionMain", options);
   return await fmt(actiontemp);

--- a/bin/si-generator/src/resource_generator.ts
+++ b/bin/si-generator/src/resource_generator.ts
@@ -1,15 +1,16 @@
 export interface ArgInput {
-  toSet: string,
-  readFrom: string,
+  toSet: string;
+  readFrom: string;
 }
 
 export interface ArgOutput {
-  toSet?: string,
-  readFrom: string,
+  toSet?: string;
+  readFrom: string;
 }
 
 export interface RefreshOptions {
   inputs: Array<ArgInput>;
+  missingResources: Array<String>;
   outputs: Array<ArgOutput>;
 }
 
@@ -18,29 +19,41 @@ export interface DeleteOptions {
 }
 
 export function parseInputOption(input: string): ArgInput {
-    const [toSet, readFrom] = input.split(':');
-    if (toSet && readFrom) {
+  const [toSet, readFrom] = input.split(":");
+  if (toSet && readFrom) {
     return { toSet, readFrom };
-    } else {
-      throw new Error(`Invalid input specifier; must be 'awsInputPath:siPropertiesPath': ${input}`);
-    }
+  } else {
+    throw new Error(
+      `Invalid input specifier; must be 'awsInputPath:siPropertiesPath': ${input}`,
+    );
+  }
 }
 
 export function parseOutputOption(output: string): ArgOutput {
-    if (output.includes(':')) {
-      const [toSet, readFrom] = output.split(':');
-      return { toSet, readFrom };
-    } else {
-      return { readFrom: output };
-    }
+  if (output.includes(":")) {
+    const [toSet, readFrom] = output.split(":");
+    return { toSet, readFrom };
+  } else {
+    return { readFrom: output };
+  }
 }
 
-
-export function makeRefreshOptions(options: { input: Array<string>, output: Array<string> }): RefreshOptions {
-  const refreshOptions: RefreshOptions = { inputs: [], outputs: [] };
+export function makeRefreshOptions(options: {
+  input: Array<string>;
+  missingResource: Array<string>;
+  output: Array<string>;
+}): RefreshOptions {
+  const refreshOptions: RefreshOptions = {
+    inputs: [],
+    missingResources: [],
+    outputs: [],
+  };
   for (const input of options.input) {
     const argInput = parseInputOption(input);
     refreshOptions.inputs.push(argInput);
+  }
+  for (const missing of options.missingResource) {
+    refreshOptions.missingResources.push(missing);
   }
   for (const output of options.output) {
     const argOutput = parseOutputOption(output);
@@ -49,8 +62,14 @@ export function makeRefreshOptions(options: { input: Array<string>, output: Arra
   return refreshOptions;
 }
 
-export function makeDeleteOrActionOptions(options: { input: Array<string> }): DeleteOptions {
-  const deleteOptions: RefreshOptions = { inputs: [], outputs: [] };
+export function makeDeleteOrActionOptions(options: {
+  input: Array<string>;
+}): DeleteOptions {
+  const deleteOptions: RefreshOptions = {
+    inputs: [],
+    missingResources: [],
+    outputs: [],
+  };
   for (const input of options.input) {
     const argInput = parseInputOption(input);
     deleteOptions.inputs.push(argInput);

--- a/bin/si-generator/src/run.ts
+++ b/bin/si-generator/src/run.ts
@@ -1,16 +1,21 @@
 import { Command } from "https://deno.land/x/cliffy@v1.0.0-rc.3/command/mod.ts";
 import { awsGenerate } from "./asset_generator.ts";
 import { makeRefreshOptions } from "./resource_generator.ts";
-import { renderAction, renderAsset, renderCodeGen, renderCreate, renderDelete, renderRefresh } from "./render.ts";
+import {
+  renderAction,
+  renderAsset,
+  renderCodeGen,
+  renderCreate,
+  renderDelete,
+  renderRefresh,
+} from "./render.ts";
 import { makeDeleteOrActionOptions } from "./resource_generator.ts";
 
 export async function run() {
   const command = new Command()
     .name("si-generator")
     .version("0.1.0")
-    .description(
-      "Generate Assets and code for System Initiative",
-    )
+    .description("Generate Assets and code for System Initiative")
     .action(() => {
       command.showHelp();
       Deno.exit(1);
@@ -33,35 +38,79 @@ export async function run() {
     .description("generate a create function from an aws cli skeleton")
     .arguments("<awsService:string> <awsCommand:string>")
     .action(async (_options, awsService, awsCommand) => {
-      const result = await renderCreate({ provider: "aws", awsService, awsCommand });
+      const result = await renderCreate({
+        provider: "aws",
+        awsService,
+        awsCommand,
+      });
       console.log(result);
     })
     .command("refresh")
     .description("generate a refresh function from an aws cli skeleton")
     .arguments("<awsService:string> <awsCommand:string>")
-    .option("--input <input:string>", "awsInputPath:siPropertiesPath; constructs CLI json data", { collect: true, required: true })
-    .option("--output <output:string>", "[siResourcePath:]awsOutputPath; constructs resource object", { collect: true, required: true })
+    .option(
+      "--input <input:string>",
+      "awsInputPath:siPropertiesPath; constructs CLI json data",
+      { collect: true, required: true },
+    )
+    .option(
+      "--missingResource <input:string>",
+      "Pass missing resource error checks",
+      {
+        collect: true,
+      },
+    )
+    .option(
+      "--output <output:string>",
+      "[siResourcePath:]awsOutputPath; constructs resource object",
+      { collect: true, required: true },
+    )
     .action(async (options, awsService, awsCommand) => {
       const refreshOptions = makeRefreshOptions(options);
-      const result = await renderRefresh({ provider: "aws", awsService, awsCommand, inputs: refreshOptions.inputs, outputs: refreshOptions.outputs });
+      const result = await renderRefresh({
+        provider: "aws",
+        awsService,
+        awsCommand,
+        inputs: refreshOptions.inputs,
+        missingResources: refreshOptions.missingResources,
+        outputs: refreshOptions.outputs,
+      });
       console.log(result);
     })
     .command("delete")
     .description("generate a delete function from an aws cli skeleton")
     .arguments("<awsService:string> <awsCommand:string>")
-    .option("--input <input:string>", "awsInputPath:siPropertiesPath; constructs CLI json data", { collect: true, required: true })
+    .option(
+      "--input <input:string>",
+      "awsInputPath:siPropertiesPath; constructs CLI json data",
+      { collect: true, required: true },
+    )
     .action(async (options, awsService, awsCommand) => {
       const deleteOptions = makeDeleteOrActionOptions(options);
-      const result = await renderDelete({ provider: "aws", awsService, awsCommand, inputs: deleteOptions.inputs });
+      const result = await renderDelete({
+        provider: "aws",
+        awsService,
+        awsCommand,
+        inputs: deleteOptions.inputs,
+      });
       console.log(result);
     })
     .command("action")
     .description("generate an action function from an aws cli skeleton")
     .arguments("<awsService:string> <awsCommand:string>")
-    .option("--input <input:string>", "awsInputPath:siPropertiesPath; constructs CLI json data", { collect: true, required: true })
+    .option(
+      "--input <input:string>",
+      "awsInputPath:siPropertiesPath; constructs CLI json data",
+      { collect: true, required: true },
+    )
     .action(async (options, awsService, awsCommand) => {
       const deleteOptions = makeDeleteOrActionOptions(options);
-      const result = await renderAction({ provider: "aws", awsService, awsCommand, inputs: deleteOptions.inputs });
+      const result = await renderAction({
+        provider: "aws",
+        awsService,
+        awsCommand,
+        inputs: deleteOptions.inputs,
+      });
       console.log(result);
     });
 

--- a/bin/si-generator/src/templates/refreshMain.ts
+++ b/bin/si-generator/src/templates/refreshMain.ts
@@ -16,11 +16,20 @@ async function main(component: Input): Promise < Output > {
 
   if (child.exitCode !== 0) {
     const payload = _.get(component, 'properties.resource.payload');
-    if (payload) {
+<% for (const missing of it.missingResources) { %>
+    if (child.stderr.includes("<%= missing %>")) {
       return {
         status: "error",
-        payload,
-        message: \`Refresh error; exit code \${child.exitCode}.\\n\\nSTDOUT:\\n\\n\${child.stdout}\\n\\nSTDERR:\\n\\n\${child.stderr}\`,
+        message: \`Refresh error; resource not found; (<%= missing %>)\`,
+      }
+    }
+<% } %>
+
+    if (payload) {
+  return {
+    status: "error",
+    payload,
+    message: \`Refresh error; exit code \${child.exitCode}.\\n\\nSTDOUT:\\n\\n\${child.stdout}\\n\\nSTDERR:\\n\\n\${child.stderr}\`,
       }
     } else {
       return {
@@ -50,4 +59,4 @@ async function main(component: Input): Promise < Output > {
     status: "ok"
   }
 }
-`
+`;


### PR DESCRIPTION
If a resource has been removed directly in AWS, we need to ensure that our refresh funcs check for specific 404s that we know mean it's been deleted so we can remove the resource locally

We can now do that:

```
si-generator  refresh eks describe-cluster --input clusterName:properties.resource.payload.clusterName --missingResource "ResourceNotFoundException" --output 'cluster'
```

This will print the following check:

```
  if (child.exitCode !== 0) {
    const payload = _.get(component, 'properties.resource.payload');
    if (child.stderr.includes("ResourceNotFoundException") {
      return {
        status: "error",
        message: `Refresh error; resource not found; (ResourceNotFoundException)`,
      }
    }
```

That will remove the resource from the system. We can pass multiple `missingResource` options and each of them will be added as specific checks