### PR TITLE
feat(dal): graph goes vroom

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -3,4 +3,8 @@ disallowed-methods = [
     { path = "std::env::vars", reason = "should not directly access environment variables within library crates, favor configuration injection, passing parameters, etc." },
     { path = "std::env::var_os", reason = "should not directly access environment variables within library crates, favor configuration injection, passing parameters, etc." },
     { path = "std::env::vars_os", reason = "should not directly access environment variables within library crates, favor configuration injection, passing parameters, etc." },
+    { path = "dal::workspace_snapshot::WorkspaceSnapshot::write_working_copy_to_disk", reason = "The snapshot should only be written to disk when debugging"},
+    { path = "dal::workspace_snapshot::WorkspaceSnapshot::write_readonly_graph_to_disk", reason = "The snapshot should only be written to disk when debugging"},
+    { path = "dal::workspace_snapshot::WorkspaceSnapshot::tiny_dot_to_file", reason = "The snapshot should only be written to disk when debugging"},
+    { path = "dal::workspace_snapshot::graph::RebaseBatch::write_to_disk", reason = "Rebase batches should only be written to disk when debugging"},
 ]

--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -315,9 +315,8 @@ impl Action {
         let mut new_node_weight = node_weight.clone();
         new_node_weight.set_state(state);
         ctx.workspace_snapshot()?
-            .add_node(NodeWeight::Action(new_node_weight))
+            .add_or_replace_node(NodeWeight::Action(new_node_weight))
             .await?;
-        ctx.workspace_snapshot()?.replace_references(idx).await?;
         Ok(())
     }
 
