### PR TITLE
fix(web, sdf, dal): Return created variant details from create_variant

### DIFF
--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -198,8 +198,10 @@ export const useAssetStore = () => {
             this.selectedFuncs = [];
           }
           this.selectedAssets = [id];
-          this.LOAD_ASSET(id);
           this.syncSelectionIntoUrl();
+          if (this.assetFromListById[id]) {
+            this.LOAD_ASSET(id);
+          }
           // no last selected func
           funcsStore.selectedFuncId = undefined;
         },
@@ -494,7 +496,24 @@ export const useAssetStore = () => {
             eventType: "SchemaVariantCreated",
             callback: (data) => {
               if (data.changeSetId !== changeSetId) return;
-              this.LOAD_ASSET_LIST();
+              const nowTs = new Date().toISOString();
+              const variant = {
+                id: data.schemaId,
+                defaultSchemaVariantId: data.schemaVariantId,
+                name: data.name,
+                displayName: "",
+                category: data.category,
+                componentType: ComponentType.Component,
+                color: data.color,
+                description: "",
+                funcs: [],
+                createdAt: nowTs,
+                updatedAt: nowTs,
+                canUpdate: false,
+                canContribute: false,
+              } as AssetListEntry;
+
+              this.assetList.push(variant);
             },
           },
           {

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -254,6 +254,10 @@ export type WsEventPayloadMap = {
   };
   SchemaVariantCreated: {
     schemaId: string;
+    schemaVariantId: string;
+    name: string;
+    category: string;
+    color: string;
     changeSetId: ChangeSetId;
   };
   SchemaVariantCloned: {

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -173,6 +173,10 @@ pub struct SchemaVariant {
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaVariantCreatedPayload {
+    schema_id: SchemaId,
+    name: String,
+    category: String,
+    color: String,
     schema_variant_id: SchemaVariantId,
     change_set_id: ChangeSetId,
 }
@@ -202,12 +206,20 @@ pub struct SchemaVariantSavedPayload {
 impl WsEvent {
     pub async fn schema_variant_created(
         ctx: &DalContext,
+        schema_id: SchemaId,
         schema_variant_id: SchemaVariantId,
+        name: String,
+        category: String,
+        color: String,
     ) -> WsEventResult<Self> {
         WsEvent::new(
             ctx,
             WsPayload::SchemaVariantCreated(SchemaVariantCreatedPayload {
+                schema_id,
                 schema_variant_id,
+                name,
+                category,
+                color,
                 change_set_id: ctx.change_set_id(),
             }),
         )

--- a/lib/sdf-server/src/server/service/variant/create_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/create_variant.rs
@@ -66,10 +66,17 @@ pub async fn create_variant(
 
     let schema = created_schema_variant.schema(&ctx).await?;
 
-    WsEvent::schema_variant_created(&ctx, created_schema_variant.id())
-        .await?
-        .publish_on_commit(&ctx)
-        .await?;
+    WsEvent::schema_variant_created(
+        &ctx,
+        schema.id(),
+        created_schema_variant.id(),
+        created_schema_variant.name().to_string(),
+        created_schema_variant.category().to_string(),
+        created_schema_variant.get_color(&ctx).await?,
+    )
+    .await?
+    .publish_on_commit(&ctx)
+    .await?;
 
     ctx.commit().await?;
 


### PR DESCRIPTION
When on HEAD and creating a new variant, we were trying to load the variant on HEAD. This returns the correct information in the WsEvent to update the store and waiting for the new changeset URL to be set before trying to load the variant