### PR TITLE
fix(web): Reset Attribute Func Attachment between attribute funcs

### DIFF
--- a/app/web/src/components/AssetFuncAttachModal.vue
+++ b/app/web/src/components/AssetFuncAttachModal.vue
@@ -320,6 +320,8 @@ const open = async (
 ) => {
   attachExisting.value = existing ?? false;
 
+  attributeOutputLocation.value = "";
+
   name.value = "";
   funcKind.value = variant ?? FuncKind.Action;
   isCreate.value = false;


### PR DESCRIPTION
We need to reset the output location when we have pop the modal for attaching new attribute funcs