### PR TITLE
feat: add process-exporter to the stack to track firecracker metrics

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -71,5 +71,27 @@ services:
       init:
         condition: service_completed_successfully
 
+  prometheus:
+    image: prom/prometheus
+    profiles: [rebaser, pinga, sdf, veritech]
+    ports:
+      - "9000:9090"
+    volumes:
+      - "config:/etc/prometheus/"
+    depends_on:
+      - otelcol
+
+  process-exporter:
+    image: ncabatoff/process-exporter
+    profiles: [veritech]
+    command:
+      - '-procfs=/host/proc'
+      - '-config.path=/config/proc-exporter.yml'
+    ports:
+      - "9256:9256"
+    volumes:
+      - "config:/config/"
+      - /proc:/host/proc:ro
+
 volumes:
   config:

--- a/component/init/configs/proc-exporter.yml
+++ b/component/init/configs/proc-exporter.yml
@@ -1,0 +1,3 @@
+process_names:
+  - comm:
+    - firecracker

--- a/component/init/configs/prometheus.yml
+++ b/component/init/configs/prometheus.yml
@@ -1,7 +1,7 @@
 global:
   scrape_interval: 100ms
 scrape_configs:
- - job_name: metrics
+ - job_name: service_metrics
    static_configs:
     - targets:
        - otelcol:9090
@@ -9,3 +9,7 @@ scrape_configs:
    static_configs:
     - targets:
        - process-exporter:9256
+ - job_name: node-exporter
+   static_configs:
+    - targets:
+      - node-exporter:9100

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -37,6 +37,7 @@ groups = {
         "promtail",
         "grafana",
         "loki",
+        "process-exporter",
     ],
 }
 
@@ -109,7 +110,7 @@ def find_group(name, groups):
 
 # Use Docker Compose to provide the platform services
 docker_compose("./docker-compose.platform.yml")
-compose_services = ["jaeger", "nats", "otelcol", "postgres", "postgres-test", "db", "db-test", "loki",  "grafana", "localstack", "promtail", "prometheus"]
+compose_services = ["jaeger", "nats", "otelcol", "postgres", "postgres-test", "db", "db-test", "loki",  "grafana", "localstack", "promtail", "prometheus", "process-exporter"]
 for service in compose_services:
     if service == "jaeger":
         links = [

--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -169,6 +169,18 @@ services:
     depends_on:
       - otelcol
 
+  process-exporter:
+    #<<: *loki-logged-service
+    image: ncabatoff/process-exporter
+    command:
+      - '-procfs=/host/proc'
+      - '-config.path=/config/config.yml'
+    ports:
+      - "9256:9256"
+    volumes:
+      - "./process-exporter-config/config.yml:/config/config.yml"
+      - "/proc:/host/proc:ro"
+
   localstack:
     #<<: *loki-logged-service
     image: localstack/localstack

--- a/dev/process-exporter-config/config.yml
+++ b/dev/process-exporter-config/config.yml
@@ -1,0 +1,3 @@
+process_names:
+  - comm:
+    - firecracker


### PR DESCRIPTION
We can use process-exporter to monitor firecracker and aggregate total CPU time and memory consumption, allowing us to derive usage over time. This works locally with this setup. Adding prometheus to the prod setup and having it scrape the local endpoints will allow us to point the region collector to it and pull the aggregated metrics from a single endpoint. 

<img src="https://media2.giphy.com/media/3o6MbjnP31zfxSI2Zi/giphy.gif"/>