### PR TITLE
fix: Cleanup graph after individual deletes

### DIFF
--- a/lib/sdf-server/src/service/diagram/delete_component.rs
+++ b/lib/sdf-server/src/service/diagram/delete_component.rs
@@ -59,6 +59,8 @@ pub async fn delete_components(
             &posthog_client,
         )
         .await?;
+        ctx.workspace_snapshot()?.cleanup().await?;
+
         components.insert(component_id, component_still_exists);
 
         let exists_on_head = components_existing_on_head.contains(&component_id);


### PR DESCRIPTION
When deleting multiple components of the same SV, we didn't clean up the graph, so after the first component deletion the orphaned AVs would be touched, but wouldn't refer to anything anymore, triggering the error - thanks @zacharyhamm for spotting this!