### PR TITLE
fix(sdf): Don't overwrite sdf config file with empty args

### DIFF
--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -302,10 +302,12 @@ impl TryFrom<Args> for Config {
                 config_map.set("create_workspace_permissions", create_workspace_permissions);
             }
 
-            config_map.set(
-                "create_workspace_allowlist",
-                args.create_workspace_allowlist,
-            );
+            if !args.create_workspace_allowlist.is_empty() {
+                config_map.set(
+                    "create_workspace_allowlist",
+                    args.create_workspace_allowlist,
+                );
+            }
 
             config_map.set("nats.connection_name", NAME);
             config_map.set("pg.application_name", NAME);

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -93,6 +93,8 @@ async fn async_main() -> Result<()> {
 
     let config = Config::try_from(args)?;
 
+    debug!(config =?config, "entire startup config");
+
     let encryption_key = Server::load_encryption_key(config.crypto().clone()).await?;
     let jwt_public_signing_key =
         Server::load_jwt_public_signing_key(config.jwt_signing_public_key().clone()).await?;


### PR DESCRIPTION
When using a config file, we didn't check that the args were empty before writing over the top