### PR TITLE
fixup: amended the way we measure success for workspace management cy…

### DIFF
--- a/app/web/cypress/e2e/workspace-management/workspace-dashboard.cy.ts
+++ b/app/web/cypress/e2e/workspace-management/workspace-dashboard.cy.ts
@@ -1,6 +1,7 @@
 // @ts-check
 ///<reference path="../global.d.ts"/>
 
+const SI_CYPRESS_MULTIPLIER = Cypress.env('VITE_SI_CYPRESS_MULTIPLIER') || import.meta.env.VITE_SI_CYPRESS_MULTIPLIER || 1;
 const AUTH0_USERNAME = Cypress.env('VITE_AUTH0_USERNAME') || import.meta.env.VITE_AUTH0_USERNAME;
 const AUTH0_PASSWORD = Cypress.env('VITE_AUTH0_PASSWORD') || import.meta.env.VITE_AUTH0_PASSWORD;
 const AUTH_PORTAL_URL = Cypress.env('VITE_AUTH_PORTAL_URL') || import.meta.env.VITE_AUTH_PORTAL_URL;
@@ -8,34 +9,33 @@ const AUTH_API_URL = Cypress.env('VITE_AUTH_API_URL') || import.meta.env.VITE_AU
 const SI_WORKSPACE_ID = Cypress.env('VITE_SI_WORKSPACE_ID') || import.meta.env.VITE_SI_WORKSPACE_ID;
 const UUID = Cypress.env('VITE_UUID') || import.meta.env.VITE_UUID || "local";
 
-describe("workspace", () => {
-  beforeEach(() => {
-    cy.visit("/");
-  });
-
-  it("dashboard_redirect", () => {
-
-    cy.loginToAuth0(AUTH0_USERNAME, AUTH0_PASSWORD);
-
-    // Go to the Synthetic User's Dashboard
-    cy.visit(AUTH_PORTAL_URL + '/dashboard')
-    cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", UUID);
-
-    cy.wait(5000);
-
-    // Find the URL for the synthetic workspace and go there
-    cy.get('a[href="' + AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go"]')
-       .should('be.visible')
-       .invoke('removeAttr', 'target')
-       .click();
-    cy.on('uncaught:exception', (e) => {
-      console.log(e);
-      return false;
+Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
+  describe("workspace", () => {
+    beforeEach(() => {
+      cy.visit("/");
     });
 
-    cy.wait(5000);
+    it("dashboard_redirect", () => {
 
-    // Check that it loaded the workspace + prompted to create a new change set
-    cy.contains('Create change set', { timeout: 10000 }).should('be.visible');
+      cy.loginToAuth0(AUTH0_USERNAME, AUTH0_PASSWORD);
+
+      // Go to the Synthetic User's Dashboard
+      cy.visit(AUTH_PORTAL_URL + '/dashboard')
+      cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", UUID);
+
+      cy.wait(5000);
+
+      // Find the URL for the synthetic workspace and go there
+      cy.get('a[href="' + AUTH_API_URL + '/workspaces/' + SI_WORKSPACE_ID + '/go"]')
+        .should('be.visible')
+        .invoke('removeAttr', 'target')
+        .click();
+      cy.on('uncaught:exception', (e) => {
+        console.log(e);
+        return false;
+      });
+
+      cy.appModelPageLoaded();
+    });
   });
 });


### PR DESCRIPTION
Amends the pesky workspace management test to measure success properly.

This now standardises the test to have the same form as the others & also uses the centralised `cy.appModelPageLoaded();` command which basically checks the page is loaded for our app.

It's not perfect, but should reduce the noise of failures from this test.