### PR TITLE
Ensure we upsert leaf funcs to the correct attribute value for existing components

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -32,6 +32,7 @@ use crate::history_event::HistoryEventMetadata;
 use crate::layer_db_types::{ComponentContent, ComponentContentV1};
 use crate::prop::{PropError, PropPath};
 use crate::qualification::QualificationError;
+use crate::schema::variant::leaves::LeafKind;
 use crate::schema::variant::root_prop::component_type::ComponentType;
 use crate::schema::variant::SchemaVariantError;
 use crate::socket::input::InputSocketError;
@@ -3252,6 +3253,23 @@ impl Component {
         } else {
             format!("{} - Copy", name)
         }
+    }
+    /// This method finds the [`AttributeValueId`](crate::AttributeValue) corresponding to either  "/root/code" or
+    /// "/root/qualification" for the given [`ComponentId`](Component) and ['LeafKind'](LeafKind).
+    pub async fn find_map_attribute_value_for_leaf_kind(
+        ctx: &DalContext,
+        component_id: ComponentId,
+        leaf_kind: LeafKind,
+    ) -> ComponentResult<AttributeValueId> {
+        let attribute_value_id = match leaf_kind {
+            LeafKind::CodeGeneration => {
+                Component::find_code_map_attribute_value_id(ctx, component_id).await?
+            }
+            LeafKind::Qualification => {
+                Component::find_qualification_map_attribute_value_id(ctx, component_id).await?
+            }
+        };
+        Ok(attribute_value_id)
     }
 }
 

--- a/lib/dal/src/component/code.rs
+++ b/lib/dal/src/component/code.rs
@@ -56,4 +56,23 @@ impl Component {
 
         Ok((code_views.clone(), true))
     }
