### PR TITLE
Calculate the inferred connection graph at the start of the job

### DIFF
--- a/lib/dal/src/component/socket.rs
+++ b/lib/dal/src/component/socket.rs
@@ -309,7 +309,7 @@ impl ComponentInputSocket {
     /// [`crate::InputSocket`] has [`crate::SocketArity::One`]
     #[instrument(
         name = "component.component_input_socket.find_connection_arity_one",
-        level = "debug",
+        level = "info",
         skip_all
     )]
     pub async fn find_connection_arity_one(

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -1418,7 +1418,7 @@ impl WorkspaceSnapshot {
 
     #[instrument(
         name = "workspace_snapshot.components_added_relative_to_base",
-        level = "debug",
+        level = "info",
         skip_all
     )]
     pub async fn components_added_relative_to_base(


### PR DESCRIPTION
This allows us to build the dependency graph with the cached values as opposed to rebuilding for each value