### PR TITLE
Add data warehouse stream client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-config"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e95816a168520d72c0e7680c405a5a8c1fb6a035b4bc4b9d7b0de8e1a941697"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 0.2.12",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-creds"
 version = "0.36.0"
 source = "git+https://github.com/ScuffleTV/rust-s3.git?branch=troy/rustls#27c5c7a0fac45ecb6e766a4b4239bdd98d9b3395"
@@ -355,6 +397,286 @@ version = "0.25.4"
 source = "git+https://github.com/ScuffleTV/rust-s3.git?branch=troy/rustls#27c5c7a0fac45ecb6e766a4b4239bdd98d9b3395"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2424565416eef55906f9f8cece2072b6b6a76075e3ff81483ebe938a89a4c05f"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-firehose"
+version = "1.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d58f8eaeddd388b3f361708c5e7bb5600accd1785be00640b513b69bf3376d7"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af0a3f676cba2c079c9563acc9233998c8951cdbe38629a0bef3c8c1b02f3658"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91b6a04495547162cf52b075e3c15a17ab6608bf9c5785d3e5a5509b3f09f5c"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c56bcd6a56cab7933980a54148b476a5a69a7694e3874d9aa2a566f150447d"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.1.0",
+ "once_cell",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01dbcb6e2588fd64cfb6d7529661b06466419e4c54ed1c62d6510d2d0350a728"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.30",
+ "hyper-rustls 0.24.2",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273dcdfd762fae3e1650b8024624e7cd50e484e37abdab73a7a706188ad34543"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.1.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
 ]
 
 [[package]]
