### PR TITLE
fix: list variant ids should only return default ids

### DIFF
--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -1138,7 +1138,7 @@ impl FuncRunner {
             .value;
 
         let mut auth_funcs = vec![];
-        for secret_defining_sv_id in SchemaVariant::list_ids(ctx).await? {
+        for secret_defining_sv_id in SchemaVariant::list_default_ids(ctx).await? {
             if Prop::find_prop_id_by_path_opt(ctx, secret_defining_sv_id, secret_definition_path)
                 .await?
                 .is_none()

--- a/lib/dal/src/input_sources.rs
+++ b/lib/dal/src/input_sources.rs
@@ -64,7 +64,7 @@ pub struct InputSources {
 impl InputSources {
     /// Assemble [`InputSources`] for all [`SchemaVariants`](SchemaVariant) in the workspace.
     pub async fn assemble_for_all_schema_variants(ctx: &DalContext) -> InputSourcesResult<Self> {
-        let all_schema_variant_ids = SchemaVariant::list_ids(ctx).await?;
+        let all_schema_variant_ids = SchemaVariant::list_default_ids(ctx).await?;
 
         let mut input_socket_views = Vec::new();
         let mut output_socket_views = Vec::new();

--- a/lib/dal/src/secret/definition_view.rs
+++ b/lib/dal/src/secret/definition_view.rs
@@ -39,7 +39,7 @@ impl SecretDefinitionView {
     /// Assembles [`views`](SecretDefinitionView) for all secret definitions in the
     /// [`snapshot`](crate::WorkspaceSnapshot).
     pub async fn list(ctx: &DalContext) -> SecretDefinitionViewResult<Vec<Self>> {
-        let schema_variant_ids = SchemaVariant::list_ids(ctx).await?;
+        let schema_variant_ids = SchemaVariant::list_default_ids(ctx).await?;
 
         let secret_definition_path = PropPath::new(["root", "secret_definition"]);
         let mut views = Vec::new();

--- a/lib/dal/tests/integration_test/schema/variant/view.rs
+++ b/lib/dal/tests/integration_test/schema/variant/view.rs
@@ -6,7 +6,7 @@ use pretty_assertions_sorted::assert_eq;
 
 #[test]
 async fn list_schema_variant_definition_views(ctx: &DalContext) {
-    let schema_variant_ids = SchemaVariant::list_ids(ctx)
+    let schema_variant_ids = SchemaVariant::list_default_ids(ctx)
         .await
         .expect("could not list schema variants");
 


### PR DESCRIPTION
The `SchemaVariant::list_ids` func was doing just that, listing all of the variant ids, when we really want the latest default. This was causing inconsistency in api returns as we would often smash results into a hashmap and the default could have been stepped on in the process.

<img src="https://media3.giphy.com/media/3oEdv3yyWiMAtYlopq/giphy.gif"/>