### PR TITLE
fix(si-layer-cache): remove spawn_blocking calls which break macOS

### DIFF
--- a/lib/si-layer-cache/src/db/serialize.rs
+++ b/lib/si-layer-cache/src/db/serialize.rs
@@ -28,7 +28,7 @@ where
 #[inline]
 #[instrument(
     name = "serialize.from_bytes",
-    level = "debug",
+    level = "trace",
     skip_all,
     fields(
         bytes.size = bytes.len(),
@@ -40,6 +40,27 @@ where
 {
     let uncompressed = miniz_oxide::inflate::decompress_to_vec(bytes)
         .map_err(|e| LayerDbError::Decompress(e.to_string()))?;
+
+    Ok(postcard::from_bytes(&uncompressed)?)
+}
+
+#[inline]
+#[instrument(
+    name = "serialize.from_bytes_async",
+    level = "trace",
+    skip_all,
+    fields(
+        bytes.size = bytes.len(),
+    )
+)]
+pub async fn from_bytes_async<T>(bytes: &[u8]) -> LayerDbResult<T>
+where
+    T: DeserializeOwned,
+{
+    let uncompressed = miniz_oxide::inflate::decompress_to_vec(bytes)
+        .map_err(|e| LayerDbError::Decompress(e.to_string()))?;
+
+    tokio::task::yield_now().await;
 
     Ok(postcard::from_bytes(&uncompressed)?)
 }

--- a/lib/si-layer-cache/src/layer_cache.rs
+++ b/lib/si-layer-cache/src/layer_cache.rs
@@ -164,8 +164,9 @@ where
     }
 
     pub async fn deserialize_memory_value(&self, bytes: Arc<Vec<u8>>) -> LayerDbResult<V> {
-        tokio::task::spawn_blocking(move || serialize::from_bytes(&bytes).map_err(Into::into))
-            .await?
+        serialize::from_bytes_async(&bytes)
+            .await
+            .map_err(Into::into)
     }
 
     pub fn memory_cache(&self) -> MemoryCache<V> {

--- a/lib/si-runtime-rs/src/lib.rs
+++ b/lib/si-runtime-rs/src/lib.rs
@@ -9,7 +9,7 @@ use tokio::runtime::{Builder, Runtime};
 use tokio_dedicated_executor::{DedicatedExecutor, DedicatedExecutorInitializeError};
 
 pub const DEFAULT_TOKIO_RT_THREAD_STACK_SIZE: usize = 2 * 1024 * 1024 * 3;
-pub const DEFAULT_TOKIO_RT_BLOCKING_POOL_SIZE: usize = 2048; // this is 4x the tokio default of 512
+pub const DEFAULT_TOKIO_RT_BLOCKING_POOL_SIZE: usize = 512;
 
 // Thread priority for compute executors (min = 0, max = 99, default = 50)
 const COMPUTE_EXECUTOR_THREAD_PRIORITY: u8 = 25;


### PR DESCRIPTION
performance seems to massively degrade on macOS when large number of spawn_blocking calls are issued, even when the max blocking pool threads are reduced to 8. Using a suggestion by @fnichol to break the deserialization up with a tokio::task::yield_now() call instead.