### PR TITLE
Reflect NixOS compatibility in the docs

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -61,11 +61,15 @@ We have a section further down that describes how to intervene.
 ### Linux
 
 Linux (GNU) is officially supported on both x86_64 (amd64) and aarch64 (arm64) architectures.
-[NixOS](https://nixos.org/) is not supported at this time, but may be desired in the future.
-Linux with MUSL instead of GNU is also not currently supported.
+Linux with MUSL instead of GNU is untested.
 
-In general, GNU-based distros that are roughly [FHS-compliant](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) will work.
+In general, GNU-based distros will work.
 Those include, but are not limited to the following: Ubuntu, Fedora, Debian, Arch Linux, and openSUSE.
+
+#### What about NixOS?
+
+If using NixOS, you need [Docker](https://nixos.wiki/wiki/Docker) to be installed and [Flakes](https://nixos.wiki/wiki/Flakes) to be enabled.
+If not using `direnv`, you can use `nix develop` or [Nix command](https://nixos.wiki/wiki/Nix_command).
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Let's start by choosing an officially supported platform.
 
 **Platform Notes:**
 * On Apple Silicon systems (i.e. macOS aarch64 (arm64)), Rosetta 2 must be installed (install it with `softwareupdate --install-rosetta`)
-* [NixOS](https://nixos.org/) and Linux with MUSL instead of GNU (e.g. [Alpine Linux](https://www.alpinelinux.org/)) will not likely work at this time
+* [NixOS](https://nixos.org/) requires [`docker`](https://nixos.wiki/wiki/Docker) to be installed and [Flakes](https://nixos.wiki/wiki/Flakes) to be enabled (see the [development environment section of the docs](DOCS.md) for more information)
+* Linux with MUSL instead of GNU (e.g. [Alpine Linux](https://www.alpinelinux.org/)) is untested
 * Systemd may need to be enabled on WSL2
 
 ### (2) Install Dependencies

--- a/app/docs/src/reference/dev/development-environment.md
+++ b/app/docs/src/reference/dev/development-environment.md
@@ -28,14 +28,17 @@ intervention. We have a section further down that describes how to intervene.
 ### Linux
 
 Linux (GNU) is officially supported on both x86_64 (amd64) and aarch64 (arm64)
-architectures. [NixOS](https://nixos.org/) is not supported at this time, but
-may be desired in the future. Linux with MUSL instead of GNU is also not
-currently supported.
+architectures. Linux with MUSL instead of GNU is untested.
 
-In general, GNU-based distros that are roughly
-[FHS-compliant](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard)
-will work. Those include, but are not limited to the following: Ubuntu, Fedora,
-Debian, Arch Linux, and openSUSE.
+In general, GNU-based distros will work. Those include, but are not limited to
+the following: Ubuntu, Fedora, Debian, Arch Linux, and openSUSE.
+
+#### What about NixOS?
+
+If using NixOS, you need [Docker](https://nixos.wiki/wiki/Docker) to be
+installed and [Flakes](https://nixos.wiki/wiki/Flakes) to be enabled. If not
+using `direnv`, you can use `nix develop` or
+[Nix command](https://nixos.wiki/wiki/Nix_command).
 
 ### Windows
 


### PR DESCRIPTION
## Description

From research on latest `main`, NixOS x86_64 and aarch64 works for both building and running SI (`buck2 run dev:up`). Data propagation in modeling and advanced function execution (e.g. "create" actions talking to AWS) works as expected. Now, the docs reflect the current state of compatibility.

<img src="https://media2.giphy.com/media/RkJlEd7Cbke4bQ8YHi/giphy.gif"/>