### PR TITLE
Ensure recycled PG connections do not have lingering open transactions

### DIFF
--- a/lib/si-data-pg/src/lib.rs
+++ b/lib/si-data-pg/src/lib.rs
@@ -63,6 +63,7 @@ const TEST_QUERY: &str = "SELECT 1";
 // We could avoid needing to discard plans by selecting exactly the columns we
 // need instead of SELECT * (unless the column type changes!)
 const CONNECTION_RECYCLING_METHOD: &str = r#"
+    ROLLBACK;
     CLOSE ALL;
     SET SESSION AUTHORIZATION DEFAULT;
     RESET ALL;


### PR DESCRIPTION
In addition to the in-process pool of PG connections, we also have connection pooling & recycling happening in pgbouncer. Because there are multiple layers that might result in us using an already established PG connection that is an unknown state, we need to make sure that we're also not dealing with a lingering open transaction in addition to the things we're already doing to make sure the connection is "clean" before we start using it.