### PR TITLE
fix dead links which is preventing docs from being deployed

### DIFF
--- a/app/docs/src/reference/index.md
+++ b/app/docs/src/reference/index.md
@@ -1,7 +1,9 @@
 # Reference Guides
 
 Reference Guides are designed to give you just the facts about the various parts
-of System Initiative. 
+of System Initiative.
 
-- [Vocabulary](./vocabulary.md) - a comprehensive guide to the terminology we use. 
-- [TypeScript Functions API](./asset-builder/index.md) - the TypeScript API documentation.
+- [Vocabulary](./vocabulary.md) - a comprehensive guide to the terminology we
+  use.
+- [TypeScript Functions API](./typescript/asset_builder/README.md) - the
+  TypeScript API documentation.

--- a/app/docs/src/reference/vocabulary.md
+++ b/app/docs/src/reference/vocabulary.md
@@ -30,13 +30,13 @@ updated to reflect the proposed changes to the model on HEAD.
 
 Creating a change set makes a new copy of the hypergraph based on the current
 data in HEAD. Learn how to create a change set in the
-[getting started tutorial](/tutorial/getting-started).
+[getting started tutorial](/tutorials/getting-started).
 
 ### Applying a Change Set
 
 When you _apply_ a change set, all of the properties and code are merged to
 HEAD, and any actions enqueued. Learn how to apply a change set in the
-[getting started tutorial](/tutorial/getting-started).
+[getting started tutorial](/tutorials/getting-started).
 
 ### Abandoning a Change Set
 


### PR DESCRIPTION
```5:34:03 PM: x Build failed in 2.43s
5:34:03 PM: ✖ building client + server bundles...
5:34:03 PM: build error:
5:34:03 PM: [vitepress] 3 dead link(s) found.
5:34:03 PM:     at Object.renderStart (file:///opt/build/repo/node_modules/.pnpm/vitepress@1.0.2_@types+node@18.15.11_typescript@4.9.5/node_modules/vitepress/dist/node/serve-CEVH7KNu.js:42308:15)
5:34:03 PM:     at file:///opt/build/repo/node_modules/.pnpm/rollup@4.18.0/node_modules/rollup/dist/es/shared/node-entry.js:19774:40
5:34:03 PM:     at async Promise.all (index 0)
5:34:03 PM:     at async PluginDriver.hookParallel (file:///opt/build/repo/node_modules/.pnpm/rollup@4.18.0/node_modules/rollup/dist/es/shared/node-entry.js:19702:9)
5:34:03 PM:     at async Bundle.generate (file:///opt/build/repo/node_modules/.pnpm/rollup@4.18.0/node_modules/rollup/dist/es/shared/node-entry.js:18132:13)
5:34:03 PM:     at async file:///opt/build/repo/node_modules/.pnpm/rollup@4.18.0/node_modules/rollup/dist/es/shared/node-entry.js:20692:27
5:34:03 PM:     at async catchUnfinishedHookActions (file:///opt/build/repo/node_modules/.pnpm/rollup@4.18.0/node_modules/rollup/dist/es/shared/node-entry.js:20119:16)
5:34:03 PM:  ELIFECYCLE  Command failed with exit code 1. (https://ntl.fyi/exit-code-1)
5:34:03 PM: ​
5:34:03 PM: "build.command" failed                                        
5:34:03 PM: ────────────────────────────────────────────────────────────────
5:34:03 PM: ​
5:34:03 PM:   Error message
5:34:03 PM:   Command failed with exit code 1: pnpm run build (https://ntl.fyi/exit-code-1)
5:34:03 PM: ​
5:34:03 PM:   Error location
5:34:03 PM:   In Build command from Netlify app:
5:34:03 PM:   pnpm run build
5:34:03 PM: ​
5:34:03 PM:   Resolved config
5:34:03 PM:   build:
5:34:03 PM:     base: /opt/build/repo/app/docs
5:34:03 PM:     command: pnpm run build
5:34:03 PM:     commandOrigin: ui
5:34:03 PM:     publish: /opt/build/repo/app/docs/dist
5:34:03 PM:     publishOrigin: ui
5:34:03 PM:   redirects:
5:34:03 PM:     - force: true
5:34:03 PM:       from: http://*
5:34:03 PM:       status: 301
5:34:03 PM:       to: https://:splat
5:34:03 PM: Build failed due to a user error: Build script returned non-zero exit code: 2
5:34:04 PM: Failed during stage 'building site': Build script returned non-zero exit code: 2 (https://ntl.fyi/exit-code-2)
5:34:04 PM: Failing build: Failed to build site
5:34:04 PM: Finished processing build request in 31.15s```