### PR TITLE
fix: correctly parse json results in component toolbox

### DIFF
--- a/component/toolbox/scripts/supporting-funcs/inputs-funcs.sh
+++ b/component/toolbox/scripts/supporting-funcs/inputs-funcs.sh
@@ -65,7 +65,7 @@ concat_and_output_json() {
   if [ -d "$results_directory/" ]; then
     # Aggregate all the individual json documents into one
     # shellcheck disable=SC2002
-    cat "${results_directory}/*" | jq -s '.' >>"$results_directory/$output_file"
+    jq -s '.' "${results_directory}"/* >>"${results_directory}/${output_file}"
     # shellcheck disable=SC2002
     cat "$results_directory/$output_file" | jq
     echo "----------------------------------------"


### PR DESCRIPTION
There was an issue with quoting around the cat glob which prevented the results being parsed correctly. This amends it and also appeases the shellcheck gods by not going from cat -> jq