### PR TITLE
feat(dal,sdf,module-index-server): use schema id when importing

### DIFF
--- a/app/web/.env
+++ b/app/web/.env
@@ -22,8 +22,8 @@ VITE_BACKEND_HOSTS=["/localhost/g","/si.keeb.dev/g","/app.systeminit.com/g","/to
 # VITE_SI_CYPRESS_MULTIPLIER=1                                   # How many times to run each test in cypress, only changes modelling tests
 
 
-# TODO: point this at public/deployed module index api
 VITE_MODULE_INDEX_API_URL=https://module-index.systeminit.com
+#VITE_MODULE_INDEX_API_URL=http://localhost:5157
 
 # vars only used for local dev, but we keep them here anyway since they dont hurt anything
 DEV_HOST=127.0.0.1 # set this to 0.0.0.0 to serve vite to external clients

--- a/lib/dal/src/layer_db_types/content_types.rs
+++ b/lib/dal/src/layer_db_types/content_types.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use si_events::ulid::Ulid;
 use si_events::{CasValue, ContentHash};
 use strum::EnumDiscriminants;
 use thiserror::Error;
@@ -317,6 +318,16 @@ pub struct InputSocketContentV1 {
 #[derive(Debug, Clone, EnumDiscriminants, Serialize, Deserialize, PartialEq)]
 pub enum ModuleContent {
     V1(ModuleContentV1),
+    V2(ModuleContentV2),
+}
+
+impl ModuleContent {
+    pub fn inner(&self) -> ModuleContentV2 {
+        match self {
+            ModuleContent::V1(inner) => inner.to_owned().into(),
+            ModuleContent::V2(inner) => inner.to_owned(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -328,6 +339,33 @@ pub struct ModuleContentV1 {
     pub description: String,
     pub created_by_email: String,
     pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct ModuleContentV2 {
+    pub timestamp: Timestamp,
+    pub name: String,
+    pub root_hash: String,
+    pub version: String,
+    pub description: String,
+    pub created_by_email: String,
+    pub created_at: DateTime<Utc>,
+    pub schema_id: Option<Ulid>,
+}
+
+impl From<ModuleContentV1> for ModuleContentV2 {
+    fn from(value: ModuleContentV1) -> Self {
+        Self {
+            timestamp: value.timestamp,
+            name: value.name,
+            root_hash: value.root_hash,
+            version: value.version,
+            description: value.description,
+            created_by_email: value.created_by_email,
+            created_at: value.created_at,
+            schema_id: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, EnumDiscriminants, Serialize, Deserialize, PartialEq)]

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -6,6 +6,7 @@ use base64::Engine;
 use chrono::Utc;
 use convert_case::{Case, Casing};
 use pkg::import::import_schema_variant;
+use si_events::ulid::Ulid;
 use si_layer_cache::LayerDbError;
 use si_pkg::{
     FuncSpec, FuncSpecBackendKind, FuncSpecBackendResponseType, FuncSpecData, MergeSkip, PkgSpec,
@@ -168,6 +169,7 @@ impl VariantAuthoringClient {
                     asset_func.clone(),
                 )])),
                 create_unlocked: true,
+                schema_id: Some(Ulid::new()),
                 ..Default::default()
             }),
         )
@@ -181,7 +183,11 @@ impl VariantAuthoringClient {
         Ok(SchemaVariant::get_by_id(ctx, schema_variant_id).await?)
     }
 
-    #[instrument(name = "variant.authoring.clone_variant", level = "info", skip_all)]
+    #[instrument(
+        name = "variant.authoring.new_schema_with_cloned_variant",
+        level = "info",
+        skip_all
+    )]
     pub async fn new_schema_with_cloned_variant(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -229,6 +235,7 @@ impl VariantAuthoringClient {
                         cloned_func.clone(),
                     )])),
                     create_unlocked: true,
+                    schema_id: Some(Ulid::new()),
                     ..Default::default()
                 }),
             )

--- a/lib/dal/tests/integration_test/pkg/mod.rs
+++ b/lib/dal/tests/integration_test/pkg/mod.rs
@@ -1,5 +1,5 @@
 use dal::pkg::export::PkgExporter;
-use dal::pkg::import_pkg_from_pkg;
+use dal::pkg::{import_pkg_from_pkg, ImportOptions};
 use dal::schema::variant::authoring::VariantAuthoringClient;
 use dal::{DalContext, FuncBackendKind, FuncBackendResponseType};
 use dal_test::test;
@@ -87,9 +87,16 @@ async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) {
     let pkg = SiPkg::load_from_spec(pkg_spec).expect("should load from spec");
 
     // import and get add variants
-    let (_, mut variants, _) = import_pkg_from_pkg(ctx, &pkg, None)
-        .await
-        .expect("should import");
+    let (_, mut variants, _) = import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema.id().into()),
+            ..Default::default()
+        }),
+    )
+    .await
+    .expect("should import");
     assert_eq!(variants.len(), 1);
 
     let default_schema_variant = schema

