### PR TITLE
fix: amend deployment strategy for tools on main

### DIFF
--- a/.github/workflows/deploy-on-main.yml
+++ b/.github/workflows/deploy-on-main.yml
@@ -1,7 +1,7 @@
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'tools/deploy/*'
 
 jobs:
   deploy-tools-prod:

--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -29,6 +29,13 @@ on:
         default: "stable"
 
 jobs:
+
+  invoke-and-check-cdn:
+    uses: ./.github/workflows/invoke-and-check-invalidations.yml
+    with:
+      environment: shared
+    secrets: inherit
+
   set-service-versions:
     uses: ./.github/workflows/set-service-version.yml
     strategy:
@@ -39,12 +46,16 @@ jobs:
       environment: ${{ inputs.environment }}
       service: ${{ matrix.service }}
       version: ${{ inputs.version }}
+    needs:
+      - invoke-and-check-cdn
     secrets: inherit
 
   set-maintenance-mode:
     uses: ./.github/workflows/set-maintenance-mode.yml
     with:
       environment: ${{ inputs.environment }}
+    needs:
+      - invoke-and-check-cdn
     secrets: inherit
 
   down: # the backend services

--- a/.github/workflows/invoke-and-check-invalidations.yml
+++ b/.github/workflows/invoke-and-check-invalidations.yml
@@ -1,0 +1,37 @@
+name: Instigate & Check CDN State
+
+run-name: Instigate & Check CDN State for ${{ inputs.environment }} 
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+        required: true
+        description: "Where to check"
+
+jobs:
+  check-cdn:
+    name: Instigate & Check CDN Invalidation
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials for ${{ inputs.environment }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: us-east-1
+
+      - name: Invalidate web cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DIST_ID }} \
+          --paths "/cyclone/stable/*" "/sdf/stable/*" "/rebaser/stable/*" "/pinga/stable/*" "/veritech/stable/*" \
+          --query 'Invalidation.Id' --output text
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check & wait for any active invalidations
+        run: |
+          component/toolbox/awsi.sh check-invalidation -r us-east-1 -p pull-from-env -t 300 -d all -a y

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -18,7 +18,7 @@ jobs:
         id: comment-branch
       - uses: "buildkite/trigger-pipeline-action@v2.1.0"
         with:
-          buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
+          buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }} # TODO(johnrwatson): This is Scott's Token at the minute, needs rotated
           pipeline: "system-initiative/si-merge-queue"
           branch: ${{ steps.comment-branch.outputs.head_ref }}
           message:  ":github: Try for branch ${{ steps.comment-branch.outputs.head_ref }}"

