### PR TITLE
Correct node_hash calculation for InputSocketNodeWeight and SchemaVariantNodeWeight

### DIFF
--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -96,7 +96,7 @@ impl ComponentNodeWeight {
 
     pub fn node_hash(&self) -> ContentHash {
         ContentHash::from(&serde_json::json![{
-            "content_address": self.content_address,
+            "content_hash": self.content_address.content_hash(),
             "to_delete": self.to_delete,
         }])
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
@@ -83,7 +83,7 @@ impl FuncArgumentNodeWeight {
 
     pub fn node_hash(&self) -> ContentHash {
         ContentHash::from(&serde_json::json![{
-            "content_address": self.content_address,
+            "content_hash": self.content_address.content_hash(),
             "name": self.name,
         }])
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
@@ -100,7 +100,7 @@ impl FuncNodeWeight {
 
     pub fn node_hash(&self) -> ContentHash {
         ContentHash::from(&serde_json::json![{
-            "content_address": self.content_address,
+            "content_hash": self.content_address.content_hash(),
             "name": self.name,
             "func_kind": self.func_kind,
         }])

--- a/lib/dal/src/workspace_snapshot/node_weight/input_socket_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/input_socket_node_weight/v1.rs
@@ -155,7 +155,7 @@ impl SiNodeWeight for InputSocketNodeWeightV1 {
     fn node_hash(&self) -> ContentHash {
         let mut content_hasher = ContentHash::hasher();
         content_hasher.update(self.arity.to_string().as_bytes());
-        content_hasher.update(self.content_address.to_string().as_bytes());
+        content_hasher.update(self.content_address.content_hash().to_string().as_bytes());
 
         content_hasher.finalize()
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
@@ -106,7 +106,7 @@ impl PropNodeWeight {
 
     pub fn node_hash(&self) -> ContentHash {
         ContentHash::from(&serde_json::json![{
-            "content_address": self.content_address,
+            "content_hash": self.content_address.content_hash(),
             "kind": self.kind,
             "name": self.name,
         }])

--- a/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
@@ -184,7 +184,7 @@ impl SiNodeWeight for SchemaVariantNodeWeightV1 {
     fn node_hash(&self) -> ContentHash {
         let mut content_hasher = ContentHash::hasher();
         content_hasher.update(if self.is_locked { &[0x01] } else { &[0x00] });
-        content_hasher.update(self.content_address.to_string().as_bytes());
+        content_hasher.update(self.content_address.content_hash().to_string().as_bytes());
 
         content_hasher.finalize()
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
@@ -99,7 +99,7 @@ impl SecretNodeWeight {
 
     pub fn node_hash(&self) -> ContentHash {
         ContentHash::from(&serde_json::json![{
-            "content_address": self.content_address,
+            "content_hash": self.content_address.content_hash(),
             "encrypted_secret_key": self.encrypted_secret_key,
         }])
     }


### PR DESCRIPTION
Turns out that `self.content_address.to_string()` is just the name of the enum variant (`SchemaVariant`, `InputSocket`, etc.) and doesn't actually include any of the hash itself.

The uses of `self.content_address` inside of `serde_json::json![...]` are technically fine, since `serde_json` will basically output a form of the debug output of the enum, but it's such an easy thing to forget that `serde_json` has special handling that it felt like we should avoid using it directly for the `node_hash` in general.