### PR TITLE
Feat/maintenance before update

### DIFF
--- a/.github/workflows/deploy-on-main.yml
+++ b/.github/workflows/deploy-on-main.yml
@@ -27,14 +27,3 @@ jobs:
       version: stable
       deploy-type: binary
     secrets: inherit
-    continue-on-error: true
-  full-deploy-on-failure:
-    if: failure() 
-    uses: ./.github/workflows/deploy-stack.yml
-    with:
-      environment: tools
-      service: all
-      version: stable
-      deploy-type: instance
-    secrets: inherit
-    needs: deploy-tools-prod

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -154,4 +154,12 @@ jobs:
 
       - name: Deploy service
         if: ${{ inputs.service != 'web' && inputs.deploy-type == 'binary' }}
-        run: component/toolbox/awsi.sh upgrade -p pull-from-env -r us-east-1 -a y -s ${{ inputs.service }}
+        run: |
+          # Push all the SDF replicas into maintenance mode if they're not already in it
+          component/toolbox/awsi.sh toggle-maintenance -p pull-from-env -r us-east-1 -s sdf -m y -a y
+          # Wait an arbitrary amount of time to allow the back end to settle down with work
+          sleep 30
+          # Upgrade all the associated services
+          component/toolbox/awsi.sh upgrade -p pull-from-env -r us-east-1 -a y -s ${{ inputs.service }}
+          # Enable SDF again if it is disabled
+          component/toolbox/awsi.sh toggle-maintenance -p pull-from-env -r us-east-1 -s sdf -m n -a y

