### PR TITLE
Calculate inferred_incoming_connections for a single component without building the whole graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,6 +1361,7 @@ dependencies = [
  "strum 0.26.3",
  "telemetry",
  "telemetry-nats",
+ "telemetry-utils",
  "tempfile",
  "thiserror",
  "tokio",

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -22,6 +22,7 @@ rust_library(
         "//lib/si-std:si-std",
         "//lib/telemetry-rs:telemetry",
         "//lib/telemetry-nats-rs:telemetry-nats",
+        "//lib/telemetry-utils-rs:telemetry-utils",
         "//lib/veritech-client:veritech-client",
         "//third-party/rust:async-recursion",
         "//third-party/rust:async-trait",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -57,6 +57,7 @@ sodiumoxide = { workspace = true }
 strum = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
 telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
+telemetry-utils = { path = "../../lib/telemetry-utils-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }


### PR DESCRIPTION
To get a single component's inferred_incoming_connections, you do not actually need to build the whole graph. You do need the whole graph when you get the outgoing_connections so that remains untouched. I also upped the instrumentation for the assemble calls so we can get a feel for the timing here and understand if there's more to do. I also added some metrics to DVU so we can see the burn down of functions being run within the jobs. 

<div><img src="https://media4.giphy.com/media/WsRSh7YgQYf3Iw0CRq/giphy.gif?cid=5a38a5a26mi5jvjh07q0xip3zgzty2c2y5l444qliiz5pxwz&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/billions/">Billions</a> on <a href="https://giphy.com/gifs/billions-season-4-episode-6-showtime-WsRSh7YgQYf3Iw0CRq">GIPHY</a></div>