### PR TITLE
Fix leaf func detachment and action func attachment

### DIFF
--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -92,12 +92,13 @@ impl From<ActionKind> for si_events::ActionKind {
         }
     }
 }
+
 impl From<si_events::ActionKind> for ActionKind {
     fn from(value: si_events::ActionKind) -> Self {
         match value {
             si_events::ActionKind::Create => ActionKind::Create,
             si_events::ActionKind::Destroy => ActionKind::Destroy,
-            si_events::ActionKind::Manual => ActionKind::Refresh,
+            si_events::ActionKind::Manual => ActionKind::Manual,
             si_events::ActionKind::Refresh => ActionKind::Refresh,
             si_events::ActionKind::Update => ActionKind::Update,
         }

--- a/lib/dal/src/func/associations.rs
+++ b/lib/dal/src/func/associations.rs
@@ -89,7 +89,8 @@ impl FuncAssociations {
         let (associations, input_type) = match func.kind {
             FuncKind::Action => {
                 let schemas_and_prototypes =
-                    SchemaVariant::list_for_action_func(ctx, func.id).await?;
+                    SchemaVariant::list_with_action_prototypes_for_action_func(ctx, func.id)
+                        .await?;
                 let schema_variant_ids = schemas_and_prototypes
                     .clone()
                     .into_iter()

--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -208,7 +208,6 @@ impl FuncAuthoringClient {
         level = "info",
         skip(ctx)
     )]
-
     pub async fn create_new_action_func(
         ctx: &DalContext,
         name: Option<String>,
@@ -226,7 +225,6 @@ impl FuncAuthoringClient {
         level = "info",
         skip(ctx)
     )]
-
     pub async fn create_new_leaf_func(
         ctx: &DalContext,
         name: Option<String>,

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -61,8 +61,6 @@ pub enum FuncBindingsError {
     CannotCompileTypes(FuncId),
     #[error("component error: {0}")]
     ComponentError(#[from] ComponentError),
-    #[error("failed to remove attribute value for leaf")]
-    FailedToRemoveLeafAttributeValue,
     #[error("func error: {0}")]
     Func(#[from] FuncError),
     #[error("func argument error: {0}")]
@@ -385,11 +383,7 @@ impl FuncBindings {
     }
 
     /// For a given [`FuncId`], gather all of the bindings for every place where it is being used
-    #[instrument(
-        level = "debug",
-        skip(ctx),
-        name = "func.binding.delete_all_bindings_for_func_id"
-    )]
+    #[instrument(level = "debug", skip(ctx), name = "func.binding.from_func_id")]
     pub async fn from_func_id(
         ctx: &DalContext,
         func_id: FuncId,


### PR DESCRIPTION
## Description

This PR ensures detaching leaf funcs from schema variants also detaches them from components using the schema variant (unless overridden). This works by removing map entry attribute values that use the prototype being deleted (i.e. detaching logic).

This PR also fixes action func attachment showing the wrong kind by fixing the conversion from the events type to the real type.

<img src="https://media4.giphy.com/media/Et8a9vvkghmf9Es1Tn/giphy.gif"/>