### PR TITLE
Use empty string for default display_name when upgrading SchemaVariantContent

### DIFF
--- a/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
@@ -91,9 +91,7 @@ impl SchemaVariantNodeWeightV1 {
                     timestamp: old_content.timestamp,
                     ui_hidden: old_content.ui_hidden,
                     version: old_content.timestamp.created_at.to_string(),
-                    display_name: old_content
-                        .display_name
-                        .unwrap_or_else(|| content_node_weight.id().to_string()),
+                    display_name: old_content.display_name.unwrap_or_else(String::new),
                     category: old_content.category,
                     color: old_content.color,
                     component_type: old_content.component_type,


### PR DESCRIPTION
Even though the field is no longer optional, the front-end has been treating it as an optional field by checking if it is the empty string, and falling back to using the schema name if so.