### PR TITLE
feat(dal): dvus for secret and attribute changes from another change set

### DIFF
--- a/lib/dal/src/workspace_snapshot/graph/correct_transforms.rs
+++ b/lib/dal/src/workspace_snapshot/graph/correct_transforms.rs
@@ -1,12 +1,20 @@
 use std::collections::{HashMap, HashSet};
 
+use petgraph::prelude::*;
+use si_events::ulid::Ulid;
+
+use crate::workspace_snapshot::node_weight::category_node_weight::CategoryNodeKind;
 use crate::workspace_snapshot::node_weight::traits::{CorrectTransforms, CorrectTransformsResult};
+use crate::workspace_snapshot::node_weight::NodeWeight;
+use crate::workspace_snapshot::NodeInformation;
+use crate::{EdgeWeight, EdgeWeightKind, NodeWeightDiscriminants};
 
 use super::{detect_updates::Update, WorkspaceSnapshotGraphV2};
 
 pub fn correct_transforms(
     graph: &WorkspaceSnapshotGraphV2,
     mut updates: Vec<Update>,
+    from_different_change_set: bool,
 ) -> CorrectTransformsResult<Vec<Update>> {
     let mut new_nodes = HashMap::new();
     let mut nodes_to_interrogate = HashSet::new();
@@ -50,7 +58,56 @@ pub fn correct_transforms(
             Some(node_index) => graph.get_node_weight_opt(node_index),
             None => new_nodes.get(&node_to_interrogate.into()),
         } {
-            updates = node_weight.correct_transforms(graph, updates)?;
+            updates = node_weight.correct_transforms(graph, updates, from_different_change_set)?;
+        }
+    }
+
+    Ok(updates)
+}
+
+/// Produce the NewNode and NewEdge updates required for adding a dependent value root to the graph
+pub fn add_dependent_value_root_updates(
+    graph: &WorkspaceSnapshotGraphV2,
+    value_ids: &HashSet<Ulid>,
+) -> CorrectTransformsResult<Vec<Update>> {
+    let mut updates = vec![];
+
+    if let Some((category_node_id, category_node_idx)) =
+        graph.get_category_node(None, CategoryNodeKind::DependentValueRoots)?
+    {
+        let existing_dvu_nodes: Vec<_> = graph
+            .edges_directed(category_node_idx, Outgoing)
+            .filter_map(|edge_ref| {
+                graph
+                    .get_node_weight_opt(edge_ref.target())
+                    .and_then(|weight| match weight {
+                        NodeWeight::DependentValueRoot(inner) => Some(inner.value_id()),
+                        _ => None,
+                    })
+            })
+            .collect();
+
+        for value_id in value_ids {
+            if existing_dvu_nodes.contains(value_id) {
+                continue;
+            }
+
+            let id = graph.generate_ulid()?;
+            let lineage_id = graph.generate_ulid()?;
+            let new_dvu_node = NodeWeight::new_dependent_value_root(id, lineage_id, *value_id);
+            let new_dvu_node_information = (&new_dvu_node).into();
+
+            updates.push(Update::NewNode {
+                node_weight: new_dvu_node,
+            });
+            updates.push(Update::NewEdge {
+                source: NodeInformation {
+                    id: category_node_id.into(),
+                    node_weight_kind: NodeWeightDiscriminants::Category,
+                },
+                destination: new_dvu_node_information,
+                edge_weight: EdgeWeight::new(EdgeWeightKind::new_use()),
+            });
         }
     }
 

--- a/lib/dal/src/workspace_snapshot/graph/tests/exclusive_outgoing_edges.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/exclusive_outgoing_edges.rs
@@ -238,7 +238,7 @@ mod test {
             },
         ];
         let new_updates = action
-            .correct_transforms(&graph, updates.clone())
+            .correct_transforms(&graph, updates.clone(), false)
             .expect("correct transforms");
         // There are no exclusive edges here so we should not produce an update
         assert_eq!(
@@ -256,7 +256,7 @@ mod test {
             },
         ];
         let new_updates = action
-            .correct_transforms(&graph, updates.clone())
+            .correct_transforms(&graph, updates.clone(), false)
             .expect("correct transforms");
         let new_remove_edge = Update::RemoveEdge {
             source: (&action).into(),
@@ -282,7 +282,7 @@ mod test {
             },
         ];
         let new_updates = action
