### PR TITLE
fix(dal): ensure we don't search for funcs by name

### DIFF
--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -112,6 +112,8 @@ pub enum PkgError {
     TakingOutputSocketAsInputForPropUnsupported(String, String),
     #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),
+    #[error(transparent)]
+    UlidDecode(#[from] ulid::DecodeError),
     #[error("url parse error: {0}")]
     Url(#[from] ParseError),
     #[error("workspace error: {0}")]

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -8,6 +8,7 @@ use si_pkg::{
 };
 use std::collections::HashSet;
 use std::fmt::Debug;
+use std::str::FromStr;
 use std::{collections::HashMap, path::Path};
 use telemetry::prelude::*;
 use tokio::sync::Mutex;
@@ -952,8 +953,10 @@ pub async fn import_only_new_funcs(
             Func::get_by_id_or_error(ctx, func_id).await?
         } else {
             // Find or create the func for the provided spec.
-            let func = if let Some(func_id) = Func::find_id_by_name(ctx, &func_spec.name()).await? {
-                Func::get_by_id_or_error(ctx, func_id).await?
+            let func = if let Some(func) =
+                Func::get_by_id(ctx, FuncId::from_str(func_spec.unique_id())?).await?
+            {
+                func
             } else {
                 create_func(ctx, &func_spec, false).await?
             };


### PR DESCRIPTION
When installing a generated variant, we need to check for the func by funcid rather than name because if we use name we can find a corresponding name and could end up with a conflicting func in a package

This was manifesting itself as a regenerate showing old func variants