### PR TITLE
chore(si): Turn off auto-deploy to tools-prod

### DIFF
--- a/.github/workflows/deploy-on-main.yml
+++ b/.github/workflows/deploy-on-main.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - main
+      - trunk
 
 jobs:
   deploy-tools-prod:


### PR DESCRIPTION
We need to be in flux during the authoring stability project