### PR TITLE
fix(web): don't recompute the whole diagram if one node is loading

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramGroupOverlay.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroupOverlay.vue
@@ -49,9 +49,11 @@ import * as _ from "lodash-es";
 import { Tween } from "konva/lib/Tween";
 import { CORNER_RADIUS } from "@/components/ModelingDiagram/diagram_constants";
 import { useComponentsStore } from "@/store/components.store";
+import { useStatusStore } from "@/store/status.store";
 import { DiagramGroupData } from "./diagram_types";
 
 const componentsStore = useComponentsStore();
+const statusStore = useStatusStore();
 
 const props = defineProps({
   group: {
@@ -107,16 +109,19 @@ const position = computed(
 // );
 
 const overlay = ref();
-watch([() => props.group.def.isLoading, overlay], ([isLoading]) => {
-  if (_.isNil(overlay)) return;
-  const node = overlay.value.getNode();
+watch(
+  [() => statusStore.componentIsLoading(props.group.def.id), overlay],
+  ([isLoading]) => {
+    if (_.isNil(overlay)) return;
+    const node = overlay.value.getNode();
 
-  const transition = new Tween({
-    node,
-    duration: 0.1,
-    opacity: isLoading ? 1 : 0,
-  });
+    const transition = new Tween({
+      node,
+      duration: 0.1,
+      opacity: isLoading ? 1 : 0,
+    });
 
-  transition.play();
-});
+    transition.play();
+  },
+);
 </script>

--- a/app/web/src/components/ModelingDiagram/DiagramNode.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramNode.vue
@@ -298,6 +298,7 @@ const props = defineProps({
     type: Object as PropType<DiagramEdgeData[]>,
     default: () => ({}),
   },
+  isLoading: Boolean,
   isHovered: Boolean,
   isSelected: Boolean,
 });
@@ -475,13 +476,13 @@ const colors = computed(() => {
 });
 
 const overlay = ref();
-watch([() => props.node.def.isLoading, overlay], () => {
+watch([() => props.isLoading, overlay], () => {
   const node = overlay.value?.getNode();
   if (!node) return;
   const transition = new Tween({
     node,
     duration: 0.1,
-    opacity: props.node.def.isLoading ? 1 : 0,
+    opacity: props.isLoading ? 1 : 0,
   });
   transition.play();
 });

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -98,6 +98,7 @@ overflow hidden */
             :connectedEdges="connectedEdgesByElementKey[node.uniqueKey]"
             :isHovered="elementIsHovered(node)"
             :isSelected="elementIsSelected(node)"
+            :isLoading="statusStore.componentIsLoading(node.def.id)"
             :node="node"
             @resize="onNodeLayoutOrLocationChange(node)"
           />
@@ -264,6 +265,7 @@ import { useChangeSetsStore } from "@/store/change_sets.store";
 import { ComponentId, EdgeId } from "@/api/sdf/dal/component";
 import { useAuthStore } from "@/store/auth.store";
 import { SchemaVariantId, ComponentType } from "@/api/sdf/dal/schema";
+import { useStatusStore } from "@/store/status.store";
 import DiagramGridBackground from "./DiagramGridBackground.vue";
 import {
   DiagramDrawEdgeState,
@@ -343,6 +345,7 @@ const emit = defineEmits<{
 }>();
 
 const componentsStore = useComponentsStore();
+const statusStore = useStatusStore();
 const modelingEventBus = componentsStore.eventBus;
 
 const edgeDisplayMode = ref<EdgeDisplayMode>("EDGES_OVER");

--- a/app/web/src/components/ModelingDiagram/diagram_types.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_types.ts
@@ -205,8 +205,6 @@ export type DiagramNodeDef = {
   isGroup: boolean;
   /** array of icons (slug and colors) to show statuses */
   statusIcons?: DiagramStatusIcon[];
-  /** if true, node shows the `loading` overlay */
-  isLoading: boolean;
   /** the list of childIds related to the node */
   childIds?: DiagramElementId[];
   /** change status of component in relation to head */

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -52,7 +52,6 @@ import {
   useQualificationsStore,
 } from "./qualifications.store";
 import { useWorkspacesStore } from "./workspaces.store";
-import { useStatusStore } from "./status.store";
 
 type RequestUlid = string;
 
@@ -464,7 +463,6 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
 
           diagramNodes(): DiagramNodeDef[] {
             const qualificationsStore = useQualificationsStore();
-            const statusStore = useStatusStore();
 
             // adding logo and qualification info into the nodes
             // TODO: probably want to include logo directly
@@ -498,9 +496,6 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                 title: component.displayName,
                 subtitle: component.schemaName,
                 canBeUpgraded: component.canBeUpgraded,
-                isLoading:
-                  // NOTE: jobelenus — every single status update causes this component and its edges to re-render
-                  statusStore.activeComponents[componentId] !== undefined,
                 typeIcon: component?.icon || "logo-si",
                 statusIcons,
               };

--- a/app/web/src/store/status.store.ts
+++ b/app/web/src/store/status.store.ts
@@ -139,6 +139,9 @@ export const useStatusStore = (forceChangeSetId?: ChangeSetId) => {
             }
             return "Model is up to date";
           },
+          componentIsLoading: (state) => (id: ComponentId) => {
+            return state.activeComponents[id] !== undefined;
+          },
         },
         onActivated() {
           if (!changeSetId) return;


### PR DESCRIPTION
Decouple diagram node calculation from the status store to (vastly) improve frontend performance.