### PR TITLE
feat(naxum): add ability to limit incoming work to a naxum app

### DIFF
--- a/lib/naxum/examples/graceful-shutdown/BUCK
+++ b/lib/naxum/examples/graceful-shutdown/BUCK
@@ -1,0 +1,20 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "rust_binary",
+)
+
+rust_binary(
+    name = "graceful-shutdown",
+    srcs = ["main.rs"],
+    crate_root = "main.rs",
+    deps = [
+        "//lib/naxum:naxum",
+        "//third-party/rust:async-nats",
+        "//third-party/rust:futures",
+        "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
+        "//third-party/rust:tower",
+        "//third-party/rust:tracing",
+        "//third-party/rust:tracing-subscriber",
+    ],
+)

--- a/lib/naxum/examples/graceful-shutdown/main.rs
+++ b/lib/naxum/examples/graceful-shutdown/main.rs
@@ -1,0 +1,143 @@
+use std::{env, error, str, time::Duration};
+
+use async_nats::jetstream;
+use naxum::{handler::Handler, middleware::ack::AckLayer, ServiceExt};
+use tokio::{
+    signal::unix::{self, SignalKind},
+    time,
+};
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tower::ServiceBuilder;
+use tracing::{debug, info};
+use tracing_subscriber::{
+    fmt::{self, format::FmtSpan},
+    layer::SubscriberExt as _,
+    util::SubscriberInitExt as _,
+    EnvFilter, Registry,
+};
+
+const TRACING_LOG_ENV_VAR: &str = "SI_LOG";
+const DEFAULT_TRACING_DIRECTIVES: &str = "graceful_shutdown=trace,naxum=debug,info";
+
+#[derive(Clone, Debug)]
+struct AppState {}
+
+async fn default(msg: async_nats::Message) -> naxum::response::Result<()> {
+    info!(subject = msg.subject.as_str(), "processing message");
+
+    let payload = str::from_utf8(&msg.payload).expect("TODO");
+
+    // Simulate a long-running operation to process this message
+    let deadline = time::sleep(Duration::from_millis(7000));
+    tokio::pin!(deadline);
+    // Emit periodic logging
+    let mut progress = time::interval_at(
+        time::Instant::now() + Duration::from_millis(500),
+        Duration::from_millis(500),
+    );
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut deadline => {
+                info!(payload, "processing complete");
+                break;
+            }
+            _ = progress.tick() => {
+                debug!(payload, "processing message...");
+            }
+
+        }
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::disallowed_methods)] // env vars are supporting alternatives in an example
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn error::Error>> {
+    Registry::default()
+        .with(
+            EnvFilter::try_from_env(TRACING_LOG_ENV_VAR)
+                .unwrap_or_else(|_| EnvFilter::new(DEFAULT_TRACING_DIRECTIVES)),
+        )
+        .with(
+            fmt::layer()
+                .with_thread_ids(true)
+                .with_thread_names(true)
+                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+                .pretty(),
+        )
+        .try_init()?;
+
+    let url = env::var("NATS_URL").unwrap_or_else(|_| "nats://localhost:4222".to_owned());
+    let subject = env::var("NATS_SUBJECT").unwrap_or_else(|_| "naxum.test.js.>".to_owned());
+    let stream_name = env::var("NATS_STREAM").unwrap_or_else(|_| "NAXUM_TEST".to_owned());
+
+    // Create a NATS client, JetStream context, a consumer, and finally an async `Stream` of
+    // messages
+    let client = async_nats::connect(url).await?;
+    let context = jetstream::new(client);
+    let stream = context
+        .get_or_create_stream(jetstream::stream::Config {
+            name: stream_name.clone(),
+            subjects: vec![subject.clone()],
+            ..Default::default()
+        })
+        .await?;
+    let consumer = stream
+        .create_consumer(jetstream::consumer::pull::Config::default())
+        .await?;
+    let messages = consumer.messages().await?;
+
+    // Setup a Tower `Service` stack with some middleware
+    let app = ServiceBuilder::new()
+        .layer(AckLayer::new())
+        .service(default.with_state(AppState {}));
+
+    // Use a Tokio `TaskTracker` and `CancellationToken` to support signal handling and graceful
+    // shutdown
+    let tracker = TaskTracker::new();
+    let token = CancellationToken::new();
+
+    let naxum_token = token.clone();
+    tracker.spawn(async move {
+        info!(
+            stream = stream_name.as_str(),
+            subject = subject.as_str(),
+            "ready to receive messages with a nats jetstream consumer",
+        );
+        // Limit the app to concurrently process 4 messages. This way when a graceful shutdown is
+        // requested, there should be *at most* 4 messages being processed (i.e. "work-in-flight").
+        naxum::serve_with_incoming_limit(messages, app.into_make_service(), 4)
+            .with_graceful_shutdown(naxum::wait_on_cancelled(naxum_token))
+            .await
+    });
+
+    info!("press `Ctrl+c` when messages are being processed");
+
+    // Create streams of `SIGINT` (i.e. `Ctrl+c`) and `SIGTERM` signals
+    let mut sig_int = unix::signal(SignalKind::interrupt())?;
+    let mut sig_term = unix::signal(SignalKind::terminate())?;
+
+    // Wait until one of the signal streams gets a signal, after which we will close the task
+    // tracker and cancel the token, signaling all holders of the token
+    tokio::select! {
+        _ = sig_int.recv() => {
+            info!("received SIGINT, performing graceful shutdown");
+            tracker.close();
+            token.cancel();
+        }
+        _ = sig_term.recv() => {
+            info!("received SIGTERM, performing graceful shutdown");
+            tracker.close();
+            token.cancel();
+        }
+    }
+
+    // Wait for all tasks to finish
+    tracker.wait().await;
+
+    info!("graceful shutdown complete");
+    Ok(())
+}

