### PR TITLE
fix: have export get the type from the variant being exported

### DIFF
--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -1081,5 +1081,5 @@ pub async fn get_component_type(
             return Ok(component_type.into());
         }
     }
-    Ok(SchemaVariantSpecComponentType::default())
+    Ok(variant.component_type().into())
 }


### PR DESCRIPTION
If we do not have an AV setting the component type we should default to whatever is set in the variant, not `component`.