### PR TITLE
feat: API test structural changes

### DIFF
--- a/bin/si-smoketest/binary_exeuction_lib.ts
+++ b/bin/si-smoketest/binary_exeuction_lib.ts
@@ -1,0 +1,18 @@
+// This lib can be used for binary args management, i.e.
+// parsing inputs
+// setting default variables
+// setting verbosity/logging levels
+// interrogating the environment to figure out exactly how to execute the tests
+
+export function parseArgs(args: string[]) {
+    if (args.length < 2) {
+      throw new Error("Expected at least 2 args: workspaceId, userEmail, and optionally userPassword and test names");
+    }
+  
+    const workspaceId = args[0];
+    const userId = args[1];
+    const password = args[2] || undefined; // Password is optional
+    const testsToRun = args.slice(3); // Skip the first three arguments
+  
+    return { workspaceId, userId, password, testsToRun };
+}

--- a/bin/si-smoketest/deno.json
+++ b/bin/si-smoketest/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run --allow-env --allow-net --watch main.ts",
-    "run": "deno run --allow-env --allow-net main.ts"
+    "dev": "deno run --allow-env --allow-net --allow-read=./tests --watch main.ts",
+    "run": "deno run --allow-env --allow-net --allow-read=./tests main.ts"
   }
 }

--- a/bin/si-smoketest/deno.lock
+++ b/bin/si-smoketest/deno.lock
@@ -88,7 +88,8 @@
     }
   },
   "redirects": {
-    "https://deno.land/x/require/mod.ts": "https://deno.land/x/require@1.0.0/mod.ts"
+    "https://deno.land/x/require/mod.ts": "https://deno.land/x/require@1.0.0/mod.ts",
+    "https://deno.land/x/uuid/mod.ts": "https://deno.land/x/uuid@v0.1.2/mod.ts"
   },
   "remote": {
     "https://deno.land/std@0.221.0/encoding/_util.ts": "beacef316c1255da9bc8e95afb1fa56ed69baef919c88dc06ae6cb7a6103d376",
@@ -185,6 +186,8 @@
     "https://deno.land/x/josnwebtoken@v0.0.2/sign.js": "90a04373ae55450a6b3c6d1caea89010b969d1a56457b56f0c2fd6b929539e9b",
     "https://deno.land/x/josnwebtoken@v0.0.2/verify.js": "fa01db296dfa5585bff7b097187ef65fcb017d636ab9900799eb53e0acee0b85",
     "https://deno.land/x/require@1.0.0/mod.ts": "94e69b8e8ced198901e71d31a96e88d88d990888179408a35d575db1169de911",
-    "https://deno.land/x/ulid@v0.3.0/mod.ts": "f7ff065b66abd485051fc68af23becef6ccc7e81f7774d7fcfd894a4b2da1984"
+    "https://deno.land/x/ulid@v0.3.0/mod.ts": "f7ff065b66abd485051fc68af23becef6ccc7e81f7774d7fcfd894a4b2da1984",
+    "https://deno.land/x/uuid@v0.1.2/mod.ts": "efc48233163b385262e5ec79662ad76f7684ad80080fc69a140c6e01e56c75d8",
+    "https://deno.land/x/uuid@v0.1.2/v4.ts": "00392ef1efb815545d6b0ec5fb0260d4ed4295259abc3162766e397c47226a7b"
   }
 }

--- a/bin/si-smoketest/main.ts
+++ b/bin/si-smoketest/main.ts
@@ -1,90 +1,61 @@
 // main.ts
 import assert from "node:assert";
 import { SdfApiClient } from "./sdf_api_client.ts";
