### PR TITLE
Use docker-compose from nix instead of "docker compose"

### DIFF
--- a/dev/healthcheck.py
+++ b/dev/healthcheck.py
@@ -62,8 +62,7 @@ def detect_docker_engine() -> int:
 def detect_docker_compose() -> int:
     result = subprocess.run(
         [
-            "docker",
-            "compose",
+            "docker-compose",
             "version",
         ],
         capture_output=True,

--- a/prelude-si/tilt.bzl
+++ b/prelude-si/tilt.bzl
@@ -51,8 +51,7 @@ def tilt_docker_compose_pull_impl(ctx: AnalysisContext) -> list[[DefaultInfo, Ru
     )
 
     run_cmd_args = cmd_args([
-        "docker",
-        "compose",
+        "docker-compose",
         "--file",
         docker_compose_file,
         "pull",
@@ -88,8 +87,7 @@ def tilt_docker_compose_stop_impl(ctx: AnalysisContext) -> list[[DefaultInfo, Ru
     )
 
     run_cmd_args = cmd_args([
-        "docker",
-        "compose",
+        "docker-compose",
         "--file",
         docker_compose_file,
         "stop",


### PR DESCRIPTION
This avoids a segfault running `buck2 dev:healthcheck`, `buck2 dev:stop` and `buck2 run dev:pull` with the latest docker version. Basically we install a `docker-compose` in nix, but we currently don't use it for these three commands.

All three commands do things that seem right when I run them after this change (they do some stuff and then segfault before the change):

```bash
jkeiser@Johns-MacBook-Pro si % buck2 run dev:healthcheck             
Build ID: 1d522276-8afd-4cf1-a031-4534207588af
Network: Up: 0B  Down: 0B
Jobs completed: 4. Time elapsed: 0.0s.
BUILD SUCCEEDED
--- Running health check on system for developing in the SI project
  - Detected `docker` command (cmd=/usr/local/bin/docker)
  - Detected running Docker Engine
  - Detected Docker Compose is installed
  - Found `bash` in Nix environment
  - Reasonable value for max open files soft limit detected in current shell (current=1048575)

--- Health check complete with **no** suggested remediations.



jkeiser@Johns-MacBook-Pro si % buck2 run dev:stop
File changed: root//app/docs/src/.vitepress/config.ts.timestamp-1721849767216-f652f4df9674.mjs
Target root//dev:stop (prelude-si//platforms:default#d53ab762f91cb194) does not have any outputs. This means the rule did not define any outputs. See https://buck2.build/docs/users/faq/common_issues/#why-does-my-target-not-have-any-outputs for more information
Build ID: 8ecf9c63-c303-4d83-93b0-64c18bc95ddf
Network: Up: 0B  Down: 0B
Jobs completed: 3. Time elapsed: 0.0s.
BUILD SUCCEEDED
[+] Stopping 9/9
 ✔ Container dev-localstack-1     Stopped                                                                                              3.5s 
 ✔ Container dev-postgres-test-1  Stopped                                                                                              0.2s 
 ✔ Container loki                 Stopped                                                                                             10.1s 
 ✔ Container grafana              Stopped                                                                                              0.2s 
 ✔ Container dev-postgres-1       Stopped                                                                                              0.2s 
 ✔ Container dev-otelcol-1        Stopped                                                                                             10.2s 
 ✔ Container dev-db-test-1        Stopped                                                                                              0.1s 
 ✔ Container dev-db-1             Stopped                                                                                              0.1s 
 ✔ Container dev-jaeger-1         Stopped                                                                                              0.1s


jkeiser@Johns-MacBook-Pro si % buck2 run dev:pull
Target root//dev:pull (prelude-si//platforms:default#d53ab762f91cb194) does not have any outputs. This means the rule did not define any outputs. See https://buck2.build/docs/users/faq/common_issues/#why-does-my-target-not-have-any-outputs for more information
Build ID: de7e49bc-7359-423b-b743-4cb33a4efe46
Network: Up: 0B  Down: 0B
Jobs completed: 3. Time elapsed: 0.0s.
BUILD SUCCEEDED
[+] Pulling 11/11
 ✔ db Skipped - Image is already being pulled by db-test                                                                               0.0s 
 ✔ postgres-test Skipped - Image is already being pulled by postgres                                                                   0.0s 
 ✔ grafana Pulled                                                                                                                      1.2s 
 ✔ jaeger Pulled                                                                                                                       1.3s 
 ✔ loki Pulled                                                                                                                         1.3s 
 ✔ db-test Pulled                                                                                                                      1.2s 
 ✔ otelcol Pulled                                                                                                                      1.3s 
 ✔ promtail Pulled                                                                                                                     1.3s 
 ✔ nats Pulled                                                                                                                         1.3s 
 ✔ localstack Pulled                                                                                                                   1.2s 
 ✔ postgres Pulled                                                                                                                     1.2s 
```