### PR TITLE
[WIP]feat: run a one-shot SDF to perform migrations on deploy

### DIFF
--- a/.github/workflows/deploy-on-main.yml
+++ b/.github/workflows/deploy-on-main.yml
@@ -1,29 +1,14 @@
 on:
   push:
-    tags:
-      # These fairly explicitly directly matches the tags we push [examples]
-      - 'bin/sdf/image/*'      # bin/sdf/image/20240820.143323.0-sha.982dd5a81
-      - 'bin/rebaser/image/*'  # bin/rebaser/image/20240820.143323.0-sha.982dd5a81
-      - 'bin/pinga/image/*'    # bin/pinga/image/20240820.143323.0-sha.982dd5a81
-      - 'bin/veritech/image/*' # bin/veritech/image/20240820.031721.0-sha.efea02a6a
-      - 'app/web/image/*'      # app/web/image/20240820.000535.0-sha.13e826961
+    branches:
+      - main
 
 jobs:
-  parse-tag:
-    runs-on: ubuntu-latest
-    outputs:
-      service: ${{ steps.service.outputs.service }}
-    steps:
-      - id: service
-        run: |
-            echo "service=$(echo "${{ github.ref_name }}" | awk -F'/' '{print $2}')" >> "$GITHUB_OUTPUT"
-
   deploy-tools-prod:
-    needs: parse-tag
     uses: ./.github/workflows/deploy-stack.yml
     with:
       environment: tools
-      service: ${{ needs.parse-tag.outputs.service }}
+      service: all
       version: stable
       deploy-type: binary
     secrets: inherit

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -152,14 +152,22 @@ jobs:
         if: ${{ inputs.service != 'web' && inputs.deploy-type == 'binary' }}
         uses: actions/checkout@v4
 
-      - name: Deploy service
-        if: ${{ inputs.service != 'web' && inputs.deploy-type == 'binary' }}
+      - name: Deploy SDF
+        if: ${{ inputs.service == 'sdf' && inputs.deploy-type == 'binary' }}
         run: |
           # Push all the SDF replicas into maintenance mode if they're not already in it
           component/toolbox/awsi.sh toggle-maintenance -p pull-from-env -r us-east-1 -s sdf -m y -a y
           # Wait an arbitrary amount of time to allow the back end to settle down with work
           sleep 30
+          # Run the migration script on one of the sdf nodes
+          component/toolbox/awsi.sh migrate -p pull-from-env -r us-east-1 -a y
           # Upgrade all the associated services
           component/toolbox/awsi.sh upgrade -p pull-from-env -r us-east-1 -a y -s ${{ inputs.service }}
           # Enable SDF again if it is disabled
           component/toolbox/awsi.sh toggle-maintenance -p pull-from-env -r us-east-1 -s sdf -m n -a y
+
+      - name: Deploy services
+        if: ${{ inputs.service != 'web' && inputs.service != 'sdf' && inputs.deploy-type == 'binary' }}
+        run: |
+          # Upgrade all the associated services
+          component/toolbox/awsi.sh upgrade -p pull-from-env -r us-east-1 -a y -s ${{ inputs.service }}

--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -67,17 +67,34 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       services: ${{ steps.services.outputs.services }}
+      run-sdf: ${{ steps.services.outputs.run-sdf }}
     steps:
       - id: services
         run: |
           if [ "${{ inputs.service }}" = "all" ]; then
-            echo 'services=["pinga", "rebaser", "sdf", "veritech", "web"]' >> "$GITHUB_OUTPUT"
+            echo 'services=["pinga", "rebaser", "veritech", "web"]' >> "$GITHUB_OUTPUT"
           else
             echo 'services=["${{ inputs.service }}"]' >> "$GITHUB_OUTPUT"
           fi
 
+          if [ "${{ inputs.service }}" = "all" || "${{ inputs.service }}" = "sdf" ]; then
+            echo 'run-sdf=true' >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy-sdf:
+    needs: define-deployment-matrix
+    if: ${{ needs.define-deployment-matrix.outputs.run-sdf == 'true' }}
+    uses: ./.github/workflows/deploy-service.yml
+    with:
+      environment: ${{ inputs.environment }}
+      service: sdf
+      version: ${{ inputs.version }}
+      deploy-type: ${{ inputs.deploy-type }}
+    secrets: inherit
+
   deploy-services:
