### PR TITLE
feat: stop burning our users with maintenance toasts

### DIFF
--- a/app/web/src/main.ts
+++ b/app/web/src/main.ts
@@ -148,6 +148,19 @@ const filterToasts = (toasts: any[]) => {
   return toasts;
 };
 
+const filterBeforeCreate = (toast: any, toasts: any[]): any | false => {
+  if (toast.content.component.__name === "MaintenanceMode") {
+    // Basically only have one maintenanace toast in the toast queue
+    // at once as they time out serially, which is a bit of a pain with
+    // longer timeouts
+    if (toasts.length >= 1) {
+      return false;
+    } else {
+      return toast;
+    }
+  }
+};
+
 const options: PluginOptions = {
   newestOnTop: true,
   containerClassName: "diagram-toast-container",
@@ -159,6 +172,7 @@ const options: PluginOptions = {
   hideProgressBar: true,
   timeout: 1500,
   filterToasts,
+  filterBeforeCreate,
   // container: asyncGetContainer // right now we cannot make the container a div within nested components that get destroyed on route transitions
   // if we could use that div, we get get TOP_RIGHT position cleanly...
 };

--- a/app/web/src/pages/WorkspaceSinglePage.vue
+++ b/app/web/src/pages/WorkspaceSinglePage.vue
@@ -19,8 +19,8 @@
     >
       <div class="flex-grow p-lg flex flex-col items-center">
         <ErrorMessage
-          >Bad workspace id - please select a workspace from the
-          dropdown</ErrorMessage
+          >Invalid Workspace ID or unable to load Workspace - Please select a
+          workspace from the dropdown to try again</ErrorMessage
         >
       </div>
     </template>

--- a/app/web/src/store/apis.ts
+++ b/app/web/src/store/apis.ts
@@ -98,7 +98,8 @@ async function handleMaintenanceMode(error: AxiosError) {
         component: MaintenanceMode,
       },
       {
-        timeout: 60000,
+        timeout: 15000,
+        hideProgressBar: false,
       },
     );
   }

--- a/app/web/src/store/status.store.ts
+++ b/app/web/src/store/status.store.ts
@@ -166,12 +166,15 @@ export const useStatusStore = (forceChangeSetId?: ChangeSetId) => {
 
           // Just in case we miss a change set written and we still think there
           // are roots, but we don't know about any active components.
-          const dvuRootCheck = setInterval(() => {
+          const dvuRootCheck = setInterval(async () => {
             if (
               this.dvuRootsCount > 0 &&
               Object.keys(this.activeComponents).length < 1
             ) {
-              debouncedFetchDvuRoots();
+              const resp = await debouncedFetchDvuRoots();
+              if (!resp?.result.success) {
+                clearInterval(dvuRootCheck);
+              }
             }
           }, 3500);
 

--- a/lib/sdf-server/src/server/routes.rs
+++ b/lib/sdf-server/src/server/routes.rs
@@ -21,7 +21,7 @@ use super::{
     state::{AppState, ApplicationRuntimeMode},
 };
 
-const MAINTENANCE_MODE_MESSAGE: &str = " SI is currently in maintenance mode. Please try again later. Reach out to support@systeminit.com or in the SI Discord for more information if this problem persists";
+const MAINTENANCE_MODE_MESSAGE: &str = " SI is currently in maintenance mode. Please refresh & try again later. Reach out to support@systeminit.com or in the SI Discord for more information if this problem persists";
 
 async fn app_state_middeware<B>(
     State(state): State<AppState>,


### PR DESCRIPTION
**Who doesn't love a good two-fold problem?**

1. The toast library we are using serially runs the toasts if you run them with a `maxToasts` of 1. If you for example throw two toasts with a 30s timeout, this means that the toast will be shown for 60s, with the second toast being shown from the 30s mark.

2. With the change introduced here yesterday https://github.com/systeminit/si/commit/a8a8ffbcade7e662e3e74fe2b562dd3fbbb310bd
```
          const dvuRootCheck = setInterval(() => {
            if (
              this.dvuRootsCount > 0 &&
              Object.keys(this.activeComponents).length < 1
            ) {
              debouncedFetchDvuRoots();
            }
          }, 3500);
```

We are running a BE API call every 3.5s if the user has active DVU pending within in the changeset. 

If you couple that with our maintenance strategy of making the backend throw 503's when in maintenance, if we have a 5 minute maintenance downtime while the user has active DVU, we will queue up `5 * 60 s of downtime / 3.5s interval * 60s toast time` which works out to 85 minutes of maintenance toasts before they will all timeout.

**To fix this I've done two things:**
* Amend the dvuRootCheck to check if the BE call was successful and if not then basically set the pending checks to 0 so it stops
* Set up a filter on the toast library, specifically saying "if you're a maintenance toast and there is already one enqueued, don't enqueue another"

<hr/>

* chore: Improved some of the language in prompts the user sees when we are experiencing an outage
* chore: added the progress bar back in for maintenance toasts as I felt it improved the user's ability to understand what's going on
* chore: drop the toast time for maintenance to 15s so it'll give the user better feedback as to when the maintenance is actually over

<hr/>
<img src="https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2E3OGZpbGVhNGZzOHVsZ3o3bXF6YWpza3Vqd2g4bDJ5bzZja3BmMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/WtDhaE4JDJDnHmd3Qz/giphy.gif"/>