### PR TITLE
fix(dal): components can only have one parent

### DIFF
--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -79,6 +79,15 @@ pub struct NodeInformation {
     pub id: NodeId,
 }
 
+impl From<&NodeWeight> for NodeInformation {
+    fn from(node_weight: &NodeWeight) -> Self {
+        Self {
+            node_weight_kind: node_weight.into(),
+            id: node_weight.id().into(),
+        }
+    }
+}
+
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum WorkspaceSnapshotError {

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -1,16 +1,23 @@
+use petgraph::{visit::EdgeRef, Direction::Incoming};
 use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::{
     workspace_snapshot::{
         content_address::{ContentAddress, ContentAddressDiscriminants},
-        graph::{deprecated::v1::DeprecatedComponentNodeWeightV1, LineageId},
+        graph::{
+            deprecated::v1::DeprecatedComponentNodeWeightV1, detect_updates::Update, LineageId,
+        },
         node_weight::traits::CorrectTransforms,
+        NodeInformation,
     },
-    EdgeWeightKindDiscriminants,
+    EdgeWeightKindDiscriminants, WorkspaceSnapshotGraphV2,
 };
 
-use super::{NodeWeightError, NodeWeightResult};
+use super::{
+    traits::CorrectTransformsResult, NodeWeightDiscriminants::Component, NodeWeightError,
+    NodeWeightResult,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ComponentNodeWeight {
@@ -120,4 +127,111 @@ impl From<DeprecatedComponentNodeWeightV1> for ComponentNodeWeight {
     }
 }
 
-impl CorrectTransforms for ComponentNodeWeight {}
+impl From<&ComponentNodeWeight> for NodeInformation {
+    fn from(value: &ComponentNodeWeight) -> Self {
+        Self {
+            node_weight_kind: Component,
+            id: value.id.into(),
+        }
+    }
+}
+
+impl CorrectTransforms for ComponentNodeWeight {
+    fn correct_transforms(
+        &self,
+        graph: &WorkspaceSnapshotGraphV2,
+        mut updates: Vec<Update>,
+    ) -> CorrectTransformsResult<Vec<Update>> {
+        let mut valid_frame_contains_source = None;
+        let mut existing_remove_edges = vec![];
+        let mut updates_to_remove = vec![];
+
+        for (i, update) in updates.iter().enumerate() {
+            match update {
+                Update::NewEdge {
+                    source,
+                    destination,
+                    edge_weight,
+                } => {
+                    // If we get more than one frame contains edge in the set of
+                    // updates we will pick the last one. Although there should
+                    // never be more than one in a single batch, this makes it
+                    // resilient against replaying multiple transform batches
+                    // (in order). Last one wins!
+                    if destination.id.into_inner() == self.id.inner()
+                        && EdgeWeightKindDiscriminants::FrameContains == edge_weight.kind().into()
+                    {
+                        valid_frame_contains_source = match valid_frame_contains_source {
+                            None => Some((i, source.id)),
+                            Some((last_index, _)) => {
+                                updates_to_remove.push(last_index);
+                                Some((i, source.id))
+                            }
+                        }
+                    }
+                }
+                Update::RemoveEdge {
+                    source,
+                    destination,
+                    edge_kind,
+                } => {
+                    if edge_kind == &EdgeWeightKindDiscriminants::FrameContains
+                        && destination.id.into_inner() == self.id.inner()
+                    {
+                        if let Some(source_index) =
+                            graph.get_node_index_by_id_opt(source.id.into_inner())
+                        {
+                            existing_remove_edges.push(source_index);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if !updates_to_remove.is_empty() {
+            let mut idx = 0;
+            // Vec::remove is O(n) for the updates, which will likely always be
+            // > than the size of updates_to_remove
+            updates.retain(|_| {
+                let should_retain = !updates_to_remove.contains(&idx);
+                idx += 1;
+                should_retain
+            })
+        }
+
+        // Add updates to remove any incoming FrameContains edges that don't
+        // have the source in valid_frame_contains_source. This ensures a
+        // component can only have one frame parent
+        if let Some((_, valid_frame_contains_source)) = valid_frame_contains_source {
+            if let (Some(valid_source), Some(self_index)) = (
+                graph.get_node_index_by_id_opt(valid_frame_contains_source),
+                graph.get_node_index_by_id_opt(self.id),
+            ) {
+                updates.extend(
+                    graph
+                        .edges_directed(self_index, Incoming)
+                        // We only want to find incoming FrameContains edges
+                        // that  are not from the current valid source
+                        .filter(|edge_ref| {
+                            EdgeWeightKindDiscriminants::FrameContains
+                                == edge_ref.weight().kind().into()
+                                && edge_ref.source() != valid_source
+                                && !existing_remove_edges.contains(&edge_ref.source())
+                        })
+                        .filter_map(|edge_ref| {
+                            graph
+                                .get_node_weight_opt(edge_ref.source())
+                                .map(|source_weight| Update::RemoveEdge {
+                                    source: source_weight.into(),
+                                    destination: self.into(),
+                                    edge_kind: EdgeWeightKindDiscriminants::FrameContains,
+                                })
+                        }),
+                );
+            }
+        }
+
+        Ok(updates)
+    }
+}

--- a/lib/dal/tests/integration_test/node_weight.rs
+++ b/lib/dal/tests/integration_test/node_weight.rs
@@ -1,1 +1,2 @@
+mod component;
 mod ordering;

--- a/lib/dal/tests/integration_test/node_weight/component.rs
+++ b/lib/dal/tests/integration_test/node_weight/component.rs
@@ -1,0 +1,150 @@
+use dal::component::frame::Frame;
+use dal::{Component, DalContext};
+use dal_test::expected::{self, create_component_for_default_schema_name};
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn component_can_only_have_one_parent(ctx: &mut DalContext) {
+    let child_one =
+        create_component_for_default_schema_name(ctx, "small even lego", "child component").await;
+
+    let frame_one =
+        create_component_for_default_schema_name(ctx, "small odd lego", "frame one").await;
+
+    let frame_two =
+        create_component_for_default_schema_name(ctx, "small odd lego", "frame two").await;
+
+    expected::apply_change_set_to_base(ctx).await;
+
+    for id in [child_one.id(), frame_one.id(), frame_two.id()] {
+        Component::get_by_id(ctx, id)
+            .await
+            .expect("component should exist in head");
+    }
+
+    assert_eq!(
+        None,
+        Component::get_parent_by_id(ctx, child_one.id())
+            .await
+            .expect("should not fail"),
+        "should not have a parent at first"
+    );
+
+    let change_set_1 = expected::fork_from_head_change_set(ctx).await;
+    Frame::upsert_parent(ctx, child_one.id(), frame_one.id())
+        .await
+        .expect("attach child to frame one");
+    expected::commit_and_update_snapshot_to_visibility(ctx).await;
+    assert_eq!(
+        Some(frame_one.id()),
+        Component::get_parent_by_id(ctx, child_one.id())
+            .await
+            .expect("get parent by id succeeds")
+    );
+
+    let _change_set_2 = expected::fork_from_head_change_set(ctx).await;
+    Frame::upsert_parent(ctx, child_one.id(), frame_two.id())
+        .await
+        .expect("attach child to frame one");
+    expected::commit_and_update_snapshot_to_visibility(ctx).await;
+    assert_eq!(
+        Some(frame_two.id()),
+        Component::get_parent_by_id(ctx, child_one.id())
+            .await
+            .expect("get parent by id succeeds")
+    );
+
+    // apply change set 2 to head
+    expected::apply_change_set_to_base(ctx).await;
+    assert_eq!(
+        Some(frame_two.id()),
+        Component::get_parent_by_id(ctx, child_one.id())
+            .await
+            .expect("get parent by id succeeds")
+    );
+
+    // switch to change set 1, and see that the component has been reparented
+    expected::update_visibility_and_snapshot_to_visibility(ctx, change_set_1.id).await;
+    assert_eq!(
+        Some(frame_two.id()),
+        Component::get_parent_by_id(ctx, child_one.id())
+            .await
+            .expect("get parent by id succeeds")
+    );
+
+    Frame::upsert_parent(ctx, child_one.id(), frame_one.id())
+        .await
+        .expect("reattach child to frame one");
+    assert_eq!(
+        Some(frame_one.id()),
+        Component::get_parent_by_id(ctx, child_one.id())
+            .await
+            .expect("get parent by id succeeds")
+    );
+    // apply change set 1 to head
+    expected::apply_change_set_to_base(ctx).await;
+    assert_eq!(
+        Some(frame_one.id()),
+        Component::get_parent_by_id(ctx, child_one.id())
+            .await
+            .expect("get parent by id succeeds")
+    );
+
+    // Both change sets have been applied, so they will stop receiving updates from head
+
+    let change_set_3 = expected::fork_from_head_change_set(ctx).await;
+    assert_eq!(
+        Some(frame_one.id()),
+        Component::get_parent_by_id(ctx, child_one.id())
+            .await
+            .expect("get parent by id succeeds")
+    );
+
+    // Move the child into frame two in change set 3
+    Frame::upsert_parent(ctx, child_one.id(), frame_two.id())
+        .await
+        .expect("reattach child to frame one");
+
+    expected::commit_and_update_snapshot_to_visibility(ctx).await;
+
+    let _change_set_4 = expected::fork_from_head_change_set(ctx).await;
+    assert_eq!(
+        Some(frame_one.id()),
+        Component::get_parent_by_id(ctx, child_one.id())
+            .await
+            .expect("get parent by id succeeds")
+    );
+
+    // Orphan child in change set 4
+    Frame::orphan_child(ctx, child_one.id())
+        .await
+        .expect("able to orphan child");
+
+    expected::apply_change_set_to_base(ctx).await;
+    assert_eq!(
+        None,
+        Component::get_parent_by_id(ctx, child_one.id())
+            .await
+            .expect("get parent by id succeeds")
+    );
+
+    expected::update_visibility_and_snapshot_to_visibility(ctx, change_set_3.id).await;
+    // despite being orphaned in change set 4, and head, we are not orphaned in
+    // 3 because the 4 and head did not know about the frame relationship in 3
+    assert_eq!(
+        Some(frame_two.id()),
+        Component::get_parent_by_id(ctx, child_one.id())
+            .await
+            .expect("get parent by id succeeds")
+    );
+
+    expected::apply_change_set_to_base(ctx).await;
+
+    assert_eq!(
+        Some(frame_two.id()),
+        Component::get_parent_by_id(ctx, child_one.id())
+            .await
+            .expect("get parent by id succeeds")
+    );
+}


### PR DESCRIPTION
Corrects the FrameContains NewEdge transforms to ensure a component can only have one frame parent at a time.