### PR TITLE
fix: ignore stdin in execa

### DIFF
--- a/bin/lang-js/src/sandbox/exec.ts
+++ b/bin/lang-js/src/sandbox/exec.ts
@@ -29,8 +29,8 @@ export const makeExec = (executionId: string) => {
   async function waitUntilEnd(
     execaFile: string,
     execaArgs?: readonly string[],
-    execaOptions?: Options<string>,
   ): Promise<SiExecResult> {
+    const execaOptions: Options<string> = { stdin: 'ignore' };
     debug(
       `running command; executionId="${executionId}"; cmd="${execaFile} ${execaArgs
         ?.map((a) => `'${a}'`)
@@ -74,7 +74,6 @@ export const makeExec = (executionId: string) => {
     const c = await waitUntilEnd(
       options.cmd,
       options.args,
-      options.execaOptions,
     );
     // Update the count of how many attempts we have made
     deadlineCount += 1;


### PR DESCRIPTION
This stops execa from waiting for stdin, so we no longer just hang forever if someone writes a function that does something cool like `cat` with no input.

This also moves the execaOptions out of siExec because letting people configure this inside of functions seems rife for mischief. 

<img src="https://media4.giphy.com/media/0XejaeIG6jJWkJzZJK/giphy.gif"/>