### PR TITLE
Resolve semantic conflicts

### DIFF
--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -1,0 +1,299 @@
+#![allow(async_fn_in_trait)]
+#![allow(missing_docs)]
+#![allow(clippy::expect_used)]
+
+use std::ops::Deref;
+
+use crate::helpers::ChangeSetTestHelpers;
+use dal::prop::{Prop, PropPath};
+use dal::property_editor::values::PropertyEditorValues;
+use dal::{
+    AttributeValue, AttributeValueId, ChangeSet, ChangeSetId, ComponentId, PropId, SchemaVariantId,
+};
+use dal::{Component, DalContext};
+use serde_json::Value;
+
+///
+/// Things that you can pass as prop paths / ids
+///
+pub trait ExpectPropId {
+    ///
+    /// Turn this into a proper prop id
+    ///
+    async fn expect_prop_id(
+        &self,
+        ctx: &DalContext,
+        schema_variant_id: impl Into<SchemaVariantId>,
+    ) -> PropId;
+}
+impl ExpectPropId for PropId {
+    async fn expect_prop_id(&self, _: &DalContext, _: impl Into<SchemaVariantId>) -> PropId {
+        *self
+    }
+}
+impl ExpectPropId for PropPath {
+    async fn expect_prop_id(
+        &self,
+        ctx: &DalContext,
+        schema_variant_id: impl Into<SchemaVariantId>,
+    ) -> PropId {
+        ExpectProp::find_prop_id_by_path(ctx, schema_variant_id, self).await
+    }
+}
+impl ExpectPropId for &str {
+    async fn expect_prop_id(
+        &self,
+        ctx: &DalContext,
+        schema_variant_id: impl Into<SchemaVariantId>,
+    ) -> PropId {
+        PropPath::new(self.split('/'))
+            .expect_prop_id(ctx, schema_variant_id)
+            .await
+    }
+}
+impl<const N: usize> ExpectPropId for [&str; N] {
+    async fn expect_prop_id(
+        &self,
+        ctx: &DalContext,
+        schema_variant_id: impl Into<SchemaVariantId>,
+    ) -> PropId {
+        PropPath::new(self)
+            .expect_prop_id(ctx, schema_variant_id)
+            .await
+    }
+}
+
+#[derive(Debug)]
+pub struct ExpectComponent;
+
+impl ExpectComponent {
+    pub async fn schema_variant_id(ctx: &DalContext, component_id: ComponentId) -> SchemaVariantId {
+        Component::schema_variant_id(ctx, component_id)
+            .await
+            .expect("find variant id for component")
+    }
+
+    pub async fn prop_id(
+        ctx: &DalContext,
+        component_id: ComponentId,
+        prop: impl ExpectPropId,
+    ) -> PropId {
+        let schema_variant_id = ExpectComponent::schema_variant_id(ctx, component_id).await;
+        prop.expect_prop_id(ctx, schema_variant_id).await
+    }
+
+    pub async fn prop(
+        ctx: &DalContext,
+        component_id: ComponentId,
+        prop: impl ExpectPropId,
+    ) -> ExpectComponentProp {
+        ExpectComponentProp(
+            component_id,
+            ExpectComponent::prop_id(ctx, component_id, prop).await,
+        )
+    }
+
+    pub async fn attribute_values_for_prop_id(
+        ctx: &DalContext,
+        component_id: ComponentId,
+        prop_id: PropId,
+    ) -> Vec<AttributeValueId> {
+        Component::attribute_values_for_prop_id(ctx, component_id, prop_id)
+            .await
+            .expect("able to list prop values")
+    }
+}
+
+#[derive(Debug)]
+pub struct ExpectComponentProp(ComponentId, PropId);
+
+impl ExpectComponentProp {
+    pub fn component_id(&self) -> ComponentId {
+        self.0
+    }
+    pub fn prop_id(&self) -> PropId {
+        self.1
+    }
+    pub async fn attribute_value_id(&self, ctx: &DalContext) -> AttributeValueId {
+        let prop_values = ExpectPropertyEditorValues::assemble(ctx, self.0).await;
+        prop_values
+            .find_by_prop_id(self.1)
+            .expect("able to find prop value")
+    }
+    pub async fn attribute_value(&self, ctx: &DalContext) -> ExpectAttributeValue {
+        let attribute_value_id = self.attribute_value_id(ctx).await;
+        ExpectAttributeValue::get_by_id(ctx, attribute_value_id).await
+    }
+
+    pub async fn get(&self, ctx: &DalContext) -> Value {
+        self.attribute_value(ctx).await.get(ctx).await
+    }
+    pub async fn set(&self, ctx: &DalContext, value: impl Into<Value>) {
+        self.update(ctx, Some(value.into())).await
+    }
+    pub async fn push(&self, ctx: &DalContext, value: impl Into<Value>) -> AttributeValueId {
+        self.insert(ctx, Some(value.into()), None).await
+    }
+    pub async fn child_at(&self, ctx: &DalContext, index: usize) -> ExpectAttributeValue {
+        self.attribute_value(ctx).await.child_at(ctx, index).await
+    }
+    pub async fn remove_child_at(&self, ctx: &DalContext, index: usize) {
+        self.attribute_value(ctx)
+            .await
+            .remove_child_at(ctx, index)
+            .await
+    }
+
+    pub async fn view(&self, ctx: &DalContext) -> Option<Value> {
+        self.attribute_value(ctx).await.view(ctx).await
+    }
+    pub async fn update(&self, ctx: &DalContext, value: Option<Value>) {
+        ExpectAttributeValue::update(ctx, self.attribute_value_id(ctx).await, value).await
+    }
+    pub async fn insert(
+        &self,
+        ctx: &DalContext,
+        value: Option<Value>,
+        key: Option<String>,
+    ) -> AttributeValueId {
+        ExpectAttributeValue::insert(ctx, self.attribute_value_id(ctx).await, value, key).await
+    }
+}
+
+#[derive(Debug)]
+pub struct ExpectAttributeValue(pub AttributeValue);
+
+impl Deref for ExpectAttributeValue {
+    type Target = AttributeValue;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ExpectAttributeValue {
+    pub async fn view(&self, ctx: &DalContext) -> Option<Value> {
+        self.0.view(ctx).await.expect("attribute value view")
+    }
+    pub async fn get(&self, ctx: &DalContext) -> Value {
+        self.view(ctx).await.expect("attribute must have value")
+    }
+    pub async fn child_at(&self, ctx: &DalContext, index: usize) -> ExpectAttributeValue {
+        let child_ids = ExpectAttributeValue::get_child_av_ids_in_order(ctx, self.0.id).await;
+        ExpectAttributeValue::get_by_id(ctx, child_ids[index]).await
+    }
+    pub async fn remove_child_at(&self, ctx: &DalContext, index: usize) {
+        let child_ids = ExpectAttributeValue::get_child_av_ids_in_order(ctx, self.0.id).await;
+        ExpectAttributeValue::remove_by_id(ctx, child_ids[index]).await
+    }
+
+    pub async fn update(
+        ctx: &DalContext,
+        attribute_value_id: AttributeValueId,
+        value: Option<Value>,
+    ) {
+        AttributeValue::update(ctx, attribute_value_id, value)
+            .await
+            .expect("update prop value failed")
+    }
+    pub async fn insert(
+        ctx: &DalContext,
+        attribute_value_id: AttributeValueId,
+        value: Option<Value>,
+        key: Option<String>,
+    ) -> AttributeValueId {
+        AttributeValue::insert(ctx, attribute_value_id, value, key)
+            .await
+            .expect("insert prop value failed")
+    }
+    pub async fn get_by_id(
+        ctx: &DalContext,
+        attribute_value_id: AttributeValueId,
+    ) -> ExpectAttributeValue {
+        ExpectAttributeValue(
+            AttributeValue::get_by_id_or_error(ctx, attribute_value_id)
+                .await
+                .expect("get prop value by id failed"),
+        )
+    }
+    pub async fn get_child_av_ids_in_order(
+        ctx: &DalContext,
+        attribute_value_id: AttributeValueId,
+    ) -> Vec<AttributeValueId> {
+        AttributeValue::get_child_av_ids_in_order(ctx, attribute_value_id)
+            .await
+            .expect("get child av ids in order")
+    }
+    pub async fn remove_by_id(ctx: &DalContext, attribute_value_id: AttributeValueId) {
+        AttributeValue::remove_by_id(ctx, attribute_value_id)
+            .await
+            .expect("remove prop value by id failed")
+    }
+}
+
+#[derive(Debug)]
+pub struct ExpectProp;
+
+impl ExpectProp {
+    pub async fn find_prop_id_by_path(
+        ctx: &DalContext,
+        schema_variant_id: impl Into<SchemaVariantId>,
+        path: &PropPath,
+    ) -> PropId {
+        Prop::find_prop_id_by_path(ctx, schema_variant_id.into(), path)
+            .await
+            .expect("able to find prop")
+    }
+    pub async fn direct_single_child_prop_id(ctx: &DalContext, prop_id: PropId) -> PropId {
+        Prop::direct_single_child_prop_id(ctx, prop_id)
+            .await
+            .expect("able to find element prop")
+    }
+}
+
+#[derive(Debug)]
+pub struct ExpectPropertyEditorValues;
+
+impl ExpectPropertyEditorValues {
+    pub async fn assemble(ctx: &DalContext, id: impl Into<ComponentId>) -> PropertyEditorValues {
+        PropertyEditorValues::assemble(ctx, id.into())
+            .await
+            .expect("able to list prop values")
+    }
+}
+
+pub async fn apply_change_set_to_base(ctx: &mut DalContext) {
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx)
+        .await
+        .expect("could not apply change set to base");
+}
+
+pub async fn fork_from_head_change_set(ctx: &mut DalContext) -> ChangeSet {
+    ChangeSetTestHelpers::fork_from_head_change_set(ctx)
+        .await
+        .expect("fork from head")
+}
+
+pub async fn create_component_for_default_schema_name(
+    ctx: &mut DalContext,
+    schema_name: impl AsRef<str>,
+    name: impl AsRef<str>,
+) -> Component {
+    crate::helpers::create_component_for_default_schema_name(ctx, schema_name, name)
+        .await
+        .expect("could not create component")
+}
+
+pub async fn update_visibility_and_snapshot_to_visibility(
+    ctx: &mut DalContext,
+    change_set_id: ChangeSetId,
+) {
+    ctx.update_visibility_and_snapshot_to_visibility(change_set_id)
+        .await
+        .expect("could not update visibility and snapshot")
+}
+
+pub async fn commit_and_update_snapshot_to_visibility(ctx: &mut DalContext) {
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot")
+}

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -61,7 +61,9 @@ use uuid::Uuid;
 #[allow(clippy::expect_used, clippy::panic)]
 pub mod expand_helpers;
 
