### PR TITLE
fix(pool-noodle): add `target_os = "linux"` cfg on Linux test

### DIFF
--- a/lib/si-pool-noodle/src/lib.rs
+++ b/lib/si-pool-noodle/src/lib.rs
@@ -136,6 +136,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(target_os = "linux")]
     async fn chop() {
         let mut config_file = veritech_server::ConfigFile::default_local_uds();
         veritech_server::detect_and_configure_development(&mut config_file)


### PR DESCRIPTION
This change ensures that a Linux-specific unit test won't run (nor will attempt to be compiled) on the macOS platform.

<img src="https://media3.giphy.com/media/L99bJZeCohNHKEdXhm/giphy.gif"/>