### PR TITLE
fix(web): decouple diagramNodes getter from qualification store

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramGroup.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroup.vue
@@ -291,14 +291,14 @@
 
     <!-- status icons -->
     <v-group
-      v-if="group.def.statusIcons?.length"
+      v-if="statusIcons?.length"
       :config="{
         x: halfWidth - 2,
         y: 0,
       }"
     >
       <DiagramIcon
-        v-for="(statusIcon, i) in _.reverse(_.slice(group.def.statusIcons))"
+        v-for="(statusIcon, i) in _.reverse(_.slice(statusIcons))"
         :key="`status-icon-${i}`"
         :icon="statusIcon.icon"
         :color="
@@ -399,6 +399,10 @@ import {
   SOCKET_MARGIN_TOP,
 } from "@/components/ModelingDiagram/diagram_constants";
 import {
+  QualificationStatus,
+  statusIconsForComponent,
+} from "@/store/qualifications.store";
+import {
   DiagramDrawEdgeState,
   DiagramEdgeData,
   DiagramElementUniqueKey,
@@ -424,6 +428,10 @@ const props = defineProps({
   },
   isHovered: Boolean,
   isSelected: Boolean,
+  qualificationStatus: {
+    type: String as PropType<QualificationStatus>,
+    required: false,
+  },
 });
 
 const diagramContext = useDiagramContext();
@@ -431,9 +439,16 @@ const diagramContext = useDiagramContext();
 const componentId = computed(() => props.group.def.componentId);
 const parentComponentId = computed(() => props.group.def.parentId);
 
+const statusIcons = computed(() =>
+  statusIconsForComponent(
+    props.qualificationStatus,
+    props.group.def.hasResource,
+  ),
+);
+
 const diffIconHover = ref(false);
 const statusIconHovers = ref(
-  new Array(props.group.def.statusIcons?.length || 0).fill(false),
+  new Array(statusIcons?.value.length || 0).fill(false),
 );
 
 const emit = defineEmits<{

--- a/app/web/src/components/ModelingDiagram/DiagramNode.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramNode.vue
@@ -106,7 +106,7 @@
         }"
       >
         <DiagramIcon
-          v-for="(statusIcon, i) in _.reverse(_.slice(node.def.statusIcons))"
+          v-for="(statusIcon, i) in _.reverse(_.slice(statusIcons))"
           :key="`status-icon-${i}`"
           :color="
             statusIcon.color || statusIcon.tone
