### PR TITLE
Fix to overwriting code

### DIFF
--- a/app/web/src/components/CodeEditor.vue
+++ b/app/web/src/components/CodeEditor.vue
@@ -280,10 +280,6 @@ function getUserInfo(userId: { id: string }) {
 let wsProvider: WebsocketProvider | undefined;
 let yText: Y.Text | undefined;
 onBeforeUnmount(() => {
-  if (view && view.state.doc.toString() !== props.modelValue) {
-    emit("change", props.recordId, view.state.doc.toString(), false);
-    emit("blur", view.state.doc.toString());
-  }
   wsProvider?.destroy();
 });
 


### PR DESCRIPTION
I'm not sure what to make of Vue mount/unmounting behavior. This is what I observed:
1. start with func A
2. select func B
3. see the props change in the CodeEditor component to func B
4. see UNMOUNT called

I don't understand why unmount would be called AFTER the props changed—I would expect it to be BEFORE (e.g. the "old" state of the component). So... we don't save on unmount anymore now, because its the wrong values.