### PR TITLE
Feat/add webhook to api test

### DIFF
--- a/.github/workflows/run-api-test.yml
+++ b/.github/workflows/run-api-test.yml
@@ -16,6 +16,9 @@ on:
         options:
           - tools
           - production
+  repository_dispatch:
+    types:
+      - webhook
 
 jobs:
   define-test-matrix:


### PR DESCRIPTION
Adds basic webhook to allow us to trigger the API tests as part of an incident runbook