### PR TITLE
fix(web): don't create NONE component attribute store

### DIFF
--- a/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
+++ b/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
@@ -43,8 +43,10 @@ const {
   selectedEdge,
 } = storeToRefs(componentsStore);
 
-const attributesStore = useComponentAttributesStore(
-  selectedComponentId.value || "NONE",
+const attributesStore = computed(() =>
+  selectedComponentId.value
+    ? useComponentAttributesStore(selectedComponentId.value)
+    : undefined,
 );
 
 function typeDisplayName() {
@@ -119,8 +121,8 @@ const rightClickMenuItems = computed(() => {
     // set component type
     {
       const updateComponentType = (componentType: ComponentType) => {
-        if (selectedComponentId.value) {
-          attributesStore.SET_COMPONENT_TYPE({
+        if (selectedComponentId.value && attributesStore.value) {
+          attributesStore.value.SET_COMPONENT_TYPE({
             componentId: selectedComponentId.value,
             componentType,
           });


### PR DESCRIPTION
If component is not selected, the right click menu creates a component attribute store for the "NONE" component id, and then we react to events by attempting to fetch data about this "NONE" component. Let's avoid that.