### PR TITLE
fix: inputs for workflow_call are available in a different context

### DIFF
--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -53,33 +53,33 @@ jobs:
 
   deploy-service:
     needs: invalidate-cache
-    if: ${{ github.event.inputs.service != 'all' }}
+    if: ${{ inputs.service != 'all' }}
     uses: ./.github/workflows/deploy-service.yml
     with:
-      environment: ${{ github.event.inputs.environment }}
-      service: ${{ github.event.inputs.service }}
-      version: ${{ github.event.inputs.version }}
+      environment: ${{ inputs.environment }}
+      service: ${{ inputs.service }}
+      version: ${{ inputs.version }}
     secrets: inherit
 
   deploy-services:
     needs: invalidate-cache
-    if: ${{ github.event.inputs.service == 'all' }}
+    if: ${{ inputs.service == 'all' }}
     strategy:
      fail-fast: false
      matrix:
       service: ["pinga", "rebaser", "sdf", "veritech", "web"]
     uses: ./.github/workflows/deploy-service.yml
     with:
-      environment: ${{ github.event.inputs.environment }}
+      environment: ${{ inputs.environment }}
       service: ${{ matrix.service }}
-      version: ${{ github.event.inputs.version }}
+      version: ${{ inputs.version }}
     secrets: inherit
 
   set-init:
     needs: invalidate-cache
     uses: ./.github/workflows/set-init-version.yml
     with:
-      environment: ${{ github.event.inputs.environment }}
-      service: ${{ github.event.inputs.service }}
-      version: ${{ github.event.inputs.version }}
+      environment: ${{ inputs.environment }}
+      service: ${{ inputs.service }}
+      version: ${{ inputs.version }}
     secrets: inherit


### PR DESCRIPTION
Apparently `workflow_call` requires the `inputs` context instead of the `github.event.inputs` context. Luckily, this context works for both types.

https://github.blog/changelog/2022-06-10-github-actions-inputs-unified-across-manual-and-reusable-workflows/