### PR TITLE
fix: remove onBlur for select boxes, only fire update on change event

### DIFF
--- a/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
@@ -420,7 +420,6 @@
             v-model="newValueString"
             :class="`attributes-panel-item__hidden-input ${propLabelParts[0]}${propLabelParts[1]}`"
             :disabled="!propIsEditable"
-            @blur="onBlur"
             @change="updateValue"
             @focus="onFocus"
           >
@@ -1047,6 +1046,7 @@ function unsetHandler() {
     attributeValueId: props.attributeDef.valueId,
   });
 }
+
 function updateValue() {
   let newVal;
   let skipUpdate = false;


### PR DESCRIPTION
This removes the double change set creation when editing a select box on HEAD. The other types seem fine, this only happened with select boxes, and using onChange appears to be enough for them.