### PR TITLE
Move SummaryDiagramComponent struct to si_frontend_types & use `into_frontend_type` fn

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramGroup.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroup.vue
@@ -552,7 +552,7 @@ const position = computed(
     props.group.def.position,
 );
 
-watch([nodeWidth, nodeHeight, position], () => {
+watch([nodeWidth, nodeHeight, position, actualSockets], () => {
   // we call on nextTick to let the component actually update itself on the stage first
   // because parent responds to this event by finding shapes on the stage and looking at location/dimensions
   nextTick(() => emit("resize"));

--- a/app/web/src/components/ModelingDiagram/DiagramNode.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramNode.vue
@@ -438,7 +438,7 @@ const position = computed(
     props.node.def.position,
 );
 
-watch([nodeWidth, nodeHeight, position], () => {
+watch([nodeWidth, nodeHeight, position, actualSockets], () => {
   // we call on nextTick to let the component actually update itself on the stage first
   // because parent responds to this event by finding shapes on the stage and looking at location/dimensions
   nextTick(() => {

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -137,7 +137,7 @@ overflow hidden */
             height: 80,
             cornerRadius: CORNER_RADIUS,
             x: pendingInsert.position!.x - 80,
-            y: pendingInsert.position!.y - 40,
+            y: pendingInsert.position!.y + 20,
             fill: 'rgba(0,0,0,.4)',
             strokeWidth: 1,
             stroke: SELECTION_COLOR,
@@ -147,7 +147,7 @@ overflow hidden */
               :color="getToneColorHex('info')"
               :size="60"
               :x="pendingInsert.position!.x"
-              :y="pendingInsert.position!.y"
+              :y="pendingInsert.position!.y + 60"
               icon="loader"
             />
           </template>
@@ -1320,7 +1320,11 @@ const currentSelectionMovableElements = computed(() => {
     } else return false;
   });
 
-  return filteredElements;
+  // cannot move elements that are actually gone already
+  return filteredElements.filter((e) => {
+    if (e.def.changeStatus === "deleted") return false;
+    return true;
+  });
 });
 
 const draggedElementsPositionsPreDrag = ref<

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -166,8 +166,7 @@ export type WsEventPayloadMap = {
   // };
 
   ComponentCreated: {
-    success: boolean;
-    componentId: string;
+    component: RawComponent;
     changeSetId: string;
   };
   ComponentDeleted: {
@@ -191,19 +190,12 @@ export type WsEventPayloadMap = {
     changeSetId: string;
     edges: RawEdge[];
   };
-  ConnectionCreated: {
-    fromComponentId: string;
-    toComponentId: string;
-    fromSocketId: string;
-    toSocketId: string;
-    changeSetId: string;
-  };
+  ConnectionUpserted: RawEdge;
   ConnectionDeleted: {
     fromComponentId: string;
     toComponentId: string;
     fromSocketId: string;
     toSocketId: string;
-    changeSetId: string;
   };
   ModuleImported: SchemaVariant[];
   WorkspaceImportBeginApprovalProcess: {

--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -12,7 +12,7 @@ use veritech_client::{ActionRunResultSuccess, ResourceStatus};
 use crate::{
     action::ActionId,
     component::ComponentUpdatedPayload,
-    diagram::{DiagramError, SummaryDiagramComponent},
+    diagram::DiagramError,
     func::{
         runner::{FuncRunner, FuncRunnerError},
         FuncId,
@@ -24,6 +24,7 @@ use crate::{
     SchemaVariantId, TransactionsError, WorkspaceSnapshotError, WsEvent, WsEventError,
     WsEventResult, WsPayload,
 };
+use si_frontend_types::SummaryDiagramComponent;
 
 #[remain::sorted]
 #[derive(Debug, Error)]

--- a/lib/dal/src/change_status.rs
+++ b/lib/dal/src/change_status.rs
@@ -2,6 +2,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use strum::{AsRefStr, Display, EnumString};
 
+use si_frontend_types::ChangeStatus as FeChangeStatus;
+
 /// An enum representing the changez status of an entity in the [`ChangeSet`](crate::ChangeSet).
 #[remain::sorted]
 #[derive(
@@ -14,4 +16,15 @@ pub enum ChangeStatus {
     Deleted,
     Modified,
     Unmodified,
+}
+
+impl From<ChangeStatus> for FeChangeStatus {
+    fn from(value: ChangeStatus) -> Self {
+        match value {
+            ChangeStatus::Added => FeChangeStatus::Added,
+            ChangeStatus::Deleted => FeChangeStatus::Deleted,
+            ChangeStatus::Modified => FeChangeStatus::Modified,
+            ChangeStatus::Unmodified => FeChangeStatus::Unmodified,
+        }
+    }
 }

--- a/lib/dal/src/socket/connection_annotation.rs
+++ b/lib/dal/src/socket/connection_annotation.rs
@@ -1,5 +1,6 @@
 use regex::Regex;
 use serde::{Deserialize, Serialize, Serializer};
+use si_frontend_types::ConnectionAnnotation as FeConnectionAnnotation;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
@@ -16,6 +17,14 @@ pub enum ConnectionAnnotationError {
 #[derive(Clone, Eq, Debug, PartialEq, Deserialize, Serialize)]
 pub struct ConnectionAnnotation {
     tokens: Vec<String>,
+}
+
+impl From<ConnectionAnnotation> for FeConnectionAnnotation {
+    fn from(value: ConnectionAnnotation) -> Self {
+        Self {
+            tokens: value.tokens.clone(),
+        }
+    }
 }
 
 impl TryFrom<String> for ConnectionAnnotation {

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -12,9 +12,10 @@ use crate::change_set::event::{
 };
 use crate::component::{
     ComponentCreatedPayload, ComponentDeletedPayload, ComponentSetPositionPayload,
-    ComponentUpdatedPayload, ComponentUpgradedPayload, ConnectionCreatedPayload,
-    ConnectionDeletedPayload, InferredEdgeRemovePayload, InferredEdgeUpsertPayload,
+    ComponentUpdatedPayload, ComponentUpgradedPayload, ConnectionDeletedPayload,
+    InferredEdgeRemovePayload, InferredEdgeUpsertPayload,
 };
+use crate::diagram::SummaryDiagramEdge;
 use crate::func::runner::FuncRunLogUpdatedPayload;
 use crate::func::{FuncWsEventCodeSaved, FuncWsEventFuncSummary, FuncWsEventPayload};
 use crate::pkg::{
@@ -84,8 +85,8 @@ pub enum WsPayload {
     ComponentDeleted(ComponentDeletedPayload),
     ComponentUpdated(ComponentUpdatedPayload),
     ComponentUpgraded(ComponentUpgradedPayload),
-    ConnectionCreated(ConnectionCreatedPayload),
     ConnectionDeleted(ConnectionDeletedPayload),
+    ConnectionUpserted(SummaryDiagramEdge),
     Cursor(CursorPayload),
     FuncArgumentsSaved(FuncWsEventPayload),
     FuncCodeSaved(FuncWsEventCodeSaved),

--- a/lib/dal/tests/integration_test/component/upgrade.rs
+++ b/lib/dal/tests/integration_test/component/upgrade.rs
@@ -222,16 +222,17 @@ async fn auto_upgrade_component(ctx: &mut DalContext) {
         .components
         .first()
         .expect("unable to get the upgradable component on the graph");
-    assert_eq!(my_upgraded_component.schema_variant_id, variant_one);
 
-    let view_after_upgrade = Component::get_by_id(ctx, my_upgraded_component.component_id)
+    assert_eq!(my_upgraded_component.schema_variant_id, variant_one.into());
+
+    let view_after_upgrade = Component::get_by_id(ctx, my_upgraded_component.component_id.into())
         .await
         .unwrap()
         .view(ctx)
         .await
         .expect("get component view");
 
-    let root_id = Component::root_attribute_value_id(ctx, my_upgraded_component.id)
+    let root_id = Component::root_attribute_value_id(ctx, my_upgraded_component.id.into())
         .await
         .expect("unable to get root av id");
 
@@ -276,7 +277,7 @@ async fn auto_upgrade_component(ctx: &mut DalContext) {
     );
 
     // see that there's still only one action enqueued
-    let mut actions = Action::find_for_component_id(ctx, my_upgraded_component.id)
+    let mut actions = Action::find_for_component_id(ctx, my_upgraded_component.id.into())
         .await
         .expect("got the actions");
     assert_eq!(actions.len(), 1);

--- a/lib/dal/tests/integration_test/diagram.rs
+++ b/lib/dal/tests/integration_test/diagram.rs
@@ -1,4 +1,4 @@
-use dal::{change_status::ChangeStatus, diagram::Diagram, Component, DalContext};
+use dal::{diagram::Diagram, Component, DalContext};
 use dal_test::{
     helpers::{create_component_for_default_schema_name, ChangeSetTestHelpers},
     test,
@@ -47,11 +47,12 @@ async fn components_removed_from_snapshot_have_virtual_diagram_entries(ctx: &mut
     let removed_component_summary = summary_diagram
         .components
         .iter()
-        .find(|comp| comp.id == component_to_remove.id())
+        .find(|comp| comp.id == component_to_remove.id().into())
         .expect("Removed Component not found in summary diagram");
     assert!(removed_component_summary.from_base_change_set);
+
     assert_eq!(
-        ChangeStatus::Deleted,
+        si_frontend_types::ChangeStatus::Deleted,
         removed_component_summary.change_status
     );
 }

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -1,7 +1,7 @@
 use dal::component::frame::{Frame, FrameError};
 use dal::component::socket::{ComponentInputSocket, ComponentOutputSocket};
 use dal::diagram::SummaryDiagramInferredEdge;
-use dal::diagram::{Diagram, DiagramResult, SummaryDiagramComponent, SummaryDiagramEdge};
+use dal::diagram::{Diagram, DiagramResult, SummaryDiagramEdge};
 use dal::func::authoring::FuncAuthoringClient;
 use dal::func::binding::EventualParent;
 use dal::prop::PropPath;
@@ -22,6 +22,7 @@ use dal_test::helpers::{
 };
 use dal_test::{test, WorkspaceSignup};
 use pretty_assertions_sorted::assert_eq;
+use si_frontend_types::SummaryDiagramComponent;
 use std::collections::HashMap;
 
 mod omega_nesting;
@@ -207,7 +208,9 @@ async fn convert_component_to_frame_and_attach_no_nesting(ctx: &mut DalContext) 
     assert!(starfield_parent_node_id.is_none());
     assert_eq!(
         starfield_component.id(),
-        fallout_parent_node_id.expect("no parent node id for fallout component")
+        fallout_parent_node_id
+            .expect("fallout should have a parent node")
+            .into()
     );
 }
 
@@ -266,8 +269,8 @@ async fn simple_frames(ctx: &mut DalContext) {
             .expect("could not get component by name");
 
         assert_eq!(
-            new_era_taylor_swift.id(),                     // expected
-            new_era_taylor_swift_assembled.0.component_id  // actual
+            new_era_taylor_swift.id(),                            // expected
+            new_era_taylor_swift_assembled.0.component_id.into()  // actual
         );
         assert!(new_era_taylor_swift_assembled.0.parent_id.is_none());
         let found_type = &new_era_taylor_swift_assembled.0.component_type;
@@ -316,13 +319,13 @@ async fn simple_frames(ctx: &mut DalContext) {
             .expect("could not get component by name");
 
         assert_eq!(
-            new_era_taylor_swift.id(),                     // expected
-            new_era_taylor_swift_assembled.0.component_id  // actual
+            new_era_taylor_swift.id(),                            // expected
+            new_era_taylor_swift_assembled.0.component_id.into()  // actual
         );
 
         assert_eq!(
-            travis_kelce_component.id(),           // expected
-            travis_kelce_assembled.0.component_id  // actual
+            travis_kelce_component.id(),                  // expected
+            travis_kelce_assembled.0.component_id.into()  // actual
         );
 
         assert!(new_era_taylor_swift_assembled.0.parent_id.is_some());
@@ -363,7 +366,7 @@ async fn simple_frames(ctx: &mut DalContext) {
                 //maybe_travis_output_socket = Some(travis_output);
                 assert_eq!(
                     travis_output_match.component_id,
-                    travis_kelce_assembled.0.component_id
+                    travis_kelce_assembled.0.component_id.into()
                 );
             }
         }
@@ -411,13 +414,13 @@ async fn simple_frames(ctx: &mut DalContext) {
             .expect("could not get component by name");
 
         assert_eq!(
-            new_era_taylor_swift.id(),                     // expected
-            new_era_taylor_swift_assembled.0.component_id  // actual
+            new_era_taylor_swift.id(),                            // expected
+            new_era_taylor_swift_assembled.0.component_id.into()  // actual
         );
 
         assert_eq!(
-            travis_kelce_component.id(),           // expected
-            travis_kelce_assembled.0.component_id  // actual
+            travis_kelce_component.id(),                  // expected
+            travis_kelce_assembled.0.component_id.into()  // actual
         );
 
         assert!(new_era_taylor_swift_assembled.0.parent_id.is_none());
@@ -1902,8 +1905,8 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
             .expect("could not get component by name");
 
         assert_eq!(
-            new_era_taylor_swift.id(),                     // expected
-            new_era_taylor_swift_assembled.0.component_id  // actual
+            new_era_taylor_swift.id(),                            // expected
+            new_era_taylor_swift_assembled.0.component_id.into()  // actual
         );
         assert!(new_era_taylor_swift_assembled.0.parent_id.is_none());
     }
@@ -1943,13 +1946,13 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
             .expect("could not get component by name");
 
         assert_eq!(
-            new_era_taylor_swift.id(),                     // expected
-            new_era_taylor_swift_assembled.0.component_id  // actual
+            new_era_taylor_swift.id(),                            // expected
+            new_era_taylor_swift_assembled.0.component_id.into()  // actual
         );
 
         assert_eq!(
-            travis_kelce_component.id(),           // expected
-            travis_kelce_assembled.0.component_id  // actual
+            travis_kelce_component.id(),                  // expected
+            travis_kelce_assembled.0.component_id.into()  // actual
         );
 
         assert!(new_era_taylor_swift_assembled.0.parent_id.is_none());
@@ -1958,7 +1961,8 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
             travis_kelce_assembled
                 .0
                 .parent_id
-                .expect("no parent node id")  // actual
+                .expect("no parent node id")
+                .into()  // actual
         );
     }
 
@@ -1997,16 +2001,16 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
             .expect("could not get component by name");
 
         assert_eq!(
-            new_era_taylor_swift.id(),                     // expected
-            new_era_taylor_swift_assembled.0.component_id  // actual
+            new_era_taylor_swift.id(),                            // expected
+            new_era_taylor_swift_assembled.0.component_id.into()  // actual
         );
         assert_eq!(
-            travis_kelce_component.id(),           // expected
-            travis_kelce_assembled.0.component_id  // actual
+            travis_kelce_component.id(),                  // expected
+            travis_kelce_assembled.0.component_id.into()  // actual
         );
         assert_eq!(
-            country_era_taylor_swift.id(),                     // expected
-            country_era_taylor_swift_assembled.0.component_id  // actual
+            country_era_taylor_swift.id(),                            // expected
+            country_era_taylor_swift_assembled.0.component_id.into()  // actual
         );
 
         assert!(new_era_taylor_swift_assembled.0.parent_id.is_none());
@@ -2016,7 +2020,8 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
             travis_kelce_assembled
                 .0
                 .parent_id
-                .expect("no parent node id")  // actual
+                .expect("no parent node id")
+                .into()  // actual
         );
     }
 
@@ -2062,20 +2067,20 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
             .expect("could not get component by name");
 
         assert_eq!(
-            new_era_taylor_swift.id(),                     // expected
-            new_era_taylor_swift_assembled.0.component_id  // actual
+            new_era_taylor_swift.id(),                            // expected
+            new_era_taylor_swift_assembled.0.component_id.into()  // actual
         );
         assert_eq!(
-            travis_kelce_component.id(),           // expected
-            travis_kelce_assembled.0.component_id  // actual
+            travis_kelce_component.id(),                  // expected
+            travis_kelce_assembled.0.component_id.into()  // actual
         );
         assert_eq!(
-            country_era_taylor_swift.id(),                     // expected
-            country_era_taylor_swift_assembled.0.component_id  // actual
+            country_era_taylor_swift.id(),                            // expected
+            country_era_taylor_swift_assembled.0.component_id.into()  // actual
         );
         assert_eq!(
-            mama_kelce.id(),                     // expected
-            mama_kelce_assembled.0.component_id  // actual
+            mama_kelce.id(),                            // expected
+            mama_kelce_assembled.0.component_id.into()  // actual
         );
 
         assert!(new_era_taylor_swift_assembled.0.parent_id.is_none());
@@ -2085,11 +2090,16 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
             travis_kelce_assembled
                 .0
                 .parent_id
-                .expect("no parent node id")  // actual
+                .expect("no parent node id")
+                .into()  // actual
         );
         assert_eq!(
             country_era_taylor_swift.id(), // expected
-            mama_kelce_assembled.0.parent_id.expect("no parent node id")  // actual
+            mama_kelce_assembled
+                .0
+                .parent_id
+                .expect("no parent node id")
+                .into()  // actual
         );
     }
 
@@ -2133,20 +2143,20 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
             .expect("could not get component by name");
 
         assert_eq!(
-            new_era_taylor_swift.id(),                     // expected
-            new_era_taylor_swift_assembled.0.component_id  // actual
+            new_era_taylor_swift.id(),                            // expected
+            new_era_taylor_swift_assembled.0.component_id.into()  // actual
         );
         assert_eq!(
-            travis_kelce_component.id(),           // expected
-            travis_kelce_assembled.0.component_id  // actual
+            travis_kelce_component.id(),                  // expected
+            travis_kelce_assembled.0.component_id.into(), // actual
         );
         assert_eq!(
-            country_era_taylor_swift.id(),                     // expected
-            country_era_taylor_swift_assembled.0.component_id  // actual
+            country_era_taylor_swift.id(),                            // expected
+            country_era_taylor_swift_assembled.0.component_id.into()  // actual
         );
         assert_eq!(
-            mama_kelce.id(),                     // expected
-            mama_kelce_assembled.0.component_id  // actual
+            mama_kelce.id(),                            // expected
+            mama_kelce_assembled.0.component_id.into()  // actual
         );
 
         assert!(new_era_taylor_swift_assembled.0.parent_id.is_none());
@@ -2156,17 +2166,23 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
                 .0
                 .parent_id
                 .expect("no parent node id")
+                .into()
         );
         assert_eq!(
             new_era_taylor_swift.id(), // expected
             travis_kelce_assembled
                 .0
                 .parent_id
-                .expect("no parent node id")  // actual
+                .expect("no parent node id") // actual
+                .into()
         );
         assert_eq!(
             country_era_taylor_swift.id(), // expected
-            mama_kelce_assembled.0.parent_id.expect("no parent node id")  // actual
+            mama_kelce_assembled
+                .0
+                .parent_id
+                .expect("no parent node id") // actual
+                .into()
         );
     }
     //Scenario 7?! No more Country Era Swift, she wants to break freeeeeee
@@ -2204,20 +2220,20 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
             .expect("could not get component by name");
 
         assert_eq!(
-            new_era_taylor_swift.id(),                     // expected
-            new_era_taylor_swift_assembled.0.component_id  // actual
+            new_era_taylor_swift.id(),                            // expected
+            new_era_taylor_swift_assembled.0.component_id.into()  // actual
         );
         assert_eq!(
-            travis_kelce_component.id(),           // expected
-            travis_kelce_assembled.0.component_id  // actual
+            travis_kelce_component.id(),                  // expected
+            travis_kelce_assembled.0.component_id.into()  // actual
         );
         assert_eq!(
-            country_era_taylor_swift.id(),                     // expected
-            country_era_taylor_swift_assembled.0.component_id  // actual
+            country_era_taylor_swift.id(),                            // expected
+            country_era_taylor_swift_assembled.0.component_id.into()  // actual
         );
         assert_eq!(
-            mama_kelce.id(),                     // expected
-            mama_kelce_assembled.0.component_id  // actual
+            mama_kelce.id(),                            // expected
+            mama_kelce_assembled.0.component_id.into()  // actual
         );
 
         assert!(new_era_taylor_swift_assembled.0.parent_id.is_none());
@@ -2228,11 +2244,16 @@ async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContex
             travis_kelce_assembled
                 .0
                 .parent_id
-                .expect("no parent node id")  // actual
+                .expect("no parent node id")
+                .into()  // actual
         );
         assert_eq!(
-            country_era_taylor_swift.id(), // expected
-            mama_kelce_assembled.0.parent_id.expect("no parent node id")  // actual
+            country_era_taylor_swift.id(), // expectedº
+            mama_kelce_assembled
+                .0
+                .parent_id
+                .expect("no parent node id")
+                .into()
         );
     }
 }
@@ -3117,7 +3138,7 @@ impl DiagramByKey {
         for component in &diagram.components {
             let mut inferred_edges = vec![];
             for inferred_edge in &diagram.inferred_edges {
-                if inferred_edge.to_component_id == component.id {
+                if inferred_edge.to_component_id == component.id.into() {
                     inferred_edges.push(inferred_edge.to_owned());
                 }
             }

--- a/lib/dal/tests/integration_test/workspace.rs
+++ b/lib/dal/tests/integration_test/workspace.rs
@@ -99,7 +99,7 @@ async fn export_import_loop(ctx: &mut DalContext) {
     let name_path = &["root", "domain", "name"];
     assert_eq!(
         original_pirate_name, // expected
-        PropEditorTestView::for_component_id(ctx, component.id) //actual
+        PropEditorTestView::for_component_id(ctx, component.id.into()) //actual
             .await
             .expect("could not get property editor test view")
             .get_value(name_path)

--- a/lib/sdf-server/src/server/service/component/delete_property_editor_value.rs
+++ b/lib/sdf-server/src/server/service/component/delete_property_editor_value.rs
@@ -5,7 +5,6 @@ use crate::service::component::ComponentResult;
 use axum::response::IntoResponse;
 use axum::Json;
 use dal::change_status::ChangeStatus;
-use dal::diagram::SummaryDiagramComponent;
 use dal::{
     AttributeValue, AttributeValueId, ChangeSet, Component, ComponentId, PropId, Visibility,
     WsEvent,
@@ -36,13 +35,9 @@ pub async fn delete_property_editor_value(
 
     let component = Component::get_by_id(&ctx, request.component_id).await?;
     let mut socket_map = HashMap::new();
-    let payload: SummaryDiagramComponent = SummaryDiagramComponent::assemble(
-        &ctx,
-        &component,
-        ChangeStatus::Unmodified,
-        &mut socket_map,
-    )
-    .await?;
+    let payload = component
+        .into_frontend_type(&ctx, ChangeStatus::Unmodified, &mut socket_map)
+        .await?;
     WsEvent::component_updated(&ctx, payload)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/component/insert_property_editor_value.rs
+++ b/lib/sdf-server/src/server/service/component/insert_property_editor_value.rs
@@ -4,8 +4,8 @@ use axum::{response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
 use dal::{
-    change_status::ChangeStatus, diagram::SummaryDiagramComponent, AttributeValue,
-    AttributeValueId, ChangeSet, Component, ComponentId, PropId, Visibility, WsEvent,
+    change_status::ChangeStatus, AttributeValue, AttributeValueId, ChangeSet, Component,
+    ComponentId, PropId, Visibility, WsEvent,
 };
 
 use crate::server::extract::{AccessBuilder, HandlerContext};
@@ -43,13 +43,9 @@ pub async fn insert_property_editor_value(
 
     let component: Component = Component::get_by_id(&ctx, request.component_id).await?;
     let mut socket_map = HashMap::new();
-    let payload: SummaryDiagramComponent = SummaryDiagramComponent::assemble(
-        &ctx,
-        &component,
-        ChangeStatus::Unmodified,
-        &mut socket_map,
-    )
-    .await?;
+    let payload = component
+        .into_frontend_type(&ctx, ChangeStatus::Unmodified, &mut socket_map)
+        .await?;
     WsEvent::component_updated(&ctx, payload)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/component/set_type.rs
+++ b/lib/sdf-server/src/server/service/component/set_type.rs
@@ -5,7 +5,6 @@ use axum::{response::IntoResponse, Json};
 
 use dal::change_status::ChangeStatus;
 use dal::component::ComponentGeometry;
-use dal::diagram::SummaryDiagramComponent;
 use dal::{ChangeSet, Component, ComponentId, ComponentType, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
 
@@ -59,13 +58,9 @@ pub async fn set_type(
     // TODO: We'll want to figure out whether this component is Added/Modified, depending on
     // whether it existed in the base change set already or not.
     let mut socket_map = HashMap::new();
-    let payload: SummaryDiagramComponent = SummaryDiagramComponent::assemble(
-        &ctx,
-        &component,
-        ChangeStatus::Unmodified,
-        &mut socket_map,
-    )
-    .await?;
+    let payload = component
+        .into_frontend_type(&ctx, ChangeStatus::Unmodified, &mut socket_map)
+        .await?;
     WsEvent::component_updated(&ctx, payload)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/component/update_property_editor_value.rs
+++ b/lib/sdf-server/src/server/service/component/update_property_editor_value.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use axum::extract::{Host, OriginalUri};
 use axum::{response::IntoResponse, Json};
 use dal::change_status::ChangeStatus;
-use dal::diagram::SummaryDiagramComponent;
 use dal::{
     AttributeValue, AttributeValueId, ChangeSet, Component, ComponentId, Prop, PropId, Secret,
     SecretId, Visibility, WsEvent,
@@ -91,13 +90,9 @@ pub async fn update_property_editor_value(
     }
 
     let mut socket_map = HashMap::new();
-    let payload: SummaryDiagramComponent = SummaryDiagramComponent::assemble(
-        &ctx,
-        &component,
-        ChangeStatus::Unmodified,
-        &mut socket_map,
-    )
-    .await?;
+    let payload = component
+        .into_frontend_type(&ctx, ChangeStatus::Unmodified, &mut socket_map)
+        .await?;
     WsEvent::component_updated(&ctx, payload)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/si-frontend-types-rs/src/component.rs
+++ b/lib/si-frontend-types-rs/src/component.rs
@@ -1,0 +1,117 @@
+use serde::{Deserialize, Serialize};
+use si_events::{ComponentId, SchemaId, SchemaVariantId};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
+
+#[remain::sorted]
+#[derive(
+    Deserialize, Serialize, Debug, PartialEq, Eq, Clone, Copy, Display, EnumString, AsRefStr,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum ChangeStatus {
+    Added,
+    Deleted,
+    Modified,
+    Unmodified,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GridPoint {
+    pub x: isize,
+    pub y: isize,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Size2D {
+    pub width: isize,
+    pub height: isize,
+}
+
+#[derive(Clone, Eq, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ConnectionAnnotation {
+    pub tokens: Vec<String>,
+}
+
+#[remain::sorted]
+#[derive(
+    AsRefStr,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Display,
+    EnumIter,
+    EnumString,
+    Eq,
+    PartialEq,
+    Serialize,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum DiagramSocketDirection {
+    Bidirectional,
+    Input,
+    Output,
+}
+
+#[remain::sorted]
+#[derive(
+    AsRefStr,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Display,
+    EnumIter,
+    EnumString,
+    Eq,
+    PartialEq,
+    Serialize,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum DiagramSocketNodeSide {
+    Left,
+    Right,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagramSocket {
+    pub id: String,
+    pub label: String,
+    pub connection_annotations: Vec<ConnectionAnnotation>,
+    pub direction: DiagramSocketDirection,
+    pub max_connections: Option<usize>,
+    pub is_required: Option<bool>,
+    pub node_side: DiagramSocketNodeSide,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct SummaryDiagramComponent {
+    pub id: ComponentId,
+    pub component_id: ComponentId,
+    pub schema_name: String,
+    pub schema_id: SchemaId,
+    pub schema_variant_id: SchemaVariantId,
+    pub schema_variant_name: String,
+    pub schema_category: String,
+    pub sockets: Vec<DiagramSocket>,
+    pub display_name: String,
+    pub position: GridPoint,
+    pub size: Size2D,
+    pub color: String,
+    pub component_type: String,
+    pub change_status: ChangeStatus,
+    pub has_resource: bool,
+    pub parent_id: Option<ComponentId>,
+    pub created_info: serde_json::Value,
+    pub updated_info: serde_json::Value,
+    pub deleted_info: serde_json::Value,
+    pub to_delete: bool,
+    pub can_be_upgraded: bool,
+    pub from_base_change_set: bool,
+}

--- a/lib/si-frontend-types-rs/src/lib.rs
+++ b/lib/si-frontend-types-rs/src/lib.rs
@@ -1,8 +1,13 @@
+mod component;
 mod conflict;
 mod func;
 mod module;
 mod schema_variant;
 
+pub use crate::component::{
+    ChangeStatus, ConnectionAnnotation, DiagramSocket, DiagramSocketDirection,
+    DiagramSocketNodeSide, GridPoint, Size2D, SummaryDiagramComponent,
+};
 pub use crate::conflict::ConflictWithHead;
 pub use crate::func::{
     AttributeArgumentBinding, FuncArgument, FuncArgumentKind, FuncBinding, FuncBindings, FuncCode,


### PR DESCRIPTION
1. Move `SummaryDiagramComponent` struct to `si_frontend_types` & use `into_frontend_type` fn.
2. Stop firing event from `Component::new`, replace with events in create, paste, and upgrade.
3. Use SummaryDiagramEdge in `WsEvent::connection_created` (now `connection_upserted`) & `connection_deleted`.
4. Ghosted edge fixes in get_diagram
5. Ghosted component & edges fixes in delete_component
6. Ghosted edges fixed in delete_connection
7. Copying and pasting components with edges between them sends correct WsEvents
8. Upgrading components sends correct WsEvents.

<img src="https://media4.giphy.com/media/HloNK1z39EkEQcreIo/giphy.gif"/>