### PR TITLE
chore: allows db proxy target to be configurable

### DIFF
--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -29,7 +29,7 @@ user = "si"
 password = "$SI_PG_PASSWORD"
 dbname = "$SI_PG_DB"
 application_name = "$SI_SERVICE"
-hostname = "localhost"
+hostname = "$SI_PG_PROXY_HOST"
 port = 5432
 pool_max_size = 500
 
@@ -47,7 +47,7 @@ user = "si"
 password = "$SI_PG_PASSWORD"
 dbname = "$SI_LAYER_CACHE_DBNAME"
 application_name = "$SI_SERVICE"
-hostname = "localhost"
+hostname = "$SI_PG_PROXY_HOST"
 port = 5432
 pool_max_size = 500
 


### PR DESCRIPTION
Making this configurable to we can more easily experiment with pg pooling mechanisms