### PR TITLE
fix: hotfix to the cypress tests amending asset selection

### DIFF
--- a/app/web/cypress/support/component-actions/create.ts
+++ b/app/web/cypress/support/component-actions/create.ts
@@ -12,7 +12,7 @@ Cypress.Commands.add("createComponent", (componentName: string) => {
   log.snapshot("before");
 
   // Find the component in the AssetPalette
-  cy.get('.asset-palette').find('.text-sm', { timeout: 30000 }).contains(componentName, { matchCase: false }).as('component');
+  cy.get('.asset-palette').find('.text-xs', { timeout: 30000 }).contains(componentName, { matchCase: false }).as('component');
 
   // Find the canvas to get a location to drag to
   cy.get('.modeling-diagram .konvajs-content').first().as('konvaStage');


### PR DESCRIPTION
Hotfix to the cypress tests in prod/tools to fix our coverage.

We changed the size from sm->xs to tighten up the UI, but caused the test regression.

Realistically we need to be selecting by data-ids in here, but this will put it green for now.