### PR TITLE
fix: kill execution sender test

### DIFF
--- a/lib/dal/tests/integration_test/func/kill_execution.rs
+++ b/lib/dal/tests/integration_test/func/kill_execution.rs
@@ -37,7 +37,7 @@ async fn kill_execution_works(ctx: &mut DalContext) {
     .await
     .expect("could new leaf func");
     let code = "async function main() {
-        const ms = 30 * 1000;
+        const ms = 240 * 1000;
         const sleep = new Promise((resolve) => setTimeout(resolve, ms));
         await sleep;
         return { payload: { \"poop\": true }, status: \"ok\" };


### PR DESCRIPTION
The kill execution sender test runs a function that sleeps for 30 seconds, but this might not be enough time in CI for the test to run, given how many services it has to interact with. Up this to 240 seconds, which hopefully should make this test less flaky.