### PR TITLE
feat: allow setting custom auth api url on sdf via env variable

### DIFF
--- a/bin/auth-api/.env
+++ b/bin/auth-api/.env
@@ -13,6 +13,8 @@ AUTH_PORTAL_URL=http://localhost:9000
 
 DATABASE_URL=postgresql://si:bugbear@localhost:5432/si_auth?schema=public
 DIRECT_DATABASE_URL=postgresql://si:bugbear@localhost:5432/si_auth?schema=public
+# Using a fixed shadow database is more stable because prisma won't force drop the shadow DB when creating migrations
+# This database is auto created with the postgres development containers
 SHADOW_DATABASE_URL=postgresql://si:bugbear@localhost:5432/si_auth_prisma_shadow_db?schema=public
 
 # default creds - only used for local dev

--- a/bin/auth-api/README.md
+++ b/bin/auth-api/README.md
@@ -37,8 +37,8 @@ While working on the auth stack, we still need to run it locally and configure t
     VITE_AUTH_API_URL=http://localhost:9001
     VITE_AUTH_PORTAL_URL=http://localhost:9000
   ```
-- run the backend but using the local auth stack by setting env var `LOCAL_AUTH_STACK=1` (
-  ex: `LOCAL_AUTH_STACK=1 buck2 run dev:up`)
+- run the backend but using the local auth stack by setting env var `SI_AUTH_API_URL=http://localhost:9001` (
+  ex: `SI_AUTH_API_URL=http://localhost:9001 buck2 run dev:up`)
 - run the db migrations (`pnpm run db:reset`) locally after booting your local database
 - run the auth api `pnmp run dev` in this directory or `pnpm dev:auth-api` at the root
 - run the auth portal `pnmp run dev` in `app/auth-portal` or `pnpm dev:auth-portal` at the root
@@ -66,7 +66,8 @@ the `Run Workflow` button and then choose the branch from which to deploy.
 
 This will build and push the image and queue a deployment to ECS.
 
-NOTE - db migrations are not yet automatic, and are being triggered manually before deploying a new version. (This is very infrequent so far...)
+NOTE - db migrations are not yet automatic, and are being triggered manually before deploying a new version. (This is
+very infrequent so far...)
 
 If new environment variables are needed to be passed to the auth-api, then a new task definition needs to be created in
 AWS ECS. When that task definition is created, the task definition can be associated with the service and a deployment

--- a/bin/auth-api/src/lib/cache.ts
+++ b/bin/auth-api/src/lib/cache.ts
@@ -4,7 +4,7 @@ if/when we add a redis component anything else, we can delete this and just use 
 */
 
 // for now we'll say everything being cached should be an object... can allow raw strings/etc later if necessary
-import { redis, REDIS_ENABLED } from './redis';
+import { redis, REDIS_ENABLED } from "./redis";
 
 type CacheableInfo = Record<string, any>;
 

--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -189,7 +189,7 @@ pub(crate) struct Args {
     #[arg(long, env = "SI_CREATE_WORKSPACE_PERMISSIONS", value_parser = PossibleValuesParser::new(WorkspacePermissionsMode::variants()))]
     pub(crate) create_workspace_permissions: Option<String>,
 
-    /// Create Workspace Permissions Allowlist
+    /// List of emails that can create workspaces
     #[arg(
         long,
         env = "SI_CREATE_WORKSPACE_ALLOWLIST",
@@ -197,6 +197,10 @@ pub(crate) struct Args {
         rename_all = "snake_case"
     )]
     pub(crate) create_workspace_allowlist: Vec<WorkspacePermissions>,
