### PR TITLE
SetType in ModelingRightClickMenu, multiple frame collapse, hotkeys...

### DIFF
--- a/app/web/src/components/ComponentCard.vue
+++ b/app/web/src/components/ComponentCard.vue
@@ -14,13 +14,18 @@
       backgroundColor: `#${bodyBg.toHex()}`,
     }"
   >
-    <div class="flex gap-xs items-center">
+    <div class="flex gap-2xs items-center">
       <Icon :name="component.icon" size="lg" class="shrink-0" />
+      <Icon
+        :name="COMPONENT_TYPE_ICONS[component.componentType]"
+        size="lg"
+        class="shrink-0"
+      />
       <Stack spacing="xs" class="">
         <div
           ref="componentNameRef"
           v-tooltip="componentNameTooltip"
-          class="font-bold break-all line-clamp-4 pb-[2px]"
+          class="font-bold break-all line-clamp-4 pb-[1px]"
         >
           {{ component.displayName }}
         </div>
@@ -72,7 +77,12 @@
 import { computed, PropType, ref } from "vue";
 import tinycolor from "tinycolor2";
 import clsx from "clsx";
-import { useTheme, Stack, Icon } from "@si/vue-lib/design-system";
+import {
+  useTheme,
+  Icon,
+  Stack,
+  COMPONENT_TYPE_ICONS,
+} from "@si/vue-lib/design-system";
 import { FullComponent, useComponentsStore } from "@/store/components.store";
 import { ComponentId } from "@/api/sdf/dal/component";
 import StatusIndicatorIcon from "./StatusIndicatorIcon.vue";

--- a/app/web/src/components/DiagramOutline/DiagramOutlineNode.vue
+++ b/app/web/src/components/DiagramOutline/DiagramOutlineNode.vue
@@ -49,7 +49,17 @@
           size="sm"
           :class="
             clsx(
-              'mr-xs flex-none',
+              'flex-none',
+              enableGroupToggle && 'group-hover:scale-0 transition-all',
+            )
+          "
+        />
+        <Icon
+          :name="COMPONENT_TYPE_ICONS[component.componentType]"
+          size="sm"
+          :class="
+            clsx(
+              'mr-2xs flex-none',
               enableGroupToggle && 'group-hover:scale-0 transition-all',
             )
           "
@@ -74,7 +84,13 @@
           <Icon
             :name="isOpen ? 'chevron--down' : 'chevron--right'"
             size="lg"
-            class="scale-[40%] translate-x-[-9px] translate-y-[13px] group-hover:scale-100 group-hover:translate-x-0 group-hover:translate-y-0 transition-all"
+            :class="
+              clsx(
+                'scale-[40%] translate-x-[-9px] translate-y-[13px] transition-all',
+                'group-hover:scale-100 group-hover:translate-x-[-2px] group-hover:translate-y-0 group-hover:w-[60px] group-hover:hover:scale-125',
+                themeClasses('hover:text-action-500', 'hover:text-action-300'),
+              )
+            "
           />
         </div>
 
@@ -180,13 +196,16 @@ import { computed, PropType, ref, watch } from "vue";
 import * as _ from "lodash-es";
 
 import clsx from "clsx";
-import { themeClasses, Icon } from "@si/vue-lib/design-system";
+import {
+  themeClasses,
+  Icon,
+  COMPONENT_TYPE_ICONS,
+} from "@si/vue-lib/design-system";
 import { useComponentsStore } from "@/store/components.store";
 import { ComponentId } from "@/api/sdf/dal/component";
 import { ComponentType } from "@/api/sdf/dal/schema";
 import { useQualificationsStore } from "@/store/qualifications.store";
 
-import { trackEvent } from "@/utils/tracking";
 import DiagramOutlineNode from "./DiagramOutlineNode.vue"; // eslint-disable-line import/no-self-import
 import StatusIndicatorIcon from "../StatusIndicatorIcon.vue";
 