@@ -457,6 +779,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,8 +832,11 @@ name = "billing-events-server"
 version = "0.1.0"
 dependencies = [
  "billing-events",
+ "data-warehouse-stream-client",
+ "derive_builder",
  "naxum",
  "remain",
+ "serde_json",
  "si-data-nats",
  "telemetry",
  "thiserror",
@@ -755,6 +1090,16 @@ dependencies = [
  "tokio-serde",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
 ]
 
 [[package]]
@@ -1069,9 +1414,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -1504,6 +1849,19 @@ name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "data-warehouse-stream-client"
+version = "0.1.0"
+dependencies = [
+ "aws-config",
+ "aws-sdk-firehose",
+ "base64 0.22.1",
+ "remain",
+ "serde_json",
+ "telemetry",
+ "thiserror",
+]
 
 [[package]]
 name = "deadpool"
@@ -2526,7 +2884,9 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.30",
+ "log",
  "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -3633,6 +3993,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,6 +4855,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5119,9 +5491,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -5139,9 +5511,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5724,9 +6096,9 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f895e3734318cc55f1fe66258926c9b910c124d47520339efecbb6c59cec7c1f"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
 dependencies = [
  "nom",
  "unicode_categories",
@@ -7080,6 +7452,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "vsock"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7558,6 +7936,12 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "lib/cyclone-server",
     "lib/dal",
     "lib/dal-test",
+    "lib/data-warehouse-stream-client",
     "lib/module-index-client",
     "lib/module-index-server",
     "lib/nats-multiplexer",
@@ -74,6 +75,8 @@ publish = false
 async-nats = { version = "0.35.1", features = ["service"] }
 async-recursion = "1.0.5"
 async-trait = "0.1.79"
+aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
+aws-sdk-firehose = "1.46.0"
 axum = { version = "0.6.20", features = ["macros", "multipart", "ws"] } # todo: upgrade this alongside hyper/http/tokio-tungstenite
 base64 = "0.22.0"
 blake3 = "1.5.1"

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -129,8 +129,10 @@ async fn async_main() -> Result<()> {
         LayerDb::from_config(config.layer_db_config().clone(), layer_db_token.clone()).await?;
     layer_db_tracker.spawn(layer_db_graceful_shutdown.into_future());
 
+    // TODO(nick): allow the ability to configure the delivery mechanism.
     let billing_events_server_future =
-        billing_events_server::new(nats_conn.clone(), billing_events_server_token.clone()).await?;
+        billing_events_server::new(nats_conn.clone(), None, billing_events_server_token.clone())
+            .await?;
     billing_events_server_tracker.spawn(billing_events_server_future);
 
     let feature_flags_service = FeatureFlagService::new(config.boot_feature_flags().clone());

--- a/lib/billing-events-server/src/app_state.rs
+++ b/lib/billing-events-server/src/app_state.rs
@@ -1,0 +1,24 @@
+use data_warehouse_stream_client::DataWarehouseStreamClient;
+
+#[derive(Debug, Clone)]
+pub(crate) struct AppState {
+    pub(crate) data_warehouse_stream_client: DataWarehouseStreamClient,
+}
+
+impl AppState {
+    pub fn new(data_warehouse_stream_client: DataWarehouseStreamClient) -> Self {
+        Self {
+            data_warehouse_stream_client,
+        }
+    }
+}
+
+// NOTE(nick,fletcher): we need an app state for all naxum apps at the time of writing, even if they are unused.
+#[derive(Debug, Clone)]
+pub(crate) struct NoopAppState {}
+
+impl NoopAppState {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/lib/billing-events-server/src/lib.rs
+++ b/lib/billing-events-server/src/lib.rs
@@ -1,24 +1,29 @@
 //! Provides a ["billing events"](billing_events) server via a future.
 
-use std::future::Future;
-use std::future::IntoFuture as _;
+use std::future::{Future, IntoFuture as _};
 use std::io;
 
+use app_state::AppState;
+use app_state::NoopAppState;
 use billing_events::{BillingEventsError, BillingEventsWorkQueue};
+use data_warehouse_stream_client::DataWarehouseStreamClient;
 use naxum::handler::Handler as _;
 use naxum::middleware::ack::AckLayer;
 use naxum::middleware::trace::{DefaultMakeSpan, DefaultOnRequest, TraceLayer};
 use naxum::{ServiceBuilder, ServiceExt as _};
 use si_data_nats::async_nats::error::Error as AsyncNatsError;
+use si_data_nats::async_nats::jetstream::consumer::pull::Stream;
 use si_data_nats::async_nats::jetstream::consumer::StreamErrorKind;
+use si_data_nats::NatsClient;
 use si_data_nats::{
     async_nats::{self, jetstream::stream::ConsumerErrorKind},
-    jetstream, NatsClient,
+    jetstream,
 };
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
 
+mod app_state;
 mod handlers;
 
 const CONCURRENCY_LIMIT: usize = 1000;
@@ -37,28 +42,47 @@ pub enum BillingEventsServerError {
 type BillingEventsServerResult<T> = Result<T, BillingEventsServerError>;
 
 /// Creates and returns a running ["billing events"](billing_events) server.
+///
+/// If a delivery stream name is not provided, billing evenets will not be published to the data
+/// warehouse stream!
+#[instrument(name = "billing_events_server.init.new", level = "info")]
 pub async fn new(
     nats: NatsClient,
+    delivery_stream_name: Option<String>,
     token: CancellationToken,
 ) -> BillingEventsServerResult<Box<dyn Future<Output = io::Result<()>> + Unpin + Send>> {
-    let (state, incoming) = {
+    let incoming = {
         let queue = BillingEventsWorkQueue::get_or_create(jetstream::new(nats)).await?;
-
-        let state = AppState::new();
         let consumer_subject = queue.workspace_update_subject("*");
-
-        (
-            state,
-            queue
-                .stream()
-                .await?
-                .create_consumer(incoming_consumer_config(consumer_subject))
-                .await?
-                .messages()
-                .await?,
-        )
+        queue
+            .stream()
+            .await?
+            .create_consumer(incoming_consumer_config(consumer_subject))
+            .await?
+            .messages()
+            .await?
     };
 
+    match delivery_stream_name {
+        Some(delivery_stream_name) => {
+            info!(%delivery_stream_name, "creating billing events server in data warehouse stream delivery mode...");
+            let client = DataWarehouseStreamClient::new(delivery_stream_name).await;
+            let state = AppState::new(client);
+            build_app(state, incoming, token)
+        }
+        None => {
+            info!("creating building events server in no-op mode...");
+            let state = NoopAppState::new();
+            build_noop_app(state, incoming, token)
+        }
+    }
+}
+
+fn build_app(
+    state: AppState,
+    incoming: Stream,
+    token: CancellationToken,
+) -> BillingEventsServerResult<Box<dyn Future<Output = io::Result<()>> + Unpin + Send>> {
     let app = ServiceBuilder::new()
         .layer(
             TraceLayer::new()
@@ -78,6 +102,30 @@ pub async fn new(
     Ok(Box::new(inner.into_future()))
 }
 
+fn build_noop_app(
+    state: NoopAppState,
+    incoming: Stream,
+    token: CancellationToken,
+) -> BillingEventsServerResult<Box<dyn Future<Output = io::Result<()>> + Unpin + Send>> {
+    let app = ServiceBuilder::new()
+        .layer(
+            TraceLayer::new()
+                .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+                .on_request(DefaultOnRequest::new().level(Level::TRACE))
+                .on_response(
+                    naxum::middleware::trace::DefaultOnResponse::new().level(Level::TRACE),
+                ),
+        )
+        .layer(AckLayer::new())
+        .service(handlers::process_request_noop.with_state(state));
+
+    let inner =
+        naxum::serve_with_incoming_limit(incoming, app.into_make_service(), CONCURRENCY_LIMIT)
+            .with_graceful_shutdown(naxum::wait_on_cancelled(token));
+
+    Ok(Box::new(inner.into_future()))
+}
+
 #[inline]
 fn incoming_consumer_config(
     subject: impl Into<String>,
@@ -86,15 +134,5 @@ fn incoming_consumer_config(
         durable_name: Some(CONSUMER_NAME.to_owned()),
         filter_subject: subject.into(),
         ..Default::default()
-    }
-}
-
-// NOTE(nick,jkeiser): we will likely use app state, so let's keep it around for now.
-#[derive(Debug, Clone)]
-struct AppState {}
-
-impl AppState {
-    pub fn new() -> Self {
-        Self {}
     }
 }

--- a/lib/billing-events/src/lib.rs
+++ b/lib/billing-events/src/lib.rs
@@ -26,6 +26,12 @@ pub enum BillingEventsError {
 
 pub type BillingEventsResult<T> = Result<T, BillingEventsError>;
 
+#[derive(Debug, Clone, Serialize, Deserialize, Copy)]
+pub enum BillingWorkspaceChangeEventLocation {
+    Local,
+    Hosted,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BillingWorkspaceChangeEvent {
     /// The workspace of this change
@@ -47,6 +53,9 @@ pub struct BillingWorkspaceChangeEvent {
     pub change_set_id: ChangeSetId,
     /// The user who requested the update (if any)
     pub merge_requested_by_user_id: Option<UserPk>,
+
+    /// The location of the billing event
+    pub location: BillingWorkspaceChangeEventLocation,
 }
 
 #[derive(Debug, Clone)]

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -2,7 +2,9 @@ use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use billing_events::{BillingEventsError, BillingWorkspaceChangeEvent};
+use billing_events::{
+    BillingEventsError, BillingWorkspaceChangeEvent, BillingWorkspaceChangeEventLocation,
+};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_layer_cache::LayerDbError;
@@ -300,6 +302,9 @@ impl ChangeSet {
                 change_set_id: self.id.into(),
                 merge_requested_by_user_id: self.merge_requested_by_user_id.map(Into::into),
                 change_description: change_description.into(),
+                // TODO(nick): we need to ensure that this is correct. This will likely come from
+                // sdf and/or the billing events server if it runs in a separate binary.
+                location: BillingWorkspaceChangeEventLocation::Local,
             };
             modify_event(&mut event);
             // Ensure queue is created

--- a/lib/data-warehouse-stream-client/BUCK
+++ b/lib/data-warehouse-stream-client/BUCK
@@ -1,17 +1,15 @@
 load("@prelude-si//:macros.bzl", "rust_library")
 
 rust_library(
-    name = "billing-events-server",
+    name = "data-warehouse-stream-client",
     deps = [
-        "//lib/billing-events:billing-events",
-        "//lib/data-warehouse-stream-client:data-warehouse-stream-client",
-        "//lib/naxum:naxum",
-        "//lib/si-data-nats:si-data-nats",
         "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:aws-config",
+        "//third-party/rust:aws-sdk-firehose",
+        "//third-party/rust:base64",
         "//third-party/rust:remain",
         "//third-party/rust:serde_json",
         "//third-party/rust:thiserror",
-        "//third-party/rust:tokio-util",
     ],
     srcs = glob([
         "src/**/*.rs",

--- a/lib/data-warehouse-stream-client/Cargo.toml
+++ b/lib/data-warehouse-stream-client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "billing-events-server"
+name = "data-warehouse-stream-client"
 edition = "2021"
 version.workspace = true
 authors.workspace = true
@@ -9,14 +9,11 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
-billing-events = { path = "../../lib/billing-events" }
-data-warehouse-stream-client = { path = "../../lib/data-warehouse-stream-client" }
-naxum = { path = "../../lib/naxum" }
-si-data-nats = { path = "../../lib/si-data-nats" }
 telemetry = { path = "../../lib/telemetry-rs" }
 
-derive_builder = { workspace = true }
+aws-config = { workspace = true }
+aws-sdk-firehose= { workspace = true }
+base64 = { workspace = true }
 remain = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio-util = { workspace = true }

--- a/lib/data-warehouse-stream-client/src/lib.rs
+++ b/lib/data-warehouse-stream-client/src/lib.rs
@@ -1,0 +1,69 @@
+//! This crate provides a client for streaming data directly or eventually to a data warehouse.
+
+use aws_sdk_firehose::{operation::put_record::PutRecordError, primitives::Blob, types::Record};
+use base64::{engine::general_purpose, Engine};
+use telemetry::prelude::*;
+use thiserror::Error;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum DataWarehouseStreamClientError {
+    #[error("firehose error: {0}")]
+    Firehose(#[from] aws_sdk_firehose::Error),
+    #[error("firehose build error: {0}")]
+    FirehoseBuild(#[from] aws_sdk_firehose::error::BuildError),
+    #[error("firehose put record error: {0}")]
+    FirehosePutRecord(#[from] aws_sdk_firehose::error::SdkError<PutRecordError>),
+}
+
+type DataWarehouseStreamClientResult<T> = Result<T, DataWarehouseStreamClientError>;
+
+#[derive(Debug, Clone)]
+pub struct DataWarehouseStreamClient {
+    delivery_stream_name: String,
+    inner: Box<aws_sdk_firehose::Client>,
+}
+
+impl DataWarehouseStreamClient {
+    #[instrument(
+        name = "data_warehouse_stream_client.new",
+        level = "info",
+        skip(delivery_stream_name)
+    )]
+    pub async fn new(delivery_stream_name: impl Into<String>) -> Self {
+        let config = aws_config::load_from_env().await;
+        let client = aws_sdk_firehose::Client::new(&config);
+        Self {
+            inner: Box::new(client),
+            delivery_stream_name: delivery_stream_name.into(),
+        }
+    }
+
+    #[instrument(
+        name = "data_warehouse_stream_client.publish",
+        level = "debug",
+        skip(raw_data)
+    )]
+    pub async fn publish(&self, raw_data: impl AsRef<[u8]>) -> DataWarehouseStreamClientResult<()> {
+        let record = Record::builder()
+            .data(Blob::new(Self::base64_encode_data(raw_data)))
+            .build()?;
+        let output = self
+            .inner
+            .put_record()
+            .delivery_stream_name(&self.delivery_stream_name)
+            .record(record)
+            .send()
+            .await?;
+
+        // TODO(nick): remove this is replace with formal logging. We will keep this until we actually
+        // use the client.
+        dbg!(&output);
+
+        Ok(())
+    }
+
+    fn base64_encode_data(input: impl AsRef<[u8]>) -> String {
+        general_purpose::STANDARD_NO_PAD.encode(input)
+    }
+}

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -659,7 +659,7 @@ cargo.rust_library(
         ":rustls-native-certs-0.7.3",
         ":rustls-pemfile-2.1.3",
         ":rustls-webpki-0.102.7",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":serde_nanos-0.1.4",
         ":serde_repr-0.1.19",
@@ -858,7 +858,7 @@ cargo.rust_library(
     deps = [
         ":http-0.2.12",
         ":log-0.4.22",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":url-2.5.2",
         ":webpki-roots-0.25.4",
@@ -882,6 +882,97 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "aws-config",
+    actual = ":aws-config-1.5.5",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "aws-config-1.5.5.crate",
+    sha256 = "4e95816a168520d72c0e7680c405a5a8c1fb6a035b4bc4b9d7b0de8e1a941697",
+    strip_prefix = "aws-config-1.5.5",
+    urls = ["https://static.crates.io/crates/aws-config/1.5.5/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-config-1.5.5",
+    srcs = [":aws-config-1.5.5.crate"],
+    crate = "aws_config",
+    crate_root = "aws-config-1.5.5.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "CARGO_MANIFEST_DIR": "aws-config-1.5.5.crate",
+        "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
+        "CARGO_PKG_DESCRIPTION": "AWS SDK config and credential provider implementations.",
+        "CARGO_PKG_NAME": "aws-config",
+        "CARGO_PKG_REPOSITORY": "https://github.com/smithy-lang/smithy-rs",
+        "CARGO_PKG_VERSION": "1.5.5",
+        "CARGO_PKG_VERSION_MAJOR": "1",
+        "CARGO_PKG_VERSION_MINOR": "5",
+        "CARGO_PKG_VERSION_PATCH": "5",
+    },
+    features = [
+        "behavior-version-latest",
+        "client-hyper",
+        "credentials-process",
+        "default",
+        "rt-tokio",
+        "rustls",
+        "sso",
+    ],
+    visibility = [],
+    deps = [
+        ":aws-credential-types-1.2.1",
+        ":aws-runtime-1.4.2",
+        ":aws-sdk-sso-1.41.0",
+        ":aws-sdk-ssooidc-1.42.0",
+        ":aws-sdk-sts-1.41.0",
+        ":aws-smithy-async-1.2.1",
+        ":aws-smithy-http-0.60.10",
+        ":aws-smithy-json-0.60.7",
+        ":aws-smithy-runtime-1.7.1",
+        ":aws-smithy-runtime-api-1.7.2",
+        ":aws-smithy-types-1.2.4",
+        ":aws-types-1.3.3",
+        ":bytes-1.7.1",
+        ":fastrand-2.1.1",
+        ":hex-0.4.3",
+        ":http-0.2.12",
+        ":ring-0.17.5",
+        ":time-0.3.36",
+        ":tokio-1.40.0",
+        ":tracing-0.1.40",
+        ":url-2.5.2",
+        ":zeroize-1.8.1",
+    ],
+)
+
+http_archive(
+    name = "aws-credential-types-1.2.1.crate",
+    sha256 = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da",
+    strip_prefix = "aws-credential-types-1.2.1",
+    urls = ["https://static.crates.io/crates/aws-credential-types/1.2.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-credential-types-1.2.1",
+    srcs = [":aws-credential-types-1.2.1.crate"],
+    crate = "aws_credential_types",
+    crate_root = "aws-credential-types-1.2.1.crate/src/lib.rs",
+    edition = "2021",
+    features = ["test-util"],
+    visibility = [],
+    deps = [
+        ":aws-smithy-async-1.2.1",
+        ":aws-smithy-runtime-api-1.7.2",
+        ":aws-smithy-types-1.2.4",
+        ":zeroize-1.8.1",
+    ],
+)
+
 cargo.rust_library(
     name = "aws-creds-0.36.0",
     srcs = [":rust-s3-61c54947c717d042.git"],
@@ -900,7 +991,7 @@ cargo.rust_library(
         ":log-0.4.22",
         ":quick-xml-0.30.0",
         ":rust-ini-0.19.0",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":thiserror-1.0.63",
         ":time-0.3.36",
         ":url-2.5.2",
@@ -915,6 +1006,580 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [":thiserror-1.0.63"],
+)
+
+http_archive(
+    name = "aws-runtime-1.4.2.crate",
+    sha256 = "2424565416eef55906f9f8cece2072b6b6a76075e3ff81483ebe938a89a4c05f",
+    strip_prefix = "aws-runtime-1.4.2",
+    urls = ["https://static.crates.io/crates/aws-runtime/1.4.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-runtime-1.4.2",
+    srcs = [":aws-runtime-1.4.2.crate"],
+    crate = "aws_runtime",
+    crate_root = "aws-runtime-1.4.2.crate/src/lib.rs",
+    edition = "2021",
+    named_deps = {
+        "http_02x": ":http-0.2.12",
+        "http_body_04x": ":http-body-0.4.6",
+    },
+    visibility = [],
+    deps = [
+        ":aws-credential-types-1.2.1",
+        ":aws-sigv4-1.2.3",
+        ":aws-smithy-async-1.2.1",
+        ":aws-smithy-http-0.60.10",
+        ":aws-smithy-runtime-1.7.1",
+        ":aws-smithy-runtime-api-1.7.2",
+        ":aws-smithy-types-1.2.4",
+        ":aws-types-1.3.3",
+        ":bytes-1.7.1",
+        ":fastrand-2.1.1",
+        ":once_cell-1.19.0",
+        ":percent-encoding-2.3.1",
+        ":pin-project-lite-0.2.14",
+        ":tracing-0.1.40",
+        ":uuid-1.10.0",
+    ],
+)
+
+alias(
+    name = "aws-sdk-firehose",
+    actual = ":aws-sdk-firehose-1.46.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "aws-sdk-firehose-1.46.0.crate",
+    sha256 = "5d58f8eaeddd388b3f361708c5e7bb5600accd1785be00640b513b69bf3376d7",
+    strip_prefix = "aws-sdk-firehose-1.46.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-firehose/1.46.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-sdk-firehose-1.46.0",
+    srcs = [":aws-sdk-firehose-1.46.0.crate"],
+    crate = "aws_sdk_firehose",
+    crate_root = "aws-sdk-firehose-1.46.0.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "CARGO_MANIFEST_DIR": "aws-sdk-firehose-1.46.0.crate",
+        "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
+        "CARGO_PKG_DESCRIPTION": "AWS SDK for Amazon Kinesis Firehose",
+        "CARGO_PKG_NAME": "aws-sdk-firehose",
+        "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
+        "CARGO_PKG_VERSION": "1.46.0",
+        "CARGO_PKG_VERSION_MAJOR": "1",
+        "CARGO_PKG_VERSION_MINOR": "46",
+        "CARGO_PKG_VERSION_PATCH": "0",
+    },
+    features = [
+        "default",
+        "rt-tokio",
+        "rustls",
+    ],
+    visibility = [],
+    deps = [
+        ":aws-credential-types-1.2.1",
+        ":aws-runtime-1.4.2",
+        ":aws-smithy-async-1.2.1",
+        ":aws-smithy-http-0.60.10",
+        ":aws-smithy-json-0.60.7",
+        ":aws-smithy-runtime-1.7.1",
+        ":aws-smithy-runtime-api-1.7.2",
+        ":aws-smithy-types-1.2.4",
+        ":aws-types-1.3.3",
+        ":bytes-1.7.1",
+        ":http-0.2.12",
+        ":once_cell-1.19.0",
+        ":regex-lite-0.1.6",
+        ":tracing-0.1.40",
+    ],
+)
+
+http_archive(
+    name = "aws-sdk-sso-1.41.0.crate",
+    sha256 = "af0a3f676cba2c079c9563acc9233998c8951cdbe38629a0bef3c8c1b02f3658",
+    strip_prefix = "aws-sdk-sso-1.41.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-sso/1.41.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-sdk-sso-1.41.0",
+    srcs = [":aws-sdk-sso-1.41.0.crate"],
+    crate = "aws_sdk_sso",
+    crate_root = "aws-sdk-sso-1.41.0.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "CARGO_MANIFEST_DIR": "aws-sdk-sso-1.41.0.crate",
+        "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
+        "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS Single Sign-On",
+        "CARGO_PKG_NAME": "aws-sdk-sso",
+        "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
+        "CARGO_PKG_VERSION": "1.41.0",
+        "CARGO_PKG_VERSION_MAJOR": "1",
+        "CARGO_PKG_VERSION_MINOR": "41",
+        "CARGO_PKG_VERSION_PATCH": "0",
+    },
+    visibility = [],
+    deps = [
+        ":aws-credential-types-1.2.1",
+        ":aws-runtime-1.4.2",
+        ":aws-smithy-async-1.2.1",
+        ":aws-smithy-http-0.60.10",
+        ":aws-smithy-json-0.60.7",
+        ":aws-smithy-runtime-1.7.1",
+        ":aws-smithy-runtime-api-1.7.2",
+        ":aws-smithy-types-1.2.4",
+        ":aws-types-1.3.3",
+        ":bytes-1.7.1",
+        ":http-0.2.12",
+        ":once_cell-1.19.0",
+        ":regex-lite-0.1.6",
+        ":tracing-0.1.40",
+    ],
+)
+
+http_archive(
+    name = "aws-sdk-ssooidc-1.42.0.crate",
+    sha256 = "c91b6a04495547162cf52b075e3c15a17ab6608bf9c5785d3e5a5509b3f09f5c",
+    strip_prefix = "aws-sdk-ssooidc-1.42.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-ssooidc/1.42.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-sdk-ssooidc-1.42.0",
+    srcs = [":aws-sdk-ssooidc-1.42.0.crate"],
+    crate = "aws_sdk_ssooidc",
+    crate_root = "aws-sdk-ssooidc-1.42.0.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "CARGO_MANIFEST_DIR": "aws-sdk-ssooidc-1.42.0.crate",
+        "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
+        "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS SSO OIDC",
+        "CARGO_PKG_NAME": "aws-sdk-ssooidc",
+        "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
+        "CARGO_PKG_VERSION": "1.42.0",
+        "CARGO_PKG_VERSION_MAJOR": "1",
+        "CARGO_PKG_VERSION_MINOR": "42",
+        "CARGO_PKG_VERSION_PATCH": "0",
+    },
+    visibility = [],
+    deps = [
+        ":aws-credential-types-1.2.1",
+        ":aws-runtime-1.4.2",
+        ":aws-smithy-async-1.2.1",
+        ":aws-smithy-http-0.60.10",
+        ":aws-smithy-json-0.60.7",
+        ":aws-smithy-runtime-1.7.1",
+        ":aws-smithy-runtime-api-1.7.2",
+        ":aws-smithy-types-1.2.4",
+        ":aws-types-1.3.3",
+        ":bytes-1.7.1",
+        ":http-0.2.12",
+        ":once_cell-1.19.0",
+        ":regex-lite-0.1.6",
+        ":tracing-0.1.40",
+    ],
+)
+
+http_archive(
+    name = "aws-sdk-sts-1.41.0.crate",
+    sha256 = "99c56bcd6a56cab7933980a54148b476a5a69a7694e3874d9aa2a566f150447d",
+    strip_prefix = "aws-sdk-sts-1.41.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-sts/1.41.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-sdk-sts-1.41.0",
+    srcs = [":aws-sdk-sts-1.41.0.crate"],
+    crate = "aws_sdk_sts",
+    crate_root = "aws-sdk-sts-1.41.0.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "CARGO_MANIFEST_DIR": "aws-sdk-sts-1.41.0.crate",
+        "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
+        "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS Security Token Service",
+        "CARGO_PKG_NAME": "aws-sdk-sts",
+        "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
+        "CARGO_PKG_VERSION": "1.41.0",
+        "CARGO_PKG_VERSION_MAJOR": "1",
+        "CARGO_PKG_VERSION_MINOR": "41",
+        "CARGO_PKG_VERSION_PATCH": "0",
+    },
+    visibility = [],
+    deps = [
+        ":aws-credential-types-1.2.1",
+        ":aws-runtime-1.4.2",
+        ":aws-smithy-async-1.2.1",
+        ":aws-smithy-http-0.60.10",
+        ":aws-smithy-json-0.60.7",
+        ":aws-smithy-query-0.60.7",
+        ":aws-smithy-runtime-1.7.1",
+        ":aws-smithy-runtime-api-1.7.2",
+        ":aws-smithy-types-1.2.4",
+        ":aws-smithy-xml-0.60.8",
+        ":aws-types-1.3.3",
+        ":http-0.2.12",
+        ":once_cell-1.19.0",
+        ":regex-lite-0.1.6",
+        ":tracing-0.1.40",
+    ],
+)
+
+http_archive(
+    name = "aws-sigv4-1.2.3.crate",
+    sha256 = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be",
+    strip_prefix = "aws-sigv4-1.2.3",
+    urls = ["https://static.crates.io/crates/aws-sigv4/1.2.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-sigv4-1.2.3",
+    srcs = [":aws-sigv4-1.2.3.crate"],
+    crate = "aws_sigv4",
+    crate_root = "aws-sigv4-1.2.3.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "http0-compat",
+        "http1",
+        "sign-http",
+    ],
+    named_deps = {
+        "http0": ":http-0.2.12",
+    },
+    visibility = [],
+    deps = [
+        ":aws-credential-types-1.2.1",
+        ":aws-smithy-http-0.60.10",
+        ":aws-smithy-runtime-api-1.7.2",
+        ":aws-smithy-types-1.2.4",
+        ":bytes-1.7.1",
+        ":form_urlencoded-1.2.1",
+        ":hex-0.4.3",
+        ":hmac-0.12.1",
+        ":http-1.1.0",
+        ":once_cell-1.19.0",
+        ":percent-encoding-2.3.1",
+        ":sha2-0.10.8",
+        ":time-0.3.36",
+        ":tracing-0.1.40",
+    ],
+)
+
+http_archive(
+    name = "aws-smithy-async-1.2.1.crate",
+    sha256 = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c",
+    strip_prefix = "aws-smithy-async-1.2.1",
+    urls = ["https://static.crates.io/crates/aws-smithy-async/1.2.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-smithy-async-1.2.1",
+    srcs = [":aws-smithy-async-1.2.1.crate"],
+    crate = "aws_smithy_async",
+    crate_root = "aws-smithy-async-1.2.1.crate/src/lib.rs",
+    edition = "2021",
+    features = ["rt-tokio"],
+    visibility = [],
+    deps = [
+        ":futures-util-0.3.30",
+        ":pin-project-lite-0.2.14",
+        ":tokio-1.40.0",
+    ],
+)
+
+http_archive(
+    name = "aws-smithy-http-0.60.10.crate",
+    sha256 = "01dbcb6e2588fd64cfb6d7529661b06466419e4c54ed1c62d6510d2d0350a728",
+    strip_prefix = "aws-smithy-http-0.60.10",
+    urls = ["https://static.crates.io/crates/aws-smithy-http/0.60.10/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-smithy-http-0.60.10",
+    srcs = [":aws-smithy-http-0.60.10.crate"],
+    crate = "aws_smithy_http",
+    crate_root = "aws-smithy-http-0.60.10.crate/src/lib.rs",
+    edition = "2021",
+    named_deps = {
+        "http_02x": ":http-0.2.12",
+        "http_body_04x": ":http-body-0.4.6",
+    },
+    visibility = [],
+    deps = [
+        ":aws-smithy-runtime-api-1.7.2",
+        ":aws-smithy-types-1.2.4",
+        ":bytes-1.7.1",
+        ":bytes-utils-0.1.4",
+        ":futures-core-0.3.30",
+        ":once_cell-1.19.0",
+        ":percent-encoding-2.3.1",
+        ":pin-project-lite-0.2.14",
+        ":pin-utils-0.1.0",
+        ":tracing-0.1.40",
+    ],
+)
+
+http_archive(
+    name = "aws-smithy-json-0.60.7.crate",
+    sha256 = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6",
+    strip_prefix = "aws-smithy-json-0.60.7",
+    urls = ["https://static.crates.io/crates/aws-smithy-json/0.60.7/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-smithy-json-0.60.7",
+    srcs = [":aws-smithy-json-0.60.7.crate"],
+    crate = "aws_smithy_json",
+    crate_root = "aws-smithy-json-0.60.7.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [":aws-smithy-types-1.2.4"],
+)
+
+http_archive(
+    name = "aws-smithy-query-0.60.7.crate",
+    sha256 = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb",
+    strip_prefix = "aws-smithy-query-0.60.7",
+    urls = ["https://static.crates.io/crates/aws-smithy-query/0.60.7/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-smithy-query-0.60.7",
+    srcs = [":aws-smithy-query-0.60.7.crate"],
+    crate = "aws_smithy_query",
+    crate_root = "aws-smithy-query-0.60.7.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":aws-smithy-types-1.2.4",
+        ":urlencoding-2.1.3",
+    ],
+)
+
+http_archive(
+    name = "aws-smithy-runtime-1.7.1.crate",
+    sha256 = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87",
+    strip_prefix = "aws-smithy-runtime-1.7.1",
+    urls = ["https://static.crates.io/crates/aws-smithy-runtime/1.7.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-smithy-runtime-1.7.1",
+    srcs = [":aws-smithy-runtime-1.7.1.crate"],
+    crate = "aws_smithy_runtime",
+    crate_root = "aws-smithy-runtime-1.7.1.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "client",
+        "connector-hyper-0-14-x",
+        "rt-tokio",
+        "tls-rustls",
+    ],
+    named_deps = {
+        "http_02x": ":http-0.2.12",
+        "http_body_04x": ":http-body-0.4.6",
+        "http_body_1x": ":http-body-1.0.1",
+        "hyper_0_14": ":hyper-0.14.30",
+    },
+    visibility = [],
+    deps = [
+        ":aws-smithy-async-1.2.1",
+        ":aws-smithy-http-0.60.10",
+        ":aws-smithy-runtime-api-1.7.2",
+        ":aws-smithy-types-1.2.4",
+        ":bytes-1.7.1",
+        ":fastrand-2.1.1",
+        ":h2-0.3.26",
+        ":httparse-1.9.4",
+        ":hyper-rustls-0.24.2",
+        ":once_cell-1.19.0",
+        ":pin-project-lite-0.2.14",
+        ":pin-utils-0.1.0",
+        ":rustls-0.21.12",
+        ":tokio-1.40.0",
+        ":tracing-0.1.40",
+    ],
+)
+
+http_archive(
+    name = "aws-smithy-runtime-api-1.7.2.crate",
+    sha256 = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96",
+    strip_prefix = "aws-smithy-runtime-api-1.7.2",
+    urls = ["https://static.crates.io/crates/aws-smithy-runtime-api/1.7.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-smithy-runtime-api-1.7.2",
+    srcs = [":aws-smithy-runtime-api-1.7.2.crate"],
+    crate = "aws_smithy_runtime_api",
+    crate_root = "aws-smithy-runtime-api-1.7.2.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "client",
+        "default",
+        "http-02x",
+        "http-1x",
+        "http-auth",
+        "test-util",
+    ],
+    named_deps = {
+        "http_02x": ":http-0.2.12",
+        "http_1x": ":http-1.1.0",
+    },
+    visibility = [],
+    deps = [
+        ":aws-smithy-async-1.2.1",
+        ":aws-smithy-types-1.2.4",
+        ":bytes-1.7.1",
+        ":pin-project-lite-0.2.14",
+        ":tokio-1.40.0",
+        ":tracing-0.1.40",
+        ":zeroize-1.8.1",
+    ],
+)
+
+http_archive(
+    name = "aws-smithy-types-1.2.4.crate",
+    sha256 = "273dcdfd762fae3e1650b8024624e7cd50e484e37abdab73a7a706188ad34543",
+    strip_prefix = "aws-smithy-types-1.2.4",
+    urls = ["https://static.crates.io/crates/aws-smithy-types/1.2.4/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-smithy-types-1.2.4",
+    srcs = [":aws-smithy-types-1.2.4.crate"],
+    crate = "aws_smithy_types",
+    crate_root = "aws-smithy-types-1.2.4.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "byte-stream-poll-next",
+        "http-body-0-4-x",
+        "http-body-1-x",
+        "rt-tokio",
+        "test-util",
+    ],
+    named_deps = {
+        "http_1x": ":http-1.1.0",
+        "http_body_0_4": ":http-body-0.4.6",
+        "http_body_1_0": ":http-body-1.0.1",
+    },
+    visibility = [],
+    deps = [
+        ":base64-simd-0.8.0",
+        ":bytes-1.7.1",
+        ":bytes-utils-0.1.4",
+        ":futures-core-0.3.30",
+        ":http-0.2.12",
+        ":http-body-util-0.1.2",
+        ":itoa-1.0.11",
+        ":num-integer-0.1.46",
+        ":pin-project-lite-0.2.14",
+        ":pin-utils-0.1.0",
+        ":ryu-1.0.18",
+        ":time-0.3.36",
+        ":tokio-1.40.0",
+        ":tokio-util-0.7.12",
+    ],
+)
+
+http_archive(
+    name = "aws-smithy-xml-0.60.8.crate",
+    sha256 = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55",
+    strip_prefix = "aws-smithy-xml-0.60.8",
+    urls = ["https://static.crates.io/crates/aws-smithy-xml/0.60.8/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-smithy-xml-0.60.8",
+    srcs = [":aws-smithy-xml-0.60.8.crate"],
+    crate = "aws_smithy_xml",
+    crate_root = "aws-smithy-xml-0.60.8.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [":xmlparser-0.13.6"],
+)
+
+http_archive(
+    name = "aws-types-1.3.3.crate",
+    sha256 = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef",
+    strip_prefix = "aws-types-1.3.3",
+    urls = ["https://static.crates.io/crates/aws-types/1.3.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-types-1.3.3",
+    srcs = [":aws-types-1.3.3.crate"],
+    crate = "aws_types",
+    crate_root = "aws-types-1.3.3.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "CARGO_MANIFEST_DIR": "aws-types-1.3.3.crate",
+        "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
+        "CARGO_PKG_DESCRIPTION": "Cross-service types for the AWS SDK.",
+        "CARGO_PKG_NAME": "aws-types",
+        "CARGO_PKG_REPOSITORY": "https://github.com/smithy-lang/smithy-rs",
+        "CARGO_PKG_VERSION": "1.3.3",
+        "CARGO_PKG_VERSION_MAJOR": "1",
+        "CARGO_PKG_VERSION_MINOR": "3",
+        "CARGO_PKG_VERSION_PATCH": "3",
+        "OUT_DIR": "$(location :aws-types-1.3.3-build-script-run[out_dir])",
+    },
+    visibility = [],
+    deps = [
+        ":aws-credential-types-1.2.1",
+        ":aws-smithy-async-1.2.1",
+        ":aws-smithy-runtime-api-1.7.2",
+        ":aws-smithy-types-1.2.4",
+        ":tracing-0.1.40",
+    ],
+)
+
+cargo.rust_binary(
+    name = "aws-types-1.3.3-build-script-build",
+    srcs = [":aws-types-1.3.3.crate"],
+    crate = "build_script_build",
+    crate_root = "aws-types-1.3.3.crate/build.rs",
+    edition = "2021",
+    env = {
+        "CARGO_MANIFEST_DIR": "aws-types-1.3.3.crate",
+        "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
+        "CARGO_PKG_DESCRIPTION": "Cross-service types for the AWS SDK.",
+        "CARGO_PKG_NAME": "aws-types",
+        "CARGO_PKG_REPOSITORY": "https://github.com/smithy-lang/smithy-rs",
+        "CARGO_PKG_VERSION": "1.3.3",
+        "CARGO_PKG_VERSION_MAJOR": "1",
+        "CARGO_PKG_VERSION_MINOR": "3",
+        "CARGO_PKG_VERSION_PATCH": "3",
+    },
+    visibility = [],
+    deps = [":rustc_version-0.4.1"],
+)
+
+buildscript_run(
+    name = "aws-types-1.3.3-build-script-run",
+    package_name = "aws-types",
+    buildscript_rule = ":aws-types-1.3.3-build-script-build",
+    version = "1.3.3",
 )
 
 alias(
@@ -970,7 +1635,7 @@ cargo.rust_library(
         ":multer-2.1.0",
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.14",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":serde_path_to_error-0.1.16",
         ":serde_urlencoded-0.7.1",
@@ -1194,6 +1859,33 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "base64-simd-0.8.0.crate",
+    sha256 = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195",
+    strip_prefix = "base64-simd-0.8.0",
+    urls = ["https://static.crates.io/crates/base64-simd/0.8.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "base64-simd-0.8.0",
+    srcs = [":base64-simd-0.8.0.crate"],
+    crate = "base64_simd",
+    crate_root = "base64-simd-0.8.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "default",
+        "detect",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":outref-0.5.1",
+        ":vsimd-0.8.0",
+    ],
+)
+
+http_archive(
     name = "base64ct-1.6.0.crate",
     sha256 = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b",
     strip_prefix = "base64ct-1.6.0",
@@ -1382,7 +2074,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde-1.0.209"],
+    deps = [":serde-1.0.210"],
 )
 
 http_archive(
@@ -1688,8 +2380,8 @@ cargo.rust_library(
         ":hyper-util-0.1.7",
         ":log-0.4.22",
         ":pin-project-lite-0.2.14",
-        ":serde-1.0.209",
-        ":serde_derive-1.0.209",
+        ":serde-1.0.210",
+        ":serde_derive-1.0.210",
         ":serde_json-1.0.125",
         ":serde_repr-0.1.19",
         ":serde_urlencoded-0.7.1",
@@ -1716,7 +2408,7 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_repr-0.1.19",
         ":serde_with-3.9.0",
     ],
@@ -1795,7 +2487,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":memchr-2.7.4",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -1867,7 +2559,32 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde-1.0.209"],
+    deps = [":serde-1.0.210"],
+)
+
+http_archive(
+    name = "bytes-utils-0.1.4.crate",
+    sha256 = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35",
+    strip_prefix = "bytes-utils-0.1.4",
+    urls = ["https://static.crates.io/crates/bytes-utils/0.1.4/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "bytes-utils-0.1.4",
+    srcs = [":bytes-utils-0.1.4.crate"],
+    crate = "bytes_utils",
+    crate_root = "bytes-utils-0.1.4.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":bytes-1.7.1",
+        ":either-1.13.0",
+    ],
 )
 
 alias(
@@ -1919,8 +2636,8 @@ cargo.rust_library(
         ":memmap2-0.5.10",
         ":miette-5.10.0",
         ":reflink-copy-0.1.19",
-        ":serde-1.0.209",
-        ":serde_derive-1.0.209",
+        ":serde-1.0.210",
+        ":serde_derive-1.0.210",
         ":serde_json-1.0.125",
         ":sha1-0.10.6",
         ":sha2-0.10.8",
@@ -2062,7 +2779,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":num-traits-0.2.19",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -2094,7 +2811,7 @@ cargo.rust_library(
     deps = [
         ":ciborium-io-0.2.2",
         ":ciborium-ll-0.2.2",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -2621,7 +3338,7 @@ cargo.rust_library(
         ":lazy_static-1.5.0",
         ":nom-7.1.3",
         ":pathdiff-0.2.1",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":toml-0.8.19",
     ],
 )
@@ -2791,7 +3508,7 @@ cargo.rust_library(
         ":mime-0.3.17",
         ":paste-1.0.15",
         ":pin-project-1.1.5",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":tar-0.4.41",
         ":thiserror-1.0.63",
@@ -2888,18 +3605,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "cpufeatures-0.2.13.crate",
-    sha256 = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad",
-    strip_prefix = "cpufeatures-0.2.13",
-    urls = ["https://static.crates.io/crates/cpufeatures/0.2.13/download"],
+    name = "cpufeatures-0.2.14.crate",
+    sha256 = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0",
+    strip_prefix = "cpufeatures-0.2.14",
+    urls = ["https://static.crates.io/crates/cpufeatures/0.2.14/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "cpufeatures-0.2.13",
-    srcs = [":cpufeatures-0.2.13.crate"],
+    name = "cpufeatures-0.2.14",
+    srcs = [":cpufeatures-0.2.14.crate"],
     crate = "cpufeatures",
-    crate_root = "cpufeatures-0.2.13.crate/src/lib.rs",
+    crate_root = "cpufeatures-0.2.14.crate/src/lib.rs",
     edition = "2018",
     platform = {
         "linux-arm64": dict(
@@ -3026,8 +3743,8 @@ cargo.rust_library(
         ":plotters-0.3.6",
         ":rayon-1.10.0",
         ":regex-1.10.6",
-        ":serde-1.0.209",
-        ":serde_derive-1.0.209",
+        ":serde-1.0.210",
+        ":serde_derive-1.0.210",
         ":serde_json-1.0.125",
         ":tinytemplate-1.2.1",
         ":tokio-1.40.0",
@@ -3485,25 +4202,25 @@ cargo.rust_library(
     platform = {
         "linux-x86_64": dict(
             deps = [
-                ":cpufeatures-0.2.13",
+                ":cpufeatures-0.2.14",
                 ":curve25519-dalek-derive-0.1.1",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":cpufeatures-0.2.13",
+                ":cpufeatures-0.2.14",
                 ":curve25519-dalek-derive-0.1.1",
             ],
         ),
         "windows-gnu": dict(
             deps = [
-                ":cpufeatures-0.2.13",
+                ":cpufeatures-0.2.14",
                 ":curve25519-dalek-derive-0.1.1",
             ],
         ),
         "windows-msvc": dict(
             deps = [
-                ":cpufeatures-0.2.13",
+                ":cpufeatures-0.2.14",
                 ":curve25519-dalek-derive-0.1.1",
             ],
         ),
@@ -3823,7 +4540,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":powerfmt-0.2.0",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -4027,7 +4744,7 @@ cargo.rust_library(
         ":rand-0.8.5",
         ":retry-1.3.1",
         ":semver-1.0.23",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -4496,7 +5213,7 @@ cargo.rust_library(
         "use_std",
     ],
     visibility = [],
-    deps = [":serde-1.0.209"],
+    deps = [":serde-1.0.210"],
 )
 
 http_archive(
@@ -5914,7 +6631,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hash32-0.2.1",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":stable_deref_trait-1.2.0",
     ],
 )
@@ -6462,12 +7179,26 @@ cargo.rust_library(
     crate = "hyper_rustls",
     crate_root = "hyper-rustls-0.24.2.crate/src/lib.rs",
     edition = "2021",
+    features = [
+        "acceptor",
+        "default",
+        "http1",
+        "http2",
+        "log",
+        "logging",
+        "native-tokio",
+        "rustls-native-certs",
+        "tls12",
+        "tokio-runtime",
+    ],
     visibility = [],
     deps = [
         ":futures-util-0.3.30",
         ":http-0.2.12",
         ":hyper-0.14.30",
+        ":log-0.4.22",
         ":rustls-0.21.12",
+        ":rustls-native-certs-0.6.3",
         ":tokio-1.40.0",
         ":tokio-rustls-0.24.1",
     ],
@@ -6733,7 +7464,7 @@ cargo.rust_library(
         ":ignore-0.4.22",
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":syn-2.0.77",
         ":toml-0.8.19",
         ":unicode-xid-0.2.5",
@@ -6815,7 +7546,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hashbrown-0.12.3",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -6849,7 +7580,7 @@ cargo.rust_library(
     deps = [
         ":equivalent-1.0.1",
         ":hashbrown-0.14.5",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -7218,7 +7949,7 @@ cargo.rust_library(
         ":p256-0.13.2",
         ":p384-0.13.0",
         ":rand-0.8.5",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":thiserror-1.0.63",
         ":zeroize-1.8.1",
@@ -9725,6 +10456,23 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "outref-0.5.1.crate",
+    sha256 = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a",
+    strip_prefix = "outref-0.5.1",
+    urls = ["https://static.crates.io/crates/outref/0.5.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "outref-0.5.1",
+    srcs = [":outref-0.5.1.crate"],
+    crate = "outref",
+    crate_root = "outref-0.5.1.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+)
+
+http_archive(
     name = "overload-0.1.1.crate",
     sha256 = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39",
     strip_prefix = "overload-0.1.1",
@@ -10006,7 +10754,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":base64-0.22.1",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -10084,8 +10832,8 @@ cargo.rust_library(
     deps = [
         ":fixedbitset-0.4.2",
         ":indexmap-2.5.0",
-        ":serde-1.0.209",
-        ":serde_derive-1.0.209",
+        ":serde-1.0.210",
+        ":serde_derive-1.0.210",
     ],
 )
 
@@ -10424,7 +11172,7 @@ cargo.rust_library(
         ":log-0.4.22",
         ":paste-1.0.15",
         ":podman-api-stubs-0.9.0",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":tar-0.4.41",
         ":thiserror-1.0.63",
@@ -10450,7 +11198,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":chrono-0.4.38",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
     ],
 )
@@ -10558,7 +11306,7 @@ cargo.rust_library(
     deps = [
         ":cobs-0.2.3",
         ":heapless-0.7.17",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -10647,7 +11395,7 @@ cargo.rust_library(
     ],
     named_deps = {
         "chrono_04": ":chrono-0.4.38",
-        "serde_1": ":serde-1.0.209",
+        "serde_1": ":serde-1.0.210",
         "serde_json_1": ":serde_json-1.0.125",
     },
     visibility = [],
@@ -11149,7 +11897,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":memchr-2.7.4",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -11832,6 +12580,28 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "regex-lite-0.1.6.crate",
+    sha256 = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a",
+    strip_prefix = "regex-lite-0.1.6",
+    urls = ["https://static.crates.io/crates/regex-lite/0.1.6/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "regex-lite-0.1.6",
+    srcs = [":regex-lite-0.1.6.crate"],
+    crate = "regex_lite",
+    crate_root = "regex-lite-0.1.6.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "std",
+        "string",
+    ],
+    visibility = [],
+)
+
+http_archive(
     name = "regex-syntax-0.6.29.crate",
     sha256 = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1",
     strip_prefix = "regex-syntax-0.6.29",
@@ -12090,7 +12860,7 @@ cargo.rust_library(
         ":futures-util-0.3.30",
         ":http-1.1.0",
         ":mime_guess-2.0.4",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":serde_urlencoded-0.7.1",
         ":sync_wrapper-1.0.1",
@@ -12976,8 +13746,8 @@ cargo.rust_library(
         ":quick-xml-0.30.0",
         ":rustls-0.21.12",
         ":rustls-native-certs-0.6.3",
-        ":serde-1.0.209",
-        ":serde_derive-1.0.209",
+        ":serde-1.0.210",
+        ":serde_derive-1.0.210",
         ":serde_json-1.0.125",
         ":sha2-0.10.8",
         ":thiserror-1.0.63",
@@ -13016,7 +13786,7 @@ cargo.rust_library(
     deps = [
         ":arrayvec-0.7.6",
         ":num-traits-0.2.19",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -13774,7 +14544,7 @@ cargo.rust_library(
         ":sea-orm-macros-0.12.15",
         ":sea-query-0.30.7",
         ":sea-query-binder-0.5.0",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":sqlx-0.7.4",
         ":strum-0.25.0",
@@ -14117,23 +14887,23 @@ buildscript_run(
 
 alias(
     name = "serde",
-    actual = ":serde-1.0.209",
+    actual = ":serde-1.0.210",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde-1.0.209.crate",
-    sha256 = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09",
-    strip_prefix = "serde-1.0.209",
-    urls = ["https://static.crates.io/crates/serde/1.0.209/download"],
+    name = "serde-1.0.210.crate",
+    sha256 = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a",
+    strip_prefix = "serde-1.0.210",
+    urls = ["https://static.crates.io/crates/serde/1.0.210/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde-1.0.209",
-    srcs = [":serde-1.0.209.crate"],
+    name = "serde-1.0.210",
+    srcs = [":serde-1.0.210.crate"],
     crate = "serde",
-    crate_root = "serde-1.0.209.crate/src/lib.rs",
+    crate_root = "serde-1.0.210.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -14144,7 +14914,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde_derive-1.0.209"],
+    deps = [":serde_derive-1.0.210"],
 )
 
 alias(
@@ -14174,24 +14944,24 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":chrono-0.4.38",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
     ],
 )
 
 http_archive(
-    name = "serde_derive-1.0.209.crate",
-    sha256 = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170",
-    strip_prefix = "serde_derive-1.0.209",
-    urls = ["https://static.crates.io/crates/serde_derive/1.0.209/download"],
+    name = "serde_derive-1.0.210.crate",
+    sha256 = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f",
+    strip_prefix = "serde_derive-1.0.210",
+    urls = ["https://static.crates.io/crates/serde_derive/1.0.210/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_derive-1.0.209",
-    srcs = [":serde_derive-1.0.209.crate"],
+    name = "serde_derive-1.0.210",
+    srcs = [":serde_derive-1.0.210.crate"],
     crate = "serde_derive",
-    crate_root = "serde_derive-1.0.209.crate/src/lib.rs",
+    crate_root = "serde_derive-1.0.210.crate/src/lib.rs",
     edition = "2015",
     features = ["default"],
     proc_macro = True,
@@ -14237,7 +15007,7 @@ cargo.rust_library(
         ":itoa-1.0.11",
         ":memchr-2.7.4",
         ":ryu-1.0.18",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -14256,7 +15026,7 @@ cargo.rust_library(
     crate_root = "serde_nanos-0.1.4.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":serde-1.0.209"],
+    deps = [":serde-1.0.210"],
 )
 
 alias(
@@ -14282,7 +15052,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":itoa-1.0.11",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -14325,7 +15095,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["serde"],
     visibility = [],
-    deps = [":serde-1.0.209"],
+    deps = [":serde-1.0.210"],
 )
 
 alias(
@@ -14350,7 +15120,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":url-2.5.2",
     ],
 )
@@ -14374,7 +15144,7 @@ cargo.rust_library(
         ":form_urlencoded-1.2.1",
         ":itoa-1.0.11",
         ":ryu-1.0.18",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -14414,8 +15184,8 @@ cargo.rust_library(
     deps = [
         ":base64-0.22.1",
         ":hex-0.4.3",
-        ":serde-1.0.209",
-        ":serde_derive-1.0.209",
+        ":serde-1.0.210",
+        ":serde_derive-1.0.210",
         ":serde_json-1.0.125",
         ":serde_with_macros-3.9.0",
     ],
@@ -14470,7 +15240,7 @@ cargo.rust_library(
         ":indexmap-2.5.0",
         ":itoa-1.0.11",
         ":ryu-1.0.18",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":unsafe-libyaml-0.2.11",
     ],
 )
@@ -14495,22 +15265,22 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "linux-x86_64": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "macos-arm64": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "macos-x86_64": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "windows-gnu": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "windows-msvc": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
     },
     visibility = [],
@@ -14540,22 +15310,22 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "linux-x86_64": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "macos-arm64": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "macos-x86_64": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "windows-gnu": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "windows-msvc": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
     },
     visibility = [],
@@ -14586,22 +15356,22 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "linux-x86_64": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "macos-arm64": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "macos-x86_64": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "windows-gnu": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
         "windows-msvc": dict(
-            deps = [":cpufeatures-0.2.13"],
+            deps = [":cpufeatures-0.2.14"],
         ),
     },
     visibility = [],
@@ -14982,7 +15752,7 @@ cargo.rust_library(
         ":ed25519-1.5.3",
         ":libc-0.2.158",
         ":libsodium-sys-0.2.7",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -15044,18 +15814,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "sqlformat-0.2.4.crate",
-    sha256 = "f895e3734318cc55f1fe66258926c9b910c124d47520339efecbb6c59cec7c1f",
-    strip_prefix = "sqlformat-0.2.4",
-    urls = ["https://static.crates.io/crates/sqlformat/0.2.4/download"],
+    name = "sqlformat-0.2.6.crate",
+    sha256 = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790",
+    strip_prefix = "sqlformat-0.2.6",
+    urls = ["https://static.crates.io/crates/sqlformat/0.2.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sqlformat-0.2.4",
-    srcs = [":sqlformat-0.2.4.crate"],
+    name = "sqlformat-0.2.6",
+    srcs = [":sqlformat-0.2.6.crate"],
     crate = "sqlformat",
-    crate_root = "sqlformat-0.2.4.crate/src/lib.rs",
+    crate_root = "sqlformat-0.2.6.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [
@@ -15164,11 +15934,11 @@ cargo.rust_library(
         ":rust_decimal-1.36.0",
         ":rustls-0.21.12",
         ":rustls-pemfile-1.0.4",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":sha2-0.10.8",
         ":smallvec-1.13.2",
-        ":sqlformat-0.2.4",
+        ":sqlformat-0.2.6",
         ":thiserror-1.0.63",
         ":time-0.3.36",
         ":tokio-1.40.0",
@@ -15238,7 +16008,7 @@ cargo.rust_library(
         ":once_cell-1.19.0",
         ":rand-0.8.5",
         ":rust_decimal-1.36.0",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":sha2-0.10.8",
         ":smallvec-1.13.2",
@@ -15287,7 +16057,7 @@ cargo.rust_library(
         ":digest-0.10.7",
         ":hex-0.4.3",
         ":miette-5.10.0",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":sha-1-0.10.1",
         ":sha2-0.10.8",
         ":thiserror-1.0.63",
@@ -15901,6 +16671,8 @@ cargo.rust_binary(
         ":async-nats-0.35.1",
         ":async-recursion-1.1.1",
         ":async-trait-0.1.82",
+        ":aws-config-1.5.5",
+        ":aws-sdk-firehose-1.46.0",
         ":axum-0.6.20",
         ":base64-0.22.1",
         ":blake3-1.5.4",
@@ -15982,7 +16754,7 @@ cargo.rust_binary(
         ":rustls-pemfile-2.1.3",
         ":sea-orm-0.12.15",
         ":self-replace-1.5.0",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde-aux-4.5.0",
         ":serde_json-1.0.125",
         ":serde_path_to_error-0.1.16",
@@ -16180,7 +16952,7 @@ cargo.rust_library(
         ":itoa-1.0.11",
         ":num-conv-0.1.0",
         ":powerfmt-0.2.0",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":time-core-0.1.2",
         ":time-macros-0.2.18",
     ],
@@ -16268,7 +17040,7 @@ cargo.rust_library(
     edition = "2015",
     visibility = [],
     deps = [
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
     ],
 )
@@ -16670,7 +17442,7 @@ cargo.rust_library(
         ":futures-core-0.3.30",
         ":futures-sink-0.3.30",
         ":pin-project-1.1.5",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
     ],
 )
@@ -16873,7 +17645,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_spanned-0.6.7",
         ":toml_datetime-0.6.8",
         ":toml_edit-0.22.20",
@@ -16896,7 +17668,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["serde"],
     visibility = [],
-    deps = [":serde-1.0.209"],
+    deps = [":serde-1.0.210"],
 )
 
 http_archive(
@@ -16922,7 +17694,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":indexmap-2.5.0",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_spanned-0.6.7",
         ":toml_datetime-0.6.8",
         ":winnow-0.6.18",
@@ -17340,7 +18112,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":tracing-core-0.1.32",
     ],
 )
@@ -17393,7 +18165,7 @@ cargo.rust_library(
         ":nu-ansi-term-0.46.0",
         ":once_cell-1.19.0",
         ":regex-1.10.6",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":sharded-slab-0.1.7",
         ":smallvec-1.13.2",
@@ -17573,7 +18345,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rand-0.8.5",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -17828,7 +18600,7 @@ cargo.rust_library(
         ":form_urlencoded-1.2.1",
         ":idna-0.5.0",
         ":percent-encoding-2.3.1",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -17931,7 +18703,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":getrandom-0.2.15",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
     ],
 )
 
@@ -18030,6 +18802,28 @@ cargo.rust_library(
         ":tar-parser2-0.9.1",
         ":vfs-0.10.0",
     ],
+)
+
+http_archive(
+    name = "vsimd-0.8.0.crate",
+    sha256 = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64",
+    strip_prefix = "vsimd-0.8.0",
+    urls = ["https://static.crates.io/crates/vsimd/0.8.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "vsimd-0.8.0",
+    srcs = [":vsimd-0.8.0.crate"],
+    crate = "vsimd",
+    crate_root = "vsimd-0.8.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "detect",
+        "std",
+    ],
+    visibility = [],
 )
 
 http_archive(
@@ -18901,6 +19695,27 @@ cargo.rust_library(
     deps = [":rustix-0.38.36"],
 )
 
+http_archive(
+    name = "xmlparser-0.13.6.crate",
+    sha256 = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4",
+    strip_prefix = "xmlparser-0.13.6",
+    urls = ["https://static.crates.io/crates/xmlparser/0.13.6/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "xmlparser-0.13.6",
+    srcs = [":xmlparser-0.13.6.crate"],
+    crate = "xmlparser",
+    crate_root = "xmlparser-0.13.6.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+)
+
 alias(
     name = "xxhash-rust",
     actual = ":xxhash-rust-0.8.12",
@@ -19021,7 +19836,7 @@ cargo.rust_library(
     deps = [
         ":atomic_refcell-0.1.13",
         ":rand-0.7.3",
-        ":serde-1.0.209",
+        ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":smallstr-0.3.0",
         ":smallvec-1.13.2",

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -343,6 +343,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-config"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e95816a168520d72c0e7680c405a5a8c1fb6a035b4bc4b9d7b0de8e1a941697"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes 1.7.1",
+ "fastrand",
+ "hex",
+ "http 0.2.12",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-creds"
 version = "0.36.0"
 source = "git+https://github.com/ScuffleTV/rust-s3.git?branch=troy/rustls#27c5c7a0fac45ecb6e766a4b4239bdd98d9b3395"
@@ -364,6 +406,286 @@ version = "0.25.4"
 source = "git+https://github.com/ScuffleTV/rust-s3.git?branch=troy/rustls#27c5c7a0fac45ecb6e766a4b4239bdd98d9b3395"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2424565416eef55906f9f8cece2072b6b6a76075e3ff81483ebe938a89a4c05f"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes 1.7.1",
+ "fastrand",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-firehose"
+version = "1.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d58f8eaeddd388b3f361708c5e7bb5600accd1785be00640b513b69bf3376d7"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes 1.7.1",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af0a3f676cba2c079c9563acc9233998c8951cdbe38629a0bef3c8c1b02f3658"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes 1.7.1",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91b6a04495547162cf52b075e3c15a17ab6608bf9c5785d3e5a5509b3f09f5c"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes 1.7.1",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c56bcd6a56cab7933980a54148b476a5a69a7694e3874d9aa2a566f150447d"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes 1.7.1",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.1.0",
+ "once_cell",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01dbcb6e2588fd64cfb6d7529661b06466419e4c54ed1c62d6510d2d0350a728"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes 1.7.1",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes 1.7.1",
+ "fastrand",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.30",
+ "hyper-rustls 0.24.2",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes 1.7.1",
+ "http 0.2.12",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273dcdfd762fae3e1650b8024624e7cd50e484e37abdab73a7a706188ad34543"
+dependencies = [
+ "base64-simd",
+ "bytes 1.7.1",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.1.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
 ]
 
 [[package]]
@@ -470,6 +792,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -730,6 +1062,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes 1.7.1",
+ "either",
 ]
 
 [[package]]
@@ -1086,9 +1428,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -2412,7 +2754,9 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.30",
+ "log",
  "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -3440,6 +3784,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4247,6 +4597,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4810,9 +5166,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -4830,9 +5186,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5153,9 +5509,9 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f895e3734318cc55f1fe66258926c9b910c124d47520339efecbb6c59cec7c1f"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
 dependencies = [
  "nom",
  "unicode_categories",
@@ -5622,6 +5978,8 @@ dependencies = [
  "async-nats",
  "async-recursion",
  "async-trait",
+ "aws-config",
+ "aws-sdk-firehose",
  "axum",
  "base64 0.22.1",
  "blake3",
@@ -6491,6 +6849,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "vsock"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6990,6 +7354,12 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -31,6 +31,8 @@ publish = false
 async-nats = { version = "0.35.1", features = ["service"] }
 async-recursion = "1.0.5"
 async-trait = "0.1.79"
+aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
+aws-sdk-firehose = "1.46.0"
 axum = { version = "0.6.20", features = ["macros", "multipart", "ws"] } # todo: upgrade this alongside hyper/http/tokio-tungstenite
 base64 = "0.22.0"
 blake3 = "1.5.1"

--- a/third-party/rust/fixups/aws-config/fixups.toml
+++ b/third-party/rust/fixups/aws-config/fixups.toml
@@ -1,0 +1,1 @@
+cargo_env = true

--- a/third-party/rust/fixups/aws-sdk-firehose/fixups.toml
+++ b/third-party/rust/fixups/aws-sdk-firehose/fixups.toml
@@ -1,0 +1,1 @@
+cargo_env = true

--- a/third-party/rust/fixups/aws-sdk-sso/fixups.toml
+++ b/third-party/rust/fixups/aws-sdk-sso/fixups.toml
@@ -1,0 +1,1 @@
+cargo_env = true

--- a/third-party/rust/fixups/aws-sdk-ssooidc/fixups.toml
+++ b/third-party/rust/fixups/aws-sdk-ssooidc/fixups.toml
@@ -1,0 +1,1 @@
+cargo_env = true

--- a/third-party/rust/fixups/aws-sdk-sts/fixups.toml
+++ b/third-party/rust/fixups/aws-sdk-sts/fixups.toml
@@ -1,0 +1,1 @@
+cargo_env = true

--- a/third-party/rust/fixups/aws-types/fixups.toml
+++ b/third-party/rust/fixups/aws-types/fixups.toml
@@ -1,0 +1,13 @@
+omit_targets = []
+extra_srcs = []
+omit_srcs = []
+rustc_flags = []
+cfgs = []
+features = []
+omit_features = []
+extra_deps = []
+omit_deps = []
+cargo_env = true
+
+[[buildscript]]
+[buildscript.gen_srcs]


### PR DESCRIPTION
## Description

<img src="https://media4.giphy.com/media/xYLZSq6wQBrRC/giphy.gif"/>

This PR adds a data warehouse stream client that can be used for multiple things, but is presently and solely concerned with publishing billing events to the stream.

The client is unused by any running service in builds using this commit. However, it is ready to be used and will likely be done so with opt-in configuration from SDF's own configuration options.

When a client is not present, the billing events server will run in "no-op" mode, which consumes the message off the NATS Jetstream stream (preventing overload), logs that the message was received and then does a whole lotta nothing.

As a result of these changes, this commit adds `aws-sdf-firehose` and `aws-config` third party dependencies to the repository. They are scoped purely to the new `data-warehouse-stream-client` crate, which is intentional.

## Disclaimer

We are avoiding creating `Server` and `Config` structs for now because the billing events "server" is really a "task". It's immediately created from its configuration options and doesn't own its long running future.

That being said, when and if it becomes its own service, we should employ the pattern established by veritech, pinga and rebaser with `si-service`.

## Additional Changes

This PR also adds a location for billing events. For now, we hardcode this value, but will tune it and use the correct value when we add configuration options to SDF for the billing events server to deliver events.