### PR TITLE
feat: Implement the paul stack load test and immediate batches to api tests

### DIFF
--- a/bin/si-api-test/binary_execution_lib.ts
+++ b/bin/si-api-test/binary_execution_lib.ts
@@ -3,7 +3,7 @@ import assert from "node:assert";
 
 export interface TestExecutionProfile {
   maxDuration: number;
-  rate: number; // Time in between test runs
+  rate: number; // Time in between test batches
   useJitter: boolean; // If true, add a random amount of time to the rate, to avoid thundering herds
 }
 
@@ -15,6 +15,7 @@ export function parseArgs(args: string[]) {
       "userId",
       "password",
       "profile",
+      "batchSize",
       "tests",
       "token",
       "reportFile",
@@ -25,6 +26,7 @@ export function parseArgs(args: string[]) {
       p: "password",
       t: "tests",
       l: "profile",
+      b: "batchSize",
       k: "token",
     },
     default: { profile: undefined, tests: "" },
@@ -45,6 +47,7 @@ Options:
   --password, -p      User password (optional)
   --tests, -t         Test names to run (comma-separated, optional)
   --profile, -l       Test profile in JSON format (optional)
+  --batchSize, -b     Number of test instances, per test, to run per batch
   --token, -k         SDF Auth Token (optional)
   --reportFile        Address of the output file, if unset it will be logged
   --help              Show this help message
@@ -58,6 +61,8 @@ Options:
   const password = parsedArgs.password || undefined;
   const token = parsedArgs.token || undefined;
   const reportFile = parsedArgs.reportFile;
+  const batchArg = parseInt(parsedArgs?.batchSize ?? "");
+  const batchSize = Math.max(batchArg, 1);
 
   // Handle optional tests argument
   const testsToRun = parsedArgs.tests
@@ -86,6 +91,7 @@ Options:
     testProfile,
     token,
     reportFile,
+    batchSize,
   };
 }
 

--- a/bin/si-api-test/main.ts
+++ b/bin/si-api-test/main.ts
@@ -24,6 +24,7 @@ if (import.meta.main) {
     testProfile,
     token,
     reportFile,
+    batchSize,
   } = parseArgs(
     Deno.args,
   );
@@ -79,15 +80,17 @@ if (import.meta.main) {
   }, 1000);
 
   do {
-    for (const testName of tests) {
-      // Execute tests asynchronously and increment sequence, show progress bar
-      const testPromise = executeTest(
-        testName,
-        testFuncs[testName],
-        sdfApiClient,
-        testExecutionSequence++,
-      );
-      testPromises.push(testPromise);
+    for (let i = 0; i < batchSize; i++) {
+      for (const testName of tests) {
+        // Execute tests asynchronously and increment sequence, show progress bar
+        const testPromise = executeTest(
+          testName,
+          testFuncs[testName],
+          sdfApiClient,
+          testExecutionSequence++,
+        );
+        testPromises.push(testPromise);
+      }
     }
 
     elapsed = Date.now() - startTime;

--- a/bin/si-api-test/test_helpers.ts
+++ b/bin/si-api-test/test_helpers.ts
@@ -7,6 +7,11 @@ export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, natural_ms));
 }
 
