### PR TITLE
Add description to Schema Variant pkg import/export to ensure it persists across lock/unlock and import/export variant

### DIFF
--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -185,6 +185,7 @@ impl PkgExporter {
         data_builder.display_name(variant.display_name());
 
         data_builder.component_type(get_component_type(ctx, variant).await?);
+        data_builder.description(variant.description());
 
         if let Some(authoring_func_id) =
             overridden_asset_func_id.or_else(|| variant.asset_func_id())

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -1976,7 +1976,7 @@ impl SchemaVariant {
     }
 
     pub fn generate_version_string() -> String {
-        format!("{}", Utc::now().format("%Y%m%d%H%M%S"))
+        format!("{}", Utc::now().format("%Y%m%d%H%M%S%f"))
     }
 
     /// Lists all default [`SchemaVariantIds`](SchemaVariant) that have a secret definition.

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -641,8 +641,7 @@ impl VariantAuthoringClient {
             .ok_or(VariantAuthoringError::PkgMissingSchemaVariant)?;
 
         let mut thing_map = import_only_new_funcs(ctx, pkg.funcs()?).await?;
-
-        Ok(import_schema_variant(
+        let new_schema_variant = import_schema_variant(
             ctx,
             &schema,
             schema_spec.clone(),
@@ -651,7 +650,17 @@ impl VariantAuthoringClient {
             &mut thing_map,
             None,
         )
-        .await?)
+        .await?;
+
+        // need to manually modify the variant to get the new version
+        // as the pkg spec used to generate this new version only has the
+        // old one.
+        Ok(new_schema_variant
+            .modify(ctx, |sv| {
+                sv.version = metadata.version;
+                Ok(())
+            })
+            .await?)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/lib/dal/src/schema/variant/json.rs
+++ b/lib/dal/src/schema/variant/json.rs
@@ -98,6 +98,7 @@ impl SchemaVariantJson {
         if let Some(link) = metadata.link {
             data_builder.try_link(link.as_str())?;
         }
+        data_builder.description(metadata.description);
 
         data_builder.func_unique_id(asset_func_spec_unique_id);
         builder.data(data_builder.build()?);
@@ -165,6 +166,7 @@ impl SchemaVariantJson {
                     link: None,
                     component_type: si_pkg::SchemaVariantSpecComponentType::Component,
                     func_unique_id: "0".into(),
+                    description: None,
                 });
 
         let metadata = SchemaVariantMetadataJson {
@@ -178,7 +180,7 @@ impl SchemaVariantJson {
                 .unwrap_or(DEFAULT_SCHEMA_VARIANT_COLOR.into()),
             component_type: variant_spec_data.component_type.into(),
             link: variant_spec_data.link.as_ref().map(|l| l.to_string()),
-            description: None, // XXX - does this exist?
+            description: variant_spec_data.description.to_owned(),
         };
 
         Ok(metadata)

--- a/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
@@ -40,7 +40,7 @@ async fn clone_variant(ctx: &mut DalContext) {
     assert_eq!(new_schema_variant.category(), existing_variant.category());
     assert_eq!(
         new_schema_variant.display_name(),
-        "dummy-secret".to_string()
+        existing_variant.display_name()
     );
     assert_eq!(
         new_schema_variant

--- a/lib/si-pkg/src/node/schema_variant.rs
+++ b/lib/si-pkg/src/node/schema_variant.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use object_tree::{
-    read_key_value_line, read_key_value_line_opt, write_key_value_line, GraphError, NameStr,
-    NodeChild, NodeKind, NodeWithChildren, ReadBytes, WriteBytes,
+    read_key_value_line, read_key_value_line_opt, write_key_value_line, write_key_value_line_opt,
+    GraphError, NameStr, NodeChild, NodeKind, NodeWithChildren, ReadBytes, WriteBytes,
 };
 use url::Url;
 
@@ -19,6 +19,7 @@ const KEY_VERSION_STR: &str = "name"; // This got renamed to Version, but we kep
 const KEY_COMPONENT_TYPE_STR: &str = "component_type";
 const KEY_FUNC_UNIQUE_ID_STR: &str = "func_unique_id";
 const KEY_IS_BUILTIN_STR: &str = "is_builtin";
+const KEY_DESCRIPTION_STR: &str = "description";
 
 #[derive(Clone, Debug)]
 pub struct SchemaVariantData {
@@ -27,6 +28,7 @@ pub struct SchemaVariantData {
     pub color: Option<String>,
     pub component_type: SchemaVariantSpecComponentType,
     pub func_unique_id: String,
+    pub description: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -60,6 +62,7 @@ impl WriteBytes for SchemaVariantNode {
                 KEY_FUNC_UNIQUE_ID_STR,
                 data.func_unique_id.to_string(),
             )?;
+            write_key_value_line_opt(writer, KEY_DESCRIPTION_STR, data.description.as_deref())?;
         }
 
         write_common_fields(writer, self.unique_id.as_deref(), self.deleted)?;
@@ -94,6 +97,7 @@ impl ReadBytes for SchemaVariantNode {
                     .map_err(GraphError::parse)?;
 
                 let func_unique_id = read_key_value_line(reader, KEY_FUNC_UNIQUE_ID_STR)?;
+                let description = read_key_value_line_opt(reader, KEY_DESCRIPTION_STR)?;
 
                 Some(SchemaVariantData {
                     version: version.to_owned(),
@@ -101,6 +105,7 @@ impl ReadBytes for SchemaVariantNode {
                     color,
                     component_type,
                     func_unique_id,
+                    description,
                 })
             }
             None => None,
@@ -168,6 +173,7 @@ impl NodeChild for SchemaVariantSpec {
                     color: data.color.as_ref().cloned(),
                     component_type: data.component_type,
                     func_unique_id: data.func_unique_id.to_owned(),
+                    description: data.description.to_owned(),
                 }),
                 unique_id: self.unique_id.to_owned(),
                 deleted: self.deleted,

--- a/lib/si-pkg/src/pkg/variant.rs
+++ b/lib/si-pkg/src/pkg/variant.rs
@@ -25,6 +25,7 @@ pub struct SiPkgSchemaVariantData {
     color: Option<String>,
     component_type: SchemaVariantSpecComponentType,
     func_unique_id: String,
+    description: Option<String>,
 }
 
 impl SiPkgSchemaVariantData {
@@ -46,6 +47,9 @@ impl SiPkgSchemaVariantData {
 
     pub fn func_unique_id(&self) -> &str {
         self.func_unique_id.as_str()
+    }
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
     }
 }
 
@@ -117,6 +121,7 @@ impl<'a> SiPkgSchemaVariant<'a> {
                 color: data.color,
                 component_type: data.component_type,
                 func_unique_id: data.func_unique_id,
+                description: data.description,
             }),
             unique_id: schema_variant_node.unique_id,
             deleted: schema_variant_node.deleted,
@@ -418,6 +423,8 @@ impl<'a> SiPkgSchemaVariant<'a> {
             if let Some(color) = data.color() {
                 data_builder.color(color);
             }
+
+            data_builder.description(data.description().map(ToOwned::to_owned));
             data_builder.func_unique_id(data.func_unique_id());
             builder.data(data_builder.build()?);
         }

--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -118,6 +118,8 @@ pub struct SchemaVariantSpecData {
     pub component_type: SchemaVariantSpecComponentType,
     #[builder(setter(into))]
     pub func_unique_id: String,
+    #[builder(setter(into), default)]
+    pub description: Option<String>,
 }
 
 impl SchemaVariantSpecData {


### PR DESCRIPTION
This PR does a few things: 
- Add description to the Schema Variant package spec so we import/export it correctly
- Ensure that the newly unlocked variant immediately has the updated version
- Versions are formatted to include the nanosecond when it was generated (previously seconds)
- Add a test for the open change set, unlock, make changes, apply to head, open new change set, unlock again


<div><img src="https://media4.giphy.com/media/SfzHzeAQte2sl2RfK2/200.gif?cid=5a38a5a2f8v56nj1w9r1i5rjudjvmagzn49qq8rr0ziin8sy&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:170px;width:300px"/><br/>via <a href="https://giphy.com/pbs/">PBS</a> on <a href="https://giphy.com/gifs/pbs-science-human-footprint-shane-campbell-staton-SfzHzeAQte2sl2RfK2">GIPHY</a></div>