+pub mod expected;
 pub mod helpers;
+
 mod signup;
 mod test_exclusive_schemas;
 

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -111,6 +111,7 @@ pub use secret::SecretUpdatedPayload;
 pub use secret::SecretVersion;
 pub use secret::SecretView;
 pub use secret::SecretViewError;
+pub use si_events::WorkspaceSnapshotAddress;
 pub use si_events::{content_hash::ContentHash, ulid::Ulid};
 pub use socket::input::{InputSocket, InputSocketId};
 pub use socket::output::{OutputSocket, OutputSocketId};

--- a/lib/dal/src/workspace_snapshot/graph/correct_transforms.rs
+++ b/lib/dal/src/workspace_snapshot/graph/correct_transforms.rs
@@ -1,0 +1,57 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::workspace_snapshot::node_weight::traits::{CorrectTransforms, CorrectTransformsResult};
+
+use super::{detect_updates::Update, WorkspaceSnapshotGraphV2};
+
+pub fn correct_transforms(
+    graph: &WorkspaceSnapshotGraphV2,
+    mut updates: Vec<Update>,
+) -> CorrectTransformsResult<Vec<Update>> {
+    let mut new_nodes = HashMap::new();
+    let mut nodes_to_interrogate = HashSet::new();
+    for update in &updates {
+        match update {
+            Update::NewEdge {
+                source,
+                destination,
+                ..
+            } => {
+                nodes_to_interrogate.insert(source.id);
+                nodes_to_interrogate.insert(destination.id);
+            }
+            Update::RemoveEdge {
+                source,
+                destination,
+                ..
+            } => {
+                nodes_to_interrogate.insert(source.id);
+                nodes_to_interrogate.insert(destination.id);
+            }
+            Update::NewNode { node_weight } => {
+                new_nodes.insert(node_weight.id(), node_weight.clone());
+                nodes_to_interrogate.insert(node_weight.id().into());
+            }
+            Update::ReplaceNode { node_weight } => {
+                nodes_to_interrogate.insert(node_weight.id().into());
+            }
+        }
+    }
+
+    //
+    // Let each node involved in the updates check for / resolve conflicts.
+    //
+    for node_to_interrogate in nodes_to_interrogate {
+        // If the node weight isn't in the graph, see if it was in a NewNode update and
+        // pass that node weight.
+        let node_index = graph.get_node_index_by_id_opt(node_to_interrogate);
+        if let Some(node_weight) = match node_index {
+            Some(node_index) => graph.get_node_weight_opt(node_index),
+            None => new_nodes.get(&node_to_interrogate.into()),
+        } {
+            updates = node_weight.correct_transforms(graph, updates)?;
+        }
+    }
+
+    Ok(updates)
+}

