### PR TITLE
feat(rebaser): support multiple rebasers that coordinate together

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,6 +5485,7 @@ dependencies = [
 name = "si-std"
 version = "0.1.0"
 dependencies = [
+ "rand 0.8.5",
  "remain",
  "serde",
  "serde_json",

--- a/lib/rebaser-server/DEBOUNCER.md
+++ b/lib/rebaser-server/DEBOUNCER.md
@@ -1,0 +1,52 @@
+# Dependent Values Update Debouncer
+
+## High Level Algorithm
+
+The debouncer task coordinates with other debouncer tasks via a NATS KV store
+which acts as a distributed lock (or could be though of as a leader election).
+Each key corresponds to a unique change set within a workspace. That is, the
+key is of the form `{workspace_pk}.{change_set_id}`. Additionally, there is a
+`max_age` set for all keys which will naturally age out if no
+update/delete/purge operations are performed. This "aging out" of a key should
+only happen when a debouncer task crashes or panics without properly cleaning
+up its state *or* when a Rebaser service is disconnected from its network or
+connection to NATS (i.e. a network partition).
+
+The general algorithm for each debouncer task is as follows:
+
+```mermaid
+stateDiagram-v2
+    Wait: Waits to become leader
+    WatchKey: Watch key for delete/age out
+    AttemptsLeader: Attempt to become leader
+    Leader: Becomes leader (owns key)
+    LeaderWaits: Wait for debounce window
+    CheckIfPending: Check if values are pending
+    PendingValues: Prepares to run DVU
+    SetRunningStatus: Set key value status to "running"
+    PerformDvu: Enqueue, run, and block on DVU
+    KeepaliveWaits: Wait for keepalive window
+    UpdateKey: Update key preventing age out
+
+    [*] --> Wait
+    Wait --> WatchKey
+    WatchKey --> AttemptsLeader: Key deleted
+    WatchKey --> AttemptsLeader: Key aged out
+    AttemptsLeader --> WatchKey: Loses key acquire
+    AttemptsLeader --> Leader: Wins key acquire
+    Leader --> Wait: Returns to waiting
+    state Leader {
+        [*] --> LeaderWaits
+        LeaderWaits --> CheckIfPending: Tick time elapses
+        CheckIfPending --> LeaderWaits: No pending values
+        CheckIfPending --> PendingValues: Pending values found
+        PendingValues --> SetRunningStatus
+        SetRunningStatus --> PerformDvu
+        PerformDvu --> DeleteKey
+        DeleteKey --> [*]
+        --
+        [*] --> KeepaliveWaits
+        KeepaliveWaits --> UpdateKey: Tick time elapsed
+        UpdateKey --> KeepaliveWaits
+    }
+```

--- a/lib/rebaser-server/src/change_set_requests/app_state.rs
+++ b/lib/rebaser-server/src/change_set_requests/app_state.rs
@@ -3,8 +3,6 @@
 use dal::DalContextBuilder;
 use si_events::{ChangeSetId, WorkspacePk};
 
-use crate::dvu_debouncer::DvuDebouncer;
-
 /// Application state.
 #[derive(Clone, Debug)]
 pub struct AppState {
@@ -14,8 +12,6 @@ pub struct AppState {
     pub change_set_id: ChangeSetId,
     /// DAL context builder for each processing request
     pub ctx_builder: DalContextBuilder,
-    /// The DVU debouncer
-    pub dvu_debouncer: DvuDebouncer,
 }
 
 impl AppState {
@@ -24,13 +20,11 @@ impl AppState {
         workspace_id: WorkspacePk,
         change_set_id: ChangeSetId,
         ctx_builder: DalContextBuilder,
-        dvu_debouncer: DvuDebouncer,
     ) -> Self {
         Self {
             workspace_id,
             change_set_id,
             ctx_builder,
-            dvu_debouncer,
         }
     }
 }

--- a/lib/rebaser-server/src/dvu_debouncer_task.rs
+++ b/lib/rebaser-server/src/dvu_debouncer_task.rs
@@ -1,0 +1,690 @@
+//! A per-changeset task to debounce dependent values updates
+
+use std::{ops::ControlFlow, str::Utf8Error, time::Duration};
+
+use dal::{
+    workspace_snapshot::graph::WorkspaceSnapshotGraphDiscriminants, ChangeSet, ChangeSetStatus,
+    DalContextBuilder, Tenancy, Visibility, Workspace,
+};
+use futures::StreamExt as _;
+use serde::{Deserialize, Serialize};
+use si_data_nats::{async_nats::jetstream::kv, Subject};
+use si_events::{ChangeSetId, WorkspacePk};
+use telemetry::prelude::*;
+use thiserror::Error;
+use tokio::{sync::mpsc, time};
+use tokio_util::sync::CancellationToken;
+
+/// An error that can be returned when running a "depdendent values update" debouncer task.
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum DvuDebouncerTaskError {
+    /// When working with a change set
+    #[error("change set: {0}")]
+    ChangeSet(#[from] dal::ChangeSetError),
+    /// When sending a control operation to an internal child task
+    #[error("keepalive error when sending ctrl op")]
+    KeepaliveCtrlSend,
+    /// When an internal child task is shutting down
+    #[error("keepalive task is shutting down; ctl op rejected")]
+    KeepaliveCtrlShutdown,
+    /// When an internal child task fails to shut down cleanly
+    #[error("keepalive task join errored")]
+    KeepaliveTaskJoin,
+    /// When a KV key fails to be created
+    #[error("kv create error")]
+    KvCreate(#[source] kv::CreateError),
+    /// When a KV key fails to be purged
+    #[error("kv purge error; err={0:?}, revision={1}, key={2}")]
+    KvPurge(#[source] kv::PurgeError, u64, String),
+    /// When a KV key fails to be purged
+    #[error("kv purge error; err={0:?}, key={1}")]
+    KvPurgeNoRevision(#[source] kv::PurgeError, String),
+    /// When failing to fetch a KV key status
+    #[error("kv status error")]
+    KvStatus(#[source] kv::StatusError),
+    /// When a KV key fails to be updated
+    #[error("kv update value error; err={0:?}, revision={1}, key={2}")]
+    KvUpdate(#[source] kv::UpdateError, u64, String),
+    /// When failing to construct a KV key watch subscription
+    #[error("kv watch error: {0}")]
+    KvWatch(#[source] kv::WatchError),
+    /// When failing to serialize a type to json
+    #[error("serialize error: {0}")]
+    Serialize(#[source] serde_json::Error),
+    /// When failing to serialize kv state to json
+    #[error("failed to serialize kv state")]
+    SerializeState(#[source] serde_json::Error),
+    /// When failing to create a DAL context
+    #[error("Transactions error: {0}")]
+    Transactions(#[from] dal::TransactionsError),
+    /// When parsing a string from bytes
+    #[error("error when parsing string from bytes: {0}")]
+    Uft8(#[from] Utf8Error),
+    /// Workspace error
+    #[error("workspace error: {0}")]
+    Workspace(#[from] dal::WorkspaceError),
+    /// When working with a workspace snapshot
+    #[error("workspace snapshot: {0}")]
+    WorkspaceSnapshot(#[from] dal::WorkspaceSnapshotError),
+}
+
+type DvuDebouncerTaskResult<T> = Result<T, DvuDebouncerTaskError>;
+
+#[remain::sorted]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+enum KvStatus {
+    Running,
+    Waiting,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct KvState {
+    instance_id: String,
+    status: KvStatus,
+}
+
+#[remain::sorted]
+#[derive(Debug)]
+#[allow(clippy::enum_variant_names)] // Variant names are more descriptive with the shared postfix
+enum DebouncerState {
+    RunningAsLeader((KvState, u64)),
+    WaitingToBecomeLeader,
+}
+
+/// A per-change set task to debounce dependent values updates.
+#[derive(Debug)]
+pub struct DvuDebouncerTask {
+    instance_id: String,
+    kv: kv::Store,
+    watch_subject: Subject,
+    workspace_id: WorkspacePk,
+    change_set_id: ChangeSetId,
+    ctx_builder: DalContextBuilder,
+    interval_duration: Duration,
+    state: DebouncerState,
+    token: CancellationToken,
+    restarted_count: usize,
+}
+
+impl DvuDebouncerTask {
+    const NAME: &'static str = "rebaser_server::dvu_debouncer_task";
+
+    /// Creates and returns a runnable [`DvuDebouncerTask`].
+    pub fn create(
+        instance_id: String,
+        kv: kv::Store,
+        workspace_id: WorkspacePk,
+        change_set_id: ChangeSetId,
+        ctx_builder: DalContextBuilder,
+        interval_duration: Duration,
+    ) -> DvuDebouncerTaskResult<Self> {
+        let watch_subject = Subject::from_utf8(format!("{workspace_id}.{change_set_id}"))?;
+
+        Ok(Self {
+            instance_id,
+            kv,
+            watch_subject,
+            workspace_id,
+            change_set_id,
+            ctx_builder,
+            state: DebouncerState::WaitingToBecomeLeader,
+            interval_duration,
+            token: CancellationToken::new(),
+            restarted_count: 0,
+        })
+    }
+
+    /// Returns a [`CancellationToken`] which can be used to cancel this task.
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+
+    /// Runs the service to completion and will restart when an internal error is encountered.
+    #[inline]
+    pub async fn run(mut self) {
+        loop {
+            match self.try_run().await {
+                Ok(_) => break,
+                Err(err) => {
+                    warn!(
+                        task = Self::NAME,
+                        error = ?err,
+                        key = self.watch_subject.to_string(),
+                        restarted_count = self.restarted_count,
+                        "error found while running task; restarting task",
+                    );
+                    self.restarted_count += 1;
+                }
+            }
+        }
+    }
+
+    /// Runs the service to completion, returning its result (i.e. whether it successful or an
+    /// internal error was encountered).
+    async fn try_run(&mut self) -> DvuDebouncerTaskResult<()> {
+        // Set initial state of waiting to become leader
+        self.state = DebouncerState::WaitingToBecomeLeader;
+
+        loop {
+            let control_flow = match &self.state {
+                DebouncerState::WaitingToBecomeLeader => self.waiting_to_become_leader().await?,
+                DebouncerState::RunningAsLeader((kv_state, revision)) => {
+                    self.running_as_leader(kv_state.clone(), *revision).await?
+                }
+            };
+
+            // Check if a clean shutdown is in progress (`control_flow` is a `break`) **or** if a
+            // shutdown was fired during a critical operation (such as a "dependent values update"
+            // operation as leader). Checking the cancellation token prevents us from entering
+            // another state only to realize that we are be in a shutdown state.
+            if control_flow.is_break() || self.token.is_cancelled() {
+                break;
+            }
+        }
+
+        debug!(
+            task = Self::NAME,
+            key = self.watch_subject.to_string(),
+            "shutdown complete",
+        );
+        Ok(())
+    }
+
+    async fn waiting_to_become_leader(&mut self) -> DvuDebouncerTaskResult<ControlFlow<()>> {
+        info!(
+            task = Self::NAME,
+            key = self.watch_subject.to_string(),
+            "waiting to become leader",
+        );
+
+        let mut watch = self
+            .kv
+            .watch_with_history(self.watch_subject.as_str())
+            .await
+            .map_err(DvuDebouncerTaskError::KvWatch)?;
+
+        let mut check_missing_key_interval = time::interval(Duration::from_secs(5));
+
+        loop {
+            tokio::select! {
+                biased;
+
+                // Cancellation token has fired, time to shut down
+                _ = self.token.cancelled() => {
+                    debug!(
+                        task = Self::NAME,
+                        key = self.watch_subject.to_string(),
+                        state = "waiting_to_become_leader",
+                        "received cancellation",
+                    );
+                    // Beggining to shut dow, return to break out of try_run loop
+                    return Ok(ControlFlow::Break(()));
+                }
+                // Received next watch item
+                maybe_entry_result = watch.next() => {
+                    match maybe_entry_result {
+                        // Next item is an watch entry
+                        Some(Ok(entry)) => match self.process_entry_update(entry).await {
+                            Ok(control_flow) => {
+                                if control_flow.is_break() {
+                                    // State change, return to continue in try_run loop
+                                    return Ok(ControlFlow::Continue(()));
+                                }
+                            }
+                            Err(err) => {
+                                warn!(
+                                    task = Self::NAME,
+                                    key = self.watch_subject.to_string(),
+                                    error = ?err,
+                                    "failed to process update message",
+                                );
+                            }
+                        },
+                        // Next item is an error
+                        Some(Err(err)) => {
+                            warn!(
+                                task = Self::NAME,
+                                key = self.watch_subject.to_string(),
+                                error = ?err,
+                                "failed to process message",
+                            );
+                        }
+                        // Watch stream has ended
+                        None => {
+                            // End of watch stream, return to break out of try_run loop
+                            return Ok(ControlFlow::Break(()));
+                        }
+                    }
+                }
+                // Interval for checking for missing key has ticked
+                _ = check_missing_key_interval.tick() => {
+                    if self.attempt_to_acquire_key().await?.is_break() {
+                        // State change, return to continue in try_run loop
+                        return Ok(ControlFlow::Continue(()));
+                    }
+                }
+            }
+        }
+    }
+
+    async fn running_as_leader(
+        &mut self,
+        kv_state: KvState,
+        revision: u64,
+    ) -> DvuDebouncerTaskResult<ControlFlow<()>> {
+        info!(
+            task = Self::NAME,
+            key = self.watch_subject.to_string(),
+            "running as leader",
+        );
+
+        let task_token = CancellationToken::new();
+        let task = DvuDebouncerKeepaliveTask::new(
+            self.kv.clone(),
+            self.watch_subject.clone(),
+            kv_state,
+            revision,
+            task_token.clone(),
+        )
+        .await?;
+        let keepalive = task.ctl();
+        // Convert the cancellation token into a drop guard to ensure task is cancelled no matter
+        // what
+        let task_drop_guard = task_token.drop_guard();
+        let task_handle = tokio::spawn(task.try_run());
+
+        // Don't early-return on errors as we want to clean up the keepalive task
+        let inner_result = self.running_as_leader_inner(keepalive).await;
+
+        // Cancel the keepalive task and await its completion. On success it returns the revision
+        // of the key
+        debug!(
+            task = Self::NAME,
+            key = self.watch_subject.to_string(),
+            "cancelling keepalive"
+        );
+        task_drop_guard.disarm().cancel();
+        match task_handle
+            .await
+            .map_err(|_err| DvuDebouncerTaskError::KeepaliveTaskJoin)?
+        {
+            Ok(revision) => {
+                self.purge_key(Some(revision)).await?;
+            }
+            Err(task_err) => {
+                warn!(
+                    task = Self::NAME,
+                    key = self.watch_subject.to_string(),
+                    error = ?task_err,
+                    "error found while awaiting keepalive task",
+                );
+                self.purge_key(None).await?;
+            }
+        };
+
+        info!(
+            task = Self::NAME,
+            key = self.watch_subject.to_string(),
+            "demoting self as leader",
+        );
+        inner_result
+    }
+
+    async fn running_as_leader_inner(
+        &mut self,
+        keepalive: DvuDebouncerKeepalive,
+    ) -> DvuDebouncerTaskResult<ControlFlow<()>> {
+        let mut interval = time::interval_at(
+            time::Instant::now() + self.interval_duration,
+            self.interval_duration,
+        );
+
+        loop {
+            tokio::select! {
+                biased;
+
+                // Cancellation token has fired, time to shut down
+                _ = self.token.cancelled() => {
+                    debug!(
+                        task = Self::NAME,
+                        key = self.watch_subject.to_string(),
+                        state = "running_as_leader",
+                        "received cancellation",
+                    );
+                    // Beggining to shut dow, return to break out of try_run loop
+                    return Ok(ControlFlow::Break(()));
+                }
+                // Interval for running dependent values update if values are pending has ticked
+                _ = interval.tick() => {
+                    // This will block the next `select` which is intended as we want a depdendent
+                    // values update to be allowed to run to completion before checking to see if
+                    // the cancellation token has fired in the meantime.
+                    if self.run_dvu_if_values_pending(&keepalive).await?.is_break() {
+                        // Dependent values update has run, return to continue try_run loop
+                        return Ok(ControlFlow::Continue(()));
+                    }
+                }
+            }
+        }
+    }
+
+    #[inline]
+    async fn process_entry_update(
+        &mut self,
+        entry: kv::Entry,
+    ) -> DvuDebouncerTaskResult<ControlFlow<()>> {
+        match entry.operation {
+            // The key has been deleted/purged so we should try to become leader
+            kv::Operation::Delete | kv::Operation::Purge => self.attempt_to_acquire_key().await,
+            // Ingore updates to key--an instance is currently leader and keeping the key alive
+            kv::Operation::Put => {
+                trace!(
+                    task = Self::NAME,
+                    key = entry.key.as_str(),
+                    "received update message",
+                );
+
+                // No leader changes, return to continue waiting to become leader loop
+                Ok(ControlFlow::Continue(()))
+            }
+        }
+    }
+
+    async fn attempt_to_acquire_key(&mut self) -> DvuDebouncerTaskResult<ControlFlow<()>> {
+        let kv_state = KvState {
+            instance_id: self.instance_id.clone(),
+            status: KvStatus::Waiting,
+        };
+
+        let value = serde_json::to_vec(&kv_state).map_err(DvuDebouncerTaskError::Serialize)?;
+
+        match self
+            .kv
+            .create(self.watch_subject.as_str(), value.into())
+            .await
+        {
+            // Success: we should set up to be the leader
+            Ok(revision) => {
+                // Update internal state to running as leader
+                self.state = DebouncerState::RunningAsLeader((kv_state, revision));
+
+                // State change, return to break out of waiting to become leader loop
+                Ok(ControlFlow::Break(()))
+            }
+            Err(err) => {
+                if !matches!(err.kind(), kv::CreateErrorKind::AlreadyExists) {
+                    warn!(
+                        task = Self::NAME,
+                        key = self.watch_subject.to_string(),
+                        error = ?err,
+                        "unexpected error while attempting to create key",
+                    );
+                }
+
+                // Lost race to become leader, return to continue waiting to become
+                // leader loop
+                Ok(ControlFlow::Continue(()))
+            }
+        }
+    }
+
+    async fn purge_key(&self, maybe_revision: Option<u64>) -> DvuDebouncerTaskResult<()> {
+        match maybe_revision {
+            Some(revision) => {
+                // Purge the key with the expected revision
+                if let Err(err) = self
+                    .kv
+                    .purge_expect_revision(self.watch_subject.as_str(), Some(revision))
+                    .await
+                {
+                    warn!(
+                        task = Self::NAME,
+                        key = self.watch_subject.to_string(),
+                        expected_revision = revision,
+                        error = ?err,
+                        "failed to purge key with expected revision",
+                    );
+                    // Attempt to purge the key without revision--as we are the leader this is our
+                    // data
+                    self.kv
+                        .purge(self.watch_subject.as_str())
+                        .await
+                        .map_err(|err| {
+                            DvuDebouncerTaskError::KvPurgeNoRevision(
+                                err,
+                                self.watch_subject.to_string(),
+                            )
+                        })?;
+                }
+            }
+            None => {
+                // Attempt to purge the key--as we are the leader this is our data
+                self.kv
+                    .purge(self.watch_subject.as_str())
+                    .await
+                    .map_err(|err| {
+                        DvuDebouncerTaskError::KvPurgeNoRevision(
+                            err,
+                            self.watch_subject.to_string(),
+                        )
+                    })?;
+            }
+        };
+
+        Ok(())
+    }
+
+    async fn run_dvu_if_values_pending(
+        &mut self,
+        keepalive: &DvuDebouncerKeepalive,
+    ) -> DvuDebouncerTaskResult<ControlFlow<()>> {
+        let builder = self.ctx_builder.clone();
+        let mut ctx = builder.build_default().await?;
+
+        ctx.update_visibility_deprecated(Visibility::new(self.change_set_id.into_raw_id().into()));
+        ctx.update_tenancy(Tenancy::new(self.workspace_id.into_raw_id().into()));
+
+        if let Some(workspace) =
+            Workspace::get_by_pk(&ctx, &self.workspace_id.into_raw_id().into()).await?
+        {
+            if workspace.snapshot_version() != WorkspaceSnapshotGraphDiscriminants::V2 {
+                debug!("snapshot not yet migrated; not attempting dependent values update");
+                // No depdendent values update to perform, return to continue running as leader loop
+                return Ok(ControlFlow::Continue(()));
+            }
+        }
+
+        if let Some(change_set) =
+            ChangeSet::find(&ctx, self.change_set_id.into_raw_id().into()).await?
+        {
+            if !matches!(
+                change_set.status,
+                ChangeSetStatus::Open
+                    | ChangeSetStatus::NeedsApproval
+                    | ChangeSetStatus::NeedsAbandonApproval
+            ) {
+                debug!(
+                    task = Self::NAME,
+                    si.workspace.id = %self.workspace_id,
+                    si.change_set.id = %self.change_set_id,
+                    "change set no longer open, not enqueuing dependent values updates",
+                );
+                return Ok(ControlFlow::Continue(()));
+            }
+        }
+
+        ctx.update_snapshot_to_visibility().await?;
+
+        if ctx
+            .workspace_snapshot()?
+            .has_dependent_value_roots()
+            .await?
+        {
+            keepalive.update_status_to_running().await?;
+
+            info!(
+                task = Self::NAME,
+                si.workspace.id = %self.workspace_id,
+                si.change_set.id = %self.change_set_id,
+                "enqueuing dependent_values_update",
+            );
+            ctx.enqueue_dependent_values_update().await?;
+            ctx.blocking_commit_no_rebase().await?;
+
+            // Update internal state to waiting to become leader again
+            self.state = DebouncerState::WaitingToBecomeLeader;
+
+            // Finished as leader, return to break out of running as leader loop
+            Ok(ControlFlow::Break(()))
+        } else {
+            // No depdendent values update to perform, return to continue running as leader loop
+            Ok(ControlFlow::Continue(()))
+        }
+    }
+}
+
+#[remain::sorted]
+#[derive(Debug)]
+enum KeepaliveOp {
+    UpdateStatusToRunning,
+}
+
+#[derive(Debug)]
+struct DvuDebouncerKeepalive(mpsc::Sender<KeepaliveOp>);
+
+impl DvuDebouncerKeepalive {
+    async fn update_status_to_running(&self) -> DvuDebouncerTaskResult<()> {
+        self.send_op(KeepaliveOp::UpdateStatusToRunning)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn send_op(&self, op: KeepaliveOp) -> DvuDebouncerTaskResult<()> {
+        if self.0.is_closed() {
+            return Err(DvuDebouncerTaskError::KeepaliveCtrlShutdown);
+        }
+
+        self.0
+            .send(op)
+            .await
+            .map_err(|_err| DvuDebouncerTaskError::KeepaliveCtrlSend)
+    }
+}
+
+#[derive(Debug)]
+struct DvuDebouncerKeepaliveTask {
+    kv: kv::Store,
+    key: Subject,
+    state: KvState,
+    revision: u64,
+    interval_duration: Duration,
+    ops_rx: mpsc::Receiver<KeepaliveOp>,
+    _ops_tx: mpsc::Sender<KeepaliveOp>,
+    token: CancellationToken,
+}
+
+impl DvuDebouncerKeepaliveTask {
+    const NAME: &'static str = "rebaser_server::dvu_debouncer_keepalive_task";
+
+    async fn new(
+        kv: kv::Store,
+        key: Subject,
+        kv_state: KvState,
+        revision: u64,
+        token: CancellationToken,
+    ) -> DvuDebouncerTaskResult<Self> {
+        // We want to keep the key from aging out and so want our interval to be *less* than the
+        // key time-to-live
+        let max_age = kv
+            .status()
+            .await
+            .map_err(DvuDebouncerTaskError::KvStatus)?
+            .max_age();
+        let interval_duration = Duration::from_secs_f64(max_age.as_secs_f64() * 0.85);
+
+        let (_ops_tx, ops_rx) = mpsc::channel(4);
+
+        Ok(Self {
+            kv,
+            key,
+            state: kv_state,
+            revision,
+            interval_duration,
+            ops_rx,
+            _ops_tx,
+            token,
+        })
+    }
+
+    fn ctl(&self) -> DvuDebouncerKeepalive {
+        DvuDebouncerKeepalive(self._ops_tx.clone())
+    }
+
+    async fn try_run(mut self) -> DvuDebouncerTaskResult<u64> {
+        let mut interval = time::interval(self.interval_duration);
+
+        loop {
+            tokio::select! {
+                biased;
+
+                // Cancellation token has fired, time to shut down
+                _ = self.token.cancelled() => {
+                    debug!(
+                        task = Self::NAME,
+                        key = self.key.to_string(),
+                        "received cancellation",
+                    );
+                    break;
+                }
+                // Interval for updating state key has ticked
+                _ = interval.tick() => self.update_entry().await?,
+                // There is a next op value on the channel
+                maybe_op = self.ops_rx.recv() => match maybe_op {
+                    // We have an op value, process it
+                    Some(op) => self.process_op(op).await?,
+                    // No more op values, channel is drained, we can break to finish shutdown
+                    None => break,
+                }
+            }
+        }
+
+        debug!(
+            task = Self::NAME,
+            key = self.key.to_string(),
+            "shutdown complete",
+        );
+        Ok(self.revision)
+    }
+
+    #[inline]
+    async fn process_op(&mut self, op: KeepaliveOp) -> DvuDebouncerTaskResult<()> {
+        match op {
+            KeepaliveOp::UpdateStatusToRunning => {
+                self.state.status = KvStatus::Running;
+                self.update_entry().await
+            }
+        }
+    }
+
+    async fn update_entry(&mut self) -> DvuDebouncerTaskResult<()> {
+        let value =
+            serde_json::to_vec(&self.state).map_err(DvuDebouncerTaskError::SerializeState)?;
+        trace!(
+            task = Self::NAME,
+            key = self.key.as_str(),
+            last_revision = self.revision,
+            "updating entry"
+        );
+        let new_revision = self
+            .kv
+            .update(self.key.as_str(), value.into(), self.revision)
+            .await
+            .map_err(|err| {
+                DvuDebouncerTaskError::KvUpdate(err, self.revision, self.key.to_string())
+            })?;
+        self.revision = new_revision;
+
+        Ok(())
+    }
+}

--- a/lib/rebaser-server/src/lib.rs
+++ b/lib/rebaser-server/src/lib.rs
@@ -27,11 +27,13 @@
     while_true
 )]
 
+use dvu_debouncer_task::DvuDebouncerTaskError;
 use thiserror::Error;
 
 pub mod change_set_requests;
 mod config;
-pub mod dvu_debouncer;
+pub mod dvu_debouncer_task;
+pub(crate) mod nats;
 mod rebase;
 mod server;
 
@@ -61,6 +63,12 @@ pub enum ServerError {
     /// When a DAL context fails to be created
     #[error("dal transactions error: {0}")]
     DalTransactions(#[from] dal::TransactionsError),
+    /// When a "dvu" debouncer task fails to be created
+    #[error("dvu debouncer error: {0}")]
+    DvuDebouncerTask(#[from] DvuDebouncerTaskError),
+    /// When a "dvu" debouncer task fails to shutdown cleanly
+    #[error("dvu debouncer task join error")]
+    DvuDebouncerTaskJoin,
     /// When attempting to launch a change set task but one is already running
     #[error("existing change set task already running for id: {0}")]
     ExistingChangeSetTask(si_events::ChangeSetId),
@@ -70,6 +78,9 @@ pub enum ServerError {
     /// When failing to create a Jetstream consumer `impl Stream` of messages
     #[error("consumer stream error: {0}")]
     JsConsumerStream(#[from] si_data_nats::async_nats::jetstream::consumer::StreamError),
+    /// When failing to get or create a NATS KV store
+    #[error("nats kv bucket get or create error: {0}")]
+    KvGetOrCreate(#[from] crate::nats::GetOrCreateKeyValueError),
     /// When a LayerDb error occurs
     #[error("layer db error: {0}")]
     LayerDb(#[from] si_layer_cache::LayerDbError),

--- a/lib/rebaser-server/src/nats.rs
+++ b/lib/rebaser-server/src/nats.rs
@@ -1,0 +1,40 @@
+use si_data_nats::{
+    async_nats::jetstream::{
+        context::{CreateKeyValueError, KeyValueError, KeyValueErrorKind},
+        kv,
+    },
+    jetstream,
+};
+use thiserror::Error;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum GetOrCreateKeyValueError {
+    #[error("create key value bucket error: {0}")]
+    CreateKeyValue(#[from] CreateKeyValueError),
+    #[error("get key value bucket error: {0}")]
+    KeyValue(#[from] KeyValueError),
+}
+
+pub(crate) async fn get_or_create_key_value(
+    context: &jetstream::Context,
+    kv_config: kv::Config,
+) -> Result<kv::Store, GetOrCreateKeyValueError> {
+    match context.get_key_value(kv_config.bucket.as_str()).await {
+        Ok(store) => Ok(store),
+        Err(err) if matches!(err.kind(), KeyValueErrorKind::GetBucket) => context
+            .create_key_value(kv_config)
+            .await
+            .map_err(Into::into),
+        Err(err) => Err(err.into()),
+    }
+}
+
+pub(crate) fn nats_stream_name(prefix: Option<&str>, suffix: impl AsRef<str>) -> String {
+    let suffix = suffix.as_ref();
+
+    match prefix {
+        Some(prefix) => format!("{prefix}_{suffix}"),
+        None => suffix.to_owned(),
+    }
+}

--- a/lib/si-std/BUCK
+++ b/lib/si-std/BUCK
@@ -6,6 +6,7 @@ rust_library(
     name = "si-std",
     edition = "2021",
     deps = [
+        "//third-party/rust:rand",
         "//third-party/rust:remain",
         "//third-party/rust:serde",
         "//third-party/rust:serde_with",

--- a/lib/si-std/Cargo.toml
+++ b/lib/si-std/Cargo.toml
@@ -11,6 +11,7 @@ publish.workspace = true
 # NOTE: dependencies should be extremely minimal or very broadly re-used
 # amongst a potential large number of component crates
 [dependencies]
+rand = { workspace = true }
 remain = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }

--- a/lib/si-std/src/lib.rs
+++ b/lib/si-std/src/lib.rs
@@ -10,6 +10,7 @@ pub mod canonical_file;
 pub mod option;
 pub mod result;
 pub mod string;
+pub mod time;
 
 pub use canonical_file::{CanonicalFile, CanonicalFileError};
 pub use option::OptionExt;

--- a/lib/si-std/src/time.rs
+++ b/lib/si-std/src/time.rs
@@ -1,0 +1,13 @@
+use std::time::Duration;
+
+/// Returns a [`Duration`] with a small amount of randomness which is not greater than the given Duration.
+///
+// Note: Jitter implementation thanks to the `fure` crate, released under the MIT license.
+//
+// See: https://github.com/Leonqn/fure/blob/8945c35655f7e0f6966d8314ab21a297181cc080/src/backoff.rs#L44-L51
+pub fn jitter_duration(duration: Duration) -> Duration {
+    let jitter = rand::random::<f64>();
+    let secs = ((duration.as_secs() as f64) * jitter).ceil() as u64;
+    let nanos = ((f64::from(duration.subsec_nanos())) * jitter).ceil() as u32;
+    Duration::new(secs, nanos)
+}


### PR DESCRIPTION
This change alters the implementation of the `DvuDebouncer` task to coordinate with other potenially running Rebaser services to ensure that (as before) only *one* dependent values update (i.e. DVU) is running per-change set.

As before, this debouncer Tokio task runs alongside each `ChangeSetRequestsTask` that a Rebaser spawns to process a work queue of rebase requests. However, the debouncer task now coordinates with other debouncer tasks via a NATS KV store which acts as a distributed lock (or could be though of as a leader election). Each key corresponds to a unique change set within a workspace. That is, the key is of the form `{workspace_pk}.{change_set_id}`. Additionally, there is a `max_age` set for all keys which will naturally age out if no update/delete/purge operations are performed. This "aging out" of a key should only happen when a debouncer task crashes or panics without properly cleaning up its state *or* when a Rebaser service is disconnected from its network or connection to NATS (i.e. a network partition).

The general algorithm for each debouncer task is as follows:

```mermaid
stateDiagram-v2
    Wait: Waits to become leader
    WatchKey: Watch key for delete/age out
    AttemptsLeader: Attempt to become leader
    Leader: Becomes leader (owns key)
    LeaderWaits: Wait for debounce window
    CheckIfPending: Check if values are pending
    PendingValues: Prepares to run DVU
    SetRunningStatus: Set key value status to "running"
    PerformDvu: Enqueue, run, and block on DVU
    KeepaliveWaits: Wait for keepalive window
    UpdateKey: Update key preventing age out

    [*] --> Wait
    Wait --> WatchKey
    WatchKey --> AttemptsLeader: Key deleted
    WatchKey --> AttemptsLeader: Key aged out
    AttemptsLeader --> WatchKey: Loses key acquire
    AttemptsLeader --> Leader: Wins key acquire
    Leader --> Wait: Returns to waiting
    state Leader {
        [*] --> LeaderWaits
        LeaderWaits --> CheckIfPending: Tick time elapses
        CheckIfPending --> LeaderWaits: No pending values
        CheckIfPending --> PendingValues: Pending values found
        PendingValues --> SetRunningStatus
        SetRunningStatus --> PerformDvu
        PerformDvu --> DeleteKey
        DeleteKey --> [*]
        --
        [*] --> KeepaliveWaits
        KeepaliveWaits --> UpdateKey: Tick time elapsed
        UpdateKey --> KeepaliveWaits
    }
```

<img src="https://media0.giphy.com/media/ToMjGpjwk1MxyYRcQnK/giphy.gif"/>