### PR TITLE
feat: update how-to guides to use us-east-1

### DIFF
--- a/app/docs/src/how-tos/aws-ha-ec2.md
+++ b/app/docs/src/how-tos/aws-ha-ec2.md
@@ -239,7 +239,7 @@ Add an `AMI` to your `Application` frame.
 
 Set the component name to be `Amazon Linux 2023`.
 
-Set the `ImageId` to be `ami-0c11a84584d4e09dd`.
+Set the `ImageId` to be `ami-0ba9883b710b05ac6`.
 
 ### Create a Launch Template component
 

--- a/app/docs/src/how-tos/aws-iam.md
+++ b/app/docs/src/how-tos/aws-iam.md
@@ -40,17 +40,17 @@ When you are through with this guide, you should have components that look like 
 
 You can learn more about [Customer Managed Identity Policies in the AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#customer-managed-policies).
 
-Set the components name to `Only EC2 In Ohio`.
+Set the components name to `Only EC2 In North Virginia`.
 
 Set the `Path` to `/si-howto/`.
 
-Set the `PolicyName` to `only-ec2-in-ohio`
+Set the `PolicyName` to `only-ec2-in-north-virginia`
 
 ### Create an AWS IAM Policy Statement component
 
-Add an `AWS IAM Policy Statement` to your `Only EC2 In Ohio` policy frame.
+Add an `AWS IAM Policy Statement` to your `Only EC2 In North Virginia` policy frame.
 
-Set the name to `Only EC2 In Ohio`.
+Set the name to `Only EC2 In North Virginia`.
 
 Set the `Effect` to `Deny`.
 
@@ -58,17 +58,17 @@ Add an item to the `Action` array, and set the value `ec2:*`.
 
 ### Create an AWS IAM Any component
 
-Add an `AWS IAM Any` component inside your `Only EC2 In Ohio` policy frame.
+Add an `AWS IAM Any` component inside your `Only EC2 In North Virginia` policy frame.
 
 Set the name to `Any EC2 Resource`.
 
-Connect the `Resource` output socket to the `Resource` input socket of your `Only EC2 In Ohio` statement.
+Connect the `Resource` output socket to the `Resource` input socket of your `Only EC2 In North Virginia` statement.
 
 ### Create an AWS IAM Condition Operator component
 
-Add an `AWS IAM Condition Operator` component inside your `Only EC2 In Ohio` policy frame.
+Add an `AWS IAM Condition Operator` component inside your `Only EC2 In North Virginia` policy frame.
 
-Set the name to `Only allow us-east-2`.
+Set the name to `Only allow us-east-1`.
 
 Set the `ConditionOperator` to `StringNotEquals`.
 
@@ -76,19 +76,19 @@ Set the `ConditionKey` to `aws:RequestedRegion`.
 
 Change the `ConditionValue` from being set via socket to being set `manually`.
 
-Add an item to the `ConditionValue` array, and set the value to `us-east-2`.
+Add an item to the `ConditionValue` array, and set the value to `us-east-1`.
 
-Connect the `Condition` output socket to the `Condition` input socket of your `Only EC2 In Ohio` statement.
+Connect the `Condition` output socket to the `Condition` input socket of your `Only EC2 In North Virginia` statement.
 
 ### Review your policy
 
-Select your `Only EC2 In Ohio` policy frame.
+Select your `Only EC2 In North Virginia` policy frame.
 
 Navigate to the `Code` sub-panel. You should see JSON that looks like the following:
 
 ```json
 {
-  "PolicyName": "Only EC2 In Ohio",
+  "PolicyName": "Only EC2 In North Virginia",
   "Path": "/si-howto/",
   "PolicyDocument": {
     "Version": "2012-10-17",
@@ -104,7 +104,7 @@ Navigate to the `Code` sub-panel. You should see JSON that looks like the follow
         "Condition": {
           "StringNotEquals": {
             "aws:RequestedRegion": [
-              "us-east-2"
+              "us-east-1"
             ]
           }
         }
@@ -118,7 +118,7 @@ Your components should be passing all their [qualifications](/reference/vocabula
 
 ### Create an AWS IAM User component
 
-Add an `AWS IAM User` to your `Region` frame. (It should be a peer of your `Only EC2 In Ohio` policy.
+Add an `AWS IAM User` to your `Region` frame. (It should be a peer of your `Only EC2 In North Virginia` policy.
 
 Set the name to `bobo`.
 
@@ -134,7 +134,7 @@ Set the name to `bobo EC2 Restrictions`.
 
 Connect the `UserName` output socket of your `bobo` AWS IAM User to the `UserName` input socket of your `bobo EC2 Restrictions` AWS IAM User Policy.
 
-Connect the `ARN` output socket of the `Only EC2 In Ohio` AWS IAM Customer Managed Identity Policy to the `Policy ARN` input socket of your `bobo EC2 Restrictions` AWS IAM User Policy.
+Connect the `ARN` output socket of the `Only EC2 In North Virginia` AWS IAM Customer Managed Identity Policy to the `Policy ARN` input socket of your `bobo EC2 Restrictions` AWS IAM User Policy.
 
 ### Apply your Change Set
 
@@ -154,7 +154,7 @@ Review the completed AWS resources by clicking the `Resource` sub-panel for each
 
 Create a new change set called `Clean up IAM How-to`
 
-Delete your `Only EC2 In Ohio` policy frame.
+Delete your `Only EC2 In North Virginia` policy frame.
 
 Delete your `bobo` AWS IAM User.
 

--- a/app/docs/src/how-tos/aws-vpc.md
+++ b/app/docs/src/how-tos/aws-vpc.md
@@ -24,7 +24,7 @@ We will cover:
 ## Setup
 
 All activities in this how-to happen within a configured AWS Region and AWS
-Credential. Set the AWS Region to be `us-east-2`.
+Credential. Set the AWS Region to be `us-east-1`.
 
 Start in a change set named `VPC How-to`.
 
@@ -39,7 +39,7 @@ this in your diagram:
 
 ### Create a VPC component
 
-Add a `VPC` to your `us-east-2` region frame.
+Add a `VPC` to your `us-east-1` region frame.
 
 Set the component type to be `Configuration Frame (down)` and expand it to fill
 the region frame.
@@ -59,9 +59,9 @@ components to your VPC frame and configure them as follows:
 
 | Component Name | `CidrBlock`   | `AvailabilityZone` | `IsPublic`  |
 | -------------- | ------------- | ------------------ | ----------- |
-| Public 1       | 10.0.128.0/20 | us-east-2a         | true        |
-| Public 2       | 10.0.144.0/20 | us-east-2b         | true        |
-| Public 3       | 10.0.160.0/20 | us-east-2c         | true        |
+| Public 1       | 10.0.128.0/20 | us-east-1a         | true        |
+| Public 2       | 10.0.144.0/20 | us-east-1b         | true        |
+| Public 3       | 10.0.160.0/20 | us-east-1c         | true        |
 
 Set the component type for each of the public subnet components to be
 `Configuration Frame (down)`.
@@ -119,9 +119,9 @@ Add 3 `Subnet` components to your VPC frame and configure them as follows:
 
 | component name | `CidrBlock`  | `AvailabilityZone` |
 | -------------- | ------------ | ------------------ |
-| Private 1      | 10.0.0.0/19  | us-east-2a         |
-| Private 2      | 10.0.32.0/19 | us-east-2b         |
-| Private 3      | 10.0.64.0/19 | us-east-2c         |
+| Private 1      | 10.0.0.0/19  | us-east-1a         |
+| Private 2      | 10.0.32.0/19 | us-east-1b         |
+| Private 3      | 10.0.64.0/19 | us-east-1c         |
 
 Set the component type for each of the public subnet components to be
 `Configuration Frame (down)`.

--- a/app/docs/src/tutorials/getting-started.md
+++ b/app/docs/src/tutorials/getting-started.md
@@ -72,14 +72,14 @@ inside your `tutorial credential` frame.
 
 Resize the region to fill the space inside the `tutorial credential` frame.
 
-Name your region `Ohio`.
+Name your region `North Virginia`.
 
-Set the region property to `us-east-2`.
+Set the region property to `us-east-1`.
 
 ## Add an AWS EC2 Key Pair and set its properties
 
 Click on the `Key Pair` from the AWS EC2 category of the asset pallete, and drop
-it inside your `ohio region` frame.
+it inside your `North Virginia region` frame.
 
 Name your key pair `si-tutorial`.
 
@@ -88,7 +88,7 @@ Set the KeyName property to `si-tutorial`.
 ## Add an AWS EC2 Instance and set its properties
 
 Click on the `EC2 Instance` from the AWS EC2 category of the asset pallete, and
-drop it inside your `ohio region` frame.
+drop it inside your `North Virginia region` frame.
 
 Name your EC2 Instance `si-tutorial`.
 
@@ -103,11 +103,11 @@ the line between them.
 ## Add an AWS EC2 AMI component and set its properties
 
 Click on the `AMI` from the AWS EC2 category of the asset pallete, and drop it
-inside your `Ohio region` frame.
+inside your `North Virginia region` frame.
 
 Name your AMI `Fedora CoreOS`.
 
-Set the ImageId property to `ami-04000bc04ccee958e`.
+Set the ImageId property to `ami-068493ac5013f0936`.
 
 ## Connect the AMI to the EC2 Instance
 


### PR DESCRIPTION
Use us-east-1 for readme's/guides rather than us-east-2

<hr/>

AMI check:

us-east-2: `ami-0c11a84584d4e09dd` is `al2023-ami-2023.5.20240730.0-kernel-6.1-x86_64`
us-east-1: `ami-0ba9883b710b05ac6` is `al2023-ami-2023.5.20240730.0-kernel-6.1-x86_64`

us-east-2: `ami-04000bc04ccee958e` is `fedora-coreos-40.20240616.3.0-x86_64`
us-east-1: `ami-068493ac5013f0936` is `fedora-coreos-40.20240616.3.0-x86_64`