### PR TITLE
fix: Delete newly created edges correctly

### DIFF
--- a/lib/sdf-server/src/service/diagram/create_connection.rs
+++ b/lib/sdf-server/src/service/diagram/create_connection.rs
@@ -4,9 +4,8 @@ use axum::{
     Json,
 };
 use dal::{
-    attribute::prototype::argument::AttributePrototypeArgumentId, change_status::ChangeStatus,
-    diagram::SummaryDiagramEdge, ChangeSet, Component, ComponentId, InputSocketId, OutputSocketId,
-    User, Visibility, WsEvent,
+    change_status::ChangeStatus, diagram::SummaryDiagramEdge, ChangeSet, Component, ComponentId,
+    InputSocketId, OutputSocketId, Visibility, WsEvent,
 };
 use serde::{Deserialize, Serialize};
 
@@ -27,14 +26,6 @@ pub struct CreateConnectionRequest {
     pub visibility: Visibility,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct CreateConnectionResponse {
-    pub id: AttributePrototypeArgumentId,
-    pub created_by: Option<User>,
-    pub deleted_by: Option<User>,
-}
-
 pub async fn create_connection(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
@@ -47,7 +38,7 @@ pub async fn create_connection(
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
-    let attribute_prototype_argument_id = Component::connect(
+    Component::connect(
         &ctx,
         request.from_component_id,
         request.from_socket_id,
@@ -99,12 +90,5 @@ pub async fn create_connection(
     if let Some(force_change_set_id) = force_change_set_id {
         response = response.header("force_change_set_id", force_change_set_id.to_string());
     }
-    Ok(response
-        .header("content-type", "application/json")
-        .body(serde_json::to_string(&CreateConnectionResponse {
-            id: attribute_prototype_argument_id,
-            // TODO(nick): figure out what to do with these fields that were left over from the "Connection" struct.
-            created_by: None,
-            deleted_by: None,
-        })?)?)
+    Ok(response.body(axum::body::Empty::new())?)
 }

--- a/lib/vue-lib/src/design-system/menus/DropdownMenuItem.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenuItem.vue
@@ -1,9 +1,9 @@
 <template>
   <component
     :is="htmlTagOrComponentType"
-    v-bind="dynamicAttrs"
     :id="id"
     ref="internalRef"
+    :aria-disabled="noInteract === true ? true : undefined"
     :class="
       clsx(
         'flex gap-xs items-center cursor-pointer select-none group',
@@ -26,37 +26,37 @@
           'pl-sm',
       )
     "
-    role="menuitem"
-    :tabIndex="noInteract === true ? undefined : -1"
-    :aria-disabled="noInteract === true ? true : undefined"
     :data-no-close-on-click="noCloseOnClick ? true : ''"
+    :tabIndex="noInteract === true ? undefined : -1"
+    role="menuitem"
+    v-bind="dynamicAttrs"
+    @click="onClick"
     @mouseenter="onMouseEnter"
     @mouseleave="onMouseLeave"
-    @click="onClick"
   >
     <Toggle
       v-if="toggleIcon"
       :selected="checked || false"
-      size="sm"
       class="pointer-events-none"
+      size="sm"
     />
     <Icon
       v-else-if="menuCtx.isCheckable.value"
       :name="checked ? 'check' : 'none'"
-      size="xs"
       class="mr-2xs shrink-0 pointer-events-none"
+      size="xs"
     />
     <slot name="icon">
       <Icon
         v-if="icon"
-        :name="icon"
-        size="sm"
         :class="
           clsx(
             'shrink-0 pointer-events-none',
             props.iconClass ? props.iconClass : '',
           )
         "
+        :name="icon"
+        size="sm"
       />
     </slot>
 
@@ -77,10 +77,10 @@
         <Icon name="chevron--right" size="sm" />
         <DropdownMenu
           ref="submenuRef"
-          variant="editor"
-          submenu
           :anchorTo="{ $el: internalRef, close: menuCtx.close }"
           :items="submenuItems"
+          submenu
+          variant="editor"
         />
       </template>
 
@@ -92,9 +92,9 @@
             'font-bold hover:underline',
           )
         "
+        @mousedown="onClickEndLink"
         @mouseenter="onMouseEnterEndLink"
         @mouseleave="onMouseLeaveEndLink"
-        @mousedown="onClickEndLink"
       >
         <slot name="endLinkLabel">
           <div v-if="endLinkLabel">{{ endLinkLabel }}</div>
@@ -206,6 +206,12 @@ const isFocused = computed(() => {
   return menuCtx.focusedItemId.value === id;
 });
 
+function trySelect() {
+  if (!noInteract.value) {
+    emit("select");
+  }
+}
+
 function onClick(event: MouseEvent) {
   if (
     noCloseOnClick.value ||
@@ -219,11 +225,9 @@ function onClick(event: MouseEvent) {
     ) {
       openSubmenu();
     }
-    if (!noInteract.value) {
-      emit("select");
-    }
+    trySelect();
   } else {
-    emit("select");
+    trySelect();
     menuCtx.close(props.doNotCloseMenuOnClick);
   }
 }


### PR DESCRIPTION
onSuccess response for create_connection was creating an edge with an outdated id on the store

bonus: Now you can't select disabled dropdown entries