### PR TITLE
Move module sync to dal, fix its tracing and add integration test

### DIFF
--- a/lib/dal/tests/integration_test/module.rs
+++ b/lib/dal/tests/integration_test/module.rs
@@ -1,8 +1,10 @@
+use chrono::Utc;
 use dal::module::Module;
 use dal::pkg::export::PkgExporter;
 use dal::{DalContext, Schema};
 use dal_test::test;
 use si_pkg::{SocketSpecArity, SocketSpecKind};
+use ulid::Ulid;
 
 #[test]
 async fn list_modules(ctx: &DalContext) {
@@ -168,4 +170,73 @@ async fn module_export_simple(ctx: &mut DalContext) {
     ];
 
     assert_eq!(exported_pkg_func_names, expected_func_names);
+}
+
+#[test]
+async fn dummy_sync(ctx: &DalContext) {
+    let schema = Schema::find_by_name(ctx, "starfield")
+        .await
+        .expect("could not perform find by name")
+        .expect("schema not found");
+    let schema_variant_id = schema
+        .get_default_schema_variant_id(ctx)
+        .await
+        .expect("could not perform get default schema variant id")
+        .expect("no schema variant id found");
+    let module = Module::find_for_member_id(ctx, schema.id())
+        .await
+        .expect("could not perform find for module schema id")
+        .expect("module not found");
+
+    // Create dummy latest modules.
+    let now = Utc::now();
+    let dummy_latest_module_upgradeable = si_frontend_types::LatestModule {
+        id: Ulid::new().to_string(),
+        name: module.name().to_owned(),
+        description: Some(module.description().to_owned()),
+        owner_user_id: "this is BS!".to_string(),
+        owner_display_name: None,
+        metadata: serde_json::Value::Null,
+        latest_hash: Ulid::new().to_string(),
+        latest_hash_created_at: now,
+        created_at: now,
+        schema_id: Some(schema.id().into()),
+    };
+    let dummy_latest_module_installable = si_frontend_types::LatestModule {
+        id: Ulid::new().to_string(),
+        name: "threadripper 7980X".to_string(),
+        description: None,
+        owner_user_id: "this is also BS!".to_string(),
+        owner_display_name: None,
+        metadata: serde_json::Value::Null,
+        latest_hash: Ulid::new().to_string(),
+        latest_hash_created_at: now,
+        created_at: now,
+        schema_id: Some(Ulid::new().to_string()),
+    };
+
+    // Assemble our expected result.
+    let mut expected = si_frontend_types::SyncedModules::new();
+    expected.upgradeable.insert(
+        schema_variant_id.into(),
+        dummy_latest_module_upgradeable.clone(),
+    );
+    expected
+        .installable
+        .push(dummy_latest_module_installable.clone());
+
+    // Perform the sync and check that the result is what we expect.
+    let actual = Module::sync(
+        ctx,
+        vec![
+            dummy_latest_module_upgradeable,
+            dummy_latest_module_installable,
+        ],
+    )
+    .await
+    .expect("could not sync");
+    assert_eq!(
+        expected, // expected
+        actual    // actual
+    );
 }

--- a/lib/sdf-server/src/server/service/v2/module/sync.rs
+++ b/lib/sdf-server/src/server/service/v2/module/sync.rs
@@ -1,13 +1,9 @@
-use std::collections::{hash_map::Entry, HashMap, HashSet};
-
 use axum::{
     extract::{OriginalUri, Path},
     Json,
 };
-use telemetry::prelude::*;
-use tokio::time::Instant;
 
-use dal::{module::Module, ChangeSetId, DalContext, SchemaId, SchemaVariant, WorkspacePk};
+use dal::{module::Module, ChangeSetId, WorkspacePk};
 use module_index_client::ModuleIndexClient;
 use si_frontend_types as frontend_types;
 
