### PR TITLE
build(deps): update `async-nats` patch to stable Git branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "async-nats"
 version = "0.35.1"
-source = "git+https://github.com/systeminit/nats.rs.git?branch=js-kv-recreate-race#520910301a1d8d57984d5ba1d03dabb0dcf644ef"
+source = "git+https://github.com/systeminit/nats.rs.git?branch=si/stable#520910301a1d8d57984d5ba1d03dabb0dcf644ef"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -761,9 +761,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
+checksum = "5fb8dd288a69fc53a1996d7ecfbf4a20d59065bff137ce7e56bbd620de191189"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cexpr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ yrs = { version = "0.17.4" }
 [patch.crates-io]
 # pending a potential merge and release of
 # https://github.com/nats-io/nats.rs/pull/1301
-async-nats = { git = "https://github.com/systeminit/nats.rs.git", branch = "js-kv-recreate-race" }
+async-nats = { git = "https://github.com/systeminit/nats.rs.git", branch = "si/stable" }
 # pending a potential merge and release of
 # https://github.com/softprops/hyperlocal/pull/53
 hyperlocal = { git = "https://github.com/fnichol/hyperlocal.git", branch = "pub-unix-stream" }

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -1935,20 +1935,21 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "cc-1.1.10.crate",
-    sha256 = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292",
-    strip_prefix = "cc-1.1.10",
-    urls = ["https://static.crates.io/crates/cc/1.1.10/download"],
+    name = "cc-1.1.11.crate",
+    sha256 = "5fb8dd288a69fc53a1996d7ecfbf4a20d59065bff137ce7e56bbd620de191189",
+    strip_prefix = "cc-1.1.11",
+    urls = ["https://static.crates.io/crates/cc/1.1.11/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "cc-1.1.10",
-    srcs = [":cc-1.1.10.crate"],
+    name = "cc-1.1.11",
+    srcs = [":cc-1.1.11.crate"],
     crate = "cc",
-    crate_root = "cc-1.1.10.crate/src/lib.rs",
+    crate_root = "cc-1.1.11.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
+    deps = [":shlex-1.3.0"],
 )
 
 http_archive(

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "async-nats"
 version = "0.35.1"
-source = "git+https://github.com/systeminit/nats.rs.git?branch=js-kv-recreate-race#520910301a1d8d57984d5ba1d03dabb0dcf644ef"
+source = "git+https://github.com/systeminit/nats.rs.git?branch=si/stable#520910301a1d8d57984d5ba1d03dabb0dcf644ef"
 dependencies = [
  "base64 0.22.1",
  "bytes 1.7.1",
@@ -761,9 +761,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
+checksum = "5fb8dd288a69fc53a1996d7ecfbf4a20d59065bff137ce7e56bbd620de191189"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cexpr"

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -153,7 +153,7 @@ yrs = { version = "0.17.4" }
 [patch.crates-io]
 # pending a potential merge and release of
 # https://github.com/nats-io/nats.rs/pull/1301
-async-nats = { git = "https://github.com/systeminit/nats.rs.git", branch = "js-kv-recreate-race" }
+async-nats = { git = "https://github.com/systeminit/nats.rs.git", branch = "si/stable" }
 # pending a potential merge and release of
 # https://github.com/softprops/hyperlocal/pull/53
 hyperlocal = { git = "https://github.com/fnichol/hyperlocal.git", branch = "pub-unix-stream" }


### PR DESCRIPTION
This change updates the Git branch to an `si/stable` branch so that any upstream changes can be made to the `js-kv-recreate-race` branch without impacting this codebase directly.

References: nats-io/nats.rs#1301