### PR TITLE
Resolving editor pain

### DIFF
--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -10,7 +10,11 @@
           class="flex flex-row items-center justify-around gap-xs p-xs border-b dark:border-neutral-600"
         >
           <VButton
-            :disabled="saveAssetReqStatus.isPending || editingAsset.isLocked"
+            :disabled="
+              saveAssetReqStatus.isPending ||
+              editingAsset.isLocked ||
+              assetStore.codeSaveIsDebouncing
+            "
             :loading="updateAssetReqStatus.isPending"
             :requestStatus="updateAssetReqStatus"
             icon="bolt"

--- a/app/web/src/components/AssetEditor.vue
+++ b/app/web/src/components/AssetEditor.vue
@@ -36,6 +36,7 @@
 
 <script lang="ts" setup>
 import { ref, watch, computed, onMounted } from "vue";
+import * as _ from "lodash-es";
 import {
   RequestStatusMessage,
   ScrollArea,
@@ -92,7 +93,11 @@ watch(
   },
 );
 
-const onChange = (_: string, code: string) => {
+const onChange = (
+  _schemaVariantId: string,
+  code: string,
+  debounce: boolean,
+) => {
   if (
     !selectedAsset.value ||
     selectedAssetFuncCode.value === editingAsset.value ||
@@ -102,13 +107,16 @@ const onChange = (_: string, code: string) => {
   }
   updatedHead.value =
     changeSetsStore.selectedChangeSetId === changeSetsStore.headChangeSetId;
-  if (!updatedHead.value)
+  if (!updatedHead.value) {
+    const asset = _.cloneDeep(selectedAsset.value);
     assetStore.enqueueVariantSave(
       {
-        ...selectedAsset.value,
+        ...asset,
       },
       code,
+      debounce,
     );
+  }
 };
 
 onMounted(async () => {

--- a/app/web/src/components/FuncEditor/FuncEditor.vue
+++ b/app/web/src/components/FuncEditor/FuncEditor.vue
@@ -103,14 +103,14 @@ watch(
     updatedHead.value = false;
   },
 );
-const updateFuncCode = (funcId: string, code: string) => {
+const updateFuncCode = (funcId: string, code: string, debounce: boolean) => {
   if (updatedHead.value) return;
   if (!funcId) return; // protecting empty string, should never happen
   if (selectedFuncSummary.value?.isLocked) return;
 
   updatedHead.value =
     changeSetsStore.selectedChangeSetId === changeSetsStore.headChangeSetId;
-  funcStore.updateFuncCode(funcId, code);
+  funcStore.updateFuncCode(funcId, code, debounce);
 };
 
 const emit = defineEmits<{

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -449,15 +449,18 @@ export const useFuncStore = () => {
           });
         },
 
-        updateFuncCode(funcId: FuncId, code: string) {
+        updateFuncCode(funcId: FuncId, code: string, debounce: boolean) {
           const func = _.cloneDeep(this.funcCodeById[funcId]);
           if (!func || func.code === code) return;
           func.code = code;
 
-          this.enqueueFuncSave(func);
+          this.enqueueFuncSave(func, debounce);
         },
 
-        enqueueFuncSave(func: FuncCode) {
+        enqueueFuncSave(func: FuncCode, debounce: boolean) {
+          if (!debounce) {
+            return this.SAVE_FUNC(func);
+          }
           this.editingFuncLatestCode[func.funcId] = func.code;
 
           // Lots of ways to handle this... we may want to handle this debouncing in the component itself

--- a/lib/sdf-server/src/server/service/variant/regenerate_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/regenerate_variant.rs
@@ -15,7 +15,7 @@ use crate::service::variant::SchemaVariantResult;
 pub struct RegenerateVariantRequest {
     // We need to get the updated data here, to ensure we create the prop the user is seeing
     pub variant: si_frontend_types::SchemaVariant,
-    pub code: String,
+    pub code: Option<String>,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -53,7 +53,7 @@ pub async fn regenerate_variant(
         variant.link,
         &variant.color,
         variant.component_type.into(),
-        Some(code),
+        code,
     )
     .await?;
 


### PR DESCRIPTION
We went down the rabbit hole on all the things that were causing code from one asset to either be presented, or saved, OVER another asset. (And the duplicate code for a bonus).

1. `Regenerate` should not accept the code body. (It had the code body because there could be a debouncing "save code" in waiting or in flight, and a user could hit regenerate and the backend would not have the most up to date code. It could either end up with the wrong result OR conflict—both bad.
2. As a result of No.1 you cannot press `Regenerate` while code debounce is in effect.
3. On unmount we emit'd a "change" event that resulted in a debounced save call. Now that call is NOT debounced, it happens immediately. Same for "onBlur". The only save that is debounced is typey-typey.
4. We only emit "change" on unmount if we know the text has changed. (This "false save" was overwriting other funcs).
5. We're no longer reading from localState. We could re-introduce this at a future state. We still write to localState, however, we were seeing failures on saving due to the size of code.
6. We were using the `sync` event on the WS provider to load the editor text. That is asynchronous and when it raced/ran twice the wrong way we would end up with duplicate code. We don't need this operation to be asynchronous. (This is one way my code size grew to a massive amount in No.5)