### PR TITLE
Add initial billing event loop (ENG-2660)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "billing-events"
+version = "0.1.0"
+dependencies = [
+ "remain",
+ "serde",
+ "serde_json",
+ "si-data-nats",
+ "si-events",
+ "thiserror",
+]
+
+[[package]]
+name = "billing-events-server"
+version = "0.1.0"
+dependencies = [
+ "billing-events",
+ "naxum",
+ "remain",
+ "si-data-nats",
+ "telemetry",
+ "thiserror",
+ "tokio-util",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,6 +1348,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "base64 0.22.1",
+ "billing-events",
  "blake3",
  "buck2-resources",
  "chrono",
@@ -4881,6 +4907,7 @@ dependencies = [
 name = "sdf"
 version = "0.1.0"
 dependencies = [
+ "billing-events-server",
  "clap",
  "color-eyre",
  "nats-multiplexer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ members = [
     "bin/sdf",
     "bin/veritech",
     "lib/auth-api-client",
+    "lib/billing-events",
+    "lib/billing-events-server",
     "lib/buck2-resources",
     "lib/bytes-lines-codec",
     "lib/config-file",

--- a/DOCS.md
+++ b/DOCS.md
@@ -25,6 +25,7 @@ Above all, for any and all questions related to either using or developing the s
 - [Preparing Your Pull Request](#preparing-your-pull-request)
 - [Core Services](#core-services)
 - [Repository Structure](#repository-structure)
+- [Adding a New Rust Library](#adding-a-new-rust-library)
 
 # How to Read This Document
 
@@ -717,3 +718,29 @@ While there are other directories in the project, these are primarily where most
 | `bin/`       | Backend programs, CLIs, servers, etc.                          |
 | `component/` | Docker container images and other ancillary tooling            |
 | `lib/`       | Supporting libraries and packages for services or applications |
+
+# Adding a New Rust Library
+
+To add a new Rust library, there are a few steps:
+
+1. Create `lib/MY-LIBRARY` and put a `Cargo.toml` there like this:
+
+```toml
+[package]
+name = "MY-LIBRARY"
+edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+```
+
+2. Put `src/lib.rs` with your code.
+3. Add your library to the top-level `Cargo.toml` inside `[workspace] members = ...`.
+4. Run `cargo check --all-targets --all-features` to get your library added to the top level `Cargo.lock`.
+
+> [!NOTE]
+> If your library adds, removes or modifies a third party crate, you may need to sync `buck2` deps.
+> See the [support/buck2](support/buck2) directory for more information.

--- a/app/web/src/store/admin.store.ts
+++ b/app/web/src/store/admin.store.ts
@@ -15,7 +15,7 @@ export interface AdminChangeSet {
   name: string;
   status: string;
   baseChangeSetId?: string;
-  workspaceSnapshotAddress?: string;
+  workspaceSnapshotAddress: string;
   workspaceId: string;
   mergeRequestedByUserId?: string;
 }

--- a/bin/sdf/BUCK
+++ b/bin/sdf/BUCK
@@ -8,6 +8,7 @@ load(
 rust_binary(
     name = "sdf",
     deps = [
+        "//lib/billing-events-server:billing-events-server",
         "//lib/nats-multiplexer:nats-multiplexer",
         "//lib/sdf-server:sdf-server",
         "//lib/si-service:si-service",

--- a/bin/sdf/Cargo.toml
+++ b/bin/sdf/Cargo.toml
@@ -13,6 +13,7 @@ name = "sdf"
 path = "src/main.rs"
 
 [dependencies]
+billing-events-server = { path = "../../lib/billing-events-server" }
 nats-multiplexer = { path = "../../lib/nats-multiplexer" }
 sdf-server = { path = "../../lib/sdf-server" }
 si-service = { path = "../../lib/si-service" }

--- a/lib/billing-events-server/BUCK
+++ b/lib/billing-events-server/BUCK
@@ -1,0 +1,17 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "billing-events-server",
+    deps = [
+        "//lib/billing-events:billing-events",
+        "//lib/naxum:naxum",
+        "//lib/si-data-nats:si-data-nats",
+        "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:remain",
+        "//third-party/rust:thiserror",
+        "//third-party/rust:tokio-util",
+    ],
+    srcs = glob([
+        "src/**/*.rs",
+    ]),
+)

--- a/lib/billing-events-server/Cargo.toml
+++ b/lib/billing-events-server/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "billing-events-server"
+edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+billing-events = { path = "../../lib/billing-events" }
+naxum = { path = "../../lib/naxum" }
+si-data-nats = { path = "../../lib/si-data-nats" }
+telemetry = { path = "../../lib/telemetry-rs" }
+
+remain = { workspace = true }
+thiserror = { workspace = true }
+tokio-util = { workspace = true }

--- a/lib/billing-events-server/src/handlers.rs
+++ b/lib/billing-events-server/src/handlers.rs
@@ -1,0 +1,32 @@
+use billing_events::BillingWorkspaceChangeEvent;
+use naxum::{
+    extract::State,
+    response::{IntoResponse, Response},
+    Json,
+};
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::AppState;
+
+// NOTE(nick,jkeiser): we will likely have fallible contents soon, so let's keep this for now.
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum HandlerError {}
+
+type HandlerResult<T> = Result<T, HandlerError>;
+
+impl IntoResponse for HandlerError {
+    fn into_response(self) -> Response {
+        error!(si.error.message = ?self, "failed to process message");
+        Response::server_error()
+    }
+}
+
+pub async fn process_request(
+    State(_state): State<AppState>,
+    Json(request): Json<BillingWorkspaceChangeEvent>,
+) -> HandlerResult<()> {
+    debug!(?request, "receieved billing workspace change event");
+    Ok(())
+}

--- a/lib/billing-events-server/src/lib.rs
+++ b/lib/billing-events-server/src/lib.rs
@@ -1,0 +1,100 @@
+//! Provides a ["billing events"](billing_events) server via a future.
+
+use std::future::Future;
+use std::future::IntoFuture as _;
+use std::io;
+
+use billing_events::{BillingEventsError, BillingEventsWorkQueue};
+use naxum::handler::Handler as _;
+use naxum::middleware::ack::AckLayer;
+use naxum::middleware::trace::{DefaultMakeSpan, DefaultOnRequest, TraceLayer};
+use naxum::{ServiceBuilder, ServiceExt as _};
+use si_data_nats::async_nats::error::Error as AsyncNatsError;
+use si_data_nats::async_nats::jetstream::consumer::StreamErrorKind;
+use si_data_nats::{
+    async_nats::{self, jetstream::stream::ConsumerErrorKind},
+    jetstream, NatsClient,
+};
+use telemetry::prelude::*;
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+
+mod handlers;
+
+const CONCURRENCY_LIMIT: usize = 1000;
+const CONSUMER_NAME: &str = "billing-events-server";
+
+#[derive(Debug, Error)]
+pub enum BillingEventsServerError {
+    #[error("async nats consumer error: {0}")]
+    AsyncNatsConsumer(#[from] AsyncNatsError<ConsumerErrorKind>),
+    #[error("async nats stream error: {0}")]
+    AsyncNatsStream(#[from] AsyncNatsError<StreamErrorKind>),
+    #[error("billing events error: {0}")]
+    BillingEvents(#[from] BillingEventsError),
+}
+
+type BillingEventsServerResult<T> = Result<T, BillingEventsServerError>;
+
+/// Creates and returns a running ["billing events"](billing_events) server.
+pub async fn new(
+    nats: NatsClient,
+    token: CancellationToken,
+) -> BillingEventsServerResult<Box<dyn Future<Output = io::Result<()>> + Unpin + Send>> {
+    let (state, incoming) = {
+        let queue = BillingEventsWorkQueue::get_or_create(jetstream::new(nats)).await?;
+
+        let state = AppState::new();
+        let consumer_subject = queue.workspace_update_subject("*");
+
+        (
+            state,
+            queue
+                .stream()
+                .await?
+                .create_consumer(incoming_consumer_config(consumer_subject))
+                .await?
+                .messages()
+                .await?,
+        )
+    };
+
+    let app = ServiceBuilder::new()
+        .layer(
+            TraceLayer::new()
+                .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+                .on_request(DefaultOnRequest::new().level(Level::TRACE))
+                .on_response(
+                    naxum::middleware::trace::DefaultOnResponse::new().level(Level::TRACE),
+                ),
+        )
+        .layer(AckLayer::new())
+        .service(handlers::process_request.with_state(state));
+
+    let inner =
+        naxum::serve_with_incoming_limit(incoming, app.into_make_service(), CONCURRENCY_LIMIT)
+            .with_graceful_shutdown(naxum::wait_on_cancelled(token));
+
+    Ok(Box::new(inner.into_future()))
+}
+
+#[inline]
+fn incoming_consumer_config(
+    subject: impl Into<String>,
+) -> async_nats::jetstream::consumer::pull::Config {
+    async_nats::jetstream::consumer::pull::Config {
+        durable_name: Some(CONSUMER_NAME.to_owned()),
+        filter_subject: subject.into(),
+        ..Default::default()
+    }
+}
+
+// NOTE(nick,jkeiser): we will likely use app state, so let's keep it around for now.
+#[derive(Debug, Clone)]
+struct AppState {}
+
+impl AppState {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/lib/billing-events/BUCK
+++ b/lib/billing-events/BUCK
@@ -1,0 +1,16 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "billing-events",
+    deps = [
+        "//lib/si-data-nats:si-data-nats",
+        "//lib/si-events-rs:si-events",
+        "//third-party/rust:remain",
+        "//third-party/rust:serde",
+        "//third-party/rust:serde_json",
+        "//third-party/rust:thiserror",
+    ],
+    srcs = glob([
+        "src/**/*.rs",
+    ]),
+)

--- a/lib/billing-events/Cargo.toml
+++ b/lib/billing-events/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "billing-events"
+edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+si-data-nats = { path = "../../lib/si-data-nats" }
+si-events = { path = "../../lib/si-events-rs" }
+
+remain = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/lib/billing-events/src/lib.rs
+++ b/lib/billing-events/src/lib.rs
@@ -1,0 +1,135 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Error;
+use si_data_nats::{
+    async_nats::jetstream::{
+        context::{CreateStreamError, PublishError},
+        stream::{Config, DiscardPolicy, RetentionPolicy, Stream},
+    },
+    jetstream,
+};
+use si_events::{ChangeSetId, UserPk, WorkspacePk, WorkspaceSnapshotAddress};
+use thiserror::Error;
+
+const STREAM_NAME: &str = "BILLING_EVENTS";
+const WORKSPACE_UPDATE_SUBJECT: &str = "billing.workspace_update";
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum BillingEventsError {
+    #[error("create stream error: {0}")]
+    CreateStream(#[from] CreateStreamError),
+    #[error("publish error: {0}")]
+    Publish(#[from] PublishError),
+    #[error("serde json error: {0}")]
+    SerdeJson(#[from] Error),
+}
+
+pub type BillingEventsResult<T> = Result<T, BillingEventsError>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BillingWorkspaceChangeEvent {
+    /// The workspace of this change
+    pub workspace: WorkspacePk,
+
+    /// The resource count of the workspace
+    pub resource_count: u64,
+
+    /// Description of the change that caused the event
+    pub change_description: String,
+
+    // TODO(nick,jkeiser): ensure that "ChangeSetStatus" can move to si-events-rs within needing to pull in si-data-pg
+    // for its "ToSql" implementation.
+    /// The status of the workspace
+    pub status: String,
+    /// The specific snapshot with this resource count
+    pub workspace_snapshot_address: WorkspaceSnapshotAddress,
+    /// The change set id of the count (should only ever be main, but this is for reconciliation)
+    pub change_set_id: ChangeSetId,
+    /// The user who requested the update (if any)
+    pub merge_requested_by_user_id: Option<UserPk>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BillingEventsWorkQueue {
+    context: jetstream::Context,
+}
+
+impl BillingEventsWorkQueue {
+    /// Create a new instance of the billing events work queue.
+    ///
+    /// Ensures the stream is created.
+    pub async fn get_or_create(context: jetstream::Context) -> BillingEventsResult<Self> {
+        // Ensure the stream is created before we start publishing to it
+        let result = Self { context };
+        result.stream().await?;
+        Ok(result)
+    }
+
+    pub fn name(&self) -> &str {
+        STREAM_NAME
+    }
+
+    /// Publish a workspace update.
+    pub async fn publish_workspace_update(
+        &self,
+        workspace_id: &str,
+        message: &impl Serialize,
+    ) -> BillingEventsResult<()> {
+        self.publish_message(WORKSPACE_UPDATE_SUBJECT, workspace_id, message)
+            .await
+    }
+
+    /// Get the events stream.
+    pub async fn stream(&self) -> BillingEventsResult<Stream> {
+        let config = Config {
+            name: self.prefixed_stream_name(STREAM_NAME),
+            description: Some("Billing actions work queue of events".to_string()),
+            subjects: vec![self.prefixed_subject(WORKSPACE_UPDATE_SUBJECT, ">")],
+            retention: RetentionPolicy::WorkQueue,
+            allow_direct: true,
+            // Enable this to apply backpressure (stop allowing changes until we can process
+            // billing events that have already happened).
+            // discard_new_per_subject: true
+            discard: DiscardPolicy::New,
+            // This prevents deletion entirely, only allowing messages to disappear when ACKed
+            // deny_delete: true,
+            // deny_purge: true,
+            ..Default::default()
+        };
+        Ok(self.context.get_or_create_stream(config).await?)
+    }
+
+    /// Provides the [`WORKSPACE_UPDATE_SUBJECT`] with an appropriate prefix and suffix.
+    pub fn workspace_update_subject(&self, suffix: &str) -> String {
+        self.prefixed_subject(WORKSPACE_UPDATE_SUBJECT, suffix)
+    }
+
+    async fn publish_message(
+        &self,
+        subject: &str,
+        parameters: &str,
+        message: &impl Serialize,
+    ) -> BillingEventsResult<()> {
+        let subject = self.prefixed_subject(subject, parameters);
+        let ack = self
+            .context
+            .publish(subject, serde_json::to_vec(message)?.into())
+            .await?;
+        ack.await?;
+        Ok(())
+    }
+
+    fn prefixed_stream_name(&self, stream_name: &str) -> String {
+        match self.context.metadata().subject_prefix() {
+            Some(prefix) => format!("{prefix}_{stream_name}"),
+            None => stream_name.to_owned(),
+        }
+    }
+
+    fn prefixed_subject(&self, subject: &str, suffix: &str) -> String {
+        match self.context.metadata().subject_prefix() {
+            Some(prefix) => format!("{prefix}.{subject}.{suffix}"),
+            None => format!("{subject}.{suffix}"),
+        }
+    }
+}

--- a/lib/dal-test/src/expand_helpers.rs
+++ b/lib/dal-test/src/expand_helpers.rs
@@ -19,7 +19,7 @@ pub async fn setup_history_actor_ctx(ctx: &mut DalContext) {
     user.associate_workspace(
         ctx,
         ctx.tenancy()
-            .workspace_pk()
+            .workspace_pk_opt()
             .expect("no workspace pk set on context"),
     )
     .await
@@ -36,9 +36,7 @@ pub async fn create_change_set_and_update_ctx(
         .await
         .expect("could not perform find change set")
         .expect("no change set found");
-    let workspace_snapshot_address = base_change_set
-        .workspace_snapshot_address
-        .expect("no workspace snapshot set on base change set");
+    let workspace_snapshot_address = base_change_set.workspace_snapshot_address;
     let change_set = ChangeSet::new(
         ctx,
         generate_fake_name().expect("could not generate fake name"),

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -7,6 +7,7 @@ load(
 rust_library(
     name = "dal",
     deps = [
+        "//lib/billing-events:billing-events",
         "//lib/nats-subscriber:nats-subscriber",
         "//lib/object-tree:object-tree",
         "//lib/pinga-core:pinga-core",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -12,6 +12,7 @@ publish.workspace = true
 async-recursion = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+billing-events = { path = "../../lib/billing-events" }
 blake3 = { workspace = true }
 chrono = { workspace = true }
 ciborium = { workspace = true }

--- a/lib/dal/src/change_set/status.rs
+++ b/lib/dal/src/change_set/status.rs
@@ -4,14 +4,21 @@ use strum::{AsRefStr, Display, EnumString};
 
 #[remain::sorted]
 #[derive(
-    AsRefStr, Deserialize, Serialize, Debug, Display, EnumString, PartialEq, Eq, Clone, ToSql,
+    AsRefStr, Deserialize, Serialize, Debug, Display, EnumString, PartialEq, Eq, Copy, Clone, ToSql,
 )]
 pub enum ChangeSetStatus {
+    /// No longer usable
     Abandoned,
+    /// Applied this changeset to its parent
     Applied,
+    /// TODO appears to be unused
     Closed,
+    /// TODO appears to be unused
     Failed,
+    /// Planned to be abandoned but needs approval first
     NeedsAbandonApproval,
+    /// Planned to be applied but needs approval first
     NeedsApproval,
+    /// Normal state: potentially usable
     Open,
 }

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -299,8 +299,8 @@ impl Diagram {
 
         let workspace = Workspace::get_by_pk_or_error(
             ctx,
-            &ctx.tenancy()
-                .workspace_pk()
+            ctx.tenancy()
+                .workspace_pk_opt()
                 .ok_or(WorkspaceSnapshotError::WorkspaceMissing)?,
         )
         .await?;

--- a/lib/dal/src/job/definition/dependent_values_update.rs
+++ b/lib/dal/src/job/definition/dependent_values_update.rs
@@ -124,7 +124,7 @@ impl JobConsumer for DependentValuesUpdate {
         span.record(
             "si.workspace.id",
             ctx.tenancy()
-                .workspace_pk()
+                .workspace_pk_opt()
                 .unwrap_or(WorkspacePk::NONE)
                 .to_string(),
         );

--- a/lib/dal/src/job/processor/nats_processor.rs
+++ b/lib/dal/src/job/processor/nats_processor.rs
@@ -52,7 +52,7 @@ impl NatsProcessor {
             let workspace_pk = job_info
                 .access_builder
                 .tenancy()
-                .workspace_pk()
+                .workspace_pk_opt()
                 .ok_or(JobQueueProcessorError::MissingWorkspacePk)?;
 
             let subject = pinga_job(
@@ -104,7 +104,7 @@ impl JobQueueProcessor for NatsProcessor {
         let workspace_pk = job_info
             .access_builder
             .tenancy()
-            .workspace_pk()
+            .workspace_pk_opt()
             .ok_or(BlockingJobError::MissingWorkspacePk)?;
 
         let subject = pinga_job(

--- a/lib/dal/src/key_pair.rs
+++ b/lib/dal/src/key_pair.rs
@@ -80,7 +80,7 @@ impl KeyPair {
                 "SELECT object FROM key_pair_create_v1($1, $2, $3, $4, $5, $6)",
                 &[
                     &name,
-                    &ctx.tenancy().workspace_pk(),
+                    &ctx.tenancy().workspace_pk_opt(),
                     &base64_encode_bytes(public_key.as_ref()),
                     &base64_encode_bytes(secret_key_crypted.as_slice()),
                     &base64_encode_bytes(secret_key_nonce.as_ref()),
@@ -175,7 +175,7 @@ impl PublicKey {
             .txns()
             .await?
             .pg()
-            .query_one(PUBLIC_KEY_GET_CURRENT, &[&ctx.tenancy().workspace_pk()])
+            .query_one(PUBLIC_KEY_GET_CURRENT, &[&ctx.tenancy().workspace_pk_opt()])
             .await?;
         let json: serde_json::Value = row.try_get("object")?;
         Ok(serde_json::from_value(json)?)

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -982,7 +982,7 @@ impl PkgExporter {
             .version(&self.version)
             .created_by(&self.created_by);
 
-        if let Some(workspace_pk) = ctx.tenancy().workspace_pk() {
+        if let Some(workspace_pk) = ctx.tenancy().workspace_pk_opt() {
             pkg_spec_builder.workspace_pk(workspace_pk.to_string());
             let workspace = Workspace::get_by_pk(ctx, &workspace_pk)
                 .await?

--- a/lib/dal/src/tenancy.rs
+++ b/lib/dal/src/tenancy.rs
@@ -8,6 +8,8 @@ use crate::WorkspacePk;
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum TenancyError {
+    #[error("no workspace")]
+    NoWorkspace,
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
 }
@@ -43,7 +45,11 @@ impl Tenancy {
         Ok(result)
     }
 
-    pub fn workspace_pk(&self) -> Option<WorkspacePk> {
+    pub fn workspace_pk(&self) -> TenancyResult<WorkspacePk> {
+        self.workspace_pk.ok_or(TenancyError::NoWorkspace)
+    }
+
+    pub fn workspace_pk_opt(&self) -> Option<WorkspacePk> {
         self.workspace_pk
     }
 

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -147,7 +147,7 @@ impl WsEvent {
         })
     }
     pub async fn new(ctx: &DalContext, payload: WsPayload) -> WsEventResult<Self> {
-        let workspace_pk = match ctx.tenancy().workspace_pk() {
+        let workspace_pk = match ctx.tenancy().workspace_pk_opt() {
             Some(pk) => pk,
             None => {
                 return Err(WsEventError::NoWorkspaceInTenancy);
@@ -158,7 +158,7 @@ impl WsEvent {
     }
 
     pub async fn new_for_workspace(ctx: &DalContext, payload: WsPayload) -> WsEventResult<Self> {
-        let workspace_pk = match ctx.tenancy().workspace_pk() {
+        let workspace_pk = match ctx.tenancy().workspace_pk_opt() {
             Some(pk) => pk,
             None => {
                 return Err(WsEventError::NoWorkspaceInTenancy);

--- a/lib/dal/tests/integration_test/secret/with_actions.rs
+++ b/lib/dal/tests/integration_test/secret/with_actions.rs
@@ -139,7 +139,7 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
     Workspace::get_by_pk(
         ctx,
         &ctx.tenancy()
-            .workspace_pk()
+            .workspace_pk_opt()
             .expect("could not get workspace pk"),
     )
     .await

--- a/lib/dal/tests/integration_test/workspace.rs
+++ b/lib/dal/tests/integration_test/workspace.rs
@@ -29,7 +29,7 @@ async fn export_import_loop(ctx: &mut DalContext) {
         .await
         .expect("commit and update snapshot to visibility");
 
-    let workspace_pk = ctx.tenancy().workspace_pk().expect("find workspace pk");
+    let workspace_pk = ctx.tenancy().workspace_pk_opt().expect("find workspace pk");
     let mut workspace = Workspace::get_by_pk(ctx, &workspace_pk)
         .await
         .expect("execute find workspace")

--- a/lib/pinga-server/src/handlers.rs
+++ b/lib/pinga-server/src/handlers.rs
@@ -108,7 +108,7 @@ async fn execute_job(
     let workspace_id_str = job_info
         .access_builder
         .tenancy()
-        .workspace_pk()
+        .workspace_pk_opt()
         .map(|id| id.to_string())
         .unwrap_or_default();
     let otel_name = {

--- a/lib/pinga-server/src/lib.rs
+++ b/lib/pinga-server/src/lib.rs
@@ -5,7 +5,7 @@ pub mod server;
 
 use std::io;
 
-use dal::InitializationError;
+use dal::{InitializationError, TransactionsError};
 use si_data_nats::{async_nats, NatsError};
 use si_data_pg::PgPoolError;
 use thiserror::Error;
@@ -39,6 +39,8 @@ pub enum ServerError {
     PgPool(#[from] Box<PgPoolError>),
     #[error("symmetric crypto error: {0}")]
     SymmetricCryptoService(#[from] si_crypto::SymmetricCryptoError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
     #[error("error when loading cyclone encryption key: {0}")]
     VeritechEncryptionKey(#[from] si_crypto::VeritechEncryptionKeyError),
 }

--- a/lib/rebaser-server/src/rebase.rs
+++ b/lib/rebaser-server/src/rebase.rs
@@ -76,10 +76,7 @@ pub async fn perform_rebase(
             .ok_or(RebaseError::MissingChangeSet(
                 message.payload.to_rebase_change_set_id.into(),
             ))?;
-    let to_rebase_workspace_snapshot_address =
-        to_rebase_change_set.workspace_snapshot_address.ok_or(
-            RebaseError::MissingWorkspaceSnapshotForChangeSet(to_rebase_change_set.id),
-        )?;
+    let to_rebase_workspace_snapshot_address = to_rebase_change_set.workspace_snapshot_address;
     debug!("before snapshot fetch and parse: {:?}", start.elapsed());
     let to_rebase_workspace_snapshot =
         WorkspaceSnapshot::find(ctx, to_rebase_workspace_snapshot_address).await?;
@@ -155,7 +152,7 @@ pub async fn perform_rebase(
     if let Some(workspace) = Workspace::get_by_pk(
         ctx,
         &ctx.tenancy()
-            .workspace_pk()
+            .workspace_pk_opt()
             .ok_or(RebaseError::WorkspacePkExpected)?,
     )
     .await?
@@ -239,7 +236,7 @@ async fn replay_changes(
     let metadata = LayeredEventMetadata::new(
         si_events::Tenancy::new(
             ctx.tenancy()
-                .workspace_pk()
+                .workspace_pk_opt()
                 .unwrap_or(WorkspacePk::NONE)
                 .into(),
             target_change_set_id.into(),

--- a/lib/rebaser-server/src/server.rs
+++ b/lib/rebaser-server/src/server.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use dal::feature_flags::FeatureFlagService;
+use dal::{context::NatsStreams, feature_flags::FeatureFlagService};
 use dal::{
     ChangeSetStatus, DalContext, DalContextBuilder, DalLayerDb, JobQueueProcessor, NatsProcessor,
     ServicesContext,
@@ -76,6 +76,7 @@ impl Server {
 
         let encryption_key = Self::load_encryption_key(config.crypto().clone()).await?;
         let nats = Self::connect_to_nats(config.nats()).await?;
+        let nats_streams = NatsStreams::get_or_create(&nats).await?;
         let pg_pool = Self::create_pg_pool(config.pg_pool()).await?;
         let veritech = Self::create_veritech_client(nats.clone());
         let job_processor = Self::create_job_processor(nats.clone());
@@ -90,6 +91,7 @@ impl Server {
         let services_context = ServicesContext::new(
             pg_pool,
             nats.clone(),
+            nats_streams,
             job_processor,
             veritech.clone(),
             encryption_key,

--- a/lib/sdf-server/src/server/server.rs
+++ b/lib/sdf-server/src/server/server.rs
@@ -1,5 +1,6 @@
 use axum::routing::IntoMakeService;
 use axum::Router;
+use dal::context::NatsStreams;
 use dal::jwt_key::JwtConfig;
 use dal::pkg::PkgError;
 use dal::workspace_snapshot::migrator::{SnapshotGraphMigrator, SnapshotGraphMigratorError};
@@ -310,6 +311,13 @@ impl Server<(), ()> {
         let client = NatsClient::new(nats_config).await?;
         debug!("successfully connected nats client");
         Ok(client)
+    }
+
+    #[instrument(name = "sdf.init.get_or_create_nats_streams", level = "info", skip_all)]
+    pub async fn get_or_create_nats_streams(client: &NatsClient) -> ServerResult<NatsStreams> {
+        let streams = NatsStreams::get_or_create(client).await?;
+        debug!("successfully connected nats streams");
+        Ok(streams)
     }
 
     pub fn create_veritech_client(nats: NatsClient) -> VeritechClient {

--- a/lib/sdf-server/src/server/service/module/approval_process.rs
+++ b/lib/sdf-server/src/server/service/module/approval_process.rs
@@ -48,7 +48,7 @@ pub async fn begin_approval_process(
 
     let workspace_pk = ctx
         .tenancy()
-        .workspace_pk()
+        .workspace_pk_opt()
         .ok_or(ModuleError::ExportingImportingWithRootTenancy)?;
 
     track(
@@ -108,7 +108,7 @@ pub async fn cancel_approval_process(
 
     let workspace_pk = ctx
         .tenancy()
-        .workspace_pk()
+        .workspace_pk_opt()
         .ok_or(ModuleError::ExportingImportingWithRootTenancy)?;
 
     track(

--- a/lib/sdf-server/src/server/service/module/export_workspace.rs
+++ b/lib/sdf-server/src/server/service/module/export_workspace.rs
@@ -41,7 +41,7 @@ pub async fn export_workspace(
 
     let workspace_pk = ctx
         .tenancy()
-        .workspace_pk()
+        .workspace_pk_opt()
         .ok_or(ModuleError::ExportingImportingWithRootTenancy)?;
     let workspace = Workspace::get_by_pk(&ctx, &workspace_pk)
         .await?

--- a/lib/sdf-server/src/server/service/module/import_workspace_vote.rs
+++ b/lib/sdf-server/src/server/service/module/import_workspace_vote.rs
@@ -34,7 +34,7 @@ pub async fn import_workspace_vote(
 
     let workspace_pk = ctx
         .tenancy()
-        .workspace_pk()
+        .workspace_pk_opt()
         .ok_or(ModuleError::ExportingImportingWithRootTenancy)?;
 
     track(

--- a/lib/sdf-server/src/server/service/module/install_workspace.rs
+++ b/lib/sdf-server/src/server/service/module/install_workspace.rs
@@ -42,7 +42,7 @@ pub async fn install_workspace(
     let workspace = {
         let workspace_pk = ctx
             .tenancy()
-            .workspace_pk()
+            .workspace_pk_opt()
             .ok_or(ModuleError::ExportingImportingWithRootTenancy)?;
         Workspace::get_by_pk(&ctx, &workspace_pk)
             .await?

--- a/lib/sdf-server/src/server/service/v2/admin.rs
+++ b/lib/sdf-server/src/server/service/v2/admin.rs
@@ -39,8 +39,6 @@ pub enum AdminAPIError {
     Transactions(#[from] dal::TransactionsError),
     #[error("workspaces error: {0}")]
     Workspace(#[from] dal::WorkspaceError),
-    #[error("change set {0} does not have a workspace snapshot address")]
-    WorkspaceSnapshotAddressNotFound(ChangeSetId),
     #[error("workspace snapshot {0} for change set {1} could not be found in durable storage")]
     WorkspaceSnapshotNotFound(WorkspaceSnapshotAddress, ChangeSetId),
 }
@@ -80,7 +78,7 @@ pub struct AdminChangeSet {
     pub name: String,
     pub status: ChangeSetStatus,
     pub base_change_set_id: Option<ChangeSetId>,
-    pub workspace_snapshot_address: Option<WorkspaceSnapshotAddress>,
+    pub workspace_snapshot_address: WorkspaceSnapshotAddress,
     pub workspace_id: Option<WorkspacePk>,
     pub merge_requested_by_user_id: Option<UserPk>,
 }

--- a/lib/sdf-server/src/server/service/v2/admin/get_snapshot.rs
+++ b/lib/sdf-server/src/server/service/v2/admin/get_snapshot.rs
@@ -21,9 +21,7 @@ pub async fn get_snapshot(
         .await?
         .ok_or(AdminAPIError::ChangeSetNotFound(change_set_id))?;
 
-    let snap_addr = change_set.workspace_snapshot_address.ok_or(
-        AdminAPIError::WorkspaceSnapshotAddressNotFound(change_set_id),
-    )?;
+    let snap_addr = change_set.workspace_snapshot_address;
 
     let bytes = ctx
         .layer_db()

--- a/lib/sdf-server/src/server/tracking.rs
+++ b/lib/sdf-server/src/server/tracking.rs
@@ -22,7 +22,7 @@ pub fn track(
     let distinct_id = ctx.history_actor().distinct_id();
     let workspace_id = ctx
         .tenancy()
-        .workspace_pk()
+        .workspace_pk_opt()
         .map(|workspace_pk| workspace_pk.to_string())
         .unwrap_or_else(|| "unknown".to_string());
     let changeset_id = ctx.change_set_id().to_string();

--- a/lib/si-data-nats/src/jetstream/context.rs
+++ b/lib/si-data-nats/src/jetstream/context.rs
@@ -45,6 +45,10 @@ impl Context {
         self.inner.set_timeout(timeout)
     }
 
+    pub fn metadata(&self) -> &ConnectionMetadata {
+        &self.metadata
+    }
+
     pub(crate) fn with_prefix(client: Client, prefix: &str) -> Self {
         let (inner_client, metadata) = client.into_parts();
         let inner = async_nats::jetstream::with_prefix(inner_client, prefix);


### PR DESCRIPTION
## Description

This PR adds the initial billing event loop. It works by publishing events to a NATS Jetstream durable queue when applying change sets to the workspace's default change set. On the consumer side, SDF now has a pet `naxum` server for consuming these billing events. At present, we effectively "no-op" on these events and debug log each event received.

As a result of these changes, two crates have been added: `billing-events` and `billing-events-server`. The former provides core functions for working with the billing events stream. The latter provides a `naxum` server as a future for consuming billing events.

<img src="https://media2.giphy.com/media/eewYSr7s7utOM/giphy.gif"/>

## Disclaimers

- Streams created during tests are not cleaned up, but this is also the case for all streams with prefixes at present (e.g. pinga jobs stream)
- This PR does not contain resource counting and it only contains the machinery for publishing and consuming the events

## Additional Changes

- Add "adding a new rust library" section to the docs
- Add `NatsStreams` to services context
- Handle optional `WorkspacePk` scenarios with a wrapper
- Remove dead code related to clearing workspaces
- Polish transactions error and result usage
- Use `Box` for `WorkspaceError` when working with transactions
- Add connection metadata accessor method to jetstream context