### PR TITLE
fix: add tls config to redis for auth-api

### DIFF
--- a/bin/auth-api/src/lib/redis.ts
+++ b/bin/auth-api/src/lib/redis.ts
@@ -8,6 +8,7 @@ export const REDIS_ENABLED = !!process.env.REDIS_URL;
 export const redis = new IORedis({
   ...redisConnectionObj[0],
   lazyConnect: true,
+  tls: {},
 }) as ExtendedIORedis;
 
 // add helper to get/set json objects without worrying about JSON serialization


### PR DESCRIPTION
I'm not entirely sure, but I assume that the more recent version of redis we are using now requires a tls config. I have verified that changing this allows us to connect to the new redis instance.

<img src="https://media2.giphy.com/media/l3vRbQpvr65zPr8DS/giphy.gif"/>