### PR TITLE
build(deps): upgrade to NATS server 2.10.20

### DIFF
--- a/component/nats/BUCK
+++ b/component/nats/BUCK
@@ -9,7 +9,7 @@ docker_image(
         "nats-server.conf": "component/nats",
     },
     build_args = {
-        "BASE_VERSION": "2.10.19",
+        "BASE_VERSION": "2.10.20",
     },
     run_docker_args = [
         "--publish",


### PR DESCRIPTION
Notably in the release notes:

> Fix regression in KV CAS operations on R=1 replicas introduced in
> v2.10.19

See: https://github.com/nats-io/nats-server/releases/tag/v2.10.20
References: nats-io/nats-server#5841