### PR TITLE
Enqueue DVU when modifying or creating attribute func bindings for variants with existing components

### DIFF
--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -762,6 +762,12 @@ impl FuncAuthoringClient {
             Ok(())
         })
         .await?;
+
+        // enqueue DVU when the func is saved if it's for an attribute/codegen/qualification
+        let attribute_prototypes = AttributePrototype::list_ids_for_func_id(ctx, func_id).await?;
+        for attribute_prototype_id in attribute_prototypes {
+            AttributeBinding::enqueue_dvu_for_impacted_values(ctx, attribute_prototype_id).await?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
One other change here to discuss Monday: 
- When resetting an attribute prototype, if the prototype is for a Prop, default to the unset intrinisic func
- If it's for an output socket, reset to the identity func, so that regenerate can re-set the prototype to a value from if it's defined in the asset definition func

Update: discussed and we are not going to do this as it prevents that prop from ever having a default value again (under current constraints)