### PR TITLE
fix(dal, sdf): auth funcs can be detached

### DIFF
--- a/lib/dal/src/func/binding/authentication.rs
+++ b/lib/dal/src/func/binding/authentication.rs
@@ -49,7 +49,7 @@ impl AuthBinding {
     #[instrument(
         level = "info",
         skip(ctx),
-        name = "func.binding.authentication.create_auth_binding"
+        name = "func.binding.authentication.delete_auth_binding"
     )]
     /// Deletes an Auth Binding for a Schema Variant
     pub async fn delete_auth_binding(
@@ -63,6 +63,11 @@ impl AuthBinding {
         Ok(EventualParent::SchemaVariant(schema_variant_id))
     }
 
+    #[instrument(
+        level = "info",
+        skip(ctx),
+        name = "func.binding.authentication.port_binding_to_new_func"
+    )]
     pub(crate) async fn port_binding_to_new_func(
         &self,
         ctx: &DalContext,

--- a/lib/dal/tests/integration_test/func/authoring/binding/authentication.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding/authentication.rs
@@ -79,3 +79,154 @@ async fn attach_multiple_auth_funcs_with_creation(ctx: &mut DalContext) {
         funcs.len()      // actual
     );
 }
+
+#[test]
+async fn detach_auth_func(ctx: &mut DalContext) {
+    let schema = Schema::find_by_name(ctx, "dummy-secret")
+        .await
+        .expect("unable to find by name")
+        .expect("no schema found");
+    let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+        .await
+        .expect("unable to get default schema variant");
+
+    // Cache the total number of funcs before continuing.
+    let funcs = FuncSummary::list_for_schema_variant_id(ctx, schema_variant_id)
+        .await
+        .expect("unable to get the funcs for a schema variant");
+    let total_funcs = funcs.len();
+
+    // Get the Auth Func
+    let fn_name = "test:setDummySecretString";
+    let func_id = Func::find_id_by_name(ctx, fn_name)
+        .await
+        .expect("found auth func")
+        .expect("has a func");
+
+    // Try to detach and see it fails
+    let delete_result = AuthBinding::delete_auth_binding(ctx, func_id, schema_variant_id).await;
+    assert!(delete_result.is_err());
+
+    // now create unlocked copy
+    let unlocked_schema_variant =
+        VariantAuthoringClient::create_unlocked_variant_copy(ctx, schema_variant_id)
+            .await
+            .expect("could create unlocked copy")
+            .id();
+
+    // detach auth func for unlocked copy
+    AuthBinding::delete_auth_binding(ctx, func_id, unlocked_schema_variant)
+        .await
+        .expect("could not delete auth binding");
+
+    // check that there's one less func
+    let funcs = FuncSummary::list_for_schema_variant_id(ctx, unlocked_schema_variant)
+        .await
+        .expect("unable to get the funcs for a schema variant");
+    assert_eq!(funcs.len(), total_funcs - 1);
+}
+
+#[test]
+async fn edit_auth_func(ctx: &mut DalContext) {
+    ChangeSetTestHelpers::fork_from_head_change_set(ctx)
+        .await
+        .expect("could not fork head");
+    // find the variant we know is default and attached to this func already
+    let schema = Schema::find_by_name(ctx, "dummy-secret")
+        .await
+        .expect("unable to find by name")
+        .expect("no schema found");
+
+    let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+        .await
+        .expect("unable to get default schema variant");
+    // Cache the total number of funcs before continuing.
+    let funcs = FuncSummary::list_for_schema_variant_id(ctx, schema_variant_id)
+        .await
+        .expect("unable to get the funcs for a schema variant");
+
+    // Get the Auth Func
+    let fn_name = "test:setDummySecretString";
+    let func_id = Func::find_id_by_name(ctx, fn_name)
+        .await
+        .expect("found auth func")
+        .expect("has a func");
+
+    // ensure the func is attached
+    assert!(funcs.into_iter().any(|func| func.id == func_id));
+
+    // create unlocked copy of it
+    let unlocked_func_id = FuncAuthoringClient::create_unlocked_func_copy(ctx, func_id, None)
+        .await
+        .expect("could not create unlocked copy");
+
+    // find unlocked copy of the variant
+    let unlocked_schema_variant = SchemaVariant::get_unlocked_for_schema(ctx, schema.id())
+        .await
+        .expect("unable to get default schema variant")
+        .expect("has unlocked variant");
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("unable to commit");
+
+    assert!(!unlocked_schema_variant.is_locked());
+
+    // ensure the unlocked variant has the new func attached and not the old one
+    let funcs = FuncSummary::list_for_schema_variant_id(ctx, unlocked_schema_variant.id)
+        .await
+        .expect("could not get func summaries");
+
+    assert!(funcs
+        .clone()
+        .into_iter()
+        .any(|func| func.id == unlocked_func_id.id));
+    assert!(funcs.into_iter().any(|func| func.id != func_id));
+
+    // edit the func
+    let new_auth_func_code = "async function auth(secret: Input): Promise<Output> { requestStorage.setItem('dummySecretString', secret.value); requestStorage.setItem('workspaceToken', secret.WorkspaceToken); console.log('success');}";
+
+    FuncAuthoringClient::save_code(ctx, unlocked_func_id.id, new_auth_func_code.to_string())
+        .await
+        .expect("could not save code");
+
+    let unlocked_func = Func::get_by_id_or_error(ctx, unlocked_func_id.id)
+        .await
+        .expect("could not get func");
+    // ensure it saved
+    let maybe_new_code = unlocked_func
+        .code_plaintext()
+        .expect("got code")
+        .expect("has code");
+
+    assert_eq!(new_auth_func_code.to_string(), maybe_new_code);
+
+    // commit and apply
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx)
+        .await
+        .expect("could not apply to base");
+
+    // ensure new func is locked
+    let new_locked_func = Func::get_by_id_or_error(ctx, unlocked_func.id)
+        .await
+        .expect("could not get func");
+
+    assert!(new_locked_func.is_locked);
+    assert_eq!(
+        new_locked_func
+            .code_plaintext()
+            .expect("got code")
+            .expect("has code"),
+        new_auth_func_code.to_string()
+    );
+
+    //ensure new schema variant is locked and default
+    let maybe_locked_schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+        .await
+        .expect("unable to get default schema variant");
+    let maybe_locked_schema_variant =
+        SchemaVariant::get_by_id_or_error(ctx, maybe_locked_schema_variant_id)
+            .await
+            .expect("could not get schema variant");
+    assert!(maybe_locked_schema_variant.is_locked());
+}

--- a/lib/sdf-server/src/server/service/v2/func.rs
+++ b/lib/sdf-server/src/server/service/v2/func.rs
@@ -29,6 +29,8 @@ pub mod update_func;
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum FuncAPIError {
+    #[error("cannot delete binding for func kind")]
+    CannotDeleteBindingForFunc,
     #[error("cannot delete locked func: {0}")]
     CannotDeleteLockedFunc(FuncId),
     #[error("change set error: {0}")]


### PR DESCRIPTION
- Fix the SDF route for `delete_binding` to allow auth funcs to be detached
- Added tests for editing and detaching auth funcs
- fixed the name of a span and added one for the porting of auth funcs