-    needs: "define-deployment-matrix"
+    needs: [ "define-deployment-matrix", "deploy-sdf" ]
+    if: ${{ needs.define-deployment-matrix.outputs.run-sdf == 'true' || always() }}
     strategy:
      fail-fast: false
      matrix:

--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -1,3 +1,4 @@
+migration_mode = "skip"
 pkgs_path = "/tmp"
 create_workspace_permissions = "$SI_WORKSPACE_PERMISSIONS"
 create_workspace_allowlist = [ "$SI_WORKSPACE_ALLOW_LIST" ]

--- a/component/toolbox/scripts/migrate
+++ b/component/toolbox/scripts/migrate
@@ -1,0 +1,118 @@
+#!/bin/bash
+# ---------------------------------------------------------------------------------------------------
+# Find an SDF node and run a one-shot instance to perform migrations.
+# ---------------------------------------------------------------------------------------------------
+
+set -eo pipefail
+
+# Find & Import all the supporting functions from the supporting folder
+# Get the directory of the current script to figure out where the
+# Supporting funcs are
+IMPORT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+for script in ${IMPORT_DIR}/supporting-funcs/*.sh; do
+    if [[ -f "$script" ]]; then
+        source "$script"
+    fi
+done
+
+# Usage for this script
+usage() {
+    echo
+    echo "migrate"
+    echo "----------------------------------"
+    echo "This script will open an SSM session to the first SDF"
+    echo "instance it finds to run SDF with migration mode set to"
+    echo "RunAndQuit."
+    echo "----------------------------------"
+    echo "Usage: migrate [-p profile] [-r region] [-a automatic]"
+    echo "  -p profile        [pull-from-env/<profile-name>] AWS profile to use"
+    echo "  -r region         AWS region to use"
+    echo "  -a automatic      [Y/N] Run through automatically/no-interact"
+    echo "----------------------------------"
+    echo "e.g. ./awsi.sh migrate -p pull-from-env -r us-east-1 -a y"
+    exit 1
+}
+
+# Add a check to see if the script is being sourced or executed
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    usage
+fi
+
+# Parse flags
+while getopts ":p:r:a:s:m:" opt; do
+    case ${opt} in
+        p)
+            profile=$OPTARG
+            ;;
+        r)
+            region=$OPTARG
+            ;;
+        a)
+            automatic=$OPTARG
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            usage
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------------------------------
+# Main script
+# ---------------------------------------------------------------------------------------------------
+echo "$0 being invoked"
+
+# Use the profile if in the invocation
+if [[ "$profile" != "pull-from-env" ]]; then
+  profile=$(get_param_or_env "$profile" "AWS_PROFILE" "Enter the AWS profile to use")
+  export AWS_PROFILE="$profile"
+fi
+region=$(get_param_or_env "$region" "AWS_REGION" "Enter the AWS region (e.g., us-west-2)")
+export AWS_REGION="$region"
+
+instances=$(list_instances "sdf" )
+if [ -z "$instances" ]; then
+    echo "No running instances found."
+    exit 1
+fi
+
+echo "----------------------------------------"
+echo "Running instances of sdf in the region $region:"
+printf "%-5s %-20s %-20s %-20s %-20s\n" "Index" "Name" "InstanceId" "InstanceType" "PrivateIpAddress"
+i=1
+while read -r line; do
+    name=$(echo "$line" | awk '{print $1}')
+    instance_id=$(echo "$line" | awk '{print $2}')
+    instance_type=$(echo "$line" | awk '{print $3}')
+    private_ip=$(echo "$line" | awk '{print $4}')
+    printf "%-5s %-20s %-20s %-20s %-20s\n" "$i" "$name" "$instance_id" "$instance_type" "$private_ip"
+    ((i++))
+done <<< "$instances"
+echo "----------------------------------------"
+
+[[ "${automatic,,}" == "y" ]] || read -p "Would you like to run migrations on one of these hosts? (Y/N) [takes ~60 seconds] " selection
+[[ "${automatic,,}" == "y" ]] || sassy_selection_check $selection
+
+# Setup somewhere unique to push the results of the check into if they chose to continue
+# Reset this results_directory variable between each execution run.
+results_directory="./results/$(date +"%Y-%m-%d_%H-%M-%S")"
+check_results_file=check_results.json
+start_results_file=start_results.json
+stop_results_file=stop_results.json
+upgrade_results_file=upgrade_results.json
+mkdir -p "$results_directory/"
+
+# get the first SDF and go do the thing
+while read -r line; do
+    instance_id=$(echo "$line" | awk '{print $2}')
+    start_and_track_ssm_session "$instance_id" "$sdf_migrate_script" "sdf" "migrate" "$results_directory" &
+    break
+done <<< "$instances"
+
+await_file_results "$results_directory" 2
+concat_and_output_json "$results_directory" "$check_results_file"

--- a/component/toolbox/scripts/ssm-scripts/si-check-node-upgrade
+++ b/component/toolbox/scripts/ssm-scripts/si-check-node-upgrade
@@ -1,0 +1,36 @@
+---
+schemaVersion: "2.2"
+description: "Run an upgrade check/status check on an EC2 Node"
+parameters:
+  Service:
+    type: "String"
+    description: "Service to Run on Node"
+    default: "N/A"
+  InstanceId:
+    type: "String"
+    description: "InstanceId of the executing node"
+    default: "N/A"
+  Action:
+    type: "String"
+    description: "Action to execute [not yet used]"
+    default: "N/A"
+
+mainSteps:
+- action: "aws:runShellScript"
+  name: "example"
+  inputs:
+    runCommand:
+    - |
+        # JW: This assessment blindly assumes that there are no additional configuration changes to the binaries or runtimes and that they are a direct application code replacement
+        # this is a little naive but we can check the deployment specs/ymls if we wish to conduct this check too.
+
+        STABLE_VERSION=$(curl -Ls https://artifacts.systeminit.com/{{ Service }}/stable/omnibus/linux/$(arch)/{{ Service }}-stable-omnibus-linux-$(arch).tar.gz.metadata.json | jq -r '.version')
+        RUNNING_VERSION=$(sudo find / -wholename '/etc/nix-omnibus/{{ Service }}/**/metadata.json' | tail -n 1 | xargs cat | jq -r '.version')
+
+        # Check if both versions are set to non-empty values
+        if [ -z "$STABLE_VERSION" ] || [ -z "$RUNNING_VERSION" ]; then
+          echo "{\"instance_id\": \"{{ InstanceId }}\", \"status\": \"error\", \"message\": \"Failed to retrieve versions\"}"
+        else
+          [[ "$STABLE_VERSION" != "$RUNNING_VERSION" ]] && UPGRADEABLE="true" || UPGRADEABLE="false"
+          echo "{\"instance_id\": \"{{ InstanceId }}\", \"status\": \"success\", \"service\": \"{{ Service }}\", \"running\": \"$RUNNING_VERSION\", \"stable\": \"$STABLE_VERSION\", \"upgradeable\": \"$UPGRADEABLE\" }"
+        fi

