### PR TITLE
chore: merge queue dummy workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,15 @@
+# This is essentially a dummy to allow us to set
+# buildkite/si-merge-queue as a status check. This
+# is run during a PR, but the Buildkite check is run
+# in the merge queue
+name: PR Checks to confuse and delight
+
+on:
+  pull_request:
+
+jobs:
+  si-merge-queue:
+    name: buildkite/si-merge-queue
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "Success!"


### PR DESCRIPTION
The only way to block merges using the queue is to require status checks from jobs on the branch. However, we do not want to run `merge-queue` by default on every push on a PR, only when we actually go to merge. Adding this dummy workflow allows us to add the status check for PRs and for Buildkite to do the real thing for the merge queue (I think).

This should fail as I intentionally broke one of the tests to validate the failure.