### PR TITLE
chore: modify module index deploy to update shared cluster

### DIFF
--- a/.github/workflows/deploy-module-index.yml
+++ b/.github/workflows/deploy-module-index.yml
@@ -3,29 +3,21 @@ name: Deploy Module Index
   workflow_dispatch: {}
 
 env:
-  MODULE_INDEX_CLUSTER: module-index-server-51059bf
+  MODULE_INDEX_CLUSTER: shared-cluster
   MODULE_INDEX_SERVICE: module-index
-  MODULE_INDEX_IMAGE: systeminit/module-index:stable
-  ECR_IMAGE: 835304779882.dkr.ecr.us-east-2.amazonaws.com/si/si-module-index:stable
 
 jobs:
   deploy:
-    name: Build and push container
+    name: Deploy latest stable image
+    environment: shared
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ECS_DEPLOYMENT_USER_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_ECS_DEPLOYMENT_USER_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_ECS_REGION }}
-      - name: Login to ECR
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Pull latest, tag, push to ECR
-        run: |
-          docker pull --platform=linux/amd64 ${{ env.MODULE_INDEX_IMAGE }}
-          docker tag ${{ env.MODULE_INDEX_IMAGE }} ${{ env.ECR_IMAGE }}
-          docker push ${{ env.ECR_IMAGE }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: us-east-1
       - name: Trigger ECS Deploy
         run: |
-          aws ecs update-service --region ${{ secrets.AWS_ECS_REGION }} --cluster ${{ env.MODULE_INDEX_CLUSTER }} --service ${{ env.MODULE_INDEX_SERVICE }} --force-new-deployment
+          aws ecs update-service --cluster ${{ env.MODULE_INDEX_CLUSTER }} --service ${{ env.MODULE_INDEX_SERVICE }} --force-new-deployment


### PR DESCRIPTION
This will simply re-roll the module-index ecs service using the current deployed image tag, most likely 'stable'. It does not build the container image anymore, so we'll need to go figure that bit out separately. 

<img src="https://media4.giphy.com/media/ROlbnsc7aCIL6Icq6h/giphy.gif"/>