### PR TITLE
feat: add automatic deployment by binary on merge to main pipeline [defaulted to original strategy]

### DIFF
--- a/.github/workflows/community-check.yml
+++ b/.github/workflows/community-check.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
       pull-requests: write
     env:
-      SI_STAFF: "adamhjk mahirl fnichol nickgerace paulocsanz jhelwig vbustamante zacharyhamm theoephraim wendybujalski stack72 britmyerss AnnaAtMax sprutton1 keeb johnrwatson jobelenus jkeiser"
+      SI_STAFF: "adamhjk mahirl fnichol nickgerace jhelwig vbustamante zacharyhamm wendybujalski stack72 britmyerss sprutton1 keeb johnrwatson jobelenus jkeiser"
     steps:
       - name: Checkout code
         id: check_author

--- a/.github/workflows/deploy-on-main.yml
+++ b/.github/workflows/deploy-on-main.yml
@@ -10,4 +10,16 @@ jobs:
       environment: tools
       service: all
       version: stable
+      deploy-type: binary
     secrets: inherit
+    continue-on-error: true
+  full-deploy-on-failure:
+    if: failure() 
+    uses: ./.github/workflows/deploy-stack.yml
+    with:
+      environment: tools
+      service: all
+      version: stable
+      deploy-type: instance
+    secrets: inherit
+    needs: deploy-tools-prod

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -18,13 +18,9 @@ on:
         required: true
         description: "version to deploy"
       deploy-type:
-        type: choice
+        type: string
         required: true
         description: "deployment variant"
-        default: "instance"
-        options:
-          - binary
-          - instance
 
 jobs:
   deploy:
@@ -81,7 +77,7 @@ jobs:
           echo "Invalidation is complete."
 
       - name: Deploy service
