### PR TITLE
feat(naxum): add `RequiredReply` extractor

### DIFF
--- a/lib/naxum/src/extract/message_parts.rs
+++ b/lib/naxum/src/extract/message_parts.rs
@@ -10,7 +10,10 @@ use crate::{
     MessageHead,
 };
 
-use super::{rejection::StringRejection, FromMessage, FromMessageHead};
+use super::{
+    rejection::{NoReplyRejection, StringRejection},
+    FromMessage, FromMessageHead,
+};
 
 #[async_trait]
 impl<S, R> FromMessage<S, R> for R
@@ -42,6 +45,17 @@ impl<S> FromMessageHead<S> for Reply {
 
     async fn from_message_head(head: &mut Head, _state: &S) -> Result<Self, Self::Rejection> {
         Ok(Self(head.reply.clone()))
+    }
+}
+
+pub struct RequiredReply(pub Subject);
+
+#[async_trait]
+impl<S> FromMessageHead<S> for RequiredReply {
+    type Rejection = NoReplyRejection;
+
+    async fn from_message_head(head: &mut Head, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(Self(head.reply.clone().ok_or(NoReplyRejection)?))
     }
 }
 

--- a/lib/naxum/src/extract/rejection.rs
+++ b/lib/naxum/src/extract/rejection.rs
@@ -73,6 +73,15 @@ impl error::Error for StringRejection {
 }
 
 define_rejection! {
+    #[status_code = 400]
+    #[body = "Reply was required for message but none was found"]
+    /// Rejection type for [`RequiredReply`].
+    ///
+    /// This rejection is used if a reply was expected on a message but one was not provided.
+    pub struct NoReplyRejection;
+}
+
+define_rejection! {
     #[status_code = 422]
     #[body = "Failed to deserialize the JSON body into the target type"]
     /// Rejection type for [`Json`].


### PR DESCRIPTION
This change adds a new extractor type `RequiredReply` that can be used by handler functions. It will ensure that a reply subject is present in the message and if not a `NoReplyRejection` is returned.

The most likely use case for this extractor is when processing core NATS messages where a reply inbox is expected. Note that there is also a `Reply` extractor already present in naxum, however it returns an `Option<Subject>`.

Example
-------

```rust
pub async fn process_message(
    RequiredReply(reply_subject): RequiredReply,
    Json(request): Json<MyRequest>,
) {
    // ...
}
````

<img src="https://media2.giphy.com/media/UtKQmptld4nXOTBBdQ/giphy.gif"/>