--- a/lib/dal/src/workspace_snapshot/graph/detect_updates.rs
+++ b/lib/dal/src/workspace_snapshot/graph/detect_updates.rs
@@ -336,7 +336,7 @@ impl<'a, 'b> Detector<'a, 'b> {
     /// Performs a post order walk of the updated graph, finding the updates
     /// made to it when compared to the base graph, using the Merkle tree hash
     /// to detect changes and ignore unchanged branches.
-    pub fn calculate_updates(&self) -> Vec<Update> {
+    pub fn detect_updates(&self) -> Vec<Update> {
         let mut updates = vec![];
         let mut difference_cache = HashMap::new();
 

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -4,13 +4,17 @@ use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash, EncryptedSecretKey};
 use strum::EnumDiscriminants;
 use thiserror::Error;
+use traits::{CorrectTransforms, CorrectTransformsResult};
 
-use crate::EdgeWeightKindDiscriminants;
 use crate::{
     action::prototype::ActionKind,
-    workspace_snapshot::{content_address::ContentAddress, vector_clock::VectorClockError},
+    workspace_snapshot::{
+        content_address::{ContentAddress, ContentAddressDiscriminants},
+        vector_clock::VectorClockError,
+    },
     ChangeSetId, PropKind,
 };
+use crate::{EdgeWeightKindDiscriminants, WorkspaceSnapshotGraphV2};
 
 use crate::func::FuncKind;
 use crate::workspace_snapshot::graph::LineageId;
@@ -29,8 +33,8 @@ pub use func_node_weight::FuncNodeWeight;
 pub use ordering_node_weight::OrderingNodeWeight;
 pub use prop_node_weight::PropNodeWeight;
 
-use super::content_address::ContentAddressDiscriminants;
 use super::graph::deprecated::v1::DeprecatedNodeWeightV1;
+use super::graph::detect_updates::Update;
 
 pub mod action_node_weight;
 pub mod action_prototype_node_weight;
@@ -45,6 +49,7 @@ pub mod func_node_weight;
 pub mod ordering_node_weight;
 pub mod prop_node_weight;
 pub mod secret_node_weight;
+pub mod traits;
 
 pub mod deprecated;
 
@@ -678,6 +683,56 @@ impl From<DeprecatedNodeWeightV1> for NodeWeight {
             DeprecatedNodeWeightV1::Secret(weight) => Self::Secret(weight.into()),
             DeprecatedNodeWeightV1::DependentValueRoot(weight) => {
                 Self::DependentValueRoot(weight.into())
+            }
+        }
+    }
+}
+
+impl CorrectTransforms for NodeWeight {
+    fn correct_transforms(
+        &self,
+        workspace_snapshot_graph: &WorkspaceSnapshotGraphV2,
+        updates: Vec<Update>,
+    ) -> CorrectTransformsResult<Vec<Update>> {
+        match self {
+            NodeWeight::Action(weight) => {
+                weight.correct_transforms(workspace_snapshot_graph, updates)
+            }
+            NodeWeight::ActionPrototype(weight) => {
+                weight.correct_transforms(workspace_snapshot_graph, updates)
+            }
+            NodeWeight::AttributePrototypeArgument(weight) => {
+                weight.correct_transforms(workspace_snapshot_graph, updates)
+            }
+            NodeWeight::AttributeValue(weight) => {
+                weight.correct_transforms(workspace_snapshot_graph, updates)
+            }
+            NodeWeight::Category(weight) => {
+                weight.correct_transforms(workspace_snapshot_graph, updates)
+            }
+            NodeWeight::Component(weight) => {
+                weight.correct_transforms(workspace_snapshot_graph, updates)
+            }
+            NodeWeight::Content(weight) => {
+                weight.correct_transforms(workspace_snapshot_graph, updates)
+            }
+            NodeWeight::DependentValueRoot(weight) => {
+                weight.correct_transforms(workspace_snapshot_graph, updates)
+            }
+            NodeWeight::Func(weight) => {
+                weight.correct_transforms(workspace_snapshot_graph, updates)
+            }
+            NodeWeight::FuncArgument(weight) => {
+                weight.correct_transforms(workspace_snapshot_graph, updates)
+            }
+            NodeWeight::Ordering(weight) => {
+                weight.correct_transforms(workspace_snapshot_graph, updates)
+            }
+            NodeWeight::Prop(weight) => {
+                weight.correct_transforms(workspace_snapshot_graph, updates)
+            }
+            NodeWeight::Secret(weight) => {
+                weight.correct_transforms(workspace_snapshot_graph, updates)
             }
         }
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
@@ -4,6 +4,7 @@ use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 use crate::{
     action::ActionState,
     workspace_snapshot::graph::{deprecated::v1::DeprecatedActionNodeWeightV1, LineageId},
+    workspace_snapshot::node_weight::traits::CorrectTransforms,
     ChangeSetId, EdgeWeightKindDiscriminants,
 };
 
@@ -88,3 +89,5 @@ impl From<DeprecatedActionNodeWeightV1> for ActionNodeWeight {
         }
     }
 }