@@ -268,6 +268,10 @@ import { Tween } from "konva/lib/Tween";
 import { getToneColorHex, useTheme } from "@si/vue-lib/design-system";
 import { useComponentsStore } from "@/store/components.store";
 import {
+  QualificationStatus,
+  statusIconsForComponent,
+} from "@/store/qualifications.store";
+import {
   DiagramEdgeData,
   DiagramElementUniqueKey,
   DiagramNodeData,
@@ -301,6 +305,9 @@ const props = defineProps({
   isLoading: Boolean,
   isHovered: Boolean,
   isSelected: Boolean,
+  qualificationStatus: {
+    type: String as PropType<QualificationStatus>,
+  },
 });
 
 const emit = defineEmits<{
@@ -310,9 +317,16 @@ const emit = defineEmits<{
 const componentsStore = useComponentsStore();
 const componentId = computed(() => props.node.def.componentId);
 
+const statusIcons = computed(() =>
+  statusIconsForComponent(
+    props.qualificationStatus,
+    props.node.def.hasResource,
+  ),
+);
+
 const diffIconHover = ref(false);
 const statusIconHovers = ref(
-  new Array(props.node.def.statusIcons?.length || 0).fill(false),
+  new Array(statusIcons.value.length || 0).fill(false),
 );
 
 const { theme } = useTheme();
@@ -424,7 +438,7 @@ const nodeBodyHeight = computed(() => {
     SOCKET_SIZE / 2 +
     // TODO: this isn't right yet!
     NODE_PADDING_BOTTOM +
-    (props.node.def.statusIcons?.length ? 30 : 0)
+    (statusIcons?.value.length ? 30 : 0)
   );
 });
 const nodeHeight = computed(

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -1,4 +1,4 @@
-Modeling diagram component * NOTE - uses a resize observer to react to size
+/* Modeling diagram component * NOTE - uses a resize observer to react to size
 changes, so this must be placed in a container that is sized explicitly has
 overflow hidden */
 <template>
@@ -79,6 +79,9 @@ overflow hidden */
             :group="group"
             :isHovered="elementIsHovered(group)"
             :isSelected="elementIsSelected(group)"
+            :qualificationStatus="
+              qualificationStore.qualificationStatusForComponentId(group.def.id)
+            "
             @resize="onNodeLayoutOrLocationChange(group)"
           />
           <template v-if="edgeDisplayMode === 'EDGES_UNDER'">
@@ -100,6 +103,9 @@ overflow hidden */
             :isSelected="elementIsSelected(node)"
             :isLoading="statusStore.componentIsLoading(node.def.id)"
             :node="node"
+            :qualificationStatus="
+              qualificationStore.qualificationStatusForComponentId(node.def.id)
+            "
             @resize="onNodeLayoutOrLocationChange(node)"
           />
           <DiagramCursor
@@ -266,6 +272,7 @@ import { ComponentId, EdgeId } from "@/api/sdf/dal/component";
 import { useAuthStore } from "@/store/auth.store";
 import { SchemaVariantId, ComponentType } from "@/api/sdf/dal/schema";
 import { useStatusStore } from "@/store/status.store";
+import { useQualificationsStore } from "@/store/qualifications.store";
 import DiagramGridBackground from "./DiagramGridBackground.vue";
 import {
   DiagramDrawEdgeState,
@@ -327,6 +334,7 @@ const toast = useToast();
 const changeSetsStore = useChangeSetsStore();
 const realtimeStore = useRealtimeStore();
 const authStore = useAuthStore();
+const qualificationStore = useQualificationsStore();
 
 // scroll pan multiplied by this and zoom level when panning
 const ZOOM_PAN_FACTOR = 0.5;

--- a/app/web/src/components/ModelingDiagram/diagram_types.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_types.ts
@@ -203,8 +203,6 @@ export type DiagramNodeDef = {
   componentType: ComponentType;
   /** type of node - define if this is a simple component or a type of frame */
   isGroup: boolean;
-  /** array of icons (slug and colors) to show statuses */
-  statusIcons?: DiagramStatusIcon[];
   /** the list of childIds related to the node */
   childIds?: DiagramElementId[];
   /** change status of component in relation to head */
@@ -215,6 +213,8 @@ export type DiagramNodeDef = {
   fromBaseChangeSet: boolean;
   /** can the component be upgraded */
   canBeUpgraded: boolean;
+  /** whether the component has a resource  */
+  hasResource: boolean;
 };
 
 export type DiagramSocketDef = {

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -47,10 +47,6 @@ import { nonNullable } from "@/utils/typescriptLinter";
 import handleStoreError from "./errors";
 import { useChangeSetsStore } from "./change_sets.store";
 import { useRealtimeStore } from "./realtime/realtime.store";
-import {
-  QualificationStatus,
-  useQualificationsStore,
-} from "./qualifications.store";
 import { useWorkspacesStore } from "./workspaces.store";
 
 type RequestUlid = string;
@@ -86,17 +82,6 @@ export type Categories = {
   displayName: string;
   schemaVariants: SchemaVariant[];
 }[];
-
-const qualificationStatusToIconMap: Record<
-  QualificationStatus | "notexists",
-  DiagramStatusIcon
-> = {
-  success: { icon: "check-hex-outline", tone: "success" },
-  warning: { icon: "check-hex-outline", tone: "warning" },
-  failure: { icon: "x-hex-outline", tone: "error" },
-  running: { icon: "loader", tone: "info" },
-  notexists: { icon: "none" },
-};
 
 export interface AttributeDebugView {
   path: string;
@@ -462,31 +447,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           },
 
           diagramNodes(): DiagramNodeDef[] {
-            const qualificationsStore = useQualificationsStore();
-
-            // adding logo and qualification info into the nodes
-            // TODO: probably want to include logo directly
             return _.map(this.allComponents, (component) => {
-              const componentId = component.id;
-
-              const qualificationStatus =
-                qualificationsStore.qualificationStatusByComponentId[
-                  componentId
-                ];
-
-              // TODO: probably dont need this generic status icon setup anymore...
-              const statusIcons: DiagramStatusIcon[] = _.compact([
-                {
-                  ...qualificationStatusToIconMap[
-                    qualificationStatus ?? "notexists"
-                  ],
-                  tabSlug: "qualifications",
-                },
-                component.hasResource
-                  ? { icon: "check-hex", tone: "success", tabSlug: "resource" }
-                  : { icon: "none" },
-              ]);
-
               return {
                 ...component,
                 // swapping "id" to be node id and passing along component id separately for the diagram
@@ -497,7 +458,6 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                 subtitle: component.schemaName,
                 canBeUpgraded: component.canBeUpgraded,
                 typeIcon: component?.icon || "logo-si",
-                statusIcons,
               };
             });
           },


### PR DESCRIPTION
computing the qualification status and resource status in the diagramNodes getter meant we re-rendered every node on the diagram whenever a single qualification status changed. This was another cause of constant frontend re-rendering during dependent values updates and action apply.