### PR TITLE
feat: implicitly pass workspace token to all secrets

### DIFF
--- a/lib/dal-test/src/test_exclusive_schemas/dummy_secret.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/dummy_secret.rs
@@ -57,7 +57,7 @@ fn build_dummy_secret_spec() -> BuiltinsResult<PkgSpec> {
         )
         .build()?;
 
-    let auth_func_code = "async function auth(secret: Input): Promise<Output> { requestStorage.setItem('dummySecretString', secret.value); }";
+    let auth_func_code = "async function auth(secret: Input): Promise<Output> { requestStorage.setItem('dummySecretString', secret.value); requestStorage.setItem('workspaceToken', secret.WorkspaceToken);}";
     let fn_name = "test:setDummySecretString";
     let auth_func = FuncSpec::builder()
         .name(fn_name)

--- a/lib/dal-test/src/test_exclusive_schemas/fallout.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/fallout.rs
@@ -232,8 +232,9 @@ fn action_funcs() -> BuiltinsResult<(FuncSpec, FuncSpec)> {
     // Add the action create func.
     let code = "async function main() {
         const authCheck = requestStorage.getItem('dummySecretString');
-        if (authCheck) {
-            if (authCheck === 'todd') {
+        const workspaceToken = requestStorage.getItem('workspaceToken');
+        if (authCheck && workspaceToken) {
+            if (authCheck === 'todd' && workspaceToken === 'token') {
                 return {
                     status: 'ok',
                     payload: {

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -334,6 +334,15 @@ impl DalContext {
         Ok(workspace.default_change_set_id())
     }
 
+    pub async fn get_workspace_token(&self) -> Result<Option<String>, TransactionsError> {
+        let workspace_pk = self.tenancy().workspace_pk().unwrap_or(WorkspacePk::NONE);
+        let workspace = Workspace::get_by_pk(self, &workspace_pk)
+            .await
+            .map_err(|err| TransactionsError::Workspace(err.to_string()))?
+            .ok_or(TransactionsError::WorkspaceNotFound(workspace_pk))?;
+        Ok(workspace.token())
+    }
+
     pub async fn update_snapshot_to_visibility(&mut self) -> Result<(), TransactionsError> {
         let change_set = ChangeSet::find(self, self.change_set_id())
             .await

--- a/lib/dal/tests/integration_test/secret/with_actions.rs
+++ b/lib/dal/tests/integration_test/secret/with_actions.rs
@@ -3,6 +3,7 @@ use dal::action::Action;
 use dal::prop::PropPath;
 use dal::property_editor::values::PropertyEditorValues;
 use dal::qualification::QualificationSubCheckStatus;
+use dal::Workspace;
 use dal::{AttributeValue, Component, DalContext, InputSocket, OutputSocket, Prop, Secret};
 use dal_test::helpers::ChangeSetTestHelpers;
 use dal_test::helpers::{create_component_for_schema_name, encrypt_message};
@@ -132,6 +133,20 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
         ActionKind::Create,           // expected
         create_action_prototype.kind, // actual
     );
+
+    // set workspace token as it is currently set by interacting with the auth-api
+    Workspace::get_by_pk(
+        ctx,
+        &ctx.tenancy()
+            .workspace_pk()
+            .expect("could not get workspace pk"),
+    )
+    .await
+    .expect("could not get workspace")
+    .expect("workspace is not some")
+    .set_token(ctx, "token".to_string())
+    .await
+    .expect("could not set token");
 
     // Ensure that the parent is head so that the "create" action will execute by default.
     // Technically, this primarily validates the test setup rather than the system itself, but it


### PR DESCRIPTION
When we go gather the before funcs we momentarily decrypt them before re-encrypting to pass them to Veritech. Now, we will inject the workspace token as an arg into the before func before re-encrpyting. This means:

* workspace token will be available on all secrets as `secret.WorkspaceToken`
* it will be correctly redacted as it is just another arg on the before_func

This method is probably not ideal for when we want to add more values, but I think that there is a pretty large conversation around the most right way to do this that we can save for a later date.

The AWS Cred will need to remove the WorkspaceId and use this instead. Here's it working:

![image](https://github.com/systeminit/si/assets/3621657/e81e04d0-3501-48ef-b10a-1c2a57ff582a)


Something about the test setup meant that I needed to manually set the token before the functions that would use it check for it. Given that the token is currently coming from the auth-api, this fairly represents the real world, but smells funny to me.