--- a/lib/module-index-client/src/lib.rs
+++ b/lib/module-index-client/src/lib.rs
@@ -2,8 +2,11 @@ pub mod client;
 pub mod types;
 
 pub use client::IndexClient;
-pub use types::{FuncMetadata, IndexClientError, IndexClientResult, ModuleDetailsResponse};
+pub use types::{
+    ExtraMetadata, FuncMetadata, IndexClientError, IndexClientResult, ModuleDetailsResponse,
+};
 
 pub const DEFAULT_URL: &str = "http://localhost:5157";
 pub const MODULE_BUNDLE_FIELD_NAME: &str = "module_bundle";
-pub const MODULE_BASED_ON_HASH_NAME: &str = "based_on_hash";
+pub const MODULE_BASED_ON_HASH_FIELD_NAME: &str = "based_on_hash";
+pub const MODULE_SCHEMA_ID_FIELD_NAME: &str = "schema_id";

--- a/lib/module-index-client/src/types.rs
+++ b/lib/module-index-client/src/types.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use ulid::Ulid;
 
 #[remain::sorted]
 #[derive(Debug, Error)]
@@ -47,6 +48,16 @@ pub struct ModuleDetailsResponse {
     pub latest_hash: String,
     pub latest_hash_created_at: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
+    pub schema_id: Option<String>,
+    pub past_hashes: Option<Vec<String>>,
+}
+
+impl ModuleDetailsResponse {
+    pub fn schema_id(&self) -> Option<Ulid> {
+        self.schema_id
+            .as_deref()
+            .and_then(|schema_id| Ulid::from_string(schema_id).ok())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -55,4 +66,12 @@ pub struct FuncMetadata {
     pub name: String,
     pub display_name: Option<String>,
     pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtraMetadata {
+    pub version: String,
+    pub schemas: Vec<String>,
+    pub funcs: Vec<FuncMetadata>,
 }

--- a/lib/module-index-server/src/migrations/U0008__add_indexes.sql
+++ b/lib/module-index-server/src/migrations/U0008__add_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX ON modules (latest_hash);
+CREATE INDEX ON modules (schema_id);

--- a/lib/module-index-server/src/routes/list_builtins_route.rs
+++ b/lib/module-index-server/src/routes/list_builtins_route.rs
@@ -4,11 +4,12 @@ use axum::{
     Json,
 };
 use hyper::StatusCode;
+use module_index_client::ModuleDetailsResponse;
 use sea_orm::{ColumnTrait, DbErr, EntityTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::models::si_module::ModuleKind;
+use crate::models::si_module::{make_module_details_response, ModuleKind, SchemaIdReferenceLink};
 use crate::{app_state::AppState, extract::DbConnection, models::si_module, whoami::WhoamiError};
 
 #[remain::sorted]
@@ -43,7 +44,7 @@ pub struct ListBuiltinsRequest {
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ListBuiltinsResponse {
-    modules: Vec<si_module::Model>,
+    modules: Vec<ModuleDetailsResponse>,
 }
 
 pub async fn list_builtins_route(
@@ -54,14 +55,19 @@ pub async fn list_builtins_route(
     let query = si_module::Entity::find();
 
     // filters
-    let query = query.filter(si_module::Column::IsBuiltinAt.is_not_null());
-
     let query = query
+        .find_with_linked(SchemaIdReferenceLink)
+        .filter(si_module::Column::IsBuiltinAt.is_not_null())
         .filter(si_module::Column::RejectedAt.is_null())
         .filter(si_module::Column::Kind.eq(ModuleKind::Module));
 
     // This should give us a list of builtin modules that are not rejected
-    let modules: Vec<si_module::Model> = query.all(&txn).await?;
+    let modules = query
+        .all(&txn)
+        .await?
+        .into_iter()
+        .map(|(module, linked_modules)| make_module_details_response(module, linked_modules))
+        .collect();
 
     Ok(Json(ListBuiltinsResponse { modules }))
 }

--- a/lib/module-index-server/src/routes/upsert_workspace_route.rs
+++ b/lib/module-index-server/src/routes/upsert_workspace_route.rs
@@ -14,11 +14,11 @@ use telemetry::prelude::*;
 use thiserror::Error;
 
 use crate::models::si_module::ModuleKind;
-use crate::routes::upsert_module_route::ExtraMetadata;
 use crate::{
     extract::{Authorization, DbConnection, ExtractedS3Bucket},
     models::si_module,
 };
+use module_index_client::ExtraMetadata;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Installing an asset that is a variant of an existing asset will use the module "schema id" (along with the hashes, if the schema id is not available) to try and install the asset as a variant of the existing schema.