-        if: ${{ inputs.service != 'web' && inputs.deploy-type == 'instance'}}
+        if: ${{ inputs.service != 'web' && inputs.deploy-type == 'instance' }}
         run: |
             check_version_exists() {
                 local version="$1"
@@ -150,8 +146,10 @@ jobs:
                 exit 1
             fi
 
+      - name: Checkout code
+        if: ${{ inputs.service != 'web' && inputs.deploy-type == 'binary' }}
+        uses: actions/checkout@v4
+
       - name: Deploy service
-        if: if: ${{ inputs.service != 'web' && inputs.deploy-type == 'binary' }}
-        run: |
-            [[ ${{ inputs.environment }} == "tools" ]] && component/toolbox/awsi.sh upgrade -p tools-prod -r us-east-1 -a y -s ${{ inputs.service }}
-            [[ ${{ inputs.environment }} == "production" ]] && component/toolbox/awsi.sh upgrade -p si-apps-prod -r us-east-1 -a y -s ${{ inputs.service }}
+        if: ${{ inputs.service != 'web' && inputs.deploy-type == 'binary' }}
+        run: component/toolbox/awsi.sh upgrade -p pull-from-env -r us-east-1 -a y -s ${{ inputs.service }}

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -17,6 +17,14 @@ on:
         type: string
         required: true
         description: "version to deploy"
+      deploy-type:
+        type: choice
+        required: true
+        description: "deployment variant"
+        default: "instance"
+        options:
+          - binary
+          - instance
 
 jobs:
   deploy:
@@ -24,7 +32,7 @@ jobs:
     name: Deploy Service
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS credentials for production
+      - name: Configure AWS credentials for ${{ inputs.environment }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
@@ -73,7 +81,7 @@ jobs:
           echo "Invalidation is complete."
 
       - name: Deploy service
-        if: ${{ inputs.service != 'web' }}
+        if: ${{ inputs.service != 'web' && inputs.deploy-type == 'instance'}}
         run: |
             check_version_exists() {
                 local version="$1"
@@ -141,3 +149,9 @@ jobs:
                 echo "Version $VERSION for $SERVICE not found in the artifacts registry. Skipping!"
                 exit 1
             fi
+
+      - name: Deploy service
+        if: if: ${{ inputs.service != 'web' && inputs.deploy-type == 'binary' }}
+        run: |
+            [[ ${{ inputs.environment }} == "tools" ]] && component/toolbox/awsi.sh upgrade -p tools-prod -r us-east-1 -a y -s ${{ inputs.service }}
+            [[ ${{ inputs.environment }} == "production" ]] && component/toolbox/awsi.sh upgrade -p si-apps-prod -r us-east-1 -a y -s ${{ inputs.service }}

--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -3,6 +3,7 @@ name: Deploy Services
 run-name: Deploy of ${{ inputs.service }} to ${{ inputs.environment }} by @${{ github.actor }}
 
 on:
+
   workflow_call:
     inputs:
       environment:
@@ -14,6 +15,10 @@ on:
       version:
         type: string
         default: "stable"
+      deploy-type:
+        type: string
+        required: false
+
   workflow_dispatch:
     inputs:
       environment:
@@ -40,6 +45,14 @@ on:
         required: true
         description: "version to deploy"
         default: "stable"
+      deploy-type:
+        type: choice
+        required: true
+        description: "deployment variant"
+        default: "instance"
+        options:
+          - binary
+          - instance
 
 jobs:
   set-init:
@@ -74,6 +87,7 @@ jobs:
       environment: ${{ inputs.environment }}
       service: ${{ matrix.service }}
       version: ${{ inputs.version }}
+      deploy-type: ${{ inputs.deploy-type }}
     secrets: inherit
 
   e2e-validation:

--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -17,14 +17,14 @@ on:
         default: "stable"
       deploy-type:
         type: string
-        required: false
+        default: "instance"
 
   workflow_dispatch:
     inputs:
       environment:
         type: choice
         required: true
-        description: "where to deploy"
+        description: "Where to deploy"
         default: "tools"
         options:
           - tools

--- a/component/toolbox/Dockerfile
+++ b/component/toolbox/Dockerfile
@@ -6,7 +6,8 @@ RUN set -eux; \
         https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_${arch}/session-manager-plugin.rpm; \
     yum install -y jq
 
-COPY ./scripts/* /usr/local/bin/si/
+COPY ./scripts/ /usr/local/bin/si/
+
 ENV PATH="/usr/local/bin/si:${PATH}"
 
 ENTRYPOINT ["bash", "-c"]

--- a/component/toolbox/awsi.sh
+++ b/component/toolbox/awsi.sh
@@ -1,3 +1,17 @@
 #!/usr/bin/env bash
 
-docker run --rm -ti -v ~/.aws:/root/.aws -v "$(pwd)":/aws systeminit/toolbox:stable "$*"
+# If running in Github, we don't have an interactive
+# terminal so the commands can't request user input
+if [ "$GITHUB_ACTIONS" = "true" ]; then
+  terminal="-t"
+else
+  terminal="-it"
+fi
+
+docker run --rm "${terminal}" \
+  -v ~/.aws:/root/.aws \
+  -v "$(pwd)":/aws \
+  -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
+  -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+  -e AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN}" \
+  systeminit/toolbox:stable "$*"

--- a/component/toolbox/scripts/ssm
+++ b/component/toolbox/scripts/ssm
@@ -1,4 +1,23 @@
 #!/bin/bash
+# ---------------------------------------------------------------------------------------------------
+# Lists all the instances in a given region and upon user selection opens an interactive SSM session
+# with that instance.
+# ---------------------------------------------------------------------------------------------------
+
+# Stop immediately if anything goes wrong, let's not create too much
+# mess if John's shell is poor
+set -eo pipefail
+
+# Find & Import all the supporting functions from the supporting folder
+# Get the directory of the current script to figure out where the 
+# Supporting funcs are
+IMPORT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+for script in ${IMPORT_DIR}/supporting-funcs/*.sh; do
+    if [[ -f "$script" ]]; then
+        source "$script"
+    fi
+done
 
 usage() {
     echo
@@ -21,17 +40,6 @@ if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
     usage
 fi
 
-# Function to list EC2 instances with their Name tag
-list_instances() {
-    aws ec2 describe-instances --query 'Reservations[*].Instances[?State.Name==`running`].[Tags[?Key==`Name`].Value | [0],InstanceId,InstanceType,PrivateIpAddress]' --output text
-}
-
-# Function to start SSM session
-start_ssm_session() {
-    instance_id=$1
-    aws ssm start-session --target "$instance_id" --document-name AWS-StartInteractiveCommand --parameters command="bash -l"
-}
-
 # Parse flags
 while getopts ":p:r:" opt; do
     case ${opt} in
@@ -51,25 +59,6 @@ while getopts ":p:r:" opt; do
             ;;
     esac
 done
-
-# Function to get input or use environment variable
-get_param_or_env() {
-    local param=$1
-    local env_var=$2
-    local prompt=$3
-
-    if [ -z "$param" ]; then
-        if [ -z "${!env_var}" ]; then
-            read -p "$prompt: " value
-            echo "$value"
-        else
-            echo "${!env_var}"
-        fi
-    else
-        echo "$param"
-    fi
-}
-
 
 # Main script
 profile=$(get_param_or_env "$profile" "AWS_PROFILE" "Enter the AWS profile to use")
@@ -105,6 +94,5 @@ if [ -z "$instance_id" ]; then
     exit 1
 fi
 
-echo "Starting SSM session with instance $instance_id..."
-start_ssm_session "$instance_id"
-
+echo "Starting Interactive SSM session with instance $instance_id..."
+start_interactive_ssm_session "$instance_id"

--- a/component/toolbox/scripts/supporting-funcs/ec2-funcs.sh
+++ b/component/toolbox/scripts/supporting-funcs/ec2-funcs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Function to list EC2 instances with their Name tag, either all or filtered
+list_instances() {
+  filter=$1
+  if [[ "${filter,,}" == "all" || -z "${filter}" ]]; then
+    aws ec2 describe-instances --query 'Reservations[*].Instances[?State.Name==`running`].[Tags[?Key==`Name`].Value | [0],InstanceId,InstanceType,PrivateIpAddress]' --output text | grep -E "sdf|veritech|pinga|rebaser"
+  elif [[ "${filter,,}" != "all" ]]; then
+    aws ec2 describe-instances --query 'Reservations[*].Instances[?State.Name==`running`].[Tags[?Key==`Name`].Value | [0],InstanceId,InstanceType,PrivateIpAddress]' --output text | grep -E "${filter}"
+  fi
+}

--- a/component/toolbox/scripts/supporting-funcs/ec2-funcs.sh
+++ b/component/toolbox/scripts/supporting-funcs/ec2-funcs.sh
@@ -4,8 +4,10 @@
 list_instances() {
   filter=$1
   if [[ "${filter,,}" == "all" || -z "${filter}" ]]; then
-    aws ec2 describe-instances --query 'Reservations[*].Instances[?State.Name==`running`].[Tags[?Key==`Name`].Value | [0],InstanceId,InstanceType,PrivateIpAddress]' --output text | grep -E "sdf|veritech|pinga|rebaser"
+    # shellcheck disable=SC2016
+    aws ec2 describe-instances --query 'Reservations[*].Instances[?State.Name==`running`].[Tags[?Key==`Name`].Value | [0],InstanceId,InstanceType,PrivateIpAddress]' --output text | grep -E 'sdf|veritech|pinga|rebaser'
   elif [[ "${filter,,}" != "all" ]]; then
+    # shellcheck disable=SC2016
     aws ec2 describe-instances --query 'Reservations[*].Instances[?State.Name==`running`].[Tags[?Key==`Name`].Value | [0],InstanceId,InstanceType,PrivateIpAddress]' --output text | grep -E "${filter}"
   fi
 }

--- a/component/toolbox/scripts/supporting-funcs/inputs-funcs.sh
+++ b/component/toolbox/scripts/supporting-funcs/inputs-funcs.sh
@@ -8,7 +8,7 @@ get_param_or_env() {
 
   if [ -z "$param" ]; then
     if [ -z "${!env_var}" ]; then
-      read -p "$prompt: " value
+      read -r -p "$prompt: " value
       echo "$value"
     else
       echo "${!env_var}"
@@ -35,7 +35,8 @@ await_file_results() {
       exit 1
     fi
 
-    file_count=$(ls "$results_directory" | wc -l)
+    # shellcheck disable=SC2012
+    file_count=$(ls "$results_directory/" | wc -l)
 
     if ((file_count >= required_file_count)); then
       break
@@ -63,8 +64,10 @@ concat_and_output_json() {
   # Check if the directory exists
   if [ -d "$results_directory/" ]; then
     # Aggregate all the individual json documents into one
-    cat $results_directory/* | jq -s '.' >>$results_directory/$output_file
-    cat $results_directory/$output_file | jq
+    # shellcheck disable=SC2002
+    cat "${results_directory}/*" | jq -s '.' >>"$results_directory/$output_file"
+    # shellcheck disable=SC2002
+    cat "$results_directory/$output_file" | jq
     echo "----------------------------------------"
     echo "Results can be found within $results_directory"
   else

--- a/component/toolbox/scripts/supporting-funcs/inputs-funcs.sh
+++ b/component/toolbox/scripts/supporting-funcs/inputs-funcs.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Function to get input or use environment variable
+get_param_or_env() {
+  local param=$1
+  local env_var=$2
+  local prompt=$3
+
+  if [ -z "$param" ]; then
+    if [ -z "${!env_var}" ]; then
+      read -p "$prompt: " value
+      echo "$value"
+    else
+      echo "${!env_var}"
+    fi
+  else
+    echo "$param"
+  fi
+}
+
+await_file_results() {
+
+  results_directory=$1
+  required_file_count=$2
+
+  timeout=60             # Timeout in seconds
+  start_time=$(date +%s) # Record the start time
+
+  while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+
+    if ((elapsed_time > timeout)); then
+      echo "Error: Timeout reached waiting for SSM document responses to arrive. Not all files are present."
+      exit 1
+    fi
+
+    file_count=$(ls "$results_directory" | wc -l)
+
+    if ((file_count >= required_file_count)); then
+      break
+    fi
+
+    # Wait for a short period before checking again
+    sleep 1
+  done
+
+}
+
+sassy_selection_check() {
+  selection=${1^^}
+  if [ "$selection" != "Y" ]; then
+    echo "Don't Trust Scott and John? We're friends I promise, exiting"
+    exit 1
+  fi
+}
+
+concat_and_output_json() {
+
+  results_directory=$1
+  output_file=$2
+
+  # Check if the directory exists
+  if [ -d "$results_directory/" ]; then
+    # Aggregate all the individual json documents into one
+    cat $results_directory/* | jq -s '.' >>$results_directory/$output_file
+    cat $results_directory/$output_file | jq
+    echo "----------------------------------------"
+    echo "Results can be found within $results_directory"
+  else
+    echo "Results Directory $results_directory does not exist."
+    exit 1
+  fi
+  echo "----------------------------------------"
+
+}

--- a/component/toolbox/scripts/supporting-funcs/ssm-funcs.sh
+++ b/component/toolbox/scripts/supporting-funcs/ssm-funcs.sh
@@ -14,8 +14,8 @@ start_and_track_ssm_session() {
   status=$?
 
   if [ $status -ne 0 ]; then
-    output=$(echo "{\"instance_id\": \"$instance_id\", \"status\": \"error\", \"service\": \"$service\", \"message\": \"$output\"}")
-    echo $output >"$results_directory/$instance_id.json"
+    output="{\"instance_id\": \"$instance_id\", \"status\": \"error\", \"service\": \"$service\", \"message\": \"$output\"}"
+    echo "$output" >"$results_directory/$instance_id.json"
     return
   fi
 
@@ -44,7 +44,7 @@ start_and_track_ssm_session() {
       --command-id "$command_id" \
       --instance-id "$instance_id" \
       | jq -r '.StandardOutputContent')
-    echo $output >"$results_directory/$instance_id.json"
+    echo "$output" >"$results_directory/$instance_id.json"
   else
     echo "Command failed with status: $status"
     exit_code=$(aws ssm get-command-invocation \

--- a/component/toolbox/scripts/supporting-funcs/ssm-funcs.sh
+++ b/component/toolbox/scripts/supporting-funcs/ssm-funcs.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Function to start SSM session
+start_and_track_ssm_session() {
+
+  instance_id=$1
+  script=$2
+  service=$3
+  action=$4
+  results_directory=$5
+
+  output=$(aws ssm send-command --instance-ids "$instance_id" --document-name "$script" --parameters "Service=$service,InstanceId=$instance_id,Action=$action" 2>&1)
+
+  status=$?
+
+  if [ $status -ne 0 ]; then
+    output=$(echo "{\"instance_id\": \"$instance_id\", \"status\": \"error\", \"service\": \"$service\", \"message\": \"$output\"}")
+    echo $output >"$results_directory/$instance_id.json"
+    return
+  fi
+
+  command_id=$(echo "$output" | jq -r '.Command.CommandId')
+
+  # Poll for command status with a timeout of 60 seconds
+  timeout=60
+  elapsed=0
+  interval=1
+
+  while [ $elapsed -lt $timeout ]; do
+    status=$(check_ssm_command_status)
+
+    if [ "$status" == "Success" ] || [ "$status" == "Failed" ] || [ "$status" == "TimedOut" ] || [ "$status" == "Cancelled" ]; then
+      break
+    fi
+
+    sleep $interval
+    elapsed=$((elapsed + interval))
+  done
+
+  # Check if command was successful
+  if [ "$status" == "Success" ]; then
+    # Get the output
+    output=$(aws ssm get-command-invocation \
+      --command-id "$command_id" \
+      --instance-id "$instance_id" \
+      | jq -r '.StandardOutputContent')
+    echo $output >"$results_directory/$instance_id.json"
+  else
+    echo "Command failed with status: $status"
+    exit_code=$(aws ssm get-command-invocation \
+      --command-id "$command_id" \
+      --instance-id "$instance_id" \
+      | jq -r '.ResponseCode')
+
+    echo "Exit code: $exit_code"
+    echo "Failure message:"
+    aws ssm get-command-invocation \
+      --command-id "$command_id" \
+      --instance-id "$instance_id" \
+      | jq -r '.StandardErrorContent'
+  fi
+
+}
+
+# Function to start an interactive SSM session with any given instance
+start_interactive_ssm_session() {
+  instance_id=$1
+  aws ssm start-session --target "$instance_id" --document-name AWS-StartInteractiveCommand --parameters command="bash -l"
+}
+
+# Function to check command status
+check_ssm_command_status() {
+  status=$(aws ssm list-command-invocations \
+    --command-id "$command_id" \
+    --details \
+    | jq -r '.CommandInvocations[0].Status')
+  echo "$status"
+}

--- a/component/toolbox/scripts/upgrade
+++ b/component/toolbox/scripts/upgrade
@@ -35,11 +35,12 @@ usage() {
     echo "them all in parallel"
     echo "----------------------------------"
     echo "Usage: upgrade [-p profile] [-r region] [-a automatic] [-s service]"
-    echo "  -p profile        AWS profile to use"
+    echo "  -p profile        [pull-from-env/<profile-name>] AWS profile to use"
     echo "  -r region         AWS region to use"
     echo "  -s service        [sdf/rebaser/pinga/veritech] SI Service to filter by, defaults to all"
     echo "  -a automatic      [Y/N] Run through automatically/no-interact"
-    echo
+    echo "----------------------------------"
+    echo "e.g. ./awsi.sh -p pull-from-env -r us-east-1 -s sdf -a y"
     exit 1
 }
 
@@ -77,15 +78,17 @@ done
 # ---------------------------------------------------------------------------------------------------
 # Main script
 # ---------------------------------------------------------------------------------------------------
-profile=$(get_param_or_env "$profile" "AWS_PROFILE" "Enter the AWS profile to use")
+# Use the profile if in the invocation
+if [[ "$profile" != "pull-from-env" ]]; then
+  profile=$(get_param_or_env "$profile" "AWS_PROFILE" "Enter the AWS profile to use")
+  export AWS_PROFILE="$profile"
+fi
 region=$(get_param_or_env "$region" "AWS_REGION" "Enter the AWS region (e.g., us-west-2)")
+export AWS_REGION="$region"
 
 # Define the SSM documents to execute the functions
 upgrade_check_script="si-check-node-upgrade"
 service_state_script="si-service-state"
-
-export AWS_PROFILE="$profile"
-export AWS_REGION="$region"
 
 # List instances with fixed-width columns and filter for the upgradeable instances
 # Based on the filter provided
@@ -124,8 +127,8 @@ mkdir -p "$results_directory/"
 i=1
 while read -r line; do
     instance_id=$(echo "$line" | awk '{print $2}')
-    service=$(echo "$line" | awk '{print $1}' | awk -F- '{print $2}')
-    start_and_track_ssm_session "$instance_id" "$upgrade_check_script" "$service" "check" "$results_directory" &
+    service_name=$(echo "$line" | awk '{print $1}' | awk -F- '{print $2}')
+    start_and_track_ssm_session "$instance_id" "$upgrade_check_script" "$service_name" "check" "$results_directory" &
     ((i++))
 done <<< "$instances"
 
@@ -153,8 +156,8 @@ mkdir -p $results_directory
 upgrade_hosts_num=$(jq 'map(select(.service == "veritech")) | .[]' <<< $upgrade_candidates_json | jq -c '.' | wc -l)
 jq 'map(select(.service == "veritech")) | .[]' <<< $upgrade_candidates_json | jq -c '.' | while read -r line; do
   instance_id=$(echo "$line" | jq -r '.instance_id')
-  service=$(echo "$line" | jq -r '.service')
-  start_and_track_ssm_session "$instance_id" "$service_state_script" "$service" "upgrade" "$results_directory" # Serially
+  service_name=$(echo "$line" | jq -r '.service')
+  start_and_track_ssm_session "$instance_id" "$service_state_script" "$service_name" "upgrade" "$results_directory" # Serially
 done
 
 # Wait until all the results arrive
@@ -164,8 +167,8 @@ await_file_results "$results_directory" "$upgrade_hosts_num"
 upgrade_hosts_num=$(jq 'map(select(.service != "veritech")) | .[]' <<< $upgrade_candidates_json | jq -c '.' | wc -l)
 jq 'map(select(.service != "veritech")) | .[]' <<< $upgrade_candidates_json | jq -c '.' | while read -r line; do
   instance_id=$(echo "$line" | jq -r '.instance_id')
-  service=$(echo "$line" | jq -r '.service')
-  start_and_track_ssm_session "$instance_id" "$service_state_script" "$service" "upgrade" "$results_directory" & # In Parallel
+  service_name=$(echo "$line" | jq -r '.service')
+  start_and_track_ssm_session "$instance_id" "$service_state_script" "$service_name" "upgrade" "$results_directory" & # In Parallel
   ((i++))
 done
 
@@ -174,7 +177,8 @@ upgrade_hosts_num=$(jq '.[]' <<< $upgrade_candidates_json | jq -c '.' | wc -l)
 await_file_results "$results_directory" "$upgrade_hosts_num"
 concat_and_output_json "$results_directory" "$upgrade_results_file"
 
-echo "All active binary services have been rotated, WEB IS STILL TO BE UPDATED."
+echo "All active binary services of ${service} have been rotated"
+echo "*******WEB IS NOT UPDATED VIA THIS TOOLING**************"
 echo "If you are running in CI, this will be ran automatically for you. If you"
 echo "executed this manually/locally, you need to run the below pipeline, with"
 echo "either tools or production, depending which environment you're executing"

--- a/component/toolbox/scripts/upgrade
+++ b/component/toolbox/scripts/upgrade
@@ -13,6 +13,18 @@
 # mess if John's shell is poor
 set -eo pipefail
 
+# Find & Import all the supporting functions from the supporting folder
+# Get the directory of the current script to figure out where the 
+# Supporting funcs are
+IMPORT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+for script in ${IMPORT_DIR}/supporting-funcs/*.sh; do
+    if [[ -f "$script" ]]; then
+        source "$script"
+    fi
+done
+
+# Usage for this script
 usage() {
     echo
     echo "upgrade"
@@ -22,10 +34,11 @@ usage() {
     echo "upgrade available, if so the user can proceed and upgrade"
     echo "them all in parallel"
     echo "----------------------------------"
-    echo "Usage: upgrade [-p profile] [-r region] [-a automatic]"
-    echo "  -p profile    AWS profile to use"
-    echo "  -r region     AWS region to use"
-    echo "  -a automatic  [Y/N] Run through automatically/no-interact"
+    echo "Usage: upgrade [-p profile] [-r region] [-a automatic] [-s service]"
+    echo "  -p profile        AWS profile to use"
+    echo "  -r region         AWS region to use"
+    echo "  -s service        [sdf/rebaser/pinga/veritech] SI Service to filter by, defaults to all"
+    echo "  -a automatic      [Y/N] Run through automatically/no-interact"
     echo
     exit 1
 }
@@ -36,7 +49,7 @@ if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
 fi
 
 # Parse flags
-while getopts ":p:r:a:" opt; do
+while getopts ":p:r:a:s:" opt; do
     case ${opt} in
         p)
             profile=$OPTARG
@@ -46,6 +59,9 @@ while getopts ":p:r:a:" opt; do
             ;;
         a)
             automatic=$OPTARG
+            ;;
+        s)
+            service=$OPTARG
             ;;
         \?)
             echo "Invalid option: -$OPTARG" >&2
@@ -57,157 +73,6 @@ while getopts ":p:r:a:" opt; do
             ;;
     esac
 done
-
-# Function to list EC2 instances with their Name tag
-list_instances() {
-  aws ec2 describe-instances --query 'Reservations[*].Instances[?State.Name==`running`].[Tags[?Key==`Name`].Value | [0],InstanceId,InstanceType,PrivateIpAddress]' --output text
-}
-
-# Function to check command status
-check_ssm_command_status() {
-  status=$(aws ssm list-command-invocations \
-    --command-id "$command_id" \
-    --details \
-    | jq -r '.CommandInvocations[0].Status')
-  echo "$status"
-}
-
-# Function to start SSM session
-start_and_track_ssm_session() {
-
-    instance_id=$1
-    script=$2
-    service=$3
-    action=$4
-    results_directory=$5
-
-    output=$(aws ssm send-command --instance-ids "$instance_id" --document-name "$script" --parameters "Service=$service,InstanceId=$instance_id,Action=$action" 2>&1)
-    
-    status=$?
-
-    if [ $status -ne 0 ]; then
-      output=$(echo "{\"instance_id\": \"$instance_id\", \"status\": \"error\", \"service\": \"$service\", \"message\": \"$output\"}")
-      echo $output > "$results_directory/$instance_id.json"
-      return
-    fi
-
-    command_id=$(echo "$output" | jq -r '.Command.CommandId')
-
-    # Poll for command status with a timeout of 60 seconds
-    timeout=60
-    elapsed=0
-    interval=1
-
-    while [ $elapsed -lt $timeout ]; do
-      status=$(check_ssm_command_status)
-      
-      if [ "$status" == "Success" ] || [ "$status" == "Failed" ] || [ "$status" == "TimedOut" ] || [ "$status" == "Cancelled" ]; then
-        break
-      fi
-      
-      sleep $interval
-      elapsed=$((elapsed + interval))
-    done
-
-    # Check if command was successful
-    if [ "$status" == "Success" ]; then
-      # Get the output
-      output=$(aws ssm get-command-invocation \
-        --command-id "$command_id" \
-        --instance-id "$instance_id" \
-        | jq -r '.StandardOutputContent')
-      echo $output > "$results_directory/$instance_id.json"
-    else
-      echo "Command failed with status: $status"
-      exit_code=$(aws ssm get-command-invocation \
-        --command-id "$command_id" \
-        --instance-id "$instance_id" \
-        | jq -r '.ResponseCode')
-      
-      echo "Exit code: $exit_code"
-      echo "Failure message:"
-      aws ssm get-command-invocation \
-        --command-id "$command_id" \
-        --instance-id "$instance_id" \
-        | jq -r '.StandardErrorContent'
-    fi
-
-  }
-
-# Function to get input or use environment variable
-get_param_or_env() {
-    local param=$1
-    local env_var=$2
-    local prompt=$3
-
-    if [ -z "$param" ]; then
-        if [ -z "${!env_var}" ]; then
-            read -p "$prompt: " value
-            echo "$value"
-        else
-            echo "${!env_var}"
-        fi
-    else
-        echo "$param"
-    fi
-}
-
-await_ssm_results() {
-
-  results_directory=$1
-  required_file_count=$2
-
-  timeout=60  # Timeout in seconds
-  start_time=$(date +%s)  # Record the start time
-
-  while true; do
-      current_time=$(date +%s)
-      elapsed_time=$((current_time - start_time))
-      
-      if (( elapsed_time > timeout )); then
-          echo "Error: Timeout reached waiting for SSM document responses to arrive. Not all files are present."
-          exit 1
-      fi
-      
-      file_count=$(ls "$results_directory" | wc -l)
-      
-      if (( file_count >= required_file_count )); then
-          break
-      fi
-      
-      # Wait for a short period before checking again
-      sleep 1
-  done
-
-}
-
-sassy_selection_check() {
-  selection=${1^^}
-  if [ "$selection" != "Y" ]; then
-    echo "Don't Trust Scott and John? We're friends I promise, exiting"
-    exit 1
-  fi
-}
-
-concat_and_output() {
- 
-  results_directory=$1
-  output_file=$2
-
-  # Check if the directory exists
-  if [ -d "$results_directory/" ]; then
-    # Aggregate all the individual json documents into one
-    cat $results_directory/* | jq -s '.' >> $results_directory/$output_file
-    cat $results_directory/$output_file | jq
-    echo "----------------------------------------"
-    echo "Results can be found within $results_directory"
-  else
-    echo "Results Directory $results_directory does not exist."
-    exit 1
-  fi
-  echo "----------------------------------------"
-
-}
 
 # ---------------------------------------------------------------------------------------------------
 # Main script
@@ -223,14 +88,15 @@ export AWS_PROFILE="$profile"
 export AWS_REGION="$region"
 
 # List instances with fixed-width columns and filter for the upgradeable instances
-instances=$(list_instances | grep -E 'sdf|pinga|rebaser|veritech' )
+# Based on the filter provided
+instances=$(list_instances ${service,,} )
 if [ -z "$instances" ]; then
     echo "No running instances found."
     exit 1
 fi
 
 echo "----------------------------------------"
-echo "Running instances of sdf/pinga/rebaser/veritech in the region $region:"
+echo "Running instances of services in the region $region:"
 printf "%-5s %-20s %-20s %-20s %-20s\n" "Index" "Name" "InstanceId" "InstanceType" "PrivateIpAddress"
 i=1
 while read -r line; do
@@ -263,16 +129,16 @@ while read -r line; do
     ((i++))
 done <<< "$instances"
 
-await_ssm_results "$results_directory" $((i - 1))
+await_file_results "$results_directory" $((i - 1))
 
-concat_and_output "$results_directory" "$check_results_file"
+concat_and_output_json "$results_directory" "$check_results_file"
 
 if jq -e 'all(.[]; .status == "success") and any(.[]; .upgradeable == "true")' "$results_directory/$check_results_file" > /dev/null; then
   [[ "${automatic,,}" == "y" ]] || read -p "Would you like to push the new binaries out to the upgradeable hosts? (Y/N) " selection
   [[ "${automatic,,}" == "y" ]] || sassy_selection_check $selection
 else
   echo "Error: Either none are upgradeable or one or more of the checks failed to determine whether it was possible to upgrade the node."
-  exit 1
+  exit 2
 fi
 
 # For all order 1 services, upgrade them in *sequence*
@@ -292,7 +158,7 @@ jq 'map(select(.service == "veritech")) | .[]' <<< $upgrade_candidates_json | jq
 done
 
 # Wait until all the results arrive
-await_ssm_results "$results_directory" "$upgrade_hosts_num"
+await_file_results "$results_directory" "$upgrade_hosts_num"
 
 # Continue with the rest of the service nodes
 upgrade_hosts_num=$(jq 'map(select(.service != "veritech")) | .[]' <<< $upgrade_candidates_json | jq -c '.' | wc -l)
@@ -305,8 +171,8 @@ done
 
 # Concatenate all the results together
 upgrade_hosts_num=$(jq '.[]' <<< $upgrade_candidates_json | jq -c '.' | wc -l)
-await_ssm_results "$results_directory" "$upgrade_hosts_num"
-concat_and_output "$results_directory" "$upgrade_results_file"
+await_file_results "$results_directory" "$upgrade_hosts_num"
+concat_and_output_json "$results_directory" "$upgrade_results_file"
 
 echo "All active binary services have been rotated, WEB IS STILL TO BE UPDATED."
 echo "If you are running in CI, this will be ran automatically for you. If you"


### PR DESCRIPTION
1. Adds support in the component toolbox for deployment to filter by service using the `-s` flag
2. Implements the CI changes to yield us a method to either deploy by binary or by a full instance refresh (the original method)
3.  Implements the CI changes to our merges to main to `just` deploy by binary