### PR TITLE
feat: add 503 on USR2 for maintenance mode in SDF

### DIFF
--- a/app/web/src/components/toasts/MaintananceMode.vue
+++ b/app/web/src/components/toasts/MaintananceMode.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="flex flex-row items-center gap-xs">
+    <Icon name="bell" class="text-destructive-600" />
+    <div class="flex flex-col text-sm text-center">
+      <div>
+        System Initiative is currently in maintenance mode. Please try again
+        later. You can check
+        <a class="text-action-500" href="https://discord.com/invite/system-init"
+          >Discord</a
+        >
+        for more information or to get assistance. You can also email
+        <a class="text-action-500" href="mailto:support@systeminit.com"
+          >support@systeminit.com</a
+        >
+        if this problem persists.
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { Icon } from "@si/vue-lib/design-system";
+</script>

--- a/app/web/src/main.ts
+++ b/app/web/src/main.ts
@@ -141,6 +141,9 @@ const filterToasts = (toasts: any[]) => {
     if (t.content.component?.__name === "Conflict") {
       return [t];
     }
+    if (t.content.component?.__name === "MaintananceMode") {
+      return [t];
+    }
   }
   return toasts;
 };

--- a/app/web/src/store/apis.ts
+++ b/app/web/src/store/apis.ts
@@ -9,6 +9,7 @@ import { useAuthStore } from "@/store/auth.store";
 import { useChangeSetsStore } from "@/store/change_sets.store";
 import { trackEvent } from "@/utils/tracking";
 import FiveHundredError from "@/components/toasts/FiveHundredError.vue";
+import MaintananceMode from "@/components/toasts/MaintananceMode.vue";
 
 // api base url - can use a proxy or set a full url
 let apiUrl: string;
@@ -89,8 +90,26 @@ async function handle500(error: AxiosError) {
   return Promise.reject(error);
 }
 
+async function handleMaintananceMode(error: AxiosError) {
+  if (error?.response?.status === 503) {
+    const toast = useToast();
+    toast(
+      {
+        component: MaintananceMode,
+      },
+      {
+        timeout: false,
+      },
+    );
+  }
+  return Promise.reject(error);
+}
+
 sdfApiInstance.interceptors.response.use(handleProxyTimeouts, handle500);
-sdfApiInstance.interceptors.response.use(handleForcedChangesetRedirection);
+sdfApiInstance.interceptors.response.use(
+  handleForcedChangesetRedirection,
+  handleMaintananceMode,
+);
 
 export const authApiInstance = Axios.create({
   headers: {

--- a/lib/si-test-macros/src/sdf_test.rs
+++ b/lib/si-test-macros/src/sdf_test.rs
@@ -379,7 +379,7 @@ impl SdfTestFnSetupExpander {
                         #task_tracker.clone(),
                     )
                     .await;
-                let (service, _, _) = ::sdf_server::build_service_for_tests(
+                let (service, _, _, _) = ::sdf_server::build_service_for_tests(
                     s_ctx,
                     #jwt_public_signing_key.clone(),
                     #posthog_client,

--- a/lib/telemetry-application-rs/src/lib.rs
+++ b/lib/telemetry-application-rs/src/lib.rs
@@ -701,7 +701,7 @@ impl TelemetryUpdateTask {
             Err(_elapsed) => {
                 warn!(
                     ?timeout,
-                    "opentelemetry shutown took too long, not waiting for full shutdown"
+                    "opentelemetry shutdown took too long, not waiting for full shutdown"
                 );
             }
         };


### PR DESCRIPTION
Implements USR2 signal interpreter on the existing SDF tokio thread which can then be used by the applications to run custom business logic like:

- Go into maintenance mode/take yourself out of the working pool
- Change application behaviour on an individual node basis
- Debug out current state of running applications/like a statuscheck

Initially, we can use this signal handler to move a node out of the working pool/for maintenance mode to prevent write corruption while updating the application binaries.

With this PR, just SDF can be pushed into maintenance mode while running, which for any `future` API requests will throw a 503 / Service Unavailable with a corresponding body. The frontend now throws a toast when receiving a 503 describing to the user that maintenance mode is active. Either the application binary can be replaced, or the USR2 can be re-sent to put a running node of SDF back into the pool.

<hr/>

chore: Fixes minor variable-naming issue within rebaser which was inconsistent based on the other binaries.

Co-authored-by: 
- John Keiser <john@johnkeiser.com>
- John Obelenus <jobelenus@gmail.com>
- Nick Gerace <nick@systeminit.com>