### PR TITLE
fix: avoid potential infinite loop in list_actions, add instrumentation

### DIFF
--- a/lib/dal/src/action/dependency_graph.rs
+++ b/lib/dal/src/action/dependency_graph.rs
@@ -32,6 +32,10 @@ impl ActionDependencyGraph {
         }
     }
 
+    pub fn is_acyclic(&self) -> bool {
+        petgraph::algo::toposort(self.inner.graph(), None).is_ok()
+    }
+
     /// Construct an [`ActionDependencyGraph`] of all of the queued [`Action`s][crate::action::Action]
     /// for the current [`WorkspaceSnapshot`][crate::WorkspaceSnapshot].
     #[instrument(
@@ -211,7 +215,6 @@ impl ActionDependencyGraph {
     /// Gets all downstream dependencies for the provided ActionId. This includes the entire subgraph
     /// starting at ActionId.
     #[instrument(level = "info", skip(self))]
-
     pub fn get_all_dependencies(&self, action_id: ActionId) -> Vec<ActionId> {
         let current_dependencies = self.inner.direct_reverse_dependencies_of(action_id);
         let mut all_dependencies = HashSet::new();

--- a/lib/sdf-server/src/server/service/action/list_actions.rs
+++ b/lib/sdf-server/src/server/service/action/list_actions.rs
@@ -7,6 +7,7 @@ use dal::Func;
 use dal::{action::ActionId, ActionPrototypeId, ChangeSetId, ComponentId, Visibility};
 use serde::{Deserialize, Serialize};
 use si_events::FuncRunId;
+use telemetry::prelude::*;
 
 use super::ActionResult;
 use crate::server::extract::{AccessBuilder, HandlerContext};
@@ -53,6 +54,10 @@ pub async fn list_actions(
     let mut queued = Vec::new();
 
     let action_graph = ActionDependencyGraph::for_workspace(&ctx).await?;
+    if !action_graph.is_acyclic() {
+        warn!("action graph for {:?} has a cycle", request.visibility);
+    }
+
     for action_id in action_ids {
         let action = Action::get_by_id(&ctx, action_id).await?;
 

--- a/lib/si-layer-cache/src/db/func_run.rs
+++ b/lib/si-layer-cache/src/db/func_run.rs
@@ -5,6 +5,7 @@ use si_events::{
     ActionId, ActionResultState, Actor, AttributeValueId, ContentHash, FuncRun, FuncRunId, Tenancy,
     WebEvent, WorkspacePk,
 };
+use telemetry::prelude::*;
 
 use crate::event::LayeredEventPayload;
 use crate::pg::PgLayer;
@@ -85,6 +86,7 @@ impl FuncRunDb {
         Ok(result)
     }
 
+    #[instrument(level = "info", skip_all)]
     pub async fn get_last_run_for_action_id(
         &self,
         workspace_pk: WorkspacePk,


### PR DESCRIPTION
`get_hold_status_influenced_by` will loop forever if there is a cycle in the dependency graph. Prevent that. Add instrumentation to detect cycles and also see more progress in list_actions.