### PR TITLE
fix(docs): Ensure docs works with DEV_HOST and DEV_PORT

### DIFF
--- a/app/docs/.env
+++ b/app/docs/.env
@@ -1,0 +1,2 @@
+DEV_HOST=localhost
+DEV_PORT=5173

--- a/app/docs/BUCK
+++ b/app/docs/BUCK
@@ -20,7 +20,7 @@ load(
 
 pnpm_task_binary(
     name = "dev",
-    command = "docs:dev",
+    command = "dev",
     srcs = glob(["src/**/*"]),
     path = "app/docs",
     deps = [

--- a/app/docs/package.json
+++ b/app/docs/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "docs:dev": "vitepress dev src"
+    "dev": "pnpm run start",
+    "start": "vitepress dev src"
   },
   "devDependencies": {
     "@si/eslint-config": "workspace:*",
@@ -16,5 +17,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "dependencies": {
+    "dotenv": "^16.0.3"
   }
 }

--- a/app/docs/src/.vitepress/config.ts
+++ b/app/docs/src/.vitepress/config.ts
@@ -1,28 +1,33 @@
 import { defineConfig } from "vitepress";
+import dotenv from "dotenv";
 
-async function load() {
-  return defineConfig({
-    title: "System Initiative Docs",
-    description: "Description goes here",
-    markdown: {
-      theme: {
-        light: "github-light",
-        dark: "github-dark",
-      },
-    },
-    cleanUrls: true,
-    themeConfig: {
-      nav: [
-        { text: "Home", link: "/" },
-        { text: "Tutorials", link: "/tutorials/" },
-        { text: "Reference Docs", link: "/reference/" },
-        { text: "Changelog", link: "/changelog/" },
-      ],
-      search: {
-        provider: "local",
-      },
-    },
-  });
-}
+dotenv.config();
 
-export default load();
+export default defineConfig({
+  title: "System Initiative Docs",
+  description: "Description goes here",
+  markdown: {
+    theme: {
+      light: "github-light",
+      dark: "github-dark",
+    },
+  },
+  cleanUrls: true,
+  themeConfig: {
+    nav: [
+      { text: "Home", link: "/" },
+      { text: "Tutorials", link: "/tutorials/" },
+      { text: "Reference Docs", link: "/reference/" },
+      { text: "Changelog", link: "/changelog/" },
+    ],
+    search: {
+      provider: "local",
+    },
+  },
+  vite: {
+    server: {
+      host: process.env.DEV_HOST,
+      port: parseInt(process.env.DEV_PORT!, 10),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,10 @@ importers:
         version: 1.8.27(typescript@4.9.5)
 
   app/docs:
+    dependencies:
+      dotenv:
+        specifier: ^16.0.3
+        version: 16.0.3
     devDependencies:
       '@si/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
Run buck2 run //app/docs:dev to start the app if outside of tilt - you can set DEV_HOST and DEV_PORT to override the .env file