### PR TITLE
chore: refactor pool_noodle loop to use cancellation token and config

### DIFF
--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -85,7 +85,7 @@ pub(crate) struct Args {
 
     /// Cyclone pool size
     #[arg(long)]
-    pub(crate) cyclone_pool_size: Option<u16>,
+    pub(crate) cyclone_pool_size: Option<u32>,
 
     /// Veritech decryption key file location [example: /run/veritech/veritech.key]
     #[arg(long)]

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -632,6 +632,7 @@ pub async fn veritech_server_for_uds_cyclone(
     let config: veritech_server::Config = {
         let mut config_file = veritech_server::ConfigFile::default_local_uds();
         config_file.nats = nats_config;
+        config_file.cyclone.set_pool_size(50);
         veritech_server::detect_and_configure_development(&mut config_file)
             .wrap_err("failed to detect and configure Veritech ConfigFile")?;
         config_file

--- a/lib/si-firecracker/src/firecracker.rs
+++ b/lib/si-firecracker/src/firecracker.rs
@@ -91,7 +91,7 @@ impl FirecrackerJail {
         Ok(())
     }
 
-    pub async fn setup(pool_size: u16) -> Result<()> {
+    pub async fn setup(pool_size: u32) -> Result<()> {
         Self::create_scripts().await?;
 
         let output = Command::new("sudo")

--- a/lib/si-pool-noodle/src/errors.rs
+++ b/lib/si-pool-noodle/src/errors.rs
@@ -3,23 +3,26 @@ use thiserror::Error;
 /// Error type for [`PoolNoodle`].
 #[remain::sorted]
 #[derive(Debug, Error)]
-pub enum PoolNoodleError {
+pub enum PoolNoodleError<E> {
     /// Failed to get a new instance ID.
     #[error("Failed to get a new instance from the execution pool!")]
     ExecutionPoolStarved,
     /// Failed to clean an instance.
     #[error("Failed to clean the instance: {0}")]
-    InstanceClean(String),
+    InstanceClean(#[source] E),
+    /// No instance found in task.
+    #[error("No instance found in task.")]
+    InstanceNotFound,
     /// Failed to prepare a new instance.
     #[error("Failed to prepare the instance: {0}")]
-    InstancePrepare(String),
+    InstancePrepare(#[source] E),
     /// Failed to spawn a new instance.
     #[error("Failed to spawn the instance: {0}")]
-    InstanceSpawn(String),
+    InstanceSpawn(#[source] E),
     /// Failed to terminate an instance.
     #[error("Failed to terminate the instance: {0}")]
-    InstanceTerminate(String),
+    InstanceTerminate(#[source] E),
     /// Failed to healthcheck instance creation.
     #[error("Failed to check pool health: {0}")]
-    Unhealthy(String),
+    Unhealthy(#[source] E),
 }

--- a/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
+++ b/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
@@ -300,7 +300,7 @@ impl LocalUdsInstance {
 }
 
 /// The [`Spec`] for [`LocalUdsInstance`]
-#[derive(Builder, Clone, Debug)]
+#[derive(Builder, Clone, Debug, Default)]
 pub struct LocalUdsInstanceSpec {
     /// Canonical path to the `cyclone` program.
     #[builder(try_setter, setter(into), default)]
@@ -343,8 +343,8 @@ pub struct LocalUdsInstanceSpec {
     action: bool,
 
     /// Size of the pool to configure for the spec.
-    #[builder(setter(into), default = "10")]
-    pub pool_size: u16,
+    #[builder(setter(into), default = "500")]
+    pub pool_size: u32,
 
     /// Sets the timeout for connecting to firecracker
     #[builder(setter(into), default = "10")]

--- a/lib/si-pool-noodle/src/lifeguard.rs
+++ b/lib/si-pool-noodle/src/lifeguard.rs
@@ -1,0 +1,90 @@
+use crate::pool_noodle::PoolNoodleInner;
+use std::sync::Arc;
+use tracing::info;
+
+use std::fmt::Display;
+
+use crate::Spec;
+
+use crate::Instance;
+
+use telemetry_utils::metric;
+
+use tracing::debug;
+
+/// LifeGuard is a wrapper for instances that come from the pool.
+/// It is carries a Sender and implements Drop. When an instance goes out of
+/// scope, it lets PoolNoodle know that the instance needs to be cleaned up.
+#[derive(Debug)]
+pub struct LifeGuard<I, E, S>
+where
+    I: Instance<Error = E> + Send + Sync + 'static,
+    S: Spec<Error = E, Instance = I> + Clone + Send + Sync + 'static,
+    E: Send + Display + 'static,
+{
+    item: Option<I>,
+    pool: Arc<PoolNoodleInner<I, S>>,
+}
+
+impl<I, E, S> LifeGuard<I, E, S>
+where
+    I: Instance<Error = E> + Send + Sync + 'static,
+    S: Spec<Error = E, Instance = I> + Clone + Send + Sync + 'static,
+    E: Send + Display,
+{
+    pub(crate) fn new(item: Option<I>, pool: Arc<PoolNoodleInner<I, S>>) -> Self {
+        Self { item, pool }
+    }
+}
+
+impl<I, E, S> Drop for LifeGuard<I, E, S>
+where
+    I: Instance<Error = E> + Send + Sync + 'static,
+    S: Spec<Error = E, Instance = I> + Clone + Send + Sync + 'static,
+    E: Send + Display + 'static,
+{
+    fn drop(&mut self)
+    where
+        I: Instance + Send + Sync,
+        S: Spec<Instance = I> + Clone + Send + Sync,
+        E: Send,
+    {
+        let item = self
+            .item
+            .take()
+            .expect("Item must be present as it is initialized with Some and never replaced.");
+        debug!("PoolNoodle: dropping instance: {}", item.id());
+
+        self.pool.push_drop_task_to_work_queue(item);
+        metric!(counter.pool_noodle.active = -1);
+        debug!("PoolNoodle: instance pushed to dropped");
+    }
+}
+
+impl<I, E, S> std::ops::Deref for LifeGuard<I, E, S>
+where
+    I: Instance<Error = E> + Send + Sync,
+    S: Spec<Error = E, Instance = I> + Clone + Send + Sync,
+    E: Send + Display,
+{
+    type Target = I;
+
+    fn deref(&self) -> &I {
+        self.item
+            .as_ref()
+            .expect("Item must be present as it is initialized with Some and never replaced.")
+    }
+}
+
+impl<I, E, S> std::ops::DerefMut for LifeGuard<I, E, S>
+where
+    I: Instance<Error = E> + Send + Sync,
+    S: Spec<Error = E, Instance = I> + Clone + Send + Sync,
+    E: Send + Display,
+{
+    fn deref_mut(&mut self) -> &mut I {
+        self.item
+            .as_mut()
+            .expect("Item must be present as it is initialized with Some and never replaced.")
+    }
+}

--- a/lib/si-pool-noodle/src/task.rs
+++ b/lib/si-pool-noodle/src/task.rs
@@ -1,0 +1,74 @@
+use crate::errors::PoolNoodleError;
+
+use std::fmt::Display;
+use std::result;
+
+use crate::Spec;
+
+use crate::Instance;
+
+type Result<T, E> = result::Result<T, PoolNoodleError<E>>;
+
+#[derive(Clone, Debug)]
+pub(crate) enum PoolNoodleTaskType<I, S> {
+    Clean(PoolNoodleTask<I, S>),
+    Drop(PoolNoodleTask<I, S>),
+    Prepare(PoolNoodleTask<I, S>),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PoolNoodleTask<I, S> {
+    instance: Option<I>,
+    id: u32,
+    spec: S,
+}
+
+impl<I, E, S> PoolNoodleTask<I, S>
+where
+    I: Instance<Error = E> + Send + Sync + 'static,
+    S: Spec<Error = E, Instance = I> + Clone + Send + Sync + 'static,
+    E: Send + Display,
+{
+    pub fn new(instance: Option<I>, id: u32, spec: S) -> Self {
+        Self { instance, id, spec }
+    }
+
+    pub fn set_instance(&mut self, instance: Option<I>) {
+        self.instance = instance;
+    }
+
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    pub async fn clean(&self) -> Result<(), E> {
+        self.spec
+            .clean(self.id)
+            .await
+            .map_err(|err| PoolNoodleError::InstanceClean(err))
+    }
+
+    pub async fn prepare(&self) -> Result<(), E> {
+        self.spec
+            .prepare(self.id)
+            .await
+            .map_err(|err| PoolNoodleError::InstancePrepare(err))
+    }
+
+    pub async fn spawn(&self) -> Result<I, E> {
+        self.spec
+            .spawn(self.id)
+            .await
+            .map_err(|err| PoolNoodleError::InstanceSpawn(err))
+    }
+
+    pub async fn terminate(self) -> Result<(), E> {
+        if let Some(mut instance) = self.instance {
+            return instance
+                .terminate()
+                .await
+                .map_err(|err| PoolNoodleError::InstanceTerminate(err));
+        }
+        Err(PoolNoodleError::InstanceNotFound)
+    }
+}

--- a/lib/veritech-server/src/config.rs
+++ b/lib/veritech-server/src/config.rs
@@ -283,7 +283,7 @@ pub enum CycloneConfig {
         #[serde(default = "default_enable_endpoint")]
         action: bool,
         #[serde(default)]
-        pool_size: u16,
+        pool_size: u32,
         #[serde(default)]
         connect_timeout: u64,
     },
@@ -394,6 +394,12 @@ impl CycloneConfig {
         match self {
             CycloneConfig::LocalUds { action, .. } => *action = value,
             CycloneConfig::LocalHttp { action, .. } => *action = value,
+        };
+    }
+
+    pub fn set_pool_size(&mut self, value: u32) {
+        if let CycloneConfig::LocalUds { pool_size, .. } = self {
+            *pool_size = value
         };
     }
 }
@@ -527,8 +533,8 @@ fn default_runtime_strategy() -> LocalUdsRuntimeStrategy {
     LocalUdsRuntimeStrategy::default()
 }
 
-fn default_pool_size() -> u16 {
-    5
+fn default_pool_size() -> u32 {
+    500
 }
 
 fn default_connect_timeout() -> u64 {

--- a/lib/veritech-server/src/handlers.rs
+++ b/lib/veritech-server/src/handlers.rs
@@ -158,7 +158,7 @@ async fn action_run_request_task(
 
 #[instrument(name = "veritech.action_run_request", level = "info", skip_all)]
 async fn action_run_request(
-    mut state: AppState,
+    state: AppState,
     mut payload_request: ActionRunRequest,
     reply_mailbox: Subject,
 ) -> HandlerResult<()> {
@@ -315,7 +315,7 @@ async fn resolver_function_request_task(
 
 #[instrument(name = "veritech.resolver_function_request", level = "info", skip_all)]
 async fn resolver_function_request(
-    mut state: AppState,
+    state: AppState,
     publisher: &Publisher<'_>,
     mut request: ResolverFunctionRequest,
 ) -> HandlerResult<FunctionResult<ResolverFunctionResultSuccess>> {
@@ -424,7 +424,7 @@ async fn schema_variant_definition_request_task(
     skip_all
 )]
 async fn schema_variant_definition_request(
-    mut state: AppState,
+    state: AppState,
     mut payload_request: SchemaVariantDefinitionRequest,
     reply_mailbox: Subject,
 ) -> HandlerResult<()> {
@@ -544,7 +544,7 @@ async fn validation_request_task(
 
 #[instrument(name = "veritech.validation_request", level = "info", skip_all)]
 async fn validation_request(
-    mut state: AppState,
+    state: AppState,
     mut payload_request: ValidationRequest,
     reply_mailbox: Subject,
 ) -> HandlerResult<()> {


### PR DESCRIPTION
Post the Veritech Jetstream changes, this refactors PoolNoodle to run over a single loop that works based on tasks in a queue. The veritech cancellation token is threaded through to we shutdown and clean up when veritech is shut down. We now only spin up as many tasks as there is max_concurrency to help manage back pressure (it's currently set to an arbitrarily high number).

This also does some quality of life changes, a config struct, better defaults, and more metrics to track things like the number of jobs waiting for instances when we're under enough pressure.

Here's an undersized pool fighting for its life.
![image](https://github.com/user-attachments/assets/34985006-8c87-427c-a7bb-c0c644cf0e4a)
