### PR TITLE
fix: Only allow keypair access from the original workspaceId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.10"
+version = "0.60.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01dbcb6e2588fd64cfb6d7529661b06466419e4c54ed1c62d6510d2d0350a728"
+checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -632,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.4"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273dcdfd762fae3e1650b8024624e7cd50e484e37abdab73a7a706188ad34543"
+checksum = "03701449087215b5369c7ea17fef0dd5d24cb93439ec5af0c7615f58c3f22605"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.8"
+version = "0.60.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55"
+checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
 dependencies = [
  "xmlparser",
 ]
@@ -1414,9 +1414,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -5492,9 +5492,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -5512,9 +5512,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6098,9 +6098,9 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.2.6"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
+checksum = "f895e3734318cc55f1fe66258926c9b910c124d47520339efecbb6c59cec7c1f"
 dependencies = [
  "nom",
  "unicode_categories",

--- a/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
@@ -133,9 +133,9 @@
                 :key="source"
               >
                 <DropdownMenuItem
-                  checkable
                   :checked="propSource === source"
                   :label="source"
+                  checkable
                   @click="setSource(source)"
                 />
               </template>
@@ -166,8 +166,8 @@
         <div v-if="numberOfHiddenChildren > 0" class="attributes-panel-item">
           <!-- TODO(wendy) - If we want to add the option to show the hidden props, add the click handler here! -->
           <div
-            class="text-center pt-2xs italic text-2xs text-neutral-400"
             :style="{ paddingLeft: indentPxPlusOne }"
+            class="text-center pt-2xs italic text-2xs text-neutral-400"
           >
             +{{ numberOfHiddenChildren }} hidden empty prop{{
               numberOfHiddenChildren > 1 ? "s" : ""
@@ -329,9 +329,9 @@
         <template v-if="propKind === 'integer'">
           <input
             v-model="newValueNumber"
+            :disabled="!propIsEditable"
             spellcheck="false"
             type="number"
-            :disabled="!propIsEditable"
             @blur="onBlur"
             @focus="onFocus"
             @keyup.enter="updateValue"
@@ -341,9 +341,9 @@
           <input
             v-model="newValueString"
             :class="`${propLabelParts[0]}${propLabelParts[1]}`"
+            :disabled="!propIsEditable"
             spellcheck="false"
             type="text"
-            :disabled="!propIsEditable"
             @blur="onBlur"
             @focus="onFocus"
             @keyup.enter="updateValue"
@@ -353,8 +353,8 @@
           <!-- todo add show/hide controls -->
           <input
             v-model="newValueString"
-            type="password"
             :disabled="!propIsEditable"
+            type="password"
             @blur="onBlur"
             @focus="onFocus"
             @keyup.enter="updateValue"
@@ -366,8 +366,8 @@
           <textarea
             v-model="newValueString"
             :class="`$propLabelParts`"
-            spellcheck="false"
             :disabled="!propIsEditable"
+            spellcheck="false"
             @blur="onBlur"
             @focus="onFocus"
             @keydown.enter="(e) => e.metaKey && updateValue()"
@@ -396,8 +396,8 @@
           <input
             :checked="newValueBoolean"
             :class="`attributes-panel-item__hidden-input ${propLabelParts[0]}${propLabelParts[1]}`"
-            type="checkbox"
             :disabled="!propIsEditable"
+            type="checkbox"
             @blur="onBlur"
             @change="updateValue"
             @focus="onFocus"
@@ -442,7 +442,15 @@
             class="attributes-panel-item__secret-value-wrap"
             @click="secretModalRef?.open()"
           >
-            <div v-if="secret" class="attributes-panel-item__secret-value">
+            <div
+              v-if="secret"
+              :class="
+                clsx(
+                  'attributes-panel-item__secret-value',
+                  secret.isUsable ? 'bg-action-700' : 'bg-destructive-600',
+                )
+              "
+            >
               <Icon name="key" size="xs" />
               {{ secret.definition }} / {{ secret.name }}
             </div>
@@ -479,7 +487,6 @@
     <!-- VALIDATION DETAILS -->
     <div
       v-if="showValidationDetails && validation"
-      :style="{ marginLeft: indentPx }"
       :class="
         clsx(
           'attributes-panel-item__validation-details flex flex-col p-2xs border mx-xs text-xs translate-y-[-5px]',
@@ -487,6 +494,7 @@
           themeClasses('bg-destructive-100', 'bg-neutral-900'),
         )
       "
+      :style="{ marginLeft: indentPx }"
     >
       {{ validation.message }}
 
@@ -994,7 +1002,17 @@ function removeChildHandler() {
   });
 }
 
-const validation = computed(() => props.attributeDef?.validation);
+const validation = computed(() => {
+  if (widgetKind.value === "secret" && secret.value?.isUsable === false) {
+    return {
+      status: "Failure",
+      message:
+        "Unusable Secret: Created in another workspace. Edit it to be able to use it.",
+    };
+  }
+
+  return props.attributeDef?.validation;
+});
 
 function getKey() {
   if (isChildOfMap.value) return props.attributeDef?.mapKey;
@@ -1646,7 +1664,6 @@ const sourceSelectMenuRef = ref<InstanceType<typeof DropdownMenu>>();
   padding: 4px;
 }
 .attributes-panel-item__secret-value {
-  background: @colors-action-700;
   display: inline-block;
   padding: 2px 10px;
   border-radius: 4px;

--- a/app/web/src/components/SecretCard.vue
+++ b/app/web/src/components/SecretCard.vue
@@ -5,7 +5,10 @@
         'flex flex-row flex-none items-center overflow-hidden text-shade-100 dark:text-shade-0',
         detailedListItem
           ? 'border-b border-neutral-200 dark:border-neutral-500'
-          : 'border rounded h-[90px] cursor-pointer border-neutral-500 dark:hover:bg-action-700 hover:bg-action-100 dark:hover:outline-action-300 hover:outline-action-500 hover:outline -outline-offset-1',
+          : 'border rounded h-[90px]',
+        !detailedListItem && secret.isUsable
+          ? 'cursor-pointer border-neutral-500 dark:hover:bg-action-700 hover:bg-action-100 dark:hover:outline-action-300 hover:outline-action-500 hover:outline -outline-offset-1'
+          : 'cursor-default border-destructive-600',
       )
     "
   >
@@ -15,6 +18,9 @@
           clsx(
             'text-md font-bold leading-tight',
             detailedListItem ? 'break-words' : 'truncate',
+            secret.isUsable
+              ? 'text-neutral-500 dark:text-neutral-300'
+              : 'text-destructive-500 font-bold',
           )
         "
       >
@@ -42,19 +48,27 @@
         v-if="!secret.updatedInfo || detailedListItem"
         :class="
           clsx(
-            'text-xs text-neutral-500 dark:text-neutral-300',
+            'text-xs',
             !detailedListItem && 'truncate',
+            secret.isUsable
+              ? 'text-neutral-500 dark:text-neutral-300'
+              : 'text-destructive-500 font-bold',
           )
         "
       >
-        Created:
-        <Timestamp
-          :date="new Date(secret.createdInfo.timestamp)"
-          :relative="!detailedListItem"
-          :size="detailedListItem ? 'extended' : 'normal'"
-        />
-        by
-        {{ secret.createdInfo.actor.label }}
+        <template v-if="secret.isUsable">
+          Created:
+          <Timestamp
+            :date="new Date(secret.createdInfo.timestamp)"
+            :relative="!detailedListItem"
+            :size="detailedListItem ? 'extended' : 'normal'"
+          />
+          by
+          {{ secret.createdInfo.actor.label }}
+        </template>
+        <template v-else>
+          Created in another workspace. Edit secret to be able to use it.
+        </template>
       </div>
       <div class="grow flex flex-row items-center">
         <div
@@ -101,28 +115,28 @@
     <div v-if="detailedListItem" class="pr-sm flex flex-col gap-xs">
       <IconButton
         icon="edit"
-        tooltip="Edit"
-        iconTone="action"
         iconIdleTone="neutral"
+        iconTone="action"
+        tooltip="Edit"
         @click="emit('edit')"
       />
       <IconButton
-        icon="trash"
-        tooltip="Delete"
-        iconTone="destructive"
         :disabled="secret.connectedComponents.length > 0"
+        icon="trash"
         iconIdleTone="neutral"
+        iconTone="destructive"
+        tooltip="Delete"
         @click="deleteSecret"
       />
     </div>
   </div>
 </template>
 
-<script setup lang="ts">
+<script lang="ts" setup>
 import { Timestamp } from "@si/vue-lib/design-system";
 import { PropType } from "vue";
 import clsx from "clsx";
-import { Secret, useSecretsStore } from "../store/secrets.store";
+import { Secret, useSecretsStore } from "@/store/secrets.store";
 import IconButton from "./IconButton.vue";
 
 const props = defineProps({

--- a/app/web/src/components/SecretsModal.vue
+++ b/app/web/src/components/SecretsModal.vue
@@ -1,10 +1,10 @@
 <template>
   <Modal
     ref="modalRef"
-    class="bg-neutral-100 dark:bg-neutral-700 text-shade-100 dark:text-shade-0"
-    titleClasses="bg-shade-0 dark:bg-shade-100 text-shade-100 dark:text-shade-0"
-    noInnerPadding
     :noExit="addingSecret"
+    class="bg-neutral-100 dark:bg-neutral-700 text-shade-100 dark:text-shade-0"
+    noInnerPadding
+    titleClasses="bg-shade-0 dark:bg-shade-100 text-shade-100 dark:text-shade-0"
   >
     <template #title>
       <div class="flex flex-col overflow-hidden">
@@ -40,8 +40,8 @@
       <AddSecretForm
         v-if="addingSecret"
         :definitionId="definitionId"
-        @save="selectSecret"
         @cancel="cancelAddSecretForm"
+        @save="selectSecret"
       />
       <ScrollArea v-else class="m-sm">
         <RequestStatusMessage
@@ -54,7 +54,7 @@
             v-for="secret in secrets"
             :key="secret.id"
             :secret="secret"
-            @click="emit('select', secret)"
+            @click="secretCardClick(secret)"
           />
         </div>
         <div v-else class="flex flex-row items-center h-full">
@@ -74,17 +74,17 @@
           <div class="flex flex-row gap-sm pt-sm">
             <VButton
               icon="x"
+              label="Close"
               tone="shade"
               variant="ghost"
-              label="Close"
               @click="close"
             />
             <VButton
               v-if="!addingSecret"
-              label="Add Secret"
-              icon="plus"
-              tone="action"
               class="flex-grow"
+              icon="plus"
+              label="Add Secret"
+              tone="action"
               @click="showAddSecretForm"
             />
           </div>
@@ -94,7 +94,7 @@
   </Modal>
 </template>
 
-<script setup lang="ts">
+<script lang="ts" setup>
 import {
   VButton,
   RequestStatusMessage,
@@ -135,6 +135,12 @@ const showAddSecretForm = () => {
 
 const cancelAddSecretForm = () => {
   addingSecret.value = false;
+};
+
+const secretCardClick = (secret: Secret) => {
+  if (secret.isUsable) {
+    emit("select", secret);
+  }
 };
 
 const selectSecret = (secret: Secret) => {

--- a/app/web/src/store/secrets.store.ts
+++ b/app/web/src/store/secrets.store.ts
@@ -61,6 +61,7 @@ export type Secret = {
   definition: SecretDefinitionId;
   name: string;
   description?: string;
+  isUsable: boolean;
   createdInfo: ActorAndTimestamp;
   updatedInfo?: ActorAndTimestamp;
   expiration?: string;
@@ -298,6 +299,7 @@ export function useSecretsStore() {
                   definition,
                   description,
                   createdInfo,
+                  isUsable: true,
                   updatedInfo: {
                     actor: { kind: "user", label: userName, id: userId },
                     timestamp: Date(),
@@ -400,6 +402,7 @@ export function useSecretsStore() {
                   definition: definitionId,
                   name,
                   description,
+                  isUsable: true,
                   createdInfo: {
                     actor: { kind: "user", label: userName, id: userId },
                     timestamp: Date(),

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -1135,8 +1135,10 @@ impl FuncRunner {
 
             // Decrypt message from EncryptedSecret
             // Skip secret if unauthorized
+            // Skip secret if we can't find keypair
             let decrypted_secret = match encrypted_secret.decrypt(ctx).await {
-                Err(SecretError::KeyPair(KeyPairError::UnauthorizedKeyAccess)) => {
+                Err(SecretError::KeyPair(KeyPairError::UnauthorizedKeyAccess))
+                | Err(SecretError::KeyPair(KeyPairError::KeyPairNotFound(_))) => {
                     continue;
                 }
                 other_result => other_result,

--- a/lib/dal/src/queries/key_pair/get_by_pk.sql
+++ b/lib/dal/src/queries/key_pair/get_by_pk.sql
@@ -1,3 +1,4 @@
+-- This query does not filter by workspacePk, but this should be checked on the result
 SELECT row_to_json(key_pairs.*) AS object
 FROM key_pairs
 WHERE key_pairs.pk = $1 AND key_pairs.visibility_deleted_at IS NULL

--- a/lib/dal/src/queries/key_pair/public_key_get_current.sql
+++ b/lib/dal/src/queries/key_pair/public_key_get_current.sql
@@ -1,5 +1,5 @@
 SELECT row_to_json(key_pairs.*) as object
-FROM key_pairs as key_pairs
+FROM key_pairs
 WHERE key_pairs.workspace_pk = $1
 ORDER BY key_pairs.created_lamport_clock DESC
 LIMIT 1;

--- a/lib/dal/src/secret/view.rs
+++ b/lib/dal/src/secret/view.rs
@@ -37,6 +37,8 @@ pub struct SecretView {
     pub updated_info: Option<HistoryEventMetadata>,
     /// The list of component Ids connected to the secret [`Secret`].
     pub connected_components: Vec<ComponentId>,
+    /// If the secret can be used on this workspace
+    pub is_usable: bool,
 }
 
 impl SecretView {
@@ -74,6 +76,7 @@ impl SecretView {
             }
         };
 
+        let is_usable = secret.can_be_decrypted(ctx).await?;
         let connected_components = secret.clone().find_connected_components(ctx).await?;
 
         Ok(Self {
@@ -84,6 +87,7 @@ impl SecretView {
             created_info,
             updated_info,
             connected_components,
+            is_usable,
         })
     }
 }


### PR DESCRIPTION
Only allow keypairs to be accessed from their original workspace, to avoid secret leaks. If a secret is unusable when gathering before funcs, the respective before func will be skipped as if the secret was empty.

Also adds UI that shows unusable secrets clearly:

<img width="408" alt="image" src="https://github.com/user-attachments/assets/ee5042b7-3d0b-4622-bb7a-8be71ffb5180">

<img width="522" alt="image" src="https://github.com/user-attachments/assets/379d2a8e-43b0-4d8f-ad8e-2a9f5a80d092">

<img width="430" alt="image" src="https://github.com/user-attachments/assets/ff61e3d4-03f4-44a4-b192-76cad1b51e86">

