### PR TITLE
feat: Return 422 on user code errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,7 @@ dependencies = [
  "si-crypto",
  "si-hash",
  "si-std",
+ "strum 0.26.3",
  "telemetry",
  "thiserror",
  "tokio",

--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -60,8 +60,8 @@
         real-world resources!
       </ErrorMessage>
       <ErrorMessage
-        v-if="execFuncReqStatus.isError"
-        :requestStatus="execFuncReqStatus"
+        v-if="latestFuncExecutionReqStatus?.isError"
+        :requestStatus="latestFuncExecutionReqStatus"
         variant="block"
       />
       <div
@@ -253,6 +253,7 @@ import {
   VormInput,
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
+import { ApiRequestStatus } from "@si/vue-lib/pinia";
 import {
   FuncKind,
   FuncId,
@@ -389,10 +390,19 @@ const isConnectedToOtherSchemas = computed<boolean>(() => {
   return true;
 });
 
+const testFuncReqStatus = funcStore.getRequestStatus("TEST_EXECUTE");
 const execFuncReqStatus = funcStore.getRequestStatus(
   "SAVE_AND_EXEC_FUNC",
   funcId,
 );
+
+const latestFuncExecutionReqStatus = ref<ApiRequestStatus | undefined>();
+const storeLatestReqStatus = (value: ApiRequestStatus) => {
+  latestFuncExecutionReqStatus.value = value;
+};
+watch(testFuncReqStatus, storeLatestReqStatus);
+watch(execFuncReqStatus, storeLatestReqStatus);
+
 const execFunc = () => {
   if (!funcId.value) return;
   funcStore.SAVE_AND_EXEC_FUNC(funcId.value);

--- a/app/web/vite.config.ts
+++ b/app/web/vite.config.ts
@@ -107,19 +107,19 @@ export default (opts: { mode: string }) => {
     build: {
       manifest: true,
       rollupOptions: {
-           output: {
-               format: 'es',
-               globals: {
-                   react: 'React',
-                   'react-dom': 'ReactDOM',
-               },
-               manualChunks(id) {
-                   if (/dynamicEnvVars.ts/.test(id)) {
-                       return 'projectEnvVariables'
-                   }
-               },
-           },
-       }
+        output: {
+          format: "es",
+          globals: {
+            react: "React",
+            "react-dom": "ReactDOM",
+          },
+          manualChunks(id) {
+            if (/dynamicEnvVars.ts/.test(id)) {
+              return "projectEnvVariables";
+            }
+          },
+        },
+      },
     },
   });
 };

--- a/bin/lang-js/tests/exec.spec.ts
+++ b/bin/lang-js/tests/exec.spec.ts
@@ -59,6 +59,7 @@ describe("exec", () => {
           return elapsed > waitUntil;
         },
       });
+
       expect(r.result.exitCode).toBe(0);
       expect(r.failed).toBe("deadlineExceeded");
     });

