### PR TITLE
feat: disable unused builds

### DIFF
--- a/bin/forklift/BUCK
+++ b/bin/forklift/BUCK
@@ -1,6 +1,5 @@
 load(
     "@prelude-si//:macros.bzl",
-    "docker_image",
     "nix_omnibus_pkg",
     "rust_binary",
 )
@@ -15,12 +14,6 @@ rust_binary(
     ],
     srcs = glob(["src/**/*.rs"]),
     env = {"CARGO_BIN_NAME": "forklift"},
-)
-
-docker_image(
-    name = "image",
-    image_name = "forklift",
-    build_deps = ["//bin/forklift:forklift"],
 )
 
 nix_omnibus_pkg(

--- a/bin/pinga/BUCK
+++ b/bin/pinga/BUCK
@@ -1,6 +1,5 @@
 load(
     "@prelude-si//:macros.bzl",
-    "docker_image",
     "nix_omnibus_pkg",
     "rust_binary",
 )
@@ -19,13 +18,6 @@ rust_binary(
         "dev.donkey.key": "//lib/dal:dev.donkey.key",
         "dev.postgres.root.crt": "//config/keys:dev.postgres.root.crt",
     },
-)
-
-docker_image(
-    name = "image",
-    image_name = "pinga",
-    flake_lock = "//:flake.lock",
-    build_deps = ["//bin/pinga:pinga"],
 )
 
 nix_omnibus_pkg(

--- a/bin/rebaser/BUCK
+++ b/bin/rebaser/BUCK
@@ -1,6 +1,5 @@
 load(
     "@prelude-si//:macros.bzl",
-    "docker_image",
     "nix_omnibus_pkg",
     "rust_binary",
 )
@@ -20,12 +19,6 @@ rust_binary(
         "dev.donkey.key": "//lib/dal:dev.donkey.key",
         "dev.postgres.root.crt": "//config/keys:dev.postgres.root.crt",
     },
-)
-
-docker_image(
-    name = "image",
-    image_name = "rebaser",
-    build_deps = ["//bin/rebaser:rebaser"],
 )
 
 nix_omnibus_pkg(

--- a/bin/sdf/BUCK
+++ b/bin/sdf/BUCK
@@ -1,6 +1,5 @@
 load(
     "@prelude-si//:macros.bzl",
-    "docker_image",
     "rust_binary",
     "nix_omnibus_pkg",
 )
@@ -22,16 +21,6 @@ rust_binary(
         "dev.donkey.key": "//lib/dal:dev.donkey.key",
         "pkgs_path": "//pkgs:pkgs",
     },
-)
-
-docker_image(
-    name = "image",
-    image_name = "sdf",
-    flake_lock = "//:flake.lock",
-    build_deps = [
-        "//bin/sdf:sdf",
-        "//pkgs:pkgs",
-    ]
 )
 
 nix_omnibus_pkg(

--- a/bin/veritech/BUCK
+++ b/bin/veritech/BUCK
@@ -1,6 +1,5 @@
 load(
     "@prelude-si//:macros.bzl",
-    "docker_image",
     "export_file",
     "nix_omnibus_pkg",
     "rust_binary",
@@ -63,18 +62,6 @@ shfmt_check(
 shellcheck(
     name = "check-lint-shell",
     srcs = [":docker-entrypoint.sh"],
-)
-
-docker_image(
-    name = "image",
-    image_name = "veritech",
-    flake_lock = "//:flake.lock",
-    build_deps = [
-        "//bin/veritech:veritech",
-        "//bin/veritech:docker-entrypoint.sh",
-        "//bin/cyclone:cyclone",
-        "//bin/lang-js:bin",
-    ],
 )
 
 nix_omnibus_pkg(


### PR DESCRIPTION
Disables unused builds.

Docker images are unused for:
- forklift
- pinga
- rebaser
- veritech
- sdf

All the other omnibus packages are used, but theoretically we could also disable some of the x86/arm variants depending on service but it's nice to have some flexibility there. If we want to disable them I think it's in the CI repository anyway.