### PR TITLE
feat/loop over telemetry levels

### DIFF
--- a/lib/telemetry-application-rs/src/lib.rs
+++ b/lib/telemetry-application-rs/src/lib.rs
@@ -548,7 +548,6 @@ struct TelemetrySignalHandlerTask {
     client: ApplicationTelemetryClient,
     shutdown_token: CancellationToken,
     sig_usr1: unix::Signal,
-    sig_usr2: unix::Signal,
 }
 
 impl TelemetrySignalHandlerTask {
@@ -559,13 +558,11 @@ impl TelemetrySignalHandlerTask {
         shutdown_token: CancellationToken,
     ) -> io::Result<Self> {
         let sig_usr1 = unix::signal(SignalKind::user_defined1())?;
-        let sig_usr2 = unix::signal(SignalKind::user_defined2())?;
 
         Ok(Self {
             client,
             shutdown_token,
             sig_usr1,
-            sig_usr2,
         })
     }
 
@@ -577,20 +574,11 @@ impl TelemetrySignalHandlerTask {
                     break;
                 }
                 Some(_) = self.sig_usr1.recv() => {
-                    if let Err(err) = self.client.increase_verbosity().await {
+                    if let Err(err) = self.client.modify_verbosity().await {
                         warn!(
                             task = Self::NAME,
                             error = ?err,
-                            "error while trying to increase verbosity",
-                        );
-                    }
-                }
-                Some(_) = self.sig_usr2.recv() => {
-                    if let Err(err) = self.client.decrease_verbosity().await {
-                        warn!(
-                            task = Self::NAME,
-                            error = ?err,
-                            "error while trying to decrease verbosity",
+                            "error while trying to modify verbosity",
                         );
                     }
                 }

--- a/lib/telemetry-rs/src/lib.rs
+++ b/lib/telemetry-rs/src/lib.rs
@@ -286,24 +286,7 @@ impl ApplicationTelemetryClient {
                 let updated = match verbosity.is_max() {
                     true => Verbosity::InfoAll,
                     false => verbosity.increase(),
-                    _ => Verbosity::InfoAll,
                 };
-                drop(guard);
-                self.set_verbosity_inner(updated, wait).await
-            }
-            TracingLevel::Custom(_) => Err(ClientError::CustomHasNoVerbosity),
-        }
-    }
-
-    async fn decrease_verbosity_inner(
-        &mut self,
-        wait: Option<oneshot::Sender<()>>,
-    ) -> Result<(), ClientError> {
-        let guard = self.tracing_level.lock().await;
-
-        match guard.deref() {
-            TracingLevel::Verbosity { verbosity, .. } => {
-                let updated = verbosity.decrease();
                 drop(guard);
                 self.set_verbosity_inner(updated, wait).await
             }

--- a/lib/telemetry-rs/src/lib.rs
+++ b/lib/telemetry-rs/src/lib.rs
@@ -161,8 +161,7 @@ impl SpanExt for tracing::Span {
 #[async_trait]
 pub trait TelemetryClient: Clone + Send + Sync + 'static {
     async fn set_verbosity(&mut self, updated: Verbosity) -> Result<(), ClientError>;
-    async fn increase_verbosity(&mut self) -> Result<(), ClientError>;
-    async fn decrease_verbosity(&mut self) -> Result<(), ClientError>;
+    async fn modify_verbosity(&mut self) -> Result<(), ClientError>;
     async fn set_custom_tracing(
         &mut self,
         directives: impl Into<String> + Send + 'async_trait,
@@ -214,30 +213,15 @@ impl ApplicationTelemetryClient {
         Ok(())
     }
 
-    pub async fn increase_verbosity_and_wait(&mut self) -> Result<(), ClientError> {
+    pub async fn modify_verbosity_and_wait(&mut self) -> Result<(), ClientError> {
         let (tx, rx) = oneshot::channel();
 
-        self.increase_verbosity_inner(Some(tx)).await?;
+        self.modify_verbosity_inner(Some(tx)).await?;
 
         if let Err(err) = rx.await {
             warn!(
                 error = ?err,
                 "sender already closed while waiting on verbosity increase change",
-            );
-        }
-
-        Ok(())
-    }
-
-    pub async fn decrease_verbosity_and_wait(&mut self) -> Result<(), ClientError> {
-        let (tx, rx) = oneshot::channel();
-
-        self.decrease_verbosity_inner(Some(tx)).await?;
-
-        if let Err(err) = rx.await {
-            warn!(
-                error = ?err,
-                "sender already closed while waiting on verbosity decrease change",
             );
         }
 
@@ -292,15 +276,18 @@ impl ApplicationTelemetryClient {
         Ok(())
     }
 
-    async fn increase_verbosity_inner(
+    async fn modify_verbosity_inner(
         &mut self,
         wait: Option<oneshot::Sender<()>>,
     ) -> Result<(), ClientError> {
         let guard = self.tracing_level.lock().await;
-
         match guard.deref() {
             TracingLevel::Verbosity { verbosity, .. } => {
-                let updated = verbosity.increase();
+                let updated = match verbosity.is_max() {
+                    true => Verbosity::InfoAll,
+                    false => verbosity.increase(),
+                    _ => Verbosity::InfoAll,
+                };
                 drop(guard);
                 self.set_verbosity_inner(updated, wait).await
             }
@@ -349,12 +336,8 @@ impl TelemetryClient for ApplicationTelemetryClient {
         self.set_verbosity_inner(updated, None).await
     }
 
-    async fn increase_verbosity(&mut self) -> Result<(), ClientError> {
-        self.increase_verbosity_inner(None).await
-    }
-
-    async fn decrease_verbosity(&mut self) -> Result<(), ClientError> {
-        self.decrease_verbosity_inner(None).await
+    async fn modify_verbosity(&mut self) -> Result<(), ClientError> {
+        self.modify_verbosity_inner(None).await
     }
 
     async fn set_custom_tracing(
@@ -385,11 +368,7 @@ impl TelemetryClient for NoopClient {
         Ok(())
     }
 
-    async fn increase_verbosity(&mut self) -> Result<(), ClientError> {
-        Ok(())
-    }
-
-    async fn decrease_verbosity(&mut self) -> Result<(), ClientError> {
+    async fn modify_verbosity(&mut self) -> Result<(), ClientError> {
         Ok(())
     }
 
@@ -493,6 +472,10 @@ impl Verbosity {
 
     fn is_debug_or_lower(&self) -> bool {
         !matches!(self, Self::InfoAll)
+    }
+
+    fn is_max(&self) -> bool {
+        matches!(self, Self::TraceAll)
     }
 
     #[inline]


### PR DESCRIPTION
Loop over telemetry levels when sending the USR1 signal to free up USR2 for maintenance mode enable/disable.

**Previously:**
- USR1: increase log level
- USR2: decrease log level

**Now:**
- USR1: modify log level. Goes up to the max (TraceAll) then loops back to InfoAll + repeats
- USR2: free (for use to enable draining/maintenance mode, etc)