### PR TITLE
Fix leaf function mutations for existing components

### DIFF
--- a/lib/dal/src/func/authoring/create.rs
+++ b/lib/dal/src/func/authoring/create.rs
@@ -255,15 +255,8 @@ async fn create_leaf_prototype(
         LeafKind::Qualification => vec![LeafInputLocation::Domain, LeafInputLocation::Code],
     };
 
-    SchemaVariant::upsert_leaf_function(
-        ctx,
-        schema_variant_id,
-        None,
-        leaf_kind,
-        &input_locations,
-        func,
-    )
-    .await?;
+    SchemaVariant::upsert_leaf_function(ctx, schema_variant_id, leaf_kind, &input_locations, func)
+        .await?;
 
     Ok(())
 }

--- a/lib/dal/src/func/authoring/save.rs
+++ b/lib/dal/src/func/authoring/save.rs
@@ -258,15 +258,9 @@ async fn update_leaf_associations(
 
     let mut views = Vec::new();
     for schema_variant_id in id_set {
-        let attribute_prototype_id = SchemaVariant::upsert_leaf_function(
-            ctx,
-            schema_variant_id,
-            None,
-            leaf_kind,
-            inputs,
-            func,
-        )
-        .await?;
+        let attribute_prototype_id =
+            SchemaVariant::upsert_leaf_function(ctx, schema_variant_id, leaf_kind, inputs, func)
+                .await?;
         views.push(AttributePrototypeBag::assemble(ctx, attribute_prototype_id).await?);
     }
 

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -580,7 +580,7 @@ async fn import_leaf_function(
 
     match thing_map.get(&leaf_func.func_unique_id().to_owned()) {
         Some(Thing::Func(func)) => {
-            SchemaVariant::upsert_leaf_function(ctx, schema_variant_id, None, kind, &inputs, func)
+            SchemaVariant::upsert_leaf_function(ctx, schema_variant_id, kind, &inputs, func)
                 .await?;
         }
         _ => {

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -245,7 +245,8 @@ impl VariantAuthoringClient {
                 ))?;
         let asset_func = Func::get_by_id_or_error(ctx, asset_func_id).await?;
 
-        let components_in_use = sv.get_components_on_graph(ctx).await?;
+        let components_in_use = SchemaVariant::list_component_ids(ctx, current_sv_id).await?;
+
         if components_in_use.is_empty() {
             Self::update_existing_variant_and_regenerate(
                 ctx,

--- a/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
@@ -1,8 +1,18 @@
+use std::collections::HashSet;
+
+use dal::attribute::prototype::AttributePrototypeEventualParent;
 use dal::diagram::Diagram;
+use dal::func::authoring::{AttributeOutputLocation, CreateFuncOptions, FuncAuthoringClient};
+use dal::func::view::FuncView;
+use dal::func::{AttributePrototypeBag, FuncAssociations, FuncKind};
 use dal::prop::PropPath;
+use dal::qualification::QualificationSubCheckStatus;
 use dal::schema::variant::authoring::VariantAuthoringClient;
-use dal::{DalContext, Prop};
-use dal_test::helpers::create_component_for_schema_name;
+use dal::{
+    AttributePrototype, AttributePrototypeId, Component, DalContext, Func, Prop, SchemaVariant,
+    SchemaVariantId,
+};
+use dal_test::helpers::{create_component_for_schema_name, ChangeSetTestHelpers};
 use dal_test::test;
 
 #[test]
@@ -124,4 +134,701 @@ async fn update_variant(ctx: &mut DalContext) {
         .expect("unable to get the default schema variant id");
     assert!(updated_default_schema_variant.is_some());
     assert_eq!(updated_default_schema_variant, Some(second_updated_sv_id));
+}
+
+#[test]
+async fn update_variant_with_new_prototypes_for_new_func(ctx: &mut DalContext) {
+    let first_variant = VariantAuthoringClient::create_variant(
+        ctx,
+        "helix",
+        None,
+        None,
+        None,
+        "modal editors",
+        "#00b0b0",
+    )
+    .await
+    .expect("could not create variant");
+    let schema = first_variant
+        .schema(ctx)
+        .await
+        .expect("could not get schema");
+
+    // Update the variant with a new string prop.
+    let updated_variant_id = VariantAuthoringClient::update_variant(
+        ctx,
+        first_variant.id(),
+        &schema.name,
+        first_variant.display_name(),
+        first_variant.category(),
+        first_variant
+            .get_color(ctx)
+            .await
+            .expect("could not get color"),
+        first_variant.link(),
+        "function main() {\n const myProp = new PropBuilder().setName(\"testProp\").setKind(\"string\").build()\n  return new AssetBuilder().addProp(myProp).build()\n}",
+        first_variant.description(),
+        first_variant.component_type(),
+    )
+    .await
+    .expect("unable to update variant");
+    assert_eq!(
+        first_variant.id(), // expected
+        updated_variant_id  // actual
+    );
+
+    // Check that the prop exists from the update.
+    let prop_id = Prop::find_prop_id_by_path(
+        ctx,
+        updated_variant_id,
+        &PropPath::new(["root", "domain", "testProp"]),
+    )
+    .await
+    .expect("could not find prop id by path");
+
+    // Create a new func and attach it to the new prop.
+    let created_func = FuncAuthoringClient::create_func(
+        ctx,
+        FuncKind::Attribute,
+        Some("zellij".to_string()),
+        Some(CreateFuncOptions::AttributeOptions {
+            output_location: AttributeOutputLocation::Prop { prop_id },
+        }),
+    )
+    .await
+    .expect("could not create func");
+
+    // Create a component using the new variant (and schema).
+    create_component_for_schema_name(ctx, &schema.name, "component")
+        .await
+        .expect("could not create component");
+    let diagram = Diagram::assemble(ctx)
+        .await
+        .expect("could not assemble diagram");
+    assert_eq!(1, diagram.components.len());
+
+    // Update the variant again, but this time, we should get a new schema variant id.
+    let second_updated_variant_id = VariantAuthoringClient::update_variant(
+        ctx,
+        first_variant.id(),
+        &schema.name,
+        first_variant.display_name(),
+        first_variant.category(),
+        first_variant
+            .get_color(ctx)
+            .await
+            .expect("could not get color"),
+        first_variant.link(),
+        "function main() {\n const myProp = new PropBuilder().setName(\"testProp\").setKind(\"string\").build();\n const anotherProp = new PropBuilder().setName(\"anotherProp\").setKind(\"integer\").build();\n  return new AssetBuilder().addProp(myProp).addProp(anotherProp).build()\n}",
+        first_variant.description(),
+        first_variant.component_type(),
+    )
+    .await
+    .expect("could not udpate variant");
+    assert_ne!(second_updated_variant_id, first_variant.id());
+
+    // Create another component and check that the second prop exists on it.
+    create_component_for_schema_name(ctx, schema.name, "component two")
+        .await
+        .expect("could not create component");
+    let diagram = Diagram::assemble(ctx)
+        .await
+        .expect("could not assemble diagram");
+    assert_eq!(2, diagram.components.len());
+    Prop::find_prop_id_by_path(
+        ctx,
+        second_updated_variant_id,
+        &PropPath::new(["root", "domain", "anotherProp"]),
+    )
+    .await
+    .expect("could not find prop id by path");
+
+    // Check that all actual prototype pairs are what we expect.
+    let mut actual_prototype_pairs = HashSet::new();
+    let attribute_prototype_ids = AttributePrototype::list_ids_for_func_id(ctx, created_func.id)
+        .await
+        .expect("could not list ids for func id");
+    assert_eq!(
+        2,                             // expected,
+        attribute_prototype_ids.len()  // actual
+    );
+    for id in attribute_prototype_ids {
+        let eventual_parent = AttributePrototype::eventual_parent(ctx, id)
+            .await
+            .expect("could not find eventual parent");
+        let schema_variant_id = match eventual_parent {
+            AttributePrototypeEventualParent::SchemaVariantFromProp(schema_variant_id, _) => {
+                schema_variant_id
+            }
+            eventual_parent => panic!("unexpected eventual parent: {eventual_parent:?}"),
+        };
+        actual_prototype_pairs.insert((id, schema_variant_id));
+    }
+
+    // Ensure that the associations match the eventual parents.
+    let func = Func::get_by_id_or_error(ctx, created_func.id)
+        .await
+        .expect("could not get func");
+    let (associations, _input_type) = FuncAssociations::from_func(ctx, &func)
+        .await
+        .expect("could not get associations");
+    let actual_prototype_pairs_from_associations: HashSet<(AttributePrototypeId, SchemaVariantId)> =
+        match associations.expect("no associations found") {
+            FuncAssociations::Attribute { prototypes } => {
+                assert_eq!(
+                    2,                // expected,
+                    prototypes.len()  // actual
+                );
+                HashSet::from_iter(
+                    prototypes
+                        .iter()
+                        .map(|p| (p.id, p.schema_variant_id.expect("no schema variant id"))),
+                )
+            }
+            associations => panic!("unexpected associations: {associations:?}"),
+        };
+    assert_eq!(
+        actual_prototype_pairs,                   // expected
+        actual_prototype_pairs_from_associations  // actual
+    );
+
+    // Check that the variants of the pairs are we what expect. Check the total number of pairs.
+    let expected_schema_variant_ids_in_pairs: HashSet<SchemaVariantId> =
+        HashSet::from([first_variant.id(), second_updated_variant_id]);
+    let actual_schema_variant_ids_in_pairs: HashSet<SchemaVariantId> =
+        HashSet::from_iter(actual_prototype_pairs.iter().map(|pair| pair.1));
+    assert_eq!(
+        expected_schema_variant_ids_in_pairs, // expected
+        actual_schema_variant_ids_in_pairs    // actual
+    );
+    assert_eq!(
+        2,                                        // expected
+        actual_schema_variant_ids_in_pairs.len()  // actual
+    )
+}
+
+#[test]
+async fn update_variant_with_leaf_func(ctx: &mut DalContext) {
+    let schema_variant = VariantAuthoringClient::create_variant(
+        ctx,
+        "helix",
+        None,
+        None,
+        None,
+        "modal editors",
+        "#00b0b0",
+    )
+    .await
+    .expect("could not create variant");
+    let schema = schema_variant
+        .schema(ctx)
+        .await
+        .expect("could not get schema");
+
+    // Update the variant with two string props. Ensure that we mutated the existing variant instead of creating a new one.
+    let code = "\
+        function main() {
+            const input1 = new PropBuilder()
+                .setName(\"input1\")
+                .setKind(\"string\")
+                .setWidget(new PropWidgetDefinitionBuilder().setKind(\"text\")
+                    .build())
+                .build();
+            const calculate = new PropBuilder()
+                .setName(\"calculated\")
+                .setKind(\"string\")
+                .setWidget(new PropWidgetDefinitionBuilder().setKind(\"text\")
+                    .build())
+                .build();
+            return new AssetBuilder().addProp(input1).addProp(calculate).build()
+        }";
+    let first_update_variant_id = VariantAuthoringClient::update_variant(
+        ctx,
+        schema_variant.id(),
+        &schema.name,
+        schema_variant.display_name(),
+        schema_variant.category(),
+        schema_variant
+            .get_color(ctx)
+            .await
+            .expect("could not get color"),
+        schema_variant.link(),
+        code,
+        schema_variant.description(),
+        schema_variant.component_type(),
+    )
+    .await
+    .expect("unable to update variant");
+    assert_eq!(
+        schema_variant.id(),     // expected
+        first_update_variant_id  // actual
+    );
+
+    // Create a component.
+    let component_one = create_component_for_schema_name(ctx, &schema.name, "one")
+        .await
+        .expect("could not create component");
+    let diagram = Diagram::assemble(ctx)
+        .await
+        .expect("could not assemble diagram");
+    assert_eq!(1, diagram.components.len());
+
+    // Commit after creating the component because qualifications rely on dependent values update.
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Create a qualification.
+    let qualification_one_name = "qualification one";
+    let created_func_one = FuncAuthoringClient::create_func(
+        ctx,
+        FuncKind::Qualification,
+        Some(qualification_one_name.to_string()),
+        Some(CreateFuncOptions::QualificationOptions {
+            schema_variant_id: first_update_variant_id,
+        }),
+    )
+    .await
+    .expect("could not create func");
+
+    // Add code to the qualification.
+    let code = "\
+        async function main(component: Input): Promise < Output > {
+            if (component.domain?.input1) {
+                var y: number = +component.domain?.input1 ?? 0;
+                if (y > 0) {
+                    return {
+                        result: 'success',
+                        message: 'Component qualified'
+                    };
+                }
+                return {
+                    result: 'failure',
+                    message: 'Component not qualified'
+                };
+
+            }
+            return {
+                result: 'success',
+                message: 'Component qualified'
+            };
+
+        }";
+    let func = Func::get_by_id_or_error(ctx, created_func_one.id)
+        .await
+        .expect("could not get func");
+    let func_view = FuncView::assemble(ctx, &func)
+        .await
+        .expect("could not assemble func view");
+    FuncAuthoringClient::save_func(
+        ctx,
+        func_view.id,
+        func_view.display_name,
+        func_view.name,
+        func_view.description,
+        Some(code.to_string()),
+        func_view.associations,
+    )
+    .await
+    .expect("could not save func");
+
+    // Create a second component.
+    let component_two = create_component_for_schema_name(ctx, &schema.name, "two")
+        .await
+        .expect("could not create component");
+    let diagram = Diagram::assemble(ctx)
+        .await
+        .expect("could not assemble diagram");
+    assert_eq!(2, diagram.components.len());
+
+    // Commit after creating the component because qualifications rely on dependent values update.
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Collect the qualifications for all components and the prototypes for all functions.
+    let component_one_qualifications = Component::list_qualifications(ctx, component_one.id())
+        .await
+        .expect("could not list qualifiications");
+    let component_two_qualifications = Component::list_qualifications(ctx, component_two.id())
+        .await
+        .expect("could not list qualifications");
+    let attribute_prototype_ids =
+        AttributePrototype::list_ids_for_func_id(ctx, created_func_one.id)
+            .await
+            .expect("could not list attribute prototype ids");
+    let mut bags = Vec::new();
+    for id in attribute_prototype_ids {
+        bags.push(
+            AttributePrototypeBag::assemble(ctx, id)
+                .await
+                .expect("could not assemble"),
+        );
+    }
+
+    // Check the qualifications.
+    assert_eq!(
+        2,                                  // expected
+        component_one_qualifications.len()  // actual
+    );
+    assert_eq!(
+        2,                                  // expected
+        component_two_qualifications.len()  // actual
+    );
+    let component_one_qualification_one_result = component_one_qualifications
+        .iter()
+        .find(|q| qualification_one_name == q.qualification_name)
+        .expect("could not find qualification")
+        .result
+        .to_owned()
+        .expect("no result found");
+    let component_two_qualification_one_result = component_two_qualifications
+        .iter()
+        .find(|q| qualification_one_name == q.qualification_name)
+        .expect("could not find qualification")
+        .result
+        .to_owned()
+        .expect("no result found");
+    assert_eq!(
+        QualificationSubCheckStatus::Success,          // expected
+        component_one_qualification_one_result.status  // actual
+    );
+    assert_eq!(
+        QualificationSubCheckStatus::Success,          // expected
+        component_two_qualification_one_result.status  // actual
+    );
+
+    // Check the prototype bags.
+    assert_eq!(
+        1,          // expected
+        bags.len(), // actual
+    );
+    let bag = bags.first().expect("no bags found");
+    let bag_schema_variant_id = bag.schema_variant_id.expect("schema variant id not found");
+    assert_eq!(
+        first_update_variant_id, // expected
+        bag_schema_variant_id    // actual
+    );
+
+    // Update the variant with a third string prop. Ensure that a new schema variant was created.
+    let code = "\
+        function main() {
+            const input1 = new PropBuilder()
+                .setName(\"input1\")
+                .setKind(\"string\")
+                .setWidget(new PropWidgetDefinitionBuilder().setKind(\"text\")
+                    .build())
+                .build();
+            const input2 = new PropBuilder()
+                .setName(\"input2\")
+                .setKind(\"string\")
+                .setWidget(new PropWidgetDefinitionBuilder().setKind(\"text\")
+                    .build())
+                .build();
+            const calculate = new PropBuilder()
+                .setName(\"calculated\")
+                .setKind(\"string\")
+                .setWidget(new PropWidgetDefinitionBuilder().setKind(\"text\")
+                    .build())
+                .build();
+            return new AssetBuilder().addProp(input1).addProp(input2).addProp(calculate).build()
+        }";
+    let schema_variant = SchemaVariant::get_by_id(ctx, first_update_variant_id)
+        .await
+        .expect("could not get schema variant");
+    let second_update_variant_id = VariantAuthoringClient::update_variant(
+        ctx,
+        schema_variant.id(),
+        &schema.name,
+        schema_variant.display_name(),
+        schema_variant.category(),
+        schema_variant
+            .get_color(ctx)
+            .await
+            .expect("could not get color"),
+        schema_variant.link(),
+        code,
+        schema_variant.description(),
+        schema_variant.component_type(),
+    )
+    .await
+    .expect("unable to update variant");
+    assert_ne!(first_update_variant_id, second_update_variant_id);
+
+    // Create a second qualification.
+    let qualification_two_name = "qualification two";
+    let created_func_two = FuncAuthoringClient::create_func(
+        ctx,
+        FuncKind::Qualification,
+        Some(qualification_two_name.to_string()),
+        Some(CreateFuncOptions::QualificationOptions {
+            schema_variant_id: second_update_variant_id,
+        }),
+    )
+    .await
+    .expect("could not create func");
+
+    // Add code to the second qualification.
+    let code = "\
+        async function main(component: Input): Promise < Output > {
+            if (component.domain?.input2) {
+                var y: number = +component.domain?.input2 ?? 0;
+                if (y > 0) {
+                    return {
+                        result: 'success',
+                        message: 'Component qualified'
+                    };
+                }
+                return {
+                    result: 'failure',
+                    message: 'Component not qualified'
+                };
+
+            }
+            return {
+                result: 'success',
+                message: 'Component qualified'
+            };
+        }";
+    let func = Func::get_by_id_or_error(ctx, created_func_two.id)
+        .await
+        .expect("could not get func");
+    let func_view = FuncView::assemble(ctx, &func)
+        .await
+        .expect("could not assemble func view");
+    FuncAuthoringClient::save_func(
+        ctx,
+        func_view.id,
+        func_view.display_name,
+        func_view.name,
+        func_view.description,
+        Some(code.to_string()),
+        func_view.associations,
+    )
+    .await
+    .expect("could not save func");
+
+    // Check the qualifications for all components.
+    let component_one_qualifications = Component::list_qualifications(ctx, component_one.id())
+        .await
+        .expect("could not list qualifications");
+    let component_two_qualifications = Component::list_qualifications(ctx, component_two.id())
+        .await
+        .expect("could not list qualifications");
+    assert_eq!(
+        2,                                  // expected
+        component_one_qualifications.len()  // actual
+    );
+    assert_eq!(
+        2,                                  // expected
+        component_two_qualifications.len()  // actual
+    );
+    let component_one_qualification_one_result = component_one_qualifications
+        .iter()
+        .find(|q| qualification_one_name == q.qualification_name)
+        .expect("could not find qualification")
+        .result
+        .to_owned()
+        .expect("no result found");
+    let component_two_qualification_one_result = component_two_qualifications
+        .iter()
+        .find(|q| qualification_one_name == q.qualification_name)
+        .expect("could not find qualification")
+        .result
+        .to_owned()
+        .expect("no result found");
+    assert_eq!(
+        QualificationSubCheckStatus::Success,          // expected
+        component_one_qualification_one_result.status  // actual
+    );
+    assert_eq!(
+        QualificationSubCheckStatus::Success,          // expected
+        component_two_qualification_one_result.status  // actual
+    );
+
+    // Check the prototype bag for the first qualification.
+    let attribute_prototype_ids =
+        AttributePrototype::list_ids_for_func_id(ctx, created_func_one.id)
+            .await
+            .expect("could not list attribute prototype ids");
+    let mut bags = Vec::new();
+    for id in attribute_prototype_ids {
+        bags.push(
+            AttributePrototypeBag::assemble(ctx, id)
+                .await
+                .expect("could not assemble"),
+        );
+    }
+    assert_eq!(
+        2,          // expected
+        bags.len(), // actual
+    );
+    let acutal: HashSet<SchemaVariantId> = HashSet::from_iter(
+        bags.iter()
+            .map(|b| b.schema_variant_id.expect("schema variant id not found")),
+    );
+    let expected = HashSet::from_iter([first_update_variant_id, second_update_variant_id]);
+    assert_eq!(
+        expected, // expected
+        acutal    // actual
+    );
+
+    // Check the prototype bag for the second qualification.
+    let attribute_prototype_ids =
+        AttributePrototype::list_ids_for_func_id(ctx, created_func_two.id)
+            .await
+            .expect("could not list attribute prototype ids");
+    let mut bags = Vec::new();
+    for id in attribute_prototype_ids {
+        bags.push(
+            AttributePrototypeBag::assemble(ctx, id)
+                .await
+                .expect("could not assemble"),
+        );
+    }
+    assert_eq!(
+        1,          // expected
+        bags.len(), // actual
+    );
+    let bag = bags.first().expect("no bags found");
+    let bag_schema_variant_id = bag.schema_variant_id.expect("schema variant id not found");
+    assert_eq!(
+        second_update_variant_id, // expected
+        bag_schema_variant_id     // actual
+    );
+
+    // Create a third component and re-check all qualifications.
+    let component_three = create_component_for_schema_name(ctx, &schema.name, "three")
+        .await
+        .expect("could not create component");
+    let diagram = Diagram::assemble(ctx)
+        .await
+        .expect("could not assemble diagram");
+    assert_eq!(3, diagram.components.len());
+
+    // Commit after creating the component because qualifications rely on dependent values update.
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Check qualifications for all components.
+    let component_one_qualifications = Component::list_qualifications(ctx, component_one.id())
+        .await
+        .expect("could not list qualifications");
+    let component_two_qualifications = Component::list_qualifications(ctx, component_two.id())
+        .await
+        .expect("could not list qualifications");
+    let component_three_qualifications = Component::list_qualifications(ctx, component_three.id())
+        .await
+        .expect("could not list qualifications");
+    assert_eq!(
+        2,                                  // expected
+        component_one_qualifications.len()  // actual
+    );
+    assert_eq!(
+        2,                                  // expected
+        component_two_qualifications.len()  // actual
+    );
+    assert_eq!(
+        3,                                    // expected
+        component_three_qualifications.len()  // actual
+    );
+    let component_one_qualification_one_result = component_one_qualifications
+        .iter()
+        .find(|q| qualification_one_name == q.qualification_name)
+        .expect("could not find qualification")
+        .result
+        .to_owned()
+        .expect("no result found");
+    let component_two_qualification_one_result = component_two_qualifications
+        .iter()
+        .find(|q| qualification_one_name == q.qualification_name)
+        .expect("could not find qualification")
+        .result
+        .to_owned()
+        .expect("no result found");
+    let component_three_qualification_one_result = component_three_qualifications
+        .iter()
+        .find(|q| qualification_one_name == q.qualification_name)
+        .expect("could not find qualification")
+        .result
+        .to_owned()
+        .expect("no result found");
+    let component_three_qualification_two_result = component_three_qualifications
+        .iter()
+        .find(|q| qualification_two_name == q.qualification_name)
+        .expect("could not find qualification")
+        .result
+        .to_owned()
+        .expect("no result found");
+    assert_eq!(
+        QualificationSubCheckStatus::Success,          // expected
+        component_one_qualification_one_result.status  // actual
+    );
+    assert_eq!(
+        QualificationSubCheckStatus::Success,          // expected
+        component_two_qualification_one_result.status  // actual
+    );
+    assert_eq!(
+        QualificationSubCheckStatus::Success,            // expected
+        component_three_qualification_one_result.status  // actual
+    );
+    assert_eq!(
+        QualificationSubCheckStatus::Success,            // expected
+        component_three_qualification_two_result.status  // actual
+    );
+
+    // Re-check the prototype bags after the third component was created.
+    {
+        // Check the prototype bag for the first qualification.
+        let attribute_prototype_ids =
+            AttributePrototype::list_ids_for_func_id(ctx, created_func_one.id)
+                .await
+                .expect("could not list attribute prototype ids");
+        let mut bags = Vec::new();
+        for id in attribute_prototype_ids {
+            bags.push(
+                AttributePrototypeBag::assemble(ctx, id)
+                    .await
+                    .expect("could not assemble"),
+            );
+        }
+        assert_eq!(
+            2,          // expected
+            bags.len(), // actual
+        );
+        let acutal: HashSet<SchemaVariantId> = HashSet::from_iter(
+            bags.iter()
+                .map(|b| b.schema_variant_id.expect("schema variant id not found")),
+        );
+        let expected = HashSet::from_iter([first_update_variant_id, second_update_variant_id]);
+        assert_eq!(
+            expected, // expected
+            acutal    // actual
+        );
+
+        // Check the prototype bag for the second qualification.
+        let attribute_prototype_ids =
+            AttributePrototype::list_ids_for_func_id(ctx, created_func_two.id)
+                .await
+                .expect("could not list attribute prototype ids");
+        let mut bags = Vec::new();
+        for id in attribute_prototype_ids {
+            bags.push(
+                AttributePrototypeBag::assemble(ctx, id)
+                    .await
+                    .expect("could not assemble"),
+            );
+        }
+        assert_eq!(
+            1,          // expected
+            bags.len(), // actual
+        );
+        let bag = bags.first().expect("no bags found");
+        let bag_schema_variant_id = bag.schema_variant_id.expect("schema variant id not found");
+        assert_eq!(
+            second_update_variant_id, // expected
+            bag_schema_variant_id     // actual
+        );
+    }
 }


### PR DESCRIPTION
## Description

This PR fixes leaf function mutations for existing components by creating attribute values when needed. Specifically, this commit focuses on mutations at the schema variant level found when regenerated assets with components in existence.

It contains an integration test used for testing leaf function additions intermingled with variant regenerations with existing components on the diagram. The test also looks at the raw attribute prototypes alongside the qualifications views themselves (`update_variant_with_leaf_func`).

<img src="https://media0.giphy.com/media/hWj3LzT8PN7sD1c04B/giphy.gif"/>

## Secondary Changes

- Polish functions related to leaf upsertion (i.e. finding attribute
  values, input calculation logic, component listing for schema
  variants, tracing touchups and more)
- Remove unused component-related leaf information for leaf upsertion
  methods
- Add integration test for new prototypes for func, which was originally
  written for another bug, but is added in this commit as a regression
  test (`update_variant_with_new_prototypes_for_new_func`)