### PR TITLE
feat(dal): use corrections to protect socket arity

### DIFF
--- a/lib/dal-test/src/test_exclusive_schemas/mod.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/mod.rs
@@ -28,6 +28,7 @@ use si_pkg::{
 };
 use starfield::migrate_test_exclusive_schema_etoiles;
 use starfield::migrate_test_exclusive_schema_morningstar;
+use starfield::migrate_test_exclusive_schema_private_language;
 use starfield::migrate_test_exclusive_schema_starfield;
 use swifty::migrate_test_exclusive_schema_swifty;
 
@@ -48,6 +49,7 @@ const PKG_CREATED_BY: &str = "System Initiative";
 pub(crate) async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
     migrate_test_exclusive_func_si_resource_payload_to_value(ctx).await?;
     migrate_test_exclusive_schema_starfield(ctx).await?;
+    migrate_test_exclusive_schema_private_language(ctx).await?;
     migrate_test_exclusive_schema_etoiles(ctx).await?;
     migrate_test_exclusive_schema_morningstar(ctx).await?;
     migrate_test_exclusive_schema_fallout(ctx).await?;

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
@@ -2,10 +2,10 @@ use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
 
 use crate::{
-    workspace_snapshot::graph::{
-        deprecated::v1::DeprecatedAttributePrototypeArgumentNodeWeightV1, LineageId,
+    workspace_snapshot::{
+        graph::{deprecated::v1::DeprecatedAttributePrototypeArgumentNodeWeightV1, LineageId},
+        node_weight::traits::CorrectTransforms,
     },
-    workspace_snapshot::node_weight::traits::CorrectTransforms,
     ComponentId, EdgeWeightKindDiscriminants, Timestamp,
 };
 

--- a/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
@@ -1,16 +1,24 @@
+use std::collections::HashMap;
+
+use petgraph::prelude::*;
 use serde::{Deserialize, Serialize};
 use si_events::merkle_tree_hash::MerkleTreeHash;
 use si_events::{ulid::Ulid, ContentHash};
 
-use crate::workspace_snapshot::content_address::ContentAddressDiscriminants;
-use crate::workspace_snapshot::graph::deprecated::v1::DeprecatedContentNodeWeightV1;
-use crate::workspace_snapshot::{
-    content_address::ContentAddress,
-    graph::LineageId,
-    node_weight::traits::CorrectTransforms,
-    node_weight::{NodeWeightError, NodeWeightResult},
+use crate::{
+    workspace_snapshot::{
+        content_address::{ContentAddress, ContentAddressDiscriminants},
+        graph::{deprecated::v1::DeprecatedContentNodeWeightV1, detect_updates::Update, LineageId},
+        node_weight::{traits::CorrectTransforms, NodeWeightError, NodeWeightResult},
+        NodeInformation,
+    },
+    ComponentId, EdgeWeightKindDiscriminants, SocketArity, WorkspaceSnapshotGraphV3,
 };
-use crate::EdgeWeightKindDiscriminants;
+
+use super::{
+    traits::{CorrectTransformsResult, SiVersionedNodeWeight},
+    NodeWeight,
+};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ContentNodeWeight {
@@ -177,4 +185,113 @@ impl From<DeprecatedContentNodeWeightV1> for ContentNodeWeight {
     }
 }
 
-impl CorrectTransforms for ContentNodeWeight {}
+fn remove_outgoing_prototype_argument_value_targets_to_dest(
+    graph: &WorkspaceSnapshotGraphV3,
+    prototype_idx: NodeIndex,
+    source: NodeInformation,
+    destination_component_id: ComponentId,
+) -> impl Iterator<Item = Update> + '_ {
+    graph
+        .edges_directed(prototype_idx, Outgoing)
+        .filter(move |edge_ref| {
+            EdgeWeightKindDiscriminants::PrototypeArgument == edge_ref.weight().kind().into()
+        })
+        .filter_map(move |edge_ref| {
+            graph
+                .get_node_weight_opt(edge_ref.target())
+                .and_then(|weight| match weight {
+                    NodeWeight::AttributePrototypeArgument(apa_inner) => {
+                        apa_inner.targets().and_then(|targets| {
+                            (targets.destination_component_id == destination_component_id)
+                                .then_some(weight)
+                        })
+                    }
+                    _ => None,
+                })
+                .map(|target_weight| Update::RemoveEdge {
+                    source,
+                    destination: target_weight.into(),
+                    edge_kind: EdgeWeightKindDiscriminants::PrototypeArgument,
+                })
+        })
+}
+
+impl CorrectTransforms for ContentNodeWeight {
+    fn correct_transforms(
+        &self,
+        graph: &WorkspaceSnapshotGraphV3,
+        mut updates: Vec<Update>,
+        _from_different_change_set: bool,
+    ) -> CorrectTransformsResult<Vec<Update>> {
+        if self.content_address_discriminants() != ContentAddressDiscriminants::AttributePrototype {
+            return Ok(updates);
+        }
+
+        let mut new_updates = vec![];
+
+        if let Some(self_idx) = graph.get_node_index_by_id_opt(self.id()) {
+            if let Some(input_socket_inner) = graph
+                .edges_directed(self_idx, Incoming)
+                .filter(|edge_ref| {
+                    EdgeWeightKindDiscriminants::Prototype == edge_ref.weight().kind().into()
+                })
+                .filter_map(|edge_ref| graph.get_node_weight_opt(edge_ref.source()))
+                .next()
+                .and_then(|node_weight| match node_weight {
+                    NodeWeight::InputSocket(inner) => Some(inner.inner()),
+                    _ => None,
+                })
+            {
+                if input_socket_inner.arity() != SocketArity::One {
+                    return Ok(updates);
+                }
+
+                let mut new_node_map = HashMap::new();
+
+                for update in &updates {
+                    match update {
+                        Update::NewNode { node_weight } => {
+                            if let NodeWeight::AttributePrototypeArgument(apa_inner) = node_weight {
+                                new_node_map.insert(node_weight.id(), apa_inner);
+                            }
+                        }
+                        Update::NewEdge {
+                            source,
+                            destination,
+                            edge_weight,
+                        } => {
+                            if source.id == self.id.into()
+                                && EdgeWeightKindDiscriminants::PrototypeArgument
+                                    == edge_weight.kind().into()
+                            {
+                                if let Some(&new_apa) = new_node_map.get(&destination.id.into()) {
+                                    let targets = match new_apa.targets() {
+                                        Some(targets) => targets,
+                                        None => {
+                                            // No targets, then we don't want you
+                                            continue;
+                                        }
+                                    };
+
+                                    new_updates.extend(
+                                        remove_outgoing_prototype_argument_value_targets_to_dest(
+                                            graph,
+                                            self_idx,
+                                            *source,
+                                            targets.destination_component_id,
+                                        ),
+                                    );
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        updates.extend(new_updates);
+
+        Ok(updates)
+    }
+}

--- a/lib/dal/tests/integration_test/module.rs
+++ b/lib/dal/tests/integration_test/module.rs
@@ -33,6 +33,7 @@ async fn list_modules(ctx: &DalContext) {
         "morningstar".to_string(),
         "pet_shop".to_string(),
         "pirate".to_string(),
+        "private_language".to_string(),
         "si-intrinsic-funcs".to_string(),
         "small even lego".to_string(),
         "small odd lego".to_string(),

--- a/lib/dal/tests/integration_test/node_weight.rs
+++ b/lib/dal/tests/integration_test/node_weight.rs
@@ -1,3 +1,4 @@
+mod attribute_prototype;
 mod attribute_value;
 mod component;
 mod ordering;

--- a/lib/dal/tests/integration_test/node_weight/attribute_prototype.rs
+++ b/lib/dal/tests/integration_test/node_weight/attribute_prototype.rs
@@ -1,0 +1,77 @@
+use dal::DalContext;
+use dal_test::{
+    expected::{
+        apply_change_set_to_base, commit_and_update_snapshot_to_visibility,
+        fork_from_head_change_set, update_visibility_and_snapshot_to_visibility, ExpectComponent,
+    },
+    helpers::connect_components_with_socket_names,
+    test,
+};
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn socket_with_arity_of_one_can_only_have_one_input(ctx: &mut DalContext) {
+    let your_beetle = ExpectComponent::create_named(ctx, "private_language", "your_beetle").await;
+    let my_beetle = ExpectComponent::create_named(ctx, "private_language", "my_beetle").await;
+    let beetle_in_a_box = ExpectComponent::create_named(ctx, "etoiles", "beetle_in_a_box")
+        .await
+        .component(ctx)
+        .await;
+
+    apply_change_set_to_base(ctx).await;
+
+    // connect your_beetle to beetle_in_a_box in one change set
+    let cs_1 = fork_from_head_change_set(ctx).await;
+    connect_components_with_socket_names(
+        ctx,
+        your_beetle.id(),
+        "private_language",
+        beetle_in_a_box.id(),
+        "private_language",
+    )
+    .await
+    .expect("connect components");
+    commit_and_update_snapshot_to_visibility(ctx).await;
+
+    let connections_on_cs_1 = beetle_in_a_box
+        .incoming_connections(ctx)
+        .await
+        .expect("get incoming connections");
+    assert_eq!(1, connections_on_cs_1.len());
+    assert_eq!(your_beetle.id(), connections_on_cs_1[0].from_component_id);
+
+    // connect my_beetle to beetle_in_a_box in another change set
+    let _cs_2 = fork_from_head_change_set(ctx).await;
+    connect_components_with_socket_names(
+        ctx,
+        my_beetle.id(),
+        "private_language",
+        beetle_in_a_box.id(),
+        "private_language",
+    )
+    .await
+    .expect("connect components");
+
+    apply_change_set_to_base(ctx).await;
+
+    // Confirm that in change set 2, we still have only one connection and it's now from my_beetle, not your_beetle
+    let connections_on_head = beetle_in_a_box
+        .incoming_connections(ctx)
+        .await
+        .expect("get incoming connections");
+
+    assert_eq!(1, connections_on_head.len());
+    assert_eq!(my_beetle.id(), connections_on_head[0].from_component_id);
+
+    update_visibility_and_snapshot_to_visibility(ctx, cs_1.id).await;
+
+    let connections_on_cs_1_again = beetle_in_a_box
+        .incoming_connections(ctx)
+        .await
+        .expect("get incoming connections");
+    assert_eq!(1, connections_on_cs_1_again.len());
+    assert_eq!(
+        my_beetle.id(),
+        connections_on_cs_1_again[0].from_component_id
+    );
+}


### PR DESCRIPTION
If a new connection update is detected for input socket with an Arity of one, issue RemoveEdge updates for any existing connections to ensure we don't accidentally merge multiple inputs to a 1-arity socket.