### PR TITLE
fix: web otel traces should not include the port by default

### DIFF
--- a/app/web/src/main.ts
+++ b/app/web/src/main.ts
@@ -30,7 +30,7 @@ let otelEndpoint =
   import.meta.env.VITE_OTEL_EXPORTER_OTLP_ENDPOINT;
 if (!otelEndpoint) otelEndpoint = window.location.host;
 const sdk = new HoneycombWebSDK({
-  endpoint: `${otelEndpoint}:4318/v1/traces`,
+  endpoint: `${otelEndpoint}/v1/traces`,
   serviceName: "si-vue",
   skipOptionsValidation: true,
   instrumentations: [


### PR DESCRIPTION
`window.location.host` includes the port, so we don't need to specify it here. It will be set by env vars at build time otherwise