--- a/lib/naxum/src/lib.rs
+++ b/lib/naxum/src/lib.rs
@@ -19,7 +19,7 @@ pub use self::error::Error;
 pub use self::json::Json;
 pub use self::make_service::IntoMakeService;
 pub use self::message::{Head, MessageHead};
-pub use self::serve::serve;
+pub use self::serve::{serve, serve_with_incoming_limit};
 pub use self::service_ext::ServiceExt;
 
 pub use async_trait::async_trait;

--- a/lib/naxum/src/serve.rs
+++ b/lib/naxum/src/serve.rs
@@ -169,16 +169,8 @@ where
                     .await
                     .unwrap_or_else(|err| match err {});
 
-                let graceful_token = graceful_token.clone();
                 tracker.spawn(async move {
-                    tokio::select! {
-                        _result = tower_svc.oneshot(msg) => {
-                            // huh
-                        }
-                        _ = graceful_token.cancelled() => {
-                            trace!("signal received in task, starting graceful shutdown");
-                        }
-                    }
+                    let _result = tower_svc.oneshot(msg).await;
                 });
             }
 

--- a/lib/naxum/src/serve.rs
+++ b/lib/naxum/src/serve.rs
@@ -5,12 +5,18 @@ use std::{
     io,
     marker::PhantomData,
     ops,
+    sync::Arc,
+    time::Duration,
 };
 
 use futures::{Stream, TryStreamExt};
+use tokio::{
+    sync::{OwnedSemaphorePermit, Semaphore},
+    time,
+};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tower::{Service, ServiceExt};
-use tracing::{trace, warn};
+use tracing::{debug, trace, warn};
 
 use crate::{message::MessageHead, response::Response};
 
