### PR TITLE
feat: don't throw 500s on action already enqueued

### DIFF
--- a/lib/sdf-server/src/server/service/change_set.rs
+++ b/lib/sdf-server/src/server/service/change_set.rs
@@ -75,6 +75,9 @@ impl IntoResponse for ChangeSetError {
         let (status, error_message) = match self {
             ChangeSetError::ChangeSetNotFound => (StatusCode::NOT_FOUND, self.to_string()),
             ChangeSetError::DalChangeSetApply(_) => (StatusCode::CONFLICT, self.to_string()),
+            ChangeSetError::ActionAlreadyEnqueued(_) => {
+                (StatusCode::NOT_MODIFIED, self.to_string())
+            }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 


### PR DESCRIPTION
Tested locally, shown to throw 304 instead now when you intentionally API call add the same action twice, no 500 modal

```
< HTTP/1.1 304 Not Modified
< Access-Control-Allow-Origin: *
< content-type: application/json
< content-length: 102
< access-control-allow-credentials: true
< vary: origin, access-control-request-method, access-control-request-headers
< date: Wed, 11 Sep 2024 00:05:28 GMT
< connection: keep-alive
< 
```

This was causing grief in Production + metrics