### PR TITLE
Fix: asset editor and install module are mutually exclusive

### DIFF
--- a/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
+++ b/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
@@ -31,15 +31,25 @@
   >
     <div class="absolute left-0 right-0 top-0 bottom-0">
       <FuncEditor
-        v-if="selectedVariantId && selectedFuncId"
+        v-if="
+          router.currentRoute.value.name === 'workspace-lab-assets' &&
+          selectedVariantId &&
+          selectedFuncId
+        "
         :funcId="selectedFuncId"
       />
       <AssetEditor
-        v-else-if="selectedVariantId"
+        v-else-if="
+          router.currentRoute.value.name === 'workspace-lab-assets' &&
+          selectedVariantId
+        "
         :schemaVariantId="selectedVariantId"
       />
       <InstallAsset
-        v-else-if="!!install?.selectedModule"
+        v-else-if="
+          router.currentRoute.value.name === 'workspace-lab-newassets' &&
+          !!install?.selectedModule
+        "
         :moduleId="install?.selectedModule.id"
         :moduleName="install?.selectedModule.name"
       />
@@ -133,6 +143,7 @@ import {
 } from "@si/vue-lib/design-system";
 import { useAssetStore } from "@/store/asset.store";
 import { useFuncStore } from "@/store/func/funcs.store";
+import router from "@/router";
 import AssetCard from "../AssetCard.vue";
 import AssetListPanel from "../AssetListPanel.vue";
 import InstallAssetsPanel from "../InstallAssetsPanel.vue";


### PR DESCRIPTION
Both routes use the `WorkspaceCustomizeAssets` component. A fuller fix would be pulling the common bits into their own component, having two separate components in the route, and use slots to place the specific per-route components in place. There are some other upsides to that approach, too. But for a Friday, this resolves the problem that would confuse a user until they figured out how to unblock themselves.
<img src="https://media1.giphy.com/media/xS0bXS6LnXaVWXIsf5/giphy.gif"/>