### PR TITLE
Fix: do not call status_with_base when... you are on base

### DIFF
--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -192,7 +192,12 @@ router.beforeResolve((to) => {
   if ("changeSetId" in to.params) {
     const changeSetStore = useChangeSetsStore();
     const changeSetId = to.params.changeSetId;
-    if (changeSetId && changeSetId !== "auto" && !Array.isArray(changeSetId))
+    if (
+      changeSetId &&
+      changeSetId !== "head" &&
+      changeSetId !== "auto" &&
+      !Array.isArray(changeSetId)
+    )
       changeSetStore.FETCH_STATUS_WITH_BASE(changeSetId);
   }
 });

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -155,6 +155,8 @@ export function useChangeSetsStore() {
           });
         },
         async FETCH_STATUS_WITH_BASE(changeSetId: ChangeSetId) {
+          // do not call this with `head`
+          if (changeSetId === "head") return Promise.resolve();
           return new ApiRequest<StatusWithBase>({
             method: "post",
             url: "change_set/status_with_base",
@@ -381,7 +383,7 @@ export function useChangeSetsStore() {
               }
 
               // TODO: jobelenus, I'm worried the WsEvent fires before commit happens
-              if (this.selectedChangeSetId)
+              if (this.selectedChangeSetId && !this.headSelected)
                 this.FETCH_STATUS_WITH_BASE(this.selectedChangeSetId);
 
               // did head get an update and I'm not on head?


### PR DESCRIPTION
But the real problem is that `head` is not a `ulid` and axum tosses it.<img src="https://media3.giphy.com/media/6o4TI6R4dvifniwOIk/giphy.gif"/>