### PR TITLE
fix(pinga): update CLI help default value for `concurrency`

### DIFF
--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -115,7 +115,7 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) symmetric_crypto_active_key_base64: Option<SensitiveString>,
 
-    /// The number of concurrent jobs that can be processed [default: 10]
+    /// The number of concurrent jobs that can be processed [default: 64]
     #[arg(long)]
     pub(crate) concurrency: Option<u32>,
 


### PR DESCRIPTION
Guess what? It's currently 64!

<img src="https://media3.giphy.com/media/3jf2hrd1XYuEuQd7dN/giphy.gif"/>