### PR TITLE
fix(dal): Remove initial component and rebase before removing others

### DIFF
--- a/lib/dal/src/job/definition/action.rs
+++ b/lib/dal/src/job/definition/action.rs
@@ -200,7 +200,7 @@ async fn prepare_for_execution(
 skip_all, level = "info", fields(
     si.action.id = ?action_id))]
 async fn process_execution(
-    ctx: &DalContext,
+    ctx: &mut DalContext,
     maybe_resource: Option<&ActionRunResultSuccess>,
     action_id: ActionId,
 ) -> JobConsumerResult<()> {
@@ -272,6 +272,9 @@ async fn process_execution(
         .publish_on_commit(ctx)
         .await?;
 
+    // Send the rebase request with the resource updated (if applicable)
+    ctx.commit().await?;
+    ctx.update_snapshot_to_visibility().await?;
     Ok(())
 }
 

--- a/lib/dal/tests/integration_test/component/delete.rs
+++ b/lib/dal/tests/integration_test/component/delete.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use dal::action::prototype::{ActionKind, ActionPrototype};
 use dal::action::Action;
 use dal::component::frame::Frame;
@@ -912,6 +914,24 @@ async fn delete_with_frames_and_resources(ctx: &mut DalContext) {
     ChangeSetTestHelpers::wait_for_actions_to_run(ctx)
         .await
         .expect("could not run actions");
+    // loop until the other components are removed
+    let total_count = 50;
+    let mut count = 0;
+
+    while count < total_count {
+        ctx.update_snapshot_to_visibility()
+            .await
+            .expect("could not update snapshot");
+        let components = Component::list(ctx)
+            .await
+            .expect("could not list components");
+        if components.is_empty() {
+            break;
+        }
+        count += 1;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
     let components = Component::list(ctx)
         .await
         .expect("could not list components");


### PR DESCRIPTION
If there is more then one component of a given variant, when delete actions run, we try and remove other eligible components.  Without rebasing the initial component's removal, there are orphaned attribute values left on the graph that are accessible via edges to the Props, which was causing an error when trying to remove the other component of the same kind as the original. 