### PR TITLE
Collapsed frame improvements

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramEdge.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramEdge.vue
@@ -154,12 +154,14 @@ const points = computed(() => {
     props.fromPoint,
     SOCKET_SIZE / 2,
   );
-  return [
+  const p = [
     fromPointWithGap.x,
     fromPointWithGap.y,
     toPointWithGap.x,
     toPointWithGap.y,
   ];
+  if (p.some((_p) => Number.isNaN(_p))) return;
+  return p;
 });
 
 const centerPoint = computed(() => {

--- a/app/web/src/components/ModelingDiagram/diagram_types.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_types.ts
@@ -1,5 +1,6 @@
 import { IconNames, Tones } from "@si/vue-lib/design-system";
 import { ConnectionAnnotation } from "@si/ts-lib";
+import { Vector2d } from "konva/lib/types";
 import { useComponentsStore } from "@/store/components.store";
 import { ChangeStatus } from "@/api/sdf/dal/change_set";
 import { ComponentId } from "@/api/sdf/dal/component";
@@ -91,7 +92,13 @@ export class DiagramSocketData extends DiagramElementData {
   }
 }
 
+export type SocketLocationInfo = { center: Vector2d };
+
 export class DiagramEdgeData extends DiagramElementData {
+  // populated from the diagram
+  fromPoint: SocketLocationInfo | undefined;
+  toPoint: SocketLocationInfo | undefined;
+
   constructor(readonly def: DiagramEdgeDef) {
     super();
   }


### PR DESCRIPTION
- Move collapsed & real children when parent moves ✅ 
- Parent resize should act as if collapsed children were never collapsed ✅ 
- Dont show multiple edges to the same coordinates ✅ 
- Dont render edges to or from a component that is not rendered because its parent is collapsed ✅ 
<img src="https://media4.giphy.com/media/CLIjz8LTTbBsfpL17K/giphy.gif"/>