### PR TITLE
feat(module-index, sdf, dal): Add ability to understand if contribution made

### DIFF
--- a/lib/dal/tests/integration_test/module.rs
+++ b/lib/dal/tests/integration_test/module.rs
@@ -227,6 +227,7 @@ async fn dummy_sync(ctx: &DalContext) {
             dummy_latest_module_installable,
         ],
         vec![],
+        vec![],
     )
     .await
     .expect("could not sync");
@@ -251,7 +252,7 @@ async fn prepare_contribution_works(ctx: &DalContext) {
         .expect("unable to get a default variant")
         .expect("error getting the default variant id");
 
-    let (actual_name, actual_version, _, _, _, _, _) =
+    let (actual_name, actual_version, _, _, _, _, _, _) =
         Module::prepare_contribution(ctx, name, version, default_variant_id)
             .await
             .expect("could not prepare contribution");

--- a/lib/module-index-client/src/lib.rs
+++ b/lib/module-index-client/src/lib.rs
@@ -94,6 +94,7 @@ impl ModuleIndexClient {
         Ok(promote_response.json::<ModulePromotedResponse>().await?)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn upload_module(
         &self,
         module_name: &str,
@@ -101,6 +102,8 @@ impl ModuleIndexClient {
         module_based_on_hash: Option<String>,
         module_schema_id: Option<String>,
         module_bytes: Vec<u8>,
+        module_schema_variant_id: Option<String>,
+        module_schema_variant_version: Option<String>,
     ) -> ModuleIndexClientResult<ModuleDetailsResponse> {
         let module_upload_part = reqwest::multipart::Part::bytes(module_bytes)
             .file_name(format!("{module_name}_{module_version}.tar"));
@@ -119,6 +122,20 @@ impl ModuleIndexClient {
             multipart_form = multipart_form.part(
                 MODULE_SCHEMA_ID_FIELD_NAME,
                 reqwest::multipart::Part::text(schema_id),
+            );
+        }
+
+        if let Some(schema_variant_id) = module_schema_variant_id {
+            multipart_form = multipart_form.part(
+                MODULE_SCHEMA_VARIANT_ID_FIELD_NAME,
+                reqwest::multipart::Part::text(schema_variant_id),
+            );
+        }
+
+        if let Some(schema_variant_version) = module_schema_variant_version {
+            multipart_form = multipart_form.part(
+                MODULE_SCHEMA_VARIANT_VERSION_FIELD_NAME,
+                reqwest::multipart::Part::text(schema_variant_version),
             );
         }
 

--- a/lib/module-index-server/src/migrations/U0009__modules_schema_variant_id_and_version.sql
+++ b/lib/module-index-server/src/migrations/U0009__modules_schema_variant_id_and_version.sql
@@ -1,0 +1,3 @@
+ALTER TABLE modules
+    ADD schema_variant_id ident,
+    ADD schema_variant_version TEXT;

--- a/lib/module-index-server/src/models/si_module.rs
+++ b/lib/module-index-server/src/models/si_module.rs
@@ -5,9 +5,11 @@ use std::str::FromStr;
 
 pub mod module_id;
 pub mod schema_id;
+pub mod schema_variant_id;
 
 pub use module_id::ModuleId;
 pub use schema_id::SchemaId;
+pub use schema_variant_id::SchemaVariantId;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -32,6 +34,9 @@ pub struct Model {
     pub is_builtin_at_by_display_name: Option<String>,
     #[sea_orm(column_type = r##"custom("ident")"##, nullable)]
     pub schema_id: Option<SchemaId>,
+    #[sea_orm(column_type = r##"custom("ident")"##, nullable)]
+    pub schema_variant_id: Option<SchemaVariantId>,
+    pub schema_variant_version: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -142,6 +147,10 @@ pub fn make_module_details_response(
         latest_hash_created_at: module.latest_hash_created_at.into(),
         created_at: module.created_at.into(),
         schema_id: module.schema_id.map(|schema_id| schema_id.to_string()),
+        schema_variant_id: module
+            .schema_variant_id
+            .map(|schema_variant_id| schema_variant_id.to_string()),
+        schema_variant_version: module.schema_variant_version,
         past_hashes: Some(
             linked_modules
                 .into_iter()

--- a/lib/module-index-server/src/models/si_module/schema_variant_id.rs
+++ b/lib/module-index-server/src/models/si_module/schema_variant_id.rs
@@ -1,0 +1,87 @@
+use sea_orm::{entity::prelude::*, sea_query, TryGetError};
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SchemaVariantId(pub Ulid);
+
+impl From<SchemaVariantId> for Value {
+    fn from(source: SchemaVariantId) -> Self {
+        Value::String(Some(Box::new(source.0.to_string())))
+    }
+}
+
+impl std::fmt::Display for SchemaVariantId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl TryFrom<String> for SchemaVariantId {
+    type Error = sea_orm::DbErr;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Ok(SchemaVariantId(
+            Ulid::from_string(&s).map_err(|err| DbErr::Type(err.to_string()))?,
+        ))
+    }
+}
+
+impl sea_orm::TryFromU64 for SchemaVariantId {
+    fn try_from_u64(_: u64) -> Result<Self, sea_orm::DbErr> {
+        Err(sea_orm::DbErr::Exec(sea_orm::RuntimeErr::Internal(
+            format!(
+                "{} cannot be converted from u64",
+                stringify!(SchemaVariantId)
+            ),
+        )))
+    }
+}
+
+impl From<SchemaVariantId> for String {
+    fn from(val: SchemaVariantId) -> Self {
+        val.0.to_string()
+    }
+}
+
+impl sea_orm::sea_query::Nullable for SchemaVariantId {
+    fn null() -> sea_orm::Value {
+        sea_orm::Value::String(None)
+    }
+}
+
+impl sea_orm::TryGetable for SchemaVariantId {
+    fn try_get_by<I: sea_orm::ColIdx>(res: &QueryResult, idx: I) -> Result<Self, TryGetError> {
+        let json_str: String =
+            res.try_get_by(idx)
+                .map_err(TryGetError::DbErr)
+                .and_then(|opt: Option<String>| {
+                    opt.ok_or(sea_orm::TryGetError::Null("null".to_string()))
+                })?;
+        Ulid::from_string(&json_str)
+            .map_err(|e| TryGetError::DbErr(DbErr::Type(e.to_string())))
+            .map(SchemaVariantId)
+    }
+}
+
+impl sea_query::ValueType for SchemaVariantId {
+    fn try_from(v: Value) -> Result<Self, sea_query::ValueTypeErr> {
+        match v {
+            Value::String(Some(x)) => Ok(SchemaVariantId(
+                Ulid::from_string(&x).map_err(|_| sea_query::ValueTypeErr)?,
+            )),
+            _ => Err(sea_query::ValueTypeErr),
+        }
+    }
+
+    fn type_name() -> String {
+        stringify!(SchemaVariantId).to_owned()
+    }
+
+    fn array_type() -> sea_orm::sea_query::ArrayType {
+        sea_orm::sea_query::ArrayType::String
+    }
+
+    fn column_type() -> sea_query::ColumnType {
+        sea_query::ColumnType::String(None)
+    }
+}

--- a/lib/module-index-server/src/routes/promote_builtin_route.rs
+++ b/lib/module-index-server/src/routes/promote_builtin_route.rs
@@ -100,6 +100,7 @@ pub async fn promote_builtin_route(
         ))),
         is_builtin_at_by_display_name: Set(Some(data)),
         schema_id: Set(module.schema_id),
+        ..Default::default() // all other attributes are `NotSet`
     };
 
     let updated_module: si_module::Model = active_module.update(&txn).await?;

--- a/lib/module-index-server/src/routes/reject_module_route.rs
+++ b/lib/module-index-server/src/routes/reject_module_route.rs
@@ -96,6 +96,7 @@ pub async fn reject_module(
         is_builtin_at: Set(module.is_builtin_at),
         is_builtin_at_by_display_name: Set(module.is_builtin_at_by_display_name),
         schema_id: Set(module.schema_id),
+        ..Default::default() // all other attributes are `NotSet`
     };
 
     let updated_module: si_module::Model = dbg!(active_module.update(&txn).await)?;

--- a/lib/module-index-types/src/lib.rs
+++ b/lib/module-index-types/src/lib.rs
@@ -5,6 +5,8 @@ use ulid::Ulid;
 pub const MODULE_BUNDLE_FIELD_NAME: &str = "module_bundle";
 pub const MODULE_BASED_ON_HASH_FIELD_NAME: &str = "based_on_hash";
 pub const MODULE_SCHEMA_ID_FIELD_NAME: &str = "schema_id";
+pub const MODULE_SCHEMA_VARIANT_ID_FIELD_NAME: &str = "schema_variant_id";
+pub const MODULE_SCHEMA_VARIANT_VERSION_FIELD_NAME: &str = "schema_variant_version";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -40,6 +42,8 @@ pub struct ModuleDetailsResponse {
     pub created_at: DateTime<Utc>,
     pub schema_id: Option<String>,
     pub past_hashes: Option<Vec<String>>,
+    pub schema_variant_id: Option<String>,
+    pub schema_variant_version: Option<String>,
 }
 
 impl ModuleDetailsResponse {

--- a/lib/sdf-server/src/server/service/v2/module/contribute.rs
+++ b/lib/sdf-server/src/server/service/v2/module/contribute.rs
@@ -37,14 +37,22 @@ pub async fn contribute(
     };
     let index_client = ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token);
 
-    let (name, version, based_on_hash, schema_id, payload, created_by_name, created_by_email) =
-        Module::prepare_contribution(
-            &ctx,
-            request.name.as_str(),
-            request.version.as_str(),
-            request.schema_variant_id.into(),
-        )
-        .await?;
+    let (
+        name,
+        version,
+        based_on_hash,
+        schema_id,
+        payload,
+        created_by_name,
+        created_by_email,
+        schema_variant_version,
+    ) = Module::prepare_contribution(
+        &ctx,
+        request.name.as_str(),
+        request.version.as_str(),
+        request.schema_variant_id.into(),
+    )
+    .await?;
 
     let response = index_client
         .upload_module(
@@ -53,6 +61,8 @@ pub async fn contribute(
             based_on_hash.clone(),
             schema_id.map(|id| id.to_string()),
             payload,
+            Some(request.schema_variant_id.to_string()),
+            Some(schema_variant_version),
         )
         .await?;
 

--- a/lib/sdf-server/src/server/service/v2/module/sync.rs
+++ b/lib/sdf-server/src/server/service/v2/module/sync.rs
@@ -26,7 +26,7 @@ pub async fn sync(
         .build(access_builder.build(change_set_id.into()))
         .await?;
 
-    let (latest_modules, module_details) = {
+    let (latest_modules, module_details, all_modules) = {
         let module_index_url = ctx
             .module_index_url()
             .ok_or(ModulesAPIError::ModuleIndexNotConfigured)?;
@@ -35,10 +35,17 @@ pub async fn sync(
         (
             module_index_client.list_latest_modules().await?,
             module_index_client.list_builtins().await?,
+            module_index_client.list_module_details().await?,
         )
     };
 
-    let synced_modules = Module::sync(&ctx, latest_modules.modules, module_details.modules).await?;
+    let synced_modules = Module::sync(
+        &ctx,
+        latest_modules.modules,
+        module_details.modules,
+        all_modules.modules,
+    )
+    .await?;
 
     track(
         &posthog_client,


### PR DESCRIPTION
When we make a contribution, we now want to store the schema_Variant_id and the schema_variant_version so that we remove the contribute button if the user has already sent the contribution

This makes it a nicer user experience! In the future, we may want to mark assets that have been contributed by the user and that have not made their way back to the system


https://github.com/user-attachments/assets/3967fb74-0e71-4993-8a28-ecc1efb4e553

