### PR TITLE
fix: be more direct in tag filtering for deploying on main

### DIFF
--- a/.github/workflows/deploy-on-main.yml
+++ b/.github/workflows/deploy-on-main.yml
@@ -1,7 +1,12 @@
 on:
   push:
     tags:
-      - '.*(sdf|rebaser|pinga|web|veritech).*'
+      # These fairly explicitly directly matches the tags we push [examples]
+      - 'bin/sdf/image/*'      # bin/sdf/image/20240820.143323.0-sha.982dd5a81
+      - 'bin/rebaser/image/*'  # bin/rebaser/image/20240820.143323.0-sha.982dd5a81
+      - 'bin/pinga/image/*'    # bin/pinga/image/20240820.143323.0-sha.982dd5a81
+      - 'bin/veritech/image/*' # bin/veritech/image/20240820.031721.0-sha.efea02a6a
+      - 'app/web/image/*'      # app/web/image/20240820.000535.0-sha.13e826961
 
 jobs:
   parse-tag:


### PR DESCRIPTION
I couldn't quite manage to figure out why the completely valid regex wasn't working, but I've validated this more explicit individual filtering per tag type does work. So switch to use that and move on with my life!

Checked with two tags:
`bin/veritech/image/20240820.031721.0-sha.0-test-jw-16-13`
`bin/sdf/image/20240820.143323.0-test-jw-16-11`

Both these triggered the correct pipeline.

There may be a bug with the pipeline still, but at least it should fire on merge.