@@ -30,7 +26,16 @@ pub async fn sync(
         .build(access_builder.build(change_set_id.into()))
         .await?;
 
-    let synced_modules = sync_inner(&ctx, &raw_access_token).await?;
+    let latest_modules = {
+        let module_index_url = ctx
+            .module_index_url()
+            .ok_or(ModulesAPIError::ModuleIndexNotConfigured)?;
+        let module_index_client =
+            ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token);
+        module_index_client.list_latest_modules().await?
+    };
+
+    let synced_modules = Module::sync(&ctx, latest_modules.modules).await?;
 
     track(
         &posthog_client,
@@ -41,108 +46,4 @@ pub async fn sync(
     );
 
     Ok(Json(synced_modules))
-}
-
-#[instrument(
-    name = "sdf.v2.module.sync.sync_inner"
-    skip_all,
-    level = "debug",
-)]
-async fn sync_inner(
-    ctx: &DalContext,
-    raw_access_token: &str,
-) -> Result<frontend_types::SyncedModules, ModulesAPIError> {
-    let start = Instant::now();
-
-    // Collect all user facing schema variants. We need to see what can be upgraded.
-    let schema_variants = SchemaVariant::list_user_facing(ctx).await?;
-
-    // Find all local hashes and mark all seen schemas.
-    let mut local_hashes = HashMap::new();
-    let mut seen_schema_ids = HashSet::new();
-    for schema_variant in &schema_variants {
-        let schema_id: SchemaId = schema_variant.schema_id.into();
-        seen_schema_ids.insert(schema_id);
-
-        if let Entry::Vacant(entry) = local_hashes.entry(schema_id) {
-            let local_module = Module::find_for_member_id(ctx, schema_id)
-                .await?
-                .ok_or(ModulesAPIError::ModuleNotFoundForSchema(schema_id))?;
-            entry.insert(local_module.root_hash().to_owned());
-        }
-    }
-
-    // Collect the latest modules.
-    let latest_modules = {
-        let module_index_url = ctx
-            .module_index_url()
-            .ok_or(ModulesAPIError::ModuleIndexNotConfigured)?;
-        let module_index_client =
-            ModuleIndexClient::new(module_index_url.try_into()?, raw_access_token);
-        module_index_client.list_latest_modules().await?
-    };
-
-    // Begin populating synced modules.
-    let mut synced_modules = frontend_types::SyncedModules::new();
-
-    // Group the latest hashes by schema. Populate installable modules along the way.
-    let mut latest_modules_by_schema: HashMap<SchemaId, frontend_types::LatestModule> =
-        HashMap::new();
-    for latest_module in latest_modules.modules {
-        let schema_id: SchemaId = latest_module
-            .schema_id()
-            .ok_or(ModulesAPIError::ModuleMissingSchemaId(
-                latest_module.id.to_owned(),
-                latest_module.latest_hash.to_owned(),
-            ))?
-            .into();
-        match latest_modules_by_schema.entry(schema_id) {
-            Entry::Occupied(entry) => {
-                let existing: frontend_types::LatestModule = entry.get().to_owned();
-                return Err(ModulesAPIError::LatestModuleTooManyForSchema(
-                    schema_id,
-                    existing.latest_hash,
-                    latest_module.latest_hash,
-                ));
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(latest_module.to_owned());
-            }
-        }
-
-        if !seen_schema_ids.contains(&schema_id) {
-            synced_modules.installable.push(latest_module.to_owned());
-        }
-    }
-
-    // Populate upgradeable modules.
-    for schema_variant in schema_variants {
-        let schema_id: SchemaId = schema_variant.schema_id.into();
-        match (
-            latest_modules_by_schema.get(&schema_id),
-            local_hashes.get(&schema_id),
-        ) {
-            (Some(latest_module), Some(local_hash)) => {
-                if &latest_module.latest_hash != local_hash {
-                    synced_modules
-                        .upgradeable
-                        .insert(schema_variant.schema_variant_id, latest_module.to_owned());
-                }
-            }
-            (maybe_latest, maybe_local) => {
-                trace!(
-                    %schema_id,
-                    %schema_variant.schema_variant_id,
-                    %schema_variant.schema_name,
-                    ?maybe_latest,
-                    ?maybe_local,
-                    "skipping since there's incomplete data for determining if schema variant can be updated (perhaps module was not prompted to builtin?)"
-                );
-            }
-        }
-    }
-
-    debug!("syncing modules took: {:?}", start.elapsed());
-
-    Ok(synced_modules)
 }


### PR DESCRIPTION
## Description

This PR moves module syncing to the dal. In addition, it fixes tracing for module syncing and includes more logging. As a result of module syncing moving to the dal, there's a new integration test too.

<img src="https://media4.giphy.com/media/qN2eJnpUIlPtbfdznz/giphy.gif"/>