+export function sleepBetween(minMs: number, maxMs: number) {
+  if (maxMs < minMs) maxMs = minMs;
+  return sleep(minMs + Math.floor((maxMs - minMs) * Math.random()));
+}
+
 // Run fn n times, with increasing intervals between tries
 export async function retryWithBackoff(
   fn: () => Promise<void>,

--- a/bin/si-api-test/tests/emulate_paul_stack.ts
+++ b/bin/si-api-test/tests/emulate_paul_stack.ts
@@ -1,0 +1,563 @@
+// deno-lint-ignore-file no-explicit-any
+import assert from "node:assert";
+import { SdfApiClient } from "../sdf_api_client.ts";
+import {
+  runWithTemporaryChangeset,
+  sleep,
+  sleepBetween,
+} from "../test_helpers.ts";
+
+export default async function emulate_paul_stack(
+  sdfApiClient: SdfApiClient,
+) {
+  await sleepBetween(500, 10000);
+  return runWithTemporaryChangeset(
+    sdfApiClient,
+    emulate_paul_stack_inner,
+  );
+}
+
+async function emulate_paul_stack_inner(
+  sdf: SdfApiClient,
+  changeSetId: string,
+) {
+  // LOAD INITIAL DATA
+  const schemaVariants = await getSchemaVariants(sdf, changeSetId);
+
+  const awsRegionVariant = await extractSchemaVariant(
+    schemaVariants,
+    "Region",
+    "AWS",
+  );
+  const awsRegionVariantId = awsRegionVariant.schemaVariantId;
+
+  const _diagram = await getDiagram(sdf, changeSetId);
+  await sleepBetween(2000, 10000);
+
+  // CREATE COMPONENTS
+  // create region component
+  const regionComponentId = await createComponent(
+    sdf,
+    changeSetId,
+    awsRegionVariantId,
+    0,
+    0,
+  );
+
+  await sleepBetween(3000, 6000);
+
+  await setComponentGeometry(
+    sdf,
+    changeSetId,
+    regionComponentId,
+    0,
+    0,
+    1800,
+    800,
+  );
+  await sleepBetween(1000, 5000);
+
+  // UPDATE REGION
+  const regionValue = "us-east-1";
+  const { values: RegionPropValues } = await getPropertyEditor(
+    sdf,
+    changeSetId,
+    regionComponentId,
+  );
+  await sleep(2000);
+
+  {
+    const {
+      attributeValueId,
+      parentAttributeValueId,
+      propId,
+    } = attributeValueIdForPropPath(
+      "/root/domain/region",
+      awsRegionVariant.props,
+      RegionPropValues,
+    );
+
+    await setAttributeValue(
+      sdf,
+      changeSetId,
+      regionComponentId,
+      attributeValueId,
+      parentAttributeValueId,
+      propId,
+      regionValue,
+    );
+  }
+
+  await sleepBetween(5000, 15000);
+
+  // CREATE VPC
+  const vpcVariant = await extractSchemaVariant(
+    schemaVariants,
+    "VPC",
+    "AWS EC2",
+  );
+  const vpcVariantId = vpcVariant.schemaVariantId;
+
+  const vpcComponentId = await createComponent(
+    sdf,
+    changeSetId,
+    vpcVariantId,
+    0,
+    0,
+  );
+
+  await sleepBetween(1000, 2000);
+
+  await setComponentType(
+    sdf,
+    changeSetId,
+    vpcComponentId,
+    "configurationFrameDown",
+  );
+
+  await setComponentGeometry(
+    sdf,
+    changeSetId,
+    vpcComponentId,
+    0,
+    80,
+    1700,
+    600,
+    {
+      newParent: regionComponentId,
+    },
+  );
+
+  await sleepBetween(1000, 5000);
+
+  // CONFIGURE VPC
+  const { values: vpcPropValues } = await getPropertyEditor(
+    sdf,
+    changeSetId,
+    vpcComponentId,
+  );
+
+  for (
+    const { p: path, v: value } of [
+      { p: "/root/si/name", v: "How to VPC" },
+      { p: "/root/domain/CidrBlock", v: "10.0.0.0/16" },
+      { p: "/root/domain/EnableDnsHostnames", v: true },
+      { p: "/root/domain/EnableDnsResolution", v: true },
+    ]
+  ) {
+    const {
+      attributeValueId,
+      parentAttributeValueId,
+      propId,
+    } = attributeValueIdForPropPath(
+      path,
+      vpcVariant.props,
+      vpcPropValues,
+    );
+
+    await setAttributeValue(
+      sdf,
+      changeSetId,
+      vpcComponentId,
+      attributeValueId,
+      parentAttributeValueId,
+      propId,
+      value,
+    );
+    await sleepBetween(2000, 8000);
+  }
+
+  // Public Subnet Components
+  const subnetVariant = await extractSchemaVariant(
+    schemaVariants,
+    "Subnet",
+    "AWS EC2",
+  );
+  const subnetVariantId = subnetVariant.schemaVariantId;
+
+  for (
+    const { index, data } of [
+      { CidrBlock: "10.0.128.0/20", AvailabilityZone: "us-east-1a" },
+      { CidrBlock: "10.0.144.0/20", AvailabilityZone: "us-east-1b" },
+      { CidrBlock: "10.0.160.0/20", AvailabilityZone: "us-east-1c" },
+    ].map((data, index) => ({ index, data }))
+  ) {
+    const subnetComponentId = await createComponent(
+      sdf,
+      changeSetId,
+      subnetVariantId,
+      -550 + (550 * index),
+      150,
+      vpcComponentId,
+    );
+    await sleepBetween(1000, 5000);
+
+    await setComponentType(
+      sdf,
+      changeSetId,
+      subnetComponentId,
+      "configurationFrameDown",
+    );
+
+    const { values: subnetPropValues } = await getPropertyEditor(
+      sdf,
+      changeSetId,
+      subnetComponentId,
+    );
+
+    // CONFIGURE Subnet
+
+    for (
+      const { p: path, v: value } of [
+        { p: "/root/si/name", v: `Public ${index + 1}` },
+        { p: "/root/domain/CidrBlock", v: data.CidrBlock },
+        { p: "/root/domain/AvailabilityZone", v: data.AvailabilityZone },
+        { p: "/root/domain/IsPublic", v: true },
+      ]
+    ) {
+      const {
+        attributeValueId,
+        parentAttributeValueId,
+        propId,
+      } = attributeValueIdForPropPath(
+        path,
+        subnetVariant.props,
+        subnetPropValues,
+      );
+
+      await setAttributeValue(
+        sdf,
+        changeSetId,
+        subnetComponentId,
+        attributeValueId,
+        parentAttributeValueId,
+        propId,
+        value,
+      );
+      await sleepBetween(3000, 10000);
+    }
+  }
+}
+
+// REQUEST HELPERS WITH VALIDATIONS
+async function createComponent(
+  sdf: SdfApiClient,
+  changeSetId: string,
+  schemaVariantId: string,
+  x: number,
+  y: number,
+  parentId?: string,
+): Promise<string> {
+  const parentArgs = parentId ? { parentId } : {};
+  const payload = {
+    schemaVariantId,
+    x: x.toString(),
+    y: y.toString(),
+    "visibility_change_set_pk": changeSetId,
+    "workspaceId": sdf.workspaceId,
+    ...parentArgs,
+  };
+  const createResp = await sdf.call({
+    route: "create_component",
+    body: payload,
+  });
+  const componentId = createResp?.componentId;
+  assert(componentId, "Expected to get a component id after creation");
+
+  // Run side effect calls
+  await Promise.all(
+    [
+      getQualificationSummary(sdf, changeSetId),
+      getActions(sdf, changeSetId),
+      getFuncs(sdf, changeSetId),
+      getPropertyEditor(sdf, changeSetId, componentId),
+    ],
+  );
+
+  return componentId;
+}
+
+async function setComponentGeometry(
+  sdf: SdfApiClient,
+  changeSetId: string,
+  componentId: string,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  parentArguments?: {
+    newParent?: string;
+    detach?: boolean;
+  },
+) {
+  const someParentArguments = parentArguments ?? {};
+  const setPositionPayload = {
+    "dataByComponentId": {
+      [componentId]: {
+        "geometry": {
+          "x": x.toString(),
+          "y": y.toString(),
+          "width": w.toString(),
+          "height": h.toString(),
+        },
+        detach: false,
+        ...someParentArguments,
+      },
+    },
+    "diagramKind": "configuration",
+    "visibility_change_set_pk": changeSetId,
+    "workspaceId": sdf.workspaceId,
+    requestUlid: changeSetId,
+  };
+
+  const result = await sdf.call({
+    route: "set_component_position",
+    body: setPositionPayload,
+  });
+
+  // Make side effect calls
+  await Promise.all(
+    [
+      getQualificationSummary(sdf, changeSetId),
+      getActions(sdf, changeSetId),
+      getFuncs(sdf, changeSetId),
+    ],
+  );
+
+  return result;
+}
+
+async function setComponentType(
+  sdf: SdfApiClient,
+  changeSetId: string,
+  componentId: string,
+  componentType:
+    | "component"
+    | "configurationFrameDown"
+    | "configurationFrameUp",
+) {
+  const payload = {
+    componentId,
+    componentType,
+    "visibility_change_set_pk": changeSetId,
+    requestUlid: changeSetId,
+  };
+
+  const result = await sdf.call({
+    route: "set_component_type",
+    body: payload,
+  });
+
+  // Make side effect calls
+  await Promise.all(
+    [
+      getQualificationSummary(sdf, changeSetId),
+      getActions(sdf, changeSetId),
+      getFuncs(sdf, changeSetId),
+      getPropertyEditor(sdf, changeSetId, componentId),
+    ],
+  );
+
+  return result;
+}
+
+async function getDiagram(
+  sdf: SdfApiClient,
+  changeSetId: string,
+): Promise<{ components: any[]; edges: any[] }> {
+  const diagram = await sdf.call({
+    route: "get_diagram",
+    routeVars: {
+      workspaceId: sdf.workspaceId,
+      changeSetId,
+    },
+  });
+
+  assert(
+    Array.isArray(diagram?.components),
+    "Expected components list on the diagram",
+  );
+  assert(Array.isArray(diagram?.edges), "Expected edges list on the diagram");
+
+  return diagram;
+}
+
+async function setAttributeValue(
+  sdf: SdfApiClient,
+  changeSetId: string,
+  componentId: string,
+  attributeValueId: string,
+  parentAttributeValueId: string,
+  propId: string,
+  value: unknown,
+) {
+  const updateValuePayload = {
+    "visibility_change_set_pk": changeSetId,
+    componentId,
+    attributeValueId,
+    parentAttributeValueId,
+    propId,
+    value,
+    "isForSecret": false,
+  };
+
+  await sdf.call({
+    route: "update_property_value",
+    body: updateValuePayload,
+  });
+}
+
+async function getSchemaVariants(
+  sdf: SdfApiClient,
+  changeSetId: string,
+) {
+  const schemaVariants = await sdf.call({
+    route: "schema_variants",
+    routeVars: {
+      workspaceId: sdf.workspaceId,
+      changeSetId,
+    },
+  });
+  assert(
+    Array.isArray(schemaVariants),
+    "List schema variants should return an array",
+  );
+
+  return schemaVariants;
+}
+
+async function getPropertyEditor(
+  sdf: SdfApiClient,
+  changeSetId: string,
+  componentId: string,
+) {
+  const values = await sdf.call({
+    route: "get_property_values",
+    routeVars: {
+      componentId,
+      changeSetId,
+    },
+  });
+  assert(typeof values?.values === "object", "Expected prop values");
+  assert(
+    typeof values?.childValues === "object",
+    "Expected prop childValues:",
+  );
+
+  const schema = await sdf.call({
+    route: "get_property_schema",
+    routeVars: {
+      componentId,
+      changeSetId,
+    },
+  });
+  assert(typeof schema?.rootPropId === "string", "Expected rootPropId");
+  assert(typeof schema?.props === "object", "Expected props");
+  assert(
+    typeof schema?.childProps === "object",
+    "Expected childProps list",
+  );
+
+  return {
+    values,
+    schema,
+  };
+}
+
+async function getQualificationSummary(
+  sdf: SdfApiClient,
+  changeSetId: string,
+) {
+  return await sdf.call({
+    route: "get_diagram",
+    routeVars: {
+      workspaceId: sdf.workspaceId,
+      changeSetId,
+    },
+  });
+}
+
+async function getActions(
+  sdf: SdfApiClient,
+  changeSetId: string,
+) {
+  return await sdf.call({
+    route: "action_list",
+    routeVars: {
+      workspaceId: sdf.workspaceId,
+      changeSetId,
+    },
+  });
+}
+
+async function getFuncs(
+  sdf: SdfApiClient,
+  changeSetId: string,
+) {
+  return await sdf.call({
+    route: "func_list",
+    routeVars: {
+      workspaceId: sdf.workspaceId,
+      changeSetId,
+    },
+  });
+}
+
+// Data Extractors
+function extractSchemaVariant(
+  schemaVariants: any[],
+  schemaName: string,
+  category?: string,
+) {
+  const variant = schemaVariants.find((sv) =>
+    sv.schemaName === schemaName && (!category || sv.category === category)
+  );
+
+  const awsRegionVariantId = variant?.schemaVariantId;
+  assert(
+    awsRegionVariantId,
+    `Expected to find ${schemaName} schema and variant`,
+  );
+
+  return variant;
+}
+
+function attributeValueIdForPropPath(
+  propPath: string,
+  propList: any[],
+  attributeValuesView: {
+    values: any[];
+    childValues: any[];
+  },
+) {
+  const prop = propList.find((p) => p.path === propPath);
+  assert(prop, `Expected to find ${propPath} prop`);
+
+  let attributeValueId;
+  for (const attributeValue in attributeValuesView.values) {
+    if (
+      attributeValuesView.values[attributeValue]?.propId === prop.id
+    ) {
+      attributeValueId = attributeValue;
+    }
+  }
+  assert(attributeValueId, "Expected source attribute value");
+
+  let parentAttributeValueId;
+  for (const attributeValue in attributeValuesView?.childValues) {
+    const avChildren = attributeValuesView?.childValues[attributeValue] ?? [];
+    if (avChildren.includes(attributeValueId)) {
+      parentAttributeValueId = attributeValue;
+    }
+  }
+  assert(
+    parentAttributeValueId,
+    "Expected parent of source attribute value",
+  );
+
+  return {
+    attributeValueId,
+    parentAttributeValueId,
+    "propId": prop.id,
+  };
+}


### PR DESCRIPTION
The paul stack tests builds a more complex diagram inspired on a section of  the  [AWS VPC si tutorial](https://docs.systeminit.com/how-tos/aws-vpc)

Adds a bunch of quick helpers to this specific test that I didn't want to declare as part of the client yet, but were invaluable for this implementation

You can run a batch of tests at once by passing -b or --batchSize to the deno task. Default for that is 1