+
+impl CorrectTransforms for ActionNodeWeight {}

--- a/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
@@ -4,6 +4,7 @@ use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 use crate::{
     action::prototype::ActionKind,
     workspace_snapshot::graph::{deprecated::v1::DeprecatedActionPrototypeNodeWeightV1, LineageId},
+    workspace_snapshot::node_weight::traits::CorrectTransforms,
     EdgeWeightKindDiscriminants,
 };
 
@@ -102,3 +103,5 @@ impl From<DeprecatedActionPrototypeNodeWeightV1> for ActionPrototypeNodeWeight {
         }
     }
 }
+
+impl CorrectTransforms for ActionPrototypeNodeWeight {}

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
@@ -5,6 +5,7 @@ use crate::{
     workspace_snapshot::graph::{
         deprecated::v1::DeprecatedAttributePrototypeArgumentNodeWeightV1, LineageId,
     },
+    workspace_snapshot::node_weight::traits::CorrectTransforms,
     ComponentId, EdgeWeightKindDiscriminants, Timestamp,
 };
 
@@ -115,3 +116,5 @@ impl From<DeprecatedAttributePrototypeArgumentNodeWeightV1>
         }
     }
 }
+
+impl CorrectTransforms for AttributePrototypeArgumentNodeWeight {}

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -5,6 +5,7 @@ use crate::{
     workspace_snapshot::{
         content_address::ContentAddress,
         graph::{deprecated::v1::DeprecatedAttributeValueNodeWeightV1, LineageId},
+        node_weight::traits::CorrectTransforms,
     },
     EdgeWeightKindDiscriminants,
 };
