### PR TITLE
feat(pinga): consume work from a Jetstream work queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,6 +1345,7 @@ dependencies = [
  "once_cell",
  "paste",
  "petgraph",
+ "pinga-core",
  "postcard",
  "postgres-types",
  "pretty_assertions_sorted",
@@ -3790,6 +3791,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "pinga-core"
+version = "0.1.0"
+dependencies = [
+ "si-data-nats",
+]
+
+[[package]]
 name = "pinga-server"
 version = "0.1.0"
 dependencies = [
@@ -3798,6 +3806,8 @@ dependencies = [
  "derive_builder",
  "futures",
  "nats-subscriber",
+ "naxum",
+ "pinga-core",
  "remain",
  "serde",
  "serde_json",
@@ -3814,6 +3824,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower",
  "ulid",
  "veritech-client",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "lib/nats-subscriber",
     "lib/naxum",
     "lib/object-tree",
+    "lib/pinga-core",
     "lib/pinga-server",
     "lib/rebaser-core",
     "lib/rebaser-server",

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -9,6 +9,7 @@ rust_library(
     deps = [
         "//lib/nats-subscriber:nats-subscriber",
         "//lib/object-tree:object-tree",
+        "//lib/pinga-core:pinga-core",
         "//lib/si-crypto:si-crypto",
         "//lib/si-data-nats:si-data-nats",
         "//lib/si-data-pg:si-data-pg",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -32,6 +32,7 @@ object-tree = { path = "../../lib/object-tree" }
 once_cell = { workspace = true }
 paste = { workspace = true }
 petgraph = { workspace = true }
+pinga-core = { path = "../../lib/pinga-core" }
 postcard = { workspace = true }
 postgres-types = { workspace = true }
 rand = { workspace = true }

--- a/lib/dal/src/job/processor.rs
+++ b/lib/dal/src/job/processor.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use dyn_clone::DynClone;
+use si_data_nats::async_nats;
 use thiserror::Error;
 
 use crate::{
@@ -17,6 +18,10 @@ pub enum JobQueueProcessorError {
     BlockingJob(#[from] BlockingJobError),
     #[error(transparent)]
     JobProducer(#[from] JobProducerError),
+    #[error("stream create error: {0}")]
+    JsCreateStreamError(#[from] async_nats::jetstream::context::CreateStreamError),
+    #[error("missing required workspace_pk")]
+    MissingWorkspacePk,
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
     #[error(transparent)]

--- a/lib/dal/src/job/producer.rs
+++ b/lib/dal/src/job/producer.rs
@@ -29,6 +29,10 @@ pub enum BlockingJobError {
     JobExecution(String),
     #[error("JobProducer error: {0}")]
     JobProducer(String),
+    #[error("stream create error: {0}")]
+    JsCreateStreamError(String),
+    #[error("missing required workspace_pk")]
+    MissingWorkspacePk,
     #[error("A nats error occurred: {0}")]
     Nats(String),
     #[error("no access builder found in job info")]

--- a/lib/pinga-core/BUCK
+++ b/lib/pinga-core/BUCK
@@ -1,0 +1,11 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "pinga-core",
+    deps = [
+        "//lib/si-data-nats:si-data-nats",
+    ],
+    srcs = glob([
+        "src/**/*.rs",
+    ]),
+)

--- a/lib/pinga-core/Cargo.toml
+++ b/lib/pinga-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "pinga-core"
+edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+si-data-nats = { path = "../../lib/si-data-nats" }

--- a/lib/pinga-core/src/lib.rs
+++ b/lib/pinga-core/src/lib.rs
@@ -1,0 +1,76 @@
+use si_data_nats::{async_nats, jetstream};
+
+const NATS_WORK_QUEUE_STREAM_NAME: &str = "PINGA_JOBS";
+const NATS_WORK_QUEUE_STREAM_SUBJECTS: &[&str] = &["pinga.jobs.>"];
+
+pub const REPLY_INBOX_HEADER_NAME: &str = "X-Reply-Inbox";
+
+pub async fn pinga_work_queue(
+    context: &jetstream::Context,
+    prefix: Option<&str>,
+) -> Result<async_nats::jetstream::stream::Stream, async_nats::jetstream::context::CreateStreamError>
+{
+    let subjects: Vec<_> = NATS_WORK_QUEUE_STREAM_SUBJECTS
+        .iter()
+        .map(|suffix| subject::nats_subject(prefix, suffix).to_string())
+        .collect();
+
+    let stream = context
+        .get_or_create_stream(async_nats::jetstream::stream::Config {
+            name: nats_stream_name(prefix, NATS_WORK_QUEUE_STREAM_NAME),
+            description: Some("Pinga work queue of jobs ".to_owned()),
+            retention: async_nats::jetstream::stream::RetentionPolicy::WorkQueue,
+            discard: async_nats::jetstream::stream::DiscardPolicy::New,
+            allow_direct: true,
+            subjects,
+            ..Default::default()
+        })
+        .await?;
+
+    Ok(stream)
+}
+
+fn nats_stream_name(prefix: Option<&str>, suffix: impl AsRef<str>) -> String {
+    let suffix = suffix.as_ref();
+
+    match prefix {
+        Some(prefix) => format!("{prefix}_{suffix}"),
+        None => suffix.to_owned(),
+    }
+}
+
+pub mod subject {
+    use si_data_nats::Subject;
+
+    const INCOMING_SUBJECT: &str = "pinga.jobs.*.*.*";
+    const SUBJECT_PREFIX: &str = "pinga.jobs";
+
+    #[inline]
+    pub fn incoming(prefix: Option<&str>) -> Subject {
+        nats_subject(prefix, INCOMING_SUBJECT)
+    }
+
+    #[inline]
+    pub fn pinga_job(
+        prefix: Option<&str>,
+        workspace_id: &str,
+        change_set_id: &str,
+        kind: &str,
+    ) -> Subject {
+        nats_subject(
+            prefix,
+            format!(
+                "{SUBJECT_PREFIX}.{}.{}.{}",
+                workspace_id, change_set_id, kind,
+            ),
+        )
+    }
+
+    pub(crate) fn nats_subject(prefix: Option<&str>, suffix: impl AsRef<str>) -> Subject {
+        let suffix = suffix.as_ref();
+        match prefix {
+            Some(prefix) => Subject::from(format!("{prefix}.{suffix}")),
+            None => Subject::from(suffix),
+        }
+    }
+}

--- a/lib/pinga-server/BUCK
+++ b/lib/pinga-server/BUCK
@@ -6,6 +6,8 @@ rust_library(
         "//lib/buck2-resources:buck2-resources",
         "//lib/dal:dal",
         "//lib/nats-subscriber:nats-subscriber",
+        "//lib/naxum:naxum",
+        "//lib/pinga-core:pinga-core",
         "//lib/si-crypto:si-crypto",
         "//lib/si-data-nats:si-data-nats",
         "//lib/si-data-pg:si-data-pg",
@@ -25,6 +27,7 @@ rust_library(
         "//third-party/rust:tokio",
         "//third-party/rust:tokio-stream",
         "//third-party/rust:tokio-util",
+        "//third-party/rust:tower",
         "//third-party/rust:ulid",
     ],
     srcs = glob([

--- a/lib/pinga-server/Cargo.toml
+++ b/lib/pinga-server/Cargo.toml
@@ -14,6 +14,8 @@ dal = { path = "../../lib/dal" }
 derive_builder = { workspace = true }
 futures = { workspace = true }
 nats-subscriber = { path = "../../lib/nats-subscriber" }
+naxum = { path = "../../lib/naxum" }
+pinga-core = { path = "../../lib/pinga-core" }
 remain = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -30,5 +32,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
+tower = { workspace = true }
 ulid = { workspace = true }
 veritech-client = { path = "../../lib/veritech-client" }

--- a/lib/pinga-server/src/app_state.rs
+++ b/lib/pinga-server/src/app_state.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use dal::DalContextBuilder;
+
+use crate::server::ServerMetadata;
+
+/// Application state.
+#[derive(Clone, Debug)]
+pub struct AppState {
+    pub metadata: Arc<ServerMetadata>,
+    pub concurrency_limit: usize,
+    /// DAL context builder for each processing request
+    pub ctx_builder: DalContextBuilder,
+}
+
+impl AppState {
+    /// Creates a new [`AppState`].
+    pub fn new(
+        metadata: Arc<ServerMetadata>,
+        concurrency_limit: usize,
+        ctx_builder: DalContextBuilder,
+    ) -> Self {
+        Self {
+            metadata,
+            concurrency_limit,
+            ctx_builder,
+        }
+    }
+}

--- a/lib/pinga-server/src/config.rs
+++ b/lib/pinga-server/src/config.rs
@@ -16,7 +16,7 @@ use ulid::Ulid;
 
 pub use si_settings::{StandardConfig, StandardConfigFile};
 
-const DEFAULT_CONCURRENCY_LIMIT: usize = 5;
+const DEFAULT_CONCURRENCY_LIMIT: usize = 64;
 
 #[remain::sorted]
 #[derive(Debug, Error)]

--- a/lib/pinga-server/src/handlers.rs
+++ b/lib/pinga-server/src/handlers.rs
@@ -1,0 +1,193 @@
+use std::{result, str::Utf8Error, sync::Arc};
+
+use dal::{
+    job::{
+        consumer::{JobConsumer, JobConsumerError, JobInfo},
+        definition::{compute_validation::ComputeValidation, ActionJob, DependentValuesUpdate},
+        producer::BlockingJobError,
+    },
+    DalContextBuilder,
+};
+use naxum::{
+    extract::{message_parts::Headers, State},
+    response::{IntoResponse, Response},
+    Json,
+};
+use pinga_core::REPLY_INBOX_HEADER_NAME;
+use si_data_nats::Subject;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::{app_state::AppState, server::ServerMetadata};
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum HandlerError {
+    #[error("job consumer error: {0}")]
+    JobConsumer(#[from] JobConsumerError),
+    #[error("unknown job kind {0}")]
+    UnknownJobKind(String),
+    #[error("utf8 error when creating subject")]
+    Utf8(#[from] Utf8Error),
+}
+
+type Result<T> = result::Result<T, HandlerError>;
+
+impl IntoResponse for HandlerError {
+    fn into_response(self) -> Response {
+        error!(si.error.message = ?self, "failed to process message");
+        Response::server_error()
+    }
+}
+
+pub async fn process_request(
+    State(state): State<AppState>,
+    subject: Subject,
+    Headers(maybe_headers): Headers,
+    Json(job_info): Json<JobInfo>,
+) -> Result<()> {
+    let reply_subject = match maybe_headers
+        .and_then(|headers| headers.get(REPLY_INBOX_HEADER_NAME).map(|v| v.to_string()))
+    {
+        Some(header_value) => Some(Subject::from_utf8(header_value)?),
+        None => None,
+    };
+
+    execute_job(
+        state.metadata,
+        state.concurrency_limit,
+        state.ctx_builder,
+        subject,
+        reply_subject,
+        job_info,
+    )
+    .await;
+    Ok(())
+}
+
+#[instrument(
+    name = "execute_job",
+    level = "info",
+    skip_all,
+    fields(
+        // TODO: revive these fields as needed
+        // concurrency.at_capacity = concurrency_limit == concurrency_count,
+        // concurrency.count = concurrency_count,
+        concurrency.limit = concurrency_limit,
+        job.id = job_info.id,
+        job.instance = metadata.instance_id(),
+        job.invoked_args = Empty,
+        job.invoked_name = job_info.kind,
+        job.invoked_provider = metadata.job_invoked_provider(),
+        job.trigger = "pubsub",
+        messaging.destination = Empty,
+        messaging.destination_kind = "topic",
+        messaging.operation = "process",
+        otel.kind = SpanKind::Consumer.as_str(),
+        otel.name = Empty,
+        otel.status_code = Empty,
+        otel.status_message = Empty,
+        si.change_set.id = %job_info.visibility.change_set_id,
+        si.job.blocking = job_info.blocking,
+        si.workspace.id = Empty,
+    )
+)]
+async fn execute_job(
+    metadata: Arc<ServerMetadata>,
+    concurrency_limit: usize,
+    ctx_builder: DalContextBuilder,
+    subject: Subject,
+    maybe_reply_subject: Option<Subject>,
+    job_info: JobInfo,
+) {
+    let span = Span::current();
+    let id = job_info.id.clone();
+
+    let arg_str = serde_json::to_string(&job_info.arg)
+        .unwrap_or_else(|_| "arg failed to serialize".to_string());
+    let workspace_id_str = job_info
+        .access_builder
+        .tenancy()
+        .workspace_pk()
+        .map(|id| id.to_string())
+        .unwrap_or_default();
+    let otel_name = {
+        let mut parts = subject.as_str().split('.');
+        match (
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+        ) {
+            (Some(p1), Some(p2), Some(_workspace_id), Some(_change_set_id), Some(kind)) => {
+                format!("{p1}.{p2}.{{workspace_id}}.{{change_set_id}}.{kind} process")
+            }
+            _ => format!("{} process", subject.as_str()),
+        }
+    };
+
+    span.record("job.invoked_arg", arg_str);
+    span.record("messaging.destination", subject.as_str());
+    span.record("otel.name", otel_name.as_str());
+    span.record("si.workspace.id", workspace_id_str);
+
+    let reply_message = match execute_job_inner(ctx_builder.clone(), job_info).await {
+        Ok(_) => {
+            span.record_ok();
+            Ok(())
+        }
+        Err(err) => {
+            error!(
+                error = ?err,
+                job.invocation_id = %id,
+                job.instance = metadata.instance_id(),
+                "job execution failed"
+            );
+            let new_err = Err(BlockingJobError::JobExecution(err.to_string()));
+            span.record_err(err);
+
+            new_err
+        }
+    };
+
+    // If a reply subject is set then the caller has requested we publish a reply
+    if let Some(reply_subject) = maybe_reply_subject {
+        if let Ok(message) = serde_json::to_vec(&reply_message) {
+            if let Err(err) = ctx_builder
+                .nats_conn()
+                .publish(reply_subject, message.into())
+                .await
+            {
+                error!(error = ?err, "Unable to notify spawning job of blocking job completion");
+            };
+        }
+    }
+}
+
+async fn execute_job_inner(mut ctx_builder: DalContextBuilder, job_info: JobInfo) -> Result<()> {
+    if job_info.blocking {
+        ctx_builder.set_blocking();
+    }
+
+    let job = match job_info.kind.as_str() {
+        stringify!(DependentValuesUpdate) => {
+            Box::new(DependentValuesUpdate::try_from(job_info.clone())?)
+                as Box<dyn JobConsumer + Send + Sync>
+        }
+        stringify!(ActionJob) => {
+            Box::new(ActionJob::try_from(job_info.clone())?) as Box<dyn JobConsumer + Send + Sync>
+        }
+        stringify!(ComputeValidation) => Box::new(ComputeValidation::try_from(job_info.clone())?)
+            as Box<dyn JobConsumer + Send + Sync>,
+        kind => return Err(HandlerError::UnknownJobKind(kind.to_owned())),
+    };
+
+    info!("Processing job");
+
+    job.run_job(ctx_builder.clone()).await?;
+
+    info!("Finished processing job");
+
+    Ok(())
+}

--- a/lib/pinga-server/src/lib.rs
+++ b/lib/pinga-server/src/lib.rs
@@ -1,25 +1,52 @@
+mod app_state;
 mod config;
+mod handlers;
 pub mod server;
+
+use std::io;
+
+use dal::InitializationError;
+use si_data_nats::{async_nats, NatsError};
+use si_data_pg::PgPoolError;
+use thiserror::Error;
 
 pub use crate::{
     config::{
         detect_and_configure_development, Config, ConfigBuilder, ConfigError, ConfigFile,
         StandardConfig, StandardConfigFile,
     },
-    server::{Server, ServerError},
+    server::Server,
 };
 
-const NATS_JOBS_DEFAULT_SUBJECT: &str = "pinga-jobs";
-const NATS_JOBS_DEFAULT_QUEUE: &str = "pinga";
-
-pub fn nats_jobs_subject(prefix: Option<&str>) -> String {
-    nats_subject(prefix, NATS_JOBS_DEFAULT_SUBJECT)
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ServerError {
+    #[error("initialization error: {0}")]
+    Initialization(#[from] InitializationError),
+    #[error("stream consumer error: {0}")]
+    JsConsumer(#[from] async_nats::jetstream::stream::ConsumerError),
+    #[error("consumer stream error: {0}")]
+    JsConsumerStream(#[from] async_nats::jetstream::consumer::StreamError),
+    #[error("stream create error: {0}")]
+    JsCreateStreamError(#[from] async_nats::jetstream::context::CreateStreamError),
+    #[error("layer cache error: {0}")]
+    LayerCache(#[from] si_layer_cache::LayerDbError),
+    #[error("failed to initialize a nats client: {0}")]
+    NatsClient(#[source] NatsError),
+    #[error("naxum error: {0}")]
+    Naxum(#[source] io::Error),
+    #[error("pg pool error: {0}")]
+    PgPool(#[from] Box<PgPoolError>),
+    #[error("symmetric crypto error: {0}")]
+    SymmetricCryptoService(#[from] si_crypto::SymmetricCryptoError),
+    #[error("error when loading cyclone encryption key: {0}")]
+    VeritechEncryptionKey(#[from] si_crypto::VeritechEncryptionKeyError),
 }
 
-fn nats_subject(prefix: Option<&str>, suffix: impl AsRef<str>) -> String {
-    let suffix = suffix.as_ref();
-    match prefix {
-        Some(prefix) => format!("{prefix}.{suffix}"),
-        None => suffix.to_string(),
+impl From<PgPoolError> for ServerError {
+    fn from(e: PgPoolError) -> Self {
+        Self::PgPool(Box::new(e))
     }
 }
+
+type ServerResult<T> = std::result::Result<T, ServerError>;

--- a/lib/pinga-server/src/server.rs
+++ b/lib/pinga-server/src/server.rs
@@ -1,115 +1,72 @@
 use std::{
-    future::IntoFuture,
+    fmt,
+    future::{Future, IntoFuture as _},
     io,
-    sync::atomic::{self, AtomicUsize},
     sync::Arc,
 };
-use telemetry_utils::metric;
 
 use dal::{
-    feature_flags::FeatureFlagService, job::definition::compute_validation::ComputeValidation,
+    feature_flags::FeatureFlagService, DalContext, JobQueueProcessor, NatsProcessor,
+    ServicesContext,
 };
-use dal::{
-    job::{
-        consumer::{JobConsumer, JobConsumerError, JobInfo},
-        definition::{ActionJob, DependentValuesUpdate},
-        producer::BlockingJobError,
+use naxum::{
+    handler::Handler as _,
+    middleware::{
+        ack::AckLayer,
+        trace::{DefaultMakeSpan, DefaultOnRequest, TraceLayer},
     },
-    DalContext, DalContextBuilder, InitializationError, JobFailure, JobFailureError,
-    JobQueueProcessor, NatsProcessor, ServicesContext, TransactionsError,
+    ServiceExt as _,
 };
-use futures::{FutureExt, Stream, StreamExt};
-use nats_subscriber::{Request, SubscriberError};
+use pinga_core::{pinga_work_queue, subject};
 use si_crypto::{
-    SymmetricCryptoError, SymmetricCryptoService, SymmetricCryptoServiceConfig,
-    VeritechCryptoConfig, VeritechEncryptionKey, VeritechEncryptionKeyError,
+    SymmetricCryptoService, SymmetricCryptoServiceConfig, VeritechCryptoConfig,
+    VeritechEncryptionKey,
 };
-use si_data_nats::{NatsClient, NatsConfig, NatsError};
-use si_data_pg::{PgPool, PgPoolConfig, PgPoolError};
-use si_layer_cache::{error::LayerDbError, LayerDb};
-use stream_cancel::StreamExt as StreamCancelStreamExt;
+use si_data_nats::{async_nats, jetstream, NatsClient, NatsConfig};
+use si_data_pg::{PgPool, PgPoolConfig};
+use si_layer_cache::LayerDb;
 use telemetry::prelude::*;
-use thiserror::Error;
-use tokio::{
-    signal::unix,
-    sync::{
-        mpsc::{self, UnboundedReceiver, UnboundedSender},
-        oneshot, watch,
-    },
-    task,
-};
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use telemetry_utils::metric;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tower::ServiceBuilder;
 use veritech_client::Client as VeritechClient;
 
-use crate::{nats_jobs_subject, Config, NATS_JOBS_DEFAULT_QUEUE};
+use crate::{app_state::AppState, handlers, Config, ServerError, ServerResult};
 
-#[remain::sorted]
-#[derive(Debug, Error)]
-pub enum ServerError {
-    #[error("error when loading cyclone encryption key: {0}")]
-    EncryptionKey(#[from] VeritechEncryptionKeyError),
-    #[error(transparent)]
-    Initialization(#[from] InitializationError),
-    #[error(transparent)]
-    JobConsumer(#[from] JobConsumerError),
-    #[error(transparent)]
-    JobFailure(#[from] Box<JobFailureError>),
-    #[error("layer cache error: {0}")]
-    LayerCache(#[from] LayerDbError),
-    #[error(transparent)]
-    Nats(#[from] NatsError),
-    #[error(transparent)]
-    PgPool(#[from] Box<PgPoolError>),
-    #[error(transparent)]
-    SerdeJson(#[from] serde_json::Error),
-    #[error("failed to setup signal handler")]
-    Signal(#[source] io::Error),
-    #[error(transparent)]
-    Subscriber(#[from] SubscriberError),
-    #[error(transparent)]
-    SymmetricCryptoService(#[from] SymmetricCryptoError),
-    #[error(transparent)]
-    Transactions(#[from] Box<TransactionsError>),
-    #[error("unable to connect to database: {0}")]
-    UnableToConnectToDatabase(Box<PgPoolError>),
-    #[error("unknown job kind {0}")]
-    UnknownJobKind(String),
+const CONSUMER_NAME: &str = "pinga-server";
+
+/// Server metadata, used with telemetry.
+#[derive(Clone, Debug)]
+pub struct ServerMetadata {
+    instance_id: String,
+    job_invoked_provider: &'static str,
 }
 
-impl From<PgPoolError> for ServerError {
-    fn from(e: PgPoolError) -> Self {
-        Self::PgPool(Box::new(e))
+impl ServerMetadata {
+    /// Returns the server's unique instance id.
+    pub fn instance_id(&self) -> &str {
+        &self.instance_id
+    }
+
+    /// Returns the job invoked provider.
+    pub fn job_invoked_provider(&self) -> &str {
+        self.job_invoked_provider
     }
 }
-
-impl From<JobFailureError> for ServerError {
-    fn from(e: JobFailureError) -> Self {
-        Self::JobFailure(Box::new(e))
-    }
-}
-
-impl From<TransactionsError> for ServerError {
-    fn from(e: TransactionsError) -> Self {
-        Self::Transactions(Box::new(e))
-    }
-}
-
-type Result<T> = std::result::Result<T, ServerError>;
 
 pub struct Server {
-    concurrency_limit: usize,
-    services_context: ServicesContext,
-    /// An internal shutdown watch receiver handle which can be provided to internal tasks which
-    /// want to be notified when a shutdown event is in progress.
-    shutdown_watch_rx: watch::Receiver<()>,
-    /// An external shutdown sender handle which can be handed out to external callers who wish to
-    /// trigger a server shutdown at will.
-    external_shutdown_tx: mpsc::Sender<ShutdownSource>,
-    /// An internal graceful shutdown receiever handle which the server's main thread uses to stop
-    /// accepting work when a shutdown event is in progress.
-    graceful_shutdown_rx: oneshot::Receiver<()>,
     metadata: Arc<ServerMetadata>,
+    inner: Box<dyn Future<Output = io::Result<()>> + Unpin + Send>,
+    shutdown_token: CancellationToken,
+}
+
+impl fmt::Debug for Server {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Server")
+            .field("metadata", &self.metadata)
+            .field("shutdown_token", &self.shutdown_token)
+            .finish()
+    }
 }
 
 impl Server {
@@ -118,7 +75,7 @@ impl Server {
         config: Config,
         token: CancellationToken,
         tracker: TaskTracker,
-    ) -> Result<Self> {
+    ) -> ServerResult<Self> {
         dal::init()?;
 
         let encryption_key = Self::load_encryption_key(config.crypto().clone()).await?;
@@ -130,7 +87,7 @@ impl Server {
             Self::create_symmetric_crypto_service(config.symmetric_crypto_service()).await?;
 
         let (layer_db, layer_db_graceful_shutdown) =
-            LayerDb::from_config(config.layer_db_config().clone(), token).await?;
+            LayerDb::from_config(config.layer_db_config().clone(), token.clone()).await?;
         tracker.spawn(layer_db_graceful_shutdown.into_future());
 
         let services_context = ServicesContext::new(
@@ -150,101 +107,100 @@ impl Server {
             config.instance_id().to_string(),
             config.concurrency(),
             services_context,
+            token,
         )
+        .await
     }
 
     #[instrument(name = "pinga.init.from_services", level = "info", skip_all)]
-    pub fn from_services(
+    pub async fn from_services(
         instance_id: impl Into<String>,
         concurrency_limit: usize,
         services_context: ServicesContext,
-    ) -> Result<Self> {
-        // An mpsc channel which can be used to externally shut down the server.
-        let (external_shutdown_tx, external_shutdown_rx) = mpsc::channel(4);
-        // A watch channel used to notify internal parts of the server that a shutdown event is in
-        // progress. The value passed along is irrelevant--we only care that the event was
-        // triggered and react accordingly.
-        let (shutdown_watch_tx, shutdown_watch_rx) = watch::channel(());
-
-        dal::init()?;
-
-        let metadata = ServerMetadata {
-            job_instance: instance_id.into(),
+        shutdown_token: CancellationToken,
+    ) -> ServerResult<Self> {
+        let metadata = Arc::new(ServerMetadata {
+            instance_id: instance_id.into(),
             job_invoked_provider: "si",
-        };
+        });
 
-        let graceful_shutdown_rx =
-            prepare_graceful_shutdown(external_shutdown_rx, shutdown_watch_tx)?;
+        // Take the *active* subject prefix from the connected NATS client
+        let prefix = services_context
+            .nats_conn()
+            .metadata()
+            .subject_prefix()
+            .map(|s| s.to_owned());
 
-        metric!(monotonic_counter.pinga.concurrency_limit = concurrency_limit);
-        Ok(Server {
-            concurrency_limit,
-            services_context,
-            shutdown_watch_rx,
-            external_shutdown_tx,
-            graceful_shutdown_rx,
-            metadata: Arc::new(metadata),
+        let context = jetstream::new(services_context.nats_conn().clone());
+
+        let incoming = pinga_work_queue(&context, prefix.as_deref())
+            .await?
+            .create_consumer(Self::incoming_consumer_config(prefix.as_deref()))
+            .await?
+            .messages()
+            .await?;
+
+        let ctx_builder = DalContext::builder(services_context, false);
+
+        let state = AppState::new(metadata.clone(), concurrency_limit, ctx_builder);
+
+        let app = ServiceBuilder::new()
+            .concurrency_limit(concurrency_limit)
+            .layer(
+                TraceLayer::new()
+                    .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+                    .on_request(DefaultOnRequest::new().level(Level::TRACE))
+                    .on_response(
+                        naxum::middleware::trace::DefaultOnResponse::new().level(Level::TRACE),
+                    ),
+            )
+            .layer(AckLayer::new())
+            .service(handlers::process_request.with_state(state));
+
+        let inner = naxum::serve(incoming, app.into_make_service())
+            .with_graceful_shutdown(naxum::wait_on_cancelled(shutdown_token.clone()));
+
+        metric!(monotonic_counter.pinga.concurrency.limit = concurrency_limit);
+        Ok(Self {
+            metadata,
+            inner: Box::new(inner.into_future()),
+            shutdown_token,
         })
     }
 
-    pub async fn run(self) -> Result<()> {
-        // First, check if we can communicate with the database. If we cannot, we need to explode.
-        self.services_context
-            .pg_pool()
-            .test_connection()
-            .await
-            .map_err(|e| ServerError::UnableToConnectToDatabase(Box::new(e)))?;
-
-        let (tx, rx) = mpsc::unbounded_channel();
-
-        // Span a task to receive and process jobs from the unbounded channel
-        drop(task::spawn(process_job_requests_task(
-            rx,
-            self.concurrency_limit,
-        )));
-
-        // Run "the main loop" which pulls message from a subscription off NATS and forwards each
-        // request to an unbounded channel
-        receive_job_requests_task(
-            tx,
-            self.metadata,
-            self.services_context,
-            self.shutdown_watch_rx,
-        )
-        .await;
-
-        let _ = self.graceful_shutdown_rx.await;
-        info!("received and processed graceful shutdown, terminating server instance");
-
-        Ok(())
+    #[inline]
+    pub async fn run(self) {
+        if let Err(err) = self.try_run().await {
+            error!(error = ?err, "error while running pinga main loop");
+        }
     }
 
-    /// Gets a [`ShutdownHandle`](PingaShutdownHandle) that can externally or on demand trigger the server's shutdown
-    /// process.
-    pub fn shutdown_handle(&self) -> PingaShutdownHandle {
-        PingaShutdownHandle {
-            shutdown_tx: self.external_shutdown_tx.clone(),
-        }
+    pub async fn try_run(self) -> ServerResult<()> {
+        self.inner.await.map_err(ServerError::Naxum)?;
+        info!("pinga main loop shutdown complete");
+        Ok(())
     }
 
     #[instrument(name = "pinga.init.load_encryption_key", level = "info", skip_all)]
     async fn load_encryption_key(
         crypto_config: VeritechCryptoConfig,
-    ) -> Result<Arc<VeritechEncryptionKey>> {
+    ) -> ServerResult<Arc<VeritechEncryptionKey>> {
         Ok(Arc::new(
             VeritechEncryptionKey::from_config(crypto_config).await?,
         ))
     }
 
     #[instrument(name = "pinga.init.connect_to_nats", level = "info", skip_all)]
-    async fn connect_to_nats(nats_config: &NatsConfig) -> Result<NatsClient> {
-        let client = NatsClient::new(nats_config).await?;
+    async fn connect_to_nats(nats_config: &NatsConfig) -> ServerResult<NatsClient> {
+        let client = NatsClient::new(nats_config)
+            .await
+            .map_err(ServerError::NatsClient)?;
         debug!("successfully connected nats client");
         Ok(client)
     }
 
     #[instrument(name = "pinga.init.create_pg_pool", level = "info", skip_all)]
-    async fn create_pg_pool(pg_pool_config: &PgPoolConfig) -> Result<PgPool> {
+    async fn create_pg_pool(pg_pool_config: &PgPoolConfig) -> ServerResult<PgPool> {
         let pool = PgPool::new(pg_pool_config).await?;
         debug!("successfully started pg pool (note that not all connections may be healthy)");
         Ok(pool)
@@ -267,342 +223,20 @@ impl Server {
     )]
     async fn create_symmetric_crypto_service(
         config: &SymmetricCryptoServiceConfig,
-    ) -> Result<SymmetricCryptoService> {
+    ) -> ServerResult<SymmetricCryptoService> {
         SymmetricCryptoService::from_config(config)
             .await
             .map_err(Into::into)
     }
-}
 
-#[derive(Clone, Debug)]
-pub struct ServerMetadata {
-    job_instance: String,
-    job_invoked_provider: &'static str,
-}
-
-pub struct PingaShutdownHandle {
-    shutdown_tx: mpsc::Sender<ShutdownSource>,
-}
-
-impl PingaShutdownHandle {
-    pub async fn shutdown(self) {
-        if let Err(err) = self.shutdown_tx.send(ShutdownSource::Handle).await {
-            warn!(error = ?err, "shutdown tx returned error, receiver is likely already closed");
+    #[inline]
+    fn incoming_consumer_config(
+        subject_prefix: Option<&str>,
+    ) -> async_nats::jetstream::consumer::pull::Config {
+        async_nats::jetstream::consumer::pull::Config {
+            durable_name: Some(CONSUMER_NAME.to_owned()),
+            filter_subject: subject::incoming(subject_prefix).to_string(),
+            ..Default::default()
         }
     }
-}
-
-#[remain::sorted]
-#[derive(Debug, Eq, PartialEq)]
-pub enum ShutdownSource {
-    Handle,
-}
-
-impl Default for ShutdownSource {
-    fn default() -> Self {
-        Self::Handle
-    }
-}
-
-pub struct JobItem {
-    metadata: Arc<ServerMetadata>,
-    ctx_builder: DalContextBuilder,
-    request: Result<Request<JobInfo>>,
-}
-
-pub struct Subscriber;
-
-impl Subscriber {
-    pub async fn jobs(
-        metadata: Arc<ServerMetadata>,
-        services_context: ServicesContext,
-    ) -> Result<impl Stream<Item = JobItem>> {
-        let nats = services_context.nats_conn().clone();
-
-        let subject = nats_jobs_subject(nats.metadata().subject_prefix());
-        debug!(
-            messaging.destination.name = subject.as_str(),
-            "subscribing for job requests"
-        );
-
-        // Make non blocking context here, and update it for each job
-        // Since the any blocking job should block on its child jobs
-        let ctx_builder = DalContext::builder(services_context, false);
-
-        Ok(nats_subscriber::Subscriber::create(subject)
-            .queue_name(NATS_JOBS_DEFAULT_QUEUE)
-            .start(&nats)
-            .await?
-            .map(move |request| JobItem {
-                metadata: metadata.clone(),
-                ctx_builder: ctx_builder.clone(),
-                request: request.map_err(Into::into),
-            }))
-    }
-}
-
-async fn receive_job_requests_task(
-    tx: UnboundedSender<JobItem>,
-    metadata: Arc<ServerMetadata>,
-    services_context: ServicesContext,
-    shutdown_watch_rx: watch::Receiver<()>,
-) {
-    if let Err(err) = receive_job_requests(tx, metadata, services_context, shutdown_watch_rx).await
-    {
-        warn!(error = ?err, "processing job requests failed");
-    }
-}
-
-async fn receive_job_requests(
-    tx: UnboundedSender<JobItem>,
-    metadata: Arc<ServerMetadata>,
-    services_context: ServicesContext,
-    mut shutdown_watch_rx: watch::Receiver<()>,
-) -> Result<()> {
-    let mut requests = Subscriber::jobs(metadata, services_context)
-        .await?
-        .take_until_if(Box::pin(shutdown_watch_rx.changed().map(|_| true)));
-
-    // Forward each request off the stream to a consuming task via an *unbounded* channel so we
-    // buffer requests until we run out of memory. Have fun!
-    while let Some(job) = requests.next().await {
-        metric!(counter.pinga.waiting_jobs = 1);
-        if let Err(_job) = tx.send(job) {
-            error!("process_job_requests rx has already closed");
-        }
-    }
-
-    Ok(())
-}
-
-static CONCURRENT_TASKS: AtomicUsize = AtomicUsize::new(0);
-
-#[instrument(level = "info", skip(rx))]
-async fn process_job_requests_task(rx: UnboundedReceiver<JobItem>, concurrency_limit: usize) {
-    UnboundedReceiverStream::new(rx)
-        .for_each_concurrent(concurrency_limit, |job| async move {
-            let concurrency_count = CONCURRENT_TASKS.fetch_add(1, atomic::Ordering::Relaxed) + 1;
-            metric!(counter.pinga.concurrency_count = 1);
-            metric!(counter.pinga.waiting_jobs = -1);
-            let span = Span::current();
-            span.record("concurrency.count", concurrency_count);
-
-            // Got the next message from the subscriber
-            trace!("pulled request into an available concurrent task");
-
-            match job.request {
-                Ok(request) => {
-                    // Spawn a task and process the request
-                    let join_handle = task::spawn(execute_job_task(
-                        job.metadata,
-                        job.ctx_builder,
-                        request,
-                        concurrency_count,
-                        concurrency_limit,
-                    ));
-                    if let Err(err) = join_handle.await {
-                        // NOTE(fnichol): This likely happens when there is contention or
-                        // an error in the Tokio runtime so we will be loud and log an
-                        // error under the assumptions that 1) this event rarely
-                        // happens and 2) the task code did not contribute to trigger
-                        // the `JoinError`.
-                        error!(
-                            error = ?err,
-                            "execute-job-task failed to execute to completion"
-                        );
-                    };
-                }
-                Err(err) => {
-                    warn!(error = ?err, "next job request had an error, job will not be executed");
-                }
-            }
-
-            let concurrency_count = CONCURRENT_TASKS.fetch_sub(1, atomic::Ordering::Relaxed) - 1;
-            metric!(counter.pinga.concurrency_count = -1);
-
-            let span = Span::current();
-            span.record("concurrency.count", concurrency_count);
-        })
-        .await;
-}
-
-#[instrument(
-    name = "execute_job_task",
-    parent = &request.process_span,
-    level = "info",
-    skip_all,
-    fields(
-        job.blocking = request.payload.blocking,
-        job.id = request.payload.id,
-        job.instance = metadata.job_instance,
-        job.invoked_args = Empty,
-        job.invoked_name = request.payload.kind,
-        job.invoked_provider = metadata.job_invoked_provider,
-        job.trigger = "pubsub",
-        job.visibility = ?request.payload.visibility,
-        concurrency.count = concurrency_count,
-        concurrency.limit = concurrency_limit,
-        concurrency.at_capacity = concurrency_limit == concurrency_count,
-        messaging.destination = Empty,
-        messaging.destination_kind = "topic",
-        messaging.operation = "process",
-        otel.kind = SpanKind::Consumer.as_str(),
-        otel.name = Empty,
-        otel.status_code = Empty,
-        otel.status_message = Empty,
-    )
-)]
-async fn execute_job_task(
-    metadata: Arc<ServerMetadata>,
-    ctx_builder: DalContextBuilder,
-    request: Request<JobInfo>,
-    concurrency_count: usize,
-    concurrency_limit: usize,
-) {
-    let span = Span::current();
-    let id = request.payload.id.clone();
-
-    let arg_str = serde_json::to_string(&request.payload.arg)
-        .unwrap_or_else(|_| "arg failed to serialize".to_string());
-
-    let messaging_destination = request.subject;
-
-    span.record("job.invoked_arg", arg_str);
-    span.record("messaging.destination", messaging_destination.as_str());
-    span.record(
-        "otel.name",
-        format!("{} process", &messaging_destination).as_str(),
-    );
-
-    let maybe_reply_channel = request.reply.clone();
-    let reply_message = match execute_job(ctx_builder.clone(), request.payload).await {
-        Ok(_) => {
-            span.record_ok();
-            Ok(())
-        }
-        Err(err) => {
-            error!(
-                error = ?err,
-                job.invocation_id = %id,
-                job.instance = &metadata.job_instance,
-                "job execution failed"
-            );
-            let new_err = Err(BlockingJobError::JobExecution(err.to_string()));
-            span.record_err(err);
-
-            new_err
-        }
-    };
-
-    if let Some(reply_channel) = maybe_reply_channel {
-        if let Ok(message) = serde_json::to_vec(&reply_message) {
-            if let Err(err) = ctx_builder
-                .nats_conn()
-                .publish(reply_channel, message.into())
-                .await
-            {
-                error!(error = ?err, "Unable to notify spawning job of blocking job completion");
-            };
-        }
-    }
-}
-
-async fn execute_job(mut ctx_builder: DalContextBuilder, job_info: JobInfo) -> Result<()> {
-    if job_info.blocking {
-        ctx_builder.set_blocking();
-    }
-
-    let job = match job_info.kind.as_str() {
-        stringify!(DependentValuesUpdate) => {
-            Box::new(DependentValuesUpdate::try_from(job_info.clone())?)
-                as Box<dyn JobConsumer + Send + Sync>
-        }
-        stringify!(ActionJob) => {
-            Box::new(ActionJob::try_from(job_info.clone())?) as Box<dyn JobConsumer + Send + Sync>
-        }
-        stringify!(ComputeValidation) => Box::new(ComputeValidation::try_from(job_info.clone())?)
-            as Box<dyn JobConsumer + Send + Sync>,
-        kind => return Err(ServerError::UnknownJobKind(kind.to_owned())),
-    };
-
-    info!("Processing job");
-
-    if let Err(err) = job.run_job(ctx_builder.clone()).await {
-        // The missing part is this, should we execute subsequent jobs if the one they depend on fail or not?
-        record_job_failure(ctx_builder, job, err).await?;
-    }
-
-    info!("Finished processing job");
-
-    Ok(())
-}
-
-#[allow(dead_code)]
-async fn record_job_failure(
-    ctx_builder: DalContextBuilder,
-    job: Box<dyn JobConsumer + Send + Sync>,
-    err: JobConsumerError,
-) -> Result<()> {
-    warn!(error = ?err, "job execution failed, recording a job failure to the database");
-
-    let access_builder = job.access_builder();
-    let visibility = job.visibility();
-    let ctx = ctx_builder.build(access_builder.build(visibility)).await?;
-
-    JobFailure::new(&ctx, job.type_name(), err.to_string()).await?;
-
-    ctx.commit().await?;
-
-    Err(err.into())
-}
-
-fn prepare_graceful_shutdown(
-    mut external_shutdown_rx: mpsc::Receiver<ShutdownSource>,
-    shutdown_watch_tx: watch::Sender<()>,
-) -> Result<oneshot::Receiver<()>> {
-    // A oneshot channel signaling the start of a graceful shutdown. Receivers can use this to
-    // perform an clean/graceful shutdown work that needs to happen to preserve server integrity.
-    let (graceful_shutdown_tx, graceful_shutdown_rx) = oneshot::channel::<()>();
-    // A stream of `SIGTERM` signals, emitted as the process receives them.
-    let mut sigterm_stream =
-        unix::signal(unix::SignalKind::terminate()).map_err(ServerError::Signal)?;
-
-    tokio::spawn(async move {
-        fn send_graceful_shutdown(
-            graceful_shutdown_tx: oneshot::Sender<()>,
-            shutdown_watch_tx: watch::Sender<()>,
-        ) {
-            // Send shutdown to all long running subscriptions, so they can cleanly terminate
-            if shutdown_watch_tx.send(()).is_err() {
-                error!("all watch shutdown receivers have already been dropped");
-            }
-            // Send graceful shutdown to main server thread which stops it from accepting requests.
-            // We'll do this step last so as to let all subscriptions have a chance to shutdown.
-            if graceful_shutdown_tx.send(()).is_err() {
-                error!("the server graceful shutdown receiver has already dropped");
-            }
-        }
-
-        info!("spawned graceful shutdown handler");
-
-        tokio::select! {
-            _ = sigterm_stream.recv() => {
-                info!("received SIGTERM signal, performing graceful shutdown");
-                send_graceful_shutdown(graceful_shutdown_tx, shutdown_watch_tx);
-            }
-            source = external_shutdown_rx.recv() => {
-                info!(
-                    "received external shutdown, performing graceful shutdown; source={:?}",
-                    source,
-                );
-                send_graceful_shutdown(graceful_shutdown_tx, shutdown_watch_tx);
-            }
-            else => {
-                // All other arms are closed, nothing left to do but return
-                trace!("returning from graceful shutdown with all select arms closed");
-            }
-        };
-    });
-
-    Ok(graceful_shutdown_rx)
 }

--- a/lib/si-test-macros/src/dal_test.rs
+++ b/lib/si-test-macros/src/dal_test.rs
@@ -78,11 +78,6 @@ fn fn_setup<'a>(params: impl Iterator<Item = &'a FnArg>) -> DalTestFnSetup {
                                 let var = var.as_ref();
                                 expander.push_arg(parse_quote! {#var});
                             }
-                            "PingaShutdownHandle" => {
-                                let var = expander.setup_pinga_shutdown_handle();
-                                let var = var.as_ref();
-                                expander.push_arg(parse_quote! {#var});
-                            }
                             "ServicesContext" => {
                                 let var = expander.setup_services_context();
                                 let var = var.as_ref();
@@ -201,7 +196,6 @@ struct DalTestFnSetupExpander {
     cancellation_token: Option<Rc<Ident>>,
     task_tracker: Option<Rc<Ident>>,
     pinga_server: Option<Rc<Ident>>,
-    pinga_shutdown_handle: Option<Rc<Ident>>,
     start_pinga_server: Option<()>,
     rebaser_server: Option<Rc<Ident>>,
     start_rebaser_server: Option<()>,
@@ -228,7 +222,6 @@ impl DalTestFnSetupExpander {
             cancellation_token: None,
             task_tracker: None,
             pinga_server: None,
-            pinga_shutdown_handle: None,
             start_pinga_server: None,
             rebaser_server: None,
             start_rebaser_server: None,
@@ -299,14 +292,6 @@ impl FnSetupExpander for DalTestFnSetupExpander {
 
     fn set_pinga_server(&mut self, value: Option<Rc<Ident>>) {
         self.pinga_server = value;
-    }
-
-    fn pinga_shutdown_handle(&self) -> Option<&Rc<Ident>> {
-        self.pinga_shutdown_handle.as_ref()
-    }
-
-    fn set_pinga_shutdown_handle(&mut self, value: Option<Rc<Ident>>) {
-        self.pinga_shutdown_handle = value;
     }
 
     fn start_pinga_server(&self) -> Option<()> {

--- a/lib/si-test-macros/src/expand.rs
+++ b/lib/si-test-macros/src/expand.rs
@@ -177,9 +177,6 @@ pub(crate) trait FnSetupExpander {
     fn pinga_server(&self) -> Option<&Rc<Ident>>;
     fn set_pinga_server(&mut self, value: Option<Rc<Ident>>);
 
-    fn pinga_shutdown_handle(&self) -> Option<&Rc<Ident>>;
-    fn set_pinga_shutdown_handle(&mut self, value: Option<Rc<Ident>>);
-
     fn start_pinga_server(&self) -> Option<()>;
     fn set_start_pinga_server(&mut self, value: Option<()>);
 
@@ -293,29 +290,15 @@ pub(crate) trait FnSetupExpander {
                         #task_tracker.clone(),
                     )
                     .await;
-                ::dal_test::pinga_server(s_ctx)?
+                ::dal_test::pinga_server(
+                    s_ctx,
+                    #cancellation_token.clone(),
+                ).await?
             };
         });
         self.set_pinga_server(Some(Rc::new(var)));
 
         self.pinga_server().unwrap().clone()
-    }
-
-    fn setup_pinga_shutdown_handle(&mut self) -> Rc<Ident> {
-        if let Some(ident) = self.pinga_shutdown_handle() {
-            return ident.clone();
-        }
-
-        let pinga_server = self.setup_pinga_server();
-        let pinga_server = pinga_server.as_ref();
-
-        let var = Ident::new("pinga_shutdown_handle", Span::call_site());
-        self.code_extend(quote! {
-            let #var = #pinga_server.shutdown_handle();
-        });
-        self.set_pinga_shutdown_handle(Some(Rc::new(var)));
-
-        self.pinga_shutdown_handle().unwrap().clone()
     }
 
     fn setup_start_pinga_server(&mut self) {

--- a/lib/si-test-macros/src/sdf_test.rs
+++ b/lib/si-test-macros/src/sdf_test.rs
@@ -90,11 +90,6 @@ fn fn_setup<'a>(params: impl Iterator<Item = &'a FnArg>) -> SdfTestFnSetup {
                                 let var = var.as_ref();
                                 expander.push_arg(parse_quote! {#var});
                             }
-                            "PingaShutdownHandle" => {
-                                let var = expander.setup_pinga_shutdown_handle();
-                                let var = var.as_ref();
-                                expander.push_arg(parse_quote! {#var});
-                            }
                             "ServicesContext" => {
                                 let var = expander.setup_services_context();
                                 let var = var.as_ref();
@@ -213,7 +208,6 @@ struct SdfTestFnSetupExpander {
     cancellation_token: Option<Rc<Ident>>,
     task_tracker: Option<Rc<Ident>>,
     pinga_server: Option<Rc<Ident>>,
-    pinga_shutdown_handle: Option<Rc<Ident>>,
     start_pinga_server: Option<()>,
     rebaser_server: Option<Rc<Ident>>,
     start_rebaser_server: Option<()>,
@@ -247,7 +241,6 @@ impl SdfTestFnSetupExpander {
             cancellation_token: None,
             task_tracker: None,
             pinga_server: None,
-            pinga_shutdown_handle: None,
             start_pinga_server: None,
             rebaser_server: None,
             start_rebaser_server: None,
@@ -478,14 +471,6 @@ impl FnSetupExpander for SdfTestFnSetupExpander {
 
     fn set_pinga_server(&mut self, value: Option<Rc<Ident>>) {
         self.pinga_server = value;
-    }
-
-    fn pinga_shutdown_handle(&self) -> Option<&Rc<Ident>> {
-        self.pinga_shutdown_handle.as_ref()
-    }
-
-    fn set_pinga_shutdown_handle(&mut self, value: Option<Rc<Ident>>) {
-        self.pinga_shutdown_handle = value;
     }
 
     fn start_pinga_server(&self) -> Option<()> {


### PR DESCRIPTION
This change refactors the Pinga server to consume its work (i.e. job requests) via a NATS Jetstream work queue. Leaving outstanding work on an external queue means that a Pinga instance won't lose pending requests when it's shut down or restarted.

The refactoring uses our `lib/naxum` crate to consume the requests from a Jetstream Stream and otherwise keeps the existing logic largely in place. Importantly:

- Processing a job request will almost unconditionally be successfully consumed. This means that if a job itself fails, it will be considered an "acked" message and a successful job run. This matches the prior behavior and can be changed in the future. The implication is that NATS currently will not help to re-deliver a job that has already been run (even if it failed).
- Jobs that have failed will no longer be tracked via the `JobFailure` DAL object and related database table. It appears as though there is no consumer of this data and it's very likely that the `JobFailure` concept came about before we improved our tracing/logging/telemetry. If this is required again, it can be revived.
- A "blocking" job will still use a core NATS reply subject as a mechanism to reply to the caller of the job. Core NATS seems to be the appropriate medium in this case as there *should* already be a subscriber to that inbox and if the caller goes away, then core NATS will simply drop the reply as no one is listening. A reply subject is added the job request via a NATS message header as the request is published on a NATS Jetstream Stream and there isn't a user-facing API to provide such a reply subject (which is by design).

In addition to using `lib/naxum` in general the following structural changes have been made:

- Remove the old graceful shutdown mechanics and rely on `CancellationToken` and `TaskTracker` types instead (these work better with naxum anyway).
- Both a Pinga server and any producer of job requests (that would be a DAL `Context` that is committing with pending jobs) will attempt to create the `PINGA_JOBS` Jetstream Stream instance, ensuring that the cold boot order of services is not important.

There is still further work to bring Pinga to a behavioral parity with prior version and still more work to address several known issues:

- The span-per-request facility isn't fully threaded through and isn't inherently OpenTelemetry-aware.
- It's unclear if some of the instrumented spans are being dropped or grouped differently without this consistent request span.
- On a graceful shutdown, any jobs in flight will simply be cancelled, whereas we would prefer the in flight jobs be given a window of time to complete before finishing a shutdown.
- Not all concurrency metrics are present. These are better delivered as middleware that can wrap around the inner service, but this hasn't been written up yet (note that this middleware can be used across Pinga, Veritech, and Rebeaser services).

<img src="https://media3.giphy.com/media/l0Ex3TbuoETxNAMfe/giphy.gif"/>