### PR TITLE
feat(sdf) - create workspace permissions system

### DIFF
--- a/bin/auth-api/src/services/workspaces.service.ts
+++ b/bin/auth-api/src/services/workspaces.service.ts
@@ -50,7 +50,6 @@ export async function createWorkspace(
     instanceUrl,
     instanceEnvType: newWorkspace.instanceEnvType,
     isDefaultWorkspace: newWorkspace.isDefault,
-    // TODO: track env type and other data when it becomes useful
   });
 
   await prisma.workspaceMembers.create({

--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -1,4 +1,6 @@
 pkgs_path = "/tmp"
+create_workspace_permissions = "$SI_WORKSPACE_PERMISSIONS"
+create_workspace_allowlist = [ "$SI_WORKSPACE_ALLOW_LIST" ]
 
 [crypto]
 encryption_key_base64 = "$SI_ENCRYPTION_KEY_BASE64"

--- a/lib/dal/src/user.rs
+++ b/lib/dal/src/user.rs
@@ -157,6 +157,23 @@ impl User {
         Ok(())
     }
 
+    pub async fn is_first_user(&self, ctx: &DalContext) -> UserResult<bool> {
+        let row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_opt("SELECT pk FROM users ORDER BY created_at ASC LIMIT 1", &[])
+            .await?;
+
+        match row {
+            Some(row) => {
+                let oldest_user_pk: UserPk = row.get("pk");
+                Ok(oldest_user_pk == self.pk)
+            }
+            None => Ok(false),
+        }
+    }
+
     pub async fn delete_user_from_workspace(
         ctx: &DalContext,
         user_pk: UserPk,

--- a/lib/sdf-server/src/server.rs
+++ b/lib/sdf-server/src/server.rs
@@ -1,6 +1,7 @@
 pub use config::{
     detect_and_configure_development, Config, ConfigBuilder, ConfigError, ConfigFile,
-    IncomingStream, StandardConfig, StandardConfigFile,
+    IncomingStream, StandardConfig, StandardConfigFile, WorkspacePermissions,
+    WorkspacePermissionsMode,
 };
 pub use dal::{JobQueueProcessor, MigrationMode, NatsProcessor, ServicesContext};
 pub use nats_multiplexer::CRDT_MULTIPLEXER_SUBJECT;

--- a/lib/sdf-server/src/server/server.rs
+++ b/lib/sdf-server/src/server/server.rs
@@ -516,6 +516,7 @@ pub fn build_service(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_service_inner(
     services_context: ServicesContext,
     jwt_public_signing_key: JwtPublicSigningKey,

--- a/lib/sdf-server/src/server/service/session.rs
+++ b/lib/sdf-server/src/server/service/session.rs
@@ -48,6 +48,8 @@ pub enum SessionError {
     Workspace(#[from] WorkspaceError),
     #[error("workspace {0} not yet migrated to new snapshot graph version. Migration required")]
     WorkspaceNotYetMigrated(WorkspacePk),
+    #[error("you do not have permission to create a workspace on this instance")]
+    WorkspacePermissions,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -67,6 +69,9 @@ impl IntoResponse for SessionError {
                 Some("WORKSPACE_NOT_INITIALIZED"),
                 None,
             ),
+            SessionError::WorkspacePermissions => {
+                (StatusCode::UNAUTHORIZED, None, Some(self.to_string()))
+            }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, None, None),
         };
 

--- a/lib/sdf-server/src/server/state.rs
+++ b/lib/sdf-server/src/server/state.rs
@@ -6,6 +6,7 @@ use std::{ops::Deref, sync::Arc};
 use tokio::sync::{broadcast, mpsc, Mutex};
 
 use super::server::ShutdownSource;
+use super::{WorkspacePermissions, WorkspacePermissionsMode};
 use crate::server::nats_multiplexer::NatsMultiplexerClients;
 use crate::server::service::ws::crdt::BroadcastGroups;
 
@@ -18,6 +19,8 @@ pub struct AppState {
     shutdown_broadcast: ShutdownBroadcast,
     for_tests: bool,
     nats_multiplexer_clients: NatsMultiplexerClients,
+    create_workspace_permissions: WorkspacePermissionsMode,
+    create_workspace_allowlist: Vec<WorkspacePermissions>,
 
     // TODO(fnichol): we're likely going to use this, but we can't allow it to be dropped because
     // that will trigger the read side and... shutdown. Cool, no?
@@ -36,6 +39,8 @@ impl AppState {
         for_tests: bool,
         ws_multiplexer_client: MultiplexerClient,
         crdt_multiplexer_client: MultiplexerClient,
+        create_workspace_permissions: WorkspacePermissionsMode,
+        create_workspace_allowlist: Vec<WorkspacePermissions>,
     ) -> Self {
         let nats_multiplexer_clients = NatsMultiplexerClients {
             ws: Arc::new(Mutex::new(ws_multiplexer_client)),
@@ -50,6 +55,8 @@ impl AppState {
             for_tests,
             nats_multiplexer_clients,
             _tmp_shutdown_tx: Arc::new(tmp_shutdown_tx),
+            create_workspace_permissions,
+            create_workspace_allowlist,
         }
     }
 
@@ -67,6 +74,14 @@ impl AppState {
 
     pub fn for_tests(&self) -> bool {
         self.for_tests
+    }
+
+    pub fn create_workspace_permissions(&self) -> WorkspacePermissionsMode {
+        self.create_workspace_permissions
+    }
+
+    pub fn create_workspace_allowlist(&self) -> &[String] {
+        &self.create_workspace_allowlist
     }
 }
 

--- a/lib/si-test-macros/src/sdf_test.rs
+++ b/lib/si-test-macros/src/sdf_test.rs
@@ -385,6 +385,8 @@ impl SdfTestFnSetupExpander {
                     #posthog_client,
                     #ws_multiplexer_client,
                     #crdt_multiplexer_client,
+                    ::sdf_server::server::WorkspacePermissionsMode::Open,
+                    vec![],
                 ).wrap_err("failed to build sdf router")?;
                 service
             };


### PR DESCRIPTION
A permissions system for creating new workspaces.
Each instance of SDF can be configured in one of three ways -
- Closed - Only the first registered user can create new workspaces
- Open - Any registered user can create new workspaces
- Allowlist - Only registered users with an email on the Allowlist can create new workspaces. The allowlist can be specific email addresses, email domains to allow all addresses from (such as @systeminit.com), or a mix of both.