### PR TITLE
feat: push unable to serve request toast on 502 and 504

### DIFF
--- a/app/web/src/components/toasts/UnscheduledDowntime.vue
+++ b/app/web/src/components/toasts/UnscheduledDowntime.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="flex flex-row items-center gap-xs">
+    <Icon name="bell" class="text-destructive-600" />
+    <div class="flex flex-col text-sm text-center">
+      <div>
+        System Initiative was unable to serve the provided request. Please try
+        again later. You can check our
+        <a class="text-action-500" href="https://status.systeminit.com"
+          >Status Page</a
+        >
+        , visit our
+        <a class="text-action-500" href="https://discord.com/invite/system-init"
+          >Discord</a
+        >
+        or email
+        <a class="text-action-500" href="mailto:support@systeminit.com"
+          >support@systeminit.com</a
+        >
+        for information or assistance if this problem persists.
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { Icon } from "@si/vue-lib/design-system";
+</script>

--- a/app/web/src/main.ts
+++ b/app/web/src/main.ts
@@ -159,6 +159,7 @@ const filterBeforeCreate = (toast: any, toasts: any[]): any | false => {
       return toast;
     }
   }
+  return toast;
 };
 
 const options: PluginOptions = {


### PR DESCRIPTION
Adds some toasty behaviour when we are experiencing an outage that we didn't internally instigate, looks a bit like this:

![Screenshot 2024-08-28 at 15 57 12](https://github.com/user-attachments/assets/3f80fbc3-0bfa-4328-88b7-f8cb784029c9)

We basically throw this "unable to serve request" toast when the backend is throwing a 502 or 504 [no backend available or something like that]

<hr/>

fixup: `  return toast;` was missing from the filterBefore toast middleware so what was happening is any other toast but the maintenance toast was getting filtered out. This is amended in this PR.