### PR TITLE
chore(tilt): change host-mounted port of Prometheus to 9091

### DIFF
--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -163,7 +163,7 @@ services:
     #<<: *loki-logged-service
     image: prom/prometheus
     ports:
-      - "9000:9090"
+      - "9091:9090"
     volumes:
       - "./prometheus-config/config.yml:/etc/prometheus/prometheus.yml"
     depends_on:


### PR DESCRIPTION
This change updates the host-mounted port of the `prometheus` service from a rebounded port assignment of `9000:9090` to `9091:9090`. That is, if a service or developer wishes to access Prometheus' port 9000, they would now access it via port `9091` rather than `9000` before this change.

In my case I have a local service running that attempts to bind to `localhost:9000` which is conflicting, causing the development environment to not completely spin up correctly.

Additionally while working this change up. I discovered that the `bin/auth-api` service will attempt to run on `localhost:9000` if needed while working on a feature/fix. This change avoids a future condition where a developer would appear unable to spin up a local auth-api as a result.

<img src="https://media3.giphy.com/media/1rRkosgBYUL018uCOb/giphy.gif"/>