### PR TITLE
Add ability to kill function executions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6907,6 +6907,7 @@ dependencies = [
  "derive_builder",
  "futures",
  "nats-subscriber",
+ "once_cell",
  "remain",
  "serde",
  "serde_json",

--- a/app/web/src/components/Workspace/WorkspaceAdminDashboard.vue
+++ b/app/web/src/components/Workspace/WorkspaceAdminDashboard.vue
@@ -1,0 +1,59 @@
+<template>
+  <div
+    class="w-full h-full flex flex-col items-center relative overflow-hidden dark:bg-neutral-800 dark:text-shade-0 bg-neutral-50 text-neutral-900"
+  >
+    <Stack spacing="lg">
+      <span class="flex flex-row mt-10 font-bold text-3xl"
+        >Admin Dashboard</span
+      >
+      <Stack>
+        <h2 class="font-bold text-lg">KILL FUNCTION EXECUTION</h2>
+        <VormInput
+          v-model="funcRunId"
+          label="FuncRunId for function execution"
+        />
+        <div class="flex flex-row-reverse gap-sm">
+          <VButton
+            :disabled="!funcRunId"
+            :requestStatus="cancelExecutionReqStatus"
+            class="flex-grow"
+            icon="plus-circle"
+            label="Kill function execution"
+            loadingText="Killing function execution"
+            tone="success"
+            @click="cancelExecution"
+          />
+        </div>
+      </Stack>
+    </Stack>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { onBeforeMount, ref } from "vue";
+import { Stack, VormInput, VButton } from "@si/vue-lib/design-system";
+import { useRouter } from "vue-router";
+import { useAdminStore } from "@/store/admin.store";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
+
+const adminStore = useAdminStore();
+const featureFlagStore = useFeatureFlagsStore();
+
+const router = useRouter();
+onBeforeMount(async () => {
+  if (!featureFlagStore.ADMIN_PANEL_ACCESS) {
+    await router.push({ name: "workspace-single" });
+  }
+});
+
+const cancelExecutionReqStatus =
+  adminStore.getRequestStatus("CANCEL_EXECUTION");
+
+const funcRunId = ref<string | null>(null);
+
+const cancelExecution = () => {
+  if (funcRunId.value) {
+    adminStore.CANCEL_EXECUTION(funcRunId.value);
+  }
+};
+</script>

--- a/app/web/src/components/layout/navbar/ProfileButton.vue
+++ b/app/web/src/components/layout/navbar/ProfileButton.vue
@@ -1,8 +1,8 @@
 <template>
   <NavbarButton
     ref="navbarButtonRef"
-    tooltipText="Profile"
     class="flex-none py-xs"
+    tooltipText="Profile"
   >
     <template #default="{ open, hovered }">
       <div class="flex-row flex text-white items-center">
@@ -29,15 +29,21 @@
       />
       <DropdownMenuItem
         v-if="isDevMode"
-        linkToNamedRoute="workspace-dev-dashboard"
         icon="cat"
         label="Dev Dashboard"
+        linkToNamedRoute="workspace-dev-dashboard"
+      />
+      <DropdownMenuItem
+        v-if="featureFlagsStore.ADMIN_PANEL_ACCESS"
+        icon="alert-triangle"
+        label="Admin Dashboard"
+        linkToNamedRoute="workspace-admin-dashboard"
       />
       <DropdownMenuItem
         class="profile-dropdown-menu-logout"
-        linkToNamedRoute="logout"
         icon="logout"
         label="Logout"
+        linkToNamedRoute="logout"
       />
     </template>
     <template #dropdownContentSecondary>
@@ -73,8 +79,11 @@ import SiArrow from "@/components/SiArrow.vue";
 import { useAuthStore } from "@/store/auth.store";
 import { isDevMode } from "@/utils/debug";
 import { useWorkspacesStore } from "@/store/workspaces.store";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import NavbarButton from "./NavbarButton.vue";
 import UserIcon from "./UserIcon.vue";
+
+const featureFlagsStore = useFeatureFlagsStore();
 
 const AUTH_PORTAL_URL = import.meta.env.VITE_AUTH_PORTAL_URL;
 const workspacesStore = useWorkspacesStore();

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -88,6 +88,12 @@ const routes: RouteRecordRaw[] = [
           },
         ],
       },