--- a/component/toolbox/scripts/ssm-scripts/si-migrate-sdf
+++ b/component/toolbox/scripts/ssm-scripts/si-migrate-sdf
@@ -1,0 +1,27 @@
+---
+schemaVersion: "2.2"
+description: "Run a oneshot SDF with MigrationMode=RunAndQuit"
+parameters:
+  Service:
+    type: "String"
+    description: "Service to Run on Node"
+    default: "N/A"
+  InstanceId:
+    type: "String"
+    description: "InstanceId of the executing node"
+    default: "N/A"
+  Action:
+    type: "String"
+    description: "Action to execute [not yet used]"
+    default: "N/A"
+
+mainSteps:
+- action: "aws:runShellScript"
+  name: "example"
+  inputs:
+    runCommand:
+    - |
+        sdf --migration-mode runAndQuit | systemd-cat \
+        && echo "{\"instance_id\": \"{{ InstanceId }}\", \"status\": \"success\", \"service\": \"sdf\"}" \
+        || echo "{\"instance_id\": \"{{ InstanceId }}\", \"status\": \"error\", \"message\": \"SDF Migration has failed!\"}"
+

--- a/component/toolbox/scripts/ssm-scripts/si-service-maintenance
+++ b/component/toolbox/scripts/ssm-scripts/si-service-maintenance
@@ -1,0 +1,45 @@
+---
+schemaVersion: "2.2"
+description: "Move a running binary into or out of maintenance mode"
+parameters:
+  Service:
+    type: "String"
+    description: "Service to Run on Node"
+    default: "N/A"
+  InstanceId:
+    type: "String"
+    description: "InstanceId of the executing Node"
+    default: "N/A"
+  Action:
+    type: "String"
+    description: "Set Maintenance Mode from y or n"
+    default: "N/A"
+mainSteps:
+- action: "aws:runShellScript"
+  name: "example"
+  inputs:
+    runCommand:
+    - |
+        flip_or_stick() {
+          requested_state=$1
+          response_code=$(curl -s -o /dev/null -w "%{http_code}" localhost:5156/api/)
+          [[ "$response_code" == "200" ]] && [[ "$requested_state" == "y" ]] && killall -s USR2 {{ Service }}
+          [[ "$response_code" == "503" ]] && [[ "$requested_state" == "n" ]] && killall -s USR2 {{ Service }}
+        }
+
+        check_state() {
+          requested_state=$1
+          response_code=$(curl -s -o /dev/null -w "%{http_code}" localhost:5156/api/)
+          if [[ "$response_code" == "503" ]] && [[ "$requested_state" == "y" ]]; then
+            echo "{\"instance_id\": \"{{ InstanceId }}\", \"status\": \"success\", \"service\": \"{{ Service }}\", \"mode\": \"maintenance\" }"
+          elif [[ "$response_code" == "200" ]] && [[ "$requested_state" == "n" ]]; then
+            echo "{\"instance_id\": \"{{ InstanceId }}\", \"status\": \"success\", \"service\": \"{{ Service }}\", \"mode\": \"running\" }"
+          else
+            echo "{\"instance_id\": \"{{ InstanceId }}\", \"status\": \"failure\", \"service\": \"{{ Service }}\", \"mode\": \"Status code from API not valid for requested action. Response Code: $response_code, Maintenance Mode Requested: {{ Action }}\" }"
+          fi
+
+        }
+
+        flip_or_stick {{ Action }}
+        check_state {{ Action }}
+

