### PR TITLE
Remove metadata field in billing event

### DIFF
--- a/lib/billing-events/src/lib.rs
+++ b/lib/billing-events/src/lib.rs
@@ -35,7 +35,7 @@ use si_data_nats::{
     jetstream,
 };
 use si_events::{
-    ChangeSetId, ChangeSetStatus, ComponentId, ResourceMetadata, SchemaId, SchemaVariantId, UserPk,
+    ChangeSetId, ChangeSetStatus, ComponentId, FuncRunId, SchemaId, SchemaVariantId, UserPk,
     WorkspacePk, WorkspaceSnapshotAddress,
 };
 use thiserror::Error;
@@ -88,8 +88,6 @@ pub struct BillingEvent {
 
     /// The total number of resources (conditional based on the event kind).
     pub resource_count: Option<usize>,
-    /// The metadata of all resources (conditional based on the event kind).
-    pub resource_metadata: Option<Vec<ResourceMetadata>>,
 
     /// The ID of the component (conditional based on the event kind).
     pub component_id: Option<ComponentId>,
@@ -101,6 +99,8 @@ pub struct BillingEvent {
     pub schema_id: Option<SchemaId>,
     /// The name of the schema (conditional based on the event kind).
     pub schema_name: Option<String>,
+    /// The ID of the func run (conditional based on the event kind).
+    pub func_run_id: Option<FuncRunId>,
 
     /// The kind of billing event.
     pub kind: BillingEventKind,

--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use petgraph::{Direction::Incoming, Outgoing};
 use serde::{Deserialize, Serialize};
-use si_events::ActionResultState;
+use si_events::{ActionResultState, FuncRunId};
 use si_layer_cache::LayerDbError;
 use si_pkg::ActionFuncSpecKind;
 use strum::Display;
@@ -296,7 +296,7 @@ impl ActionPrototype {
         ctx: &DalContext,
         id: ActionPrototypeId,
         component_id: ComponentId,
-    ) -> ActionPrototypeResult<Option<ActionRunResultSuccess>> {
+    ) -> ActionPrototypeResult<(Option<ActionRunResultSuccess>, FuncRunId)> {
         let component = Component::get_by_id(ctx, component_id).await?;
         let component_view = component.view(ctx).await?;
         let func_id = Self::func_id(ctx, id).await?;
@@ -398,7 +398,7 @@ impl ActionPrototype {
             }
         }
 
-        Ok(maybe_run_result)
+        Ok((maybe_run_result, func_run_value.func_run_id()))
     }
 
     pub async fn for_variant(

--- a/lib/dal/src/billing_publish.rs
+++ b/lib/dal/src/billing_publish.rs
@@ -26,6 +26,7 @@
 )]
 
 use billing_events::{BillingEvent, BillingEventKind, BillingEventsError};
+use si_events::FuncRunId;
 use telemetry::prelude::*;
 use thiserror::Error;
 
@@ -72,6 +73,8 @@ pub(crate) async fn for_head_change_set_pointer_update(
         return Ok(());
     };
 
+    // NOTE(nick): the metadata itself is not sent over the wire at the time of writing due to unbounded size in the
+    // message payload. We should store this locally and batch up in a separate process.
     let metadata = resource_metadata::list(ctx).await?;
     let resource_count = metadata.len();
 
@@ -84,13 +87,13 @@ pub(crate) async fn for_head_change_set_pointer_update(
         merge_requested_by_user_id: change_set.merge_requested_by_user_id.map(Into::into),
 
         resource_count: Some(resource_count),
-        resource_metadata: Some(metadata),
 
         component_id: None,
         component_name: None,
         schema_variant_id: None,
         schema_id: None,
         schema_name: None,
+        func_run_id: None,
 
         kind: BillingEventKind::HeadChangeSetPointerUpdate,
     };
@@ -121,6 +124,8 @@ pub(crate) async fn for_change_set_status_update(
         return Ok(());
     };
 
+    // NOTE(nick): the metadata itself is not sent over the wire at the time of writing due to unbounded size in the
+    // message payload. We should store this locally and batch up in a separate process.
     let metadata = resource_metadata::list(ctx).await?;
     let resource_count = metadata.len();
 