@@ -25,9 +31,26 @@ where
     E: error::Error,
     R: MessageHead,
 {
+    serve_with_incoming_limit(stream, make_service, None)
+}
+
+pub fn serve_with_incoming_limit<M, S, T, E, R>(
+    stream: T,
+    make_service: M,
+    limit: impl Into<Option<usize>>,
+) -> Serve<M, S, T, E, R>
+where
+    M: for<'a> Service<IncomingMessage<'a, R>, Error = Infallible, Response = S>,
+    S: Service<R, Response = Response, Error = Infallible> + Clone + Send + 'static,
+    S::Future: Send,
+    T: Stream<Item = Result<R, E>>,
+    E: error::Error,
+    R: MessageHead,
+{
     Serve {
         stream,
         make_service,
+        limit: limit.into(),
         _service_marker: PhantomData,
         _stream_error_marker: PhantomData,
         _request_marker: PhantomData,
@@ -38,6 +61,7 @@ where
 pub struct Serve<M, S, T, E, R> {
     stream: T,
     make_service: M,
+    limit: Option<usize>,
     _service_marker: PhantomData<S>,
     _stream_error_marker: PhantomData<E>,
     _request_marker: PhantomData<R>,
@@ -62,6 +86,7 @@ impl<M, S, T, E, R> Serve<M, S, T, E, R> {
         WithGracefulShutdown {
             stream: self.stream,
             make_service: self.make_service,
+            limit: self.limit,
             signal,
             _service_marker: PhantomData,
             _stream_error_marker: PhantomData,
@@ -75,6 +100,7 @@ impl<M, S, T, E, R> Serve<M, S, T, E, R> {
 pub struct WithGracefulShutdown<M, S, T, E, R, F> {
     stream: T,
     make_service: M,
+    limit: Option<usize>,
     signal: F,
     _service_marker: PhantomData<S>,
     _stream_error_marker: PhantomData<E>,
@@ -113,6 +139,7 @@ where
         let Self {
             mut stream,
             mut make_service,
+            limit,
             signal,
             ..
         } = self;
@@ -129,14 +156,23 @@ where
 
         let mut failed_count = 0;
 
+        let semaphore = limit.map(|limit| Arc::new(Semaphore::new(limit)));
+
         private::ServeFuture(Box::pin(async move {
             loop {
-                let msg = tokio::select! {
-                    msg = next_message(&mut stream, failed_count) => {
+                let (msg, permit) = tokio::select! {
+                    biased;
+
+                    _ = graceful_token.cancelled() => {
+                        trace!("signal received, not accepting new messages");
+                        tracker.close();
+                        break;
+                    }
+                    (msg, permit) = next_message(&mut stream, semaphore.clone(), failed_count) => {
                         match msg {
                             Some(Ok(msg)) => {
                                 failed_count = 0;
-                                msg
+                                (msg, permit)
                             },
                             Some(Err(err)) => {
                                 // TODO(fnichol): this level might need to be `trace!()`, just
@@ -150,11 +186,6 @@ where
                                 break;
                             },
                         }
-                    }
-                    _ = graceful_token.cancelled() => {
-                        trace!("signal received, not accepting new messages");
-                        tracker.close();
-                        break;
                     }
                 };
 
@@ -171,24 +202,62 @@ where
 
                 tracker.spawn(async move {
                     let _result = tower_svc.oneshot(msg).await;
+
+                    trace!("message processed");
+
+                    drop(permit);
                 });
             }
 
-            tracker.wait().await;
+            trace!("waiting for {} task(s) to finish", tracker.len());
+            let mut progress_interval = time::interval_at(
+                time::Instant::now() + Duration::from_secs(5),
+                Duration::from_secs(5),
+            );
+            loop {
+                tokio::select! {
+                    _ = tracker.wait() => {
+                        break;
+                    }
+                    _ = progress_interval.tick() => {
+                        debug!("waiting for {} task(s) to finish", tracker.len());
+                    }
+                }
+            }
 
             Ok(())
         }))
     }
 }
 
-async fn next_message<T, E, R>(stream: &mut T, failed_count: usize) -> Option<Result<R, E>>
+async fn next_message<T, E, R>(
+    stream: &mut T,
+    semaphore: Option<Arc<Semaphore>>,
+    failed_count: usize,
+) -> (Option<Result<R, E>>, Option<OwnedSemaphorePermit>)
 where
     T: Stream<Item = Result<R, E>> + Unpin + Send + 'static,
     E: error::Error,
     R: MessageHead + Send + 'static,
 {
+    let permit = match semaphore {
+        Some(semaphore) => {
+            // Acquire permit before awaitng next message on stream, thereby limiting the number of
+            // spawned processing requests
+            Some(
+                #[allow(clippy::expect_used)]
+                // errors only if semaphore is closed (we never close)
+                semaphore
+                    .acquire_owned()
+                    .await
+                    .expect("semaphore will not be closed"),
+            )
+        }
+        None => None,
+    };
+
     match stream.try_next().await {
-        Ok(maybe) => Ok(maybe).transpose(),
+        Ok(maybe) => (Ok(maybe).transpose(), permit),
         Err(err) => {
             if failed_count > MAX_FAILED_MESSAGES {
                 warn!(
@@ -196,9 +265,9 @@ where
                     "failed to read message in after {} consecutive failures; closing stream",
                     failed_count,
                 );
-                None
+                (None, permit)
             } else {
-                Some(Err(err))
+                (Some(Err(err)), permit)
             }
         }
     }


### PR DESCRIPTION
This change adds an alternative naxum app setup `naxum::serve_with_incoming_limit` which takes an optional number. When set, the app will limit the number of incoming messages being handled at the same time.

<img src="https://media2.giphy.com/media/f9mn4iOZEwxBlH9Wzp/giphy.gif"/>