### PR TITLE
fix: use json body instead of query in delete secret request

### DIFF
--- a/lib/sdf-server/src/server/service/secret/delete_secret.rs
+++ b/lib/sdf-server/src/server/service/secret/delete_secret.rs
@@ -1,5 +1,5 @@
-use axum::extract::Query;
 use axum::response::IntoResponse;
+use axum::Json;
 use dal::SecretView;
 use dal::{ChangeSet, Visibility, WsEvent};
 use dal::{Secret, SecretId};
@@ -22,7 +22,7 @@ pub type UpdateSecretResponse = SecretView;
 pub async fn delete_secret(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_tx): AccessBuilder,
-    Query(request): Query<DeleteSecretRequest>,
+    Json(request): Json<DeleteSecretRequest>,
 ) -> SecretResult<impl IntoResponse> {
     let mut ctx = builder.build(request_tx.build(request.visibility)).await?;
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;


### PR DESCRIPTION
https://github.com/systeminit/si/pull/4544 means we only allow content in the body of a DELETE method (this is the longstanding behavior). So this route, which was written before this fix landed, needs to be changed.