### PR TITLE
feat: forward metrics from firecracker jails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "cyclone-server",
+ "si-firecracker",
  "si-service",
  "telemetry-application",
  "tokio",
@@ -1288,7 +1289,9 @@ dependencies = [
  "derive_builder",
  "futures",
  "hyper 0.14.30",
+ "nix 0.27.1",
  "pin-project-lite",
+ "procfs",
  "remain",
  "serde",
  "serde_json",
@@ -1297,6 +1300,7 @@ dependencies = [
  "si-std",
  "telemetry",
  "telemetry-http",
+ "telemetry-utils",
  "thiserror",
  "tokio",
  "tokio-serde",
@@ -4000,6 +4004,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags 2.6.0",
+ "chrono",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.6.0",
+ "chrono",
+ "hex",
+]
+
+[[package]]
 name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5317,6 +5347,8 @@ dependencies = [
  "remain",
  "thiserror",
  "tokio",
+ "tokio-util",
+ "tokio-vsock",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ mime_guess = { version = "=2.0.4" } # TODO(fnichol): 2.0.5 sets an env var in bu
 miniz_oxide = { version = "0.7.2", features = ["simd"] }
 moka = { version = "0.12.5", features = ["future"] }
 names = { version = "0.14.0", default-features = false }
-nix = { version = "0.27.1", features = ["mount", "process", "signal"] }
+nix = { version = "0.27.1", features = ["mount", "process", "signal", "user"] }
 nkeys = "0.4.0"
 num_cpus = "1.16.0"
 once_cell = "1.19.0"
@@ -136,6 +136,7 @@ postcard = { version = "1.0.8", features = ["use-std"] }
 postgres-types = { version = "0.2.6", features = ["derive"] }
 pretty_assertions_sorted = "1.2.3"
 proc-macro2 = "1.0.79"
+procfs = "0.16.0"
 quote = "1.0.35"
 rand = "0.8.5"
 refinery = { version = "= 0.8.12", features = ["tokio-postgres"] }
@@ -185,6 +186,7 @@ uuid = { version = "1.8.0", features = ["serde", "v4"] }
 vfs = "0.12.0"
 vfs-tar = { version = "0.4.1", features = ["mmap"] }
 webpki-roots = { version = "0.25.4" }
+version_check = "0.9.4"
 xxhash-rust = { version = "0.8.10", features = ["xxh3", "const_xxh3"] }
 y-sync = { version = "0.4.0", features = ["net"] }
 yrs = { version = "0.17.4" }

--- a/bin/cyclone/BUCK
+++ b/bin/cyclone/BUCK
@@ -37,7 +37,12 @@ rust_binary(
         "//third-party/rust:color-eyre",
         "//third-party/rust:tokio",
         "//third-party/rust:tokio-util",
-    ],
+    ] + select({
+        "DEFAULT": [],
+        "config//os:linux": [
+            "//lib/si-firecracker:si-firecracker",
+        ],
+    }),
     srcs = glob(["src/**/*.rs"]),
 )
 

--- a/bin/cyclone/Cargo.toml
+++ b/bin/cyclone/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 clap = { workspace = true }
 color-eyre = { workspace = true }
 cyclone-server = { path = "../../lib/cyclone-server" }
