### PR TITLE
feat: move events away from base64 encooded, add timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
 name = "billing-events"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "remain",
  "serde",
  "serde_json",

--- a/lib/billing-events/BUCK
+++ b/lib/billing-events/BUCK
@@ -5,6 +5,7 @@ rust_library(
     deps = [
         "//lib/si-data-nats:si-data-nats",
         "//lib/si-events-rs:si-events",
+        "//third-party/rust:chrono",
         "//third-party/rust:remain",
         "//third-party/rust:serde",
         "//third-party/rust:serde_json",

--- a/lib/billing-events/Cargo.toml
+++ b/lib/billing-events/Cargo.toml
@@ -11,7 +11,7 @@ publish.workspace = true
 [dependencies]
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-events = { path = "../../lib/si-events-rs" }
-
+chrono = { workspace = true }
 remain = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/lib/billing-events/src/lib.rs
+++ b/lib/billing-events/src/lib.rs
@@ -25,6 +25,7 @@
     while_true
 )]
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Error;
 use si_data_nats::{
@@ -78,6 +79,8 @@ pub struct BillingEvent {
     pub workspace_id: WorkspacePk,
     /// The ID of the change set.
     pub change_set_id: ChangeSetId,
+    /// The UTC Timestamp when it was created
+    pub event_timestamp: DateTime<Utc>,
 
     /// The specific snapshot that the change set is pointing at.
     pub workspace_snapshot_address: WorkspaceSnapshotAddress,

--- a/lib/dal/src/billing_publish.rs
+++ b/lib/dal/src/billing_publish.rs
@@ -26,6 +26,7 @@
 )]
 
 use billing_events::{BillingEvent, BillingEventKind, BillingEventsError};
+use chrono::Utc;
 use si_events::FuncRunId;
 use telemetry::prelude::*;
 use thiserror::Error;
@@ -82,6 +83,7 @@ pub(crate) async fn for_head_change_set_pointer_update(
     let event = BillingEvent {
         workspace_id: workspace_id.into(),
         workspace_snapshot_address: change_set.workspace_snapshot_address,
+        event_timestamp: Utc::now(),
         change_set_status: change_set.status.into(),
         change_set_id: change_set.id.into(),
         merge_requested_by_user_id: change_set.merge_requested_by_user_id.map(Into::into),
@@ -133,6 +135,7 @@ pub(crate) async fn for_change_set_status_update(
     let event = BillingEvent {
         workspace_id: workspace_id.into(),
         workspace_snapshot_address: change_set.workspace_snapshot_address,
+        event_timestamp: Utc::now(),
         change_set_status: change_set.status.into(),
         change_set_id: change_set.id.into(),
         merge_requested_by_user_id: change_set.merge_requested_by_user_id.map(Into::into),
@@ -188,6 +191,7 @@ pub(crate) async fn for_resource_create(
     let event = BillingEvent {
         workspace_id: workspace_id.into(),
         workspace_snapshot_address: change_set.workspace_snapshot_address,
+        event_timestamp: Utc::now(),
         change_set_status: change_set.status.into(),
         change_set_id: change_set.id.into(),
         merge_requested_by_user_id: change_set.merge_requested_by_user_id.map(Into::into),
@@ -243,6 +247,7 @@ pub(crate) async fn for_resource_delete(
     let event = BillingEvent {
         workspace_id: workspace_id.into(),
         workspace_snapshot_address: change_set.workspace_snapshot_address,
+        event_timestamp: Utc::now(),
         change_set_status: change_set.status.into(),
         change_set_id: change_set.id.into(),
         merge_requested_by_user_id: change_set.merge_requested_by_user_id.map(Into::into),

--- a/lib/data-warehouse-stream-client/src/lib.rs
+++ b/lib/data-warehouse-stream-client/src/lib.rs
@@ -26,7 +26,6 @@
 )]
 
 use aws_sdk_firehose::{operation::put_record::PutRecordError, primitives::Blob, types::Record};
-use base64::{engine::general_purpose, Engine};
 use telemetry::prelude::*;
 use thiserror::Error;
 
@@ -75,7 +74,7 @@ impl DataWarehouseStreamClient {
     )]
     pub async fn publish(&self, raw_data: impl AsRef<[u8]>) -> DataWarehouseStreamClientResult<()> {
         let record = Record::builder()
-            .data(Blob::new(Self::base64_encode_data(raw_data)))
+            .data(Blob::new(raw_data.as_ref()))
             .build()?;
         let output = self
             .inner
@@ -89,9 +88,5 @@ impl DataWarehouseStreamClient {
             "output from sending put record request to kinesis firehose stream"
         );
         Ok(())
-    }
-
-    fn base64_encode_data(input: impl AsRef<[u8]>) -> String {
-        general_purpose::STANDARD_NO_PAD.encode(input)
     }
 }

--- a/lib/forklift-server/src/handlers.rs
+++ b/lib/forklift-server/src/handlers.rs
@@ -35,7 +35,6 @@ pub(crate) async fn process_request(
     Json(request): Json<BillingEvent>,
 ) -> HandlerResult<()> {
     trace!(kind = ?request.kind, ?request, "received billing event");
-
     let serialized_request = serde_json::to_vec(&request)?;
     state
         .data_warehouse_stream_client


### PR DESCRIPTION
We were base64 encoding before forklifting, this wasn't required but was caused by confusion in the rust docs for the AWS client lib. Also when the data landed in S3 we can't analyse it.

Also we had no idea which order the events landed in, so I've added a timestamp to each event.