### PR TITLE
fix(*): upgrade cacache-rs to get panic fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,9 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "ring",
- "rustls-native-certs 0.7.2",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.1.3",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.102.7",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -236,7 +236,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -258,18 +258,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -420,7 +420,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -500,7 +500,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -633,7 +633,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
  "syn_derive",
 ]
 
@@ -735,8 +735,7 @@ dependencies = [
 [[package]]
 name = "cacache"
 version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61ff12b19d89c752c213316b87fdb4a587f073d219b893cc56974b8c9f39bf7"
+source = "git+https://github.com/zkat/cacache-rs?rev=146a593c8e3abea8bc4c1888ae6781a3f2e1422e#146a593c8e3abea8bc4c1888ae6781a3f2e1422e"
 dependencies = [
  "digest",
  "either",
@@ -767,9 +766,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "shlex",
 ]
@@ -880,7 +879,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1008,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -1116,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1193,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "ct-codecs"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
+checksum = "026ac6ceace6298d2c557ef5ed798894962296469ec7842288ea64674201a2d1"
 
 [[package]]
 name = "curve25519-dalek"
@@ -1220,7 +1219,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1337,7 +1336,7 @@ dependencies = [
  "futures",
  "hex",
  "iftree",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "itertools 0.12.1",
  "jwt-simple",
  "lazy_static",
@@ -1448,7 +1447,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1459,7 +1458,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1547,33 +1546,33 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+checksum = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
+checksum = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1586,7 +1585,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1740,7 +1739,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1811,7 +1810,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1899,9 +1898,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "ff"
@@ -1921,9 +1920,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1939,9 +1938,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.0",
@@ -2059,7 +2058,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2177,7 +2176,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2521,7 +2520,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
- "webpki-roots 0.26.3",
+ "webpki-roots 0.26.5",
 ]
 
 [[package]]
@@ -2632,7 +2631,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.75",
+ "syn 2.0.77",
  "toml",
  "unicode-xid",
 ]
@@ -2672,9 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -2695,7 +2694,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2848,7 +2847,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -2925,7 +2924,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2998,7 +2997,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3590,7 +3589,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3604,7 +3603,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3667,7 +3666,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3722,7 +3721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "serde",
  "serde_derive",
 ]
@@ -3762,7 +3761,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3893,9 +3892,9 @@ checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "postcard"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ee10b999a00ca189ac2cb99f5db1ca71fb7371e3d5f493b879ca95d2a67220"
+checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -3913,7 +3912,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3995,11 +3994,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4043,7 +4042,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
  "version_check",
  "yansi 1.0.1",
 ]
@@ -4094,7 +4093,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4144,9 +4143,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -4162,9 +4161,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -4179,22 +4178,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -4359,15 +4358,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
@@ -4426,7 +4416,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4492,7 +4482,7 @@ checksum = "46aef80f842736de545ada6ec65b81ee91504efd6853f4b96de7414c42ae7443"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4543,7 +4533,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.3",
+ "webpki-roots 0.26.5",
  "windows-registry",
 ]
 
@@ -4710,18 +4700,18 @@ checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -4751,7 +4741,7 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.102.7",
  "subtle",
  "zeroize",
 ]
@@ -4765,7 +4755,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.102.7",
  "subtle",
  "zeroize",
 ]
@@ -4784,9 +4774,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04182dffc9091a404e0fc069ea5cd60e5b866c3adf881eff99a32d048242dffa"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 2.1.3",
@@ -4832,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4973,7 +4963,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5014,7 +5004,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.75",
+ "syn 2.0.77",
  "unicode-ident",
 ]
 
@@ -5102,9 +5092,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -5122,13 +5112,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5137,7 +5127,7 @@ version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "itoa",
  "memchr",
  "ryu",
@@ -5171,7 +5161,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5215,7 +5205,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5232,7 +5222,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5241,7 +5231,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "itoa",
  "ryu",
  "serde",
@@ -5322,7 +5312,7 @@ dependencies = [
  "futures",
  "nkeys",
  "remain",
- "rustls-native-certs 0.7.2",
+ "rustls-native-certs 0.7.3",
  "serde",
  "serde_json",
  "telemetry",
@@ -5461,7 +5451,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "derive_builder",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "object-tree",
  "petgraph",
  "remain",
@@ -5488,7 +5478,7 @@ dependencies = [
  "cyclone-core",
  "derive_builder",
  "futures",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "nix 0.27.1",
  "opentelemetry",
  "rand 0.8.5",
@@ -5577,7 +5567,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5752,7 +5742,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "log",
  "memchr",
  "once_cell",
@@ -6014,7 +6004,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6049,9 +6039,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6067,7 +6057,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6223,7 +6213,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6243,7 +6233,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6323,9 +6313,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6357,7 +6347,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6522,7 +6512,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.20",
+ "toml_edit",
 ]
 
 [[package]]
@@ -6536,26 +6526,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap 2.4.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.18",
+ "winnow",
 ]
 
 [[package]]
@@ -6660,7 +6639,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7124,7 +7103,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -7158,7 +7137,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7197,20 +7176,20 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.3"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "whoami"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "wasite",
  "web-sys",
 ]
@@ -7286,7 +7265,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7297,7 +7276,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7480,15 +7459,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
@@ -7607,7 +7577,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7627,7 +7597,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[patch.unused]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ base64 = "0.22.0"
 blake3 = "1.5.1"
 bollard = "0.16.1"
 bytes = "1.6.0"
-cacache = { version = "13.0.0", default-features = false, features = [ "tokio-runtime", "mmap" ] }
+cacache = { git = "https://github.com/zkat/cacache-rs", rev = "146a593c8e3abea8bc4c1888ae6781a3f2e1422e", default-features = false, features = [ "tokio-runtime", "mmap" ] }
 chrono = { version = "0.4.37", features = ["serde"] }
 ciborium = "0.2.2"
 clap = { version = "4.5.4", features = ["derive", "color", "env", "wrap_help"] }