+import { createDefaultTestReportEntry, printTestReport, TestReportEntry } from "./test_execution_lib.ts";
+import { parseArgs } from "./binary_exeuction_lib.ts"; 
 
 if (import.meta.main) {
-  assert(Deno.env.get("SDF_API_URL")?.length > 0, "Expected SDF_API_URL env var");
-  assert(Deno.env.get("AUTH_API_URL")?.length > 0, "Expected AUTH_API_URL env var");
-
-  assert([2, 3].includes(Deno.args.length), "Expected args: workspaceId, userEmail and userPassword (optional)");
-  const workspaceId = Deno.args[0];
-  const userId = Deno.args[1];
-  const password = Deno.args[2];
-
+  const { workspaceId, userId, password, testsToRun } = parseArgs(Deno.args);
+  
+  // Init the SDF Module
   const sdfApiClient = await SdfApiClient.init(workspaceId, userId, password);
 
-  // Run tests
-  let testStart = new Date();
-  await get_head_changeset(sdfApiClient);
-  console.log(`get_head_changeset OK - ${(new Date() - testStart)}ms`);
+  // Dynamically load test files from the ./tests directory
+  const testFiles: { [key: string]: string } = {};
+  for await (const dirEntry of Deno.readDir("./tests")) {
+    if (dirEntry.isFile && dirEntry.name.endsWith(".ts")) {
+      const testName = dirEntry.name.replace(".ts", "");
+      testFiles[testName] = `./tests/${dirEntry.name}`;
+    }
+  }
 
-  testStart = new Date();
-  await create_and_delete_component(sdfApiClient);
-  console.log(`create_and_delete_component OK - ${(new Date() - testStart)}ms`);
+  // If no tests are specified, run all tests by default
+  const tests = testsToRun.length > 0 ? testsToRun : Object.keys(testFiles);
+  const testReport: TestReportEntry[] = [];
 
-  console.log("~~ SUCCESS ~~");
-}
+  for (const testName of tests) {
+    const testPath = testFiles[testName];
+    const testEntry = createDefaultTestReportEntry(testName);
 
-async function get_head_changeset(sdfApiClient: SdfApiClient) {
-  const data = await sdfApiClient.listOpenChangeSets();
+    try {
+      if (testPath) {
+        try {
+          const { default: testFunc } = await import(testPath);
+          let testStart = new Date();
+          await testFunc(sdfApiClient);
+          testEntry.test_result = "success";
+          testEntry.finish_time = new Date().toISOString();
+          testEntry.test_duration = `${new Date().getTime() - testStart.getTime()}ms`;
+        } catch (importError) {
+          testEntry.message = `Failed to load test file "${testPath}": ${importError.message}`;
+        }
+      } else {
+        testEntry.message = `test "${testName}" not found.`;
+      }
+    } catch (error) {
+      testEntry.message = error.message;
+    } finally {
+      testEntry.finish_time = new Date().toISOString();
+      testEntry.test_duration = `${new Date().getTime() - new Date(testEntry.start_time).getTime()}ms`;
+      testReport.push(testEntry);
+    }
+  }
 
-  assert(data.headChangeSetId, "Expected headChangeSetId");
-  const head = data.changeSets.find((c) => c.id === data.headChangeSetId);
-  assert(head, "Expected a HEAD changeset");
-}
+  // Generate and print the report
+  printTestReport(testReport);
 
