### PR TITLE
fix: use head_ref to get the correct branch name

### DIFF
--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
           pipeline: "system-initiative/si-merge-queue"
-          branch: ${{ github.ref_name }}
-          message:  ":github: Try for branch ${{ github.ref_name }}"
+          branch: ${{ github.head_ref }}
+          message:  ":github: Try for branch ${{ github.head_ref }}"
           ignore_pipeline_branch_filter: true
           send_pull_request: true


### PR DESCRIPTION
This value is different depending on how the action is run. Neat!