### PR TITLE
fix(auth-portal): Redirect tutorial to workspaces

### DIFF
--- a/app/auth-portal/src/router.ts
+++ b/app/auth-portal/src/router.ts
@@ -50,6 +50,13 @@ export const routerOptions: RouterOptions = {
         return { name: "workspaces" };
       },
     },
+    {
+      path: "/tutorial",
+      name: "tutorial",
+      redirect() {
+        return { name: "workspaces" };
+      },
+    },
     { path: "/workspaces", name: "workspaces", component: WorkspacesPage },
     {
       path: "/workspace/:workspaceId",


### PR DESCRIPTION
The tutorial page was deleted so we should redirect to the workspaces page