### PR TITLE
Increase log level and log when module not found for schema

### DIFF
--- a/lib/sdf-server/src/server/service/v2/module.rs
+++ b/lib/sdf-server/src/server/service/v2/module.rs
@@ -37,8 +37,10 @@ impl IntoResponse for ModulesAPIError {
             Self::Transactions(dal::TransactionsError::ConflictsOccurred(_)) => {
                 StatusCode::CONFLICT
             }
-            Self::Module(dal::module::ModuleError::NotFoundForSchema(_))
-            | Self::SchemaVariant(dal::SchemaVariantError::NotFound(_)) => StatusCode::NOT_FOUND,
+            Self::SchemaVariant(dal::SchemaVariantError::NotFound(schema_variant_id)) => {
+                error!(%schema_variant_id, "schema variant not found");
+                StatusCode::NOT_FOUND
+            }
             _ => ApiError::DEFAULT_ERROR_STATUS_CODE,
         };
 


### PR DESCRIPTION
## Description

This PR increases the log level for module syncing as well as tunes inner logs' levels. In addition, we now log instead of returning an error because either the deployment existed during a time where schemas were not one-to-one with modules, or the developer is testing schemas without corresponding modules (e.g. recent AWS IAM creation efforts).

<img src="https://media3.giphy.com/media/jU3Oz64GHix56dhZ1V/giphy.gif"/>
