### PR TITLE
Add cyclone client timeout and make func execution timeouts configurable

### DIFF
--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -90,6 +90,10 @@ pub(crate) struct Args {
     /// Veritech decryption key file location [example: /run/veritech/veritech.key]
     #[arg(long)]
     pub(crate) decryption_key: Option<PathBuf>,
+
+    /// Execution timeout when communicating with a cyclone instance executing a function, in seconds
+    #[arg(long)]
+    pub(crate) cyclone_client_execution_timeout: Option<u64>,
 }
 
 impl TryFrom<Args> for Config {
@@ -128,6 +132,9 @@ impl TryFrom<Args> for Config {
                 );
             }
             config_map.set("nats.connection_name", NAME);
+            if let Some(timeout) = args.cyclone_client_execution_timeout {
+                config_map.set("cyclone_client_execution_timeout", timeout);
+            }
         })?
         .try_into()
     }

--- a/lib/cyclone-client/src/client.rs
+++ b/lib/cyclone-client/src/client.rs
@@ -139,7 +139,7 @@ where
 
     async fn execute_ping(&mut self) -> result::Result<PingExecution<Strm>, ClientError>;
 
-    async fn execute_resolver(
+    async fn prepare_resolver_execution(
         &mut self,
         request: CycloneRequest<ResolverFunctionRequest>,
     ) -> result::Result<
@@ -147,12 +147,12 @@ where
         ClientError,
     >;
 
-    async fn execute_action_run(
+    async fn prepare_action_run_execution(
         &mut self,
         request: CycloneRequest<ActionRunRequest>,
     ) -> result::Result<Execution<Strm, ActionRunRequest, ActionRunResultSuccess>, ClientError>;
 
-    async fn execute_reconciliation(
+    async fn prepare_reconciliation_execution(
         &mut self,
         request: CycloneRequest<ReconciliationRequest>,
     ) -> result::Result<
@@ -160,12 +160,12 @@ where
         ClientError,
     >;
 
-    async fn execute_validation(
+    async fn prepare_validation_execution(
         &mut self,
         request: CycloneRequest<ValidationRequest>,
     ) -> result::Result<Execution<Strm, ValidationRequest, ValidationResultSuccess>, ClientError>;
 
-    async fn execute_schema_variant_definition(
+    async fn prepare_schema_variant_definition_execution(
         &mut self,
         request: CycloneRequest<SchemaVariantDefinitionRequest>,
     ) -> result::Result<
@@ -284,24 +284,24 @@ where
         Ok(ping::execute(stream))
     }
 
-    async fn execute_resolver(
+    async fn prepare_resolver_execution(
         &mut self,
         request: CycloneRequest<ResolverFunctionRequest>,
     ) -> Result<Execution<Strm, ResolverFunctionRequest, ResolverFunctionResultSuccess>> {
         let stream = self.websocket_stream("/execute/resolver").await?;
-        Ok(execution::execute(stream, request))
+        Ok(execution::new_unstarted_execution(stream, request))
     }
 
-    async fn execute_action_run(
+    async fn prepare_action_run_execution(
         &mut self,
         request: CycloneRequest<ActionRunRequest>,
     ) -> result::Result<Execution<Strm, ActionRunRequest, ActionRunResultSuccess>, ClientError>
     {
         let stream = self.websocket_stream("/execute/command").await?;
-        Ok(execution::execute(stream, request))
+        Ok(execution::new_unstarted_execution(stream, request))
     }
 
-    async fn execute_reconciliation(
+    async fn prepare_reconciliation_execution(
         &mut self,
         request: CycloneRequest<ReconciliationRequest>,
     ) -> result::Result<
@@ -309,28 +309,28 @@ where
         ClientError,
     > {
         let stream = self.websocket_stream("/execute/reconciliation").await?;
-        Ok(execution::execute(stream, request))
+        Ok(execution::new_unstarted_execution(stream, request))
     }
 
-    async fn execute_validation(
+    async fn prepare_validation_execution(
         &mut self,
         request: CycloneRequest<ValidationRequest>,
     ) -> result::Result<Execution<Strm, ValidationRequest, ValidationResultSuccess>, ClientError>
     {
-        Ok(execution::execute(
+        Ok(execution::new_unstarted_execution(
             self.websocket_stream("/execute/validation").await?,
             request,
         ))
     }
 
-    async fn execute_schema_variant_definition(
+    async fn prepare_schema_variant_definition_execution(
         &mut self,
         request: CycloneRequest<SchemaVariantDefinitionRequest>,
     ) -> result::Result<
         Execution<Strm, SchemaVariantDefinitionRequest, SchemaVariantDefinitionResultSuccess>,
         ClientError,
     > {
-        Ok(execution::execute(
+        Ok(execution::new_unstarted_execution(
             self.websocket_stream("/execute/schema_variant_definition")
                 .await?,
             request,
@@ -839,7 +839,7 @@ mod tests {
 
         // Start the protocol
         let mut progress = client
-            .execute_resolver(CycloneRequest::from_parts(req, Default::default()))
+            .prepare_resolver_execution(CycloneRequest::from_parts(req, Default::default()))
             .await
             .expect("failed to establish websocket stream")
             .start()
@@ -940,7 +940,7 @@ mod tests {
 
         // Start the protocol
         let mut progress = client
-            .execute_resolver(CycloneRequest::from_parts(req, Default::default()))
+            .prepare_resolver_execution(CycloneRequest::from_parts(req, Default::default()))
             .await
             .expect("failed to establish websocket stream")
             .start()
@@ -1012,7 +1012,7 @@ mod tests {
             before: vec![],
         };
         let mut progress = client
-            .execute_validation(CycloneRequest::from_parts(req, Default::default()))
+            .prepare_validation_execution(CycloneRequest::from_parts(req, Default::default()))
             .await
             .expect("failed to establish websocket stream")
             .start()
@@ -1082,7 +1082,7 @@ mod tests {
 
         // Start the protocol
         let mut progress = client
-            .execute_action_run(CycloneRequest::from_parts(req, Default::default()))
+            .prepare_action_run_execution(CycloneRequest::from_parts(req, Default::default()))
             .await
             .expect("failed to establish websocket stream")
             .start()
@@ -1168,7 +1168,7 @@ mod tests {
 
         // Start the protocol
         let mut progress = client
-            .execute_action_run(CycloneRequest::from_parts(req, Default::default()))
+            .prepare_action_run_execution(CycloneRequest::from_parts(req, Default::default()))
             .await
             .expect("failed to establish websocket stream")
             .start()
@@ -1253,7 +1253,7 @@ mod tests {
 
         // Start the protocol
         let mut progress = client
-            .execute_reconciliation(CycloneRequest::from_parts(req, Default::default()))
+            .prepare_reconciliation_execution(CycloneRequest::from_parts(req, Default::default()))
             .await
             .expect("failed to establish websocket stream")
             .start()
@@ -1328,7 +1328,7 @@ mod tests {
 
         // Start the protocol
         let mut progress = client
-            .execute_reconciliation(CycloneRequest::from_parts(req, Default::default()))
+            .prepare_reconciliation_execution(CycloneRequest::from_parts(req, Default::default()))
             .await
             .expect("failed to establish websocket stream")
             .start()
@@ -1405,7 +1405,10 @@ mod tests {
 
         // Start the protocol
         let mut progress = client
-            .execute_schema_variant_definition(CycloneRequest::from_parts(req, Default::default()))
+            .prepare_schema_variant_definition_execution(CycloneRequest::from_parts(
+                req,
+                Default::default(),
+            ))
             .await
             .expect("failed to establish websocket stream")
             .start()
@@ -1482,7 +1485,10 @@ mod tests {
 
         // Start the protocol
         let mut progress = client
-            .execute_schema_variant_definition(CycloneRequest::from_parts(req, Default::default()))
+            .prepare_schema_variant_definition_execution(CycloneRequest::from_parts(
+                req,
+                Default::default(),
+            ))
             .await
             .expect("failed to establish websocket stream")
             .start()

--- a/lib/cyclone-server/src/config.rs
+++ b/lib/cyclone-server/src/config.rs
@@ -55,6 +55,9 @@ pub struct Config {
     #[builder(default)]
     lang_server_function_timeout: Option<usize>,
 
+    #[builder(default)]
+    lang_server_process_timeout: Option<u64>,
+
     #[builder(setter(into), default)]
     limit_requests: Option<u32>,
 }
@@ -124,6 +127,12 @@ impl Config {
     #[must_use]
     pub fn lang_server_function_timeout(&self) -> Option<usize> {
         self.lang_server_function_timeout
+    }
+
+    /// Gets a reference to the config's lang server process timeout optional override.
+    #[must_use]
+    pub fn lang_server_process_timeout(&self) -> Option<u64> {
+        self.lang_server_process_timeout
     }
 
     /// Gets a reference to the config's limit requests.

--- a/lib/cyclone-server/src/server.rs
+++ b/lib/cyclone-server/src/server.rs
@@ -218,6 +218,7 @@ fn build_service(
         config.lang_server_path(),
         telemetry_level,
         config.lang_server_function_timeout(),
+        config.lang_server_process_timeout(),
     );
 
     let routes = routes(config, state, shutdown_tx);

--- a/lib/cyclone-server/src/state.rs
+++ b/lib/cyclone-server/src/state.rs
@@ -13,6 +13,7 @@ pub struct AppState {
     lang_server_path: LangServerPath,
     telemetry_level: TelemetryLevel,
     lang_server_function_timeout: LangServerFunctionTimeout,
+    lang_server_process_timeout: LangServerProcessTimeout,
 }
 
 impl AppState {
@@ -20,12 +21,16 @@ impl AppState {
         lang_server_path: impl Into<PathBuf>,
         telemetry_level: Box<dyn telemetry::TelemetryLevel>,
         lang_server_function_timeout: Option<usize>,
+        lang_server_process_timeout: Option<u64>,
     ) -> Self {
         Self {
             lang_server_path: LangServerPath(Arc::new(lang_server_path.into())),
             telemetry_level: TelemetryLevel(Arc::new(telemetry_level)),
             lang_server_function_timeout: LangServerFunctionTimeout(Arc::new(
                 lang_server_function_timeout,
+            )),
+            lang_server_process_timeout: LangServerProcessTimeout(Arc::new(
+                lang_server_process_timeout,
             )),
         }
     }
@@ -56,6 +61,15 @@ pub struct LangServerFunctionTimeout(Arc<Option<usize>>);
 
 impl LangServerFunctionTimeout {
     pub fn inner(&self) -> Option<usize> {
+        Arc::clone(&self.0).as_ref().to_owned()
+    }
+}
+
+#[derive(Clone, Debug, FromRef)]
+pub struct LangServerProcessTimeout(Arc<Option<u64>>);
+
+impl LangServerProcessTimeout {
+    pub fn inner(&self) -> Option<u64> {
         Arc::clone(&self.0).as_ref().to_owned()
     }
 }

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -623,10 +623,7 @@ pub async fn veritech_server_for_uds_cyclone(
     nats_config: NatsConfig,
 ) -> Result<veritech_server::Server> {
     let config: veritech_server::Config = {
-        let mut config_file = veritech_server::ConfigFile {
-            nats: nats_config,
-            ..Default::default()
-        };
+        let mut config_file = veritech_server::ConfigFile::new_for_dal_test(nats_config);
         veritech_server::detect_and_configure_development(&mut config_file)
             .wrap_err("failed to detect and configure Veritech ConfigFile")?;
         config_file

--- a/lib/si-pool-noodle/src/instance/cyclone/local_http.rs
+++ b/lib/si-pool-noodle/src/instance/cyclone/local_http.rs
@@ -140,7 +140,7 @@ impl CycloneClient<TcpStream> for LocalHttpInstance {
         result
     }
 
-    async fn execute_resolver(
+    async fn prepare_resolver_execution(
         &mut self,
         request: CycloneRequest<ResolverFunctionRequest>,
     ) -> result::Result<
@@ -151,13 +151,13 @@ impl CycloneClient<TcpStream> for LocalHttpInstance {
             .await
             .map_err(ClientError::unhealthy)?;
 
-        let result = self.client.execute_resolver(request).await;
+        let result = self.client.prepare_resolver_execution(request).await;
         self.count_request();
 
         result
     }
 
-    async fn execute_validation(
+    async fn prepare_validation_execution(
         &mut self,
         request: CycloneRequest<ValidationRequest>,
     ) -> result::Result<Execution<TcpStream, ValidationRequest, ValidationResultSuccess>, ClientError>
@@ -166,13 +166,13 @@ impl CycloneClient<TcpStream> for LocalHttpInstance {
             .await
             .map_err(ClientError::unhealthy)?;
 
-        let result = self.client.execute_validation(request).await;
+        let result = self.client.prepare_validation_execution(request).await;
         self.count_request();
 
         result
     }
 
-    async fn execute_action_run(
+    async fn prepare_action_run_execution(
         &mut self,
         request: CycloneRequest<ActionRunRequest>,
     ) -> result::Result<Execution<TcpStream, ActionRunRequest, ActionRunResultSuccess>, ClientError>
@@ -181,13 +181,13 @@ impl CycloneClient<TcpStream> for LocalHttpInstance {
             .await
             .map_err(ClientError::unhealthy)?;
 
-        let result = self.client.execute_action_run(request).await;
+        let result = self.client.prepare_action_run_execution(request).await;
         self.count_request();
 
         result
     }
 
-    async fn execute_reconciliation(
+    async fn prepare_reconciliation_execution(
         &mut self,
         request: CycloneRequest<ReconciliationRequest>,
     ) -> result::Result<
@@ -198,13 +198,13 @@ impl CycloneClient<TcpStream> for LocalHttpInstance {
             .await
             .map_err(ClientError::unhealthy)?;
 
-        let result = self.client.execute_reconciliation(request).await;
+        let result = self.client.prepare_reconciliation_execution(request).await;
         self.count_request();
 
         result
     }
 
-    async fn execute_schema_variant_definition(
+    async fn prepare_schema_variant_definition_execution(
         &mut self,
         request: CycloneRequest<SchemaVariantDefinitionRequest>,
     ) -> result::Result<
@@ -215,7 +215,10 @@ impl CycloneClient<TcpStream> for LocalHttpInstance {
             .await
             .map_err(ClientError::unhealthy)?;
 
-        let result = self.client.execute_schema_variant_definition(request).await;
+        let result = self
+            .client
+            .prepare_schema_variant_definition_execution(request)
+            .await;
         self.count_request();
 
         result

--- a/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
+++ b/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
@@ -174,7 +174,7 @@ impl CycloneClient<UnixStream> for LocalUdsInstance {
         result
     }
 
-    async fn execute_resolver(
+    async fn prepare_resolver_execution(
         &mut self,
         request: CycloneRequest<ResolverFunctionRequest>,
     ) -> result::Result<
@@ -184,12 +184,12 @@ impl CycloneClient<UnixStream> for LocalUdsInstance {
         self.ensure_healthy_client()
             .await
             .map_err(ClientError::unhealthy)?;
-        let result = self.client.execute_resolver(request).await;
+        let result = self.client.prepare_resolver_execution(request).await;
         self.count_request();
         result
     }
 
-    async fn execute_validation(
+    async fn prepare_validation_execution(
         &mut self,
         request: CycloneRequest<ValidationRequest>,
     ) -> result::Result<
@@ -199,7 +199,7 @@ impl CycloneClient<UnixStream> for LocalUdsInstance {
         self.ensure_healthy_client()
             .await
             .map_err(ClientError::unhealthy)?;
-        let result = self.client.execute_validation(request).await;
+        let result = self.client.prepare_validation_execution(request).await;
         self.count_request();
 
         result
@@ -207,7 +207,7 @@ impl CycloneClient<UnixStream> for LocalUdsInstance {
 
     // The request argument is the same as that in the "impl FuncDispatch for
     // FuncBackendJsAction" in the dal.
-    async fn execute_action_run(
+    async fn prepare_action_run_execution(
         &mut self,
         request: CycloneRequest<ActionRunRequest>,
     ) -> result::Result<Execution<UnixStream, ActionRunRequest, ActionRunResultSuccess>, ClientError>
@@ -216,13 +216,13 @@ impl CycloneClient<UnixStream> for LocalUdsInstance {
             .await
             .map_err(ClientError::unhealthy)?;
         // Use the websocket client for cyclone to execute command run.
-        let result = self.client.execute_action_run(request).await;
+        let result = self.client.prepare_action_run_execution(request).await;
         self.count_request();
 
         result
     }
 
-    async fn execute_reconciliation(
+    async fn prepare_reconciliation_execution(
         &mut self,
         request: CycloneRequest<ReconciliationRequest>,
     ) -> result::Result<
@@ -233,13 +233,13 @@ impl CycloneClient<UnixStream> for LocalUdsInstance {
             .await
             .map_err(ClientError::unhealthy)?;
         // Use the websocket client for cyclone to execute reconciliation.
-        let result = self.client.execute_reconciliation(request).await;
+        let result = self.client.prepare_reconciliation_execution(request).await;
         self.count_request();
 
         result
     }
 
-    async fn execute_schema_variant_definition(
+    async fn prepare_schema_variant_definition_execution(
         &mut self,
         request: CycloneRequest<SchemaVariantDefinitionRequest>,
     ) -> result::Result<
@@ -250,7 +250,10 @@ impl CycloneClient<UnixStream> for LocalUdsInstance {
             .await
             .map_err(ClientError::unhealthy)?;
         // Use the websocket client for cyclone to execute reconciliation.
-        let result = self.client.execute_schema_variant_definition(request).await;
+        let result = self
+            .client
+            .prepare_schema_variant_definition_execution(request)
+            .await;
         self.count_request();
 
         result


### PR DESCRIPTION
## Description

This PR adds a timeout wrapper when executing functions via the cyclone client in veritech. In addition, the default timeout value can be overriden as well as the recently added timeout value for cyclone server's lang server process.

As a result of this commit and recent commits, the following values are now configurable:

- cyclone client timeout
  - dynamically configurable via veritech args and/or config file
- cyclone server timeout
  - statically configurable with cyclone args and/or config file
- lang-js function timeout
  - statically configurable with cyclone args and/or config file
  - dynamically configurable with lang-js args, but they are also statically configured due to how cyclone is invoked via firecracker (see the rootfs builder script for more information)

This PR also renames some functions for clarity, fixes some doc comments and does some cleanup.

<img src="https://media0.giphy.com/media/pJRKbawg9fAsjDdIBf/giphy.gif"/>