### PR TITLE
Polish UX around secrets depending on secrets

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -96,6 +96,7 @@ export interface PropertyEditorProp {
   documentation?: string;
   validationFormat?: string;
   defaultCanBeSetBySocket: boolean;
+  isOriginSecret: boolean;
 }
 
 export interface PropertyEditorSchema {

--- a/app/web/src/assets/static/editor_typescript.txt
+++ b/app/web/src/assets/static/editor_typescript.txt
@@ -615,12 +615,15 @@ declare class PropBuilder implements IPropBuilder {
 
 interface SecretPropDefinition extends PropDefinition {
   hasInputSocket: boolean;
+  connectionAnnotation: string;
 }
 
 interface ISecretPropBuilder {
   setName(name: string): this;
 
   setSecretKind(kind: string): this;
+  
+  setConnectionAnnotation(annotation: string): this;
 
   setDocLinkRef(ref: string): this;
 
@@ -668,6 +671,8 @@ declare class SecretPropBuilder implements ISecretPropBuilder {
    * .setSecretKind("DigitalOcean Credential")
    */
   setSecretKind(kind: string): this;
+  
+  setConnectionAnnotation(annotation: string): this;
 
   setDocLinkRef(ref: string): this;
 

--- a/app/web/src/components/AttributesPanel/AttributesPanel.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanel.vue
@@ -118,11 +118,6 @@ import { useComponentAttributesStore } from "@/store/component_attributes.store"
 import { ComponentType } from "@/api/sdf/dal/schema";
 import AttributesPanelItem from "./AttributesPanelItem.vue";
 
-const props = defineProps({
-  object: Object,
-  numPreviewProps: { type: Number, default: 3 },
-});
-
 const rootRef = ref<HTMLDivElement>();
 
 // toggle to true to show JSON tree explorer or attributes/values

--- a/bin/lang-js/src/asset_builder.ts
+++ b/bin/lang-js/src/asset_builder.ts
@@ -62,8 +62,7 @@ export class ValueFromBuilder implements IValueFromBuilder {
    */
   setSocketName(name: string): this {
     if (
-      this.valueFrom.kind !== "inputSocket"
-      && this.valueFrom.kind !== "outputSocket"
+      this.valueFrom.kind !== "inputSocket" && this.valueFrom.kind !== "outputSocket"
     ) {
       return this;
     }
@@ -301,8 +300,7 @@ export interface IPropWidgetDefinitionBuilder {
  *  .setKind("text")
  *  .build()
  */
-export class PropWidgetDefinitionBuilder
-implements IPropWidgetDefinitionBuilder {
+export class PropWidgetDefinitionBuilder implements IPropWidgetDefinitionBuilder {
   propWidget = <PropWidgetDefinition>{};
 
   constructor() {
@@ -450,8 +448,7 @@ export interface ISiPropValueFromDefinitionBuilder {
   build(): SiPropValueFromDefinition;
 }
 
-export class SiPropValueFromDefinitionBuilder
-implements ISiPropValueFromDefinitionBuilder {
+export class SiPropValueFromDefinitionBuilder implements ISiPropValueFromDefinitionBuilder {
   definition = <SiPropValueFromDefinition>{};
 
   constructor() {
@@ -791,12 +788,15 @@ export class PropBuilder implements IPropBuilder {
 
 export interface SecretPropDefinition extends PropDefinition {
   hasInputSocket: boolean;
+  connectionAnnotation: string;
 }
 
 export interface ISecretPropBuilder {
   setName(name: string): this;
 
   setSecretKind(kind: string): this;
+
+  setConnectionAnnotation(annotation: string): this;
 
   setDocLinkRef(ref: string): this;
 
@@ -856,6 +856,11 @@ export class SecretPropBuilder implements ISecretPropBuilder {
    */
   setSecretKind(kind: string): this {
     this.prop.widget?.options.push({ label: "secretKind", value: kind });
+    return this;
+  }
+
+  setConnectionAnnotation(annotation: string): this {
+    this.prop.connectionAnnotation = annotation;
     return this;
   }
 
@@ -1102,8 +1107,7 @@ export class AssetBuilder implements IAssetBuilder {
       );
 
     if (
-      definition.connectionAnnotations
-      && definition.connectionAnnotations !== ""
+      definition.connectionAnnotations && definition.connectionAnnotations !== ""
     ) {
       outputSocketBuilder.setConnectionAnnotation(
         definition.connectionAnnotations,

--- a/lib/dal/src/func/authoring/data/ts_types/asset_types_with_secrets.d.ts
+++ b/lib/dal/src/func/authoring/data/ts_types/asset_types_with_secrets.d.ts
@@ -615,12 +615,15 @@ declare class PropBuilder implements IPropBuilder {
 
 interface SecretPropDefinition extends PropDefinition {
   hasInputSocket: boolean;
+  connectionAnnotation: string;
 }
 
 interface ISecretPropBuilder {
   setName(name: string): this;
 
   setSecretKind(kind: string): this;
+  
+  setConnectionAnnotation(annotation: string): this;
 
   setDocLinkRef(ref: string): this;
 
@@ -668,6 +671,8 @@ declare class SecretPropBuilder implements ISecretPropBuilder {
    * .setSecretKind("DigitalOcean Credential")
    */
   setSecretKind(kind: string): this;
+  
+  setConnectionAnnotation(annotation: string): this;
 
   setDocLinkRef(ref: string): this;
 

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -113,6 +113,8 @@ pub enum FuncRunnerError {
     Secret(#[from] SecretError),
     #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
+    #[error("too many attribute prototype arguments for protoype corresponding to component ({0}) and prop ({1}): {2:?}")]
+    TooManyAttributePrototypeArguments(ComponentId, PropId, Vec<AttributePrototypeArgumentId>),
     #[error("too many attribute values for component ({0}) and prop ({1})")]
     TooManyAttributeValues(ComponentId, PropId),
     #[error("transactions error: {0}")]
@@ -1151,6 +1153,16 @@ impl FuncRunner {
                 let attribute_prototype_argument_ids =
                     AttributePrototypeArgument::list_ids_for_prototype(ctx, attribute_prototype_id)
                         .await?;
+                if attribute_prototype_argument_ids.len() > 1 {
+                    return Err(FuncRunnerError::TooManyAttributePrototypeArguments(
+                        component_id,
+                        secret_child_prop_id,
+                        attribute_prototype_argument_ids.clone(),
+                    ));
+                }
+
+                // If there's not attribute prototype argument yet, the prototype is either using "si:unset" or nothing
+                // has been connected to us.
                 let attribute_prototype_argument_id = match attribute_prototype_argument_ids.first()
                 {
                     Some(attribute_prototype_argument_id) => *attribute_prototype_argument_id,

--- a/lib/dal/src/property_editor.rs
+++ b/lib/dal/src/property_editor.rs
@@ -12,8 +12,8 @@ use crate::validation::ValidationError;
 use crate::workspace_snapshot::node_weight::NodeWeightError;
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
-    pk, AttributeValueId, ComponentError, PropId, SchemaVariantId, SecretError, StandardModelError,
-    TransactionsError,
+    pk, AttributeValueId, ComponentError, PropId, SchemaVariantError, SchemaVariantId, SecretError,
+    StandardModelError, TransactionsError,
 };
 
 pub mod schema;
@@ -38,6 +38,8 @@ pub enum PropertyEditorError {
     Prop(#[from] PropError),
     #[error("property editor value not found by prop id: {0}")]
     PropertyEditorValueNotFoundByPropId(PropId),
+    #[error("schema variant error: {0}")]
+    SchemaVariant(#[from] SchemaVariantError),
     #[error("schema variant not found: {0}")]
     SchemaVariantNotFound(SchemaVariantId),
     #[error("secret error: {0}")]

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -1907,14 +1907,7 @@ impl SchemaVariant {
     ) -> SchemaVariantResult<Vec<SchemaVariantId>> {
         let mut ids = Vec::new();
         for maybe_secret_defining_id in Self::list_default_ids(ctx).await? {
-            if Prop::find_prop_id_by_path_opt(
-                ctx,
-                maybe_secret_defining_id,
-                &PropPath::new(["root", "secret_definition"]),
-            )
-            .await?
-            .is_some()
-            {
+            if Self::is_secret_defining(ctx, maybe_secret_defining_id).await? {
                 ids.push(maybe_secret_defining_id);
             }
         }
@@ -1945,5 +1938,17 @@ impl SchemaVariant {
             SchemaVariantError::SecretDefiningSchemaVariantMissingOutputSocket(secret_defining_id),
         )?;
         Ok(secret_output_socket.to_owned())
+    }
+
+    /// Determines if the given [`SchemaVariant`] defines a [`Secret`](crate::Secret).
+    pub async fn is_secret_defining(
+        ctx: &DalContext,
+        id: SchemaVariantId,
+    ) -> SchemaVariantResult<bool> {
+        Ok(
+            Prop::find_prop_id_by_path_opt(ctx, id, &PropPath::new(["root", "secret_definition"]))
+                .await?
+                .is_some(),
+        )
     }
 }

--- a/lib/dal/tests/integration_test/func/authoring/binding/attribute.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding/attribute.rs
@@ -6,8 +6,8 @@ use dal::attribute::prototype::argument::AttributePrototypeArgument;
 use dal::func::argument::{FuncArgument, FuncArgumentKind};
 use dal::func::binding::attribute::AttributeBinding;
 use dal::func::binding::{
-    AttributeArgumentBinding, AttributeFuncDestination, AttributeFuncArgumentSource, EventualParent,
-    FuncBinding, FuncBindings,
+    AttributeArgumentBinding, AttributeFuncArgumentSource, AttributeFuncDestination,
+    EventualParent, FuncBinding, FuncBindings,
 };
 use dal::func::summary::FuncSummary;
 use dal::prop::PropPath;


### PR DESCRIPTION
## Description

This PR polishes the UX around secrets depending on secrets.

<img src="https://media4.giphy.com/media/DgvvgMXmv88XLFfvT8/giphy.gif"/>

## Commit 1 of 2

This commit allows connection annotations for input sockets corresponding to `/root/secrets/<secret>` props. This allows components to accept multiple secret shapes for a single input socket.

## Commit 2 of 2

This commit does the following:

1. Shows the real definition for a populated secret rather than the secret for its kind (e.g. show `ECR Credential / <name>` and not `Docker Hub Credential / <name>` on a `Docker Image` component) since we now have connection annotations for input sockets and output sockets for secrets.
2. Blocks populating secrets outside of secret-defining components. This ensures that secrets are only selected at origin, which reduces papercuts when selecting secrets that may depend on secrets. In addition, it narrows the number of secrets you can select. For example, if `Docker Image` has multiple connection annotations that correspond to different secret shapes, you would have to support something like a multi-secret-shape picker in `Docker Image`.

### Secondary Changes

- Create `PropertyEditorProps` with a builder to cache the secret origin `PropId`
- Add an additional check for number of attribute prototype arguments when determining value sources while collecting before funcs
- Move `is_secret_defining` logic into its own function