### PR TITLE
Do not regenerate if the return type is not Asset

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -241,6 +241,17 @@ However, if you are a contributor seeking build times suitable for rapid iterati
 > _Contributors should test your changes with integration tests and with release optimizations when running the full stack._
 > _The aforementioned options are solely recommended for rapid iteration._
 
+## What if I want to access my local instance remotely?
+
+You run the full stack the same way, but with additional environment variables.
+
+```shell
+TILT_HOST=0.0.0.0 DEV_HOST=0.0.0.0 buck2 run dev:up
+```
+
+> [!CAUTION]
+> _The user is responsible for maintaining secure access (local, remote, etc.) to their local instance._
+
 # Using LocalStack for Secrets and Credentials
 
 This section contains information related to using [LocalStack](https://github.com/localstack/localstack) when working on the System Initiative software.
@@ -377,6 +388,32 @@ Short version: you'll use the following pattern:
 # Pattern for integration tests
 <ENV> buck2 run <PATH/TO/RUST/LIBRARY/DIRECTORY/WITH/BUCK>:test-integration -- <ARGS>
 ```
+
+## How do I build all Rust targets with `buck2`?
+
+With `xargs` installed, run the following command:
+
+```shell
+buck2 uquery 'kind("rust_(binary|library|test)", set("//bin/..." "//lib/..."))' | xargs buck2 build
+```
+
+This commands queries for all `rust_binary`, `rust_library` and `rust_test` targets found in `bin/**` `lib/**` directories with `BUCK` files.
+Then, it pipes that output into `buck2 build`.
+
+## How do I build all runnable services written in Rust with `buck2`?
+
+If you intend to run these services with optimial performance, you need to build with release mode.
+Here is an example building `sdf`, `pinga`, `veritech` and `rebaser` from the repository root:
+
+```shell
+buck2 build @//mode/release bin/sdf bin/pinga bin/veritech bin/rebaser
+```
+
+## What are modes used in `buck2` builds?
+
+Specifying modes (i.e. `@//mode/<mode>`) from the [mode](mode) directory changes the build optimizations for buildable targets.
+The build cache is not shared between modes and changing modes does not invalidate the cache for other modes.
+In other words, you build the same buildable target with two different modes and retain both caches.
 
 ## Where are `buck2` users hanging out?
 

--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -60,7 +60,7 @@
 
       <Stack class="p-xs" spacing="none">
         <div>
-          <ErrorMessage :requestStatus="updateAssetReqStatus" />
+          <ErrorMessage :requestStatus="updateAssetReqStatus" variant="block" />
         </div>
         <VormInput
           id="schemaName"

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1459,7 +1459,7 @@ impl Component {
         component_id: ComponentId,
     ) -> ComponentResult<SchemaVariant> {
         let schema_variant_id = Self::schema_variant_id(ctx, component_id).await?;
-        Ok(SchemaVariant::get_by_id(ctx, schema_variant_id).await?)
+        Ok(SchemaVariant::get_by_id_or_error(ctx, schema_variant_id).await?)
     }
 
     pub async fn schema_variant(&self, ctx: &DalContext) -> ComponentResult<SchemaVariant> {

--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -602,7 +602,8 @@ impl FuncAuthoringClient {
 
         let schema = SchemaVariant::schema_id_for_schema_variant_id(ctx, schema_variant_id).await?;
         // is the current schema varaint already unlocked? if so, proceed
-        let current_schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
+        let current_schema_variant =
+            SchemaVariant::get_by_id_or_error(ctx, schema_variant_id).await?;
         let new_func = if !current_schema_variant.is_locked() {
             //already on an unlocked variant, just create unlocked copy of the func and reattach
             // bindings for that schema variant

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -390,7 +390,7 @@ impl FuncBinding {
                     }
                     None => {
                         if !SchemaVariant::is_locked_by_id(ctx, schema_variant_id).await?
-                            || SchemaVariant::get_by_id(ctx, schema_variant_id)
+                            || SchemaVariant::get_by_id_or_error(ctx, schema_variant_id)
                                 .await?
                                 .is_default(ctx)
                                 .await?

--- a/lib/dal/src/module.rs
+++ b/lib/dal/src/module.rs
@@ -344,7 +344,7 @@ impl Module {
                     inner.content_address().into();
 
                 if inner_addr_discrim == ContentAddressDiscriminants::SchemaVariant {
-                    let variant = SchemaVariant::get_by_id(ctx, inner.id().into()).await?;
+                    let variant = SchemaVariant::get_by_id_or_error(ctx, inner.id().into()).await?;
                     all_schema_variants.push(variant);
                 }
             }

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -329,7 +329,7 @@ impl PkgExporter {
         ctx: &DalContext,
         variant_id: SchemaVariantId,
     ) -> PkgResult<Vec<SiPropFuncSpec>> {
-        let _variant = SchemaVariant::get_by_id(ctx, variant_id).await?;
+        let _variant = SchemaVariant::get_by_id_or_error(ctx, variant_id).await?;
         let mut specs = vec![];
 
         for kind in SiPropFuncSpecKind::iter() {
@@ -1029,7 +1029,7 @@ impl PkgExporter {
             }
         }
 
-        let variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
+        let variant = SchemaVariant::get_by_id_or_error(ctx, schema_variant_id).await?;
 
         // Asset Funcs are not stored in the FuncMap
         // So we need to look it up directly then store it!

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -577,7 +577,10 @@ impl SchemaVariant {
         Ok(all_props)
     }
 
-    pub async fn get_by_id(ctx: &DalContext, id: SchemaVariantId) -> SchemaVariantResult<Self> {
+    pub async fn get_by_id_or_error(
+        ctx: &DalContext,
+        id: SchemaVariantId,
+    ) -> SchemaVariantResult<Self> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let node_index = workspace_snapshot
@@ -698,7 +701,7 @@ impl SchemaVariant {
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
     ) -> SchemaVariantResult<bool> {
-        let schema_variant = Self::get_by_id(ctx, schema_variant_id).await?;
+        let schema_variant = Self::get_by_id_or_error(ctx, schema_variant_id).await?;
         Ok(schema_variant.is_locked)
     }
 
@@ -728,7 +731,7 @@ impl SchemaVariant {
             .await?
             .ok_or(SchemaVariantError::DefaultSchemaVariantNotFound(schema_id))?;
 
-        Self::get_by_id(ctx, default_schema_variant_id).await
+        Self::get_by_id_or_error(ctx, default_schema_variant_id).await
     }
 
     pub async fn get_default_id_for_schema(

--- a/lib/dal/src/schema/variant/json.rs
+++ b/lib/dal/src/schema/variant/json.rs
@@ -49,7 +49,7 @@ impl SchemaVariantMetadataJson {
 /// The json definition for a [`SchemaVariant`](crate::SchemaVariant)'s [`Prop`](crate::Prop) tree (and
 /// more in the future).
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SchemaVariantJson {
     /// The immediate child [`Props`](crate::Prop) underneath "/root/domain".
     #[serde(default)]

--- a/lib/dal/tests/integration_test/asset.rs
+++ b/lib/dal/tests/integration_test/asset.rs
@@ -1,0 +1,121 @@
+use dal::schema::variant::authoring::{VariantAuthoringClient, VariantAuthoringError};
+use dal::schema::variant::DEFAULT_SCHEMA_VARIANT_COLOR;
+use dal::{DalContext, SchemaVariant, SchemaVariantId};
+use dal_test::helpers::ChangeSetTestHelpers;
+use dal_test::test;
+
+#[test]
+async fn asset_func_execution_papercuts(ctx: &mut DalContext) {
+    let (schema_name, unstable_schema_variant_id) = {
+        let schema_variant = VariantAuthoringClient::create_schema_and_variant(
+            ctx,
+            "name",
+            None::<String>,
+            None::<String>,
+            "category",
+            DEFAULT_SCHEMA_VARIANT_COLOR,
+        )
+        .await
+        .expect("could not create schema and variant");
+        let schema = schema_variant
+            .schema(ctx)
+            .await
+            .expect("could not get schema");
+        ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+            .await
+            .expect("could not commit and update snapshot to visibility");
+        (schema.name, schema_variant.id)
+    };
+
+    // PASS - save with the default code and regenerate
+    let code = "function main() { return new AssetBuilder().build(); }";
+    let unstable_schema_variant_id =
+        save_and_regenerate(ctx, code, &schema_name, unstable_schema_variant_id)
+            .await
+            .expect("could not save and regenerate");
+
+    // FAIL - create a socket, but drop the build call
+    let code = "function main() {
+      const socket = new SocketDefinitionBuilder()
+        .setName(\"socket\")
+        .setArity(\"many\")
+        .build();
+      return new AssetBuilder()
+        .addOutputSocket(socket);
+    }";
+    match save_and_regenerate(ctx, code, &schema_name, unstable_schema_variant_id).await {
+        Ok(_) => panic!("expected failure upon regeneration"),
+        Err(box_err) => match box_err.downcast_ref::<VariantAuthoringError>() {
+            Some(err) => match err {
+                VariantAuthoringError::AssetTypeNotReturnedForAssetFunc(_, _) => {}
+                err => panic!("{:?}", err),
+            },
+            None => panic!("{:?}", box_err),
+        },
+    }
+
+    // FAIL - mmediately return the builder and regenerate
+    let code = "function main() {
+      const socket = new SocketDefinitionBuilder()
+        .setName(\"socket\")
+        .setArity(\"many\")
+        .build();
+      return new AssetBuilder()
+        .addOutputSocket(socket);
+    }";
+    match save_and_regenerate(ctx, code, &schema_name, unstable_schema_variant_id).await {
+        Ok(_) => panic!("expected failure upon regeneration"),
+        Err(box_err) => match box_err.downcast_ref::<VariantAuthoringError>() {
+            Some(err) => match err {
+                VariantAuthoringError::AssetTypeNotReturnedForAssetFunc(_, _) => {}
+                err => panic!("{:?}", err),
+            },
+            None => panic!("{:?}", box_err),
+        },
+    }
+
+    // PASS - add the build call when creating a socket
+    let code = "function main() {
+      const socket = new SocketDefinitionBuilder()
+        .setName(\"socket\")
+        .setArity(\"many\")
+        .build();
+      return new AssetBuilder()
+        .addOutputSocket(socket)
+        .build();
+    }";
+    let _unstable_schema_variant_id =
+        save_and_regenerate(ctx, code, &schema_name, unstable_schema_variant_id)
+            .await
+            .expect("could not save and regenerate");
+}
+
+async fn save_and_regenerate(
+    ctx: &mut DalContext,
+    code: impl Into<String>,
+    schema_name: impl AsRef<str>,
+    schema_variant_id: SchemaVariantId,
+) -> Result<SchemaVariantId, Box<dyn std::error::Error>> {
+    let schema_variant = SchemaVariant::get_by_id_or_error(ctx, schema_variant_id).await?;
+    let schema_name = schema_name.as_ref();
+
+    VariantAuthoringClient::save_variant_content(
+        ctx,
+        schema_variant.id,
+        schema_name,
+        schema_variant.display_name(),
+        schema_variant.category(),
+        schema_variant.description(),
+        schema_variant.link(),
+        schema_variant.get_color(ctx).await?,
+        schema_variant.component_type(),
+        Some(code),
+    )
+    .await?;
+    let updated_schema_variant_id =
+        VariantAuthoringClient::regenerate_variant(ctx, schema_variant.id).await?;
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    Ok(updated_schema_variant_id)
+}

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -10,7 +10,9 @@ use dal::property_editor::values::PropertyEditorValues;
 use dal::{AttributeValue, AttributeValueId, Func, InputSocket, OutputSocket};
 use dal::{Component, DalContext, Schema, SchemaVariant};
 use dal_test::helpers::ChangeSetTestHelpers;
-use dal_test::helpers::{connect_components_with_socket_names, create_component_for_default_schema_name};
+use dal_test::helpers::{
+    connect_components_with_socket_names, create_component_for_default_schema_name,
+};
 use dal_test::test;
 use pretty_assertions_sorted::assert_eq;
 use veritech_client::ResourceStatus;
@@ -22,9 +24,10 @@ mod set_type;
 mod upgrade;
 #[test]
 async fn update_and_insert_and_update(ctx: &mut DalContext) {
-    let component = create_component_for_default_schema_name(ctx, "Docker Image", "a tulip in a cup")
-        .await
-        .expect("could not create component");
+    let component =
+        create_component_for_default_schema_name(ctx, "Docker Image", "a tulip in a cup")
+            .await
+            .expect("could not create component");
     let variant_id = Component::schema_variant_id(ctx, component.id())
         .await
         .expect("find variant id for component");
@@ -705,9 +708,10 @@ async fn through_the_wormholes_dynamic_child_value_reactivity(ctx: &mut DalConte
 
 #[test]
 async fn set_the_universe(ctx: &mut DalContext) {
-    let component = create_component_for_default_schema_name(ctx, "starfield", "across the universe")
-        .await
-        .expect("could not create component");
+    let component =
+        create_component_for_default_schema_name(ctx, "starfield", "across the universe")
+            .await
+            .expect("could not create component");
     let variant_id = Component::schema_variant_id(ctx, component.id())
         .await
         .expect("find variant id for component");

--- a/lib/dal/tests/integration_test/component/debug.rs
+++ b/lib/dal/tests/integration_test/component/debug.rs
@@ -9,9 +9,10 @@ use pretty_assertions_sorted::assert_eq;
 #[test]
 async fn get_debug_view(ctx: &mut DalContext) {
     //create a new component for starfield schema
-    let component: Component = create_component_for_default_schema_name(ctx, "starfield", "new component")
-        .await
-        .expect("could not create component");
+    let component: Component =
+        create_component_for_default_schema_name(ctx, "starfield", "new component")
+            .await
+            .expect("could not create component");
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update snapshot to visibility");

--- a/lib/dal/tests/integration_test/component/upgrade.rs
+++ b/lib/dal/tests/integration_test/component/upgrade.rs
@@ -116,10 +116,13 @@ async fn auto_upgrade_component(ctx: &mut DalContext) {
     assert_eq!(variant_zero.id(), updated_variant_id);
 
     // Add a component to the diagram
-    let initial_component =
-        create_component_for_default_schema_name(ctx, my_asset_schema.name.clone(), "demo component")
-            .await
-            .expect("could not create component");
+    let initial_component = create_component_for_default_schema_name(
+        ctx,
+        my_asset_schema.name.clone(),
+        "demo component",
+    )
+    .await
+    .expect("could not create component");
     let initial_diagram = Diagram::assemble(ctx)
         .await
         .expect("could not assemble diagram");

--- a/lib/dal/tests/integration_test/connection.rs
+++ b/lib/dal/tests/integration_test/connection.rs
@@ -11,12 +11,14 @@ use serde::Deserialize;
 #[test]
 async fn make_multiple_trees(ctx: &mut DalContext) {
     // create 2 even legos
-    let even_lego_1 = create_component_for_default_schema_name(ctx, "large even lego", "even lego 1")
-        .await
-        .expect("could not create component");
-    let even_lego_2 = create_component_for_default_schema_name(ctx, "large even lego", "even lego 2")
-        .await
-        .expect("could not create component");
+    let even_lego_1 =
+        create_component_for_default_schema_name(ctx, "large even lego", "even lego 1")
+            .await
+            .expect("could not create component");
+    let even_lego_2 =
+        create_component_for_default_schema_name(ctx, "large even lego", "even lego 2")
+            .await
+            .expect("could not create component");
 
     let even_sv_id = even_lego_1
         .schema_variant(ctx)
@@ -92,15 +94,18 @@ async fn make_multiple_trees(ctx: &mut DalContext) {
 #[test]
 async fn make_chain_remove_middle(ctx: &mut DalContext) {
     // make chain of odd lego 1 -> even lego 1 -> odd lego 2
-    let odd_component_1 = create_component_for_default_schema_name(ctx, "large odd lego", "odd lego 1")
-        .await
-        .expect("could not create component");
-    let even_component_1 = create_component_for_default_schema_name(ctx, "large even lego", "even lego 1")
-        .await
-        .expect("could not create component");
-    let odd_component_2 = create_component_for_default_schema_name(ctx, "large odd lego", "odd lego 2")
-        .await
-        .expect("could not create component");
+    let odd_component_1 =
+        create_component_for_default_schema_name(ctx, "large odd lego", "odd lego 1")
+            .await
+            .expect("could not create component");
+    let even_component_1 =
+        create_component_for_default_schema_name(ctx, "large even lego", "even lego 1")
+            .await
+            .expect("could not create component");
+    let odd_component_2 =
+        create_component_for_default_schema_name(ctx, "large odd lego", "odd lego 2")
+            .await
+            .expect("could not create component");
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update snapshot to visibility");

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -939,9 +939,10 @@ async fn down_frames_moving_deeply_nested_frames(ctx: &mut DalContext) {
         .await
         .expect("could not set type");
     // create child components
-    let first_child_component = create_component_for_default_schema_name(ctx, "medium odd lego", "child 1")
-        .await
-        .expect("could not create component");
+    let first_child_component =
+        create_component_for_default_schema_name(ctx, "medium odd lego", "child 1")
+            .await
+            .expect("could not create component");
     first_child_component
         .set_type(ctx, ComponentType::ConfigurationFrameDown)
         .await
@@ -1177,9 +1178,10 @@ async fn up_frames_moving_deeply_nested_frames(ctx: &mut DalContext) {
         .await
         .expect("could not set type");
     // create child components
-    let first_child_component = create_component_for_default_schema_name(ctx, "medium odd lego", "child 1")
-        .await
-        .expect("could not create component");
+    let first_child_component =
+        create_component_for_default_schema_name(ctx, "medium odd lego", "child 1")
+            .await
+            .expect("could not create component");
     first_child_component
         .set_type(ctx, ComponentType::ConfigurationFrameUp)
         .await
@@ -1364,18 +1366,20 @@ async fn up_frames_moving_deeply_nested_frames(ctx: &mut DalContext) {
 #[test]
 async fn simple_down_frames_nesting(ctx: &mut DalContext) {
     // create parent frame
-    let even_parent_frame = create_component_for_default_schema_name(ctx, "large even lego", "even parent")
-        .await
-        .expect("could not create component");
+    let even_parent_frame =
+        create_component_for_default_schema_name(ctx, "large even lego", "even parent")
+            .await
+            .expect("could not create component");
 
     even_parent_frame
         .set_type(ctx, ComponentType::ConfigurationFrameDown)
         .await
         .expect("could not set type");
     // create child frame
-    let even_child_frame = create_component_for_default_schema_name(ctx, "medium even lego", "even child")
-        .await
-        .expect("could not create component");
+    let even_child_frame =
+        create_component_for_default_schema_name(ctx, "medium even lego", "even child")
+            .await
+            .expect("could not create component");
 
     even_child_frame
         .set_type(ctx, ComponentType::ConfigurationFrameDown)
@@ -1583,9 +1587,10 @@ async fn simple_up_frames_some_nesting(ctx: &mut DalContext) {
     assert_eq!(input_value, serde_json::json!("3"));
 
     //now let's drop that up frame into an even up frame, driving the even values
-    let even_up_frame = create_component_for_default_schema_name(ctx, "large even lego", "another even")
-        .await
-        .expect("could not create component");
+    let even_up_frame =
+        create_component_for_default_schema_name(ctx, "large even lego", "another even")
+            .await
+            .expect("could not create component");
 
     even_up_frame
         .set_type(ctx, ComponentType::ConfigurationFrameUp)
@@ -1639,9 +1644,10 @@ async fn up_frames_multiple_children_moves_and_deletes(ctx: &mut DalContext) {
         create_component_for_default_schema_name(ctx, "medium even lego", "second_component")
             .await
             .expect("could not create component");
-    let first_up_frame = create_component_for_default_schema_name(ctx, "medium odd lego", "first_frame")
-        .await
-        .expect("could not create component");
+    let first_up_frame =
+        create_component_for_default_schema_name(ctx, "medium odd lego", "first_frame")
+            .await
+            .expect("could not create component");
     first_up_frame
         .set_type(ctx, ComponentType::ConfigurationFrameUp)
         .await
@@ -1705,9 +1711,10 @@ async fn up_frames_multiple_children_moves_and_deletes(ctx: &mut DalContext) {
         create_component_for_default_schema_name(ctx, "medium even lego", "second_component")
             .await
             .expect("could not create component");
-    let second_up_frame = create_component_for_default_schema_name(ctx, "medium odd lego", "first_frame")
-        .await
-        .expect("could not create component");
+    let second_up_frame =
+        create_component_for_default_schema_name(ctx, "medium odd lego", "first_frame")
+            .await
+            .expect("could not create component");
     //cache ids for later
     let third_component_id = third_component.id();
     let fourth_component_id = fourth_component.id();
@@ -1763,9 +1770,10 @@ async fn up_frames_multiple_children_moves_and_deletes(ctx: &mut DalContext) {
     assert_eq!(input_value, serde_json::json!(["3", "4"]));
     // both up frames feed the final up frame
 
-    let parent_up_frame = create_component_for_default_schema_name(ctx, "small even lego", "parent_frame")
-        .await
-        .expect("could not create component");
+    let parent_up_frame =
+        create_component_for_default_schema_name(ctx, "small even lego", "parent_frame")
+            .await
+            .expect("could not create component");
     let parent_up_frame_id = parent_up_frame.id();
     Frame::upsert_parent(ctx, first_up_frame_id, parent_up_frame_id)
         .await

--- a/lib/dal/tests/integration_test/frame/with_actions.rs
+++ b/lib/dal/tests/integration_test/frame/with_actions.rs
@@ -19,9 +19,10 @@ use pretty_assertions_sorted::assert_eq;
 async fn delete_frame_with_child_with_resource(ctx: &mut DalContext, nw: WorkspaceSignup) {
     // Create the components we need and commit.
     let parent_component_id = {
-        let parent_component = create_component_for_default_schema_name(ctx, "dummy-secret", "parent")
-            .await
-            .expect("could not create component");
+        let parent_component =
+            create_component_for_default_schema_name(ctx, "dummy-secret", "parent")
+                .await
+                .expect("could not create component");
         parent_component
             .set_type(ctx, ComponentType::ConfigurationFrameDown)
             .await

--- a/lib/dal/tests/integration_test/func/authoring.rs
+++ b/lib/dal/tests/integration_test/func/authoring.rs
@@ -156,7 +156,9 @@ async fn create_unlocked_copy_attribute_func(ctx: &mut DalContext) {
         panic!("expect parent to be for schema variant");
     };
 
-    let sv = SchemaVariant::get_by_id(ctx, sv_id).await.expect("has sv");
+    let sv = SchemaVariant::get_by_id_or_error(ctx, sv_id)
+        .await
+        .expect("has sv");
     assert!(sv.is_locked());
 
     // let's try to edit the func, this will fail because it's currently locked

--- a/lib/dal/tests/integration_test/func/authoring/binding.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding.rs
@@ -1,4 +1,3 @@
-
 mod action;
 mod attribute;
 mod authentication;

--- a/lib/dal/tests/integration_test/func/authoring/save_func/detach.rs
+++ b/lib/dal/tests/integration_test/func/authoring/save_func/detach.rs
@@ -1,9 +1,9 @@
 use dal::func::authoring::FuncAuthoringClient;
 use dal::func::summary::FuncSummary;
 use dal::func::view::FuncView;
-use dal::func::{AttributePrototypeBag};
+use dal::func::AttributePrototypeBag;
 use dal::{DalContext, Func, Schema, SchemaVariant};
-use dal_test::helpers::{ChangeSetTestHelpers};
+use dal_test::helpers::ChangeSetTestHelpers;
 use dal_test::test;
 
 #[test]

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -1,4 +1,5 @@
 mod action;
+mod asset;
 mod attribute;
 mod builtins;
 mod change_set;

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -45,7 +45,7 @@ async fn verify_prop_used_as_input_flag(ctx: &DalContext) {
         .expect("should be able to get default")
         .expect("should have a default schema variant");
 
-    let _pirate = SchemaVariant::get_by_id(ctx, pirate_default_variant_id)
+    let _pirate = SchemaVariant::get_by_id_or_error(ctx, pirate_default_variant_id)
         .await
         .expect("should be able to get pirate sv");
 

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -3,7 +3,8 @@ use dal::property_editor::values::PropertyEditorValues;
 use dal::{AttributeValue, Component, DalContext, Schema, SchemaVariant};
 use dal_test::helpers::ChangeSetTestHelpers;
 use dal_test::helpers::{
-    connect_components_with_socket_names, create_component_for_default_schema_name, PropEditorTestView,
+    connect_components_with_socket_names, create_component_for_default_schema_name,
+    PropEditorTestView,
 };
 use dal_test::test;
 use serde_json::json;
@@ -294,9 +295,10 @@ async fn array_map_manipulation(ctx: &DalContext) {
 #[test]
 async fn override_value_then_reset(ctx: &mut DalContext) {
     let original_pirate_name = "Thomas Cavendish";
-    let pirate_component = create_component_for_default_schema_name(ctx, "pirate", original_pirate_name)
-        .await
-        .expect("could not create component");
+    let pirate_component =
+        create_component_for_default_schema_name(ctx, "pirate", original_pirate_name)
+            .await
+            .expect("could not create component");
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update snapshot to visibility");
@@ -393,9 +395,10 @@ async fn override_value_then_reset(ctx: &mut DalContext) {
 #[test]
 async fn override_array_then_reset(ctx: &mut DalContext) {
     let original_pirate_name = "Thomas Cavendish";
-    let pirate_component = create_component_for_default_schema_name(ctx, "pirate", original_pirate_name)
-        .await
-        .expect("could not create component");
+    let pirate_component =
+        create_component_for_default_schema_name(ctx, "pirate", original_pirate_name)
+            .await
+            .expect("could not create component");
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update snapshot to visibility");

--- a/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
@@ -20,7 +20,7 @@ async fn clone_variant(ctx: &mut DalContext) {
         .get_default_schema_variant_id(ctx)
         .await
         .expect("Unable to find the default schema variant id");
-    let existing_variant = SchemaVariant::get_by_id(
+    let existing_variant = SchemaVariant::get_by_id_or_error(
         ctx,
         default_schema_variant.expect("unable to unwrap schema variant id"),
     )

--- a/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
@@ -559,7 +559,7 @@ async fn update_variant_with_leaf_func(ctx: &mut DalContext) {
                 .build();
             return new AssetBuilder().addProp(input1).addProp(input2).addProp(calculate).build()
         }";
-    let schema_variant = SchemaVariant::get_by_id(ctx, first_update_variant_id)
+    let schema_variant = SchemaVariant::get_by_id_or_error(ctx, first_update_variant_id)
         .await
         .expect("could not get schema variant");
 

--- a/lib/dal/tests/integration_test/secret.rs
+++ b/lib/dal/tests/integration_test/secret.rs
@@ -6,7 +6,9 @@ use dal::{
     AttributeValue, Component, DalContext, EncryptedSecret, OutputSocket, Prop, Secret,
     SecretAlgorithm, SecretVersion,
 };
-use dal_test::helpers::{create_component_for_default_schema_name, encrypt_message, ChangeSetTestHelpers};
+use dal_test::helpers::{
+    create_component_for_default_schema_name, encrypt_message, ChangeSetTestHelpers,
+};
 use dal_test::{helpers::generate_fake_name, test, WorkspaceSignup};
 use pretty_assertions_sorted::assert_eq;
 use serde_json::Value;
@@ -265,9 +267,10 @@ async fn update_encrypted_contents_with_dependent_values(
     nw: &WorkspaceSignup,
 ) {
     // Create a component and commit.
-    let component = create_component_for_default_schema_name(ctx, "dummy-secret", "secret-definition")
-        .await
-        .expect("could not create component");
+    let component =
+        create_component_for_default_schema_name(ctx, "dummy-secret", "secret-definition")
+            .await
+            .expect("could not create component");
     let schema_variant_id = Component::schema_variant_id(ctx, component.id())
         .await
         .expect("could not get schema variant id for component");

--- a/lib/dal/tests/integration_test/secret/with_actions.rs
+++ b/lib/dal/tests/integration_test/secret/with_actions.rs
@@ -19,9 +19,10 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
     let source_schema_variant_id = Component::schema_variant_id(ctx, source_component.id())
         .await
         .expect("could not get schema variant id for component");
-    let destination_component = create_component_for_default_schema_name(ctx, "fallout", "destination")
-        .await
-        .expect("could not create component");
+    let destination_component =
+        create_component_for_default_schema_name(ctx, "fallout", "destination")
+            .await
+            .expect("could not create component");
     let destination_schema_variant_id =
         Component::schema_variant_id(ctx, destination_component.id())
             .await

--- a/lib/dal/tests/integration_test/validations.rs
+++ b/lib/dal/tests/integration_test/validations.rs
@@ -2,7 +2,8 @@ use dal::workspace_snapshot::content_address::ContentAddressDiscriminants;
 use dal::workspace_snapshot::edge_weight::EdgeWeightKindDiscriminants;
 use dal::{AttributeValue, Component, DalContext};
 use dal_test::helpers::{
-    connect_components_with_socket_names, create_component_for_default_schema_name, PropEditorTestView,
+    connect_components_with_socket_names, create_component_for_default_schema_name,
+    PropEditorTestView,
 };
 use dal_test::helpers::{extract_value_and_validation, ChangeSetTestHelpers};
 use dal_test::test;
@@ -140,9 +141,10 @@ async fn prop_editor_validation(ctx: &mut DalContext) {
 
 #[test]
 async fn validation_on_dependent_value(ctx: &mut DalContext) {
-    let output_component = create_component_for_default_schema_name(ctx, "ValidatedOutput", "Output")
-        .await
-        .expect("could not create component");
+    let output_component =
+        create_component_for_default_schema_name(ctx, "ValidatedOutput", "Output")
+            .await
+            .expect("could not create component");
     let input_component = create_component_for_default_schema_name(ctx, "ValidatedInput", "Input")
         .await
         .expect("could not create component");

--- a/lib/sdf-server/src/server/service/diagram/create_component.rs
+++ b/lib/sdf-server/src/server/service/diagram/create_component.rs
@@ -45,7 +45,7 @@ pub async fn create_component(
 
     let name = generate_name();
 
-    let variant = SchemaVariant::get_by_id(&ctx, request.schema_variant_id).await?;
+    let variant = SchemaVariant::get_by_id_or_error(&ctx, request.schema_variant_id).await?;
 
     let mut component = Component::new(&ctx, &name, variant.id()).await?;
 

--- a/lib/sdf-server/src/server/service/graphviz.rs
+++ b/lib/sdf-server/src/server/service/graphviz.rs
@@ -107,7 +107,7 @@ pub async fn schema_variant(
     let mut added_edges = HashSet::new();
     let mut root_node_id: Option<Ulid> = None;
 
-    let sv = SchemaVariant::get_by_id(&ctx, request.schema_variant_id).await?;
+    let sv = SchemaVariant::get_by_id_or_error(&ctx, request.schema_variant_id).await?;
     let workspace_snapshot = ctx.workspace_snapshot()?;
 
     let sv_node: GraphVizNode = {

--- a/lib/sdf-server/src/server/service/module/export_module.rs
+++ b/lib/sdf-server/src/server/service/module/export_module.rs
@@ -71,7 +71,7 @@ pub async fn export_module(
     // XXX:rework frontend to send schema ids
     let mut schema_ids = vec![];
     for variant_id in &request.schema_variants {
-        let schema = SchemaVariant::get_by_id(&ctx, *variant_id)
+        let schema = SchemaVariant::get_by_id_or_error(&ctx, *variant_id)
             .await?
             .schema(&ctx)
             .await?;

--- a/lib/sdf-server/src/server/service/v2/variant.rs
+++ b/lib/sdf-server/src/server/service/v2/variant.rs
@@ -87,7 +87,7 @@ pub async fn get_variant(
         .build(access_builder.build(change_set_id.into()))
         .await?;
 
-    let schema_variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
+    let schema_variant = SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
     let schema_id = SchemaVariant::schema_id_for_schema_variant_id(&ctx, schema_variant_id).await?;
     let schema_variant = schema_variant.into_frontend_type(&ctx, schema_id).await?;
 

--- a/lib/sdf-server/src/server/service/variant.rs
+++ b/lib/sdf-server/src/server/service/variant.rs
@@ -83,6 +83,12 @@ impl IntoResponse for SchemaVariantError {
             SchemaVariantError::Transactions(TransactionsError::ConflictsOccurred(_)) => {
                 (StatusCode::CONFLICT, self.to_string())
             }
+            SchemaVariantError::VariantAuthoring(
+                VariantAuthoringError::AssetTypeNotReturnedForAssetFunc(_, _),
+            ) => (
+                StatusCode::NOT_MODIFIED,
+                "unexpected return type, expected 'Asset' return type".to_string(),
+            ),
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 

--- a/lib/sdf-server/src/server/service/variant/create_unlocked_copy.rs
+++ b/lib/sdf-server/src/server/service/variant/create_unlocked_copy.rs
@@ -32,7 +32,7 @@ pub async fn create_unlocked_copy(
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
-    let original_variant = SchemaVariant::get_by_id(&ctx, request.id).await?;
+    let original_variant = SchemaVariant::get_by_id_or_error(&ctx, request.id).await?;
 
     let schema = original_variant.schema(&ctx).await?;
 

--- a/lib/sdf-server/src/server/service/variant/get_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/get_variant.rs
@@ -54,7 +54,7 @@ pub async fn get_variant(
     let default_schema_variant_id = schema.get_default_schema_variant_id(&ctx).await?.ok_or(
         SchemaVariantError::NoDefaultSchemaVariantFoundForSchema(schema.id()),
     )?;
-    let variant = SchemaVariant::get_by_id(&ctx, default_schema_variant_id).await?;
+    let variant = SchemaVariant::get_by_id_or_error(&ctx, default_schema_variant_id).await?;
 
     // Collect the funcs for all schema variants corresponding to the schema. We want this because
     // while asset editing generally corresponds to the current default schema variant id, you are


### PR DESCRIPTION
## Description

This PR ensures that an error is generated when the return type for an asset func is not an 'Asset' (defined in the asset builder). It uses the "block" variant of the error message component and generates a user-friendly error message in `sdf`.

<img src="https://media2.giphy.com/media/XF4Ze94RLIJIwG1b1y/giphy.gif"/>

## Additional Changes

- Rename `SchemaVariant::get_by_id` to `SchemaVariant::get_by_id_or_error`
- Add new docs for building all rust targets, release modes and accessing a local full stack remotely