### PR TITLE
fix: Same account diagram position multiplayer

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -1064,6 +1064,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
 
           async SET_COMPONENT_GEOMETRY(
             componentUpdates: SingleSetComponentGeometryData[],
+            clientUlid: string,
           ) {
             if (changeSetsStore.creatingChangeSet)
               throw new Error("race, wait until the change set is created");
@@ -1094,6 +1095,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               params: {
                 dataByComponentId,
                 diagramKind: "configuration",
+                clientUlid,
                 ...visibilityParams,
               },
               onFail: (err) => {
@@ -1154,7 +1156,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                     });
                   }
                   const payload = this.constructGeometryData(components);
-                  this.SET_COMPONENT_GEOMETRY(payload);
+                  this.SET_COMPONENT_GEOMETRY(payload, clientUlid);
                 }
               },
               onSuccess: (response) => {

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -52,7 +52,7 @@ export interface OnlineRequest {
 export interface ComponentPositionRequest {
   kind: "ComponentSetPosition";
   data: {
-    userPk: UserId;
+    clientUlid?: string;
     changeSetId: string | null;
     positions: ComponentGeometry[];
   };
@@ -78,7 +78,7 @@ export type WsEventPayloadMap = {
 
   SetComponentPosition: {
     changeSetId: ChangeSetId;
-    userPk: UserId;
+    clientUlid: string;
     positions: [
       {
         componentId: ComponentId;

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -62,7 +62,7 @@ use crate::{
     id, implement_add_edge_to, AttributePrototype, AttributeValue, AttributeValueId, ChangeSetId,
     DalContext, Func, FuncError, FuncId, HelperError, InputSocket, InputSocketId, OutputSocket,
     OutputSocketId, Prop, PropId, PropKind, Schema, SchemaVariant, SchemaVariantId,
-    StandardModelError, Timestamp, TransactionsError, UserPk, WorkspaceError, WorkspacePk, WsEvent,
+    StandardModelError, Timestamp, TransactionsError, WorkspaceError, WorkspacePk, WsEvent,
     WsEventError, WsEventResult, WsPayload,
 };
 
@@ -3354,7 +3354,8 @@ pub struct ComponentSetPosition {
 pub struct ComponentSetPositionPayload {
     change_set_id: ChangeSetId,
     positions: Vec<ComponentSetPosition>,
-    user_pk: Option<UserPk>,
+    // Used so the client can ignore the messages it caused. created by the frontend, and not stored
+    client_ulid: Option<ulid::Ulid>,
 }
 
 impl ComponentSetPositionPayload {
@@ -3435,7 +3436,7 @@ impl WsEvent {
         ctx: &DalContext,
         change_set_id: ChangeSetId,
         components: Vec<Component>,
-        user_pk: Option<UserPk>,
+        client_ulid: Option<ulid::Ulid>,
     ) -> WsEventResult<Self> {
         let mut positions: Vec<ComponentSetPosition> = vec![];
         for component in components {
@@ -3458,7 +3459,7 @@ impl WsEvent {
             WsPayload::SetComponentPosition(ComponentSetPositionPayload {
                 change_set_id,
                 positions,
-                user_pk,
+                client_ulid,
             }),
         )
         .await


### PR DESCRIPTION
We were filtering component geometry websocket requests via user pk, which made diagrams from different tabs for the same user not be in sync with each other. 

Now the frontend generates a temporary client_ulid so it can know to ignore messages from the same tab (movement gets laggy if we don't), but not from other tabs from the same user.

<img src="https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExcHoybjR6cmF4cTlmenVpbHpwZG1jdDdnMGM2bWt3azQzbmhzY3VzNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/FPnfb51YrCFHO/giphy.webp" />