### PR TITLE
Feat: improve diagram node selection

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramGroup.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroup.vue
@@ -12,7 +12,7 @@
   >
     <!-- selection box outline -->
     <v-rect
-      v-if="isHovered || isSelected || highlightParent || highlightAsNewParent"
+      v-if="isHovered || highlightParent || highlightAsNewParent"
       :config="{
         width: nodeWidth + 8,
         height: nodeHeight + 8,
@@ -20,7 +20,7 @@
         y: -4 - nodeHeaderHeight - GROUP_HEADER_BOTTOM_MARGIN,
         cornerRadius: CORNER_RADIUS + 3,
         stroke: SELECTION_COLOR,
-        strokeWidth: isSelected ? 3 : 1,
+        strokeWidth: 1,
         listening: false,
       }"
     />

--- a/app/web/src/components/ModelingDiagram/DiagramNode.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramNode.vue
@@ -189,7 +189,7 @@
 
     <!-- selection box outline -->
     <v-rect
-      v-if="isHovered || isSelected"
+      v-if="isHovered"
       :config="{
         width: nodeWidth + 8,
         height: nodeHeight + 8,
@@ -197,7 +197,7 @@
         y: -4,
         cornerRadius: CORNER_RADIUS + 3,
         stroke: SELECTION_COLOR,
-        strokeWidth: isSelected ? 3 : 1,
+        strokeWidth: 1,
         listening: false,
       }"
     />


### PR DESCRIPTION
Always have the selection box on top of all other nodes.

For example, if a frame gets trapped behind another frame, even when you select it from the diagram outliner, you have no indication where it is.

The solve here is to have the selection outline boxes drawn on a canvas layer above all other components.
<img src="https://media0.giphy.com/media/g01FakEbcUua6yM34a/giphy.gif"/>