### PR TITLE
fix(dal): Only create attribute prototype arguments when configuring the binding, wipe existing attribute prototype arguments when resetting the attribute prototype for schema variants

### DIFF
--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -59,9 +59,9 @@ use crate::func::FuncKind;
 use crate::prop::PropError;
 use crate::socket::output::OutputSocketError;
 use crate::{
-    AttributePrototype, AttributePrototypeId, ComponentError, ComponentId, DalContext, Func,
-    FuncBackendKind, FuncBackendResponseType, FuncError, FuncId, OutputSocketId, PropId,
-    SchemaVariantError, SchemaVariantId, TransactionsError, WorkspaceSnapshotError, WsEventError,
+    AttributePrototypeId, ComponentError, ComponentId, DalContext, Func, FuncBackendKind,
+    FuncBackendResponseType, FuncError, FuncId, OutputSocketId, PropId, SchemaVariantError,
+    SchemaVariantId, TransactionsError, WorkspaceSnapshotError, WsEventError,
 };
 
 use super::runner::{FuncRunner, FuncRunnerError};
@@ -283,11 +283,7 @@ impl FuncAuthoringClient {
             ));
         }
 
-        let func_argument = FuncArgument::new(ctx, name, kind, element_kind, id).await?;
-
-        for attribute_prototype_id in AttributePrototype::list_ids_for_func_id(ctx, id).await? {
-            AttributePrototypeArgument::new(ctx, attribute_prototype_id, func_argument.id).await?;
-        }
+        let _func_argument = FuncArgument::new(ctx, name, kind, element_kind, id).await?;
 
         Ok(())
     }


### PR DESCRIPTION
In the short term, when the user detaches a func, if the func was driving a socket which was previously taking it's input from another prop (as defined in the schema variant definition), they'll need to regenerate the asset to get this functionality back. If the func was driving a prop, it'll be manually editable in the component or they can choose/create a new attribute func to feed it. 

As the half-configured attribute prototype bag was driving some of the UI, I needed to also map the bag to the existing func args available, otherwise they never showed up as we no longer had a placeholder AttributePrototypeArgument that was only waiting for a path. 

