### PR TITLE
feat(web, sdf): Add ability to delete a secret

### DIFF
--- a/app/web/src/components/SecretCard.vue
+++ b/app/web/src/components/SecretCard.vue
@@ -56,6 +56,18 @@
         by
         {{ secret.createdInfo.actor.label }}
       </div>
+      <div class="grow flex flex-row items-center">
+        <div
+          :class="
+            clsx(
+              'italic text-xs text-neutral-400',
+              !detailedListItem && 'line-clamp-2',
+            )
+          "
+        >
+          Connected Components: {{ secret.connectedComponents.length }}
+        </div>
+      </div>
       <!-- TODO(Wendy) - eventually we will add expiry to secrets, here's the code to display it! -->
       <!-- <div
       v-if="detailedListItem"
@@ -94,6 +106,14 @@
         iconIdleTone="neutral"
         @click="emit('edit')"
       />
+      <IconButton
+        icon="trash"
+        tooltip="Delete"
+        iconTone="destructive"
+        :disabled="secret.connectedComponents.length > 0"
+        iconIdleTone="neutral"
+        @click="deleteSecret"
+      />
     </div>
   </div>
 </template>
@@ -102,13 +122,21 @@
 import { Timestamp } from "@si/vue-lib/design-system";
 import { PropType } from "vue";
 import clsx from "clsx";
-import { Secret } from "../store/secrets.store";
+import { Secret, useSecretsStore } from "../store/secrets.store";
 import IconButton from "./IconButton.vue";
 
-defineProps({
+const props = defineProps({
   secret: { type: Object as PropType<Secret>, required: true },
   detailedListItem: { type: Boolean },
 });
+
+const secretsStore = useSecretsStore();
+
+const deleteSecret = async () => {
+  if (!props.secret || !props.secret.id) return;
+
+  await secretsStore.DELETE_SECRET(props.secret.id);
+};
 
 const emit = defineEmits<{
   (e: "edit"): void;

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -242,6 +242,10 @@ export type WsEventPayloadMap = {
     actionId: ActionId;
     changeSetId: ChangeSetId;
   };
+  SecretDeleted: {
+    secretId: SecretId;
+    changeSetId: ChangeSetId;
+  };
   SecretUpdated: {
     secretId: SecretId;
     changeSetId: ChangeSetId;

--- a/app/web/src/store/secrets.store.ts
+++ b/app/web/src/store/secrets.store.ts
@@ -64,6 +64,7 @@ export type Secret = {
   createdInfo: ActorAndTimestamp;
   updatedInfo?: ActorAndTimestamp;
   expiration?: string;
+  connectedComponents: string[];
 };
 
 export interface SecretFormSchema {
@@ -301,6 +302,7 @@ export function useSecretsStore() {
                     actor: { kind: "user", label: userName, id: userId },
                     timestamp: Date(),
                   },
+                  connectedComponents: [],
                 });
                 this.secretIsTransitioning[id] = true;
 
@@ -402,6 +404,7 @@ export function useSecretsStore() {
                     actor: { kind: "user", label: userName, id: userId },
                     timestamp: Date(),
                   },
+                  connectedComponents: [],
                 });
                 this.secretIsTransitioning[tempId] = true;
 
@@ -433,7 +436,6 @@ export function useSecretsStore() {
               },
             });
           },
-          // This is totally unimplemented, as of 2024-01-29 -- Adam
           async DELETE_SECRET(id: SecretId) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
