### PR TITLE
fix(dal-test): reduce the default cyclone pool size for tests

### DIFF
--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -640,7 +640,7 @@ pub async fn veritech_server_for_uds_cyclone(
     let config: veritech_server::Config = {
         let mut config_file = veritech_server::ConfigFile::default_local_uds();
         config_file.nats = nats_config;
-        config_file.cyclone.set_pool_size(50);
+        config_file.cyclone.set_pool_size(4);
         veritech_server::detect_and_configure_development(&mut config_file)
             .wrap_err("failed to detect and configure Veritech ConfigFile")?;
         config_file


### PR DESCRIPTION
This change changes the size of the cyclone pool that are set for *each* integration test. Prior to this change the value was updated recently to `50` and this led to issues running the DAL integration test suite on some larger Linux systems (namely Threadripper workstations with 64 or 128-cores). The test suite issue would manifest as:

```
thread 'main' panicked at third-party/rust/tokio-1.40.0.crate/src/runtime/scheduler/multi_thread/worker.rs:466:13:
OS can't spawn worker thread: Resource temporarily unavailable (os error 11)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

A little misleading in that the number of threads per-process *and* the number of processes both contribute to this failure.

While the update pool size is considerably smaller, the total runtime of `lib/dal:test-integration` didn't seem to vary by more than about 5 seconds when runs were attempted with different values.