### PR TITLE
feat(sdf-server): admin auth middleware for api/v2/admin

### DIFF
--- a/lib/sdf-server/src/server/routes.rs
+++ b/lib/sdf-server/src/server/routes.rs
@@ -74,7 +74,7 @@ pub fn routes(state: AppState) -> Router {
         .nest("/api/ws", crate::server::service::ws::routes())
         .nest("/api/module", crate::server::service::module::routes())
         .nest("/api/variant", crate::server::service::variant::routes())
-        .nest("/api/v2", crate::server::service::v2::routes())
+        .nest("/api/v2", crate::server::service::v2::routes(state.clone()))
         .layer(CompressionLayer::new())
         // allows us to be permissive about cors from our owned subdomains
         .layer(
@@ -110,6 +110,8 @@ pub fn routes(state: AppState) -> Router {
     // Load dev routes if we are in dev mode (decided by "opt-level" at the moment).
     router = dev_routes(router);
 
+    // Consider turning app state into an Arc so that all of the middleware
+    // share the same state object, instead of cloning
     router.with_state(state)
 }
 

--- a/lib/sdf-server/src/server/service/v2.rs
+++ b/lib/sdf-server/src/server/service/v2.rs
@@ -10,11 +10,11 @@ pub mod variant;
 const WORKSPACE_ONLY_PREFIX: &str = "/workspaces/:workspace_id";
 const PREFIX: &str = "/workspaces/:workspace_id/change-sets/:change_set_id";
 
-pub fn routes() -> Router<AppState> {
+pub fn routes(state: AppState) -> Router<AppState> {
     Router::new()
         .nest(
             &format!("{WORKSPACE_ONLY_PREFIX}/admin"),
-            admin::v2_routes(),
+            admin::v2_routes(state),
         )
         .nest(&format!("{PREFIX}/schema-variants"), variant::v2_routes())
         .nest(&format!("{PREFIX}/funcs"), func::v2_routes())

--- a/lib/sdf-server/src/server/service/v2/admin.rs
+++ b/lib/sdf-server/src/server/service/v2/admin.rs
@@ -7,8 +7,8 @@ use axum::{
 use dal::func::runner::FuncRunnerError;
 use thiserror::Error;
 
-use crate::server::error;
 use crate::server::state::AppState;
+use crate::server::{error, extract::AdminAccessBuilder};
 use crate::service::ApiError;
 
 mod kill_execution;
@@ -41,9 +41,14 @@ impl IntoResponse for AdminAPIError {
 
 pub type AdminAPIResult<T> = Result<T, AdminAPIError>;
 
-pub fn v2_routes() -> Router<AppState> {
-    Router::new().route(
-        "/func/runs/:func_run_id/kill_execution",
-        put(kill_execution::kill_execution),
-    )
+pub fn v2_routes(state: AppState) -> Router<AppState> {
+    Router::new()
+        .route(
+            "/func/runs/:func_run_id/kill_execution",
+            put(kill_execution::kill_execution),
+        )
+        .route_layer(axum::middleware::from_extractor_with_state::<
+            AdminAccessBuilder,
+            AppState,
+        >(state))
 }


### PR DESCRIPTION
Adds middleware for the entire api/v2/admin route set that limits it to users with @systeminit.com email addresses.