### PR TITLE
chore: update userdata example to include dockerhub login

### DIFF
--- a/bin/veritech/scripts/userdata.sh
+++ b/bin/veritech/scripts/userdata.sh
@@ -73,6 +73,9 @@ wget https://artifacts.systeminit.com/${SI_SERVICE}/${SI_VERSION}/omnibus/linux/
 
 # prep system
 mkdir -p /run/app
+
+DOCKER_CREDS=$(aws secretsmanager get-secret-value --region us-east-1 --secret-id ${SI_HOSTENV}-dockerhub-creds | jq -r '.SecretString')
+docker login --username $(echo $DOCKER_CREDS | jq -r '.username') --password-stdin <<< $(echo $DOCKER_CREDS | jq -r '.password')
 wget https://raw.githubusercontent.com/systeminit/si/${BRANCH:-main}/component/deploy/docker-compose.yaml -O /run/app/docker-compose.yaml
 
 docker-compose -f /run/app/docker-compose.yaml --profile $SI_SERVICE up --wait

--- a/component/deploy/userdata
+++ b/component/deploy/userdata
@@ -22,6 +22,9 @@ wget https://artifacts.systeminit.com/${SI_SERVICE}/${SI_VERSION}/omnibus/linux/
 
 # prep system
 mkdir -p /run/app
+
+DOCKER_CREDS=$(aws secretsmanager get-secret-value --region us-east-1 --secret-id ${SI_HOSTENV}-dockerhub-creds | jq -r '.SecretString')
+docker login --username $(echo $DOCKER_CREDS | jq -r '.username') --password-stdin <<< $(echo $DOCKER_CREDS | jq -r '.password')
 wget https://raw.githubusercontent.com/systeminit/si/${BRANCH:-main}/component/deploy/docker-compose.yaml -O /run/app/docker-compose.yaml
 
 docker-compose -f /run/app/docker-compose.yaml --profile $SI_SERVICE up --wait


### PR DESCRIPTION
Dockerhub is a curse on the land. SDF failed to start correctly because we use docker to build the config file and the pull was rate limited. I'm also going to change the healthcheck so the LB will kill the instance if it is unresponsive. We need better healthchecks for the other services, though.