### PR TITLE
Make it hard to accidentally get all socket values

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1930,26 +1930,8 @@ impl Component {
             }
         }
 
-        let destination_attribute_value_ids =
-            InputSocket::attribute_values_for_input_socket_id(ctx, destination_input_socket_id)
-                .await?;
-
         // filter the value ids by destination_component_id
-        let mut destination_attribute_value_id: Option<AttributeValueId> = None;
-        for value_id in destination_attribute_value_ids {
-            let component_id = AttributeValue::component_id(ctx, value_id).await?;
-            if component_id == destination_component_id {
-                destination_attribute_value_id = Some(value_id);
-                break;
-            }
-        }
-
-        let destination_attribute_value_id = destination_attribute_value_id.ok_or(
-            ComponentError::DestinationComponentMissingAttributeValueForInputSocket(
-                destination_component_id,
-                destination_input_socket_id,
-            ),
-        )?;
+        let destination_attribute_value_id = InputSocket::component_attribute_value_for_input_socket_id(ctx, destination_input_socket_id, destination_component_id).await?;
 
         let destination_prototype_id =
             AttributeValue::prototype_id(ctx, destination_attribute_value_id).await?;
@@ -2809,30 +2791,13 @@ impl Component {
                                 )
                                 .await?;
 
-                                let destination_attribute_value_ids =
-                                    InputSocket::attribute_values_for_input_socket_id(
+                                let destination_attribute_value_id =
+                                    InputSocket::component_attribute_value_for_input_socket_id(
                                         ctx,
                                         destination_input_socket_id,
+                                        destination_component_id
                                     )
                                     .await?;
-                                // filter the value ids by destination_component_id
-                                let mut destination_attribute_value_id: Option<AttributeValueId> =
-                                    None;
-                                for value_id in destination_attribute_value_ids {
-                                    let component_id =
-                                        AttributeValue::component_id(ctx, value_id).await?;
-                                    if component_id == destination_component_id {
-                                        destination_attribute_value_id = Some(value_id);
-                                        break;
-                                    }
-                                }
-
-                                let destination_attribute_value_id = destination_attribute_value_id.ok_or(
-                                ComponentError::DestinationComponentMissingAttributeValueForInputSocket(
-                                         destination_component_id,
-                                         destination_input_socket_id,
-                                       ),
-                                   )?;
 
                                 ctx.add_dependent_values_and_enqueue(vec![
                                     destination_attribute_value_id,

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1931,7 +1931,13 @@ impl Component {
         }
 
         // filter the value ids by destination_component_id
-        let destination_attribute_value_id = InputSocket::component_attribute_value_for_input_socket_id(ctx, destination_input_socket_id, destination_component_id).await?;
+        let destination_attribute_value_id =
+            InputSocket::component_attribute_value_for_input_socket_id(
+                ctx,
+                destination_input_socket_id,
+                destination_component_id,
+            )
+            .await?;
 
         let destination_prototype_id =
             AttributeValue::prototype_id(ctx, destination_attribute_value_id).await?;
@@ -2795,7 +2801,7 @@ impl Component {
                                     InputSocket::component_attribute_value_for_input_socket_id(
                                         ctx,
                                         destination_input_socket_id,
-                                        destination_component_id
+                                        destination_component_id,
                                     )
                                     .await?;
 

--- a/lib/dal/src/func/authoring/save.rs
+++ b/lib/dal/src/func/authoring/save.rs
@@ -498,7 +498,12 @@ pub(crate) async fn create_new_attribute_prototype(
         }
     } else if let Some(output_socket_id) = prototype_bag.output_socket_id {
         if let Some(component_id) = component_id_cannot_be_nil_id {
-            let attribute_value_id = OutputSocket::component_attribute_value_for_output_socket_id(ctx, output_socket_id, component_id).await?;
+            let attribute_value_id = OutputSocket::component_attribute_value_for_output_socket_id(
+                ctx,
+                output_socket_id,
+                component_id,
+            )
+            .await?;
             AttributeValue::set_component_prototype_id(
                 ctx,
                 attribute_value_id,

--- a/lib/dal/src/func/authoring/save.rs
+++ b/lib/dal/src/func/authoring/save.rs
@@ -498,20 +498,15 @@ pub(crate) async fn create_new_attribute_prototype(
         }
     } else if let Some(output_socket_id) = prototype_bag.output_socket_id {
         if let Some(component_id) = component_id_cannot_be_nil_id {
-            let attribute_value_ids =
-                OutputSocket::attribute_values_for_output_socket_id(ctx, output_socket_id).await?;
-            for attribute_value_id in attribute_value_ids {
-                if component_id == AttributeValue::component_id(ctx, attribute_value_id).await? {
-                    AttributeValue::set_component_prototype_id(
-                        ctx,
-                        attribute_value_id,
-                        attribute_prototype.id,
-                        None,
-                    )
-                    .await?;
-                    affected_attribute_value_ids.push(attribute_value_id);
-                }
-            }
+            let attribute_value_id = OutputSocket::component_attribute_value_for_output_socket_id(ctx, output_socket_id, component_id).await?;
+            AttributeValue::set_component_prototype_id(
+                ctx,
+                attribute_value_id,
+                attribute_prototype.id,
+                None,
+            )
+            .await?;
+            affected_attribute_value_ids.push(attribute_value_id);
         } else {
             // remove the existing attribute prototype and arguments
             if let Some(existing_proto) =

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -253,7 +253,13 @@ impl AttributeBinding {
                         .await?;
                     }
                     EventualParent::Component(component_id) => {
-                        let attribute_value_id = OutputSocket::component_attribute_value_for_output_socket_id(ctx, output_socket_id, component_id).await?;
+                        let attribute_value_id =
+                            OutputSocket::component_attribute_value_for_output_socket_id(
+                                ctx,
+                                output_socket_id,
+                                component_id,
+                            )
+                            .await?;
                         AttributeValue::set_component_prototype_id(
                             ctx,
                             attribute_value_id,

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -253,25 +253,14 @@ impl AttributeBinding {
                         .await?;
                     }
                     EventualParent::Component(component_id) => {
-                        let attribute_value_ids =
-                            OutputSocket::attribute_values_for_output_socket_id(
-                                ctx,
-                                output_socket_id,
-                            )
-                            .await?;
-                        for attribute_value_id in attribute_value_ids {
-                            if component_id
-                                == AttributeValue::component_id(ctx, attribute_value_id).await?
-                            {
-                                AttributeValue::set_component_prototype_id(
-                                    ctx,
-                                    attribute_value_id,
-                                    attribute_prototype.id,
-                                    None,
-                                )
-                                .await?;
-                            }
-                        }
+                        let attribute_value_id = OutputSocket::component_attribute_value_for_output_socket_id(ctx, output_socket_id, component_id).await?;
+                        AttributeValue::set_component_prototype_id(
+                            ctx,
+                            attribute_value_id,
+                            attribute_prototype.id,
+                            None,
+                        )
+                        .await?;
                     }
                 }
             }

--- a/lib/dal/src/socket/input.rs
+++ b/lib/dal/src/socket/input.rs
@@ -43,6 +43,8 @@ pub enum InputSocketError {
     ComponentError(#[from] Box<ComponentError>),
     #[error(transparent)]
     ConnectionAnnotation(#[from] ConnectionAnnotationError),
+    #[error("found too many matches for input and socket: {0}, {1}")]
+    FoundTooManyForInputSocketId(InputSocketId, ComponentId),
     #[error("func error: {0}")]
     Func(#[from] FuncError),
     #[error("helper error: {0}")]
@@ -372,7 +374,13 @@ impl InputSocket {
         Ok(input_sockets)
     }
 
-    pub async fn attribute_values_for_input_socket_id(
+    ///
+    /// Get all attribute values from all components that are connected to this input socket.
+    ///
+    /// NOTE: call component_attribute_value_for_input_socket_id() if you want the attribute
+    /// value for a specific component.
+    ///
+    pub async fn all_attribute_values_everywhere_for_input_socket_id(
         ctx: &DalContext,
         input_socket_id: InputSocketId,
     ) -> InputSocketResult<Vec<AttributeValueId>> {
@@ -402,22 +410,32 @@ impl InputSocket {
         input_socket_id: InputSocketId,
         component_id: ComponentId,
     ) -> InputSocketResult<AttributeValueId> {
+        let mut result = None;
         for attribute_value_id in
-            Self::attribute_values_for_input_socket_id(ctx, input_socket_id).await?
+            Self::all_attribute_values_everywhere_for_input_socket_id(ctx, input_socket_id)
+                .await?
         {
             if AttributeValue::component_id(ctx, attribute_value_id)
                 .await
                 .map_err(Box::new)?
                 == component_id
             {
-                return Ok(attribute_value_id);
+                if result.is_some() {
+                    return Err(InputSocketError::FoundTooManyForInputSocketId(
+                        input_socket_id,
+                        component_id,
+                    ));
+                }
+                result = Some(attribute_value_id);
             }
         }
-        Err(InputSocketError::MissingAttributeValueForComponent(
-            input_socket_id,
-            component_id,
-        ))
-    }
+        match result {
+            Some(attribute_value_id) => Ok(attribute_value_id),
+            None => Err(InputSocketError::MissingAttributeValueForComponent(
+                input_socket_id,
+                component_id,
+            ))
+        }    }
 
     pub async fn find_for_attribute_value_id(
         ctx: &DalContext,

--- a/lib/dal/src/socket/input.rs
+++ b/lib/dal/src/socket/input.rs
@@ -412,8 +412,7 @@ impl InputSocket {
     ) -> InputSocketResult<AttributeValueId> {
         let mut result = None;
         for attribute_value_id in
-            Self::all_attribute_values_everywhere_for_input_socket_id(ctx, input_socket_id)
-                .await?
+            Self::all_attribute_values_everywhere_for_input_socket_id(ctx, input_socket_id).await?
         {
             if AttributeValue::component_id(ctx, attribute_value_id)
                 .await
@@ -434,8 +433,9 @@ impl InputSocket {
             None => Err(InputSocketError::MissingAttributeValueForComponent(
                 input_socket_id,
                 component_id,
-            ))
-        }    }
+            )),
+        }
+    }
 
     pub async fn find_for_attribute_value_id(
         ctx: &DalContext,

--- a/lib/dal/src/socket/output.rs
+++ b/lib/dal/src/socket/output.rs
@@ -315,7 +315,7 @@ impl OutputSocket {
             None => Err(OutputSocketError::MissingAttributeValueForComponent(
                 output_socket_id,
                 component_id,
-            ))
+            )),
         }
     }
 

--- a/lib/dal/tests/integration_test/node_weight/attribute_value.rs
+++ b/lib/dal/tests/integration_test/node_weight/attribute_value.rs
@@ -3,7 +3,6 @@ use dal_test::expected::{
     apply_change_set_to_base, commit_and_update_snapshot_to_visibility, fork_from_head_change_set,
     update_visibility_and_snapshot_to_visibility, ExpectComponent,
 };
-use dal_test::helpers::connect_components_with_socket_names;
 use dal_test::test;
 
 #[test]
@@ -14,15 +13,9 @@ async fn change_in_output_component_produces_dvu_root_in_other_change_set(ctx: &
 
     let cs_with_butane = fork_from_head_change_set(ctx).await;
     let butane = ExpectComponent::create(ctx, "Butane").await;
-    connect_components_with_socket_names(
-        ctx,
-        docker_image.id(),
-        "Container Image",
-        butane.id(),
-        "Container Image",
-    )
-    .await
-    .expect("able to connect");
+    docker_image
+        .connect(ctx, "Container Image", butane, "Container Image")
+        .await;
 
     commit_and_update_snapshot_to_visibility(ctx).await;
     fork_from_head_change_set(ctx).await;

--- a/lib/dal/tests/integration_test/secret.rs
+++ b/lib/dal/tests/integration_test/secret.rs
@@ -520,14 +520,14 @@ async fn secret_definition_works_with_dummy_qualification(
             .expect("could not commit and update snapshot to visibility");
 
         // Check that the output socket value looks correct.
-        let mut output_socket_attribute_value_ids =
-            OutputSocket::attribute_values_for_output_socket_id(ctx, output_socket.id())
-                .await
-                .expect("could not perform attribute values for output socket id");
-        let output_socket_attribute_value_id = output_socket_attribute_value_ids
-            .pop()
-            .expect("no output attribute value found");
-        assert!(output_socket_attribute_value_ids.is_empty());
+        let output_socket_attribute_value_id =
+            OutputSocket::component_attribute_value_for_output_socket_id(
+                ctx,
+                output_socket.id(),
+                secret_definition_component.id()
+            )
+            .await
+            .expect("could not get attribute value for output socket id");
         let output_socket_attribute_value =
             AttributeValue::get_by_id_or_error(ctx, output_socket_attribute_value_id)
                 .await
@@ -603,14 +603,14 @@ async fn secret_definition_works_with_dummy_qualification(
             .expect("could not commit and update snapshot to visibility");
 
         // Check that the output socket value looks correct.
-        let mut output_socket_attribute_value_ids =
-            OutputSocket::attribute_values_for_output_socket_id(ctx, output_socket.id())
-                .await
-                .expect("could not perform attribute values for output socket id");
-        let output_socket_attribute_value_id = output_socket_attribute_value_ids
-            .pop()
-            .expect("no output attribute value found");
-        assert!(output_socket_attribute_value_ids.is_empty());
+        let output_socket_attribute_value_id =
+            OutputSocket::component_attribute_value_for_output_socket_id(
+                ctx,
+                output_socket.id(),
+                secret_definition_component.id()
+            )
+            .await
+            .expect("could not perform attribute values for output socket id");
         let output_socket_attribute_value =
             AttributeValue::get_by_id_or_error(ctx, output_socket_attribute_value_id)
                 .await

--- a/lib/sdf-server/src/server/service/attribute/get_prototype_arguments.rs
+++ b/lib/sdf-server/src/server/service/attribute/get_prototype_arguments.rs
@@ -53,7 +53,11 @@ pub async fn get_prototype_arguments(
         }
         (None, Some(output_socket_id)) => {
             let attribute_value_ids =
-                OutputSocket::attribute_values_for_output_socket_id(&ctx, output_socket_id).await?;
+                OutputSocket::all_attribute_values_everywhere_for_output_socket_id(
+                    &ctx,
+                    output_socket_id,
+                )
+                .await?;
             if attribute_value_ids.len() > 1 {
                 return Err(AttributeError::MultipleAttributeValuesForOutputSocket(
                     attribute_value_ids.to_owned(),


### PR DESCRIPTION
Just like with prop values, but this time for input and output sockets. This PR:

* Renames `Input/OutputSocket::attribute_values_for_input/output_socket_id()` to `all_attribute_values_everywhere_for_input/output_socket_id()`
* Adds `component_attribute_value_for_output_socket_id()` to `OutputSocket` for parity with `InputSocket`.
* Uses `Input/OutputSocket::component_attribute_value_for_input/output_socket_id()` wherever the everywhere method isn't needed.
* Also adds socket capabilities to `expected`.