### PR TITLE
feat(dal,sdf): Expose the ability to configure Identity and Unset Attribute Bindings via SDF.

### DIFF
--- a/app/web/src/api/sdf/dal/func.ts
+++ b/app/web/src/api/sdf/dal/func.ts
@@ -95,6 +95,24 @@ export interface FuncArgument {
   updated_at: IsoDateString;
 }
 
+export enum FuncBackendKind {
+  Array = "Array",
+  Boolean = "Boolean",
+  Diff = "Diff",
+  Identity = "Identity",
+  Integer = "Integer",
+  JsAction = "JsAction",
+  JsAttribute = "JsAction",
+  JsAuthentication = "JsAuthentication",
+  Json = "Json",
+  JsReconciliation = "JsReconciliation",
+  JsSchemaVariantDefinition = "JsSchemaVariantDefinition",
+  Map = "Map",
+  Object = "Object",
+  String = "String",
+  Unset = "Unset",
+  Validation = "Validation",
+}
 export interface FuncSummary {
   funcId: FuncId;
   kind: FuncKind;
@@ -103,6 +121,7 @@ export interface FuncSummary {
   description: string | null;
   isLocked: boolean;
   arguments: FuncArgument[];
+  backendKind: FuncBackendKind;
   bindings: FuncBinding[];
   types?: string | null;
 }

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -319,6 +319,26 @@ impl Func {
         Self::get_by_id_inner(ctx, &hash, &func_node_weight).await
     }
 
+    /// If you know the func_id is supposed to be for an [`IntrinsicFunc`], get which one or error
+    pub async fn get_intrinsic_kind_by_id_or_error(
+        ctx: &DalContext,
+        id: FuncId,
+    ) -> FuncResult<IntrinsicFunc> {
+        let func = Self::get_by_id_or_error(ctx, id).await?;
+
+        Self::get_intrinsic_kind_by_id(ctx, id)
+            .await?
+            .ok_or(FuncError::IntrinsicFuncNotFound(func.name))
+    }
+
+    pub async fn get_intrinsic_kind_by_id(
+        ctx: &DalContext,
+        id: FuncId,
+    ) -> FuncResult<Option<IntrinsicFunc>> {
+        let func = Self::get_by_id_or_error(ctx, id).await?;
+        Ok(IntrinsicFunc::maybe_from_str(func.name.clone()))
+    }
+
     async fn get_by_id_inner(
         ctx: &DalContext,
         hash: &ContentHash,
@@ -702,6 +722,7 @@ impl Func {
             func_id: self.id.into(),
             kind: self.kind.into(),
             name: self.name.clone(),
+            backend_kind: self.backend_kind.into(),
             display_name: self.display_name.clone(),
             description: self.description.clone(),
             is_locked: self.is_locked,

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     workspace_snapshot::graph::WorkspaceSnapshotGraphError,
     AttributePrototype, AttributePrototypeId, AttributeValue, Component, DalContext,
-    EdgeWeightKind, Func, FuncId, OutputSocket, Prop, WorkspaceSnapshotError,
+    EdgeWeightKind, Func, FuncBackendKind, FuncId, OutputSocket, Prop, WorkspaceSnapshotError,
 };
 
 use super::{
@@ -80,8 +80,8 @@ impl AttributeBinding {
             AttributePrototypeEventualParent::SchemaVariantFromProp(_, prop_id) => {
                 AttributeFuncDestination::Prop(prop_id)
             }
-            AttributePrototypeEventualParent::SchemaVariantFromInputSocket(_, _) => {
-                return Err(FuncBindingError::MalformedInput("()".to_owned()));
+            AttributePrototypeEventualParent::SchemaVariantFromInputSocket(_, input_socket_id) => {
+                AttributeFuncDestination::InputSocket(input_socket_id)
             }
         };
         Ok(output_location)
@@ -131,6 +131,62 @@ impl AttributeBinding {
         Ok(output_location)
     }
 
+    /// assemble bindings for an [`IntrinsicFunc`]
+    /// This filters out Component specific bindings and bindings for input sockets
+    /// as we don't want users to be able to set prototypes for input sockets and we're
+    /// not supported component specific bindings just yet
+    pub(crate) async fn assemble_intrinsic_bindings(
+        ctx: &DalContext,
+        func_id: FuncId,
+    ) -> FuncBindingResult<Vec<FuncBinding>> {
+        let mut bindings = vec![];
+        let intrinsic_func_kind: IntrinsicFunc =
+            Func::get_intrinsic_kind_by_id_or_error(ctx, func_id).await?;
+
+        for attribute_prototype_id in AttributePrototype::list_ids_for_func_id(ctx, func_id).await?
+        {
+            let eventual_parent = Self::find_eventual_parent(ctx, attribute_prototype_id).await?;
+            // skip this binding if it's for a component (until we support component specific bindings)
+            if let EventualParent::Component(component_id) = eventual_parent {
+                trace!(
+                    "skipping component {} for intrinsic {}",
+                    component_id,
+                    intrinsic_func_kind
+                );
+                continue;
+            }
+            let output_location = Self::find_output_location(ctx, attribute_prototype_id).await?;
+            // skip this binding if it's for an input socket as we don't let users change bindings for input sockets
+            if let AttributeFuncDestination::InputSocket(input_socket_id) = output_location {
+                trace!(
+                    "skipping input socket {} for intrinsic {}",
+                    input_socket_id,
+                    intrinsic_func_kind
+                );
+                continue;
+            }
+            let attribute_prototype_argument_ids =
+                AttributePrototypeArgument::list_ids_for_prototype(ctx, attribute_prototype_id)
+                    .await?;
+
+            let mut argument_bindings = Vec::with_capacity(attribute_prototype_argument_ids.len());
+            for attribute_prototype_argument_id in attribute_prototype_argument_ids {
+                argument_bindings.push(
+                    AttributeArgumentBinding::assemble(ctx, attribute_prototype_argument_id)
+                        .await?,
+                );
+            }
+            bindings.push(FuncBinding::Attribute(AttributeBinding {
+                func_id,
+                attribute_prototype_id,
+                eventual_parent,
+                output_location,
+                argument_bindings,
+            }));
+        }
+        Ok(bindings)
+    }
+
     pub(crate) async fn assemble_attribute_bindings(
         ctx: &DalContext,
         func_id: FuncId,
@@ -173,6 +229,7 @@ impl AttributeBinding {
     /// Collect impacted AttributeValues and enqueue them for DependentValuesUpdate
     /// so the functions run upon being attached.
     /// Returns an error if we're trying to upsert an attribute binding for a locked [`SchemaVariant`]
+    /// This is also used for Intrinsics, and we return an error if incorrect config values are passed in
     pub async fn upsert_attribute_binding(
         ctx: &DalContext,
         func_id: FuncId,
@@ -181,9 +238,13 @@ impl AttributeBinding {
         prototype_arguments: Vec<AttributeArgumentBinding>,
     ) -> FuncBindingResult<AttributePrototype> {
         let func = Func::get_by_id_or_error(ctx, func_id).await?;
-        if func.kind != FuncKind::Attribute {
-            return Err(FuncBindingError::UnexpectedFuncKind(func.kind));
-        }
+
+        let needs_validate_intrinsic_input = match func.kind {
+            FuncKind::Attribute => false,
+            FuncKind::Intrinsic => true,
+            kind => return Err(FuncBindingError::UnexpectedFuncKind(kind)),
+        };
+
         // if a parent was specified, use it. otherwise find the schema variant
         // for the output location
         let eventual_parent = match eventual_parent {
@@ -193,9 +254,23 @@ impl AttributeBinding {
         // return an error if the parent is a schema variant and it's locked
         eventual_parent.error_if_locked(ctx).await?;
 
+        if needs_validate_intrinsic_input {
+            validate_intrinsic_inputs(
+                ctx,
+                func_id,
+                eventual_parent,
+                output_location,
+                prototype_arguments.clone(),
+            )
+            .await?;
+        }
+
         let attribute_prototype = AttributePrototype::new(ctx, func_id).await?;
         let attribute_prototype_id = attribute_prototype.id;
 
+        // cache attribute values that need to be updated from their prototype func after
+        // we update the prototype
+        let mut attribute_values_to_update = vec![];
         match output_location {
             AttributeFuncDestination::Prop(prop_id) => {
                 match eventual_parent {
@@ -203,6 +278,16 @@ impl AttributeBinding {
                         if let Some(existing_prototype_id) =
                             AttributePrototype::find_for_prop(ctx, prop_id, &None).await?
                         {
+                            // if we're setting this to unset, need to also clear any existing attribute values
+                            if func.backend_kind == FuncBackendKind::Unset {
+                                let attribute_value_ids = AttributePrototype::attribute_value_ids(
+                                    ctx,
+                                    existing_prototype_id,
+                                )
+                                .await?;
+                                attribute_values_to_update.extend(attribute_value_ids);
+                            }
+
                             // remove existing attribute prototype and arguments before we add the
                             // edge to the new one
 
@@ -221,6 +306,10 @@ impl AttributeBinding {
                         let attribute_value_ids =
                             Component::attribute_values_for_prop_id(ctx, component_id, prop_id)
                                 .await?;
+                        // if we're setting this to unset, need to also clear any existing attribute values
+                        if func.backend_kind == FuncBackendKind::Unset {
+                            attribute_values_to_update.extend(attribute_value_ids.clone());
+                        }
 
                         for attribute_value_id in attribute_value_ids {
                             AttributeValue::set_component_prototype_id(
@@ -238,11 +327,22 @@ impl AttributeBinding {
                 // remove existing attribute prototype and arguments
                 match eventual_parent {
                     EventualParent::SchemaVariant(_) => {
-                        if let Some(existing_proto) =
+                        if let Some(existing_prototype_id) =
                             AttributePrototype::find_for_output_socket(ctx, output_socket_id)
                                 .await?
                         {
-                            Self::delete_attribute_prototype_and_args(ctx, existing_proto).await?;
+                            // if we're setting this to unset, need to also clear any existing attribute values
+                            if func.backend_kind == FuncBackendKind::Unset {
+                                let attribute_value_ids = AttributePrototype::attribute_value_ids(
+                                    ctx,
+                                    existing_prototype_id,
+                                )
+                                .await?;
+                                attribute_values_to_update.extend(attribute_value_ids);
+                            }
+
+                            Self::delete_attribute_prototype_and_args(ctx, existing_prototype_id)
+                                .await?;
                         }
                         OutputSocket::add_edge_to_attribute_prototype(
                             ctx,
@@ -260,6 +360,10 @@ impl AttributeBinding {
                                 component_id,
                             )
                             .await?;
+                        // if we're setting this to unset, need to also clear any existing attribute values
+                        if func.backend_kind == FuncBackendKind::Unset {
+                            attribute_values_to_update.push(attribute_value_id);
+                        }
                         AttributeValue::set_component_prototype_id(
                             ctx,
                             attribute_value_id,
@@ -270,6 +374,17 @@ impl AttributeBinding {
                     }
                 }
             }
+            // we don't let users configure this right now
+            AttributeFuncDestination::InputSocket(_) => {
+                return Err(FuncBindingError::InvalidAttributePrototypeDestination(
+                    output_location,
+                ));
+            }
+        }
+
+        // if there are attribute values that need to be updated from prototype function - do it here!
+        for attribute_value in attribute_values_to_update {
+            AttributeValue::update_from_prototype_function(ctx, attribute_value).await?;
         }
 
         for arg in &prototype_arguments {
@@ -287,28 +402,51 @@ impl AttributeBinding {
                 }
             }
 
-            let attribute_prototype_argument =
-                AttributePrototypeArgument::new(ctx, attribute_prototype_id, arg.func_argument_id)
-                    .await?;
             match &arg.attribute_func_input_location {
                 super::AttributeFuncArgumentSource::Prop(prop_id) => {
+                    let attribute_prototype_argument = AttributePrototypeArgument::new(
+                        ctx,
+                        attribute_prototype_id,
+                        arg.func_argument_id,
+                    )
+                    .await?;
                     attribute_prototype_argument
                         .set_value_from_prop_id(ctx, *prop_id)
-                        .await?
+                        .await?;
                 }
                 super::AttributeFuncArgumentSource::InputSocket(input_socket_id) => {
+                    let attribute_prototype_argument = AttributePrototypeArgument::new(
+                        ctx,
+                        attribute_prototype_id,
+                        arg.func_argument_id,
+                    )
+                    .await?;
                     attribute_prototype_argument
                         .set_value_from_input_socket_id(ctx, *input_socket_id)
-                        .await?
+                        .await?;
                 }
                 // note: this isn't in use yet, but is ready for when we enable users to set default values via the UI
                 super::AttributeFuncArgumentSource::StaticArgument(value) => {
+                    let attribute_prototype_argument = AttributePrototypeArgument::new(
+                        ctx,
+                        attribute_prototype_id,
+                        arg.func_argument_id,
+                    )
+                    .await?;
                     attribute_prototype_argument
-                        .set_value_from_static_value(
-                            ctx,
-                            serde_json::from_str::<serde_json::Value>(value.as_str())?,
-                        )
-                        .await?
+                        .set_value_from_static_value(ctx, value.clone())
+                        .await?;
+                }
+                // we do not allow users to manually set these as inputs right now
+                super::AttributeFuncArgumentSource::Secret(secret_id) => {
+                    return Err(FuncBindingError::InvalidAttributePrototypeArgumentSource(
+                        AttributeFuncArgumentSource::Secret(*secret_id),
+                    ))
+                }
+                super::AttributeFuncArgumentSource::OutputSocket(output_socket_id) => {
+                    return Err(FuncBindingError::InvalidAttributePrototypeArgumentSource(
+                        AttributeFuncArgumentSource::OutputSocket(*output_socket_id),
+                    ))
                 }
             };
         }
@@ -334,6 +472,18 @@ impl AttributeBinding {
         eventual_parent.error_if_locked(ctx).await?;
 
         let func_id = AttributePrototype::func_id(ctx, attribute_prototype_id).await?;
+        // if this func is intrinsic, make sure everything looks good
+        if (Func::get_intrinsic_kind_by_id(ctx, func_id).await?).is_some() {
+            let output_location = Self::find_output_location(ctx, attribute_prototype_id).await?;
+            validate_intrinsic_inputs(
+                ctx,
+                func_id,
+                eventual_parent,
+                output_location,
+                prototype_arguments.clone(),
+            )
+            .await?;
+        };
         //remove existing arguments first
         Self::delete_attribute_prototype_args(ctx, attribute_prototype_id).await?;
 
@@ -352,27 +502,51 @@ impl AttributeBinding {
                 }
             }
 
-            let attribute_prototype_argument =
-                AttributePrototypeArgument::new(ctx, attribute_prototype_id, arg.func_argument_id)
-                    .await?;
             match &arg.attribute_func_input_location {
                 super::AttributeFuncArgumentSource::Prop(prop_id) => {
+                    let attribute_prototype_argument = AttributePrototypeArgument::new(
+                        ctx,
+                        attribute_prototype_id,
+                        arg.func_argument_id,
+                    )
+                    .await?;
                     attribute_prototype_argument
                         .set_value_from_prop_id(ctx, *prop_id)
-                        .await?
+                        .await?;
                 }
                 super::AttributeFuncArgumentSource::InputSocket(input_socket_id) => {
+                    let attribute_prototype_argument = AttributePrototypeArgument::new(
+                        ctx,
+                        attribute_prototype_id,
+                        arg.func_argument_id,
+                    )
+                    .await?;
                     attribute_prototype_argument
                         .set_value_from_input_socket_id(ctx, *input_socket_id)
-                        .await?
+                        .await?;
                 }
+                // note: this isn't in use yet, but is ready for when we enable users to set default values via the UI
                 super::AttributeFuncArgumentSource::StaticArgument(value) => {
+                    let attribute_prototype_argument = AttributePrototypeArgument::new(
+                        ctx,
+                        attribute_prototype_id,
+                        arg.func_argument_id,
+                    )
+                    .await?;
                     attribute_prototype_argument
-                        .set_value_from_static_value(
-                            ctx,
-                            serde_json::from_str::<serde_json::Value>(value.as_str())?,
-                        )
-                        .await?
+                        .set_value_from_static_value(ctx, value.clone())
+                        .await?;
+                }
+                // we do not allow users to manually set these as inputs right now
+                super::AttributeFuncArgumentSource::Secret(secret_id) => {
+                    return Err(FuncBindingError::InvalidAttributePrototypeArgumentSource(
+                        AttributeFuncArgumentSource::Secret(*secret_id),
+                    ))
+                }
+                super::AttributeFuncArgumentSource::OutputSocket(output_socket_id) => {
+                    return Err(FuncBindingError::InvalidAttributePrototypeArgumentSource(
+                        AttributeFuncArgumentSource::OutputSocket(*output_socket_id),
+                    ))
                 }
             };
         }
@@ -573,4 +747,89 @@ impl AttributeBinding {
 
         FuncBinding::for_func_id(ctx, new_func_id).await
     }
+}
+
+async fn validate_intrinsic_inputs(
+    ctx: &DalContext,
+    func_id: FuncId,
+    eventual_parent: EventualParent,
+    output_location: AttributeFuncDestination,
+    prototype_arguments: Vec<AttributeArgumentBinding>,
+) -> FuncBindingResult<()> {
+    let intrinsic_kind = Func::get_intrinsic_kind_by_id_or_error(ctx, func_id).await?;
+    if let EventualParent::Component(component_id) = eventual_parent {
+        return Err(FuncBindingError::CannotSetIntrinsicForComponent(
+            component_id,
+        ));
+    }
+    match intrinsic_kind {
+        IntrinsicFunc::Identity => {
+            // for now we only support configuring one input location at a time
+            if prototype_arguments.len() > 1 {
+                return Err(FuncBindingError::InvalidIntrinsicBinding);
+            }
+            match output_location {
+                // props can only take input from other props and input sockets
+                AttributeFuncDestination::Prop(_) => {
+                    let mut maybe_invalid_inputs = prototype_arguments.clone();
+                    maybe_invalid_inputs.retain(|arg| match arg.attribute_func_input_location {
+                        AttributeFuncArgumentSource::Prop(_) => false,
+                        AttributeFuncArgumentSource::InputSocket(_) => false,
+                        AttributeFuncArgumentSource::StaticArgument(_) => true,
+                        AttributeFuncArgumentSource::OutputSocket(_) => true,
+                        AttributeFuncArgumentSource::Secret(_) => true,
+                    });
+                    if !maybe_invalid_inputs.is_empty() {
+                        return Err(FuncBindingError::InvalidIntrinsicBinding);
+                    }
+                }
+                // output sockets can take input from props or input sockets
+                AttributeFuncDestination::OutputSocket(_) => {
+                    let mut maybe_invalid_inputs = prototype_arguments.clone();
+                    maybe_invalid_inputs.retain(|arg| match arg.attribute_func_input_location {
+                        AttributeFuncArgumentSource::Prop(_) => false,
+                        AttributeFuncArgumentSource::InputSocket(_) => false,
+                        AttributeFuncArgumentSource::StaticArgument(_) => true,
+                        AttributeFuncArgumentSource::OutputSocket(_) => true,
+                        AttributeFuncArgumentSource::Secret(_) => true,
+                    });
+                    if !maybe_invalid_inputs.is_empty() {
+                        return Err(FuncBindingError::InvalidIntrinsicBinding);
+                    }
+                }
+                // input sockets can't take input from anything this way
+                AttributeFuncDestination::InputSocket(_) => {
+                    return Err(FuncBindingError::InvalidAttributePrototypeDestination(
+                        output_location,
+                    ))
+                }
+            }
+        }
+        IntrinsicFunc::Unset => {
+            // ensure no args are sent
+            if !prototype_arguments.is_empty() {
+                return Err(FuncBindingError::InvalidIntrinsicBinding);
+            }
+            match output_location {
+                AttributeFuncDestination::Prop(_) | AttributeFuncDestination::OutputSocket(_) => {}
+                AttributeFuncDestination::InputSocket(_) => {
+                    return Err(FuncBindingError::InvalidIntrinsicBinding)
+                }
+            }
+        }
+        IntrinsicFunc::SetArray
+        | IntrinsicFunc::SetBoolean
+        | IntrinsicFunc::SetInteger
+        | IntrinsicFunc::SetJson
+        | IntrinsicFunc::SetMap
+        | IntrinsicFunc::SetObject
+        | IntrinsicFunc::SetString => {
+            // ensure there's only one value
+            if prototype_arguments.len() > 1 {
+                return Err(FuncBindingError::InvalidIntrinsicBinding);
+            }
+        }
+        IntrinsicFunc::Validation => return Err(FuncBindingError::InvalidIntrinsicBinding),
+    };
+    Ok(())
 }

--- a/lib/dal/src/func/binding/leaf.rs
+++ b/lib/dal/src/func/binding/leaf.rs
@@ -40,6 +40,10 @@ impl LeafBinding {
             let eventual_parent =
                 AttributeBinding::find_eventual_parent(ctx, attribute_prototype_id).await?;
 
+            if let EventualParent::Component(_) = eventual_parent {
+                // skip components for now
+                continue;
+            }
             let binding = match leaf_kind {
                 LeafKind::CodeGeneration => FuncBinding::CodeGeneration(LeafBinding {
                     func_id,

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -1033,7 +1033,8 @@ impl PkgExporter {
         schema_variant_id: SchemaVariantId,
         overridden_asset_func_id: Option<FuncId>,
     ) -> PkgResult<Vec<FuncSpec>> {
-        let related_funcs = SchemaVariant::all_funcs(ctx, schema_variant_id).await?;
+        let related_funcs =
+            SchemaVariant::all_funcs_without_intrinsics(ctx, schema_variant_id).await?;
         let mut funcs = vec![];
 
         for func in &related_funcs {

--- a/lib/dal/tests/integration_test/func/authoring/binding.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding.rs
@@ -3,6 +3,7 @@ use dal::{
     attribute::prototype::argument::{AttributePrototypeArgument, AttributePrototypeArgumentError},
     func::{
         argument::{FuncArgument, FuncArgumentKind},
+        authoring::FuncAuthoringClient,
         binding::{
             action::ActionBinding, attribute::AttributeBinding, authentication::AuthBinding,
             leaf::LeafBinding, AttributeArgumentBinding, AttributeFuncArgumentSource,
@@ -10,16 +11,135 @@ use dal::{
         },
     },
     prop::PropPath,
-    schema::variant::leaves::{LeafInputLocation, LeafKind},
+    property_editor::values::PropertyEditorValues,
+    schema::variant::{
+        authoring::VariantAuthoringClient,
+        leaves::{LeafInputLocation, LeafKind},
+    },
     workspace_snapshot::graph::WorkspaceSnapshotGraphError,
-    AttributePrototype, DalContext, Func, Prop, Schema, SchemaVariantError, WorkspaceSnapshotError,
+    AttributePrototype, Component, DalContext, Func, InputSocket, OutputSocket, Prop, Schema,
+    SchemaVariant, SchemaVariantError, Secret, WorkspaceSnapshotError,
 };
-use dal_test::{helpers::create_unlocked_variant_copy_for_schema_name, test};
+use dal_test::{
+    helpers::{
+        create_component_for_default_schema_name, create_unlocked_variant_copy_for_schema_name,
+        encrypt_message, ChangeSetTestHelpers,
+    },
+    test, WorkspaceSignup,
+};
+use itertools::Itertools;
 use pretty_assertions_sorted::assert_eq;
 
 mod action;
 mod attribute;
 mod authentication;
+
+#[test]
+#[ignore]
+async fn get_bindings_for_latest_schema_variants(ctx: &mut DalContext) {
+    let func_name = "test:createActionStarfield".to_string();
+
+    let func_id = Func::find_id_by_name(ctx, func_name)
+        .await
+        .expect("found func")
+        .expect("is some");
+
+    let mut bindings = FuncBinding::for_func_id(ctx, func_id)
+        .await
+        .expect("found func bindings");
+    assert_eq!(bindings.len(), 1);
+
+    let binding = bindings.pop().expect("has a binding");
+
+    let old_schema_variant_id = binding.get_schema_variant().expect("has a schema variant");
+
+    // this schema variant is locked
+    let old_schema_variant = SchemaVariant::get_by_id_or_error(ctx, old_schema_variant_id)
+        .await
+        .expect("has a schema variant");
+
+    //this one is locked
+    assert!(old_schema_variant.is_locked());
+
+    let unlocked_binding = FuncBinding::get_bindings_for_unlocked_schema_variants(ctx, func_id)
+        .await
+        .expect("got latest unlocked");
+    // no unlocked bindings currently
+    assert!(unlocked_binding.is_empty());
+
+    // manually unlock the sv
+    let new_sv = VariantAuthoringClient::create_unlocked_variant_copy(ctx, old_schema_variant_id)
+        .await
+        .expect("created unlocked copy");
+
+    // new sv should have old funcs attached?!
+    let new_bindings = FuncBinding::for_func_id(ctx, func_id)
+        .await
+        .expect("has bindings");
+
+    assert_eq!(
+        2,                  // expected
+        new_bindings.len(), // actual
+    );
+
+    for binding in new_bindings {
+        let _sv =
+            SchemaVariant::get_by_id_or_error(ctx, binding.get_schema_variant().expect("has sv"))
+                .await
+                .expect("has sv");
+    }
+
+    // now we should have 1 unlocked func binding
+    let mut latest_sv = FuncBinding::get_bindings_for_unlocked_schema_variants(ctx, func_id)
+        .await
+        .expect("got latest for default");
+
+    assert_eq!(1, latest_sv.len());
+
+    let latest_sv_from_binding = latest_sv
+        .pop()
+        .expect("has one")
+        .get_schema_variant()
+        .expect("has sv");
+    assert_eq!(latest_sv_from_binding, new_sv.id);
+
+    let latest_unlocked = FuncBinding::get_bindings_for_unlocked_schema_variants(ctx, func_id)
+        .await
+        .expect("got latest unlocked");
+
+    // should have one latest unlocked now!
+    assert_eq!(1, latest_unlocked.len());
+
+    // now create a copy of the func (unlock it!)
+
+    let new_func = FuncAuthoringClient::create_unlocked_func_copy(ctx, func_id, None)
+        .await
+        .expect("can create unlocked copy");
+    let new_func_id = new_func.id;
+
+    // get the bindings and make sure everything looks good
+    let mut latest_sv = FuncBinding::get_bindings_for_default_schema_variants(ctx, new_func_id)
+        .await
+        .expect("got latest for default");
+
+    assert_eq!(1, latest_sv.len());
+
+    // latest sv should be the new one!
+    let sv_id = latest_sv
+        .pop()
+        .expect("has one func")
+        .get_schema_variant()
+        .expect("has a schema variant");
+
+    assert_eq!(new_sv.id, sv_id);
+
+    // old func should have no unlocked variants
+    let unlocked_binding = FuncBinding::get_bindings_for_unlocked_schema_variants(ctx, func_id)
+        .await
+        .expect("got latest unlocked");
+    // no unlocked bindings currently
+    assert!(unlocked_binding.is_empty());
+}
 
 #[test]
 async fn for_action(ctx: &mut DalContext) {
@@ -356,6 +476,208 @@ async fn for_attribute_with_input_socket_input(ctx: &mut DalContext) {
     assert_eq!(FuncArgumentKind::Array, func_argument.kind);
     assert_eq!(Some(FuncArgumentKind::Object), func_argument.element_kind);
 }
+#[test]
+async fn for_intrinsics(ctx: &mut DalContext) {
+    let schema = Schema::find_by_name(ctx, "starfield")
+        .await
+        .expect("unable to get schema")
+        .expect("schema not found");
+    let schema_variant_id = schema
+        .get_default_schema_variant_id(ctx)
+        .await
+        .expect("unable to get schema variant")
+        .expect("schema variant not found");
+    let all_funcs = SchemaVariant::all_funcs(ctx, schema_variant_id)
+        .await
+        .expect("unable to get all funcs");
+    let mut unset_props = Vec::from([
+        PropPath::new(["root"]),
+        PropPath::new(["root", "si", "protected"]),
+        PropPath::new(["root", "si"]),
+        PropPath::new(["root", "si", "protected"]),
+        PropPath::new(["root", "secrets"]),
+        PropPath::new(["root", "resource"]),
+        PropPath::new(["root", "resource", "message"]),
+        PropPath::new(["root", "resource", "last_synced"]),
+        PropPath::new(["root", "resource", "payload"]),
+        PropPath::new(["root", "resource", "status"]),
+        PropPath::new(["root", "code"]),
+        PropPath::new(["root", "code", "codeItem"]),
+        PropPath::new(["root", "code", "codeItem", "format"]),
+        PropPath::new(["root", "code", "codeItem", "code"]),
+        PropPath::new(["root", "qualification"]),
+        PropPath::new(["root", "qualification", "qualificationItem"]),
+        PropPath::new(["root", "qualification", "qualificationItem", "result"]),
+        PropPath::new(["root", "qualification", "qualificationItem", "message"]),
+        PropPath::new(["root", "domain", "universe"]),
+        PropPath::new(["root", "domain"]),
+        PropPath::new(["root", "domain", "universe", "galaxies", "galaxy"]),
+        PropPath::new([
+            "root", "domain", "universe", "galaxies", "galaxy", "planets",
+        ]),
+        PropPath::new(["root", "domain", "universe", "galaxies", "galaxy", "sun"]),
+        PropPath::new(["root", "domain", "possible_world_b"]),
+        PropPath::new(["root", "domain", "possible_world_b", "wormhole_1"]),
+        PropPath::new([
+            "root",
+            "domain",
+            "possible_world_b",
+            "wormhole_1",
+            "wormhole_2",
+        ]),
+        PropPath::new([
+            "root",
+            "domain",
+            "possible_world_b",
+            "wormhole_1",
+            "wormhole_2",
+            "wormhole_3",
+        ]),
+        PropPath::new([
+            "root",
+            "domain",
+            "possible_world_a",
+            "wormhole_1",
+            "wormhole_2",
+            "wormhole_3",
+            "rigid_designator",
+        ]),
+        PropPath::new(["root", "domain", "possible_world_a"]),
+        PropPath::new(["root", "domain", "possible_world_a", "wormhole_1"]),
+        PropPath::new([
+            "root",
+            "domain",
+            "possible_world_a",
+            "wormhole_1",
+            "wormhole_2",
+        ]),
+        PropPath::new([
+            "root",
+            "domain",
+            "possible_world_a",
+            "wormhole_1",
+            "wormhole_2",
+            "wormhole_3",
+        ]),
+        PropPath::new(["root", "domain", "freestar"]),
+        PropPath::new(["root", "domain", "hidden_prop"]),
+        PropPath::new(["root", "deleted_at"]),
+    ]);
+    for func in all_funcs {
+        match func.backend_kind {
+            dal::FuncBackendKind::Unset => {
+                let attribute_bindings: Vec<AttributeBinding> =
+                    FuncBinding::get_attribute_bindings_for_func_id(ctx, func.id)
+                        .await
+                        .expect("could not get attribute bindings")
+                        .into_iter()
+                        .filter(|binding| {
+                            binding.eventual_parent
+                                == EventualParent::SchemaVariant(schema_variant_id)
+                        })
+                        .collect();
+                let mut prop_paths_for_bindings: Vec<PropPath> = vec![];
+                for binding in attribute_bindings {
+                    let AttributeFuncDestination::Prop(prop_id) = binding.output_location else {
+                        panic!("Non-Prop is set to unset, which is unexpected!")
+                    };
+                    let prop = Prop::get_by_id_or_error(ctx, prop_id)
+                        .await
+                        .expect("couldn't get prop");
+                    let path = prop.path(ctx).await.expect("could not get prop path");
+                    prop_paths_for_bindings.push(path);
+                }
+                // prop_paths_for_bindings.retain(|binding| !unset_props.contains(binding));
+                prop_paths_for_bindings.retain(|prop_path| {
+                    if unset_props.contains(prop_path) {
+                        unset_props.retain(|p| p != prop_path);
+                        false
+                    } else {
+                        true
+                    }
+                });
+                assert!(prop_paths_for_bindings.is_empty());
+            }
+            dal::FuncBackendKind::Identity => {
+                let attribute_bindings: Vec<AttributeBinding> =
+                    FuncBinding::get_attribute_bindings_for_func_id(ctx, func.id)
+                        .await
+                        .expect("could not get attribute bindings")
+                        .into_iter()
+                        .filter(|binding| {
+                            binding.eventual_parent
+                                == EventualParent::SchemaVariant(schema_variant_id)
+                        })
+                        .collect();
+                assert_eq!(2, attribute_bindings.len());
+                for binding in attribute_bindings {
+                    if let AttributeFuncDestination::Prop(prop_id) = binding.output_location {
+                        let prop = Prop::get_by_id_or_error(ctx, prop_id)
+                            .await
+                            .expect("couldn't get prop");
+                        let path = prop.path(ctx).await.expect("bad");
+                        match path.with_replaced_sep("/").as_str() {
+                            "root/domain/name" => {
+                                let arg_bindings: AttributeFuncArgumentSource = binding
+                                    .clone()
+                                    .argument_bindings
+                                    .into_iter()
+                                    .map(|binding| binding.attribute_func_input_location)
+                                    .collect_vec()
+                                    .pop()
+                                    .expect("has a value");
+                                let AttributeFuncArgumentSource::Prop(prop_id) = arg_bindings
+                                else {
+                                    panic!("Non-Prop is set to unset, which is unexpected!")
+                                };
+                                let prop = Prop::get_by_id_or_error(ctx, prop_id)
+                                    .await
+                                    .expect("couldn't get prop");
+                                let path = prop
+                                    .path(ctx)
+                                    .await
+                                    .expect("couldn't get prop path")
+                                    .with_replaced_sep("/");
+                                // ensure root/domain/name takes its value from root/si/name
+                                assert_eq!("root/si/name", path);
+                            }
+                            "root/domain/attributes" => {
+                                let arg_bindings: AttributeFuncArgumentSource = binding
+                                    .clone()
+                                    .argument_bindings
+                                    .into_iter()
+                                    .map(|binding| binding.attribute_func_input_location)
+                                    .collect_vec()
+                                    .pop()
+                                    .expect("has a value");
+                                let AttributeFuncArgumentSource::InputSocket(input_socket_id) =
+                                    arg_bindings
+                                else {
+                                    panic!("Non-Prop is set to unset, which is unexpected!")
+                                };
+                                let input_socket = InputSocket::get_by_id(ctx, input_socket_id)
+                                    .await
+                                    .expect("couldn't get prop");
+                                // ensure root/domain/attributes takes its value from the bethesda socket
+                                assert_eq!("bethesda", input_socket.name())
+                            }
+                            _ => panic!("unexpected prop set to identity"),
+                        }
+                    };
+                    if let AttributeFuncDestination::InputSocket(_) = binding.output_location {
+                        panic!("unexpected input socket set to identity")
+                    }
+                }
+            }
+            dal::FuncBackendKind::JsAttribute | dal::FuncBackendKind::JsAction => {} // not testing these right now
+            _ => {
+                panic!("there should not be any other funcs returned for this variant");
+            }
+        }
+    }
+    // make sure we found all of the expected props/sockets associated with intrinsics we care about (unset + identity)
+    assert!(unset_props.is_empty());
+}
 
 #[test]
 async fn code_gen_cannot_create_cycle(ctx: &mut DalContext) {
@@ -408,5 +730,323 @@ async fn code_gen_cannot_create_cycle(ctx: &mut DalContext) {
             ),
         ))) => {}
         _ => panic!("Test should fail if we don't get this error"),
+    }
+}
+
+#[test]
+async fn return_the_right_bindings(ctx: &mut DalContext, nw: &WorkspaceSignup) {
+    // create two components and draw an edge between them
+    // one is a secret defining component
+    // create a complicated component too
+    // ensure we're returning the right data
+    let _starfield = create_component_for_default_schema_name(ctx, "starfield", "starfield")
+        .await
+        .expect("could not create component");
+    let source_component = create_component_for_default_schema_name(ctx, "dummy-secret", "source")
+        .await
+        .expect("could not create component");
+    let source_schema_variant_id = Component::schema_variant_id(ctx, source_component.id())
+        .await
+        .expect("could not get schema variant id for component");
+    let destination_component =
+        create_component_for_default_schema_name(ctx, "fallout", "destination")
+            .await
+            .expect("could not create component");
+    let destination_schema_variant_id =
+        Component::schema_variant_id(ctx, destination_component.id())
+            .await
+            .expect("could not get schema variant id for component");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Cache the name of the secret definition from the test exclusive schema. Afterward, cache the
+    // prop we need for attribute value update.
+    let secret_definition_name = "dummy";
+    let reference_to_secret_prop = Prop::find_prop_by_path(
+        ctx,
+        source_schema_variant_id,
+        &PropPath::new(["root", "secrets", secret_definition_name]),
+    )
+    .await
+    .expect("could not find prop by path");
+
+    // Connect the two components to propagate the secret value and commit.
+    let source_output_socket = OutputSocket::find_with_name(ctx, "dummy", source_schema_variant_id)
+        .await
+        .expect("could not perform find with name")
+        .expect("output socket not found by name");
+    let destination_input_socket =
+        InputSocket::find_with_name(ctx, "dummy", destination_schema_variant_id)
+            .await
+            .expect("could not perform find with name")
+            .expect("input socket not found by name");
+    Component::connect(
+        ctx,
+        source_component.id(),
+        source_output_socket.id(),
+        destination_component.id(),
+        destination_input_socket.id(),
+    )
+    .await
+    .expect("could not connect");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Create the secret and commit.
+    let secret = Secret::new(
+        ctx,
+        "johnqt",
+        secret_definition_name.to_string(),
+        None,
+        &encrypt_message(ctx, nw.key_pair.pk(), &serde_json::json![{"value": "todd"}])
+            .await
+            .expect("could not encrypt message"),
+        nw.key_pair.pk(),
+        Default::default(),
+        Default::default(),
+    )
+    .await
+    .expect("cannot create secret");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // Use the secret in the source component and commit.
+    let property_values = PropertyEditorValues::assemble(ctx, source_component.id())
+        .await
+        .expect("unable to list prop values");
+    let reference_to_secret_attribute_value_id = property_values
+        .find_by_prop_id(reference_to_secret_prop.id)
+        .expect("could not find attribute value");
+    Secret::attach_for_attribute_value(
+        ctx,
+        reference_to_secret_attribute_value_id,
+        Some(secret.id()),
+    )
+    .await
+    .expect("could not attach secret");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+
+    // now lets get bindings and ensure nothing explodes
+    let funcs = Func::list_all(ctx).await.expect("could not get funcs");
+    for func in funcs {
+        let bindings = FuncBinding::for_func_id(ctx, func.id)
+            .await
+            .expect("could not get func bindings");
+        let intrinsic = Func::get_intrinsic_kind_by_id_or_error(ctx, func.id).await;
+        let maybe_intrinsic = match intrinsic {
+            Ok(intrinsic_kind) => Some(intrinsic_kind),
+            Err(_) => None,
+        };
+
+        for binding in bindings {
+            match binding {
+                FuncBinding::Attribute(attribute_binding) => {
+                    match attribute_binding.output_location {
+                        AttributeFuncDestination::Prop(_) => {
+                            // if the output location is a prop and the func is intrinsic, there are special things
+                            if let Some(intrinsic) = maybe_intrinsic {
+                                match intrinsic {
+                                    dal::func::intrinsics::IntrinsicFunc::Identity => {
+                                        // Props only take inputs from input sockets or other props
+                                        let mut maybe_invalid_args =
+                                            attribute_binding.argument_bindings.clone();
+                                        let mut maybe_valid_args =
+                                            attribute_binding.argument_bindings.clone();
+                                        maybe_invalid_args.retain(|arg| {
+                                            match arg.attribute_func_input_location {
+                                                AttributeFuncArgumentSource::Prop(_) => false,
+                                                AttributeFuncArgumentSource::InputSocket(_) => {
+                                                    false
+                                                }
+                                                AttributeFuncArgumentSource::StaticArgument(_) => {
+                                                    false // is this allowed? todo
+                                                }
+                                                AttributeFuncArgumentSource::OutputSocket(_) => {
+                                                    true
+                                                }
+                                                AttributeFuncArgumentSource::Secret(_) => true,
+                                            }
+                                        });
+                                        assert!(maybe_invalid_args.is_empty());
+                                        maybe_valid_args.retain(|arg| {
+                                            match arg.attribute_func_input_location {
+                                                AttributeFuncArgumentSource::Prop(_) => true,
+                                                AttributeFuncArgumentSource::InputSocket(_) => true,
+                                                AttributeFuncArgumentSource::StaticArgument(_) => {
+                                                    false
+                                                }
+                                                AttributeFuncArgumentSource::OutputSocket(_) => {
+                                                    false
+                                                }
+                                                AttributeFuncArgumentSource::Secret(_) => false,
+                                            }
+                                        });
+                                        // should only be one input right now
+                                        assert_eq!(maybe_valid_args.len(), 1);
+                                    }
+                                    dal::func::intrinsics::IntrinsicFunc::Unset => {
+                                        assert!(attribute_binding.argument_bindings.is_empty());
+                                    }
+                                    dal::func::intrinsics::IntrinsicFunc::SetArray
+                                    | dal::func::intrinsics::IntrinsicFunc::SetBoolean
+                                    | dal::func::intrinsics::IntrinsicFunc::SetInteger
+                                    | dal::func::intrinsics::IntrinsicFunc::SetJson
+                                    | dal::func::intrinsics::IntrinsicFunc::SetMap
+                                    | dal::func::intrinsics::IntrinsicFunc::SetObject
+                                    | dal::func::intrinsics::IntrinsicFunc::SetString
+                                    | dal::func::intrinsics::IntrinsicFunc::Validation => {
+                                        assert_eq!(attribute_binding.argument_bindings.len(), 1);
+                                    }
+                                }
+                            }
+                        }
+                        AttributeFuncDestination::OutputSocket(_) => {
+                            if let Some(intrinsic) = maybe_intrinsic {
+                                match intrinsic {
+                                    dal::func::intrinsics::IntrinsicFunc::Identity => {
+                                        // Output Sockets only take inputs from input sockets or props
+                                        let mut maybe_invalid_args =
+                                            attribute_binding.argument_bindings.clone();
+                                        let mut maybe_valid_args =
+                                            attribute_binding.argument_bindings.clone();
+                                        maybe_invalid_args.retain(|arg| {
+                                            match arg.attribute_func_input_location {
+                                                AttributeFuncArgumentSource::Prop(_) => false,
+                                                AttributeFuncArgumentSource::InputSocket(_) => {
+                                                    false
+                                                }
+                                                AttributeFuncArgumentSource::StaticArgument(_) => {
+                                                    true
+                                                }
+                                                AttributeFuncArgumentSource::OutputSocket(_) => {
+                                                    true
+                                                }
+                                                AttributeFuncArgumentSource::Secret(_) => true,
+                                            }
+                                        });
+                                        assert!(maybe_invalid_args.is_empty());
+                                        maybe_valid_args.retain(|arg| {
+                                            match arg.attribute_func_input_location {
+                                                AttributeFuncArgumentSource::Prop(_) => true,
+                                                AttributeFuncArgumentSource::InputSocket(_) => true,
+                                                AttributeFuncArgumentSource::StaticArgument(_) => {
+                                                    false
+                                                }
+                                                AttributeFuncArgumentSource::OutputSocket(_) => {
+                                                    false
+                                                }
+                                                AttributeFuncArgumentSource::Secret(_) => false,
+                                            }
+                                        });
+                                        // should only be one or zero input right now
+                                        assert!(maybe_valid_args.len() < 2);
+                                    }
+                                    // unset has no args
+                                    dal::func::intrinsics::IntrinsicFunc::Unset => {
+                                        assert!(attribute_binding.argument_bindings.is_empty());
+                                    }
+                                    // these intrinsics only have one arg
+                                    dal::func::intrinsics::IntrinsicFunc::SetArray
+                                    | dal::func::intrinsics::IntrinsicFunc::SetBoolean
+                                    | dal::func::intrinsics::IntrinsicFunc::SetInteger
+                                    | dal::func::intrinsics::IntrinsicFunc::SetJson
+                                    | dal::func::intrinsics::IntrinsicFunc::SetMap
+                                    | dal::func::intrinsics::IntrinsicFunc::SetObject
+                                    | dal::func::intrinsics::IntrinsicFunc::SetString
+                                    | dal::func::intrinsics::IntrinsicFunc::Validation => {
+                                        assert_eq!(attribute_binding.argument_bindings.len(), 1);
+                                    }
+                                }
+                            }
+                        }
+
+                        AttributeFuncDestination::InputSocket(_) => {
+                            panic!("should not be seeing input sockets for output locations")
+                        }
+                    }
+                }
+
+                FuncBinding::Authentication(_)
+                | FuncBinding::Action(_)
+                | FuncBinding::CodeGeneration(_)
+                | FuncBinding::Qualification(_) => {} // nothing really to check here
+            }
+        }
+
+        let func_summary = func
+            .into_frontend_type(ctx)
+            .await
+            .expect("could not get front end type");
+        for binding in func_summary.bindings.bindings {
+            match binding {
+                si_frontend_types::FuncBinding::Action {
+                    schema_variant_id,
+                    action_prototype_id,
+                    func_id,
+                    kind,
+                } => {
+                    assert!(kind.is_some());
+                    assert!(schema_variant_id.is_some());
+                    assert!(func_id.is_some());
+                    assert!(action_prototype_id.is_some());
+                }
+                si_frontend_types::FuncBinding::Attribute {
+                    component_id,
+                    schema_variant_id,
+                    prop_id,
+                    output_socket_id,
+                    func_id,
+                    attribute_prototype_id,
+                    ..
+                } => {
+                    assert!(component_id.is_none());
+                    assert!(schema_variant_id.is_some());
+                    match prop_id {
+                        Some(_) => {
+                            assert!(output_socket_id.is_none());
+                        }
+                        None => assert!(output_socket_id.is_some()),
+                    }
+
+                    assert!(func_id.is_some());
+                    assert!(attribute_prototype_id.is_some());
+                }
+                si_frontend_types::FuncBinding::CodeGeneration {
+                    schema_variant_id,
+                    component_id,
+                    inputs,
+                    func_id,
+                    attribute_prototype_id,
+                } => {
+                    assert!(schema_variant_id.is_some());
+                    assert!(component_id.is_none());
+                    for input in inputs {
+                        assert!(input != LeafInputLocation::Code.into())
+                    }
+                    assert!(func_id.is_some());
+                    assert!(attribute_prototype_id.is_some());
+                }
+                si_frontend_types::FuncBinding::Qualification {
+                    schema_variant_id,
+                    component_id,
+                    func_id,
+                    attribute_prototype_id,
+                    ..
+                } => {
+                    assert!(schema_variant_id.is_some());
+                    assert!(component_id.is_none());
+                    assert!(func_id.is_some());
+                    assert!(attribute_prototype_id.is_some());
+                }
+                si_frontend_types::FuncBinding::Authentication { func_id, .. } => {
+                    assert!(func_id.is_some());
+                }
+            }
+        }
     }
 }

--- a/lib/dal/tests/integration_test/func/authoring/binding/attribute.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding/attribute.rs
@@ -7,13 +7,20 @@ use dal::func::binding::{
     AttributeArgumentBinding, AttributeFuncArgumentSource, AttributeFuncDestination,
     EventualParent, FuncBinding,
 };
+use dal::func::intrinsics::IntrinsicFunc;
 use dal::prop::PropPath;
 use dal::schema::variant::authoring::VariantAuthoringClient;
 use dal::{
-    AttributePrototype, AttributePrototypeId, DalContext, Func, Prop, Schema, SchemaVariant,
+    AttributePrototype, AttributePrototypeId, DalContext, Func, FuncBackendKind, InputSocket,
+    OutputSocket, Prop, Schema, SchemaVariant,
 };
-use dal_test::helpers::ChangeSetTestHelpers;
+use dal_test::helpers::{
+    connect_components_with_socket_names, create_component_for_default_schema_name,
+    get_attribute_value_for_component, get_component_output_socket_value,
+    update_attribute_value_for_component, ChangeSetTestHelpers,
+};
 use dal_test::test;
+use itertools::Itertools;
 pub use si_frontend_types;
 use std::collections::HashSet;
 
@@ -223,6 +230,594 @@ async fn create_attribute_prototype_with_attribute_prototype_argument(ctx: &mut 
     assert_eq!("entries", argument.name.as_str());
     assert_eq!(FuncArgumentKind::Array, argument.kind);
     assert_eq!(Some(FuncArgumentKind::Object), argument.element_kind);
+}
+
+#[test]
+async fn create_intrinsic_binding_then_unset(ctx: &mut DalContext) {
+    // Let's create a new asset
+    let asset_name = "paulsTestAsset".to_string();
+    let description = None;
+    let link = None;
+    let category = "Integration Tests".to_string();
+    let color = "#00b0b0".to_string();
+    let first_variant = VariantAuthoringClient::create_schema_and_variant(
+        ctx,
+        asset_name.clone(),
+        description.clone(),
+        link.clone(),
+        category.clone(),
+        color.clone(),
+    )
+    .await
+    .expect("Unable to create new asset");
+
+    let schema = first_variant
+        .schema(ctx)
+        .await
+        .expect("Unable to get the schema for the variant");
+
+    let default_schema_variant = schema
+        .get_default_schema_variant_id(ctx)
+        .await
+        .expect("unable to get the default schema variant id");
+    assert!(default_schema_variant.is_some());
+    assert_eq!(default_schema_variant, Some(first_variant.id()));
+
+    // Now let's update the asset and create two props, an input socket, and an output socket
+    let new_code = "function main() {\n const myProp = new PropBuilder().setName(\"testProp\").setKind(\"string\").build();\n const inputSocket = new SocketDefinitionBuilder()
+    .setName(\"one\")
+    .setArity(\"many\")
+    .build();\n const outputSocket = new SocketDefinitionBuilder()
+    .setName(\"output\")
+    .setArity(\"many\")
+    .build();\n const anotherProp = new PropBuilder().setName(\"anotherProp\").setKind(\"integer\").build();\n  return new AssetBuilder().addProp(myProp).addInputSocket(inputSocket).addOutputSocket(outputSocket).addProp(anotherProp).build()\n}".to_string();
+
+    VariantAuthoringClient::save_variant_content(
+        ctx,
+        first_variant.id(),
+        &schema.name,
+        first_variant.display_name(),
+        first_variant.category(),
+        first_variant.description(),
+        first_variant.link(),
+        first_variant
+            .get_color(ctx)
+            .await
+            .expect("get color from schema variant"),
+        first_variant.component_type(),
+        Some(new_code),
+    )
+    .await
+    .expect("save variant contents");
+
+    let updated_sv_id = VariantAuthoringClient::regenerate_variant(ctx, first_variant.id())
+        .await
+        .expect("regenerate asset");
+
+    let another_prop = Prop::find_prop_id_by_path(
+        ctx,
+        updated_sv_id,
+        &PropPath::new(["root", "domain", "anotherProp"]),
+    )
+    .await
+    .expect("able to find anotherProp prop");
+    let test_prop = Prop::find_prop_id_by_path(
+        ctx,
+        updated_sv_id,
+        &PropPath::new(["root", "domain", "testProp"]),
+    )
+    .await
+    .expect("able to find anotherProp prop");
+    let input_socket = InputSocket::find_with_name_or_error(ctx, "one", updated_sv_id)
+        .await
+        .expect("couldn't find input socket");
+    let output_socket = OutputSocket::find_with_name_or_error(ctx, "output", updated_sv_id)
+        .await
+        .expect("could not find output socket");
+
+    // let's set another prop to identity of test prop
+    let output_location = AttributeFuncDestination::Prop(another_prop);
+    let input_location = AttributeFuncArgumentSource::Prop(test_prop);
+    // find the func for si:identity
+    let identity_func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity)
+        .await
+        .expect("could not find identity func");
+    let intrinsic_arg = FuncArgument::list_for_func(ctx, identity_func_id)
+        .await
+        .expect("could not get args");
+    assert_eq!(intrinsic_arg.len(), 1);
+    let func_arg_id = intrinsic_arg.first().expect("is some");
+    let arguments: Vec<AttributeArgumentBinding> = vec![
+        (AttributeArgumentBinding {
+            func_argument_id: func_arg_id.id,
+            attribute_func_input_location: input_location,
+            attribute_prototype_argument_id: None,
+        }),
+    ];
+
+    AttributeBinding::upsert_attribute_binding(
+        ctx,
+        identity_func_id,
+        Some(EventualParent::SchemaVariant(updated_sv_id)),
+        output_location,
+        arguments,
+    )
+    .await
+    .expect("could not upsert identity func");
+
+    // let's set test prop to identity of input socket
+    let output_location = AttributeFuncDestination::Prop(test_prop);
+    let input_location = AttributeFuncArgumentSource::InputSocket(input_socket.id());
+    // find the func for si:identity
+    let identity_func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity)
+        .await
+        .expect("could not find identity func");
+    let intrinsic_arg = FuncArgument::list_for_func(ctx, identity_func_id)
+        .await
+        .expect("could not get args");
+    assert_eq!(intrinsic_arg.len(), 1);
+    let func_arg_id = intrinsic_arg.first().expect("is some");
+    let arguments: Vec<AttributeArgumentBinding> = vec![
+        (AttributeArgumentBinding {
+            func_argument_id: func_arg_id.id,
+            attribute_func_input_location: input_location,
+            attribute_prototype_argument_id: None,
+        }),
+    ];
+
+    AttributeBinding::upsert_attribute_binding(
+        ctx,
+        identity_func_id,
+        Some(EventualParent::SchemaVariant(updated_sv_id)),
+        output_location,
+        arguments,
+    )
+    .await
+    .expect("could not upsert identity func");
+
+    // let's set output socket to identity of another prop
+    let output_location = AttributeFuncDestination::OutputSocket(output_socket.id());
+    let input_location = AttributeFuncArgumentSource::Prop(another_prop);
+    // find the func for si:identity
+    let identity_func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity)
+        .await
+        .expect("could not find identity func");
+    let intrinsic_arg = FuncArgument::list_for_func(ctx, identity_func_id)
+        .await
+        .expect("could not get args");
+    assert_eq!(intrinsic_arg.len(), 1);
+    let func_arg_id = intrinsic_arg.first().expect("is some");
+    let arguments: Vec<AttributeArgumentBinding> = vec![
+        (AttributeArgumentBinding {
+            func_argument_id: func_arg_id.id,
+            attribute_func_input_location: input_location,
+            attribute_prototype_argument_id: None,
+        }),
+    ];
+
+    AttributeBinding::upsert_attribute_binding(
+        ctx,
+        identity_func_id,
+        Some(EventualParent::SchemaVariant(updated_sv_id)),
+        output_location,
+        arguments,
+    )
+    .await
+    .expect("could not upsert identity func");
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not update");
+
+    // Let's ensure that our latest props/sockets are visible in the component
+    let component =
+        create_component_for_default_schema_name(ctx, schema.name.clone(), "demo component 2")
+            .await
+            .expect("could not create component");
+    let connected_component =
+        create_component_for_default_schema_name(ctx, "small even lego", "lego")
+            .await
+            .expect("could not create component");
+    // connect the two components
+    connect_components_with_socket_names(
+        ctx,
+        connected_component.id(),
+        "one",
+        component.id(),
+        "one",
+    )
+    .await
+    .expect("could not create connection");
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not update");
+
+    // let's make sure we can see the identity func for this schema variant
+    let maybe_funcs = SchemaVariant::all_funcs(ctx, updated_sv_id)
+        .await
+        .expect("could not get all funcs for sv");
+    let intrinsic = maybe_funcs
+        .into_iter()
+        .find(|func| func.is_intrinsic() && (func.backend_kind == FuncBackendKind::Identity))
+        .expect("is some");
+    let attributes = FuncBinding::get_attribute_bindings_for_func_id(ctx, intrinsic.id)
+        .await
+        .expect("could not get bindings");
+    let prototypes = attributes
+        .into_iter()
+        .filter(|p| p.eventual_parent == EventualParent::SchemaVariant(updated_sv_id))
+        .collect_vec();
+    assert_eq!(prototypes.len(), 3);
+    assert!(prototypes.into_iter().any(|binding| {
+        binding.output_location == AttributeFuncDestination::Prop(another_prop)
+            || binding.output_location == AttributeFuncDestination::Prop(test_prop)
+            || binding.output_location == AttributeFuncDestination::OutputSocket(output_socket.id())
+    }));
+
+    // Change attribute value for one on the component
+    update_attribute_value_for_component(
+        ctx,
+        connected_component.id(),
+        &["root", "domain", "one"],
+        serde_json::Value::String("test".to_string()),
+    )
+    .await
+    .expect("could not update attribute value");
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not update");
+    // check the other prop to make sure the value propagated
+
+    let test_prop_path = &["root", "domain", "testProp"];
+    let another_test_prop_path = &["root", "domain", "anotherProp"];
+
+    // check test prop to make sure the value propagated
+    let value = get_attribute_value_for_component(ctx, component.id(), test_prop_path)
+        .await
+        .expect("could not get attribute value")
+        .expect("attribute value is none");
+    assert_eq!(serde_json::Value::String("test".to_string()), value);
+
+    // check another prop too
+    let value = get_attribute_value_for_component(ctx, component.id(), another_test_prop_path)
+        .await
+        .expect("could not get attribute value")
+        .expect("attribute value is none");
+    assert_eq!(serde_json::Value::String("test".to_string()), value);
+
+    // check output socket
+    let value = get_component_output_socket_value(ctx, component.id(), "output")
+        .await
+        .expect("could not get attribute value")
+        .expect("value is empty");
+
+    assert_eq!(serde_json::Value::String("test".to_string()), value);
+
+    // let's set another_prop to unset now - which should clear the value fot that component
+    // and the output socket
+    let output_location = AttributeFuncDestination::Prop(another_prop);
+
+    let unset_func = Func::find_intrinsic(ctx, IntrinsicFunc::Unset)
+        .await
+        .expect("could not find unset func");
+    AttributeBinding::upsert_attribute_binding(
+        ctx,
+        unset_func,
+        Some(EventualParent::SchemaVariant(updated_sv_id)),
+        output_location,
+        vec![],
+    )
+    .await
+    .expect("could not upsert unset func");
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit");
+    // let's make sure we can see the identity func for this schema variant
+    let maybe_funcs = SchemaVariant::all_funcs(ctx, updated_sv_id)
+        .await
+        .expect("could not get all funcs for sv");
+    let intrinsic = maybe_funcs
+        .into_iter()
+        .find(|func| func.is_intrinsic() && (func.backend_kind == FuncBackendKind::Unset))
+        .expect("is some");
+    let attributes = FuncBinding::get_attribute_bindings_for_func_id(ctx, intrinsic.id)
+        .await
+        .expect("could not get bindings");
+    let prototypes = attributes
+        .into_iter()
+        .filter(|p| p.eventual_parent == EventualParent::SchemaVariant(updated_sv_id))
+        .collect_vec();
+    assert!(prototypes
+        .into_iter()
+        .any(|binding| binding.output_location == AttributeFuncDestination::Prop(another_prop)));
+
+    // let's make sure another_prop was cleared!
+    let value = get_attribute_value_for_component(ctx, component.id(), another_test_prop_path)
+        .await
+        .expect("could not get attribute value");
+
+    assert!(value.is_none());
+
+    // check the output socket too
+    let value = get_component_output_socket_value(ctx, component.id(), "output")
+        .await
+        .expect("could not get attribute value");
+    assert!(value.is_none());
+}
+
+#[test]
+async fn invalid_identity_bindings(ctx: &mut DalContext) {
+    // Let's create a new asset
+    let asset_name = "paulsTestAsset".to_string();
+    let description = None;
+    let link = None;
+    let category = "Integration Tests".to_string();
+    let color = "#00b0b0".to_string();
+    let first_variant = VariantAuthoringClient::create_schema_and_variant(
+        ctx,
+        asset_name.clone(),
+        description.clone(),
+        link.clone(),
+        category.clone(),
+        color.clone(),
+    )
+    .await
+    .expect("Unable to create new asset");
+
+    let schema = first_variant
+        .schema(ctx)
+        .await
+        .expect("Unable to get the schema for the variant");
+
+    let default_schema_variant = schema
+        .get_default_schema_variant_id(ctx)
+        .await
+        .expect("unable to get the default schema variant id");
+    assert!(default_schema_variant.is_some());
+    assert_eq!(default_schema_variant, Some(first_variant.id()));
+
+    // Now let's update the asset and create two props, an input socket, and an output socket
+    let new_code = "function main() {\n const myProp = new PropBuilder().setName(\"testProp\").setKind(\"string\").build();\n const inputSocket = new SocketDefinitionBuilder()
+        .setName(\"input\")
+        .setArity(\"many\")
+        .build();\n const outputSocket = new SocketDefinitionBuilder()
+        .setName(\"output\")
+        .setArity(\"many\")
+        .build();\n const anotherProp = new PropBuilder().setName(\"anotherProp\").setKind(\"integer\").build();\n  return new AssetBuilder().addProp(myProp).addInputSocket(inputSocket).addOutputSocket(outputSocket).addProp(anotherProp).build()\n}".to_string();
+
+    VariantAuthoringClient::save_variant_content(
+        ctx,
+        first_variant.id(),
+        &schema.name,
+        first_variant.display_name(),
+        first_variant.category(),
+        first_variant.description(),
+        first_variant.link(),
+        first_variant
+            .get_color(ctx)
+            .await
+            .expect("get color from schema variant"),
+        first_variant.component_type(),
+        Some(new_code),
+    )
+    .await
+    .expect("save variant contents");
+
+    let updated_sv_id = VariantAuthoringClient::regenerate_variant(ctx, first_variant.id())
+        .await
+        .expect("regenerate asset");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not update");
+
+    let another_prop = Prop::find_prop_id_by_path(
+        ctx,
+        updated_sv_id,
+        &PropPath::new(["root", "domain", "anotherProp"]),
+    )
+    .await
+    .expect("able to find anotherProp prop");
+    let test_prop = Prop::find_prop_id_by_path(
+        ctx,
+        updated_sv_id,
+        &PropPath::new(["root", "domain", "testProp"]),
+    )
+    .await
+    .expect("able to find anotherProp prop");
+    let input_socket = InputSocket::find_with_name_or_error(ctx, "input", updated_sv_id)
+        .await
+        .expect("couldn't find input socket");
+    let output_socket = OutputSocket::find_with_name_or_error(ctx, "output", updated_sv_id)
+        .await
+        .expect("could not find output socket");
+
+    // ensure we can't create a cycle when checking
+    // have test prop take another prop, and another prop take test prop
+    let cycle_check_guard = ctx
+        .workspace_snapshot()
+        .expect("could not get snapshot")
+        .enable_cycle_check()
+        .await;
+    // test prop can't take input from itself
+    let output_location = AttributeFuncDestination::Prop(test_prop);
+    let input_location = AttributeFuncArgumentSource::Prop(test_prop);
+    // find the func for si:identity
+    let identity_func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity)
+        .await
+        .expect("could not find identity func");
+    let intrinsic_arg = FuncArgument::list_for_func(ctx, identity_func_id)
+        .await
+        .expect("could not get args");
+    assert_eq!(intrinsic_arg.len(), 1);
+    let func_arg_id = intrinsic_arg.first().expect("is some");
+    let arguments: Vec<AttributeArgumentBinding> = vec![
+        (AttributeArgumentBinding {
+            func_argument_id: func_arg_id.id,
+            attribute_func_input_location: input_location,
+            attribute_prototype_argument_id: None,
+        }),
+    ];
+
+    let attempt = AttributeBinding::upsert_attribute_binding(
+        ctx,
+        identity_func_id,
+        Some(EventualParent::SchemaVariant(updated_sv_id)),
+        output_location,
+        arguments,
+    )
+    .await;
+    assert!(attempt.is_err());
+    // output socket can't take input from itself
+    let output_location = AttributeFuncDestination::OutputSocket(output_socket.id());
+    let input_location = AttributeFuncArgumentSource::OutputSocket(output_socket.id());
+    // find the func for si:identity
+    let identity_func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity)
+        .await
+        .expect("could not find identity func");
+    let intrinsic_arg = FuncArgument::list_for_func(ctx, identity_func_id)
+        .await
+        .expect("could not get args");
+    assert_eq!(intrinsic_arg.len(), 1);
+    let func_arg_id = intrinsic_arg.first().expect("is some");
+    let arguments: Vec<AttributeArgumentBinding> = vec![
+        (AttributeArgumentBinding {
+            func_argument_id: func_arg_id.id,
+            attribute_func_input_location: input_location,
+            attribute_prototype_argument_id: None,
+        }),
+    ];
+
+    let attempt = AttributeBinding::upsert_attribute_binding(
+        ctx,
+        identity_func_id,
+        Some(EventualParent::SchemaVariant(updated_sv_id)),
+        output_location,
+        arguments,
+    )
+    .await;
+    assert!(attempt.is_err());
+
+    // input socket can't take inputs from anything
+    let output_location = AttributeFuncDestination::InputSocket(input_socket.id());
+    let input_location = AttributeFuncArgumentSource::OutputSocket(output_socket.id());
+    // find the func for si:identity
+    let identity_func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity)
+        .await
+        .expect("could not find identity func");
+    let intrinsic_arg = FuncArgument::list_for_func(ctx, identity_func_id)
+        .await
+        .expect("could not get args");
+    assert_eq!(intrinsic_arg.len(), 1);
+    let func_arg_id = intrinsic_arg.first().expect("is some");
+    let arguments: Vec<AttributeArgumentBinding> = vec![
+        (AttributeArgumentBinding {
+            func_argument_id: func_arg_id.id,
+            attribute_func_input_location: input_location,
+            attribute_prototype_argument_id: None,
+        }),
+    ];
+
+    let attempt = AttributeBinding::upsert_attribute_binding(
+        ctx,
+        identity_func_id,
+        Some(EventualParent::SchemaVariant(updated_sv_id)),
+        output_location,
+        arguments,
+    )
+    .await;
+    assert!(attempt.is_err());
+
+    // prop can't take inputs from output socket
+    let output_location = AttributeFuncDestination::Prop(test_prop);
+    let input_location = AttributeFuncArgumentSource::OutputSocket(output_socket.id());
+    // find the func for si:identity
+    let identity_func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity)
+        .await
+        .expect("could not find identity func");
+    let intrinsic_arg = FuncArgument::list_for_func(ctx, identity_func_id)
+        .await
+        .expect("could not get args");
+    assert_eq!(intrinsic_arg.len(), 1);
+    let func_arg_id = intrinsic_arg.first().expect("is some");
+    let arguments: Vec<AttributeArgumentBinding> = vec![
+        (AttributeArgumentBinding {
+            func_argument_id: func_arg_id.id,
+            attribute_func_input_location: input_location,
+            attribute_prototype_argument_id: None,
+        }),
+    ];
+
+    let attempt = AttributeBinding::upsert_attribute_binding(
+        ctx,
+        identity_func_id,
+        Some(EventualParent::SchemaVariant(updated_sv_id)),
+        output_location,
+        arguments,
+    )
+    .await;
+    assert!(attempt.is_err());
+
+    let output_location = AttributeFuncDestination::Prop(test_prop);
+    let input_location = AttributeFuncArgumentSource::Prop(another_prop);
+    // find the func for si:identity
+    let identity_func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity)
+        .await
+        .expect("could not find identity func");
+    let intrinsic_arg = FuncArgument::list_for_func(ctx, identity_func_id)
+        .await
+        .expect("could not get args");
+    assert_eq!(intrinsic_arg.len(), 1);
+    let func_arg_id = intrinsic_arg.first().expect("is some");
+    let arguments: Vec<AttributeArgumentBinding> = vec![
+        (AttributeArgumentBinding {
+            func_argument_id: func_arg_id.id,
+            attribute_func_input_location: input_location,
+            attribute_prototype_argument_id: None,
+        }),
+    ];
+
+    let _attempt = AttributeBinding::upsert_attribute_binding(
+        ctx,
+        identity_func_id,
+        Some(EventualParent::SchemaVariant(updated_sv_id)),
+        output_location,
+        arguments,
+    )
+    .await
+    .expect("unable to upsert binding");
+
+    let output_location = AttributeFuncDestination::Prop(another_prop);
+    let input_location = AttributeFuncArgumentSource::Prop(test_prop);
+    // find the func for si:identity
+    let identity_func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity)
+        .await
+        .expect("could not find identity func");
+    let intrinsic_arg = FuncArgument::list_for_func(ctx, identity_func_id)
+        .await
+        .expect("could not get args");
+    assert_eq!(intrinsic_arg.len(), 1);
+    let func_arg_id = intrinsic_arg.first().expect("is some");
+    let arguments: Vec<AttributeArgumentBinding> = vec![
+        (AttributeArgumentBinding {
+            func_argument_id: func_arg_id.id,
+            attribute_func_input_location: input_location,
+            attribute_prototype_argument_id: None,
+        }),
+    ];
+
+    let attempt = AttributeBinding::upsert_attribute_binding(
+        ctx,
+        identity_func_id,
+        Some(EventualParent::SchemaVariant(updated_sv_id)),
+        output_location,
+        arguments,
+    )
+    .await;
+    assert!(attempt.is_err());
+    drop(cycle_check_guard);
 }
 
 #[test]

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -201,7 +201,9 @@ async fn all_funcs(ctx: &DalContext) {
 
     let (expected, actual) = prepare_for_assertion(
         &[
+            "si:identity",
             "si:resourcePayloadToValue",
+            "si:unset",
             "test:createActionSwifty",
             "test:deleteActionSwifty",
             "test:generateCode",
@@ -229,7 +231,9 @@ async fn all_funcs(ctx: &DalContext) {
     let (expected, actual) = prepare_for_assertion(
         &[
             "hesperus_is_phosphorus",
+            "si:identity",
             "si:resourcePayloadToValue",
+            "si:unset",
             "test:createActionStarfield",
             "test:falloutEntriesToGalaxies",
             "test:refreshActionStarfield",

--- a/lib/dal/tests/integration_test/schema/variant/view.rs
+++ b/lib/dal/tests/integration_test/schema/variant/view.rs
@@ -43,12 +43,14 @@ async fn get_schema_variant(ctx: &DalContext) {
         .await
         .expect("Unable to get all schema variant funcs");
 
-    assert_eq!(7, sv_funcs.len());
+    assert_eq!(9, sv_funcs.len());
 
     let mut func_names: Vec<String> = sv_funcs.iter().map(|f| f.name.clone()).collect();
     func_names.sort();
     let expected: Vec<String> = vec![
+        "si:identity".to_string(),
         "si:resourcePayloadToValue".to_string(),
+        "si:unset".to_string(),
         "test:createActionSwifty".to_string(),
         "test:deleteActionSwifty".to_string(),
         "test:generateCode".to_string(),

--- a/lib/rebaser-server/src/dvu_debouncer_task.rs
+++ b/lib/rebaser-server/src/dvu_debouncer_task.rs
@@ -539,7 +539,6 @@ impl DvuDebouncerTask {
                     si.change_set.id = %self.change_set_id,
                     "change set no longer open, not enqueuing dependent values updates",
                 );
-
                 return Ok(None);
             }
         }

--- a/lib/sdf-server/src/server/service/v2/func/binding/create_binding.rs
+++ b/lib/sdf-server/src/server/service/v2/func/binding/create_binding.rs
@@ -39,7 +39,7 @@ pub async fn create_binding(
     // add cycle check so we don't end up with a cycle as a result of creating this binding
     let cycle_check_guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
     match func.kind {
-        dal::func::FuncKind::Attribute => {
+        dal::func::FuncKind::Attribute | dal::func::FuncKind::Intrinsic => {
             for binding in request.bindings {
                 if let frontend_types::FuncBinding::Attribute {
                     func_id,
@@ -70,6 +70,7 @@ pub async fn create_binding(
                                     AttributeArgumentBinding::assemble_attribute_input_location(
                                         arg_binding.prop_id,
                                         arg_binding.input_socket_id,
+                                        arg_binding.static_value,
                                     )?;
                                 arguments.push(AttributeArgumentBinding {
                                     func_argument_id: arg_binding
@@ -271,6 +272,7 @@ pub async fn create_binding(
                 }
             }
         }
+
         _ => {
             return Err(FuncAPIError::WrongFunctionKindForBinding);
         }

--- a/lib/sdf-server/src/server/service/v2/func/binding/update_binding.rs
+++ b/lib/sdf-server/src/server/service/v2/func/binding/update_binding.rs
@@ -38,7 +38,7 @@ pub async fn update_binding(
     // add cycle check so we don't end up with a cycle as a result of updating this binding
     let cycle_check_guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
     match func.kind {
-        dal::func::FuncKind::Attribute => {
+        dal::func::FuncKind::Attribute | dal::func::FuncKind::Intrinsic => {
             for binding in request.bindings {
                 if let frontend_types::FuncBinding::Attribute {
                     argument_bindings,
@@ -54,6 +54,7 @@ pub async fn update_binding(
                                     AttributeArgumentBinding::assemble_attribute_input_location(
                                         arg_binding.prop_id,
                                         arg_binding.input_socket_id,
+                                        arg_binding.static_value,
                                     )?;
                                 arguments.push(AttributeArgumentBinding {
                                     func_argument_id: arg_binding

--- a/lib/si-frontend-types-rs/src/func.rs
+++ b/lib/si-frontend-types-rs/src/func.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 use si_events::{
     ActionKind, ActionPrototypeId, AttributePrototypeArgumentId, AttributePrototypeId, ComponentId,
-    FuncArgumentId, FuncId, FuncKind, InputSocketId, OutputSocketId, PropId, SchemaVariantId,
-    Timestamp,
+    FuncArgumentId, FuncBackendKind, FuncId, FuncKind, InputSocketId, OutputSocketId, PropId,
+    SchemaVariantId, Timestamp,
 };
 use strum::{AsRefStr, Display, EnumIter, EnumString};
 
@@ -34,7 +34,9 @@ pub struct FuncSummary {
     #[serde(flatten)]
     pub bindings: FuncBindings,
     pub types: Option<String>,
+    pub backend_kind: FuncBackendKind,
 }
+
 #[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct FuncArgument {
@@ -136,6 +138,7 @@ pub struct AttributeArgumentBinding {
     pub attribute_prototype_argument_id: Option<AttributePrototypeArgumentId>,
     pub prop_id: Option<PropId>,
     pub input_socket_id: Option<InputSocketId>,
+    pub static_value: Option<serde_json::Value>,
 }
 
 /// This enum provides available child [`Prop`](crate::Prop) trees of [`RootProp`](crate::RootProp)


### PR DESCRIPTION
This is part one of the intrinsics work, adding support to SDF while filtering these out on the front end so there's no impact to users. 

Intrinsic Functions will rely on the existing Attribute Bindings subsystem (as opposed to adding another abstraction as with Leaf Funcs).  For now, we are filtering out component specific bindings, and bindings for Input Sockets as these will not be configurable by users.  

Now, when listing functions, we include Attribute Bindings for the Identity and Unset Functions, so that we can expose the ability for users to configure identity funcs in the UI as opposed to using the asset builder `setValueFrom()` or having to create an attribute function that simply returns another prop/socket.  

This enables us to build the experience for configuring them, but we can ship this without having that completed as there is no noticeable impact to users (just returning more data that we're not showing)

<div><img src="https://media0.giphy.com/media/yCZojdBqH7OkNayjMA/giphy.gif?cid=5a38a5a2ejno9xtixuamw2keqv84zn6bn87zorhrzudcxfh6&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/therokuchannel/">The Roku Channel</a> on <a href="https://giphy.com/gifs/therokuchannel-season-1-episode-3-empty-nest-refresh-yCZojdBqH7OkNayjMA">GIPHY</a></div>