### PR TITLE
fix: regenerate was racing websockets

### DIFF
--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -158,10 +158,10 @@
                 :id="config.socketName"
                 v-model="config.value"
                 :disabled="editingAsset.isLocked"
-                compact
                 :label="config.socketName + '&lt;&mdash;'"
-                type="dropdown"
                 :options="optionsForIntrinsicDisplay"
+                compact
+                type="dropdown"
                 @change="updateOutputSocketIntrinsics(config)"
               />
             </li>
@@ -175,10 +175,10 @@
                 :id="prop.path"
                 v-model="prop.value"
                 :disabled="editingAsset.isLocked"
-                compact
                 :label="prop.path + '&lt;&mdash;'"
-                type="dropdown"
                 :options="optionsForIntrinsicDisplay"
+                compact
+                type="dropdown"
                 @change="updatePropIntrinsics(prop)"
               />
             </li>
@@ -527,12 +527,7 @@ const saveAssetReqStatus = assetStore.getRequestStatus(
 );
 const executeAsset = async () => {
   if (editingAsset.value) {
-    const resp = await assetStore.REGENERATE_VARIANT(
-      editingAsset.value.schemaVariantId,
-    );
-    if (resp.result.success) {
-      assetStore.setSchemaVariantSelection(resp.result.data.schemaVariantId);
-    }
+    await assetStore.REGENERATE_VARIANT(editingAsset.value.schemaVariantId);
   }
 };
 

--- a/app/web/src/components/AssetListItem.vue
+++ b/app/web/src/components/AssetListItem.vue
@@ -7,7 +7,7 @@
       )
     "
     :color="a.color"
-    :isSelected="selectedAssets.includes(a.schemaVariantId)"
+    :isSelected="isSelected"
     showSelection
     @mousedown.left.stop="onClick"
     @click.right.prevent
@@ -65,19 +65,28 @@ const moduleStore = useModuleStore();
 
 const { selectedSchemaVariants: selectedAssets } = storeToRefs(assetStore);
 
