### PR TITLE
Disambiguate Schema Name, Schema Variant Name, and Schema Variant Display Name across the UI. On import, if there's no display name, hydrate with Schema name. Same thing on regenerate. This is a step towards schema names being immutable.

### DIFF
--- a/app/web/src/api/sdf/dal/diagram.ts
+++ b/app/web/src/api/sdf/dal/diagram.ts
@@ -42,7 +42,8 @@ export interface DiagramSchemaVariant {
 
 export interface DiagramSchema {
   id: string;
-  name: string;
+  name: string; // schema name
+  displayName: string; // variant display name
   builtin: boolean;
 
   variants: DiagramSchemaVariant[];

--- a/app/web/src/components/AssetCard.vue
+++ b/app/web/src/components/AssetCard.vue
@@ -24,7 +24,7 @@
             {{ asset.displayName }}
           </template>
           <template v-else>
-            {{ asset.name }}
+            {{ asset.schemaName }}
           </template>
         </div>
       </Stack>

--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -61,14 +61,22 @@
         <div>
           <ErrorMessage :requestStatus="execAssetReqStatus" />
         </div>
-
+        <VormInput
+          id="schemaName"
+          v-model="editingAsset.schemaName"
+          type="text"
+          label="Asset Name"
+          compact
+          placeholder="(mandatory) Provide the asset a name"
+          @blur="updateAsset"
+        />
         <VormInput
           id="name"
           v-model="editingAsset.name"
           type="text"
-          label="Name"
+          label="Asset Version Name"
           compact
-          placeholder="(mandatory) Provide the asset a name"
+          placeholder="(mandatory) Provide the asset version a name"
           @blur="updateAsset"
         />
 
@@ -78,7 +86,7 @@
           type="text"
           label="Display name"
           compact
-          placeholder="(optional) Provide the asset a shorter display name"
+          placeholder="(optional) Provide the asset version a display name"
           @blur="updateAsset"
         />
         <VormInput

--- a/app/web/src/components/AssetEditorTabs.vue
+++ b/app/web/src/components/AssetEditorTabs.vue
@@ -44,7 +44,7 @@
 import isEqual from "lodash-es/isEqual";
 import { watch, ref, computed } from "vue";
 import { TabGroup, TabGroupItem } from "@si/vue-lib/design-system";
-import { useAssetStore } from "@/store/asset.store";
+import { useAssetStore, assetDisplayName } from "@/store/asset.store";
 import { useFuncStore } from "@/store/func/funcs.store";
 import AssetEditor from "./AssetEditor.vue";
 import FuncEditor from "./FuncEditor/FuncEditor.vue";
@@ -74,10 +74,10 @@ watch(
     if (!requestStatus.isSuccess || !assetId) {
       return;
     }
-
+    const asset = assetStore.assetFromListById[assetId];
     const assetTab = {
       type: "asset",
-      label: assetStore.assetFromListById[assetId]?.name ?? "error",
+      label: asset ? assetDisplayName(asset) ?? "error" : "error",
       id: assetId,
     };
 

--- a/app/web/src/components/AssetListPanel.vue
+++ b/app/web/src/components/AssetListPanel.vue
@@ -199,7 +199,7 @@ const categorizedAssets = computed(() =>
 
       if (include && searchString.value.length) {
         include = !!(
-          asset.name.toLocaleLowerCase().includes(searchString.value) ||
+          asset.schemaName.toLocaleLowerCase().includes(searchString.value) ||
           asset.displayName?.toLocaleLowerCase().includes(searchString.value)
         );
       }

--- a/app/web/src/components/AssetPalette.vue
+++ b/app/web/src/components/AssetPalette.vue
@@ -284,9 +284,11 @@ const schemaDisplayName = (
   schemas: DiagramSchemaWithDisplayMetadata[],
 ) => {
   const duplicates = schemas.filter((s) => s.name === schema.name);
+  let displayName = schema.variants[0]?.displayName;
+  if (!displayName) displayName = schema.name;
   if (duplicates.length > 1) {
-    return `${schema.name} (${duplicates.indexOf(schema)})`;
-  } else return schema.name;
+    return `${displayName} (${duplicates.indexOf(schema)})`;
+  } else return displayName;
 };
 
 const updateMouseNode = (e: MouseEvent) => {

--- a/app/web/src/components/FuncEditor/AttributeBindings.vue
+++ b/app/web/src/components/FuncEditor/AttributeBindings.vue
@@ -19,6 +19,10 @@
           <h1 class="pt-xs text-neutral-700 type-bold-sm dark:text-neutral-50">
             Asset:
           </h1>
+          <h2 class="pb-xs text-sm">{{ proto.schema }}</h2>
+          <h1 class="pt-xs text-neutral-700 type-bold-sm dark:text-neutral-50">
+            Asset version:
+          </h1>
           <h2 class="pb-xs text-sm">{{ proto.schemaVariant }}</h2>
 
           <h1 class="pt-xs text-neutral-700 type-bold-sm dark:text-neutral-50">
@@ -227,9 +231,11 @@ const prototypeViews = computed(() => {
       ];
 
     const schemaVariant =
+      useComponentsStore().schemaVariantsById[schemaVariantId ?? ""]?.name ??
+      "none";
+    const schema =
       useComponentsStore().schemaVariantsById[schemaVariantId ?? ""]
         ?.schemaName ?? "none";
-
     const component =
       funcStore.componentOptions.find((c) => c.value === proto.componentId)
         ?.label ?? "all";
@@ -256,6 +262,7 @@ const prototypeViews = computed(() => {
 
     return {
       id: proto.id,
+      schema,
       schemaVariant,
       component,
       outputLocation,

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -74,6 +74,7 @@ export interface DetachedValidationPrototype {
 export interface ListedVariant {
   id: AssetId;
   defaultSchemaVariantId: string;
+  schemaName: string;
   name: string;
   displayName?: string;
   category: string;
@@ -106,7 +107,7 @@ export type AssetCreateRequest = Omit<
 export type AssetCloneRequest = Visibility & { id: AssetId; name: string };
 
 export const assetDisplayName = (asset: Asset | AssetListEntry) =>
-  (asset.displayName ?? "").length === 0 ? asset.name : asset.displayName;
+  (asset.displayName ?? "").length === 0 ? asset.schemaName : asset.displayName;
 
 export const useAssetStore = () => {
   const changeSetsStore = useChangeSetsStore();
@@ -303,7 +304,8 @@ export const useAssetStore = () => {
           return {
             id: nilId(),
             defaultSchemaVariantId: "",
-            name,
+            schemaName: name,
+            name: "v0",
             displayName: name,
             code: "",
             color: this.generateMockColor(),
@@ -399,8 +401,6 @@ export const useAssetStore = () => {
               return () => {
                 if (current) {
                   this.assetsById[asset.id] = current;
-                } else {
-                  delete this.assetsById[asset.id];
                 }
               };
             },
@@ -494,6 +494,7 @@ export const useAssetStore = () => {
               const variant = {
                 id: data.schemaId,
                 defaultSchemaVariantId: data.schemaVariantId,
+                schemaName: data.schemaName,
                 name: data.name,
                 displayName: "",
                 category: data.category,

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -570,6 +570,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                 schemasWithAtLeastOneVariant.push({
                   id: schema.id,
                   name: schema.name,
+                  displayName: schema.displayName,
                   builtin: schema.builtin,
                   variants: schema.variants,
                   category: schema.variants[0].category,

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -257,6 +257,7 @@ export type WsEventPayloadMap = {
     schemaId: string;
     schemaVariantId: string;
     name: string;
+    schemaName: string;
     category: string;
     color: string;
     changeSetId: ChangeSetId;

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -24,7 +24,7 @@ use crate::{
     SchemaVariantId, TransactionsError, UserPk, WorkspaceError, WorkspacePk, WsEvent,
     WsEventResult, WsPayload,
 };
-use crate::{AttributePrototypeId, FuncId, PropId, PropKind};
+use crate::{AttributePrototypeId, FuncId, HistoryEventError, PropId, PropKind};
 
 use crate::module::ModuleError;
 use crate::socket::connection_annotation::ConnectionAnnotationError;
@@ -64,6 +64,8 @@ pub enum PkgError {
     FuncArgumentNotFoundByName(FuncId, String),
     #[error("func {0} could not be found by name")]
     FuncNotFoundByName(String),
+    #[error("history event error: {0}")]
+    HistoryEvent(#[from] HistoryEventError),
     #[error("input socket error: {0}")]
     InputSocket(#[from] InputSocketError),
     #[error("Missing Func {1} for AttributePrototype {0}")]

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -971,6 +971,7 @@ pub(crate) async fn import_schema_variant(
         let (variant, created) = match existing_schema_variant {
             None => {
                 let spec = schema_spec.to_spec().await?;
+                let schema_name = &spec.name.clone();
                 let metadata = SchemaVariantJson::metadata_from_spec(spec)?;
 
                 let mut asset_func_id: Option<FuncId> = None;
@@ -987,12 +988,17 @@ pub(crate) async fn import_schema_variant(
                         asset_func_id = Some(asset_func.id)
                     }
                 }
+                let display_name = match metadata.display_name {
+                    Some(name) => name,
+                    None => schema_name.into(),
+                };
+                info!(%display_name, "display_name");
                 (
                     SchemaVariant::new(
                         ctx,
                         schema.id(),
                         variant_spec.name(),
-                        metadata.menu_name,
+                        display_name,
                         metadata.category,
                         metadata.color,
                         metadata.component_type,

--- a/lib/dal/src/schema/variant/metadata_view.rs
+++ b/lib/dal/src/schema/variant/metadata_view.rs
@@ -10,6 +10,7 @@ use crate::{
 pub struct SchemaVariantMetadataView {
     id: SchemaId,
     default_schema_variant_id: SchemaVariantId,
+    schema_name: String,
     name: String,
     category: String,
     #[serde(alias = "display_name")]
@@ -33,7 +34,8 @@ impl SchemaVariantMetadataView {
             views.push(SchemaVariantMetadataView {
                 id: schema.id,
                 default_schema_variant_id: default_schema_variant.id,
-                name: schema.name.to_owned(),
+                schema_name: schema.name.to_owned(),
+                name: default_schema_variant.name.to_owned(),
                 category: default_schema_variant.category.to_owned(),
                 color: default_schema_variant.get_color(ctx).await?,
                 timestamp: default_schema_variant.timestamp.to_owned(),

--- a/lib/dal/src/user.rs
+++ b/lib/dal/src/user.rs
@@ -123,6 +123,11 @@ impl User {
             Ok(None)
         }
     }
+    pub async fn get_by_pk_or_error(ctx: &DalContext, pk: UserPk) -> UserResult<Self> {
+        Self::get_by_pk(ctx, pk)
+            .await?
+            .ok_or_else(|| UserError::NotFoundInTenancy(pk, *ctx.tenancy()))
+    }
 
     pub async fn authorize(
         ctx: &DalContext,

--- a/lib/dal/tests/integration_test/pkg/mod.rs
+++ b/lib/dal/tests/integration_test/pkg/mod.rs
@@ -40,9 +40,10 @@ async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) {
     assert_eq!(default_schema_variant, Some(variant.id()));
 
     // now lets create a pkg from the asset and import it
-    let (variant_spec, variant_funcs) = PkgExporter::export_variant_standalone(ctx, &variant)
-        .await
-        .expect("should go to spec");
+    let (variant_spec, variant_funcs) =
+        PkgExporter::export_variant_standalone(ctx, &variant, schema.name())
+            .await
+            .expect("should go to spec");
 
     let schema_spec = SchemaSpec::builder()
         .name(schema.name())

--- a/lib/dal/tests/integration_test/schema/variant/authoring/create_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/create_variant.rs
@@ -37,7 +37,9 @@ async fn create_variant(ctx: &mut DalContext) {
 
     assert_eq!(variant.category(), category.clone());
     assert_eq!(new_schema.name(), asset_name.clone());
-    assert_eq!(variant.display_name(), display_name.clone());
+    // we update the display_name to match the schema name if display_name is none
+
+    assert_eq!(variant.display_name(), Some(asset_name.clone()));
     assert_eq!(
         variant.get_color(ctx).await.expect("unable to get color"),
         color.clone()

--- a/lib/dal/tests/integration_test/schema/variant/authoring/save_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/save_variant.rs
@@ -37,7 +37,8 @@ async fn save_variant(ctx: &mut DalContext) {
 
     assert_eq!(variant.category(), category.clone());
     assert_eq!(new_schema.name(), asset_name.clone());
-    assert_eq!(variant.display_name(), display_name.clone());
+    // we update the display_name to match the schema name if display_name is none
+    assert_eq!(variant.display_name(), Some(asset_name.clone()));
     assert_eq!(
         variant.get_color(ctx).await.expect("unable to get color"),
         color.clone()
@@ -77,6 +78,7 @@ async fn save_variant(ctx: &mut DalContext) {
     VariantAuthoringClient::save_variant_content(
         ctx,
         variant.id(),
+        updated_func_name.clone(),
         updated_func_name.clone(),
         display_name.clone(),
         link.clone(),

--- a/lib/sdf-server/src/server/service/variant/clone_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/clone_variant.rs
@@ -60,7 +60,7 @@ pub async fn clone_variant(
         serde_json::json!({
             "variant_name": request.name,
             "variant_category": cloned_schema_variant.category(),
-            "variant_menu_name": cloned_schema_variant.display_name(),
+            "variant_display_name": cloned_schema_variant.display_name(),
             "variant_id": cloned_schema_variant.id(),
             "variant_component_type": cloned_schema_variant.component_type(),
         }),

--- a/lib/sdf-server/src/server/service/variant/create_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/create_variant.rs
@@ -64,7 +64,7 @@ pub async fn create_variant(
         serde_json::json!({
             "variant_name": request.name.clone(),
             "variant_category": request.category.clone(),
-            "variant_menu_name": request.display_name.clone(),
+            "variant_display_name": request.display_name.clone(),
             "variant_id": created_schema_variant.id().clone(),
         }),
     );

--- a/lib/sdf-server/src/server/service/variant/get_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/get_variant.rs
@@ -24,6 +24,7 @@ pub struct GetVariantRequest {
 pub struct GetVariantResponse {
     pub id: SchemaId,
     pub default_schema_variant_id: SchemaVariantId,
+    pub schema_name: String,
     pub name: String,
     pub display_name: Option<String>,
     pub category: String,
@@ -64,7 +65,8 @@ pub async fn get_variant(
     let mut response: GetVariantResponse = GetVariantResponse {
         id: request.id,
         default_schema_variant_id,
-        name: schema.name().into(),
+        schema_name: schema.name().into(),
+        name: variant.name().into(),
         display_name: variant.display_name(),
         category: variant.category().into(),
         color: variant.get_color(&ctx).await?,
@@ -101,7 +103,7 @@ pub async fn get_variant(
         serde_json::json!({
                     "variant_name": variant.name(),
                     "variant_category": variant.category(),
-                    "variant_menu_name": variant.display_name(),
+                    "variant_display_name": variant.display_name(),
                     "variant_id": variant.id(),
                     "schema_id": schema.id(),
                     "variant_component_type": variant.component_type(),

--- a/lib/sdf-server/src/server/service/variant/save_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/save_variant.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 pub struct SaveVariantRequest {
     pub id: SchemaId,
     pub default_schema_variant_id: SchemaVariantId,
+    pub schema_name: String,
     pub name: String,
     pub display_name: Option<String>,
     pub category: String,
@@ -44,6 +45,7 @@ pub async fn save_variant(
     VariantAuthoringClient::save_variant_content(
         &ctx,
         request.default_schema_variant_id,
+        request.schema_name.clone(),
         request.name.clone(),
         request.display_name.clone(),
         request.link.clone(),
@@ -64,7 +66,7 @@ pub async fn save_variant(
                 "variant_id": request.id,
                 "variant_category": request.category,
                 "variant_name": request.name,
-                "variant_menu_name": request.display_name,
+                "variant_display_name": request.display_name,
         }),
     );
 

--- a/lib/sdf-server/src/server/service/variant/update_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/update_variant.rs
@@ -59,7 +59,7 @@ pub async fn update_variant(
         serde_json::json!({
             "variant_name": request.name.clone(),
             "variant_category": request.category.clone(),
-            "variant_menu_name": request.display_name.clone(),
+            "variant_display_name": request.display_name.clone(),
             "variant_id": updated_schema_variant_id,
         }),
     );

--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -112,7 +112,8 @@ pub struct SchemaVariantSpecData {
     pub link: Option<Url>,
     #[builder(setter(into, strip_option), default)]
     pub color: Option<String>,
-
+    #[builder(setter(into, strip_option), default)]
+    pub display_name: Option<String>,
     #[builder(setter(into), default)]
     pub component_type: SchemaVariantSpecComponentType,
     #[builder(setter(into))]


### PR DESCRIPTION
This PR does the following: 
- On import, if the schema variant we're importing doesn't already have a display name, we copy the schema name to it
- On regenerate, if the variant doesn't have a display name, copy the schema name to it
- Return schema name separately in list routes
- Allow mutating the schema name separately from the variant name 
- Throughout the UI, default to Variant Display Name, and if it doesn't exist, show the Schema Name.   

This PR sets us up to be able to make schema names immutable by exposing what is necessary for us to update builtins with what we want the immutable schema name to be.  For now though, we must keep the names of builtins the same until we match by unique ID vs name on import.

<div><img src="https://media1.giphy.com/media/9PqOegBqgBnMHvERV3/giphy.gif?cid=5a38a5a2rbyw6q3hziwhfewsun0y3jrclt210uhrhjqfnsvb&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:231px;width:300px"/><br/>via <a href="https://giphy.com/channel/hauntsss/">Haunts</a> on <a href="https://giphy.com/gifs/hello-my-name-is-9PqOegBqgBnMHvERV3">GIPHY</a></div>