### PR TITLE
Zack/vector clock simplification

### DIFF
--- a/lib/dal/examples/snapshot-analyzer/main.rs
+++ b/lib/dal/examples/snapshot-analyzer/main.rs
@@ -6,6 +6,7 @@ use dal::{
     workspace_snapshot::{
         content_address::ContentAddressDiscriminants,
         node_weight::{NodeWeight, NodeWeightDiscriminants},
+        vector_clock::HasVectorClocks,
     },
     EdgeWeightKindDiscriminants, WorkspaceSnapshotGraph,
 };

--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -18,8 +18,11 @@ use crate::{
     func::FuncExecutionPk,
     id, implement_add_edge_to,
     job::definition::ActionJob,
-    workspace_snapshot::node_weight::{
-        category_node_weight::CategoryNodeKind, ActionNodeWeight, NodeWeight, NodeWeightError,
+    workspace_snapshot::{
+        node_weight::{
+            category_node_weight::CategoryNodeKind, ActionNodeWeight, NodeWeight, NodeWeightError,
+        },
+        vector_clock::HasVectorClocks,
     },
     AttributeValue, ChangeSetError, ChangeSetId, ComponentError, ComponentId, DalContext,
     EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants, HelperError, TransactionsError,
@@ -314,7 +317,7 @@ impl Action {
             .await?
             .get_action_node_weight()?;
         let mut new_node_weight =
-            node_weight.new_with_incremented_vector_clock(ctx.change_set()?)?;
+            node_weight.new_with_incremented_vector_clock(ctx.change_set()?.vector_clock_id());
         new_node_weight.set_state(state);
         ctx.workspace_snapshot()?
             .add_node(NodeWeight::Action(new_node_weight))

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -73,7 +73,9 @@ use crate::workspace_snapshot::edge_weight::{
 use crate::workspace_snapshot::node_weight::{
     AttributeValueNodeWeight, NodeWeight, NodeWeightDiscriminants, NodeWeightError,
 };
-use crate::workspace_snapshot::{serde_value_to_string_type, WorkspaceSnapshotError};
+use crate::workspace_snapshot::{
+    serde_value_to_string_type, vector_clock::HasVectorClocks, WorkspaceSnapshotError,
+};
 use crate::{
     implement_add_edge_to, pk, AttributePrototype, AttributePrototypeId, Component, ComponentError,
     ComponentId, DalContext, Func, FuncError, FuncId, HelperError, InputSocket, InputSocketId,
@@ -1941,7 +1943,7 @@ impl AttributeValue {
             .await?;
 
         let mut new_av_node_weight =
-            av_node_weight.new_with_incremented_vector_clock(ctx.change_set()?)?;
+            av_node_weight.new_with_incremented_vector_clock(ctx.change_set()?.vector_clock_id());
 
         new_av_node_weight.set_value(value_address.map(ContentAddress::JsonValue));
         new_av_node_weight

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -43,6 +43,7 @@ use crate::workspace_snapshot::edge_weight::{
 use crate::workspace_snapshot::node_weight::attribute_prototype_argument_node_weight::ArgumentTargets;
 use crate::workspace_snapshot::node_weight::category_node_weight::CategoryNodeKind;
 use crate::workspace_snapshot::node_weight::{ComponentNodeWeight, NodeWeight, NodeWeightError};
+use crate::workspace_snapshot::vector_clock::HasVectorClocks;
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::SocketArity;
 
@@ -1859,8 +1860,8 @@ impl Component {
                 .get_node_weight(component_idx)
                 .await?
                 .get_component_node_weight()?;
-            let mut new_component_node_weight =
-                component_node_weight.new_with_incremented_vector_clock(ctx.change_set()?)?;
+            let mut new_component_node_weight = component_node_weight
+                .new_with_incremented_vector_clock(ctx.change_set()?.vector_clock_id());
             new_component_node_weight.set_to_delete(component.to_delete);
             ctx.workspace_snapshot()?
                 .add_node(NodeWeight::Component(new_component_node_weight))

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -19,6 +19,7 @@ use crate::workspace_snapshot::edge_weight::{
 use crate::workspace_snapshot::graph::WorkspaceSnapshotGraphError;
 use crate::workspace_snapshot::node_weight::category_node_weight::CategoryNodeKind;
 use crate::workspace_snapshot::node_weight::{FuncNodeWeight, NodeWeight, NodeWeightError};
+use crate::workspace_snapshot::vector_clock::HasVectorClocks;
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
     id, implement_add_edge_to, pk, ChangeSetId, DalContext, HelperError, Timestamp,
@@ -440,7 +441,8 @@ impl Func {
 
             workspace_snapshot
                 .add_node(NodeWeight::Func(
-                    node_weight.new_with_incremented_vector_clock(ctx.change_set()?)?,
+                    node_weight
+                        .new_with_incremented_vector_clock(ctx.change_set()?.vector_clock_id()),
                 ))
                 .await?;
 

--- a/lib/dal/src/func/argument.rs
+++ b/lib/dal/src/func/argument.rs
@@ -18,6 +18,7 @@ use crate::workspace_snapshot::graph::WorkspaceSnapshotGraphError;
 use crate::workspace_snapshot::node_weight::{
     FuncArgumentNodeWeight, NodeWeight, NodeWeightDiscriminants, NodeWeightError,
 };
+use crate::workspace_snapshot::vector_clock::HasVectorClocks;
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
     id, DalContext, EdgeWeightKind, Func, FuncError, FuncId, HistoryEventError, PropKind,
@@ -386,7 +387,8 @@ impl FuncArgument {
 
             workspace_snapshot
                 .add_node(NodeWeight::FuncArgument(
-                    node_weight.new_with_incremented_vector_clock(ctx.change_set()?)?,
+                    node_weight
+                        .new_with_incremented_vector_clock(ctx.change_set()?.vector_clock_id()),
                 ))
                 .await?;
 

--- a/lib/dal/src/module.rs
+++ b/lib/dal/src/module.rs
@@ -148,7 +148,7 @@ impl Module {
         workspace_snapshot
             .add_edge(
                 schema_module_index_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())?,
                 id,
             )
             .await?;
@@ -214,7 +214,10 @@ impl Module {
         workspace_snapshot
             .add_edge(
                 self.id,
-                EdgeWeight::new(ctx.change_set()?, EdgeWeightKind::new_use())?,
+                EdgeWeight::new(
+                    ctx.change_set()?.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )?,
                 target_id,
             )
             .await?;

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -138,7 +138,7 @@ impl Schema {
         workspace_snapshot
             .add_edge(
                 schema_category_index_id,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())?,
                 id,
             )
             .await?;

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -61,6 +61,7 @@ use crate::workspace_snapshot::edge_weight::{
 use crate::workspace_snapshot::node_weight::category_node_weight::CategoryNodeKind;
 use crate::workspace_snapshot::node_weight::secret_node_weight::SecretNodeWeight;
 use crate::workspace_snapshot::node_weight::{NodeWeight, NodeWeightError};
+use crate::workspace_snapshot::vector_clock::HasVectorClocks;
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
     id, implement_add_edge_to, AttributePrototype, AttributeValue, AttributeValueId,
@@ -647,7 +648,8 @@ impl Secret {
 
             workspace_snapshot
                 .add_node(NodeWeight::Secret(
-                    secret_node_weight.new_with_incremented_vector_clock(ctx.change_set()?)?,
+                    secret_node_weight
+                        .new_with_incremented_vector_clock(ctx.change_set()?.vector_clock_id()),
                 ))
                 .await?;
 

--- a/lib/dal/src/standard_connection.rs
+++ b/lib/dal/src/standard_connection.rs
@@ -37,7 +37,7 @@ macro_rules! implement_add_edge_to {
                 ctx.workspace_snapshot()?
                     .add_edge(
                         source_id,
-                        $crate::EdgeWeight::new(ctx.change_set()?, weight)?,
+                        $crate::EdgeWeight::new(ctx.change_set()?.vector_clock_id(), weight)?,
                         destination_id,
                     )
                     .await?;
@@ -52,9 +52,9 @@ macro_rules! implement_add_edge_to {
 
                 ctx.workspace_snapshot()?
                     .add_ordered_edge(
-                        ctx.change_set()?,
+                        ctx.change_set()?.vector_clock_id(),
                         source_id,
-                        $crate::EdgeWeight::new(ctx.change_set()?, weight)?,
+                        $crate::EdgeWeight::new(ctx.change_set()?.vector_clock_id(), weight)?,
                         destination_id
                     )
                     .await?;

--- a/lib/dal/src/validation.rs
+++ b/lib/dal/src/validation.rs
@@ -16,6 +16,7 @@ use crate::workspace_snapshot::edge_weight::{
     EdgeWeight, EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
 };
 use crate::workspace_snapshot::node_weight::{NodeWeight, NodeWeightError};
+use crate::workspace_snapshot::vector_clock::HasVectorClocks;
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
     pk, schema::variant::SchemaVariantError, AttributeValue, AttributeValueId, ChangeSetError,
@@ -158,7 +159,7 @@ impl ValidationOutputNode {
                 .get_content_node_weight_of_kind(ContentAddressDiscriminants::ValidationOutput)?;
 
             let mut new_node_weight =
-                node_weight.new_with_incremented_vector_clock(ctx.change_set()?)?;
+                node_weight.new_with_incremented_vector_clock(ctx.change_set()?.vector_clock_id());
 
             new_node_weight.new_content_hash(hash)?;
 
@@ -178,7 +179,10 @@ impl ValidationOutputNode {
             workspace_snapshot
                 .add_edge(
                     attribute_value_id,
-                    EdgeWeight::new(change_set, EdgeWeightKind::ValidationOutput)?,
+                    EdgeWeight::new(
+                        change_set.vector_clock_id(),
+                        EdgeWeightKind::ValidationOutput,
+                    )?,
                     id,
                 )
                 .await?;

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -273,7 +273,7 @@ impl WorkspaceSnapshot {
             let category_node_index = graph.add_category_node(change_set, category_node_kind)?;
             graph.add_edge(
                 graph.root(),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())?,
                 category_node_index,
             )?;
         }
@@ -544,7 +544,7 @@ impl WorkspaceSnapshot {
     )]
     pub async fn add_ordered_edge(
         &self,
-        change_set: &ChangeSet,
+        vector_clock_id: VectorClockId,
         from_node_id: impl Into<Ulid>,
         edge_weight: EdgeWeight,
         to_node_id: impl Into<Ulid>,
@@ -555,7 +555,7 @@ impl WorkspaceSnapshot {
             .get_node_index_by_id(from_node_id)?;
         let to_node_index = self.working_copy().await.get_node_index_by_id(to_node_id)?;
         let (edge_index, _) = self.working_copy_mut().await.add_ordered_edge(
-            change_set,
+            vector_clock_id,
             from_node_index,
             edge_weight,
             to_node_index,
@@ -1558,7 +1558,7 @@ impl WorkspaceSnapshot {
                     .add_category_node(change_set, CategoryNodeKind::DependentValueRoots)?;
                 working_copy.add_edge(
                     root_idx,
-                    EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
+                    EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())?,
                     category_node_idx,
                 )?;
 
@@ -1610,7 +1610,7 @@ impl WorkspaceSnapshot {
 
         self.add_edge(
             dv_category_id,
-            EdgeWeight::new(change_set, EdgeWeightKind::new_use())?,
+            EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())?,
             new_dv_node_id,
         )
         .await?;

--- a/lib/dal/src/workspace_snapshot/graph/tests.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests.rs
@@ -71,7 +71,8 @@ fn add_edges(
         graph
             .add_edge(
                 source,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use()).expect("create edge weight"),
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
+                    .expect("create edge weight"),
                 target,
             )
             .expect("add edge");
@@ -285,7 +286,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -293,7 +294,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -303,7 +304,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -313,7 +314,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -351,7 +352,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 func_index,
             )
@@ -361,7 +362,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 prop_index,
             )
@@ -371,7 +372,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(func_id)
@@ -432,7 +433,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 initial_component_node_index,
             )
@@ -440,7 +441,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 initial_schema_node_index,
             )
@@ -450,7 +451,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to find NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 initial_schema_variant_node_index,
             )
@@ -460,7 +461,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to find NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -476,7 +477,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to find NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(component_id)
@@ -533,7 +534,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -541,7 +542,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -551,7 +552,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -561,7 +562,7 @@ mod test {
                 graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(schema_variant_id)
@@ -671,7 +672,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -681,7 +682,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -703,7 +704,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 func_index,
             )
@@ -728,7 +729,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 prop_index,
             )
@@ -738,7 +739,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(func_id)
@@ -763,11 +764,11 @@ mod test {
             .expect("Unable to add ordered prop");
         graph
             .add_ordered_edge(
-                change_set,
+                change_set.vector_clock_id(),
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_1_index,
             )
@@ -788,11 +789,11 @@ mod test {
             .expect("Unable to add ordered prop");
         graph
             .add_ordered_edge(
-                change_set,
+                change_set.vector_clock_id(),
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_2_index,
             )
@@ -813,11 +814,11 @@ mod test {
             .expect("Unable to add ordered prop");
         graph
             .add_ordered_edge(
-                change_set,
+                change_set.vector_clock_id(),
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_3_index,
             )
@@ -867,8 +868,11 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(active_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    active_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 prop_index,
             )
             .expect("Unable to add root -> prop edge");
@@ -924,7 +928,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -934,7 +938,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -956,7 +960,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 func_index,
             )
@@ -981,7 +985,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 prop_index,
             )
@@ -991,7 +995,7 @@ mod test {
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(func_id)
@@ -1016,11 +1020,11 @@ mod test {
             .expect("Unable to add ordered prop");
         graph
             .add_ordered_edge(
-                change_set,
+                change_set.vector_clock_id(),
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_1_index,
             )
@@ -1041,11 +1045,11 @@ mod test {
             .expect("Unable to add ordered prop");
         graph
             .add_ordered_edge(
-                change_set,
+                change_set.vector_clock_id(),
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_2_index,
             )
@@ -1066,11 +1070,11 @@ mod test {
             .expect("Unable to add ordered prop");
         graph
             .add_ordered_edge(
-                change_set,
+                change_set.vector_clock_id(),
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_3_index,
             )
@@ -1091,11 +1095,11 @@ mod test {
             .expect("Unable to add ordered prop");
         graph
             .add_ordered_edge(
-                change_set,
+                change_set.vector_clock_id(),
                 graph
                     .get_node_index_by_id(prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_4_index,
             )
@@ -1129,7 +1133,7 @@ mod test {
         ];
 
         graph
-            .update_order(change_set, prop_id, new_order)
+            .update_order(change_set.vector_clock_id(), prop_id, new_order)
             .expect("Unable to update order of prop's children");
 
         assert_eq!(
@@ -1191,8 +1195,11 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
             .expect("Unable to add root -> schema edge");
@@ -1201,8 +1208,11 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
             .expect("Unable to add schema -> schema variant edge");
@@ -1228,8 +1238,11 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 schema_variant_2_index,
             )
             .expect("Unable to add schema -> schema variant edge");
@@ -1348,7 +1361,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -1358,7 +1371,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -1383,7 +1396,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_2_index,
             )
@@ -1471,7 +1484,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -1481,7 +1494,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -1503,7 +1516,7 @@ mod test {
         graph
             .add_edge(
                 graph.root_index,
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 func_index,
             )
@@ -1528,7 +1541,7 @@ mod test {
                 graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 root_prop_index,
             )
@@ -1538,7 +1551,7 @@ mod test {
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 graph
                     .get_node_index_by_id(func_id)
@@ -1563,11 +1576,11 @@ mod test {
             .expect("Unable to add ordered prop");
         graph
             .add_ordered_edge(
-                change_set,
+                change_set.vector_clock_id(),
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_1_index,
             )
@@ -1588,11 +1601,11 @@ mod test {
             .expect("Unable to add ordered prop");
         graph
             .add_ordered_edge(
-                change_set,
+                change_set.vector_clock_id(),
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_2_index,
             )
@@ -1613,11 +1626,11 @@ mod test {
             .expect("Unable to add ordered prop");
         graph
             .add_ordered_edge(
-                change_set,
+                change_set.vector_clock_id(),
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_3_index,
             )
@@ -1638,11 +1651,11 @@ mod test {
             .expect("Unable to add ordered prop");
         graph
             .add_ordered_edge(
-                change_set,
+                change_set.vector_clock_id(),
                 graph
                     .get_node_index_by_id(root_prop_id)
                     .expect("Unable to get NodeWeight for prop"),
-                EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create uses edge weight"),
                 ordered_prop_4_index,
             )

--- a/lib/dal/src/workspace_snapshot/graph/tests/detect_conflicts_and_updates.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/detect_conflicts_and_updates.rs
@@ -17,7 +17,8 @@ mod test {
     use crate::workspace_snapshot::node_weight::NodeWeight;
     use crate::workspace_snapshot::update::Update;
     use crate::workspace_snapshot::{
-        conflict::Conflict, graph::ConflictsAndUpdates, NodeInformation,
+        conflict::Conflict, graph::ConflictsAndUpdates, vector_clock::HasVectorClocks,
+        NodeInformation,
     };
     use crate::{change_set::ChangeSet, NodeWeightDiscriminants};
     use crate::{PropKind, WorkspaceSnapshotGraph};
@@ -116,8 +117,11 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
             .expect("Unable to add root -> schema edge");
@@ -126,8 +130,11 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
             .expect("Unable to add schema -> schema variant edge");
@@ -156,7 +163,7 @@ mod test {
         new_graph
             .add_edge(
                 new_graph.root_index,
-                EdgeWeight::new(new_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(new_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -166,7 +173,7 @@ mod test {
                 new_graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(new_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(new_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 new_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -232,7 +239,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -242,7 +249,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -273,7 +280,7 @@ mod test {
         let _new_onto_root_component_edge_index = base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 new_onto_component_index,
             )
@@ -283,7 +290,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(new_onto_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -346,7 +353,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -378,7 +385,7 @@ mod test {
         new_graph
             .add_edge(
                 new_graph.root_index,
-                EdgeWeight::new(new_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(new_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 new_component_index,
             )
@@ -462,7 +469,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -472,7 +479,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -503,7 +510,7 @@ mod test {
         new_graph
             .add_edge(
                 new_graph.root_index,
-                EdgeWeight::new(new_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(new_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -513,7 +520,7 @@ mod test {
                 new_graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(new_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(new_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 new_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -542,7 +549,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 new_onto_component_index,
             )
@@ -552,7 +559,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(new_onto_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -629,7 +636,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -639,7 +646,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -661,7 +668,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -671,7 +678,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -784,7 +791,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
@@ -794,7 +801,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
@@ -816,7 +823,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 component_index,
             )
@@ -826,7 +833,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(schema_variant_id)
@@ -924,8 +931,11 @@ mod test {
             active_graph
                 .add_edge(
                     active_graph.root_index,
-                    EdgeWeight::new(active_change_set, EdgeWeightKind::new_use())
-                        .expect("Unable to create EdgeWeight"),
+                    EdgeWeight::new(
+                        active_change_set.vector_clock_id(),
+                        EdgeWeightKind::new_use(),
+                    )
+                    .expect("Unable to create EdgeWeight"),
                     prop_index,
                 )
                 .expect("Unable to add sv -> prop edge");
@@ -954,12 +964,15 @@ mod test {
                 .expect("Unable to add ordered prop");
             active_graph
                 .add_ordered_edge(
-                    active_change_set,
+                    active_change_set.vector_clock_id(),
                     active_graph
                         .get_node_index_by_id(base_prop_id)
                         .expect("Unable to get prop NodeIndex"),
-                    EdgeWeight::new(active_change_set, EdgeWeightKind::new_use())
-                        .expect("Unable to create uses edge weight"),
+                    EdgeWeight::new(
+                        active_change_set.vector_clock_id(),
+                        EdgeWeightKind::new_use(),
+                    )
+                    .expect("Unable to create uses edge weight"),
                     ordered_prop_index,
                 )
                 .expect("Unable to add prop -> ordered_prop_1 edge");
@@ -989,8 +1002,11 @@ mod test {
             active_graph
                 .add_edge(
                     active_graph.root_index,
-                    EdgeWeight::new(active_change_set, EdgeWeightKind::new_use())
-                        .expect("Unable to create EdgeWeight"),
+                    EdgeWeight::new(
+                        active_change_set.vector_clock_id(),
+                        EdgeWeightKind::new_use(),
+                    )
+                    .expect("Unable to create EdgeWeight"),
                     node_index,
                 )
                 .expect("Unable to add root -> prototype edge");
@@ -1015,8 +1031,11 @@ mod test {
                 active_graph
                     .get_node_index_by_id(base_prop_id)
                     .expect("Unable to get prop NodeIndex"),
-                EdgeWeight::new(active_change_set, EdgeWeightKind::Prototype(None))
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    active_change_set.vector_clock_id(),
+                    EdgeWeightKind::Prototype(None),
+                )
+                .expect("Unable to create EdgeWeight"),
                 active_graph
                     .get_node_index_by_id(attribute_prototype_id)
                     .expect("Unable to get prop NodeIndex"),
@@ -1097,7 +1116,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 docker_image_schema_index,
             )
@@ -1124,7 +1143,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(docker_image_schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 docker_image_schema_variant_index,
             )
@@ -1152,7 +1171,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 nginx_docker_image_component_index,
             )
@@ -1168,7 +1187,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(nginx_docker_image_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(docker_image_schema_variant_id)
@@ -1198,7 +1217,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 alpine_component_index,
             )
@@ -1211,7 +1230,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(alpine_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(docker_image_schema_variant_id)
@@ -1241,7 +1260,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 butane_schema_index,
             )
@@ -1268,7 +1287,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(butane_schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 butane_schema_variant_index,
             )
@@ -1296,7 +1315,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 nginx_butane_node_index,
             )
@@ -1312,7 +1331,7 @@ mod test {
                 base_graph
                     .get_node_index_by_id(nginx_butane_component_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 base_graph
                     .get_node_index_by_id(butane_schema_variant_id)
@@ -1517,8 +1536,11 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
             .expect("Unable to add root -> schema edge");
@@ -1527,8 +1549,11 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
             .expect("Unable to add schema -> schema variant edge");
@@ -1554,8 +1579,11 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 container_prop_index,
             )
             .expect("Unable to add schema variant -> container prop edge");
@@ -1577,12 +1605,15 @@ mod test {
             .expect("Unable to add ordered prop 1");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_1_index,
             )
             .expect("Unable to add container prop -> ordered prop 1 edge");
@@ -1604,12 +1635,15 @@ mod test {
             .expect("Unable to add ordered prop 2");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_2_index,
             )
             .expect("Unable to add container prop -> ordered prop 2 edge");
@@ -1631,12 +1665,15 @@ mod test {
             .expect("Unable to add ordered prop 3");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_3_index,
             )
             .expect("Unable to add container prop -> ordered prop 3 edge");
@@ -1658,12 +1695,15 @@ mod test {
             .expect("Unable to add ordered prop 4");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_4_index,
             )
             .expect("Unable to add container prop -> ordered prop 4 edge");
@@ -1696,11 +1736,11 @@ mod test {
             .expect("Unable to add ordered prop 5");
         new_graph
             .add_ordered_edge(
-                new_change_set,
+                new_change_set.vector_clock_id(),
                 new_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(new_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(new_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create EdgeWeight"),
                 ordered_prop_5_index,
             )
@@ -1761,8 +1801,11 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
             .expect("Unable to add root -> schema edge");
@@ -1771,8 +1814,11 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
             .expect("Unable to add schema -> schema variant edge");
@@ -1798,8 +1844,11 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 container_prop_index,
             )
             .expect("Unable to add schema variant -> container prop edge");
@@ -1821,12 +1870,15 @@ mod test {
             .expect("Unable to add ordered prop 1");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_1_index,
             )
             .expect("Unable to add container prop -> ordered prop 1 edge");
@@ -1848,12 +1900,15 @@ mod test {
             .expect("Unable to add ordered prop 2");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_2_index,
             )
             .expect("Unable to add container prop -> ordered prop 2 edge");
@@ -1875,12 +1930,15 @@ mod test {
             .expect("Unable to add ordered prop 3");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_3_index,
             )
             .expect("Unable to add container prop -> ordered prop 3 edge");
@@ -1902,12 +1960,15 @@ mod test {
             .expect("Unable to add ordered prop 4");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_4_index,
             )
             .expect("Unable to add container prop -> ordered prop 4 edge");
@@ -1936,11 +1997,14 @@ mod test {
                 .expect("Unable to create NodeWeight"),
             )
             .expect("Unable to add ordered prop 5");
-        let new_edge_weight = EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-            .expect("Unable to create EdgeWeight");
+        let new_edge_weight = EdgeWeight::new(
+            initial_change_set.vector_clock_id(),
+            EdgeWeightKind::new_use(),
+        )
+        .expect("Unable to create EdgeWeight");
         let (_, maybe_ordinal_edge_information) = initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
@@ -2099,8 +2163,11 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
             .expect("Unable to add root -> schema edge");
@@ -2109,8 +2176,11 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
             .expect("Unable to add schema -> schema variant edge");
@@ -2136,8 +2206,11 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 container_prop_index,
             )
             .expect("Unable to add schema variant -> container prop edge");
@@ -2159,12 +2232,15 @@ mod test {
             .expect("Unable to add ordered prop 1");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_1_index,
             )
             .expect("Unable to add container prop -> ordered prop 1 edge");
@@ -2186,12 +2262,15 @@ mod test {
             .expect("Unable to add ordered prop 2");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_2_index,
             )
             .expect("Unable to add container prop -> ordered prop 2 edge");
@@ -2213,12 +2292,15 @@ mod test {
             .expect("Unable to add ordered prop 3");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_3_index,
             )
             .expect("Unable to add container prop -> ordered prop 3 edge");
@@ -2240,12 +2322,15 @@ mod test {
             .expect("Unable to add ordered prop 4");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_4_index,
             )
             .expect("Unable to add container prop -> ordered prop 4 edge");
@@ -2266,7 +2351,11 @@ mod test {
             ordered_prop_3_id,
         ];
         new_graph
-            .update_order(new_change_set, container_prop_id, new_order)
+            .update_order(
+                new_change_set.vector_clock_id(),
+                container_prop_id,
+                new_order,
+            )
             .expect("Unable to update order of container prop's children");
 
         let ordered_prop_5_id = initial_change_set
@@ -2284,11 +2373,14 @@ mod test {
                 .expect("Unable to create NodeWeight"),
             )
             .expect("Unable to add ordered prop 5");
-        let new_edge_weight = EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-            .expect("Unable to create EdgeWeight");
+        let new_edge_weight = EdgeWeight::new(
+            initial_change_set.vector_clock_id(),
+            EdgeWeightKind::new_use(),
+        )
+        .expect("Unable to create EdgeWeight");
         let (_, maybe_ordinal_edge_information) = initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
@@ -2456,8 +2548,11 @@ mod test {
         initial_graph
             .add_edge(
                 initial_graph.root_index,
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 schema_index,
             )
             .expect("Unable to add root -> schema edge");
@@ -2466,8 +2561,11 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 schema_variant_index,
             )
             .expect("Unable to add schema -> schema variant edge");
@@ -2493,8 +2591,11 @@ mod test {
                 initial_graph
                     .get_node_index_by_id(schema_variant_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 container_prop_index,
             )
             .expect("Unable to add schema variant -> container prop edge");
@@ -2516,12 +2617,15 @@ mod test {
             .expect("Unable to add ordered prop 1");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_1_index,
             )
             .expect("Unable to add container prop -> ordered prop 1 edge");
@@ -2545,12 +2649,15 @@ mod test {
             .expect("Unable to add ordered prop 2");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_2_index,
             )
             .expect("Unable to add container prop -> ordered prop 2 edge");
@@ -2574,12 +2681,15 @@ mod test {
             .expect("Unable to add ordered prop 3");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_3_index,
             )
             .expect("Unable to add container prop -> ordered prop 3 edge");
@@ -2603,12 +2713,15 @@ mod test {
             .expect("Unable to add ordered prop 4");
         initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
-                EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-                    .expect("Unable to create EdgeWeight"),
+                EdgeWeight::new(
+                    initial_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("Unable to create EdgeWeight"),
                 ordered_prop_4_index,
             )
             .expect("Unable to add container prop -> ordered prop 4 edge");
@@ -2654,11 +2767,14 @@ mod test {
             )
             .expect("Unable to add ordered prop 5");
 
-        let new_edge_weight = EdgeWeight::new(initial_change_set, EdgeWeightKind::new_use())
-            .expect("Unable to create EdgeWeight");
+        let new_edge_weight = EdgeWeight::new(
+            initial_change_set.vector_clock_id(),
+            EdgeWeightKind::new_use(),
+        )
+        .expect("Unable to create EdgeWeight");
         let (_, maybe_ordinal_edge_information) = initial_graph
             .add_ordered_edge(
-                initial_change_set,
+                initial_change_set.vector_clock_id(),
                 initial_graph
                     .get_node_index_by_id(container_prop_id)
                     .expect("Unable to get NodeIndex"),
@@ -2813,7 +2929,7 @@ mod test {
             base_graph
                 .add_edge(
                     source,
-                    EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                    EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                         .expect("create edge weight"),
                     target,
                 )
@@ -2968,7 +3084,7 @@ mod test {
         base_graph
             .add_edge(
                 base_graph.root_index,
-                EdgeWeight::new(base_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(base_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("Unable to create edge weight"),
                 base_graph
                     .get_node_index_by_id(av_id)
@@ -3004,8 +3120,11 @@ mod test {
                 new_changes_graph
                     .get_node_index_by_id(av_id)
                     .expect("Unable to get AV node index"),
-                EdgeWeight::new(new_change_set, EdgeWeightKind::Prototype(None))
-                    .expect("Unable to create edge weight"),
+                EdgeWeight::new(
+                    new_change_set.vector_clock_id(),
+                    EdgeWeightKind::Prototype(None),
+                )
+                .expect("Unable to create edge weight"),
                 new_changes_graph
                     .get_node_index_by_id(prototype_a_id)
                     .expect("Unable to get node index for AttributePrototype"),
@@ -3054,8 +3173,11 @@ mod test {
                 conflicting_graph
                     .get_node_index_by_id(av_id)
                     .expect("Unable to get AV node index"),
-                EdgeWeight::new(conflicting_change_set, EdgeWeightKind::Prototype(None))
-                    .expect("Unable to create edge weight"),
+                EdgeWeight::new(
+                    conflicting_change_set.vector_clock_id(),
+                    EdgeWeightKind::Prototype(None),
+                )
+                .expect("Unable to create edge weight"),
                 conflicting_graph
                     .get_node_index_by_id(prototype_b_id)
                     .expect("Unable to get node index for AttributePrototype"),
@@ -3174,8 +3296,11 @@ mod test {
         to_rebase_graph
             .add_edge(
                 to_rebase_graph.root(),
-                EdgeWeight::new(&to_rebase_change_set, EdgeWeightKind::Prototype(None))
-                    .expect("make edge weight"),
+                EdgeWeight::new(
+                    to_rebase_change_set.vector_clock_id(),
+                    EdgeWeightKind::Prototype(None),
+                )
+                .expect("make edge weight"),
                 to_rebase_graph
                     .get_node_index_by_id(prototype_node_id)
                     .expect("get_node_index_by_id"),
@@ -3247,8 +3372,11 @@ mod test {
         to_rebase_graph
             .add_edge(
                 to_rebase_graph.root(),
-                EdgeWeight::new(&to_rebase_change_set, EdgeWeightKind::Prototype(None))
-                    .expect("make edge weight"),
+                EdgeWeight::new(
+                    to_rebase_change_set.vector_clock_id(),
+                    EdgeWeightKind::Prototype(None),
+                )
+                .expect("make edge weight"),
                 to_rebase_graph
                     .get_node_index_by_id(prototype_node_id)
                     .expect("get_node_index_by_id"),
@@ -3296,9 +3424,7 @@ mod test {
         content_node
             .new_content_hash(ContentHash::from("prototype_change"))
             .expect("update_content_hash");
-        content_node
-            .increment_vector_clock(&onto_change_set)
-            .expect("increment_vector_clock");
+        content_node.increment_vector_clocks(onto_change_set.vector_clock_id());
         onto_graph
             .add_node(NodeWeight::Content(content_node))
             .expect("add_node");
@@ -3376,8 +3502,11 @@ mod test {
         to_rebase_graph
             .add_edge(
                 to_rebase_graph.root_index,
-                EdgeWeight::new(&to_rebase_change_set, EdgeWeightKind::new_use())
-                    .expect("unable to make edge weigh"),
+                EdgeWeight::new(
+                    to_rebase_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("unable to make edge weigh"),
                 cat_node_idx,
             )
             .expect("unable add edge ");
@@ -3388,7 +3517,7 @@ mod test {
         onto_graph
             .add_edge(
                 onto_graph.root_index,
-                EdgeWeight::new(&onto_change_set, EdgeWeightKind::new_use())
+                EdgeWeight::new(onto_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                     .expect("unable to make edge weigh"),
                 cat_node_idx,
             )
@@ -3431,7 +3560,7 @@ mod test {
                         graph
                             .get_node_index_by_id(cat_id)
                             .expect("unable to get node index for category"),
-                        EdgeWeight::new(change_set, EdgeWeightKind::new_use())
+                        EdgeWeight::new(change_set.vector_clock_id(), EdgeWeightKind::new_use())
                             .expect("unable to make edge weight"),
                         dvu_root_idx,
                     )

--- a/lib/dal/src/workspace_snapshot/graph/tests/rebase.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/rebase.rs
@@ -28,8 +28,11 @@ mod test {
         to_rebase
             .add_edge(
                 to_rebase.root_index,
-                EdgeWeight::new(to_rebase_change_set, EdgeWeightKind::new_use())
-                    .expect("could not create edge weight"),
+                EdgeWeight::new(
+                    to_rebase_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("could not create edge weight"),
                 schema_category_node_index,
             )
             .expect("could not add edge");
@@ -39,8 +42,11 @@ mod test {
         to_rebase
             .add_edge(
                 to_rebase.root_index,
-                EdgeWeight::new(to_rebase_change_set, EdgeWeightKind::new_use())
-                    .expect("could not create edge weight"),
+                EdgeWeight::new(
+                    to_rebase_change_set.vector_clock_id(),
+                    EdgeWeightKind::new_use(),
+                )
+                .expect("could not create edge weight"),
                 func_category_node_index,
             )
             .expect("could not add edge");
@@ -67,7 +73,7 @@ mod test {
             .expect("could not add node");
         onto.add_edge(
             func_category_node_index,
-            EdgeWeight::new(onto_change_set, EdgeWeightKind::new_use())
+            EdgeWeight::new(onto_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                 .expect("could not create edge weight"),
             func_node_index,
         )
@@ -87,7 +93,7 @@ mod test {
             .expect("could not add node");
         onto.add_edge(
             schema_category_node_index,
-            EdgeWeight::new(onto_change_set, EdgeWeightKind::new_use())
+            EdgeWeight::new(onto_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                 .expect("could not create edge weight"),
             schema_node_index,
         )
@@ -107,7 +113,7 @@ mod test {
             .expect("could not add node");
         onto.add_edge(
             schema_node_index,
-            EdgeWeight::new(onto_change_set, EdgeWeightKind::new_use())
+            EdgeWeight::new(onto_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                 .expect("could not create edge weight"),
             schema_variant_node_index,
         )
@@ -119,7 +125,7 @@ mod test {
             .expect("could not get node index by id");
         onto.add_edge(
             schema_variant_node_index,
-            EdgeWeight::new(onto_change_set, EdgeWeightKind::new_use())
+            EdgeWeight::new(onto_change_set.vector_clock_id(), EdgeWeightKind::new_use())
                 .expect("could not create edge weight"),
             func_node_index,
         )

--- a/lib/dal/src/workspace_snapshot/lamport_clock.rs
+++ b/lib/dal/src/workspace_snapshot/lamport_clock.rs
@@ -20,20 +20,24 @@ pub struct LamportClock {
     pub counter: DateTime<Utc>,
 }
 
+impl Default for LamportClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LamportClock {
-    pub fn new() -> LamportClockResult<LamportClock> {
+    pub fn new() -> Self {
         let counter = Utc::now();
-        Ok(LamportClock { counter })
+        Self { counter }
     }
 
     pub fn new_with_value(new_value: DateTime<Utc>) -> Self {
         LamportClock { counter: new_value }
     }
 
-    pub fn inc(&mut self) -> LamportClockResult<()> {
+    pub fn inc(&mut self) {
         self.counter = Utc::now();
-
-        Ok(())
     }
 
     pub fn inc_to(&mut self, new_value: DateTime<Utc>) {

--- a/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
@@ -7,7 +6,7 @@ use crate::{
     func::FuncExecutionPk,
     workspace_snapshot::{
         graph::LineageId,
-        vector_clock::{VectorClock, VectorClockId},
+        vector_clock::{HasVectorClocks, VectorClock},
     },
     ChangeSet, ChangeSetId, EdgeWeightKindDiscriminants,
 };
@@ -34,7 +33,7 @@ impl ActionNodeWeight {
         originating_change_set_id: ChangeSetId,
         id: Ulid,
     ) -> NodeWeightResult<Self> {
-        let new_vector_clock = VectorClock::new(change_set.vector_clock_id())?;
+        let new_vector_clock = VectorClock::new(change_set.vector_clock_id());
 
         Ok(Self {
             id,
@@ -83,56 +82,12 @@ impl ActionNodeWeight {
         self.func_execution_pk
     }
 
-    pub fn increment_vector_clock(&mut self, change_set: &ChangeSet) -> NodeWeightResult<()> {
-        self.vector_clock_write.inc(change_set.vector_clock_id())?;
-        self.vector_clock_recently_seen
-            .inc(change_set.vector_clock_id())?;
-
-        Ok(())
-    }
-
     pub fn lineage_id(&self) -> Ulid {
         self.lineage_id
     }
 
-    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
-        self.vector_clock_recently_seen
-            .inc_to(vector_clock_id, seen_at);
-        if self
-            .vector_clock_first_seen
-            .entry_for(vector_clock_id)
-            .is_none()
-        {
-            self.vector_clock_first_seen
-                .inc_to(vector_clock_id, seen_at);
-        }
-    }
-
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
-        self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
-
-        Ok(())
-    }
-
     pub fn merkle_tree_hash(&self) -> MerkleTreeHash {
         self.merkle_tree_hash
-    }
-
-    pub fn new_with_incremented_vector_clock(
-        &self,
-        change_set: &ChangeSet,
-    ) -> NodeWeightResult<Self> {
-        let mut new_node_weight = self.clone();
-        new_node_weight.increment_vector_clock(change_set)?;
-
-        Ok(new_node_weight)
     }
 
     pub fn node_hash(&self) -> ContentHash {
@@ -149,40 +104,33 @@ impl ActionNodeWeight {
         self.merkle_tree_hash = new_hash;
     }
 
-    pub fn set_vector_clock_recently_seen_to(
-        &mut self,
-        change_set: &ChangeSet,
-        new_val: DateTime<Utc>,
-    ) {
-        self.vector_clock_recently_seen
-            .inc_to(change_set.vector_clock_id(), new_val);
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[EdgeWeightKindDiscriminants::Use]
     }
+}
 
-    pub fn vector_clock_first_seen(&self) -> &VectorClock {
+impl HasVectorClocks for ActionNodeWeight {
+    fn vector_clock_first_seen(&self) -> &VectorClock {
         &self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen(&self) -> &VectorClock {
+    fn vector_clock_recently_seen(&self) -> &VectorClock {
         &self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write(&self) -> &VectorClock {
+    fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
     }
 
-    pub fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_write
-    }
-
-    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
-        &[EdgeWeightKindDiscriminants::Use]
     }
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
@@ -6,7 +5,7 @@ use crate::{
     action::prototype::ActionKind,
     workspace_snapshot::{
         graph::LineageId,
-        vector_clock::{VectorClock, VectorClockId},
+        vector_clock::{HasVectorClocks, VectorClock},
     },
     ChangeSet, EdgeWeightKindDiscriminants,
 };
@@ -36,7 +35,7 @@ impl ActionPrototypeNodeWeight {
         name: impl AsRef<str>,
         description: Option<impl AsRef<str>>,
     ) -> NodeWeightResult<Self> {
-        let new_vector_clock = VectorClock::new(change_set.vector_clock_id())?;
+        let new_vector_clock = VectorClock::new(change_set.vector_clock_id());
         let name = name.as_ref().to_string();
         let description = description.map(|d| d.as_ref().to_string());
 
@@ -77,56 +76,12 @@ impl ActionPrototypeNodeWeight {
         self.description.as_deref()
     }
 
-    pub fn increment_vector_clock(&mut self, change_set: &ChangeSet) -> NodeWeightResult<()> {
-        self.vector_clock_write.inc(change_set.vector_clock_id())?;
-        self.vector_clock_recently_seen
-            .inc(change_set.vector_clock_id())?;
-
-        Ok(())
-    }
-
     pub fn lineage_id(&self) -> Ulid {
         self.lineage_id
     }
 
-    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
-        self.vector_clock_recently_seen
-            .inc_to(vector_clock_id, seen_at);
-        if self
-            .vector_clock_first_seen
-            .entry_for(vector_clock_id)
-            .is_none()
-        {
-            self.vector_clock_first_seen
-                .inc_to(vector_clock_id, seen_at);
-        }
-    }
-
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
-        self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
-
-        Ok(())
-    }
-
     pub fn merkle_tree_hash(&self) -> MerkleTreeHash {
         self.merkle_tree_hash
-    }
-
-    pub fn new_with_incremented_vector_clock(
-        &self,
-        change_set: &ChangeSet,
-    ) -> NodeWeightResult<Self> {
-        let mut new_node_weight = self.clone();
-        new_node_weight.increment_vector_clock(change_set)?;
-
-        Ok(new_node_weight)
     }
 
     pub fn node_hash(&self) -> ContentHash {
@@ -142,40 +97,33 @@ impl ActionPrototypeNodeWeight {
         self.merkle_tree_hash = new_hash;
     }
 
-    pub fn set_vector_clock_recently_seen_to(
-        &mut self,
-        change_set: &ChangeSet,
-        new_val: DateTime<Utc>,
-    ) {
-        self.vector_clock_recently_seen
-            .inc_to(change_set.vector_clock_id(), new_val);
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[EdgeWeightKindDiscriminants::Use]
     }
+}
 
-    pub fn vector_clock_first_seen(&self) -> &VectorClock {
+impl HasVectorClocks for ActionPrototypeNodeWeight {
+    fn vector_clock_first_seen(&self) -> &VectorClock {
         &self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen(&self) -> &VectorClock {
+    fn vector_clock_recently_seen(&self) -> &VectorClock {
         &self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write(&self) -> &VectorClock {
+    fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
     }
 
-    pub fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_write
-    }
-
-    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
-        &[EdgeWeightKindDiscriminants::Use]
     }
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
@@ -9,7 +8,7 @@ use crate::{
         content_address::ContentAddress,
         graph::LineageId,
         node_weight::NodeWeightResult,
-        vector_clock::{VectorClock, VectorClockId},
+        vector_clock::{HasVectorClocks, VectorClock},
     },
     EdgeWeightKindDiscriminants,
 };
@@ -44,9 +43,9 @@ impl AttributeValueNodeWeight {
             id,
             lineage_id: change_set.generate_ulid()?,
             merkle_tree_hash: MerkleTreeHash::default(),
-            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id())?,
-            vector_clock_recently_seen: VectorClock::new(change_set.vector_clock_id())?,
-            vector_clock_write: VectorClock::new(change_set.vector_clock_id())?,
+            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id()),
+            vector_clock_recently_seen: VectorClock::new(change_set.vector_clock_id()),
+            vector_clock_write: VectorClock::new(change_set.vector_clock_id()),
             unprocessed_value,
             value,
             func_execution_pk: None,
@@ -96,56 +95,12 @@ impl AttributeValueNodeWeight {
         self.func_execution_pk
     }
 
-    pub fn increment_vector_clock(&mut self, change_set: &ChangeSet) -> NodeWeightResult<()> {
-        self.vector_clock_write.inc(change_set.vector_clock_id())?;
-        self.vector_clock_recently_seen
-            .inc(change_set.vector_clock_id())?;
-
-        Ok(())
-    }
-
     pub fn lineage_id(&self) -> Ulid {
         self.lineage_id
     }
 
-    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
-        self.vector_clock_recently_seen
-            .inc_to(vector_clock_id, seen_at);
-        if self
-            .vector_clock_first_seen
-            .entry_for(vector_clock_id)
-            .is_none()
-        {
-            self.vector_clock_first_seen
-                .inc_to(vector_clock_id, seen_at);
-        }
-    }
-
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
-        self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
-
-        Ok(())
-    }
-
     pub fn merkle_tree_hash(&self) -> MerkleTreeHash {
         self.merkle_tree_hash
-    }
-
-    pub fn new_with_incremented_vector_clock(
-        &self,
-        change_set: &ChangeSet,
-    ) -> NodeWeightResult<Self> {
-        let mut new_node_weight = self.clone();
-        new_node_weight.increment_vector_clock(change_set)?;
-
-        Ok(new_node_weight)
     }
 
     pub fn content_hash(&self) -> ContentHash {
@@ -163,45 +118,38 @@ impl AttributeValueNodeWeight {
         self.merkle_tree_hash = new_hash;
     }
 
-    pub fn set_vector_clock_recently_seen_to(
-        &mut self,
-        change_set: &ChangeSet,
-        new_val: DateTime<Utc>,
-    ) {
-        self.vector_clock_recently_seen
-            .inc_to(change_set.vector_clock_id(), new_val);
-    }
-
-    pub fn vector_clock_first_seen(&self) -> &VectorClock {
-        &self.vector_clock_first_seen
-    }
-
-    pub fn vector_clock_recently_seen(&self) -> &VectorClock {
-        &self.vector_clock_recently_seen
-    }
-
-    pub fn vector_clock_write(&self) -> &VectorClock {
-        &self.vector_clock_write
-    }
-
-    pub fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_first_seen
-    }
-
-    pub fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_recently_seen
-    }
-
-    pub fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_write
-    }
-
     pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
         &[
             EdgeWeightKindDiscriminants::Prototype,
             EdgeWeightKindDiscriminants::Prop,
             EdgeWeightKindDiscriminants::Socket,
         ]
+    }
+}
+
+impl HasVectorClocks for AttributeValueNodeWeight {
+    fn vector_clock_first_seen(&self) -> &VectorClock {
+        &self.vector_clock_first_seen
+    }
+
+    fn vector_clock_recently_seen(&self) -> &VectorClock {
+        &self.vector_clock_recently_seen
+    }
+
+    fn vector_clock_write(&self) -> &VectorClock {
+        &self.vector_clock_write
+    }
+
+    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
+        &mut self.vector_clock_first_seen
+    }
+
+    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
+        &mut self.vector_clock_recently_seen
+    }
+
+    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
+        &mut self.vector_clock_write
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
@@ -1,10 +1,9 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 use strum::{Display, EnumIter};
 
 use crate::change_set::ChangeSet;
-use crate::workspace_snapshot::vector_clock::VectorClockId;
+use crate::workspace_snapshot::vector_clock::HasVectorClocks;
 use crate::workspace_snapshot::{node_weight::NodeWeightResult, vector_clock::VectorClock};
 use crate::EdgeWeightKindDiscriminants;
 
@@ -56,53 +55,16 @@ impl CategoryNodeWeight {
         self.kind
     }
 
-    pub fn increment_seen_vector_clock(&mut self, change_set: &ChangeSet) -> NodeWeightResult<()> {
-        self.vector_clock_first_seen
-            .inc(change_set.vector_clock_id())?;
-
-        Ok(())
-    }
-
-    pub fn increment_vector_clock(&mut self, change_set: &ChangeSet) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .inc(change_set.vector_clock_id())
-            .map_err(Into::into)
-    }
-
     pub fn lineage_id(&self) -> Ulid {
         self.lineage_id
     }
 
-    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
-        self.vector_clock_recently_seen
-            .inc_to(vector_clock_id, seen_at);
-        if self
-            .vector_clock_first_seen
-            .entry_for(vector_clock_id)
-            .is_none()
-        {
-            self.vector_clock_first_seen
-                .inc_to(vector_clock_id, seen_at);
-        }
-    }
-
-    pub fn merge_clocks(
-        &mut self,
-        change_set: &ChangeSet,
-        other: &CategoryNodeWeight,
-    ) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), other.vector_clock_write())?;
-        self.vector_clock_first_seen.merge(
-            change_set.vector_clock_id(),
-            other.vector_clock_first_seen(),
-        )?;
-
-        Ok(())
-    }
-
     pub fn merkle_tree_hash(&self) -> MerkleTreeHash {
         self.merkle_tree_hash
+    }
+
+    pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {
+        self.merkle_tree_hash = new_hash;
     }
 
     pub fn new(change_set: &ChangeSet, kind: CategoryNodeKind) -> NodeWeightResult<Self> {
@@ -110,67 +72,46 @@ impl CategoryNodeWeight {
             id: change_set.generate_ulid()?,
             lineage_id: change_set.generate_ulid()?,
             kind,
-            vector_clock_write: VectorClock::new(change_set.vector_clock_id())?,
-            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id())?,
+            vector_clock_write: VectorClock::new(change_set.vector_clock_id()),
+            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id()),
             content_hash: ContentHash::from(&serde_json::json![kind]),
             merkle_tree_hash: Default::default(),
             vector_clock_recently_seen: Default::default(),
         })
     }
 
-    pub fn new_with_incremented_vector_clock(
-        &self,
-        change_set: &ChangeSet,
-    ) -> NodeWeightResult<Self> {
-        let mut new_category_node_weight = self.clone();
-        new_category_node_weight.increment_vector_clock(change_set)?;
-
-        Ok(new_category_node_weight)
-    }
-
     pub fn node_hash(&self) -> ContentHash {
         self.content_hash()
     }
 
-    pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {
-        self.merkle_tree_hash = new_hash;
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[]
     }
+}
 
-    pub fn set_vector_clock_recently_seen_to(
-        &mut self,
-        change_set: &ChangeSet,
-        new_val: DateTime<Utc>,
-    ) {
-        self.vector_clock_recently_seen
-            .inc_to(change_set.vector_clock_id(), new_val);
-    }
-
-    pub fn vector_clock_first_seen(&self) -> &VectorClock {
+impl HasVectorClocks for CategoryNodeWeight {
+    fn vector_clock_first_seen(&self) -> &VectorClock {
         &self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen(&self) -> &VectorClock {
+    fn vector_clock_recently_seen(&self) -> &VectorClock {
         &self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write(&self) -> &VectorClock {
+    fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
     }
 
-    pub fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_write
-    }
-
-    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
-        &[]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
@@ -7,7 +6,7 @@ use crate::{
     workspace_snapshot::{
         content_address::{ContentAddress, ContentAddressDiscriminants},
         graph::LineageId,
-        vector_clock::{VectorClock, VectorClockId},
+        vector_clock::{HasVectorClocks, VectorClock},
     },
     EdgeWeightKindDiscriminants,
 };
@@ -32,7 +31,7 @@ impl ComponentNodeWeight {
         id: Ulid,
         content_address: ContentAddress,
     ) -> NodeWeightResult<Self> {
-        let new_vector_clock = VectorClock::new(change_set.vector_clock_id())?;
+        let new_vector_clock = VectorClock::new(change_set.vector_clock_id());
 
         Ok(Self {
             id,
@@ -62,42 +61,8 @@ impl ComponentNodeWeight {
         self.id
     }
 
-    pub fn increment_vector_clock(&mut self, change_set: &ChangeSet) -> NodeWeightResult<()> {
-        self.vector_clock_write.inc(change_set.vector_clock_id())?;
-        self.vector_clock_recently_seen
-            .inc(change_set.vector_clock_id())?;
-
-        Ok(())
-    }
-
     pub fn lineage_id(&self) -> Ulid {
         self.lineage_id
-    }
-
-    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
-        self.vector_clock_recently_seen
-            .inc_to(vector_clock_id, seen_at);
-        if self
-            .vector_clock_first_seen
-            .entry_for(vector_clock_id)
-            .is_none()
-        {
-            self.vector_clock_first_seen
-                .inc_to(vector_clock_id, seen_at);
-        }
-    }
-
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
-        self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
-
-        Ok(())
     }
 
     pub fn merkle_tree_hash(&self) -> MerkleTreeHash {
@@ -129,16 +94,6 @@ impl ComponentNodeWeight {
         Ok(())
     }
 
-    pub fn new_with_incremented_vector_clock(
-        &self,
-        change_set: &ChangeSet,
-    ) -> NodeWeightResult<Self> {
-        let mut new_node_weight = self.clone();
-        new_node_weight.increment_vector_clock(change_set)?;
-
-        Ok(new_node_weight)
-    }
-
     pub fn node_hash(&self) -> ContentHash {
         ContentHash::from(&serde_json::json![{
             "content_address": self.content_address,
@@ -150,44 +105,37 @@ impl ComponentNodeWeight {
         self.merkle_tree_hash = new_hash;
     }
 
-    pub fn set_vector_clock_recently_seen_to(
-        &mut self,
-        change_set: &ChangeSet,
-        new_val: DateTime<Utc>,
-    ) {
-        self.vector_clock_recently_seen
-            .inc_to(change_set.vector_clock_id(), new_val);
-    }
-
-    pub fn vector_clock_first_seen(&self) -> &VectorClock {
-        &self.vector_clock_first_seen
-    }
-
-    pub fn vector_clock_recently_seen(&self) -> &VectorClock {
-        &self.vector_clock_recently_seen
-    }
-
-    pub fn vector_clock_write(&self) -> &VectorClock {
-        &self.vector_clock_write
-    }
-
-    pub fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_first_seen
-    }
-
-    pub fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_recently_seen
-    }
-
-    pub fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_write
-    }
-
     pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
         &[
             EdgeWeightKindDiscriminants::Use,
             EdgeWeightKindDiscriminants::Root,
             EdgeWeightKindDiscriminants::SocketValue,
         ]
+    }
+}
+
+impl HasVectorClocks for ComponentNodeWeight {
+    fn vector_clock_first_seen(&self) -> &VectorClock {
+        &self.vector_clock_first_seen
+    }
+
+    fn vector_clock_recently_seen(&self) -> &VectorClock {
+        &self.vector_clock_recently_seen
+    }
+
+    fn vector_clock_write(&self) -> &VectorClock {
+        &self.vector_clock_write
+    }
+
+    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
+        &mut self.vector_clock_first_seen
+    }
+
+    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
+        &mut self.vector_clock_recently_seen
+    }
+
+    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
+        &mut self.vector_clock_write
     }
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/dependent_value_root_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/dependent_value_root_node_weight.rs
@@ -1,8 +1,7 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
-use crate::workspace_snapshot::vector_clock::{VectorClock, VectorClockId};
+use crate::workspace_snapshot::vector_clock::{HasVectorClocks, VectorClock};
 use crate::{ChangeSet, EdgeWeightKindDiscriminants};
 
 use super::NodeWeightResult;
@@ -12,11 +11,7 @@ pub struct DependentValueRootNodeWeight {
     id: Ulid,
     lineage_id: Ulid,
     value_id: Ulid,
-    // how many times has this been re-enqueued before being processed. u16 is
-    // maybe small (65536 touches), although if that many snapshots are produced
-    // before a dependent value update processes this root, something has gone
-    // wrong.
-    pub touch_count: u16,
+    pub touch_count: u16, // unused
     merkle_tree_hash: MerkleTreeHash,
     vector_clock_first_seen: VectorClock,
     vector_clock_recently_seen: VectorClock,
@@ -40,45 +35,17 @@ impl DependentValueRootNodeWeight {
         self.value_id
     }
 
-    pub fn increment_seen_vector_clock(&mut self, change_set: &ChangeSet) -> NodeWeightResult<()> {
-        self.vector_clock_first_seen
-            .inc(change_set.vector_clock_id())?;
-
-        Ok(())
-    }
-
-    pub fn increment_vector_clock(&mut self, change_set: &ChangeSet) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .inc(change_set.vector_clock_id())
-            .map_err(Into::into)
-    }
-
     pub fn lineage_id(&self) -> Ulid {
         self.lineage_id
     }
 
-    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
-        self.vector_clock_recently_seen
-            .inc_to(vector_clock_id, seen_at);
-        if self
-            .vector_clock_first_seen
-            .entry_for(vector_clock_id)
-            .is_none()
-        {
-            self.vector_clock_first_seen
-                .inc_to(vector_clock_id, seen_at);
-        }
-    }
-
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
+    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) {
         self.vector_clock_write
-            .merge(change_set.vector_clock_id(), other.vector_clock_write())?;
+            .merge(change_set.vector_clock_id(), other.vector_clock_write());
         self.vector_clock_first_seen.merge(
             change_set.vector_clock_id(),
             other.vector_clock_first_seen(),
-        )?;
-
-        Ok(())
+        );
     }
 
     pub fn merkle_tree_hash(&self) -> MerkleTreeHash {
@@ -91,28 +58,11 @@ impl DependentValueRootNodeWeight {
             lineage_id: change_set.generate_ulid()?,
             value_id,
             touch_count: 0,
-            vector_clock_write: VectorClock::new(change_set.vector_clock_id())?,
-            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id())?,
+            vector_clock_write: VectorClock::new(change_set.vector_clock_id()),
+            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id()),
             merkle_tree_hash: Default::default(),
             vector_clock_recently_seen: Default::default(),
         })
-    }
-
-    pub fn touch(self, change_set: &ChangeSet) -> NodeWeightResult<Self> {
-        let mut new = self.new_with_incremented_vector_clock(change_set)?;
-        new.touch_count += 1;
-
-        Ok(new)
-    }
-
-    pub fn new_with_incremented_vector_clock(
-        &self,
-        change_set: &ChangeSet,
-    ) -> NodeWeightResult<Self> {
-        let mut new_node_weight = self.clone();
-        new_node_weight.increment_vector_clock(change_set)?;
-
-        Ok(new_node_weight)
     }
 
     pub fn node_hash(&self) -> ContentHash {
@@ -126,41 +76,34 @@ impl DependentValueRootNodeWeight {
         self.merkle_tree_hash = new_hash;
     }
 
-    pub fn set_vector_clock_recently_seen_to(
-        &mut self,
-        change_set: &ChangeSet,
-        new_val: DateTime<Utc>,
-    ) {
-        self.vector_clock_recently_seen
-            .inc_to(change_set.vector_clock_id(), new_val);
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[]
     }
+}
 
-    pub fn vector_clock_first_seen(&self) -> &VectorClock {
+impl HasVectorClocks for DependentValueRootNodeWeight {
+    fn vector_clock_first_seen(&self) -> &VectorClock {
         &self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen(&self) -> &VectorClock {
+    fn vector_clock_recently_seen(&self) -> &VectorClock {
         &self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write(&self) -> &VectorClock {
+    fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
     }
 
-    pub fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_write
-    }
-
-    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
-        &[]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
@@ -8,7 +7,7 @@ use crate::{
         content_address::{ContentAddress, ContentAddressDiscriminants},
         graph::LineageId,
         node_weight::NodeWeightResult,
-        vector_clock::{VectorClock, VectorClockId},
+        vector_clock::{HasVectorClocks, VectorClock},
         NodeWeightError,
     },
     EdgeWeightKindDiscriminants,
@@ -39,9 +38,9 @@ impl FuncArgumentNodeWeight {
             content_address,
             merkle_tree_hash: MerkleTreeHash::default(),
             name,
-            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id())?,
-            vector_clock_recently_seen: VectorClock::new(change_set.vector_clock_id())?,
-            vector_clock_write: VectorClock::new(change_set.vector_clock_id())?,
+            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id()),
+            vector_clock_recently_seen: VectorClock::new(change_set.vector_clock_id()),
+            vector_clock_write: VectorClock::new(change_set.vector_clock_id()),
         })
     }
 
@@ -61,42 +60,8 @@ impl FuncArgumentNodeWeight {
         self.id
     }
 
-    pub fn increment_vector_clock(&mut self, change_set: &ChangeSet) -> NodeWeightResult<()> {
-        self.vector_clock_write.inc(change_set.vector_clock_id())?;
-        self.vector_clock_recently_seen
-            .inc(change_set.vector_clock_id())?;
-
-        Ok(())
-    }
-
     pub fn lineage_id(&self) -> Ulid {
         self.lineage_id
-    }
-
-    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
-        self.vector_clock_recently_seen
-            .inc_to(vector_clock_id, seen_at);
-        if self
-            .vector_clock_first_seen
-            .entry_for(vector_clock_id)
-            .is_none()
-        {
-            self.vector_clock_first_seen
-                .inc_to(vector_clock_id, seen_at);
-        }
-    }
-
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
-        self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
-
-        Ok(())
     }
 
     pub fn merkle_tree_hash(&self) -> MerkleTreeHash {
@@ -128,16 +93,6 @@ impl FuncArgumentNodeWeight {
         Ok(())
     }
 
-    pub fn new_with_incremented_vector_clock(
-        &self,
-        change_set: &ChangeSet,
-    ) -> NodeWeightResult<Self> {
-        let mut new_node_weight = self.clone();
-        new_node_weight.increment_vector_clock(change_set)?;
-
-        Ok(new_node_weight)
-    }
-
     pub fn node_hash(&self) -> ContentHash {
         ContentHash::from(&serde_json::json![{
             "content_address": self.content_address,
@@ -149,41 +104,34 @@ impl FuncArgumentNodeWeight {
         self.merkle_tree_hash = new_hash;
     }
 
-    pub fn set_vector_clock_recently_seen_to(
-        &mut self,
-        change_set: &ChangeSet,
-        new_val: DateTime<Utc>,
-    ) {
-        self.vector_clock_recently_seen
-            .inc_to(change_set.vector_clock_id(), new_val);
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[]
     }
+}
 
-    pub fn vector_clock_first_seen(&self) -> &VectorClock {
+impl HasVectorClocks for FuncArgumentNodeWeight {
+    fn vector_clock_first_seen(&self) -> &VectorClock {
         &self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen(&self) -> &VectorClock {
+    fn vector_clock_recently_seen(&self) -> &VectorClock {
         &self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write(&self) -> &VectorClock {
+    fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
     }
 
-    pub fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_write
-    }
-
-    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
-        &[]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
@@ -1,10 +1,9 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::func::FuncKind;
 use crate::workspace_snapshot::content_address::ContentAddressDiscriminants;
-use crate::workspace_snapshot::vector_clock::VectorClockId;
+use crate::workspace_snapshot::vector_clock::HasVectorClocks;
 use crate::EdgeWeightKindDiscriminants;
 use crate::{
     change_set::ChangeSet,
@@ -44,9 +43,9 @@ impl FuncNodeWeight {
             merkle_tree_hash: MerkleTreeHash::default(),
             name,
             func_kind,
-            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id())?,
-            vector_clock_recently_seen: VectorClock::new(change_set.vector_clock_id())?,
-            vector_clock_write: VectorClock::new(change_set.vector_clock_id())?,
+            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id()),
+            vector_clock_recently_seen: VectorClock::new(change_set.vector_clock_id()),
+            vector_clock_write: VectorClock::new(change_set.vector_clock_id()),
         })
     }
 
@@ -66,42 +65,8 @@ impl FuncNodeWeight {
         self.id
     }
 
-    pub fn increment_vector_clock(&mut self, change_set: &ChangeSet) -> NodeWeightResult<()> {
-        self.vector_clock_write.inc(change_set.vector_clock_id())?;
-        self.vector_clock_recently_seen
-            .inc(change_set.vector_clock_id())?;
-
-        Ok(())
-    }
-
     pub fn lineage_id(&self) -> Ulid {
         self.lineage_id
-    }
-
-    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
-        self.vector_clock_recently_seen
-            .inc_to(vector_clock_id, seen_at);
-        if self
-            .vector_clock_first_seen
-            .entry_for(vector_clock_id)
-            .is_none()
-        {
-            self.vector_clock_first_seen
-                .inc_to(vector_clock_id, seen_at);
-        }
-    }
-
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
-        self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
-
-        Ok(())
     }
 
     pub fn merkle_tree_hash(&self) -> MerkleTreeHash {
@@ -142,16 +107,6 @@ impl FuncNodeWeight {
         Ok(())
     }
 
-    pub fn new_with_incremented_vector_clock(
-        &self,
-        change_set: &ChangeSet,
-    ) -> NodeWeightResult<Self> {
-        let mut new_node_weight = self.clone();
-        new_node_weight.increment_vector_clock(change_set)?;
-
-        Ok(new_node_weight)
-    }
-
     pub fn node_hash(&self) -> ContentHash {
         ContentHash::from(&serde_json::json![{
             "content_address": self.content_address,
@@ -164,41 +119,34 @@ impl FuncNodeWeight {
         self.merkle_tree_hash = new_hash;
     }
 
-    pub fn set_vector_clock_recently_seen_to(
-        &mut self,
-        change_set: &ChangeSet,
-        new_val: DateTime<Utc>,
-    ) {
-        self.vector_clock_recently_seen
-            .inc_to(change_set.vector_clock_id(), new_val);
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[]
     }
+}
 
-    pub fn vector_clock_first_seen(&self) -> &VectorClock {
+impl HasVectorClocks for FuncNodeWeight {
+    fn vector_clock_first_seen(&self) -> &VectorClock {
         &self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen(&self) -> &VectorClock {
+    fn vector_clock_recently_seen(&self) -> &VectorClock {
         &self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write(&self) -> &VectorClock {
+    fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
     }
 
-    pub fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_write
-    }
-
-    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
-        &[]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
@@ -1,9 +1,8 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::workspace_snapshot::content_address::ContentAddressDiscriminants;
-use crate::workspace_snapshot::vector_clock::VectorClockId;
+use crate::workspace_snapshot::vector_clock::HasVectorClocks;
 use crate::EdgeWeightKindDiscriminants;
 use crate::{
     change_set::ChangeSet,
@@ -46,9 +45,9 @@ impl PropNodeWeight {
             kind,
             name,
             can_be_used_as_prototype_arg: false,
-            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id())?,
-            vector_clock_recently_seen: VectorClock::new(change_set.vector_clock_id())?,
-            vector_clock_write: VectorClock::new(change_set.vector_clock_id())?,
+            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id()),
+            vector_clock_recently_seen: VectorClock::new(change_set.vector_clock_id()),
+            vector_clock_write: VectorClock::new(change_set.vector_clock_id()),
         })
     }
 
@@ -80,46 +79,16 @@ impl PropNodeWeight {
         self.id
     }
 
-    pub fn increment_vector_clock(&mut self, change_set: &ChangeSet) -> NodeWeightResult<()> {
-        self.vector_clock_write.inc(change_set.vector_clock_id())?;
-        self.vector_clock_recently_seen
-            .inc(change_set.vector_clock_id())?;
-
-        Ok(())
-    }
-
     pub fn lineage_id(&self) -> Ulid {
         self.lineage_id
     }
 
-    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
-        self.vector_clock_recently_seen
-            .inc_to(vector_clock_id, seen_at);
-        if self
-            .vector_clock_first_seen
-            .entry_for(vector_clock_id)
-            .is_none()
-        {
-            self.vector_clock_first_seen
-                .inc_to(vector_clock_id, seen_at);
-        }
-    }
-
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
-        self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
-
-        Ok(())
-    }
-
     pub fn merkle_tree_hash(&self) -> MerkleTreeHash {
         self.merkle_tree_hash
+    }
+
+    pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {
+        self.merkle_tree_hash = new_hash;
     }
 
     pub fn name(&self) -> &str {
@@ -142,16 +111,6 @@ impl PropNodeWeight {
         Ok(())
     }
 
-    pub fn new_with_incremented_vector_clock(
-        &self,
-        change_set: &ChangeSet,
-    ) -> NodeWeightResult<Self> {
-        let mut new_node_weight = self.clone();
-        new_node_weight.increment_vector_clock(change_set)?;
-
-        Ok(new_node_weight)
-    }
-
     pub fn node_hash(&self) -> ContentHash {
         ContentHash::from(&serde_json::json![{
             "content_address": self.content_address,
@@ -160,45 +119,34 @@ impl PropNodeWeight {
         }])
     }
 
-    pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {
-        self.merkle_tree_hash = new_hash;
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[]
     }
+}
 
-    pub fn set_vector_clock_recently_seen_to(
-        &mut self,
-        change_set: &ChangeSet,
-        new_val: DateTime<Utc>,
-    ) {
-        self.vector_clock_recently_seen
-            .inc_to(change_set.vector_clock_id(), new_val);
-    }
-
-    pub fn vector_clock_first_seen(&self) -> &VectorClock {
+impl HasVectorClocks for PropNodeWeight {
+    fn vector_clock_first_seen(&self) -> &VectorClock {
         &self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen(&self) -> &VectorClock {
+    fn vector_clock_recently_seen(&self) -> &VectorClock {
         &self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write(&self) -> &VectorClock {
+    fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
     }
 
-    pub fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_write
-    }
-
-    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
-        &[]
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
@@ -1,9 +1,8 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash, EncryptedSecretKey};
 
 use crate::workspace_snapshot::content_address::ContentAddressDiscriminants;
-use crate::workspace_snapshot::vector_clock::VectorClockId;
+use crate::workspace_snapshot::vector_clock::HasVectorClocks;
 use crate::EdgeWeightKindDiscriminants;
 use crate::{
     change_set::ChangeSet,
@@ -39,9 +38,9 @@ impl SecretNodeWeight {
             lineage_id: change_set.generate_ulid()?,
             content_address,
             merkle_tree_hash: MerkleTreeHash::default(),
-            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id())?,
-            vector_clock_recently_seen: VectorClock::new(change_set.vector_clock_id())?,
-            vector_clock_write: VectorClock::new(change_set.vector_clock_id())?,
+            vector_clock_first_seen: VectorClock::new(change_set.vector_clock_id()),
+            vector_clock_recently_seen: VectorClock::new(change_set.vector_clock_id()),
+            vector_clock_write: VectorClock::new(change_set.vector_clock_id()),
             encrypted_secret_key,
         })
     }
@@ -62,42 +61,8 @@ impl SecretNodeWeight {
         self.id
     }
 
-    pub fn increment_vector_clock(&mut self, change_set: &ChangeSet) -> NodeWeightResult<()> {
-        self.vector_clock_write.inc(change_set.vector_clock_id())?;
-        self.vector_clock_recently_seen
-            .inc(change_set.vector_clock_id())?;
-
-        Ok(())
-    }
-
     pub fn lineage_id(&self) -> Ulid {
         self.lineage_id
-    }
-
-    pub fn mark_seen_at(&mut self, vector_clock_id: VectorClockId, seen_at: DateTime<Utc>) {
-        self.vector_clock_recently_seen
-            .inc_to(vector_clock_id, seen_at);
-        if self
-            .vector_clock_first_seen
-            .entry_for(vector_clock_id)
-            .is_none()
-        {
-            self.vector_clock_first_seen
-                .inc_to(vector_clock_id, seen_at);
-        }
-    }
-
-    pub fn merge_clocks(&mut self, change_set: &ChangeSet, other: &Self) -> NodeWeightResult<()> {
-        self.vector_clock_write
-            .merge(change_set.vector_clock_id(), &other.vector_clock_write)?;
-        self.vector_clock_first_seen
-            .merge(change_set.vector_clock_id(), &other.vector_clock_first_seen)?;
-        self.vector_clock_recently_seen.merge(
-            change_set.vector_clock_id(),
-            &other.vector_clock_recently_seen,
-        )?;
-
-        Ok(())
     }
 
     pub fn merkle_tree_hash(&self) -> MerkleTreeHash {
@@ -132,16 +97,6 @@ impl SecretNodeWeight {
         Ok(())
     }
 
-    pub fn new_with_incremented_vector_clock(
-        &self,
-        change_set: &ChangeSet,
-    ) -> NodeWeightResult<Self> {
-        let mut new_node_weight = self.clone();
-        new_node_weight.increment_vector_clock(change_set)?;
-
-        Ok(new_node_weight)
-    }
-
     pub fn node_hash(&self) -> ContentHash {
         ContentHash::from(&serde_json::json![{
             "content_address": self.content_address,
@@ -153,41 +108,34 @@ impl SecretNodeWeight {
         self.merkle_tree_hash = new_hash;
     }
 
-    pub fn set_vector_clock_recently_seen_to(
-        &mut self,
-        change_set: &ChangeSet,
-        new_val: DateTime<Utc>,
-    ) {
-        self.vector_clock_recently_seen
-            .inc_to(change_set.vector_clock_id(), new_val);
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[EdgeWeightKindDiscriminants::Use]
     }
+}
 
-    pub fn vector_clock_first_seen(&self) -> &VectorClock {
+impl HasVectorClocks for SecretNodeWeight {
+    fn vector_clock_first_seen(&self) -> &VectorClock {
         &self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen(&self) -> &VectorClock {
+    fn vector_clock_recently_seen(&self) -> &VectorClock {
         &self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write(&self) -> &VectorClock {
+    fn vector_clock_write(&self) -> &VectorClock {
         &self.vector_clock_write
     }
 
-    pub fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_first_seen
     }
 
-    pub fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_recently_seen
     }
 
-    pub fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
+    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
         &mut self.vector_clock_write
-    }
-
-    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
-        &[EdgeWeightKindDiscriminants::Use]
     }
 }
 

--- a/lib/si-events-rs/src/lib.rs
+++ b/lib/si-events-rs/src/lib.rs
@@ -11,6 +11,7 @@ mod func_execution;
 mod func_run;
 mod func_run_log;
 mod tenancy;
+mod vector_clock_id;
 mod web_event;
 
 pub use crate::{
@@ -29,6 +30,7 @@ pub use crate::{
     tenancy::ChangeSetId,
     tenancy::Tenancy,
     tenancy::WorkspacePk,
+    vector_clock_id::{VectorClockActorId, VectorClockChangeSetId, VectorClockId},
     web_event::WebEvent,
     workspace_snapshot_address::WorkspaceSnapshotAddress,
 };

--- a/lib/si-events-rs/src/ulid.rs
+++ b/lib/si-events-rs/src/ulid.rs
@@ -1,5 +1,5 @@
-use ulid::Ulid as CoreUlid;
 pub use ulid::ULID_LEN;
+use ulid::{DecodeError, Ulid as CoreUlid};
 
 /// Size is the size in bytes, len is the string length
 const ULID_SIZE: usize = 16;
@@ -15,6 +15,13 @@ impl Ulid {
     pub fn inner(&self) -> CoreUlid {
         self.0
     }
+
+    pub fn from_string(encoded: &str) -> Result<Self, DecodeError> {
+        match CoreUlid::from_string(encoded) {
+            Ok(ulid) => Ok(ulid.into()),
+            Err(err) => Err(err),
+        }
+    }
 }
 struct UlidVisitor;
 
@@ -22,7 +29,7 @@ impl<'de> ::serde::de::Visitor<'de> for UlidVisitor {
     type Value = Ulid;
 
     fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        formatter.write_str("a 16 byte slice representing an xxh3 hash")
+        formatter.write_str("a 16 byte slice representing a Ulid")
     }
 
     fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
@@ -62,7 +69,7 @@ impl ::serde::Serialize for Ulid {
 
 impl std::fmt::Display for Ulid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Ulid({})", self.0.to_string())
+        write!(f, "{}", self.0.to_string())
     }
 }
 

--- a/lib/si-events-rs/src/vector_clock_id.rs
+++ b/lib/si-events-rs/src/vector_clock_id.rs
@@ -1,0 +1,77 @@
+use serde::{Deserialize, Serialize};
+
+use crate::ulid::Ulid;
+
+#[derive(Serialize, Deserialize, Hash, PartialEq, Eq, Clone, Copy, Debug)]
+pub struct VectorClockChangeSetId(Ulid);
+
+impl std::fmt::Display for VectorClockChangeSetId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Serialize, Deserialize, Hash, PartialEq, Eq, Clone, Copy, Debug)]
+pub struct VectorClockActorId(Ulid);
+
+impl std::fmt::Display for VectorClockActorId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Serialize, Deserialize, Hash, PartialEq, Eq, Clone, Copy, Debug)]
+pub struct VectorClockId {
+    change_set_id: VectorClockChangeSetId,
+    actor_id: VectorClockActorId,
+}
+
+impl std::fmt::Display for VectorClockId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "(ChangeSet({}), Actor({}))",
+            self.change_set_id, self.actor_id
+        )
+    }
+}
+
+impl VectorClockId {
+    pub fn new(change_set_id: VectorClockChangeSetId, actor_id: VectorClockActorId) -> Self {
+        Self {
+            change_set_id,
+            actor_id,
+        }
+    }
+
+    pub fn change_set_id(&self) -> VectorClockChangeSetId {
+        self.change_set_id
+    }
+
+    pub fn actor_id(&self) -> VectorClockActorId {
+        self.actor_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display() {
+        let cs_text = "01D39ZY06FGSCTVN4T2V9PKHFZ";
+        let actor_text = "00000000000000000000000000";
+
+        let change_set_ulid = Ulid::from_string(cs_text).expect("make ulid from string");
+        let actor_ulid = Ulid::from_string(actor_text).expect("make actor from string");
+
+        let vector_clock_id = VectorClockId::new(
+            VectorClockChangeSetId(change_set_ulid),
+            VectorClockActorId(actor_ulid),
+        );
+
+        let expected = format!("(ChangeSet({cs_text}), Actor({actor_text}))");
+        let display = format!("{vector_clock_id}");
+        assert_eq!(expected, display);
+    }
+}


### PR DESCRIPTION
Introduces a HasVectorClocks trait that handles vector clock operations that are the same across all types that use vector clocks, to reduce the chance of bugs in different vector clock operations and make it easier to change the vector clock id.