### PR TITLE
Stop calling status_with_base

### DIFF
--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -5,7 +5,7 @@ import { posthog } from "@/utils/posthog";
 import { useAuthStore } from "./store/auth.store";
 import { useRouterStore } from "./store/router.store";
 import { isDevMode } from "./utils/debug";
-import { useChangeSetsStore } from "./store/change_sets.store";
+// import { useChangeSetsStore } from "./store/change_sets.store";
 
 // Cannot use inside the template directly.
 const AUTH_PORTAL_URL = import.meta.env.VITE_AUTH_PORTAL_URL;
@@ -189,7 +189,7 @@ router.beforeResolve((to) => {
 
   // whenever we navigate across changesets we need to stay
   // up to date with the status against base
-  if ("changeSetId" in to.params) {
+  /* if ("changeSetId" in to.params) {
     const changeSetStore = useChangeSetsStore();
     const changeSetId = to.params.changeSetId;
     if (
@@ -199,7 +199,7 @@ router.beforeResolve((to) => {
       !Array.isArray(changeSetId)
     )
       changeSetStore.FETCH_STATUS_WITH_BASE(changeSetId);
-  }
+  } */
 });
 
 router.afterEach((to) => {

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -385,8 +385,8 @@ export function useChangeSetsStore() {
               }
 
               // TODO: jobelenus, I'm worried the WsEvent fires before commit happens
-              if (this.selectedChangeSetId && !this.headSelected)
-                this.FETCH_STATUS_WITH_BASE(this.selectedChangeSetId);
+              /* if (this.selectedChangeSetId && !this.headSelected)
+                this.FETCH_STATUS_WITH_BASE(this.selectedChangeSetId); */
 
               // did head get an update and I'm not on head?
               // and make sure I'm not moving to head


### PR DESCRIPTION
We're seeing 500s on this endpoint. And its purpose is moot given that rebaser doesn't conflict with the most recent work.<img src="https://media1.giphy.com/media/26xBzL5fpjhJ9dQNa/giphy.gif"/>