### PR TITLE
feat: change broadcast channel depth to 1000000

### DIFF
--- a/lib/si-layer-cache/src/activities.rs
+++ b/lib/si-layer-cache/src/activities.rs
@@ -238,7 +238,7 @@ impl ActivityMultiplexer {
             has_filter_array,
         )
         .await?;
-        let (tx, rx) = broadcast::channel(1000); // the 1_000_000 here is the depth the channel will
+        let (tx, rx) = broadcast::channel(1000000); // the 1_000_000 here is the depth the channel will
 
         let mut amx_task = ActivityMultiplexerTask::new(activity_stream, tx.clone());
         let amx_shutdown_token = self.shutdown_token.clone();


### PR DESCRIPTION
Based on the investigation, increasing the queue depth removes the bottleneck currently implied on the system. Onwards and upwards.