### PR TITLE
chore: bring back root pnpm dev targets for auth api

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "SI monorepo",
   "scripts": {
+    "dev:auth": "pnpm run --filter=\"@si/auth-portal\" --filter=\"@si/auth-api\" dev",
+    "dev:auth-api": "pnpm run --filter=\"@si/auth-api\" dev",
+    "dev:auth-portal": "pnpm run --filter=\"@si/auth-portal\" dev",
     "preinstall": "npx only-allow pnpm",
     "nodev": "node -v",
     "whichnode": "which node"


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/RiPZ7XmQQSKRRgCdrw/giphy.gif"/>

This will go away when buck2 can run the auth API, but for now it's very helpful