### PR TITLE
fix(dal): add dvu roots for removed dangling connections

### DIFF
--- a/lib/dal/src/workspace_snapshot/node_weight/traits.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/traits.rs
@@ -1,4 +1,7 @@
-use crate::{workspace_snapshot::graph::detect_updates::Update, WorkspaceSnapshotGraphV2};
+use crate::{
+    workspace_snapshot::graph::{detect_updates::Update, WorkspaceSnapshotGraphError},
+    WorkspaceSnapshotGraphV2,
+};
 use thiserror::Error;
 
 use super::NodeWeightDiscriminants;
@@ -11,6 +14,8 @@ pub use correct_exclusive_outgoing_edge::CorrectExclusiveOutgoingEdge;
 pub enum CorrectTransformsError {
     #[error("expected a node weight of kind {0} but got another, or none")]
     UnexpectedNodeWeight(NodeWeightDiscriminants),
+    #[error("workspace snapshot graph: {0}")]
+    WorkspaceSnapshotGraph(#[from] WorkspaceSnapshotGraphError),
 }
 
 pub type CorrectTransformsResult<T> = Result<T, CorrectTransformsError>;


### PR DESCRIPTION
When a dangling APA is removed, we should also walk to the value that it was a prototype argument for, and add that value to the dvu roots so that input sockets are recalculated.