### PR TITLE
Allow secrets to depend on secrets with before func ordering

### DIFF
--- a/bin/lang-js/src/asset_builder.ts
+++ b/bin/lang-js/src/asset_builder.ts
@@ -1154,12 +1154,9 @@ export class AssetBuilder implements IAssetBuilder {
   }
 
   build() {
-    if (this.asset.secretDefinition && this.asset.secretProps?.length !== 1) {
-      throw new Error(
-        "Secret defining schema shouldn't define any extra secret props",
-      );
+    if (this.asset.secretDefinition && this.asset.outputSockets?.length > 1) {
+      throw new Error("secret defining assets cannot have more than one output socket since it can only output the secret corresponding to the definition");
     }
-
     return this.asset;
   }
 }

--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -147,7 +147,7 @@ pub async fn get_component_input_socket_value(
         .get(&input_socket.id())
         .ok_or(eyre!("no input socket match found"))?;
     let input_socket_av =
-        AttributeValue::get_by_id(ctx, input_socket_match.attribute_value_id).await?;
+        AttributeValue::get_by_id_or_error(ctx, input_socket_match.attribute_value_id).await?;
     Ok(input_socket_av.view(ctx).await?)
 }
 
@@ -167,7 +167,7 @@ pub async fn get_component_output_socket_value(
         .get(&output_socket.id())
         .ok_or(eyre!("no output socket match found"))?;
     let output_socket_av =
-        AttributeValue::get_by_id(ctx, output_socket_match.attribute_value_id).await?;
+        AttributeValue::get_by_id_or_error(ctx, output_socket_match.attribute_value_id).await?;
     Ok(output_socket_av.view(ctx).await?)
 }
 /// Update the [`Value`] for a specific [`AttributeValue`] for the given [`Component`](ComponentId) by the [`PropPath`]
@@ -222,7 +222,7 @@ pub async fn fetch_resource_last_synced_value(
         return Err(eyre!("unexpected: more than one attribute value found"));
     }
 
-    let last_synced_value = AttributeValue::get_by_id(ctx, attribute_value_id)
+    let last_synced_value = AttributeValue::get_by_id_or_error(ctx, attribute_value_id)
         .await?
         .view(ctx)
         .await?;

