### PR TITLE
fix: restore maintenance mode signal handler

### DIFF
--- a/lib/sdf-server/src/lib.rs
+++ b/lib/sdf-server/src/lib.rs
@@ -12,6 +12,8 @@
     clippy::module_name_repetitions
 )]
 
+use std::io;
+
 use thiserror::Error;
 
 mod app;
@@ -59,6 +61,8 @@ pub enum ServerError {
     Init(#[from] init::InitError),
     #[error("nats multipler error: {0}")]
     NatsMultiplexer(#[from] ::nats_multiplexer::MultiplexerError),
+    #[error("Failed to set up signal handler")]
+    Signal(#[source] io::Error),
     #[error("unix domain socket incoming stream error: {0}")]
     Uds(#[from] uds::UdsIncomingStreamError),
 }


### PR DESCRIPTION
The sdf refactor dropped the sigusr2 handler that set maintenance mode. This restores it. We don't have maintenance mode in prod right now so will have to be careful when deploying.