### PR TITLE
chore/toolbox-ssm-adjustments

### DIFF
--- a/component/toolbox/scripts/ssm-scripts/si-service-state
+++ b/component/toolbox/scripts/ssm-scripts/si-service-state
@@ -43,7 +43,7 @@ mainSteps:
                 wait
                 docker-compose -f /run/app/docker-compose.yaml --profile $SI_SERVICE up --wait
 
-                wget https://artifacts.systeminit.com/{{ Service }}/${SI_VERSION}/omnibus/linux/$(arch)/{{ Service }}-${SI_VERSION}-omnibus-linux-$(arch).tar.gz -O - | tar -xzf - -C /
+                wget --no-verbose https://artifacts.systeminit.com/{{ Service }}/${SI_VERSION}/omnibus/linux/$(arch)/{{ Service }}-${SI_VERSION}-omnibus-linux-$(arch).tar.gz -O - | tar -xzf - -C /
                 METADATA=$(sudo find / -wholename '/etc/nix-omnibus/{{ Service }}/**/metadata.json' | tail -n 1 | xargs cat | jq)
                 COMMIT=$(echo $METADATA | jq -r '.commit')
                 RUNNING_VERSION=$(echo $METADATA | jq -r '.version')

--- a/component/toolbox/scripts/supporting-funcs/ssm-funcs.sh
+++ b/component/toolbox/scripts/supporting-funcs/ssm-funcs.sh
@@ -27,11 +27,12 @@ start_and_track_ssm_session() {
   fi
 
   command_id=$(echo "$output" | jq -r '.Command.CommandId')
+  echo "Info: tracking SSM execution ID: $command_id"
 
   # Poll for command status with a timeout of 60 seconds
-  timeout=60
+  timeout=180
   elapsed=0
-  interval=1
+  interval=5
 
   while [ $elapsed -lt $timeout ]; do
     status=$(check_ssm_command_status)


### PR DESCRIPTION
1. Stop being so aggressive with querying the ListInvocations endpoint
2. Upgrades can take >60s, give more time
3. Log out the Invocation ID for SSM so we can track it into AWS rather than trying to figure out what's going on by time correlation
4. wget --no-verbose, so we actually get logs we can read