### PR TITLE
fix: re-enable SDF migrations on boot

### DIFF
--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -1,4 +1,3 @@
-migration_mode = "skip"
 pkgs_path = "/tmp"
 create_workspace_permissions = "$SI_WORKSPACE_PERMISSIONS"
 create_workspace_allowlist = [ "$SI_WORKSPACE_ALLOW_LIST" ]


### PR DESCRIPTION
See [here](https://systeminit.slack.com/archives/C07KK832MDX) for details.

TL;DR it is not safe to migrateAndQuit right now as we don't wait for layerdb to finish writes. Until we fix the graceful shutdown logic in SDF it is not safe to do this.