### PR TITLE
fix(dal): speed up get diagram

### DIFF
--- a/lib/dal/src/action/dependency_graph.rs
+++ b/lib/dal/src/action/dependency_graph.rs
@@ -74,7 +74,7 @@ impl ActionDependencyGraph {
         // Get all inferred connections up front so we don't build this tree each time
         let components_to_find = actions_by_component_id.keys().copied().collect_vec();
         let component_tree =
-            InferredConnectionGraph::assemble_for_components(ctx, components_to_find).await?;
+            InferredConnectionGraph::assemble_for_components(ctx, components_to_find, None).await?;
         // Action dependencies are primarily based on the data flow between Components. Things that
         // feed data into other things must have their actions run before the actions for the
         // things they are feeding data into.

--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -87,7 +87,7 @@ impl DependentValueGraph {
             // job always operates on the current state of the change set's snapshot, not the state
             // at the time the job was created.
             if workspace_snapshot
-                .try_get_node_index_by_id(initial_id)
+                .get_node_index_by_id_opt(initial_id)
                 .await
                 .is_none()
             {

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1377,7 +1377,7 @@ impl Component {
         component_id: ComponentId,
     ) -> ComponentResult<Option<(ComponentNodeWeight, ContentHash)>> {
         let id: Ulid = component_id.into();
-        if let Some(node_index) = ctx.workspace_snapshot()?.try_get_node_index_by_id(id).await {
+        if let Some(node_index) = ctx.workspace_snapshot()?.get_node_index_by_id_opt(id).await {
             let node_weight = ctx
                 .workspace_snapshot()?
                 .get_node_weight(node_index)
@@ -2328,7 +2328,7 @@ impl Component {
     ) -> ComponentResult<Option<bool>> {
         match ctx
             .workspace_snapshot()?
-            .try_get_node_index_by_id(component_id)
+            .get_node_index_by_id_opt(component_id)
             .await
         {
             Some(component_idx) => {

--- a/lib/dal/src/job/definition/action.rs
+++ b/lib/dal/src/job/definition/action.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -266,10 +266,12 @@ async fn process_and_record_execution(
                     Component::remove(&ctx, component.id()).await?;
                     to_remove_nodes.push(component.id().into());
                 } else {
+                    let mut diagram_sockets = HashMap::new();
                     let summary = SummaryDiagramComponent::assemble(
                         &ctx,
                         &component,
                         ChangeStatus::Unmodified,
+                        &mut diagram_sockets,
                     )
                     .await?;
                     WsEvent::resource_refreshed(&ctx, summary)
@@ -278,9 +280,14 @@ async fn process_and_record_execution(
                         .await?;
                 }
             } else {
-                let summary =
-                    SummaryDiagramComponent::assemble(&ctx, &component, ChangeStatus::Unmodified)
-                        .await?;
+                let mut diagram_sockets = HashMap::new();
+                let summary = SummaryDiagramComponent::assemble(
+                    &ctx,
+                    &component,
+                    ChangeStatus::Unmodified,
+                    &mut diagram_sockets,
+                )
+                .await?;
                 WsEvent::resource_refreshed(&ctx, summary)
                     .await?
                     .publish_on_commit(&ctx)

--- a/lib/dal/src/job/definition/compute_validation.rs
+++ b/lib/dal/src/job/definition/compute_validation.rs
@@ -93,7 +93,7 @@ impl JobConsumer for ComputeValidation {
             // executing, as the job always operates on the current state of the change set's snapshot, not the state at the time
             // the job was created.
             if workspace_snapshot
-                .try_get_node_index_by_id(av_id)
+                .get_node_index_by_id_opt(av_id)
                 .await
                 .is_none()
             {

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -531,8 +531,7 @@ impl Workspace {
             for change_set_data in change_sets {
                 let imported_snapshot = WorkspaceSnapshot::from_bytes(
                     &change_set_data.workspace_snapshot_serialized_data,
-                )
-                .await?;
+                )?;
 
                 // If base_change_set is default_change_set_base, it pointed to the builtin workspace
                 // originally, so this change set needs to be the new default for the workspace - HEAD

--- a/lib/sdf-server/src/server/service/component/delete_property_editor_value.rs
+++ b/lib/sdf-server/src/server/service/component/delete_property_editor_value.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::server::extract::{AccessBuilder, HandlerContext};
 use crate::service::component::ComponentResult;
 use axum::response::IntoResponse;
@@ -33,8 +35,14 @@ pub async fn delete_property_editor_value(
     AttributeValue::remove_by_id(&ctx, request.attribute_value_id).await?;
 
     let component = Component::get_by_id(&ctx, request.component_id).await?;
-    let payload: SummaryDiagramComponent =
-        SummaryDiagramComponent::assemble(&ctx, &component, ChangeStatus::Unmodified).await?;
+    let mut socket_map = HashMap::new();
+    let payload: SummaryDiagramComponent = SummaryDiagramComponent::assemble(
+        &ctx,
+        &component,
+        ChangeStatus::Unmodified,
+        &mut socket_map,
+    )
+    .await?;
     WsEvent::component_updated(&ctx, payload)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/component/insert_property_editor_value.rs
+++ b/lib/sdf-server/src/server/service/component/insert_property_editor_value.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use axum::{response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
@@ -40,8 +42,14 @@ pub async fn insert_property_editor_value(
     .await?;
 
     let component: Component = Component::get_by_id(&ctx, request.component_id).await?;
-    let payload: SummaryDiagramComponent =
-        SummaryDiagramComponent::assemble(&ctx, &component, ChangeStatus::Unmodified).await?;
+    let mut socket_map = HashMap::new();
+    let payload: SummaryDiagramComponent = SummaryDiagramComponent::assemble(
+        &ctx,
+        &component,
+        ChangeStatus::Unmodified,
+        &mut socket_map,
+    )
+    .await?;
     WsEvent::component_updated(&ctx, payload)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/component/set_type.rs
+++ b/lib/sdf-server/src/server/service/component/set_type.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use axum::extract::{Host, OriginalUri};
 use axum::{response::IntoResponse, Json};
 
@@ -56,8 +58,14 @@ pub async fn set_type(
     let component = Component::get_by_id(&ctx, component_id).await?;
     // TODO: We'll want to figure out whether this component is Added/Modified, depending on
     // whether it existed in the base change set already or not.
-    let payload: SummaryDiagramComponent =
-        SummaryDiagramComponent::assemble(&ctx, &component, ChangeStatus::Unmodified).await?;
+    let mut socket_map = HashMap::new();
+    let payload: SummaryDiagramComponent = SummaryDiagramComponent::assemble(
+        &ctx,
+        &component,
+        ChangeStatus::Unmodified,
+        &mut socket_map,
+    )
+    .await?;
     WsEvent::component_updated(&ctx, payload)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/component/update_property_editor_value.rs
+++ b/lib/sdf-server/src/server/service/component/update_property_editor_value.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use axum::extract::{Host, OriginalUri};
 use axum::{response::IntoResponse, Json};
 use dal::change_status::ChangeStatus;
@@ -88,8 +90,14 @@ pub async fn update_property_editor_value(
         );
     }
 
-    let payload: SummaryDiagramComponent =
-        SummaryDiagramComponent::assemble(&ctx, &component, ChangeStatus::Unmodified).await?;
+    let mut socket_map = HashMap::new();
+    let payload: SummaryDiagramComponent = SummaryDiagramComponent::assemble(
+        &ctx,
+        &component,
+        ChangeStatus::Unmodified,
+        &mut socket_map,
+    )
+    .await?;
     WsEvent::component_updated(&ctx, payload)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/component/upgrade.rs
+++ b/lib/sdf-server/src/server/service/component/upgrade.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
 use crate::server::tracking::track;
 use crate::service::component::{ComponentError, ComponentResult};
@@ -75,9 +77,14 @@ pub async fn upgrade(
         }),
     );
 
-    let payload: SummaryDiagramComponent =
-        SummaryDiagramComponent::assemble(&ctx, &upgraded_component, ChangeStatus::Unmodified)
-            .await?;
+    let mut socket_map = HashMap::new();
+    let payload: SummaryDiagramComponent = SummaryDiagramComponent::assemble(
+        &ctx,
+        &upgraded_component,
+        ChangeStatus::Unmodified,
+        &mut socket_map,
+    )
+    .await?;
     WsEvent::component_upgraded(&ctx, payload, request.component_id)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/server/service/diagram.rs
+++ b/lib/sdf-server/src/server/service/diagram.rs
@@ -7,6 +7,7 @@ use dal::attribute::prototype::argument::AttributePrototypeArgumentError;
 use dal::attribute::prototype::AttributePrototypeError;
 use dal::attribute::value::AttributeValueError;
 use dal::component::ComponentError;
+use dal::slow_rt::SlowRuntimeError;
 use dal::socket::input::InputSocketError;
 use dal::socket::output::OutputSocketError;
 use dal::workspace_snapshot::WorkspaceSnapshotError;
@@ -15,6 +16,7 @@ use dal::{ChangeSetError, SchemaVariantId, StandardModelError, TransactionsError
 use std::num::ParseFloatError;
 use telemetry::prelude::*;
 use thiserror::Error;
+use tokio::task::JoinError;
 
 use crate::server::state::AppState;
 
@@ -70,6 +72,8 @@ pub enum DiagramError {
     InvalidRequest,
     #[error("invalid system")]
     InvalidSystem,
+    #[error("tokio join error: {0}")]
+    Join(#[from] JoinError),
     #[error(transparent)]
     Nats(#[from] si_data_nats::NatsError),
     #[error("not authorized")]
@@ -88,6 +92,8 @@ pub enum DiagramError {
     SchemaNotFound,
     #[error("serde error: {0}")]
     Serde(#[from] serde_json::Error),
+    #[error("slow runtime error: {0}")]
+    SlowRuntime(#[from] SlowRuntimeError),
     #[error("socket not found")]
     SocketNotFound,
     #[error(transparent)]

--- a/lib/sdf-server/src/server/service/diagram/delete_component.rs
+++ b/lib/sdf-server/src/server/service/diagram/delete_component.rs
@@ -35,6 +35,7 @@ pub async fn delete_components(
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
     let mut components = HashMap::new();
+    let mut socket_map = HashMap::new();
     for component_id in request.component_ids {
         let component_still_exists = delete_single_component(
             &ctx,
@@ -50,8 +51,13 @@ pub async fn delete_components(
         if component_still_exists {
             // to_delete=True
             let component: Component = Component::get_by_id(&ctx, component_id).await?;
-            let payload: SummaryDiagramComponent =
-                SummaryDiagramComponent::assemble(&ctx, &component, ChangeStatus::Deleted).await?;
+            let payload: SummaryDiagramComponent = SummaryDiagramComponent::assemble(
+                &ctx,
+                &component,
+                ChangeStatus::Deleted,
+                &mut socket_map,
+            )
+            .await?;
             WsEvent::component_updated(&ctx, payload)
                 .await?
                 .publish_on_commit(&ctx)


### PR DESCRIPTION
Avoid expensive recomputation of various values in get_diagram. Provides about a 50% speedup locally. Also removes some noisy telemetry