### PR TITLE
Remove all usage of serde_json::json![...] in node_hash node weight methods

### DIFF
--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -78,7 +78,7 @@ impl From<ActionPrototypeId> for si_events::ActionPrototypeId {
     }
 }
 
-#[derive(Debug, Copy, Clone, Deserialize, Serialize, EnumDiscriminants, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Deserialize, Serialize, EnumDiscriminants, PartialEq, Eq, Display)]
 #[strum_discriminants(derive(strum::Display, Serialize, Deserialize))]
 pub enum ActionState {
     /// Action has been determined to be eligible to run, and has had its job sent to the job

--- a/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
@@ -70,12 +70,13 @@ impl ActionNodeWeight {
     }
 
     pub fn node_hash(&self) -> ContentHash {
-        ContentHash::from(&serde_json::json![{
-            "id": self.id,
-            "lineage_id": self.lineage_id,
-            "state": self.state,
-            "originating_changeset_id": self.originating_change_set_id,
-        }])
+        let mut content_hasher = ContentHash::hasher();
+        content_hasher.update(&self.id.inner().to_bytes());
+        content_hasher.update(&self.lineage_id.inner().to_bytes());
+        content_hasher.update(self.state.to_string().as_bytes());
+        content_hasher.update(self.originating_change_set_id.to_string().as_bytes());
+
+        content_hasher.finalize()
     }
 
     pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {

--- a/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
@@ -74,12 +74,19 @@ impl ActionPrototypeNodeWeight {
     }
 
     pub fn node_hash(&self) -> ContentHash {
-        ContentHash::from(&serde_json::json![{
-            "id": self.id,
-            "kind": self.kind,
-            "name": self.name,
-            "description": self.description,
-        }])
+        let mut content_hasher = ContentHash::hasher();
+        content_hasher.update(&self.id.inner().to_bytes());
+        content_hasher.update(self.kind.to_string().as_bytes());
+        content_hasher.update(self.name.as_bytes());
+        content_hasher.update(
+            &self
+                .description
+                .as_ref()
+                .map(|d| d.as_bytes().to_owned())
+                .unwrap_or_else(|| vec![0x00]),
+        );
+
+        content_hasher.finalize()
     }
 
     pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -95,10 +95,21 @@ impl AttributeValueNodeWeight {
     }
 
     pub fn node_hash(&self) -> ContentHash {
-        ContentHash::from(&serde_json::json![{
-            "unprocessed_value": self.unprocessed_value,
-            "value": self.value,
-        }])
+        let mut content_hasher = ContentHash::hasher();
+        content_hasher.update(
+            &self
+                .unprocessed_value
+                .map(|v| v.content_hash().as_bytes().to_owned())
+                .unwrap_or_else(|| vec![0x00]),
+        );
+        content_hasher.update(
+            &self
+                .value
+                .map(|v| v.content_hash().as_bytes().to_owned())
+                .unwrap_or_else(|| vec![0x00]),
+        );
+
+        content_hasher.finalize()
     }
 
     pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {

--- a/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
@@ -72,7 +72,10 @@ impl CategoryNodeWeight {
     }
 
     pub fn node_hash(&self) -> ContentHash {
-        ContentHash::from(&serde_json::json![self.kind])
+        let mut content_hasher = ContentHash::hasher();
+        content_hasher.update(self.kind.to_string().as_bytes());
+
+        content_hasher.finalize()
     }
 
     pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -95,10 +95,11 @@ impl ComponentNodeWeight {
     }
 
     pub fn node_hash(&self) -> ContentHash {
-        ContentHash::from(&serde_json::json![{
-            "content_hash": self.content_address.content_hash(),
-            "to_delete": self.to_delete,
-        }])
+        let mut content_hasher = ContentHash::hasher();
+        content_hasher.update(self.content_address.content_hash().as_bytes());
+        content_hasher.update(&[u8::from(self.to_delete)]);
+
+        content_hasher.finalize()
     }
 
     pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {

--- a/lib/dal/src/workspace_snapshot/node_weight/dependent_value_root_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/dependent_value_root_node_weight.rs
@@ -49,9 +49,10 @@ impl DependentValueRootNodeWeight {
     }
 
     pub fn node_hash(&self) -> ContentHash {
-        ContentHash::from(&serde_json::json![{
-            "value_id": self.value_id,
-        }])
+        let mut content_hasher = ContentHash::hasher();
+        content_hasher.update(self.value_id.to_string().as_bytes());
+
+        content_hasher.finalize()
     }
 
     pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {

--- a/lib/dal/src/workspace_snapshot/node_weight/finished_dependent_value_root_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/finished_dependent_value_root_node_weight.rs
@@ -48,9 +48,10 @@ impl FinishedDependentValueRootNodeWeight {
     }
 
     pub fn node_hash(&self) -> ContentHash {
-        ContentHash::from(&serde_json::json![{
-            "value_id": self.value_id,
-        }])
+        let mut content_hasher = ContentHash::hasher();
+        content_hasher.update(&self.value_id.inner().to_bytes());
+
+        content_hasher.finalize()
     }
 
     pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {

--- a/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
@@ -82,10 +82,11 @@ impl FuncArgumentNodeWeight {
     }
 
     pub fn node_hash(&self) -> ContentHash {
-        ContentHash::from(&serde_json::json![{
-            "content_hash": self.content_address.content_hash(),
-            "name": self.name,
-        }])
+        let mut content_hasher = ContentHash::hasher();
+        content_hasher.update(self.content_address.content_hash().as_bytes());
+        content_hasher.update(self.name.as_bytes());
+
+        content_hasher.finalize()
     }
 
     pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {

--- a/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
@@ -99,11 +99,12 @@ impl FuncNodeWeight {
     }
 
     pub fn node_hash(&self) -> ContentHash {
-        ContentHash::from(&serde_json::json![{
-            "content_hash": self.content_address.content_hash(),
-            "name": self.name,
-            "func_kind": self.func_kind,
-        }])
+        let mut content_hasher = ContentHash::hasher();
+        content_hasher.update(self.content_address.content_hash().as_bytes());
+        content_hasher.update(self.name.as_bytes());
+        content_hasher.update(self.func_kind.to_string().as_bytes());
+
+        content_hasher.finalize()
     }
 
     pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {

--- a/lib/dal/src/workspace_snapshot/node_weight/input_socket_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/input_socket_node_weight/v1.rs
@@ -155,7 +155,7 @@ impl SiNodeWeight for InputSocketNodeWeightV1 {
     fn node_hash(&self) -> ContentHash {
         let mut content_hasher = ContentHash::hasher();
         content_hasher.update(self.arity.to_string().as_bytes());
-        content_hasher.update(self.content_address.content_hash().to_string().as_bytes());
+        content_hasher.update(self.content_address.content_hash().as_bytes());
 
         content_hasher.finalize()
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
@@ -105,11 +105,12 @@ impl PropNodeWeight {
     }
 
     pub fn node_hash(&self) -> ContentHash {
-        ContentHash::from(&serde_json::json![{
-            "content_hash": self.content_address.content_hash(),
-            "kind": self.kind,
-            "name": self.name,
-        }])
+        let mut content_hasher = ContentHash::hasher();
+        content_hasher.update(self.content_address.content_hash().as_bytes());
+        content_hasher.update(self.kind.to_string().as_bytes());
+        content_hasher.update(self.name.as_bytes());
+
+        content_hasher.finalize()
     }
 
     pub const fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {

--- a/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
@@ -183,8 +183,8 @@ impl SiNodeWeight for SchemaVariantNodeWeightV1 {
 
     fn node_hash(&self) -> ContentHash {
         let mut content_hasher = ContentHash::hasher();
-        content_hasher.update(if self.is_locked { &[0x01] } else { &[0x00] });
-        content_hasher.update(self.content_address.content_hash().to_string().as_bytes());
+        content_hasher.update(&[u8::from(self.is_locked)]);
+        content_hasher.update(self.content_address.content_hash().as_bytes());
 
         content_hasher.finalize()
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
@@ -98,10 +98,11 @@ impl SecretNodeWeight {
     }
 
     pub fn node_hash(&self) -> ContentHash {
-        ContentHash::from(&serde_json::json![{
-            "content_hash": self.content_address.content_hash(),
-            "encrypted_secret_key": self.encrypted_secret_key,
-        }])
+        let mut content_hasher = ContentHash::hasher();
+        content_hasher.update(self.content_address.content_hash().as_bytes());
+        content_hasher.update(self.encrypted_secret_key.as_bytes());
+
+        content_hasher.finalize()
     }
 
     pub fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {


### PR DESCRIPTION
The only reason we were using `serde_json::json![...]` was to have something to feed into the `ContentHash` hasher. We didn't need the JSON itself as anything other than a sequence of bytes.

Rather than spending the time to serialize everything as JSON, just to feed the string representation as a sequence of bytes to the hasher, we now feed the values in directly to the hasher as sequences of bytes, bypassing the JSON serialization entirely.