### PR TITLE
Add ability to update assets (upgrade modules)

### DIFF
--- a/app/web/src/components/AssetListPanel.vue
+++ b/app/web/src/components/AssetListPanel.vue
@@ -57,6 +57,7 @@
             tooltip="Update All"
             tooltipPlacement="top"
             variant="simple"
+            @click="updateAllAssets"
           />
         </div>
         <AssetNameModal
@@ -146,10 +147,12 @@ import {
   TreeNode,
   PillCounter,
 } from "@si/vue-lib/design-system";
+import { useRouter } from "vue-router";
 import SiSearch, { Filter } from "@/components/SiSearch.vue";
 import { useAssetStore } from "@/store/asset.store";
 import { SchemaVariant } from "@/api/sdf/dal/schema";
 import { getAssetIcon } from "@/store/components.store";
+import { useModuleStore } from "@/store/module.store";
 import AssetNameModal from "./AssetNameModal.vue";
 import AssetListItem from "./AssetListItem.vue";
 import ModuleExportModal from "./modules/ModuleExportModal.vue";
@@ -157,6 +160,9 @@ import SidebarSubpanelTitle from "./SidebarSubpanelTitle.vue";
 import IconButton from "./IconButton.vue";
 
 const assetStore = useAssetStore();
+const moduleStore = useModuleStore();
+const router = useRouter();
+
 const { variantList: assetList } = storeToRefs(assetStore);
 
 const createAssetReqStatus = assetStore.getRequestStatus("CREATE_VARIANT");
@@ -268,6 +274,15 @@ const newAsset = async (newAssetName: string) => {
     newAssetModalRef.value?.setError("That name is already in use");
   }
   newAssetModalRef.value?.reset();
+};
+
+const updateAllAssets = () => {
+  Object.values(assetStore.upgradeableModules).forEach((module) => {
+    moduleStore.INSTALL_REMOTE_MODULE(module.id);
+  });
+  router.replace({
+    name: "workspace-lab-assets",
+  });
 };
 
 const contributeAsset = () => contributeAssetModalRef.value?.open();

--- a/lib/dal/src/module.rs
+++ b/lib/dal/src/module.rs
@@ -490,8 +490,8 @@ impl Module {
                 local_hashes.get(&schema_id),
             ) {
                 (Some(latest_module), Some(local_hash)) => {
-                    trace!(?latest_module, %local_hash, "comparing hashes");
-                    if &latest_module.latest_hash != local_hash {
+                    debug!(?latest_module, %local_hash, schema_variant.is_locked, "comparing hashes");
+                    if &latest_module.latest_hash != local_hash && schema_variant.is_locked {
                         synced_modules
                             .upgradeable
                             .insert(schema_variant.schema_variant_id, latest_module.to_owned());


### PR DESCRIPTION
## Description

This PR adds the ability to update assets, which is known on the backend as "upgrading modules". There are two ways to do so:

1. Update all assets at once by clicking the update button on the upper left-hand side of the asset list panel
2. Update individual assets by selecting them and then clicking the update button on the upper right-hand side of the asset card on the right-hand side of the application

In both cases, we unset the currently selected asset in order to avoid a mismatched state. In the future, we may be able to avoid unsetting (only for the "update all" case) by checking if the currently selected asset is not in the "upgradeable" list.

This PR also ensures that unlocked schema variants do not appear as "upgradeable".

<img src="https://media4.giphy.com/media/x2edi9sI9KkfjJZnyw/giphy.gif"/>