### PR TITLE
Cleanup and encapsulate the logic for finding inferred connections

### DIFF
--- a/lib/dal/src/component/inferred_connection_graph.rs
+++ b/lib/dal/src/component/inferred_connection_graph.rs
@@ -1,0 +1,623 @@
+//! This module encapsulates the logic for finding the inferred incoming and outgoing connections.
+//!
+//! When determining what sockets can infer their connections via Frames, you must take into account:
+//! the [`ComponentType`], and the [`SocketArity`], in addition to where a [`Component`] exists
+//! relative to its parents, children, siblings, and all components in the 'tree'.
+//!
+//! A [`InferredConnectionGraph`] can be assembled by providing one or many [`ComponentId`]s, building
+//! one or many trees that where the [`Component`] exists, then interrogating each [`Component`]'s [`InputSocket`]s
+//! to find which [`OutputSocket`]s they can be connected to.
+//!
+//! As [`OutputSocket`]s do not care which [`InputSocket`]s are pulling data from them, we
+//! build this mapping only from the perspective of the [`InputSocket`] and use that mapping to hydrate both
+//! the Incoming and Outgoing Inferred Connections for a given [`ComponentId`]
+
+use itertools::Itertools;
+use std::collections::{HashMap, HashSet, VecDeque};
+use telemetry::prelude::*;
+
+use super::{
+    socket::{ComponentInputSocket, ComponentOutputSocket},
+    ComponentResult,
+};
+use crate::{
+    Component, ComponentId, ComponentType, DalContext, InputSocket, OutputSocket, OutputSocketId,
+    SocketArity,
+};
+
+#[derive(Eq, PartialEq, Clone, Debug, Default)]
+pub struct InferredConnections {
+    pub input_sockets: HashMap<ComponentInputSocket, HashSet<ComponentOutputSocket>>,
+    pub output_sockets: HashMap<ComponentOutputSocket, HashSet<ComponentInputSocket>>,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug)]
+pub struct InferredConnection {
+    pub input_socket: ComponentInputSocket,
+    pub output_socket: ComponentOutputSocket,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug)]
+pub struct InferredConnectionGraph {
+    components: HashMap<ComponentId, HashSet<ComponentId>>,
+    connections: HashMap<ComponentId, InferredConnections>,
+}
+
+impl InferredConnectionGraph {
+    /// Assembles the [`InferredConnectionGraph`] from the perspective of the given [`ComponentId`]s by first creating a
+    /// a tree representing this Component and all others in the lineage grouping (i.e walk to the top and then get all children)
+    /// for all given ComponentIds.
+    /// Then, find all inferred connections for everything we've found
+    #[instrument(
+        name = "component.inferred_connection_graph.assemble_for_components",
+        level = "debug",
+        skip(ctx)
+    )]
+    pub async fn assemble_for_components(
+        ctx: &DalContext,
+        component_ids: Vec<ComponentId>,
+    ) -> ComponentResult<Self> {
+        let mut component_incoming_connections: HashMap<
+            ComponentId,
+            HashMap<ComponentInputSocket, HashSet<ComponentOutputSocket>>,
+        > = HashMap::new();
+        let mut top_parents: HashSet<ComponentId> = HashSet::new();
+        let mut components: HashMap<ComponentId, HashSet<ComponentId>> = HashMap::new();
+
+        for component_id in component_ids {
+            // Check if the component_id is either a key or a value in the components HashMap
+            let is_in_tree = components.contains_key(&component_id)
+                || components.values().any(|x| x.contains(&component_id));
+
+            // If this component id isn't already in the hashmap somewhere, skip it
+            // since we already have accounted for it!
+            if !is_in_tree {
+                // Get the outermost parent of this tree
+                let first_top_parent = Self::find_top_parent(ctx, component_id).await?;
+                top_parents.insert(first_top_parent);
+                let this_tree = Self::build_tree(ctx, first_top_parent).await?;
+                components.extend(this_tree);
+            }
+        }
+
+        for parent in &top_parents {
+            // Walk down the tree and accumulate connections for every input socket
+            let mut work_queue = VecDeque::new();
+            work_queue.push_back(*parent);
+
+            while let Some(component) = work_queue.pop_front() {
+                let (input_sockets, duplicates) = Self::process_component(ctx, component).await?;
+                Self::update_incoming_connections(
+                    &mut component_incoming_connections,
+                    component,
+                    input_sockets,
+                    duplicates,
+                );
+
+                // Load up next children
+                if let Some(children) = components.get(&component) {
+                    work_queue.extend(children.clone());
+                }
+            }
+        }
+
+        // Populate outgoing connections
+        let component_tree = Self::populate_graph(component_incoming_connections);
+
+        Ok(InferredConnectionGraph {
+            connections: component_tree,
+            components,
+        })
+    }
+
+    /// Create a [`InferredConnectionGraph`] containing all [`Component`]s in this Workspace
+    #[instrument(
+        name = "component.inferred_connection_graph.for_workspace",
+        level = "debug",
+        skip(ctx)
+    )]
+    pub async fn for_workspace(ctx: &DalContext) -> ComponentResult<Self> {
+        // get all components
+        let components = Component::list(ctx)
+            .await?
+            .into_iter()
+            .map(|component| component.id())
+            .collect_vec();
+        Self::assemble_for_components(ctx, components).await
+    }
+
+    /// Assembles the [`InferredConnectionGraph`] from the perspective of this single [`ComponentId`] by first creating a
+    /// a tree representing this Component and all others in the lineage grouping (i.e walk to the top and then get all children)
+    /// Then, find all inferred connections for everything in the tree
+    #[instrument(
+        name = "component.inferred_connection_graph.assemble",
+        level = "debug",
+        skip(ctx)
+    )]
+    pub async fn assemble(
+        ctx: &DalContext,
+        with_component_id: ComponentId,
+    ) -> ComponentResult<Self> {
+        Self::assemble_for_components(ctx, vec![with_component_id]).await
+    }
+
+    /// Walk the frame contains edges to find the top most parent with the given ComponentId beneath it
+    async fn find_top_parent(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<ComponentId> {
+        let mut parent_id = component_id;
+        while let Some(parent) = Component::get_parent_by_id(ctx, parent_id).await? {
+            parent_id = parent;
+        }
+        Ok(parent_id)
+    }
+
+    /// find all inferred incoming connections for the provided component by looping through the component's
+    /// input sockets
+    async fn process_component(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<(
+        HashMap<ComponentInputSocket, HashSet<ComponentOutputSocket>>,
+        HashSet<ComponentOutputSocket>,
+    )> {
+        let mut input_sockets: HashMap<ComponentInputSocket, HashSet<ComponentOutputSocket>> =
+            HashMap::new();
+        let mut duplicate_tracker: HashSet<ComponentOutputSocket> = HashSet::new();
+        let mut duplicates: HashSet<ComponentOutputSocket> = HashSet::new();
+
+        let current_component_input_sockets =
+            ComponentInputSocket::list_for_component_id(ctx, component_id).await?;
+
+        for input_socket in current_component_input_sockets {
+            let incoming_connections = Self::find_available_connections(ctx, input_socket).await?;
+            // Get all existing explicit outgoing connections so that we don't create an inferred connection to the same output socket
+            let existing_incoming_connections =
+                Component::incoming_connections_for_id(ctx, component_id).await?;
+            for incoming_connection in existing_incoming_connections {
+                let component_output_socket = ComponentOutputSocket::get_by_ids_or_error(
+                    ctx,
+                    incoming_connection.from_component_id,
+                    incoming_connection.from_output_socket_id,
+                )
+                .await?;
+                // note: we don't care if a user has drawn multiple edges to the same output socket
+                duplicate_tracker.insert(component_output_socket);
+            }
+            for output_socket in &incoming_connections {
+                if !duplicate_tracker.insert(*output_socket) {
+                    duplicates.insert(*output_socket);
+                }
+            }
+            input_sockets
+                .entry(input_socket)
+                .or_insert(incoming_connections);
+        }
+        Ok((input_sockets, duplicates))
+    }
+
+    /// Adds the found incoming connections to the map, removing duplicate connections (if one input socket is connected to
+    /// two output sockets from the same component)
+    fn update_incoming_connections(
+        component_incoming_connections: &mut HashMap<
+            ComponentId,
+            HashMap<ComponentInputSocket, HashSet<ComponentOutputSocket>>,
+        >,
+        component: ComponentId,
+        input_sockets: HashMap<ComponentInputSocket, HashSet<ComponentOutputSocket>>,
+        duplicates: HashSet<ComponentOutputSocket>,
+    ) {
+        for (input_socket, output_vec) in input_sockets {
+            let filtered_output_vec: HashSet<ComponentOutputSocket> = output_vec
+                .into_iter()
+                .filter(|os| !duplicates.contains(os))
+                .collect();
+
+            // if filtered is empty, there are no connections to this input socket, don't add it
+            if !filtered_output_vec.is_empty() {
+                component_incoming_connections
+                    .entry(component)
+                    .and_modify(|connections| {
+                        connections
+                            .entry(input_socket)
+                            .or_insert_with(|| filtered_output_vec.clone());
+                    })
+                    .or_insert_with(|| HashMap::from([(input_socket, filtered_output_vec)]));
+            }
+        }
+    }
+
+    /// Given the full list of incoming connections, use it to build the map of outgoing connections keyed by output socket
+    fn populate_graph(
+        component_incoming_connections: HashMap<
+            ComponentId,
+            HashMap<ComponentInputSocket, HashSet<ComponentOutputSocket>>,
+        >,
+    ) -> HashMap<ComponentId, InferredConnections> {
+        let mut component_tree: HashMap<ComponentId, InferredConnections> = HashMap::new();
+        for (component, incoming_connections) in component_incoming_connections {
+            for (input_socket, output_sockets) in incoming_connections {
+                component_tree
+                    .entry(component)
+                    .or_default()
+                    .input_sockets
+                    .entry(input_socket)
+                    .and_modify(|outgoing| outgoing.extend(output_sockets.iter().cloned()))
+                    .or_insert_with(|| output_sockets.clone());
+
+                for output_socket in output_sockets {
+                    component_tree
+                        .entry(output_socket.component_id)
+                        .or_default()
+                        .output_sockets
+                        .entry(output_socket)
+                        .and_modify(|connections| {
+                            connections.insert(input_socket);
+                        })
+                        .or_insert_with(|| HashSet::from([input_socket]));
+                }
+            }
+        }
+
+        component_tree
+    }
+
+    fn get_component_inferred_connections(&self, component_id: ComponentId) -> InferredConnections {
+        let connections = match self.connections.get(&component_id) {
+            Some(connections) => connections.clone(),
+            None => InferredConnections {
+                input_sockets: HashMap::new(),
+                output_sockets: HashMap::new(),
+            },
+        };
+        connections
+    }
+
+    /// Get all inferred incoming connections for a given component
+    pub fn get_inferred_incoming_connections_to_component(
+        &self,
+        component_id: ComponentId,
+    ) -> Vec<InferredConnection> {
+        let mut inferred_incoming_connections = Vec::new();
+        let incoming_connections = self.get_component_inferred_connections(component_id);
+        for (input_socket, output_sockets) in incoming_connections.input_sockets {
+            for output_socket in output_sockets {
+                inferred_incoming_connections.push(InferredConnection {
+                    input_socket,
+                    output_socket,
+                });
+            }
+        }
+        inferred_incoming_connections
+    }
+
+    /// Get all inferred outgoing connections for a given [`ComponentId`]
+    pub fn get_inferred_outgoing_connections_for_component(
+        &self,
+        component_id: ComponentId,
+    ) -> Vec<InferredConnection> {
+        let mut inferred_outgoing_connections = Vec::new();
+        let connections = self.get_component_inferred_connections(component_id);
+        for (output_socket, input_sockets) in connections.output_sockets {
+            for input_socket in input_sockets {
+                inferred_outgoing_connections.push(InferredConnection {
+                    input_socket,
+                    output_socket,
+                });
+            }
+        }
+        inferred_outgoing_connections
+    }
+
+    /// Get all inferred connections to a given [`ComponentId`] and [`OutputSocketId`]
+    pub fn get_component_connections_to_output_socket(
+        &self,
+        component_id: ComponentId,
+        output_socket_id: OutputSocketId,
+    ) -> HashSet<ComponentInputSocket> {
+        self.get_component_inferred_connections(component_id)
+            .output_sockets
+            .into_iter()
+            .find_map(|(output_socket, input_sockets)| {
+                if output_socket.output_socket_id == output_socket_id {
+                    Some(input_sockets)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(HashSet::new)
+            .clone()
+    }
+
+    /// Get all inferred connections to a given [`ComponentInputSocket`]
+    pub fn get_component_connections_to_input_socket(
+        &self,
+        component_input_socket: ComponentInputSocket,
+    ) -> HashSet<ComponentOutputSocket> {
+        self.get_component_inferred_connections(component_input_socket.component_id)
+            .input_sockets
+            .get(&component_input_socket)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Get all inferred connections that exist for the constructed [`InferredConnectionGraph`].
+    pub fn get_all_inferred_connections(&self) -> Vec<InferredConnection> {
+        let mut incoming_connections = Vec::new();
+        for inferred_connection in self.connections.values() {
+            for (input_socket, output_sockets) in inferred_connection.input_sockets.clone() {
+                for output_socket in output_sockets {
+                    incoming_connections.push(InferredConnection {
+                        input_socket,
+                        output_socket,
+                    });
+                }
+            }
+        }
+        incoming_connections
+    }
+
+    /// For the provided [`ComponentId`], build a tree of all Components that are a descendant (directly or indirectly)
+    async fn build_tree(
+        ctx: &DalContext,
+        first_top_parent: ComponentId,
+    ) -> ComponentResult<HashMap<ComponentId, HashSet<ComponentId>>> {
+        let mut resp = HashMap::new();
+        let mut work_queue = VecDeque::new();
+        work_queue.push_back(first_top_parent);
+        while let Some(parent) = work_queue.pop_front() {
+            let children = Component::get_children_for_id(ctx, parent).await?;
+            resp.insert(
+                parent,
+                children
+                    .clone()
+                    .into_iter()
+                    .collect::<HashSet<ComponentId>>(),
+            );
+            work_queue.extend(children);
+        }
+        Ok(resp)
+    }
+
+    /// For a given [`ComponentInputSocket`], find all incoming connections based on the [`ComponentType`]. If the
+    /// [`ComponentInputSocket`] is manually configured (aka a user has drawn an edge to it), we return early as we do not
+    /// mix and match Inferred/Explicit connections.
+    ///
+    /// [`ComponentType::Component`]s and [`ComponentType::ConfigurationFrameDown`] search up the ancestry tree
+    /// and will connect to the closest matching [`ComponentOutputSocket`]
+    ///
+    /// [`ComponentType::ConfigurationFrameUp`] can connect to both descendants of the up frame, and ascendants of the up frame
+    /// if the ascendant is a [`ComponentType::ConfigurationFrameDown`]
+    async fn find_available_connections(
+        ctx: &DalContext,
+        component_input_socket: ComponentInputSocket,
+    ) -> ComponentResult<HashSet<ComponentOutputSocket>> {
+        // if this socket is manually configured, early return
+        if ComponentInputSocket::is_manually_configured(ctx, component_input_socket).await? {
+            return Ok(HashSet::new());
+        }
+
+        let destination_sockets =
+            match Component::get_type_by_id(ctx, component_input_socket.component_id).await? {
+                ComponentType::Component | ComponentType::ConfigurationFrameDown => {
+                    //For a component, or a down frame, check my parents and other ancestors
+                    // find the first output socket match that is a down frame and use it!
+                    Self::find_closest_connection_in_ancestors(
+                        ctx,
+                        component_input_socket,
+                        vec![ComponentType::ConfigurationFrameDown],
+                    )
+                    .await?
+                }
+                ComponentType::ConfigurationFrameUp => {
+                    // An up frame's input sockets are sourced from either its children's output sockets
+                    // or an ancestor.  Based on the input socket's arity, we match many (sorted by component ulid)
+                    // or if the arity is single, we return none
+                    let mut matches = vec![];
+                    let descendant_matches = Self::find_connections_in_descendants(
+                        ctx,
+                        component_input_socket,
+                        vec![
+                            ComponentType::ConfigurationFrameUp,
+                            ComponentType::Component,
+                        ],
+                    )
+                    .await?;
+                    matches.extend(descendant_matches);
+
+                    if let [connection] = Self::find_closest_connection_in_ancestors(
+                        ctx,
+                        component_input_socket,
+                        vec![ComponentType::ConfigurationFrameDown],
+                    )
+                    .await?
+                    .as_slice()
+                    {
+                        matches.push(*connection);
+                    }
+
+                    let input_socket =
+                        InputSocket::get_by_id(ctx, component_input_socket.input_socket_id).await?;
+                    if input_socket.arity() == SocketArity::One && matches.len() > 1 {
+                        vec![]
+                    } else {
+                        matches
+                    }
+                }
+                ComponentType::AggregationFrame => vec![], // Aggregation Frames are not supported
+            };
+        Ok(destination_sockets
+            .into_iter()
+            .collect::<HashSet<ComponentOutputSocket>>())
+    }
+
+    /// For the given [`ComponentInputSocket`], discover if this set of children has any connections.  If the
+    /// [`ComponentInputSocket`] is [`SocketArity::Many`], we allow multiple children to connect to it. If it's
+    /// a [`SocketArity::One`], we only allow one [`ComponentOutputSocket`] to connect to it, so if we find that
+    /// there are multiple connections, we return an empty list which will force the user to decide which one they
+    /// want.
+    ///
+    /// This helper is useful so that we can early return and stop looking if we find there is a potential connection
+    /// that is ambiguious (as we don't skip ambiguous connections and continue search their children)
+    async fn find_connections_for_children(
+        ctx: &DalContext,
+        input_socket: ComponentInputSocket,
+        component_types: &[ComponentType],
+        children: Vec<ComponentId>,
+        arity: SocketArity,
+    ) -> ComponentResult<(Vec<ComponentOutputSocket>, Vec<ComponentId>)> {
+        let mut output_matches = vec![];
+        let mut next_children = vec![];
+
+        for child in children {
+            if component_types.contains(&Component::get_type_by_id(ctx, child).await?) {
+                let matches = Self::find_connections_in_component(ctx, input_socket, child).await?;
+                match arity {
+                    SocketArity::One if matches.len() == 1 => {
+                        output_matches.push(matches[0]);
+                        return Ok((output_matches, vec![])); // Stop searching after finding one match
+                    }
+                    SocketArity::One if matches.len() > 1 => {
+                        return Ok((vec![], vec![])); // Multiple matches found, return empty
+                    }
+                    SocketArity::One => {} // no matches, do nothing and keep looking
+                    SocketArity::Many => {
+                        output_matches.extend(matches);
+                    }
+                }
+            }
+            next_children.extend(Component::get_children_for_id(ctx, child).await?);
+        }
+
+        Ok((output_matches, next_children))
+    }
+
+    /// For the provided [`ComponentInputSocket`], find any matching [`ComponentOutputSocket`] that should
+    /// drive this [`InputSocket`] by searching down the descendants of the [`Component`],
+    /// checking children first and walking down until we find any matches.
+    ///
+    /// If the provided [`ComponentInputSocket`] has a [`SocketArity::One`], we look for only one
+    /// eligible [`OutputSocket`]. If we find multiple, we won't return any, forcing the
+    /// user to explicity draw the edge.
+    ///
+    /// If it has an [`SocketArity::Many`], we will look for multiple matches, but they must
+    /// be at the same 'level' to be considered valid.
+    async fn find_connections_in_descendants(
+        ctx: &DalContext,
+        component_input_socket: ComponentInputSocket,
+        component_types: Vec<ComponentType>,
+    ) -> ComponentResult<Vec<ComponentOutputSocket>> {
+        let component_id = component_input_socket.component_id;
+        let children = Component::get_children_for_id(ctx, component_id).await?;
+        let socket_arrity = InputSocket::get_by_id(ctx, component_input_socket.input_socket_id)
+            .await?
+            .arity();
+        //load up the children and look for matches
+        let mut work_queue: VecDeque<Vec<ComponentId>> = VecDeque::new();
+        work_queue.push_front(children);
+        while let Some(children) = work_queue.pop_front() {
+            let (matches, next_children) = Self::find_connections_for_children(
+                ctx,
+                component_input_socket,
+                &component_types,
+                children,
+                socket_arrity,
+            )
+            .await?;
+
+            // if there are matches found, return them and stop looking
+            // otherwise, load up the next children if there are any
+            if matches.is_empty() && !next_children.is_empty() {
+                work_queue.push_back(next_children);
+            } else {
+                return Ok(matches);
+            }
+        }
+        Ok(vec![])
+    }
+
+    /// For the provided [`ComponentInputSocket`], find the nearest [`ComponentOutputSocket`] in the ancestry tree
+    /// that should drive this [`InputSocket`] (first searching parents and onwards up the ancestry tree)
+    #[instrument(level = "debug", skip(ctx))]
+    async fn find_closest_connection_in_ancestors(
+        ctx: &DalContext,
+        component_input_socket: ComponentInputSocket,
+        component_types: Vec<ComponentType>,
+    ) -> ComponentResult<Vec<ComponentOutputSocket>> {
+        if let Some(parent_id) =
+            Component::get_parent_by_id(ctx, component_input_socket.component_id).await?
+        {
+            let mut work_queue = VecDeque::from([parent_id]);
+            while let Some(component_id) = work_queue.pop_front() {
+                // see if this component is the right type
+
+                if component_types.contains(&Component::get_type_by_id(ctx, component_id).await?) {
+                    // get all output sockets for this component
+                    let maybe_matches = Self::find_connections_in_component(
+                        ctx,
+                        component_input_socket,
+                        component_id,
+                    )
+                    .await?;
+                    {
+                        if maybe_matches.len() > 1 {
+                            // this ancestor has more than one match
+                            // stop looking and return None to force
+                            // the user to manually draw an edge to this socket
+                            debug!("More than one match found: {:?}", maybe_matches);
+                            return Ok(vec![]);
+                        }
+                        if maybe_matches.len() == 1 {
+                            // this ancestor has 1 match!
+                            // return and stop looking
+                            return Ok(maybe_matches);
+                        }
+                    }
+                }
+                // didn't find it, so let's queue up the next parent if it exists
+                if let Some(maybe_parent_id) =
+                    Component::get_parent_by_id(ctx, component_id).await?
+                {
+                    work_queue.push_back(maybe_parent_id);
+                }
+            }
+        }
+
+        Ok(vec![])
+    }
+
+    /// For a given [`ComponentInputSocket`], search within the given [`ComponentId`] to see if there are any [`ComponentOutputSocket`]s
+    /// Note: this does not enforce or check [`SocketArity`]. Even though we do not want one [`InputSocket`] to match multiple [`OutputSocket`]s
+    /// from the same Component, that is enforced elsewhere to differentiate between 'this is an ambiguous connection' and 'there are no available
+    /// connections here'
+    async fn find_connections_in_component(
+        ctx: &DalContext,
+        input_socket_match: ComponentInputSocket,
+        source_component_id: ComponentId,
+    ) -> ComponentResult<Vec<ComponentOutputSocket>> {
+        // check for matching output socket names for this input socket
+        let parent_sv_id = Component::schema_variant_id(ctx, source_component_id).await?;
+        let output_socket_ids =
+            OutputSocket::list_ids_for_schema_variant(ctx, parent_sv_id).await?;
+        let mut maybe_matches = vec![];
+
+        for output_socket_id in output_socket_ids {
+            if OutputSocket::fits_input_by_id(
+                ctx,
+                input_socket_match.input_socket_id,
+                output_socket_id,
+            )
+            .await?
+            {
+                if let Some(component_output_socket) =
+                    ComponentOutputSocket::get_by_ids(ctx, source_component_id, output_socket_id)
+                        .await?
+                {
+                    maybe_matches.push(component_output_socket);
+                }
+            }
+        }
+        Ok(maybe_matches)
+    }
+}

--- a/lib/dal/src/component/socket.rs
+++ b/lib/dal/src/component/socket.rs
@@ -1,0 +1,381 @@
+use std::collections::{hash_map, HashMap};
+
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use telemetry::prelude::*;
+
+use crate::{
+    attribute::{prototype::argument::AttributePrototypeArgument, value::ValueIsFor},
+    AttributePrototype, AttributeValue, AttributeValueId, Component, ComponentId, DalContext,
+    InputSocketId, OutputSocketId,
+};
+
+use super::{inferred_connection_graph::InferredConnectionGraph, ComponentError, ComponentResult};
+
+/// Represents a given [`Component`]'s [`crate::InputSocket`], identified by its
+/// (non-unique) [`InputSocketId`] and unique [`AttributeValueId`]
+#[derive(Eq, Hash, PartialEq, Clone, Debug, Copy, Serialize, Deserialize)]
+pub struct ComponentInputSocket {
+    pub component_id: ComponentId,
+    pub input_socket_id: InputSocketId,
+    pub attribute_value_id: AttributeValueId,
+}
+
+/// Represents a given [`Component`]'s [`crate::OutputSocket`], identified by its
+/// (non-unique) [`OutputSocketId`] and unique [`AttributeValueId`]
+#[derive(Eq, Hash, PartialEq, Clone, Debug, Copy, Serialize, Deserialize)]
+pub struct ComponentOutputSocket {
+    pub component_id: ComponentId,
+    pub output_socket_id: OutputSocketId,
+    pub attribute_value_id: AttributeValueId,
+}
+
+impl ComponentOutputSocket {
+    /// Find all inferred [`ComponentInputSocket`]s that are pulling data from the provided
+    /// [`AttributeValueId`] that represents an [`crate::OutputSocket`] for a specific [`Component`]
+    ///
+    /// Output sockets can drive Input Sockets through inference based on the following logic:
+    ///
+    /// Components, Down Frames, and Up Frames can drive Input Sockets of their parents if the parent is an
+    /// Up Frame.
+    ///
+    /// Down Frames can drive Input Sockets of their children if the child is a Down Frame
+    /// or a Component or an Up Frame.
+    #[instrument(level = "debug", name="component.component_output_socket.find_inferred_connections" skip(ctx))]
+    pub async fn find_inferred_connections(
+        ctx: &DalContext,
+        attribute_value_id: AttributeValueId,
+    ) -> ComponentResult<Vec<ComponentInputSocket>> {
+        // let's make sure this av is actually for an output socket
+        let value_is_for = AttributeValue::is_for(ctx, attribute_value_id).await?;
+        let output_socket_id = match value_is_for {
+            ValueIsFor::Prop(_) | ValueIsFor::InputSocket(_) => {
+                return Err(ComponentError::WrongAttributeValueType(
+                    attribute_value_id,
+                    value_is_for,
+                ))
+            }
+            ValueIsFor::OutputSocket(sock) => sock,
+        };
+        let component_id = AttributeValue::component_id(ctx, attribute_value_id).await?;
+        // build the latest component tree for this component
+        let component_tree = InferredConnectionGraph::assemble(ctx, component_id).await?;
+        // get the input sockets using this output socket
+        let mut connections: Vec<ComponentInputSocket> = component_tree
+            .get_component_connections_to_output_socket(component_id, output_socket_id)
+            .into_iter()
+            .collect();
+        // sort by component id for consistent ordering
+        connections.sort_by_key(|input| input.component_id);
+        Ok(connections)
+    }
+
+    /// Given a [`ComponentId`] and [`OutputSocketId`] find the [`ComponentOutputSocket`]
+    pub async fn get_by_ids(
+        ctx: &DalContext,
+        component_id: ComponentId,
+        output_socket_id: OutputSocketId,
+    ) -> ComponentResult<Option<ComponentOutputSocket>> {
+        let output_socket = Self::list_for_component_id(ctx, component_id)
+            .await?
+            .into_iter()
+            .find(|socket| socket.output_socket_id == output_socket_id);
+
+        Ok(output_socket)
+    }
+
+    /// Given a [`ComponentId`] and [`OutputSocketId`] find the [`ComponentOutputSocket`]
+    /// returns an error if one is not found
+    pub async fn get_by_ids_or_error(
+        ctx: &DalContext,
+        component_id: ComponentId,
+        output_socket_id: OutputSocketId,
+    ) -> ComponentResult<ComponentOutputSocket> {
+        match Self::get_by_ids(ctx, component_id, output_socket_id).await? {
+            Some(component_output_socket) => Ok(component_output_socket),
+            None => Err(ComponentError::OutputSocketNotFoundForComponentId(
+                output_socket_id,
+                component_id,
+            )),
+        }
+    }
+
+    /// List all [`ComponentOutputSocket`]s for a given [`ComponentId`]
+    pub async fn list_for_component_id(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<Vec<Self>> {
+        let mut result = Vec::new();
+
+        let socket_values = Component::attribute_values_for_all_sockets(ctx, component_id).await?;
+
+        for attribute_value_id in socket_values {
+            if let Some(output_socket_id) = AttributeValue::is_for(ctx, attribute_value_id)
+                .await?
+                .output_socket_id()
+            {
+                result.push(ComponentOutputSocket {
+                    component_id,
+                    output_socket_id,
+                    attribute_value_id,
+                });
+            }
+        }
+        Ok(result)
+    }
+
+    /// List all [`AttributeValueId`]s for the given [`ComponentId`]s [`crate::OutputSocket`]s
+    pub async fn attribute_values_for_component_id(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<Vec<AttributeValueId>> {
+        let mut result = HashMap::new();
+
+        let socket_values = Component::attribute_values_for_all_sockets(ctx, component_id).await?;
+
+        for socket_value_id in socket_values {
+            if let Some(output_socket_id) = AttributeValue::is_for(ctx, socket_value_id)
+                .await?
+                .output_socket_id()
+            {
+                match result.entry(output_socket_id) {
+                    hash_map::Entry::Vacant(entry) => {
+                        entry.insert(ComponentOutputSocket {
+                            component_id,
+                            attribute_value_id: socket_value_id,
+                            output_socket_id,
+                        });
+                    }
+                    hash_map::Entry::Occupied(_) => {
+                        return Err(ComponentError::OutputSocketTooManyAttributeValues(
+                            output_socket_id,
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(result
+            .into_values()
+            .map(|component_output_socket| component_output_socket.attribute_value_id)
+            .collect_vec())
+    }
+}
+
+impl ComponentInputSocket {
+    /// Find all inferred [`ComponentOutputSocket`]s for the provided
+    /// [`ComponentInputSocket`] is pulling data from.
+    ///
+    /// [`crate::InputSocket`]s pull data through inference based on the following logic:
+    ///
+    /// Components and Down Frames find the closest [`crate::OutputSocket`] in their
+    /// ancestors they can connect to
+    ///
+    /// Depending on the [`crate::SocketArity`], Up Frames can connect to ancestors AND descendants.
+    /// If there is ever ambiguity about which [`crate::InputSocket`] they should connect to, we default
+    /// to none, forcing the user to explicity configure a connection by drawing an Edge
+    #[instrument(level = "debug", name="component.component_output_socket.find_inferred_connections" skip(ctx))]
+
+    pub async fn find_inferred_connections(
+        ctx: &DalContext,
+        component_input_socket: ComponentInputSocket,
+    ) -> ComponentResult<Vec<ComponentOutputSocket>> {
+        let component_graph =
+            InferredConnectionGraph::assemble(ctx, component_input_socket.component_id).await?;
+        let mut connections: Vec<ComponentOutputSocket> = component_graph
+            .get_component_connections_to_input_socket(component_input_socket)
+            .into_iter()
+            .collect();
+
+        connections.sort_by_key(|output| output.component_id);
+        Ok(connections)
+    }
+
+    /// List all [`ComponentInputSocket`]s for a given [`ComponentId`]
+    pub async fn list_for_component_id(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<Vec<ComponentInputSocket>> {
+        let mut result = Vec::new();
+
+        let socket_values = Component::attribute_values_for_all_sockets(ctx, component_id).await?;
+
+        for attribute_value_id in socket_values {
+            if let Some(input_socket_id) = AttributeValue::is_for(ctx, attribute_value_id)
+                .await?
+                .input_socket_id()
+            {
+                result.push(ComponentInputSocket {
+                    component_id,
+                    input_socket_id,
+                    attribute_value_id,
+                });
+            }
+        }
+        Ok(result)
+    }
+
+    /// Given a [`ComponentId`] and [`InputSocketId`] find the [`ComponentInputSocket`]
+    pub async fn get_by_ids(
+        ctx: &DalContext,
+        component_id: ComponentId,
+        input_socket_id: InputSocketId,
+    ) -> ComponentResult<Option<ComponentInputSocket>> {
+        let input_socket = Self::list_for_component_id(ctx, component_id)
+            .await?
+            .into_iter()
+            .find(|socket| socket.input_socket_id == input_socket_id);
+
+        Ok(input_socket)
+    }
+
+    /// Given a [`ComponentId`] and [`InputSocketId`] find the [`ComponentInputSocket`]
+    /// return an error if one is not found
+    pub async fn get_by_ids_or_error(
+        ctx: &DalContext,
+        component_id: ComponentId,
+        input_socket_id: InputSocketId,
+    ) -> ComponentResult<ComponentInputSocket> {
+        match Self::get_by_ids(ctx, component_id, input_socket_id).await? {
+            Some(component_input_socket) => Ok(component_input_socket),
+            None => Err(ComponentError::InputSocketNotFoundForComponentId(
+                input_socket_id,
+                component_id,
+            )),
+        }
+    }
+
+    /// List all [`AttributeValueId`]s for the given [`ComponentId`]s [`crate::InputSocket`]s
+    pub async fn attribute_values_for_component_id(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<Vec<AttributeValueId>> {
+        let mut result = HashMap::new();
+
+        let socket_values = Component::attribute_values_for_all_sockets(ctx, component_id).await?;
+
+        for socket_value_id in socket_values {
+            if let Some(input_socket_id) = AttributeValue::is_for(ctx, socket_value_id)
+                .await?
+                .input_socket_id()
+            {
+                match result.entry(input_socket_id) {
+                    hash_map::Entry::Vacant(entry) => {
+                        entry.insert(ComponentInputSocket {
+                            component_id,
+                            attribute_value_id: socket_value_id,
+                            input_socket_id,
+                        });
+                    }
+                    hash_map::Entry::Occupied(_) => {
+                        return Err(ComponentError::InputSocketTooManyAttributeValues(
+                            input_socket_id,
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(result
+            .into_values()
+            .map(|input_socket| input_socket.attribute_value_id)
+            .collect_vec())
+    }
+
+    /// Finds the source [`Component`] of any [`crate::ComponentType`] for a given [`ComponentInputSocket`] where the
+    /// [`crate::InputSocket`] has [`crate::SocketArity::One`]
+    #[instrument(
+        name = "component.component_input_socket.find_connection_arity_one",
+        level = "debug",
+        skip_all
+    )]
+    pub async fn find_connection_arity_one(
+        ctx: &DalContext,
+        component_input_socket: ComponentInputSocket,
+    ) -> ComponentResult<Option<ComponentId>> {
+        let maybe_explicit_connection_source = {
+            let explicit_connections =
+                Component::incoming_connections_for_id(ctx, component_input_socket.component_id)
+                    .await?;
+            let filtered_explicit_connection_sources: Vec<ComponentId> = explicit_connections
+                .iter()
+                .filter(|c| c.to_input_socket_id == component_input_socket.input_socket_id)
+                .map(|c| c.from_component_id)
+                .collect();
+            if filtered_explicit_connection_sources.len() > 1 {
+                return Err(ComponentError::TooManyExplicitConnectionSources(
+                    filtered_explicit_connection_sources,
+                    component_input_socket.component_id,
+                    component_input_socket.input_socket_id,
+                ));
+            }
+            filtered_explicit_connection_sources.first().copied()
+        };
+        let maybe_inferred_connection_source = {
+            let inferred_connections = match Self::find_inferred_connections(
+                ctx,
+                component_input_socket,
+            )
+            .await
+            {
+                Ok(inferred_connections) => inferred_connections,
+                Err(ComponentError::ComponentMissingTypeValueMaterializedView(_)) => {
+                    debug!(?component_input_socket, "component type not yet set when finding available inferred connections to input socket");
+                    Vec::new()
+                }
+                Err(other_err) => Err(other_err)?,
+            };
+            if inferred_connections.len() > 1 {
+                return Err(ComponentError::TooManyInferredConnections(
+                    inferred_connections,
+                    component_input_socket,
+                ));
+            }
+            inferred_connections.first().map(|c| c.component_id)
+        };
+
+        match (
+            maybe_explicit_connection_source,
+            maybe_inferred_connection_source,
+        ) {
+            (Some(explicit_source), Some(inferred_source)) => {
+                Err(ComponentError::UnexpectedExplicitAndInferredSources(
+                    explicit_source,
+                    inferred_source,
+                    component_input_socket,
+                ))
+            }
+            (Some(explicit_source), None) => Ok(Some(explicit_source)),
+            (None, Some(inferred_source)) => Ok(Some(inferred_source)),
+            (None, None) => Ok(None),
+        }
+    }
+
+    /// Return true if the input socket already has an explicit connection (a user drew an edge)
+    #[instrument(level = "debug", skip(ctx))]
+    pub async fn is_manually_configured(
+        ctx: &DalContext,
+        component_input_socket: ComponentInputSocket,
+    ) -> ComponentResult<bool> {
+        // if the input socket has an explicit connection, then we will not gather any implicit
+        // note we could do some weird logic here when it comes to sockets with arrity of many
+        // but let's punt for now
+        if let Some(maybe_attribute_prototype) =
+            AttributePrototype::find_for_input_socket(ctx, component_input_socket.input_socket_id)
+                .await?
+        {
+            // if this socket has an attribute prototype argument,
+            //that means it has an explicit connection and we should not
+            // look for implicits
+            let maybe_apa = AttributePrototypeArgument::list_ids_for_prototype_and_destination(
+                ctx,
+                maybe_attribute_prototype,
+                component_input_socket.component_id,
+            )
+            .await?;
+            if !maybe_apa.is_empty() {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -21,7 +21,7 @@ use crate::attribute::prototype::argument::value_source::ValueSource;
 use crate::attribute::prototype::argument::{
     AttributePrototypeArgument, AttributePrototypeArgumentError, AttributePrototypeArgumentId,
 };
-use crate::component::InputSocketMatch;
+use crate::component::socket::ComponentInputSocket;
 use crate::prop::PropError;
 use crate::schema::variant::root_prop::RootPropChild;
 use crate::TransactionsError;
@@ -1181,9 +1181,9 @@ impl FuncRunner {
                 ))? {
                     ValueSource::InputSocket(input_socket_id) => {
                         if let Some(source_component_id) =
-                            Component::source_component_for_arity_one_input_socket_match(
+                            ComponentInputSocket::find_connection_arity_one(
                                 ctx,
-                                InputSocketMatch {
+                                ComponentInputSocket {
                                     component_id,
                                     input_socket_id,
                                     attribute_value_id,

--- a/lib/dal/src/socket/input.rs
+++ b/lib/dal/src/socket/input.rs
@@ -7,13 +7,10 @@ use std::sync::Arc;
 use telemetry::prelude::*;
 use thiserror::Error;
 
-use crate::attribute::prototype::argument::{
-    AttributePrototypeArgument, AttributePrototypeArgumentError,
-};
+use crate::attribute::prototype::argument::AttributePrototypeArgumentError;
 use crate::attribute::prototype::AttributePrototypeError;
 use crate::attribute::value::AttributeValueError;
 use crate::change_set::ChangeSetError;
-use crate::component::InputSocketMatch;
 use crate::func::FuncError;
 use crate::layer_db_types::{InputSocketContent, InputSocketContentV1};
 
@@ -451,33 +448,6 @@ impl InputSocket {
         };
 
         Ok(maybe_input_socket)
-    }
-    #[instrument(level = "debug", skip(ctx))]
-    pub async fn is_manually_configured(
-        ctx: &DalContext,
-        input_socket_match: InputSocketMatch,
-    ) -> InputSocketResult<bool> {
-        // if the input socket has an explicit connection, then we will not gather any implicit
-        // note we could do some weird logic here when it comes to sockets with arrity of many
-        // but let's punt for now
-        if let Some(maybe_attribute_prototype) =
-            AttributePrototype::find_for_input_socket(ctx, input_socket_match.input_socket_id)
-                .await?
-        {
-            // if this socket has an attribute prototype argument,
-            //that means it has an explicit connection and we should not
-            // look for implicits
-            let maybe_apa = AttributePrototypeArgument::list_ids_for_prototype_and_destination(
-                ctx,
-                maybe_attribute_prototype,
-                input_socket_match.component_id,
-            )
-            .await?;
-            if !maybe_apa.is_empty() {
-                return Ok(true);
-            }
-        }
-        Ok(false)
     }
 
     pub async fn find_equivalent_in_schema_variant(


### PR DESCRIPTION
This PR includes bug fixes and cleanup as the functionality of Frames has evolved since it was first ported to the new engine and there was lingering traversal bugs depending on if you were searching for Outgoing or Incoming inferred connections. 

There is a new module InferredConnectionGraph which encapsulates the logic around finding Inferred Connections (incoming and outgoing), moving this logic out of the Component module.  

All of the existing tests apply and I added a new one to account for the fix to ensure that multiple Input Sockets for an Up Frame don't connect to the same Output Socket.

<div><img src="https://media2.giphy.com/media/bgT142FWjRwV4hWsvX/giphy.gif?cid=5a38a5a2mbwtgikerycvivyv8g63x0a346srhucvnqku7f9m&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/kiszkiloszki/">Kiszkiloszki</a> on <a href="https://giphy.com/gifs/art-loop-hand-bgT142FWjRwV4hWsvX">GIPHY</a></div>