### PR TITLE
fix(dal): Use the correct attribute value id when looking for connections

### DIFF
--- a/lib/dal/src/component/inferred_connection_graph.rs
+++ b/lib/dal/src/component/inferred_connection_graph.rs
@@ -320,7 +320,9 @@ impl InferredConnectionGraph {
             .output_sockets
             .into_iter()
             .find_map(|(output_socket, input_sockets)| {
-                if output_socket.output_socket_id == output_socket_id {
+                if output_socket.output_socket_id == output_socket_id
+                    && output_socket.component_id == component_id
+                {
                     Some(input_sockets)
                 } else {
                     None

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -1243,17 +1243,20 @@ impl FuncRunner {
                     attribute_prototype_argument_id,
                 ))? {
                     ValueSource::InputSocket(input_socket_id) => {
+                        let component_input_socket = ComponentInputSocket::get_by_ids_or_error(
+                            ctx,
+                            component_id,
+                            input_socket_id,
+                        )
+                        .await?;
                         if let Some(source_component_id) =
                             ComponentInputSocket::find_connection_arity_one(
                                 ctx,
-                                ComponentInputSocket {
-                                    component_id,
-                                    input_socket_id,
-                                    attribute_value_id,
-                                },
+                                component_input_socket,
                             )
                             .await?
                         {
+                            dbg!("Source component ID: {}", &source_component_id);
                             work_queue.push_back(source_component_id);
                         }
                     }


### PR DESCRIPTION
This fixes a bug where we were incorrectly using the Attribute Value Id of the Secret Prop, not the Input Socket when gathering before funcs.  Also adds a test to ensure that secrets propagate correctly when using Frames and that DVU fires as expected when the secret being used changes