### PR TITLE
feat(sdf,web): report the count of dvu roots to prevent apply

### DIFF
--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -74,6 +74,7 @@ import { usePresenceStore } from "@/store/presence.store";
 // import ActionProgressOverlay from "@/components/ActionProgressOverlay.vue";
 import { useSecretsStore } from "@/store/secrets.store";
 import EraseSelectionModal from "@/components/ModelingView/EraseSelectionModal.vue";
+import { useStatusStore } from "@/store/status.store";
 import ModelingDiagram from "../ModelingDiagram/ModelingDiagram.vue";
 import AssetPalette from "../AssetPalette.vue";
 import { RightClickElementEvent } from "../ModelingDiagram/diagram_types";
@@ -90,6 +91,7 @@ const componentsStore = useComponentsStore();
 const actionsStore = useActionsStore();
 const presenceStore = usePresenceStore();
 const _secretsStore = useSecretsStore(); // adding this so we fetch once
+const statusStore = useStatusStore();
 
 const actionsAreRunning = computed(
   () =>
@@ -125,6 +127,7 @@ const onKeyDown = async (e: KeyboardEvent) => {
 
 onMounted(() => {
   window.addEventListener("keydown", onKeyDown);
+  statusStore.FETCH_DVU_ROOTS();
 });
 
 onBeforeUnmount(() => {

--- a/lib/sdf-server/src/server/service/diagram.rs
+++ b/lib/sdf-server/src/server/service/diagram.rs
@@ -31,6 +31,8 @@ pub mod delete_connection;
 pub mod paste_component;
 pub mod remove_delete_intent;
 
+pub mod dvu_roots;
+
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum DiagramError {
@@ -156,4 +158,5 @@ pub fn routes() -> Router<AppState> {
         )
         .route("/get_diagram", get(get_diagram::get_diagram))
         .route("/list_schemas", get(list_schemas::list_schemas))
+        .route("/dvu_roots", get(dvu_roots::dvu_roots))
 }

--- a/lib/sdf-server/src/server/service/diagram/dvu_roots.rs
+++ b/lib/sdf-server/src/server/service/diagram/dvu_roots.rs
@@ -1,0 +1,34 @@
+use axum::extract::{Json, Query};
+use dal::Visibility;
+use serde::{Deserialize, Serialize};
+
+use super::DiagramResult;
+use crate::server::extract::{AccessBuilder, HandlerContext};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DvuRootsRequest {
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct DvuRootsResponse {
+    count: usize,
+}
+
+pub async fn dvu_roots(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    Query(request): Query<DvuRootsRequest>,
+) -> DiagramResult<Json<DvuRootsResponse>> {
+    let ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let count = ctx
+        .workspace_snapshot()?
+        .list_dependent_value_value_ids()
+        .await?
+        .len();
+
+    Ok(Json(DvuRootsResponse { count }))
+}


### PR DESCRIPTION
While a dependent values update job is running we should prevent applying, even if you come into the changeset after the status messages have all been sent but not "finished".