+      {
+        path: "admin",
+        name: "workspace-admin-dashboard",
+        component: () =>
+          import("@/components/Workspace/WorkspaceAdminDashboard.vue"),
+      },
       ...(isDevMode
         ? [
             {

--- a/app/web/src/store/admin.store.ts
+++ b/app/web/src/store/admin.store.ts
@@ -1,0 +1,30 @@
+import { addStoreHooks, ApiRequest } from "@si/vue-lib/pinia";
+import { defineStore } from "pinia";
+import { FuncRunId } from "@/store/func_runs.store";
+import { useWorkspacesStore } from "./workspaces.store";
+
+export const useAdminStore = () => {
+  const workspacesStore = useWorkspacesStore();
+  const workspaceId = workspacesStore.selectedWorkspacePk;
+
+  const API_PREFIX = `v2/workspaces/${workspaceId}/admin`;
+
+  return addStoreHooks(
+    workspaceId,
+    null,
+    defineStore(`ws${workspaceId || "NONE"}/admin`, {
+      state: () => ({}),
+      actions: {
+        async CANCEL_EXECUTION(funcRunId: FuncRunId) {
+          return new ApiRequest<null>({
+            method: "put",
+            url: `${API_PREFIX}/func/runs/${funcRunId}/cancel_execution`,
+          });
+        },
+      },
+      onActivated() {
+        return () => {};
+      },
+    }),
+  )();
+};

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -9,6 +9,7 @@ const FLAG_MAPPING = {
   MODULES_TAB: "modules_tab",
   FIRST_TIME_TUTORIAL_MODAL: "first_time_tutorial_modal",
   DEV_SLICE_REBASING: "dev-slice-rebasing",
+  ADMIN_PANEL_ACCESS: "si_admin_panel_access",
 };
 
 type FeatureFlags = keyof typeof FLAG_MAPPING;

--- a/bin/lang-js/.eslintignore
+++ b/bin/lang-js/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 coverage
+examples

--- a/bin/lang-js/.eslintrc.cjs
+++ b/bin/lang-js/.eslintrc.cjs
@@ -10,8 +10,8 @@ module.exports = {
     {
       files: ["**/*.ts"],
       rules: {
-        "no-console": "off",
+        "no-console": "off"
       }
     }
-  ],
+  ]
 };

--- a/lib/cyclone-core/src/cancel_execution.rs
+++ b/lib/cyclone-core/src/cancel_execution.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CancelExecutionRequest {
+    pub execution_id: String,
+}

--- a/lib/cyclone-core/src/lib.rs
+++ b/lib/cyclone-core/src/lib.rs
@@ -13,6 +13,7 @@
 
 mod action_run;
 mod before;
+mod cancel_execution;
 mod canonical_command;
 mod component_view;
 mod liveness;
@@ -30,6 +31,7 @@ pub use si_crypto::SensitiveStrings;
 
 pub use action_run::{ActionRunRequest, ActionRunResultSuccess, ResourceStatus};
 pub use before::BeforeFunction;
+pub use cancel_execution::CancelExecutionRequest;
 pub use canonical_command::{CanonicalCommand, CanonicalCommandError};
 pub use component_view::{ComponentKind, ComponentView};
 pub use liveness::{LivenessStatus, LivenessStatusParseError};

--- a/lib/cyclone-core/src/progress.rs
+++ b/lib/cyclone-core/src/progress.rs
@@ -1,5 +1,8 @@
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
+/// The error kind for function result failures when the error occurs within the veritech server.
+const FUNCTION_RESULT_FAILURE_ERROR_KIND_VERITECH_SERVER: &str = "veritechServer";
+
 /// A line of output, streamed from an executing function.
 ///
 /// An instance of this type typically maps to a single line of output from a process--either on
@@ -97,11 +100,50 @@ pub enum FunctionResult<S> {
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]
 pub struct FunctionResultFailure {
-    pub execution_id: String,
-    pub error: FunctionResultFailureError,
-    // FIXME(nick,wendy): get the Utc::now() shape as well
-    // (perhaps struct Foo { raw: Utc::now(), timestamp: crate::timestamp() } )
-    pub timestamp: u64,
+    execution_id: String,
+    error: FunctionResultFailureError,
+    timestamp: u64,
+}
+
+impl FunctionResultFailure {
+    /// Creates a [`FunctionResultFailure`].
+    pub fn new(
+        execution_id: impl Into<String>,
+        error: FunctionResultFailureError,
+        timestamp: u64,
+    ) -> Self {
+        Self {
+            execution_id: execution_id.into(),
+            error,
+            timestamp,
+        }
+    }
+
+    /// This kind of [`FunctionResultFailure`] occurs when the veritech server encounters an error.
+    pub fn new_for_veritech_server_error(
+        execution_id: impl Into<String>,
+        message: impl Into<String>,
+        timestamp: u64,
+    ) -> Self {
+        Self {
+            execution_id: execution_id.into(),
+            error: FunctionResultFailureError {
+                kind: FUNCTION_RESULT_FAILURE_ERROR_KIND_VERITECH_SERVER.to_string(),
+                message: message.into(),
+            },
+            timestamp,
+        }
+    }
+
+    /// Returns a reference to the "execution_id".
+    pub fn execution_id(&self) -> &String {
+        &self.execution_id
+    }
+
+    /// Returns a reference to the "error".
+    pub fn error(&self) -> &FunctionResultFailureError {
+        &self.error
+    }
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]

--- a/lib/cyclone-server/src/execution.rs
+++ b/lib/cyclone-server/src/execution.rs
@@ -471,14 +471,14 @@ where
     fn from(value: LangServerResult<LangServerSuccess>) -> Self {
         match value {
             LangServerResult::Success(success) => Self::Success(success.into()),
-            LangServerResult::Failure(failure) => Self::Failure(FunctionResultFailure {
-                execution_id: failure.execution_id,
-                error: FunctionResultFailureError {
+            LangServerResult::Failure(failure) => Self::Failure(FunctionResultFailure::new(
+                failure.execution_id,
+                FunctionResultFailureError {
                     kind: failure.error.kind,
                     message: failure.error.message,
                 },
-                timestamp: crate::timestamp(),
-            }),
+                crate::timestamp(),
+            )),
         }
     }
 }

--- a/lib/dal/src/func/backend/js_attribute.rs
+++ b/lib/dal/src/func/backend/js_attribute.rs
@@ -33,9 +33,7 @@ impl FuncDispatch for FuncBackendJsAttribute {
         before: Vec<BeforeFunction>,
     ) -> Box<Self> {
         let request = ResolverFunctionRequest {
-            // Once we start tracking the state of these executions, then this id will be useful,
-            // but for now it's passed along and back, and is opaque
-            execution_id: "tomcruise".to_string(),
+            execution_id: context.func_run_id.to_string(),
             handler: handler.into(),
             component: args.component,
             response_type: args.response_type,
@@ -66,10 +64,10 @@ impl FuncDispatch for FuncBackendJsAttribute {
                 | ResolverFunctionResponseType::Json => FunctionResult::Failure(failure),
                 ResolverFunctionResponseType::Qualification => {
                     FunctionResult::Success(Self::Output {
-                        execution_id: failure.execution_id,
+                        execution_id: failure.execution_id().to_owned(),
                         data: serde_json::json!({
                             "result": "failure",
-                            "message": format!("Function execution failed: {}", failure.error.message),
+                            "message": format!("Function execution failed: {}", failure.error().message),
                         }),
                         unset: false,
                         timestamp: u64::try_from(std::cmp::max(Utc::now().timestamp(), 0))
@@ -78,11 +76,11 @@ impl FuncDispatch for FuncBackendJsAttribute {
                 }
                 ResolverFunctionResponseType::CodeGeneration => {
                     FunctionResult::Success(Self::Output {
-                        execution_id: failure.execution_id,
+                        execution_id: failure.execution_id().to_owned(),
                         data: serde_json::json!({
                             "format": "json",
                             "code": "null",
-                            "message": format!("Function execution failed: {}", failure.error.message),
+                            "message": format!("Function execution failed: {}", failure.error().message),
                         }),
                         unset: false,
                         timestamp: u64::try_from(std::cmp::max(Utc::now().timestamp(), 0))

--- a/lib/dal/src/func/backend/js_reconciliation.rs
+++ b/lib/dal/src/func/backend/js_reconciliation.rs
@@ -46,9 +46,7 @@ impl FuncDispatch for FuncBackendJsReconciliation {
         before: Vec<BeforeFunction>,
     ) -> Box<Self> {
         let request = ReconciliationRequest {
-            // Once we start tracking the state of these executions, then this id will be useful,
-            // but for now it's passed along and back, and is opaue
-            execution_id: "freeronaldinhogauchojsreconciliation".to_string(),
+            execution_id: context.func_run_id.to_string(),
             handler: handler.into(),
             code_base64: code_base64.into(),
             args: serde_json::to_value(args)
@@ -68,10 +66,10 @@ impl FuncDispatch for FuncBackendJsReconciliation {
             .await?;
         let value = match value {
             FunctionResult::Failure(failure) => FunctionResult::Success(Self::Output {
-                execution_id: failure.execution_id,
+                execution_id: failure.execution_id().to_owned(),
                 updates: Default::default(),
                 actions: Default::default(),
-                message: Some(failure.error.message.clone()),
+                message: Some(failure.error().message.to_owned()),
             }),
             FunctionResult::Success(value) => FunctionResult::Success(value),
         };

--- a/lib/dal/src/func/backend/js_schema_variant_definition.rs
+++ b/lib/dal/src/func/backend/js_schema_variant_definition.rs
@@ -24,7 +24,7 @@ impl FuncDispatch for FuncBackendJsSchemaVariantDefinition {
         _before: Vec<BeforeFunction>,
     ) -> Box<Self> {
         let request = SchemaVariantDefinitionRequest {
-            execution_id: "villanelle".to_string(),
+            execution_id: context.func_run_id.to_string(),
             handler: handler.into(),
             code_base64: code_base64.to_owned(),
         };
@@ -39,9 +39,9 @@ impl FuncDispatch for FuncBackendJsSchemaVariantDefinition {
             .await?;
         let value = match value {
             FunctionResult::Failure(failure) => FunctionResult::Success(Self::Output {
-                execution_id: failure.execution_id,
+                execution_id: failure.execution_id().to_owned(),
                 definition: serde_json::Value::Null,
-                error: Some(failure.error.message.clone()),
+                error: Some(failure.error().message.to_owned()),
             }),
             FunctionResult::Success(value) => FunctionResult::Success(value),
         };

--- a/lib/dal/src/func/backend/validation.rs
+++ b/lib/dal/src/func/backend/validation.rs
@@ -28,7 +28,7 @@ impl FuncDispatch for FuncBackendValidation {
         _before: Vec<BeforeFunction>,
     ) -> Box<Self> {
         let request = ValidationRequest {
-            execution_id: "guarabyra".to_string(),
+            execution_id: context.func_run_id.to_string(),
             value: args.value,
             validation_format: args.validation_format,
             handler: "".to_string(),

--- a/lib/dal/src/history_event.rs
+++ b/lib/dal/src/history_event.rs
@@ -10,6 +10,9 @@ use crate::actor_view::ActorView;
 use crate::{pk, DalContext, Timestamp, User, UserPk};
 use crate::{Tenancy, TransactionsError};
 
+const SYSTEMINIT_EMAIL_SUFFIX: &str = "@systeminit.com";
+const TEST_SYSTEMINIT_EMAIL_SUFFIX: &str = "@test.systeminit.com";
+
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum HistoryEventError {
@@ -53,6 +56,12 @@ impl HistoryActor {
                 .email()
                 .clone(),
         })
+    }
+
+    pub async fn email_is_systeminit(&self, ctx: &DalContext) -> HistoryEventResult<bool> {
+        let email_as_lowercase = self.email(ctx).await?.to_lowercase();
+        Ok(email_as_lowercase.ends_with(SYSTEMINIT_EMAIL_SUFFIX)
+            || email_as_lowercase.ends_with(TEST_SYSTEMINIT_EMAIL_SUFFIX))
     }
 }
 

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -8,6 +8,7 @@ use pretty_assertions_sorted::assert_eq;
 mod argument;
 mod associations;
 mod authoring;
+mod cancel_execution;
 
 #[test]
 async fn summary(ctx: &mut DalContext) {

--- a/lib/dal/tests/integration_test/func/cancel_execution.rs
+++ b/lib/dal/tests/integration_test/func/cancel_execution.rs
@@ -1,0 +1,109 @@
+use std::time::Duration;
+
+use dal::action::prototype::ActionKind;
+use dal::action::Action;
+use dal::func::authoring::FuncAuthoringClient;
+use dal::func::runner::FuncRunner;
+use dal::schema::variant::authoring::VariantAuthoringClient;
+use dal::{Component, DalContext};
+use dal_test::helpers::ChangeSetTestHelpers;
+use dal_test::test;
+use pretty_assertions_sorted::assert_eq;
+use si_events::FuncRunState;
+
+#[test]
+async fn cancel_execution_works(ctx: &mut DalContext) {
+    let variant = VariantAuthoringClient::create_schema_and_variant(
+        ctx,
+        "DOOM ETERNAL",
+        None,
+        None,
+        "ID SOFTWARE",
+        "#00b0b0",
+    )
+    .await
+    .expect("could not create variant");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Add a new func to that asset that will be killed (it sleeps for awhile). After this, let's commit.
+    let func = FuncAuthoringClient::create_new_action_func(
+        ctx,
+        Some("test:longAssCreateAction".to_string()),
+        ActionKind::Create,
+        variant.id(),
+    )
+    .await
+    .expect("could new leaf func");
+    let code = "async function main() {
+        const ms = 30 * 1000;
+        const sleep = new Promise((resolve) => setTimeout(resolve, ms));
+        await sleep;
+        return { payload: { \"poop\": true }, status: \"ok\" };
+    }";
+    FuncAuthoringClient::save_code(ctx, func.id, code.to_string())
+        .await
+        .expect("could not save code");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Create a new component for the new asset and commit.
+    let _component = Component::new(ctx, "component", variant.id())
+        .await
+        .expect("could not create component");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Apply to the base change set and wait for all actions to run.
+    assert!(ctx
+        .parent_is_head()
+        .await
+        .expect("could not perform parent is head"));
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx)
+        .await
+        .expect("could not apply change set");
+
+    // Find the action and its func run id.
+    let mut action_ids = Action::list_topologically(ctx)
+        .await
+        .expect("could not list actions");
+    let action_id = action_ids.pop().expect("empty actions");
+    assert!(action_ids.is_empty());
+
+    // Wait for the func run to start.
+    let mut maybe_func_run_id = None;
+    for _ in 0..20 {
+        maybe_func_run_id = ctx
+            .layer_db()
+            .func_run()
+            .get_last_run_for_action_id(ctx.events_tenancy().workspace_pk, action_id.into())
+            .await
+            .expect("could not get last func run for action id")
+            .map(|f| f.id());
+        if maybe_func_run_id.is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let func_run_id = maybe_func_run_id.expect("no func run found");
+
+    // Cancel the active func run and observe that it worked.
+    FuncRunner::cancel_execution(ctx, func_run_id)
+        .await
+        .expect("could not cancel execution");
+    let func_run_state = ctx
+        .layer_db()
+        .func_run()
+        .read(func_run_id)
+        .await
+        .expect("could not get func run")
+        .expect("no func run found")
+        .state();
+    assert_eq!(
+        FuncRunState::Cancelled, // expected
+        func_run_state           // actual
+    );
+}

--- a/lib/sdf-server/src/server/service/v2.rs
+++ b/lib/sdf-server/src/server/service/v2.rs
@@ -2,13 +2,20 @@ use axum::Router;
 
 use crate::server::state::AppState;
 
+pub mod admin;
 pub mod func;
 pub mod module;
 pub mod variant;
 
+const WORKSPACE_ONLY_PREFIX: &str = "/workspaces/:workspace_id";
+const PREFIX: &str = "/workspaces/:workspace_id/change-sets/:change_set_id";
+
 pub fn routes() -> Router<AppState> {
-    const PREFIX: &str = "/workspaces/:workspace_id/change-sets/:change_set_id";
     Router::new()
+        .nest(
+            &format!("{WORKSPACE_ONLY_PREFIX}/admin"),
+            admin::v2_routes(),
+        )
         .nest(&format!("{PREFIX}/schema-variants"), variant::v2_routes())
         .nest(&format!("{PREFIX}/funcs"), func::v2_routes())
         .nest(&format!("{PREFIX}/modules"), module::v2_routes())

--- a/lib/sdf-server/src/server/service/v2/admin.rs
+++ b/lib/sdf-server/src/server/service/v2/admin.rs
@@ -1,0 +1,49 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::put,
+    Router,
+};
+use dal::func::runner::FuncRunnerError;
+use thiserror::Error;
+
+use crate::server::error;
+use crate::server::state::AppState;
+use crate::service::ApiError;
+
+mod cancel_execution;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum AdminAPIError {
+    #[error("func runner error: {0}")]
+    FuncRunner(#[from] FuncRunnerError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] dal::TransactionsError),
+}
+
+impl IntoResponse for AdminAPIError {
+    fn into_response(self) -> Response {
+        let status_code = match &self {
+            Self::Transactions(dal::TransactionsError::BadWorkspaceAndChangeSet) => {
+                StatusCode::FORBIDDEN
+            }
+            AdminAPIError::FuncRunner(FuncRunnerError::DoNotHavePermissionToCancelExecution) => {
+                StatusCode::UNAUTHORIZED
+            }
+            _ => ApiError::DEFAULT_ERROR_STATUS_CODE,
+        };
+        error!(si.error.message = ?self.to_string());
+
+        ApiError::new(status_code, self).into_response()
+    }
+}
+
+pub type AdminAPIResult<T> = Result<T, AdminAPIError>;
+
+pub fn v2_routes() -> Router<AppState> {
+    Router::new().route(
+        "/func/runs/:func_run_id/cancel_execution",
+        put(cancel_execution::cancel_execution),
+    )
+}

--- a/lib/sdf-server/src/server/service/v2/admin/cancel_execution.rs
+++ b/lib/sdf-server/src/server/service/v2/admin/cancel_execution.rs
@@ -1,0 +1,22 @@
+use axum::{extract::Path, response::IntoResponse};
+use dal::func::runner::FuncRunner;
+use si_events::{FuncRunId, WorkspacePk};
+
+use crate::server::extract::{AccessBuilder, HandlerContext};
+
+use super::AdminAPIResult;
+
+pub async fn cancel_execution(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    Path((_workspace_pk, func_run_id)): Path<(WorkspacePk, FuncRunId)>,
+) -> AdminAPIResult<impl IntoResponse> {
+    let ctx = builder.build_head(access_builder).await?;
+
+    FuncRunner::cancel_execution(&ctx, func_run_id).await?;
+
+    // We commit without a rebase here because we need to commit our func run table changes.
+    ctx.commit_no_rebase().await?;
+
+    Ok(())
+}

--- a/lib/si-events-rs/src/func_run.rs
+++ b/lib/si-events-rs/src/func_run.rs
@@ -15,6 +15,7 @@ id!(AttributePrototypeArgumentId);
 
 #[derive(AsRefStr, Deserialize, Display, Serialize, Debug, Eq, PartialEq, Clone, Copy)]
 pub enum FuncRunState {
+    Cancelled,
     Created,
     Dispatched,
     Running,
@@ -225,6 +226,11 @@ impl FuncRun {
     pub fn set_state_to_failure(&mut self) {
         self.updated_at = Utc::now();
         self.state = FuncRunState::Failure;
+    }
+
+    pub fn set_state_to_cancelled(&mut self) {
+        self.updated_at = Utc::now();
+        self.state = FuncRunState::Cancelled;
     }
 
     pub fn id(&self) -> FuncRunId {

--- a/lib/si-layer-cache/src/db/func_run.rs
+++ b/lib/si-layer-cache/src/db/func_run.rs
@@ -209,6 +209,22 @@ impl FuncRunDb {
         Ok(())
     }
 
+    pub async fn set_state_to_cancelled(
+        &self,
+        func_run_id: FuncRunId,
+        tenancy: Tenancy,
+        actor: Actor,
+    ) -> LayerDbResult<()> {
+        let func_run_old = self.try_read(func_run_id).await?;
+        let mut func_run_new = Arc::unwrap_or_clone(func_run_old);
+        func_run_new.set_state_to_cancelled();
+
+        self.write(Arc::new(func_run_new), None, tenancy, actor)
+            .await?;
+
+        Ok(())
+    }
+
     pub async fn set_action_result_state(
         &self,
         func_run_id: FuncRunId,

--- a/lib/si-pool-noodle/src/lib.rs
+++ b/lib/si-pool-noodle/src/lib.rs
@@ -21,12 +21,12 @@ pub use crate::pool_noodle::PoolNoodle;
 pub use cyclone_client::{ClientError, CycloneClient, ExecutionError};
 
 pub use cyclone_core::{
-    ActionRunRequest, ActionRunResultSuccess, BeforeFunction, ComponentView, CycloneRequest,
-    FunctionResult, FunctionResultFailure, FunctionResultFailureError, OutputStream,
-    ProgressMessage, ReconciliationRequest, ReconciliationResultSuccess, ResolverFunctionRequest,
-    ResolverFunctionResultSuccess, ResourceStatus, SchemaVariantDefinitionRequest,
-    SchemaVariantDefinitionResultSuccess, SensitiveStrings, ValidationRequest,
-    ValidationResultSuccess,
+    ActionRunRequest, ActionRunResultSuccess, BeforeFunction, CancelExecutionRequest,
+    ComponentView, CycloneRequest, FunctionResult, FunctionResultFailure,
+    FunctionResultFailureError, OutputStream, ProgressMessage, ReconciliationRequest,
+    ReconciliationResultSuccess, ResolverFunctionRequest, ResolverFunctionResultSuccess,
+    ResourceStatus, SchemaVariantDefinitionRequest, SchemaVariantDefinitionResultSuccess,
+    SensitiveStrings, ValidationRequest, ValidationResultSuccess,
 };
 
 /// [`PoolNoodleError`] implementations.

--- a/lib/veritech-client/tests/integration.rs
+++ b/lib/veritech-client/tests/integration.rs
@@ -249,8 +249,8 @@ async fn type_checks_resolve_function() {
                 panic!("should have failed :(");
             }
             FunctionResult::Failure(failure) => {
-                assert_eq!(failure.error.kind, "InvalidReturnType");
-                assert_eq!(failure.execution_id, "1234");
+                assert_eq!(failure.error().kind, "InvalidReturnType");
+                assert_eq!(failure.execution_id(), "1234");
             }
         }
     }

--- a/lib/veritech-client/tests/integration.rs
+++ b/lib/veritech-client/tests/integration.rs
@@ -161,8 +161,10 @@ async fn type_checks_resolve_function() {
             }
         });
 
+        let execution_id = "type_checks_resolve_function";
+
         let request = ResolverFunctionRequest {
-            execution_id: "1234".to_string(),
+            execution_id: execution_id.to_string(),
             handler: "returnInputValue".to_string(),
             component: ResolverFunctionComponent {
                 data: ComponentView {
@@ -183,7 +185,7 @@ async fn type_checks_resolve_function() {
 
         match result {
             FunctionResult::Success(success) => {
-                assert_eq!(success.execution_id, "1234");
+                assert_eq!(success.execution_id, execution_id.to_string());
                 if let serde_json::Value::Object(inner) = value {
                     let value = inner.get("value").expect("value should exist").clone();
                     assert_eq!(value, success.data);
@@ -223,8 +225,9 @@ async fn type_checks_resolve_function() {
             }
         });
 
+        let execution_id = "type_checks_resolve_function";
         let request = ResolverFunctionRequest {
-            execution_id: "1234".to_string(),
+            execution_id: execution_id.to_string(),
             handler: "returnInputValue".to_string(),
             component: ResolverFunctionComponent {
                 data: ComponentView {
@@ -250,7 +253,7 @@ async fn type_checks_resolve_function() {
             }
             FunctionResult::Failure(failure) => {
                 assert_eq!(failure.error().kind, "InvalidReturnType");
-                assert_eq!(failure.execution_id(), "1234");
+                assert_eq!(failure.execution_id(), execution_id);
             }
         }
     }

--- a/lib/veritech-core/src/lib.rs
+++ b/lib/veritech-core/src/lib.rs
@@ -17,6 +17,10 @@ pub use crypto::{
     decrypt_value_tree, encrypt_value_tree, VeritechValueDecryptError, VeritechValueEncryptError,
 };
 
+// "meta" subjects (those pertaining to veritech management)
+const NATS_CANCEL_EXECUTION_DEFAULT_SUBJECT: &str = "veritech.meta.cancelexecution";
+
+// "fn" subjects (those pertaining to function to be execution via cyclone)
 const NATS_ACTION_RUN_DEFAULT_SUBJECT: &str = "veritech.fn.actionrun";
 const NATS_CONCILIATION_DEFAULT_SUBJECT: &str = "veritech.fn.reconciliation";
 const NATS_RESOLVER_FUNCTION_DEFAULT_SUBJECT: &str = "veritech.fn.resolverfunction";
@@ -55,6 +59,10 @@ pub fn nats_reconciliation_subject(prefix: Option<&str>) -> String {
 
 pub fn nats_schema_variant_definition_subject(prefix: Option<&str>) -> String {
     nats_subject(prefix, NATS_SCHEMA_VARIANT_DEFINITION_DEFAULT_SUBJECT)
+}
+
+pub fn nats_cancel_execution_subject(prefix: Option<&str>) -> String {
+    nats_subject(prefix, NATS_CANCEL_EXECUTION_DEFAULT_SUBJECT)
 }
 
 pub fn nats_subject(prefix: Option<&str>, suffix: impl AsRef<str>) -> String {

--- a/lib/veritech-server/BUCK
+++ b/lib/veritech-server/BUCK
@@ -17,6 +17,7 @@ rust_library(
         "//third-party/rust:chrono",
         "//third-party/rust:derive_builder",
         "//third-party/rust:futures",
+        "//third-party/rust:once_cell",
         "//third-party/rust:remain",
         "//third-party/rust:serde",
         "//third-party/rust:serde_json",

--- a/lib/veritech-server/Cargo.toml
+++ b/lib/veritech-server/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { workspace = true }
 derive_builder = { workspace = true }
 futures = { workspace = true }
 nats-subscriber = { path = "../../lib/nats-subscriber" }
+once_cell = { workspace = true }
 remain = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Description

This PR contains the ability to kill function executions as well as a variety of other enhancements and tuning to the function execution layer.

Killing function executions occurs through the `FuncRunner` by using its new "cancel execution" functionality. This works by using the `veritech` client to request that `veritech` kill its ongoing function execution via a `tokio::sync::oneshot` channel.

What about multiple `veritechs`? This PR is untested with multiple `veritechs`, but the use case was considered. The idea is that all `veritechs` will receive the message and only one of them will act upon it. The other `veritechs` will "no-op". This will require testing and potential tuning to the NATS subscriptions. For example, they should all consume the same messages for requests to cancel active executions.

![image](https://github.com/user-attachments/assets/350dfa3e-5f27-4a9d-84f8-b53ad32db126)

## Future Work

We need to de-duplicate a lot of the `veritech` server logic. We also need to keep an eye on the mutex locking and be sure that we cannot hit a deadlock. While we are there, it would be worth seeing if we can use our once cell lazy implementation of the "kill sender map" or if we should store it in an `Arc<Mutex<T>>` on the server itself. Finally, we should test multiple `veritechs` and "no-op" if a "kill sender" could not be found (only one `veritech` will have it).

## Primary Changes

- Add ability to cancel `FuncRun` executions via the `FuncRunner`
- Add ability to kill function executions from the admin dashboard and in the API
- Add "meta" subscriber and "meta" NATS subject prefix for `veritech` communication unrelated to literal function execution (i.e. communication for `veritech` itself)
- Replace hardcoded execution ids with `FuncRunId` converted to a `String` (potential to make this strongly typed in the future)
  - We now thread through the `FuncRunId` in the `FuncDispatchContext`
- Add `FuncRunState::Cancelled` for cancelled `FuncRuns`, but do not do the same for `ActionRunState`
  - They should still fail, but their reason for failing is due to a cancelled `FuncRun`
  - This also makes it clear that the `ActionRun` can be retried whereas if we added a similar "cancelled" `ActionRunState`, it would be unclear

##  Secondary Changes

- Add admin dashboard and endpoint (no change set required)
- Add `ADMIN_PANEL_ACCESS` feature flag
- Group `veritech` internal errors to be sent to a `veritech` client by a single kind stored by a const (`"veritechServer"`)
- Make `FunctionResultFailure` fields private and provide two constructor methods: one for generic use and one for internal `veritech` errors
  - We found existing locations where `FunctionResultFailure` was used for `veritech` internal errors by using the `"veritechServer"` kind, so we now group this functionality for clarity (and `"veritechServer"` is now stored in a const)
- Add ability to determine if the history actor's email is a `"systeminit"` email
- Add integration test for cancel execution
- Remove unused `"with_subject"` functions from the `veritech` client
- Make the `"output_tx"` option for `veritech` client requests
  - We do not need it for cancelling function executions