-async function create_and_delete_component(sdfApiClient: SdfApiClient) {
-  const startTime = new Date();
-  const changeSetName = `API_TEST create_and_delete_component - ${startTime.toISOString()}`;
+  // Assert that all tests passed
+  assert(testReport.every(entry => entry.test_result === "success"), "Not all tests passed. Please check the logs for details.");
 
-  // CREATE CHANGE SET
-  const data = await sdfApiClient.createChangeSet(changeSetName);
-  assert(typeof data.changeSet === "object", "Expected changeSet in response");
-  const changeSet = data.changeSet;
-  assert(changeSet?.id, "Expected Change Set id");
-  assert(changeSet?.name === changeSetName, `Changeset name should be ${changeSetName}`);
-  const changeSetId = changeSet.id;
-
-  // CREATE COMPONENT
-  const schemaVariants = await sdfApiClient.listSchemaVariants(changeSetId);
-  assert(Array.isArray(schemaVariants), "List schema variants should return an array");
-  const genericFrameVariantId = schemaVariants.find((sv) => sv.schemaName === "Generic Frame")?.schemaVariantId;
-  assert(genericFrameVariantId, "Expected to find Generic Frame schema and variant");
-
-  // Actually create component
-  const createComponentPayload = {
-    schemaVariantId: genericFrameVariantId,
-    x: "0",
-    y: "0",
-    visibility_change_set_pk: changeSetId,
-    workspaceId: sdfApiClient.workspaceId,
-  };
-  const createComponentResp = await sdfApiClient.createComponent(createComponentPayload);
-  const newComponentId = createComponentResp?.componentId;
-  assert(newComponentId, "Expected to get a component id after creation");
-
-  // Check that component exists on diagram
-  const diagram = await sdfApiClient.getDiagram(changeSetId);
-  assert(diagram?.components, "Expected components list on the diagram");
-  assert(diagram.components.length === 1, "Expected a single component on the diagram");
-  const createdComponent = diagram.components[0];
-  assert(createdComponent?.id === newComponentId, "Expected diagram component id to match create component API return ID");
-  assert(createdComponent?.schemaVariantId === genericFrameVariantId, "Expected diagram component schema variant id to match generic frame sv id");
-
-  // DELETE COMPONENT
-  const deleteComponentPayload = {
-    componentIds: [newComponentId],
-    forceErase: false,
-    visibility_change_set_pk: changeSetId,
-    workspaceId: sdfApiClient.workspaceId,
-  };
-  await sdfApiClient.deleteComponents(deleteComponentPayload);
-
-  // Check that component has been removed from diagram
-  const diagramAfterDelete = await sdfApiClient.getDiagram(changeSetId);
-  assert(diagramAfterDelete?.components, "Expected components list on the diagram");
-  assert(diagramAfterDelete.components.length === 0, "Expected no components on the diagram");
-
-  // DELETE CHANGE SET
-  await sdfApiClient.abandonChangeSet(changeSetId);
+  console.log("~~ ALL TESTS PASSED ~~");
 }

--- a/bin/si-smoketest/test_execution_lib.ts
+++ b/bin/si-smoketest/test_execution_lib.ts
@@ -1,0 +1,71 @@
+// This library can be used to handle test report output specifically
+// to pass it back up to the user, i.e.
+// setting thread/parallelisation numbers
+// setting test execution strategy, i.e.
+//   - linear
+//   - soak
+//   - ramp
+//   - one-shot
+
+import { V4 } from "https://deno.land/x/uuid@v0.1.2/mod.ts";
+
+export interface TestReportEntry {
+    test_name: string;
+    start_time: string;
+    finish_time: string;
+    test_duration: string;
+    test_result: "success" | "failure";
+    message?: string;
+    test_execution_sequence: number;
+    uuid: string;   
+}
+
+let executionCount = 0;
+
+export function createDefaultTestReportEntry(testName: string): TestReportEntry {
+    executionCount++;
+    return {
+      test_name: testName,
+      start_time: new Date().toISOString(),
+      finish_time: "",
+      test_duration: "",
+      test_result: "failure",
+      message: "",
+      test_execution_sequence: executionCount,
+      uuid: V4.uuid(),
+    };
+  }
+
+export function printTestReport(report: TestReportEntry[]) {
+    console.log("Test Report:");
+    console.log(JSON.stringify(report, null, 2));
+}
+  
+export class ExecutionTracker {
+        
+    private reports: TestReport[] = [];
+
+    startTest(testName: string): TestReport {
+        const startTime = new Date();
+        return {
+        test_name: testName,
+        start_time: startTime.toISOString(),
+        finish_time: "",
+        test_duration: "",
+        test_result: "",
+        };
+    }
+
+    finishTest(report: TestReport, result: string): void {
+        const finishTime = new Date();
+        const startTime = new Date(report.start_time);
+        report.finish_time = finishTime.toISOString();
+        report.test_duration = `${finishTime.getTime() - startTime.getTime()}ms`;
+        report.test_result = result;
+        this.reports.push(report);
+    }
+
+    getReports(): TestReport[] {
+        return this.reports;
+    }
+}

