### PR TITLE
Fix: when abandoning a changeset, if you've selected an asset or...

### DIFF
--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -133,6 +133,14 @@ export function useChangeSetsStore() {
               changeSetId: this.selectedChangeSet.id,
             },
             onSuccess: (response) => {
+              if (
+                router.currentRoute.value.name &&
+                ["workspace-lab-packages", "workspace-lab-assets"].includes(
+                  router.currentRoute.value.name.toString(),
+                )
+              ) {
+                router.push({ name: "workspace-lab" });
+              }
               // this.changeSetsById[response.changeSet.pk] = response.changeSet;
             },
           });


### PR DESCRIPTION
module, it could be gone in the new changeset, so navigate to base authoring url!

<img src="https://media4.giphy.com/media/KbBu3wKwEHKsIVPcWk/giphy-downsized-medium.gif"/>