### PR TITLE
feat: adds real time platform status indicator to UI

### DIFF
--- a/app/web/src/App.vue
+++ b/app/web/src/App.vue
@@ -16,7 +16,6 @@
     </template>
     <template v-else>
       <CachedAppNotification />
-      <RealtimeConnectionStatus />
       <RouterView :key="selectedWorkspace?.pk" />
       <Teleport to="body">
         <canvas
@@ -42,7 +41,6 @@ import { useCustomFontsLoadedProvider } from "./utils/useFontLoaded";
 import { useAuthStore } from "./store/auth.store";
 import { useWorkspacesStore } from "./store/workspaces.store";
 import { useRealtimeStore } from "./store/realtime/realtime.store";
-import RealtimeConnectionStatus from "./components/RealtimeConnectionStatus.vue";
 import CachedAppNotification from "./components/CachedAppNotification.vue";
 
 useCustomFontsLoadedProvider();

--- a/app/web/src/components/RealtimeStatusPageState.vue
+++ b/app/web/src/components/RealtimeStatusPageState.vue
@@ -1,0 +1,62 @@
+<template>
+  <div
+    v-if="status !== 'operational' && status !== 'unknown'"
+    id="status_container"
+  >
+    <div
+      class="realtime-status-page-state"
+      :class="
+        clsx({
+          'bg-destructive-400': status === 'unavailable',
+          'bg-warning-600': status === 'degraded',
+          'bg-action-600': status === 'maintenance',
+          'bg-success-400': status === 'operational',
+        })
+      "
+    ></div>
+    <div class="text-xs realtime-status-page-description">
+      Currently {{ status === "maintenance" ? "in maintenance" : status }}, see
+      <a
+        class="text-action-600"
+        href="https://status.systeminit.com"
+        target="_blank"
+        >Status</a
+      >
+      for more information
+    </div>
+    <div id="clear"></div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import clsx from "clsx";
+import { useRealtimeStore } from "@/store/realtime/realtime.store";
+
+const realtimeStore = useRealtimeStore();
+const status = computed(() => realtimeStore.applicationStatus);
+</script>
+
+<style>
+.realtime-status-page-state {
+  margin-left: 0.5em;
+  margin-right: 0.2em;
+  width: 5px;
+  height: 5px;
+  border-radius: 100%;
+  float: left;
+}
+#status_container {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.realtime-status-page-description {
+  width: 350px;
+  float: left;
+  flex: 1;
+}
+.clear {
+  clear: both;
+}
+</style>

--- a/app/web/src/components/StatusBar/StatusBar.vue
+++ b/app/web/src/components/StatusBar/StatusBar.vue
@@ -9,7 +9,9 @@
   >
     <div class="flex text-sm items-center pl-xs mr-lg w-full">
       System&nbsp;Initiative
+      <RealtimeStatusPageState />
     </div>
+
     <div class="border-l border-shade-100">
       <StatusBarDiffSummary v-if="!changeSetStore.headSelected" />
     </div>
@@ -28,6 +30,7 @@ import * as _ from "lodash-es";
 import clsx from "clsx";
 import { useChangeSetsStore } from "@/store/change_sets.store";
 
+import RealtimeStatusPageState from "@/components/RealtimeStatusPageState.vue";
 import StatusBarDiffSummary from "./StatusBarDiffSummary.vue";
 import StatusBarResourceSummary from "./StatusBarResourceSummary.vue";
 import StatusBarQualificationSummary from "./StatusBarQualificationSummary.vue";

--- a/app/web/src/store/realtime/realtime.store.ts
+++ b/app/web/src/store/realtime/realtime.store.ts
@@ -100,6 +100,72 @@ export const useRealtimeStore = defineStore("realtime", () => {
     }
   });
 
