### PR TITLE
Fix: actions duplicated, filter bindings for just this variant

### DIFF
--- a/app/web/src/components/AssetActionsDetails.vue
+++ b/app/web/src/components/AssetActionsDetails.vue
@@ -80,7 +80,11 @@ const bindings = computed(() => {
     ];
   variant?.funcIds.forEach((funcId) => {
     const summary = funcStore.funcsById[funcId];
-    const actions = funcStore.actionBindings[funcId];
+    const actions = funcStore.actionBindings[funcId]?.filter(
+      (b) =>
+        b.schemaVariantId ===
+        componentsStore.selectedComponent?.schemaVariantId,
+    );
     if (actions && actions.length > 0) {
       actions.forEach((b) => {
         const a = _.cloneDeep(b) as BindingWithDisplayName;


### PR DESCRIPTION
These were getting duped in certain cases. Fixed up!
![image](https://github.com/user-attachments/assets/5cca2f71-b7a7-4c3e-8fb2-6ea0ce1b3aee)
