### PR TITLE
Fix: dont show edge if socket is gone

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -522,11 +522,17 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           },
 
           diagramEdges(): DiagramEdgeDef[] {
-            return _.filter(this.allEdges, (edge) => {
-              return (
-                !!this.componentsById[edge.toComponentId] &&
-                !!this.componentsById[edge.fromComponentId]
-              );
+            // filter out edge data if neither component exists
+            // or the toComponent Socket doesn't exist
+            return this.allEdges.filter((edge) => {
+              const toComponent = this.componentsById[edge.toComponentId];
+              if (!this.componentsById[edge.fromComponentId]) return false;
+              if (!toComponent) return false;
+              else if (
+                !toComponent.sockets.find((s) => s.id === edge.toSocketId)
+              )
+                return false;
+              return true;
             });
           },
 


### PR DESCRIPTION
Component Upgrade replaces the old component with a new one at the same ID. But the socket ID's change. We aren't yet receiving a "RemoveEdge" event from SDF. So we're wrongly displaying edges that connect to a non-existing socket. This filters them out from what we draw.