### PR TITLE
Fix Attribute Func Attachment

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1734,6 +1734,7 @@ impl AttributeValue {
     }
 
     /// Set's the component specific prototype id for this attribute value.
+    /// Removes the existing component specific prototype if it exists.
     #[instrument(level = "info", skip(ctx))]
     pub async fn set_component_prototype_id(
         ctx: &DalContext,

--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -351,8 +351,6 @@ impl FuncAuthoringClient {
         }
         let prototype_bag = AttributePrototypeBag::assemble(ctx, attribute_prototype_id).await?;
 
-        save::reset_attribute_prototype(ctx, attribute_prototype_id, true).await?;
-
         let new_prototype_bag = AttributePrototypeBag {
             id: attribute_prototype_id,
             component_id: prototype_bag.component_id,

--- a/lib/dal/tests/integration.rs
+++ b/lib/dal/tests/integration.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 const TEST_PG_DBNAME: &str = "si_test_dal";
 const SI_TEST_LAYER_CACHE_PG_DBNAME: &str = "si_test_layer_db";
 


### PR DESCRIPTION
Remove existing attribute prototypes when creating a new one or updating an existing one. This prevents us from having duplicate attribute prototypes for Props/Sockets that the user has manually attached attribute funcs for, and therefore ensures we run the correct, most recently configured one, with no lingering prototypes to the identity func. 

I added some traces to help us find resolution more quickly for other issues and fixed up a couple doc comments too.

<div><img src="https://media1.giphy.com/media/FuZjDL4fZ3vDz9E6EK/giphy.gif?cid=5a38a5a269kfc2sz7gbscidv7g3se7unhd2wwjl8kzvbj8o1&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/starz/">STARZ</a> on <a href="https://giphy.com/gifs/starz-106-01x06-the-gloaming-FuZjDL4fZ3vDz9E6EK">GIPHY</a></div>