### PR TITLE
fix(lang-js): Set env vars before we iterate on beforeFuncs

### DIFF
--- a/bin/lang-js/src/function.ts
+++ b/bin/lang-js/src/function.ts
@@ -97,13 +97,12 @@ export async function executeFunction(kind: FunctionKind, request: Request) {
 
   for (const beforeFunction of request.before || []) {
     await executor(ctx, beforeFunction, FunctionKind.Before, before);
-  }
-
-  // Set process environment variables, set from requestStorage
-  {
-    const requestStorageEnv = rawStorageRequest().env();
-    for (const key in requestStorageEnv) {
-      process.env[key] = requestStorageEnv[key];
+    // Set process environment variables, set from requestStorage
+    {
+      const requestStorageEnv = rawStorageRequest().env();
+      for (const key in requestStorageEnv) {
+        process.env[key] = requestStorageEnv[key];
+      }
     }
   }
 


### PR DESCRIPTION
In a world where before funcs depend on beforeFuncs, we want the funcs to be able to see the results of each other so that they can work as expected

So if Func A writes to the environment, then we want that to be written before Func B runs otherwise Func B can't do it's thing