### PR TITLE
fix: auth-api pnpm version in dockerfile

### DIFF
--- a/bin/auth-api/Dockerfile
+++ b/bin/auth-api/Dockerfile
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=18.16.0
-ARG PNPM_VERSION=8.1.1
+# ARG PNPM_VERSION=8.1.1
 ARG PACKAGE_PATH=@si/auth-api
 
 FROM node:$NODE_VERSION-slim AS base
@@ -21,7 +21,7 @@ WORKDIR /app
 COPY .gitignore .gitignore
 COPY --from=base /app/out/json/ ./
 COPY --from=base /app/out/pnpm-lock.yaml ./app/out/pnpm-workspace.yaml ./
-RUN npm i -g pnpm@$PNPM_VERSION
+RUN npm i -g pnpm@8.1.1
 
 RUN --mount=type=cache,id=pnpm-store,target=/root/.pnpm-store\
   # ↑ By caching the content-addressable store we stop downloading the same packages again and again
@@ -90,7 +90,7 @@ RUN PRISMA_SKIP_POSTINSTALL_GENERATE=1 pnpm --prod --filter @si/auth-api deploy 
 RUN rm -rf pruned/src
 
 FROM node:$NODE_VERSION-alpine as runner
-RUN PRISMA_SKIP_POSTINSTALL_GENERATE=1 npm i -g pnpm@$PNPM_VERSION
+RUN PRISMA_SKIP_POSTINSTALL_GENERATE=1 npm i -g pnpm@8.1.1
 
 WORKDIR /app
 


### PR DESCRIPTION
Cover jank with jank, we are hard pinning the version because it seems like the ARG commands are not passing the version correctly and we've just gotten lucky so far...

<img src="https://media3.giphy.com/media/xTk9ZPSV1TLrKjONO0/giphy.gif"/>