### PR TITLE
feat: nack veritech function run failures

### DIFF
--- a/lib/si-pool-noodle/src/errors.rs
+++ b/lib/si-pool-noodle/src/errors.rs
@@ -25,4 +25,7 @@ pub enum PoolNoodleError<E> {
     /// Failed to healthcheck instance creation.
     #[error("Failed to check pool health: {0}")]
     Unhealthy(#[source] E),
+    /// Failed to healthcheck instance creation in time.
+    #[error("Failed to check pool health in time")]
+    UnhealthyTimeout(#[source] tokio::time::error::Elapsed),
 }

--- a/lib/veritech-server/src/handlers.rs
+++ b/lib/veritech-server/src/handlers.rs
@@ -120,7 +120,7 @@ pub async fn process_request(
             let request: ActionRunRequest =
                 serde_json::from_slice(&msg.payload).map_err(HandlerError::RequestDerializing)?;
             info!(execution_kind = %NATS_ACTION_RUN_DEFAULT_SUBJECT_SUFFIX, execution_id = %request.execution_id, "validated request and about to execute");
-            action_run_request_task(state, request, reply_subject).await?
+            action_run_request(state, request, reply_subject).await?
         }
         (Some(NATS_RESOLVER_FUNCTION_DEFAULT_SUBJECT_SUFFIX), None) => {
             let request: ResolverFunctionRequest =
@@ -132,26 +132,18 @@ pub async fn process_request(
             let request: SchemaVariantDefinitionRequest =
                 serde_json::from_slice(&msg.payload).map_err(HandlerError::RequestDerializing)?;
             info!(execution_kind = %NATS_SCHEMA_VARIANT_DEFINITION_DEFAULT_SUBJECT_SUFFIX, execution_id = %request.execution_id, "validated request and about to execute");
-            schema_variant_definition_request_task(state, request, reply_subject).await?
+            schema_variant_definition_request(state, request, reply_subject).await?
         }
         (Some(NATS_VALIDATION_DEFAULT_SUBJECT_SUFFIX), None) => {
             let request: ValidationRequest =
                 serde_json::from_slice(&msg.payload).map_err(HandlerError::RequestDerializing)?;
             info!(execution_kind = %NATS_VALIDATION_DEFAULT_SUBJECT_SUFFIX, execution_id = %request.execution_id, "validated request and about to execute");
-            validation_request_task(state, request, reply_subject).await?
+            validation_request(state, request, reply_subject).await?
         }
         _ => return Err(HandlerError::InvalidIncomingSubject(subject)),
     }
 
     Ok(())
-}
-
-async fn action_run_request_task(
-    state: AppState,
-    cyclone_request: ActionRunRequest,
-    reply_mailbox: Subject,
-) -> HandlerResult<()> {
-    action_run_request(state, cyclone_request, reply_mailbox).await
 }
 
 #[instrument(name = "veritech.action_run_request", level = "info", skip_all)]
@@ -425,14 +417,6 @@ async fn resolver_function_request(
     Ok(function_result)
 }
 
-async fn schema_variant_definition_request_task(
-    state: AppState,
-    cyclone_request: SchemaVariantDefinitionRequest,
-    reply_mailbox: Subject,
-) -> HandlerResult<()> {
-    schema_variant_definition_request(state, cyclone_request, reply_mailbox).await
-}
-
 #[instrument(
     name = "veritech.schema_variant_definition_request",
     level = "info",
@@ -562,14 +546,6 @@ async fn schema_variant_definition_request(
     }
 
     Ok(())
-}
-
-async fn validation_request_task(
-    state: AppState,
-    cyclone_request: ValidationRequest,
-    reply_mailbox: Subject,
-) -> HandlerResult<()> {
-    validation_request(state, cyclone_request, reply_mailbox).await
 }
 
 #[instrument(name = "veritech.validation_request", level = "info", skip_all)]

--- a/lib/veritech-server/src/server.rs
+++ b/lib/veritech-server/src/server.rs
@@ -36,6 +36,7 @@ use crate::{
 };
 
 const CONSUMER_NAME: &str = "veritech-server";
+const CONSUMER_MAX_DELIVERY: i64 = 5;
 
 /// Server metadata, used with telemetry.
 #[derive(Clone, Debug)]
@@ -288,6 +289,7 @@ impl Server {
         async_nats::jetstream::consumer::pull::Config {
             durable_name: Some(CONSUMER_NAME.to_owned()),
             filter_subject: subject::incoming(subject_prefix).to_string(),
+            max_deliver: CONSUMER_MAX_DELIVERY,
             ..Default::default()
         }
     }


### PR DESCRIPTION
This allows Veritech to `nack` function run requests that fail prior to the actual function execution, such as if the cyclone pool is starved or the message fails to deserialize. On `nack`, the message will be put back into Jetstream, allowing an Veritech to pick it up (the same one or a different one) and try again. This should help cover off on pool starvation scenarios, giving us a chance the retry failures and let the pool refill. We will retry messages up to five times before giving up.

In the future, we should consider a [dead letter queue](https://docs.nats.io/using-nats/developer/develop_jetstream/consumers#dead-letter-queues-type-functionality) so we can determine what to do with these when they completely fail out.

This PR also reduces the execution pool timeout to 2 minutes, assuming that if we can't serve the `get` within that window another Veritech might be able to. I also added a timeout to the pool healthcheck to catch cases where we might hang on startup.

For @fnichol and @nickgerace , I made a light attempt at refactoring this to remove the code duplication, but found wrestling with the types made it a fairly large effort and thought it would be better served in a PR that does the refactor only so we aren't also contending with behavior changes while trying to get it right.

<img src="https://media1.giphy.com/media/VL48WGMDjD64umCEkv/giphy.gif"/>