--- a/component/toolbox/scripts/ssm-scripts/si-service-state
+++ b/component/toolbox/scripts/ssm-scripts/si-service-state
@@ -1,0 +1,36 @@
+---
+schemaVersion: "2.2"
+description: "Run an binary service action, either stop, start or upgrade"
+parameters:
+  Service:
+    type: "String"
+    description: "Service to Run on Node"
+    default: "N/A"
+  InstanceId:
+    type: "String"
+    description: "InstanceId of the executing Node"
+    default: "N/A"
+  Action:
+    type: "String"
+    description: "Action to execute on the Node"
+    default: "N/A"
+mainSteps:
+- action: "aws:runShellScript"
+  name: "example"
+  inputs:
+    runCommand:
+    - |
+        case {{ Action }} in
+            "upgrade")
+                service {{ Service }} stop
+                wget https://artifacts.systeminit.com/{{ Service }}/stable/omnibus/linux/$(arch)/{{ Service }}-stable-omnibus-linux-$(arch).tar.gz -O - | tar -xzf - -C /
+                service {{ Service }} start
+                STABLE_VERSION=$(curl -Ls https://artifacts.systeminit.com/{{ Service }}/stable/omnibus/linux/$(arch)/{{ Service }}-stable-omnibus-linux-$(arch).tar.gz.metadata.json | jq -r '.version')
+                RUNNING_VERSION=$(sudo find / -wholename '/etc/nix-omnibus/{{ Service }}/**/metadata.json' | tail -n 1 | xargs cat | jq -r '.version')
+                echo "{\"instance_id\": \"{{ InstanceId }}\", \"status\": \"success\", \"service\": \"{{ Service }}\", \"running\": \"$RUNNING_VERSION\", \"stable\": \"$STABLE_VERSION\" }"
+                ;;
+            *)
+                echo "{\"instance_id\": \"{{ InstanceId }}\", \"status\": \"error\", \"message\": \"Failed to execute action {{ Action }}, not supported.\"}"
+                ;;
+        esac
+

--- a/component/toolbox/scripts/supporting-funcs/ssm-funcs.sh
+++ b/component/toolbox/scripts/supporting-funcs/ssm-funcs.sh
@@ -6,6 +6,7 @@
 upgrade_check_script="si-check-node-upgrade"
 service_maintenance_script="si-service-maintenance"
 service_state_script="si-service-state"
+sdf_migrate_script="si-migrate-sdf"
 
 # Function to start SSM session
 start_and_track_ssm_session() {


### PR DESCRIPTION
Toolbox script to run a one-shot SDF migration on a single SDF instance while we are in maintenance mode.

We may need to break this migrate out as a separate step before we start rolling services as otherwise we're going to run this once for each service we are deploying.