### PR TITLE
Accept schema variant id when cloning

### DIFF
--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -216,10 +216,6 @@ const openAttachModal = (warning: { kind?: FuncKind; funcId?: FuncId }) => {
 };
 
 const componentTypeOptions = [
-  {
-    label: "Aggregation Frame",
-    value: ComponentType.AggregationFrame,
-  },
   { label: "Component", value: ComponentType.Component },
   {
     label: "Configuration Frame (down)",
@@ -296,9 +292,14 @@ const cloneAsset = async (name: string) => {
       name,
     );
     if (result.result.success) {
+      assetStore.setSchemaVariantSelection(result.result.data.schemaVariantId);
       cloneAssetModalRef.value?.modal?.close();
-      assetStore.setSchemaVariantSelection(result.result.data.id);
+    } else if (result.result.statusCode === 409) {
+      cloneAssetModalRef.value?.setError(
+        "That name is already in use, please choose another",
+      );
     }
+    cloneAssetModalRef.value?.reset();
   }
 };
 </script>

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -335,10 +335,7 @@ export const useAssetStore = () => {
           if (changeSetStore.headSelected)
             changeSetStore.creatingChangeSet = true;
 
-          return new ApiRequest<
-            { id: SchemaVariantId; success: boolean },
-            SchemaVariantCloneRequest
-          >({
+          return new ApiRequest<SchemaVariant, SchemaVariantCloneRequest>({
             method: "post",
             keyRequestStatusBy: schemaVariantId,
             url: "/variant/clone_variant",
@@ -346,6 +343,13 @@ export const useAssetStore = () => {
               ...visibility,
               id: schemaVariantId,
               name,
+            },
+            onSuccess: (variant) => {
+              const savedAssetIdx = this.variantList.findIndex(
+                (a) => a.schemaVariantId === variant.schemaVariantId,
+              );
+              if (savedAssetIdx === -1) this.variantList.push(variant);
+              else this.variantList.splice(savedAssetIdx, 1, variant);
             },
           });
         },

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -226,11 +226,12 @@ impl VariantAuthoringClient {
                 .await?;
             let cloned_func_spec = build_asset_func_spec(&cloned_func)?;
             let definition = Self::execute_asset_func(ctx, &cloned_func).await?;
+            let display_name = format!("{}-Clone", variant.display_name());
 
             let metadata = SchemaVariantMetadataJson {
                 schema_name: schema_name.clone(),
                 version: SchemaVariant::generate_version_string(),
-                display_name: variant.display_name().to_string(),
+                display_name,
                 category: variant.category().to_string(),
                 color: variant.get_color(ctx).await?,
                 component_type: variant.component_type(),

--- a/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
@@ -29,11 +29,11 @@ async fn clone_variant(ctx: &mut DalContext) {
 
     assert!(default_schema_variant.is_some());
 
-    let clone_name = format!("{}-clone", schema.name());
+    let clone_name = format!("{}-Clone", schema.name());
     let (new_schema_variant, _) = VariantAuthoringClient::new_schema_with_cloned_variant(
         ctx,
         default_schema_variant.expect("unable to get the schema variant id from the option"),
-        dbg!(clone_name),
+        clone_name,
     )
     .await
     .expect("unable to clone the schema variant");
@@ -41,7 +41,7 @@ async fn clone_variant(ctx: &mut DalContext) {
     assert_eq!(new_schema_variant.category(), existing_variant.category());
     assert_eq!(
         new_schema_variant.display_name(),
-        existing_variant.display_name()
+        format!("{}-Clone", existing_variant.display_name())
     );
     assert_eq!(
         new_schema_variant

--- a/lib/sdf-server/src/server/service/variant/clone_variant.rs
+++ b/lib/sdf-server/src/server/service/variant/clone_variant.rs
@@ -1,26 +1,19 @@
 use crate::server::extract::{AccessBuilder, HandlerContext, PosthogClient};
 use crate::server::tracking::track;
-use crate::service::variant::{SchemaVariantError, SchemaVariantResult};
+use crate::service::variant::SchemaVariantResult;
 use axum::extract::{Host, OriginalUri};
 use axum::{response::IntoResponse, Json};
 use dal::schema::variant::authoring::VariantAuthoringClient;
-use dal::{ChangeSet, Schema, SchemaId, Visibility, WsEvent};
+use dal::{ChangeSet, Schema, SchemaVariantId, Visibility, WsEvent};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CloneVariantRequest {
-    pub id: SchemaId,
+    pub id: SchemaVariantId,
     pub name: String,
     #[serde(flatten)]
     pub visibility: Visibility,
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct CloneVariantResponse {
-    pub id: SchemaId,
-    pub success: bool,
 }
 
 pub async fn clone_variant(
@@ -32,7 +25,6 @@ pub async fn clone_variant(
     Json(request): Json<CloneVariantRequest>,
 ) -> SchemaVariantResult<impl IntoResponse> {
     let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
-
     if Schema::is_name_taken(&ctx, &request.name).await? {
         return Ok(axum::response::Response::builder()
             .status(409)
@@ -41,14 +33,9 @@ pub async fn clone_variant(
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
-    let schema = Schema::get_by_id(&ctx, request.id).await?;
-    let default_schema_variant_id = schema.get_default_schema_variant_id(&ctx).await?.ok_or(
-        SchemaVariantError::NoDefaultSchemaVariantFoundForSchema(schema.id()),
-    )?;
-
     let (cloned_schema_variant, schema) = VariantAuthoringClient::new_schema_with_cloned_variant(
         &ctx,
-        default_schema_variant_id,
+        request.id,
         request.name.clone(),
     )
     .await?;
@@ -81,8 +68,9 @@ pub async fn clone_variant(
         response = response.header("force_change_set_id", force_change_set_id.to_string());
     }
 
-    Ok(response.body(serde_json::to_string(&CloneVariantResponse {
-        id: schema.id(),
-        success: true,
-    })?)?)
+    Ok(response.body(serde_json::to_string(
+        &cloned_schema_variant
+            .into_frontend_type(&ctx, schema.id())
+            .await?,
+    )?)?)
 }


### PR DESCRIPTION
The front end is sending the schema variant id, and as we were using the schema id to get the variant anyways, this change modifies the sdf route to accept the variant id.  This also enables users to clone any variant they can view (including unlocked). This change also fixes up the asset name picker and adds "-Clone" to the end of the display name so it's differentiated from what you were cloning.

<div><img src="https://media3.giphy.com/media/oCCLHVNt8YO64/giphy.gif?cid=5a38a5a2dzc2h47ngh1sg2gqcmas9i4btbybza5k29xsa6c6&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:444px;width:300px"/><br/>via <a href="https://giphy.com/gifs/oCCLHVNt8YO64">GIPHY</a></div>