### PR TITLE
ENG-2639: collapsed frames

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramEdge.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramEdge.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-group v-if="shouldDraw && points && centerPoint">
+  <v-group v-if="points && centerPoint">
     <v-line
       :config="{
         visible: isHovered || isSelected,
@@ -196,10 +196,6 @@ function onMouseOut(_e: KonvaEventObject<MouseEvent>) {
 function onMouseDown(_e: KonvaEventObject<MouseEvent>) {
   // e.cancelBubble = true; // stops dragging of parent
 }
-
-const shouldDraw = computed(() =>
-  isDevMode ? true : !props.edge.def.isInferred,
-);
 
 // defineExpose({ recalculatePoints });
 </script>

--- a/app/web/src/components/ModelingDiagram/DiagramGroupOverlay.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroupOverlay.vue
@@ -60,6 +60,7 @@ const props = defineProps({
     type: Object as PropType<DiagramGroupData>,
     required: true,
   },
+  collapsed: Boolean,
   isHovered: Boolean,
   isSelected: Boolean,
 });
@@ -69,7 +70,7 @@ const groupRef = ref();
 
 const size = computed(
   () =>
-    componentsStore.resizedElementSizes[props.group.uniqueKey] ||
+    componentsStore.combinedElementSizes[props.group.uniqueKey] ||
     props.group.def.size || { width: 500, height: 500 },
 );
 
@@ -100,7 +101,7 @@ const nodeBodyHeight = computed(() => size.value.height);
 
 const position = computed(
   () =>
-    componentsStore.movedElementPositions[props.group.uniqueKey] ||
+    componentsStore.combinedElementPositions[props.group.uniqueKey] ||
     props.group.def.position,
 );
 // const isDeleted = computed(() => props.group?.def.changeStatus === "deleted");

--- a/app/web/src/components/ModelingDiagram/DiagramIcon.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramIcon.vue
@@ -30,6 +30,7 @@ it from the diagram config's registry of icons */
       :color="color"
       :config="{ width, height }"
       :spin="icon === 'loader' || spin"
+      :rotation="rotation"
     />
   </v-group>
 </template>
@@ -57,6 +58,7 @@ const props = defineProps({
   shadeBg: { type: Boolean },
   circleBg: { type: Boolean },
   config: { type: Object },
+  rotation: { type: Number },
   origin: {
     type: String as PropType<
       "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right"

--- a/app/web/src/components/ModelingDiagram/diagram_types.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_types.ts
@@ -86,7 +86,6 @@ export class DiagramSocketData extends DiagramElementData {
     );
   }
 
-  // socket ids are only assumed to be unique within their parent
   static generateUniqueKey(parentKey: string, id: string | number) {
     return `${parentKey}--s-${id}`;
   }
@@ -215,6 +214,9 @@ export type DiagramNodeDef = {
   canBeUpgraded: boolean;
   /** whether the component has a resource  */
   hasResource: boolean;
+  /** stats from recursive children */
+  numChildren: number;
+  numChildrenResources: number;
 };
 
 export type DiagramSocketDef = {


### PR DESCRIPTION
- Use diagram outliner to collapse frames
- Use context menu to collapse frames
- Add caret icon to frame upper left to collapse frames
- Store positions, sizes, and collapsed state in browser local storage
- Incoming connections terminate at the center of the frame
- Display children stats for collapsed frames in the bottom right corner
- Removing resize handles on collapsed frame
- Collapsed frames can be moved
- Enforce boundary box on collapsed child within a parent
- Send stats to posthog
<img src="https://media3.giphy.com/media/JUh0yTz4h931K/giphy.gif"/>