+
+    /// This method finds the [`AttributeValueId`](crate::AttributeValue) corresponding to "/root/code" for
+    /// the given [`ComponentId`](Component).
+    pub async fn find_code_map_attribute_value_id(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<AttributeValueId> {
+        match Self::attribute_values_for_prop_by_id(
+            ctx,
+            component_id,
+            RootPropChild::Code.prop_path().as_parts().as_slice(),
+        )
+        .await?
+        .first()
+        {
+            Some(qualification_map_attribute_value_id) => Ok(*qualification_map_attribute_value_id),
+            None => Err(ComponentError::MissingCodeValue(component_id)),
+        }
+    }
 }

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -1116,13 +1116,18 @@ impl SchemaVariant {
                             .await?;
 
                     // Before returning the new prototype, we need to ensure all existing components use the new
-                    // qualification.
+                    // leaf prop (either qualification or code gen).
                     let mut new_attribute_value_ids = Vec::new();
                     for component_id in Self::list_component_ids(ctx, schema_variant_id).await? {
                         let parent_attribute_value_id =
-                            Component::find_qualification_map_attribute_value_id(ctx, component_id)
-                                .await
-                                .map_err(Box::new)?;
+                            Component::find_map_attribute_value_for_leaf_kind(
+                                ctx,
+                                component_id,
+                                leaf_kind,
+                            )
+                            .await
+                            .map_err(Box::new)?;
+
                         let new_attribute_value = AttributeValue::new(
                             ctx,
                             ValueIsFor::Prop(leaf_item_prop_id),

--- a/lib/dal/tests/integration_test/func/authoring/create_func.rs
+++ b/lib/dal/tests/integration_test/func/authoring/create_func.rs
@@ -1,11 +1,13 @@
 use dal::action::prototype::ActionKind;
+use dal::diagram::Diagram;
 use dal::func::authoring::{
     AttributeOutputLocation, CreateFuncOptions, FuncAuthoringClient, FuncAuthoringError,
 };
 use dal::func::FuncKind;
 use dal::prop::PropPath;
-use dal::{ChangeSet, DalContext, Func, OutputSocket, Prop, Schema, SchemaVariant};
-use dal_test::helpers::ChangeSetTestHelpers;
+use dal::schema::variant::authoring::VariantAuthoringClient;
+use dal::{AttributeValue, ChangeSet, DalContext, Func, OutputSocket, Prop, Schema, SchemaVariant};
+use dal_test::helpers::{create_component_for_schema_name, ChangeSetTestHelpers};
 use dal_test::test;
 
 #[test]
@@ -528,4 +530,206 @@ async fn duplicate_func_name_causes_error(ctx: &mut DalContext) {
     } else {
         panic!("Test should fail if we don't get this func exists in change set error")
     }
+}
+
+#[test]
+async fn create_qualification_and_code_gen_with_existing_component(ctx: &mut DalContext) {
+    let asset_name = "britsTestAsset".to_string();
+    let display_name = None;
+    let description = None;
+    let link = None;
+    let category = "Integration Tests".to_string();
+    let color = "#00b0b0".to_string();
+    let variant_zero = VariantAuthoringClient::create_variant(
+        ctx,
+        asset_name.clone(),
+        display_name.clone(),
+        description.clone(),
+        link.clone(),
+        category.clone(),
+        color.clone(),
+    )
+    .await
+    .expect("Unable to create new asset");
+
+    let my_asset_schema = variant_zero
+        .schema(ctx)
+        .await
+        .expect("Unable to get the schema for the variant");
+
+    let default_schema_variant = my_asset_schema
+        .get_default_schema_variant_id(ctx)
+        .await
+        .expect("unable to get the default schema variant id");
+    assert!(default_schema_variant.is_some());
+    assert_eq!(default_schema_variant, Some(variant_zero.id()));
+
+    // Now let's update the variant
+    let first_code_update = "function main() {\n
+     const myProp = new PropBuilder().setName(\"testProp\").setKind(\"string\").build()
+     const myProp2 = new PropBuilder().setName(\"testPropWillRemove\").setKind(\"string\").build()
+     const arrayProp = new PropBuilder().setName(\"arrayProp\").setKind(\"array\").setEntry(\n
+        new PropBuilder().setName(\"arrayElem\").setKind(\"string\").build()\n
+    ).build();\n
+     return new AssetBuilder().addProp(myProp).addProp(arrayProp).build()\n}"
+        .to_string();
+    let updated_variant_id = VariantAuthoringClient::update_variant(
+        ctx,
+        variant_zero.id(),
+        my_asset_schema.name.clone(),
+        variant_zero.display_name(),
+        variant_zero.category().to_string(),
+        variant_zero
+            .get_color(ctx)
+            .await
+            .expect("Unable to get color of variant"),
+        variant_zero.link(),
+        first_code_update,
+        variant_zero.description(),
+        variant_zero.component_type(),
+    )
+    .await
+    .expect("unable to update asset");
+
+    // We should still see that the schema variant we updated is the same as we have no components on the graph
+    assert_eq!(variant_zero.id(), updated_variant_id);
+    // Add a component to the diagram
+    let initial_component =
+        create_component_for_schema_name(ctx, my_asset_schema.name.clone(), "demo component")
+            .await
+            .expect("could not create component");
+    let initial_diagram = Diagram::assemble(ctx)
+        .await
+        .expect("could not assemble diagram");
+    assert_eq!(1, initial_diagram.components.len());
+
+    let domain_prop_av_id = initial_component
+        .domain_prop_attribute_value(ctx)
+        .await
+        .expect("able to get domain prop");
+
+    // Set the domain so we get some array elements
+    AttributeValue::update(
+        ctx,
+        domain_prop_av_id,
+        Some(serde_json::json!({
+            "testProp": "test",
+            "testPropWillRemove": "testToBeRemoved",
+            "arrayProp": [
+                "first",
+                "second"
+            ]
+        })),
+    )
+    .await
+    .expect("update failed");
+
+    // Let's ensure that our prop is visible in the component
+    Prop::find_prop_id_by_path(
+        ctx,
+        updated_variant_id,
+        &PropPath::new(["root", "domain", "testProp"]),
+    )
+    .await
+    .expect("able to find testProp prop");
+    // now let's create a new code gen for the new schema variant
+    let func_name = "Code Gen Func".to_string();
+    let func = FuncAuthoringClient::create_func(
+        ctx,
+        FuncKind::CodeGeneration,
+        Some(func_name.clone()),
+        Some(CreateFuncOptions::CodeGenerationOptions {
+            schema_variant_id: updated_variant_id,
+        }),
+    )
+    .await
+    .expect("unable to create func");
+
+    let schema_funcs = SchemaVariant::all_funcs(ctx, updated_variant_id)
+        .await
+        .expect("Unable to get all schema variant funcs");
+
+    assert_eq!(FuncKind::CodeGeneration, func.kind);
+    assert_eq!(func_name, func.name);
+    assert_eq!(Some("main".to_string()), func.handler);
+    assert_eq!(Some("async function main(component: Input): Promise<Output> {\n  return {\n    format: \"json\",\n    code: JSON.stringify(component),\n  };\n}\n".to_string()),  func.code);
+
+    let mut expected_func: Vec<Func> = schema_funcs
+        .into_iter()
+        .filter(|f| f.name == func_name)
+        .collect();
+    assert!(!expected_func.is_empty());
+    assert_eq!(func_name, expected_func.pop().unwrap().name);
+
+    // let's also create a new qualification fo the new schema variant
+    let func_name = "Qualification Func".to_string();
+    let func = FuncAuthoringClient::create_func(
+        ctx,
+        FuncKind::Qualification,
+        Some(func_name.clone()),
+        Some(CreateFuncOptions::QualificationOptions {
+            schema_variant_id: updated_variant_id,
+        }),
+    )
+    .await
+    .expect("unable to create func");
+
+    let schema_funcs = SchemaVariant::all_funcs(ctx, updated_variant_id)
+        .await
+        .expect("Unable to get all schema variant funcs");
+
+    assert_eq!(FuncKind::Qualification, func.kind);
+    assert_eq!(func_name, func.name);
+    assert_eq!(Some("main".to_string()), func.handler);
+    assert_eq!(Some("async function main(component: Input): Promise<Output> {\n  return {\n    result: 'success',\n    message: 'Component qualified'\n  };\n}\n".to_string()),  func.code);
+
+    let mut expected_func: Vec<Func> = schema_funcs
+        .into_iter()
+        .filter(|f| f.name == func_name)
+        .collect();
+    assert!(!expected_func.is_empty());
+    assert_eq!(func_name, expected_func.pop().unwrap().name);
+
+    // commit changes, so DVU kicks off and we should see the outcome of the new qualification and code gen func
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+    let component_view = initial_component
+        .view(ctx)
+        .await
+        .expect("get component view");
+
+    // This test confirms the code gen and qualification ran for the existing component with expected outputs
+    assert_eq!(
+        Some(serde_json::json!({
+            "si": {
+                "name": "demo component",
+                "type": "component",
+                "color": "#00b0b0",
+            },
+            "domain": {
+                "testProp": "test",
+                "arrayProp": [
+                    "first",
+                    "second",
+                ]
+            },
+            "resource_value": {
+            },
+            "code": {
+                "Code Gen Func": {
+                    "code": "{\"domain\":{\"testProp\":\"test\",\"arrayProp\":[\"first\",\"second\"]}}",
+                    "format":
+                        "json",
+                },
+            },
+            "qualification":{
+                "Qualification Func": {
+                    "result":"success",
+                    "message":"Component qualified",
+                }
+            }
+        })),
+        component_view
+    );
 }


### PR DESCRIPTION
When we author a new code gen or qualification, we find all existing components created with that schema variant and add the func to them. When doing this, we were incorrectly mapping new code gen functions to the qualification attribute value, now we find the correct attribute value for either the code gen or qualification attribute value and create the new attribute value for the new func there!

Also added a test!

Note: This is broken on upgrade until we fix BUG-405, meaning if you have a component on the diagram, regenerate the schema variant, add a new qualification or code gen function to the new schema variant, when you upgrade the component, the new qualification/code gen func won't be attached. Zack is fixing this in 405

<div><img src="https://media2.giphy.com/media/xUNd9YJwF6ifDUnqNi/200.gif?cid=5a38a5a247c1cnqouecty4kbf64mmbe4mxzs01fzv7l07xog&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:168px;width:300px"/><br/>via <a href="https://giphy.com/abcnetwork/">ABC Network</a> on <a href="https://giphy.com/gifs/thegoldbergs-season-5-episode-1-xUNd9YJwF6ifDUnqNi">GIPHY</a></div>