### PR TITLE
Allow components with secrets to be copy/pasted

### DIFF
--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -418,20 +418,20 @@ impl AttributePrototypeArgument {
     }
 
     pub async fn set_value_source(
-        self,
         ctx: &DalContext,
-        value_id: Ulid,
-    ) -> AttributePrototypeArgumentResult<Self> {
+        apa_id: AttributePrototypeArgumentId,
+        value_source: ValueSource,
+    ) -> AttributePrototypeArgumentResult<()> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         for existing_value_source in workspace_snapshot
             .outgoing_targets_for_edge_weight_kind(
-                self.id,
+                apa_id,
                 EdgeWeightKindDiscriminants::PrototypeArgumentValue,
             )
             .await?
         {
-            let self_node_index = workspace_snapshot.get_node_index_by_id(self.id).await?;
+            let self_node_index = workspace_snapshot.get_node_index_by_id(apa_id).await?;
             workspace_snapshot
                 .remove_edge(
                     self_node_index,
@@ -443,13 +443,13 @@ impl AttributePrototypeArgument {
 
         Self::add_edge_to_value(
             ctx,
-            self.id,
-            value_id,
+            apa_id,
+            value_source.into_inner_id().into(),
             EdgeWeightKind::PrototypeArgumentValue,
         )
         .await?;
 
-        Ok(self)
+        Ok(())
     }
 
     pub async fn prototype_id_for_argument_id(
@@ -496,7 +496,9 @@ impl AttributePrototypeArgument {
         ctx: &DalContext,
         input_socket_id: InputSocketId,
     ) -> AttributePrototypeArgumentResult<Self> {
-        self.set_value_source(ctx, input_socket_id.into()).await
+        Self::set_value_source(ctx, self.id, input_socket_id.into())
+            .await
+            .and(Ok(self))
     }
 
     pub async fn set_value_from_output_socket_id(
@@ -504,7 +506,9 @@ impl AttributePrototypeArgument {
         ctx: &DalContext,
         output_socket_id: OutputSocketId,
     ) -> AttributePrototypeArgumentResult<Self> {
-        self.set_value_source(ctx, output_socket_id.into()).await
+        Self::set_value_source(ctx, self.id, output_socket_id.into())
+            .await
+            .and(Ok(self))
     }
 
     pub async fn set_value_from_prop_id(
@@ -512,7 +516,9 @@ impl AttributePrototypeArgument {
         ctx: &DalContext,
         prop_id: PropId,
     ) -> AttributePrototypeArgumentResult<Self> {
-        self.set_value_source(ctx, prop_id.into()).await
+        Self::set_value_source(ctx, self.id, prop_id.into())
+            .await
+            .and(Ok(self))
     }
 
     pub async fn set_value_from_secret_id(
@@ -520,7 +526,9 @@ impl AttributePrototypeArgument {
         ctx: &DalContext,
         secret_id: SecretId,
     ) -> AttributePrototypeArgumentResult<Self> {
-        self.set_value_source(ctx, secret_id.into()).await
+        Self::set_value_source(ctx, self.id, secret_id.into())
+            .await
+            .and(Ok(self))
     }
 
     pub async fn set_value_from_static_value_id(
@@ -528,7 +536,9 @@ impl AttributePrototypeArgument {
         ctx: &DalContext,
         value_id: StaticArgumentValueId,
     ) -> AttributePrototypeArgumentResult<Self> {
-        self.set_value_source(ctx, value_id.into()).await
+        Self::set_value_source(ctx, self.id, value_id.into())
+            .await
+            .and(Ok(self))
     }
 
     pub async fn set_value_from_static_value(

--- a/lib/dal/src/attribute/prototype/argument/value_source.rs
+++ b/lib/dal/src/attribute/prototype/argument/value_source.rs
@@ -47,6 +47,32 @@ pub enum ValueSource {
     StaticArgumentValue(StaticArgumentValueId),
 }
 
+impl From<InputSocketId> for ValueSource {
+    fn from(id: InputSocketId) -> Self {
+        Self::InputSocket(id)
+    }
+}
+impl From<OutputSocketId> for ValueSource {
+    fn from(id: OutputSocketId) -> Self {
+        Self::OutputSocket(id)
+    }
+}
+impl From<PropId> for ValueSource {
+    fn from(id: PropId) -> Self {
+        Self::Prop(id)
+    }
+}
+impl From<SecretId> for ValueSource {
+    fn from(id: SecretId) -> Self {
+        Self::Secret(id)
+    }
+}
+impl From<StaticArgumentValueId> for ValueSource {
+    fn from(id: StaticArgumentValueId) -> Self {
+        Self::StaticArgumentValue(id)
+    }
+}
+
 impl ValueSource {
     async fn all_attribute_values_everywhere(
         &self,

--- a/lib/si-pkg/src/spec/attribute_value.rs
+++ b/lib/si-pkg/src/spec/attribute_value.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use std::hash::Hash;
 
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
@@ -19,7 +20,7 @@ pub enum AttributeValuePath {
     OutputSocket(String),
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum KeyOrIndex {
     Key(String),


### PR DESCRIPTION
With @nickgerace

Right now, if you try to copy/paste a component with a credential hooked up, we fail to copy and toss an error.

### How it works now

This is because when we copy/paste the attributes to the new component, we currently:

1. Extract the attribute value as JSON and set the new attribute value to it (which removes reactive links to secret nodes, input/output sockets, and props).
2. Set the name and clear the resource_value.
3. Go back and fix up the prototypes to point to the correct nodes.

However, when there is a secret, we don't get that far, because when we try to set a secret to a JSON value it immediately throws an error trying to get the secret to compute dependent values.

### This PR

This PR straight up clones the attribute prototypes and skips the JSON setting, and does the name setting and resource clearing at the end. This should get rid of dependent values churn during copy/paste as well as make the process simpler.

While trying to untangle the logic, I built a helper to iterate child attribute pairs (which I've seen done several other places, so we should be able to consolidate).

### Roads not taken

An alternate path not explored was to share code with the "upgrade component to new schema variant" code, which also clones a value and carries data from old to new. It's a very different path, however, and it's unclear how much code sharing there really is to be had besides a superficial structure similarity.


NOTE: I will squash this down before pushing; right now the commits are self-contained enough that some people might prefer to look at the commits, but they don't matter long term.