@@ -220,30 +239,8 @@ const uniqueKey = computed<string | null>(() => {
 });
 
 const toggleGroup = () => {
-  isOpen.value = !isOpen.value;
-  if (!uniqueKey.value) return;
-  if (isOpen.value) {
-    componentsStore.expandComponents(uniqueKey.value);
-    trackEvent("expand-components", {
-      source: "diagram-outline-node",
-      schemaVariantName: component.value?.schemaVariantName,
-      schemaName: component.value?.schemaName,
-      hasParent: !!component.value?.parentId,
-    });
-  } else {
-    const { position, size } =
-      componentsStore.initMinimzedElementPositionAndSize(uniqueKey.value);
-    componentsStore.updateMinimzedElementPositionAndSize({
-      uniqueKey: uniqueKey.value,
-      position,
-      size,
-    });
-    trackEvent("collapse-components", {
-      source: "diagram-outline-node",
-      schemaVariantName: component.value?.schemaVariantName,
-      schemaName: component.value?.schemaName,
-      hasParent: !!component.value?.parentId,
-    });
+  if (component.value) {
+    componentsStore.toggleCollapse("diagram-outline-node", component.value.id);
   }
 };
 

--- a/app/web/src/components/ModelingDiagram/DiagramGroup.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroup.vue
@@ -254,15 +254,24 @@
         @click="toggleChevron"
       />
 
+      <DiagramIcon
+        :icon="COMPONENT_TYPE_ICONS[group.def.componentType]"
+        origin="top-left"
+        :size="32"
+        :x="32"
+        :y="5"
+        :color="colors.headerText"
+      />
+
       <!-- header text -->
       <v-text
         ref="titleTextRef"
         :config="{
-          x: 30,
+          x: 30 + GROUP_HEADER_ICON_SIZE - 2,
           y: 2,
           verticalAlign: 'top',
           align: 'left',
-          width: headerWidth - GROUP_HEADER_ICON_SIZE - 2,
+          width: headerWidth - GROUP_HEADER_ICON_SIZE * 2,
           text: group.def.title,
           padding: 6,
           fill: colors.headerText,
@@ -279,11 +288,11 @@
       <v-text
         ref="titleTextRef"
         :config="{
-          x: 30,
+          x: 30 + GROUP_HEADER_ICON_SIZE - 2,
           y: 20,
           verticalAlign: 'top',
           align: 'left',
-          width: headerWidth - GROUP_HEADER_ICON_SIZE - 2,
+          width: headerWidth - GROUP_HEADER_ICON_SIZE * 2,
           text: `${group.def.subtitle}: ${childCount ?? 0}`,
           padding: 6,
           fill: colors.headerText,
@@ -294,7 +303,6 @@
           wrap: 'none',
           ellipsis: true,
         }"
-      />
       />
     </v-group>
 
@@ -463,7 +471,11 @@ import * as _ from "lodash-es";
 import tinycolor from "tinycolor2";
 
 import { KonvaEventObject } from "konva/lib/Node";