@@ -128,3 +129,5 @@ impl From<DeprecatedAttributeValueNodeWeightV1> for AttributeValueNodeWeight {
         }
     }
 }
+
+impl CorrectTransforms for AttributeValueNodeWeight {}

--- a/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
@@ -4,6 +4,7 @@ use strum::{Display, EnumIter};
 
 use crate::workspace_snapshot::graph::deprecated::v1::DeprecatedCategoryNodeWeightV1;
 use crate::workspace_snapshot::graph::LineageId;
+use crate::workspace_snapshot::node_weight::traits::CorrectTransforms;
 use crate::EdgeWeightKindDiscriminants;
 
 /// NOTE: adding new categories can be done in a backwards compatible way, so long as we don't
@@ -99,3 +100,5 @@ impl From<DeprecatedCategoryNodeWeightV1> for CategoryNodeWeight {
         }
     }
 }
+
+impl CorrectTransforms for CategoryNodeWeight {}

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -5,6 +5,7 @@ use crate::{
     workspace_snapshot::{
         content_address::{ContentAddress, ContentAddressDiscriminants},
         graph::{deprecated::v1::DeprecatedComponentNodeWeightV1, LineageId},
+        node_weight::traits::CorrectTransforms,
     },
     EdgeWeightKindDiscriminants,
 };
@@ -118,3 +119,5 @@ impl From<DeprecatedComponentNodeWeightV1> for ComponentNodeWeight {
         }
     }
 }
+
+impl CorrectTransforms for ComponentNodeWeight {}

--- a/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
@@ -7,6 +7,7 @@ use crate::workspace_snapshot::graph::deprecated::v1::DeprecatedContentNodeWeigh
 use crate::workspace_snapshot::{
     content_address::ContentAddress,
     graph::LineageId,
+    node_weight::traits::CorrectTransforms,
     node_weight::{NodeWeightError, NodeWeightResult},
 };
 use crate::EdgeWeightKindDiscriminants;
@@ -165,3 +166,5 @@ impl From<DeprecatedContentNodeWeightV1> for ContentNodeWeight {
         }
     }
 }
+
+impl CorrectTransforms for ContentNodeWeight {}

--- a/lib/dal/src/workspace_snapshot/node_weight/dependent_value_root_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/dependent_value_root_node_weight.rs
@@ -3,7 +3,7 @@ use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::{
     workspace_snapshot::graph::deprecated::v1::DeprecatedDependentValueRootNodeWeightV1,
-    EdgeWeightKindDiscriminants,
+    workspace_snapshot::node_weight::traits::CorrectTransforms, EdgeWeightKindDiscriminants,
 };
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -84,3 +84,5 @@ impl From<DeprecatedDependentValueRootNodeWeightV1> for DependentValueRootNodeWe
         }
     }
 }
+
+impl CorrectTransforms for DependentValueRootNodeWeight {}

--- a/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
@@ -5,6 +5,7 @@ use crate::{
     workspace_snapshot::{
         content_address::{ContentAddress, ContentAddressDiscriminants},
         graph::{deprecated::v1::DeprecatedFuncArgumentNodeWeightV1, LineageId},
+        node_weight::traits::CorrectTransforms,
         node_weight::NodeWeightResult,
         NodeWeightError,
     },
@@ -119,3 +120,5 @@ impl From<DeprecatedFuncArgumentNodeWeightV1> for FuncArgumentNodeWeight {
         }
     }
 }