+const isSelected = computed(() =>
+  selectedAssets.value.includes(props.a.schemaVariantId),
+);
+
 const canUpdate = computed(
   () => !!moduleStore.upgradeableModules[props.a.schemaVariantId],
 );
 
 const canContribute = computed(() => {
   return (
-    !!moduleStore.contributableModules.includes(props.a.schemaVariantId) ||
+    moduleStore.contributableModules.includes(props.a.schemaVariantId) ||
     props.a.canContribute
   );
 });
 
 const onClick = (e: MouseEvent) => {
-  if (e.shiftKey) assetStore.addSchemaVariantSelection(props.a.schemaVariantId);
-  else assetStore.setSchemaVariantSelection(props.a.schemaVariantId);
+  if (e.shiftKey) {
+    if (isSelected.value) {
+      assetStore.removeSchemaVariantSelection(props.a.schemaVariantId);
+    } else {
+      assetStore.addSchemaVariantSelection(props.a.schemaVariantId);
+    }
+  } else assetStore.setSchemaVariantSelection(props.a.schemaVariantId);
 };
 </script>

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -611,6 +611,24 @@ export const useAssetStore = () => {
             },
           },
           {
+            eventType: "SchemaVariantReplaced",
+            callback: (data, metadata) => {
+              if (metadata.change_set_id !== changeSetId) return;
+
+              const newVariant = data.newSchemaVariant;
+              const oldVariantId = data.oldSchemaVariantId;
+
+              const oldAssetIdx = this.variantList.findIndex(
+                (a) => a.schemaVariantId === oldVariantId,
+              );
+              if (oldAssetIdx !== -1) {
+                this.variantList.splice(oldAssetIdx, 1, newVariant);
+
+                this.setSchemaVariantSelection(newVariant.schemaVariantId);
+              } else this.variantList.push(newVariant);
+            },
+          },
+          {
             eventType: "ModuleImported",
             callback: (schemaVariants, metadata) => {
               if (metadata.change_set_id !== changeSetId) return;

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -174,6 +174,15 @@ export const useAssetStore = () => {
             this.selectedFuncs = [];
           }
         },
+        removeSchemaVariantSelection(id: SchemaVariantId) {
+          const thisAssetIdx = this.selectedSchemaVariants.findIndex(
+            (thisId) => thisId === id,
+          );
+          if (thisAssetIdx !== -1) {
+            this.selectedSchemaVariants.splice(thisAssetIdx, 1);
+            this.syncSelectionIntoUrl();
+          }
+        },
         setSchemaVariantSelection(id: SchemaVariantId) {
           this.setFuncSelection(undefined);
 
@@ -604,28 +613,47 @@ export const useAssetStore = () => {
               const savedAssetIdx = this.variantList.findIndex(
                 (a) => a.schemaVariantId === variant.schemaVariantId,
               );
+
+              if (variant?.assetFuncId)
+                funcStore.FETCH_CODE(variant.assetFuncId);
+
               if (savedAssetIdx !== -1) {
                 this.variantList.splice(savedAssetIdx, 1, variant);
-                this.setSchemaVariantSelection(variant.schemaVariantId);
               } else this.variantList.push(variant);
             },
           },
           {
             eventType: "SchemaVariantReplaced",
-            callback: (data, metadata) => {
+            callback: (
+              {
+                newSchemaVariant: newVariant,
+                oldSchemaVariantId: oldVariantId,
+              },
+              metadata,
+            ) => {
               if (metadata.change_set_id !== changeSetId) return;
-
-              const newVariant = data.newSchemaVariant;
-              const oldVariantId = data.oldSchemaVariantId;
 
               const oldAssetIdx = this.variantList.findIndex(
                 (a) => a.schemaVariantId === oldVariantId,
               );
               if (oldAssetIdx !== -1) {
                 this.variantList.splice(oldAssetIdx, 1, newVariant);
-
-                this.setSchemaVariantSelection(newVariant.schemaVariantId);
               } else this.variantList.push(newVariant);
+
+              if (this.selectedSchemaVariants.includes(oldVariantId)) {
+                if (this.selectedSchemaVariants.length === 1) {
+                  const selectedFuncs = _.clone(this.selectedFuncs);
+                  this.setSchemaVariantSelection(newVariant.schemaVariantId);
+                  // Right now you can't multi select functions but they're in an array,
+                  // so we just set the values in the array, which will leave the last one selected
+                  for (const funcId of selectedFuncs) {
+                    this.setFuncSelection(funcId);
+                  }
+                } else {
+                  this.removeSchemaVariantSelection(oldVariantId);
+                  this.addSchemaVariantSelection(newVariant.schemaVariantId);
+                }
+              }
             },
           },
           {

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -261,6 +261,12 @@ export type WsEventPayloadMap = {
   };
   SchemaVariantCreated: SchemaVariant;
   SchemaVariantUpdated: SchemaVariant;
+  SchemaVariantReplaced: {
+    schemaId: SchemaId;
+    oldSchemaVariantId: SchemaVariantId;
+    newSchemaVariant: SchemaVariant;
+    changeSetId: ChangeSetId;
+  };
   SchemaVariantCloned: {
     schemaVariantId: string;
     changeSetId: ChangeSetId;

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -309,6 +309,15 @@ pub struct SchemaVariantDeletedPayload {
     change_set_id: ChangeSetId,
 }
 
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaVariantReplacedPayload {
+    schema_id: SchemaId,
+    old_schema_variant_id: SchemaVariantId,
+    new_schema_variant: frontend_types::SchemaVariant,
+    change_set_id: ChangeSetId,
+}
+
 impl WsEvent {
     pub async fn schema_variant_created(
         ctx: &DalContext,
@@ -337,6 +346,26 @@ impl WsEvent {
             WsPayload::SchemaVariantDeleted(SchemaVariantDeletedPayload {
                 schema_variant_id,
                 schema_id,
+                change_set_id: ctx.change_set_id(),
+            }),
+        )
+        .await
+    }
+    pub async fn schema_variant_replaced(
+        ctx: &DalContext,
+        schema_id: SchemaId,
+        old_schema_variant_id: SchemaVariantId,
+        new_schema_variant: SchemaVariant,
+    ) -> WsEventResult<Self> {
+        let new_schema_variant = new_schema_variant
+            .into_frontend_type(ctx, schema_id)
+            .await?;
+        WsEvent::new(
+            ctx,
+            WsPayload::SchemaVariantReplaced(SchemaVariantReplacedPayload {
+                schema_id,
+                old_schema_variant_id,
+                new_schema_variant,
                 change_set_id: ctx.change_set_id(),
             }),
         )

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -23,8 +23,8 @@ use crate::pkg::{
 };
 use crate::qualification::QualificationCheckPayload;
 use crate::schema::variant::{
-    SchemaVariantClonedPayload, SchemaVariantDeletedPayload, SchemaVariantSavedPayload,
-    SchemaVariantUpdatedPayload,
+    SchemaVariantClonedPayload, SchemaVariantDeletedPayload, SchemaVariantReplacedPayload,
+    SchemaVariantSavedPayload, SchemaVariantUpdatedPayload,
 };
 use crate::secret::SecretDeletedPayload;
 use crate::status::StatusUpdate;
@@ -105,6 +105,7 @@ pub enum WsPayload {
     SchemaVariantCloned(SchemaVariantClonedPayload),
     SchemaVariantCreated(frontend_types::SchemaVariant),
     SchemaVariantDeleted(SchemaVariantDeletedPayload),
+    SchemaVariantReplaced(SchemaVariantReplacedPayload),
     SchemaVariantSaved(SchemaVariantSavedPayload),
     SchemaVariantUpdated(frontend_types::SchemaVariant),
     SchemaVariantUpdateFinished(SchemaVariantUpdatedPayload),


### PR DESCRIPTION
Regenerate could set the active asset id to a value that the websocket hadn't filled in yet. This PR makes schema variant replace operation into a single message, and the regenerate success call back not do anything, so we don't race anymore.

Schema variant update also used to move multiplayer users to the latest updated asset even if they weren't editing it, this PR fixes that.

<img src="https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExMTRrejFuZDIwd3hhb3d4OG5vemNsOWhxcWdzbXVzNGs3ODV5NHRkeiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/zCzrh9mEOULVm/200.webp"/>