+si-firecracker = { path = "../../lib/si-firecracker" }
 si-service = { path = "../../lib/si-service" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 tokio = { workspace = true }

--- a/bin/cyclone/src/args.rs
+++ b/bin/cyclone/src/args.rs
@@ -138,6 +138,22 @@ pub(crate) struct Args {
     /// Limits execution requests to the given value before shutting down
     #[arg(long, group = "request_limiting")]
     pub(crate) limit_requests: Option<u32>,
+
+    /// Enables vsock forwarder.
+    #[arg(long, group = "forwarder")]
+    pub(crate) enable_forwarder: bool,
+
+    /// Disables vsock forwarder.
+    #[arg(long, group = "forwarder")]
+    pub(crate) disable_forwarder: bool,
+
+    /// Enables process gatherer.
+    #[arg(long, group = "gatherer")]
+    pub(crate) enable_process_gatherer: bool,
+
+    /// Disables process gatherer.
+    #[arg(long, group = "gatherer")]
+    pub(crate) disable_process_gatherer: bool,
 }
 
 impl TryFrom<Args> for Config {
@@ -192,6 +208,17 @@ impl TryFrom<Args> for Config {
             builder.limit_requests(limit_requests);
         }
 
+        if args.enable_forwarder {
+            builder.enable_forwarder(true);
+        } else if args.disable_forwarder {
+            builder.enable_forwarder(false);
+        }
+
+        if args.enable_process_gatherer {
+            builder.enable_process_gatherer(true);
+        } else if args.disable_process_gatherer {
+            builder.enable_forwarder(false);
+        }
         builder.build().map_err(Into::into)
     }
 }

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -235,10 +235,10 @@ local_resource(
     labels = ["backend"],
     cmd = cmd,
     serve_cmd = serve_cmd,
-    serve_env = {"SI_FORCE_COLOR": "true"},
-    # This is the serve command you might need if you want to execute on firecracker for 10 functione executions.
+    # serve_cmd = "buck2 run {} -- --cyclone-local-firecracker --cyclone-pool-size 10".format(veritech_target),
+    # This ^ is the serve command you might need if you want to execute on firecracker for 10 functione executions.
     # NB: BUCK2 MUST RUN AS ROOT OR THIS WILL NOT WORK
-    # serve_cmd = "SI_LOG=debug buck2 run {} -- --cyclone-local-firecracker --cyclone-pool-size 10".format(veritech_target),
+    serve_env = {"SI_FORCE_COLOR": "true"},
     allow_parallel = True,
     resource_deps = [
         "nats",

--- a/lib/cyclone-server/BUCK
+++ b/lib/cyclone-server/BUCK
@@ -10,6 +10,7 @@ rust_library(
         "//lib/si-std:si-std",
         "//lib/telemetry-http-rs:telemetry-http",
         "//lib/telemetry-rs:telemetry",
+        "//lib/telemetry-utils-rs:telemetry-utils",
         "//third-party/rust:async-trait",
         "//third-party/rust:axum",
         "//third-party/rust:base64",
@@ -17,6 +18,7 @@ rust_library(
         "//third-party/rust:derive_builder",
         "//third-party/rust:futures",
         "//third-party/rust:hyper",
+        "//third-party/rust:nix",
         "//third-party/rust:pin-project-lite",
         "//third-party/rust:remain",
         "//third-party/rust:serde",
@@ -30,6 +32,7 @@ rust_library(
     ] + select({
         "DEFAULT": [],
         "config//os:linux": [
+            "//third-party/rust:procfs",
             "//third-party/rust:tokio-vsock",
         ],
     }),

--- a/lib/cyclone-server/Cargo.toml
+++ b/lib/cyclone-server/Cargo.toml
@@ -18,7 +18,9 @@ cyclone-core = { path = "../../lib/cyclone-core" }
 derive_builder = { workspace = true }
 futures = { workspace = true }
 hyper = { workspace = true }
+nix = { workspace = true }
 pin-project-lite = { workspace = true }
+procfs = { workspace = true }
 remain = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -26,6 +28,7 @@ si-crypto = { path = "../../lib/si-crypto" }
 si-settings = { path = "../../lib/si-settings" }
 si-std = { path = "../../lib/si-std" }
 telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-utils = { path = "../../lib/telemetry-utils-rs" }
 telemetry-http = { path = "../../lib/telemetry-http-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/lib/cyclone-server/src/config.rs
+++ b/lib/cyclone-server/src/config.rs
@@ -60,6 +60,12 @@ pub struct Config {
 
     #[builder(setter(into), default)]
     limit_requests: Option<u32>,
+
+    #[builder(setter(into), default = "false")]
+    enable_forwarder: bool,
+
+    #[builder(setter(into), default = "false")]
+    enable_process_gatherer: bool,
 }
 
 impl Config {
@@ -139,6 +145,18 @@ impl Config {
     #[must_use]
     pub fn limit_requests(&self) -> Option<u32> {
         self.limit_requests
+    }
+
+    /// Gets a reference to the config's enable forwarder.
+    #[must_use]
+    pub fn enable_forwarder(&self) -> bool {
+        self.enable_forwarder
+    }
+
+    /// Gets a reference to the config's enable process gatherer.
+    #[must_use]
+    pub fn enable_process_gatherer(&self) -> bool {
+        self.enable_process_gatherer
     }
 }
 

--- a/lib/cyclone-server/src/lib.rs
+++ b/lib/cyclone-server/src/lib.rs
@@ -2,6 +2,8 @@ mod config;
 mod execution;
 mod extract;
 mod handlers;
+#[cfg(target_os = "linux")]
+pub mod process_gatherer;
 mod result;
 mod routes;
 mod server;
@@ -15,6 +17,8 @@ mod watch;
 
 pub use axum::extract::ws::Message as WebSocketMessage;
 pub use config::{Config, ConfigBuilder, ConfigError, IncomingStream};
+#[cfg(target_os = "linux")]
+pub use process_gatherer::init;
 pub use server::{Runnable, Server, ShutdownSource};
 pub use timestamp::timestamp;
 #[cfg(target_os = "linux")]

--- a/lib/cyclone-server/src/process_gatherer.rs
+++ b/lib/cyclone-server/src/process_gatherer.rs
@@ -1,0 +1,122 @@
+use nix::unistd::{getpgrp, Pid};
+#[cfg(target_os = "linux")]
+use procfs::process::all_processes;
+use std::collections::HashSet;
+use std::result;
+use telemetry::prelude::info;
+use telemetry::tracing::debug;
+use tokio::sync::{mpsc, Mutex};
+use tokio::time::Duration;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+use telemetry_utils::metric;
+use thiserror::Error;
+use tokio::time::sleep;
+
+type Result<T> = result::Result<T, ProcessGathererError>;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ProcessGathererError {
+    #[error("failed to get processes: {0}")]
+    Process(#[from] procfs::ProcError),
+    #[error("shutdown error: {0}")]
+    Shutdown(#[from] mpsc::error::SendError<CancellationToken>),
+}
+
+pub struct ProcessGathererTask {
+    client: ProcessGatherer,
+    shutdown_token: CancellationToken,
+}
+
+impl ProcessGathererTask {
+    const NAME: &'static str = "ProcessGathererTask";
+
+    fn create(client: ProcessGatherer, shutdown_token: CancellationToken) -> Result<Self> {
+        Ok(Self {
+            client,
+            shutdown_token,
+        })
+    }
+
+    async fn run(mut self) {
+        loop {
+            tokio::select! {
+                _ = self.shutdown_token.cancelled() => {
+                    debug!(task = Self::NAME, "received cancellation");
+                    self.client.stop().await;
+                    break;
+                }
+                _ = self.client.start() => {
+                }
+                else => {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct ProcessGatherer {
+    procs: Mutex<HashSet<String>>,
+}
+
+impl ProcessGatherer {
+    pub fn new() -> Self {
+        let procs = HashSet::new().into();
+        Self { procs }
+    }
+
+    pub async fn start(&mut self) -> Result<()> {
+        loop {
+            {
+                let mut procs = self.procs.lock().await;
+                for proc in all_processes()?.flatten() {
+                    if let Ok(stat) = proc.stat() {
+                        if Pid::from_raw(stat.pgrp) == getpgrp() {
+                            procs.insert(stat.comm);
+                        }
+                    }
+                }
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    }
+    pub async fn stop(&mut self) {
+        for proc in self.procs.lock().await.iter() {
+            metric!(counter.cyclone.process = 1, proc = proc);
+            info!(counter.cyclone.process = 1, proc = proc);
+        }
+    }
+}
+
+#[must_use]
+pub struct ProcessGathererShutdownGuard {
+    shutdown_token: CancellationToken,
+}
+
+impl ProcessGathererShutdownGuard {
+    pub async fn wait(self) -> Result<()> {
+        self.shutdown_token.cancelled().await;
+        Ok(())
+    }
+}
+
+pub fn init(
+    enable: bool,
+    tracker: &TaskTracker,
+    shutdown_token: CancellationToken,
+) -> Result<ProcessGathererShutdownGuard> {
+    let client = ProcessGatherer::new();
+
+    let guard = ProcessGathererShutdownGuard {
+        shutdown_token: shutdown_token.clone(),
+    };
+    if enable {
+        tracker.spawn(ProcessGathererTask::create(client, shutdown_token.clone())?.run());
+    }
+
+    Ok(guard)
+}

--- a/lib/si-firecracker/BUCK
+++ b/lib/si-firecracker/BUCK
@@ -4,16 +4,19 @@ rust_library(
     name = "si-firecracker",
     deps = [
         "//lib/cyclone-core:cyclone-core",
+        "//third-party/rust:futures",
         "//third-party/rust:remain",
         "//third-party/rust:nix",
         "//third-party/rust:thiserror",
         "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
         "//third-party/rust:tracing",
     ] + select({
         "DEFAULT": [],
         "config//os:linux": [
             "//third-party/rust:krata-loopdev",
             "//third-party/rust:devicemapper",
+            "//third-party/rust:tokio-vsock",
         ],
     }),
     srcs = glob(["src/**/*.rs","src/scripts/*"]),

--- a/lib/si-firecracker/Cargo.toml
+++ b/lib/si-firecracker/Cargo.toml
@@ -15,6 +15,7 @@ nix = { workspace = true }
 remain = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
@@ -22,3 +23,4 @@ tracing = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 devicemapper =  { workspace = true }
 krata-loopdev = { workspace = true }
+tokio-vsock = { workspace = true }

--- a/lib/si-firecracker/src/disk.rs
+++ b/lib/si-firecracker/src/disk.rs
@@ -65,7 +65,7 @@ impl FirecrackerDisk {
         Ok(())
     }
 
-    fn jail_dir_from_id(id: u32) -> PathBuf {
+    pub fn jail_dir_from_id(id: u32) -> PathBuf {
         let path = PathBuf::from(JAIL_PATH_PREFIX);
         path.join(id.to_string()).join("root")
     }

--- a/lib/si-firecracker/src/errors.rs
+++ b/lib/si-firecracker/src/errors.rs
@@ -1,5 +1,7 @@
 use thiserror::Error;
 
+use crate::stream::StreamForwarderError;
+
 /// Error type for [`PoolNoodle`].
 #[remain::sorted]
 #[derive(Debug, Error)]
@@ -26,6 +28,9 @@ pub enum FirecrackerJailError {
     // Failed to spawn firecracker
     #[error("Failed to spawn firecracker: {0}")]
     Spawn(#[source] tokio::io::Error),
+    // StreamForwarderError
+    #[error("StreamForwarderError: {0}")]
+    StreamForwarder(#[from] StreamForwarderError),
     // Failed to terminate firecracker
     #[error("Failed to terminate firecracker: {0}")]
     Terminate(#[from] cyclone_core::process::ShutdownError),

--- a/lib/si-firecracker/src/firecracker.rs
+++ b/lib/si-firecracker/src/firecracker.rs
@@ -1,6 +1,8 @@
 #[cfg(target_os = "linux")]
 use crate::disk::FirecrackerDisk;
 use crate::errors::FirecrackerJailError;
+#[cfg(target_os = "linux")]
+use crate::stream::UnixStreamForwarder;
 use cyclone_core::process;
 use std::fs::Permissions;
 use std::os::unix::fs::PermissionsExt;
@@ -81,6 +83,13 @@ impl FirecrackerJail {
                     .unwrap_or_else(|_| "Failed to decode stderr".to_string()),
             ));
         }
+
+        #[cfg(target_os = "linux")]
+        UnixStreamForwarder::new(FirecrackerDisk::jail_dir_from_id(id), id)
+            .await?
+            .start()
+            .await?;
+
         Ok(())
     }
 

--- a/lib/si-firecracker/src/lib.rs
+++ b/lib/si-firecracker/src/lib.rs
@@ -4,3 +4,4 @@ mod disk;
 pub mod errors;
 /// [`FirecrackerJail`] implementations.
 pub mod firecracker;
+pub mod stream;

--- a/lib/si-firecracker/src/scripts/firecracker-setup.sh
+++ b/lib/si-firecracker/src/scripts/firecracker-setup.sh
@@ -234,13 +234,6 @@ execute_configuration_management() {
         # Adjust MTU to make it consistent
         ip link set dev $(ip route get 8.8.8.8 | awk -- '{printf $5}') mtu 1500
 
-        # This permits NAT from within the Jail to access the otelcol running on the external interface of the machine. Localhost is `not` resolveable from
-        # within the jail or the micro-vm directly due to /etc/hosts misalignment. Hardcoding the destination to 12.0.0.1 for the otel endpoint allows us to
-        # ship a static copy of the rootfs but allow us to keep the dynamic nature of the machine hosting.
-        if ! iptables -t nat -C PREROUTING -p tcp --dport 4316 -d 1.0.0.1 -j DNAT --to-destination $(ip route get 8.8.8.8 | awk -- '{printf $7}'):4317; then
-          iptables -t nat -A PREROUTING -p tcp --dport 4316 -d 1.0.0.1 -j DNAT --to-destination $(ip route get 8.8.8.8 | awk -- '{printf $7}'):4317
-        fi
-
     else
         echo "Error: Unsupported or unknown configuration management tool specified, exiting."
         exit 1

--- a/lib/si-firecracker/src/stream.rs
+++ b/lib/si-firecracker/src/stream.rs
@@ -1,0 +1,145 @@
+use tokio::{
+    io::{copy_bidirectional, AsyncRead, AsyncWrite},
+    task::JoinHandle,
+};
+use tracing::debug;
+
+use nix::unistd::{chown, Gid, Uid};
+use std::path::{Path, PathBuf};
+use tokio::net::{TcpListener, TcpStream};
+#[cfg(target_os = "linux")]
+use tokio_vsock::VsockStream;
+
+use tokio::fs;
+
+use thiserror::Error;
+
+use tokio::net::UnixListener;
+
+const UID_BASE: u32 = 5000;
+const GID: u32 = 10000;
+const HOST_CID: u32 = 2;
+const DEFAULT_OTEL_PORT: u32 = 4317;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum StreamForwarderError {
+    #[error("failed to accept stream: {0}")]
+    Accept(#[source] std::io::Error),
+    #[error("failed to bind to socket: {1}")]
+    Bind(#[source] std::io::Error, PathBuf),
+    #[error("chown error: {0}")]
+    Chown(#[source] nix::errno::Errno),
+    #[error("stream copy error: {0}")]
+    Copy(#[source] std::io::Error),
+    #[error("Unix Read error: {0}")]
+    Read(#[source] std::io::Error),
+    #[error("TCP Stream error: {0}")]
+    Tcp(#[source] std::io::Error),
+    #[error("Vsock Stream error: {0}")]
+    Vsock(#[source] std::io::Error),
+}
+
+type Result<T> = std::result::Result<T, StreamForwarderError>;
+
+#[derive(Debug)]
+pub struct UnixStreamForwarder {
+    source: UnixListener,
+    port: u32,
+}
+
+impl UnixStreamForwarder {
+    pub async fn new(in_path: impl AsRef<Path>, id: u32) -> Result<Self> {
+        let port = DEFAULT_OTEL_PORT;
+        let mut path = in_path.as_ref().to_path_buf();
+        path.push(format!("v.sock_{port}"));
+        // cleanup just in case the socket already exists somehow
+        let _ignored = fs::remove_file(path.clone()).await;
+
+        let source = UnixListener::bind(&path)
+            .map_err(|err| StreamForwarderError::Bind(err, path.clone()))?;
+        // the jailer runs as a specific user and that user must own the socket
+        chown_for_id(path, id)?;
+
+        Ok(Self { source, port })
+    }
+
+    #[allow(clippy::let_underscore_future)] // These needs to just run in the background forever.
+    pub async fn start(self) -> Result<()> {
+        debug!(port = %self.port, "starting uds -> tcp forwarder");
+        let _: JoinHandle<Result<()>> = tokio::spawn(async move {
+            loop {
+                let (uds_stream, _) = self
+                    .source
+                    .accept()
+                    .await
+                    .map_err(StreamForwarderError::Accept)?;
+
+                let tcp_stream = TcpStream::connect(format!("127.0.0.1:{}", self.port))
+                    .await
+                    .map_err(StreamForwarderError::Tcp)?;
+
+                tokio::spawn(read_and_forward(uds_stream, tcp_stream));
+            }
+        });
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct TcpStreamForwarder {
+    source: TcpListener,
+    port: u32,
+}
+
+impl TcpStreamForwarder {
+    pub async fn new() -> Result<Self> {
+        let port = DEFAULT_OTEL_PORT;
+        let addr = format!("127.0.0.1:{}", port);
+        let source = TcpListener::bind(addr)
+            .await
+            .map_err(StreamForwarderError::Tcp)?;
+
+        Ok(Self { source, port })
+    }
+
+    #[allow(clippy::let_underscore_future)] // These needs to just run in the background forever.
+    #[cfg(target_os = "linux")]
+    pub async fn start(self) -> Result<()> {
+        debug!(port = %self.port, "starting tcp -> vsock forwarder");
+        let _: JoinHandle<Result<()>> = tokio::spawn(async move {
+            loop {
+                let (tcp_stream, _) = self
+                    .source
+                    .accept()
+                    .await
+                    .map_err(StreamForwarderError::Accept)?;
+
+                let vsock_stream = VsockStream::connect(HOST_CID, self.port)
+                    .await
+                    .map_err(StreamForwarderError::Vsock)?;
+
+                tokio::spawn(read_and_forward(tcp_stream, vsock_stream));
+            }
+        });
+        Ok(())
+    }
+}
+async fn read_and_forward<StreamA, StreamB>(mut a: StreamA, mut b: StreamB) -> Result<()>
+where
+    StreamA: AsyncRead + AsyncWrite + Unpin + 'static,
+    StreamB: AsyncRead + AsyncWrite + Unpin + 'static,
+{
+    copy_bidirectional(&mut a, &mut b)
+        .await
+        .map_err(StreamForwarderError::Copy)?;
+
+    Ok(())
+}
+
+fn chown_for_id(path: PathBuf, id: u32) -> Result<()> {
+    let uid = Uid::from_raw(UID_BASE + id);
+    let gid = Gid::from_raw(GID);
+    chown(&path, Some(uid), Some(gid)).map_err(StreamForwarderError::Chown)?;
+    Ok(())
+}

--- a/lib/si-pool-noodle/src/pool_noodle.rs
+++ b/lib/si-pool-noodle/src/pool_noodle.rs
@@ -300,7 +300,7 @@ where
                 }
             } else {
                 retries += 1;
-                debug!(
+                info!(
                     "Failed to get from pool, retry ({} of {})",
                     retries, max_retries
                 );

--- a/lib/telemetry-utils-rs/src/lib.rs
+++ b/lib/telemetry-utils-rs/src/lib.rs
@@ -1,12 +1,15 @@
 #[macro_export]
 macro_rules! metric {
-    ($key:ident = $value:expr) => {
-        info!(metrics = true, $key = $value);
+    ($key:ident = $value:expr, *) => {
+        info!(metrics = true, $key = $value, *);
     };
-    ($key:literal = $value:expr) => {
-        info!(metrics = true, $key = $value);
+    ($key:literal = $value:expr, *) => {
+        info!(metrics = true, $key = $value, *);
     };
     ($($key:ident).+ = $value:expr) => {
         info!(metrics = true, $($key).+ = $value);
+    };
+    ($($key:ident).+ = $value:expr, $label:ident = $label_value:expr) => {
+        info!(metrics = true, $($key).+ = $value, $label = $label_value);
     };
 }

--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -85,12 +85,12 @@ sudo mount -v "$ROOTFS" "$ROOTFSMOUNT"
 cyclone_args=(
   --bind-vsock 3:52
   --lang-server /usr/local/bin/lang-js
-  --enable-watch
   --limit-requests 1
   --watch-timeout 30
   --enable-ping
-  --enable-resolver
-  --enable-action-run
+  --enable-watch
+  --enable-forwarder
+  --enable-process-gatherer
   -vvvv
 )
 
@@ -130,7 +130,7 @@ rc-update add sshd
 echo "ttyS0::respawn:/sbin/mingetty --autologin root --noclear ttyS0" >> /etc/inittab
 sed -i 's/root:*::0:::::/root:::0:::::/g' /etc/shadow
 
-# mount decryption key volume
+# mount scripts volume
 cat <<EOV >>"/etc/fstab"
 LABEL=scripts     /mnt/scripts    ext4   defaults 0 0
 EOV
@@ -145,7 +145,6 @@ supervisor="supervise-daemon"
 pidfile="/cyclone/agent.pid"
 
 start(){
-  export OTEL_EXPORTER_OTLP_ENDPOINT=http://1.0.0.1:4316
   if [ -f /mnt/scripts/scripts ]; then
       source /mnt/scripts/scripts
   fi
@@ -158,7 +157,6 @@ depend(){
 EOF
 
 chmod +x "/etc/init.d/cyclone"
-
 rc-update add cyclone
 
 # Set up TAP device route/escape

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -7953,7 +7953,9 @@ cargo.rust_library(
         "general",
         "ioctl",
         "no_std",
+        "prctl",
         "std",
+        "system",
     ],
     visibility = [],
 )
@@ -8741,12 +8743,14 @@ cargo.rust_library(
     edition = "2021",
     features = [
         "default",
+        "feature",
         "fs",
         "ioctl",
         "mount",
         "process",
         "signal",
         "uio",
+        "user",
     ],
     visibility = [],
     deps = [
@@ -10879,6 +10883,98 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "procfs",
+    actual = ":procfs-0.16.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "procfs-0.16.0.crate",
+    sha256 = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4",
+    strip_prefix = "procfs-0.16.0",
+    urls = ["https://static.crates.io/crates/procfs/0.16.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "procfs-0.16.0",
+    srcs = [":procfs-0.16.0.crate"],
+    crate = "procfs",
+    crate_root = "procfs-0.16.0.crate/src/lib.rs",
+    edition = "2018",
+    env = {
+        "OUT_DIR": "$(location :procfs-0.16.0-build-script-run[out_dir])",
+    },
+    features = [
+        "chrono",
+        "default",
+        "flate2",
+    ],
+    visibility = [],
+    deps = [
+        ":bitflags-2.6.0",
+        ":chrono-0.4.38",
+        ":flate2-1.0.31",
+        ":hex-0.4.3",
+        ":lazy_static-1.5.0",
+        ":procfs-core-0.16.0",
+        ":rustix-0.38.34",
+    ],
+)
+
+cargo.rust_binary(
+    name = "procfs-0.16.0-build-script-build",
+    srcs = [":procfs-0.16.0.crate"],
+    crate = "build_script_build",
+    crate_root = "procfs-0.16.0.crate/build.rs",
+    edition = "2018",
+    features = [
+        "chrono",
+        "default",
+        "flate2",
+    ],
+    visibility = [],
+)
+
+buildscript_run(
+    name = "procfs-0.16.0-build-script-run",
+    package_name = "procfs",
+    buildscript_rule = ":procfs-0.16.0-build-script-build",
+    features = [
+        "chrono",
+        "default",
+        "flate2",
+    ],
+    version = "0.16.0",
+)
+
+http_archive(
+    name = "procfs-core-0.16.0.crate",
+    sha256 = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29",
+    strip_prefix = "procfs-core-0.16.0",
+    urls = ["https://static.crates.io/crates/procfs-core/0.16.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "procfs-core-0.16.0",
+    srcs = [":procfs-core-0.16.0.crate"],
+    crate = "procfs_core",
+    crate_root = "procfs-core-0.16.0.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "chrono",
+        "default",
+    ],
+    visibility = [],
+    deps = [
+        ":bitflags-2.6.0",
+        ":chrono-0.4.38",
+        ":hex-0.4.3",
+    ],
+)
+
 http_archive(
     name = "prost-0.12.6.crate",
     sha256 = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29",
@@ -13004,8 +13100,12 @@ cargo.rust_library(
         "default",
         "fs",
         "libc-extra-traits",
+        "param",
+        "process",
         "std",
+        "system",
         "termios",
+        "thread",
         "use-libc-auxv",
     ],
     platform = {
@@ -13068,8 +13168,12 @@ cargo.rust_binary(
         "default",
         "fs",
         "libc-extra-traits",
+        "param",
+        "process",
         "std",
+        "system",
         "termios",
+        "thread",
         "use-libc-auxv",
     ],
     visibility = [],
@@ -13084,8 +13188,12 @@ buildscript_run(
         "default",
         "fs",
         "libc-extra-traits",
+        "param",
+        "process",
         "std",
+        "system",
         "termios",
+        "thread",
         "use-libc-auxv",
     ],
     version = "0.38.34",
@@ -15804,6 +15912,7 @@ cargo.rust_binary(
         ":postgres-types-0.2.7",
         ":pretty_assertions_sorted-1.2.3",
         ":proc-macro2-1.0.86",
+        ":procfs-0.16.0",
         ":quote-1.0.36",
         ":rand-0.8.5",
         ":refinery-0.8.12",
@@ -15850,6 +15959,7 @@ cargo.rust_binary(
         ":ulid-1.1.3",
         ":url-2.5.2",
         ":uuid-1.10.0",
+        ":version_check-0.9.5",
         ":vfs-0.12.0",
         ":vfs-tar-0.4.1",
         ":webpki-roots-0.25.4",
@@ -17709,6 +17819,12 @@ cargo.rust_library(
         ":getrandom-0.2.15",
         ":serde-1.0.207",
     ],
+)
+
+alias(
+    name = "version_check",
+    actual = ":version_check-0.9.5",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -3866,6 +3866,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags 2.6.0",
+ "chrono",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.6.0",
+ "chrono",
+ "hex",
+]
+
+[[package]]
 name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5650,6 +5676,7 @@ dependencies = [
  "postgres-types",
  "pretty_assertions_sorted",
  "proc-macro2",
+ "procfs",
  "quote",
  "rand 0.8.5",
  "refinery",
@@ -5696,6 +5723,7 @@ dependencies = [
  "ulid",
  "url",
  "uuid",
+ "version_check",
  "vfs 0.12.0",
  "vfs-tar",
  "webpki-roots 0.25.4",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -78,7 +78,7 @@ mime_guess = { version = "=2.0.4" } # TODO(fnichol): 2.0.5 sets an env var in bu
 miniz_oxide = { version = "0.7.2", features = ["simd"] }
 moka = { version = "0.12.5", features = ["future"] }
 names = { version = "0.14.0", default-features = false }
-nix = { version = "0.27.1", features = ["mount", "process", "signal"] }
+nix = { version = "0.27.1", features = ["mount", "process", "signal", "user"] }
 nkeys = "0.4.0"
 num_cpus = "1.16.0"
 once_cell = "1.19.0"
@@ -97,6 +97,7 @@ postcard = { version = "1.0.8", features = ["use-std"] }
 postgres-types = { version = "0.2.6", features = ["derive"] }
 pretty_assertions_sorted = "1.2.3"
 proc-macro2 = "1.0.79"
+procfs = "0.16.0"
 quote = "1.0.35"
 rand = "0.8.5"
 refinery = { version = "= 0.8.12", features = ["tokio-postgres"] }
@@ -146,6 +147,7 @@ uuid = { version = "1.8.0", features = ["serde", "v4"] }
 vfs = "0.12.0"
 vfs-tar = { version = "0.4.1", features = ["mmap"] }
 webpki-roots = { version = "0.25.4" }
+version_check = "0.9.4"
 xxhash-rust = { version = "0.8.10", features = ["xxh3", "const_xxh3"] }
 y-sync = { version = "0.4.0", features = ["net"] }
 yrs = { version = "0.17.4" }

--- a/third-party/rust/fixups/procfs/fixups.toml
+++ b/third-party/rust/fixups/procfs/fixups.toml
@@ -1,0 +1,2 @@
+[[buildscript]]
+[buildscript.gen_srcs]


### PR DESCRIPTION
Hokay, so.

This PR creates three things:
1. A tool that can listen to TCP streams and forward the data to a vsock socket
2. A tool that can listen to UDS streams and forward the data to a TCP stream
3. A tool that polls the currently running processes and spits them out as metrics

All of these combined allows us to have Cyclone Server forward metric/trace calls to otel to a vsock socket on the host, Veritech to listen to a vsock-per-jail to accept that traffic and forward it along to the local otel, and for Cyclone Server to emit the processes that run through the lifetime of the jail as metrics so we can keep track of what people are doing with all these functions.

In short, this means we no longer need to rely on dodgy iptables rules to ship otel from cyclone.

The stream forwarder and the process gatherer are disabled by default and should really only be run when using firecracker. 

<img src="https://media1.giphy.com/media/G1q9aWw8RJwuOMaVDw/giphy.gif"/>