+
+impl CorrectTransforms for FuncArgumentNodeWeight {}

--- a/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
@@ -7,6 +7,7 @@ use crate::workspace_snapshot::graph::deprecated::v1::DeprecatedFuncNodeWeightV1
 use crate::workspace_snapshot::{
     content_address::ContentAddress,
     graph::LineageId,
+    node_weight::traits::CorrectTransforms,
     node_weight::{NodeWeightError, NodeWeightResult},
 };
 use crate::EdgeWeightKindDiscriminants;
@@ -139,3 +140,5 @@ impl From<DeprecatedFuncNodeWeightV1> for FuncNodeWeight {
         }
     }
 }
+
+impl CorrectTransforms for FuncNodeWeight {}

--- a/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
@@ -8,6 +8,7 @@ use crate::{
     workspace_snapshot::{
         content_address::ContentAddress,
         graph::LineageId,
+        node_weight::traits::CorrectTransforms,
         node_weight::{NodeWeightError, NodeWeightResult},
     },
     PropKind,
@@ -142,3 +143,5 @@ impl From<DeprecatedPropNodeWeightV1> for PropNodeWeight {
         }
     }
 }
+
+impl CorrectTransforms for PropNodeWeight {}

--- a/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
@@ -6,6 +6,7 @@ use crate::workspace_snapshot::graph::deprecated::v1::DeprecatedSecretNodeWeight
 use crate::workspace_snapshot::{
     content_address::ContentAddress,
     graph::LineageId,
+    node_weight::traits::CorrectTransforms,
     node_weight::{NodeWeightError, NodeWeightResult},
 };
 use crate::EdgeWeightKindDiscriminants;
@@ -126,3 +127,5 @@ impl From<DeprecatedSecretNodeWeightV1> for SecretNodeWeight {
         }
     }
 }
+
+impl CorrectTransforms for SecretNodeWeight {}

