### PR TITLE
Point localstack credentials docs at localhost

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -272,7 +272,7 @@ To use LocalStack with "AWS Credential", do the following:
 
 1. Create a `Component` using the `SchemaVariant`.
 1. Create a `Secret` and use it in the property editor.
-1. Populate `http://0.0.0.0:4566` in the "Endpoint" field for the `Secret`.
+1. Populate `http://localhost:4566` in the "Endpoint" field for the `Secret`.
 
 Now, you can use LocalStack in your development setup.
 


### PR DESCRIPTION
We bind localhost by default, and 0.0.0.0 doesn't work.