### PR TITLE
fix: manually set home dir in cyclone service

### DIFF
--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -148,6 +148,7 @@ start(){
   if [ -f /mnt/scripts/scripts ]; then
       source /mnt/scripts/scripts
   fi
+  export HOME=/root
   cyclone ${cyclone_args[*]} >> /var/log/cyclone.log 2>&1 &
 }
 


### PR DESCRIPTION
`$HOME` is set, but it does not show up in the envs for cyclone as it runs via rc-service. Manually setting it here causes it to be available to `siExec`.

Note that in some cases running with `shell: true` is required for the env var to be expanded properly.

```typescript
await siExec.waitUntilEnd("echo", ["$HOME"], {shell: true});
````