### PR TITLE
fix: cloudfront dist id from secret instead of by name

### DIFF
--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -62,8 +62,7 @@ jobs:
       - name: Invalidate web cache
         if: ${{ inputs.service == 'web' }}
         run: |
-          ENV=${{ inputs.environment }}
-          DIST_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[?Comment=='$ENV-cdn'].Id | [0]" --output text)
+          DIST_ID=${{ secrets.CLOUDFRONT_DIST_ID }}
           # Create a CloudFront invalidation for all objects (/*)
           invalidation_id=$(aws cloudfront create-invalidation --distribution-id $DIST_ID --paths "/*" --query 'Invalidation.Id' --output text)
           # Check the status of the invalidation until it's completed


### PR DESCRIPTION
Pass the dist id instead of string matching the name will be much more reliable.

<img src="https://media3.giphy.com/media/eg3UdqgFbQU04wUdm2/giphy.gif"/>