### PR TITLE
fix: fail pipeline on tests, correct concurrency naming

### DIFF
--- a/.github/workflows/deploy-on-main.yml
+++ b/.github/workflows/deploy-on-main.yml
@@ -12,11 +12,11 @@ jobs:
       environment: tools
       version: stable
     secrets: inherit
-    
+
   on-failure:
     runs-on: ubuntu-latest
     needs: deploy-tools-prod
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: failure()
     steps:
       - run: |
           curl -X POST \

--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -105,7 +105,7 @@ jobs:
     # We want to ensure that in-progress cron runs against tools-prod
     # are canceled when we do a deploy so they don't fail erroneously
     concurrency:
-      group: e2e-${{ inputs.environment }}
+      group: api-test-${{ inputs.environment }}
       cancel-in-progress: true
     needs:
       - upgrade-web

--- a/bin/si-api-test/main.ts
+++ b/bin/si-api-test/main.ts
@@ -1,5 +1,5 @@
 import { SdfApiClient } from "./sdf_api_client.ts";
-import { createDefaultTestReportEntry, printTestReport, TestReportEntry } from "./test_execution_lib.ts";
+import { createDefaultTestReportEntry, printTestReport, TestReportEntry, testsFailed } from "./test_execution_lib.ts";
 import { checkEnvironmentVariables, parseArgs } from "./binary_execution_lib.ts";
 
 if (import.meta.main) {
@@ -132,5 +132,7 @@ if (import.meta.main) {
     await Promise.all(oneShotPromises);
     console.log("~~ FINAL REPORT GENERATED ~~");
     printTestReport(testReport);
+    let exitCode = testsFailed(testReport) ? 1 : 0;
+    Deno.exit(exitCode);
   }
 }

--- a/bin/si-api-test/test_execution_lib.ts
+++ b/bin/si-api-test/test_execution_lib.ts
@@ -17,7 +17,7 @@ export interface TestReportEntry {
     test_result: "success" | "failure";
     message?: string;
     test_execution_sequence: number;
-    uuid: string;   
+    uuid: string;
 }
 
 let executionCount = 0;
@@ -40,9 +40,13 @@ export function printTestReport(report: TestReportEntry[]) {
     console.log("Test Report:");
     console.log(JSON.stringify(report, null, 2));
 }
-  
+
+export function testsFailed(report: TestReportEntry[]) {
+  return report.some(test => test.test_result === 'failure');
+}
+
 export class ExecutionTracker {
-        
+
     private reports: TestReport[] = [];
 
     startTest(testName: string): TestReport {
@@ -68,4 +72,5 @@ export class ExecutionTracker {
     getReports(): TestReport[] {
         return this.reports;
     }
+
 }


### PR DESCRIPTION
This fixes the concurrency of the api-tests in the pipeline so they don't inadvertently cancel the cypress tests. Tests should also exit 1 if they contain a `failure`.