+
+    /// Override for the auth api url
+    #[arg(long, env = "SI_AUTH_API_URL")]
+    pub(crate) auth_api_url: Option<String>,
 }
 
 impl TryFrom<Args> for Config {
@@ -294,6 +298,10 @@ impl TryFrom<Args> for Config {
             }
             if let Some(module_index_url) = args.module_index_url {
                 config_map.set("module_index_url", module_index_url);
+            }
+
+            if let Some(auth_api_url) = args.auth_api_url {
+                config_map.set("auth_api_url", auth_api_url);
             }
 
             config_map.set("boot_feature_flags", args.features);

--- a/lib/module-index-server/src/config.rs
+++ b/lib/module-index-server/src/config.rs
@@ -176,10 +176,8 @@ fn buck2_development(config: &mut ConfigFile) -> Result<()> {
     let resources = Buck2Resources::read().map_err(ConfigError::development)?;
 
     #[allow(clippy::disallowed_methods)] // Used in development with a local auth services
-    //
-    // TODO(fnichol): this environment variable should be at least prefixed with `SI_` for
-    // consistency and discoverability.
-    let jwt_signing_public_key_path = if env::var("LOCAL_AUTH_STACK").is_ok() {
+    // Note(victor): If the user has set a custom auth ip url via env variable we assume dev mode
+    let jwt_signing_public_key_path = if env::var("SI_AUTH_API_URL").is_ok() {
         resources
             .get_ends_with("dev.jwt_signing_public_key.pem")
             .map_err(ConfigError::development)?
@@ -213,10 +211,8 @@ fn buck2_development(config: &mut ConfigFile) -> Result<()> {
 
 fn cargo_development(dir: String, config: &mut ConfigFile) -> Result<()> {
     #[allow(clippy::disallowed_methods)] // Used in development with a local auth services
-    //
-    // TODO(fnichol): this environment variable should be at least prefixed with `SI_` for
-    // consistency and discoverability.
-    let jwt_signing_public_key_path = if env::var("LOCAL_AUTH_STACK").is_ok() {
+    // Note(victor): If the user has set a custom auth ip url via env variable we assume dev mode
+    let jwt_signing_public_key_path = if env::var("SI_AUTH_API_URL").is_ok() {
         Path::new(&dir)
             .join("../../config/keys/dev.jwt_signing_public_key.pem")
             .to_string_lossy()

--- a/lib/sdf-server/src/server/config.rs
+++ b/lib/sdf-server/src/server/config.rs
@@ -27,6 +27,7 @@ pub use si_crypto::VeritechKeyPair;
 pub use si_settings::{StandardConfig, StandardConfigFile};
 
 const DEFAULT_MODULE_INDEX_URL: &str = "https://module-index.systeminit.com";
+const DEFAULT_AUTH_API_URL: &str = "https://auth-api.systeminit.com";
 
 #[derive(
     Debug,
@@ -95,6 +96,9 @@ pub struct Config {
 
     #[builder(default = "default_module_index_url()")]
     module_index_url: String,
+
+    #[builder(default = "default_auth_api_url()")]
+    auth_api_url: String,
 
     #[builder(default = "NatsConfig::default()")]
     nats: NatsConfig,
@@ -189,6 +193,12 @@ impl Config {
         &self.module_index_url
     }
 
+    /// URL to the auth API
+    #[must_use]
+    pub fn auth_api_url(&self) -> &str {
+        &self.auth_api_url
+    }
+
     /// Feature flags defined at boot time, via config files or the FEATURES env variable
     #[must_use]
     pub fn boot_feature_flags(&self) -> &HashSet<FeatureFlag> {
@@ -241,6 +251,8 @@ pub struct ConfigFile {
     layer_db_config: LayerDbConfig,
     #[serde(default)]
     pub module_index_url: String,
+    #[serde(default = "default_auth_api_url")]
+    pub auth_api_url: String,
     #[serde(default = "default_symmetric_crypto_config")]
     symmetric_crypto_service: SymmetricCryptoServiceConfigFile,
     #[serde(default)]
@@ -263,6 +275,7 @@ impl Default for ConfigFile {
             posthog: Default::default(),
             layer_db_config: default_layer_db_config(),
             module_index_url: default_module_index_url(),
+            auth_api_url: default_auth_api_url(),
             symmetric_crypto_service: default_symmetric_crypto_config(),
             boot_feature_flags: Default::default(),
             create_workspace_permissions: Default::default(),
@@ -290,6 +303,7 @@ impl TryFrom<ConfigFile> for Config {
         config.pkgs_path(value.pkgs_path.try_into()?);
         config.posthog(value.posthog);
         config.module_index_url(value.module_index_url);
+        config.auth_api_url(value.auth_api_url);
         config.symmetric_crypto_service(value.symmetric_crypto_service.try_into()?);
         config.layer_db_config(value.layer_db_config);
         config.boot_feature_flags(value.boot_feature_flags.into_iter().collect::<HashSet<_>>());
@@ -344,6 +358,10 @@ fn default_module_index_url() -> String {
     DEFAULT_MODULE_INDEX_URL.into()
 }
 
+fn default_auth_api_url() -> String {
+    DEFAULT_AUTH_API_URL.into()
+}
+
 fn default_layer_db_config() -> LayerDbConfig {
     LayerDbConfig::default_for_service("sdf")
 }
@@ -363,10 +381,8 @@ fn buck2_development(config: &mut ConfigFile) -> Result<()> {
     let resources = Buck2Resources::read().map_err(ConfigError::development)?;
 
     #[allow(clippy::disallowed_methods)] // Used in development with a local auth services
-    //
-    // TODO(fnichol): this environment variable should be at least prefixed with `SI_` for
-    // consistency and discoverability.
-    let jwt_signing_public_key_path = if env::var("LOCAL_AUTH_STACK").is_ok() {
+    // Note(victor): If the user has set a custom auth ip url via env variable we assume dev mode
+    let jwt_signing_public_key_path = if env::var("SI_AUTH_API_URL").is_ok() {
         resources
             .get_ends_with("dev.jwt_signing_public_key.pem")
             .map_err(ConfigError::development)?
@@ -430,10 +446,8 @@ fn buck2_development(config: &mut ConfigFile) -> Result<()> {
 
 fn cargo_development(dir: String, config: &mut ConfigFile) -> Result<()> {
     #[allow(clippy::disallowed_methods)] // Used in development with a local auth services
-    //
-    // TODO(fnichol): this environment variable should be at least prefixed with `SI_` for
-    // consistency and discoverability.
-    let jwt_signing_public_key_path = if env::var("LOCAL_AUTH_STACK").is_ok() {
+    // Note(victor): If the user has set a custom auth ip url via env variable we assume dev mode
+    let jwt_signing_public_key_path = if env::var("SI_AUTH_API_URL").is_ok() {
         Path::new(&dir)
             .join("../../config/keys/dev.jwt_signing_public_key.pem")
             .to_string_lossy()

--- a/lib/sdf-server/src/server/server.rs
+++ b/lib/sdf-server/src/server/server.rs
@@ -137,6 +137,7 @@ impl Server<(), ()> {
                     services_context,
                     jwt_public_signing_key,
                     posthog_client,
+                    config.auth_api_url(),
                     ws_multiplexer_client,
                     crdt_multiplexer_client,
                     *config.create_workspace_permissions(),
@@ -183,6 +184,7 @@ impl Server<(), ()> {
                     services_context,
                     jwt_public_signing_key,
                     posthog_client,
+                    config.auth_api_url(),
                     ws_multiplexer_client,
                     crdt_multiplexer_client,
                     *config.create_workspace_permissions(),
@@ -484,10 +486,12 @@ async fn fetch_builtin(
     Ok(SiPkg::load_from_bytes(module)?)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn build_service_for_tests(
     services_context: ServicesContext,
     jwt_public_signing_key: JwtPublicSigningKey,
     posthog_client: PosthogClient,
+    auth_api_url: impl AsRef<str>,
     ws_multiplexer_client: MultiplexerClient,
     crdt_multiplexer_client: MultiplexerClient,
     create_workspace_permissions: WorkspacePermissionsMode,
@@ -497,6 +501,7 @@ pub fn build_service_for_tests(
         services_context,
         jwt_public_signing_key,
         posthog_client,
+        auth_api_url,
         true,
         ws_multiplexer_client,
         crdt_multiplexer_client,
@@ -505,10 +510,12 @@ pub fn build_service_for_tests(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn build_service(
     services_context: ServicesContext,
     jwt_public_signing_key: JwtPublicSigningKey,
     posthog_client: PosthogClient,
+    auth_api_url: impl AsRef<str>,
     ws_multiplexer_client: MultiplexerClient,
     crdt_multiplexer_client: MultiplexerClient,
     create_workspace_permissions: WorkspacePermissionsMode,
@@ -518,6 +525,7 @@ pub fn build_service(
         services_context,
         jwt_public_signing_key,
         posthog_client,
+        auth_api_url,
         false,
         ws_multiplexer_client,
         crdt_multiplexer_client,
@@ -531,6 +539,7 @@ fn build_service_inner(
     services_context: ServicesContext,
     jwt_public_signing_key: JwtPublicSigningKey,
     posthog_client: PosthogClient,
+    auth_api_url: impl AsRef<str>,
     for_tests: bool,
     ws_multiplexer_client: MultiplexerClient,
     crdt_multiplexer_client: MultiplexerClient,
@@ -544,6 +553,7 @@ fn build_service_inner(
         services_context,
         jwt_public_signing_key,
         posthog_client,
+        auth_api_url,
         shutdown_broadcast_tx.clone(),
         shutdown_tx,
         for_tests,

--- a/lib/sdf-server/src/server/service/session/auth_connect.rs
+++ b/lib/sdf-server/src/server/service/session/auth_connect.rs
@@ -157,13 +157,9 @@ pub async fn auth_connect(
     Json(request): Json<AuthConnectRequest>,
 ) -> SessionResult<Json<AuthConnectResponse>> {
     let client = reqwest::Client::new();
-    let auth_api_url = match option_env!("LOCAL_AUTH_STACK") {
-        Some(_) => "http://localhost:9001",
-        None => "https://auth-api.systeminit.com",
-    };
 
     let res = client
-        .post(format!("{}/complete-auth-connect", auth_api_url))
+        .post(format!("{}/complete-auth-connect", state.auth_api_url()))
         .json(&json!({"code": request.code }))
         .send()
         .await?;
@@ -202,14 +198,9 @@ pub async fn auth_reconnect(
     RawAccessToken(raw_access_token): RawAccessToken,
     State(state): State<AppState>,
 ) -> SessionResult<Json<AuthReconnectResponse>> {
-    let auth_api_url = match option_env!("LOCAL_AUTH_STACK") {
-        Some(_) => "http://localhost:9001",
-        None => "https://auth-api.systeminit.com",
-    };
-
     let client = reqwest::Client::new();
     let res = client
-        .get(format!("{}/auth-reconnect", auth_api_url))
+        .get(format!("{}/auth-reconnect", state.auth_api_url()))
         .bearer_auth(&raw_access_token)
         .send()
         .await?;

--- a/lib/sdf-server/src/server/state.rs
+++ b/lib/sdf-server/src/server/state.rs
@@ -23,6 +23,7 @@ pub struct AppState {
     broadcast_groups: BroadcastGroups,
     jwt_public_signing_key: JwtPublicSigningKey,
     posthog_client: PosthogClient,
+    auth_api_url: String, // TODO(victor) store the auth client on state instead of just the URL
     shutdown_broadcast: ShutdownBroadcast,
     for_tests: bool,
     nats_multiplexer_clients: NatsMultiplexerClients,
@@ -42,6 +43,7 @@ impl AppState {
         services_context: impl Into<ServicesContext>,
         jwt_public_signing_key: impl Into<JwtPublicSigningKey>,
         posthog_client: impl Into<PosthogClient>,
+        auth_api_url: impl AsRef<str>,
         shutdown_broadcast_tx: broadcast::Sender<()>,
         tmp_shutdown_tx: mpsc::Sender<ShutdownSource>,
         for_tests: bool,
@@ -54,11 +56,14 @@ impl AppState {
             ws: Arc::new(Mutex::new(ws_multiplexer_client)),
             crdt: Arc::new(Mutex::new(crdt_multiplexer_client)),
         };
+
+        let auth_api_url = auth_api_url.as_ref().to_string();
         Self {
             services_context: services_context.into(),
             jwt_public_signing_key: jwt_public_signing_key.into(),
             broadcast_groups: Default::default(),
             posthog_client: posthog_client.into(),
+            auth_api_url,
             shutdown_broadcast: ShutdownBroadcast(shutdown_broadcast_tx),
             for_tests,
             nats_multiplexer_clients,
@@ -75,6 +80,10 @@ impl AppState {
 
     pub fn posthog_client(&self) -> &PosthogClient {
         &self.posthog_client
+    }
+
+    pub fn auth_api_url(&self) -> &String {
+        &self.auth_api_url
     }
 
     pub fn jwt_public_signing_key(&self) -> &JwtPublicSigningKey {

--- a/lib/si-test-macros/src/sdf_test.rs
+++ b/lib/si-test-macros/src/sdf_test.rs
@@ -383,6 +383,7 @@ impl SdfTestFnSetupExpander {
                     s_ctx,
                     #jwt_public_signing_key.clone(),
                     #posthog_client,
+                    "https://auth-api.systeminit.com".to_string(),
                     #ws_multiplexer_client,
                     #crdt_multiplexer_client,
                     ::sdf_server::server::WorkspacePermissionsMode::Open,


### PR DESCRIPTION
Run buck2 with the env variable `SI_AUTH_API_URL` to point to a dev auth_api

Previously, the variable LOCAL_AUTH_STACK only allowed to use localhost, which is not always wanted (also reportedly it didn't work anyway) 