### PR TITLE
feat: move api calls into their own constructor within api test toolbox

### DIFF
--- a/bin/si-smoketest/sdf_api_client.ts
+++ b/bin/si-smoketest/sdf_api_client.ts
@@ -1,11 +1,12 @@
+// sdf_client.ts
 import JWT from "npm:jsonwebtoken";
 
 export class SdfApiClient {
-  readonly token: string;
-  readonly baseUrl: string;
-  readonly workspaceId: string;
+  private readonly token: string;
+  private readonly baseUrl: string;
+  public readonly workspaceId: string;
 
-  // We can't have async constructor so init() should be used to get a client instance
+  // Constructor is private to enforce using the init method
   private constructor(
     token: string,
     baseUrl: string,
@@ -16,8 +17,7 @@ export class SdfApiClient {
     this.workspaceId = workspaceId;
   }
 
-  /// Get a client to do web requests to sdf. if JWT_PRIVATE_KEY is set, the
-  /// second argument should be the userId to be baked in the token.
+  // Initializes the SdfApiClient with authentication
   public static async init(
     workspaceId: string,
     userEmailOrId: string,
@@ -26,12 +26,17 @@ export class SdfApiClient {
     const token = await getSdfJWT(workspaceId, userEmailOrId, password);
     const baseUrl = Deno.env.get("SDF_API_URL");
 
+    if (!baseUrl) {
+      throw new Error("SDF_API_URL environment variable is missing.");
+    }
+
     return new SdfApiClient(token, baseUrl, workspaceId);
   }
 
-  async fetch(path: string, options?: {
+  // General fetch method
+  private async fetch(path: string, options?: {
     headers?: Record<string, string>
-    body?: Record<string, string>
+    body?: Record<string, unknown>
     method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH"
   }) {
     const resp = await this.fetch_no_throw(path, options);
@@ -42,10 +47,10 @@ export class SdfApiClient {
     return resp;
   }
 
-  /// Don't automatically throw on errors
-  fetch_no_throw(path: string, options?: {
+  // Fetch method without automatic error throwing
+  private fetch_no_throw(path: string, options?: {
     headers?: Record<string, string>
-    body?: Record<string, string>
+    body?: Record<string, unknown>
     method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH"
   }) {
     const url = `${this.baseUrl}${path}`;
@@ -62,15 +67,54 @@ export class SdfApiClient {
     const body = options?.body ? JSON.stringify(options.body) : undefined;
 
     return fetch(url, {
-      headers, body, method: options?.method
+      headers, body, method
     });
+  }
+
+  // High-level API methods are located below
+  // --------------------------------------------------------------------------------
+
+  // Fetch list of open change sets
+  public async listOpenChangeSets() {
+    return listOpenChangeSets(this);
+  }
+
+  // Create a new change set
+  public async createChangeSet(changeSetName: string) {
+    return createChangeSet(this, changeSetName);
+  }
+
+  // Fetch list of schema variants for a specific change set
+  public async listSchemaVariants(changeSetId: string) {
+    return listSchemaVariants(this, changeSetId);
+  }
+
+  // Create a component in a diagram
+  public async createComponent(payload: Record<string, unknown>) {
+    return createComponent(this, payload);
+  }
+
+  // Get the current state of a diagram
+  public async getDiagram(changeSetId: string) {
+    return getDiagram(this, changeSetId);
+  }
+
+  // Delete components from a diagram
+  public async deleteComponents(payload: Record<string, unknown>) {
+    return deleteComponents(this, payload);
+  }
+
+  // Abandon a change set
+  public async abandonChangeSet(changeSetId: string) {
+    return abandonChangeSet(this, changeSetId);
   }
 }
 
+// Helper functions for JWT generation and fetching
 async function getSdfJWT(workspaceId: string, userEmailOrId: string, password: string) {
   const privateKey = Deno.env.get("JWT_PRIVATE_KEY");
   if (privateKey && privateKey.length > 0) {
-    console.log("JWT_PRIVATE_KEY is set, signing jwt locally. UserId  should be passed in instead of email");
+    console.log("JWT_PRIVATE_KEY is set, signing jwt locally. UserId should be passed in instead of email");
 
     return createJWTFromPrivateKey(workspaceId, userEmailOrId, privateKey);
   } else {
@@ -78,19 +122,18 @@ async function getSdfJWT(workspaceId: string, userEmailOrId: string, password: s
   }
 }
 
-async function getSdfJWTFromAuth0(workspaceId: string, email: string, password: string): string {
-  const auth_api_url = Deno.env.get("AUTH_API_URL");
+async function getSdfJWTFromAuth0(workspaceId: string, email: string, password: string): Promise<string> {
+  const authApiUrl = Deno.env.get("AUTH_API_URL");
 
-  if (!auth_api_url || auth_api_url.length === 0) {
+  if (!authApiUrl || authApiUrl.length === 0) {
     throw new Error("Missing AUTH_API_URL");
   }
 
-  const login_resp = await fetch(`${auth_api_url}/auth/login`, {
+  const loginResp = await fetch(`${authApiUrl}/auth/login`, {
     headers: {
       "Accept": "application/json",
       "Content-Type": "application/json"
     },
-
     body: JSON.stringify({
       email,
       password,
@@ -99,25 +142,78 @@ async function getSdfJWTFromAuth0(workspaceId: string, email: string, password: 
     method: "POST"
   });
 
-  const { token, message } = await login_resp.json();
+  const { token, message } = await loginResp.json();
 
   if (!token) {
-    const error_message = message ?? "Unknown Error";
-    throw Error(`Could not get token: ${error_message}`);
+    const errorMessage = message ?? "Unknown Error";
+    throw new Error(`Could not get token: ${errorMessage}`);
   }
 
   return token;
 }
 
 async function createJWTFromPrivateKey(
-  workspaceId: String,
-  userId: String,
-  private_key: String
-): string {
+  workspaceId: string,
+  userId: string,
+  privateKey: string
+): Promise<string> {
   return JWT.sign({
     user_pk: userId,
     workspace_pk: workspaceId
-  }, private_key, { algorithm: "RS256", ...{ subject: userId } });
+  }, privateKey, { algorithm: "RS256", subject: userId });
 }
 
+// API-Endpoint Specific Functions
+// --------------------------------------------------------------------------------
 
+// List open change sets
+async function listOpenChangeSets(client: SdfApiClient) {
+  const response = await client.fetch("/change_set/list_open_change_sets");
+  return await response.json();
+}
+
+// Create a change set
+async function createChangeSet(client: SdfApiClient, changeSetName: string) {
+  const response = await client.fetch("/change_set/create_change_set", {
+    method: "POST",
+    body: { changeSetName },
+  });
+  return await response.json();
+}
+
+// List schema variants for a change set
+async function listSchemaVariants(client: SdfApiClient, changeSetId: string) {
+  const response = await client.fetch(`/v2/workspaces/${client.workspaceId}/change-sets/${changeSetId}/schema-variants`);
+  return await response.json();
+}
+
+// Create a component in a diagram
+async function createComponent(client: SdfApiClient, payload: Record<string, unknown>) {
+  const response = await client.fetch("/diagram/create_component", {
+    method: "POST",
+    body: payload,
+  });
+  return await response.json();
+}
+
+// Get the current state of a diagram
+async function getDiagram(client: SdfApiClient, changeSetId: string) {
+  const response = await client.fetch(`/diagram/get_diagram?visibility_change_set_pk=${changeSetId}&workspaceId=${client.workspaceId}`);
+  return await response.json();
+}
+
+// Delete components from a diagram
+async function deleteComponents(client: SdfApiClient, payload: Record<string, unknown>) {
+  await client.fetch("/diagram/delete_components", {
+    method: "POST",
+    body: payload,
+  });
+}
+
+// Abandon a change set
+async function abandonChangeSet(client: SdfApiClient, changeSetId: string) {
+  await client.fetch("/change_set/abandon_change_set", {
+    method: "POST",
+    body: { changeSetId },
+  });
+}


### PR DESCRIPTION
Moves the api test suite to use constructor-type pattern for each API endpoint we want to use to drive SDF, means you can use them like:
```
await sdfApiService.abandonChangeSet(changeSetId);

or

await sdfApiService.createChangeSet(changeSetName);
```

Tested locally using

```
SDF_API_URL="https://app.systeminit.com/api" AUTH_API_URL="https://auth-api.systeminit.com" deno task run workspaceid 'username@systeminit.com' 'pass' 
Task run deno run --allow-env --allow-net main.ts "workspaceid" "username" "pass"
calling GET https://app.systeminit.com/api/change_set/list_open_change_sets
get_head_changeset OK - 445ms
calling POST https://app.systeminit.com/api/change_set/create_change_set
calling GET https://app.systeminit.com/api/v2/workspaces/workspaceid/change-sets/01J6ZNQYE4FBZ6HZ3FMTQPD1M6/schema-variants
calling POST https://app.systeminit.com/api/diagram/create_component
calling GET https://app.systeminit.com/api/diagram/get_diagram?visibility_change_set_pk=01J6ZNQYE4FBZ6HZ3FMTQPD1M6&workspaceId=workspaceid
calling POST https://app.systeminit.com/api/diagram/delete_components
calling GET https://app.systeminit.com/api/diagram/get_diagram?visibility_change_set_pk=01J6ZNQYE4FBZ6HZ3FMTQPD1M6&workspaceId=workspaceid
calling POST https://app.systeminit.com/api/change_set/abandon_change_set
create_and_delete_component OK - 2530ms
~~ SUCCESS ~~
```