### PR TITLE
feat(*): remove vector clocks

### DIFF
--- a/lib/dal/examples/rebase/main.rs
+++ b/lib/dal/examples/rebase/main.rs
@@ -2,13 +2,13 @@ use std::{env, fs::File, io::prelude::*};
 
 use si_layer_cache::db::serialize;
 
-use dal::WorkspaceSnapshotGraphV1;
+use dal::WorkspaceSnapshotGraphV2;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + 'static>>;
 
 const USAGE: &str = "usage: cargo run --example rebase <TO_REBASE_FILE_PATH> <ONTO_FILE_PATH>";
 
-fn load_snapshot_graph(path: &str) -> Result<WorkspaceSnapshotGraphV1> {
+fn load_snapshot_graph(path: &str) -> Result<WorkspaceSnapshotGraphV2> {
     let mut file = File::open(path)?;
     let mut bytes = vec![];
     file.read_to_end(&mut bytes)?;

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -26,9 +26,7 @@ use crate::attribute::value::AttributeValueError;
 use crate::change_set::ChangeSetError;
 use crate::layer_db_types::{AttributePrototypeContent, AttributePrototypeContentV1};
 use crate::workspace_snapshot::content_address::{ContentAddress, ContentAddressDiscriminants};
-use crate::workspace_snapshot::edge_weight::{
-    EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
-};
+use crate::workspace_snapshot::edge_weight::{EdgeWeightKind, EdgeWeightKindDiscriminants};
 use crate::workspace_snapshot::node_weight::{
     content_node_weight, NodeWeight, NodeWeightDiscriminants, NodeWeightError,
 };
@@ -53,8 +51,6 @@ pub enum AttributePrototypeError {
     AttributeValue(#[from] Box<AttributeValueError>),
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
-    #[error("edge weight error: {0}")]
-    EdgeWeight(#[from] EdgeWeightError),
     #[error("func error: {0}")]
     Func(#[from] FuncError),
     #[error("helper error: {0}")]
@@ -163,12 +159,8 @@ impl AttributePrototype {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let id = workspace_snapshot.generate_ulid().await?;
         let lineage_id = workspace_snapshot.generate_ulid().await?;
-        let node_weight = NodeWeight::new_content(
-            ctx.vector_clock_id()?,
-            id,
-            lineage_id,
-            ContentAddress::AttributePrototype(hash),
-        )?;
+        let node_weight =
+            NodeWeight::new_content(id, lineage_id, ContentAddress::AttributePrototype(hash));
         let _node_index = workspace_snapshot.add_node(node_weight).await?;
 
         let prototype = AttributePrototype::assemble(id.into(), &content);
@@ -481,7 +473,7 @@ impl AttributePrototype {
         prototype_id: AttributePrototypeId,
     ) -> AttributePrototypeResult<()> {
         ctx.workspace_snapshot()?
-            .remove_node_by_id(ctx.vector_clock_id()?, prototype_id)
+            .remove_node_by_id(prototype_id)
             .await?;
 
         Ok(())

--- a/lib/dal/src/attribute/prototype/argument/static_value.rs
+++ b/lib/dal/src/attribute/prototype/argument/static_value.rs
@@ -58,12 +58,8 @@ impl StaticArgumentValue {
 
         let id = ctx.workspace_snapshot()?.generate_ulid().await?;
         let lineage_id = ctx.workspace_snapshot()?.generate_ulid().await?;
-        let node_weight = NodeWeight::new_content(
-            ctx.vector_clock_id()?,
-            id,
-            lineage_id,
-            ContentAddress::StaticArgumentValue(hash),
-        )?;
+        let node_weight =
+            NodeWeight::new_content(id, lineage_id, ContentAddress::StaticArgumentValue(hash));
 
         ctx.workspace_snapshot()?.add_node(node_weight).await?;
 

--- a/lib/dal/src/component/frame.rs
+++ b/lib/dal/src/component/frame.rs
@@ -7,9 +7,7 @@ use thiserror::Error;
 use crate::attribute::value::AttributeValueError;
 use crate::diagram::SummaryDiagramInferredEdge;
 use crate::socket::input::InputSocketError;
-use crate::workspace_snapshot::edge_weight::{
-    EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
-};
+use crate::workspace_snapshot::edge_weight::{EdgeWeightKind, EdgeWeightKindDiscriminants};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
     Component, ComponentError, ComponentId, ComponentType, DalContext, TransactionsError, WsEvent,
@@ -27,8 +25,6 @@ pub enum FrameError {
     AttributeValueError(#[from] AttributeValueError),
     #[error("component error: {0}")]
     Component(#[from] ComponentError),
-    #[error("edge weight error: {0}")]
-    EdgeWeight(#[from] EdgeWeightError),
     #[error("input socket error: {0}")]
     InputSocketError(#[from] InputSocketError),
     #[error("parent is not a frame (child id: {0}) (parent id: {1})")]

--- a/lib/dal/src/job/definition/action.rs
+++ b/lib/dal/src/job/definition/action.rs
@@ -180,9 +180,7 @@ async fn ensure_deletes_happened(
         match snapshot.get_node_weight_by_id(node_id).await {
             Ok(_) => {
                 warn!(?node_id, "removing node with edge because it is lingering");
-                snapshot
-                    .remove_node_by_id(ctx.vector_clock_id()?, node_id)
-                    .await?;
+                snapshot.remove_node_by_id(node_id).await?;
                 removed_at_least_once = true;
             }
             Err(WorkspaceSnapshotError::WorkspaceSnapshotGraph(

--- a/lib/dal/src/job/definition/dependent_values_update.rs
+++ b/lib/dal/src/job/definition/dependent_values_update.rs
@@ -134,10 +134,7 @@ impl DependentValuesUpdate {
     ) -> DependentValueUpdateResult<JobCompletionState> {
         let start = tokio::time::Instant::now();
         let span = Span::current();
-        let node_ids = ctx
-            .workspace_snapshot()?
-            .take_dependent_values(ctx.vector_clock_id()?)
-            .await?;
+        let node_ids = ctx.workspace_snapshot()?.take_dependent_values().await?;
 
         let mut dependency_graph = DependentValueGraph::new(ctx, node_ids).await?;
 

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -123,9 +123,9 @@ pub use timestamp::{Timestamp, TimestampError};
 pub use user::{User, UserClaim, UserError, UserPk, UserResult};
 pub use visibility::Visibility;
 pub use workspace::{Workspace, WorkspaceError, WorkspacePk, WorkspaceResult};
-pub use workspace_snapshot::graph::{WorkspaceSnapshotGraph, WorkspaceSnapshotGraphV1};
+pub use workspace_snapshot::graph::{WorkspaceSnapshotGraph, WorkspaceSnapshotGraphV2};
 pub use workspace_snapshot::{
-    edge_weight::{EdgeWeight, EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants},
+    edge_weight::{EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants},
     node_weight::NodeWeightDiscriminants,
 };
 pub use workspace_snapshot::{WorkspaceSnapshot, WorkspaceSnapshotError};

--- a/lib/dal/src/module.rs
+++ b/lib/dal/src/module.rs
@@ -18,7 +18,7 @@ use crate::pkg::export::PkgExporter;
 use crate::pkg::PkgError;
 use crate::workspace_snapshot::content_address::{ContentAddress, ContentAddressDiscriminants};
 use crate::workspace_snapshot::edge_weight::{
-    EdgeWeight, EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
+    EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants,
 };
 use crate::workspace_snapshot::node_weight::category_node_weight::CategoryNodeKind;
 use crate::workspace_snapshot::node_weight::{NodeWeight, NodeWeightError};
@@ -34,8 +34,6 @@ use crate::{
 pub enum ModuleError {
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
-    #[error("edge weight error: {0}")]
-    EdgeWeight(#[from] EdgeWeightError),
     #[error("found empty metadata (name: '{0}') (version: '{1}')")]
     EmptyMetadata(String, String),
     #[error("func error: {0}")]
@@ -166,12 +164,7 @@ impl Module {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let id = workspace_snapshot.generate_ulid().await?;
         let lineage_id = workspace_snapshot.generate_ulid().await?;
-        let node_weight = NodeWeight::new_content(
-            ctx.vector_clock_id()?,
-            id,
-            lineage_id,
-            ContentAddress::Module(hash),
-        )?;
+        let node_weight = NodeWeight::new_content(id, lineage_id, ContentAddress::Module(hash));
 
         workspace_snapshot.add_node(node_weight).await?;
 
@@ -181,7 +174,7 @@ impl Module {
         workspace_snapshot
             .add_edge(
                 schema_module_index_id,
-                EdgeWeight::new(ctx.vector_clock_id()?, EdgeWeightKind::new_use())?,
+                EdgeWeight::new(EdgeWeightKind::new_use()),
                 id,
             )
             .await?;
@@ -291,7 +284,7 @@ impl Module {
         workspace_snapshot
             .add_edge(
                 self.id,
-                EdgeWeight::new(ctx.vector_clock_id()?, EdgeWeightKind::new_use())?,
+                EdgeWeight::new(EdgeWeightKind::new_use()),
                 target_id,
             )
             .await?;

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -13,7 +13,7 @@ use crate::change_set::ChangeSetError;
 use crate::layer_db_types::{SchemaContent, SchemaContentDiscriminants, SchemaContentV1};
 use crate::workspace_snapshot::content_address::{ContentAddress, ContentAddressDiscriminants};
 use crate::workspace_snapshot::edge_weight::{
-    EdgeWeight, EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
+    EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants,
 };
 use crate::workspace_snapshot::node_weight::category_node_weight::CategoryNodeKind;
 use crate::workspace_snapshot::node_weight::{NodeWeight, NodeWeightError};
@@ -35,8 +35,6 @@ pub const SCHEMA_VERSION: SchemaContentDiscriminants = SchemaContentDiscriminant
 pub enum SchemaError {
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
-    #[error("edge weight error: {0}")]
-    EdgeWeight(#[from] EdgeWeightError),
     #[error("func error: {0}")]
     Func(#[from] FuncError),
     #[error("helper error: {0}")]
@@ -156,12 +154,8 @@ impl Schema {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let lineage_id = workspace_snapshot.generate_ulid().await?;
-        let node_weight = NodeWeight::new_content(
-            ctx.vector_clock_id()?,
-            id.into(),
-            lineage_id,
-            ContentAddress::Schema(hash),
-        )?;
+        let node_weight =
+            NodeWeight::new_content(id.into(), lineage_id, ContentAddress::Schema(hash));
 
         workspace_snapshot.add_node(node_weight).await?;
 
@@ -171,7 +165,7 @@ impl Schema {
         workspace_snapshot
             .add_edge(
                 schema_category_index_id,
-                EdgeWeight::new(ctx.vector_clock_id()?, EdgeWeightKind::new_use())?,
+                EdgeWeight::new(EdgeWeightKind::new_use()),
                 id,
             )
             .await?;
@@ -354,7 +348,7 @@ impl Schema {
                 .await?;
 
             ctx.workspace_snapshot()?
-                .update_content(ctx.vector_clock_id()?, schema.id.into(), hash)
+                .update_content(schema.id.into(), hash)
                 .await?;
         }
 

--- a/lib/dal/src/socket/input.rs
+++ b/lib/dal/src/socket/input.rs
@@ -19,9 +19,7 @@ use crate::layer_db_types::{InputSocketContent, InputSocketContentV1};
 
 use crate::socket::{SocketArity, SocketKind};
 use crate::workspace_snapshot::content_address::{ContentAddress, ContentAddressDiscriminants};
-use crate::workspace_snapshot::edge_weight::{
-    EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
-};
+use crate::workspace_snapshot::edge_weight::{EdgeWeightKind, EdgeWeightKindDiscriminants};
 use crate::workspace_snapshot::node_weight::{NodeWeight, NodeWeightError};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
@@ -48,8 +46,6 @@ pub enum InputSocketError {
     ComponentError(#[from] Box<ComponentError>),
     #[error(transparent)]
     ConnectionAnnotation(#[from] ConnectionAnnotationError),
-    #[error("edge weight error: {0}")]
-    EdgeWeight(#[from] EdgeWeightError),
     #[error("func error: {0}")]
     Func(#[from] FuncError),
     #[error("helper error: {0}")]
@@ -276,12 +272,8 @@ impl InputSocket {
         let id = workspace_snapshot.generate_ulid().await?;
         let lineage_id = workspace_snapshot.generate_ulid().await?;
 
-        let node_weight = NodeWeight::new_content(
-            ctx.vector_clock_id()?,
-            id,
-            lineage_id,
-            ContentAddress::InputSocket(hash),
-        )?;
+        let node_weight =
+            NodeWeight::new_content(id, lineage_id, ContentAddress::InputSocket(hash));
         workspace_snapshot.add_node(node_weight).await?;
         SchemaVariant::add_edge_to_input_socket(
             ctx,

--- a/lib/dal/src/socket/output.rs
+++ b/lib/dal/src/socket/output.rs
@@ -13,9 +13,7 @@ use crate::change_set::ChangeSetError;
 use crate::layer_db_types::{OutputSocketContent, OutputSocketContentV1};
 use crate::socket::{SocketArity, SocketKind};
 use crate::workspace_snapshot::content_address::{ContentAddress, ContentAddressDiscriminants};
-use crate::workspace_snapshot::edge_weight::{
-    EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants,
-};
+use crate::workspace_snapshot::edge_weight::{EdgeWeightKind, EdgeWeightKindDiscriminants};
 use crate::workspace_snapshot::node_weight::{ContentNodeWeight, NodeWeight, NodeWeightError};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
@@ -39,8 +37,6 @@ pub enum OutputSocketError {
     ChangeSet(#[from] ChangeSetError),
     #[error(transparent)]
     ConnectionAnnotation(#[from] ConnectionAnnotationError),
-    #[error("edge weight error: {0}")]
-    EdgeWeight(#[from] EdgeWeightError),
     #[error("found too many matches for input and socket: {0}, {1}")]
     FoundTooManyForInputSocketId(InputSocketId, ComponentId),
     #[error("helper error: {0}")]
@@ -195,12 +191,8 @@ impl OutputSocket {
 
         let id = workspace_snapshot.generate_ulid().await?;
         let lineage_id = workspace_snapshot.generate_ulid().await?;
-        let node_weight = NodeWeight::new_content(
-            ctx.vector_clock_id()?,
-            id,
-            lineage_id,
-            ContentAddress::OutputSocket(hash),
-        )?;
+        let node_weight =
+            NodeWeight::new_content(id, lineage_id, ContentAddress::OutputSocket(hash));
 
         workspace_snapshot.add_node(node_weight).await?;
 

--- a/lib/dal/src/standard_connection.rs
+++ b/lib/dal/src/standard_connection.rs
@@ -1,6 +1,5 @@
 use crate::{
-    EdgeWeightError, EdgeWeightKind, EdgeWeightKindDiscriminants, TransactionsError,
-    WorkspaceSnapshotError,
+    EdgeWeightKind, EdgeWeightKindDiscriminants, TransactionsError, WorkspaceSnapshotError,
 };
 use thiserror::Error;
 
@@ -8,8 +7,6 @@ use thiserror::Error;
 pub enum HelperError {
     #[error("invalid edge weight, got {0:?} expected discriminant {1:?}")]
     InvalidEdgeWeight(EdgeWeightKind, EdgeWeightKindDiscriminants),
-    #[error("edge weight error: {0}")]
-    EdgeWeight(#[from] EdgeWeightError),
     #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),
     #[error("workspace snapshot error: {0}")]
@@ -37,7 +34,7 @@ macro_rules! implement_add_edge_to {
                 ctx.workspace_snapshot()?
                     .add_edge(
                         source_id,
-                        $crate::EdgeWeight::new(ctx.vector_clock_id()?, weight)?,
+                        $crate::EdgeWeight::new(weight),
                         destination_id,
                     )
                     .await?;
@@ -50,13 +47,10 @@ macro_rules! implement_add_edge_to {
                     return Err($crate::HelperError::InvalidEdgeWeight(weight, $discriminant))?;
                 }
 
-                let vector_clock_id = ctx.vector_clock_id()?;
-
                 ctx.workspace_snapshot()?
                     .add_ordered_edge(
-                        vector_clock_id,
                         source_id,
-                        $crate::EdgeWeight::new(vector_clock_id, weight)?,
+                        $crate::EdgeWeight::new(weight),
                         destination_id
                     )
                     .await?;

--- a/lib/dal/src/workspace_snapshot/edge_weight/deprecated.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight/deprecated.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{workspace_snapshot::vector_clock::deprecated::DeprecatedVectorClock, EdgeWeightKind};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct DeprecatedEdgeWeight {
+pub struct DeprecatedEdgeWeightLegacy {
     pub kind: EdgeWeightKind,
     pub vector_clock_first_seen: DeprecatedVectorClock,
     pub vector_clock_recently_seen: DeprecatedVectorClock,

--- a/lib/dal/src/workspace_snapshot/graph/deprecated.rs
+++ b/lib/dal/src/workspace_snapshot/graph/deprecated.rs
@@ -4,15 +4,20 @@ use petgraph::prelude::*;
 use serde::{Deserialize, Serialize};
 use si_events::ulid::Ulid;
 
+pub mod v1;
+
+pub use v1::DeprecatedWorkspaceSnapshotGraphV1;
+
 use crate::workspace_snapshot::{
-    edge_weight::deprecated::DeprecatedEdgeWeight, node_weight::deprecated::DeprecatedNodeWeight,
+    edge_weight::deprecated::DeprecatedEdgeWeightLegacy,
+    node_weight::deprecated::DeprecatedNodeWeightLegacy,
 };
 
 use super::LineageId;
 
 #[derive(Default, Deserialize, Serialize, Clone)]
-pub struct DeprecatedWorkspaceSnapshotGraph {
-    pub graph: StableDiGraph<DeprecatedNodeWeight, DeprecatedEdgeWeight>,
+pub struct DeprecatedWorkspaceSnapshotGraphLegacy {
+    pub graph: StableDiGraph<DeprecatedNodeWeightLegacy, DeprecatedEdgeWeightLegacy>,
     pub node_index_by_id: HashMap<Ulid, NodeIndex>,
     pub node_indices_by_lineage_id: HashMap<LineageId, HashSet<NodeIndex>>,
     pub root_index: NodeIndex,

--- a/lib/dal/src/workspace_snapshot/graph/deprecated/v1.rs
+++ b/lib/dal/src/workspace_snapshot/graph/deprecated/v1.rs
@@ -1,0 +1,210 @@
+use std::collections::{HashMap, HashSet};
+
+use petgraph::prelude::*;
+use serde::{Deserialize, Serialize};
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash, EncryptedSecretKey};
+use strum::EnumDiscriminants;
+
+use crate::{
+    action::{prototype::ActionKind, ActionState},
+    func::FuncKind,
+    workspace_snapshot::{
+        content_address::ContentAddress,
+        graph::LineageId,
+        node_weight::{category_node_weight::CategoryNodeKind, ArgumentTargets},
+        vector_clock::VectorClock,
+    },
+    ChangeSetId, EdgeWeightKind, PropKind, Timestamp,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeprecatedActionNodeWeightV1 {
+    pub id: Ulid,
+    pub state: ActionState,
+    pub originating_change_set_id: ChangeSetId,
+    pub lineage_id: LineageId,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeprecatedActionPrototypeNodeWeightV1 {
+    pub id: Ulid,
+    pub kind: ActionKind,
+    pub name: String,
+    pub description: Option<String>,
+    pub lineage_id: LineageId,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct DeprecatedAttributeValueNodeWeightV1 {
+    pub id: Ulid,
+    pub lineage_id: LineageId,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+    pub unprocessed_value: Option<ContentAddress>,
+    pub value: Option<ContentAddress>,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct DeprecatedAttributePrototypeArgumentNodeWeightV1 {
+    pub id: Ulid,
+    pub lineage_id: LineageId,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+    pub targets: Option<ArgumentTargets>,
+    pub timestamp: Timestamp,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct DeprecatedCategoryNodeWeightV1 {
+    pub id: Ulid,
+    pub lineage_id: LineageId,
+    pub kind: CategoryNodeKind,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeprecatedComponentNodeWeightV1 {
+    pub id: Ulid,
+    pub lineage_id: LineageId,
+    pub content_address: ContentAddress,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+    pub to_delete: bool,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct DeprecatedContentNodeWeightV1 {
+    pub id: Ulid,
+    pub lineage_id: LineageId,
+    pub content_address: ContentAddress,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+    pub to_delete: bool,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct DeprecatedDependentValueRootNodeWeightV1 {
+    pub id: Ulid,
+    pub lineage_id: Ulid,
+    pub value_id: Ulid,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct DeprecatedFuncArgumentNodeWeightV1 {
+    pub id: Ulid,
+    pub lineage_id: LineageId,
+    pub content_address: ContentAddress,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+    pub name: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct DeprecatedFuncNodeWeightV1 {
+    pub id: Ulid,
+    pub lineage_id: LineageId,
+    pub content_address: ContentAddress,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+    pub name: String,
+    pub func_kind: FuncKind,
+}
+
+#[derive(Clone, Serialize, Deserialize, Default, PartialEq, Eq, Debug)]
+pub struct DeprecatedOrderingNodeWeightV1 {
+    pub id: Ulid,
+    pub lineage_id: Ulid,
+    pub order: Vec<Ulid>,
+    pub content_hash: ContentHash,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct DeprecatedPropNodeWeightV1 {
+    pub id: Ulid,
+    pub lineage_id: LineageId,
+    pub content_address: ContentAddress,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub kind: PropKind,
+    pub name: String,
+    pub can_be_used_as_prototype_arg: bool,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct DeprecatedSecretNodeWeightV1 {
+    pub id: Ulid,
+    pub lineage_id: LineageId,
+    pub content_address: ContentAddress,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+    pub encrypted_secret_key: EncryptedSecretKey,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, EnumDiscriminants, PartialEq, Eq)]
+#[strum_discriminants(derive(strum::Display, Hash, Serialize, Deserialize))]
+pub enum DeprecatedNodeWeightV1 {
+    Action(DeprecatedActionNodeWeightV1),
+    ActionPrototype(DeprecatedActionPrototypeNodeWeightV1),
+    AttributePrototypeArgument(DeprecatedAttributePrototypeArgumentNodeWeightV1),
+    AttributeValue(DeprecatedAttributeValueNodeWeightV1),
+    Category(DeprecatedCategoryNodeWeightV1),
+    Component(DeprecatedComponentNodeWeightV1),
+    Content(DeprecatedContentNodeWeightV1),
+    DependentValueRoot(DeprecatedDependentValueRootNodeWeightV1),
+    Func(DeprecatedFuncNodeWeightV1),
+    FuncArgument(DeprecatedFuncArgumentNodeWeightV1),
+    Ordering(DeprecatedOrderingNodeWeightV1),
+    Prop(DeprecatedPropNodeWeightV1),
+    Secret(DeprecatedSecretNodeWeightV1),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct DeprecatedEdgeWeightV1 {
+    pub kind: EdgeWeightKind,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+}
+
+#[derive(Default, Deserialize, Serialize, Clone, Debug)]
+pub struct DeprecatedWorkspaceSnapshotGraphV1 {
+    pub graph: StableDiGraph<DeprecatedNodeWeightV1, DeprecatedEdgeWeightV1>,
+    pub node_index_by_id: HashMap<Ulid, NodeIndex>,
+    pub node_indices_by_lineage_id: HashMap<LineageId, HashSet<NodeIndex>>,
+    pub root_index: NodeIndex,
+}

--- a/lib/dal/src/workspace_snapshot/graph/detect_updates.rs
+++ b/lib/dal/src/workspace_snapshot/graph/detect_updates.rs
@@ -13,7 +13,7 @@ use crate::{
     EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants,
 };
 
-use super::WorkspaceSnapshotGraphV1;
+use super::WorkspaceSnapshotGraphV2;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, EnumDiscriminants)]
 pub enum Update {
@@ -42,14 +42,14 @@ enum NodeDifference {
 }
 
 pub struct Detector<'a, 'b> {
-    base_graph: &'a WorkspaceSnapshotGraphV1,
-    updated_graph: &'b WorkspaceSnapshotGraphV1,
+    base_graph: &'a WorkspaceSnapshotGraphV2,
+    updated_graph: &'b WorkspaceSnapshotGraphV2,
 }
 
 impl<'a, 'b> Detector<'a, 'b> {
     pub fn new(
-        base_graph: &'a WorkspaceSnapshotGraphV1,
-        updated_graph: &'b WorkspaceSnapshotGraphV1,
+        base_graph: &'a WorkspaceSnapshotGraphV2,
+        updated_graph: &'b WorkspaceSnapshotGraphV2,
     ) -> Self {
         Self {
             base_graph,

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
@@ -1,16 +1,12 @@
 use serde::{Deserialize, Serialize};
-use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash, VectorClockId};
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::{
-    workspace_snapshot::{
-        graph::LineageId,
-        node_weight::NodeWeightResult,
-        vector_clock::{HasVectorClocks, VectorClock},
+    workspace_snapshot::graph::{
+        deprecated::v1::DeprecatedAttributePrototypeArgumentNodeWeightV1, LineageId,
     },
     ComponentId, EdgeWeightKindDiscriminants, Timestamp,
 };
-
-use super::deprecated::DeprecatedAttributePrototypeArgumentNodeWeight;
 
 /// When this `AttributePrototypeArgument` represents a connection between two
 /// components, we need to know which components are being connected.
@@ -25,30 +21,19 @@ pub struct AttributePrototypeArgumentNodeWeight {
     pub id: Ulid,
     pub lineage_id: LineageId,
     merkle_tree_hash: MerkleTreeHash,
-    vector_clock_first_seen: VectorClock,
-    vector_clock_recently_seen: VectorClock,
-    vector_clock_write: VectorClock,
     targets: Option<ArgumentTargets>,
     timestamp: Timestamp,
 }
 
 impl AttributePrototypeArgumentNodeWeight {
-    pub fn new(
-        vector_clock_id: VectorClockId,
-        id: Ulid,
-        lineage_id: Ulid,
-        targets: Option<ArgumentTargets>,
-    ) -> NodeWeightResult<Self> {
-        Ok(Self {
+    pub fn new(id: Ulid, lineage_id: Ulid, targets: Option<ArgumentTargets>) -> Self {
+        Self {
             id,
             lineage_id,
             merkle_tree_hash: MerkleTreeHash::default(),
             targets,
-            vector_clock_first_seen: VectorClock::new(vector_clock_id),
-            vector_clock_recently_seen: VectorClock::new(vector_clock_id),
-            vector_clock_write: VectorClock::new(vector_clock_id),
             timestamp: Timestamp::now(),
-        })
+        }
     }
 
     pub fn timestamp(&self) -> &Timestamp {
@@ -105,32 +90,6 @@ impl AttributePrototypeArgumentNodeWeight {
     }
 }
 
-impl HasVectorClocks for AttributePrototypeArgumentNodeWeight {
-    fn vector_clock_first_seen(&self) -> &VectorClock {
-        &self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen(&self) -> &VectorClock {
-        &self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write(&self) -> &VectorClock {
-        &self.vector_clock_write
-    }
-
-    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_write
-    }
-}
-
 impl std::fmt::Debug for AttributePrototypeArgumentNodeWeight {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("AttributePrototypeArgumentNodeWeight")
@@ -139,25 +98,18 @@ impl std::fmt::Debug for AttributePrototypeArgumentNodeWeight {
             .field("targets", &self.targets)
             .field("node_hash", &self.node_hash())
             .field("merkle_tree_hash", &self.merkle_tree_hash)
-            .field("vector_clock_first_seen", &self.vector_clock_first_seen)
-            .field(
-                "vector_clock_recently_seen",
-                &self.vector_clock_recently_seen,
-            )
-            .field("vector_clock_write", &self.vector_clock_write)
             .finish()
     }
 }
 
-impl From<DeprecatedAttributePrototypeArgumentNodeWeight> for AttributePrototypeArgumentNodeWeight {
-    fn from(value: DeprecatedAttributePrototypeArgumentNodeWeight) -> Self {
+impl From<DeprecatedAttributePrototypeArgumentNodeWeightV1>
+    for AttributePrototypeArgumentNodeWeight
+{
+    fn from(value: DeprecatedAttributePrototypeArgumentNodeWeightV1) -> Self {
         Self {
             id: value.id,
             lineage_id: value.lineage_id,
             merkle_tree_hash: value.merkle_tree_hash,
-            vector_clock_first_seen: VectorClock::empty(),
-            vector_clock_recently_seen: VectorClock::empty(),
-            vector_clock_write: VectorClock::empty(),
             targets: value.targets,
             timestamp: value.timestamp,
         }

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -1,26 +1,19 @@
 use serde::{Deserialize, Serialize};
-use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash, VectorClockId};
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::{
     workspace_snapshot::{
         content_address::ContentAddress,
-        graph::LineageId,
-        node_weight::NodeWeightResult,
-        vector_clock::{HasVectorClocks, VectorClock},
+        graph::{deprecated::v1::DeprecatedAttributeValueNodeWeightV1, LineageId},
     },
     EdgeWeightKindDiscriminants,
 };
-
-use super::deprecated::DeprecatedAttributeValueNodeWeight;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AttributeValueNodeWeight {
     pub id: Ulid,
     pub lineage_id: LineageId,
     merkle_tree_hash: MerkleTreeHash,
-    vector_clock_first_seen: VectorClock,
-    vector_clock_recently_seen: VectorClock,
-    vector_clock_write: VectorClock,
     /// The unprocessed return value is the "real" result, unprocessed for any other behavior.
     /// This is potentially-maybe-only-kinda-sort-of(?) useful for non-scalar values.
     /// Example: a populated array.
@@ -32,22 +25,18 @@ pub struct AttributeValueNodeWeight {
 
 impl AttributeValueNodeWeight {
     pub fn new(
-        vector_clock_id: VectorClockId,
         id: Ulid,
         lineage_id: Ulid,
         unprocessed_value: Option<ContentAddress>,
         value: Option<ContentAddress>,
-    ) -> NodeWeightResult<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             id,
             lineage_id,
             merkle_tree_hash: MerkleTreeHash::default(),
-            vector_clock_first_seen: VectorClock::new(vector_clock_id),
-            vector_clock_recently_seen: VectorClock::new(vector_clock_id),
-            vector_clock_write: VectorClock::new(vector_clock_id),
             unprocessed_value,
             value,
-        })
+        }
     }
 
     pub fn content_store_hashes(&self) -> Vec<ContentHash> {
@@ -115,32 +104,6 @@ impl AttributeValueNodeWeight {
     }
 }
 
-impl HasVectorClocks for AttributeValueNodeWeight {
-    fn vector_clock_first_seen(&self) -> &VectorClock {
-        &self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen(&self) -> &VectorClock {
-        &self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write(&self) -> &VectorClock {
-        &self.vector_clock_write
-    }
-
-    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_write
-    }
-}
-
 impl std::fmt::Debug for AttributeValueNodeWeight {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("AttributeValueNodeWeight")
@@ -150,25 +113,16 @@ impl std::fmt::Debug for AttributeValueNodeWeight {
             .field("unprocessed_value", &self.unprocessed_value)
             .field("node_hash", &self.node_hash())
             .field("merkle_tree_hash", &self.merkle_tree_hash)
-            .field("vector_clock_first_seen", &self.vector_clock_first_seen)
-            .field(
-                "vector_clock_recently_seen",
-                &self.vector_clock_recently_seen,
-            )
-            .field("vector_clock_write", &self.vector_clock_write)
             .finish()
     }
 }
 
-impl From<DeprecatedAttributeValueNodeWeight> for AttributeValueNodeWeight {
-    fn from(value: DeprecatedAttributeValueNodeWeight) -> Self {
+impl From<DeprecatedAttributeValueNodeWeightV1> for AttributeValueNodeWeight {
+    fn from(value: DeprecatedAttributeValueNodeWeightV1) -> Self {
         Self {
             id: value.id,
             lineage_id: value.lineage_id,
             merkle_tree_hash: value.merkle_tree_hash,
-            vector_clock_first_seen: VectorClock::empty(),
-            vector_clock_recently_seen: VectorClock::empty(),
-            vector_clock_write: VectorClock::empty(),
             unprocessed_value: value.unprocessed_value,
             value: value.value,
         }

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -1,16 +1,15 @@
 use serde::{Deserialize, Serialize};
-use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash, VectorClockId};
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::{
     workspace_snapshot::{
         content_address::{ContentAddress, ContentAddressDiscriminants},
-        graph::LineageId,
-        vector_clock::{HasVectorClocks, VectorClock},
+        graph::{deprecated::v1::DeprecatedComponentNodeWeightV1, LineageId},
     },
     EdgeWeightKindDiscriminants,
 };
 
-use super::{deprecated::DeprecatedComponentNodeWeight, NodeWeightError, NodeWeightResult};
+use super::{NodeWeightError, NodeWeightResult};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ComponentNodeWeight {
@@ -18,31 +17,18 @@ pub struct ComponentNodeWeight {
     pub lineage_id: LineageId,
     content_address: ContentAddress,
     merkle_tree_hash: MerkleTreeHash,
-    vector_clock_first_seen: VectorClock,
-    vector_clock_recently_seen: VectorClock,
-    vector_clock_write: VectorClock,
     to_delete: bool,
 }
 
 impl ComponentNodeWeight {
-    pub fn new(
-        vector_clock_id: VectorClockId,
-        id: Ulid,
-        lineage_id: Ulid,
-        content_address: ContentAddress,
-    ) -> NodeWeightResult<Self> {
-        let new_vector_clock = VectorClock::new(vector_clock_id);
-
-        Ok(Self {
+    pub fn new(id: Ulid, lineage_id: Ulid, content_address: ContentAddress) -> Self {
+        Self {
             id,
             lineage_id,
             content_address,
             merkle_tree_hash: MerkleTreeHash::default(),
             to_delete: false,
-            vector_clock_first_seen: new_vector_clock.clone(),
-            vector_clock_recently_seen: new_vector_clock.clone(),
-            vector_clock_write: new_vector_clock,
-        })
+        }
     }
 
     pub fn content_address(&self) -> ContentAddress {
@@ -121,42 +107,13 @@ impl ComponentNodeWeight {
     }
 }
 
-impl HasVectorClocks for ComponentNodeWeight {
-    fn vector_clock_first_seen(&self) -> &VectorClock {
-        &self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen(&self) -> &VectorClock {
-        &self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write(&self) -> &VectorClock {
-        &self.vector_clock_write
-    }
-
-    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_write
-    }
-}
-
-impl From<DeprecatedComponentNodeWeight> for ComponentNodeWeight {
-    fn from(value: DeprecatedComponentNodeWeight) -> Self {
+impl From<DeprecatedComponentNodeWeightV1> for ComponentNodeWeight {
+    fn from(value: DeprecatedComponentNodeWeightV1) -> Self {
         Self {
             id: value.id,
             lineage_id: value.lineage_id,
             content_address: value.content_address,
             merkle_tree_hash: value.merkle_tree_hash,
-            vector_clock_first_seen: VectorClock::empty(),
-            vector_clock_recently_seen: VectorClock::empty(),
-            vector_clock_write: VectorClock::empty(),
             to_delete: value.to_delete,
         }
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/dependent_value_root_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/dependent_value_root_node_weight.rs
@@ -1,12 +1,10 @@
 use serde::{Deserialize, Serialize};
-use si_events::VectorClockId;
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
-use crate::workspace_snapshot::vector_clock::{HasVectorClocks, VectorClock};
-use crate::EdgeWeightKindDiscriminants;
-
-use super::deprecated::DeprecatedDependentValueRootNodeWeight;
-use super::NodeWeightResult;
+use crate::{
+    workspace_snapshot::graph::deprecated::v1::DeprecatedDependentValueRootNodeWeightV1,
+    EdgeWeightKindDiscriminants,
+};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DependentValueRootNodeWeight {
@@ -14,9 +12,6 @@ pub struct DependentValueRootNodeWeight {
     pub lineage_id: Ulid,
     value_id: Ulid,
     merkle_tree_hash: MerkleTreeHash,
-    vector_clock_first_seen: VectorClock,
-    vector_clock_recently_seen: VectorClock,
-    vector_clock_write: VectorClock,
 }
 
 impl DependentValueRootNodeWeight {
@@ -40,34 +35,17 @@ impl DependentValueRootNodeWeight {
         self.lineage_id
     }
 
-    pub fn merge_clocks(&mut self, vector_clock_id: VectorClockId, other: &Self) {
-        self.vector_clock_write
-            .merge(vector_clock_id, other.vector_clock_write());
-        self.vector_clock_first_seen
-            .merge(vector_clock_id, other.vector_clock_first_seen());
-        self.vector_clock_recently_seen
-            .merge(vector_clock_id, other.vector_clock_recently_seen());
-    }
-
     pub fn merkle_tree_hash(&self) -> MerkleTreeHash {
         self.merkle_tree_hash
     }
 
-    pub fn new(
-        vector_clock_id: VectorClockId,
-        id: Ulid,
-        lineage_id: Ulid,
-        value_id: Ulid,
-    ) -> NodeWeightResult<Self> {
-        Ok(Self {
+    pub fn new(id: Ulid, lineage_id: Ulid, value_id: Ulid) -> Self {
+        Self {
             id,
             lineage_id,
             value_id,
-            vector_clock_write: VectorClock::new(vector_clock_id),
-            vector_clock_first_seen: VectorClock::new(vector_clock_id),
             merkle_tree_hash: Default::default(),
-            vector_clock_recently_seen: VectorClock::new(vector_clock_id),
-        })
+        }
     }
 
     pub fn node_hash(&self) -> ContentHash {
@@ -85,32 +63,6 @@ impl DependentValueRootNodeWeight {
     }
 }
 
-impl HasVectorClocks for DependentValueRootNodeWeight {
-    fn vector_clock_first_seen(&self) -> &VectorClock {
-        &self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen(&self) -> &VectorClock {
-        &self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write(&self) -> &VectorClock {
-        &self.vector_clock_write
-    }
-
-    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_write
-    }
-}
-
 impl std::fmt::Debug for DependentValueRootNodeWeight {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("DependentValueNodeWeight")
@@ -118,26 +70,17 @@ impl std::fmt::Debug for DependentValueRootNodeWeight {
             .field("lineage_id", &self.lineage_id.to_string())
             .field("value_id", &self.value_id.to_string())
             .field("merkle_tree_hash", &self.merkle_tree_hash)
-            .field("vector_clock_first_seen", &self.vector_clock_first_seen)
-            .field(
-                "vector_clock_recently_seen",
-                &self.vector_clock_recently_seen,
-            )
-            .field("vector_clock_write", &self.vector_clock_write)
             .finish()
     }
 }
 
-impl From<DeprecatedDependentValueRootNodeWeight> for DependentValueRootNodeWeight {
-    fn from(value: DeprecatedDependentValueRootNodeWeight) -> Self {
+impl From<DeprecatedDependentValueRootNodeWeightV1> for DependentValueRootNodeWeight {
+    fn from(value: DeprecatedDependentValueRootNodeWeightV1) -> Self {
         Self {
             id: value.id,
             lineage_id: value.lineage_id,
             value_id: value.value_id,
             merkle_tree_hash: value.merkle_tree_hash,
-            vector_clock_first_seen: VectorClock::empty(),
-            vector_clock_recently_seen: VectorClock::empty(),
-            vector_clock_write: VectorClock::empty(),
         }
     }
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/action_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/action_node_weight.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DeprecatedActionNodeWeight {
+pub struct DeprecatedActionNodeWeightLegacy {
     pub id: Ulid,
     pub state: ActionState,
     pub originating_changeset_id: ChangeSetId,

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/action_prototype_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/action_prototype_node_weight.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DeprecatedActionPrototypeNodeWeight {
+pub struct DeprecatedActionPrototypeNodeWeightLegacy {
     pub id: Ulid,
     pub kind: ActionKind,
     // TODO: Move behind ContentHash, and out of the node weight directly.

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/attribute_prototype_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/attribute_prototype_argument_node_weight.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct DeprecatedAttributePrototypeArgumentNodeWeight {
+pub struct DeprecatedAttributePrototypeArgumentNodeWeightLegacy {
     pub id: Ulid,
     pub lineage_id: LineageId,
     pub merkle_tree_hash: MerkleTreeHash,

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/attribute_value_node_weight.rs
@@ -4,13 +4,14 @@ use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
 use crate::{
     func::FuncExecutionPk,
     workspace_snapshot::{
-        content_address::ContentAddress, graph::LineageId,
-        vector_clock::deprecated::DeprecatedVectorClock,
+        content_address::ContentAddress,
+        graph::LineageId,
+        vector_clock::{deprecated::DeprecatedVectorClock, VectorClock},
     },
 };
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct DeprecatedAttributeValueNodeWeight {
+pub struct DeprecatedAttributeValueNodeWeightLegacy {
     pub id: Ulid,
     pub lineage_id: LineageId,
     pub merkle_tree_hash: MerkleTreeHash,
@@ -26,4 +27,21 @@ pub struct DeprecatedAttributeValueNodeWeight {
     pub value: Option<ContentAddress>,
     // DEPRECATED - this was the old function execution system
     pub func_execution_pk: Option<FuncExecutionPk>,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct DeprecatedAttributeValueNodeWeightV1 {
+    pub id: Ulid,
+    pub lineage_id: LineageId,
+    pub merkle_tree_hash: MerkleTreeHash,
+    pub vector_clock_first_seen: VectorClock,
+    pub vector_clock_recently_seen: VectorClock,
+    pub vector_clock_write: VectorClock,
+    /// The unprocessed return value is the "real" result, unprocessed for any other behavior.
+    /// This is potentially-maybe-only-kinda-sort-of(?) useful for non-scalar values.
+    /// Example: a populated array.
+    pub unprocessed_value: Option<ContentAddress>,
+    /// The processed return value.
+    /// Example: empty array.
+    pub value: Option<ContentAddress>,
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/category_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/category_node_weight.rs
@@ -6,7 +6,7 @@ use crate::workspace_snapshot::node_weight::category_node_weight::CategoryNodeKi
 use crate::workspace_snapshot::vector_clock::deprecated::DeprecatedVectorClock;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct DeprecatedCategoryNodeWeight {
+pub struct DeprecatedCategoryNodeWeightLegacy {
     pub id: Ulid,
     pub lineage_id: LineageId,
     pub kind: CategoryNodeKind,

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/component_node_weight.rs
@@ -7,7 +7,7 @@ use crate::workspace_snapshot::{
 };
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct DeprecatedComponentNodeWeight {
+pub struct DeprecatedComponentNodeWeightLegacy {
     pub id: Ulid,
     pub lineage_id: LineageId,
     pub content_address: ContentAddress,

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/content_node_weight.rs
@@ -6,7 +6,7 @@ use crate::workspace_snapshot::vector_clock::deprecated::DeprecatedVectorClock;
 use crate::workspace_snapshot::{content_address::ContentAddress, graph::LineageId};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct DeprecatedContentNodeWeight {
+pub struct DeprecatedContentNodeWeightLegacy {
     pub id: Ulid,
     pub lineage_id: LineageId,
     pub content_address: ContentAddress,

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/dependent_value_root_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/dependent_value_root_node_weight.rs
@@ -4,7 +4,7 @@ use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
 use crate::workspace_snapshot::vector_clock::deprecated::DeprecatedVectorClock;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct DeprecatedDependentValueRootNodeWeight {
+pub struct DeprecatedDependentValueRootNodeWeightLegacy {
     pub id: Ulid,
     pub lineage_id: Ulid,
     pub value_id: Ulid,

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/func_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/func_argument_node_weight.rs
@@ -7,7 +7,7 @@ use crate::workspace_snapshot::{
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DeprecatedFuncArgumentNodeWeight {
+pub struct DeprecatedFuncArgumentNodeWeightLegacy {
     pub id: Ulid,
     pub lineage_id: LineageId,
     pub content_address: ContentAddress,

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/func_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/func_node_weight.rs
@@ -6,7 +6,7 @@ use crate::workspace_snapshot::vector_clock::deprecated::DeprecatedVectorClock;
 use crate::workspace_snapshot::{content_address::ContentAddress, graph::LineageId};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct DeprecatedFuncNodeWeight {
+pub struct DeprecatedFuncNodeWeightLegacy {
     pub id: Ulid,
     pub lineage_id: LineageId,
     pub content_address: ContentAddress,

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/mod.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/mod.rs
@@ -1,18 +1,18 @@
 use serde::{Deserialize, Serialize};
 
-pub use action_node_weight::DeprecatedActionNodeWeight;
-pub use action_prototype_node_weight::DeprecatedActionPrototypeNodeWeight;
-pub use attribute_prototype_argument_node_weight::DeprecatedAttributePrototypeArgumentNodeWeight;
-pub use attribute_value_node_weight::DeprecatedAttributeValueNodeWeight;
-pub use category_node_weight::DeprecatedCategoryNodeWeight;
-pub use component_node_weight::DeprecatedComponentNodeWeight;
-pub use content_node_weight::DeprecatedContentNodeWeight;
-pub use dependent_value_root_node_weight::DeprecatedDependentValueRootNodeWeight;
-pub use func_argument_node_weight::DeprecatedFuncArgumentNodeWeight;
-pub use func_node_weight::DeprecatedFuncNodeWeight;
-pub use ordering_node_weight::DeprecatedOrderingNodeWeight;
-pub use prop_node_weight::DeprecatedPropNodeWeight;
-pub use secret_node_weight::DeprecatedSecretNodeWeight;
+pub use action_node_weight::DeprecatedActionNodeWeightLegacy;
+pub use action_prototype_node_weight::DeprecatedActionPrototypeNodeWeightLegacy;
+pub use attribute_prototype_argument_node_weight::DeprecatedAttributePrototypeArgumentNodeWeightLegacy;
+pub use attribute_value_node_weight::DeprecatedAttributeValueNodeWeightLegacy;
+pub use category_node_weight::DeprecatedCategoryNodeWeightLegacy;
+pub use component_node_weight::DeprecatedComponentNodeWeightLegacy;
+pub use content_node_weight::DeprecatedContentNodeWeightLegacy;
+pub use dependent_value_root_node_weight::DeprecatedDependentValueRootNodeWeightLegacy;
+pub use func_argument_node_weight::DeprecatedFuncArgumentNodeWeightLegacy;
+pub use func_node_weight::DeprecatedFuncNodeWeightLegacy;
+pub use ordering_node_weight::DeprecatedOrderingNodeWeightLegacy;
+pub use prop_node_weight::DeprecatedPropNodeWeightLegacy;
+pub use secret_node_weight::DeprecatedSecretNodeWeightLegacy;
 
 use crate::workspace_snapshot::vector_clock::deprecated::DeprecatedVectorClock;
 
@@ -31,40 +31,46 @@ pub mod prop_node_weight;
 pub mod secret_node_weight;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum DeprecatedNodeWeight {
-    Action(DeprecatedActionNodeWeight),
-    ActionPrototype(DeprecatedActionPrototypeNodeWeight),
-    AttributePrototypeArgument(DeprecatedAttributePrototypeArgumentNodeWeight),
-    AttributeValue(DeprecatedAttributeValueNodeWeight),
-    Category(DeprecatedCategoryNodeWeight),
-    Component(DeprecatedComponentNodeWeight),
-    Content(DeprecatedContentNodeWeight),
-    Func(DeprecatedFuncNodeWeight),
-    FuncArgument(DeprecatedFuncArgumentNodeWeight),
-    Ordering(DeprecatedOrderingNodeWeight),
-    Prop(DeprecatedPropNodeWeight),
-    Secret(DeprecatedSecretNodeWeight),
-    DependentValueRoot(DeprecatedDependentValueRootNodeWeight),
+pub enum DeprecatedNodeWeightLegacy {
+    Action(DeprecatedActionNodeWeightLegacy),
+    ActionPrototype(DeprecatedActionPrototypeNodeWeightLegacy),
+    AttributePrototypeArgument(DeprecatedAttributePrototypeArgumentNodeWeightLegacy),
+    AttributeValue(DeprecatedAttributeValueNodeWeightLegacy),
+    Category(DeprecatedCategoryNodeWeightLegacy),
+    Component(DeprecatedComponentNodeWeightLegacy),
+    Content(DeprecatedContentNodeWeightLegacy),
+    Func(DeprecatedFuncNodeWeightLegacy),
+    FuncArgument(DeprecatedFuncArgumentNodeWeightLegacy),
+    Ordering(DeprecatedOrderingNodeWeightLegacy),
+    Prop(DeprecatedPropNodeWeightLegacy),
+    Secret(DeprecatedSecretNodeWeightLegacy),
+    DependentValueRoot(DeprecatedDependentValueRootNodeWeightLegacy),
 }
 
-impl DeprecatedNodeWeight {
+impl DeprecatedNodeWeightLegacy {
     pub fn vector_clock_first_seen(&self) -> DeprecatedVectorClock {
         match self {
-            DeprecatedNodeWeight::Action(weight) => weight.vector_clock_first_seen.clone(),
-            DeprecatedNodeWeight::ActionPrototype(weight) => weight.vector_clock_first_seen.clone(),
-            DeprecatedNodeWeight::AttributePrototypeArgument(weight) => {
+            DeprecatedNodeWeightLegacy::Action(weight) => weight.vector_clock_first_seen.clone(),
+            DeprecatedNodeWeightLegacy::ActionPrototype(weight) => {
                 weight.vector_clock_first_seen.clone()
             }
-            DeprecatedNodeWeight::AttributeValue(weight) => weight.vector_clock_first_seen.clone(),
-            DeprecatedNodeWeight::Category(weight) => weight.vector_clock_first_seen.clone(),
-            DeprecatedNodeWeight::Component(weight) => weight.vector_clock_first_seen.clone(),
-            DeprecatedNodeWeight::Content(weight) => weight.vector_clock_first_seen.clone(),
-            DeprecatedNodeWeight::Func(weight) => weight.vector_clock_first_seen.clone(),
-            DeprecatedNodeWeight::FuncArgument(weight) => weight.vector_clock_first_seen.clone(),
-            DeprecatedNodeWeight::Ordering(weight) => weight.vector_clock_first_seen.clone(),
-            DeprecatedNodeWeight::Prop(weight) => weight.vector_clock_first_seen.clone(),
-            DeprecatedNodeWeight::Secret(weight) => weight.vector_clock_first_seen.clone(),
-            DeprecatedNodeWeight::DependentValueRoot(weight) => {
+            DeprecatedNodeWeightLegacy::AttributePrototypeArgument(weight) => {
+                weight.vector_clock_first_seen.clone()
+            }
+            DeprecatedNodeWeightLegacy::AttributeValue(weight) => {
+                weight.vector_clock_first_seen.clone()
+            }
+            DeprecatedNodeWeightLegacy::Category(weight) => weight.vector_clock_first_seen.clone(),
+            DeprecatedNodeWeightLegacy::Component(weight) => weight.vector_clock_first_seen.clone(),
+            DeprecatedNodeWeightLegacy::Content(weight) => weight.vector_clock_first_seen.clone(),
+            DeprecatedNodeWeightLegacy::Func(weight) => weight.vector_clock_first_seen.clone(),
+            DeprecatedNodeWeightLegacy::FuncArgument(weight) => {
+                weight.vector_clock_first_seen.clone()
+            }
+            DeprecatedNodeWeightLegacy::Ordering(weight) => weight.vector_clock_first_seen.clone(),
+            DeprecatedNodeWeightLegacy::Prop(weight) => weight.vector_clock_first_seen.clone(),
+            DeprecatedNodeWeightLegacy::Secret(weight) => weight.vector_clock_first_seen.clone(),
+            DeprecatedNodeWeightLegacy::DependentValueRoot(weight) => {
                 weight.vector_clock_first_seen.clone()
             }
         }
@@ -72,25 +78,35 @@ impl DeprecatedNodeWeight {
 
     pub fn vector_clock_recently_seen(&self) -> DeprecatedVectorClock {
         match self {
-            DeprecatedNodeWeight::Action(weight) => weight.vector_clock_recently_seen.clone(),
-            DeprecatedNodeWeight::ActionPrototype(weight) => {
+            DeprecatedNodeWeightLegacy::Action(weight) => weight.vector_clock_recently_seen.clone(),
+            DeprecatedNodeWeightLegacy::ActionPrototype(weight) => {
                 weight.vector_clock_recently_seen.clone()
             }
-            DeprecatedNodeWeight::AttributePrototypeArgument(weight) => {
+            DeprecatedNodeWeightLegacy::AttributePrototypeArgument(weight) => {
                 weight.vector_clock_recently_seen.clone()
             }
-            DeprecatedNodeWeight::AttributeValue(weight) => {
+            DeprecatedNodeWeightLegacy::AttributeValue(weight) => {
                 weight.vector_clock_recently_seen.clone()
             }
-            DeprecatedNodeWeight::Category(weight) => weight.vector_clock_recently_seen.clone(),
-            DeprecatedNodeWeight::Component(weight) => weight.vector_clock_recently_seen.clone(),
-            DeprecatedNodeWeight::Content(weight) => weight.vector_clock_recently_seen.clone(),
-            DeprecatedNodeWeight::Func(weight) => weight.vector_clock_recently_seen.clone(),
-            DeprecatedNodeWeight::FuncArgument(weight) => weight.vector_clock_recently_seen.clone(),
-            DeprecatedNodeWeight::Ordering(weight) => weight.vector_clock_recently_seen.clone(),
-            DeprecatedNodeWeight::Prop(weight) => weight.vector_clock_recently_seen.clone(),
-            DeprecatedNodeWeight::Secret(weight) => weight.vector_clock_recently_seen.clone(),
-            DeprecatedNodeWeight::DependentValueRoot(weight) => {
+            DeprecatedNodeWeightLegacy::Category(weight) => {
+                weight.vector_clock_recently_seen.clone()
+            }
+            DeprecatedNodeWeightLegacy::Component(weight) => {
+                weight.vector_clock_recently_seen.clone()
+            }
+            DeprecatedNodeWeightLegacy::Content(weight) => {
+                weight.vector_clock_recently_seen.clone()
+            }
+            DeprecatedNodeWeightLegacy::Func(weight) => weight.vector_clock_recently_seen.clone(),
+            DeprecatedNodeWeightLegacy::FuncArgument(weight) => {
+                weight.vector_clock_recently_seen.clone()
+            }
+            DeprecatedNodeWeightLegacy::Ordering(weight) => {
+                weight.vector_clock_recently_seen.clone()
+            }
+            DeprecatedNodeWeightLegacy::Prop(weight) => weight.vector_clock_recently_seen.clone(),
+            DeprecatedNodeWeightLegacy::Secret(weight) => weight.vector_clock_recently_seen.clone(),
+            DeprecatedNodeWeightLegacy::DependentValueRoot(weight) => {
                 weight.vector_clock_recently_seen.clone()
             }
         }
@@ -98,21 +114,25 @@ impl DeprecatedNodeWeight {
 
     pub fn vector_clock_write(&self) -> DeprecatedVectorClock {
         match self {
-            DeprecatedNodeWeight::Action(weight) => weight.vector_clock_write.clone(),
-            DeprecatedNodeWeight::ActionPrototype(weight) => weight.vector_clock_write.clone(),
-            DeprecatedNodeWeight::AttributePrototypeArgument(weight) => {
+            DeprecatedNodeWeightLegacy::Action(weight) => weight.vector_clock_write.clone(),
+            DeprecatedNodeWeightLegacy::ActionPrototype(weight) => {
                 weight.vector_clock_write.clone()
             }
-            DeprecatedNodeWeight::AttributeValue(weight) => weight.vector_clock_write.clone(),
-            DeprecatedNodeWeight::Category(weight) => weight.vector_clock_write.clone(),
-            DeprecatedNodeWeight::Component(weight) => weight.vector_clock_write.clone(),
-            DeprecatedNodeWeight::Content(weight) => weight.vector_clock_write.clone(),
-            DeprecatedNodeWeight::Func(weight) => weight.vector_clock_write.clone(),
-            DeprecatedNodeWeight::FuncArgument(weight) => weight.vector_clock_write.clone(),
-            DeprecatedNodeWeight::Ordering(weight) => weight.vector_clock_write.clone(),
-            DeprecatedNodeWeight::Prop(weight) => weight.vector_clock_write.clone(),
-            DeprecatedNodeWeight::Secret(weight) => weight.vector_clock_write.clone(),
-            DeprecatedNodeWeight::DependentValueRoot(weight) => weight.vector_clock_write.clone(),
+            DeprecatedNodeWeightLegacy::AttributePrototypeArgument(weight) => {
+                weight.vector_clock_write.clone()
+            }
+            DeprecatedNodeWeightLegacy::AttributeValue(weight) => weight.vector_clock_write.clone(),
+            DeprecatedNodeWeightLegacy::Category(weight) => weight.vector_clock_write.clone(),
+            DeprecatedNodeWeightLegacy::Component(weight) => weight.vector_clock_write.clone(),
+            DeprecatedNodeWeightLegacy::Content(weight) => weight.vector_clock_write.clone(),
+            DeprecatedNodeWeightLegacy::Func(weight) => weight.vector_clock_write.clone(),
+            DeprecatedNodeWeightLegacy::FuncArgument(weight) => weight.vector_clock_write.clone(),
+            DeprecatedNodeWeightLegacy::Ordering(weight) => weight.vector_clock_write.clone(),
+            DeprecatedNodeWeightLegacy::Prop(weight) => weight.vector_clock_write.clone(),
+            DeprecatedNodeWeightLegacy::Secret(weight) => weight.vector_clock_write.clone(),
+            DeprecatedNodeWeightLegacy::DependentValueRoot(weight) => {
+                weight.vector_clock_write.clone()
+            }
         }
     }
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/ordering_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/ordering_node_weight.rs
@@ -4,7 +4,7 @@ use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 use crate::workspace_snapshot::vector_clock::deprecated::DeprecatedVectorClock;
 
 #[derive(Clone, Serialize, Deserialize, Default, Debug)]
-pub struct DeprecatedOrderingNodeWeight {
+pub struct DeprecatedOrderingNodeWeightLegacy {
     pub id: Ulid,
     pub lineage_id: Ulid,
     pub order: Vec<Ulid>,

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/prop_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/prop_node_weight.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct DeprecatedPropNodeWeight {
+pub struct DeprecatedPropNodeWeightLegacy {
     pub id: Ulid,
     pub lineage_id: LineageId,
     pub content_address: ContentAddress,

--- a/lib/dal/src/workspace_snapshot/node_weight/deprecated/secret_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/deprecated/secret_node_weight.rs
@@ -5,7 +5,7 @@ use crate::workspace_snapshot::vector_clock::deprecated::DeprecatedVectorClock;
 use crate::workspace_snapshot::{content_address::ContentAddress, graph::LineageId};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct DeprecatedSecretNodeWeight {
+pub struct DeprecatedSecretNodeWeightLegacy {
     pub id: Ulid,
     pub lineage_id: LineageId,
     pub content_address: ContentAddress,

--- a/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
@@ -1,18 +1,15 @@
 use serde::{Deserialize, Serialize};
-use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash, VectorClockId};
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::{
     workspace_snapshot::{
         content_address::{ContentAddress, ContentAddressDiscriminants},
-        graph::LineageId,
+        graph::{deprecated::v1::DeprecatedFuncArgumentNodeWeightV1, LineageId},
         node_weight::NodeWeightResult,
-        vector_clock::{HasVectorClocks, VectorClock},
         NodeWeightError,
     },
     EdgeWeightKindDiscriminants,
 };
-
-use super::deprecated::DeprecatedFuncArgumentNodeWeight;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FuncArgumentNodeWeight {
@@ -20,30 +17,18 @@ pub struct FuncArgumentNodeWeight {
     pub lineage_id: LineageId,
     content_address: ContentAddress,
     merkle_tree_hash: MerkleTreeHash,
-    vector_clock_first_seen: VectorClock,
-    vector_clock_recently_seen: VectorClock,
-    vector_clock_write: VectorClock,
     name: String,
 }
 
 impl FuncArgumentNodeWeight {
-    pub fn new(
-        vector_clock_id: VectorClockId,
-        id: Ulid,
-        lineage_id: Ulid,
-        content_address: ContentAddress,
-        name: String,
-    ) -> NodeWeightResult<Self> {
-        Ok(Self {
+    pub fn new(id: Ulid, lineage_id: Ulid, content_address: ContentAddress, name: String) -> Self {
+        Self {
             id,
             lineage_id,
             content_address,
             merkle_tree_hash: MerkleTreeHash::default(),
             name,
-            vector_clock_first_seen: VectorClock::new(vector_clock_id),
-            vector_clock_recently_seen: VectorClock::new(vector_clock_id),
-            vector_clock_write: VectorClock::new(vector_clock_id),
-        })
+        }
     }
 
     pub fn content_address(&self) -> ContentAddress {
@@ -111,32 +96,6 @@ impl FuncArgumentNodeWeight {
     }
 }
 
-impl HasVectorClocks for FuncArgumentNodeWeight {
-    fn vector_clock_first_seen(&self) -> &VectorClock {
-        &self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen(&self) -> &VectorClock {
-        &self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write(&self) -> &VectorClock {
-        &self.vector_clock_write
-    }
-
-    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_write
-    }
-}
-
 impl std::fmt::Debug for FuncArgumentNodeWeight {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("FuncNodeWeight")
@@ -145,26 +104,17 @@ impl std::fmt::Debug for FuncArgumentNodeWeight {
             .field("name", &self.name)
             .field("content_hash", &self.content_hash())
             .field("merkle_tree_hash", &self.merkle_tree_hash)
-            .field("vector_clock_first_seen", &self.vector_clock_first_seen)
-            .field(
-                "vector_clock_recently_seen",
-                &self.vector_clock_recently_seen,
-            )
-            .field("vector_clock_write", &self.vector_clock_write)
             .finish()
     }
 }
 
-impl From<DeprecatedFuncArgumentNodeWeight> for FuncArgumentNodeWeight {
-    fn from(value: DeprecatedFuncArgumentNodeWeight) -> Self {
+impl From<DeprecatedFuncArgumentNodeWeightV1> for FuncArgumentNodeWeight {
+    fn from(value: DeprecatedFuncArgumentNodeWeightV1) -> Self {
         Self {
             id: value.id,
             lineage_id: value.lineage_id,
             content_address: value.content_address,
             merkle_tree_hash: value.merkle_tree_hash,
-            vector_clock_first_seen: VectorClock::empty(),
-            vector_clock_recently_seen: VectorClock::empty(),
-            vector_clock_write: VectorClock::empty(),
             name: value.name,
         }
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
@@ -1,19 +1,15 @@
 use serde::{Deserialize, Serialize};
-use si_events::VectorClockId;
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::func::FuncKind;
 use crate::workspace_snapshot::content_address::ContentAddressDiscriminants;
-use crate::workspace_snapshot::vector_clock::HasVectorClocks;
+use crate::workspace_snapshot::graph::deprecated::v1::DeprecatedFuncNodeWeightV1;
 use crate::workspace_snapshot::{
     content_address::ContentAddress,
     graph::LineageId,
     node_weight::{NodeWeightError, NodeWeightResult},
-    vector_clock::VectorClock,
 };
 use crate::EdgeWeightKindDiscriminants;
-
-use super::deprecated::DeprecatedFuncNodeWeight;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FuncNodeWeight {
@@ -21,33 +17,26 @@ pub struct FuncNodeWeight {
     pub lineage_id: LineageId,
     content_address: ContentAddress,
     merkle_tree_hash: MerkleTreeHash,
-    vector_clock_first_seen: VectorClock,
-    vector_clock_recently_seen: VectorClock,
-    vector_clock_write: VectorClock,
     name: String,
     func_kind: FuncKind,
 }
 
 impl FuncNodeWeight {
     pub fn new(
-        vector_clock_id: VectorClockId,
         id: Ulid,
         lineage_id: Ulid,
         content_address: ContentAddress,
         name: String,
         func_kind: FuncKind,
-    ) -> NodeWeightResult<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             id,
             lineage_id,
             content_address,
             merkle_tree_hash: MerkleTreeHash::default(),
             name,
             func_kind,
-            vector_clock_first_seen: VectorClock::new(vector_clock_id),
-            vector_clock_recently_seen: VectorClock::new(vector_clock_id),
-            vector_clock_write: VectorClock::new(vector_clock_id),
-        })
+        }
     }
 
     pub fn content_address(&self) -> ContentAddress {
@@ -125,32 +114,6 @@ impl FuncNodeWeight {
     }
 }
 
-impl HasVectorClocks for FuncNodeWeight {
-    fn vector_clock_first_seen(&self) -> &VectorClock {
-        &self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen(&self) -> &VectorClock {
-        &self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write(&self) -> &VectorClock {
-        &self.vector_clock_write
-    }
-
-    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_write
-    }
-}
-
 impl std::fmt::Debug for FuncNodeWeight {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("FuncNodeWeight")
@@ -160,26 +123,17 @@ impl std::fmt::Debug for FuncNodeWeight {
             .field("func_kind", &self.func_kind)
             .field("content_hash", &self.content_hash())
             .field("merkle_tree_hash", &self.merkle_tree_hash)
-            .field("vector_clock_first_seen", &self.vector_clock_first_seen)
-            .field(
-                "vector_clock_recently_seen",
-                &self.vector_clock_recently_seen,
-            )
-            .field("vector_clock_write", &self.vector_clock_write)
             .finish()
     }
 }
 
-impl From<DeprecatedFuncNodeWeight> for FuncNodeWeight {
-    fn from(value: DeprecatedFuncNodeWeight) -> Self {
+impl From<DeprecatedFuncNodeWeightV1> for FuncNodeWeight {
+    fn from(value: DeprecatedFuncNodeWeightV1) -> Self {
         Self {
             id: value.id,
             lineage_id: value.lineage_id,
             content_address: value.content_address,
             merkle_tree_hash: value.merkle_tree_hash,
-            vector_clock_first_seen: VectorClock::empty(),
-            vector_clock_recently_seen: VectorClock::empty(),
-            vector_clock_write: VectorClock::empty(),
             name: value.name,
             func_kind: value.func_kind,
         }

--- a/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
@@ -1,10 +1,9 @@
 use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
-use super::deprecated::DeprecatedOrderingNodeWeight;
 use super::NodeWeightError;
-use crate::workspace_snapshot::vector_clock::{HasVectorClocks, VectorClockId};
-use crate::workspace_snapshot::{node_weight::NodeWeightResult, vector_clock::VectorClock};
+use crate::workspace_snapshot::graph::deprecated::v1::DeprecatedOrderingNodeWeightV1;
+use crate::workspace_snapshot::node_weight::NodeWeightResult;
 use crate::EdgeWeightKindDiscriminants;
 
 #[derive(Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -13,16 +12,12 @@ pub struct OrderingNodeWeight {
     pub lineage_id: Ulid,
     /// The `id` of the items, in the order that they should appear in the container.
     order: Vec<Ulid>,
-    content_hash: ContentHash,
     merkle_tree_hash: MerkleTreeHash,
-    vector_clock_first_seen: VectorClock,
-    vector_clock_recently_seen: VectorClock,
-    vector_clock_write: VectorClock,
 }
 
 impl OrderingNodeWeight {
     pub fn content_hash(&self) -> ContentHash {
-        self.content_hash
+        self.node_hash()
     }
 
     pub fn content_store_hashes(&self) -> Vec<ContentHash> {
@@ -41,23 +36,22 @@ impl OrderingNodeWeight {
         self.merkle_tree_hash
     }
 
-    pub fn new(
-        id: Ulid,
-        lineage_id: Ulid,
-        vector_clock_id: VectorClockId,
-    ) -> NodeWeightResult<Self> {
-        Ok(Self {
+    pub fn new(id: Ulid, lineage_id: Ulid) -> Self {
+        Self {
             id,
             lineage_id,
-            vector_clock_write: VectorClock::new(vector_clock_id),
-            vector_clock_first_seen: VectorClock::new(vector_clock_id),
-            vector_clock_recently_seen: VectorClock::new(vector_clock_id),
             ..Default::default()
-        })
+        }
     }
 
     pub fn node_hash(&self) -> ContentHash {
-        self.content_hash()
+        let mut content_hasher = ContentHash::hasher();
+        for id in &self.order {
+            let bytes = id.inner().to_bytes();
+            content_hasher.update(&bytes);
+        }
+
+        content_hasher.finalize()
     }
 
     pub fn order(&self) -> &Vec<Ulid> {
@@ -68,34 +62,12 @@ impl OrderingNodeWeight {
         self.merkle_tree_hash = new_hash;
     }
 
-    pub fn set_order(&mut self, vector_clock_id: VectorClockId, order: Vec<Ulid>) {
-        self.set_order_without_inc_clocks(order);
-        self.increment_vector_clocks(vector_clock_id);
-    }
-
-    fn set_order_without_inc_clocks(&mut self, order: Vec<Ulid>) {
+    pub fn set_order(&mut self, order: Vec<Ulid>) {
         self.order = order;
-        self.update_content_hash();
     }
 
-    fn update_content_hash(&mut self) {
-        let mut content_hasher = ContentHash::hasher();
-        let concat_elements = self
-            .order
-            .iter()
-            .map(|e| e.to_string())
-            .collect::<Vec<String>>()
-            .join(" ");
-        let content_bytes = concat_elements.as_bytes();
-        content_hasher.update(content_bytes);
-
-        self.content_hash = content_hasher.finalize();
-    }
-
-    pub fn push_to_order(&mut self, vector_clock_id: VectorClockId, id: Ulid) {
-        let mut order = self.order().to_owned();
-        order.push(id);
-        self.set_order(vector_clock_id, order);
+    pub fn push_to_order(&mut self, id: Ulid) {
+        self.order.push(id);
     }
 
     /// Returns `true` if the id passed was actually removed, `false` if not (because not in the order)
@@ -123,32 +95,6 @@ impl OrderingNodeWeight {
     }
 }
 
-impl HasVectorClocks for OrderingNodeWeight {
-    fn vector_clock_first_seen(&self) -> &VectorClock {
-        &self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen(&self) -> &VectorClock {
-        &self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write(&self) -> &VectorClock {
-        &self.vector_clock_write
-    }
-
-    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_write
-    }
-}
-
 impl std::fmt::Debug for OrderingNodeWeight {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("OrderingNodeWeight")
@@ -162,29 +108,19 @@ impl std::fmt::Debug for OrderingNodeWeight {
                     .map(|id| id.to_string())
                     .collect::<Vec<String>>(),
             )
-            .field("content_hash", &self.content_hash)
+            .field("content_hash", &self.content_hash())
             .field("merkle_tree_hash", &self.merkle_tree_hash)
-            .field("vector_clock_first_seen", &self.vector_clock_first_seen)
-            .field(
-                "vector_clock_recently_seen",
-                &self.vector_clock_recently_seen,
-            )
-            .field("vector_clock_write", &self.vector_clock_write)
             .finish()
     }
 }
 
-impl From<DeprecatedOrderingNodeWeight> for OrderingNodeWeight {
-    fn from(value: DeprecatedOrderingNodeWeight) -> Self {
+impl From<DeprecatedOrderingNodeWeightV1> for OrderingNodeWeight {
+    fn from(value: DeprecatedOrderingNodeWeightV1) -> Self {
         Self {
             id: value.id,
             lineage_id: value.lineage_id,
             order: value.order,
-            content_hash: value.content_hash,
             merkle_tree_hash: value.merkle_tree_hash,
-            vector_clock_first_seen: VectorClock::empty(),
-            vector_clock_recently_seen: VectorClock::empty(),
-            vector_clock_write: VectorClock::empty(),
         }
     }
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
@@ -1,21 +1,17 @@
 use serde::{Deserialize, Serialize};
-use si_events::VectorClockId;
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::workspace_snapshot::content_address::ContentAddressDiscriminants;
-use crate::workspace_snapshot::vector_clock::HasVectorClocks;
+use crate::workspace_snapshot::graph::deprecated::v1::DeprecatedPropNodeWeightV1;
 use crate::EdgeWeightKindDiscriminants;
 use crate::{
     workspace_snapshot::{
         content_address::ContentAddress,
         graph::LineageId,
         node_weight::{NodeWeightError, NodeWeightResult},
-        vector_clock::VectorClock,
     },
     PropKind,
 };
-
-use super::deprecated::DeprecatedPropNodeWeight;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PropNodeWeight {
@@ -26,21 +22,17 @@ pub struct PropNodeWeight {
     kind: PropKind,
     name: String,
     can_be_used_as_prototype_arg: bool,
-    vector_clock_first_seen: VectorClock,
-    vector_clock_recently_seen: VectorClock,
-    vector_clock_write: VectorClock,
 }
 
 impl PropNodeWeight {
     pub fn new(
-        vector_clock_id: VectorClockId,
         id: Ulid,
         lineage_id: Ulid,
         content_address: ContentAddress,
         kind: PropKind,
         name: String,
-    ) -> NodeWeightResult<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             id,
             lineage_id,
             content_address,
@@ -48,10 +40,7 @@ impl PropNodeWeight {
             kind,
             name,
             can_be_used_as_prototype_arg: false,
-            vector_clock_first_seen: VectorClock::new(vector_clock_id),
-            vector_clock_recently_seen: VectorClock::new(vector_clock_id),
-            vector_clock_write: VectorClock::new(vector_clock_id),
-        })
+        }
     }
 
     pub fn kind(&self) -> PropKind {
@@ -127,32 +116,6 @@ impl PropNodeWeight {
     }
 }
 
-impl HasVectorClocks for PropNodeWeight {
-    fn vector_clock_first_seen(&self) -> &VectorClock {
-        &self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen(&self) -> &VectorClock {
-        &self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write(&self) -> &VectorClock {
-        &self.vector_clock_write
-    }
-
-    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_write
-    }
-}
-
 impl std::fmt::Debug for PropNodeWeight {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("PropNodeWeight")
@@ -162,18 +125,12 @@ impl std::fmt::Debug for PropNodeWeight {
             .field("name", &self.name)
             .field("content_hash", &self.content_hash())
             .field("merkle_tree_hash", &self.merkle_tree_hash)
-            .field("vector_clock_first_seen", &self.vector_clock_first_seen)
-            .field(
-                "vector_clock_recently_seen",
-                &self.vector_clock_recently_seen,
-            )
-            .field("vector_clock_write", &self.vector_clock_write)
             .finish()
     }
 }
 
-impl From<DeprecatedPropNodeWeight> for PropNodeWeight {
-    fn from(value: DeprecatedPropNodeWeight) -> Self {
+impl From<DeprecatedPropNodeWeightV1> for PropNodeWeight {
+    fn from(value: DeprecatedPropNodeWeightV1) -> Self {
         Self {
             id: value.id,
             lineage_id: value.lineage_id,
@@ -182,9 +139,6 @@ impl From<DeprecatedPropNodeWeight> for PropNodeWeight {
             kind: value.kind,
             name: value.name,
             can_be_used_as_prototype_arg: value.can_be_used_as_prototype_arg,
-            vector_clock_first_seen: VectorClock::empty(),
-            vector_clock_recently_seen: VectorClock::empty(),
-            vector_clock_write: VectorClock::empty(),
         }
     }
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
@@ -1,18 +1,14 @@
 use serde::{Deserialize, Serialize};
-use si_events::VectorClockId;
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash, EncryptedSecretKey};
 
 use crate::workspace_snapshot::content_address::ContentAddressDiscriminants;
-use crate::workspace_snapshot::vector_clock::HasVectorClocks;
+use crate::workspace_snapshot::graph::deprecated::v1::DeprecatedSecretNodeWeightV1;
 use crate::workspace_snapshot::{
     content_address::ContentAddress,
     graph::LineageId,
     node_weight::{NodeWeightError, NodeWeightResult},
-    vector_clock::VectorClock,
 };
 use crate::EdgeWeightKindDiscriminants;
-
-use super::deprecated::DeprecatedSecretNodeWeight;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SecretNodeWeight {
@@ -20,30 +16,23 @@ pub struct SecretNodeWeight {
     pub lineage_id: LineageId,
     content_address: ContentAddress,
     merkle_tree_hash: MerkleTreeHash,
-    vector_clock_first_seen: VectorClock,
-    vector_clock_recently_seen: VectorClock,
-    vector_clock_write: VectorClock,
     encrypted_secret_key: EncryptedSecretKey,
 }
 
 impl SecretNodeWeight {
     pub fn new(
-        vector_clock_id: VectorClockId,
         id: Ulid,
         lineage_id: Ulid,
         content_address: ContentAddress,
         encrypted_secret_key: EncryptedSecretKey,
-    ) -> NodeWeightResult<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             id,
             lineage_id,
             content_address,
             merkle_tree_hash: MerkleTreeHash::default(),
-            vector_clock_first_seen: VectorClock::new(vector_clock_id),
-            vector_clock_recently_seen: VectorClock::new(vector_clock_id),
-            vector_clock_write: VectorClock::new(vector_clock_id),
             encrypted_secret_key,
-        })
+        }
     }
 
     pub fn content_address(&self) -> ContentAddress {
@@ -114,32 +103,6 @@ impl SecretNodeWeight {
     }
 }
 
-impl HasVectorClocks for SecretNodeWeight {
-    fn vector_clock_first_seen(&self) -> &VectorClock {
-        &self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen(&self) -> &VectorClock {
-        &self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write(&self) -> &VectorClock {
-        &self.vector_clock_write
-    }
-
-    fn vector_clock_first_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_first_seen
-    }
-
-    fn vector_clock_recently_seen_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_recently_seen
-    }
-
-    fn vector_clock_write_mut(&mut self) -> &mut VectorClock {
-        &mut self.vector_clock_write
-    }
-}
-
 impl std::fmt::Debug for SecretNodeWeight {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("SecretNodeWeight")
@@ -147,27 +110,18 @@ impl std::fmt::Debug for SecretNodeWeight {
             .field("lineage_id", &self.lineage_id.to_string())
             .field("content_hash", &self.content_hash())
             .field("merkle_tree_hash", &self.merkle_tree_hash)
-            .field("vector_clock_first_seen", &self.vector_clock_first_seen)
-            .field(
-                "vector_clock_recently_seen",
-                &self.vector_clock_recently_seen,
-            )
-            .field("vector_clock_write", &self.vector_clock_write)
             .field("encrypted_secret_key", &self.encrypted_secret_key)
             .finish()
     }
 }
 
-impl From<DeprecatedSecretNodeWeight> for SecretNodeWeight {
-    fn from(value: DeprecatedSecretNodeWeight) -> Self {
+impl From<DeprecatedSecretNodeWeightV1> for SecretNodeWeight {
+    fn from(value: DeprecatedSecretNodeWeightV1) -> Self {
         Self {
             id: value.id,
             lineage_id: value.lineage_id,
             content_address: value.content_address,
             merkle_tree_hash: value.merkle_tree_hash,
-            vector_clock_first_seen: VectorClock::empty(),
-            vector_clock_recently_seen: VectorClock::empty(),
-            vector_clock_write: VectorClock::empty(),
             encrypted_secret_key: value.encrypted_secret_key,
         }
     }

--- a/lib/sdf-server/src/server/service/session/auth_connect.rs
+++ b/lib/sdf-server/src/server/service/session/auth_connect.rs
@@ -108,7 +108,7 @@ async fn find_or_create_user_and_workspace(
                 workspace.set_token(&ctx, auth_api_workspace.token).await?;
             }
 
-            if workspace.snapshot_version() != WorkspaceSnapshotGraphDiscriminants::V1 {
+            if workspace.snapshot_version() != WorkspaceSnapshotGraphDiscriminants::V2 {
                 return Err(SessionError::WorkspaceNotYetMigrated(*workspace.pk()));
             }
 

--- a/lib/si-layer-cache/src/db/serialize.rs
+++ b/lib/si-layer-cache/src/db/serialize.rs
@@ -40,6 +40,7 @@ where
 {
     let uncompressed = miniz_oxide::inflate::decompress_to_vec(bytes)
         .map_err(|e| LayerDbError::Decompress(e.to_string()))?;
+
     Ok(postcard::from_bytes(&uncompressed)?)
 }
 


### PR DESCRIPTION
Vector clocks are no longer used for update detection, so remove them from the graph. Automigrates all snapshots on SDF boot to the new, vector-clock free version.