### PR TITLE
fix: cfg out linux-only firecracker dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,8 +54,6 @@
           ripgrep
           rust-toolchain
           minica
-          lvm2
-          llvmPackages.libclang.lib
 
           # breakpointHook
         ]
@@ -68,6 +66,8 @@
         ++ lib.optionals pkgs.stdenv.isLinux [
           glibc
           glibc.libgcc
+          lvm2
+          llvmPackages.libclang.lib
         ]
         ++ lib.optionals pkgs.stdenv.isDarwin [
           libiconv

--- a/lib/si-firecracker/BUCK
+++ b/lib/si-firecracker/BUCK
@@ -4,14 +4,18 @@ rust_library(
     name = "si-firecracker",
     deps = [
         "//lib/cyclone-core:cyclone-core",
-        "//third-party/rust:devicemapper",
-        "//third-party/rust:krata-loopdev",
         "//third-party/rust:remain",
         "//third-party/rust:nix",
         "//third-party/rust:thiserror",
         "//third-party/rust:tokio",
         "//third-party/rust:tracing",
-    ],
+    ] + select({
+        "DEFAULT": [],
+        "config//os:linux": [
+            "//third-party/rust:krata-loopdev",
+            "//third-party/rust:devicemapper",
+        ],
+    }),
     srcs = glob(["src/**/*.rs","src/scripts/*"]),
 )
 

--- a/lib/si-firecracker/Cargo.toml
+++ b/lib/si-firecracker/Cargo.toml
@@ -10,9 +10,7 @@ publish.workspace = true
 
 [dependencies]
 cyclone-core = { path = "../cyclone-core" }
-devicemapper =  { workspace = true }
 futures = { workspace = true }
-krata-loopdev = { workspace = true }
 nix = { workspace = true }
 remain = { workspace = true }
 thiserror = { workspace = true }
@@ -20,3 +18,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+
+[target.'cfg(target_os = "linux")'.dependencies]
+devicemapper =  { workspace = true }
+krata-loopdev = { workspace = true }

--- a/lib/si-firecracker/src/errors.rs
+++ b/lib/si-firecracker/src/errors.rs
@@ -8,6 +8,7 @@ pub enum FirecrackerJailError {
     #[error("Failed to clean a jail: {0}")]
     Clean(#[source] tokio::io::Error),
     // Error from DmSetup
+    #[cfg(target_os = "linux")]
     #[error("dmsetup error: {0}")]
     DmSetup(#[from] devicemapper::DmError),
     // Failed to interact with a mount

--- a/lib/si-firecracker/src/firecracker.rs
+++ b/lib/si-firecracker/src/firecracker.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "linux")]
 use crate::disk::FirecrackerDisk;
 use crate::errors::FirecrackerJailError;
 use cyclone_core::process;
@@ -61,6 +62,8 @@ impl FirecrackerJail {
     }
 
     pub async fn clean(id: u32) -> Result<()> {
+        let _ = id;
+        #[cfg(target_os = "linux")]
         FirecrackerDisk::clean(id)?;
         Ok(())
     }

--- a/lib/si-firecracker/src/lib.rs
+++ b/lib/si-firecracker/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "linux")]
 mod disk;
 /// [`FirecrackerJailError`] implementations.
 pub mod errors;

--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -78,7 +78,7 @@ setup_traps cleanup
 
 # create disk and mount to a known location
 mkdir -pv "$ROOTFSMOUNT"
-dd if=/dev/zero of="$ROOTFS" bs=1M count=2048
+dd if=/dev/zero of="$ROOTFS" bs=1M count=3072
 mkfs.ext4 -v "$ROOTFS"
 sudo mount -v "$ROOTFS" "$ROOTFSMOUNT"
 


### PR DESCRIPTION
Fixes the flake and hide linux-only dependencies behind comp targets. This is kind of a hokey way to do this but I think the most correct way is likely a refactor of the instance itself, which is a pretty huge undertaking.

<img src="https://media4.giphy.com/media/bfrlODgSLqXxS/giphy.gif"/>