### PR TITLE
fix(dal): quiet info messages in debug routes

### DIFF
--- a/lib/dal/src/attribute/value/debug.rs
+++ b/lib/dal/src/attribute/value/debug.rs
@@ -73,7 +73,7 @@ pub enum AttributeDebugViewError {
     WorkspaceSnapshotError(#[from] WorkspaceSnapshotError),
 }
 impl AttributeDebugView {
-    #[instrument(level = "info", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn new(
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,

--- a/lib/dal/src/component/debug.rs
+++ b/lib/dal/src/component/debug.rs
@@ -97,7 +97,7 @@ pub enum ComponentDebugViewError {
 }
 
 impl ComponentDebugView {
-    #[instrument(level = "info", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn new(
         ctx: &DalContext,
         component_id: ComponentId,
@@ -152,7 +152,7 @@ impl ComponentDebugView {
 }
 
 impl ComponentDebugData {
-    #[instrument(level = "info", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn new(ctx: &DalContext, component: &Component) -> ComponentDebugViewResult<Self> {
         let schema_variant_id = Component::schema_variant_id(ctx, component.id()).await?;
         let parent_id = component.parent(ctx).await?;
@@ -179,7 +179,7 @@ impl ComponentDebugData {
         Ok(debug_view)
     }
 
-    #[instrument(level = "info", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn get_input_sockets_for_component(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -197,7 +197,7 @@ impl ComponentDebugData {
         Ok(input_sockets)
     }
 
-    #[instrument(level = "info", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn get_output_sockets_for_component(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
@@ -216,7 +216,7 @@ impl ComponentDebugData {
         Ok(output_sockets)
     }
 
-    #[instrument(level = "info", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn get_attribute_value_tree_for_component(
         ctx: &DalContext,
         component_id: ComponentId,

--- a/lib/dal/src/socket/debug.rs
+++ b/lib/dal/src/socket/debug.rs
@@ -57,7 +57,7 @@ pub enum SocketDebugViewError {
 }
 
 impl SocketDebugView {
-    #[instrument(level = "info", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub async fn new_for_output_socket(
         ctx: &DalContext,
         component_output_socket: ComponentOutputSocket,
@@ -119,7 +119,6 @@ impl SocketDebugView {
         let prototype_debug_view =
             AttributePrototypeDebugView::new(ctx, component_input_socket.attribute_value_id)
                 .await?;
-        info!("prototype_debug_view: {:?}", prototype_debug_view);
         let attribute_value = AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
         let input_socket =
             InputSocket::get_by_id(ctx, component_input_socket.input_socket_id).await?;
@@ -152,7 +151,6 @@ impl SocketDebugView {
             name: input_socket.name().to_string(),
             inferred_connections,
         };
-        info!("Socket Debug View: {:?}", view);
         Ok(view)
     }
 }


### PR DESCRIPTION
The info! in the component debug routes is not helping us anymore, and fills up the logs, making them harder to read. Let's ditch it