### PR TITLE
feat: add workspace token ULID

### DIFF
--- a/app/web/src/api/sdf/dal/workspace.ts
+++ b/app/web/src/api/sdf/dal/workspace.ts
@@ -3,4 +3,5 @@ export interface Workspace {
   name: string;
   created_at: IsoDateString;
   updated_at: IsoDateString;
+  token: string;
 }

--- a/app/web/src/components/layout/navbar/WorkspaceSettingsMenu.vue
+++ b/app/web/src/components/layout/navbar/WorkspaceSettingsMenu.vue
@@ -25,6 +25,11 @@
         label="Visualizer"
         @click="gotoViz"
       />
+      <DropdownMenuItem
+        icon="clipboard-copy"
+        label="Copy Workspace Token"
+        @click="copyWorkspaceToken"
+      />
     </template>
   </NavbarButton>
 
@@ -69,5 +74,11 @@ const gotoViz = () => {
       changeSetId: changeSetStore.selectedChangeSetId,
     },
   });
+};
+
+const copyWorkspaceToken = () => {
+  const currentWorkspace = workspacesStore.selectedWorkspace;
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  navigator.clipboard.writeText(currentWorkspace?.token || "");
 };
 </script>

--- a/app/web/src/store/workspaces.store.ts
+++ b/app/web/src/store/workspaces.store.ts
@@ -27,6 +27,7 @@ type AuthApiWorkspace = {
   // instanceEnvType: "LOCAL" // not used yet...
   instanceUrl: string;
   role: "OWNER" | "EDITOR";
+  token: string;
 };
 
 export type WorkspaceImportSummary = {

--- a/bin/auth-api/prisma/migrations/20240620202654_workspace_token/migration.sql
+++ b/bin/auth-api/prisma/migrations/20240620202654_workspace_token/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "workspaces" ADD COLUMN     "token" CHAR(26);

--- a/bin/auth-api/prisma/schema.prisma
+++ b/bin/auth-api/prisma/schema.prisma
@@ -8,6 +8,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
+  directUrl      = env("DIRECT_DATABASE_URL")
 }
 
 model User {
@@ -71,6 +72,9 @@ model Workspace {
 
   // The time in which the workspace was deleted
   deletedAt DateTime? @map("deleted_at")
+
+  /// secret token for the workspace (ULID)
+  token String? @db.Char(26)
 
   @@index(fields: [creatorUserId])
   @@map("workspaces")

--- a/bin/auth-api/src/services/workspaces.service.ts
+++ b/bin/auth-api/src/services/workspaces.service.ts
@@ -31,6 +31,7 @@ export async function createWorkspace(creatorUser: User, instanceUrl = 'http://l
   const newWorkspace = await prisma.workspace.create({
     data: {
       id: ulid(),
+      token: ulid(),
       instanceEnvType: InstanceEnvType.LOCAL,
       instanceUrl,
       displayName,

--- a/lib/dal/src/migrations/U3012__add_token_to_workspace.sql
+++ b/lib/dal/src/migrations/U3012__add_token_to_workspace.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workspaces
+    ADD COLUMN token text NULL;


### PR DESCRIPTION
This allows the auth-api to generate new ulid on create -- the unique workspace token. The idea here is that we want some workspace-specific value to exist that can act as a protected value. It can then be used to integrate with things like AWS assume-role to identity a workspace. We should not use the existing workspace ID for this as it lives in the URL, so is trivial to leak. 

Caveats:
1. This does not populate the existing workspaces in the auth-api with new tokens. Prisma does not provide a way to do this via migrations for ULIDs (that I could find)
2. This does not does populate the existing workspaces in the SI database either. However, if a workspace is retrieved from the auth-api and it contains a token, the workspace record will be updated

So, if we write a script to update the auth-api with new tokens, the SI workspaces will eventually become consistent. Or we could just update those, too. 

Follow on work is to update the auth-api database and then  decide how to thread this token value through to SecretDefinitions. 

<img src="https://media4.giphy.com/media/RRmVIBEcGbEqlkIV2u/giphy.gif"/>