--- a/BUCK
+++ b/BUCK
@@ -97,3 +97,4 @@ export_file(
 workspace_node_modules(
     name = "node_modules",
 )
+

--- a/component/toolbox/scripts/check-invalidation
+++ b/component/toolbox/scripts/check-invalidation
@@ -1,0 +1,119 @@
+#!/bin/bash
+# ---------------------------------------------------------------------------------------------------
+# Checks a  cloudfront distribution and allows you to check for active invalidations & wait until
+# they are complete
+# ---------------------------------------------------------------------------------------------------
+
+set -eo pipefail
+
+# Find & Import all the supporting functions from the supporting folder
+# Get the directory of the current script to figure out where the
+# Supporting funcs are
+IMPORT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+for script in ${IMPORT_DIR}/supporting-funcs/*.sh; do
+	if [[ -f "$script" ]]; then
+		source "$script"
+	fi
+done
+
+# Usage for this script
+usage() {
+	echo
+	echo "check-invalidation"
+	echo "----------------------------------"
+	echo "This script will check for an active invalidation against a cloudfront"
+	echo "distribution and wait for n seconds for it to finish"
+	echo "----------------------------------"
+	echo "Usage: migrate [-p profile] [-r region] [-a automatic]"
+	echo "  -p profile        [pull-from-env/<profile-name>] AWS profile to use"
+	echo "  -r region         AWS region to use"
+	echo "  -a automatic      [Y/N] Run through automatically/no-interact"
+	echo "  -t time           Time to wait for active invalidations to pass"
+	echo "  -d distribution   ID of the distribution to check/use"
+	echo "----------------------------------"
+	echo "e.g. ./awsi.sh migrate -p pull-from-env -r us-east-1 -a y"
+	exit 1
+}
+
+# Add a check to see if the script is being sourced or executed
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+	usage
+fi
+
+# Parse flags
+while getopts ":p:r:a:t:d:" opt; do
+	case ${opt} in
+	p)
+		profile=$OPTARG
+		;;
+	r)
+		region=$OPTARG
+		;;
+	a)
+		automatic=$OPTARG
+		;;
+	t)
+		time=$OPTARG
+		;;
+	d)
+		distribution=$OPTARG
+		;;
+	\?)
+		echo "Invalid option: -$OPTARG" >&2
+		usage
+		;;
+	:)
+		echo "Option -$OPTARG requires an argument." >&2
+		usage
+		;;
+	esac
+done
+
+# ---------------------------------------------------------------------------------------------------
+# Main script
+# ---------------------------------------------------------------------------------------------------
+echo "$0 being invoked"
+
+# Use the profile if in the invocation
+if [[ "$profile" != "pull-from-env" ]]; then
+	profile=$(get_param_or_env "$profile" "AWS_PROFILE" "Enter the AWS profile to use")
+	export AWS_PROFILE="$profile"
+fi
+region=$(get_param_or_env "$region" "AWS_REGION" "Enter the AWS region (e.g., us-west-2)")
+export AWS_REGION="$region"
+
+distributions=$(list_distributions "$distribution")
+if [ -z "$distributions" ]; then
+	echo "No Cloudfront Distributions found."
+	exit 1
+fi
+
+echo "----------------------------------------"
+echo "Cloudfront Distributions in the region $region:"
+printf "%-5s %-20s %-20s         %-20s %-20s\n" "Index" "Id" "DomainName" "Status" "Comment"
+i=1
+while read -r line; do
+	name=$(echo "$line" | awk '{print $1}')
+	distribution_id=$(echo "$line" | awk '{print $2}')
+	domain_name=$(echo "$line" | awk '{print $3}')
+	status=$(echo "$line" | awk '{print $4}')
+	printf "%-5s %-20s %-20s %-20s %-20s\n" "$i" "$name" "$distribution_id" "$domain_name" "$status"
+	((i++))
+done <<<"$distributions"
+echo "----------------------------------------"
+
+[[ "${automatic,,}" == "y" ]] || read -p "Would you like to check for invalidations on one of these distributions? (Y/N) [takes ~5 seconds] " selection
+[[ "${automatic,,}" == "y" ]] || sassy_selection_check $selection
+
+echo "----------------------------------------"
+
+while read -r line; do
+	distribution_id=$(echo "$line" | awk '{print $1}')
+	track_invalidations "$distribution_id" "$time"
+done <<<"$distributions"
+
+echo "----------------------------------------"
+echo "All Invalidations on the selected Cloudfront Distribution IDs have completed"
+echo "----------------------------------------"
+exit 0

--- a/component/toolbox/scripts/supporting-funcs/cloudfront-funcs.sh
+++ b/component/toolbox/scripts/supporting-funcs/cloudfront-funcs.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Function to list CloudFront Distributions by ID
+list_distributions() {
+  filter=$1
+  if [[ "${filter,,}" == "all" || -z "${filter}" ]]; then
+    # List all CloudFront distributions
+    aws cloudfront list-distributions --query 'DistributionList.Items[*].[Id,DomainName,Status,Comment]' --output text
+  else
+    # Filter CloudFront distributions based on the provided filter
+    aws cloudfront list-distributions --query 'DistributionList.Items[*].[Id,DomainName,Status,Comment]' --output text | grep -E "${filter}"
+  fi
+}
+
+# Function to start an interactive SSM session with any given instance
+track_invalidations() {
+  distribution_id=$1
+  time=$2
+
+  # Get the end time by adding the current time and the specified time in seconds
+  end_time=$((SECONDS + time))
+
+  echo "Checking CloudFront invalidations for distribution ID: $distribution_id"
+
+  # Loop until the time has expired
+  while [ $SECONDS -lt $end_time ]; do
+    # Get the list of invalidations that are still in progress
+    active_invalidations=$(aws cloudfront list-invalidations --distribution-id "$distribution_id" --query "InvalidationList.Items[?Status=='InProgress'].Id" --output text)
+
+    if [ -z "$active_invalidations" ]; then
+      return
+    else
+      echo "$distribution_id: Active invalidation $active_invalidations | [current time: $SECONDS / timeout: $end_time]"
+    fi
+
+    # Sleep for 1 second before polling again
+    sleep 1
+  done
+
+  echo "Time expired. There may still be active invalidations."
+  exit 1
+}


### PR DESCRIPTION
Sister PR to https://github.com/systeminit/si-ci/pull/132/files once it's merged we can hook off the tag to deploy on merge to main more cleanly. 

We were having trouble with cloudfront cache so this invalidates the cache explicitly before every deployment.

Adds a cloudfront distribution checker to the toolbox so we can quickly validate that the CDN is invalidated, or there are no active invalidations before continuing with the deployment.