### PR TITLE
feat: change pool noodle to use channels to prevent spamming pop

### DIFF
--- a/lib/si-pool-noodle/src/lib.rs
+++ b/lib/si-pool-noodle/src/lib.rs
@@ -74,7 +74,8 @@ mod tests {
                 shutdown_token,
                 spec: spec.clone(),
                 ..Default::default()
-            });
+            })
+            .await;
         pool.run().expect("failed to start");
 
         let mut instance = pool.get().await.expect("pool is empty!");
@@ -118,7 +119,8 @@ mod tests {
                 shutdown_token,
                 spec: spec.clone(),
                 ..Default::default()
-            });
+            })
+            .await;
         pool.run().expect("failed to start");
         let mut instance = pool.get().await.expect("pool is empty!");
 
@@ -176,7 +178,8 @@ mod tests {
                 shutdown_token,
                 spec: spec.clone(),
                 ..Default::default()
-            });
+            })
+            .await;
         pool.run().expect("failed to start");
         let mut instance = pool.get().await.expect("should be able to get an instance");
         instance.ensure_healthy().await.expect("failed healthy");

--- a/lib/veritech-client/tests/integration.rs
+++ b/lib/veritech-client/tests/integration.rs
@@ -53,6 +53,7 @@ async fn veritech_server_for_uds_cyclone(
             .try_lang_server_cmd_path(config_file.cyclone.lang_server_cmd_path())
             .expect("failed to setup lang_js_cmd_path")
             .all_endpoints()
+            .pool_size(4_u32)
             .build()
             .expect("failed to build cyclone spec"),
     );
@@ -73,8 +74,6 @@ async fn client(subject_prefix: String) -> Client {
 }
 
 async fn run_veritech_server_for_uds_cyclone(subject_prefix: String) -> JoinHandle<()> {
-    // NOTE(nick,fletcher): thread through the cancellation token for tests. For now, we don't use
-    // it all, but it may be useful in the future.
     let shutdown_token = CancellationToken::new();
     tokio::spawn(
         veritech_server_for_uds_cyclone(subject_prefix, shutdown_token)

--- a/lib/veritech-server/src/config.rs
+++ b/lib/veritech-server/src/config.rs
@@ -534,7 +534,7 @@ fn default_runtime_strategy() -> LocalUdsRuntimeStrategy {
 }
 
 fn default_pool_size() -> u32 {
-    500
+    50
 }
 
 fn default_connect_timeout() -> u64 {

--- a/lib/veritech-server/src/server.rs
+++ b/lib/veritech-server/src/server.rs
@@ -122,7 +122,7 @@ impl Server {
                 };
 
                 let mut cyclone_pool: PoolNoodle<LocalUdsInstance, LocalUdsInstanceSpec> =
-                    PoolNoodle::new(pool_config);
+                    PoolNoodle::new(pool_config).await;
 
                 spec.clone()
                     .setup()


### PR DESCRIPTION
After a conversation with @fnichol we decided it would be better to use channels to pass work around here so we aren't hammering `pop()` in a bunch of threads and are instead just polling for work. We should be just as fast (if not faster) under load, but we'll be a lot quieter when sitting still. We limit total threads using a semaphore so we will block work until new slots  appear. 