### PR TITLE
Remove graph::has_path_to_root

### DIFF
--- a/lib/dal/src/workspace_snapshot/graph/detect_updates.rs
+++ b/lib/dal/src/workspace_snapshot/graph/detect_updates.rs
@@ -75,16 +75,11 @@ impl<'a, 'b> Detector<'a, 'b> {
                     // `onto`.
                     base_graph_node_indexes.insert(self.base_graph.root());
                 } else {
-                    // Only retain node indexes... or indices... if they are part of the current
-                    // graph. There may still be garbage from previous updates to the graph
-                    // laying around.
-                    let mut potential_base_graph_node_indexes = self
+                    let new_base_graph_node_indexes = self
                         .base_graph
                         .get_node_index_by_lineage(updated_graph_node_weight.lineage_id());
-                    potential_base_graph_node_indexes
-                        .retain(|node_index| self.base_graph.has_path_to_root(*node_index));
 
-                    base_graph_node_indexes.extend(potential_base_graph_node_indexes);
+                    base_graph_node_indexes.extend(new_base_graph_node_indexes);
                 }
 
                 base_graph_node_indexes
@@ -336,6 +331,10 @@ impl<'a, 'b> Detector<'a, 'b> {
     /// Performs a post order walk of the updated graph, finding the updates
     /// made to it when compared to the base graph, using the Merkle tree hash
     /// to detect changes and ignore unchanged branches.
+    ///
+    /// This assumes that all graphs involved to not have any "garbage" laying around. If in doubt,
+    /// run [`cleanup`][WorkspaceSnapshotGraph::cleanup] on all involved graphs, before handing
+    /// them over to the [`Detector`].
     pub fn detect_updates(&self) -> Vec<Update> {
         let mut updates = vec![];
         let mut difference_cache = HashMap::new();

--- a/lib/dal/src/workspace_snapshot/graph/v3.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v3.rs
@@ -934,10 +934,6 @@ impl WorkspaceSnapshotGraphV3 {
         Ok(self.graph.edge_weight(edge_index))
     }
 
-    pub fn has_path_to_root(&self, node: NodeIndex) -> bool {
-        algo::has_path_connecting(&self.graph, self.root_index, node, None)
-    }
-
     pub fn import_component_subgraph(
         &mut self,
         other: &WorkspaceSnapshotGraphV3,
@@ -1097,12 +1093,6 @@ impl WorkspaceSnapshotGraphV3 {
     pub fn is_acyclic_directed(&self) -> bool {
         // Using this because "is_cyclic_directed" is recursive.
         algo::toposort(&self.graph, None).is_ok()
-    }
-
-    #[allow(dead_code)]
-    fn is_on_path_between(&self, start: NodeIndex, end: NodeIndex, node: NodeIndex) -> bool {
-        algo::has_path_connecting(&self.graph, start, node, None)
-            && algo::has_path_connecting(&self.graph, node, end, None)
     }
 
     pub fn node_count(&self) -> usize {

--- a/lib/dal/src/workspace_snapshot/graph/v3/tests.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v3/tests.rs
@@ -208,9 +208,6 @@ mod test {
                 source.unwrap_or("root"),
                 target
             );
-
-            assert!(graph.has_path_to_root(source_idx));
-            assert!(graph.has_path_to_root(target_idx));
         }
         assert!(graph.is_acyclic_directed());
 


### PR DESCRIPTION
`has_path_to_root` was only used in one place to make sure that if we were given a dirty graph, we wouldn't end up looking at "zombie" nodes (prior versions of things that can no longer be reached using forward edges from the current root node). This check would end up walking parts of the graph multiple times through the course of detecting diffs.

Given we are already calling `graph.cleanup()` in the place where we would have been looking at a dirty graph, this check is not necessary.

This PR is built on #4436.