### PR TITLE
fix: remove pinga heartbeat

### DIFF
--- a/bin/lang-js/src/index.ts
+++ b/bin/lang-js/src/index.ts
@@ -68,10 +68,6 @@ async function main() {
   // We don't have the executionId yet, so this field will be empty
   let errorFn = makeConsole(executionId).error;
 
-  const interval = setInterval(() => {
-    console.log(JSON.stringify({ protocol: "heartbeat" }));
-  }, 5000);
-
   try {
     const requestJson = fs.readFileSync(STDIN_FD, "utf8");
     debug({ request: requestJson });
@@ -97,8 +93,6 @@ async function main() {
   } catch (err) {
     onError(errorFn, err as Error, executionId);
   }
-
-  clearInterval(interval);
 
   // NOTE(nick): hey friends, Nick here. I won't implicate @jobelenus in this comment because I have a solid chance of
   // going off the rails, but I do need to give him attribution here. Thank you for pairing with me to find this.

--- a/lib/cyclone-server/src/execution.rs
+++ b/lib/cyclone-server/src/execution.rs
@@ -266,7 +266,6 @@ where
             .stdout
             .map(|ls_result| match ls_result {
                 Ok(ls_msg) => match ls_msg {
-                    LangServerMessage::Heartbeat => Ok(Message::Heartbeat),
                     LangServerMessage::Output(mut output) => {
                         Self::filter_output(&mut output, &self.sensitive_strings)?;
                         Ok(Message::OutputStream(output.into()))
@@ -427,7 +426,6 @@ where
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "protocol", rename_all = "camelCase")]
 pub enum LangServerMessage<Success> {
-    Heartbeat,
     Output(LangServerOutput),
     Result(LangServerResult<Success>),
 }

--- a/lib/veritech-server/src/publisher.rs
+++ b/lib/veritech-server/src/publisher.rs
@@ -3,10 +3,7 @@ use si_data_nats::{NatsClient, Subject};
 use si_pool_noodle::{FunctionResult, OutputStream};
 use telemetry_nats::propagation;
 use thiserror::Error;
-use veritech_core::{
-    reply_mailbox_for_keep_alive, reply_mailbox_for_output, reply_mailbox_for_result,
-    FINAL_MESSAGE_HEADER_KEY,
-};
+use veritech_core::{reply_mailbox_for_output, reply_mailbox_for_result, FINAL_MESSAGE_HEADER_KEY};
 
 #[remain::sorted]
 #[derive(Error, Debug)]
@@ -22,7 +19,6 @@ type Result<T> = std::result::Result<T, PublisherError>;
 #[derive(Debug)]
 pub struct Publisher<'a> {
     nats: &'a NatsClient,
-    reply_mailbox_keep_alive: Subject,
     reply_mailbox_output: Subject,
     reply_mailbox_result: Subject,
 }
@@ -33,7 +29,6 @@ impl<'a> Publisher<'a> {
             nats,
             reply_mailbox_output: reply_mailbox_for_output(reply_mailbox).into(),
             reply_mailbox_result: reply_mailbox_for_result(reply_mailbox).into(),
-            reply_mailbox_keep_alive: reply_mailbox_for_keep_alive(reply_mailbox).into(),
         }
     }
 
@@ -74,20 +69,5 @@ impl<'a> Publisher<'a> {
             )
             .await
             .map_err(|err| PublisherError::NatsPublish(err, self.reply_mailbox_result.to_string()))
-    }
-
-    pub async fn publish_keep_alive(&self) -> Result<()> {
-        let nats_msg = serde_json::to_string(&()).map_err(PublisherError::JSONSerialize)?;
-
-        self.nats
-            .publish_with_headers(
-                self.reply_mailbox_keep_alive.clone(),
-                propagation::empty_injected_headers(),
-                nats_msg.into(),
-            )
-            .await
-            .map_err(|err| {
-                PublisherError::NatsPublish(err, self.reply_mailbox_keep_alive.to_string())
-            })
     }
 }

--- a/lib/veritech-server/src/server.rs
+++ b/lib/veritech-server/src/server.rs
@@ -509,10 +509,6 @@ async fn resolver_function_request(
                 }
                 Ok(ProgressMessage::Heartbeat) => {
                     trace!("received heartbeat message");
-                    publisher.publish_keep_alive().await.map_err(|err| {
-                        metric!(counter.function_run.resolver = -1);
-                        span.record_err(err)
-                    })?
                 }
                 Err(err) => {
                     warn!(error = ?err, "next progress message was an error, bailing out");


### PR DESCRIPTION
This removes the timeout we added to the veritech client (used by pinga) in favor of the timeouts we threaded through between cyclone client/server and lang-js. This particular timeout could be naughty because the timer starts immediately, so it's possible the a system under enough load would fail to even start lang-js before the timer times out. We believe that the scenarios this was put in to cover are also covered by the other timeouts we added, so away it goes.

<img src="https://media1.giphy.com/media/NAy2FD8xWrH4jUIBrq/giphy-downsized-medium.gif"/>