### PR TITLE
feat: add authoring new asset API test

### DIFF
--- a/bin/si-api-test/sdf_api_client.ts
+++ b/bin/si-api-test/sdf_api_client.ts
@@ -42,13 +42,16 @@ export const ROUTES = {
     path: () => `/diagram/delete_components`,
     method: "POST"
   },
-  create_component: { path: () => "/diagram/create_component", method: "POST" },
+  create_component: { 
+    path: () => "/diagram/create_component", 
+    method: "POST"
+  },
   create_connection: {
     path: () => "/diagram/create_connection",
     method: "POST"
   },
 
-  // Property Editor
+  // Property Editor ------------------------------------------------------------
   get_property_values: {
     path: (vars: ROUTE_VARS) => `/component/get_property_editor_values?visibility_change_set_pk=${vars.changeSetId}&componentId=${vars.componentId}`,
     method: "GET"
@@ -56,7 +59,13 @@ export const ROUTES = {
   update_property_value: {
     path: () => `/component/update_property_editor_value`,
     method: "POST"
-  }
+  },
+
+  // Variant Management -----------------------------------------------------------
+  create_variant: {
+    path: (vars: ROUTE_VARS) => `/variant/create_variant`,
+    method: "POST"
+  },
 
 
   // Add more groups below ------------------------------------------------------

--- a/bin/si-api-test/tests/create_and_use_variant.ts
+++ b/bin/si-api-test/tests/create_and_use_variant.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert";
+import { SdfApiClient } from "../sdf_api_client.ts";
+import { runWithTemporaryChangeset } from "../test_helpers.ts";
+
+export default async function create_variant(sdfApiClient: SdfApiClient) {
+  return runWithTemporaryChangeset(sdfApiClient, create_variant_inner);
+}
+
+export async function create_variant_inner(sdfApiClient: SdfApiClient, changeSetId: string) {
+
+  const startTime = new Date();
+  const variantName = `Test_Variant - ${startTime.toISOString()}`;
+
+  // Create the Varint
+  const createVariantPayload = {
+    "name": variantName,
+    "color": "0",
+    "visibility_change_set_pk": changeSetId,
+  };
+
+  const createVariantResp = await sdfApiClient.call({
+    route: "create_variant", routeVars: {
+      workspaceId: sdfApiClient.workspaceId,
+    },
+    body: createVariantPayload,
+  });
+
+  const schemaVariantId = createVariantResp?.schemaVariantId;
+  assert(schemaVariantId, "Expected to get a schemaVariantId after creation");
+
+  // create new variant as a component
+  let createInstancePayload = {
+    "schemaVariantId": schemaVariantId,
+    "x": "200",
+    "y": "0",
+    "visibility_change_set_pk": changeSetId,
+    "workspaceId": sdfApiClient.workspaceId
+  };
+
+  const createInstanceResp = await sdfApiClient.call({
+    route: "create_component",
+    body: createInstancePayload
+  });
+
+  const newSchemaComponentId = createInstanceResp?.componentId;
+  assert(newSchemaComponentId, "Expected to get a component id after creation");
+
+  // Check that components exists on diagram
+  const diagram = await sdfApiClient.call({
+    route: "get_diagram",
+    routeVars: {
+      workspaceId: sdfApiClient.workspaceId,
+      changeSetId,
+    }
+  });
+
+  assert(diagram?.components, "Expected components list on the diagram");
+  assert(diagram.components.length === 1, "Expected a single component on the diagram");
+
+  const regionComponentOnDiagram = diagram.components.find((c) => c.id === newSchemaComponentId);
+  assert(regionComponentOnDiagram, "Expected to find the new schema variant on the diagram");
+  assert(regionComponentOnDiagram?.schemaVariantId === schemaVariantId, "Expected diagram component schema variant id to be correct");
+
+}


### PR DESCRIPTION
API Test to cover creating a new asset in a changeset and dropping it onto the diagram