### PR TITLE
Fix: always show code editor loading state when switching between funcs

### DIFF
--- a/app/web/src/components/AssetEditor.vue
+++ b/app/web/src/components/AssetEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <RequestStatusMessage
-    v-if="loadAssetReqStatus.isPending"
+    v-if="!loadAssetReqStatus || loadAssetReqStatus.isPending"
     :requestStatus="loadAssetReqStatus"
   />
   <div
@@ -37,7 +37,8 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch, computed, onMounted } from "vue";
+import { ref, watch, computed, onMounted, ComputedRef } from "vue";
+import { ApiRequestStatus } from "@si/vue-lib/pinia";
 import * as _ from "lodash-es";
 import {
   RequestStatusMessage,
@@ -75,9 +76,17 @@ const selectedAssetFuncCode = computed(() => {
 
 const editingAsset = ref<string>(selectedAssetFuncCode.value ?? "");
 
-const loadAssetReqStatus = funcStore.getRequestStatus(
-  "FETCH_CODE",
-  selectedAsset.value?.assetFuncId,
+let loadAssetReqStatus: ComputedRef<ApiRequestStatus>;
+
+watch(
+  () => selectedAsset.value?.assetFuncId,
+  () => {
+    loadAssetReqStatus = funcStore.getRequestStatus(
+      "FETCH_CODE",
+      selectedAsset.value?.assetFuncId,
+    );
+  },
+  { immediate: true },
 );
 
 watch(


### PR DESCRIPTION
On slower connections we were seeing old code in the editor, after a new code was selected, until it finally loaded and it all snapped into place.

This was happening because changing props does not re-run a component's setup code. Instantiating `loadFuncDetailsReq` with `props.funcId`means that as props change, the request watcher *does not update*. Basically, as the `props.funcId` changed from 123 -> 456, the `loadFuncDetailsReq` only ever observed the API request for funcId 123.

Instead, use a watcher to re-assign the value each time. This ensures that we get a new loading state when user selects another function.