### PR TITLE
fix(web): Remove Asset.Store SchemaVariantSaved Event

### DIFF
--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -499,13 +499,6 @@ export const useAssetStore = () => {
             },
           },
           {
-            eventType: "SchemaVariantSaved",
-            callback: (data) => {
-              if (data.changeSetId !== changeSetId) return;
-              this.LOAD_ASSET_LIST();
-            },
-          },
-          {
             eventType: "SchemaVariantUpdateFinished",
             callback: async (data) => {
               if (data.changeSetId !== changeSetId) return;


### PR DESCRIPTION
We are continually reloading the page when this WsEvent fires. The variant autosaves every few seconds so we don't need to reload everything every few seconds