@@ -153,7 +153,7 @@ sea-orm = { version = "0.12.15", features = ["sqlx-postgres", "runtime-tokio-rus
 self-replace = "1.3.7"
 serde = { version = "1.0.197", features = ["derive", "rc"] }
 serde-aux = "4.5.0"
-serde_json = { version = "1.0.115", features = ["preserve_order"] }
+serde_json = { version = "=1.0.125", features = ["preserve_order"] }
 serde_path_to_error = { version = "0.1.16" }
 serde_url_params = "0.2.1"
 serde_with = "3.7.0"

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -11,6 +11,13 @@ load(
 )
 
 git_fetch(
+    name = "cacache-rs-0f5ffc5d45a69a85.git",
+    repo = "https://github.com/zkat/cacache-rs",
+    rev = "146a593c8e3abea8bc4c1888ae6781a3f2e1422e",
+    visibility = [],
+)
+
+git_fetch(
     name = "hyperlocal-49be1e49c1f262a7.git",
     repo = "https://github.com/fnichol/hyperlocal.git",
     rev = "6dfd2ad721d7031876ce494f62aae98bc5de0fae",
@@ -573,11 +580,11 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":brotli-6.0.0",
-        ":flate2-1.0.32",
+        ":flate2-1.0.33",
         ":futures-core-0.3.30",
         ":memchr-2.7.4",
         ":pin-project-lite-0.2.14",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
     ],
 )
 
@@ -649,16 +656,16 @@ cargo.rust_library(
         ":rand-0.8.5",
         ":regex-1.10.6",
         ":ring-0.17.5",
-        ":rustls-native-certs-0.7.2",
+        ":rustls-native-certs-0.7.3",
         ":rustls-pemfile-2.1.3",
-        ":rustls-webpki-0.102.6",
-        ":serde-1.0.208",
+        ":rustls-webpki-0.102.7",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
         ":serde_nanos-0.1.4",
         ":serde_repr-0.1.19",
         ":thiserror-1.0.63",
         ":time-0.3.36",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-rustls-0.26.0",
         ":tracing-0.1.40",
         ":tryhard-0.5.1",
@@ -690,8 +697,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -735,37 +742,37 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
 alias(
     name = "async-trait",
-    actual = ":async-trait-0.1.81",
+    actual = ":async-trait-0.1.82",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "async-trait-0.1.81.crate",
-    sha256 = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107",
-    strip_prefix = "async-trait-0.1.81",
-    urls = ["https://static.crates.io/crates/async-trait/0.1.81/download"],
+    name = "async-trait-0.1.82.crate",
+    sha256 = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1",
+    strip_prefix = "async-trait-0.1.82",
+    urls = ["https://static.crates.io/crates/async-trait/0.1.82/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-trait-0.1.81",
-    srcs = [":async-trait-0.1.81.crate"],
+    name = "async-trait-0.1.82",
+    srcs = [":async-trait-0.1.82.crate"],
     crate = "async_trait",
-    crate_root = "async-trait-0.1.81.crate/src/lib.rs",
+    crate_root = "async-trait-0.1.82.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -851,7 +858,7 @@ cargo.rust_library(
     deps = [
         ":http-0.2.12",
         ":log-0.4.22",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
         ":url-2.5.2",
         ":webpki-roots-0.25.4",
@@ -893,7 +900,7 @@ cargo.rust_library(
         ":log-0.4.22",
         ":quick-xml-0.30.0",
         ":rust-ini-0.19.0",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":thiserror-1.0.63",
         ":time-0.3.36",
         ":url-2.5.2",
@@ -946,7 +953,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.81",
+        ":async-trait-0.1.82",
         ":axum-core-0.3.4",
         ":axum-macros-0.3.8",
         ":base64-0.21.7",
@@ -963,13 +970,13 @@ cargo.rust_library(
         ":multer-2.1.0",
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.14",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
         ":serde_path_to_error-0.1.16",
         ":serde_urlencoded-0.7.1",
         ":sha1-0.10.6",
         ":sync_wrapper-0.1.2",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-tungstenite-0.20.1",
         ":tower-0.4.13",
         ":tower-layer-0.3.3",
@@ -993,7 +1000,7 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":async-trait-0.1.81",
+        ":async-trait-0.1.82",
         ":bytes-1.7.1",
         ":futures-util-0.3.30",
         ":http-0.2.12",
@@ -1024,8 +1031,8 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -1284,11 +1291,11 @@ cargo.rust_library(
         ":lazycell-1.3.0",
         ":peeking_take_while-0.1.2",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
+        ":quote-1.0.37",
         ":regex-1.10.6",
         ":rustc-hash-1.1.0",
         ":shlex-1.3.0",
-        ":syn-2.0.75",
+        ":syn-2.0.77",
     ],
 )
 
@@ -1375,7 +1382,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde-1.0.208"],
+    deps = [":serde-1.0.209"],
 )
 
 http_archive(
@@ -1400,7 +1407,7 @@ cargo.rust_library(
     deps = [
         ":arrayref-0.3.8",
         ":arrayvec-0.7.6",
-        ":constant_time_eq-0.3.0",
+        ":constant_time_eq-0.3.1",
     ],
 )
 
@@ -1499,7 +1506,7 @@ cargo.rust_library(
         ":arrayref-0.3.8",
         ":arrayvec-0.7.6",
         ":cfg-if-1.0.0",
-        ":constant_time_eq-0.3.0",
+        ":constant_time_eq-0.3.1",
     ],
 )
 
@@ -1681,13 +1688,13 @@ cargo.rust_library(
         ":hyper-util-0.1.7",
         ":log-0.4.22",
         ":pin-project-lite-0.2.14",
-        ":serde-1.0.208",
-        ":serde_derive-1.0.208",
+        ":serde-1.0.209",
+        ":serde_derive-1.0.209",
         ":serde_json-1.0.125",
         ":serde_repr-0.1.19",
         ":serde_urlencoded-0.7.1",
         ":thiserror-1.0.63",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-util-0.7.11",
         ":url-2.5.2",
     ],
@@ -1709,7 +1716,7 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_repr-0.1.19",
         ":serde_with-3.9.0",
     ],
@@ -1788,7 +1795,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":memchr-2.7.4",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -1860,7 +1867,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde-1.0.208"],
+    deps = [":serde-1.0.209"],
 )
 
 alias(
@@ -1869,22 +1876,14 @@ alias(
     visibility = ["PUBLIC"],
 )
 
-http_archive(
-    name = "cacache-13.0.0.crate",
-    sha256 = "a61ff12b19d89c752c213316b87fdb4a587f073d219b893cc56974b8c9f39bf7",
-    strip_prefix = "cacache-13.0.0",
-    urls = ["https://static.crates.io/crates/cacache/13.0.0/download"],
-    visibility = [],
-)
-
 cargo.rust_library(
     name = "cacache-13.0.0",
-    srcs = [":cacache-13.0.0.crate"],
+    srcs = [":cacache-rs-0f5ffc5d45a69a85.git"],
     crate = "cacache",
-    crate_root = "cacache-13.0.0.crate/src/lib.rs",
+    crate_root = "cacache-rs-0f5ffc5d45a69a85/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "cacache-13.0.0.crate",
+        "CARGO_MANIFEST_DIR": "cacache-rs-0f5ffc5d45a69a85",
         "CARGO_PKG_AUTHORS": "Kat Marchán <kzm@zkat.tech>",
         "CARGO_PKG_DESCRIPTION": "Content-addressable, key-value, high-performance, on-disk cache.",
         "CARGO_PKG_NAME": "cacache",
@@ -1920,15 +1919,15 @@ cargo.rust_library(
         ":memmap2-0.5.10",
         ":miette-5.10.0",
         ":reflink-copy-0.1.19",
-        ":serde-1.0.208",
-        ":serde_derive-1.0.208",
+        ":serde-1.0.209",
+        ":serde_derive-1.0.209",
         ":serde_json-1.0.125",
         ":sha1-0.10.6",
         ":sha2-0.10.8",
         ":ssri-9.2.0",
         ":tempfile-3.12.0",
         ":thiserror-1.0.63",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-stream-0.1.15",
         ":walkdir-2.5.0",
     ],
@@ -1952,18 +1951,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "cc-1.1.13.crate",
-    sha256 = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48",
-    strip_prefix = "cc-1.1.13",
-    urls = ["https://static.crates.io/crates/cc/1.1.13/download"],
+    name = "cc-1.1.15.crate",
+    sha256 = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6",
+    strip_prefix = "cc-1.1.15",
+    urls = ["https://static.crates.io/crates/cc/1.1.15/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "cc-1.1.13",
-    srcs = [":cc-1.1.13.crate"],
+    name = "cc-1.1.15",
+    srcs = [":cc-1.1.15.crate"],
     crate = "cc",
-    crate_root = "cc-1.1.13.crate/src/lib.rs",
+    crate_root = "cc-1.1.15.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
     deps = [":shlex-1.3.0"],
@@ -2063,7 +2062,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":num-traits-0.2.19",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -2095,7 +2094,7 @@ cargo.rust_library(
     deps = [
         ":ciborium-io-0.2.2",
         ":ciborium-ll-0.2.2",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -2332,8 +2331,8 @@ cargo.rust_library(
     deps = [
         ":heck-0.5.0",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -2622,7 +2621,7 @@ cargo.rust_library(
         ":lazy_static-1.5.0",
         ":nom-7.1.3",
         ":pathdiff-0.2.1",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":toml-0.8.19",
     ],
 )
@@ -2733,18 +2732,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "constant_time_eq-0.3.0.crate",
-    sha256 = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2",
-    strip_prefix = "constant_time_eq-0.3.0",
-    urls = ["https://static.crates.io/crates/constant_time_eq/0.3.0/download"],
+    name = "constant_time_eq-0.3.1.crate",
+    sha256 = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6",
+    strip_prefix = "constant_time_eq-0.3.1",
+    urls = ["https://static.crates.io/crates/constant_time_eq/0.3.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "constant_time_eq-0.3.0",
-    srcs = [":constant_time_eq-0.3.0.crate"],
+    name = "constant_time_eq-0.3.1",
+    srcs = [":constant_time_eq-0.3.1.crate"],
     crate = "constant_time_eq",
-    crate_root = "constant_time_eq-0.3.0.crate/src/lib.rs",
+    crate_root = "constant_time_eq-0.3.1.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
 )
@@ -2784,7 +2783,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":chrono-0.4.38",
-        ":flate2-1.0.32",
+        ":flate2-1.0.33",
         ":futures-util-0.3.30",
         ":http-0.2.12",
         ":hyper-0.14.30",
@@ -2792,11 +2791,11 @@ cargo.rust_library(
         ":mime-0.3.17",
         ":paste-1.0.15",
         ":pin-project-1.1.5",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
         ":tar-0.4.41",
         ":thiserror-1.0.63",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":url-2.5.2",
     ],
 )
@@ -3027,11 +3026,11 @@ cargo.rust_library(
         ":plotters-0.3.6",
         ":rayon-1.10.0",
         ":regex-1.10.6",
-        ":serde-1.0.208",
-        ":serde_derive-1.0.208",
+        ":serde-1.0.209",
+        ":serde_derive-1.0.209",
         ":serde_json-1.0.125",
         ":tinytemplate-1.2.1",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":walkdir-2.5.0",
     ],
 )
@@ -3448,18 +3447,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "ct-codecs-1.1.1.crate",
-    sha256 = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df",
-    strip_prefix = "ct-codecs-1.1.1",
-    urls = ["https://static.crates.io/crates/ct-codecs/1.1.1/download"],
+    name = "ct-codecs-1.1.2.crate",
+    sha256 = "026ac6ceace6298d2c557ef5ed798894962296469ec7842288ea64674201a2d1",
+    strip_prefix = "ct-codecs-1.1.2",
+    urls = ["https://static.crates.io/crates/ct-codecs/1.1.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "ct-codecs-1.1.1",
-    srcs = [":ct-codecs-1.1.1.crate"],
+    name = "ct-codecs-1.1.2",
+    srcs = [":ct-codecs-1.1.2.crate"],
     crate = "ct_codecs",
-    crate_root = "ct-codecs-1.1.1.crate/src/lib.rs",
+    crate_root = "ct-codecs-1.1.2.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -3526,7 +3525,7 @@ cargo.rust_binary(
     edition = "2021",
     features = ["digest"],
     visibility = [],
-    deps = [":rustc_version-0.4.0"],
+    deps = [":rustc_version-0.4.1"],
 )
 
 buildscript_run(
@@ -3555,8 +3554,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -3608,9 +3607,9 @@ cargo.rust_library(
         ":fnv-1.0.7",
         ":ident_case-1.0.1",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
+        ":quote-1.0.37",
         ":strsim-0.11.1",
-        ":syn-2.0.75",
+        ":syn-2.0.77",
     ],
 )
 
@@ -3632,8 +3631,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":darling_core-0.20.10",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -3711,10 +3710,10 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.81",
+        ":async-trait-0.1.82",
         ":deadpool-runtime-0.1.4",
         ":num_cpus-1.16.0",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
     ],
 )
 
@@ -3745,7 +3744,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":deadpool-0.10.0",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-postgres-0.7.11",
         ":tracing-0.1.40",
     ],
@@ -3767,7 +3766,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["tokio_1"],
     named_deps = {
-        "tokio_1": ":tokio-1.39.3",
+        "tokio_1": ":tokio-1.40.0",
     },
     visibility = [],
 )
@@ -3824,7 +3823,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":powerfmt-0.2.0",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -3846,83 +3845,83 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
+        ":quote-1.0.37",
         ":syn-1.0.109",
     ],
 )
 
 alias(
     name = "derive_builder",
-    actual = ":derive_builder-0.20.0",
+    actual = ":derive_builder-0.20.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "derive_builder-0.20.0.crate",
-    sha256 = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7",
-    strip_prefix = "derive_builder-0.20.0",
-    urls = ["https://static.crates.io/crates/derive_builder/0.20.0/download"],
+    name = "derive_builder-0.20.1.crate",
+    sha256 = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b",
+    strip_prefix = "derive_builder-0.20.1",
+    urls = ["https://static.crates.io/crates/derive_builder/0.20.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "derive_builder-0.20.0",
-    srcs = [":derive_builder-0.20.0.crate"],
+    name = "derive_builder-0.20.1",
+    srcs = [":derive_builder-0.20.1.crate"],
     crate = "derive_builder",
-    crate_root = "derive_builder-0.20.0.crate/src/lib.rs",
+    crate_root = "derive_builder-0.20.1.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
         "std",
     ],
     visibility = [],
-    deps = [":derive_builder_macro-0.20.0"],
+    deps = [":derive_builder_macro-0.20.1"],
 )
 
 http_archive(
-    name = "derive_builder_core-0.20.0.crate",
-    sha256 = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d",
-    strip_prefix = "derive_builder_core-0.20.0",
-    urls = ["https://static.crates.io/crates/derive_builder_core/0.20.0/download"],
+    name = "derive_builder_core-0.20.1.crate",
+    sha256 = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38",
+    strip_prefix = "derive_builder_core-0.20.1",
+    urls = ["https://static.crates.io/crates/derive_builder_core/0.20.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "derive_builder_core-0.20.0",
-    srcs = [":derive_builder_core-0.20.0.crate"],
+    name = "derive_builder_core-0.20.1",
+    srcs = [":derive_builder_core-0.20.1.crate"],
     crate = "derive_builder_core",
-    crate_root = "derive_builder_core-0.20.0.crate/src/lib.rs",
+    crate_root = "derive_builder_core-0.20.1.crate/src/lib.rs",
     edition = "2018",
     features = ["lib_has_std"],
     visibility = [],
     deps = [
         ":darling-0.20.10",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
 http_archive(
-    name = "derive_builder_macro-0.20.0.crate",
-    sha256 = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b",
-    strip_prefix = "derive_builder_macro-0.20.0",
-    urls = ["https://static.crates.io/crates/derive_builder_macro/0.20.0/download"],
+    name = "derive_builder_macro-0.20.1.crate",
+    sha256 = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc",
+    strip_prefix = "derive_builder_macro-0.20.1",
+    urls = ["https://static.crates.io/crates/derive_builder_macro/0.20.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "derive_builder_macro-0.20.0",
-    srcs = [":derive_builder_macro-0.20.0.crate"],
+    name = "derive_builder_macro-0.20.1",
+    srcs = [":derive_builder_macro-0.20.1.crate"],
     crate = "derive_builder_macro",
-    crate_root = "derive_builder_macro-0.20.0.crate/src/lib.rs",
+    crate_root = "derive_builder_macro-0.20.1.crate/src/lib.rs",
     edition = "2018",
     features = ["lib_has_std"],
     proc_macro = True,
     visibility = [],
     deps = [
-        ":derive_builder_core-0.20.0",
-        ":syn-2.0.75",
+        ":derive_builder_core-0.20.1",
+        ":syn-2.0.77",
     ],
 )
 
@@ -3979,8 +3978,8 @@ cargo.rust_library(
     deps = [
         ":convert_case-0.4.0",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -4028,7 +4027,7 @@ cargo.rust_library(
         ":rand-0.8.5",
         ":retry-1.3.1",
         ":semver-1.0.23",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -4418,7 +4417,7 @@ cargo.rust_library(
         ),
     },
     visibility = [],
-    deps = [":ct-codecs-1.1.1"],
+    deps = [":ct-codecs-1.1.2"],
 )
 
 http_archive(
@@ -4472,8 +4471,8 @@ cargo.rust_library(
     deps = [
         ":enum-ordinalize-4.3.0",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -4497,7 +4496,7 @@ cargo.rust_library(
         "use_std",
     ],
     visibility = [],
-    deps = [":serde-1.0.208"],
+    deps = [":serde-1.0.209"],
 )
 
 http_archive(
@@ -4661,8 +4660,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -4914,35 +4913,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "fastrand-1.9.0.crate",
-    sha256 = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be",
-    strip_prefix = "fastrand-1.9.0",
-    urls = ["https://static.crates.io/crates/fastrand/1.9.0/download"],
+    name = "fastrand-2.1.1.crate",
+    sha256 = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6",
+    strip_prefix = "fastrand-2.1.1",
+    urls = ["https://static.crates.io/crates/fastrand/2.1.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "fastrand-1.9.0",
-    srcs = [":fastrand-1.9.0.crate"],
+    name = "fastrand-2.1.1",
+    srcs = [":fastrand-2.1.1.crate"],
     crate = "fastrand",
-    crate_root = "fastrand-1.9.0.crate/src/lib.rs",
-    edition = "2018",
-    visibility = [],
-)
-
-http_archive(
-    name = "fastrand-2.1.0.crate",
-    sha256 = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a",
-    strip_prefix = "fastrand-2.1.0",
-    urls = ["https://static.crates.io/crates/fastrand/2.1.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "fastrand-2.1.0",
-    srcs = [":fastrand-2.1.0.crate"],
-    crate = "fastrand",
-    crate_root = "fastrand-2.1.0.crate/src/lib.rs",
+    crate_root = "fastrand-2.1.1.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -4975,18 +4957,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "filetime-0.2.24.crate",
-    sha256 = "bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550",
-    strip_prefix = "filetime-0.2.24",
-    urls = ["https://static.crates.io/crates/filetime/0.2.24/download"],
+    name = "filetime-0.2.25.crate",
+    sha256 = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586",
+    strip_prefix = "filetime-0.2.25",
+    urls = ["https://static.crates.io/crates/filetime/0.2.25/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "filetime-0.2.24",
-    srcs = [":filetime-0.2.24.crate"],
+    name = "filetime-0.2.25",
+    srcs = [":filetime-0.2.25.crate"],
     crate = "filetime",
-    crate_root = "filetime-0.2.24.crate/src/lib.rs",
+    crate_root = "filetime-0.2.25.crate/src/lib.rs",
     edition = "2018",
     platform = {
         "linux-arm64": dict(
@@ -5031,23 +5013,23 @@ cargo.rust_library(
 
 alias(
     name = "flate2",
-    actual = ":flate2-1.0.32",
+    actual = ":flate2-1.0.33",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "flate2-1.0.32.crate",
-    sha256 = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666",
-    strip_prefix = "flate2-1.0.32",
-    urls = ["https://static.crates.io/crates/flate2/1.0.32/download"],
+    name = "flate2-1.0.33.crate",
+    sha256 = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253",
+    strip_prefix = "flate2-1.0.33",
+    urls = ["https://static.crates.io/crates/flate2/1.0.33/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "flate2-1.0.32",
-    srcs = [":flate2-1.0.32.crate"],
+    name = "flate2-1.0.33",
+    srcs = [":flate2-1.0.33.crate"],
     crate = "flate2",
-    crate_root = "flate2-1.0.32.crate/src/lib.rs",
+    crate_root = "flate2-1.0.33.crate/src/lib.rs",
     edition = "2018",
     features = [
         "any_impl",
@@ -5324,7 +5306,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":fastrand-2.1.0",
+        ":fastrand-2.1.1",
         ":futures-core-0.3.30",
         ":futures-io-0.3.30",
         ":parking-2.2.0",
@@ -5350,8 +5332,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -5744,9 +5726,9 @@ cargo.rust_library(
         ":futures-sink-0.3.30",
         ":futures-util-0.3.30",
         ":http-0.2.12",
-        ":indexmap-2.4.0",
+        ":indexmap-2.5.0",
         ":slab-0.4.9",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-util-0.7.11",
         ":tracing-0.1.40",
     ],
@@ -5932,7 +5914,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hash32-0.2.1",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":stable_deref_trait-1.2.0",
     ],
 )
@@ -6398,7 +6380,7 @@ cargo.rust_library(
         ":itoa-1.0.11",
         ":pin-project-lite-0.2.14",
         ":socket2-0.5.7",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tower-service-0.3.3",
         ":tracing-0.1.40",
         ":want-0.3.1",
@@ -6435,7 +6417,7 @@ cargo.rust_library(
         ":itoa-1.0.11",
         ":pin-project-lite-0.2.14",
         ":smallvec-1.13.2",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":want-0.3.1",
     ],
 )
@@ -6460,7 +6442,7 @@ cargo.rust_library(
         ":hyper-1.4.1",
         ":hyper-util-0.1.7",
         ":pin-project-lite-0.2.14",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tower-service-0.3.3",
         ":winapi-0.3.9",
     ],
@@ -6486,7 +6468,7 @@ cargo.rust_library(
         ":http-0.2.12",
         ":hyper-0.14.30",
         ":rustls-0.21.12",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-rustls-0.24.1",
     ],
 )
@@ -6522,10 +6504,10 @@ cargo.rust_library(
         ":hyper-1.4.1",
         ":hyper-util-0.1.7",
         ":rustls-0.23.12",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-rustls-0.26.0",
         ":tower-service-0.3.3",
-        ":webpki-roots-0.26.3",
+        ":webpki-roots-0.26.5",
     ],
 )
 
@@ -6547,7 +6529,7 @@ cargo.rust_library(
     deps = [
         ":hyper-0.14.30",
         ":pin-project-lite-0.2.14",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-io-timeout-1.2.0",
     ],
 )
@@ -6583,7 +6565,7 @@ cargo.rust_library(
         ":hyper-1.4.1",
         ":pin-project-lite-0.2.14",
         ":socket2-0.5.7",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tower-0.4.13",
         ":tower-service-0.3.3",
         ":tracing-0.1.40",
@@ -6613,7 +6595,7 @@ cargo.rust_library(
         ":hex-0.4.3",
         ":hyper-0.14.30",
         ":pin-project-1.1.5",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
     ],
 )
 
@@ -6645,7 +6627,7 @@ cargo.rust_library(
         ":hyper-1.4.1",
         ":hyper-util-0.1.7",
         ":pin-project-lite-0.2.14",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tower-service-0.3.3",
     ],
 )
@@ -6750,9 +6732,9 @@ cargo.rust_library(
     deps = [
         ":ignore-0.4.22",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":serde-1.0.208",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":serde-1.0.209",
+        ":syn-2.0.77",
         ":toml-0.8.19",
         ":unicode-xid-0.2.5",
     ],
@@ -6833,29 +6815,29 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hashbrown-0.12.3",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
 alias(
     name = "indexmap",
-    actual = ":indexmap-2.4.0",
+    actual = ":indexmap-2.5.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "indexmap-2.4.0.crate",
-    sha256 = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c",
-    strip_prefix = "indexmap-2.4.0",
-    urls = ["https://static.crates.io/crates/indexmap/2.4.0/download"],
+    name = "indexmap-2.5.0.crate",
+    sha256 = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5",
+    strip_prefix = "indexmap-2.5.0",
+    urls = ["https://static.crates.io/crates/indexmap/2.5.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "indexmap-2.4.0",
-    srcs = [":indexmap-2.4.0.crate"],
+    name = "indexmap-2.5.0",
+    srcs = [":indexmap-2.5.0.crate"],
     crate = "indexmap",
-    crate_root = "indexmap-2.4.0.crate/src/lib.rs",
+    crate_root = "indexmap-2.5.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -6867,7 +6849,7 @@ cargo.rust_library(
     deps = [
         ":equivalent-1.0.1",
         ":hashbrown-0.14.5",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -6946,8 +6928,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -7227,7 +7209,7 @@ cargo.rust_library(
         ":binstring-0.1.1",
         ":blake2b_simd-1.0.2",
         ":coarsetime-0.1.34",
-        ":ct-codecs-1.1.1",
+        ":ct-codecs-1.1.2",
         ":ed25519-compact-2.1.1",
         ":hmac-sha1-compact-1.1.4",
         ":hmac-sha256-1.1.7",
@@ -7236,7 +7218,7 @@ cargo.rust_library(
         ":p256-0.13.2",
         ":p384-0.13.0",
         ":rand-0.8.5",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
         ":thiserror-1.0.63",
         ":zeroize-1.8.1",
@@ -8090,8 +8072,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -8298,8 +8280,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -8569,7 +8551,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-lock-3.4.0",
-        ":async-trait-0.1.81",
+        ":async-trait-0.1.82",
         ":crossbeam-channel-0.5.13",
         ":crossbeam-epoch-0.9.18",
         ":crossbeam-utils-0.8.20",
@@ -9401,7 +9383,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.81",
+        ":async-trait-0.1.82",
         ":futures-core-0.3.30",
         ":http-0.2.12",
         ":opentelemetry-0.22.0",
@@ -9410,7 +9392,7 @@ cargo.rust_library(
         ":opentelemetry_sdk-0.22.1",
         ":prost-0.12.6",
         ":thiserror-1.0.63",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tonic-0.11.0",
     ],
 )
@@ -9515,7 +9497,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.81",
+        ":async-trait-0.1.82",
         ":crossbeam-channel-0.5.13",
         ":futures-channel-0.3.30",
         ":futures-executor-0.3.30",
@@ -9527,7 +9509,7 @@ cargo.rust_library(
         ":percent-encoding-2.3.1",
         ":rand-0.8.5",
         ":thiserror-1.0.63",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-stream-0.1.15",
     ],
 )
@@ -9710,8 +9692,8 @@ cargo.rust_library(
         ":heck-0.4.1",
         ":proc-macro-error-1.0.4",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -9737,8 +9719,8 @@ cargo.rust_library(
         ":itertools-0.12.1",
         ":proc-macro2-1.0.86",
         ":proc-macro2-diagnostics-0.10.1",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -10018,7 +10000,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":base64-0.22.1",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -10095,9 +10077,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":fixedbitset-0.4.2",
-        ":indexmap-2.4.0",
-        ":serde-1.0.208",
-        ":serde_derive-1.0.208",
+        ":indexmap-2.5.0",
+        ":serde-1.0.209",
+        ":serde_derive-1.0.209",
     ],
 )
 
@@ -10196,7 +10178,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
+        ":quote-1.0.37",
         ":syn-1.0.109",
     ],
 )
@@ -10219,8 +10201,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -10430,17 +10412,17 @@ cargo.rust_library(
         ":bytes-1.7.1",
         ":chrono-0.4.38",
         ":containers-api-0.8.0",
-        ":flate2-1.0.32",
+        ":flate2-1.0.33",
         ":futures-util-0.3.30",
         ":futures_codec-0.4.1",
         ":log-0.4.22",
         ":paste-1.0.15",
         ":podman-api-stubs-0.9.0",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
         ":tar-0.4.41",
         ":thiserror-1.0.63",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":url-2.5.2",
     ],
 )
@@ -10462,7 +10444,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":chrono-0.4.38",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
     ],
 )
@@ -10537,23 +10519,23 @@ buildscript_run(
 
 alias(
     name = "postcard",
-    actual = ":postcard-1.0.9",
+    actual = ":postcard-1.0.10",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "postcard-1.0.9.crate",
-    sha256 = "20ee10b999a00ca189ac2cb99f5db1ca71fb7371e3d5f493b879ca95d2a67220",
-    strip_prefix = "postcard-1.0.9",
-    urls = ["https://static.crates.io/crates/postcard/1.0.9/download"],
+    name = "postcard-1.0.10.crate",
+    sha256 = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e",
+    strip_prefix = "postcard-1.0.10",
+    urls = ["https://static.crates.io/crates/postcard/1.0.10/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "postcard-1.0.9",
-    srcs = [":postcard-1.0.9.crate"],
+    name = "postcard-1.0.10",
+    srcs = [":postcard-1.0.10.crate"],
     crate = "postcard",
-    crate_root = "postcard-1.0.9.crate/src/lib.rs",
+    crate_root = "postcard-1.0.10.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -10570,7 +10552,7 @@ cargo.rust_library(
     deps = [
         ":cobs-0.2.3",
         ":heapless-0.7.17",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -10593,8 +10575,8 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -10659,7 +10641,7 @@ cargo.rust_library(
     ],
     named_deps = {
         "chrono_04": ":chrono-0.4.38",
-        "serde_1": ":serde-1.0.208",
+        "serde_1": ":serde-1.0.209",
         "serde_json_1": ":serde_json-1.0.125",
     },
     visibility = [],
@@ -10804,7 +10786,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro-error-attr-1.0.4",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
+        ":quote-1.0.37",
         ":syn-1.0.109",
     ],
 )
@@ -10854,7 +10836,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
+        ":quote-1.0.37",
     ],
 )
 
@@ -10933,8 +10915,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
         ":yansi-1.0.1",
     ],
 )
@@ -10971,11 +10953,11 @@ cargo.rust_library(
     deps = [
         ":bitflags-2.6.0",
         ":chrono-0.4.38",
-        ":flate2-1.0.32",
+        ":flate2-1.0.33",
         ":hex-0.4.3",
         ":lazy_static-1.5.0",
         ":procfs-core-0.16.0",
-        ":rustix-0.38.34",
+        ":rustix-0.38.35",
     ],
 )
 
@@ -11077,8 +11059,8 @@ cargo.rust_library(
         ":anyhow-1.0.86",
         ":itertools-0.12.1",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -11161,23 +11143,23 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":memchr-2.7.4",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
 http_archive(
-    name = "quinn-0.11.3.crate",
-    sha256 = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156",
-    strip_prefix = "quinn-0.11.3",
-    urls = ["https://static.crates.io/crates/quinn/0.11.3/download"],
+    name = "quinn-0.11.5.crate",
+    sha256 = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684",
+    strip_prefix = "quinn-0.11.5",
+    urls = ["https://static.crates.io/crates/quinn/0.11.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "quinn-0.11.3",
-    srcs = [":quinn-0.11.3.crate"],
+    name = "quinn-0.11.5",
+    srcs = [":quinn-0.11.5.crate"],
     crate = "quinn",
-    crate_root = "quinn-0.11.3.crate/src/lib.rs",
+    crate_root = "quinn-0.11.5.crate/src/lib.rs",
     edition = "2021",
     features = [
         "ring",
@@ -11185,8 +11167,8 @@ cargo.rust_library(
         "rustls",
     ],
     named_deps = {
-        "proto": ":quinn-proto-0.11.6",
-        "udp": ":quinn-udp-0.5.4",
+        "proto": ":quinn-proto-0.11.8",
+        "udp": ":quinn-udp-0.5.5",
     },
     visibility = [],
     deps = [
@@ -11196,24 +11178,24 @@ cargo.rust_library(
         ":rustls-0.23.12",
         ":socket2-0.5.7",
         ":thiserror-1.0.63",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tracing-0.1.40",
     ],
 )
 
 http_archive(
-    name = "quinn-proto-0.11.6.crate",
-    sha256 = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd",
-    strip_prefix = "quinn-proto-0.11.6",
-    urls = ["https://static.crates.io/crates/quinn-proto/0.11.6/download"],
+    name = "quinn-proto-0.11.8.crate",
+    sha256 = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6",
+    strip_prefix = "quinn-proto-0.11.8",
+    urls = ["https://static.crates.io/crates/quinn-proto/0.11.8/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "quinn-proto-0.11.6",
-    srcs = [":quinn-proto-0.11.6.crate"],
+    name = "quinn-proto-0.11.8",
+    srcs = [":quinn-proto-0.11.8.crate"],
     crate = "quinn_proto",
-    crate_root = "quinn-proto-0.11.6.crate/src/lib.rs",
+    crate_root = "quinn-proto-0.11.8.crate/src/lib.rs",
     edition = "2021",
     features = [
         "ring",
@@ -11234,31 +11216,31 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "quinn-udp-0.5.4.crate",
-    sha256 = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285",
-    strip_prefix = "quinn-udp-0.5.4",
-    urls = ["https://static.crates.io/crates/quinn-udp/0.5.4/download"],
+    name = "quinn-udp-0.5.5.crate",
+    sha256 = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b",
+    strip_prefix = "quinn-udp-0.5.5",
+    urls = ["https://static.crates.io/crates/quinn-udp/0.5.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "quinn-udp-0.5.4",
-    srcs = [":quinn-udp-0.5.4.crate"],
+    name = "quinn-udp-0.5.5",
+    srcs = [":quinn-udp-0.5.5.crate"],
     crate = "quinn_udp",
-    crate_root = "quinn-udp-0.5.4.crate/src/lib.rs",
+    crate_root = "quinn-udp-0.5.5.crate/src/lib.rs",
     edition = "2021",
     features = ["tracing"],
     platform = {
         "windows-gnu": dict(
             deps = [
                 ":once_cell-1.19.0",
-                ":windows-sys-0.52.0",
+                ":windows-sys-0.59.0",
             ],
         ),
         "windows-msvc": dict(
             deps = [
                 ":once_cell-1.19.0",
-                ":windows-sys-0.52.0",
+                ":windows-sys-0.59.0",
             ],
         ),
     },
@@ -11272,23 +11254,23 @@ cargo.rust_library(
 
 alias(
     name = "quote",
-    actual = ":quote-1.0.36",
+    actual = ":quote-1.0.37",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "quote-1.0.36.crate",
-    sha256 = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7",
-    strip_prefix = "quote-1.0.36",
-    urls = ["https://static.crates.io/crates/quote/1.0.36/download"],
+    name = "quote-1.0.37.crate",
+    sha256 = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
+    strip_prefix = "quote-1.0.37",
+    urls = ["https://static.crates.io/crates/quote/1.0.37/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "quote-1.0.36",
-    srcs = [":quote-1.0.36.crate"],
+    name = "quote-1.0.37",
+    srcs = [":quote-1.0.37.crate"],
     crate = "quote",
-    crate_root = "quote-1.0.36.crate/src/lib.rs",
+    crate_root = "quote-1.0.37.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -11652,14 +11634,14 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.81",
+        ":async-trait-0.1.82",
         ":cfg-if-1.0.0",
         ":log-0.4.22",
         ":regex-1.10.6",
         ":siphasher-1.0.1",
         ":thiserror-1.0.63",
         ":time-0.3.36",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-postgres-0.7.11",
         ":url-2.5.2",
         ":walkdir-2.5.0",
@@ -11685,10 +11667,10 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
+        ":quote-1.0.37",
         ":refinery-core-0.8.14",
         ":regex-1.10.6",
-        ":syn-2.0.75",
+        ":syn-2.0.77",
     ],
 )
 
@@ -11708,10 +11690,10 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":rustix-0.38.34"],
+            deps = [":rustix-0.38.35"],
         ),
         "linux-x86_64": dict(
-            deps = [":rustix-0.38.34"],
+            deps = [":rustix-0.38.35"],
         ),
         "windows-gnu": dict(
             deps = [":windows-0.58.0"],
@@ -11924,8 +11906,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -11972,13 +11954,13 @@ cargo.rust_library(
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
-                ":quinn-0.11.3",
+                ":quinn-0.11.5",
                 ":rustls-0.23.12",
                 ":rustls-pemfile-2.1.3",
                 ":rustls-pki-types-1.8.0",
-                ":tokio-1.39.3",
+                ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
-                ":webpki-roots-0.26.3",
+                ":webpki-roots-0.26.5",
             ],
         ),
         "linux-x86_64": dict(
@@ -11994,13 +11976,13 @@ cargo.rust_library(
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
-                ":quinn-0.11.3",
+                ":quinn-0.11.5",
                 ":rustls-0.23.12",
                 ":rustls-pemfile-2.1.3",
                 ":rustls-pki-types-1.8.0",
-                ":tokio-1.39.3",
+                ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
-                ":webpki-roots-0.26.3",
+                ":webpki-roots-0.26.5",
             ],
         ),
         "macos-arm64": dict(
@@ -12016,13 +11998,13 @@ cargo.rust_library(
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
-                ":quinn-0.11.3",
+                ":quinn-0.11.5",
                 ":rustls-0.23.12",
                 ":rustls-pemfile-2.1.3",
                 ":rustls-pki-types-1.8.0",
-                ":tokio-1.39.3",
+                ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
-                ":webpki-roots-0.26.3",
+                ":webpki-roots-0.26.5",
             ],
         ),
         "macos-x86_64": dict(
@@ -12038,13 +12020,13 @@ cargo.rust_library(
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
-                ":quinn-0.11.3",
+                ":quinn-0.11.5",
                 ":rustls-0.23.12",
                 ":rustls-pemfile-2.1.3",
                 ":rustls-pki-types-1.8.0",
-                ":tokio-1.39.3",
+                ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
-                ":webpki-roots-0.26.3",
+                ":webpki-roots-0.26.5",
             ],
         ),
         "windows-gnu": dict(
@@ -12060,13 +12042,13 @@ cargo.rust_library(
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
-                ":quinn-0.11.3",
+                ":quinn-0.11.5",
                 ":rustls-0.23.12",
                 ":rustls-pemfile-2.1.3",
                 ":rustls-pki-types-1.8.0",
-                ":tokio-1.39.3",
+                ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
-                ":webpki-roots-0.26.3",
+                ":webpki-roots-0.26.5",
                 ":windows-registry-0.2.0",
             ],
         ),
@@ -12083,13 +12065,13 @@ cargo.rust_library(
                 ":once_cell-1.19.0",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
-                ":quinn-0.11.3",
+                ":quinn-0.11.5",
                 ":rustls-0.23.12",
                 ":rustls-pemfile-2.1.3",
                 ":rustls-pki-types-1.8.0",
-                ":tokio-1.39.3",
+                ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
-                ":webpki-roots-0.26.3",
+                ":webpki-roots-0.26.5",
                 ":windows-registry-0.2.0",
             ],
         ),
@@ -12102,7 +12084,7 @@ cargo.rust_library(
         ":futures-util-0.3.30",
         ":http-1.1.0",
         ":mime_guess-2.0.4",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
         ":serde_urlencoded-0.7.1",
         ":sync_wrapper-1.0.1",
@@ -12969,7 +12951,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.81",
+        ":async-trait-0.1.82",
         ":aws-creds-0.36.0",
         ":aws-region-0.25.4",
         ":base64-0.21.7",
@@ -12988,13 +12970,13 @@ cargo.rust_library(
         ":quick-xml-0.30.0",
         ":rustls-0.21.12",
         ":rustls-native-certs-0.6.3",
-        ":serde-1.0.208",
-        ":serde_derive-1.0.208",
+        ":serde-1.0.209",
+        ":serde_derive-1.0.209",
         ":serde_json-1.0.125",
         ":sha2-0.10.8",
         ":thiserror-1.0.63",
         ":time-0.3.36",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-rustls-0.24.1",
         ":tokio-stream-0.1.15",
         ":url-2.5.2",
@@ -13028,7 +13010,7 @@ cargo.rust_library(
     deps = [
         ":arrayvec-0.7.6",
         ":num-traits-0.2.19",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -13120,36 +13102,36 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "rustc_version-0.4.0.crate",
-    sha256 = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366",
-    strip_prefix = "rustc_version-0.4.0",
-    urls = ["https://static.crates.io/crates/rustc_version/0.4.0/download"],
+    name = "rustc_version-0.4.1.crate",
+    sha256 = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92",
+    strip_prefix = "rustc_version-0.4.1",
+    urls = ["https://static.crates.io/crates/rustc_version/0.4.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustc_version-0.4.0",
-    srcs = [":rustc_version-0.4.0.crate"],
+    name = "rustc_version-0.4.1",
+    srcs = [":rustc_version-0.4.1.crate"],
     crate = "rustc_version",
-    crate_root = "rustc_version-0.4.0.crate/src/lib.rs",
+    crate_root = "rustc_version-0.4.1.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
     deps = [":semver-1.0.23"],
 )
 
 http_archive(
-    name = "rustix-0.38.34.crate",
-    sha256 = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f",
-    strip_prefix = "rustix-0.38.34",
-    urls = ["https://static.crates.io/crates/rustix/0.38.34/download"],
+    name = "rustix-0.38.35.crate",
+    sha256 = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f",
+    strip_prefix = "rustix-0.38.35",
+    urls = ["https://static.crates.io/crates/rustix/0.38.35/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustix-0.38.34",
-    srcs = [":rustix-0.38.34.crate"],
+    name = "rustix-0.38.35",
+    srcs = [":rustix-0.38.35.crate"],
     crate = "rustix",
-    crate_root = "rustix-0.38.34.crate/src/lib.rs",
+    crate_root = "rustix-0.38.35.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -13208,16 +13190,16 @@ cargo.rust_library(
             deps = [":windows-sys-0.52.0"],
         ),
     },
-    rustc_flags = ["@$(location :rustix-0.38.34-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :rustix-0.38.35-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [":bitflags-2.6.0"],
 )
 
 cargo.rust_binary(
-    name = "rustix-0.38.34-build-script-build",
-    srcs = [":rustix-0.38.34.crate"],
+    name = "rustix-0.38.35-build-script-build",
+    srcs = [":rustix-0.38.35.crate"],
     crate = "build_script_build",
-    crate_root = "rustix-0.38.34.crate/build.rs",
+    crate_root = "rustix-0.38.35.crate/build.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -13236,9 +13218,9 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "rustix-0.38.34-build-script-run",
+    name = "rustix-0.38.35-build-script-run",
     package_name = "rustix",
-    buildscript_rule = ":rustix-0.38.34-build-script-build",
+    buildscript_rule = ":rustix-0.38.35-build-script-build",
     features = [
         "alloc",
         "default",
@@ -13252,7 +13234,7 @@ buildscript_run(
         "thread",
         "use-libc-auxv",
     ],
-    version = "0.38.34",
+    version = "0.38.35",
 )
 
 http_archive(
@@ -13319,7 +13301,7 @@ cargo.rust_library(
     deps = [
         ":log-0.4.22",
         ":ring-0.17.5",
-        ":rustls-webpki-0.102.6",
+        ":rustls-webpki-0.102.7",
         ":subtle-2.6.1",
         ":zeroize-1.8.1",
     ],
@@ -13351,7 +13333,7 @@ cargo.rust_library(
     deps = [
         ":once_cell-1.19.0",
         ":ring-0.17.5",
-        ":rustls-webpki-0.102.6",
+        ":rustls-webpki-0.102.7",
         ":subtle-2.6.1",
         ":zeroize-1.8.1",
     ],
@@ -13397,23 +13379,23 @@ cargo.rust_library(
 
 alias(
     name = "rustls-native-certs",
-    actual = ":rustls-native-certs-0.7.2",
+    actual = ":rustls-native-certs-0.7.3",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "rustls-native-certs-0.7.2.crate",
-    sha256 = "04182dffc9091a404e0fc069ea5cd60e5b866c3adf881eff99a32d048242dffa",
-    strip_prefix = "rustls-native-certs-0.7.2",
-    urls = ["https://static.crates.io/crates/rustls-native-certs/0.7.2/download"],
+    name = "rustls-native-certs-0.7.3.crate",
+    sha256 = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5",
+    strip_prefix = "rustls-native-certs-0.7.3",
+    urls = ["https://static.crates.io/crates/rustls-native-certs/0.7.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-native-certs-0.7.2",
-    srcs = [":rustls-native-certs-0.7.2.crate"],
+    name = "rustls-native-certs-0.7.3",
+    srcs = [":rustls-native-certs-0.7.3.crate"],
     crate = "rustls_native_certs",
-    crate_root = "rustls-native-certs-0.7.2.crate/src/lib.rs",
+    crate_root = "rustls-native-certs-0.7.3.crate/src/lib.rs",
     edition = "2021",
     named_deps = {
         "pki_types": ":rustls-pki-types-1.8.0",
@@ -13540,18 +13522,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "rustls-webpki-0.102.6.crate",
-    sha256 = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e",
-    strip_prefix = "rustls-webpki-0.102.6",
-    urls = ["https://static.crates.io/crates/rustls-webpki/0.102.6/download"],
+    name = "rustls-webpki-0.102.7.crate",
+    sha256 = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56",
+    strip_prefix = "rustls-webpki-0.102.7",
+    urls = ["https://static.crates.io/crates/rustls-webpki/0.102.7/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-webpki-0.102.6",
-    srcs = [":rustls-webpki-0.102.6.crate"],
+    name = "rustls-webpki-0.102.7",
+    srcs = [":rustls-webpki-0.102.7.crate"],
     crate = "webpki",
-    crate_root = "rustls-webpki-0.102.6.crate/src/lib.rs",
+    crate_root = "rustls-webpki-0.102.7.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -13724,8 +13706,8 @@ cargo.rust_library(
         ":heck-0.4.1",
         ":proc-macro-error-1.0.4",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -13776,7 +13758,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-stream-0.3.5",
-        ":async-trait-0.1.81",
+        ":async-trait-0.1.82",
         ":bigdecimal-0.3.1",
         ":chrono-0.4.38",
         ":futures-0.3.30",
@@ -13786,7 +13768,7 @@ cargo.rust_library(
         ":sea-orm-macros-0.12.15",
         ":sea-query-0.30.7",
         ":sea-query-binder-0.5.0",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
         ":sqlx-0.7.4",
         ":strum-0.25.0",
@@ -13826,8 +13808,8 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
         ":unicode-ident-1.0.12",
     ],
 )
@@ -14023,35 +14005,35 @@ cargo.rust_library(
 
 alias(
     name = "self-replace",
-    actual = ":self-replace-1.4.0",
+    actual = ":self-replace-1.5.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "self-replace-1.4.0.crate",
-    sha256 = "f7828a58998685d8bf5a3c5e7a3379a5867289c20828c3ee436280b44b598515",
-    strip_prefix = "self-replace-1.4.0",
-    urls = ["https://static.crates.io/crates/self-replace/1.4.0/download"],
+    name = "self-replace-1.5.0.crate",
+    sha256 = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7",
+    strip_prefix = "self-replace-1.5.0",
+    urls = ["https://static.crates.io/crates/self-replace/1.5.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "self-replace-1.4.0",
-    srcs = [":self-replace-1.4.0.crate"],
+    name = "self-replace-1.5.0",
+    srcs = [":self-replace-1.5.0.crate"],
     crate = "self_replace",
-    crate_root = "self-replace-1.4.0.crate/src/lib.rs",
+    crate_root = "self-replace-1.5.0.crate/src/lib.rs",
     edition = "2018",
     platform = {
         "windows-gnu": dict(
             deps = [
-                ":fastrand-1.9.0",
-                ":windows-sys-0.48.0",
+                ":fastrand-2.1.1",
+                ":windows-sys-0.52.0",
             ],
         ),
         "windows-msvc": dict(
             deps = [
-                ":fastrand-1.9.0",
-                ":windows-sys-0.48.0",
+                ":fastrand-2.1.1",
+                ":windows-sys-0.52.0",
             ],
         ),
     },
@@ -14129,23 +14111,23 @@ buildscript_run(
 
 alias(
     name = "serde",
-    actual = ":serde-1.0.208",
+    actual = ":serde-1.0.209",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde-1.0.208.crate",
-    sha256 = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2",
-    strip_prefix = "serde-1.0.208",
-    urls = ["https://static.crates.io/crates/serde/1.0.208/download"],
+    name = "serde-1.0.209.crate",
+    sha256 = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09",
+    strip_prefix = "serde-1.0.209",
+    urls = ["https://static.crates.io/crates/serde/1.0.209/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde-1.0.208",
-    srcs = [":serde-1.0.208.crate"],
+    name = "serde-1.0.209",
+    srcs = [":serde-1.0.209.crate"],
     crate = "serde",
-    crate_root = "serde-1.0.208.crate/src/lib.rs",
+    crate_root = "serde-1.0.209.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -14156,7 +14138,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde_derive-1.0.208"],
+    deps = [":serde_derive-1.0.209"],
 )
 
 alias(
@@ -14186,32 +14168,32 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":chrono-0.4.38",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
     ],
 )
 
 http_archive(
-    name = "serde_derive-1.0.208.crate",
-    sha256 = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf",
-    strip_prefix = "serde_derive-1.0.208",
-    urls = ["https://static.crates.io/crates/serde_derive/1.0.208/download"],
+    name = "serde_derive-1.0.209.crate",
+    sha256 = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170",
+    strip_prefix = "serde_derive-1.0.209",
+    urls = ["https://static.crates.io/crates/serde_derive/1.0.209/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_derive-1.0.208",
-    srcs = [":serde_derive-1.0.208.crate"],
+    name = "serde_derive-1.0.209",
+    srcs = [":serde_derive-1.0.209.crate"],
     crate = "serde_derive",
-    crate_root = "serde_derive-1.0.208.crate/src/lib.rs",
+    crate_root = "serde_derive-1.0.209.crate/src/lib.rs",
     edition = "2015",
     features = ["default"],
     proc_macro = True,
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -14245,11 +14227,11 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":indexmap-2.4.0",
+        ":indexmap-2.5.0",
         ":itoa-1.0.11",
         ":memchr-2.7.4",
         ":ryu-1.0.18",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -14268,7 +14250,7 @@ cargo.rust_library(
     crate_root = "serde_nanos-0.1.4.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":serde-1.0.208"],
+    deps = [":serde-1.0.209"],
 )
 
 alias(
@@ -14294,7 +14276,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":itoa-1.0.11",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -14316,8 +14298,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -14337,7 +14319,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["serde"],
     visibility = [],
-    deps = [":serde-1.0.208"],
+    deps = [":serde-1.0.209"],
 )
 
 alias(
@@ -14362,7 +14344,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":url-2.5.2",
     ],
 )
@@ -14386,7 +14368,7 @@ cargo.rust_library(
         ":form_urlencoded-1.2.1",
         ":itoa-1.0.11",
         ":ryu-1.0.18",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -14419,15 +14401,15 @@ cargo.rust_library(
     named_deps = {
         "chrono_0_4": ":chrono-0.4.38",
         "indexmap_1": ":indexmap-1.9.3",
-        "indexmap_2": ":indexmap-2.4.0",
+        "indexmap_2": ":indexmap-2.5.0",
         "time_0_3": ":time-0.3.36",
     },
     visibility = [],
     deps = [
         ":base64-0.22.1",
         ":hex-0.4.3",
-        ":serde-1.0.208",
-        ":serde_derive-1.0.208",
+        ":serde-1.0.209",
+        ":serde_derive-1.0.209",
         ":serde_json-1.0.125",
         ":serde_with_macros-3.9.0",
     ],
@@ -14452,8 +14434,8 @@ cargo.rust_library(
     deps = [
         ":darling-0.20.10",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -14479,10 +14461,10 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":indexmap-2.4.0",
+        ":indexmap-2.5.0",
         ":itoa-1.0.11",
         ":ryu-1.0.18",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":unsafe-libyaml-0.2.11",
     ],
 )
@@ -14994,7 +14976,7 @@ cargo.rust_library(
         ":ed25519-1.5.3",
         ":libc-0.2.158",
         ":libsodium-sys-0.2.7",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -15167,7 +15149,7 @@ cargo.rust_library(
         ":futures-util-0.3.30",
         ":hashlink-0.8.4",
         ":hex-0.4.3",
-        ":indexmap-2.4.0",
+        ":indexmap-2.5.0",
         ":log-0.4.22",
         ":memchr-2.7.4",
         ":once_cell-1.19.0",
@@ -15176,14 +15158,14 @@ cargo.rust_library(
         ":rust_decimal-1.36.0",
         ":rustls-0.21.12",
         ":rustls-pemfile-1.0.4",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
         ":sha2-0.10.8",
         ":smallvec-1.13.2",
         ":sqlformat-0.2.4",
         ":thiserror-1.0.63",
         ":time-0.3.36",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-stream-0.1.15",
         ":tracing-0.1.40",
         ":url-2.5.2",
@@ -15250,7 +15232,7 @@ cargo.rust_library(
         ":once_cell-1.19.0",
         ":rand-0.8.5",
         ":rust_decimal-1.36.0",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
         ":sha2-0.10.8",
         ":smallvec-1.13.2",
@@ -15260,7 +15242,7 @@ cargo.rust_library(
         ":time-0.3.36",
         ":tracing-0.1.40",
         ":uuid-1.10.0",
-        ":whoami-1.5.1",
+        ":whoami-1.5.2",
     ],
 )
 
@@ -15299,7 +15281,7 @@ cargo.rust_library(
         ":digest-0.10.7",
         ":hex-0.4.3",
         ":miette-5.10.0",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":sha-1-0.10.1",
         ":sha2-0.10.8",
         ":thiserror-1.0.63",
@@ -15370,7 +15352,7 @@ cargo.rust_library(
     deps = [
         ":futures-core-0.3.30",
         ":pin-project-1.1.5",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
     ],
 )
 
@@ -15479,9 +15461,9 @@ cargo.rust_library(
     deps = [
         ":heck-0.5.0",
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
+        ":quote-1.0.37",
         ":rustversion-1.0.17",
-        ":syn-2.0.75",
+        ":syn-2.0.77",
     ],
 )
 
@@ -15566,30 +15548,30 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
+        ":quote-1.0.37",
         ":unicode-ident-1.0.12",
     ],
 )
 
 alias(
     name = "syn",
-    actual = ":syn-2.0.75",
+    actual = ":syn-2.0.77",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "syn-2.0.75.crate",
-    sha256 = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9",
-    strip_prefix = "syn-2.0.75",
-    urls = ["https://static.crates.io/crates/syn/2.0.75/download"],
+    name = "syn-2.0.77.crate",
+    sha256 = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed",
+    strip_prefix = "syn-2.0.77",
+    urls = ["https://static.crates.io/crates/syn/2.0.77/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "syn-2.0.75",
-    srcs = [":syn-2.0.75.crate"],
+    name = "syn-2.0.77",
+    srcs = [":syn-2.0.77.crate"],
     crate = "syn",
-    crate_root = "syn-2.0.75.crate/src/lib.rs",
+    crate_root = "syn-2.0.77.crate/src/lib.rs",
     edition = "2021",
     features = [
         "clone-impls",
@@ -15607,7 +15589,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
+        ":quote-1.0.37",
         ":unicode-ident-1.0.12",
     ],
 )
@@ -15719,7 +15701,7 @@ cargo.rust_library(
         ),
     },
     visibility = [],
-    deps = [":filetime-0.2.24"],
+    deps = [":filetime-0.2.25"],
 )
 
 http_archive(
@@ -15762,16 +15744,16 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":rustix-0.38.34"],
+            deps = [":rustix-0.38.35"],
         ),
         "linux-x86_64": dict(
-            deps = [":rustix-0.38.34"],
+            deps = [":rustix-0.38.35"],
         ),
         "macos-arm64": dict(
-            deps = [":rustix-0.38.34"],
+            deps = [":rustix-0.38.35"],
         ),
         "macos-x86_64": dict(
-            deps = [":rustix-0.38.34"],
+            deps = [":rustix-0.38.35"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.59.0"],
@@ -15783,7 +15765,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":cfg-if-1.0.0",
-        ":fastrand-2.1.0",
+        ":fastrand-2.1.1",
         ":once_cell-1.19.0",
     ],
 )
@@ -15829,16 +15811,16 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":rustix-0.38.34"],
+            deps = [":rustix-0.38.35"],
         ),
         "linux-x86_64": dict(
-            deps = [":rustix-0.38.34"],
+            deps = [":rustix-0.38.35"],
         ),
         "macos-arm64": dict(
-            deps = [":rustix-0.38.34"],
+            deps = [":rustix-0.38.35"],
         ),
         "macos-x86_64": dict(
-            deps = [":rustix-0.38.34"],
+            deps = [":rustix-0.38.35"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.48.0"],
@@ -15897,8 +15879,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -15912,7 +15894,7 @@ cargo.rust_binary(
     deps = [
         ":async-nats-0.35.1",
         ":async-recursion-1.1.1",
-        ":async-trait-0.1.81",
+        ":async-trait-0.1.82",
         ":axum-0.6.20",
         ":base64-0.22.1",
         ":blake3-1.5.4",
@@ -15933,13 +15915,13 @@ cargo.rust_binary(
         ":crossbeam-queue-0.3.11",
         ":deadpool-0.10.0",
         ":deadpool-postgres-0.12.1",
-        ":derive_builder-0.20.0",
+        ":derive_builder-0.20.1",
         ":derive_more-0.99.18",
         ":devicemapper-0.34.1",
         ":diff-0.1.13",
         ":directories-5.0.1",
         ":dyn-clone-1.0.17",
-        ":flate2-1.0.32",
+        ":flate2-1.0.33",
         ":futures-0.3.30",
         ":futures-lite-2.3.0",
         ":glob-0.3.1",
@@ -15948,7 +15930,7 @@ cargo.rust_binary(
         ":hyper-0.14.30",
         ":hyperlocal-0.8.0",
         ":iftree-1.0.5",
-        ":indexmap-2.4.0",
+        ":indexmap-2.5.0",
         ":indicatif-0.17.8",
         ":indoc-2.0.5",
         ":inquire-0.7.5",
@@ -15975,12 +15957,12 @@ cargo.rust_binary(
         ":petgraph-0.6.5",
         ":pin-project-lite-0.2.14",
         ":podman-api-0.10.0",
-        ":postcard-1.0.9",
+        ":postcard-1.0.10",
         ":postgres-types-0.2.7",
         ":pretty_assertions_sorted-1.2.3",
         ":proc-macro2-1.0.86",
         ":procfs-0.16.0",
-        ":quote-1.0.36",
+        ":quote-1.0.37",
         ":rand-0.8.5",
         ":refinery-0.8.12",
         ":regex-1.10.6",
@@ -15989,11 +15971,11 @@ cargo.rust_binary(
         ":ring-0.17.5",
         ":rust-s3-0.34.0-rc4",
         ":rustls-0.22.4",
-        ":rustls-native-certs-0.7.2",
+        ":rustls-native-certs-0.7.3",
         ":rustls-pemfile-2.1.3",
         ":sea-orm-0.12.15",
-        ":self-replace-1.4.0",
-        ":serde-1.0.208",
+        ":self-replace-1.5.0",
+        ":serde-1.0.209",
         ":serde-aux-4.5.0",
         ":serde_json-1.0.125",
         ":serde_path_to_error-0.1.16",
@@ -16003,12 +15985,12 @@ cargo.rust_binary(
         ":sodiumoxide-0.2.7",
         ":stream-cancel-0.8.2",
         ":strum-0.26.3",
-        ":syn-2.0.75",
+        ":syn-2.0.77",
         ":tar-0.4.41",
         ":tempfile-3.12.0",
         ":test-log-0.2.16",
         ":thiserror-1.0.63",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-postgres-0.7.11",
         ":tokio-postgres-rustls-0.11.1",
         ":tokio-serde-0.9.0",
@@ -16079,8 +16061,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -16135,7 +16117,7 @@ cargo.rust_library(
         ":itoa-1.0.11",
         ":num-conv-0.1.0",
         ":powerfmt-0.2.0",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":time-core-0.1.2",
         ":time-macros-0.2.18",
     ],
@@ -16223,7 +16205,7 @@ cargo.rust_library(
     edition = "2015",
     visibility = [],
     deps = [
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
     ],
 )
@@ -16270,23 +16252,23 @@ cargo.rust_library(
 
 alias(
     name = "tokio",
-    actual = ":tokio-1.39.3",
+    actual = ":tokio-1.40.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tokio-1.39.3.crate",
-    sha256 = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5",
-    strip_prefix = "tokio-1.39.3",
-    urls = ["https://static.crates.io/crates/tokio/1.39.3/download"],
+    name = "tokio-1.40.0.crate",
+    sha256 = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998",
+    strip_prefix = "tokio-1.40.0",
+    urls = ["https://static.crates.io/crates/tokio/1.40.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tokio-1.39.3",
-    srcs = [":tokio-1.39.3.crate"],
+    name = "tokio-1.40.0",
+    srcs = [":tokio-1.40.0.crate"],
     crate = "tokio",
-    crate_root = "tokio-1.39.3.crate/src/lib.rs",
+    crate_root = "tokio-1.40.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "bytes",
@@ -16387,7 +16369,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":pin-project-lite-0.2.14",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
     ],
 )
 
@@ -16409,8 +16391,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -16462,7 +16444,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":async-trait-0.1.81",
+        ":async-trait-0.1.82",
         ":byteorder-1.5.0",
         ":bytes-1.7.1",
         ":fallible-iterator-0.2.0",
@@ -16476,9 +16458,9 @@ cargo.rust_library(
         ":postgres-protocol-0.6.7",
         ":postgres-types-0.2.7",
         ":rand-0.8.5",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-util-0.7.11",
-        ":whoami-1.5.1",
+        ":whoami-1.5.2",
     ],
 )
 
@@ -16507,7 +16489,7 @@ cargo.rust_library(
         ":futures-0.3.30",
         ":ring-0.17.5",
         ":rustls-0.22.4",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-postgres-0.7.11",
         ":tokio-rustls-0.25.0",
         ":x509-certificate-0.23.1",
@@ -16536,7 +16518,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rustls-0.21.12",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
     ],
 )
 
@@ -16560,7 +16542,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rustls-0.22.4",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
     ],
 )
 
@@ -16588,7 +16570,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rustls-0.23.12",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
     ],
 )
 
@@ -16625,7 +16607,7 @@ cargo.rust_library(
         ":futures-core-0.3.30",
         ":futures-sink-0.3.30",
         ":pin-project-1.1.5",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
     ],
 )
@@ -16662,7 +16644,7 @@ cargo.rust_library(
     deps = [
         ":futures-core-0.3.30",
         ":pin-project-lite-0.2.14",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-util-0.7.11",
     ],
 )
@@ -16692,7 +16674,7 @@ cargo.rust_library(
         ":async-stream-0.3.5",
         ":bytes-1.7.1",
         ":futures-core-0.3.30",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-stream-0.1.15",
     ],
 )
@@ -16727,7 +16709,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.30",
         ":log-0.4.22",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tungstenite-0.20.1",
     ],
 )
@@ -16767,7 +16749,7 @@ cargo.rust_library(
         ":futures-sink-0.3.30",
         ":futures-util-0.3.30",
         ":pin-project-lite-0.2.14",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
     ],
 )
 
@@ -16796,7 +16778,7 @@ cargo.rust_library(
         ":bytes-1.7.1",
         ":futures-0.3.30",
         ":libc-0.2.158",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":vsock-0.3.0",
     ],
 )
@@ -16828,7 +16810,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_spanned-0.6.7",
         ":toml_datetime-0.6.8",
         ":toml_edit-0.22.20",
@@ -16851,7 +16833,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["serde"],
     visibility = [],
-    deps = [":serde-1.0.208"],
+    deps = [":serde-1.0.209"],
 )
 
 http_archive(
@@ -16869,14 +16851,15 @@ cargo.rust_library(
     crate_root = "toml_edit-0.22.20.crate/src/lib.rs",
     edition = "2021",
     features = [
+        "default",
         "display",
         "parse",
         "serde",
     ],
     visibility = [],
     deps = [
-        ":indexmap-2.4.0",
-        ":serde-1.0.208",
+        ":indexmap-2.5.0",
+        ":serde-1.0.209",
         ":serde_spanned-0.6.7",
         ":toml_datetime-0.6.8",
         ":winnow-0.6.18",
@@ -16917,7 +16900,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-stream-0.3.5",
-        ":async-trait-0.1.81",
+        ":async-trait-0.1.82",
         ":axum-0.6.20",
         ":base64-0.21.7",
         ":bytes-1.7.1",
@@ -16929,7 +16912,7 @@ cargo.rust_library(
         ":percent-encoding-2.3.1",
         ":pin-project-1.1.5",
         ":prost-0.12.6",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-stream-0.1.15",
         ":tower-0.4.13",
         ":tower-layer-0.3.3",
@@ -17001,7 +16984,7 @@ cargo.rust_library(
         ":pin-project-lite-0.2.14",
         ":rand-0.8.5",
         ":slab-0.4.9",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-util-0.7.11",
         ":tower-layer-0.3.3",
         ":tower-service-0.3.3",
@@ -17052,7 +17035,7 @@ cargo.rust_library(
         ":http-body-0.4.6",
         ":http-range-header-0.3.1",
         ":pin-project-lite-0.2.14",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":tokio-util-0.7.11",
         ":tower-layer-0.3.3",
         ":tower-service-0.3.3",
@@ -17148,8 +17131,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -17294,7 +17277,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":tracing-core-0.1.32",
     ],
 )
@@ -17347,7 +17330,7 @@ cargo.rust_library(
         ":nu-ansi-term-0.46.0",
         ":once_cell-1.19.0",
         ":regex-1.10.6",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
         ":sharded-slab-0.1.7",
         ":smallvec-1.13.2",
@@ -17417,7 +17400,7 @@ cargo.rust_library(
     deps = [
         ":futures-0.3.30",
         ":pin-project-lite-0.2.14",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
     ],
 )
 
@@ -17527,7 +17510,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rand-0.8.5",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -17782,7 +17765,7 @@ cargo.rust_library(
         ":form_urlencoded-1.2.1",
         ":idna-0.5.0",
         ":percent-encoding-2.3.1",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -17885,7 +17868,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":getrandom-0.2.15",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
     ],
 )
 
@@ -17950,7 +17933,7 @@ cargo.rust_library(
     crate_root = "vfs-0.12.0.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":filetime-0.2.24"],
+    deps = [":filetime-0.2.25"],
 )
 
 alias(
@@ -18052,7 +18035,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
+        ":quote-1.0.37",
     ],
 )
 
@@ -18124,18 +18107,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "webpki-roots-0.26.3.crate",
-    sha256 = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd",
-    strip_prefix = "webpki-roots-0.26.3",
-    urls = ["https://static.crates.io/crates/webpki-roots/0.26.3/download"],
+    name = "webpki-roots-0.26.5.crate",
+    sha256 = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a",
+    strip_prefix = "webpki-roots-0.26.5",
+    urls = ["https://static.crates.io/crates/webpki-roots/0.26.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "webpki-roots-0.26.3",
-    srcs = [":webpki-roots-0.26.3.crate"],
+    name = "webpki-roots-0.26.5",
+    srcs = [":webpki-roots-0.26.5.crate"],
     crate = "webpki_roots",
-    crate_root = "webpki-roots-0.26.3.crate/src/lib.rs",
+    crate_root = "webpki-roots-0.26.5.crate/src/lib.rs",
     edition = "2018",
     named_deps = {
         "pki_types": ":rustls-pki-types-1.8.0",
@@ -18144,18 +18127,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "whoami-1.5.1.crate",
-    sha256 = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9",
-    strip_prefix = "whoami-1.5.1",
-    urls = ["https://static.crates.io/crates/whoami/1.5.1/download"],
+    name = "whoami-1.5.2.crate",
+    sha256 = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d",
+    strip_prefix = "whoami-1.5.2",
+    urls = ["https://static.crates.io/crates/whoami/1.5.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "whoami-1.5.1",
-    srcs = [":whoami-1.5.1.crate"],
+    name = "whoami-1.5.2",
+    srcs = [":whoami-1.5.2.crate"],
     crate = "whoami",
-    crate_root = "whoami-1.5.1.crate/src/lib.rs",
+    crate_root = "whoami-1.5.2.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -18416,8 +18399,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -18439,8 +18422,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -18539,10 +18522,7 @@ cargo.rust_library(
         "Win32_System",
         "Win32_System_Com",
         "Win32_System_Console",
-        "Win32_System_Environment",
         "Win32_System_IO",
-        "Win32_System_LibraryLoader",
-        "Win32_System_Memory",
         "Win32_System_Pipes",
         "Win32_System_Threading",
         "Win32_System_WindowsProgramming",
@@ -18593,7 +18573,9 @@ cargo.rust_library(
         "Win32_System_Console",
         "Win32_System_Diagnostics",
         "Win32_System_Diagnostics_Debug",
+        "Win32_System_Environment",
         "Win32_System_IO",
+        "Win32_System_LibraryLoader",
         "Win32_System_Memory",
         "Win32_System_Pipes",
         "Win32_System_SystemServices",
@@ -18626,10 +18608,13 @@ cargo.rust_library(
     features = [
         "Win32",
         "Win32_Foundation",
+        "Win32_Networking",
+        "Win32_Networking_WinSock",
         "Win32_Storage",
         "Win32_Storage_FileSystem",
         "Win32_System",
         "Win32_System_Console",
+        "Win32_System_IO",
         "Win32_System_SystemInformation",
         "default",
     ],
@@ -18841,7 +18826,7 @@ cargo.rust_library(
         ),
     },
     visibility = [],
-    deps = [":rustix-0.38.34"],
+    deps = [":rustix-0.38.35"],
 )
 
 alias(
@@ -18896,7 +18881,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.30",
         ":thiserror-1.0.63",
-        ":tokio-1.39.3",
+        ":tokio-1.40.0",
         ":yrs-0.17.4",
     ],
 )
@@ -18964,7 +18949,7 @@ cargo.rust_library(
     deps = [
         ":atomic_refcell-0.1.13",
         ":rand-0.7.3",
-        ":serde-1.0.208",
+        ":serde-1.0.209",
         ":serde_json-1.0.125",
         ":smallstr-0.3.0",
         ":smallvec-1.13.2",
@@ -19029,8 +19014,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )
 
@@ -19076,7 +19061,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
-        ":quote-1.0.36",
-        ":syn-2.0.75",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
     ],
 )

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -237,9 +237,9 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "ring",
- "rustls-native-certs 0.7.2",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.1.3",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.102.7",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -261,7 +261,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -283,18 +283,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -429,7 +429,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -515,7 +515,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -648,7 +648,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
  "syn_derive",
 ]
 
@@ -735,8 +735,7 @@ dependencies = [
 [[package]]
 name = "cacache"
 version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61ff12b19d89c752c213316b87fdb4a587f073d219b893cc56974b8c9f39bf7"
+source = "git+https://github.com/zkat/cacache-rs?rev=146a593c8e3abea8bc4c1888ae6781a3f2e1422e#146a593c8e3abea8bc4c1888ae6781a3f2e1422e"
 dependencies = [
  "digest",
  "either",
@@ -767,9 +766,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "shlex",
 ]
@@ -880,7 +879,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1026,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "containers-api"
@@ -1158,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1273,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "ct-codecs"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
+checksum = "026ac6ceace6298d2c557ef5ed798894962296469ec7842288ea64674201a2d1"
 
 [[package]]
 name = "curve25519-dalek"
@@ -1300,7 +1299,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1324,7 +1323,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1335,7 +1334,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1423,33 +1422,33 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+checksum = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
+checksum = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1462,7 +1461,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1616,7 +1615,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1693,7 +1692,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1781,18 +1780,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "ff"
@@ -1812,9 +1802,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1830,9 +1820,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.0",
@@ -1935,7 +1925,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "fastrand 2.1.0",
+ "fastrand",
  "futures-core",
  "futures-io",
  "parking",
@@ -1950,7 +1940,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2098,7 +2088,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2442,7 +2432,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
- "webpki-roots 0.26.3",
+ "webpki-roots 0.26.5",
 ]
 
 [[package]]
@@ -2553,7 +2543,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.75",
+ "syn 2.0.77",
  "toml",
  "unicode-xid",
 ]
@@ -2593,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -2629,7 +2619,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2827,7 +2817,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -2898,7 +2888,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2971,7 +2961,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3432,7 +3422,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3446,7 +3436,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3509,7 +3499,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3564,7 +3554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "serde",
  "serde_derive",
 ]
@@ -3624,7 +3614,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3738,9 +3728,9 @@ checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "postcard"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ee10b999a00ca189ac2cb99f5db1ca71fb7371e3d5f493b879ca95d2a67220"
+checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -3758,7 +3748,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3840,11 +3830,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3888,7 +3878,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
  "version_check",
  "yansi 1.0.1",
 ]
@@ -3939,7 +3929,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3989,9 +3979,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
 dependencies = [
  "bytes 1.7.1",
  "pin-project-lite",
@@ -4007,9 +3997,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes 1.7.1",
  "rand 0.8.5",
@@ -4024,22 +4014,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -4152,15 +4142,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
@@ -4219,7 +4200,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4285,7 +4266,7 @@ checksum = "46aef80f842736de545ada6ec65b81ee91504efd6853f4b96de7414c42ae7443"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4336,7 +4317,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.3",
+ "webpki-roots 0.26.5",
  "windows-registry",
 ]
 
@@ -4502,18 +4483,18 @@ checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -4543,7 +4524,7 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.102.7",
  "subtle",
  "zeroize",
 ]
@@ -4557,7 +4538,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.102.7",
  "subtle",
  "zeroize",
 ]
@@ -4576,9 +4557,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04182dffc9091a404e0fc069ea5cd60e5b866c3adf881eff99a32d048242dffa"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 2.1.3",
@@ -4624,9 +4605,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4689,7 +4670,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4730,7 +4711,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.75",
+ "syn 2.0.77",
  "unicode-ident",
 ]
 
@@ -4812,13 +4793,13 @@ dependencies = [
 
 [[package]]
 name = "self-replace"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7828a58998685d8bf5a3c5e7a3379a5867289c20828c3ee436280b44b598515"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
 dependencies = [
- "fastrand 1.9.0",
+ "fastrand",
  "tempfile",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4829,9 +4810,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -4849,13 +4830,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4864,7 +4845,7 @@ version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "itoa",
  "memchr",
  "ryu",
@@ -4898,7 +4879,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4942,7 +4923,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4959,7 +4940,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4968,7 +4949,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "itoa",
  "ryu",
  "serde",
@@ -5216,7 +5197,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "log",
  "memchr",
  "once_cell",
@@ -5478,7 +5459,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5513,9 +5494,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5531,7 +5512,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5588,7 +5569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
- "fastrand 2.1.0",
+ "fastrand",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -5631,7 +5612,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5676,7 +5657,7 @@ dependencies = [
  "hyper 0.14.30",
  "hyperlocal",
  "iftree",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "indicatif",
  "indoc",
  "inquire",
@@ -5717,7 +5698,7 @@ dependencies = [
  "ring",
  "rust-s3",
  "rustls 0.22.4",
- "rustls-native-certs 0.7.2",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.1.3",
  "sea-orm",
  "self-replace",
@@ -5731,7 +5712,7 @@ dependencies = [
  "sodiumoxide",
  "stream-cancel",
  "strum 0.26.3",
- "syn 2.0.75",
+ "syn 2.0.77",
  "tar",
  "tempfile",
  "test-log",
@@ -5781,7 +5762,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5861,9 +5842,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes 1.7.1",
@@ -5895,7 +5876,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6060,7 +6041,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.20",
+ "toml_edit",
 ]
 
 [[package]]
@@ -6074,26 +6055,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap 2.4.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.18",
+ "winnow",
 ]
 
 [[package]]
@@ -6198,7 +6168,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6603,7 +6573,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -6637,7 +6607,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6676,20 +6646,20 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.3"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "whoami"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "wasite",
  "web-sys",
 ]
@@ -6765,7 +6735,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6776,7 +6746,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6959,15 +6929,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
@@ -7077,7 +7038,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7097,7 +7058,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[patch.unused]]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -36,7 +36,7 @@ base64 = "0.22.0"
 blake3 = "1.5.1"
 bollard = "0.16.1"
 bytes = "1.6.0"
-cacache = { version = "13.0.0", default-features = false, features = [ "tokio-runtime", "mmap" ] }
+cacache = { git = "https://github.com/zkat/cacache-rs", rev = "146a593c8e3abea8bc4c1888ae6781a3f2e1422e", default-features = false, features = [ "tokio-runtime", "mmap" ] }
 chrono = { version = "0.4.37", features = ["serde"] }
 ciborium = "0.2.2"
 clap = { version = "4.5.4", features = ["derive", "color", "env", "wrap_help"] }
@@ -113,7 +113,7 @@ sea-orm = { version = "0.12.15", features = ["sqlx-postgres", "runtime-tokio-rus
 self-replace = "1.3.7"
 serde = { version = "1.0.197", features = ["derive", "rc"] }
 serde-aux = "4.5.0"
-serde_json = { version = "1.0.115", features = ["preserve_order"] }
+serde_json = { version = "=1.0.125", features = ["preserve_order"] }
 serde_path_to_error = { version = "0.1.16" }
 serde_url_params = "0.2.1"
 serde_with = "3.7.0"


### PR DESCRIPTION
Unwraps in cacache-rs are eliminated in a recent PR, which should solve some panics we get (mostly in CI).

For sync-deps, I had to pin serde_json since the latest requires a more recent rust than we use.