@@ -444,32 +446,15 @@ export function useSecretsStore() {
 
             if (_.isNil(secret)) return;
 
-            return new ApiRequest({
+            return new ApiRequest<Secret>({
               method: "delete",
               url: "secret",
               params: {
                 ...visibilityParams,
                 id,
               },
-              optimistic: () => {
-                this.secretIsTransitioning[secret.id] = true;
-
-                return () => {
-                  this.secretIsTransitioning[secret.id] = false;
-                };
-              },
               onSuccess: () => {
-                const secretsOnDef =
-                  this.secretsByDefinitionId[secret.definition];
-                if (secretsOnDef === undefined) return;
-
-                this.secretsByDefinitionId[secret.definition] =
-                  secretsOnDef.filter((s) => s.id !== id);
-
-                this.secretIsTransitioning[secret.id] = false;
-              },
-              onFail: () => {
-                changeSetsStore.creatingChangeSet = false;
+                // WsEvents will sort this out
               },
             });
           },
@@ -506,6 +491,13 @@ export function useSecretsStore() {
             },
             {
               eventType: "SecretUpdated",
+              callback: (data) => {
+                if (data.changeSetId !== changeSetId) return;
+                this.LOAD_SECRETS();
+              },
+            },
+            {
+              eventType: "SecretDeleted",
               callback: (data) => {
                 if (data.changeSetId !== changeSetId) return;
                 this.LOAD_SECRETS();

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -53,6 +53,7 @@ use crate::func::intrinsics::IntrinsicFunc;
 use crate::key_pair::KeyPairPk;
 use crate::layer_db_types::{SecretContent, SecretContentV1};
 use crate::prop::PropError;
+use crate::schema::variant::root_prop::RootPropChild;
 use crate::serde_impls::base64_bytes_serde;
 use crate::serde_impls::nonce_serde;
 use crate::workspace_snapshot::edge_weight::{EdgeWeightKind, EdgeWeightKindDiscriminants};
@@ -62,9 +63,9 @@ use crate::workspace_snapshot::node_weight::{NodeWeight, NodeWeightError};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
     id, implement_add_edge_to, AttributePrototype, AttributeValue, AttributeValueId,
-    ChangeSetError, DalContext, Func, FuncError, FuncId, HelperError, HistoryActor,
-    HistoryEventError, KeyPair, KeyPairError, SchemaVariantError, StandardModelError, Timestamp,
-    TransactionsError, UserPk,
+    ChangeSetError, ComponentError, ComponentId, DalContext, Func, FuncError, FuncId, HelperError,
+    HistoryActor, HistoryEventError, KeyPair, KeyPairError, Prop, SchemaVariant,
+    SchemaVariantError, StandardModelError, Timestamp, TransactionsError, UserPk,
 };
 use si_events::encrypted_secret::EncryptedSecretKeyParseError;
 
@@ -78,6 +79,7 @@ pub use algorithm::SecretVersion;
 pub use definition_view::SecretDefinitionView;
 pub use definition_view::SecretDefinitionViewError;
 pub use event::SecretCreatedPayload;
+pub use event::SecretDeletedPayload;
 pub use event::SecretUpdatedPayload;
 pub use view::SecretView;
 pub use view::SecretViewError;
@@ -95,6 +97,8 @@ pub enum SecretError {
     AttributeValue(#[from] AttributeValueError),
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
+    #[error("component error: {0}")]
+    Component(#[from] ComponentError),
     #[error("error when decrypting encrypted secret")]
     DecryptionFailed,
     #[error("error deserializing message: {0}")]
@@ -594,6 +598,54 @@ impl Secret {
             Ok(())
         })
         .await
+    }
+
+    /// Finds all the connected component Ids for the [`Secret`]
+    pub async fn find_connected_components(
+        self,
+        ctx: &DalContext,
+    ) -> SecretResult<Vec<ComponentId>> {
+        let secret_details = self.encrypted_secret_key().to_string();
+        let mut connected_components = Vec::new();
+        let mut secret_props = Vec::new();
+        let schema_variants = SchemaVariant::list_user_facing(ctx).await?;
+        for schema_variant in schema_variants {
+            let secrets_prop = Prop::find_prop_by_path(
+                ctx,
+                schema_variant.schema_variant_id.into(),
+                &RootPropChild::Secrets.prop_path(),
+            )
+            .await?;
+            let secret_props_children =
+                Prop::direct_child_props_ordered(ctx, secrets_prop.clone().id()).await?;
+            for secret_child in secret_props_children {
+                secret_props.push(secret_child.clone());
+            }
+        }
+
+        for secret_prop in secret_props {
+            let all_connected_attribute_values =
+                Prop::all_attribute_values_everywhere_for_prop_id(ctx, secret_prop.id()).await?;
+            for connected_av in all_connected_attribute_values {
+                let av = AttributeValue::get_by_id_or_error(ctx, connected_av).await?;
+                if let Some(val) = av.value(ctx).await? {
+                    if val == secret_details {
+                        let connected_component =
+                            AttributeValue::component_id(ctx, connected_av).await?;
+                        connected_components.push(connected_component)
+                    }
+                }
+            }
+        }
+        Ok(connected_components)
+    }
+
+    /// Deletes the secret node.
+    pub async fn delete(self, ctx: &DalContext) -> SecretResult<()> {
+        //TODO: Doesn't delete from layer_db or memory at this time!
+        ctx.workspace_snapshot()?.remove_node_by_id(self.id).await?;
+
+        Ok(())
     }
 
     async fn modify<L>(self, ctx: &DalContext, lambda: L) -> SecretResult<Self>

--- a/lib/dal/src/secret/event.rs
+++ b/lib/dal/src/secret/event.rs
@@ -18,6 +18,14 @@ pub struct SecretUpdatedPayload {
     change_set_id: ChangeSetId,
 }
 
+#[allow(missing_docs)]
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SecretDeletedPayload {
+    secret_id: SecretId,
+    change_set_id: ChangeSetId,
+}
+
 impl WsEvent {
     #[allow(missing_docs)]
     pub async fn secret_created(ctx: &DalContext, secret_id: SecretId) -> WsEventResult<Self> {
@@ -36,6 +44,18 @@ impl WsEvent {
         WsEvent::new(
             ctx,
             WsPayload::SecretUpdated(SecretUpdatedPayload {
+                secret_id,
+                change_set_id: ctx.change_set_id(),
+            }),
+        )
+        .await
+    }
+
+    #[allow(missing_docs)]
+    pub async fn secret_deleted(ctx: &DalContext, secret_id: SecretId) -> WsEventResult<Self> {
+        WsEvent::new(
+            ctx,
+            WsPayload::SecretDeleted(SecretDeletedPayload {
                 secret_id,
                 change_set_id: ctx.change_set_id(),
             }),

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -26,6 +26,7 @@ use crate::schema::variant::{
     SchemaVariantClonedPayload, SchemaVariantDeletedPayload, SchemaVariantSavedPayload,
     SchemaVariantUpdatedPayload,
 };
+use crate::secret::SecretDeletedPayload;
 use crate::status::StatusUpdate;
 use crate::user::OnlinePayload;
 use crate::{
@@ -108,6 +109,7 @@ pub enum WsPayload {
     SchemaVariantUpdated(frontend_types::SchemaVariant),
     SchemaVariantUpdateFinished(SchemaVariantUpdatedPayload),
     SecretCreated(SecretCreatedPayload),
+    SecretDeleted(SecretDeletedPayload),
     SecretUpdated(SecretUpdatedPayload),
     SetComponentPosition(ComponentSetPositionPayload),
     StatusUpdate(StatusUpdate),

--- a/lib/sdf-server/src/server/service/secret.rs
+++ b/lib/sdf-server/src/server/service/secret.rs
@@ -1,4 +1,4 @@
-use axum::routing::{get, patch};
+use axum::routing::{delete, get, patch};
 use axum::{response::Response, routing::post, Json, Router};
 use dal::{
     ChangeSetError, KeyPairError, SecretId, StandardModelError, TransactionsError, UserError,
@@ -11,6 +11,7 @@ use crate::server::impl_default_error_into_response;
 use crate::server::state::AppState;
 
 pub mod create_secret;
+pub mod delete_secret;
 pub mod get_public_key;
 pub mod list_secrets;
 pub mod update_secret;
@@ -18,6 +19,8 @@ pub mod update_secret;
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum SecretError {
+    #[error("can't delete a secret with components connected: {0}")]
+    CantDeleteSecret(SecretId),
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
     #[error("dal secret error: {0}")]
@@ -60,4 +63,5 @@ pub fn routes() -> Router<AppState> {
         .route("/", post(create_secret::create_secret))
         .route("/", get(list_secrets::list_secrets))
         .route("/", patch(update_secret::update_secret))
+        .route("/", delete(delete_secret::delete_secret))
 }

--- a/lib/sdf-server/src/server/service/secret/delete_secret.rs
+++ b/lib/sdf-server/src/server/service/secret/delete_secret.rs
@@ -1,0 +1,52 @@
+use axum::extract::Query;
+use axum::response::IntoResponse;
+use dal::SecretView;
+use dal::{ChangeSet, Visibility, WsEvent};
+use dal::{Secret, SecretId};
+use serde::{Deserialize, Serialize};
+
+use crate::server::extract::{AccessBuilder, HandlerContext};
+
+use super::{SecretError, SecretResult};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteSecretRequest {
+    pub id: SecretId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+pub type UpdateSecretResponse = SecretView;
+
+pub async fn delete_secret(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_tx): AccessBuilder,
+    Query(request): Query<DeleteSecretRequest>,
+) -> SecretResult<impl IntoResponse> {
+    let mut ctx = builder.build(request_tx.build(request.visibility)).await?;
+    let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
+
+    // Delete Secret
+    let secret = Secret::get_by_id_or_error(&ctx, request.id).await?;
+
+    let connected_components = secret.clone().find_connected_components(&ctx).await?;
+    if !connected_components.is_empty() {
+        return Err(SecretError::CantDeleteSecret(request.id));
+    }
+
+    secret.delete(&ctx).await?;
+
+    WsEvent::secret_deleted(&ctx, request.id)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    ctx.commit().await?;
+
+    let mut response = axum::response::Response::builder();
+    if let Some(force_change_set_id) = force_change_set_id {
+        response = response.header("force_change_set_id", force_change_set_id.to_string());
+    }
+    Ok(response.body(axum::body::Empty::new())?)
+}


### PR DESCRIPTION
We can delete a secret if it has no connected components. Now we will also allow a user to see how many components are connected to a secret as part of the secrets list

<img width="548" alt="Screenshot 2024-09-10 at 02 52 50" src="https://github.com/user-attachments/assets/983adb7d-c9b5-4607-9fe8-ae5274d44ccc">
