### PR TITLE
Fail on apply if DVU roots are not empty

### DIFF
--- a/app/web/src/components/ApplyChangeSetButton.vue
+++ b/app/web/src/components/ApplyChangeSetButton.vue
@@ -71,19 +71,22 @@ import {
   themeClasses,
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
+import { useToast } from "vue-toastification";
 import { useChangeSetsStore } from "@/store/change_sets.store";
 import { useStatusStore } from "@/store/status.store";
 import { useActionsStore } from "@/store/actions.store";
 import { useAuthStore } from "@/store/auth.store";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
+import RetryApply from "@/components/toasts/RetryApply.vue";
 import ApprovalFlowModal from "./ApprovalFlowModal.vue";
 
-const statusStore = useStatusStore();
-const changeSetsStore = useChangeSetsStore();
 const actionsStore = useActionsStore();
 const authStore = useAuthStore();
-const router = useRouter();
+const changeSetsStore = useChangeSetsStore();
 const route = useRoute();
+const router = useRouter();
+const statusStore = useStatusStore();
+const toast = useToast();
 
 const displayCount = computed(() => actionsStore.proposedActions.length);
 
@@ -111,6 +114,10 @@ const applyChangeSet = async () => {
         ...route.params,
         changeSetId: "head",
       },
+    });
+  } else if (resp.result.statusCode === 428) {
+    toast({
+      component: RetryApply,
     });
   }
 };

--- a/app/web/src/components/toasts/RetryApply.vue
+++ b/app/web/src/components/toasts/RetryApply.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    <div
+      class="flex flex-row gap-sm items-center dark:bg-black bg-white max-h-[75vh] overflow-y-auto max-w-lg"
+    >
+      <Icon
+        name="alert-circle"
+        class="text-warning-600 content-center ml-md"
+        size="lg"
+      />
+      <p class="grow py-md max-w-lg">
+        Error when attemping to apply changes: found dependent values that need
+        to be processed. Please retry applying your changes! No further action
+        should be required.
+      </p>
+    </div>
+    <div class="flex flex-row gap-sm items-center mt-xs">
+      <VButton
+        class="grow text-action-300 dark:hover:text-white hover:text-black hover:bg-action-400 hover:underline"
+        label="Close"
+        tone="empty"
+        variant="solid"
+        @click="$emit('close-toast')"
+      ></VButton>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { VButton, Icon } from "@si/vue-lib/design-system";
+
+const emit = defineEmits<{
+  (e: "close-toast"): void;
+}>();
+</script>
+
+<style lang="less">
+pre {
+  font-family: monospace;
+  resize: none;
+  display: block;
+}
+</style>


### PR DESCRIPTION
## Description

This PR ensures that we fail on applying a change set in `sdf` if DVU roots are not empty. A toast will be fired if this happens, which should be rare and require no additional user action.

<img src="https://media2.giphy.com/media/cb2MIvWW4nG4o/giphy.gif"/>