### PR TITLE
BUG-482: create reactivity in the func history panel

### DIFF
--- a/app/web/src/components/Actions/ActionCard.vue
+++ b/app/web/src/components/Actions/ActionCard.vue
@@ -51,7 +51,7 @@
           :class="clsx(themeClasses('text-action-700', 'text-action-300'))"
           name="play"
           size="sm"
-          @click="retry"
+          @click.stop="retry"
         />
         <Icon
           :class="

--- a/app/web/src/components/CodeViewer.vue
+++ b/app/web/src/components/CodeViewer.vue
@@ -196,7 +196,12 @@ function syncEditorCode() {
 onMounted(initCodeMirrorEditor);
 onBeforeMount(teardownCodeMirrorEditor);
 watch(editorExtensionList, syncEditorConfig, { immediate: true });
-watch(() => props.code, syncEditorCode);
+watch(
+  () => props.code,
+  () => {
+    syncEditorCode();
+  },
+);
 
 // This doesn't work on IE, do we care? (is it polyfilled by our build system?)
 // RE ^^: https://www.youtube.com/watch?v=Ram7AKbtkGE

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -17,6 +17,8 @@ import { StatusUpdate } from "../status.store";
 import { CursorContainerKind } from "../presence.store";
 import { UserId } from "../auth.store";
 import { SecretId } from "../secrets.store";
+import { FuncRunId } from "../actions.store";
+import { FuncRunLogId } from "../func_runs.store";
 
 export type WebsocketRequest =
   | CursorRequest
@@ -310,5 +312,10 @@ export type WsEventPayloadMap = {
   FuncArgumentsSaved: {
     funcId: FuncId;
     changeSetId: ChangeSetId;
+  };
+  FuncRunLogUpdated: {
+    funcRunId: FuncRunId;
+    funcRunLogId: FuncRunLogId;
+    actionId?: ActionId;
   };
 };


### PR DESCRIPTION
1. Put the action ID in the func runner payload
2. When fun run logs come in over the wire, update a timestamp
3. Watch the time stamp, and reload the action from the now updated action list that has the new func run id