### PR TITLE
feat(auth-portal): Redirect to the default workspace on login

### DIFF
--- a/app/auth-portal/src/pages/DefaultWorkspacePage.vue
+++ b/app/auth-portal/src/pages/DefaultWorkspacePage.vue
@@ -1,0 +1,29 @@
+<template><div>Redirect to default workspace</div></template>
+
+<script setup lang="ts">
+import { computed, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import { useWorkspacesStore } from "@/store/workspaces.store";
+import { useAuthStore } from "@/store/auth.store";
+import { API_HTTP_URL } from "@/store/api";
+
+const authStore = useAuthStore();
+const router = useRouter();
+const workspacesStore = useWorkspacesStore();
+const defaultWorkspace = computed(() => workspacesStore.defaultWorkspace);
+
+onMounted(async () => {
+  if (import.meta.env.SSR) return;
+  if (!authStore.userIsLoggedIn) return;
+
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  await workspacesStore.LOAD_WORKSPACES();
+  if (defaultWorkspace.value) {
+    window.location.href = `${API_HTTP_URL}/workspaces/${defaultWorkspace.value.id}/go`;
+  } else {
+    await router.push({
+      name: "workspaces",
+    });
+  }
+});
+</script>

--- a/app/auth-portal/src/pages/ProfilePage.vue
+++ b/app/auth-portal/src/pages/ProfilePage.vue
@@ -230,7 +230,7 @@ const saveHandler = async () => {
     const completeProfileReq = await authStore.COMPLETE_PROFILE({});
     if (completeProfileReq.result.success) {
       if (featureFlagsStore.SIMPLIFIED_SIGNUP) {
-        if (authStore.user?.emailVerified) {
+        if (authStore.user?.emailVerified && workspacesStore.defaultWorkspace) {
           tracker.trackEvent("workspace_launcher_widget_click");
           window.location.href = `${API_HTTP_URL}/workspaces/${workspacesStore.defaultWorkspace.id}/go`;
         } else {

--- a/app/auth-portal/src/router.ts
+++ b/app/auth-portal/src/router.ts
@@ -11,6 +11,7 @@ import LogoutSuccessPage from "./pages/LogoutSuccessPage.vue";
 import NotFoundPage from "./pages/NotFoundPage.vue";
 import WorkspacesPage from "./pages/WorkspacesPage.vue";
 import ProfilePage from "./pages/ProfilePage.vue";
+import DefaultWorkspacePage from "./pages/DefaultWorkspacePage.vue";
 
 // normally we'd initialze a router directly, but instead we pass the options to ViteSSG
 export const routerOptions: RouterOptions = {
@@ -59,6 +60,11 @@ export const routerOptions: RouterOptions = {
     },
     { path: "/workspaces", name: "workspaces", component: WorkspacesPage },
     {
+      path: "/default_workspace",
+      name: "default-workspace",
+      component: DefaultWorkspacePage,
+    },
+    {
       path: "/workspace/:workspaceId",
       name: "workspace-settings",
       component: WorkspaceDetailsPage,
@@ -77,7 +83,7 @@ export const routerOptions: RouterOptions = {
         // see App.vue for logic saving this redirect location
         const savedPath = storage.getItem("SI-LOGIN-REDIRECT");
         storage.removeItem("SI-LOGIN-REDIRECT");
-        return savedPath || { name: "workspaces" };
+        return savedPath || { name: "default-workspace" };
       },
     },
     { path: "/:catchAll(.*)", name: "404", component: NotFoundPage },


### PR DESCRIPTION
When a user logs into the app (not from a redirect), we want to take the user to their default workspace.
The default workspace is chosen in the following order:
* If the workspace has a flag of isDefault
* The first production workspace owned by the user

This means that by shipping this code, we only affect users who have a production workspace. This will not redirect users with a local workspace