### PR TITLE
fix: Clone object children of arrays and maps correctly

### DIFF
--- a/lib/sdf-server/src/server/service/component/insert_property_editor_value.rs
+++ b/lib/sdf-server/src/server/service/component/insert_property_editor_value.rs
@@ -33,7 +33,7 @@ pub async fn insert_property_editor_value(
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
-    let _ = AttributeValue::insert(
+    AttributeValue::insert(
         &ctx,
         request.parent_attribute_value_id,
         request.value,


### PR DESCRIPTION
Previously, when upgrading a component and reaching an attribute value that didn't have a correspondent on the new variant yet, we assumed it was a map or array scalar item and created it, which resulted in us not creating attribute values for fields of objects inside arrays and maps. This resulted in unusable array entries on the prop editor. 

Now, when cloning objects that are inside arrays and maps, we forcefully create all attributes.

This unearthed another problem, which was that we were using the prop id + the key to determine equivalency between avs of new and old components, meaning in the case of fields of objects within arrays (which don't have keys or indices themselves), we'd copy the value from random items with the same prop id. This is resolved by matching on the full av path instead of just the key or index

![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExdm9xMnQ3NDc5dWszYnM2eHExeHc5eWlrcTlyNmwzd2lwZXF2aGxoaCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xUPGcll4R0dtfh5H6o/giphy.webp)

