### PR TITLE
feat: include the env and service name in the toolbox shell

### DIFF
--- a/component/toolbox/scripts/ssm
+++ b/component/toolbox/scripts/ssm
@@ -9,7 +9,7 @@
 set -eo pipefail
 
 # Find & Import all the supporting functions from the supporting folder
-# Get the directory of the current script to figure out where the 
+# Get the directory of the current script to figure out where the
 # Supporting funcs are
 IMPORT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 
@@ -88,6 +88,7 @@ done <<< "$instances"
 
 read -p "Select an instance by index: " selection
 instance_id=$(echo "$instances" | sed -n "${selection}p" | awk '{print $2}')
+name=$(echo "$instances" | sed -n "${selection}p" | awk '{print $1}')
 
 if [ -z "$instance_id" ]; then
     echo "Invalid selection."
@@ -95,4 +96,4 @@ if [ -z "$instance_id" ]; then
 fi
 
 echo "Starting Interactive SSM session with instance $instance_id..."
-start_interactive_ssm_session "$instance_id"
+start_interactive_ssm_session "$instance_id" "$name"

--- a/component/toolbox/scripts/supporting-funcs/ssm-funcs.sh
+++ b/component/toolbox/scripts/supporting-funcs/ssm-funcs.sh
@@ -72,7 +72,9 @@ start_and_track_ssm_session() {
 # Function to start an interactive SSM session with any given instance
 start_interactive_ssm_session() {
   instance_id=$1
-  aws ssm start-session --target "$instance_id" --document-name AWS-StartInteractiveCommand --parameters command="bash -l"
+  name=$2
+  aws ssm start-session --target "$instance_id" --document-name AWS-StartInteractiveCommand --parameters \
+    "{\"command\": [\"PS1=\\\"\\\\u@\\\\h \\\\e[32m$name\\\\e[0m > \\\" bash -l\"]}"
 }
 
 # Function to check command status


### PR DESCRIPTION
It is easy to confuse which service or environment you are interacting with when using this tool. This adds a custom prompt that makes it very obvious.

![image](https://github.com/user-attachments/assets/ba405fab-3d82-4784-bbe5-eddf430a63b3)
