### PR TITLE
chore(pinga,rebaser,veritech): extract bin name into const

### DIFF
--- a/bin/pinga/BUCK
+++ b/bin/pinga/BUCK
@@ -1,8 +1,8 @@
 load(
     "@prelude-si//:macros.bzl",
     "docker_image",
-    "rust_binary",
     "nix_omnibus_pkg",
+    "rust_binary",
 )
 
 rust_binary(
@@ -18,6 +18,7 @@ rust_binary(
         "//third-party/rust:tokio-util",
     ],
     srcs = glob(["src/**/*.rs"]),
+    env = {"CARGO_BIN_NAME": "pinga"},
     resources = {
         "dev.encryption.key": "//lib/veritech-server:dev.encryption.key",
         "dev.donkey.key": "//lib/dal:dev.donkey.key",
@@ -29,7 +30,7 @@ docker_image(
     name = "image",
     image_name = "pinga",
     flake_lock = "//:flake.lock",
-    build_deps = ["//bin/pinga:pinga"]
+    build_deps = ["//bin/pinga:pinga"],
 )
 
 nix_omnibus_pkg(

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -5,10 +5,13 @@ use si_service::{color_eyre, prelude::*, rt, shutdown, startup, telemetry_applic
 
 mod args;
 
+const BIN_NAME: &str = env!("CARGO_BIN_NAME");
+const LIB_NAME: &str = concat!(env!("CARGO_BIN_NAME"), "_server");
+
 const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60 * 10);
 
 fn main() -> Result<()> {
-    rt::block_on("bin/pinga-tokio::runtime", async_main())
+    rt::block_on(BIN_NAME, async_main())
 }
 
 async fn async_main() -> Result<()> {
@@ -30,10 +33,10 @@ async fn async_main() -> Result<()> {
                     .then_some(ConsoleLogFormat::Json)
                     .unwrap_or_default(),
             )
-            .service_name("pinga")
+            .service_name(BIN_NAME)
             .service_namespace("si")
             .log_env_var_prefix("SI")
-            .app_modules(vec!["pinga", "pinga_server"])
+            .app_modules(vec![BIN_NAME, LIB_NAME])
             .interesting_modules(vec![
                 "dal",
                 "naxum",
@@ -47,7 +50,7 @@ async fn async_main() -> Result<()> {
         telemetry_application::init(config, &telemetry_tracker, telemetry_token.clone())?
     };
 
-    startup::startup("pinga").await?;
+    startup::startup(BIN_NAME).await?;
 
     if args.verbose > 0 {
         telemetry

--- a/bin/rebaser/BUCK
+++ b/bin/rebaser/BUCK
@@ -14,6 +14,7 @@ rust_binary(
         "//third-party/rust:clap",
     ],
     srcs = glob(["src/**/*.rs"]),
+    env = {"CARGO_BIN_NAME": "rebaser"},
     resources = {
         "dev.encryption.key": "//lib/veritech-server:dev.encryption.key",
         "dev.donkey.key": "//lib/dal:dev.donkey.key",

--- a/bin/rebaser/src/main.rs
+++ b/bin/rebaser/src/main.rs
@@ -7,8 +7,11 @@ mod args;
 
 const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60 * 10);
 
+const BIN_NAME: &str = env!("CARGO_BIN_NAME");
+const LIB_NAME: &str = concat!(env!("CARGO_BIN_NAME"), "_server");
+
 fn main() -> Result<()> {
-    rt::block_on("bin/rebaser-tokio::runtime", async_main())
+    rt::block_on(BIN_NAME, async_main())
 }
 
 async fn async_main() -> Result<()> {
@@ -30,10 +33,10 @@ async fn async_main() -> Result<()> {
                     .then_some(ConsoleLogFormat::Json)
                     .unwrap_or_default(),
             )
-            .service_name("rebaser")
+            .service_name(BIN_NAME)
             .service_namespace("si")
             .log_env_var_prefix("SI")
-            .app_modules(vec!["rebaser", "rebaser_server"])
+            .app_modules(vec![BIN_NAME, LIB_NAME])
             .interesting_modules(vec![
                 "dal",
                 "naxum",
@@ -47,7 +50,7 @@ async fn async_main() -> Result<()> {
         telemetry_application::init(config, &telemetry_tracker, telemetry_token.clone())?
     };
 
-    startup::startup("rebaser").await?;
+    startup::startup(BIN_NAME).await?;
 
     if args.verbose > 0 {
         telemetry

--- a/bin/veritech/BUCK
+++ b/bin/veritech/BUCK
@@ -40,6 +40,7 @@ rust_binary(
         "//third-party/rust:tokio-util",
     ],
     srcs = glob(["src/**/*.rs"]),
+    env = {"CARGO_BIN_NAME": "rebaser"},
     resources = {
         "cyclone": "//bin/cyclone:cyclone",
         "dev.decryption.key": "//lib/veritech-server:dev.decryption.key",
@@ -73,7 +74,7 @@ docker_image(
         "//bin/veritech:docker-entrypoint.sh",
         "//bin/cyclone:cyclone",
         "//bin/lang-js:bin",
-    ]
+    ],
 )
 
 nix_omnibus_pkg(
@@ -81,4 +82,3 @@ nix_omnibus_pkg(
     pkg_name = "veritech",
     build_dep = "//bin/veritech:veritech",
 )
-

--- a/bin/veritech/src/main.rs
+++ b/bin/veritech/src/main.rs
@@ -5,10 +5,13 @@ use veritech_server::{Config, Server};
 
 mod args;
 
+const BIN_NAME: &str = env!("CARGO_BIN_NAME");
+const LIB_NAME: &str = concat!(env!("CARGO_BIN_NAME"), "_server");
+
 const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 6);
 
 fn main() -> Result<()> {
-    rt::block_on("bin/veritch-tokio::runtime", async_main())
+    rt::block_on(BIN_NAME, async_main())
 }
 
 async fn async_main() -> Result<()> {
@@ -28,17 +31,17 @@ async fn async_main() -> Result<()> {
                     .then_some(ConsoleLogFormat::Json)
                     .unwrap_or_default(),
             )
-            .service_name("veritech")
+            .service_name(BIN_NAME)
             .service_namespace("si")
             .log_env_var_prefix("SI")
-            .app_modules(vec!["veritech", "veritech_server"])
+            .app_modules(vec![BIN_NAME, LIB_NAME])
             .interesting_modules(vec!["naxum", "si_data_nats", "si_service"])
             .build()?;
 
         telemetry_application::init(config, &telemetry_tracker, telemetry_token.clone())?
     };
 
-    startup::startup("veritech").await?;
+    startup::startup(BIN_NAME).await?;
 
     if args.verbose > 0 {
         telemetry


### PR DESCRIPTION
This change uses the `CARGO_BIN_NAME` in the programs' `main.rs` in an effort to more closely unify the construction of a common SI Rust program.