### PR TITLE
chore: temporary rollback of labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: labeler
 
 on:
-  - pull_request
+  - pull_request_target
 
 jobs:
   label:


### PR DESCRIPTION
This labeler update includes a breaking change that needs to be staged out in a specific way. Rolling this back so I can make that change. 