### PR TITLE
Avoid orphaned components that can't be restored

### DIFF
--- a/lib/dal-test/src/helpers/change_set.rs
+++ b/lib/dal-test/src/helpers/change_set.rs
@@ -178,8 +178,6 @@ impl ChangeSetTestHelpers {
     }
 
     async fn blocking_commit(ctx: &DalContext) -> Result<()> {
-        // TODO(nick,brit): we need to expand Brit's 409 conflict work to work with blocking commits
-        // too rather than evaluating an optional set of conflicts.
         ctx.blocking_commit().await?;
         Ok(())
     }

--- a/lib/dal-test/src/test_exclusive_schemas/legos/large.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/legos/large.rs
@@ -43,11 +43,20 @@ pub(crate) async fn migrate_test_exclusive_schema_large_odd_lego(
     let fn_name = "test:refreshActionLargeLego";
     let refresh_action_func = build_action_func(refresh_action_code, fn_name)?;
 
+    // Build Update Action Func
     let update_action_code = "async function main(component: Input): Promise<Output> {
               return { payload: { \"poonami\": true }, status: \"ok\" };
             }";
     let fn_name = "test:updateActionLargeLego";
     let update_action_func = build_action_func(update_action_code, fn_name)?;
+
+    // Build Delete Action Func
+    let delete_action_code = "async function main() {
+        return { payload: null, status: \"ok\" };
+    }";
+
+    let fn_name = "test:deleteActionLargeLego";
+    let delete_action_func = build_action_func(delete_action_code, fn_name)?;
 
     // Create Scaffold Func
     let fn_name = "test:scaffoldLargeLegoAsset";
@@ -110,6 +119,12 @@ pub(crate) async fn migrate_test_exclusive_schema_large_odd_lego(
                         .func_unique_id(&update_action_func.unique_id)
                         .build()?,
                 )
+                .action_func(
+                    ActionFuncSpec::builder()
+                        .kind(ActionKind::Destroy)
+                        .func_unique_id(&delete_action_func.unique_id)
+                        .build()?,
+                )
                 .build()?,
         )
         .build()?;
@@ -119,6 +134,7 @@ pub(crate) async fn migrate_test_exclusive_schema_large_odd_lego(
         .func(refresh_action_func)
         .func(create_action_func)
         .func(update_action_func)
+        .func(delete_action_func)
         .func(large_lego_authoring_schema_func)
         .func(resource_payload_to_value_func)
         .schema(large_lego_schema)
@@ -165,6 +181,14 @@ pub(crate) async fn migrate_test_exclusive_schema_large_even_lego(
             }";
     let fn_name = "test:updateActionLargeLego";
     let update_action_func = build_action_func(update_action_code, fn_name)?;
+
+    // Build Delete Action Func
+    let delete_action_code = "async function main() {
+        return { payload: null, status: \"ok\" };
+    }";
+
+    let fn_name = "test:deleteActionLargeLego";
+    let delete_action_func = build_action_func(delete_action_code, fn_name)?;
 
     // Create Scaffold Func
     let fn_name = "test:scaffoldLargeLegoAsset";
@@ -227,6 +251,12 @@ pub(crate) async fn migrate_test_exclusive_schema_large_even_lego(
                         .func_unique_id(&update_action_func.unique_id)
                         .build()?,
                 )
+                .action_func(
+                    ActionFuncSpec::builder()
+                        .kind(ActionKind::Destroy)
+                        .func_unique_id(&delete_action_func.unique_id)
+                        .build()?,
+                )
                 .build()?,
         )
         .build()?;
@@ -236,6 +266,7 @@ pub(crate) async fn migrate_test_exclusive_schema_large_even_lego(
         .func(refresh_action_func)
         .func(create_action_func)
         .func(update_action_func)
+        .func(delete_action_func)
         .func(large_lego_authoring_schema_func)
         .func(resource_payload_to_value_func)
         .schema(large_lego_schema)

--- a/lib/dal-test/src/test_exclusive_schemas/legos/medium.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/legos/medium.rs
@@ -43,11 +43,20 @@ pub(crate) async fn migrate_test_exclusive_schema_medium_odd_lego(
     let fn_name = "test:refreshActionMediumLego";
     let refresh_action_func = build_action_func(refresh_action_code, fn_name)?;
 
+    // Build Update Action Func
     let update_action_code = "async function main(component: Input): Promise<Output> {
               return { payload: { \"poonami\": true }, status: \"ok\" };
             }";
     let fn_name = "test:updateActionMediumLego";
     let update_action_func = build_action_func(update_action_code, fn_name)?;
+
+    // Build Delete Action Func
+    let delete_action_code = "async function main() {
+        return { payload: null, status: \"ok\" };
+    }";
+
+    let fn_name = "test:deleteActionMediumLego";
+    let delete_action_func = build_action_func(delete_action_code, fn_name)?;
 
     // Create Scaffold Func
     let fn_name = "test:scaffoldMediumLegoAsset";
@@ -106,6 +115,12 @@ pub(crate) async fn migrate_test_exclusive_schema_medium_odd_lego(
                         .func_unique_id(&update_action_func.unique_id)
                         .build()?,
                 )
+                .action_func(
+                    ActionFuncSpec::builder()
+                        .kind(ActionKind::Destroy)
+                        .func_unique_id(&delete_action_func.unique_id)
+                        .build()?,
+                )
                 .build()?,
         )
         .build()?;
@@ -115,6 +130,7 @@ pub(crate) async fn migrate_test_exclusive_schema_medium_odd_lego(
         .func(refresh_action_func)
         .func(create_action_func)
         .func(update_action_func)
+        .func(delete_action_func)
         .func(medium_lego_authoring_schema_func)
         .func(resource_payload_to_value_func)
         .schema(medium_lego_schema)
@@ -160,6 +176,14 @@ pub(crate) async fn migrate_test_exclusive_schema_medium_even_lego(
             }";
     let fn_name = "test:updateActionMediumLego";
     let update_action_func = build_action_func(update_action_code, fn_name)?;
+
+    // Build Delete Action Func
+    let delete_action_code = "async function main() {
+        return { payload: null, status: \"ok\" };
+    }";
+
+    let fn_name = "test:deleteActionMediumLego";
+    let delete_action_func = build_action_func(delete_action_code, fn_name)?;
 
     // Create Scaffold Func
     let fn_name = "test:scaffoldMediumLegoAsset";
@@ -218,6 +242,12 @@ pub(crate) async fn migrate_test_exclusive_schema_medium_even_lego(
                         .func_unique_id(&update_action_func.unique_id)
                         .build()?,
                 )
+                .action_func(
+                    ActionFuncSpec::builder()
+                        .kind(ActionKind::Destroy)
+                        .func_unique_id(&delete_action_func.unique_id)
+                        .build()?,
+                )
                 .build()?,
         )
         .build()?;
@@ -227,6 +257,7 @@ pub(crate) async fn migrate_test_exclusive_schema_medium_even_lego(
         .func(refresh_action_func)
         .func(create_action_func)
         .func(update_action_func)
+        .func(delete_action_func)
         .func(medium_lego_authoring_schema_func)
         .func(resource_payload_to_value_func)
         .schema(medium_lego_schema)

--- a/lib/dal-test/src/test_exclusive_schemas/legos/small.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/legos/small.rs
@@ -43,11 +43,20 @@ pub(crate) async fn migrate_test_exclusive_schema_small_odd_lego(
     let fn_name = "test:refreshActionSmallLego";
     let refresh_action_func = build_action_func(refresh_action_code, fn_name)?;
 
+    // Build Update Action Func
     let update_action_code = "async function main(component: Input): Promise<Output> {
               return { payload: { \"poonami\": true }, status: \"ok\" };
             }";
     let fn_name = "test:updateActionSmallLego";
     let update_action_func = build_action_func(update_action_code, fn_name)?;
+
+    // Build Delete Action Func
+    let delete_action_code = "async function main() {
+        return { payload: null, status: \"ok\" };
+    }";
+
+    let fn_name = "test:deleteActionSmallLego";
+    let delete_action_func = build_action_func(delete_action_code, fn_name)?;
 
     // Create Scaffold Func
     let fn_name = "test:scaffoldSmallLegoAsset";
@@ -102,6 +111,12 @@ pub(crate) async fn migrate_test_exclusive_schema_small_odd_lego(
                         .func_unique_id(&update_action_func.unique_id)
                         .build()?,
                 )
+                .action_func(
+                    ActionFuncSpec::builder()
+                        .kind(ActionKind::Destroy)
+                        .func_unique_id(&delete_action_func.unique_id)
+                        .build()?,
+                )
                 .build()?,
         )
         .build()?;
@@ -111,6 +126,7 @@ pub(crate) async fn migrate_test_exclusive_schema_small_odd_lego(
         .func(refresh_action_func)
         .func(create_action_func)
         .func(update_action_func)
+        .func(delete_action_func)
         .func(small_lego_authoring_schema_func)
         .func(resource_payload_to_value_func)
         .schema(small_lego_schema)
@@ -157,6 +173,14 @@ pub(crate) async fn migrate_test_exclusive_schema_small_even_lego(
             }";
     let fn_name = "test:updateActionSmallLego";
     let update_action_func = build_action_func(update_action_code, fn_name)?;
+
+    // Build Delete Action Func
+    let delete_action_code = "async function main() {
+        return { payload: null, status: \"ok\" };
+    }";
+
+    let fn_name = "test:deleteActionSmallLego";
+    let delete_action_func = build_action_func(delete_action_code, fn_name)?;
 
     // Create Scaffold Func
     let fn_name = "test:scaffoldSmallLegoAsset";
@@ -211,6 +235,12 @@ pub(crate) async fn migrate_test_exclusive_schema_small_even_lego(
                         .func_unique_id(&update_action_func.unique_id)
                         .build()?,
                 )
+                .action_func(
+                    ActionFuncSpec::builder()
+                        .kind(ActionKind::Destroy)
+                        .func_unique_id(&delete_action_func.unique_id)
+                        .build()?,
+                )
                 .build()?,
         )
         .build()?;
@@ -220,6 +250,7 @@ pub(crate) async fn migrate_test_exclusive_schema_small_even_lego(
         .func(refresh_action_func)
         .func(create_action_func)
         .func(update_action_func)
+        .func(delete_action_func)
         .func(small_lego_authoring_schema_func)
         .func(resource_payload_to_value_func)
         .schema(small_lego_schema)


### PR DESCRIPTION
This change includes a few things:
- When we remove a component from the graph, re-parent any of it's children if they can be re-parented (we were already doing this in sdf, so just moved this logic to the dal)
- Rip out more of the work we were doing to compensate for conflicts in actions
- When deleting a frame with children, we were only marking it as 'to_delete' if the component was feeding data to other components that had resources. Now, we also check if there any children that have resources, regardless if data is flowing to them specifically, so that we don't need to deal with reparenting and other edge cases
- Adds a couple tests for this!