+  // TODO(johnrwatson): Fetching status from a public status page JSON representation
+  // I have a DNS record set up for this but it's giving me grief, I'll come back and amend to
+  // status-data.systeminit.com
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function fetchStatusPage(): Promise<any> {
+    const response = await fetch(
+      "https://nhzefkyp7l.execute-api.us-east-1.amazonaws.com/data/payload.json",
+    );
+    const data = await response.json();
+    return data;
+  }
+
+  // Custom sort function to sort incidents by severity
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function sortIncidentsBySeverity(incidents: any[]): any[] {
+    const severityOrder: { [key: string]: number } = {
+      MAINTENANCE: 4,
+      UNAVAILABLE: 3,
+      DEGRADED: 2,
+      OPERATIONAL: 1,
+    };
+
+    return incidents.sort((a, b) => {
+      const severityA = severityOrder[a.severitySlug?.toUpperCase()] || 5;
+      const severityB = severityOrder[b.severitySlug?.toUpperCase()] || 5;
+      return severityA - severityB;
+    });
+  }
+
+  const applicationStatus = ref<string>("operational");
+
+  // Check whether there is a degraded or outage state against the public statuspage
+  const statusPageState = async () => {
+    applicationStatus.value = "operational";
+
+    try {
+      const statusData = await fetchStatusPage();
+
+      const incidents = sortIncidentsBySeverity(statusData.incidents);
+
+      // Loop through each incident after sorting
+      for (const incident of incidents) {
+        const resolvedTimestamp = incident.timestamps?.resolved;
+
+        if (incident.components) {
+          for (const component of incident.components) {
+            // Check if the incident is unresolved and its severity is relevant
+            if (
+              !resolvedTimestamp &&
+              ["UNAVAILABLE", "DEGRADED", "MAINTENANCE"].includes(
+                component.condition.toUpperCase(),
+              )
+            ) {
+              applicationStatus.value = component.condition.toLowerCase(); // Return the lowercased version of severity and break the loop
+              break;
+            }
+          }
+        }
+      }
+    } catch (error) {
+      reportError(error);
+    }
+  };
+
+  setInterval(statusPageState, 30 * 1000);
+
   // track subscriptions w/ topics, subscribers, etc
   let subCounter = 0;
   // const topicSubscriptionCounter = {} as Record<SubscriptionTopic, number>;
@@ -234,6 +300,7 @@ export const useRealtimeStore = defineStore("realtime", () => {
   });
 
   return {
+    applicationStatus,
     connectionStatus,
     sendMessage,
     // subscriptions, // can expose here to show in devtools


### PR DESCRIPTION
Adds dynamic status indicator to the bottom status bar beside "System Initative"

It queries status.systeminit.com/data/payload.json every 30s and checks for active incidents, if we are:

- Degraded on any component it shows:

![Screenshot 2024-08-23 at 00 56 26](https://github.com/user-attachments/assets/c838d1ef-8357-4a10-84b0-8dc7ff91c1b9)

- Offline on any component it shows:

![Screenshot 2024-08-23 at 00 55 56](https://github.com/user-attachments/assets/2c5631f9-9b08-4d89-8394-4ecb0b7c989e)

- In maintenance on any component it shows:

![Screenshot 2024-08-23 at 00 55 15](https://github.com/user-attachments/assets/8443329a-8c07-4915-9de3-3bfe21d6a0b6)

- if we are operational/no active incidents with affected components or the value cannot be established, the div is hidden/we are assumed to be operational.

### 
**A memo: Death by CORS**
Running the application on one domain and querying another is tricky as client errors will present themselves from CORS if the server does not respond with valid `Access-Control-Allow-Origin` entries for the caller hostname. To get around this I have done two things:
- Asked firehydrant to include our managed platform hostnames in the headers from responses from our statuspage
- [si-shared-prod] While waiting to see if they want to do that, added an API Gateway layer as an HTTP proxy to proxy the traffic through to the public /data/payload.json endpoint on the statuspage and then inject the headers at the API Gateway layer. I very intentionally did not use the existing CNAME entry of status.systeminit.com for all traffic through to the statuspage, just in the case of an API Gateway outage. To that end, I have created a CNAME entry of status-data.systeminit.com which is specifically for this purpose. This means if there is an issue with this part of the stack the only piece of impact is that our customers won't be directly informed through the comms channel this PR implements.


<hr />

I have added a DNS record CNAME from status-data.systeminit.com -> the API gateway serving the HTTP redirect but I'm getting certificate errors. I'll come back and adjust that name in the code to tidy things up properly.