### PR TITLE
Show all funcs for all versions of an asset and do not clone funcs on regeneration

### DIFF
--- a/app/web/src/components/FuncEditor/AttributeBindings.vue
+++ b/app/web/src/components/FuncEditor/AttributeBindings.vue
@@ -16,7 +16,7 @@
     <ul class="flex flex-col p-3 gap-2xs break-words">
       <li v-for="proto in prototypeViews" :key="proto.id">
         <h1 class="pt-xs text-neutral-700 type-bold-sm dark:text-neutral-50">
-          Schema Variant:
+          Asset:
         </h1>
         <h2 class="pb-xs text-sm">{{ proto.schemaVariant }}</h2>
 

--- a/app/web/src/components/FuncEditor/AttributeBindingsModal.vue
+++ b/app/web/src/components/FuncEditor/AttributeBindingsModal.vue
@@ -10,7 +10,7 @@
     <div class="p-4 flex flex-col place-content-center">
       <template v-if="!schemaVariantId">
         <h1 class="pt-2 text-neutral-700 type-bold-sm dark:text-neutral-50">
-          Schema Variant:
+          Asset:
         </h1>
         <SelectMenu
           v-model="selectedVariant"

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -375,23 +375,14 @@ export const useAssetStore = () => {
             changeSetsStore.creatingChangeSet = true;
 
           this.detachmentWarnings = [];
-
           const asset = this.assetsById[assetId];
-          return new ApiRequest<
-            {
-              taskId: string;
-            },
-            AssetSaveRequest
-          >({
+
+          return new ApiRequest<null>({
             method: "post",
             url: "/variant/update_variant",
-            keyRequestStatusBy: assetId,
             params: {
               ...visibility,
               ..._.omit(asset, ["hasComponents", "createdAt", "updatedAt"]),
-            },
-            onSuccess: (response) => {
-              this.executeAssetTaskId = response.taskId;
             },
           });
         },

--- a/lib/dal/src/func/argument.rs
+++ b/lib/dal/src/func/argument.rs
@@ -332,6 +332,8 @@ impl FuncArgument {
         Ok(func_args)
     }
 
+    /// Find the [`FuncArgument`] by its name for a given [`Func`]. For a given [`Func`], all argument names must be
+    /// unique. This method returns `None` if no argument was found.
     pub async fn find_by_name_for_func(
         ctx: &DalContext,
         name: impl AsRef<str>,

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -72,8 +72,8 @@ pub enum PkgError {
     MissingExportedFunc(FuncId),
     #[error("Cannot find FuncArgument {0} for Func {1}")]
     MissingFuncArgument(String, FuncId),
-    #[error("Package asked for a function with the unique id {0} but none could be found")]
-    MissingFuncUniqueId(String),
+    #[error("Package asked for a function with the unique id {0} but none could be found ({1})")]
+    MissingFuncUniqueId(String, &'static str),
     #[error("Cannot find InputSocket for name: {0}")]
     MissingInputSocketName(String),
     #[error("Intrinsic function {0} not found")]

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -187,7 +187,10 @@ impl PkgExporter {
             let asset_func_unique_id = self
                 .func_map
                 .get(&authoring_func_id)
-                .ok_or(PkgError::MissingFuncUniqueId(authoring_func_id.to_string()))?
+                .ok_or(PkgError::MissingFuncUniqueId(
+                    authoring_func_id.to_string(),
+                    "error found while exporting variant",
+                ))?
                 .unique_id
                 .to_owned();
             data_builder.func_unique_id(asset_func_unique_id);

--- a/lib/sdf-server/src/server/service/variant.rs
+++ b/lib/sdf-server/src/server/service/variant.rs
@@ -6,7 +6,7 @@ use dal::func::summary::FuncSummaryError;
 use dal::pkg::PkgError;
 use dal::schema::variant::authoring::VariantAuthoringError;
 use dal::{
-    ChangeSetError, FuncError, FuncId, SchemaError, SchemaVariantId, TransactionsError,
+    ChangeSetError, FuncError, FuncId, SchemaError, SchemaId, SchemaVariantId, TransactionsError,
     WsEventError,
 };
 use si_pkg::{SiPkgError, SpecError};
@@ -44,8 +44,8 @@ pub enum SchemaVariantError {
     Hyper(#[from] hyper::http::Error),
     #[error("no new asset was created")]
     NoAssetCreated,
-    #[error("no default schema variant found for schema")]
-    NoDefaultSchemaVariantFoundForSchema,
+    #[error("no default schema variant found for schema: {0}")]
+    NoDefaultSchemaVariantFoundForSchema(SchemaId),
     #[error("pkg error: {0}")]
     Pkg(#[from] PkgError),
     #[error("schema error: {0}")]


### PR DESCRIPTION
## Description

This PR contains a bunch of changes related to authoring schemas (assets), schema variants (asset versions) and funcs involved when authoring them. Primarily, this commit is focused on showing all funcs for all versions of an asset to ensure the user has all the data they need for authoring.

When you regenerate an asset when there are components on the diagram using it, a new version of the asset is created (a new schema variant). As a result, the default schema variant changes for the asset (schema). If you were to edit the output location or change anything that would affect the bindings the asset, upon regeneration, you could lose access
to the func.

_Here's what we do to solve that problem, among others that are downstream to that problem:_

- List ALL funcs in existence when asked, rather than just those that belong to assets (i.e. allow users to attach funcs that are free floating and aren't attached to any assets)
- List all funcs for all versions of an asset in the "ASSET FUNCTIONS" section (i.e. if a component is using an older version of an asset and that older version is using a func that is no longer in use, you can now access that func)
- Do not clone funcs on regeneration since the user should be explicit about changing the func to something else

<img src="https://media2.giphy.com/media/UoSWDKPpCNaRLmaBKm/giphy.gif"/>