### PR TITLE
fix(dal): deleting a component removes dangling apas

### DIFF
--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -994,6 +994,11 @@ impl WorkspaceSnapshotGraphV2 {
             .ok_or(WorkspaceSnapshotGraphError::NodeWeightNotFound)
     }
 
+    pub fn get_node_weight_by_id_opt(&self, id: impl Into<Ulid>) -> Option<&NodeWeight> {
+        self.get_node_index_by_id_opt(id)
+            .and_then(|index| self.get_node_weight_opt(index))
+    }
+
     fn get_node_weight_mut(
         &mut self,
         node_index: NodeIndex,


### PR DESCRIPTION
Corrects transforms so that if a component is deleted in one change set, when the deletion is applied to another, we will delete any dangling AttributePrototypeArguments that have that component as a "source" in their argument targets.