### PR TITLE
feat: health check pool on Veritech startup

### DIFF
--- a/bin/veritech/scripts/prepare_jailer.sh
+++ b/bin/veritech/scripts/prepare_jailer.sh
@@ -67,7 +67,7 @@ rm -rf "$JAIL/{dev,run}"
 
 touch $JAIL/logs
 touch $JAIL/metrics
-cp $DATA_DIR/$SCRIPTS $JAIL
+[[ -e $DATA_DIR/$SCRIPTS ]] && cp $DATA_DIR/$SCRIPTS $JAIL
 
 function kernel_prep() {
   cp $KERNEL_IMG "$JAIL/$KERNEL"
@@ -174,13 +174,13 @@ cat << EOF
       "is_root_device": true,
       "is_read_only": false,
       "path_on_host": "./rootfs.ext4"
-    },
+    }
 EOF
 
 if [ -e $JAIL/$SCRIPTS ]; then
 
 cat << EOF
-    {
+    ,{
       "drive_id": "2",
       "is_root_device": false,
       "is_read_only": true,

--- a/lib/si-pool-noodle/src/errors.rs
+++ b/lib/si-pool-noodle/src/errors.rs
@@ -19,4 +19,7 @@ pub enum PoolNoodleError {
     /// Failed to terminate an instance.
     #[error("Failed to terminate the instance: {0}")]
     InstanceTerminate(String),
+    /// Failed to healthcheck instance creation.
+    #[error("Failed to check pool health: {0}")]
+    Unhealthy(String),
 }

--- a/lib/si-pool-noodle/src/lib.rs
+++ b/lib/si-pool-noodle/src/lib.rs
@@ -67,7 +67,7 @@ mod tests {
         let (shutdown_broadcast_tx, _) = broadcast::channel(16);
         let mut pool: PoolNoodle<LocalUdsInstance, instance::cyclone::LocalUdsInstanceSpec> =
             PoolNoodle::new(10, spec.clone(), shutdown_broadcast_tx.subscribe());
-        pool.start();
+        pool.start(false).expect("failed to start");
 
         let mut instance = pool.get().await.expect("pool is empty!");
 
@@ -104,7 +104,7 @@ mod tests {
 
         let (shutdown_broadcast_tx, _) = broadcast::channel(16);
         let mut pool = PoolNoodle::new(10, spec.clone(), shutdown_broadcast_tx.subscribe());
-        pool.start();
+        pool.start(false).expect("failed to start");
 
         let mut instance = pool.get().await.expect("pool is empty!");
 
@@ -155,7 +155,7 @@ mod tests {
 
         let (shutdown_broadcast_tx, _) = broadcast::channel(16);
         let mut pool = PoolNoodle::new(10, spec.clone(), shutdown_broadcast_tx.subscribe());
-        pool.start();
+        pool.start(false).expect("failed to start");
         let mut instance = pool.get().await.expect("should be able to get an instance");
         instance.ensure_healthy().await.expect("failed healthy");
     }

--- a/lib/veritech-client/tests/integration.rs
+++ b/lib/veritech-client/tests/integration.rs
@@ -55,6 +55,7 @@ async fn veritech_server_for_uds_cyclone(subject_prefix: String) -> Server {
         .nats(nats_config(subject_prefix.clone()))
         .cyclone_spec(cyclone_spec)
         .crypto(config_file.crypto)
+        .healthcheck_pool(false)
         .build()
         .expect("failed to build spec");
     Server::for_cyclone_uds(config)

--- a/lib/veritech-server/src/config.rs
+++ b/lib/veritech-server/src/config.rs
@@ -61,6 +61,9 @@ pub struct Config {
 
     #[builder(default = "random_instance_id()")]
     instance_id: String,
+
+    #[builder(default = "healthcheck_pool_default()")]
+    healthcheck_pool: bool,
 }
 
 #[remain::sorted]
@@ -79,6 +82,7 @@ pub struct ConfigFile {
     pub nats: NatsConfig,
     pub cyclone: CycloneConfig,
     pub crypto: VeritechCryptoConfig,
+    pub healthcheck_pool: bool,
 }
 
 impl ConfigFile {
@@ -87,6 +91,7 @@ impl ConfigFile {
             nats: Default::default(),
             cyclone: CycloneConfig::default_local_http(),
             crypto: Default::default(),
+            healthcheck_pool: healthcheck_pool_default(),
         }
     }
 
@@ -95,6 +100,7 @@ impl ConfigFile {
             nats: Default::default(),
             cyclone: CycloneConfig::default_local_uds(),
             crypto: Default::default(),
+            healthcheck_pool: healthcheck_pool_default(),
         }
     }
 }
@@ -142,6 +148,11 @@ impl Config {
     /// Gets the config's instance ID.
     pub fn instance_id(&self) -> &str {
         self.instance_id.as_ref()
+    }
+
+    /// Gets the config's healtch pool bool.
+    pub fn healthcheck_pool(&self) -> bool {
+        self.healthcheck_pool
     }
 
     // Consumes into a [`CycloneSpec`].
@@ -460,6 +471,10 @@ fn default_connect_timeout() -> u64 {
 
 fn random_instance_id() -> String {
     Ulid::new().to_string()
+}
+
+fn healthcheck_pool_default() -> bool {
+    true
 }
 
 #[allow(clippy::disallowed_methods)] // Used to determine if running in development

--- a/lib/veritech-server/src/server.rs
+++ b/lib/veritech-server/src/server.rs
@@ -135,7 +135,9 @@ impl Server {
                     .setup()
                     .await
                     .map_err(|e| ServerError::CycloneSetupError(Box::new(e)))?;
-                cyclone_pool.start();
+                cyclone_pool
+                    .start(config.healthcheck_pool())
+                    .map_err(|e| ServerError::CyclonePool(Box::new(e)))?;
 
                 let metadata = ServerMetadata {
                     job_instance: config.instance_id().into(),

--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -146,7 +146,9 @@ pidfile="/cyclone/agent.pid"
 
 start(){
   export OTEL_EXPORTER_OTLP_ENDPOINT=http://1.0.0.1:4316
-  source /mnt/scripts/scripts
+  if [ -f /mnt/scripts/scripts ]; then
+      source /mnt/scripts/scripts
+  fi
   cyclone ${cyclone_args[*]} >> /var/log/cyclone.log 2>&1 &
 }
 


### PR DESCRIPTION
This runs a quick loop of whatever instance type is selected for Cyclone when starting Veritech. The idea is to catch faulty jail implementations at startup so we can report the service as unhealthy if it can't run functions