### PR TITLE
feat: cypress on cron, cancel on deploy

### DIFF
--- a/.github/workflows/crons.yml
+++ b/.github/workflows/crons.yml
@@ -1,0 +1,17 @@
+on:
+  schedule:
+    - cron: '*/15 * * * *'  # Runs every 15 minutes
+
+# We want to ensure that in-progress cron runs are canceled
+# when do a deploy so they don't fail erroneously, but these
+# cannot cancel deploys
+concurrency:
+  group: e2e
+  cancel-in-progress: false
+
+jobs:
+  e2e-validation:
+    uses: ./.github/workflows/e2e-validation.yml
+    with:
+      environment: tools
+    secrets: inherit

--- a/.github/workflows/deploy-on-main.yml
+++ b/.github/workflows/deploy-on-main.yml
@@ -2,6 +2,13 @@ on:
   push:
     branches:
       - main
+
+# We want to ensure that in-progress cron runs are canceled
+# when do a deploy so they don't fail erroneously
+concurrency:
+  group: e2e
+  cancel-in-progress: true
+
 jobs:
   deploy-tools-prod:
     uses: ./.github/workflows/deploy-stack.yml

--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -1,8 +1,6 @@
 name: Cypress E2E Tests
 
 on:
-#  schedule:
-#    - cron: '*/5 * * * *'  # Runs every 5 minutes
   workflow_call:
     inputs:
       environment:
@@ -30,7 +28,9 @@ jobs:
       fail-fast: false
       matrix:
         # run copies of the current job in parallel
-        containers: [1] # , 2, 3, 4, 5, 6, 7, 8, 9, 10] - temp disabled mass
+        # TODO: we really should build once and set it as an
+        # artifact so we aren't rebuilding for each of these
+        containers: [1, 2, 3] #, 4, 5, 6, 7, 8, 9, 10] - temp disabled mass
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
We're going to start running the cypress jobs on a 15 minute timer. Since they are now also running on merge after we deploy tools-prod, we want to cancel in-progress cypress jobs because they will fail anyways when we deploy. If a new cypress job is started while we are still deploying, it will queue up and wait it's turn.