--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -185,7 +185,7 @@ impl AttributePrototypeDebugView {
                             .await?
                         {
                             let attribute_value =
-                                AttributeValue::get_by_id(ctx, attribute_value_id).await?;
+                                AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
                             let prop_path =
                                 AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
                             let view = attribute_value.view(ctx).await?.unwrap_or(Value::Null);
@@ -212,7 +212,7 @@ impl AttributePrototypeDebugView {
                             .await?
                         {
                             let attribute_value =
-                                AttributeValue::get_by_id(ctx, attribute_value_id).await?;
+                                AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
                             let attribute_value_path =
                                 AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
 
@@ -241,7 +241,7 @@ impl AttributePrototypeDebugView {
                             .await?
                         {
                             let attribute_value =
-                                AttributeValue::get_by_id(ctx, attribute_value_id).await?;
+                                AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
                             let attribute_value_path =
                                 AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
 
@@ -297,7 +297,8 @@ impl AttributePrototypeDebugView {
                     let attribute_value_path =
                         AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
                     let output_av =
-                        AttributeValue::get_by_id(ctx, output_match.attribute_value_id).await?;
+                        AttributeValue::get_by_id_or_error(ctx, output_match.attribute_value_id)
+                            .await?;
                     let value_view = output_av.view(ctx).await?.unwrap_or(Value::Null);
                     let input_func = AttributePrototype::func_id(ctx, prototype_id).await?;
                     if let Some(func_argument) =

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -646,7 +646,8 @@ impl AttributeValue {
                                 )
                                 .await?
                             {
-                                let attribute_value = AttributeValue::get_by_id(ctx, av_id).await?;
+                                let attribute_value =
+                                    AttributeValue::get_by_id_or_error(ctx, av_id).await?;
                                 // XXX: We need to properly handle the difference between "there is
                                 // XXX: no value" vs "the value is null", but right now we collapse
                                 // XXX: the two to just be "null" when passing these to a function.
@@ -754,7 +755,8 @@ impl AttributeValue {
                     // XXX: We need to properly handle the difference between "there is
                     // XXX: no value" vs "the value is null", but right now we collapse
                     // XXX: the two to just be "null" when passing these to a function.
-                    let output_av = Self::get_by_id(ctx, output_match.attribute_value_id).await?;
+                    let output_av =
+                        Self::get_by_id_or_error(ctx, output_match.attribute_value_id).await?;
                     let view = output_av.view(ctx).await?.unwrap_or(Value::Null);
                     inputs.push(view);
                 }
@@ -1016,7 +1018,7 @@ impl AttributeValue {
                 prop_node.kind()
             };
 
-            let attribute_value = Self::get_by_id(ctx, attribute_value_id).await?;
+            let attribute_value = Self::get_by_id_or_error(ctx, attribute_value_id).await?;
 
             // If value is for scalar, just go to parent
             if !prop_kind.is_scalar() {
@@ -1226,7 +1228,8 @@ impl AttributeValue {
                             AttributeValue::get_child_av_ids_in_order(ctx, attribute_value_id)
                                 .await?
                         {
-                            let child_av = AttributeValue::get_by_id(ctx, child_av_id).await?;
+                            let child_av =
+                                AttributeValue::get_by_id_or_error(ctx, child_av_id).await?;
 
                             if let ValueIsFor::Prop(child_prop_id) =
                                 AttributeValue::is_for(ctx, child_av.id()).await?
@@ -1284,7 +1287,8 @@ impl AttributeValue {
                                 workspace_snapshot.get_node_index_by_id(child_av_id).await?;
 
                             if let Some(key) = child_av_keys.get(&node_index) {
-                                let child_av = AttributeValue::get_by_id(ctx, child_av_id).await?;
+                                let child_av =
+                                    AttributeValue::get_by_id_or_error(ctx, child_av_id).await?;
                                 if let Some(view) = child_av.view(ctx).await? {
                                     map_view.insert(key.to_owned(), view);
                                 }
@@ -1306,7 +1310,8 @@ impl AttributeValue {
                         };
 
                         for element_av_id in element_av_ids {
-                            let av = AttributeValue::get_by_id(ctx, element_av_id.into()).await?;
+                            let av = AttributeValue::get_by_id_or_error(ctx, element_av_id.into())
+                                .await?;
                             if let Some(view) = av.view(ctx).await? {
                                 array_view.push(view);
                             }
@@ -1999,7 +2004,7 @@ impl AttributeValue {
         Ok(())
     }
 
-    pub async fn get_by_id(
+    pub async fn get_by_id_or_error(
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
     ) -> AttributeValueResult<Self> {

--- a/lib/dal/src/attribute/value/debug.rs
+++ b/lib/dal/src/attribute/value/debug.rs
@@ -80,7 +80,7 @@ impl AttributeDebugView {
         key: Option<String>,
         parent_id: Option<AttributeValueId>,
     ) -> AttributeDebugViewResult<AttributeDebugView> {
-        let attribute_value = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
+        let attribute_value = AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
         let prototype_id = AttributeValue::prototype_id(ctx, attribute_value_id).await?;
         let value_is_for = AttributeValue::is_for(ctx, attribute_value_id).await?;
 

--- a/lib/dal/src/code_view.rs
+++ b/lib/dal/src/code_view.rs
@@ -76,7 +76,7 @@ impl CodeView {
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
     ) -> Result<Option<Self>, CodeViewError> {
-        let attribute_value = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
+        let attribute_value = AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
         let code_view_name = match attribute_value.key(ctx).await? {
             Some(key) => key,
             None => return Ok(None),

--- a/lib/dal/src/job/definition/compute_validation.rs
+++ b/lib/dal/src/job/definition/compute_validation.rs
@@ -100,7 +100,7 @@ impl JobConsumer for ComputeValidation {
                 continue;
             }
 
-            let value = AttributeValue::get_by_id(ctx, av_id)
+            let value = AttributeValue::get_by_id_or_error(ctx, av_id)
                 .await?
                 .value(ctx)
                 .await?;

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -555,7 +555,7 @@ impl PkgExporter {
         }
 
         let mut stack: Vec<(PropId, Option<PropId>)> = Vec::new();
-        for child_tree_node in Prop::direct_child_prop_ids(ctx, root_prop.id()).await? {
+        for child_tree_node in Prop::direct_child_prop_ids_unordered(ctx, root_prop.id()).await? {
             stack.push((child_tree_node, None));
         }
 
@@ -607,7 +607,8 @@ impl PkgExporter {
                 parent_prop_id,
             });
 
-            for child_tree_node in Prop::direct_child_prop_ids(ctx, child_prop.id).await? {
+            for child_tree_node in Prop::direct_child_prop_ids_unordered(ctx, child_prop.id).await?
+            {
                 stack.push((child_tree_node, Some(prop_id)));
             }
         }
@@ -1044,7 +1045,7 @@ pub async fn get_component_type(
         .await?
         .pop()
     {
-        let av = AttributeValue::get_by_id(ctx, av_id).await?;
+        let av = AttributeValue::get_by_id_or_error(ctx, av_id).await?;
         if let Some(type_value) = av.view(ctx).await? {
             let component_type: ComponentType = serde_json::from_value(type_value)?;
             return Ok(component_type.into());

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -561,7 +561,7 @@ impl Prop {
         }
     }
 
-    pub async fn direct_child_prop_ids(
+    pub async fn direct_child_prop_ids_unordered(
         ctx: &DalContext,
         prop_id: PropId,
     ) -> PropResult<Vec<PropId>> {
@@ -595,7 +595,7 @@ impl Prop {
         prop_id: PropId,
     ) -> PropResult<PropId> {
         let mut direct_child_prop_ids_should_only_be_one =
-            Self::direct_child_prop_ids(ctx, prop_id).await?;
+            Self::direct_child_prop_ids_unordered(ctx, prop_id).await?;
 
         let single_child_prop_id = direct_child_prop_ids_should_only_be_one
             .pop()

--- a/lib/dal/src/property_editor/values.rs
+++ b/lib/dal/src/property_editor/values.rs
@@ -60,7 +60,8 @@ impl PropertyEditorValues {
         let root_property_editor_value_id = PropertyEditorValueId::from(root_attribute_value_id);
         let root_prop_id =
             AttributeValue::prop_id_for_id_or_error(ctx, root_attribute_value_id).await?;
-        let root_attribute_value = AttributeValue::get_by_id(ctx, root_attribute_value_id).await?;
+        let root_attribute_value =
+            AttributeValue::get_by_id_or_error(ctx, root_attribute_value_id).await?;
 
         let validation =
             ValidationOutputNode::find_for_attribute_value_id(ctx, root_attribute_value_id)
@@ -144,7 +145,8 @@ impl PropertyEditorValues {
             for (child_av_id, key) in cache {
                 // NOTE(nick): we already have the node weight, but I believe we still want to use "get_by_id" to
                 // get the content from the store. Perhaps, there's a more efficient way that we can do this.
-                let child_attribute_value = AttributeValue::get_by_id(ctx, child_av_id).await?;
+                let child_attribute_value =
+                    AttributeValue::get_by_id_or_error(ctx, child_av_id).await?;
                 let prop_id_for_child_attribute_value =
                     AttributeValue::prop_id_for_id_or_error(ctx, child_av_id).await?;
                 let child_property_editor_value_id = PropertyEditorValueId::from(child_av_id);
@@ -249,7 +251,9 @@ impl PropertyEditorValues {
             ids_by_key
         };
 
-        for secret_prop_id in Prop::direct_child_prop_ids(ctx, secret_object_prop_id).await? {
+        for secret_prop_id in
+            Prop::direct_child_prop_ids_unordered(ctx, secret_object_prop_id).await?
+        {
             let attribute_value_id = self.find_by_prop_id(secret_prop_id).ok_or(
                 PropertyEditorError::PropertyEditorValueNotFoundByPropId(secret_object_prop_id),
             )?;

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -177,7 +177,7 @@ impl QualificationView {
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
     ) -> Result<Option<Self>, QualificationError> {
-        let attribute_value = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
+        let attribute_value = AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
         let maybe_qual_run = ctx
             .layer_db()
             .func_run()

--- a/lib/dal/src/socket/debug.rs
+++ b/lib/dal/src/socket/debug.rs
@@ -70,7 +70,7 @@ impl SocketDebugView {
 
         let prototype_debug_view =
             AttributePrototypeDebugView::new(ctx, attribute_value_id).await?;
-        let attribute_value = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
+        let attribute_value = AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
         let output_socket =
             OutputSocket::get_by_id(ctx, output_socket_match.output_socket_id).await?;
         let connection_annotations = output_socket
@@ -117,7 +117,7 @@ impl SocketDebugView {
         let prototype_debug_view =
             AttributePrototypeDebugView::new(ctx, input_socket_match.attribute_value_id).await?;
         info!("prototype_debug_view: {:?}", prototype_debug_view);
-        let attribute_value = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
+        let attribute_value = AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
         let input_socket = InputSocket::get_by_id(ctx, input_socket_match.input_socket_id).await?;
         let connection_annotations = input_socket
             .connection_annotations()

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -322,7 +322,7 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) {
     .await
     .expect("able to set universe value");
 
-    let view = AttributeValue::get_by_id(ctx, rigid_designator_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, rigid_designator_value_id)
         .await
         .expect("get av")
         .view(ctx)
@@ -336,13 +336,14 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let naming_and_necessity_view = AttributeValue::get_by_id(ctx, naming_and_necessity_value_id)
-        .await
-        .expect("able to get attribute value for `naming_and_necessity_value_id`")
-        .view(ctx)
-        .await
-        .expect("able to get view for `naming_and_necessity_value_id`")
-        .expect("naming and necessity has a value");
+    let naming_and_necessity_view =
+        AttributeValue::get_by_id_or_error(ctx, naming_and_necessity_value_id)
+            .await
+            .expect("able to get attribute value for `naming_and_necessity_value_id`")
+            .view(ctx)
+            .await
+            .expect("able to get view for `naming_and_necessity_value_id`")
+            .expect("naming and necessity has a value");
 
     // hesperus is phosphorus (the attr func on naming_and_necessity_value_id will return
     // phosphorus if it receives hesperus)
@@ -359,7 +360,7 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) {
         .copied()
         .expect("a value exists for the root prop");
 
-    let root_value = AttributeValue::get_by_id(ctx, root_value_id)
+    let root_value = AttributeValue::get_by_id_or_error(ctx, root_value_id)
         .await
         .expect("able to get the value for the root prop attriburte value id");
 
@@ -492,7 +493,7 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
     .await
     .expect("able to set universe value");
 
-    let view = AttributeValue::get_by_id(ctx, possible_world_a_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, possible_world_a_value_id)
         .await
         .expect("get av")
         .view(ctx)
@@ -506,13 +507,14 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let naming_and_necessity_view = AttributeValue::get_by_id(ctx, naming_and_necessity_value_id)
-        .await
-        .expect("able to get attribute value for `naming_and_necessity_value_id`")
-        .view(ctx)
-        .await
-        .expect("able to get view for `naming_and_necessity_value_id`")
-        .expect("naming and necessity has a value");
+    let naming_and_necessity_view =
+        AttributeValue::get_by_id_or_error(ctx, naming_and_necessity_value_id)
+            .await
+            .expect("able to get attribute value for `naming_and_necessity_value_id`")
+            .view(ctx)
+            .await
+            .expect("able to get view for `naming_and_necessity_value_id`")
+            .expect("naming and necessity has a value");
 
     // hesperus is phosphorus (the attr func on naming_and_necessity_value_id will return
     // phosphorus if it receives hesperus)
@@ -529,7 +531,7 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
         .copied()
         .expect("a value exists for the root prop");
 
-    let root_value = AttributeValue::get_by_id(ctx, root_value_id)
+    let root_value = AttributeValue::get_by_id_or_error(ctx, root_value_id)
         .await
         .expect("able to get the value for the root prop attriburte value id");
 
@@ -641,7 +643,7 @@ async fn through_the_wormholes_dynamic_child_value_reactivity(ctx: &mut DalConte
         .copied()
         .expect("get first value id");
 
-    let value = AttributeValue::get_by_id(ctx, possible_world_b_value_id)
+    let value = AttributeValue::get_by_id_or_error(ctx, possible_world_b_value_id)
         .await
         .expect("able to get av by id");
 
@@ -689,7 +691,7 @@ async fn through_the_wormholes_dynamic_child_value_reactivity(ctx: &mut DalConte
         .copied()
         .expect("get first value id");
 
-    let stars_value = AttributeValue::get_by_id(ctx, stars_value_id)
+    let stars_value = AttributeValue::get_by_id_or_error(ctx, stars_value_id)
         .await
         .expect("able to get av by id");
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
@@ -748,7 +750,7 @@ async fn set_the_universe(ctx: &mut DalContext) {
         .await
         .expect("able to set universe value");
 
-    let view = AttributeValue::get_by_id(ctx, universe_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, universe_value_id)
         .await
         .expect("get av")
         .view(ctx)
@@ -762,7 +764,7 @@ async fn set_the_universe(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let view = AttributeValue::get_by_id(ctx, universe_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, universe_value_id)
         .await
         .expect("get av")
         .view(ctx)
@@ -881,7 +883,7 @@ async fn deletion_updates_downstream_components(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -925,7 +927,7 @@ async fn deletion_updates_downstream_components(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -1045,7 +1047,7 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -1092,7 +1094,7 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -1137,7 +1139,7 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -1167,7 +1169,7 @@ async fn undoing_deletion_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)

--- a/lib/dal/tests/integration_test/connection.rs
+++ b/lib/dal/tests/integration_test/connection.rs
@@ -337,7 +337,7 @@ async fn connect_and_disconnect_components_explicit_connection(ctx: &mut DalCont
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -379,7 +379,7 @@ async fn connect_and_disconnect_components_explicit_connection(ctx: &mut DalCont
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -421,7 +421,7 @@ async fn connect_and_disconnect_components_explicit_connection(ctx: &mut DalCont
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -601,7 +601,7 @@ async fn remove_connection(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -638,7 +638,7 @@ async fn remove_connection(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)

--- a/lib/dal/tests/integration_test/dependent_values_update.rs
+++ b/lib/dal/tests/integration_test/dependent_values_update.rs
@@ -132,7 +132,7 @@ async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -177,7 +177,7 @@ async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -298,7 +298,7 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -341,7 +341,7 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -384,7 +384,7 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
+    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -551,7 +551,7 @@ async fn output_sockets_can_have_both(ctx: &mut DalContext) {
         .into_iter()
         .next()
         .expect("got av");
-    let odd_component_1_mat_view = AttributeValue::get_by_id(ctx, odd_component_1_av)
+    let odd_component_1_mat_view = AttributeValue::get_by_id_or_error(ctx, odd_component_1_av)
         .await
         .expect("got av")
         .view(ctx)
@@ -569,7 +569,7 @@ async fn output_sockets_can_have_both(ctx: &mut DalContext) {
         .into_iter()
         .next()
         .expect("got av");
-    let odd_component_2_mat_view = AttributeValue::get_by_id(ctx, odd_component_2_av)
+    let odd_component_2_mat_view = AttributeValue::get_by_id_or_error(ctx, odd_component_2_av)
         .await
         .expect("got av")
         .view(ctx)

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -121,7 +121,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
         AttributeValue::get_child_av_ids_in_order(ctx, parrot_names_value_id)
             .await
             .expect("get the vec of child ids");
-    let parrot_names_third_item = AttributeValue::get_by_id(
+    let parrot_names_third_item = AttributeValue::get_by_id_or_error(
         ctx,
         *parrot_names_child_ids
             .get(2)
@@ -141,7 +141,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
     let treasure_child_ids = AttributeValue::get_child_av_ids_in_order(ctx, treasure_map_value_id)
         .await
         .expect("get the vec of child ids");
-    let treasure_second_item = AttributeValue::get_by_id(
+    let treasure_second_item = AttributeValue::get_by_id_or_error(
         ctx,
         *treasure_child_ids
             .get(1)
@@ -190,7 +190,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
     // Check that the items around the removed item are correct
 
     // Get the second item in the array
-    let parrot_names_second_item = AttributeValue::get_by_id(
+    let parrot_names_second_item = AttributeValue::get_by_id_or_error(
         ctx,
         *parrot_names_child_ids
             .get(1)
@@ -207,7 +207,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
     assert_eq!(parrot_names_second_item_value, Some("samantha".into()));
 
     // Get the third item in the array
-    let parrot_names_third_item = AttributeValue::get_by_id(
+    let parrot_names_third_item = AttributeValue::get_by_id_or_error(
         ctx,
         *parrot_names_child_ids
             .get(2)
@@ -241,7 +241,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
     // Check that the items around the removed item are correct
 
     // Get the first item in the treasure map
-    let treasure_first_item = AttributeValue::get_by_id(
+    let treasure_first_item = AttributeValue::get_by_id_or_error(
         ctx,
         *treasure_child_ids
             .first()
@@ -266,7 +266,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
     assert_eq!(treasure_first_item_key, Some("ohio".to_string()));
 
     // Get the second item in the treasure map
-    let treasure_second_item = AttributeValue::get_by_id(
+    let treasure_second_item = AttributeValue::get_by_id_or_error(
         ctx,
         *treasure_child_ids
             .get(1)

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -84,16 +84,17 @@ async fn list_root_si_child_props(ctx: &DalContext) {
     .expect("cannot create schema variant");
 
     // Gather all children of "/root/si".
-    let expected_si_child_prop_ids = Prop::direct_child_prop_ids(ctx, root_prop.si_prop_id)
-        .await
-        .expect("could not get direct child prop ids");
+    let expected_si_child_prop_ids =
+        Prop::direct_child_prop_ids_unordered(ctx, root_prop.si_prop_id)
+            .await
+            .expect("could not get direct child prop ids");
 
     // Now, test our query.
     let found_si_prop =
         SchemaVariant::find_root_child_prop_id(ctx, schema_variant.id(), RootPropChild::Si)
             .await
             .expect("could not get si prop");
-    let found_si_child_prop_ids = Prop::direct_child_prop_ids(ctx, found_si_prop)
+    let found_si_child_prop_ids = Prop::direct_child_prop_ids_unordered(ctx, found_si_prop)
         .await
         .expect("could not get direct child prop ids");
 

--- a/lib/dal/tests/integration_test/secret.rs
+++ b/lib/dal/tests/integration_test/secret.rs
@@ -526,7 +526,7 @@ async fn secret_definition_works_with_dummy_qualification(
             .expect("no output attribute value found");
         assert!(output_socket_attribute_value_ids.is_empty());
         let output_socket_attribute_value =
-            AttributeValue::get_by_id(ctx, output_socket_attribute_value_id)
+            AttributeValue::get_by_id_or_error(ctx, output_socket_attribute_value_id)
                 .await
                 .expect("could not get attribute value by id")
                 .value(ctx)
@@ -609,7 +609,7 @@ async fn secret_definition_works_with_dummy_qualification(
             .expect("no output attribute value found");
         assert!(output_socket_attribute_value_ids.is_empty());
         let output_socket_attribute_value =
-            AttributeValue::get_by_id(ctx, output_socket_attribute_value_id)
+            AttributeValue::get_by_id_or_error(ctx, output_socket_attribute_value_id)
                 .await
                 .expect("could not get attribute value by id")
                 .value(ctx)

--- a/lib/dal/tests/integration_test/secret/with_actions.rs
+++ b/lib/dal/tests/integration_test/secret/with_actions.rs
@@ -197,7 +197,7 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
         .pop()
         .expect("should have an av for last synced");
 
-    let last_synced_value = AttributeValue::get_by_id(ctx, last_synced_av_id)
+    let last_synced_value = AttributeValue::get_by_id_or_error(ctx, last_synced_av_id)
         .await
         .expect("should be able to get last synced av")
         .view(ctx)


### PR DESCRIPTION
## Description

This PR allows secrets to depend on secrets by ensuring before funcs are ordered. The ordering is determined by the underlying dependency graph based on the target component's ancestry, regardless of component type (e.g. "frame" or "component").

This PR also changes the asset builder to only allow one output socket for secret-defining assets as well as allows more than one secret prop (needed for secrets dependent on secrets).

<img src="https://media1.giphy.com/media/eWN3KoFveUDPfQUO3m/giphy.gif"/>

## Secondary Changes

- Add ability to find a source component by a given input socket match where the input socket has an arity of one
- Make secret errors related to widgets more clear in func runner
- Find auth funcs for a given secret child prop id based on output socket rather than secret definition props (related to the asset builder change)
- Add ability to list default secret defining schema variants by id
- Add ability to find the output socket for a secret defining schema variant
- Change `AttributeValue::get_by_id` to `AttributeValue::get_by_id_or_error` since the function will generate an error if the attribute value does not exist
- Change `Prop::direct_child_prop_ids` to `Prop::direct_child_prop_ids_unordered` since there is an ordered function that is likely preferable for most use cases