### PR TITLE
feat: push scripts file into cyclone jails

### DIFF
--- a/bin/veritech/scripts/prepare_jailer.sh
+++ b/bin/veritech/scripts/prepare_jailer.sh
@@ -29,6 +29,7 @@ JAILER_BINARY="/usr/bin/jailer"
 
 ROOTFS="rootfs.ext4"
 KERNEL="image-kernel.bin"
+SCRIPTS="scripts"
 
 RO_DRIVE="$DATA_DIR/$ROOTFS"
 KERNEL_IMG="$DATA_DIR/$KERNEL"
@@ -66,6 +67,7 @@ rm -rf "$JAIL/{dev,run}"
 
 touch $JAIL/logs
 touch $JAIL/metrics
+cp $DATA_DIR/$SCRIPTS $JAIL
 
 function kernel_prep() {
   cp $KERNEL_IMG "$JAIL/$KERNEL"
@@ -159,7 +161,8 @@ fi
 ##########        Firecracker Prep       #########
 ########## ############################# #########
 
-cat << EOF > $JAIL/firecracker.conf
+{
+cat << EOF
 {
   "boot-source": {
     "kernel_image_path": "./$KERNEL",
@@ -171,7 +174,22 @@ cat << EOF > $JAIL/firecracker.conf
       "is_root_device": true,
       "is_read_only": false,
       "path_on_host": "./rootfs.ext4"
+    },
+EOF
+
+if [ -e $JAIL/$SCRIPTS ]; then
+
+cat << EOF
+    {
+      "drive_id": "2",
+      "is_root_device": false,
+      "is_read_only": true,
+      "path_on_host": "./scripts"
     }
+EOF
+fi
+
+cat << EOF
   ],
   "machine-config": {
     "vcpu_count": 4,
@@ -197,3 +215,4 @@ cat << EOF > $JAIL/firecracker.conf
   }
 }
 EOF
+} > $JAIL/firecracker.conf

--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -132,7 +132,7 @@ sed -i 's/root:*::0:::::/root:::0:::::/g' /etc/shadow
 
 # mount decryption key volume
 cat <<EOV >>"/etc/fstab"
-LABEL=dkey     /mnt/dkey    ext4   defaults 0 0
+LABEL=scripts     /mnt/scripts    ext4   defaults 0 0
 EOV
 
 # autostart cyclone
@@ -146,6 +146,7 @@ pidfile="/cyclone/agent.pid"
 
 start(){
   export OTEL_EXPORTER_OTLP_ENDPOINT=http://1.0.0.1:4316
+  source /mnt/scripts/scripts
   cyclone ${cyclone_args[*]} >> /var/log/cyclone.log 2>&1 &
 }
 


### PR DESCRIPTION
This allows us to push arbitrary scripts into Firecracker Jails that will be executed just before Cyclone starts. The use case for this today is to push AWS credentials into a known location so we can use them to assume roles across accounts.

<img src="https://media3.giphy.com/media/26tn33aiTi1jkl6H6/giphy.gif"/>