### PR TITLE
fix: ignore erroneous 404s in cypress tests

### DIFF
--- a/app/web/cypress/e2e/authentication/login.cy.ts
+++ b/app/web/cypress/e2e/authentication/login.cy.ts
@@ -13,7 +13,10 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
 
     it("log_in", () => {
       cy.loginToAuth0(AUTH0_USERNAME, AUTH0_PASSWORD);
-      cy.visit(AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go');
+      cy.visit({
+        url:AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go',
+        failOnStatusCode: false
+      });
       cy.on('uncaught:exception', (e) => {
         console.log(e);
         return false;

--- a/app/web/cypress/e2e/authentication/logout.cy.ts
+++ b/app/web/cypress/e2e/authentication/logout.cy.ts
@@ -14,7 +14,10 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
     });
 
     it("log_out", () => {
-      cy.visit(AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go');
+      cy.visit({
+        url:AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go',
+        failOnStatusCode: false
+      });
       cy.on('uncaught:exception', (e) => {
         console.log(e);
         return false;

--- a/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/create-component.cy.ts
@@ -16,7 +16,10 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
     });
 
     it('create', () => {
-      cy.visit(AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go');
+      cy.visit({
+        url:AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go',
+        failOnStatusCode: false
+      });
       cy.on('uncaught:exception', (e) => {
         console.log(e);
         return false;
@@ -24,7 +27,7 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
       cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", UUID);
 
       cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', 'Change Set 1');
-      
+
       cy.get('#vorm-input-3').clear().type(UUID);
 
       cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', UUID);

--- a/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/delete-component.cy.ts
@@ -15,14 +15,17 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
     });
 
     it('delete', () => {
-      cy.visit(AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go');
+      cy.visit({
+        url:AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go',
+        failOnStatusCode: false
+      });
       cy.on('uncaught:exception', (e) => {
         console.log(e);
         return false;
       });
       cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", UUID);
       cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', 'Change Set 1');
-      
+
       cy.get('#vorm-input-3').clear().type(UUID);
 
       cy.get('#vorm-input-3', { timeout: 30000 }).should('have.value', UUID);

--- a/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
@@ -24,7 +24,10 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
       cy.log(UUID);
 
       // Go to the Synthetic Workspace
-      cy.visit(AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go');
+      cy.visit({
+        url:AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go',
+        failOnStatusCode: false
+      });
       cy.on('uncaught:exception', (e) => {
         console.log(e);
         return false;
@@ -81,7 +84,10 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
 
         // Visit the new URL
         console.log(newUrl.href);
-        cy.visit(newUrl.href);
+        cy.visit({
+          url: newUrl.href,
+          failOnStatusCode: false,
+        });
       });
 
       // Give the page a few seconds to load
@@ -103,7 +109,10 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
         let newUrl = new URL(currentUrl);
         newUrl.searchParams.set('s', 'c_'+componentIDB);
         newUrl.searchParams.set('t', 'attributes');
-        cy.visit(newUrl.href);
+        cy.visit({
+          url: newUrl.href,
+          failOnStatusCode: false,
+        });
       });
 
       // Wait for the values to propagate

--- a/app/web/cypress/e2e/web-functionality/get-summary.cy.ts
+++ b/app/web/cypress/e2e/web-functionality/get-summary.cy.ts
@@ -14,7 +14,10 @@ describe('web', () => {
 
   it('get_summary', () => {
     // Go to the Synthetic Workspace
-    cy.visit(SI_WORKSPACE_URL + '/w/' + SI_WORKSPACE_ID + '/head');
+    cy.visit({
+        url: SI_WORKSPACE_URL + '/w/' + SI_WORKSPACE_ID + '/head',
+        failOnStatusCode: false
+    });
     cy.on('uncaught:exception', (e) => {
       console.log(e);
       return false;

--- a/app/web/cypress/support/auth-provider-commands/auth0.ts
+++ b/app/web/cypress/support/auth-provider-commands/auth0.ts
@@ -36,7 +36,10 @@ Cypress.Commands.add("loginToAuth0", (username: string, password: string) => {
       cy.url().should("contain", import.meta.env.VITE_AUTH_PORTAL_URL);
 
       // Push onto the workspace requested
-      cy.visit(import.meta.env.VITE_AUTH_API_URL + '/workspaces/' + import.meta.env.VITE_SI_WORKSPACE_ID + '/go');
+      cy.visit({
+        url: import.meta.env.VITE_AUTH_API_URL + '/workspaces/' + import.meta.env.VITE_SI_WORKSPACE_ID + '/go',
+        failOnStatusCode: false
+      });
 
     },
     // {


### PR DESCRIPTION
We're getting erroneuous `404`s when these tests are running that seem to have to do with the redirect and hosting on S3. These 404s do not appear when using the app in practice. I'm ignoring them here because in every case we go on to validate actual behavior after we visit. 

<img src="https://media3.giphy.com/media/UoeaPqYrimha6rdTFV/giphy.gif"/>