### PR TITLE
feat: add tokio_console to the telemetry stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,7 +606,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.1",
@@ -688,7 +694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "axum-macros",
  "base64 0.21.7",
  "bitflags 1.3.2",
@@ -719,6 +725,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.1",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-core"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +764,26 @@ dependencies = [
  "http-body 0.4.6",
  "mime",
  "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
  "tower-layer",
  "tower-service",
 ]
@@ -1337,6 +1390,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ed14aa9c9f927213c6e4f3ef75faaad3406134efe84ba2cb7983431d5f0931"
+dependencies = [
+ "futures-core",
+ "prost 0.13.2",
+ "prost-types",
+ "tonic 0.12.2",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e3a111a37f3333946ebf9da370ba5c5577b18eb342ec683eb488dd21980302"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost 0.13.2",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.12.2",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,7 +1736,7 @@ name = "cyclone-server"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.22.1",
  "bytes-lines-codec",
  "chrono",
@@ -2586,6 +2678,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.5.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,7 +2755,10 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
+ "base64 0.21.7",
  "byteorder",
+ "flate2",
+ "nom",
  "num-traits",
 ]
 
@@ -2845,7 +2959,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2868,9 +2982,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2937,6 +3053,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3493,7 +3622,7 @@ name = "module-index-server"
 version = "0.1.0"
 dependencies = [
  "auth-api-client",
- "axum",
+ "axum 0.6.20",
  "base64 0.22.1",
  "buck2-resources",
  "chrono",
@@ -3874,10 +4003,10 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.12.6",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -3888,8 +4017,8 @@ checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.12.6",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -4487,7 +4616,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.2",
 ]
 
 [[package]]
@@ -4501,6 +4640,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60caa6738c7369b940c3d49246a8d1749323674c65cb13010134f5c9bad5b519"
+dependencies = [
+ "prost 0.13.2",
 ]
 
 [[package]]
@@ -5304,7 +5465,7 @@ name = "sdf-server"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.22.1",
  "buck2-resources",
  "chrono",
