### PR TITLE
feat(si-service): refactor `shutdown::graceful` to a builder pattern

### DIFF
--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -40,6 +40,7 @@ async fn async_main() -> Result<()> {
                 "si_data_nats",
                 "si_data_pg",
                 "si_layer_cache",
+                "si_service",
             ])
             .build()?;
 
@@ -70,15 +71,13 @@ async fn async_main() -> Result<()> {
         server.run().await
     });
 
-    shutdown::graceful(
-        [
-            (main_tracker, main_token),
-            (layer_db_tracker, layer_db_token),
-            (telemetry_tracker, telemetry_token),
-        ],
-        Some(telemetry_shutdown.into_future()),
-        Some(GRACEFUL_SHUTDOWN_TIMEOUT),
-    )
-    .await
-    .map_err(Into::into)
+    shutdown::graceful()
+        .group(main_tracker, main_token)
+        .group(layer_db_tracker, layer_db_token)
+        .group(telemetry_tracker, telemetry_token)
+        .telemetry_guard(telemetry_shutdown.into_future())
+        .timeout(GRACEFUL_SHUTDOWN_TIMEOUT)
+        .wait()
+        .await
+        .map_err(Into::into)
 }


### PR DESCRIPTION
This change updates the common binary program `graceful()` function into a function that returns an internal builder capable of the same graceful shutdown logic as before. This refactoring will allow for future extensions (i.e. additional optional shutdown scenarios) as well as making the setup a little more ergonomic.