### PR TITLE
chore: remove proccess-exporter from prod

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -82,17 +82,5 @@ services:
     depends_on:
       - otelcol
 
-  process-exporter:
-    image: ncabatoff/process-exporter
-    profiles: [veritech]
-    command:
-      - '-procfs=/host/proc'
-      - '-config.path=/config/proc-exporter.yml'
-    ports:
-      - "9256:9256"
-    volumes:
-      - "config:/config/"
-      - /proc:/host/proc:ro
-
 volumes:
   config:


### PR DESCRIPTION
This tool is useful for collecting metrics about firecraccker specs, but ultimately burns a non-trivial amount of cpu on the machine that we could be using to operate more quickly. We can collect these usage metrics locally.