### PR TITLE
feat: check rootfs version before downloading

### DIFF
--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -10,7 +10,7 @@ decryption_key_base64 = "$SI_DECRYPTION_KEY_BASE64"
 
 [cyclone]
 connect_timeout = 100
-pool_size = 100
+pool_size = $SI_VERITECH_POOL_SIZE
 runtime_strategy = "LocalFirecracker"
 
 [jwt_signing_public_key]


### PR DESCRIPTION
I don't know why I waited so long to do this. We get the version metadata and keep it locally. Don't download a new rootfs if we already have the same one locally.

Also, making the pool size configurable in ssm.

<img src="https://media1.giphy.com/media/RtccJnP9kwde8/giphy.gif"/>