@@ -133,13 +138,13 @@ pub(crate) async fn for_change_set_status_update(
         merge_requested_by_user_id: change_set.merge_requested_by_user_id.map(Into::into),
 
         resource_count: Some(resource_count),
-        resource_metadata: Some(metadata),
 
         component_id: None,
         component_name: None,
         schema_variant_id: None,
         schema_id: None,
         schema_name: None,
+        func_run_id: None,
 
         kind: BillingEventKind::ChangeSetStatusUpdate,
     };
@@ -161,6 +166,7 @@ pub(crate) async fn for_change_set_status_update(
 pub(crate) async fn for_resource_create(
     ctx: &DalContext,
     component_id: ComponentId,
+    func_run_id: FuncRunId,
 ) -> BillingPublishResult<()> {
     let change_set = ctx.change_set()?;
 
@@ -187,13 +193,13 @@ pub(crate) async fn for_resource_create(
         merge_requested_by_user_id: change_set.merge_requested_by_user_id.map(Into::into),
 
         resource_count: None,
-        resource_metadata: None,
 
         component_id: Some(component_id.into()),
         component_name: Some(component_name),
         schema_variant_id: Some(schema_variant_id.into()),
         schema_id: Some(schema_id.into()),
         schema_name: Some(schema_name),
+        func_run_id: Some(func_run_id),
 
         kind: BillingEventKind::ResourceCreate,
     };
@@ -215,6 +221,7 @@ pub(crate) async fn for_resource_create(
 pub(crate) async fn for_resource_delete(
     ctx: &DalContext,
     component_id: ComponentId,
+    func_run_id: FuncRunId,
 ) -> BillingPublishResult<()> {
     let change_set = ctx.change_set()?;
 
@@ -241,13 +248,13 @@ pub(crate) async fn for_resource_delete(
         merge_requested_by_user_id: change_set.merge_requested_by_user_id.map(Into::into),
 
         resource_count: None,
-        resource_metadata: None,
 
         component_id: Some(component_id.into()),
         component_name: Some(component_name),
         schema_variant_id: Some(schema_variant_id.into()),
         schema_id: Some(schema_id.into()),
         schema_name: Some(schema_name),
+        func_run_id: Some(func_run_id),
 
         kind: BillingEventKind::ResourceDelete,
     };

--- a/lib/dal/src/job/definition/action.rs
+++ b/lib/dal/src/job/definition/action.rs
@@ -140,7 +140,8 @@ async fn inner_run(
     let (prototype_id, component_id) = prepare_for_execution(ctx, action_id).await?;
 
     // Execute the action function
-    let maybe_resource = ActionPrototype::run(ctx, prototype_id, component_id).await?;
+    let (maybe_resource, func_run_id) =
+        ActionPrototype::run(ctx, prototype_id, component_id).await?;
 
     // process the result
     process_execution(ctx, maybe_resource.as_ref(), action_id).await?;
@@ -172,10 +173,10 @@ async fn inner_run(
     // Now that everything has passed, we can send billing events.
     match prototype.kind {
         ActionKind::Create => {
-            billing_publish::for_resource_create(ctx, component_id).await?;
+            billing_publish::for_resource_create(ctx, component_id, func_run_id).await?;
         }
         ActionKind::Destroy => {
-            billing_publish::for_resource_delete(ctx, component_id).await?;
+            billing_publish::for_resource_delete(ctx, component_id, func_run_id).await?;
         }
         ActionKind::Manual | ActionKind::Refresh | ActionKind::Update => {}
     }

--- a/lib/dal/tests/integration_test/action.rs
+++ b/lib/dal/tests/integration_test/action.rs
@@ -165,10 +165,10 @@ async fn run(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    assert!(ActionPrototype::run(ctx, proto.id(), component.id())
+    let (maybe_resource, _func_run_id) = ActionPrototype::run(ctx, proto.id(), component.id())
         .await
-        .expect("unable to run ActionPrototype")
-        .is_some());
+        .expect("unable to run ActionPrototype");
+    assert!(maybe_resource.is_some());
 }
 
 #[test]


### PR DESCRIPTION
## Description

This PR removes the metadata field in billing events due to its potential unbounded size. While the metadata retrieval logic is still in play (mainly due to the "count"), it is unused. In the future, it should be batched up and sent in a another process or thread to adhere to data warehouse design conventions.

In addition to these changes, the ID of the func run is now recorded for both resource creations and resource deletions.

<img src="https://media4.giphy.com/media/4V5T0iN9dkyn7Xx5L2/giphy.gif"/>

## Disclaimer

The chunking idea from #4562 has been abandoned, but the PR is there for history's sake.