### PR TITLE
Add regression test for existing code gen funcs and new variants

### DIFF
--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -313,7 +313,7 @@ impl Func {
         Ok(Self::assemble(func_node_weight, &inner))
     }
 
-    pub async fn find_by_name(
+    pub async fn find_id_by_name(
         ctx: &DalContext,
         name: impl AsRef<str>,
     ) -> FuncResult<Option<FuncId>> {
@@ -514,7 +514,7 @@ impl Func {
 
     pub async fn find_intrinsic(ctx: &DalContext, intrinsic: IntrinsicFunc) -> FuncResult<FuncId> {
         let name = intrinsic.name();
-        Self::find_by_name(ctx, name)
+        Self::find_id_by_name(ctx, name)
             .await?
             .ok_or(FuncError::IntrinsicFuncNotFound(name.to_owned()))
     }

--- a/lib/dal/src/func/authoring/create.rs
+++ b/lib/dal/src/func/authoring/create.rs
@@ -277,7 +277,7 @@ async fn create_func_stub(
     handler: &str,
 ) -> FuncAuthoringResult<Func> {
     let name = name.unwrap_or(generate_name());
-    if Func::find_by_name(ctx, &name).await?.is_some() {
+    if Func::find_id_by_name(ctx, &name).await?.is_some() {
         return Err(FuncAuthoringError::FuncNameExists(name));
     }
 

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -940,7 +940,7 @@ impl PkgExporter {
             let intrinsic_name = intrinsic.name();
             // We need a unique id for intrinsic funcs to refer to them in custom bindings (for example
             // mapping one prop to another via si:identity)
-            let intrinsic_func_id = Func::find_by_name(ctx, intrinsic_name)
+            let intrinsic_func_id = Func::find_id_by_name(ctx, intrinsic_name)
                 .await?
                 .ok_or(PkgError::MissingIntrinsicFunc(intrinsic_name.to_string()))?;
 
@@ -1021,7 +1021,7 @@ impl PkgExporter {
     async fn export_intrinsics(&mut self, ctx: &DalContext) -> PkgResult<Vec<FuncSpec>> {
         let mut funcs = vec![];
         for instrinsic in IntrinsicFunc::iter() {
-            let intrinsic_func_id = Func::find_by_name(ctx, instrinsic.name()).await?.ok_or(
+            let intrinsic_func_id = Func::find_id_by_name(ctx, instrinsic.name()).await?.ok_or(
                 PkgError::MissingIntrinsicFunc(instrinsic.name().to_string()),
             )?;
 

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -87,7 +87,7 @@ async fn import_change_set(
         // packages. We also apply this to si:resourcePayloadToValue since it should be an
         // intrinsic but is only in our packages
         if func::is_intrinsic(func_spec.name()) || SPECIAL_CASE_FUNCS.contains(&func_spec.name()) {
-            if let Some(func_id) = Func::find_by_name(ctx, func_spec.name()).await? {
+            if let Some(func_id) = Func::find_id_by_name(ctx, func_spec.name()).await? {
                 let func = Func::get_by_id_or_error(ctx, func_id).await?;
 
                 thing_map.insert(unique_id.to_owned(), Thing::Func(func.to_owned()));
@@ -903,7 +903,7 @@ pub async fn clone_and_import_funcs(
         let func = if func::is_intrinsic(func_spec.name())
             || SPECIAL_CASE_FUNCS.contains(&func_spec.name())
         {
-            let func_id = Func::find_by_name(ctx, &func_spec.name())
+            let func_id = Func::find_id_by_name(ctx, &func_spec.name())
                 .await?
                 .ok_or(PkgError::MissingIntrinsicFunc(func_spec.name().to_owned()))?;
 
@@ -1617,7 +1617,7 @@ pub async fn attach_resource_payload_to_value(
     ctx: &DalContext,
     schema_variant_id: SchemaVariantId,
 ) -> PkgResult<()> {
-    let func_id = Func::find_by_name(ctx, "si:resourcePayloadToValue")
+    let func_id = Func::find_id_by_name(ctx, "si:resourcePayloadToValue")
         .await?
         .ok_or(PkgError::FuncNotFoundByName(
             "si:resourcePayloadToValue".into(),

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -17,7 +17,7 @@ async fn find_for_prop(ctx: &mut DalContext) {
     let func_name = "test:generateCode";
 
     // Find the sole attribute prototype via its func. Ensure that we find one and only one.
-    let func_id = Func::find_by_name(ctx, func_name)
+    let func_id = Func::find_id_by_name(ctx, func_name)
         .await
         .expect("could not perform find by name")
         .expect("func not found");

--- a/lib/dal/tests/integration_test/func/argument.rs
+++ b/lib/dal/tests/integration_test/func/argument.rs
@@ -7,7 +7,7 @@ use pretty_assertions_sorted::assert_eq;
 
 #[test]
 async fn modify(ctx: &mut DalContext) {
-    let func_id = Func::find_by_name(ctx, "test:falloutEntriesToGalaxies")
+    let func_id = Func::find_id_by_name(ctx, "test:falloutEntriesToGalaxies")
         .await
         .expect("could not perform find by name")
         .expect("no func found");
@@ -43,7 +43,7 @@ async fn modify(ctx: &mut DalContext) {
 
 #[test]
 async fn list_attribute_prototype_argument_ids(ctx: &DalContext) {
-    let func_id = Func::find_by_name(ctx, "test:falloutEntriesToGalaxies")
+    let func_id = Func::find_id_by_name(ctx, "test:falloutEntriesToGalaxies")
         .await
         .expect("could not perform find by name")
         .expect("no func found");

--- a/lib/dal/tests/integration_test/func/associations.rs
+++ b/lib/dal/tests/integration_test/func/associations.rs
@@ -20,7 +20,7 @@ async fn for_action(ctx: &mut DalContext) {
         .expect("could not perform get default schema variant")
         .expect("default schema variant not found");
 
-    let func_id = Func::find_by_name(ctx, "test:createActionSwifty")
+    let func_id = Func::find_id_by_name(ctx, "test:createActionSwifty")
         .await
         .expect("could not perform find func by name")
         .expect("func not found");
@@ -42,7 +42,7 @@ async fn for_action(ctx: &mut DalContext) {
 
 #[test]
 async fn for_attribute_with_input_socket_input(ctx: &mut DalContext) {
-    let func_id = Func::find_by_name(ctx, "test:falloutEntriesToGalaxies")
+    let func_id = Func::find_id_by_name(ctx, "test:falloutEntriesToGalaxies")
         .await
         .expect("could not perform find func by name")
         .expect("func not found");
@@ -140,7 +140,7 @@ async fn for_attribute_with_input_socket_input(ctx: &mut DalContext) {
 
 #[test]
 async fn for_attribute_with_prop_input(ctx: &mut DalContext) {
-    let func_id = Func::find_by_name(ctx, "hesperus_is_phosphorus")
+    let func_id = Func::find_id_by_name(ctx, "hesperus_is_phosphorus")
         .await
         .expect("could not perform find func by name")
         .expect("func not found");
@@ -262,7 +262,7 @@ async fn for_authentication(ctx: &mut DalContext) {
         .expect("could not perform get default schema variant")
         .expect("default schema variant not found");
 
-    let func_id = Func::find_by_name(ctx, "test:setDummySecretString")
+    let func_id = Func::find_id_by_name(ctx, "test:setDummySecretString")
         .await
         .expect("could not perform find func by name")
         .expect("func not found");
@@ -293,7 +293,7 @@ async fn for_code_generation(ctx: &mut DalContext) {
         .expect("could not perform get default schema variant")
         .expect("default schema variant not found");
 
-    let func_id = Func::find_by_name(ctx, "test:generateStringCode")
+    let func_id = Func::find_id_by_name(ctx, "test:generateStringCode")
         .await
         .expect("could not perform find func by name")
         .expect("func not found");
@@ -326,7 +326,7 @@ async fn for_qualification(ctx: &mut DalContext) {
         .expect("could not perform get default schema variant")
         .expect("default schema variant not found");
 
-    let func_id = Func::find_by_name(ctx, "test:qualificationDummySecretStringIsTodd")
+    let func_id = Func::find_id_by_name(ctx, "test:qualificationDummySecretStringIsTodd")
         .await
         .expect("could not perform find func by name")
         .expect("func not found");

--- a/lib/dal/tests/integration_test/func/authoring/create_func.rs
+++ b/lib/dal/tests/integration_test/func/authoring/create_func.rs
@@ -45,7 +45,7 @@ async fn create_qualification_no_options(ctx: &mut DalContext) {
         .await
         .expect("Unable to go back to HEAD");
 
-    let head_func = Func::find_by_name(ctx, func_name.clone())
+    let head_func = Func::find_id_by_name(ctx, func_name.clone())
         .await
         .expect("Unable to get a func");
     assert!(head_func.is_none());
@@ -103,7 +103,7 @@ async fn create_qualification_with_schema_variant(ctx: &mut DalContext) {
         .await
         .expect("Unable to go back to HEAD");
 
-    let head_func = Func::find_by_name(ctx, func_name.clone())
+    let head_func = Func::find_id_by_name(ctx, func_name.clone())
         .await
         .expect("Unable to get a func");
     assert!(head_func.is_none());
@@ -135,7 +135,7 @@ async fn create_codegen_no_options(ctx: &mut DalContext) {
         .await
         .expect("Unable to go back to HEAD");
 
-    let head_func = Func::find_by_name(ctx, func_name.clone())
+    let head_func = Func::find_id_by_name(ctx, func_name.clone())
         .await
         .expect("Unable to get a func");
     assert!(head_func.is_none());
@@ -193,7 +193,7 @@ async fn create_codegen_with_schema_variant(ctx: &mut DalContext) {
         .await
         .expect("Unable to go back to HEAD");
 
-    let head_func = Func::find_by_name(ctx, func_name.clone())
+    let head_func = Func::find_id_by_name(ctx, func_name.clone())
         .await
         .expect("Unable to get a func");
     assert!(head_func.is_none());
@@ -226,7 +226,7 @@ async fn create_attribute_no_options(ctx: &mut DalContext) {
         .await
         .expect("Unable to go back to HEAD");
 
-    let head_func = Func::find_by_name(ctx, func_name.clone())
+    let head_func = Func::find_id_by_name(ctx, func_name.clone())
         .await
         .expect("Unable to get a func");
     assert!(head_func.is_none());
@@ -297,7 +297,7 @@ async fn create_attribute_override_dynamic_func_for_prop(ctx: &mut DalContext) {
     ctx.update_visibility_and_snapshot_to_visibility_no_editing_change_set(head_change_set)
         .await
         .expect("Unable to go back to HEAD");
-    let head_func = Func::find_by_name(ctx, func_name)
+    let head_func = Func::find_id_by_name(ctx, func_name)
         .await
         .expect("Unable to get a func");
     assert!(head_func.is_none());
@@ -367,7 +367,7 @@ async fn create_attribute_override_dynamic_func_for_output_socket(ctx: &mut DalC
     ctx.update_visibility_and_snapshot_to_visibility_no_editing_change_set(head_change_set)
         .await
         .expect("Unable to go back to HEAD");
-    let head_func = Func::find_by_name(ctx, func_name)
+    let head_func = Func::find_id_by_name(ctx, func_name)
         .await
         .expect("Unable to get a func");
     assert!(head_func.is_none());
@@ -398,7 +398,7 @@ async fn create_action_no_options(ctx: &mut DalContext) {
         .await
         .expect("Unable to go back to HEAD");
 
-    let head_func = Func::find_by_name(ctx, func_name.clone())
+    let head_func = Func::find_id_by_name(ctx, func_name.clone())
         .await
         .expect("Unable to get a func");
     assert!(head_func.is_none());
@@ -462,7 +462,7 @@ async fn create_action_with_schema_variant(ctx: &mut DalContext) {
         .await
         .expect("Unable to go back to HEAD");
 
-    let head_func = Func::find_by_name(ctx, func_name.clone())
+    let head_func = Func::find_id_by_name(ctx, func_name.clone())
         .await
         .expect("Unable to get a func");
     assert!(head_func.is_none());

--- a/lib/dal/tests/integration_test/func/authoring/save_and_exec.rs
+++ b/lib/dal/tests/integration_test/func/authoring/save_and_exec.rs
@@ -7,7 +7,7 @@ use dal_test::test;
 #[test]
 async fn save_and_exec_action_func(ctx: &mut DalContext) {
     let func_name = "test:createActionStarfield";
-    let func_id = Func::find_by_name(ctx, func_name)
+    let func_id = Func::find_id_by_name(ctx, func_name)
         .await
         .expect("could not perform find func by name")
         .expect("no func found");
@@ -42,7 +42,7 @@ async fn save_and_exec_action_func(ctx: &mut DalContext) {
 #[test]
 async fn save_and_exec_attribute_func(ctx: &mut DalContext) {
     let func_name = "test:falloutEntriesToGalaxies";
-    let func_id = Func::find_by_name(ctx, func_name)
+    let func_id = Func::find_id_by_name(ctx, func_name)
         .await
         .expect("could not perform find func by name")
         .expect("no func found");

--- a/lib/dal/tests/integration_test/func/authoring/save_func.rs
+++ b/lib/dal/tests/integration_test/func/authoring/save_func.rs
@@ -33,7 +33,7 @@ async fn qualification(ctx: &mut DalContext) {
 // Sets up the tests within the module. Find the func to be saved by name and then save it
 // immediately when found. This is the basic "does it work in place" check.
 async fn save_func_setup(ctx: &mut DalContext, func_name: impl AsRef<str>) -> (FuncId, FuncView) {
-    let func_id = Func::find_by_name(ctx, func_name)
+    let func_id = Func::find_id_by_name(ctx, func_name)
         .await
         .expect("could not perform find func by name")
         .expect("no func found");

--- a/lib/dal/tests/integration_test/func/authoring/save_func/attach.rs
+++ b/lib/dal/tests/integration_test/func/authoring/save_func/attach.rs
@@ -24,7 +24,7 @@ async fn attach_multiple_action_funcs(ctx: &mut DalContext) {
     let total_funcs = funcs.len();
 
     // Attach one action func to the schema variant and commit.
-    let func_id = Func::find_by_name(ctx, "test:createActionFallout")
+    let func_id = Func::find_id_by_name(ctx, "test:createActionFallout")
         .await
         .expect("unable to find the func")
         .expect("no func found");
@@ -59,7 +59,7 @@ async fn attach_multiple_action_funcs(ctx: &mut DalContext) {
         .expect("could not commit and update snapshot to visibility");
 
     // Attach a second action func to the same schema variant and commit.
-    let func_id = Func::find_by_name(ctx, "test:deleteActionSwifty")
+    let func_id = Func::find_id_by_name(ctx, "test:deleteActionSwifty")
         .await
         .expect("unable to find the func")
         .expect("no func found");
@@ -112,7 +112,7 @@ async fn error_when_attaching_an_exisiting_type(ctx: &mut DalContext) {
     let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
         .await
         .expect("unable to get default schema variant");
-    let func_id = Func::find_by_name(ctx, "test:createActionFallout")
+    let func_id = Func::find_id_by_name(ctx, "test:createActionFallout")
         .await
         .expect("unable to find the func");
     assert!(func_id.is_some());
@@ -127,7 +127,7 @@ async fn error_when_attaching_an_exisiting_type(ctx: &mut DalContext) {
     .await
     .expect("could not create func");
 
-    let func_id = Func::find_by_name(ctx, new_action_func_name)
+    let func_id = Func::find_id_by_name(ctx, new_action_func_name)
         .await
         .expect("unable to find the func")
         .expect("no func found");
@@ -176,7 +176,7 @@ async fn attach_multiple_auth_funcs_with_creation(ctx: &mut DalContext) {
     let total_funcs = funcs.len();
 
     // Attach one auth func to the schema variant and commit.
-    let func_id = Func::find_by_name(ctx, "test:setDummySecretString")
+    let func_id = Func::find_id_by_name(ctx, "test:setDummySecretString")
         .await
         .expect("unable to find the func")
         .expect("no func found");
@@ -222,7 +222,7 @@ async fn attach_multiple_auth_funcs_with_creation(ctx: &mut DalContext) {
         .expect("could not commit and update snapshot to visibility");
 
     // Attach a second auth func (the new one) to the same schema variant and commit.
-    let func_id = Func::find_by_name(ctx, new_auth_func_name)
+    let func_id = Func::find_id_by_name(ctx, new_auth_func_name)
         .await
         .expect("unable to find the func")
         .expect("no func found");

--- a/lib/dal/tests/integration_test/func/authoring/save_func/detach.rs
+++ b/lib/dal/tests/integration_test/func/authoring/save_func/detach.rs
@@ -23,7 +23,7 @@ async fn detach_attribute_func(ctx: &mut DalContext) {
     let total_funcs = funcs.len();
 
     // Detach one action func to the schema variant and commit.
-    let func_id = Func::find_by_name(ctx, "test:falloutEntriesToGalaxies")
+    let func_id = Func::find_id_by_name(ctx, "test:falloutEntriesToGalaxies")
         .await
         .expect("unable to find the func")
         .expect("no func found");

--- a/lib/dal/tests/integration_test/func/authoring/test_execute.rs
+++ b/lib/dal/tests/integration_test/func/authoring/test_execute.rs
@@ -20,7 +20,7 @@ async fn test_execute_action_func(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let func_id = Func::find_by_name(ctx, func_name)
+    let func_id = Func::find_id_by_name(ctx, func_name)
         .await
         .expect("could not perform find func by name")
         .expect("no func found");
@@ -66,7 +66,7 @@ async fn test_execute_attribute_func(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let func_id = Func::find_by_name(ctx, func_name)
+    let func_id = Func::find_id_by_name(ctx, func_name)
         .await
         .expect("could not perform find func by name")
         .expect("no func found");
@@ -112,7 +112,7 @@ async fn test_execute_code_generation_func(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let func_id = Func::find_by_name(ctx, func_name)
+    let func_id = Func::find_id_by_name(ctx, func_name)
         .await
         .expect("could not perform find func by name")
         .expect("no func found");
@@ -158,7 +158,7 @@ async fn test_execute_qualification_func(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let func_id = Func::find_by_name(ctx, func_name)
+    let func_id = Func::find_id_by_name(ctx, func_name)
         .await
         .expect("could not perform find func by name")
         .expect("no func found");
@@ -204,7 +204,7 @@ async fn test_execute_with_modified_code(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let func_id = Func::find_by_name(ctx, func_name)
+    let func_id = Func::find_id_by_name(ctx, func_name)
         .await
         .expect("could not perform find func by name")
         .expect("no func found");

--- a/lib/dal/tests/integration_test/secret.rs
+++ b/lib/dal/tests/integration_test/secret.rs
@@ -13,6 +13,7 @@ use serde_json::Value;
 
 mod bench;
 mod with_actions;
+mod with_schema_variant_authoring;
 
 #[test]
 async fn new(ctx: &DalContext, nw: &WorkspaceSignup) {

--- a/lib/dal/tests/integration_test/secret/with_schema_variant_authoring.rs
+++ b/lib/dal/tests/integration_test/secret/with_schema_variant_authoring.rs
@@ -1,0 +1,108 @@
+use dal::func::authoring::FuncAuthoringClient;
+use dal::func::view::FuncView;
+use dal::func::FuncAssociations;
+use dal::schema::variant::authoring::VariantAuthoringClient;
+use dal::schema::variant::leaves::LeafInputLocation;
+use dal::{DalContext, Func};
+use dal_test::helpers::ChangeSetTestHelpers;
+use dal_test::test;
+
+#[test]
+async fn existing_code_gen_func_using_secrets_for_new_schema_variant(ctx: &mut DalContext) {
+    // Create a new schema variant and commit.
+    let schema_variant = VariantAuthoringClient::create_variant(
+        ctx, "ergo sum", None, None, None, "bungie", "#00b0b0",
+    )
+    .await
+    .expect("could not create new asset");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Get the current func view of a func used by another schema variant. We want to use and
+    // validate its associations.
+    let func_id = Func::find_id_by_name(ctx, "test:generateStringCode")
+        .await
+        .expect("could not perform find by name")
+        .expect("func not found");
+    let func = Func::get_by_id_or_error(ctx, func_id)
+        .await
+        .expect("could not get func by id");
+    let func_view = FuncView::assemble(ctx, &func)
+        .await
+        .expect("could not get func view");
+    let (mut schema_variant_ids, component_ids, mut inputs) =
+        match func_view.associations.expect("no associations found") {
+            FuncAssociations::CodeGeneration {
+                schema_variant_ids,
+                component_ids,
+                inputs,
+            } => (schema_variant_ids, component_ids, inputs),
+            associations => panic!("unexpected associations kind: {associations:?}"),
+        };
+
+    // Add the schema variant and commit.
+    schema_variant_ids.push(schema_variant.id());
+    FuncAuthoringClient::save_func(
+        ctx,
+        func_view.id,
+        func_view.display_name.clone(),
+        func_view.name.clone(),
+        func_view.description.clone(),
+        func_view.code.clone(),
+        Some(FuncAssociations::CodeGeneration {
+            schema_variant_ids: schema_variant_ids.clone(),
+            component_ids: component_ids.clone(),
+            inputs: inputs.clone(),
+        }),
+    )
+    .await
+    .expect("could not save func");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Add the secrets input and commit.
+    inputs.push(LeafInputLocation::Secrets);
+    FuncAuthoringClient::save_func(
+        ctx,
+        func_view.id,
+        func_view.display_name,
+        func_view.name,
+        func_view.description,
+        func_view.code,
+        Some(FuncAssociations::CodeGeneration {
+            schema_variant_ids,
+            component_ids,
+            inputs,
+        }),
+    )
+    .await
+    .expect("could not save func");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Update the schema variant and ensure that it succeeds.
+    let schema = schema_variant
+        .schema(ctx)
+        .await
+        .expect("could not get schema");
+    let _updated_schema_variant_id = VariantAuthoringClient::update_variant(
+        ctx,
+        schema_variant.id(),
+        schema.name,
+        schema_variant.display_name(),
+        schema_variant.category().to_string(),
+        schema_variant
+            .get_color(ctx)
+            .await
+            .expect("could not get color"),
+        schema_variant.link(),
+        "function main() { return new AssetBuilder().build() }",
+        Some("let's update the description".to_string()),
+        schema_variant.component_type(),
+    )
+    .await
+    .expect("could not upgrade variant");
+}


### PR DESCRIPTION
## Description

This PR adds a regression test for attaching existing code gen funcs to new schema variants. Specifically, the "attaching" step works, but when the "Secrets" input is added, sometimes we are unable to regenerate the variant due the following error: `pkg error: Can't convert identity to LeafInputLocation`.

The bug appears to no longer exist on main, but the test should still be valuable in catching a future regression.

## Secondary Changes

- Rename `find_by_name` to `find_id_by_name` when looking for funcs by name