@@ -342,7 +341,9 @@ impl Action {
         let originating_change_set_id = ctx.change_set_id();
         let node_weight =
             NodeWeight::new_action(originating_change_set_id, new_id.into(), lineage_id);
-        ctx.workspace_snapshot()?.add_node(node_weight).await?;
+        ctx.workspace_snapshot()?
+            .add_or_replace_node(node_weight)
+            .await?;
 
         let action_category_id = ctx
             .workspace_snapshot()?

--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -164,7 +164,9 @@ impl ActionPrototype {
         let lineage_id = ctx.workspace_snapshot()?.generate_ulid().await?;
         let node_weight =
             NodeWeight::new_action_prototype(new_id.into(), lineage_id, kind, name, description);
-        ctx.workspace_snapshot()?.add_node(node_weight).await?;
+        ctx.workspace_snapshot()?
+            .add_or_replace_node(node_weight)
+            .await?;
 
         Self::add_edge_to_func(ctx, new_id, func_id, EdgeWeightKind::new_use()).await?;
 

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -159,7 +159,7 @@ impl AttributePrototype {
         let lineage_id = workspace_snapshot.generate_ulid().await?;
         let node_weight =
             NodeWeight::new_content(id, lineage_id, ContentAddress::AttributePrototype(hash));
-        let _node_index = workspace_snapshot.add_node(node_weight).await?;
+        let _node_index = workspace_snapshot.add_or_replace_node(node_weight).await?;
 
         let prototype = AttributePrototype::assemble(id.into(), &content);
 

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -213,7 +213,9 @@ impl AttributePrototypeArgument {
 
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        workspace_snapshot.add_node(node_weight.clone()).await?;
+        workspace_snapshot
+            .add_or_replace_node(node_weight.clone())
+            .await?;
 
         AttributePrototype::add_edge_to_argument(
             ctx,
@@ -268,7 +270,9 @@ impl AttributePrototypeArgument {
         let prototype_arg: Self = {
             let workspace_snapshot = ctx.workspace_snapshot()?;
 
-            workspace_snapshot.add_node(node_weight.clone()).await?;
+            workspace_snapshot
+                .add_or_replace_node(node_weight.clone())
+                .await?;
 
             AttributePrototype::add_edge_to_argument(
                 ctx,

--- a/lib/dal/src/attribute/prototype/argument/static_value.rs
+++ b/lib/dal/src/attribute/prototype/argument/static_value.rs
@@ -61,7 +61,9 @@ impl StaticArgumentValue {
         let node_weight =
             NodeWeight::new_content(id, lineage_id, ContentAddress::StaticArgumentValue(hash));
 
-        ctx.workspace_snapshot()?.add_node(node_weight).await?;
+        ctx.workspace_snapshot()?
+            .add_or_replace_node(node_weight)
+            .await?;
 
         Ok(StaticArgumentValue::assemble(id.into(), content))
     }

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -442,7 +442,7 @@ impl Component {
         let node_weight = NodeWeight::new_component(id, lineage_id, content_address);
 
         // Attach component to category and add use edge to schema variant
-        workspace_snapshot.add_node(node_weight).await?;
+        workspace_snapshot.add_or_replace_node(node_weight).await?;
 
         // Root --> Component Category --> Component (this)
         let component_category_id = workspace_snapshot
@@ -2100,7 +2100,7 @@ impl Component {
         // We only need to import the AttributePrototypeArgument node, as all of the other relevant
         // nodes should already exist.
         ctx.workspace_snapshot()?
-            .add_node(base_attribute_prototype_argument_node_weight.clone())
+            .add_or_replace_node(base_attribute_prototype_argument_node_weight.clone())
             .await?;
         ctx.workspace_snapshot()?
             .add_edge(
@@ -2296,10 +2296,7 @@ impl Component {
             let mut new_component_node_weight = component_node_weight.clone();
             new_component_node_weight.set_to_delete(component.to_delete);
             ctx.workspace_snapshot()?
-                .add_node(NodeWeight::Component(new_component_node_weight))
-                .await?;
-            ctx.workspace_snapshot()?
-                .replace_references(component_idx)
+                .add_or_replace_node(NodeWeight::Component(new_component_node_weight))
                 .await?;
         }
 

--- a/lib/dal/src/module.rs
+++ b/lib/dal/src/module.rs
@@ -166,7 +166,7 @@ impl Module {
         let lineage_id = workspace_snapshot.generate_ulid().await?;
         let node_weight = NodeWeight::new_content(id, lineage_id, ContentAddress::Module(hash));
 
-        workspace_snapshot.add_node(node_weight).await?;
+        workspace_snapshot.add_or_replace_node(node_weight).await?;
 
         let schema_module_index_id = workspace_snapshot
             .get_category_node_or_err(None, CategoryNodeKind::Module)

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -551,7 +551,7 @@ impl Prop {
         if ordered {
             workspace_snapshot.add_ordered_node(node_weight).await?;
         } else {
-            workspace_snapshot.add_node(node_weight).await?;
+            workspace_snapshot.add_or_replace_node(node_weight).await?;
         }
 
         Ok(Self::assemble(prop_node_weight, content))

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -157,7 +157,7 @@ impl Schema {
         let node_weight =
             NodeWeight::new_content(id.into(), lineage_id, ContentAddress::Schema(hash));
 
-        workspace_snapshot.add_node(node_weight).await?;
+        workspace_snapshot.add_or_replace_node(node_weight).await?;
 
         let schema_category_index_id = workspace_snapshot
             .get_category_node_or_err(None, CategoryNodeKind::Schema)

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -493,7 +493,7 @@ impl SchemaVariant {
         let lineage_id = workspace_snapshot.generate_ulid().await?;
         let node_weight =
             NodeWeight::new_content(id, lineage_id, ContentAddress::SchemaVariant(hash));
-        workspace_snapshot.add_node(node_weight).await?;
+        workspace_snapshot.add_or_replace_node(node_weight).await?;
 
         // Schema --Use--> SchemaVariant (this)
         Schema::add_edge_to_variant(ctx, schema_id, id.into(), EdgeWeightKind::new_use()).await?;

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -249,7 +249,7 @@ impl Secret {
         let secret_node_weight = node_weight.get_secret_node_weight()?;
 
         let workspace_snapshot = ctx.workspace_snapshot()?;
-        workspace_snapshot.add_node(node_weight).await?;
+        workspace_snapshot.add_or_replace_node(node_weight).await?;
 
         // Root --> Secret Category --> Secret (this)
         let secret_category_id = workspace_snapshot
@@ -641,16 +641,10 @@ impl Secret {
         // we always update the actor and timestamp data if anything has changed. This could be
         // optimized to do it only once.
         if secret.encrypted_secret_key() != secret_node_weight.encrypted_secret_key() {
-            let original_node_index = workspace_snapshot.get_node_index_by_id(secret.id).await?;
-
             secret_node_weight.set_encrypted_secret_key(secret.encrypted_secret_key);
 
             workspace_snapshot
-                .add_node(NodeWeight::Secret(secret_node_weight.clone()))
-                .await?;
-
-            workspace_snapshot
-                .replace_references(original_node_index)
+                .add_or_replace_node(NodeWeight::Secret(secret_node_weight.clone()))
                 .await?;
         }
         let updated = SecretContentV1::from(secret.clone());

--- a/lib/dal/src/socket/input.rs
+++ b/lib/dal/src/socket/input.rs
@@ -273,7 +273,7 @@ impl InputSocket {
 
         let node_weight =
             NodeWeight::new_content(id, lineage_id, ContentAddress::InputSocket(hash));
-        workspace_snapshot.add_node(node_weight).await?;
+        workspace_snapshot.add_or_replace_node(node_weight).await?;
         SchemaVariant::add_edge_to_input_socket(
             ctx,
             schema_variant_id,

--- a/lib/dal/src/socket/output.rs
+++ b/lib/dal/src/socket/output.rs
@@ -199,7 +199,7 @@ impl OutputSocket {
         let node_weight =
             NodeWeight::new_content(id, lineage_id, ContentAddress::OutputSocket(hash));
 
-        workspace_snapshot.add_node(node_weight).await?;
+        workspace_snapshot.add_or_replace_node(node_weight).await?;
 
         SchemaVariant::add_edge_to_output_socket(
             ctx,

--- a/lib/dal/src/validation.rs
+++ b/lib/dal/src/validation.rs
@@ -161,9 +161,8 @@ impl ValidationOutputNode {
             new_node_weight.new_content_hash(hash)?;
 
             workspace_snapshot
-                .add_node(NodeWeight::Content(new_node_weight))
+                .add_or_replace_node(NodeWeight::Content(new_node_weight))
                 .await?;
-            workspace_snapshot.replace_references(idx).await?;
 
             id
         } else {
@@ -171,7 +170,7 @@ impl ValidationOutputNode {
             let lineage_id = workspace_snapshot.generate_ulid().await?;
             let node_weight =
                 NodeWeight::new_content(id, lineage_id, ContentAddress::ValidationOutput(hash));
-            workspace_snapshot.add_node(node_weight).await?;
+            workspace_snapshot.add_or_replace_node(node_weight).await?;
 
             workspace_snapshot
                 .add_edge(

--- a/lib/dal/src/workspace_snapshot/graph/tests/detect_updates.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/detect_updates.rs
@@ -25,7 +25,7 @@ mod test {
 
         let schema_id = base_graph.generate_ulid().expect("Unable to generate Ulid");
         let schema_index = base_graph
-            .add_node(NodeWeight::new_content(
+            .add_or_replace_node(NodeWeight::new_content(
                 schema_id,
                 Ulid::new(),
                 ContentAddress::Schema(ContentHash::from("Schema A")),
@@ -33,7 +33,7 @@ mod test {
             .expect("Unable to add Schema A");
         let schema_variant_id = base_graph.generate_ulid().expect("Unable to generate Ulid");
         let schema_variant_index = base_graph
-            .add_node(NodeWeight::new_content(
+            .add_or_replace_node(NodeWeight::new_content(
                 schema_variant_id,
                 Ulid::new(),
                 ContentAddress::SchemaVariant(ContentHash::from("Schema Variant A")),
@@ -59,11 +59,14 @@ mod test {
 
         base_graph.dot();
 
+        base_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
         let new_graph = base_graph.clone();
 
         let new_onto_component_id = new_graph.generate_ulid().expect("Unable to generate Ulid");
         let new_onto_component_index = base_graph
-            .add_node(NodeWeight::new_content(
+            .add_or_replace_node(NodeWeight::new_content(
                 new_onto_component_id,
                 Ulid::new(),
                 ContentAddress::Component(ContentHash::from("Component B")),
@@ -90,6 +93,9 @@ mod test {
 
         base_graph.dot();
 
+        base_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
         let updates = new_graph.detect_updates(&base_graph);
 
         let _new_onto_component_index = base_graph
@@ -111,7 +117,7 @@ mod test {
 
         let component_id = base_graph.generate_ulid().expect("Unable to generate Ulid");
         let component_index = base_graph
-            .add_node(NodeWeight::new_content(
+            .add_or_replace_node(NodeWeight::new_content(
                 component_id,
                 Ulid::new(),
                 ContentAddress::Component(ContentHash::from("Component A")),
@@ -125,14 +131,16 @@ mod test {
             )
             .expect("Unable to add root -> component edge");
 
-        base_graph.cleanup();
+        base_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
         base_graph.dot();
 
         let mut new_graph = base_graph.clone();
 
         let new_component_id = new_graph.generate_ulid().expect("Unable to generate Ulid");
         let new_component_index = new_graph
-            .add_node(NodeWeight::new_content(
+            .add_or_replace_node(NodeWeight::new_content(
                 new_component_id,
                 Ulid::new(),
                 ContentAddress::Component(ContentHash::from("Component B")),
@@ -146,7 +154,9 @@ mod test {
             )
             .expect("Unable to add root -> component edge");
 
-        new_graph.cleanup();
+        new_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
         new_graph.dot();
 
         let updates = base_graph.detect_updates(&new_graph);
@@ -194,7 +204,7 @@ mod test {
             .generate_ulid()
             .expect("Unable to generate Ulid");
         let ordered_prop_1_index = active_graph
-            .add_node(NodeWeight::new_content(
+            .add_or_replace_node(NodeWeight::new_content(
                 ordered_prop_1_id,
                 Ulid::new(),
                 ContentAddress::Prop(ContentHash::new(ordered_prop_1_id.to_string().as_bytes())),
@@ -210,7 +220,9 @@ mod test {
             )
             .expect("Unable to add prop -> ordered_prop_1 edge");
 
-        active_graph.cleanup();
+        active_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
 
         // Get new graph
         let mut new_graph = base_graph.clone();
@@ -224,7 +236,7 @@ mod test {
         );
 
         let ordered_prop_2_index = new_graph
-            .add_node(ordered_prop_node_weight.clone())
+            .add_or_replace_node(ordered_prop_node_weight.clone())
             .expect("Unable to add ordered prop");
         new_graph
             .add_ordered_edge(
@@ -248,6 +260,9 @@ mod test {
                 .expect("Node is not an ordered node")
         );
 
+        new_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
         let updates = base_graph.detect_updates(new_graph);
 
         let update_1 = updates.first().expect("update exists").to_owned();
@@ -289,6 +304,9 @@ mod test {
         new_graph_2.remove_node(ordered_prop_2_index);
         new_graph_2.remove_node_id(ordered_prop_2_id);
 
+        new_graph_2
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
         let updates = new_graph.detect_updates(&new_graph_2);
 
         let update_1 = updates.first().expect("update exists").to_owned();
@@ -340,7 +358,9 @@ mod test {
             prop_id
         };
 
-        active_graph.cleanup();
+        active_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
 
         // Create two prop nodes children of base prop
         let ordered_prop_1_index = {
@@ -348,7 +368,7 @@ mod test {
                 .generate_ulid()
                 .expect("Unable to generate Ulid");
             let ordered_prop_index = active_graph
-                .add_node(NodeWeight::new_content(
+                .add_or_replace_node(NodeWeight::new_content(
                     ordered_prop_id,
                     Ulid::new(),
                     ContentAddress::Prop(ContentHash::new(ordered_prop_id.to_string().as_bytes())),
@@ -367,14 +387,16 @@ mod test {
             ordered_prop_index
         };
 
-        active_graph.cleanup();
+        active_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
 
         let attribute_prototype_id = {
             let node_id = active_graph
                 .generate_ulid()
                 .expect("Unable to generate Ulid");
             let node_index = active_graph
-                .add_node(NodeWeight::new_content(
+                .add_or_replace_node(NodeWeight::new_content(
                     node_id,
                     Ulid::new(),
                     ContentAddress::AttributePrototype(ContentHash::new(
@@ -394,7 +416,9 @@ mod test {
             node_id
         };
 
-        active_graph.cleanup();
+        active_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
 
         // Get new graph
         let mut new_graph = base_graph.clone();
@@ -412,7 +436,9 @@ mod test {
                     .expect("Unable to get prop NodeIndex"),
             )
             .expect("Unable to add sv -> prop edge");
-        new_graph.cleanup();
+        new_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
         let base_prop_node_index = new_graph
             .get_node_index_by_id(base_prop_id)
             .expect("Unable to get base prop NodeIndex");
@@ -464,7 +490,7 @@ mod test {
                 ContentHash::new(node.as_bytes()),
             );
             base_graph
-                .add_node(prop_node_weight)
+                .add_or_replace_node(prop_node_weight)
                 .expect("Unable to add prop");
 
             node_id_map.insert(node, node_id);
@@ -499,7 +525,9 @@ mod test {
         }
 
         // Clean up the graph before ensuring that it was constructed properly.
-        base_graph.cleanup();
+        base_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
 
         // Ensure the graph construction worked.
         for (source, target) in edges {
@@ -576,11 +604,16 @@ mod test {
         new_graph.remove_node(c_idx);
         new_graph.remove_node_id(c_id);
 
-        new_graph.cleanup();
+        new_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
 
         // base_graph.tiny_dot_to_file(Some("to_rebase"));
         // new_graph.tiny_dot_to_file(Some("onto"));
 
+        base_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
         let updates = base_graph.detect_updates(&new_graph);
 
         assert_eq!(
@@ -612,7 +645,7 @@ mod test {
         );
 
         to_rebase_graph
-            .add_node(prototype_node)
+            .add_or_replace_node(prototype_node)
             .expect("unable to add node");
         to_rebase_graph
             .add_edge(
@@ -625,7 +658,9 @@ mod test {
             .expect("unable to add edge");
 
         // "write" the graph
-        to_rebase_graph.cleanup();
+        to_rebase_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
 
         // "fork" a working changeset from the current one
         let mut onto_graph = to_rebase_graph.clone();
@@ -640,8 +675,9 @@ mod test {
             )
             .expect("remove_edge");
 
-        onto_graph.cleanup();
-
+        onto_graph
+            .cleanup_and_merkle_tree_hash()
+            .expect("cleanup and merkle");
         let updates = to_rebase_graph.detect_updates(&onto_graph);
 
         assert_eq!(1, updates.len());

--- a/lib/dal/src/workspace_snapshot/graph/tests/exclusive_outgoing_edges.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/exclusive_outgoing_edges.rs
@@ -48,7 +48,7 @@ mod test {
             ContentHash::new(&component_id.inner().to_bytes()),
         );
 
-        let sv_1_idx = graph.add_node(sv_1.clone())?;
+        let sv_1_idx = graph.add_or_replace_node(sv_1.clone())?;
 
         graph.add_edge(
             graph.root(),
@@ -56,7 +56,7 @@ mod test {
             sv_1_idx,
         )?;
 
-        let component_idx = graph.add_node(component.clone())?;
+        let component_idx = graph.add_or_replace_node(component.clone())?;
 
         graph.add_edge(
             graph.root_index,
@@ -181,7 +181,7 @@ mod test {
         let component_2_id = graph.generate_ulid()?;
 
         let action = NodeWeight::new_action(Ulid::new().into(), action_id, action_id);
-        graph.add_node(action.clone())?;
+        graph.add_or_replace_node(action.clone())?;
 
         let prototype_1 = NodeWeight::new_action_prototype(
             prototype_1_id,
@@ -211,7 +211,7 @@ mod test {
             ContentHash::new(&component_2_id.inner().to_bytes()),
         );
 
-        let prototype_1_idx = graph.add_node(prototype_1.clone())?;
+        let prototype_1_idx = graph.add_or_replace_node(prototype_1.clone())?;
 
         graph.add_edge(
             graph.root(),

--- a/lib/dal/src/workspace_snapshot/graph/tests/rebase.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/rebase.rs
@@ -54,7 +54,7 @@ mod test {
         );
 
         let func_node_index = onto
-            .add_node(NodeWeight::Func(func_node_weight))
+            .add_or_replace_node(NodeWeight::Func(func_node_weight))
             .expect("could not add node");
         onto.add_edge(
             func_category_node_index,
@@ -71,7 +71,7 @@ mod test {
         );
 
         let schema_node_index = onto
-            .add_node(NodeWeight::Content(schema_node_weight))
+            .add_or_replace_node(NodeWeight::Content(schema_node_weight))
             .expect("could not add node");
         onto.add_edge(
             schema_category_node_index,
@@ -88,7 +88,7 @@ mod test {
         );
 
         let schema_variant_node_index = onto
-            .add_node(NodeWeight::Content(schema_variant_node_weight))
+            .add_or_replace_node(NodeWeight::Content(schema_variant_node_weight))
             .expect("could not add node");
         onto.add_edge(
             schema_node_index,
@@ -108,12 +108,11 @@ mod test {
         )
         .expect("could not add edge");
 
-        // Before cleanup, detect conflicts and updates.
-        let before_cleanup_updates = to_rebase.detect_updates(&onto);
-
         // Cleanup and check node count.
-        onto.cleanup();
-        to_rebase.cleanup();
+        onto.cleanup_and_merkle_tree_hash().expect("merkle it!");
+        to_rebase
+            .cleanup_and_merkle_tree_hash()
+            .expect("merkle it!");
         assert_eq!(
             6,                 // expected
             onto.node_count()  // actual
@@ -124,10 +123,6 @@ mod test {
         assert_eq!(
             7,             // expected
             updates.len()  // actual
-        );
-        assert_eq!(
-            before_cleanup_updates, // expected
-            updates                 // actual
         );
 
         // Ensure that we do not have duplicate updates.


### PR DESCRIPTION
Profiling of slow rebases with lots of updates revealed that most of the time was being spent in replace_references, both calculating the merkle tree hash and cloning node weights in copy_node_index_by_id. This "copy on write" logic no longer makes sense to me with the operational transforms. And in any case, we are still copy on write (from the read only graph to the working copy). This PR removes the "copy on write" logic which no longer makes sense. Instead we mutate the graph in place, and keep a list of touched nodes. Using that list of touched nodes, we recalculate the merkle tree hash for the graph once, in `cleanup_and_merkle_tree_hash`. The result is a massive speed up in graph operations. Even huge rebases come in under a second, and usually under 300ms. Small rebase operations stay very fast, typically under 50ms.