### PR TITLE
fix(web): Remove the Multiplayer CodeEditor

### DIFF
--- a/app/web/src/components/CodeEditor.vue
+++ b/app/web/src/components/CodeEditor.vue
@@ -57,11 +57,11 @@ import beautify from "js-beautify";
 import * as Y from "yjs";
 import { WebsocketProvider } from "y-websocket";
 // import { IndexeddbPersistence } from "y-indexeddb";
-import { yCollab, yUndoManagerKeymap } from "yjs-codemirror-plugin";
+import { yUndoManagerKeymap } from "yjs-codemirror-plugin";
 import { useAuthStore } from "@/store/auth.store";
 import { useChangeSetsStore } from "@/store/change_sets.store";
-import { API_WS_URL } from "@/store/apis";
-import { usePresenceStore } from "@/store/presence.store";
+// import { API_WS_URL } from "@/store/apis";
+// import { usePresenceStore } from "@/store/presence.store";
 import {
   createTypescriptSource,
   GetTooltipFromPos,
@@ -146,7 +146,7 @@ const styleExtensionCompartment = new Compartment();
 const vimCompartment = new Compartment();
 const hoverTooltipCompartment = new Compartment();
 const removeTooltipOnUpdateCompartment = new Compartment();
-const yCompartment = new Compartment();
+// const yCompartment = new Compartment();
 
 // Theme / style ///////////////////////////////////////////////////////////////////////////////////////////
 const { theme: appTheme } = useTheme();
@@ -266,16 +266,16 @@ const codeTooltip = {
   },
 };
 
-const presenceStore = usePresenceStore();
+// const presenceStore = usePresenceStore();
 
-function getUserInfo(userId: { id: string }) {
-  const user = presenceStore.usersById[userId.id];
-  return {
-    name: user?.name,
-    colorLight: user?.color ? `${user.color}30` : undefined,
-    color: user?.color || undefined,
-  };
-}
+// function getUserInfo(userId: { id: string }) {
+//   const user = presenceStore.usersById[userId.id];
+//   return {
+//     name: user?.name,
+//     colorLight: user?.color ? `${user.color}30` : undefined,
+//     color: user?.color || undefined,
+//   };
+// }
 
 let wsProvider: WebsocketProvider | undefined;
 let yText: Y.Text | undefined;
@@ -376,27 +376,27 @@ const mountEditor = async () => {
   // https://github.com/yjs/y-codemirror.next/issues/8
   // https://github.com/yjs/y-codemirror.next/pull/17
 
-  const id = `${changeSetsStore.selectedChangeSetId}-${props.id}`;
+  // const id = `${changeSetsStore.selectedChangeSetId}-${props.id}`;
 
   // const _storageProvider = new IndexeddbPersistence(id, ydoc);
 
-  wsProvider?.destroy();
-  wsProvider = new WebsocketProvider(
-    `${API_WS_URL}/crdt?token=Bearer+${authStore.selectedWorkspaceToken}&id=${id}`,
-    id,
-    ydoc,
-  );
+  // wsProvider?.destroy();
+  // wsProvider = new WebsocketProvider(
+  //   `${API_WS_URL}/crdt?token=Bearer+${authStore.selectedWorkspaceToken}&id=${id}`,
+  //   id,
+  //   ydoc,
+  // );
 
-  wsProvider.awareness.setLocalStateField("user", {
-    id: authStore.user?.pk,
-  });
+  // wsProvider.awareness.setLocalStateField("user", {
+  //   id: authStore.user?.pk,
+  // });
 
   extensions.push(keymap.of([...yUndoManagerKeymap]));
 
   // const undoManager = new Y.UndoManager(yText);
-  extensions.push(
-    yCompartment.of(yCollab(yText, wsProvider.awareness, { getUserInfo })), // , { undoManager })),
-  );
+  // extensions.push(
+  //   yCompartment.of(yCollab(yText, wsProvider.awareness, { getUserInfo })), // , { undoManager })),
+  // );
 
   yText.delete(0, yText.length);
   yText.insert(0, props.modelValue);


### PR DESCRIPTION
We are going to redesign that multi-player code editor. To limit the issues the current subsystem is creating, we are going to turn it off

This will be re-incarnated in a new format!

We lose the autoformat as part of this but that can come back