### PR TITLE
fix: remove even more func run writes

### DIFF
--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -239,6 +239,7 @@ impl FuncAuthoringClient {
             }
         }
 
+        let is_intrinsic = func.is_intrinsic();
         let (func_run_id, result_channel) =
             FuncRunner::run_test(ctx, func, args, component_id).await?;
 
@@ -283,16 +284,18 @@ impl FuncAuthoringClient {
             None => None,
         };
 
-        ctx.layer_db()
-            .func_run()
-            .set_values_and_set_state_to_success(
-                func_run_value.func_run_id(),
-                unprocessed_value_address,
-                value_address,
-                ctx.events_tenancy(),
-                ctx.events_actor(),
-            )
-            .await?;
+        if !is_intrinsic {
+            ctx.layer_db()
+                .func_run()
+                .set_values_and_set_state_to_success(
+                    func_run_value.func_run_id(),
+                    unprocessed_value_address,
+                    value_address,
+                    ctx.events_tenancy(),
+                    ctx.events_actor(),
+                )
+                .await?;
+        }
 
         Ok(func_run_id)
     }

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -1502,16 +1502,19 @@ impl FuncRunnerExecutionTask {
         let mut running_state_func_run_inner = Arc::unwrap_or_clone(self.func_run.clone());
         running_state_func_run_inner.set_state_to_running();
         let running_state_func_run = Arc::new(running_state_func_run_inner);
-        self.ctx
-            .layer_db()
-            .func_run()
-            .write(
-                running_state_func_run.clone(),
-                None,
-                self.ctx.events_tenancy(),
-                self.ctx.events_actor(),
-            )
-            .await?;
+
+        if !self.func.is_intrinsic() {
+            self.ctx
+                .layer_db()
+                .func_run()
+                .write(
+                    running_state_func_run.clone(),
+                    None,
+                    self.ctx.events_tenancy(),
+                    self.ctx.events_actor(),
+                )
+                .await?;
+        }
 
         let execution_result = match self.func_run.backend_kind().into() {
             FuncBackendKind::JsAction => {
@@ -1616,16 +1619,20 @@ impl FuncRunnerExecutionTask {
                 let mut next_state_inner = Arc::unwrap_or_clone(running_state_func_run.clone());
                 next_state_inner.set_state_to_post_processing();
                 let next_state = Arc::new(next_state_inner);
-                self.ctx
-                    .layer_db()
-                    .func_run()
-                    .write(
-                        next_state.clone(),
-                        None,
-                        self.ctx.events_tenancy(),
-                        self.ctx.events_actor(),
-                    )
-                    .await?;
+
+                if !self.func.is_intrinsic() {
+                    self.ctx
+                        .layer_db()
+                        .func_run()
+                        .write(
+                            next_state.clone(),
+                            None,
+                            self.ctx.events_tenancy(),
+                            self.ctx.events_actor(),
+                        )
+                        .await?;
+                }
+
                 let _ = self.result_tx.send(Ok(FuncRunValue::new(
                     next_state.id(),
                     unprocessed_value,
@@ -1640,16 +1647,18 @@ impl FuncRunnerExecutionTask {
                 let mut next_state_inner = Arc::unwrap_or_clone(running_state_func_run.clone());
                 next_state_inner.set_state_to_failure();
                 let next_state = Arc::new(next_state_inner);
-                self.ctx
-                    .layer_db()
-                    .func_run()
-                    .write(
-                        next_state.clone(),
-                        None,
-                        self.ctx.events_tenancy(),
-                        self.ctx.events_actor(),
-                    )
-                    .await?;
+                if !self.func.is_intrinsic() {
+                    self.ctx
+                        .layer_db()
+                        .func_run()
+                        .write(
+                            next_state.clone(),
+                            None,
+                            self.ctx.events_tenancy(),
+                            self.ctx.events_actor(),
+                        )
+                        .await?;
+                }
 
                 let _ = self.result_tx.send(Err(FuncRunnerError::ResultFailure {
                     kind,
@@ -1661,16 +1670,20 @@ impl FuncRunnerExecutionTask {
                 let mut next_state_inner = Arc::unwrap_or_clone(running_state_func_run.clone());
                 next_state_inner.set_state_to_failure();
                 let next_state = Arc::new(next_state_inner);
-                self.ctx
-                    .layer_db()
-                    .func_run()
-                    .write(
-                        next_state.clone(),
-                        None,
-                        self.ctx.events_tenancy(),
-                        self.ctx.events_actor(),
-                    )
-                    .await?;
+
+                if !self.func.is_intrinsic() {
+                    self.ctx
+                        .layer_db()
+                        .func_run()
+                        .write(
+                            next_state.clone(),
+                            None,
+                            self.ctx.events_tenancy(),
+                            self.ctx.events_actor(),
+                        )
+                        .await?;
+                }
+
                 let _ = self.result_tx.send(Err(err.into()));
             }
         }


### PR DESCRIPTION
There were several more func run writes hiding in the execution path for functions. Removing these for intrinsics. We should also consider doing them less often for js attributes if it makes sense.