### PR TITLE
fix(dal): pick correct ordering node in ReplaceSubgraph

### DIFF
--- a/lib/dal/src/workspace_snapshot/graph/tests.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests.rs
@@ -16,6 +16,7 @@ fn add_prop_nodes_to_graph<'a, 'b>(
     graph: &'a mut WorkspaceSnapshotGraph,
     change_set: &'a ChangeSet,
     nodes: &'a [&'b str],
+    ordered: bool,
 ) -> HashMap<&'b str, Ulid> {
     let mut node_id_map = HashMap::new();
     for node in nodes {
@@ -30,9 +31,15 @@ fn add_prop_nodes_to_graph<'a, 'b>(
             ContentHash::new(node.as_bytes()),
         )
         .expect("create prop node weight");
-        graph
-            .add_node(prop_node_weight)
-            .expect("Unable to add prop");
+        if ordered {
+            graph
+                .add_ordered_node(change_set, prop_node_weight)
+                .expect("Unable to add prop");
+        } else {
+            graph
+                .add_node(prop_node_weight)
+                .expect("Unable to add prop");
+        }
 
         node_id_map.insert(*node, node_id);
     }
@@ -185,7 +192,7 @@ mod test {
         let mut graph = WorkspaceSnapshotGraph::new(change_set)
             .expect("Unable to create WorkspaceSnapshotGraph");
 
-        let node_id_map = add_prop_nodes_to_graph(&mut graph, change_set, &nodes);
+        let node_id_map = add_prop_nodes_to_graph(&mut graph, change_set, &nodes, false);
         add_edges(&mut graph, &node_id_map, change_set, &edges);
 
         graph.cleanup();

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -291,7 +291,8 @@ impl NodeWeight {
     ) -> NodeWeightResult<()> {
         match self {
             NodeWeight::Ordering(ordering_weight) => {
-                ordering_weight.set_order(vector_clock_id, order)
+                ordering_weight.set_order(vector_clock_id, order);
+                Ok(())
             }
             NodeWeight::Action(_)
             | NodeWeight::ActionPrototype(_)


### PR DESCRIPTION
If an ordered node's children are replaced, and the RemoveEdge operations come before the ReplaceSubgraph update for the ordering node, the ordering node's vector clock write will have been incremented *during the update*, which leads us to pick the wrong node, with the result that the ordering node now has incorrect children in its order property. This fixes that by not incrementing the vector clock write for the ordering node when processing a RemoveEdge update (and *only* when processing a RemoveEdge update).

Discovery of this bug came from the VectorClockId tuple work, but this bug exists on main.