--- a/bin/si-smoketest/tests/create_and_delete_component.ts
+++ b/bin/si-smoketest/tests/create_and_delete_component.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert";
+import { SdfApiClient } from "../sdf_api_client.ts";
+
+export default async function create_and_delete_component(sdfApiClient: SdfApiClient) {
+  const startTime = new Date();
+  const changeSetName = `API_TEST create_and_delete_component - ${startTime.toISOString()}`;
+
+  // CREATE CHANGE SET
+  const data = await sdfApiClient.createChangeSet(changeSetName);
+  assert(typeof data.changeSet === "object", "Expected changeSet in response");
+  const changeSet = data.changeSet;
+  assert(changeSet?.id, "Expected Change Set id");
+  assert(changeSet?.name === changeSetName, `Changeset name should be ${changeSetName}`);
+  const changeSetId = changeSet.id;
+
+  // CREATE COMPONENT
+  const schemaVariants = await sdfApiClient.listSchemaVariants(changeSetId);
+  assert(Array.isArray(schemaVariants), "List schema variants should return an array");
+  const genericFrameVariantId = schemaVariants.find((sv) => sv.schemaName === "Generic Frame")?.schemaVariantId;
+  assert(genericFrameVariantId, "Expected to find Generic Frame schema and variant");
+
+  // Actually create component
+  const createComponentPayload = {
+    schemaVariantId: genericFrameVariantId,
+    x: "0",
+    y: "0",
+    visibility_change_set_pk: changeSetId,
+    workspaceId: sdfApiClient.workspaceId,
+  };
+  const createComponentResp = await sdfApiClient.createComponent(createComponentPayload);
+  const newComponentId = createComponentResp?.componentId;
+  assert(newComponentId, "Expected to get a component id after creation");
+
+  // Check that component exists on diagram
+  const diagram = await sdfApiClient.getDiagram(changeSetId);
+  assert(diagram?.components, "Expected components list on the diagram");
+  assert(diagram.components.length === 1, "Expected a single component on the diagram");
+  const createdComponent = diagram.components[0];
+  assert(createdComponent?.id === newComponentId, "Expected diagram component id to match create component API return ID");
+  assert(createdComponent?.schemaVariantId === genericFrameVariantId, "Expected diagram component schema variant id to match generic frame sv id");
+
+  // DELETE COMPONENT
+  const deleteComponentPayload = {
+    componentIds: [newComponentId],
+    forceErase: false,
+    visibility_change_set_pk: changeSetId,
+    workspaceId: sdfApiClient.workspaceId,
+  };
+  await sdfApiClient.deleteComponents(deleteComponentPayload);
+
+  // Check that component has been removed from diagram
+  const diagramAfterDelete = await sdfApiClient.getDiagram(changeSetId);
+  assert(diagramAfterDelete?.components, "Expected components list on the diagram");
+  assert(diagramAfterDelete.components.length === 0, "Expected no components on the diagram");
+
+  // DELETE CHANGE SET
+  await sdfApiClient.abandonChangeSet(changeSetId);
+}

--- a/bin/si-smoketest/tests/get_head_changeset.ts
+++ b/bin/si-smoketest/tests/get_head_changeset.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert";
+import { SdfApiClient } from "../sdf_api_client.ts";
+
+export default async function get_head_changeset(sdfApiClient: SdfApiClient) {
+  const data = await sdfApiClient.listOpenChangeSets();
+
+  assert(data.headChangeSetId, "Expected headChangeSetId");
+  const head = data.changeSets.find((c) => c.id === data.headChangeSetId);
+  assert(head, "Expected a HEAD changeset");
+}


### PR DESCRIPTION
Various changes to the libraries + call pattern in the test deno application. 

Adds a structured JSON output based on the execution of the tests itself. 

Allows the users to also specify individual tests which is helpful if you're developing a new one you don't have to run the whole collection all the time.

Test report looks like this for now:
```
Test Report:
[
  {
    "test_name": "create_and_delete_component",
    "start_time": "2024-09-05T11:42:30.081Z",
    "finish_time": "2024-09-05T11:42:32.858Z",
    "test_duration": "2777ms",
    "test_result": "success",
    "message": "",
    "test_execution_sequence": 1,
    "uuid": "5d39beb5-1fe1-4592-87aa-fa1146185b87"
  },
  {
    "test_name": "get_head_changeset",
    "start_time": "2024-09-05T11:42:32.858Z",
    "finish_time": "2024-09-05T11:42:33.077Z",
    "test_duration": "219ms",
    "test_result": "success",
    "message": "",
    "test_execution_sequence": 2,
    "uuid": "31662fbc-0893-4f23-87ad-0b20a8108fbe"
  }
]
```