### PR TITLE
feat(dal, sdf): Migrate workspace at create time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,6 +1329,7 @@ dependencies = [
  "itertools 0.12.1",
  "jwt-simple",
  "lazy_static",
+ "module-index-client",
  "nats-subscriber",
  "object-tree",
  "once_cell",

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -7,6 +7,7 @@ load(
 rust_library(
     name = "dal",
     deps = [
+        "//lib/module-index-client:module-index-client",
         "//lib/nats-subscriber:nats-subscriber",
         "//lib/object-tree:object-tree",
         "//lib/si-crypto:si-crypto",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -27,6 +27,7 @@ indexmap = { workspace = true }
 itertools = { workspace = true }
 jwt-simple = { workspace = true }
 lazy_static = { workspace = true }
+module-index-client = { path = "../../lib/module-index-client" }
 nats-subscriber = { path = "../../lib/nats-subscriber" }
 object-tree = { path = "../../lib/object-tree" }
 once_cell = { workspace = true }


### PR DESCRIPTION
When a workspace was created, we used the Default workspace as the starting point of it's existence. This meant that if the default workspace got out of sync with the real world, then each new workspace created would also be out of sync

We now want to replace the login in workspace::new with the migration of the workspace and not even care about the default workspace. This will allow new users to continually get the latest builtins without the need to tell them to migrate all of the builtins on installation