### PR TITLE
fix(dal, web): Ensure attribute functions can't set incorrect output locations

### DIFF
--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -277,16 +277,18 @@ export const useFuncStore = () => {
             (schemaVariantId === nilId()
               ? _.flatten(Object.values(this.inputSourceProps))
               : this.inputSourceProps[schemaVariantId]
-            )?.map((prop) => {
-              const label = this.propIdToSourceName(prop.propId) ?? "none";
-              return {
-                label,
-                value: {
+            )
+              ?.filter((p) => p.eligibleForOutput)
+              .map((prop) => {
+                const label = this.propIdToSourceName(prop.propId) ?? "none";
+                return {
                   label,
-                  propId: prop.propId,
-                },
-              };
-            }) ?? [];
+                  value: {
+                    label,
+                    propId: prop.propId,
+                  },
+                };
+              }) ?? [];
 
           const socketOptions =
             (schemaVariantId === nilId()

--- a/app/web/src/store/func/types.ts
+++ b/app/web/src/store/func/types.ts
@@ -79,6 +79,7 @@ export interface InputSourceProp {
   schemaVariantId: string;
   path: string;
   name: string;
+  eligibleForOutput: boolean;
 }
 
 export interface OutputLocationProp {

--- a/lib/dal/src/input_sources.rs
+++ b/lib/dal/src/input_sources.rs
@@ -51,6 +51,7 @@ pub struct InputSourceProp {
     pub kind: PropKind,
     pub name: String,
     pub path: String,
+    pub eligible_for_output: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -151,12 +152,20 @@ impl InputSources {
                 work_queue.extend(Prop::direct_child_props_ordered(ctx, prop.id).await?);
             }
 
+            let path = prop.path(ctx).await?.with_replaced_sep_and_prefix("/");
+
+            let eligible_for_output = path == "/root/resource_value"
+                || path == "/root/si/color"
+                || path.starts_with("/root/domain/")
+                || path.starts_with("/root/resource_value/");
+
             input_socket_props.push(InputSourceProp {
                 schema_variant_id,
                 prop_id: prop.id,
                 kind: prop.kind,
                 name: prop.name.to_owned(),
-                path: prop.path(ctx).await?.with_replaced_sep_and_prefix("/"),
+                path,
+                eligible_for_output,
             })
         }
 


### PR DESCRIPTION
Without this, people can set root or root/secrets - which is the dangerous props people can set

We now made it:

/root/resource_value/*
/root/domain/*
/root/si/color