### PR TITLE
Typescript chill-out, Qualification display fix, contribution always on

### DIFF
--- a/app/web/src/components/AssetListPanel.vue
+++ b/app/web/src/components/AssetListPanel.vue
@@ -27,7 +27,7 @@
             @click="() => newAssetModalRef?.modal?.open()"
           />
           <IconButton
-            v-if="canContribute"
+            v-if="canContribute || true"
             class="hover:scale-125"
             icon="cloud-upload"
             size="sm"

--- a/app/web/src/components/QualificationViewerSingle.vue
+++ b/app/web/src/components/QualificationViewerSingle.vue
@@ -45,7 +45,9 @@
               :key="idx"
               class="p-2 break-words"
             >
-              {{ subCheck.description }}
+              <pre trim>
+{{ subCheck.description }}
+              </pre>
             </li>
           </ul>
         </div>

--- a/app/web/src/components/QualificationViewerSingle.vue
+++ b/app/web/src/components/QualificationViewerSingle.vue
@@ -45,8 +45,8 @@
               :key="idx"
               class="p-2 break-words"
             >
-              <pre trim>
-{{ subCheck.description }}
+              <pre trim
+                >{{ subCheck.description }}
               </pre>
             </li>
           </ul>

--- a/app/web/src/utils/typescriptLinter.ts
+++ b/app/web/src/utils/typescriptLinter.ts
@@ -64,6 +64,10 @@ export const createTypescriptSource = async (
     target: ts.ScriptTarget.ES2020,
     noUncheckedIndexedAccess: true,
     lib: ["ES2020", "DOM"],
+    allowJs: true,
+    checkJs: true,
+    strict: false,
+    suppressImplicitAnyIndexErrors: true,
   };
 
   if (!fsMap && !vfsSystem) {
@@ -78,10 +82,11 @@ export const createTypescriptSource = async (
 
   fsMap.set(defaultFilename, fallbackCode);
   fsMap.set("func.d.ts", types);
+  fsMap.set("lodash.d.ts", "declare var _: any");
 
   tsEnv = createVirtualTypeScriptEnvironment(
     vfsSystem,
-    [defaultFilename, "func.d.ts"],
+    [defaultFilename, "func.d.ts", "lodash.d.ts"],
     ts,
     compilerOptions,
   );


### PR DESCRIPTION
* When showing the output of a qualification, we wrap it in a <pre> so that you can see newlines be rendered.
* We want to always show the contribute button, because otherwise we can never see it.
* Typescript is now configured to be much more relaxed, and to have an 'any' type for `_` while we figure out how to get the types for lodash loaded up.