### PR TITLE
fix: firecracker lifecycle fixes

### DIFF
--- a/lib/si-firecracker/BUCK
+++ b/lib/si-firecracker/BUCK
@@ -14,8 +14,8 @@ rust_library(
     ] + select({
         "DEFAULT": [],
         "config//os:linux": [
-            "//third-party/rust:krata-loopdev",
             "//third-party/rust:devicemapper",
+            "//third-party/rust:krata-loopdev",
             "//third-party/rust:tokio-vsock",
         ],
     }),

--- a/lib/si-firecracker/src/errors.rs
+++ b/lib/si-firecracker/src/errors.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use thiserror::Error;
 
 use crate::stream::StreamForwarderError;
@@ -13,8 +15,8 @@ pub enum FirecrackerJailError {
     #[error("dmsetup error: {0}")]
     DmSetup(#[from] devicemapper::DmError),
     // Failed to interact with a mount
-    #[error("Mount error: {0}")]
-    Mount(#[from] nix::Error),
+    #[error("Mount error when working with {1}: {0}")]
+    Mount(#[source] nix::Error, PathBuf),
     // Failed running a script to output
     #[error("Failed to run a script: {0}")]
     Output(String),

--- a/lib/si-firecracker/src/firecracker.rs
+++ b/lib/si-firecracker/src/firecracker.rs
@@ -3,6 +3,8 @@ use crate::errors::FirecrackerJailError;
 use crate::stream::UnixStreamForwarder;
 use cyclone_core::process;
 use std::fs::Permissions;
+use std::io::Error;
+use std::io::ErrorKind;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::path::PathBuf;
@@ -62,7 +64,6 @@ impl FirecrackerJail {
     }
 
     pub async fn clean(id: u32) -> Result<()> {
-        let _ = id;
         FirecrackerDisk::clean(id)?;
         Ok(())
     }
@@ -75,10 +76,11 @@ impl FirecrackerJail {
             .map_err(FirecrackerJailError::Prepare)?;
 
         if !output.status.success() {
-            return Err(FirecrackerJailError::Output(
+            return Err(FirecrackerJailError::Prepare(Error::new(
+                ErrorKind::Other,
                 String::from_utf8(output.stderr)
                     .unwrap_or_else(|_| "Failed to decode stderr".to_string()),
-            ));
+            )));
         }
 
         UnixStreamForwarder::new(FirecrackerDisk::jail_dir_from_id(id), id)
@@ -102,10 +104,11 @@ impl FirecrackerJail {
             .await?;
 
         if !output.status.success() {
-            return Err(FirecrackerJailError::Output(
+            return Err(FirecrackerJailError::Setup(Error::new(
+                ErrorKind::Other,
                 String::from_utf8(output.stderr)
                     .unwrap_or_else(|_| "Failed to decode stderr".to_string()),
-            ));
+            )));
         }
 
         Ok(())

--- a/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
+++ b/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
@@ -408,7 +408,7 @@ impl Spec for LocalUdsInstanceSpec {
         // Establish the client watch session. As the process may be booting, we will retry for a
         // period before giving up and assuming that the server instance has failed.
         let watch = {
-            let mut retries = 30;
+            let mut retries = 300;
             loop {
                 match client.watch().await {
                     Ok(watch) => {
@@ -417,6 +417,7 @@ impl Spec for LocalUdsInstanceSpec {
                     Err(err) => err,
                 };
                 if retries < 1 {
+                    runtime.terminate().await?;
                     return Err(Self::Error::WatchInitTimeout);
                 }
                 retries -= 1;

--- a/lib/si-pool-noodle/src/pool_noodle.rs
+++ b/lib/si-pool-noodle/src/pool_noodle.rs
@@ -283,7 +283,7 @@ where
                 // Try to ensure the item is healthy
                 match &mut instance.ensure_healthy().await {
                     Ok(_) => {
-                        info!(
+                        debug!(
                             "PoolNoodle: got instance for func execution: {}",
                             &instance.id()
                         );
@@ -300,7 +300,7 @@ where
                 }
             } else {
                 retries += 1;
-                info!(
+                debug!(
                     "Failed to get from pool, retry ({} of {})",
                     retries, max_retries
                 );


### PR DESCRIPTION
Okay, so I kept thinking that our issues with larger pools were related to us not being able to unmount the disks quickly enough when under enough pressure, but after a dive I realized:

1. In some cases, we were failing because the disk was already unmounted, but we failed at a later step so we would retry and then fail forever when trying to unmount again
2. What surfaced as an unmount error (`EBUSY`) was actually because we would sometimes, when under enough pressure, timeout when waiting for the firecracker jail to startup. The timeout would error, but we wouldn't cleanup the spawned instance so the process would hang out and prevent us from unmounting the disk (hence `EBUSY`).

Solutions: swallow the "unmounted" error and ensure that we call `terminate` if we fail to start a watch. I also gave us more time to start the watch so failures were less common under load.

<img src="https://media4.giphy.com/media/JZVne3wlmhiGARrOfu/giphy-downsized-medium.gif"/>