### PR TITLE
Implement USR2 signal handler

### DIFF
--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -32,6 +32,9 @@ async fn main() -> Result<()> {
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
     };
 
+    // Startup the management service for maintenance mode etc
+    startup::init(&task_tracker, shutdown_token.clone())?;
+
     startup::startup("cyclone").await?;
 
     if args.verbose > 0 {

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -46,6 +46,9 @@ async fn async_main() -> Result<()> {
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
     };
 
+    // Startup the management service for maintenance mode etc
+    startup::init(&task_tracker, shutdown_token.clone())?;
+
     startup::startup("pinga").await?;
 
     if args.verbose > 0 {

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -58,6 +58,9 @@ async fn async_main() -> Result<()> {
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
     };
 
+    // Startup the management service for maintenance mode etc
+    startup::init(&task_tracker, shutdown_token.clone())?;
+
     startup::startup("sdf").await?;
 
     if args.verbose > 0 {

--- a/bin/veritech/src/main.rs
+++ b/bin/veritech/src/main.rs
@@ -32,6 +32,9 @@ async fn main() -> Result<()> {
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
     };
 
+    // Startup the management service for maintenance mode etc
+    startup::init(&task_tracker, shutdown_token.clone())?;
+
     startup::startup("veritech").await?;
 
     if args.verbose > 0 {

--- a/lib/telemetry-application-rs/src/lib.rs
+++ b/lib/telemetry-application-rs/src/lib.rs
@@ -701,7 +701,7 @@ impl TelemetryUpdateTask {
             Err(_elapsed) => {
                 warn!(
                     ?timeout,
-                    "opentelemetry shutown took too long, not waiting for full shutdown"
+                    "opentelemetry shutdown took too long, not waiting for full shutdown"
                 );
             }
         };


### PR DESCRIPTION
Implements USR2 signal interpreter on a new tokio thread which can then be used by the applications to run custom business logic like:
- Go into maintenance mode/take yourself out of the working pool
- Change application behaviour on an individual node basis
- Debug out current state of running applications/like a statuscheck

Initially, we can use this signal handler to move a node out of the working pool/for maintenance mode to prevent write corruption while updating the application binaries.

With this PR, it just logs out a message after the message has been caught successfully

<hr/>

chore: Fixes minor variable-naming issue within rebaser which was inconsistent based on the other binaries.