@@ -6534,6 +6695,7 @@ dependencies = [
 name = "telemetry-application"
 version = "0.1.0"
 dependencies = [
+ "console-subscriber",
  "derive_builder",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -6551,7 +6713,7 @@ dependencies = [
 name = "telemetry-http"
 version = "0.1.0"
 dependencies = [
- "axum",
+ "axum 0.6.20",
  "http 0.2.12",
  "hyper 0.14.30",
  "remain",
@@ -6750,6 +6912,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -6983,17 +7146,47 @@ checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.12.6",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.5",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.2",
+ "socket2",
  "tokio",
  "tokio-stream",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ rust-version = "1.78"
 publish = false
 
 [workspace.dependencies]
+console-subscriber = "0.4.0"
 async-nats = { version = "0.36.0", features = ["service"] }
 async-recursion = "1.0.5"
 async-trait = "0.1.79"
@@ -175,7 +176,7 @@ tempfile = "3.10.1"
 test-log = { version = "0.2.15", default-features = false, features = ["trace"] }
 thiserror = "1.0.58"
 thread-priority = "1.1.0"
-tokio = { version = "1.37.0", features = ["full"] }
+tokio = { version = "1.37.0", features = ["full", "tracing"] }
 tokio-postgres = { version = "0.7.10", features = ["runtime", "with-chrono-0_4", "with-serde_json-1"] }
 tokio-postgres-rustls = { version = "0.11.1" }
 tokio-serde = { version = "0.9.0", features = ["json"] }

--- a/lib/telemetry-application-rs/BUCK
+++ b/lib/telemetry-application-rs/BUCK
@@ -4,6 +4,7 @@ rust_library(
     name = "telemetry-application",
     deps = [
         "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:console-subscriber",
         "//third-party/rust:derive_builder",
         "//third-party/rust:opentelemetry-otlp",
         "//third-party/rust:opentelemetry-semantic-conventions",

--- a/lib/telemetry-application-rs/Cargo.toml
+++ b/lib/telemetry-application-rs/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
+console-subscriber = { workspace = true }
 derive_builder = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }

--- a/lib/telemetry-application-rs/src/lib.rs
+++ b/lib/telemetry-application-rs/src/lib.rs
@@ -390,10 +390,12 @@ fn tracing_subscriber(
         (layer, reloader)
     };
 
+    let console_layer = console_subscriber::spawn();
     let registry = Registry::default();
     let registry = registry.with(console_log_layer);
     let registry = registry.with(otel_layer);
     let registry = registry.with(metrics_layer);
+    let registry = registry.with(console_layer);
 
     let handles = TelemetryHandles {
         console_log_filter_reload,

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -801,6 +801,23 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "atomic-waker-1.1.2.crate",
+    sha256 = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0",
+    strip_prefix = "atomic-waker-1.1.2",
+    urls = ["https://static.crates.io/crates/atomic-waker/1.1.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "atomic-waker-1.1.2",
+    srcs = [":atomic-waker-1.1.2.crate"],
+    crate = "atomic_waker",
+    crate_root = "atomic-waker-1.1.2.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+)
+
+http_archive(
     name = "atomic_refcell-0.1.13.crate",
     sha256 = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c",
     strip_prefix = "atomic_refcell-0.1.13",
@@ -1652,6 +1669,43 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "axum-0.7.5.crate",
+    sha256 = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf",
+    strip_prefix = "axum-0.7.5",
+    urls = ["https://static.crates.io/crates/axum/0.7.5/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "axum-0.7.5",
+    srcs = [":axum-0.7.5.crate"],
+    crate = "axum",
+    crate_root = "axum-0.7.5.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":async-trait-0.1.82",
+        ":axum-core-0.4.3",
+        ":bytes-1.7.1",
+        ":futures-util-0.3.30",
+        ":http-1.1.0",
+        ":http-body-1.0.1",
+        ":http-body-util-0.1.2",
+        ":itoa-1.0.11",
+        ":matchit-0.7.3",
+        ":memchr-2.7.4",
+        ":mime-0.3.17",
+        ":percent-encoding-2.3.1",
+        ":pin-project-lite-0.2.14",
+        ":serde-1.0.210",
+        ":sync_wrapper-1.0.1",
+        ":tower-0.4.13",
+        ":tower-layer-0.3.3",
+        ":tower-service-0.3.3",
+    ],
+)
+
+http_archive(
     name = "axum-core-0.3.4.crate",
     sha256 = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c",
     strip_prefix = "axum-core-0.3.4",
@@ -1673,6 +1727,36 @@ cargo.rust_library(
         ":http-0.2.12",
         ":http-body-0.4.6",
         ":mime-0.3.17",
+        ":tower-layer-0.3.3",
+        ":tower-service-0.3.3",
+    ],
+)
+
+http_archive(
+    name = "axum-core-0.4.3.crate",
+    sha256 = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3",
+    strip_prefix = "axum-core-0.4.3",
+    urls = ["https://static.crates.io/crates/axum-core/0.4.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "axum-core-0.4.3",
+    srcs = [":axum-core-0.4.3.crate"],
+    crate = "axum_core",
+    crate_root = "axum-core-0.4.3.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":async-trait-0.1.82",
+        ":bytes-1.7.1",
+        ":futures-util-0.3.30",
+        ":http-1.1.0",
+        ":http-body-1.0.1",
+        ":http-body-util-0.1.2",
+        ":mime-0.3.17",
+        ":pin-project-lite-0.2.14",
+        ":sync_wrapper-0.1.2",
         ":tower-layer-0.3.3",
         ":tower-service-0.3.3",
     ],
@@ -3389,6 +3473,79 @@ cargo.rust_library(
         ":lazy_static-1.5.0",
         ":libc-0.2.158",
         ":unicode-width-0.1.13",
+    ],
+)
+
+http_archive(
+    name = "console-api-0.8.0.crate",
+    sha256 = "86ed14aa9c9f927213c6e4f3ef75faaad3406134efe84ba2cb7983431d5f0931",
+    strip_prefix = "console-api-0.8.0",
+    urls = ["https://static.crates.io/crates/console-api/0.8.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "console-api-0.8.0",
+    srcs = [":console-api-0.8.0.crate"],
+    crate = "console_api",
+    crate_root = "console-api-0.8.0.crate/src/lib.rs",
+    edition = "2021",
+    features = ["transport"],
+    visibility = [],
+    deps = [
+        ":futures-core-0.3.30",
+        ":prost-0.13.2",
+        ":prost-types-0.13.2",
+        ":tonic-0.12.2",
+        ":tracing-core-0.1.32",
+    ],
+)
+
+alias(
+    name = "console-subscriber",
+    actual = ":console-subscriber-0.4.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "console-subscriber-0.4.0.crate",
+    sha256 = "e2e3a111a37f3333946ebf9da370ba5c5577b18eb342ec683eb488dd21980302",
+    strip_prefix = "console-subscriber-0.4.0",
+    urls = ["https://static.crates.io/crates/console-subscriber/0.4.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "console-subscriber-0.4.0",
+    srcs = [":console-subscriber-0.4.0.crate"],
+    crate = "console_subscriber",
+    crate_root = "console-subscriber-0.4.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "env-filter",
+    ],
+    rustc_flags = ["--cfg=tokio_unstable"],
+    visibility = [],
+    deps = [
+        ":console-api-0.8.0",
+        ":crossbeam-channel-0.5.13",
+        ":crossbeam-utils-0.8.20",
+        ":futures-task-0.3.30",
+        ":hdrhistogram-7.5.4",
+        ":humantime-2.1.0",
+        ":hyper-util-0.1.8",
+        ":prost-0.13.2",
+        ":prost-types-0.13.2",
+        ":serde-1.0.210",
+        ":serde_json-1.0.125",
+        ":thread_local-1.1.8",
+        ":tokio-1.40.0",
+        ":tokio-stream-0.1.16",
+        ":tonic-0.12.2",
+        ":tracing-0.1.40",
+        ":tracing-core-0.1.32",
+        ":tracing-subscriber-0.3.18",
     ],
 )
 
@@ -6454,6 +6611,36 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "h2-0.4.6.crate",
+    sha256 = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205",
+    strip_prefix = "h2-0.4.6",
+    urls = ["https://static.crates.io/crates/h2/0.4.6/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "h2-0.4.6",
+    srcs = [":h2-0.4.6.crate"],
+    crate = "h2",
+    crate_root = "h2-0.4.6.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":atomic-waker-1.1.2",
+        ":bytes-1.7.1",
+        ":fnv-1.0.7",
+        ":futures-core-0.3.30",
+        ":futures-sink-0.3.30",
+        ":http-1.1.0",
+        ":indexmap-2.5.0",
+        ":slab-0.4.9",
+        ":tokio-1.40.0",
+        ":tokio-util-0.7.12",
+        ":tracing-0.1.40",
+    ],
+)
+
+http_archive(
     name = "half-2.4.1.crate",
     sha256 = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888",
     strip_prefix = "half-2.4.1",
@@ -6590,9 +6777,18 @@ cargo.rust_library(
     crate = "hdrhistogram",
     crate_root = "hdrhistogram-7.5.4.crate/src/lib.rs",
     edition = "2018",
+    features = [
+        "base64",
+        "flate2",
+        "nom",
+        "serialization",
+    ],
     visibility = [],
     deps = [
+        ":base64-0.21.7",
         ":byteorder-1.5.0",
+        ":flate2-1.0.33",
+        ":nom-7.1.3",
         ":num-traits-0.2.19",
     ],
 )
@@ -7124,15 +7320,19 @@ cargo.rust_library(
         "client",
         "default",
         "http1",
+        "http2",
+        "server",
     ],
     visibility = [],
     deps = [
         ":bytes-1.7.1",
         ":futures-channel-0.3.30",
         ":futures-util-0.3.30",
+        ":h2-0.4.6",
         ":http-1.1.0",
         ":http-body-1.0.1",
         ":httparse-1.9.4",
+        ":httpdate-1.0.3",
         ":itoa-1.0.11",
         ":pin-project-lite-0.2.14",
         ":smallvec-1.13.2",
@@ -7268,6 +7468,30 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "hyper-timeout-0.5.1.crate",
+    sha256 = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793",
+    strip_prefix = "hyper-timeout-0.5.1",
+    urls = ["https://static.crates.io/crates/hyper-timeout/0.5.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "hyper-timeout-0.5.1",
+    srcs = [":hyper-timeout-0.5.1.crate"],
+    crate = "hyper_timeout",
+    crate_root = "hyper-timeout-0.5.1.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":hyper-1.4.1",
+        ":hyper-util-0.1.8",
+        ":pin-project-lite-0.2.14",
+        ":tokio-1.40.0",
+        ":tower-service-0.3.3",
+    ],
+)
+
+http_archive(
     name = "hyper-util-0.1.8.crate",
     sha256 = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba",
     strip_prefix = "hyper-util-0.1.8",
@@ -7286,6 +7510,10 @@ cargo.rust_library(
         "client-legacy",
         "default",
         "http1",
+        "http2",
+        "server",
+        "server-auto",
+        "service",
         "tokio",
     ],
     visibility = [],
@@ -11796,6 +12024,33 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "prost-0.13.2.crate",
+    sha256 = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995",
+    strip_prefix = "prost-0.13.2",
+    urls = ["https://static.crates.io/crates/prost/0.13.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "prost-0.13.2",
+    srcs = [":prost-0.13.2.crate"],
+    crate = "prost",
+    crate_root = "prost-0.13.2.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "derive",
+        "prost-derive",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":bytes-1.7.1",
+        ":prost-derive-0.13.2",
+    ],
+)
+
+http_archive(
     name = "prost-derive-0.12.6.crate",
     sha256 = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1",
     strip_prefix = "prost-derive-0.12.6",
@@ -11818,6 +12073,53 @@ cargo.rust_library(
         ":quote-1.0.37",
         ":syn-2.0.77",
     ],
+)
+
+http_archive(
+    name = "prost-derive-0.13.2.crate",
+    sha256 = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac",
+    strip_prefix = "prost-derive-0.13.2",
+    urls = ["https://static.crates.io/crates/prost-derive/0.13.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "prost-derive-0.13.2",
+    srcs = [":prost-derive-0.13.2.crate"],
+    crate = "prost_derive",
+    crate_root = "prost-derive-0.13.2.crate/src/lib.rs",
+    edition = "2021",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":anyhow-1.0.88",
+        ":itertools-0.12.1",
+        ":proc-macro2-1.0.86",
+        ":quote-1.0.37",
+        ":syn-2.0.77",
+    ],
+)
+
+http_archive(
+    name = "prost-types-0.13.2.crate",
+    sha256 = "60caa6738c7369b940c3d49246a8d1749323674c65cb13010134f5c9bad5b519",
+    strip_prefix = "prost-types-0.13.2",
+    urls = ["https://static.crates.io/crates/prost-types/0.13.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "prost-types-0.13.2",
+    srcs = [":prost-types-0.13.2.crate"],
+    crate = "prost_types",
+    crate_root = "prost-types-0.13.2.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [":prost-0.13.2"],
 )
 
 http_archive(
@@ -16689,6 +16991,7 @@ cargo.rust_binary(
         ":comfy-table-7.1.1",
         ":config-0.14.0",
         ":console-0.15.8",
+        ":console-subscriber-0.4.0",
         ":convert_case-0.6.0",
         ":criterion-0.5.1",
         ":crossbeam-channel-0.5.13",
@@ -17130,6 +17433,7 @@ cargo.rust_library(
         "time",
         "tokio-macros",
         "tokio_track_caller",
+        "tracing",
         "windows-sys",
     ],
     platform = {
@@ -17473,6 +17777,7 @@ cargo.rust_library(
         "default",
         "fs",
         "io-util",
+        "net",
         "sync",
         "time",
         "tokio-util",
@@ -17749,6 +18054,67 @@ cargo.rust_library(
         ":percent-encoding-2.3.1",
         ":pin-project-1.1.5",
         ":prost-0.12.6",
+        ":tokio-1.40.0",
+        ":tokio-stream-0.1.16",
+        ":tower-0.4.13",
+        ":tower-layer-0.3.3",
+        ":tower-service-0.3.3",
+        ":tracing-0.1.40",
+    ],
+)
+
+http_archive(
+    name = "tonic-0.12.2.crate",
+    sha256 = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad",
+    strip_prefix = "tonic-0.12.2",
+    urls = ["https://static.crates.io/crates/tonic/0.12.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tonic-0.12.2",
+    srcs = [":tonic-0.12.2.crate"],
+    crate = "tonic",
+    crate_root = "tonic-0.12.2.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "CARGO_MANIFEST_DIR": "tonic-0.12.2.crate",
+        "CARGO_PKG_AUTHORS": "Lucio Franco <luciofranco14@gmail.com>",
+        "CARGO_PKG_DESCRIPTION": "A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility.\n",
+        "CARGO_PKG_NAME": "tonic",
+        "CARGO_PKG_REPOSITORY": "https://github.com/hyperium/tonic",
+        "CARGO_PKG_VERSION": "0.12.2",
+        "CARGO_PKG_VERSION_MAJOR": "0",
+        "CARGO_PKG_VERSION_MINOR": "12",
+        "CARGO_PKG_VERSION_PATCH": "2",
+    },
+    features = [
+        "channel",
+        "codegen",
+        "default",
+        "prost",
+        "router",
+        "server",
+        "transport",
+    ],
+    visibility = [],
+    deps = [
+        ":async-stream-0.3.5",
+        ":async-trait-0.1.82",
+        ":axum-0.7.5",
+        ":base64-0.22.1",
+        ":bytes-1.7.1",
+        ":h2-0.4.6",
+        ":http-1.1.0",
+        ":http-body-1.0.1",
+        ":http-body-util-0.1.2",
+        ":hyper-1.4.1",
+        ":hyper-timeout-0.5.1",
+        ":hyper-util-0.1.8",
+        ":percent-encoding-2.3.1",
+        ":pin-project-1.1.5",
+        ":prost-0.13.2",
+        ":socket2-0.5.7",
         ":tokio-1.40.0",
         ":tokio-stream-0.1.16",
         ":tower-0.4.13",

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -318,6 +318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,7 +615,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes 1.7.1",
  "fastrand",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.1",
@@ -697,7 +703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "axum-macros",
  "base64 0.21.7",
  "bitflags 1.3.2",
@@ -728,6 +734,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "bytes 1.7.1",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.1",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-core"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +773,26 @@ dependencies = [
  "http-body 0.4.6",
  "mime",
  "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes 1.7.1",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
  "tower-layer",
  "tower-service",
 ]
@@ -1339,6 +1392,45 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "console-api"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ed14aa9c9f927213c6e4f3ef75faaad3406134efe84ba2cb7983431d5f0931"
+dependencies = [
+ "futures-core",
+ "prost 0.13.2",
+ "prost-types",
+ "tonic 0.12.2",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e3a111a37f3333946ebf9da370ba5c5577b18eb342ec683eb488dd21980302"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost 0.13.2",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.12.2",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2440,6 +2532,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes 1.7.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.5.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2498,7 +2609,10 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
+ "base64 0.21.7",
  "byteorder",
+ "flate2",
+ "nom",
  "num-traits",
 ]
 
@@ -2699,7 +2813,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2722,9 +2836,11 @@ dependencies = [
  "bytes 1.7.1",
  "futures-channel",
  "futures-util",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2791,6 +2907,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3647,10 +3776,10 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.12.6",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -3661,8 +3790,8 @@ checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.12.6",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -4268,7 +4397,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes 1.7.1",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
+dependencies = [
+ "bytes 1.7.1",
+ "prost-derive 0.13.2",
 ]
 
 [[package]]
@@ -4282,6 +4421,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60caa6738c7369b940c3d49246a8d1749323674c65cb13010134f5c9bad5b519"
+dependencies = [
+ "prost 0.13.2",
 ]
 
 [[package]]
@@ -5982,7 +6143,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-firehose",
- "axum",
+ "axum 0.6.20",
  "base64 0.22.1",
  "blake3",
  "bollard",
@@ -5996,6 +6157,7 @@ dependencies = [
  "comfy-table",
  "config",
  "console",
+ "console-subscriber",
  "convert_case 0.6.0",
  "criterion",
  "crossbeam-channel",
@@ -6231,6 +6393,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -6450,17 +6613,47 @@ checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes 1.7.1",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project 1.1.5",
- "prost",
+ "prost 0.12.6",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.5",
+ "base64 0.22.1",
+ "bytes 1.7.1",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project 1.1.5",
+ "prost 0.13.2",
+ "socket2",
  "tokio",
  "tokio-stream",
  "tower",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -28,6 +28,7 @@ rust-version = "1.78"
 publish = false
 
 [dependencies]
+console-subscriber = "0.4.0"
 async-nats = { version = "0.36.0", features = ["service"] }
 async-recursion = "1.0.5"
 async-trait = "0.1.79"


### PR DESCRIPTION
Note: this acts badly in local dev as each service will attempt to spin this up. We can make this behave more nicely if we decide we want to ship this for real.