### PR TITLE
fix(sdf): Allow getting code_execution_history

### DIFF
--- a/lib/sdf-server/src/server/service/v2/func.rs
+++ b/lib/sdf-server/src/server/service/v2/func.rs
@@ -20,7 +20,7 @@ pub mod create_unlocked_copy;
 pub mod delete_func;
 pub mod execute_func;
 pub mod get_code;
-mod get_func_run;
+pub mod get_func_run;
 pub mod list_all_funcs;
 pub mod list_funcs;
 pub mod save_code;
@@ -120,7 +120,7 @@ pub fn v2_routes() -> Router<AppState> {
         .route("/", get(list_funcs::list_funcs))
         .route("/including_pruned", get(list_all_funcs::list_all_funcs))
         .route("/code", get(get_code::get_code)) // accepts a list of func_ids
-        .route("/runs/:func_run_id", get(get_code::get_code)) // accepts a list of func_ids
+        .route("/runs/:func_run_id", get(get_func_run::get_func_run)) // accepts a list of func_ids
         .route("/", post(create_func::create_func))
         .route("/:func_id", put(update_func::update_func)) // only save the func's metadata
         .route("/:func_id/code", post(get_func_run::get_func_run)) // only saves func code


### PR DESCRIPTION
We were making an incorrect API call to get the func execution history for a specific func run

![Screenshot 2024-07-31 at 22 23 25](https://github.com/user-attachments/assets/6206e593-1b69-4f67-be52-9b7b6f51a860)
