### PR TITLE
Retain validations from asset func on regeneration

### DIFF
--- a/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
@@ -286,7 +286,8 @@
 
       <div
         :class="{
-          'force-border-red-400': validation && validation.status !== 'Success',
+          'force-border-destructive-500':
+            validation && validation.status !== 'Success',
           'my-1': validation && validation.status !== 'Success',
         }"
         class="attributes-panel-item__input-wrap"
@@ -474,7 +475,7 @@
     <div
       v-if="showValidationDetails && validation"
       :style="{ marginLeft: indentPx }"
-      class="text-red-400 flex flex-col bg-black pl-3 border-y border-red-400 pb-1 my-1"
+      class="flex flex-col pl-3 border pb-1 m-2 text-destructive-500 border-destructive-500 bg-destructive-100 dark:text-destructive-900 dark:border-destructive-900 dark:bg-destructive-500"
     >
       <p class="my-3">{{ validation.message }}</p>
 
@@ -1269,8 +1270,8 @@ const sourceSelectMenuRef = ref<InstanceType<typeof DropdownMenu>>();
   }
 }
 
-.force-border-red-400 {
-  border-color: rgb(251 113 133 / var(--tw-border-opacity)) !important;
+.force-border-destructive-500 {
+  border-color: @colors-destructive-500 !important;
 }
 .attributes-panel-item__input-wrap {
   position: relative;

--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -228,3 +228,20 @@ pub async fn fetch_resource_last_synced_value(
         .await?;
     Ok(last_synced_value)
 }
+
+/// Extracts the value and validation from a raw property edtior value.
+pub fn extract_value_and_validation(
+    prop_editor_value: serde_json::Value,
+) -> Result<serde_json::Value> {
+    let value = prop_editor_value
+        .get("value")
+        .ok_or(eyre!("get value from property editor value"))?;
+    let validation = prop_editor_value
+        .get("validation")
+        .ok_or(eyre!("get validation from property editor value"))?;
+
+    Ok(serde_json::json!({
+        "value": value,
+        "validation": validation,
+    }))
+}

--- a/lib/dal/src/schema/variant/json.rs
+++ b/lib/dal/src/schema/variant/json.rs
@@ -305,6 +305,9 @@ impl PropDefinition {
                 builder.map_key_func(map_key_func.to_spec(identity_func_unique_id)?);
             }
         }
+        if let Some(validation_format) = &self.validation_format {
+            builder.validation_format(validation_format);
+        }
 
         Ok(builder.build()?)
     }


### PR DESCRIPTION
## Description

This PR retains validations from asset funcs upon regeneration. Currently, we successfully execute the asset func when regenerating an asset. We see the validations in the resulting definition. However, when exporting using the definition and converting it into a spec, the validations are dropped. This PR ensures that are no longer dropped.

This PR also contains minor changes to how validations appear in the attribute panel. The existing classes relied on colors outside of our asset panel and neither matcher our light nor our dark theme. While the current colors are not likely the final ones, they are closer to our design language (even if only a little).

<img src="https://media0.giphy.com/media/ooqveOiijEc6K7fRB2/giphy.gif"/>

## Disclaimer

This will require all affected assets to be regenerated and re-exported, as applicable.