### PR TITLE
fix(auth-portal): Ensure that the default workspace is one you created

### DIFF
--- a/app/auth-portal/src/store/workspaces.store.ts
+++ b/app/auth-portal/src/store/workspaces.store.ts
@@ -47,7 +47,10 @@ export const useWorkspacesStore = defineStore("workspaces", {
 
       // Let's first check for a defaultWorkspace
       const defaultWorkspace = _.head(
-        _.filter(_.values(state.workspacesById), (w) => w.isDefault),
+        _.filter(
+          _.values(state.workspacesById),
+          (w) => w.isDefault && w.creatorUserId === authStore.user?.id,
+        ),
       );
       if (defaultWorkspace) return defaultWorkspace;
 


### PR DESCRIPTION
We just grabbed any of the workspaces you had in your list and redirected to that. it must be a workspace you created for it to be your default workspace