### PR TITLE
feat(dal): dvu component concurrency limit

### DIFF
--- a/lib/dal-test/src/test_exclusive_schemas/starfield.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/starfield.rs
@@ -4,12 +4,12 @@ use dal::func::intrinsics::IntrinsicFunc;
 use dal::pkg::import_pkg_from_pkg;
 use dal::prop::PropPath;
 use dal::{BuiltinsResult, DalContext, PropKind};
-use si_pkg::SchemaSpecData;
 use si_pkg::{
     ActionFuncSpec, AttrFuncInputSpec, AttrFuncInputSpecKind, FuncArgumentSpec, FuncSpec,
     FuncSpecBackendKind, FuncSpecBackendResponseType, FuncSpecData, PkgSpec, PropSpec, SchemaSpec,
     SchemaVariantSpec, SchemaVariantSpecData, SiPkg, SocketSpec, SocketSpecData, SocketSpecKind,
 };
+use si_pkg::{SchemaSpecData, SocketSpecArity};
 
 use crate::test_exclusive_schemas::{PKG_CREATED_BY, PKG_VERSION};
 
@@ -516,6 +516,7 @@ pub(crate) async fn migrate_test_exclusive_schema_morningstar(
                         .name("naming_and_necessity")
                         .data(
                             SocketSpecData::builder()
+                                .arity(SocketSpecArity::Many)
                                 .name("naming_and_necessity")
                                 .connection_annotations(serde_json::to_string(&vec![
                                     "naming_and_necessity",

--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -562,7 +562,7 @@ impl Action {
         let dependent_value_graph = DependentValueGraph::new(
             ctx,
             ctx.workspace_snapshot()?
-                .list_dependent_value_value_ids()
+                .get_dependent_value_roots()
                 .await?,
         )
         .await?;

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -845,6 +845,15 @@ impl AttributeValue {
             .is_dynamic())
     }
 
+    pub async fn is_set_by_intrinsic(
+        ctx: &DalContext,
+        attribute_value_id: AttributeValueId,
+    ) -> AttributeValueResult<bool> {
+        Ok(Self::prototype_func(ctx, attribute_value_id)
+            .await?
+            .is_intrinsic())
+    }
+
     pub async fn is_set_by_unset(
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
@@ -2415,10 +2424,6 @@ impl AttributeValue {
             .ok_or(AttributeValueError::RemovingWhenNotChildOrMapOrArray(id))?;
 
         ctx.workspace_snapshot()?.remove_node_by_id(id).await?;
-        ctx.workspace_snapshot()?
-            .remove_dependent_value_root(id)
-            .await?;
-
         ctx.add_dependent_values_and_enqueue(vec![parent_av_id])
             .await?;
         Ok(())

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -375,6 +375,10 @@ impl Func {
         Self::is_dynamic_for_name_string(&self.name)
     }
 
+    pub fn is_intrinsic(&self) -> bool {
+        IntrinsicFunc::maybe_from_str(&self.name).is_some()
+    }
+
     /// A non-dynamic Func is an Intrinsic func that returns a fixed value, set by a StaticArgumentValue in the graph
     /// opposingly, a dynamic Func is a func that returns a non statically predictable value, possibly user defined.
     ///

--- a/lib/dal/src/migrations/U3101__add_component_concurrency_limit_to_workspaces.sql
+++ b/lib/dal/src/migrations/U3101__add_component_concurrency_limit_to_workspaces.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workspaces
+    ADD COLUMN component_concurrency_limit integer NULL;

--- a/lib/dal/src/workspace_snapshot/graph/v2.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v2.rs
@@ -824,8 +824,12 @@ impl WorkspaceSnapshotGraphV2 {
                         "black",
                     ),
                     NodeWeight::DependentValueRoot(node_weight) => (
-                        format!("DependentValue\n{}", node_weight.value_id()),
+                        format!("UnfinishedDependentValue\n{}", node_weight.value_id()),
                         "purple",
+                    ),
+                    NodeWeight::FinishedDependentValueRoot(node_weight) => (
+                        format!("FinishedDependentValue\n{}", node_weight.value_id()),
+                        "red",
                     ),
                 };
                 let color = color.to_string();

--- a/lib/dal/src/workspace_snapshot/node_weight/finished_dependent_value_root_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/finished_dependent_value_root_node_weight.rs
@@ -1,0 +1,76 @@
+use serde::{Deserialize, Serialize};
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
+
+use crate::{
+    workspace_snapshot::node_weight::traits::CorrectTransforms, EdgeWeightKindDiscriminants,
+};
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FinishedDependentValueRootNodeWeight {
+    pub id: Ulid,
+    pub lineage_id: Ulid,
+    value_id: Ulid,
+    merkle_tree_hash: MerkleTreeHash,
+}
+
+impl FinishedDependentValueRootNodeWeight {
+    pub fn content_hash(&self) -> ContentHash {
+        self.node_hash()
+    }
+
+    pub fn content_store_hashes(&self) -> Vec<ContentHash> {
+        vec![]
+    }
+
+    pub fn id(&self) -> Ulid {
+        self.id
+    }
+
+    pub fn value_id(&self) -> Ulid {
+        self.value_id
+    }
+
+    pub fn lineage_id(&self) -> Ulid {
+        self.lineage_id
+    }
+
+    pub fn merkle_tree_hash(&self) -> MerkleTreeHash {
+        self.merkle_tree_hash
+    }
+
+    pub fn new(id: Ulid, lineage_id: Ulid, value_id: Ulid) -> Self {
+        Self {
+            id,
+            lineage_id,
+            value_id,
+            merkle_tree_hash: Default::default(),
+        }
+    }
+
+    pub fn node_hash(&self) -> ContentHash {
+        ContentHash::from(&serde_json::json![{
+            "value_id": self.value_id,
+        }])
+    }
+
+    pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {
+        self.merkle_tree_hash = new_hash;
+    }
+
+    pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
+        &[]
+    }
+}
+
+impl std::fmt::Debug for FinishedDependentValueRootNodeWeight {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("FinishedDependentValueNodeWeight")
+            .field("id", &self.id.to_string())
+            .field("lineage_id", &self.lineage_id.to_string())
+            .field("value_id", &self.value_id.to_string())
+            .field("merkle_tree_hash", &self.merkle_tree_hash)
+            .finish()
+    }
+}
+
+impl CorrectTransforms for FinishedDependentValueRootNodeWeight {}

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -3,6 +3,7 @@ use dal::component::{DEFAULT_COMPONENT_HEIGHT, DEFAULT_COMPONENT_WIDTH};
 use dal::diagram::Diagram;
 use dal::prop::{Prop, PropPath};
 use dal::property_editor::values::PropertyEditorValues;
+use dal::workspace_snapshot::DependentValueRoot;
 use dal::{AttributeValue, AttributeValueId};
 use dal::{Component, DalContext, Schema, SchemaVariant};
 use dal_test::expected::{self, ExpectComponent};
@@ -297,9 +298,14 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) {
             .copied()
             .expect("get first value id");
 
-    let update_graph = DependentValueGraph::new(ctx, vec![rigid_designator_value_id])
-        .await
-        .expect("able to generate update graph");
+    let update_graph = DependentValueGraph::new(
+        ctx,
+        vec![DependentValueRoot::Unfinished(
+            rigid_designator_value_id.into(),
+        )],
+    )
+    .await
+    .expect("able to generate update graph");
 
     assert!(
         update_graph.contains_value(naming_and_necessity_value_id),
@@ -468,9 +474,14 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
             .copied()
             .expect("get first value id");
 
-    let update_graph = DependentValueGraph::new(ctx, vec![possible_world_a_value_id])
-        .await
-        .expect("able to generate update graph");
+    let update_graph = DependentValueGraph::new(
+        ctx,
+        vec![DependentValueRoot::Unfinished(
+            possible_world_a_value_id.into(),
+        )],
+    )
+    .await
+    .expect("able to generate update graph");
 
     assert!(
         update_graph.contains_value(naming_and_necessity_value_id),

--- a/lib/dal/tests/integration_test/node_weight/attribute_value.rs
+++ b/lib/dal/tests/integration_test/node_weight/attribute_value.rs
@@ -1,3 +1,4 @@
+use dal::workspace_snapshot::DependentValueRoot;
 use dal::DalContext;
 use dal_test::expected::{
     apply_change_set_to_base, commit_and_update_snapshot_to_visibility, fork_from_head_change_set,
@@ -35,8 +36,10 @@ async fn change_in_output_component_produces_dvu_root_in_other_change_set(ctx: &
     assert!(ctx
         .workspace_snapshot()
         .expect("get snap")
-        .list_dependent_value_value_ids()
+        .get_dependent_value_roots()
         .await
         .expect("able to get dvu values")
-        .contains(&image.attribute_value(ctx).await.id().into()));
+        .contains(&DependentValueRoot::Unfinished(
+            image.attribute_value(ctx).await.id().into()
+        )));
 }

--- a/lib/rebaser-server/src/config.rs
+++ b/lib/rebaser-server/src/config.rs
@@ -66,7 +66,7 @@ pub struct Config {
     #[builder(default = "random_instance_id()")]
     instance_id: String,
 
-    #[builder(default = "5000")]
+    #[builder(default = "800")]
     dvu_interval_millis: u64,
 }
 

--- a/lib/sdf-server/src/server/service/diagram/dvu_roots.rs
+++ b/lib/sdf-server/src/server/service/diagram/dvu_roots.rs
@@ -26,7 +26,7 @@ pub async fn dvu_roots(
 
     let count = ctx
         .workspace_snapshot()?
-        .list_dependent_value_value_ids()
+        .get_dependent_value_roots()
         .await?
         .len();
 


### PR DESCRIPTION
Adds a column to the workspaces table that allows us to control how many components can be updated by the DependentValuesUpdate job in one run. When the limit is reached, the job will write the current set of DVU roots back to the graph so the dependency graph can be reconstructed in the state it was when the job finished. Currently every workspace will get a hefty default limit of 256 components, but this is configurable by updating the column in the workspaces table, which the Admin panel will make possible in a future change.

Also reduces the dvu interval for the rebaser to 800ms, so that dvu jobs are enqueued more frequently.

This adds a database migration, and a new node weight, so cannot be rolled back easily (however no graph migration will be required)