### PR TITLE
Fix create new auth function

### DIFF
--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -205,7 +205,7 @@ impl From<FuncBinding> for si_frontend_types::FuncBinding {
             },
             FuncBinding::Authentication(auth) => si_frontend_types::FuncBinding::Authentication {
                 schema_variant_id: auth.schema_variant_id.into(),
-                func_id: auth.func_id.into(),
+                func_id: Some(auth.func_id.into()),
             },
             FuncBinding::CodeGeneration(code_gen) => {
                 si_frontend_types::FuncBinding::CodeGeneration {

--- a/lib/sdf-server/src/server/service/v2/func/binding/create_binding.rs
+++ b/lib/sdf-server/src/server/service/v2/func/binding/create_binding.rs
@@ -101,12 +101,17 @@ pub async fn create_binding(
                     func_id,
                 } = binding
                 {
-                    AuthBinding::create_auth_binding(
-                        &ctx,
-                        func_id.into(),
-                        schema_variant_id.into(),
-                    )
-                    .await?;
+                    match func_id {
+                        Some(func_id) => {
+                            AuthBinding::create_auth_binding(
+                                &ctx,
+                                func_id.into(),
+                                schema_variant_id.into(),
+                            )
+                            .await?;
+                        }
+                        None => return Err(FuncAPIError::MissingFuncId),
+                    }
                 }
             }
         }

--- a/lib/si-frontend-types-rs/src/func.rs
+++ b/lib/si-frontend-types-rs/src/func.rs
@@ -103,7 +103,7 @@ pub enum FuncBinding {
     Authentication {
         // unique ids
         schema_variant_id: SchemaVariantId,
-        func_id: FuncId,
+        func_id: Option<FuncId>,
     },
     #[serde(rename_all = "camelCase")]
     CodeGeneration {


### PR DESCRIPTION
When creating a new auth function, the front end doesn't send us a func id (because it doesn't exist yet!) so I just needed to update the front end type to accept an `Option<FuncId>` and make sure that when creating a new binding for an existing Auth Func, the `FuncId` exists