### PR TITLE
feat(dal,sdf): use cached inferred conn graph when available

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -2679,11 +2679,22 @@ impl Component {
     ) -> ComponentResult<Vec<InferredConnection>> {
         let to_component_id = self.id();
         let mut connections = vec![];
-        // assemble tree
-        let tree = InferredConnectionGraph::assemble(ctx, to_component_id).await?;
-        for incoming_connection in
-            tree.get_inferred_incoming_connections_to_component(to_component_id)
+
+        let incoming_connections = match ctx
+            .workspace_snapshot()?
+            .get_cached_inferred_connection_graph()
+            .await
+            .as_ref()
         {
+            Some(cached_graph) => {
+                cached_graph.get_inferred_incoming_connections_to_component(to_component_id)
+            }
+            None => InferredConnectionGraph::assemble(ctx, to_component_id)
+                .await?
+                .get_inferred_incoming_connections_to_component(to_component_id),
+        };
+
+        for incoming_connection in incoming_connections {
             // add the check for to_delete on either to or from component
             // Both "deleted" and not deleted Components can feed data into
             // "deleted" Components. **ONLY** not deleted Components can feed
@@ -2720,12 +2731,22 @@ impl Component {
     ) -> ComponentResult<Vec<InferredConnection>> {
         let from_component_id = self.id();
         let mut connections = vec![];
-        // get up to date component tree
-        let component_tree = InferredConnectionGraph::assemble(ctx, from_component_id).await?;
 
-        for outgoing_connection in
-            component_tree.get_inferred_outgoing_connections_for_component(from_component_id)
+        let outgoing_connections = match ctx
+            .workspace_snapshot()?
+            .get_cached_inferred_connection_graph()
+            .await
+            .as_ref()
         {
+            Some(cached_graph) => {
+                cached_graph.get_inferred_outgoing_connections_for_component(from_component_id)
+            }
+            None => InferredConnectionGraph::assemble(ctx, from_component_id)
+                .await?
+                .get_inferred_outgoing_connections_for_component(from_component_id),
+        };
+
+        for outgoing_connection in outgoing_connections {
             // add the check for to_delete on either to or from component
             // Both "deleted" and not deleted Components can feed data into
             // "deleted" Components. **ONLY** not deleted Components can feed

--- a/lib/dal/src/component/inferred_connection_graph.rs
+++ b/lib/dal/src/component/inferred_connection_graph.rs
@@ -69,7 +69,7 @@ impl InferredConnectionGraph {
             let is_in_tree = components.contains_key(&component_id)
                 || components.values().any(|x| x.contains(&component_id));
 
-            // If this component id isn't already in the hashmap somewhere, skip it
+            // If this component id is already in the hashmap somewhere, skip it
             // since we already have accounted for it!
             if !is_in_tree {
                 // Get the outermost parent of this tree

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -1256,7 +1256,6 @@ impl FuncRunner {
                             )
                             .await?
                         {
-                            dbg!("Source component ID: {}", &source_component_id);
                             work_queue.push_back(source_component_id);
                         }
                     }

--- a/lib/dal/tests/integration_test/attribute/value.rs
+++ b/lib/dal/tests/integration_test/attribute/value.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use dal::prop::PropPath;
 use dal::{AttributeValue, Component, DalContext, Prop, Schema};
 use dal_test::helpers::ChangeSetTestHelpers;
@@ -46,13 +44,10 @@ async fn arguments_for_prototype_function_execution(ctx: &mut DalContext) {
         .pop()
         .expect("empty attribute value ids");
     assert!(attribute_value_ids.is_empty());
-    let (_, arguments) = AttributeValue::prepare_arguments_for_prototype_function_execution(
-        ctx,
-        attribute_value_id,
-        Arc::new(None),
-    )
-    .await
-    .expect("could not prepare arguments");
+    let (_, arguments) =
+        AttributeValue::prepare_arguments_for_prototype_function_execution(ctx, attribute_value_id)
+            .await
+            .expect("could not prepare arguments");
     assert_eq!(
         serde_json::json![{
             "identity": expected

--- a/lib/sdf-server/src/server/service/attribute/get_prototype_arguments.rs
+++ b/lib/sdf-server/src/server/service/attribute/get_prototype_arguments.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use axum::extract::{Host, OriginalUri};
 use axum::{extract::Query, Json};
 use dal::{AttributeValue, OutputSocket, OutputSocketId, Prop, PropId, Visibility};
@@ -77,7 +75,6 @@ pub async fn get_prototype_arguments(
         AttributeValue::prepare_arguments_for_prototype_function_execution(
             &ctx,
             attribute_value_id,
-            Arc::new(None),
         )
         .await?;
 


### PR DESCRIPTION
Precompute the entire InferredConnectionGraph at the start of the DependentValuesUpdate job, store it on the WorkspaceSnapshot struct for that session only and use the cached version instead of calling `assemble` whenever possible.