--- a/bin/lang-js/tests/executeFunction.spec.ts
+++ b/bin/lang-js/tests/executeFunction.spec.ts
@@ -145,7 +145,11 @@ const scenarios: FuncScenario[] = [
     result: {
       protocol: "result",
       status: "failure",
-      error: { kind: "JoiValidationJsonParsingError" },
+      error: {
+        kind: {
+          UserCodeException: "JoiValidationJsonParsingError",
+        },
+      },
     },
   },
   {
@@ -160,7 +164,12 @@ const scenarios: FuncScenario[] = [
     result: {
       protocol: "result",
       status: "failure",
-      error: { kind: "JoiValidationFormatError" },
+      error: {
+        kind: {
+          UserCodeException: "JoiValidationFormatError",
+        },
+        message: "validationFormat must be of type object",
+      },
     },
   },
   {
@@ -244,7 +253,7 @@ describe("executeFunction", () => {
           }, scenario.timeout);
           fail("expected function to hit timeout, but no error was thrown");
         } catch (error) {
-          expect(error.message).toBe(`Error: function timed out after ${scenario.timeout} seconds`);
+          expect(error.message).toBe(`function timed out after ${scenario.timeout} seconds`);
         }
       } else {
         await executeFunction(scenario.kind, {

--- a/lib/cyclone-core/BUCK
+++ b/lib/cyclone-core/BUCK
@@ -12,6 +12,7 @@ rust_library(
         "//third-party/rust:remain",
         "//third-party/rust:serde",
         "//third-party/rust:serde_json",
+        "//third-party/rust:strum",
         "//third-party/rust:thiserror",
         "//third-party/rust:tokio",
     ],

--- a/lib/cyclone-core/Cargo.toml
+++ b/lib/cyclone-core/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = { workspace = true }
 si-crypto = { path = "../../lib/si-crypto" }
 si-hash = { path = "../../lib/si-hash" }
 si-std = { path = "../../lib/si-std" }
+strum = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/lib/cyclone-core/src/lib.rs
+++ b/lib/cyclone-core/src/lib.rs
@@ -36,8 +36,8 @@ pub use component_view::{ComponentKind, ComponentView};
 pub use kill_execution::KillExecutionRequest;
 pub use liveness::{LivenessStatus, LivenessStatusParseError};
 pub use progress::{
-    FunctionResult, FunctionResultFailure, FunctionResultFailureError, Message, OutputStream,
-    ProgressMessage,
+    FunctionResult, FunctionResultFailure, FunctionResultFailureError,
+    FunctionResultFailureErrorKind, Message, OutputStream, ProgressMessage,
 };
 pub use readiness::{ReadinessStatus, ReadinessStatusParseError};
 pub use reconciliation::{ReconciliationRequest, ReconciliationResultSuccess};

--- a/lib/cyclone-core/src/progress.rs
+++ b/lib/cyclone-core/src/progress.rs
@@ -1,7 +1,5 @@
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-
-/// The error kind for function result failures when the error occurs within the veritech server.
-const FUNCTION_RESULT_FAILURE_ERROR_KIND_VERITECH_SERVER: &str = "veritechServer";
+use strum::Display;
 
 /// A line of output, streamed from an executing function.
 ///
@@ -128,7 +126,7 @@ impl FunctionResultFailure {
         Self {
             execution_id: execution_id.into(),
             error: FunctionResultFailureError {
-                kind: FUNCTION_RESULT_FAILURE_ERROR_KIND_VERITECH_SERVER.to_string(),
+                kind: FunctionResultFailureErrorKind::VeritechServer,
                 message: message.into(),
             },
             timestamp,
@@ -146,9 +144,20 @@ impl FunctionResultFailure {
     }
 }
 
+#[remain::sorted]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Display)]
+pub enum FunctionResultFailureErrorKind {
+    ActionFieldWrongType,
+    InvalidReturnType,
+    KilledExecution,
+    ReconciliationFieldWrongType,
+    UserCodeException(String),
+    VeritechServer,
+}
+
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]
 pub struct FunctionResultFailureError {
-    pub kind: String,
+    pub kind: FunctionResultFailureErrorKind,
     pub message: String,
 }
 

--- a/lib/cyclone-server/src/execution.rs
+++ b/lib/cyclone-server/src/execution.rs
@@ -12,8 +12,8 @@ use axum::extract::ws::WebSocket;
 use bytes_lines_codec::BytesLinesCodec;
 use cyclone_core::{
     process::{self, ShutdownError},
-    CycloneRequest, FunctionResult, FunctionResultFailure, FunctionResultFailureError, Message,
-    OutputStream,
+    CycloneRequest, FunctionResult, FunctionResultFailure, FunctionResultFailureError,
+    FunctionResultFailureErrorKind, Message, OutputStream,
 };
 use futures::{SinkExt, StreamExt, TryStreamExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -492,6 +492,6 @@ pub struct LangServerFailure {
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct LangServerFailureError {
-    kind: String,
+    kind: FunctionResultFailureErrorKind,
     message: String,
 }

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -8,8 +8,8 @@ use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 use veritech_client::{
-    ActionRunResultSuccess, BeforeFunction, Client as VeritechClient, FunctionResult, OutputStream,
-    ResolverFunctionResponseType,
+    ActionRunResultSuccess, BeforeFunction, Client as VeritechClient, FunctionResult,
+    FunctionResultFailureErrorKind, OutputStream, ResolverFunctionResponseType,
 };
 
 use crate::label_list::ToLabelList;
@@ -46,7 +46,7 @@ pub enum FuncBackendError {
     InvalidArrayEntryData(serde_json::Value),
     #[error("result failure: kind={kind}, message={message}, backend={backend}")]
     ResultFailure {
-        kind: String,
+        kind: FunctionResultFailureErrorKind,
         message: String,
         backend: String,
     },

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -117,7 +117,7 @@ const DEFAULT_ASSET_CODE: &str = r#"function main() {
 
 #[derive(Debug, Deserialize, Serialize)]
 struct SchemaVariantJsonWrapper {
-    definition: SchemaVariantJson,
+    definition: Option<SchemaVariantJson>,
     error: Option<String>,
 }
 
@@ -792,6 +792,12 @@ impl VariantAuthoringClient {
             ));
         }
 
+        let Some(definition) = wrapper.definition else {
+            return Err(VariantAuthoringError::FuncExecutionFailure(
+                "definition cannot be undefined or null".to_string(),
+            ));
+        };
+
         ctx.layer_db()
             .func_run()
             .set_state_to_success(
@@ -801,7 +807,7 @@ impl VariantAuthoringClient {
             )
             .await?;
 
-        Ok(wrapper.definition)
+        Ok(definition)
     }
 }
 

--- a/lib/dal/tests/integration_test/func/authoring.rs
+++ b/lib/dal/tests/integration_test/func/authoring.rs
@@ -74,7 +74,6 @@ async fn create_unlocked_copy_code_gen_func(ctx: &mut DalContext) {
 
     let code_gen_binding = new_bindings.pop().expect("has one binding");
 
-    dbg!(&code_gen_binding);
     assert_eq!(
         LeafKind::CodeGeneration,   // expected
         code_gen_binding.leaf_kind  // actual

--- a/lib/dal/tests/integration_test/validations.rs
+++ b/lib/dal/tests/integration_test/validations.rs
@@ -29,7 +29,7 @@ async fn validation_format_errors(ctx: &mut DalContext) {
             "value": null,
             "validation": {
                 "status": "Error",
-                "message": "JoiValidationJsonParsingError: Unexpected token ' in JSON at position 0",
+                "message": "UserCodeException: Unexpected token ' in JSON at position 0",
             }
         }),
         extract_value_and_validation(prop_view).expect("could not extract")
@@ -47,7 +47,7 @@ async fn validation_format_errors(ctx: &mut DalContext) {
             "value": null,
             "validation": {
                 "status": "Error",
-                "message": "JoiValidationFormatError: validationFormat must be of type object",
+                "message": "UserCodeException: validationFormat must be of type object",
             }
         }),
         extract_value_and_validation(prop_view).expect("could not extract")

--- a/lib/sdf-server/src/server/service.rs
+++ b/lib/sdf-server/src/server/service.rs
@@ -4,6 +4,7 @@ use axum::{
     Json,
 };
 use serde::{Serialize, Serializer};
+use std::fmt::Display;
 use telemetry::prelude::*;
 
 pub mod action;
@@ -35,10 +36,7 @@ struct ApiError {
 impl ApiError {
     const DEFAULT_ERROR_STATUS_CODE: StatusCode = StatusCode::INTERNAL_SERVER_ERROR;
 
-    fn new<E>(status_code: StatusCode, err: E) -> Self
-    where
-        E: std::error::Error,
-    {
+    fn new<E: Display>(status_code: StatusCode, err: E) -> Self {
         Self {
             error: ApiErrorError {
                 message: err.to_string(),

--- a/lib/sdf-server/src/server/service/v2/func/test_execute.rs
+++ b/lib/sdf-server/src/server/service/v2/func/test_execute.rs
@@ -42,8 +42,6 @@ pub async fn test_execute(
     let ctx = builder
         .build(access_builder.build(change_set_id.into()))
         .await?;
-    // should we force a changeset to test execute?
-    // let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
     let func = Func::get_by_id_or_error(&ctx, func_id).await?;
     let func_run_id = FuncAuthoringClient::test_execute_func(

--- a/lib/sdf-server/src/server/service/variant.rs
+++ b/lib/sdf-server/src/server/service/variant.rs
@@ -87,6 +87,9 @@ impl IntoResponse for SchemaVariantError {
                 StatusCode::NOT_MODIFIED,
                 "unexpected return type, expected 'Asset' return type".to_string(),
             ),
+            SchemaVariantError::VariantAuthoring(VariantAuthoringError::FuncExecutionFailure(
+                message,
+            )) => (StatusCode::UNPROCESSABLE_ENTITY, message),
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 

--- a/lib/si-pool-noodle/src/lib.rs
+++ b/lib/si-pool-noodle/src/lib.rs
@@ -22,11 +22,12 @@ pub use cyclone_client::{ClientError, CycloneClient, ExecutionError};
 
 pub use cyclone_core::{
     ActionRunRequest, ActionRunResultSuccess, BeforeFunction, ComponentView, CycloneRequest,
-    FunctionResult, FunctionResultFailure, FunctionResultFailureError, KillExecutionRequest,
-    OutputStream, ProgressMessage, ReconciliationRequest, ReconciliationResultSuccess,
-    ResolverFunctionRequest, ResolverFunctionResultSuccess, ResourceStatus,
-    SchemaVariantDefinitionRequest, SchemaVariantDefinitionResultSuccess, SensitiveStrings,
-    ValidationRequest, ValidationResultSuccess,
+    FunctionResult, FunctionResultFailure, FunctionResultFailureError,
+    FunctionResultFailureErrorKind, KillExecutionRequest, OutputStream, ProgressMessage,
+    ReconciliationRequest, ReconciliationResultSuccess, ResolverFunctionRequest,
+    ResolverFunctionResultSuccess, ResourceStatus, SchemaVariantDefinitionRequest,
+    SchemaVariantDefinitionResultSuccess, SensitiveStrings, ValidationRequest,
+    ValidationResultSuccess,
 };
 
 /// [`PoolNoodleError`] implementations.

--- a/lib/veritech-client/src/lib.rs
+++ b/lib/veritech-client/src/lib.rs
@@ -16,8 +16,8 @@ use veritech_core::{
 
 pub use cyclone_core::{
     ActionRunRequest, ActionRunResultSuccess, BeforeFunction, ComponentKind, ComponentView,
-    FunctionResult, FunctionResultFailure, KillExecutionRequest, OutputStream,
-    ReconciliationRequest, ReconciliationResultSuccess, ResolverFunctionComponent,
+    FunctionResult, FunctionResultFailure, FunctionResultFailureErrorKind, KillExecutionRequest,
+    OutputStream, ReconciliationRequest, ReconciliationResultSuccess, ResolverFunctionComponent,
     ResolverFunctionRequest, ResolverFunctionResponseType, ResolverFunctionResultSuccess,
     ResourceStatus, SchemaVariantDefinitionRequest, SchemaVariantDefinitionResultSuccess,
     SensitiveContainer, ValidationRequest, ValidationResultSuccess,

--- a/lib/veritech-client/tests/integration.rs
+++ b/lib/veritech-client/tests/integration.rs
@@ -2,9 +2,9 @@ use std::env;
 
 use base64::{engine::general_purpose, Engine};
 use cyclone_core::{
-    ComponentKind, ComponentView, FunctionResult, ResolverFunctionComponent,
-    ResolverFunctionRequest, ResolverFunctionResponseType, SchemaVariantDefinitionRequest,
-    ValidationRequest,
+    ComponentKind, ComponentView, FunctionResult, FunctionResultFailureErrorKind,
+    ResolverFunctionComponent, ResolverFunctionRequest, ResolverFunctionResponseType,
+    SchemaVariantDefinitionRequest, ValidationRequest,
 };
 use si_data_nats::{NatsClient, NatsConfig};
 use test_log::test;
@@ -262,7 +262,10 @@ async fn type_checks_resolve_function() {
                 panic!("should have failed :(");
             }
             FunctionResult::Failure(failure) => {
-                assert_eq!(failure.error().kind, "InvalidReturnType");
+                assert_eq!(
+                    failure.error().kind,
+                    FunctionResultFailureErrorKind::InvalidReturnType
+                );
                 assert_eq!(failure.execution_id(), execution_id);
             }
         }

--- a/lib/veritech-server/src/handlers/kill.rs
+++ b/lib/veritech-server/src/handlers/kill.rs
@@ -3,7 +3,10 @@ use naxum::{
     Json,
 };
 use si_data_nats::Subject;
-use si_pool_noodle::{FunctionResult, FunctionResultFailure, KillExecutionRequest};
+use si_pool_noodle::{
+    FunctionResult, FunctionResultFailure, FunctionResultFailureError,
+    FunctionResultFailureErrorKind, KillExecutionRequest,
+};
 use telemetry::prelude::*;
 
 use crate::{app_state::KillAppState, Publisher};
@@ -38,9 +41,12 @@ async fn kill_execution_request_task(
 
     let result = match kill_execution_request(state, execution_id.to_owned()).await {
         Ok(()) => FunctionResult::Success(()),
-        Err(err) => FunctionResult::Failure(FunctionResultFailure::new_for_veritech_server_error(
+        Err(err) => FunctionResult::Failure(FunctionResultFailure::new(
             execution_id,
-            err.to_string(),
+            FunctionResultFailureError {
+                kind: FunctionResultFailureErrorKind::KilledExecution,
+                message: err.to_string(),
+            },
             timestamp(),
         )),
     };

--- a/lib/veritech-server/src/server.rs
+++ b/lib/veritech-server/src/server.rs
@@ -4,6 +4,7 @@ use naxum::middleware::ack::AckLayer;
 use naxum::middleware::trace::{DefaultMakeSpan, DefaultOnRequest, TraceLayer};
 use naxum::ServiceBuilder;
 use naxum::ServiceExt as _;
+
 use si_crypto::{VeritechDecryptionKey, VeritechDecryptionKeyError};
 use si_data_nats::{async_nats, jetstream, NatsClient, NatsError, Subject, Subscriber};
 use si_pool_noodle::{
@@ -18,8 +19,7 @@ use std::time::Duration;
 use std::{io, sync::Arc};
 use telemetry::prelude::*;
 use thiserror::Error;
-use tokio::sync::oneshot;
-use tokio::sync::Mutex;
+use tokio::sync::{oneshot, Mutex};
 use tokio::task::JoinError;
 use tokio_util::sync::CancellationToken;
 use veritech_core::{subject, veritech_work_queue, ExecutionId};


### PR DESCRIPTION
To ensure bad user code is not reported as server errors, we return 422 Unprocessable Content when that's the reason for an API call failure.

To enable this, I had to make the language server errors static and parseable into a rust enum, that has an extra UserCodeException variant containing a string so easily support JS errors on the frontend.

This PR also cleans up code error messages in the frontend

<img width="933" alt="image" src="https://github.com/user-attachments/assets/83ac273d-433b-4077-92db-9a303a0af30d">
 