### PR TITLE
Skip migrating graph version for orphaned change sets

### DIFF
--- a/lib/dal/src/workspace_snapshot/migrator.rs
+++ b/lib/dal/src/workspace_snapshot/migrator.rs
@@ -96,6 +96,14 @@ impl SnapshotGraphMigrator {
                 let mut change_set = ChangeSet::find(ctx, change_set_id)
                     .await?
                     .ok_or(ChangeSetError::ChangeSetNotFound(change_set_id))?;
+                if change_set.workspace_id.is_none() {
+                    // These are broken/garbage change sets generated during migrations of the
+                    // "universal" workspace/change set. They're not actually accessible via normal
+                    // means, as we generally follow the chain starting at the workspace, and these
+                    // aren't associated with any workspace.
+                    change_set_graph.remove_id(change_set_id);
+                    continue;
+                }
 
                 if let Some(snapshot_address) = change_set.workspace_snapshot_address {
                     info!(


### PR DESCRIPTION
During migration of the "universal" change set, we have been orphaning change sets, and some of these change sets are broken (referencing content store content that has not been successfully saved). Rather than attempting to migrate snapshots that are both unreferenced, and likely broken, we'll skip over them.