### PR TITLE
fix(dal): export default values correctly

### DIFF
--- a/lib/si-pkg/src/pkg/variant.rs
+++ b/lib/si-pkg/src/pkg/variant.rs
@@ -469,7 +469,7 @@ async fn create_prop_stack(
     builder.has_data(false);
 
     let default_value = match &spec {
-        SiPkgProp::Array { data, .. }
+        SiPkgProp::String { data, .. }
         | SiPkgProp::Boolean { data, .. }
         | SiPkgProp::Number { data, .. } => {
             data.as_ref().and_then(|data| data.default_value.to_owned())


### PR DESCRIPTION
A bit of code left over from the old system (where default values were the attribute value for a prop at the schema variant context) was grabbing the first attribute value and making it the default for props if a component existed on export. This fixes it and fixes the export of default values for strings.

Default values now can only be defined in the asset spec.