--- a/lib/dal/src/workspace_snapshot/node_weight/traits.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/traits.rs
@@ -1,0 +1,22 @@
+use crate::{workspace_snapshot::graph::detect_updates::Update, WorkspaceSnapshotGraphV2};
+use thiserror::Error;
+
+use super::NodeWeightDiscriminants;
+
+#[derive(Debug, Error)]
+pub enum CorrectTransformsError {
+    #[error("expected a node weight of kind {0} but got another, or none")]
+    UnexpectedNodeWeight(NodeWeightDiscriminants),
+}
+
+pub type CorrectTransformsResult<T> = Result<T, CorrectTransformsError>;
+
+pub trait CorrectTransforms {
+    fn correct_transforms(
+        &self,
+        _workspace_snapshot_graph: &WorkspaceSnapshotGraphV2,
+        updates: Vec<Update>,
+    ) -> CorrectTransformsResult<Vec<Update>> {
+        Ok(updates)
+    }
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -11,6 +11,7 @@ mod frame;
 mod func;
 mod input_sources;
 mod module;
+mod node_weight;
 mod pkg;
 mod prop;
 mod property_editor;

--- a/lib/dal/tests/integration_test/node_weight.rs
+++ b/lib/dal/tests/integration_test/node_weight.rs
@@ -1,0 +1,1 @@
+mod ordering;

--- a/lib/dal/tests/integration_test/node_weight/ordering.rs
+++ b/lib/dal/tests/integration_test/node_weight/ordering.rs
@@ -1,0 +1,162 @@
+use dal::DalContext;
+use dal_test::expected::{self, ExpectComponent};
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+use serde_json::json;
+
+//
+// Expecteds
+//
+// | Graph               | Updates             |
+// |---------------------|---------------------|
+// |                     | removed ordering    | node is removed
+// | removed ordering    | removed ordering    | node is removed
+// |                     | added   ordering    | node is added
+// | add+remove ordinals | add/remove ordinals | new edge should
+
+#[test]
+async fn correct_transforms_no_corrections(ctx: &mut DalContext) {
+    //
+    // Make a docker image with two ExposedPorts
+    //
+    let component =
+        expected::create_component_for_default_schema_name(ctx, "Docker Image", "a tulip in a cup")
+            .await;
+    let exposed_ports =
+        ExpectComponent::prop(ctx, component.id(), "root/domain/ExposedPorts").await;
+    exposed_ports.push(ctx, "1").await;
+    exposed_ports.push(ctx, "2").await;
+    assert_eq!(json!(["1", "2"]), exposed_ports.get(ctx).await);
+    expected::apply_change_set_to_base(ctx).await;
+
+    // Add 3, 4 and apply
+    expected::fork_from_head_change_set(ctx).await;
+    exposed_ports.push(ctx, "3").await;
+    exposed_ports.push(ctx, "4").await;
+    expected::apply_change_set_to_base(ctx).await;
+
+    // Remove all edges and apply
+    expected::fork_from_head_change_set(ctx).await;
+    exposed_ports.update(ctx, None).await;
+    expected::apply_change_set_to_base(ctx).await;
+
+    assert_eq!(exposed_ports.view(ctx).await, None);
+}
+
+#[test]
+async fn correct_transforms_added_edges(ctx: &mut DalContext) {
+    // Make a docker image with ExposedPorts = 1, 22, and 33
+    let component =
+        expected::create_component_for_default_schema_name(ctx, "Docker Image", "a tulip in a cup")
+            .await;
+    let exposed_ports =
+        ExpectComponent::prop(ctx, component.id(), ["root", "domain", "ExposedPorts"]).await;
+    exposed_ports.push(ctx, "1").await;
+    expected::apply_change_set_to_base(ctx).await;
+    assert_eq!(json!(["1"]), exposed_ports.get(ctx).await);
+
+    // Fork a change set, remove 22 and add 2
+    let change_set_2 = expected::fork_from_head_change_set(ctx).await;
+    exposed_ports.push(ctx, "2").await;
+    expected::commit_and_update_snapshot_to_visibility(ctx).await;
+    assert_eq!(json!(["1", "2"]), exposed_ports.get(ctx).await);
+
+    // Fork a separate change set, remove 33 and add 3
+    let change_set_3 = expected::fork_from_head_change_set(ctx).await;
+    exposed_ports.push(ctx, "3").await;
+    expected::commit_and_update_snapshot_to_visibility(ctx).await;
+    assert_eq!(json!(["1", "3"]), exposed_ports.get(ctx).await);
+
+    // Apply both changesets
+    expected::update_visibility_and_snapshot_to_visibility(ctx, change_set_2.id).await;
+    assert_eq!(json!(["1", "2"]), exposed_ports.get(ctx).await);
+    expected::apply_change_set_to_base(ctx).await;
+
+    expected::update_visibility_and_snapshot_to_visibility(ctx, change_set_3.id).await;
+    assert_eq!(json!(["1", "2", "3"]), exposed_ports.get(ctx).await);
+}
+
+#[test]
+async fn correct_transforms_removed_edges(ctx: &mut DalContext) {
+    // Make a docker image with ExposedPorts = 1, 22, and 33
+    let component =
+        expected::create_component_for_default_schema_name(ctx, "Docker Image", "a tulip in a cup")
+            .await;
+    let exposed_ports =
+        ExpectComponent::prop(ctx, component.id(), ["root", "domain", "ExposedPorts"]).await;
+    exposed_ports.push(ctx, "1").await;
+    exposed_ports.push(ctx, "33").await;
+    exposed_ports.push(ctx, "22").await;
+    expected::apply_change_set_to_base(ctx).await;
+    assert_eq!(json!(["1", "33", "22"]), exposed_ports.get(ctx).await);
+
+    // Fork a change set, remove 22 and add 2
+    let change_set_2 = expected::fork_from_head_change_set(ctx).await;
+    exposed_ports.remove_child_at(ctx, 2).await;
+    expected::commit_and_update_snapshot_to_visibility(ctx).await;
+    assert_eq!(json!(["1", "33"]), exposed_ports.get(ctx).await);
+
+    // Fork a separate change set, remove 33 and add 3
+    let change_set_3 = expected::fork_from_head_change_set(ctx).await;
+    exposed_ports.remove_child_at(ctx, 1).await;
+    expected::commit_and_update_snapshot_to_visibility(ctx).await;
+    assert_eq!(json!(["1", "22"]), dbg!(exposed_ports.get(ctx).await));
+
+    // Apply both changesets
+    expected::update_visibility_and_snapshot_to_visibility(ctx, change_set_2.id).await;
+    assert_eq!(json!(["1", "33"]), exposed_ports.get(ctx).await);
+    expected::apply_change_set_to_base(ctx).await;
+    assert_eq!(json!(["1", "33"]), exposed_ports.get(ctx).await);
+
+    expected::update_visibility_and_snapshot_to_visibility(ctx, change_set_3.id).await;
+    // 22 was removed in change set 2, which was applied, so we're down to one
+    assert_eq!(json!(["1"]), exposed_ports.get(ctx).await);
+    expected::apply_change_set_to_base(ctx).await;
+
+    // 33 was removed in change set 3, so we end up with just "1"
+    assert_eq!(json!(["1"]), exposed_ports.get(ctx).await);
+}
+
+#[test]
+async fn correct_transforms_both_added_and_removed_edges(ctx: &mut DalContext) {
+    // Make a docker image with ExposedPorts = 1, 22, and 33
+    let component =
+        expected::create_component_for_default_schema_name(ctx, "Docker Image", "a tulip in a cup")
+            .await;
+    let exposed_ports =
+        ExpectComponent::prop(ctx, component.id(), ["root", "domain", "ExposedPorts"]).await;
+    exposed_ports.push(ctx, "1").await;
+    exposed_ports.push(ctx, "33").await;
+    exposed_ports.push(ctx, "22").await;
+    expected::apply_change_set_to_base(ctx).await;
+    assert_eq!(json!(["1", "33", "22"]), exposed_ports.get(ctx).await);
+
+    // Fork a change set, remove 22 and add 2
+    let change_set_2 = expected::fork_from_head_change_set(ctx).await;
+    // Add "2" and remove "22"
+    exposed_ports.push(ctx, "2").await;
+    exposed_ports.remove_child_at(ctx, 2).await;
+    expected::commit_and_update_snapshot_to_visibility(ctx).await;
+    assert_eq!(json!(["1", "33", "2"]), exposed_ports.get(ctx).await);
+
+    // Fork a separate change set, remove 33 and add 3
+    let change_set_3 = expected::fork_from_head_change_set(ctx).await;
+    // Add "3" and remove "33"
+    exposed_ports.push(ctx, "3").await;
+    exposed_ports.remove_child_at(ctx, 1).await;
+    expected::commit_and_update_snapshot_to_visibility(ctx).await;
+    assert_eq!(json!(["1", "22", "3"]), exposed_ports.get(ctx).await);
+
+    // Apply both changesets
+    expected::update_visibility_and_snapshot_to_visibility(ctx, change_set_2.id).await;
+    assert_eq!(json!(["1", "33", "2"]), exposed_ports.get(ctx).await);
+    expected::apply_change_set_to_base(ctx).await;
+
+    expected::update_visibility_and_snapshot_to_visibility(ctx, change_set_3.id).await;
+    // The removal of "22" from the applied change set above will be reflected
+    // in the change set, and the addition of "2" will come in
+    assert_eq!(json!(["1", "2", "3"]), exposed_ports.get(ctx).await);
+    expected::apply_change_set_to_base(ctx).await;
+
+    assert_eq!(json!(["1", "2", "3"]), exposed_ports.get(ctx).await);
+}

--- a/lib/rebaser-server/src/rebase.rs
+++ b/lib/rebaser-server/src/rebase.rs
@@ -99,13 +99,18 @@ pub async fn perform_rebase(
     );
     debug!("after snapshot fetch and parse: {:?}", start.elapsed());
 
+    let corrected_updates = to_rebase_workspace_snapshot
+        .correct_transforms(rebase_batch.updates().to_vec())
+        .await?;
+    debug!("corrected transforms: {:?}", start.elapsed());
+
     to_rebase_workspace_snapshot
-        .perform_updates(rebase_batch.updates())
+        .perform_updates(&corrected_updates)
         .await?;
 
     debug!("updates complete: {:?}", start.elapsed());
 
-    if !rebase_batch.updates().is_empty() {
+    if !corrected_updates.is_empty() {
         // Once all updates have been performed, we can write out, mark everything as recently seen
         // and update the pointer.
         to_rebase_workspace_snapshot.write(ctx).await?;


### PR DESCRIPTION
This adds a framework designed by @jhelwig for us to detect when graph merges will create nonsensical results, and smooth them out. When we receive a set of OTs (updates) to apply to our branch, we ask the relevant nodes in our graph whether the set of updates makes sense, and give them a chance to massage the updates (modify, add, remove, etc.) until it generates a consistent graph.

The `CorrectTransforms` trait, implemented by all NodeWeights, is where the code for correcting transforms/updates goes. It is passed the entire set of updates and must return the set of updates (if there are no changes, it must return the updates unchanged).

Right now, the only conflict we're resolving is the `Ordering` node, which determines the order of values in an array value. If two people add ports to a docker image's `ExposedPorts` in a short time, this code will try to honor both of their choices, producing an array with both ports added.

This PR also adds the `expected` module for DAL testing, which eliminates a lot of the boilerplate `expect` calls in our tests. Most of these calls aren't the actual thing we're trying to test, and they took up a lot of extra horizontal and vertical space (often on their own line). At least for me, the noise was high enough that it made it harder to figure out what the test was actually testing :) In the tests I added, `expected` stuff cut the lines of code per test by more than half (probably 2/3 or so at a rough estimate).