-            .correct_transforms(&graph, updates.clone())
+            .correct_transforms(&graph, updates.clone(), false)
             .expect("correct transforms");
         // There are no exclusive edges here so we should not produce an update
         assert_eq!(
@@ -311,7 +311,7 @@ mod test {
         ];
 
         let mut new_updates = action
-            .correct_transforms(&graph, updates.clone())
+            .correct_transforms(&graph, updates.clone(), false)
             .expect("correct transforms");
         let new_remove_edge_prototype = Update::RemoveEdge {
             source: (&action).into(),

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -693,47 +693,74 @@ impl CorrectTransforms for NodeWeight {
         &self,
         workspace_snapshot_graph: &WorkspaceSnapshotGraphV2,
         updates: Vec<Update>,
+        from_different_change_set: bool,
     ) -> CorrectTransformsResult<Vec<Update>> {
         let updates = match self {
-            NodeWeight::Action(weight) => {
-                weight.correct_transforms(workspace_snapshot_graph, updates)
-            }
-            NodeWeight::ActionPrototype(weight) => {
-                weight.correct_transforms(workspace_snapshot_graph, updates)
-            }
-            NodeWeight::AttributePrototypeArgument(weight) => {
-                weight.correct_transforms(workspace_snapshot_graph, updates)
-            }
-            NodeWeight::AttributeValue(weight) => {
-                weight.correct_transforms(workspace_snapshot_graph, updates)
-            }
-            NodeWeight::Category(weight) => {
-                weight.correct_transforms(workspace_snapshot_graph, updates)
-            }
-            NodeWeight::Component(weight) => {
-                weight.correct_transforms(workspace_snapshot_graph, updates)
-            }
-            NodeWeight::Content(weight) => {
-                weight.correct_transforms(workspace_snapshot_graph, updates)
-            }
-            NodeWeight::DependentValueRoot(weight) => {
-                weight.correct_transforms(workspace_snapshot_graph, updates)
-            }
-            NodeWeight::Func(weight) => {
-                weight.correct_transforms(workspace_snapshot_graph, updates)
-            }
-            NodeWeight::FuncArgument(weight) => {
-                weight.correct_transforms(workspace_snapshot_graph, updates)
-            }
-            NodeWeight::Ordering(weight) => {
-                weight.correct_transforms(workspace_snapshot_graph, updates)
-            }
-            NodeWeight::Prop(weight) => {
-                weight.correct_transforms(workspace_snapshot_graph, updates)
-            }
-            NodeWeight::Secret(weight) => {
-                weight.correct_transforms(workspace_snapshot_graph, updates)
-            }
+            NodeWeight::Action(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
+            NodeWeight::ActionPrototype(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
+            NodeWeight::AttributePrototypeArgument(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
+            NodeWeight::AttributeValue(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
+            NodeWeight::Category(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
+            NodeWeight::Component(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
+            NodeWeight::Content(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
+            NodeWeight::DependentValueRoot(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
+            NodeWeight::Func(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
+            NodeWeight::FuncArgument(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
+            NodeWeight::Ordering(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
+            NodeWeight::Prop(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
+            NodeWeight::Secret(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
         }?;
 
         Ok(self.correct_exclusive_outgoing_edges(workspace_snapshot_graph, updates))

--- a/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
@@ -112,6 +112,7 @@ impl CorrectTransforms for ActionNodeWeight {
         &self,
         graph: &WorkspaceSnapshotGraphV2,
         mut updates: Vec<Update>,
+        _from_different_change_set: bool,
     ) -> CorrectTransformsResult<Vec<Update>> {
         // An action's Use edge should be exclusive for both the component and
         // the prototype. The generic exclusive edge logic assumes there can be

--- a/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
@@ -135,6 +135,7 @@ impl CorrectTransforms for OrderingNodeWeight {
         &self,
         _workspace_snapshot_graph: &WorkspaceSnapshotGraphV2,
         updates: Vec<Update>,
+        _from_different_change_set: bool,
     ) -> CorrectTransformsResult<Vec<Update>> {
         let mut updates = updates;
 

--- a/lib/dal/src/workspace_snapshot/node_weight/traits.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/traits.rs
@@ -25,6 +25,7 @@ pub trait CorrectTransforms {
         &self,
         _workspace_snapshot_graph: &WorkspaceSnapshotGraphV2,
         updates: Vec<Update>,
+        _from_different_change_set: bool,
     ) -> CorrectTransformsResult<Vec<Update>> {
         Ok(updates)
     }

--- a/lib/dal/tests/integration_test/node_weight.rs
+++ b/lib/dal/tests/integration_test/node_weight.rs
@@ -1,2 +1,4 @@
+mod attribute_value;
 mod component;
 mod ordering;
+//mod secret;

--- a/lib/dal/tests/integration_test/node_weight/attribute_value.rs
+++ b/lib/dal/tests/integration_test/node_weight/attribute_value.rs
@@ -1,0 +1,78 @@
+use dal::prop::PropPath;
+use dal::{AttributeValue, DalContext, Prop};
+use dal_test::expected::{
+    apply_change_set_to_base, commit_and_update_snapshot_to_visibility, fork_from_head_change_set,
+    update_visibility_and_snapshot_to_visibility, ExpectComponent,
+};
+use dal_test::helpers::{
+    connect_components_with_socket_names, create_component_for_default_schema_name,
+};
+use dal_test::test;
+
+#[test]
+async fn change_in_output_component_produces_dvu_root_in_other_change_set(ctx: &mut DalContext) {
+    let docker_image = create_component_for_default_schema_name(ctx, "Docker Image", "foobar")
+        .await
+        .expect("component creation");
+
+    apply_change_set_to_base(ctx).await;
+
+    let cs_with_butane = fork_from_head_change_set(ctx).await;
+    let butane = create_component_for_default_schema_name(ctx, "Butane", "butane")
+        .await
+        .expect("create component");
+    connect_components_with_socket_names(
+        ctx,
+        docker_image.id(),
+        "Container Image",
+        butane.id(),
+        "Container Image",
+    )
+    .await
+    .expect("able to connect");
+
+    commit_and_update_snapshot_to_visibility(ctx).await;
+    fork_from_head_change_set(ctx).await;
+
+    let expect_component: ExpectComponent = docker_image.clone().into();
+
+    let prop_id = expect_component
+        .prop(ctx, PropPath::new(["root", "domain", "image"]))
+        .await
+        .prop()
+        .id();
+
+    let image_av_id = Prop::attribute_values_for_prop_id(ctx, prop_id)
+        .await
+        .expect("get attribute values")[0];
+
+    AttributeValue::update(ctx, image_av_id, Some("unpossible".into()))
+        .await
+        .expect("able to update value");
+
+    apply_change_set_to_base(ctx).await;
+
+    update_visibility_and_snapshot_to_visibility(ctx, cs_with_butane.id).await;
+
+    assert_eq!(
+        serde_json::json!("unpossible"),
+        AttributeValue::get_by_id_or_error(ctx, image_av_id)
+            .await
+            .expect("get av")
+            .view(ctx)
+            .await
+            .expect("get view")
+            .expect("has view")
+    );
+
+    // DVU debouncer does not run in tests so these roots will never get
+    // processed unless we explicitly enqueue a dvu. It's enough to see that it
+    // made it into the roots
+    assert!(ctx
+        .workspace_snapshot()
+        .expect("get snap")
+        .list_dependent_value_value_ids()
+        .await
+        .expect("able to get dvu values")
+        .contains(&image_av_id.into()));
+}


### PR DESCRIPTION
When a secret changes or an attribute value changes, and those changes are replayed from head onto another change set, we need to add these values into the dvu roots so that any values that depend on them are recomputed in the context of that change set.

This is a pretty big hammer: if we detect any change in an attribute on replay that is already present in the graph, we add it to the dvu roots. This potentially means adding quite a few roots to the graph on big replays, and it also means recalculating a lot of values that really do not need to be recalculated.

Right now we don't have enough information in the transform corrections to be more surgical. What we would need would be

  1. The snapshot of the graph that we are replaying updates *from*, after it has been updated.
  2. Input socket kind on the Socket node weight.

This would allow us to find all the components that exist only the change set that is receiving the replay and add *just* their input sockets to the DVU, which would mean we recompute just the components that were not already computed, and not recompute the ones that are already properly computed when the DVU ran on the change set that originally made these changes.