### PR TITLE
Use Component::attribute_values instead Prop almost everywhere

### DIFF
--- a/lib/dal/src/attribute/prototype/argument/value_source.rs
+++ b/lib/dal/src/attribute/prototype/argument/value_source.rs
@@ -46,12 +46,11 @@ pub enum ValueSource {
 }
 
 impl ValueSource {
-    pub async fn attribute_values(
-        &self,
-        ctx: &DalContext,
-    ) -> ValueSourceResult<Vec<AttributeValueId>> {
+    async fn attribute_values(&self, ctx: &DalContext) -> ValueSourceResult<Vec<AttributeValueId>> {
         Ok(match self {
-            Self::Prop(prop_id) => Prop::attribute_values_for_prop_id(ctx, *prop_id).await?,
+            Self::Prop(prop_id) => {
+                Prop::all_attribute_values_everywhere_for_prop_id(ctx, *prop_id).await?
+            }
             Self::OutputSocket(ep_id) => {
                 OutputSocket::attribute_values_for_output_socket_id(ctx, *ep_id).await?
             }

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -343,8 +343,7 @@ impl Component {
         let root_prop_id =
             Prop::find_prop_id_by_path(ctx, schema_variant_id, &PropPath::new(["root"])).await?;
 
-        let root_value_ids = Prop::attribute_values_for_prop_id(ctx, root_prop_id).await?;
-        for value_id in root_value_ids {
+        for value_id in Component::attribute_values_for_prop_id(ctx, id, root_prop_id).await? {
             let value_component_id = AttributeValue::component_id(ctx, value_id).await?;
             if value_component_id == id {
                 let root_value = AttributeValue::get_by_id_or_error(ctx, value_id).await?;
@@ -1792,7 +1791,9 @@ impl Component {
         prop_id: PropId,
     ) -> ComponentResult<Vec<AttributeValueId>> {
         let mut result = vec![];
-        for attribute_value_id in Prop::attribute_values_for_prop_id(ctx, prop_id).await? {
+        for attribute_value_id in
+            Prop::all_attribute_values_everywhere_for_prop_id(ctx, prop_id).await?
+        {
             let value_component_id = AttributeValue::component_id(ctx, attribute_value_id).await?;
             if value_component_id == component_id {
                 result.push(attribute_value_id)

--- a/lib/dal/src/func/authoring/save.rs
+++ b/lib/dal/src/func/authoring/save.rs
@@ -1,0 +1,540 @@
+use std::collections::HashSet;
+use telemetry::prelude::*;
+
+use crate::action::prototype::{ActionKind, ActionPrototype};
+use crate::attribute::prototype::argument::{
+    AttributePrototypeArgument, AttributePrototypeArgumentId,
+};
+use crate::func::argument::{FuncArgument, FuncArgumentError};
+use crate::func::associations::FuncAssociations;
+use crate::func::authoring::{FuncAuthoringError, FuncAuthoringResult};
+use crate::func::intrinsics::IntrinsicFunc;
+use crate::func::{AttributePrototypeArgumentBag, AttributePrototypeBag, FuncKind};
+use crate::schema::variant::leaves::{LeafInputLocation, LeafKind};
+use crate::workspace_snapshot::graph::WorkspaceSnapshotGraphError;
+use crate::{
+    AttributePrototype, AttributePrototypeId, AttributeValue, Component, ComponentId, DalContext,
+    EdgeWeightKind, Func, FuncBackendResponseType, FuncId, OutputSocket, Prop, SchemaVariant,
+    SchemaVariantId, WorkspaceSnapshotError,
+};
+
+#[instrument(
+    name = "func.authoring.save_func.update_associations",
+    level = "debug",
+    skip(ctx)
+)]
+pub(crate) async fn update_associations(
+    ctx: &DalContext,
+    func: &Func,
+    associations: FuncAssociations,
+) -> FuncAuthoringResult<()> {
+    match func.kind {
+        FuncKind::Action => match associations {
+            FuncAssociations::Action {
+                kind,
+                schema_variant_ids,
+            } => update_action_associations(ctx, func, kind, schema_variant_ids).await,
+            invalid => {
+                return Err(FuncAuthoringError::InvalidFuncAssociationsForFunc(
+                    invalid, func.id, func.kind,
+                ))
+            }
+        },
+        // NOTE(nick): I'm re-reading the below comment and thinking we need to just destroy
+        // associations for attribute funcs. If they are not useful, demolish them.
+        // ------------------------------------------------------------------------------
+        // don't update attribute associations this way
+        // attribute associations are updated through calling
+        // create/remove/update attribute binding directly
+        FuncKind::Attribute => Ok(()),
+        FuncKind::Authentication => match associations {
+            FuncAssociations::Authentication { schema_variant_ids } => {
+                update_authentication_associations(ctx, func, schema_variant_ids).await
+            }
+            invalid => {
+                return Err(FuncAuthoringError::InvalidFuncAssociationsForFunc(
+                    invalid, func.id, func.kind,
+                ))
+            }
+        },
+        FuncKind::CodeGeneration => match associations {
+            FuncAssociations::CodeGeneration {
+                schema_variant_ids,
+                component_ids,
+                inputs,
+            } => {
+                update_leaf_associations(
+                    ctx,
+                    func,
+                    schema_variant_ids,
+                    component_ids,
+                    &inputs,
+                    LeafKind::CodeGeneration,
+                )
+                .await
+            }
+            invalid => Err(FuncAuthoringError::InvalidFuncAssociationsForFunc(
+                invalid, func.id, func.kind,
+            )),
+        },
+        FuncKind::Qualification => match associations {
+            FuncAssociations::Qualification {
+                schema_variant_ids,
+                component_ids,
+                inputs,
+            } => {
+                update_leaf_associations(
+                    ctx,
+                    func,
+                    schema_variant_ids,
+                    component_ids,
+                    &inputs,
+                    LeafKind::Qualification,
+                )
+                .await
+            }
+            invalid => Err(FuncAuthoringError::InvalidFuncAssociationsForFunc(
+                invalid, func.id, func.kind,
+            )),
+        },
+        kind => Err(FuncAuthoringError::FuncCannotHaveAssociations(
+            func.id,
+            kind,
+            associations,
+        )),
+    }
+}
+
+#[instrument(
+    name = "func.authoring.save_func.update_associations.action",
+    level = "debug",
+    skip(ctx)
+)]
+async fn update_action_associations(
+    ctx: &DalContext,
+    func: &Func,
+    kind: ActionKind,
+    schema_variant_ids: Vec<SchemaVariantId>,
+) -> FuncAuthoringResult<()> {
+    let id_set: HashSet<SchemaVariantId> = HashSet::from_iter(schema_variant_ids.iter().copied());
+
+    // Add the new action to schema variants who do not already have a prototype or re-create the
+    // prototype if the kind has been mutated.
+    for schema_variant_id in schema_variant_ids {
+        let existing_action_prototypes =
+            ActionPrototype::for_variant(ctx, schema_variant_id).await?;
+
+        // Assume that the prototype needs to be created. Bail the moment that we know one already
+        // exists the moment that we know that the kind has been mutated, which means we will need
+        // to re-create the prototype with the new kind.
+        let mut needs_creation = true;
+        let mut outdated_action_prototype_id = None;
+        for (existing_action_prototype_id, exiting_action_prototype_kind) in
+            existing_action_prototypes.iter().map(|p| (p.id, p.kind))
+        {
+            let prototype_func_id =
+                ActionPrototype::func_id(ctx, existing_action_prototype_id).await?;
+
+            // Match found! We need to now decide if we need to re-create the prototype. If the user
+            // is keeping the prototype kind the same, then we don't need to create a new prototype.
+            // If the user wishes to mutate the kind, then we need to delete the existing prototype
+            // and create a new one.
+            if func.id == prototype_func_id {
+                if kind == exiting_action_prototype_kind {
+                    needs_creation = false;
+                } else {
+                    outdated_action_prototype_id = Some(existing_action_prototype_id);
+                }
+                break;
+            }
+        }
+
+        // Any time that we need to create a new prototype, we need to first check that it will not
+        // collide with an existing prototype using the same, non-manual kind that we provided.
+        if needs_creation {
+            if kind != ActionKind::Manual
+                && existing_action_prototypes.iter().any(|p| p.kind == kind)
+            {
+                return Err(FuncAuthoringError::ActionKindAlreadyExists(
+                    kind,
+                    schema_variant_id,
+                ));
+            }
+
+            // Remove the prototype that needs to be re-created, if necessary.
+            if let Some(outdated_action_prototype_id) = outdated_action_prototype_id {
+                ActionPrototype::remove(ctx, outdated_action_prototype_id).await?;
+            }
+
+            ActionPrototype::new(
+                ctx,
+                kind,
+                func.name.to_owned(),
+                func.description.to_owned(),
+                schema_variant_id,
+                func.id,
+            )
+            .await?;
+        }
+    }
+
+    // Remove action prototypes using our func from schema variants that weren't seen.
+    for action_prototype_id in ActionPrototype::list_for_func_id(ctx, func.id).await? {
+        let schema_variant_id =
+            ActionPrototype::schema_variant_id(ctx, action_prototype_id).await?;
+        if !id_set.contains(&schema_variant_id) {
+            ActionPrototype::remove(ctx, action_prototype_id).await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[instrument(
+    name = "func.authoring.save_func.update_associations.authentication",
+    level = "debug",
+    skip(ctx)
+)]
+async fn update_authentication_associations(
+    ctx: &DalContext,
+    func: &Func,
+    schema_variant_ids: Vec<SchemaVariantId>,
+) -> FuncAuthoringResult<()> {
+    let mut id_set = HashSet::new();
+
+    // Add the new authentication prototype to schema variants who do not already have a prototype.
+    // We do not need to re-create or edit the prototypes that already exist because the prototype
+    // is merely an edge.
+    for schema_variant_id in schema_variant_ids {
+        let existing_auth_func_ids =
+            SchemaVariant::list_auth_func_ids_for_id(ctx, schema_variant_id).await?;
+
+        if !existing_auth_func_ids.iter().any(|id| *id == func.id) {
+            SchemaVariant::new_authentication_prototype(ctx, func.id, schema_variant_id).await?;
+        }
+
+        id_set.insert(schema_variant_id);
+    }
+
+    // Remove authentication prototypes from schema variants that haven't been seen.
+    for schema_variant_id in
+        SchemaVariant::list_schema_variant_ids_using_auth_func_id(ctx, func.id).await?
+    {
+        if !id_set.contains(&schema_variant_id) {
+            SchemaVariant::remove_authentication_prototype(ctx, func.id, schema_variant_id).await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[instrument(
+    name = "func.authoring.save_func.update_associations.leaf",
+    level = "info",
+    skip(ctx)
+)]
+async fn update_leaf_associations(
+    ctx: &DalContext,
+    func: &Func,
+    schema_variant_ids: Vec<SchemaVariantId>,
+    component_ids: Vec<ComponentId>,
+    inputs: &[LeafInputLocation],
+    leaf_kind: LeafKind,
+) -> FuncAuthoringResult<()> {
+    let mut id_set = HashSet::new();
+
+    // Populate the id set with the provided schema variant ids as well as the schema variant ids
+    // for the provided components.
+    id_set.extend(schema_variant_ids);
+    for component_id in component_ids {
+        // TODO(nick): destroy nilId. Log a warning at the moment in case the frontend sends value
+        // for no-ops. I will come back and destroy nil id soon.
+        if component_id == ComponentId::NONE {
+            warn!("skipping component id set to nil id");
+        } else {
+            id_set.insert(Component::schema_variant_id(ctx, component_id).await?);
+        }
+    }
+
+    let mut views = Vec::new();
+    for schema_variant_id in id_set {
+        let attribute_prototype_id =
+            SchemaVariant::upsert_leaf_function(ctx, schema_variant_id, leaf_kind, inputs, func)
+                .await?;
+        views.push(AttributePrototypeBag::assemble(ctx, attribute_prototype_id).await?);
+    }
+
+    let key = Some(func.name.to_owned());
+
+    save_attr_func_prototypes(ctx, func, views, false, key).await?;
+
+    Ok(())
+}
+#[instrument(
+    name = "func.authoring.save_func.save_attr_func_prototypes",
+    level = "info",
+    skip(ctx)
+)]
+async fn save_attr_func_prototypes(
+    ctx: &DalContext,
+    func: &Func,
+    prototype_bags: Vec<AttributePrototypeBag>,
+    attempt_to_use_default_prototype: bool,
+    key: Option<String>,
+) -> FuncAuthoringResult<FuncBackendResponseType> {
+    let mut id_set = HashSet::new();
+    let mut computed_backend_response_type = func.backend_response_type;
+
+    // Update all prototypes using the func.
+    for prototype_bag in prototype_bags {
+        // TODO(nick): don't use the nil id in the future.
+        let attribute_prototype_id = if AttributePrototypeId::NONE == prototype_bag.id {
+            create_new_attribute_prototype(ctx, &prototype_bag, func.id, key.clone()).await?
+        } else {
+            AttributePrototype::update_func_by_id(ctx, prototype_bag.id, func.id).await?;
+            prototype_bag.id
+        };
+        id_set.insert(attribute_prototype_id);
+
+        // Use the attribute prototype id variable rather than the one off the iterator so that we
+        // don't use the nil one by accident.
+        save_attr_func_proto_arguments(
+            ctx,
+            attribute_prototype_id,
+            prototype_bag.prototype_arguments,
+        )
+        .await?;
+    }
+
+    // Reset all prototypes that are unused.
+    for attribute_prototype_id in AttributePrototype::list_ids_for_func_id(ctx, func.id).await? {
+        if !id_set.contains(&attribute_prototype_id) {
+            reset_attribute_prototype(
+                ctx,
+                attribute_prototype_id,
+                attempt_to_use_default_prototype,
+            )
+            .await?;
+        }
+    }
+
+    // Use the "unset" response type if all bindings have been removed.
+    if id_set.is_empty() {
+        computed_backend_response_type = FuncBackendResponseType::Unset;
+    }
+
+    Ok(computed_backend_response_type)
+}
+#[instrument(
+    name = "func.authoring.save_func.delete_attribute_prototype_and_args",
+    level = "info",
+    skip(ctx)
+)]
+pub(crate) async fn delete_attribute_prototype_and_args(
+    ctx: &DalContext,
+    attribute_prototype_id: AttributePrototypeId,
+) -> FuncAuthoringResult<()> {
+    let current_attribute_prototype_arguments =
+        AttributePrototypeArgument::list_ids_for_prototype(ctx, attribute_prototype_id).await?;
+    for apa in current_attribute_prototype_arguments {
+        AttributePrototypeArgument::remove(ctx, apa).await?;
+    }
+    AttributePrototype::remove(ctx, attribute_prototype_id).await?;
+    Ok(())
+}
+
+// NOTE(nick,john): this is doing way too much bullshit. We probably need to break out its usages
+// and users.
+#[instrument(
+    name = "func.authoring.save_func.reset_attribute_prototype",
+    level = "info",
+    skip(ctx)
+)]
+pub(crate) async fn reset_attribute_prototype(
+    ctx: &DalContext,
+    attribute_prototype_id: AttributePrototypeId,
+    attempt_to_use_default_prototype: bool,
+) -> FuncAuthoringResult<()> {
+    if attempt_to_use_default_prototype {
+        if let Some(attribute_value_id) =
+            AttributePrototype::attribute_value_id(ctx, attribute_prototype_id).await?
+        {
+            AttributeValue::use_default_prototype(ctx, attribute_value_id).await?;
+            return Ok(());
+        }
+    }
+
+    // If we aren't trying to use the default prototype, or the default prototype is the same as the
+    // prototype we're trying to 'reset', then set this prototype to be identity and remove all existing arguments.
+    // By setting to identity, this ensures that IF the user regenerates the schema variant def in the future,
+    // we'll correctly reset the value sources based on what's in that code
+
+    let identity_func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity).await?;
+    AttributePrototype::update_func_by_id(ctx, attribute_prototype_id, identity_func_id).await?;
+    // loop through and delete all existing attribute prototype arguments
+    let current_attribute_prototype_arguments =
+        AttributePrototypeArgument::list_ids_for_prototype(ctx, attribute_prototype_id).await?;
+    for apa in current_attribute_prototype_arguments {
+        AttributePrototypeArgument::remove(ctx, apa).await?;
+    }
+    Ok(())
+}
+#[instrument(
+    name = "func.authoring.save_func.save_attr_func_proto_arguments",
+    level = "info",
+    skip(ctx)
+)]
+pub(crate) async fn save_attr_func_proto_arguments(
+    ctx: &DalContext,
+    attribute_prototype_id: AttributePrototypeId,
+    arguments: Vec<AttributePrototypeArgumentBag>,
+) -> FuncAuthoringResult<()> {
+    let mut id_set = HashSet::new();
+
+    for arg in &arguments {
+        // Ensure the func argument exists before continuing. By continuing, we will not add the
+        // attribute prototype to the id set and will be deleted.
+        if let Err(err) = FuncArgument::get_by_id_or_error(ctx, arg.func_argument_id).await {
+            match err {
+                FuncArgumentError::WorkspaceSnapshot(
+                    WorkspaceSnapshotError::WorkspaceSnapshotGraph(
+                        WorkspaceSnapshotGraphError::NodeWithIdNotFound(raw_id),
+                    ),
+                ) if raw_id == arg.func_argument_id.into() => continue,
+                err => return Err(err.into()),
+            }
+        }
+
+        // Always remove and recreate the argument because the func argument or input socket
+        // could have changed.
+        if AttributePrototypeArgumentId::NONE != arg.id {
+            AttributePrototypeArgument::remove_or_no_op(ctx, arg.id).await?;
+        }
+
+        let attribute_prototype_argument =
+            AttributePrototypeArgument::new(ctx, attribute_prototype_id, arg.func_argument_id)
+                .await?;
+        let attribute_prototype_argument_id = attribute_prototype_argument.id();
+
+        if let Some(input_socket_id) = arg.input_socket_id {
+            attribute_prototype_argument
+                .set_value_from_input_socket_id(ctx, input_socket_id)
+                .await?;
+        } else if let Some(prop_id) = arg.prop_id {
+            attribute_prototype_argument
+                .set_value_from_prop_id(ctx, prop_id)
+                .await?;
+        } else {
+            return Err(FuncAuthoringError::NoInputLocationGiven(
+                attribute_prototype_id,
+                arg.func_argument_id,
+            ));
+        }
+
+        id_set.insert(attribute_prototype_argument_id);
+    }
+
+    for attribute_prototype_argument_id in
+        AttributePrototypeArgument::list_ids_for_prototype(ctx, attribute_prototype_id).await?
+    {
+        if !id_set.contains(&attribute_prototype_argument_id) {
+            AttributePrototypeArgument::remove_or_no_op(ctx, attribute_prototype_argument_id)
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+/// Creates a new attribute prototype for a given prop/socket/component id.
+/// Also removes the existing prototype and args that exist so we don't end up
+/// with duplicates
+pub(crate) async fn create_new_attribute_prototype(
+    ctx: &DalContext,
+    prototype_bag: &AttributePrototypeBag,
+    func_id: FuncId,
+    key: Option<String>,
+) -> FuncAuthoringResult<AttributePrototypeId> {
+    let attribute_prototype = AttributePrototype::new(ctx, func_id).await?;
+
+    // TODO(nick): just destroy and burn nilId to the ground. We need to use the "id!" macro instead
+    // of the "pk!" macro and be done with it.
+    let component_id_cannot_be_nil_id = match prototype_bag.component_id {
+        None | Some(ComponentId::NONE) => None,
+        Some(component_id) => Some(component_id),
+    };
+
+    let mut affected_attribute_value_ids = Vec::new();
+
+    if let Some(prop_id) = prototype_bag.prop_id {
+        if let Some(component_id) = component_id_cannot_be_nil_id {
+            let attribute_value_ids =
+                Component::attribute_values_for_prop_id(ctx, component_id, prop_id).await?;
+
+            for attribute_value_id in attribute_value_ids {
+                AttributeValue::set_component_prototype_id(
+                    ctx,
+                    attribute_value_id,
+                    attribute_prototype.id,
+                    None,
+                )
+                .await?;
+                affected_attribute_value_ids.push(attribute_value_id);
+            }
+        } else {
+            // remove the existing attribute prototype and arguments
+            if let Some(existing_proto) =
+                AttributePrototype::find_for_prop(ctx, prop_id, &key).await?
+            {
+                delete_attribute_prototype_and_args(ctx, existing_proto).await?;
+            }
+
+            Prop::add_edge_to_attribute_prototype(
+                ctx,
+                prop_id,
+                attribute_prototype.id,
+                EdgeWeightKind::Prototype(key),
+            )
+            .await?;
+        }
+    } else if let Some(output_socket_id) = prototype_bag.output_socket_id {
+        if let Some(component_id) = component_id_cannot_be_nil_id {
+            let attribute_value_ids =
+                OutputSocket::attribute_values_for_output_socket_id(ctx, output_socket_id).await?;
+            for attribute_value_id in attribute_value_ids {
+                if component_id == AttributeValue::component_id(ctx, attribute_value_id).await? {
+                    AttributeValue::set_component_prototype_id(
+                        ctx,
+                        attribute_value_id,
+                        attribute_prototype.id,
+                        None,
+                    )
+                    .await?;
+                    affected_attribute_value_ids.push(attribute_value_id);
+                }
+            }
+        } else {
+            // remove the existing attribute prototype and arguments
+            if let Some(existing_proto) =
+                AttributePrototype::find_for_output_socket(ctx, output_socket_id).await?
+            {
+                delete_attribute_prototype_and_args(ctx, existing_proto).await?;
+            }
+            OutputSocket::add_edge_to_attribute_prototype(
+                ctx,
+                output_socket_id,
+                attribute_prototype.id,
+                EdgeWeightKind::Prototype(key),
+            )
+            .await?;
+        }
+    } else {
+        return Err(FuncAuthoringError::NoOutputLocationGiven(func_id));
+    }
+
+    if !affected_attribute_value_ids.is_empty() {
+        ctx.add_dependent_values_and_enqueue(affected_attribute_value_ids)
+            .await?;
+    }
+
+    Ok(attribute_prototype.id)
+}

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -219,20 +219,17 @@ impl AttributeBinding {
                     }
                     EventualParent::Component(component_id) => {
                         let attribute_value_ids =
-                            Prop::attribute_values_for_prop_id(ctx, prop_id).await?;
+                            Component::attribute_values_for_prop_id(ctx, component_id, prop_id)
+                                .await?;
 
                         for attribute_value_id in attribute_value_ids {
-                            if component_id
-                                == AttributeValue::component_id(ctx, attribute_value_id).await?
-                            {
-                                AttributeValue::set_component_prototype_id(
-                                    ctx,
-                                    attribute_value_id,
-                                    attribute_prototype.id,
-                                    None,
-                                )
-                                .await?;
-                            }
+                            AttributeValue::set_component_prototype_id(
+                                ctx,
+                                attribute_value_id,
+                                attribute_prototype.id,
+                                None,
+                            )
+                            .await?;
                         }
                     }
                 }

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -686,7 +686,13 @@ impl Prop {
         Self::path_by_id(ctx, self.id).await
     }
 
-    pub async fn attribute_values_for_prop_id(
+    ///
+    /// Get all attribute values from all components associated with this prop id.
+    ///
+    /// NOTE: If you want a component's prop value, use
+    /// `Component::attribute_values_for_prop_id()` instead.
+    ///
+    pub async fn all_attribute_values_everywhere_for_prop_id(
         ctx: &DalContext,
         prop_id: PropId,
     ) -> PropResult<Vec<AttributeValueId>> {

--- a/lib/dal/tests/integration_test/attribute/value.rs
+++ b/lib/dal/tests/integration_test/attribute/value.rs
@@ -23,7 +23,7 @@ async fn arguments_for_prototype_function_execution(ctx: &mut DalContext) {
     // that the value of "/root/si/name" comes in, as expected. The name is set when creating a
     // component, so we do not need to do additional setup.
     let expected = "you should see this name in the arguments";
-    let _component = Component::new(ctx, expected, schema_variant_id)
+    let component = Component::new(ctx, expected, schema_variant_id)
         .await
         .expect("could not create component");
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
@@ -38,9 +38,10 @@ async fn arguments_for_prototype_function_execution(ctx: &mut DalContext) {
     )
     .await
     .expect("could not find prop id by path");
-    let mut attribute_value_ids = Prop::attribute_values_for_prop_id(ctx, prop_id)
-        .await
-        .expect("could not list attribute value ids for prop id");
+    let mut attribute_value_ids =
+        Component::attribute_values_for_prop_id(ctx, component.id(), prop_id)
+            .await
+            .expect("could not list attribute value ids for prop id");
     let attribute_value_id = attribute_value_ids
         .pop()
         .expect("empty attribute value ids");

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -254,9 +254,10 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) {
     .await
     .expect("able to find 'rigid_designator' prop");
 
-    let rigid_designator_values = Prop::attribute_values_for_prop_id(ctx, rigid_designator_prop_id)
-        .await
-        .expect("able to get attribute value for universe prop");
+    let rigid_designator_values =
+        Component::attribute_values_for_prop_id(ctx, component.id(), rigid_designator_prop_id)
+            .await
+            .expect("able to get attribute value for universe prop");
 
     assert_eq!(1, rigid_designator_values.len());
 
@@ -289,7 +290,7 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) {
     .expect("able to find 'naming_and_necessity' prop");
 
     let naming_and_necessity_value_id =
-        Prop::attribute_values_for_prop_id(ctx, naming_and_necessity_prop_id)
+        Component::attribute_values_for_prop_id(ctx, component.id(), naming_and_necessity_prop_id)
             .await
             .expect("able to get values for naming_and_necessity")
             .first()
@@ -353,7 +354,7 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) {
         .await
         .expect("able to find root prop");
 
-    let root_value_id = Prop::attribute_values_for_prop_id(ctx, root_prop_id)
+    let root_value_id = Component::attribute_values_for_prop_id(ctx, component.id(), root_prop_id)
         .await
         .expect("get root prop value id")
         .first()
@@ -424,9 +425,10 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
     .await
     .expect("able to find 'possible_world' prop");
 
-    let possible_world_values = Prop::attribute_values_for_prop_id(ctx, possible_world_a_prop_id)
-        .await
-        .expect("able to get attribute value for universe prop");
+    let possible_world_values =
+        Component::attribute_values_for_prop_id(ctx, component.id(), possible_world_a_prop_id)
+            .await
+            .expect("able to get attribute value for universe prop");
 
     assert_eq!(1, possible_world_values.len());
 
@@ -459,7 +461,7 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
     .expect("able to find 'naming_and_necessity' prop");
 
     let naming_and_necessity_value_id =
-        Prop::attribute_values_for_prop_id(ctx, naming_and_necessity_prop_id)
+        Component::attribute_values_for_prop_id(ctx, component.id(), naming_and_necessity_prop_id)
             .await
             .expect("able to get values for naming_and_necessity")
             .first()
@@ -526,7 +528,7 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
         .await
         .expect("able to find root prop");
 
-    let root_value_id = Prop::attribute_values_for_prop_id(ctx, root_prop_id)
+    let root_value_id = Component::attribute_values_for_prop_id(ctx, component.id(), root_prop_id)
         .await
         .expect("get root prop value id")
         .first()
@@ -597,9 +599,13 @@ async fn through_the_wormholes_dynamic_child_value_reactivity(ctx: &mut DalConte
     .await
     .expect("able to find 'possible_world_a' prop");
 
-    let possible_world_values = Prop::attribute_values_for_prop_id(ctx, possible_world_a_prop_id)
-        .await
-        .expect("able to get attribute value for universe prop");
+    let possible_world_values = Component::attribute_values_for_prop_id(
+        ctx,
+        etoiles_component.id(),
+        possible_world_a_prop_id,
+    )
+    .await
+    .expect("able to get attribute value for universe prop");
 
     let possible_world_a_value_id = possible_world_values
         .first()
@@ -636,9 +642,13 @@ async fn through_the_wormholes_dynamic_child_value_reactivity(ctx: &mut DalConte
     .await
     .expect("able to find 'possible_world_b' prop");
 
-    let possible_world_values = Prop::attribute_values_for_prop_id(ctx, possible_world_b_prop_id)
-        .await
-        .expect("able to get attribute value for possible world prop");
+    let possible_world_values = Component::attribute_values_for_prop_id(
+        ctx,
+        etoiles_component.id(),
+        possible_world_b_prop_id,
+    )
+    .await
+    .expect("able to get attribute value for possible world prop");
 
     let possible_world_b_value_id = possible_world_values
         .first()
@@ -686,12 +696,13 @@ async fn through_the_wormholes_dynamic_child_value_reactivity(ctx: &mut DalConte
     .await
     .expect("able to find 'stars' prop");
 
-    let stars_value_id = Prop::attribute_values_for_prop_id(ctx, stars_prop_id)
-        .await
-        .expect("able to get attribute value for possible world prop")
-        .first()
-        .copied()
-        .expect("get first value id");
+    let stars_value_id =
+        Component::attribute_values_for_prop_id(ctx, morningstar_component.id(), stars_prop_id)
+            .await
+            .expect("able to get attribute value for possible world prop")
+            .first()
+            .copied()
+            .expect("get first value id");
 
     let stars_value = AttributeValue::get_by_id_or_error(ctx, stars_value_id)
         .await
@@ -723,9 +734,10 @@ async fn set_the_universe(ctx: &mut DalContext) {
     .await
     .expect("able to find 'root/domain/universe' prop");
 
-    let universe_values = Prop::attribute_values_for_prop_id(ctx, universe_prop_id)
-        .await
-        .expect("able to get attribute value for universe prop");
+    let universe_values =
+        Component::attribute_values_for_prop_id(ctx, component.id(), universe_prop_id)
+            .await
+            .expect("able to get attribute value for universe prop");
 
     assert_eq!(1, universe_values.len());
 

--- a/lib/dal/tests/integration_test/component/debug.rs
+++ b/lib/dal/tests/integration_test/component/debug.rs
@@ -64,9 +64,10 @@ async fn get_debug_view(ctx: &mut DalContext) {
     let rigid_designator_prop_id = Prop::find_prop_id_by_path(ctx, sv_id.id(), &rigid_prop_path)
         .await
         .expect("able to find 'rigid_designator' prop");
-    let rigid_designator_values = Prop::attribute_values_for_prop_id(ctx, rigid_designator_prop_id)
-        .await
-        .expect("able to get attribute value for rigid_designator prop");
+    let rigid_designator_values =
+        Component::attribute_values_for_prop_id(ctx, component.id(), rigid_designator_prop_id)
+            .await
+            .expect("able to get attribute value for rigid_designator prop");
 
     let rigid_designator_value_id = rigid_designator_values
         .first()

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -2983,12 +2983,15 @@ async fn frames_and_secrets(ctx: &mut DalContext, nw: &WorkspaceSignup) {
 
         // check that the secret propagated
 
-        let component_secret_av =
-            Prop::attribute_values_for_prop_id(ctx, component_secret_prop.id())
-                .await
-                .expect("could not get attribute values")
-                .pop()
-                .expect("has a value");
+        let component_secret_av = Component::attribute_values_for_prop_id(
+            ctx,
+            child_component.id(),
+            component_secret_prop.id(),
+        )
+        .await
+        .expect("could not get attribute values")
+        .pop()
+        .expect("has a value");
         let component_secret_value = AttributeValue::get_by_id_or_error(ctx, component_secret_av)
             .await
             .expect("could not get attribute value by id")
@@ -3061,12 +3064,15 @@ async fn frames_and_secrets(ctx: &mut DalContext, nw: &WorkspaceSignup) {
             .expect("could not commit and update snapshot to visibility");
 
         // check that the value propagates
-        let component_secret_av =
-            Prop::attribute_values_for_prop_id(ctx, component_secret_prop.id())
-                .await
-                .expect("could not get attribute values")
-                .pop()
-                .expect("has a value");
+        let component_secret_av = Component::attribute_values_for_prop_id(
+            ctx,
+            child_component.id(),
+            component_secret_prop.id(),
+        )
+        .await
+        .expect("could not get attribute values")
+        .pop()
+        .expect("has a value");
         let component_secret_value = AttributeValue::get_by_id_or_error(ctx, component_secret_av)
             .await
             .expect("could not get attribute value by id")

--- a/lib/dal/tests/integration_test/node_weight/attribute_value.rs
+++ b/lib/dal/tests/integration_test/node_weight/attribute_value.rs
@@ -1,26 +1,19 @@
-use dal::prop::PropPath;
-use dal::{AttributeValue, DalContext, Prop};
+use dal::DalContext;
 use dal_test::expected::{
     apply_change_set_to_base, commit_and_update_snapshot_to_visibility, fork_from_head_change_set,
     update_visibility_and_snapshot_to_visibility, ExpectComponent,
 };
-use dal_test::helpers::{
-    connect_components_with_socket_names, create_component_for_default_schema_name,
-};
+use dal_test::helpers::connect_components_with_socket_names;
 use dal_test::test;
 
 #[test]
 async fn change_in_output_component_produces_dvu_root_in_other_change_set(ctx: &mut DalContext) {
-    let docker_image = create_component_for_default_schema_name(ctx, "Docker Image", "foobar")
-        .await
-        .expect("component creation");
+    let docker_image = ExpectComponent::create(ctx, "Docker Image").await;
 
     apply_change_set_to_base(ctx).await;
 
     let cs_with_butane = fork_from_head_change_set(ctx).await;
-    let butane = create_component_for_default_schema_name(ctx, "Butane", "butane")
-        .await
-        .expect("create component");
+    let butane = ExpectComponent::create(ctx, "Butane").await;
     connect_components_with_socket_names(
         ctx,
         docker_image.id(),
@@ -34,36 +27,14 @@ async fn change_in_output_component_produces_dvu_root_in_other_change_set(ctx: &
     commit_and_update_snapshot_to_visibility(ctx).await;
     fork_from_head_change_set(ctx).await;
 
-    let expect_component: ExpectComponent = docker_image.clone().into();
-
-    let prop_id = expect_component
-        .prop(ctx, PropPath::new(["root", "domain", "image"]))
-        .await
-        .prop()
-        .id();
-
-    let image_av_id = Prop::attribute_values_for_prop_id(ctx, prop_id)
-        .await
-        .expect("get attribute values")[0];
-
-    AttributeValue::update(ctx, image_av_id, Some("unpossible".into()))
-        .await
-        .expect("able to update value");
+    let image = docker_image.prop(ctx, ["root", "domain", "image"]).await;
+    image.set(ctx, "unpossible").await;
 
     apply_change_set_to_base(ctx).await;
 
     update_visibility_and_snapshot_to_visibility(ctx, cs_with_butane.id).await;
 
-    assert_eq!(
-        serde_json::json!("unpossible"),
-        AttributeValue::get_by_id_or_error(ctx, image_av_id)
-            .await
-            .expect("get av")
-            .view(ctx)
-            .await
-            .expect("get view")
-            .expect("has view")
-    );
+    assert_eq!(serde_json::json!("unpossible"), image.get(ctx).await);
 
     // DVU debouncer does not run in tests so these roots will never get
     // processed unless we explicitly enqueue a dvu. It's enough to see that it
@@ -74,5 +45,5 @@ async fn change_in_output_component_produces_dvu_root_in_other_change_set(ctx: &
         .list_dependent_value_value_ids()
         .await
         .expect("able to get dvu values")
-        .contains(&image_av_id.into()));
+        .contains(&image.attribute_value(ctx).await.id().into()));
 }

--- a/lib/sdf-server/src/server/service/attribute/get_prototype_arguments.rs
+++ b/lib/sdf-server/src/server/service/attribute/get_prototype_arguments.rs
@@ -39,7 +39,8 @@ pub async fn get_prototype_arguments(
     // prototype. There should only be one.
     let attribute_value_id = match (request.prop_id, request.output_socket_id) {
         (Some(prop_id), None) => {
-            let attribute_value_ids = Prop::attribute_values_for_prop_id(&ctx, prop_id).await?;
+            let attribute_value_ids =
+                Prop::all_attribute_values_everywhere_for_prop_id(&ctx, prop_id).await?;
             if attribute_value_ids.len() > 1 {
                 return Err(AttributeError::MultipleAttributeValuesForProp(
                     attribute_value_ids.to_owned(),


### PR DESCRIPTION
One of our recent bugs was due to using Prop::attribute_values_for_prop_id instead of Component::attribute_values_for_prop_id, and it'd be nice to make it more obvious that the former method is almost never what you want.

This PR:
* Renames `Prop::attribute_values_for_prop_id` to the scarier and more accurate `Prop::all_attribute_values_everywhere_for_prop_id`, and adds a comment so that people will know where to get the method they probably *meant* to call.
* Calls `Component::attribute_values_for_prop_id()` everywhere we were previously calling the Prop version but really meant to get a component-specific value for the prop.

There do not appear to be other bugs around this, but the PR makes how we get props a bit more uniform and smaller to boot.