### PR TITLE
feat: ack nats streams as soon as we get them

### DIFF
--- a/lib/naxum/src/middleware/ack/maintain_progress.rs
+++ b/lib/naxum/src/middleware/ack/maintain_progress.rs
@@ -28,6 +28,10 @@ impl MaintainProgressTask {
 
     pub async fn run(mut self) {
         trace!(task = Self::NAME, "running task");
+        debug!(task = Self::NAME, "first ack message");
+        if let Err(err) = self.acker.ack_with(jetstream::AckKind::Progress).await {
+            warn!(error = ?err, "failed initial ack");
+        }
 
         loop {
             tokio::select! {


### PR DESCRIPTION
Make it so we `ack` messages as soon as we get them and then continue the current `ack` loop on a timer. This is to ensure we aren't doing duplicate work when under load by accidentally pulling the same message multiple times.

<img src="https://media4.giphy.com/media/13ea4eXuOuQsmY/giphy.gif"/>