### PR TITLE
fix(sdf): Prevent creating unlocked copies of funcs and variants

### DIFF
--- a/lib/sdf-server/src/server/service/v2/func.rs
+++ b/lib/sdf-server/src/server/service/v2/func.rs
@@ -39,6 +39,8 @@ pub enum FuncAPIError {
     ChangeSet(#[from] ChangeSetError),
     #[error("func error: {0}")]
     Func(#[from] FuncError),
+    #[error("func already unlocked: {0}")]
+    FuncAlreadyUnlocked(FuncId),
     #[error("func argument error: {0}")]
     FuncArgument(#[from] FuncArgumentError),
     #[error("func authoring error: {0}")]

--- a/lib/sdf-server/src/server/service/v2/variant/create_unlocked_copy.rs
+++ b/lib/sdf-server/src/server/service/v2/variant/create_unlocked_copy.rs
@@ -37,6 +37,12 @@ pub async fn create_unlocked_copy(
         ));
     }
 
+    if !original_variant.is_locked() {
+        return Err(SchemaVariantError::VariantAlreadyUnlocked(
+            original_variant.id,
+        ));
+    }
+
     let unlocked_variant =
         VariantAuthoringClient::create_unlocked_variant_copy(&ctx, original_variant.id()).await?;
 

--- a/lib/sdf-server/src/server/service/variant.rs
+++ b/lib/sdf-server/src/server/service/variant.rs
@@ -42,7 +42,6 @@ pub enum SchemaVariantError {
     FuncNotFound(FuncId),
     #[error("func summary error: {0}")]
     FuncSummary(#[from] FuncSummaryError),
-
     #[error("hyper error: {0}")]
     Hyper(#[from] hyper::http::Error),
     #[error("no new asset was created")]
@@ -63,6 +62,8 @@ pub enum SchemaVariantError {
     Spec(#[from] SpecError),
     #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),
+    #[error("schema variant already is unlocked: {0}")]
+    VariantAlreadyUnlocked(SchemaVariantId),
     #[error("variant authoring: {0}")]
     VariantAuthoring(#[from] VariantAuthoringError),
     #[error("schema variant not found: {0}")]


### PR DESCRIPTION
IF you clicked the button fast enough you could dispatch multiple requests to create an unlocked schema variant. This resulted in multiple unlocked variants when the constraint is one.

This introduces a little defensive coding to prevent that from happening in the backend