### PR TITLE
feat: add readme and helper to toolbox

### DIFF
--- a/component/toolbox/Dockerfile
+++ b/component/toolbox/Dockerfile
@@ -5,6 +5,7 @@ RUN set -eux; \
     arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/64bit/) && yum install -y \
         https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_${arch}/session-manager-plugin.rpm;
 
-COPY ./scripts/* /usr/local/bin/
+COPY ./scripts/* /usr/local/bin/si/
+ENV PATH="/usr/local/bin/si:${PATH}"
 
-ENTRYPOINT ["sh", "-c"]
+ENTRYPOINT ["bash", "-c"]

--- a/component/toolbox/README.md
+++ b/component/toolbox/README.md
@@ -1,0 +1,29 @@
+# Toolbox
+
+This container provides a suite of tools that can be used to support
+our production and non-production sites.
+
+Run
+
+```bash
+$ ./awsi.sh info
+```
+
+for more details.
+
+## Prereqs
+
+Most scripts require you to have an active AWS profile. In order to set
+one up, Run
+
+```bash
+$ aws configure sso
+SSO session name (Recommended): session-name
+SSO start URL [None]: https://systeminit.awsapps.com/start
+SSO region [None]: us-east-1
+...
+CLI profile name: a-profile-name-I-will-definitely-remember
+```
+
+When interacting with the scripts, if they require or ask for an AWS Profile,
+the `CLI profile name` mentioned above is what is being referenced.

--- a/component/toolbox/scripts/info
+++ b/component/toolbox/scripts/info
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+usage() {
+    echo "----------------------------------"
+    echo "The toolbox provides a bunch of helper"
+    echo "scripts to support SI. Here's what you"
+    echo "can do:"
+    list_usages
+    exit 1
+}
+
+list_usages() {
+  for script in /usr/local/bin/si/*; do
+    if [[ -f "$script" && $(basename "$script") != "info" ]]; then
+      source "$script"
+      usage
+    fi
+  done
+}
+
+usage

--- a/component/toolbox/scripts/ssm
+++ b/component/toolbox/scripts/ssm
@@ -1,12 +1,25 @@
 #!/bin/bash
 
-# Function to display usage message
 usage() {
-    echo "Usage: $0 [-p profile] [-r region]"
+    echo
+    echo "ssm"
+    echo "----------------------------------"
+    echo "This script will open an SSH session to"
+    echo "an EC2 instance you select. It finds all"
+    echo "EC2 instances in a given region of the"
+    echo "AWS account of the supplied profile."
+    echo "----------------------------------"
+    echo "Usage: ssm [-p profile] [-r region]"
     echo "  -p profile    AWS profile to use"
     echo "  -r region     AWS region to use"
+    echo
     exit 1
 }
+
+# Add a check to see if the script is being sourced or executed
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    usage
+fi
 
 # Function to list EC2 instances with their Name tag
 list_instances() {
@@ -56,6 +69,7 @@ get_param_or_env() {
         echo "$param"
     fi
 }
+
 
 # Main script
 profile=$(get_param_or_env "$profile" "AWS_PROFILE" "Enter the AWS profile to use")


### PR DESCRIPTION
Adds a readme and a helper script to the toolbox. You can invoke it via 

```bash
./awsci.sh info
```

Like so

![image](https://github.com/systeminit/si/assets/3621657/6f1b111d-609c-4562-9bcd-9515828d6d21)
