### PR TITLE
chore: minor fixups to cypress tests

### DIFF
--- a/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
+++ b/app/web/cypress/e2e/modelling-functionality/value-attribute-propogation.cy.ts
@@ -116,6 +116,9 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
       cy.appModelPageLoaded();
       cy.clickButtonByIdIfExists("first-time-modal-continue-button");
 
+      // This is needed if the page has loaded, but the function to propogate the value has not passed yet
+      cy.wait(10000);
+
       // Validate that the value has propagated through the system
       cy.get('.attributes-panel-item__input-wrap input.region')
       .should('have.value', 'us-east-1');

--- a/app/web/cypress/support/commands.ts
+++ b/app/web/cypress/support/commands.ts
@@ -80,7 +80,8 @@ Cypress.Commands.add('clickButtonByIdIfExists', (id: string) => {
     if ($body.find(`#${id}`).length > 0) {
       // Element exists, perform click
       cy.log(`Trying to click the #${id} now`);
-      cy.get(`#${id}`).click();
+      // Sometimes the div is hidden behind another modal, the force allows it to be clicked anyway
+      cy.get(`#${id}`).click( { force: true });
     } else {
       // Element does not exist, continue with other actions
       cy.log('Button not found, continuing with other actions');


### PR DESCRIPTION
Minor fixes required to get the tests green again.

Builds upon previous PR https://github.com/systeminit/si/pull/4252 to:
- Give enough time for slightly slower workspaces (like tools prod) to allow the function value propagation completed before asserting the value is correct or not
- As they're dynamically loaded, the "create new change set" and "new user" modals seem to sometimes come into the user view in different orders. The force on the button click means we can dismiss the "You're an awesome new user!" modal even if it's behind.