### PR TITLE
Fix function timeout set to 0 by default

### DIFF
--- a/lib/veritech-server/src/config.rs
+++ b/lib/veritech-server/src/config.rs
@@ -65,8 +65,8 @@ pub struct Config {
     #[builder(default = "healthcheck_pool_default()")]
     healthcheck_pool: bool,
 
-    #[builder(default = "default_cyclone_client_execution_timeout()")]
-    cyclone_client_execution_timeout: u64,
+    #[builder(default)]
+    cyclone_client_execution_timeout: Option<u64>,
 }
 
 #[remain::sorted]
@@ -86,7 +86,7 @@ pub struct ConfigFile {
     pub cyclone: CycloneConfig,
     pub crypto: VeritechCryptoConfig,
     pub healthcheck_pool: bool,
-    pub cyclone_client_execution_timeout: u64,
+    pub cyclone_client_execution_timeout: Option<u64>,
 }
 
 impl ConfigFile {
@@ -96,7 +96,7 @@ impl ConfigFile {
             cyclone: CycloneConfig::default_local_http(),
             crypto: Default::default(),
             healthcheck_pool: healthcheck_pool_default(),
-            cyclone_client_execution_timeout: default_cyclone_client_execution_timeout(),
+            cyclone_client_execution_timeout: None,
         }
     }
 
@@ -106,14 +106,13 @@ impl ConfigFile {
             cyclone: CycloneConfig::default_local_uds(),
             crypto: Default::default(),
             healthcheck_pool: healthcheck_pool_default(),
-            cyclone_client_execution_timeout: default_cyclone_client_execution_timeout(),
+            cyclone_client_execution_timeout: None,
         }
     }
 
     pub fn new_for_dal_test(nats: NatsConfig) -> Self {
         Self {
             nats,
-            cyclone_client_execution_timeout: default_cyclone_client_execution_timeout(),
             ..Default::default()
         }
     }
@@ -175,8 +174,8 @@ impl Config {
         self.cyclone_spec
     }
 
-    /// Gets the config's execution timeout, in seconds.
-    pub fn cyclone_client_execution_timeout(&self) -> u64 {
+    /// Gets the config's option override cyclone client execution timeout, in seconds.
+    pub fn cyclone_client_execution_timeout(&self) -> Option<u64> {
         self.cyclone_client_execution_timeout
     }
 }
@@ -509,10 +508,6 @@ fn random_instance_id() -> String {
 
 fn healthcheck_pool_default() -> bool {
     true
-}
-
-fn default_cyclone_client_execution_timeout() -> u64 {
-    35 * 60
 }
 
 #[allow(clippy::disallowed_methods)] // Used to determine if running in development

--- a/lib/veritech-server/src/server.rs
+++ b/lib/veritech-server/src/server.rs
@@ -29,6 +29,8 @@ use crate::{
     PublisherError,
 };
 
+const DEFAULT_CYCLONE_CLIENT_EXECUTION_TIMEOUT: Duration = Duration::from_secs(35 * 60);
+
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum ServerError {
@@ -164,9 +166,12 @@ impl Server {
                     shutdown_tx,
                     shutdown_rx: graceful_shutdown_rx,
                     metadata: Arc::new(metadata),
-                    cyclone_client_execution_timeout: Duration::from_secs(
-                        config.cyclone_client_execution_timeout(),
-                    ),
+                    cyclone_client_execution_timeout: match config
+                        .cyclone_client_execution_timeout()
+                    {
+                        Some(timeout) => Duration::from_secs(timeout),
+                        None => DEFAULT_CYCLONE_CLIENT_EXECUTION_TIMEOUT,
+                    },
                 })
             }
             wrong @ CycloneSpec::LocalHttp(_) => Err(ServerError::WrongCycloneSpec(


### PR DESCRIPTION
## Description

This is an embarrassing one. We tested #4318 extensively, but due to a last minute change with appeasing the test harness config, the default value of the veritech config would be "0" unless you specifically called the right constructor method to provide the correct value.

As a result of this change, the config for veritech is more clear anyway because the config option should be... well, optional. So now, whenever the config does not specify and option, we will fallback to the 35 minute timeout. Sorry, Victor, this is on me.

/<img src="https://media3.giphy.com/media/TJawtKM6OCKkvwCIqX/giphy.gif"/>