### PR TITLE
chore(pinga,veritech): normalize server config & setups

### DIFF
--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -91,9 +91,20 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) decryption_key: Option<PathBuf>,
 
-    /// Execution timeout when communicating with a cyclone instance executing a function, in seconds
+    /// Execution timeout when communicating with a cyclone instance executing a function
     #[arg(long)]
-    pub(crate) cyclone_client_execution_timeout: Option<u64>,
+    pub(crate) cyclone_client_execution_timeout_secs: Option<u64>,
+
+    /// The number of concurrent functions that can be executed [default: 1000]
+    #[arg(long)]
+    pub(crate) concurrency: Option<u32>,
+
+    /// Instance ID [example: 01GWEAANW5BVFK5KDRVS6DEY0F"]
+    ///
+    /// And instance ID is used when tracking the execution of jobs in a way that can be traced
+    /// back to an instance of a Pinga service.
+    #[arg(long)]
+    pub(crate) instance_id: Option<String>,
 }
 
 impl TryFrom<Args> for Config {
@@ -132,8 +143,14 @@ impl TryFrom<Args> for Config {
                 );
             }
             config_map.set("nats.connection_name", NAME);
-            if let Some(timeout) = args.cyclone_client_execution_timeout {
-                config_map.set("cyclone_client_execution_timeout", timeout);
+            if let Some(timeout) = args.cyclone_client_execution_timeout_secs {
+                config_map.set("cyclone_client_execution_timeout_secs", timeout);
+            }
+            if let Some(concurrency) = args.concurrency {
+                config_map.set("concurrency_limit", i64::from(concurrency));
+            }
+            if let Some(instance_id) = args.instance_id {
+                config_map.set("instance_id", instance_id);
             }
         })?
         .try_into()

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -591,7 +591,7 @@ pub async fn pinga_server(
 
     let server = pinga_server::Server::from_services(
         config.instance_id(),
-        config.concurrency(),
+        config.concurrency_limit(),
         services_context,
         shutdown_token,
     )
@@ -630,7 +630,8 @@ pub async fn veritech_server_for_uds_cyclone(
     token: CancellationToken,
 ) -> Result<veritech_server::Server> {
     let config: veritech_server::Config = {
-        let mut config_file = veritech_server::ConfigFile::new_for_dal_test(nats_config);
+        let mut config_file = veritech_server::ConfigFile::default_local_uds();
+        config_file.nats = nats_config;
         veritech_server::detect_and_configure_development(&mut config_file)
             .wrap_err("failed to detect and configure Veritech ConfigFile")?;
         config_file
@@ -638,7 +639,7 @@ pub async fn veritech_server_for_uds_cyclone(
             .wrap_err("failed to build Veritech server config")?
     };
 
-    let server = veritech_server::Server::for_cyclone_uds(config, token)
+    let server = veritech_server::Server::from_config(config, token)
         .await
         .wrap_err("failed to create Veritech server")?;
 

--- a/lib/pinga-server/src/config.rs
+++ b/lib/pinga-server/src/config.rs
@@ -53,7 +53,7 @@ pub struct Config {
     crypto: VeritechCryptoConfig,
 
     #[builder(default = "default_concurrency_limit()")]
-    concurrency: usize,
+    concurrency_limit: usize,
 
     #[builder(default = "random_instance_id()")]
     instance_id: String,
@@ -98,8 +98,8 @@ impl Config {
     }
 
     /// Gets the config's concurrency limit.
-    pub fn concurrency(&self) -> usize {
-        self.concurrency
+    pub fn concurrency_limit(&self) -> usize {
+        self.concurrency_limit
     }
 
     /// Gets the config's instance ID.
@@ -159,7 +159,7 @@ impl TryFrom<ConfigFile> for Config {
         config.pg_pool(value.pg);
         config.nats(value.nats);
         config.crypto(value.crypto);
-        config.concurrency(value.concurrency_limit);
+        config.concurrency_limit(value.concurrency_limit);
         config.instance_id(value.instance_id);
         config.symmetric_crypto_service(value.symmetric_crypto_service.try_into()?);
         config.layer_db_config(value.layer_db_config);

--- a/lib/pinga-server/src/server.rs
+++ b/lib/pinga-server/src/server.rs
@@ -105,7 +105,7 @@ impl Server {
 
         Self::from_services(
             config.instance_id().to_string(),
-            config.concurrency(),
+            config.concurrency_limit(),
             services_context,
             token,
         )

--- a/lib/veritech-client/tests/integration.rs
+++ b/lib/veritech-client/tests/integration.rs
@@ -63,7 +63,7 @@ async fn veritech_server_for_uds_cyclone(
         .healthcheck_pool(false)
         .build()
         .expect("failed to build spec");
-    Server::for_cyclone_uds(config, shutdown_token)
+    Server::from_config(config, shutdown_token)
         .await
         .expect("failed to create server")
 }

--- a/lib/veritech-server/src/lib.rs
+++ b/lib/veritech-server/src/lib.rs
@@ -5,13 +5,47 @@ mod publisher;
 mod request;
 mod server;
 
+use std::io;
+
+use si_data_nats::{async_nats, NatsError, Subject};
+use thiserror::Error;
+
 pub use si_pool_noodle::{instance::cyclone::LocalUdsInstance, Instance};
 
 pub(crate) use crate::publisher::{Publisher, PublisherError};
-
-pub use crate::config::{
-    detect_and_configure_development, Config, ConfigBuilder, ConfigError, ConfigFile, CycloneSpec,
-    CycloneStream, StandardConfig, StandardConfigFile,
+pub use crate::{
+    config::{
+        detect_and_configure_development, Config, ConfigBuilder, ConfigError, ConfigFile,
+        CycloneSpec, CycloneStream, StandardConfig, StandardConfigFile,
+    },
+    server::Server,
 };
-pub use crate::server::Server;
-pub use crate::server::ServerError;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ServerError {
+    #[error("cyclone pool error: {0}")]
+    CyclonePool(#[source] Box<dyn std::error::Error + Sync + Send + 'static>),
+    #[error("cyclone spec setup error: {0}")]
+    CycloneSetupError(#[source] Box<dyn std::error::Error + Sync + Send + 'static>),
+    #[error("jetstream consumer error: {0}")]
+    JetStreamConsumer(#[from] async_nats::jetstream::stream::ConsumerError),
+    #[error("jetstream consumer stream error: {0}")]
+    JetStreamConsumerStream(#[from] async_nats::jetstream::consumer::StreamError),
+    #[error("jetstream create stream error: {0}")]
+    JetStreamCreateStreamError(#[from] async_nats::jetstream::context::CreateStreamError),
+    #[error("join error: {0}")]
+    Join(#[from] tokio::task::JoinError),
+    #[error("failed to initialize a nats client: {0}")]
+    NatsClient(#[source] NatsError),
+    #[error("failed to subscribe to nats subject ({0}): {1}")]
+    NatsSubscribe(Subject, #[source] NatsError),
+    #[error("naxum error: {0}")]
+    Naxum(#[source] io::Error),
+    #[error("veritech decryption key error: {0}")]
+    VeritechDecryptionKey(#[from] si_crypto::VeritechDecryptionKeyError),
+    #[error("wrong cyclone spec type for {0} spec: {1:?}")]
+    WrongCycloneSpec(&'static str, Box<CycloneSpec>),
+}
+
+type ServerResult<T> = Result<T, ServerError>;

--- a/lib/veritech-server/src/server.rs
+++ b/lib/veritech-server/src/server.rs
@@ -1,87 +1,53 @@
-use futures::{join, Future, StreamExt};
-use naxum::handler::Handler as _;
-use naxum::middleware::ack::AckLayer;
-use naxum::middleware::trace::{DefaultMakeSpan, DefaultOnRequest, TraceLayer};
-use naxum::ServiceBuilder;
-use naxum::ServiceExt as _;
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    fmt,
+    future::{Future, IntoFuture as _},
+    io,
+    sync::Arc,
+    time::Duration,
+};
 
-use si_crypto::{VeritechDecryptionKey, VeritechDecryptionKeyError};
-use si_data_nats::{async_nats, jetstream, NatsClient, NatsError, Subject, Subscriber};
+use futures::{join, StreamExt};
+use naxum::{
+    handler::Handler as _,
+    middleware::{
+        ack::AckLayer,
+        trace::{DefaultMakeSpan, DefaultOnRequest, TraceLayer},
+    },
+    ServiceBuilder, ServiceExt as _,
+};
+use si_crypto::VeritechDecryptionKey;
+use si_data_nats::{async_nats, jetstream, NatsClient, Subscriber};
 use si_pool_noodle::{
     instance::cyclone::{LocalUdsInstance, LocalUdsInstanceSpec},
     PoolNoodle, Spec,
 };
-use std::collections::HashMap;
-use std::convert::Infallible;
-use std::fmt;
-use std::future::IntoFuture;
-use std::time::Duration;
-use std::{io, sync::Arc};
 use telemetry::prelude::*;
-use thiserror::Error;
 use tokio::sync::{oneshot, Mutex};
-use tokio::task::JoinError;
 use tokio_util::sync::CancellationToken;
 use veritech_core::{subject, veritech_work_queue, ExecutionId};
 
-use crate::app_state::{AppState, KillAppState};
-use crate::handlers;
-use crate::{config::CycloneSpec, Config};
+use crate::{
+    app_state::{AppState, KillAppState},
+    config::CycloneSpec,
+    handlers, Config, ServerError, ServerResult,
+};
 
 const CONSUMER_NAME: &str = "veritech-server";
-
-const DEFAULT_CONCURRENCY_LIMIT: usize = 1000;
-const DEFAULT_CYCLONE_CLIENT_EXECUTION_TIMEOUT: Duration = Duration::from_secs(35 * 60);
-
-#[remain::sorted]
-#[derive(Error, Debug)]
-pub enum ServerError {
-    #[error("cyclone pool error: {0}")]
-    CyclonePool(#[source] Box<dyn std::error::Error + Sync + Send + 'static>),
-    #[error("cyclone spec setup error: {0}")]
-    CycloneSetupError(#[source] Box<dyn std::error::Error + Sync + Send + 'static>),
-    #[error("jetstream consumer error: {0}")]
-    JetStreamConsumer(#[from] async_nats::jetstream::stream::ConsumerError),
-    #[error("jetstream consumer stream error: {0}")]
-    JetStreamConsumerStream(#[from] async_nats::jetstream::consumer::StreamError),
-    #[error("jetstream create stream error: {0}")]
-    JetStreamCreateStreamError(#[from] async_nats::jetstream::context::CreateStreamError),
-    #[error("join error: {0}")]
-    Join(#[from] JoinError),
-    #[error("failed to initialize a nats client: {0}")]
-    NatsClient(#[source] NatsError),
-    #[error("failed to subscribe to nats subject ({0}): {1}")]
-    NatsSubscribe(Subject, #[source] NatsError),
-    #[error("naxum error: {0}")]
-    Naxum(#[source] io::Error),
-    #[error("veritech decryption key error: {0}")]
-    VeritechDecryptionKey(#[from] VeritechDecryptionKeyError),
-    #[error("wrong cyclone spec type for {0} spec: {1:?}")]
-    WrongCycloneSpec(&'static str, Box<CycloneSpec>),
-}
-
-type ServerResult<T> = Result<T, ServerError>;
 
 /// Server metadata, used with telemetry.
 #[derive(Clone, Debug)]
 pub struct ServerMetadata {
-    #[allow(unused)]
+    #[allow(dead_code)]
     instance_id: String,
-    #[allow(unused)]
-    job_invoked_provider: &'static str,
 }
 
 impl ServerMetadata {
     /// Returns the server's unique instance id.
-    #[allow(unused)]
+    #[allow(dead_code)]
     pub fn instance_id(&self) -> &str {
         &self.instance_id
-    }
-
-    /// Returns the job invoked provider.
-    #[allow(unused)]
-    pub fn job_invoked_provider(&self) -> &str {
-        self.job_invoked_provider
     }
 }
 
@@ -102,12 +68,50 @@ impl fmt::Debug for Server {
 }
 
 impl Server {
-    #[instrument(name = "veritech.init.cyclone.uds", level = "info", skip_all)]
-    pub async fn for_cyclone_uds(config: Config, token: CancellationToken) -> ServerResult<Self> {
-        match config.cyclone_spec() {
-            CycloneSpec::LocalUds(spec) => {
-                let nats = Self::connect_to_nats(&config).await?;
+    #[instrument(name = "veritech.init.from_config", level = "info", skip_all)]
+    pub async fn from_config(config: Config, token: CancellationToken) -> ServerResult<Self> {
+        let nats = Self::connect_to_nats(&config).await?;
 
+        let metadata = Arc::new(ServerMetadata {
+            instance_id: config.instance_id().into(),
+        });
+
+        let decryption_key = VeritechDecryptionKey::from_config(config.crypto().clone()).await?;
+
+        let kill_senders = Arc::new(Mutex::new(HashMap::new()));
+
+        match config.cyclone_spec() {
+            CycloneSpec::LocalHttp(_spec) => {
+                //
+                // TODO(fnichol): Hi there! Ultimately, the Veritech server should be able to work
+                // with a LocalUds Cyclone backend and a LocalHttp version. But since this involves
+                // threading through some generic types which themselves have trait
+                // constraints--well we can add this back in the near future... Good luck to us
+                // all.
+                //
+                // let mut cyclone_pool: PoolNoodle<LocalUdsInstance, LocalUdsInstanceSpec> =
+                //     PoolNoodle::new(spec.pool_size.into(), spec.clone(), token.clone());
+                //
+                // spec.clone()
+                //     .setup()
+                //     .await
+                //     .map_err(|e| ServerError::CycloneSetupError(Box::new(e)))?;
+                // cyclone_pool
+                //     .start(config.healthcheck_pool())
+                //     .map_err(|e| ServerError::CyclonePool(Box::new(e)))?;
+                //
+                // // ...
+                //
+                // Ok(Server {
+                //     metadata,
+                //     inner: inner_future,
+                //     kill_inner: kill_inner_future,
+                //     shutdown_token: token,
+                // })
+
+                unimplemented!("get ready for a surprise!!")
+            }
+            CycloneSpec::LocalUds(spec) => {
                 let mut cyclone_pool: PoolNoodle<LocalUdsInstance, LocalUdsInstanceSpec> =
                     PoolNoodle::new(spec.pool_size.into(), spec.clone(), token.clone());
 
@@ -119,32 +123,18 @@ impl Server {
                     .start(config.healthcheck_pool())
                     .map_err(|e| ServerError::CyclonePool(Box::new(e)))?;
 
-                let metadata = Arc::new(ServerMetadata {
-                    instance_id: config.instance_id().into(),
-                    job_invoked_provider: "si",
-                });
-
-                let decryption_key =
-                    VeritechDecryptionKey::from_config(config.crypto().clone()).await?;
-
-                let cyclone_client_execution_timeout =
-                    match config.cyclone_client_execution_timeout() {
-                        Some(timeout) => Duration::from_secs(timeout),
-                        None => DEFAULT_CYCLONE_CLIENT_EXECUTION_TIMEOUT,
-                    };
-
-                let kill_senders = Arc::new(Mutex::new(HashMap::new()));
-
                 let inner_future = Self::build_app(
                     metadata.clone(),
+                    config.concurrency_limit(),
                     cyclone_pool,
                     Arc::new(decryption_key),
-                    cyclone_client_execution_timeout,
+                    config.cyclone_client_execution_timeout(),
                     nats.clone(),
                     kill_senders.clone(),
                     token.clone(),
                 )
                 .await?;
+
                 let kill_inner_future =
                     Self::build_kill_app(metadata.clone(), nats, kill_senders, token.clone())
                         .await?;
@@ -156,37 +146,6 @@ impl Server {
                     shutdown_token: token,
                 })
             }
-            wrong @ CycloneSpec::LocalHttp(_) => Err(ServerError::WrongCycloneSpec(
-                "LocalUds",
-                Box::new(wrong.clone()),
-            )),
-        }
-    }
-
-    #[instrument(name = "veritech.init.cyclone.http", level = "info", skip_all)]
-    pub async fn for_cyclone_http(config: Config, _token: CancellationToken) -> ServerResult<Self> {
-        match config.cyclone_spec() {
-            CycloneSpec::LocalHttp(_spec) => {
-                // TODO(fnichol): Hi there! Ultimately, the Veritech server should be able to work
-                // with a LocalUds Cyclone backend and a LocalHttp version. But since this involves
-                // threading through some generic types which themselves have trait
-                // constraints--well we can add this back in the near future... Note that the
-                // immediately prior state to this line change is roughly the starting point for
-                // adding the types back. Good luck to us all.
-                //
-                // let nats = connect_to_nats(&config).await?;
-                // let manager = Manager::new(spec.clone());
-                // let cyclone_pool = Pool::builder(manager)
-                //     .build()
-                //     .map_err(|err| ServerError::CycloneSpec(Box::new(err)))?;
-
-                // Ok(Server { nats, cyclone_pool })
-                unimplemented!("get ready for a surprise!!")
-            }
-            wrong @ CycloneSpec::LocalUds(_) => Err(ServerError::WrongCycloneSpec(
-                "LocalHttp",
-                Box::new(wrong.clone()),
-            )),
         }
     }
 
@@ -208,8 +167,10 @@ impl Server {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn build_app(
         metadata: Arc<ServerMetadata>,
+        concurrency_limit: usize,
         cyclone_pool: PoolNoodle<LocalUdsInstance, LocalUdsInstanceSpec>,
         decryption_key: Arc<VeritechDecryptionKey>,
         cyclone_client_execution_timeout: Duration,
@@ -239,7 +200,7 @@ impl Server {
         );
 
         let app = ServiceBuilder::new()
-            .concurrency_limit(DEFAULT_CONCURRENCY_LIMIT)
+            .concurrency_limit(concurrency_limit)
             .layer(
                 TraceLayer::new()
                     .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
@@ -268,8 +229,8 @@ impl Server {
             Self::kill_subscriber(&nats, prefix.as_deref())
                 .await?
                 .map(|msg| msg.into_parts().0)
-                // Core NATS subscriptions are a stream of `Option<Message>` so we convert this into a
-                // stream of `Option<Result<Message, Infallible>>`
+                // Core NATS subscriptions are a stream of `Option<Message>` so we convert this
+                // into a stream of `Option<Result<Message, Infallible>>`
                 .map(Ok::<_, Infallible>)
         };
 
@@ -292,9 +253,9 @@ impl Server {
         Ok(Box::new(inner.into_future()))
     }
 
-    // NOTE(nick,fletcher): it's a little funky that the prefix is taken from the nats client, but we ask for both
-    // here. We don't want users to forget the prefix, so being explicit is helpful, but maybe we can change this
-    // in the future.
+    // NOTE(nick,fletcher): it's a little funky that the prefix is taken from the nats client, but
+    // we ask for both here. We don't want users to forget the prefix, so being explicit is
+    // helpful, but maybe we can change this in the future.
     async fn kill_subscriber(nats: &NatsClient, prefix: Option<&str>) -> ServerResult<Subscriber> {
         let subject = veritech_core::subject::veritech_kill_request(prefix);
         nats.subscribe(subject.clone())


### PR DESCRIPTION
This change harmonizes the server configuration and server setups between Pinga and Veritech. The following changes are made:

- Veritech takes an `--instance-id` option on the CLI and a random ID is generated if not provided (similar to other services).
- Veritech takes a `--concurrency` option to override the default concurrency limit.
- The concurrency option is `--concurrency` in both Veritech & Pinga.
- The config file value `concurrency_limit` is honored in both Veritech & Pinga.
- Default for concurrency limits are now in each respective server's `config` module and is used to render the value indirectly through its `Config` type.
- Veritech's execution timeout option is updated to `--cyclone-client-execution-timeout-secs` to reflect the numerial value.
- Veritech's execution timeout is a duration and is computed via its `Config` type.
- Veritech's `main.rs` is updated to be follow the same pattern as Pinga and Rebaser.
- Veritech's binary sets a graceful shutdown timeout, currently set to 6 hours (which likely needs adjustment but was inifinte prior to this change).
- Veritech's server setup now uses a `from_config` function, similar to Pinga and Rebaser.

<img src="https://media3.giphy.com/media/2x1kNFwOGVzblPfPaq/giphy.gif"/>