### PR TITLE
Clone or New Asset: provide an initial schema name in a modal

### DIFF
--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -25,9 +25,15 @@
             tone="neutral"
             icon="clipboard-copy"
             size="md"
-            @click="cloneAsset"
+            @click="() => cloneAssetModalRef?.modal?.open()"
           />
         </div>
+        <AssetNameModal
+          ref="cloneAssetModalRef"
+          title="Asset Name"
+          buttonLabel="Clone Asset"
+          @submit="cloneAsset"
+        />
 
         <ErrorMessage
           v-for="(warning, index) in assetStore.detachmentWarnings"
@@ -165,6 +171,7 @@ import { FuncId } from "@/store/func/funcs.store";
 import { ComponentType } from "@/api/sdf/dal/diagram";
 import ColorPicker from "./ColorPicker.vue";
 import AssetFuncAttachModal from "./AssetFuncAttachModal.vue";
+import AssetNameModal from "./AssetNameModal.vue";
 
 const props = defineProps<{
   assetId?: string;
@@ -176,6 +183,7 @@ const loadAssetReqStatus = assetStore.getRequestStatus(
   props.assetId,
 );
 const executeAssetModalRef = ref();
+const cloneAssetModalRef = ref<InstanceType<typeof AssetNameModal>>();
 
 const openAttachModal = (warning: { kind?: FuncKind; funcId?: FuncId }) => {
   if (!warning.kind) return;
@@ -232,10 +240,11 @@ const closeHandler = () => {
   assetStore.executeAssetTaskId = undefined;
 };
 
-const cloneAsset = async () => {
+const cloneAsset = async (name: string) => {
   if (editingAsset.value?.id) {
-    const result = await assetStore.CLONE_ASSET(editingAsset.value.id);
+    const result = await assetStore.CLONE_ASSET(editingAsset.value.id, name);
     if (result.result.success) {
+      cloneAssetModalRef.value?.modal?.close();
       await assetStore.setAssetSelection(result.result.data.id);
     }
   }

--- a/app/web/src/components/AssetNameModal.vue
+++ b/app/web/src/components/AssetNameModal.vue
@@ -1,0 +1,44 @@
+<template>
+  <Modal ref="modal" size="sm" :title="props.title">
+    <VormInput
+      ref="assetNameVorm"
+      v-model="assetName"
+      type="text"
+      label="Asset Name"
+      required
+      @enterPressed="submit"
+    />
+    <VButton class="mt-md" @click="submit">{{ props.buttonLabel }}</VButton>
+  </Modal>
+</template>
+
+<script lang="ts" setup>
+import { ref } from "vue";
+import { Modal, VormInput, VButton } from "@si/vue-lib/design-system";
+
+const props = defineProps<{
+  title: string;
+  buttonLabel: string;
+}>();
+
+const modal = ref<InstanceType<typeof Modal>>();
+const assetName = ref("");
+const assetNameVorm = ref<InstanceType<typeof VormInput>>();
+
+const submit = () => {
+  emit("submit", assetName.value);
+};
+
+const setError = (msg: string) => {
+  if (assetNameVorm.value) {
+    assetNameVorm.value.validationState.isError = true;
+    assetNameVorm.value.validationState.errorMessage = msg;
+  }
+};
+
+defineExpose({
+  modal,
+  setError,
+});
+const emit = defineEmits(["submit"]);
+</script>

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -103,7 +103,7 @@ export type AssetCreateRequest = Omit<
   AssetSaveRequest,
   "id" | "definition" | "variantExists"
 >;
-export type AssetCloneRequest = Visibility & { id: AssetId };
+export type AssetCloneRequest = Visibility & { id: AssetId; name: string };
 
 export const assetDisplayName = (asset: Asset | AssetListEntry) =>
   (asset.displayName ?? "").length === 0 ? asset.name : asset.displayName;
@@ -298,11 +298,13 @@ export const useAssetStore = () => {
           ])}`;
         },
 
-        createNewAsset(): Asset {
+        createNewAsset(name?: string): Asset {
+          name = name || `new asset ${Math.floor(Math.random() * 10000)}`;
           return {
             id: nilId(),
             defaultSchemaVariantId: "",
-            name: `new asset ${Math.floor(Math.random() * 10000)}`,
+            name,
+            displayName: name,
             code: "",
             color: this.generateMockColor(),
             description: "",
@@ -339,7 +341,7 @@ export const useAssetStore = () => {
           });
         },
 
-        async CLONE_ASSET(assetId: AssetId) {
+        async CLONE_ASSET(assetId: AssetId, name: string) {
           if (changeSetsStore.creatingChangeSet)
             throw new Error("race, wait until the change set is created");
           if (changeSetsStore.headSelected)
@@ -355,6 +357,7 @@ export const useAssetStore = () => {
             params: {
               ...visibility,
               id: assetId,
+              name,
             },
           });
         },

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -473,4 +473,8 @@ impl Schema {
         let funcs = Func::list_from_ids(ctx, func_ids.as_slice()).await?;
         Ok(funcs)
     }
+
+    pub async fn is_name_taken(ctx: &DalContext, name: &String) -> SchemaResult<bool> {
+        Ok(Self::list(ctx).await?.iter().any(|s| s.name.eq(name)))
+    }
 }

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -20,9 +20,8 @@ use crate::pkg::import::import_only_new_funcs;
 use crate::pkg::{import_pkg_from_pkg, PkgError};
 use crate::schema::variant::{SchemaVariantJson, SchemaVariantMetadataJson};
 use crate::{
-    generate_unique_id, pkg, ComponentType, DalContext, Func, FuncBackendKind,
-    FuncBackendResponseType, FuncError, FuncId, Schema, SchemaError, SchemaVariant,
-    SchemaVariantError, SchemaVariantId,
+    pkg, ComponentType, DalContext, Func, FuncBackendKind, FuncBackendResponseType, FuncError,
+    FuncId, Schema, SchemaError, SchemaVariant, SchemaVariantError, SchemaVariantId,
 };
 
 #[allow(missing_docs)]
@@ -159,22 +158,22 @@ impl VariantAuthoringClient {
     pub async fn clone_variant(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
+        name: String,
     ) -> VariantAuthoringResult<(SchemaVariant, Schema)> {
         println!("clone variant");
         let variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
         let schema = variant.schema(ctx).await?;
 
-        let new_name = format!("{} Clone {}", schema.name(), generate_unique_id(4));
         let menu_name = variant.display_name().map(|mn| format!("{mn} Clone"));
 
         if let Some(asset_func_id) = variant.asset_func_id() {
             let old_func = Func::get_by_id_or_error(ctx, asset_func_id).await?;
 
-            let cloned_func = old_func.duplicate(ctx, new_name.clone()).await?;
+            let cloned_func = old_func.duplicate(ctx, name.clone()).await?;
             let cloned_func_spec = build_asset_func_spec(&cloned_func)?;
             let definition = execute_asset_func(ctx, &cloned_func).await?;
             let metadata = SchemaVariantMetadataJson {
-                name: new_name.clone(),
+                name: name,
                 menu_name: menu_name.clone(),
                 category: variant.category().to_string(),
                 color: variant.get_color(ctx).await?,

--- a/lib/dal/src/schema/variant/json.rs
+++ b/lib/dal/src/schema/variant/json.rs
@@ -16,7 +16,7 @@ use crate::{ComponentType, PropKind, SchemaVariantError, SocketArity};
 pub struct SchemaVariantMetadataJson {
     /// Name for this variant. Actually, this is the name for this [`Schema`](crate::Schema), we're
     /// punting on the issue of multiple variants for the moment.
-    pub name: String,
+    pub schema_name: String,
     /// Override for the UI name for this schema
     #[serde(alias = "menu_name")]
     pub menu_name: Option<String>,
@@ -31,11 +31,11 @@ pub struct SchemaVariantMetadataJson {
 }
 
 impl SchemaVariantMetadataJson {
-    pub fn to_spec(&self, variant: SchemaVariantSpec) -> SchemaVariantResult<SchemaSpec> {
+    pub fn to_schema_spec(&self, variant: SchemaVariantSpec) -> SchemaVariantResult<SchemaSpec> {
         let mut builder = SchemaSpec::builder();
-        builder.name(&self.name);
+        builder.name(&self.schema_name);
         let mut data_builder = SchemaSpecData::builder();
-        data_builder.name(&self.name);
+        data_builder.name(&self.schema_name);
         data_builder.category(&self.category);
         if let Some(menu_name) = &self.menu_name {
             data_builder.category_name(menu_name.as_str());
@@ -168,7 +168,7 @@ impl SchemaVariantJson {
                 });
 
         let metadata = SchemaVariantMetadataJson {
-            name: schema_spec.name,
+            schema_name: schema_spec.name,
             menu_name: schema_data.category_name,
             category: schema_data.category,
             color: variant_spec_data

--- a/lib/dal/tests/integration_test/component/upgrade.rs
+++ b/lib/dal/tests/integration_test/component/upgrade.rs
@@ -21,7 +21,7 @@ async fn upgrade_component(ctx: &mut DalContext) {
     let link = None;
     let category = "Integration Tests".to_string();
     let color = "#00b0b0".to_string();
-    let variant_zero = VariantAuthoringClient::create_variant(
+    let variant_zero = VariantAuthoringClient::create_schema_and_variant(
         ctx,
         asset_name.clone(),
         display_name.clone(),

--- a/lib/dal/tests/integration_test/func/authoring/create_func.rs
+++ b/lib/dal/tests/integration_test/func/authoring/create_func.rs
@@ -540,7 +540,7 @@ async fn create_qualification_and_code_gen_with_existing_component(ctx: &mut Dal
     let link = None;
     let category = "Integration Tests".to_string();
     let color = "#00b0b0".to_string();
-    let variant_zero = VariantAuthoringClient::create_variant(
+    let variant_zero = VariantAuthoringClient::create_schema_and_variant(
         ctx,
         asset_name.clone(),
         display_name.clone(),

--- a/lib/dal/tests/integration_test/pkg/mod.rs
+++ b/lib/dal/tests/integration_test/pkg/mod.rs
@@ -14,7 +14,7 @@ async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) {
     let link = None;
     let category = "Integration Tests".to_string();
     let color = "#00b0b0".to_string();
-    let variant = VariantAuthoringClient::create_variant(
+    let variant = VariantAuthoringClient::create_schema_and_variant(
         ctx,
         asset_name.clone(),
         display_name.clone(),

--- a/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
@@ -32,6 +32,7 @@ async fn clone_variant(ctx: &mut DalContext) {
     let (new_schema_variant, _) = VariantAuthoringClient::clone_variant(
         ctx,
         default_schema_variant.expect("unable to get the schema variant id from the option"),
+        existing_schema.name().to_string(),
     )
     .await
     .expect("unable to clone the schema variant");

--- a/lib/dal/tests/integration_test/schema/variant/authoring/create_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/create_variant.rs
@@ -18,7 +18,7 @@ async fn create_variant(ctx: &mut DalContext) {
     let link = None;
     let category = "Integration Tests".to_string();
     let color = "#00b0b0".to_string();
-    let variant = VariantAuthoringClient::create_variant(
+    let variant = VariantAuthoringClient::create_schema_and_variant(
         ctx,
         asset_name.clone(),
         display_name.clone(),

--- a/lib/dal/tests/integration_test/schema/variant/authoring/save_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/save_variant.rs
@@ -18,7 +18,7 @@ async fn save_variant(ctx: &mut DalContext) {
     let link = None;
     let category = "Integration Tests".to_string();
     let color = "#00b0b0".to_string();
-    let variant = VariantAuthoringClient::create_variant(
+    let variant = VariantAuthoringClient::create_schema_and_variant(
         ctx,
         asset_name.clone(),
         display_name.clone(),

--- a/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
@@ -24,7 +24,7 @@ async fn update_variant(ctx: &mut DalContext) {
     let link = None;
     let category = "Integration Tests".to_string();
     let color = "#00b0b0".to_string();
-    let my_first_variant = VariantAuthoringClient::create_variant(
+    let my_first_variant = VariantAuthoringClient::create_schema_and_variant(
         ctx,
         asset_name.clone(),
         display_name.clone(),
@@ -138,7 +138,7 @@ async fn update_variant(ctx: &mut DalContext) {
 
 #[test]
 async fn update_variant_with_new_prototypes_for_new_func(ctx: &mut DalContext) {
-    let first_variant = VariantAuthoringClient::create_variant(
+    let first_variant = VariantAuthoringClient::create_schema_and_variant(
         ctx,
         "helix",
         None,
@@ -309,7 +309,7 @@ async fn update_variant_with_new_prototypes_for_new_func(ctx: &mut DalContext) {
 
 #[test]
 async fn update_variant_with_leaf_func(ctx: &mut DalContext) {
-    let schema_variant = VariantAuthoringClient::create_variant(
+    let schema_variant = VariantAuthoringClient::create_schema_and_variant(
         ctx,
         "helix",
         None,

--- a/lib/dal/tests/integration_test/secret/with_schema_variant_authoring.rs
+++ b/lib/dal/tests/integration_test/secret/with_schema_variant_authoring.rs
@@ -10,7 +10,7 @@ use dal_test::test;
 #[test]
 async fn existing_code_gen_func_using_secrets_for_new_schema_variant(ctx: &mut DalContext) {
     // Create a new schema variant and commit.
-    let schema_variant = VariantAuthoringClient::create_variant(
+    let schema_variant = VariantAuthoringClient::create_schema_and_variant(
         ctx, "ergo sum", None, None, None, "bungie", "#00b0b0",
     )
     .await

--- a/lib/sdf-server/src/server/service/variant/clone_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/clone_variant.rs
@@ -32,6 +32,12 @@ pub async fn clone_variant(
 ) -> SchemaVariantResult<impl IntoResponse> {
     let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
+    if Schema::is_name_taken(&ctx, &request.name).await? {
+        return Ok(axum::response::Response::builder()
+            .status(409)
+            .body("schema name already taken".to_string())?);
+    }
+
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
     let schema = Schema::get_by_id(&ctx, request.id).await?;

--- a/lib/sdf-server/src/server/service/variant/clone_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/clone_variant.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct CloneVariantRequest {
     pub id: SchemaId,
+    pub name: String,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -38,8 +39,12 @@ pub async fn clone_variant(
         SchemaVariantError::NoDefaultSchemaVariantFoundForSchema(schema.id()),
     )?;
 
-    let (cloned_schema_variant, schema) =
-        VariantAuthoringClient::clone_variant(&ctx, default_schema_variant_id).await?;
+    let (cloned_schema_variant, schema) = VariantAuthoringClient::clone_variant(
+        &ctx,
+        default_schema_variant_id,
+        request.name.clone(),
+    )
+    .await?;
 
     track(
         &posthog_client,
@@ -47,7 +52,7 @@ pub async fn clone_variant(
         &original_uri,
         "clone_variant",
         serde_json::json!({
-            "variant_name": schema.name(),
+            "variant_name": request.name,
             "variant_category": cloned_schema_variant.category(),
             "variant_menu_name": cloned_schema_variant.display_name(),
             "variant_id": cloned_schema_variant.id(),

--- a/lib/vue-lib/src/pinia/pinia_api_tools.ts
+++ b/lib/vue-lib/src/pinia/pinia_api_tools.ts
@@ -106,7 +106,12 @@ export class ApiRequest<
   // ie, checking success guarantees data is present
   get result():
     | { success: true; data: Response }
-    | { success: false; err: Error; errBody?: any } {
+    | {
+        success: false;
+        err: Error;
+        errBody?: any;
+        statusCode?: number | undefined;
+      } {
     /* eslint-disable @typescript-eslint/no-non-null-assertion */
     if (this.rawSuccess === undefined)
       throw new Error("You must await the request to access the result");
@@ -121,6 +126,7 @@ export class ApiRequest<
         // the (json) body of the failed request, if applicable
         ...(this.rawResponseError instanceof AxiosError && {
           errBody: this.rawResponseError.response?.data,
+          statusCode: this.rawResponseError.response?.status,
         }),
       };
     }


### PR DESCRIPTION
This is in anticipation of making the schema name immutable after creation.