### PR TITLE
fix: don't replay onto the change set that was just applied

### DIFF
--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -513,7 +513,8 @@ impl ChangeSet {
         if let Some(rebase_batch) = self.detect_updates_that_will_be_applied(ctx).await? {
             let rebase_batch_address = ctx.write_rebase_batch(rebase_batch).await?;
 
-            let rebase_request = RebaseRequest::new(base_change_set_id, rebase_batch_address);
+            let rebase_request =
+                RebaseRequest::new(base_change_set_id, rebase_batch_address, Some(self.id));
             ctx.do_rebase_request(rebase_request).await?;
         }
 

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -480,7 +480,7 @@ impl DalContext {
             .write_current_rebase_batch()
             .await?
             .map(|rebase_batch_address| {
-                RebaseRequest::new(self.change_set_id(), rebase_batch_address)
+                RebaseRequest::new(self.change_set_id(), rebase_batch_address, None)
             });
 
         if self.blocking {
@@ -565,7 +565,7 @@ impl DalContext {
             .write_current_rebase_batch()
             .await?
             .map(|rebase_batch_address| {
-                RebaseRequest::new(self.change_set_id(), rebase_batch_address)
+                RebaseRequest::new(self.change_set_id(), rebase_batch_address, None)
             });
 
         info!("rebase_request: {:?}", rebase_request);
@@ -1209,16 +1209,19 @@ pub struct Transactions {
 pub struct RebaseRequest {
     pub to_rebase_change_set_id: ChangeSetId,
     pub rebase_batch_address: RebaseBatchAddress,
+    pub from_change_set_id: Option<ChangeSetId>,
 }
 
 impl RebaseRequest {
     pub fn new(
         to_rebase_change_set_id: ChangeSetId,
         rebase_batch_address: RebaseBatchAddress,
+        from_change_set_id: Option<ChangeSetId>,
     ) -> Self {
         Self {
             to_rebase_change_set_id,
             rebase_batch_address,
+            from_change_set_id,
         }
     }
 }
@@ -1278,6 +1281,7 @@ async fn rebase(
         .rebase()
         .rebase_and_wait(
             rebase_request.to_rebase_change_set_id.into(),
+            rebase_request.from_change_set_id.map(Into::into),
             rebase_request.rebase_batch_address,
             metadata,
         )

--- a/lib/sdf-server/src/service/change_set/rebase_on_base.rs
+++ b/lib/sdf-server/src/service/change_set/rebase_on_base.rs
@@ -57,7 +57,7 @@ pub async fn rebase_on_base(
     .await?
     {
         let rebase_batch_address = ctx.write_rebase_batch(rebase_batch).await?;
-        let rebase_request = RebaseRequest::new(ctx.change_set_id(), rebase_batch_address);
+        let rebase_request = RebaseRequest::new(ctx.change_set_id(), rebase_batch_address, None);
         ctx.do_rebase_request(rebase_request).await?;
     }
 

--- a/lib/si-layer-cache/src/activities/rebase.rs
+++ b/lib/si-layer-cache/src/activities/rebase.rs
@@ -135,10 +135,15 @@ impl<'a> ActivityRebase<'a> {
     pub async fn rebase_and_wait(
         &self,
         to_rebase_change_set_id: Ulid,
+        from_change_set_id: Option<Ulid>,
         rebase_batch_address: RebaseBatchAddress,
         metadata: LayeredEventMetadata,
     ) -> LayerDbResult<Activity> {
-        let payload = RebaseRequest::new(to_rebase_change_set_id, rebase_batch_address, None);
+        let payload = RebaseRequest::new(
+            to_rebase_change_set_id,
+            rebase_batch_address,
+            from_change_set_id,
+        );
         let activity = Activity::rebase(payload, metadata);
         // println!("trigger: sending rebase and waiting for response");
         debug!(?activity, "sending rebase and waiting for response");

--- a/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
@@ -210,6 +210,7 @@ async fn rebase_and_wait() {
             .rebase()
             .rebase_and_wait(
                 Ulid::new(),
+                None,
                 RebaseBatchAddress::new(b"poop"),
                 metadata_for_task,
             )
@@ -505,7 +506,7 @@ async fn rebase_and_wait_stress() {
                 let _response = ldb_slash_clone
                     .activity()
                     .rebase()
-                    .rebase_and_wait(Ulid::new(), RebaseBatchAddress::new(b"poop"), mp)
+                    .rebase_and_wait(Ulid::new(), None, RebaseBatchAddress::new(b"poop"), mp)
                     .await;
                 RECV_REPLY_COUNTER.fetch_add(1, Ordering::Relaxed);
             }


### PR DESCRIPTION
Ensure we send the "from change set id" when applying to head, so that we can avoid replaying changes onto the change set that was just applied.