### PR TITLE
chore: increase parent_activity_timeout to 60 seconds

### DIFF
--- a/lib/si-layer-cache/src/activity_client.rs
+++ b/lib/si-layer-cache/src/activity_client.rs
@@ -18,6 +18,8 @@ use crate::{
     nats,
 };
 
+const PARENT_ACTIVITY_WAIT_TIMEOUT: u64 = 60;
+
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct ActivityClient {
@@ -134,7 +136,8 @@ impl ActivityClient {
                 false
             }
         });
-        let timeout_stream = filter_stream.timeout(Duration::from_secs(30));
+        let timeout_stream =
+            filter_stream.timeout(Duration::from_secs(PARENT_ACTIVITY_WAIT_TIMEOUT));
         pin!(timeout_stream);
         if let Some(activity_result_or_timeout) = timeout_stream.next().await {
             match activity_result_or_timeout {


### PR DESCRIPTION
This is a pretty naive attempt to allow the system to wait longer during rebases to ensure we are correct even if we are slower. During load testing, the vast majority of errors seem to come from pressure on nats. While we definitely can (and will) scale up nats, it seems like having more padding here would be good under high-pressure situations. We typically see either nats failing to ack, which is likely directly due to nats being under too much load, and us throwing [this error](https://github.com/systeminit/si/blob/main/lib/si-layer-cache/src/error.rs#L33-L34), which is probably due to the same root cause, but is a lever we can pull more directly.

<img src="https://media1.giphy.com/media/3s39mJ7zXU94mfAq4W/giphy.gif"/>