--- a/component/toolbox/scripts/supporting-funcs/ssm-funcs.sh
+++ b/component/toolbox/scripts/supporting-funcs/ssm-funcs.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# shellcheck disable=SC2034
+
+# Define the SSM documents to execute the functions
+upgrade_check_script="si-check-node-upgrade"
+service_maintenance_script="si-service-maintenance"
+service_state_script="si-service-state"
+
 # Function to start SSM session
 start_and_track_ssm_session() {
 

--- a/component/toolbox/scripts/toggle-maintenance
+++ b/component/toolbox/scripts/toggle-maintenance
@@ -1,0 +1,143 @@
+#!/bin/bash
+# ---------------------------------------------------------------------------------------------------
+# Identify all the service replicas/machines and permits you to toggle maintenance mode on or off via
+# an SSM document execution on the host. If the json output from the SSM executions is not enough to 
+# debug just look in AWS and you'll see the whole execution history in SSM Command Execution History.
+# ---------------------------------------------------------------------------------------------------
+
+# Stop immediately if anything goes wrong, let's not create too much
+# mess if John's shell is poor
+set -eo pipefail
+
+# Find & Import all the supporting functions from the supporting folder
+# Get the directory of the current script to figure out where the 
+# Supporting funcs are
+IMPORT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+for script in ${IMPORT_DIR}/supporting-funcs/*.sh; do
+    if [[ -f "$script" ]]; then
+        source "$script"
+    fi
+done
+
+# Usage for this script
+usage() {
+    echo
+    echo "toggle-maintenance"
+    echo "----------------------------------"
+    echo "This script will open an SSM session to all available"
+    echo "service nodes in the region and will attempt to toggle on"
+    echo "or off the maintenance mode via a USR2 linux signal"
+    echo "----------------------------------"
+    echo "Usage: toggle-maintenance [-p profile] [-r region] [-a automatic] [-s service] [-m maintenance]"
+    echo "  -p profile        [pull-from-env/<profile-name>] AWS profile to use"
+    echo "  -r region         AWS region to use"
+    echo "  -s service        [sdf/rebaser/pinga/veritech] SI Service to filter by, defaults to all"
+    echo "  -a automatic      [Y/N] Run through automatically/no-interact"
+    echo "  -m maintenance    [Y/N] Whether maintenance should be on"
+    echo "----------------------------------"
+    echo "e.g. ./awsi.sh toggle-maintenance -p pull-from-env -r us-east-1 -s sdf -a y -m y"
+    exit 1
+}
+
+# Add a check to see if the script is being sourced or executed
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    usage
+fi
+
+# Parse flags
+while getopts ":p:r:a:s:m:" opt; do
+    case ${opt} in
+        p)
+            profile=$OPTARG
+            ;;
+        r)
+            region=$OPTARG
+            ;;
+        a)
+            automatic=$OPTARG
+            ;;
+        s)
+            service=$OPTARG
+            ;;
+        m)
+            maintenance=$OPTARG
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            usage
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------------------------------
+# Main script
+# ---------------------------------------------------------------------------------------------------
+echo "$0 being invoked"
+
+# Use the profile if in the invocation
+if [[ "$profile" != "pull-from-env" ]]; then
+  profile=$(get_param_or_env "$profile" "AWS_PROFILE" "Enter the AWS profile to use")
+  export AWS_PROFILE="$profile"
+fi
+region=$(get_param_or_env "$region" "AWS_REGION" "Enter the AWS region (e.g., us-west-2)")
+export AWS_REGION="$region"
+
+# List instances with fixed-width columns and filter for the upgradeable instances
+# Based on the filter provided, always include SDF for the maintenance mode enable/disable
+instances=$(list_instances "${service,,}" )
+if [ -z "$instances" ]; then
+    echo "No running instances found."
+    exit 1
+fi
+
+echo "----------------------------------------"
+echo "Running instances of service $service in the region $region:"
+printf "%-5s %-20s %-20s %-20s %-20s\n" "Index" "Name" "InstanceId" "InstanceType" "PrivateIpAddress"
+i=1
+while read -r line; do
+    name=$(echo "$line" | awk '{print $1}')
+    instance_id=$(echo "$line" | awk '{print $2}')
+    instance_type=$(echo "$line" | awk '{print $3}')
+    private_ip=$(echo "$line" | awk '{print $4}')
+    printf "%-5s %-20s %-20s %-20s %-20s\n" "$i" "$name" "$instance_id" "$instance_type" "$private_ip"
+    ((i++))
+done <<< "$instances"
+echo "----------------------------------------"
+
+[[ "${automatic,,}" == "y" ]] || read -p "Would you like to toggle maintenance mode to $maintenance on these hosts? (Y/N) [takes ~10 seconds] " selection
+[[ "${automatic,,}" == "y" ]] || sassy_selection_check $selection
+
+# Setup somewhere unique to push the results of the check into if they chose to continue
+# Reset this results_directory variable between each execution run.
+results_directory="./results/$(date +"%Y-%m-%d_%H-%M-%S")"
+check_results_file=check_results.json
+start_results_file=start_results.json
+stop_results_file=stop_results.json
+upgrade_results_file=upgrade_results.json
+mkdir -p "$results_directory/"
+
+i=1
+while read -r line; do
+    instance_id=$(echo "$line" | awk '{print $2}')
+    service_name=$(echo "$line" | awk '{print $1}' | awk -F- '{print $2}')
+    start_and_track_ssm_session "$instance_id" "$service_maintenance_script" "$service_name" "$maintenance" "$results_directory" &
+    ((i++))
+done <<< "$instances"
+
+await_file_results "$results_directory" $((i - 1))
+
+concat_and_output_json "$results_directory" "$check_results_file"
+
+if jq --arg maintenance="$maintenance" -e 'all(.[]; .status == "success") and all(.[]; .maintenance == "$maintenance")' "$results_directory/$check_results_file" > /dev/null; then
+  echo "All running service nodes of ${service} have had maintenance mode set to $maintenance"
+  echo "----------------------------------------"
+  exit 0
+else
+  echo "Error: One or more of the checks failed to push a node into maintenance mode, try again later or look at the logs"
+  exit 2
+fi

--- a/component/toolbox/scripts/upgrade
+++ b/component/toolbox/scripts/upgrade
@@ -40,7 +40,7 @@ usage() {
     echo "  -s service        [sdf/rebaser/pinga/veritech] SI Service to filter by, defaults to all"
     echo "  -a automatic      [Y/N] Run through automatically/no-interact"
     echo "----------------------------------"
-    echo "e.g. ./awsi.sh -p pull-from-env -r us-east-1 -s sdf -a y"
+    echo "e.g. ./awsi.sh upgrade -p pull-from-env -r us-east-1 -s sdf -a y"
     exit 1
 }
 
@@ -78,6 +78,8 @@ done
 # ---------------------------------------------------------------------------------------------------
 # Main script
 # ---------------------------------------------------------------------------------------------------
+echo "$0 being invoked"
+
 # Use the profile if in the invocation
 if [[ "$profile" != "pull-from-env" ]]; then
   profile=$(get_param_or_env "$profile" "AWS_PROFILE" "Enter the AWS profile to use")
@@ -85,10 +87,6 @@ if [[ "$profile" != "pull-from-env" ]]; then
 fi
 region=$(get_param_or_env "$region" "AWS_REGION" "Enter the AWS region (e.g., us-west-2)")
 export AWS_REGION="$region"
-
-# Define the SSM documents to execute the functions
-upgrade_check_script="si-check-node-upgrade"
-service_state_script="si-service-state"
 
 # List instances with fixed-width columns and filter for the upgradeable instances
 # Based on the filter provided


### PR DESCRIPTION
Adds maintenance mode to be enabled for 30s before binaries are updated via the component/toolbox & implements the change into the deployment pipeline for Tools and Production.

<hr/>

Adds the functionality directly to the toolbox, so we can now invoke
```
./awsi.sh toggle-maintenance -r us-east-1 -p tools-prod -s sdf -m y -a y
```

Where `-m y` sets maintenance mode to on for the SDF replicas in the deployment. 

```
----------------------------------
This script will open an SSM session to all available
service nodes in the region and will attempt to toggle on
or off the maintenance mode via a USR2 linux signal
----------------------------------
Usage: toggle-maintenance [-p profile] [-r region] [-a automatic] [-s service] [-m maintenance]
  -p profile        [pull-from-env/<profile-name>] AWS profile to use
  -r region         AWS region to use
  -s service        [sdf/rebaser/pinga/veritech] SI Service to filter by, defaults to all
  -a automatic      [Y/N] Run through automatically/no-interact
  -m maintenance    [Y/N] Whether maintenance should be on
----------------------------------"
e.g. ./awsi.sh toggle-maintenance -p pull-from-env -r us-east-1 -s sdf -a y -m y"
 ```
 
 <hr/>
 
 chore: also fixes minor issue with the merge to main pipeline whereby it was waiting for a downstream pipeline on failure that does not exist.