-import { getToneColorHex, useTheme } from "@si/vue-lib/design-system";
+import {
+  getToneColorHex,
+  useTheme,
+  COMPONENT_TYPE_ICONS,
+} from "@si/vue-lib/design-system";
 import { useComponentsStore } from "@/store/components.store";
 import DiagramNodeSocket from "@/components/ModelingDiagram/DiagramNodeSocket.vue";
 import {

--- a/app/web/src/components/ModelingDiagram/DiagramHelpModal.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramHelpModal.vue
@@ -80,6 +80,23 @@
         </div>
         <div>Press ⌘ and E to erase selection.</div>
       </div>
+      <div class="flex flex-row items-center gap-xs">
+        <div class="w-12 flex flex-row items-center justify-center">
+          <div class="text-xl font-bold leading-none flex-grow text-center">
+            \
+          </div>
+        </div>
+        <div>Press the backslash key to collapse selected frame(s).</div>
+      </div>
+      <div class="flex flex-row items-center gap-xs">
+        <div class="w-12 flex flex-row items-center justify-center">
+          <Icon name="command" />
+          <div class="text-xl font-bold leading-none flex-grow text-center">
+            \
+          </div>
+        </div>
+        <div>Press ⌘ and \ to collapse all frames.</div>
+      </div>
     </div>
   </Modal>
 </template>

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -772,6 +772,9 @@ async function onKeyDown(e: KeyboardEvent) {
   if (!props.readOnly && e.key === "e" && e.metaKey) {
     modelingEventBus.emit("eraseSelection");
   }
+  if (e.key === "a" && e.metaKey) {
+    // TODO(Wendy) - select all!
+  }
   if (
     !props.readOnly &&
     e.key === "r" &&
@@ -779,6 +782,18 @@ async function onKeyDown(e: KeyboardEvent) {
     changeSetsStore.selectedChangeSetId === changeSetsStore.headChangeSetId
   ) {
     componentsStore.REFRESH_RESOURCE_INFO(componentsStore.selectedComponent.id);
+  }
+  if (!props.readOnly && e.code === "Backslash") {
+    if (e.metaKey) {
+      // collapse all
+      componentsStore.toggleCollapse(
+        "hotkey",
+        ...componentsStore.allComponentIds,
+      );
+    } else {
+      // collapse selected
+      componentsStore.toggleSelectedCollapse("hotkey");
+    }
   }
 }
 
@@ -2952,6 +2967,13 @@ function getElementByKey(key?: DiagramElementUniqueKey) {
   return key ? allElementsByKey.value[key] : undefined;
 }
 
+function nodeShouldBeRendered(key: DiagramElementUniqueKey) {
+  return (
+    groups.value.find((n) => n.uniqueKey === key) ||
+    nodes.value.find((n) => n.uniqueKey === key)
+  );
+}
+
 // Selection rects
 const selectionRects = computed(() => {
   const rects = [] as (Size2D & Vector2d)[];
@@ -2979,7 +3001,9 @@ const selectionRects = computed(() => {
         r.height += adjust;
         r.y -= adjust;
       }
-      rects.push(r);
+      if (nodeShouldBeRendered(uniqueKey)) {
+        rects.push(r);
+      }
     }
   });
   return rects;

--- a/app/web/src/components/SidebarSubpanelTitle.vue
+++ b/app/web/src/components/SidebarSubpanelTitle.vue
@@ -3,6 +3,7 @@
     :class="
       clsx(
         'flex text-neutral-500 dark:text-neutral-400 border-b items-center px-xs py-2xs gap-xs',
+        !selectable && 'select-none',
         variant === 'title'
           ? 'dark:border-neutral-500'
           : 'border-neutral-200 dark:border-neutral-600',
@@ -48,5 +49,6 @@ const props = defineProps({
     type: String as PropType<SidebarSubpanelTitleVariant>,
     default: "title",
   },
+  selectable: { type: Boolean },
 });
 </script>

--- a/app/web/src/components/StatusBar/StatusBar.vue
+++ b/app/web/src/components/StatusBar/StatusBar.vue
@@ -4,6 +4,7 @@
       clsx(
         'flex justify-end',
         'bg-neutral-900 text-white relative border-t border-shade-100 shadow-[0_4px_4px_0_rgba(0,0,0,0.15)] z-90 h-10',
+        'select-none',
       )
     "
   >

--- a/app/web/src/components/layout/navbar/Navbar.vue
+++ b/app/web/src/components/layout/navbar/Navbar.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    class="navbar bg-neutral-900 text-white relative shadow-[0_4px_4px_0_rgba(0,0,0,0.15)] z-90 h-[60px] overflow-hidden shrink-0 flex gap-sm"
+    class="navbar bg-neutral-900 text-white relative shadow-[0_4px_4px_0_rgba(0,0,0,0.15)] z-90 h-[60px] overflow-hidden shrink-0 flex gap-sm select-none"
   >
     <!-- Left side -->
     <NavbarPanelLeft />

--- a/app/web/src/components/layout/navbar/NavbarPanelLeft.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelLeft.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-1 items-center">
+  <div class="flex flex-1 items-center select-none">
     <SiLogo class="block h-[44px] w-[44px] ml-[12px] mr-[12px] flex-none" />
 
     <label>

--- a/lib/vue-lib/src/design-system/forms/VormInput.vue
+++ b/lib/vue-lib/src/design-system/forms/VormInput.vue
@@ -66,7 +66,7 @@ you can pass in options as props too */
                 : '',
               compact
                 ? 'vorm-input-compact__input vorm-input__hidden-input'
-                : 'vorm-input__input',
+                : 'vorm-input__input cursor-pointer',
             ]"
             :disabled="disabledBySelfOrParent"
             :value="valueForSelectField"

--- a/lib/vue-lib/src/design-system/icons/custom-icons/framedown.svg
+++ b/lib/vue-lib/src/design-system/icons/custom-icons/framedown.svg
@@ -1,0 +1,4 @@
+<svg width="21" height="21" viewBox="0 0 21 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path transform="translate(0, 21) scale(1, -1)" fill="currentColor" d="M4.2476 4.15h11.7v11.7H4.2476Z M10.0976 6.49753L6.04761 10.5475L6.9943 11.4942L9.4243 9.07941V14.5975H10.776V9.07941L13.206 11.4942L14.1527 10.5475L10.1027 6.49753H10.0976Z" />
+  <path d="M1.09741 4.47148H19.0974M1.09741 15.7236H19.0974M4.47136 1.09753V19.0975M15.7235 1.09753V19.0975" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/lib/vue-lib/src/design-system/icons/custom-icons/frameup.svg
+++ b/lib/vue-lib/src/design-system/icons/custom-icons/frameup.svg
@@ -1,0 +1,4 @@
+<svg width="21" height="21" viewBox="0 0 21 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" d="M4.2476 4.15h11.7v11.7H4.2476Z M10.0976 6.49753L6.04761 10.5475L6.9943 11.4942L9.4243 9.07941V14.5975H10.776V9.07941L13.206 11.4942L14.1527 10.5475L10.1027 6.49753H10.0976Z" />
+  <path d="M1.09741 4.47148H19.0974M1.09741 15.7236H19.0974M4.47136 1.09753V19.0975M15.7235 1.09753V19.0975" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -190,6 +190,8 @@ import LogsPop from "./custom-icons/logs-pop.svg?raw";
 import CodePopSquare from "./custom-icons/code-pop-square.svg?raw";
 import LogsPopSquare from "./custom-icons/logs-pop-square.svg?raw";
 import Func from "./custom-icons/func.svg?raw";
+import FrameUp from "./custom-icons/frameup.svg?raw";
+import FrameDown from "./custom-icons/framedown.svg?raw";
 
 // restricting the type here (Record<string, FunctionalComponent>) kills our IconName type below
 /* eslint sort-keys: "error" */
@@ -254,6 +256,8 @@ export const ICONS = Object.freeze({
   eye: Eye,
   filter: Filter,
   frame: Frame,
+  "frame-down": FrameDown,
+  "frame-up": FrameUp,
   func: Func,
   "git-branch": GitBranch,
   "git-branch-plus": GitBranchPlus,
@@ -358,6 +362,13 @@ export const LOGO_ICONS = Object.freeze({
   "logo-github": GithubLogo,
   "logo-vim": VimLogo,
 });
+
+export const COMPONENT_TYPE_ICONS = {
+  component: "component" as IconNames,
+  configurationFrameDown: "frame-down" as IconNames,
+  configurationFrameUp: "frame-up" as IconNames,
+  aggregationFrame: "frame" as IconNames,
+};
 
 /*
   additional aliases which makes it easy to be more consistent with icon usage

--- a/lib/vue-lib/src/design-system/tabs/TabGroup.vue
+++ b/lib/vue-lib/src/design-system/tabs/TabGroup.vue
@@ -22,7 +22,7 @@
                 sm: 'mt-sm',
                 md: 'mt-md',
               }[marginTop],
-            'w-full h-8 relative flex flex-row shrink-0 bg-white dark:bg-neutral-800 overflow-hidden',
+            'w-full h-8 relative flex flex-row shrink-0 bg-white dark:bg-neutral-800 overflow-hidden select-none',
           )
         "
       >


### PR DESCRIPTION
![Screenshot 2024-09-05 at 3 48 32 PM](https://github.com/user-attachments/assets/a876b733-3925-411f-8f7c-35aedcaa6982)

- SetType submenu in ModelingRightClickMenu
- ComponentType icons - Component, Up Frame, Down Frame - these show in the DiagramOutline, on Frames in the ModelingDiagram, on the ComponentCard, and on the new IconButton dropdown to change component type
- Ability to collapse multiple selected frames
- Hotkeys for collapsing selected frames and collapsing ALL frames