### PR TITLE
Show that assets can be updated

### DIFF
--- a/app/web/src/api/sdf/dal/schema.ts
+++ b/app/web/src/api/sdf/dal/schema.ts
@@ -66,6 +66,9 @@ export interface SchemaVariant {
   outputSockets: OutputSocket[];
   props: Prop[];
   canCreateNewComponents: boolean;
+
+  canContribute: boolean;
+  canUpdate: boolean;
 }
 
 export const outputSocketsAndPropsFor = (schemaVariant: SchemaVariant) => {

--- a/app/web/src/components/AssetCard.vue
+++ b/app/web/src/components/AssetCard.vue
@@ -87,8 +87,8 @@ import { computed, PropType, ref } from "vue";
 import tinycolor from "tinycolor2";
 import clsx from "clsx";
 import { useTheme, Stack, Icon, ErrorMessage } from "@si/vue-lib/design-system";
-import { useAssetStore, SchemaVariantListEntry } from "@/store/asset.store";
-import { SchemaVariantId } from "@/api/sdf/dal/schema";
+import { useAssetStore } from "@/store/asset.store";
+import { SchemaVariant, SchemaVariantId } from "@/api/sdf/dal/schema";
 import { getAssetIcon } from "@/store/components.store";
 import IconButton from "./IconButton.vue";
 import EditingPill from "./EditingPill.vue";
@@ -108,7 +108,7 @@ const editingVersionDoesNotExist = computed<boolean>(
 
 const assetStore = useAssetStore();
 const asset = computed(
-  (): SchemaVariantListEntry | undefined =>
+  (): SchemaVariant | undefined =>
     assetStore.variantFromListById[props.assetId],
 );
 

--- a/app/web/src/components/AssetFuncListPanel.vue
+++ b/app/web/src/components/AssetFuncListPanel.vue
@@ -48,11 +48,11 @@ import * as _ from "lodash-es";
 import { computed, ref } from "vue";
 import groupBy from "lodash-es/groupBy";
 import { ScrollArea } from "@si/vue-lib/design-system";
-import { useAssetStore, SchemaVariantListEntry } from "@/store/asset.store";
+import { useAssetStore } from "@/store/asset.store";
 import { useFuncStore } from "@/store/func/funcs.store";
 import { FuncSummary } from "@/api/sdf/dal/func";
 import SidebarSubpanelTitle from "@/components/SidebarSubpanelTitle.vue";
-import { SchemaVariantId } from "@/api/sdf/dal/schema";
+import { SchemaVariantId, SchemaVariant } from "@/api/sdf/dal/schema";
 import AssetFuncAttachModal from "./AssetFuncAttachModal.vue";
 import AssetFuncAttachDropdown from "./AssetFuncAttachDropdown.vue";
 import FuncList from "./FuncEditor/FuncList.vue";
@@ -63,7 +63,7 @@ const props = defineProps<{ schemaVariantId?: SchemaVariantId }>();
 const assetStore = useAssetStore();
 const funcStore = useFuncStore();
 
-interface VariantsWithFunctionSummary extends SchemaVariantListEntry {
+interface VariantsWithFunctionSummary extends SchemaVariant {
   funcSummaries: FuncSummary[];
   assetFunc: FuncSummary;
 }

--- a/app/web/src/components/AssetListItem.vue
+++ b/app/web/src/components/AssetListItem.vue
@@ -52,16 +52,13 @@ import { PropType } from "vue";
 import { storeToRefs } from "pinia";
 import { TreeNode, Icon } from "@si/vue-lib/design-system";
 import clsx from "clsx";
-import {
-  SchemaVariantListEntry,
-  useAssetStore,
-  schemaVariantDisplayName,
-} from "@/store/asset.store";
+import { useAssetStore, schemaVariantDisplayName } from "@/store/asset.store";
+import { SchemaVariant } from "@/api/sdf/dal/schema";
 import EditingPill from "./EditingPill.vue";
 
 const props = defineProps({
-  a: { type: Object as PropType<SchemaVariantListEntry>, required: true },
-  c: { type: Array<SchemaVariantListEntry> },
+  a: { type: Object as PropType<SchemaVariant>, required: true },
+  c: { type: Array<SchemaVariant> },
 });
 
 const assetStore = useAssetStore();

--- a/app/web/src/components/AssetListPanel.vue
+++ b/app/web/src/components/AssetListPanel.vue
@@ -133,7 +133,8 @@ import {
   PillCounter,
 } from "@si/vue-lib/design-system";
 import SiSearch, { Filter } from "@/components/SiSearch.vue";
-import { SchemaVariantListEntry, useAssetStore } from "@/store/asset.store";
+import { useAssetStore } from "@/store/asset.store";
+import { SchemaVariant } from "@/api/sdf/dal/schema";
 import { getAssetIcon } from "@/store/components.store";
 import AssetNameModal from "./AssetNameModal.vue";
 import AssetListItem from "./AssetListItem.vue";
@@ -224,7 +225,7 @@ const categorizedAssets = computed(() =>
       catList.push(asset);
       categorized[asset.category] = catList;
       return categorized;
-    }, {} as { [key: string]: SchemaVariantListEntry[] }),
+    }, {} as { [key: string]: SchemaVariant[] }),
 );
 
 const categoryColor = (category: string) => {

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -59,10 +59,6 @@ export interface DetachedValidationPrototype {
   propKind: PropKind;
 }
 
-export type SchemaVariantListEntry = SchemaVariant & {
-  canUpdate: boolean;
-  canContribute: boolean;
-};
 export type SchemaVariantSaveRequest = Visibility & { code?: string } & {
   variant: Omit<SchemaVariant, "created_at" | "updated_at">;
 };
@@ -96,7 +92,7 @@ export const useAssetStore = () => {
   return addStoreHooks(
     defineStore(`ws${workspaceId || "NONE"}/cs${changeSetId || "NONE"}/asset`, {
       state: () => ({
-        variantList: [] as SchemaVariantListEntry[],
+        variantList: [] as SchemaVariant[],
         variantsById: {} as Record<SchemaVariantId, SchemaVariant>,
 
         executeSchemaVariantTaskId: undefined as string | undefined,
@@ -129,7 +125,7 @@ export const useAssetStore = () => {
           if (this.selectedVariantId)
             return this.variantFromListById[this.selectedVariantId];
         },
-        selectedSchemaVariantRecords(): SchemaVariantListEntry[] {
+        selectedSchemaVariantRecords(): SchemaVariant[] {
           return this.selectedSchemaVariants
             .map((id) => this.variantFromListById[id])
             .filter(nonNullable);
@@ -308,13 +304,11 @@ export const useAssetStore = () => {
               color: this.generateMockColor(),
             },
             onSuccess: (variant) => {
-              const v = variant as SchemaVariantListEntry;
-              v.canUpdate = false;
               const savedAssetIdx = this.variantList.findIndex(
                 (a) => a.schemaVariantId === variant.schemaVariantId,
               );
-              if (savedAssetIdx === -1) this.variantList.push(v);
-              else this.variantList.splice(savedAssetIdx, 1, v);
+              if (savedAssetIdx === -1) this.variantList.push(variant);
+              else this.variantList.splice(savedAssetIdx, 1, variant);
             },
           });
         },
@@ -433,11 +427,7 @@ export const useAssetStore = () => {
             url: `v2/workspaces/${workspaceId}/change-sets/${changeSetId}/schema-variants`,
             params: { ...visibility },
             onSuccess: (response) => {
-              this.variantList = response.map((v) => {
-                const e = v as SchemaVariantListEntry;
-                e.canUpdate = false;
-                return e;
-              });
+              this.variantList = response;
             },
           });
         },
@@ -459,13 +449,11 @@ export const useAssetStore = () => {
               id,
             },
             onSuccess: (variant) => {
-              const v = variant as SchemaVariantListEntry;
-              v.canUpdate = false;
               const savedAssetIdx = this.variantList.findIndex(
                 (a) => a.schemaVariantId === variant.schemaVariantId,
               );
-              if (savedAssetIdx === -1) this.variantList.push(v);
-              else this.variantList.splice(savedAssetIdx, 1, v);
+              if (savedAssetIdx === -1) this.variantList.push(variant);
+              else this.variantList.splice(savedAssetIdx, 1, variant);
             },
           });
         },
@@ -495,14 +483,11 @@ export const useAssetStore = () => {
             eventType: "SchemaVariantCreated",
             callback: (variant, metadata) => {
               if (metadata.change_set_id !== changeSetId) return;
-              const v = variant as SchemaVariantListEntry;
-              v.canUpdate = false;
-
               const savedAssetIdx = this.variantList.findIndex(
                 (a) => a.schemaVariantId === variant.schemaVariantId,
               );
-              if (savedAssetIdx === -1) this.variantList.push(v);
-              else this.variantList.splice(savedAssetIdx, 1, v);
+              if (savedAssetIdx === -1) this.variantList.push(variant);
+              else this.variantList.splice(savedAssetIdx, 1, variant);
             },
           },
           {
@@ -564,12 +549,10 @@ export const useAssetStore = () => {
             eventType: "SchemaVariantUpdated",
             callback: (variant, metadata) => {
               if (metadata.change_set_id !== changeSetId) return;
-              const v = variant as SchemaVariantListEntry;
-              v.canUpdate = false;
               const savedAssetIdx = this.variantList.findIndex(
                 (a) => a.schemaVariantId === variant.schemaVariantId,
               );
-              this.variantList.splice(savedAssetIdx, 1, v);
+              this.variantList.splice(savedAssetIdx, 1, variant);
             },
           },
           {

--- a/bin/module-index/README.md
+++ b/bin/module-index/README.md
@@ -1,0 +1,18 @@
+# `module-index`
+
+This document contains information related to running the `module-index`.
+
+## Running Locally with the Full Stack
+
+1. Export valid AWS credentials in your environment (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`)
+1. Modify `app/web/.env` to use the following line: `VITE_MODULE_INDEX_API_URL=http://localhost:5157` _(do not commit this change!)_
+1. Run the following command: `SI_MODULE_INDEX_URL=http://localhost:5157 buck2 run dev:up`
+1. Navigate to the Tilt dashboard
+1. Observe that `sdf` will fail on first boot because our local `module-index` isn't running
+1. Run `module-index` in the Tilt dashboard
+1. Restart `sdf` and observe that it starts successfully
+
+If you are editing source code, you can restart all core services, as usual.
+
+> [!NOTE]
+> Running `module-index` locally does not yet work with [LocalStack](https://github.com/localstack/localstack) since credential validation requires multiple `AWS_*` variables and not just `AWS_ENDPOINT`.

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -263,6 +263,7 @@ impl SchemaVariant {
             props: front_end_props,
             can_create_new_components: is_default || !self.is_locked,
             can_contribute,
+            can_update: false,
         })
     }
 }

--- a/lib/module-index-client/src/types.rs
+++ b/lib/module-index-client/src/types.rs
@@ -14,8 +14,6 @@ pub enum IndexClientError {
     Request(#[from] reqwest::Error),
     #[error("Serialization error: {0}")]
     Serialization(serde_json::Error),
-    #[error("Upload error: {0}")]
-    Upload(String),
     #[error("Url parse error: {0}")]
     UrlParse(#[from] url::ParseError),
 }
@@ -74,4 +72,41 @@ pub struct ExtraMetadata {
     pub version: String,
     pub schemas: Vec<String>,
     pub funcs: Vec<FuncMetadata>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListLatestModulesRequest {
+    pub hashes: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListLatestModulesResponse {
+    pub modules: Vec<LatestModuleResponse>,
+}
+
+/// This struct is nearly the same as the [`ModuleDetailsResponse`], but it does not include `past_hashes` since the
+/// data is unneeded and requires additional query logic.
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct LatestModuleResponse {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub owner_user_id: String,
+    pub owner_display_name: Option<String>,
+    pub metadata: serde_json::Value,
+    pub latest_hash: String,
+    pub latest_hash_created_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+    pub schema_id: Option<String>,
+}
+
+impl LatestModuleResponse {
+    pub fn schema_id(&self) -> Option<Ulid> {
+        self.schema_id
+            .as_deref()
+            .and_then(|schema_id| Ulid::from_string(schema_id).ok())
+    }
 }

--- a/lib/module-index-server/BUCK
+++ b/lib/module-index-server/BUCK
@@ -39,6 +39,7 @@ rust_library(
     srcs = glob([
         "src/**/*.rs",
         "src/migrations/**/*.sql",
+        "src/queries/**/*.sql",
     ]),
     env = {
         "CARGO_MANIFEST_DIR": ".",

--- a/lib/module-index-server/src/queries/list_latest_modules.sql
+++ b/lib/module-index-server/src/queries/list_latest_modules.sql
@@ -1,0 +1,71 @@
+WITH RECURSIVE filtered_modules AS (
+    SELECT
+        id,
+        name,
+        description,
+        owner_user_id,
+        owner_display_name,
+        jsonb_build_object('metadata', metadata) AS metadata,
+        latest_hash,
+        latest_hash_created_at,
+        created_at,
+        rejected_at,
+        rejected_by_display_name,
+        kind,
+        is_builtin_at,
+        is_builtin_at_by_display_name,
+        schema_id
+    FROM
+        modules 
+    WHERE 
+        rejected_at IS NULL
+        AND kind = 'module'
+        AND schema_id IS NOT NULL
+        AND latest_hash = ANY($1)
+    UNION
+    SELECT
+        a.id,
+        a.name,
+        a.description,
+        a.owner_user_id,
+        a.owner_display_name,
+        jsonb_build_object('metadata', a.metadata) AS metadata,
+        a.latest_hash,
+        a.latest_hash_created_at,
+        a.created_at,
+        a.rejected_at,
+        a.rejected_by_display_name,
+        a.kind,
+        a.is_builtin_at,
+        a.is_builtin_at_by_display_name,
+        a.schema_id
+    FROM
+        modules a
+    JOIN
+        filtered_modules b
+    ON
+        a.schema_id = b.schema_id
+)
+SELECT DISTINCT ON (filtered_modules.schema_id)
+    filtered_modules.id,
+    filtered_modules.name,
+    filtered_modules.description,
+    filtered_modules.owner_user_id,
+    filtered_modules.owner_display_name,
+    filtered_modules.metadata,
+    filtered_modules.latest_hash,
+    filtered_modules.latest_hash_created_at,
+    filtered_modules.created_at,
+    filtered_modules.rejected_at,
+    filtered_modules.rejected_by_display_name,
+    filtered_modules.kind,
+    filtered_modules.is_builtin_at,
+    filtered_modules.is_builtin_at_by_display_name,
+    filtered_modules.schema_id
+FROM
+    filtered_modules
+WHERE
+    filtered_modules.is_builtin_at IS NOT NULL -- NOTE(nick,paul): only show the latest, _promoted_ builtin
+ORDER BY
+    filtered_modules.schema_id,
+    filtered_modules.created_at DESC;

--- a/lib/module-index-server/src/routes.rs
+++ b/lib/module-index-server/src/routes.rs
@@ -17,6 +17,7 @@ mod download_module_route;
 mod download_workspace_route;
 mod get_module_details_route;
 mod list_builtins_route;
+mod list_latest_modules_route;
 mod list_modules_route;
 pub(crate) mod promote_builtin_route;
 pub(crate) mod reject_module_route;
@@ -34,6 +35,10 @@ pub fn routes(state: AppState) -> Router {
     router = router
         .route("/", get(system_status_route))
         .route("/modules", get(list_modules_route::list_module_route))
+        .route(
+            "/modules/latest",
+            get(list_latest_modules_route::list_latest_modules_route),
+        )
         .route("/builtins", get(list_builtins_route::list_builtins_route))
         .route(
             "/builtins/:module_id/promote",

--- a/lib/module-index-server/src/routes/list_latest_modules_route.rs
+++ b/lib/module-index-server/src/routes/list_latest_modules_route.rs
@@ -1,0 +1,61 @@
+use axum::{
+    response::{IntoResponse, Response},
+    Json,
+};
+use hyper::StatusCode;
+use module_index_client::types::{ListLatestModulesRequest, ListLatestModulesResponse};
+use sea_orm::{DbBackend, DbErr, EntityTrait, Statement};
+use thiserror::Error;
+
+use crate::{
+    extract::DbConnection,
+    models::si_module::{self, make_latest_modules_response},
+    whoami::WhoamiError,
+};
+
+const LIST_LATEST_MODULES_QUERY: &str = include_str!("../queries/list_latest_modules.sql");
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum ListModulesError {
+    #[error("db error: {0}")]
+    DbErr(#[from] DbErr),
+    #[error("whoami error: {0}")]
+    Whoami(#[from] WhoamiError),
+}
+
+// TODO: figure out how to not keep this serialization logic here
+impl IntoResponse for ListModulesError {
+    fn into_response(self) -> Response {
+        let (status, error_message) = (StatusCode::INTERNAL_SERVER_ERROR, self.to_string());
+
+        let body = Json(
+            serde_json::json!({ "error": { "message": error_message, "code": 42, "statusCode": status.as_u16() } }),
+        );
+
+        (status, body).into_response()
+    }
+}
+
+pub async fn list_latest_modules_route(
+    DbConnection(txn): DbConnection,
+    Json(request): Json<ListLatestModulesRequest>,
+) -> Result<Json<ListLatestModulesResponse>, ListModulesError> {
+    // NOTE(nick,paul): this only shows the latest, _promoted_ builtin module for each hash, where each hash eventually
+    // resolves to a schema id.
+    let raw_modules = si_module::Entity::find()
+        .from_raw_sql(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            LIST_LATEST_MODULES_QUERY,
+            [request.hashes.into()],
+        ))
+        .all(&txn)
+        .await?;
+
+    let modules = raw_modules
+        .into_iter()
+        .map(make_latest_modules_response)
+        .collect();
+
+    Ok(Json(ListLatestModulesResponse { modules }))
+}

--- a/lib/sdf-server/src/server/service/v2/variant.rs
+++ b/lib/sdf-server/src/server/service/v2/variant.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 
 use axum::{
     extract::{OriginalUri, Path},
@@ -7,19 +7,73 @@ use axum::{
     routing::get,
     Json, Router,
 };
-use dal::{ChangeSetId, Schema, SchemaVariant, SchemaVariantId, WorkspacePk};
+use telemetry::prelude::*;
 use thiserror::Error;
+use tokio::time::Instant;
 
+use dal::{
+    module::Module, ChangeSetId, DalContext, Schema, SchemaId, SchemaVariant, SchemaVariantId,
+    WorkspacePk,
+};
+use module_index_client::IndexClient;
 use si_frontend_types as frontend_types;
 
 use crate::{
     server::{
-        extract::{AccessBuilder, HandlerContext, PosthogClient},
+        extract::{AccessBuilder, HandlerContext, PosthogClient, RawAccessToken},
         state::AppState,
         tracking::track,
     },
     service::ApiError,
 };
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum SchemaVariantsAPIError {
+    #[error("latest module not found for hash: {0}")]
+    LatestModuleNotFoundForHash(String),
+    #[error("too many modules found when attempting to find latest module for hash: {0}")]
+    LatestModuleTooManyForHash(String),
+    #[error("too many latest modules for schema: {0} (at least two hashes found: {1} and {2})")]
+    LatestModuleTooManyForSchema(SchemaId, String, String),
+    #[error("module error: {0}")]
+    Module(#[from] dal::module::ModuleError),
+    #[error("module index error: {0}")]
+    ModuleIndex(#[from] module_index_client::IndexClientError),
+    #[error("module index not configured")]
+    ModuleIndexNotConfigured,
+    #[error("module missing schema id (module id: {0}) (module hash: {1})")]
+    ModuleMissingSchemaId(String, String),
+    #[error("module not found for schema: {0}")]
+    ModuleNotFoundForSchema(SchemaId),
+    #[error("schema error: {0}")]
+    Schema(#[from] dal::SchemaError),
+    #[error("schema error: {0}")]
+    SchemaVariant(#[from] dal::SchemaVariantError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] dal::TransactionsError),
+    #[error("url parse error: {0}")]
+    UrlParse(#[from] url::ParseError),
+}
+
+impl IntoResponse for SchemaVariantsAPIError {
+    fn into_response(self) -> Response {
+        let status_code = match &self {
+            Self::Transactions(dal::TransactionsError::BadWorkspaceAndChangeSet) => {
+                StatusCode::FORBIDDEN
+            }
+            // Return 409 when we see a conflict
+            Self::Transactions(dal::TransactionsError::ConflictsOccurred(_)) => {
+                StatusCode::CONFLICT
+            }
+            // When a graph node cannot be found for a schema variant, it is not found
+            Self::SchemaVariant(dal::SchemaVariantError::NotFound(_)) => StatusCode::NOT_FOUND,
+            _ => ApiError::DEFAULT_ERROR_STATUS_CODE,
+        };
+
+        ApiError::new(status_code, self).into_response()
+    }
+}
 
 pub fn v2_routes() -> Router<AppState> {
     Router::new()
@@ -30,6 +84,7 @@ pub fn v2_routes() -> Router<AppState> {
 pub async fn list_schema_variants(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(access_builder): AccessBuilder,
+    RawAccessToken(raw_access_token): RawAccessToken,
     PosthogClient(posthog_client): PosthogClient,
     OriginalUri(original_uri): OriginalUri,
     Path((_workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
@@ -59,6 +114,7 @@ pub async fn list_schema_variants(
                 );
             }
         }
+
         for schema_variant in SchemaVariant::list_for_schema(&ctx, schema_id).await? {
             if !SchemaVariant::list_component_ids(&ctx, schema_variant.id())
                 .await?
@@ -70,6 +126,11 @@ pub async fn list_schema_variants(
                 );
             }
         }
+    }
+
+    if let Err(err) = determine_can_update_many(&ctx, &mut schema_variants, &raw_access_token).await
+    {
+        error!(?err, "could not perform 'determine_can_update_many'");
     }
 
     track(
@@ -86,6 +147,7 @@ pub async fn list_schema_variants(
 pub async fn get_variant(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(access_builder): AccessBuilder,
+    RawAccessToken(raw_access_token): RawAccessToken,
     PosthogClient(posthog_client): PosthogClient,
     OriginalUri(original_uri): OriginalUri,
     Path((_workspace_pk, change_set_id, schema_variant_id)): Path<(
@@ -100,7 +162,11 @@ pub async fn get_variant(
 
     let schema_variant = SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
     let schema_id = SchemaVariant::schema_id_for_schema_variant_id(&ctx, schema_variant_id).await?;
-    let schema_variant = schema_variant.into_frontend_type(&ctx, schema_id).await?;
+    let mut schema_variant = schema_variant.into_frontend_type(&ctx, schema_id).await?;
+
+    if let Err(err) = determine_can_update_one(&ctx, &mut schema_variant, &raw_access_token).await {
+        error!(?err, "could not perform 'determine_can_update_one'");
+    }
 
     // Ported from `lib/sdf-server/src/server/service/variant/get_variant.rs`, so changes may be
     // desired here...
@@ -122,32 +188,148 @@ pub async fn get_variant(
 
     Ok(Json(schema_variant))
 }
-#[remain::sorted]
-#[derive(Debug, Error)]
-pub enum SchemaVariantsAPIError {
-    #[error("schema error: {0}")]
-    Schema(#[from] dal::SchemaError),
-    #[error("schema error: {0}")]
-    SchemaVariant(#[from] dal::SchemaVariantError),
-    #[error("transactions error: {0}")]
-    Transactions(#[from] dal::TransactionsError),
+
+#[instrument(
+    name = "sdf.v2.variant.determine_can_update_many",
+    level = "debug",
+    skip_all
+)]
+async fn determine_can_update_many(
+    ctx: &DalContext,
+    schema_variants: &mut HashMap<SchemaVariantId, frontend_types::SchemaVariant>,
+    raw_access_token: &str,
+) -> Result<(), SchemaVariantsAPIError> {
+    let start = Instant::now();
+
+    // Find all local hashes.
+    let mut local_hashes = HashMap::new();
+    for schema_variant in schema_variants.values() {
+        let schema_id: SchemaId = schema_variant.schema_id.into();
+        if let Entry::Vacant(entry) = local_hashes.entry(schema_id) {
+            let local_module = Module::find_for_module_schema_id(ctx, schema_id.into())
+                .await?
+                .ok_or(SchemaVariantsAPIError::ModuleNotFoundForSchema(schema_id))?;
+            entry.insert(local_module.root_hash().to_owned());
+        }
+    }
+
+    // Collect the latest modules.
+    let latest_modules = {
+        let module_index_url = ctx
+            .module_index_url()
+            .ok_or(SchemaVariantsAPIError::ModuleIndexNotConfigured)?;
+        let module_index_client = IndexClient::new(module_index_url.try_into()?, raw_access_token);
+        module_index_client
+            .list_latest_modules(local_hashes.values().map(|h| h.to_owned()).collect())
+            .await?
+    };
+
+    // Find the latest hashes from the latest modules.
+    let mut latest_hashes: HashMap<SchemaId, String> = HashMap::new();
+    for latest_module in latest_modules.modules {
+        let schema_id: SchemaId = latest_module
+            .schema_id()
+            .ok_or(SchemaVariantsAPIError::ModuleMissingSchemaId(
+                latest_module.id.to_owned(),
+                latest_module.latest_hash.to_owned(),
+            ))?
+            .into();
+        match latest_hashes.entry(schema_id) {
+            Entry::Occupied(entry) => {
+                let existing_hash: String = entry.get().to_owned();
+                return Err(SchemaVariantsAPIError::LatestModuleTooManyForSchema(
+                    schema_id,
+                    existing_hash,
+                    latest_module.latest_hash,
+                ));
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(latest_module.latest_hash);
+            }
+        }
+    }
+
+    // Determine if we can update based on the latest modules.
+    for schema_variant in schema_variants.values_mut() {
+        let schema_id: SchemaId = schema_variant.schema_id.into();
+        match (latest_hashes.get(&schema_id), local_hashes.get(&schema_id)) {
+            (Some(latest_hash), Some(local_hash)) => {
+                if latest_hash != local_hash {
+                    schema_variant.can_update = true;
+                }
+            }
+            (maybe_latest, maybe_local) => {
+                trace!(
+                    %schema_id,
+                    %schema_variant.schema_variant_id,
+                    %schema_variant.schema_name,
+                    ?maybe_latest,
+                    ?maybe_local,
+                    "skipping since there's incomplete data for determining if schema variant can be updated (perhaps module was not prompted to builtin?)"
+                );
+            }
+        }
+    }
+
+    debug!(
+        "function 'determine_can_update_many' took: {:?}",
+        start.elapsed()
+    );
+
+    Ok(())
 }
 
-impl IntoResponse for SchemaVariantsAPIError {
-    fn into_response(self) -> Response {
-        let status_code = match &self {
-            Self::Transactions(dal::TransactionsError::BadWorkspaceAndChangeSet) => {
-                StatusCode::FORBIDDEN
-            }
-            // Return 409 when we see a conflict
-            Self::Transactions(dal::TransactionsError::ConflictsOccurred(_)) => {
-                StatusCode::CONFLICT
-            }
-            // When a graph node cannot be found for a schema variant, it is not found
-            Self::SchemaVariant(dal::SchemaVariantError::NotFound(_)) => StatusCode::NOT_FOUND,
-            _ => ApiError::DEFAULT_ERROR_STATUS_CODE,
-        };
+#[instrument(
+    name = "sdf.v2.variant.determine_can_update_one",
+    level = "debug",
+    skip_all
+)]
+async fn determine_can_update_one(
+    ctx: &DalContext,
+    schema_variant: &mut frontend_types::SchemaVariant,
+    raw_access_token: &str,
+) -> Result<(), SchemaVariantsAPIError> {
+    let start = Instant::now();
 
-        ApiError::new(status_code, self).into_response()
+    // Find the local hash.
+    let schema_id: SchemaId = schema_variant.schema_id.into();
+    let local_module = Module::find_for_module_schema_id(ctx, schema_id.into())
+        .await?
+        .ok_or(SchemaVariantsAPIError::ModuleNotFoundForSchema(schema_id))?;
+    let local_hash = local_module.root_hash().to_owned();
+
+    // Collect the latest module.
+    let latest_modules = {
+        let module_index_url = ctx
+            .module_index_url()
+            .ok_or(SchemaVariantsAPIError::ModuleIndexNotConfigured)?;
+        let module_index_client = IndexClient::new(module_index_url.try_into()?, raw_access_token);
+        module_index_client
+            .list_latest_modules(vec![local_hash.to_owned()])
+            .await?
+    };
+    if latest_modules.modules.len() > 1 {
+        return Err(SchemaVariantsAPIError::LatestModuleTooManyForHash(
+            local_hash.to_owned(),
+        ));
     }
+    let latest_module = latest_modules
+        .modules
+        .first()
+        .ok_or(SchemaVariantsAPIError::LatestModuleNotFoundForHash(
+            local_hash.to_owned(),
+        ))?
+        .to_owned();
+
+    // Determine if we can update based on the latest module.
+    if latest_module.latest_hash != local_hash {
+        schema_variant.can_update = true;
+    }
+
+    debug!(
+        "function 'determine_can_update_one' took: {:?}",
+        start.elapsed()
+    );
+
+    Ok(())
 }

--- a/lib/si-frontend-types-rs/src/schema_variant.rs
+++ b/lib/si-frontend-types-rs/src/schema_variant.rs
@@ -27,6 +27,7 @@ pub struct SchemaVariant {
     pub timestamp: Timestamp,
     pub can_create_new_components: bool, // if yes, show in modeling screen, if not, only show in customize
     pub can_contribute: bool,
+    pub can_update: bool,
 }
 
 #[remain::sorted]


### PR DESCRIPTION
## Description

This PR shows that an asset can be updated. This functionality is achieved by asking the module index what the latest module is for the corresponding local hash.

Why not use the `SchemaId` instead of the local hash? Existing SI deployments may not have the `SchemaId` in their local modules since the module-to-schema enforcement and corresponding table columns were only put in place recently.

One consideration for the future: we may want the "can I update?" logic to be moved into a different route in order to not hold up listing variants. For now, the determination logic is wrapper in an infallible wrapper in case something goes wrong, but that does not prevent poor performance.

<img src="https://media1.giphy.com/media/5xaOcLyzuYxpQyCgy9G/giphy.gif"/>

## Secondary Changes
- Ensure `app/web` no longer mutates the `canUpdate` field for `SchemaVariants`
- Add `README` for `module-index` with instructions for local development
- Remove `SchemaVariantListEntry` as it is no longer needed

## Rendered `module-index` Documentation

[Click here!](https://github.com/systeminit/si/blob/nick/eng-2593/bin/module-index/README.md)