### PR TITLE
fix(sdf): Restore the correct name of the module contribution event

### DIFF
--- a/lib/sdf-server/src/server/service/v2/module/contribute.rs
+++ b/lib/sdf-server/src/server/service/v2/module/contribute.rs
@@ -59,7 +59,7 @@ pub async fn contribute(
         &posthog_client,
         &ctx,
         &original_uri,
-        "contribute",
+        "export_module",
         serde_json::json!({
             "name": name,
             "version": version,


### PR DESCRIPTION
Without this event, none of the associated triggers on the event were firing