### PR TITLE
Switch to new asset details panel paradigm

### DIFF
--- a/app/docs/src/reference/typescript/asset_builder/classes/MapKeyFuncBuilder.md
+++ b/app/docs/src/reference/typescript/asset_builder/classes/MapKeyFuncBuilder.md
@@ -110,8 +110,14 @@ this
 
 > **setValueFrom**(`valueFrom`): `this`
 
-DEPRECATED: Set the value of this socket using a ValueFromBuilder.
-The recommended way to do this is to attach an attribute function.
+DEPRECATED: this method no longer does anything. It will be ignored
+when executing the asset function. Please use the asset editing
+interface to perform equivalent functionality.
+
+If the entry is new, you will need to regenerate the asset first!
+
+In the past, this was used to set the value of this entry using a
+ValueFromBuilder.
 
 #### Parameters
 

--- a/app/docs/src/reference/typescript/asset_builder/classes/PropBuilder.md
+++ b/app/docs/src/reference/typescript/asset_builder/classes/PropBuilder.md
@@ -433,8 +433,14 @@ this
 
 > **setValueFrom**(`valueFrom`): `this`
 
-DEPRECATED: Set the value of this socket using a ValueFromBuilder.
-The recommended way to do this is to attach an attribute function.
+DEPRECATED: this method no longer does anything. It will be ignored
+when executing the asset function. Please use the asset editing
+interface to perform equivalent functionality.
+
+If the prop is new, you will need to regenerate the asset first!
+
+In the past, this was used to set the value of this prop using a
+ValueFromBuilder.
 
 #### Parameters
 

--- a/app/docs/src/reference/typescript/asset_builder/classes/SocketDefinitionBuilder.md
+++ b/app/docs/src/reference/typescript/asset_builder/classes/SocketDefinitionBuilder.md
@@ -230,8 +230,14 @@ this
 
 > **setValueFrom**(`valueFrom`): `this`
 
-DEPRECATED: Set the value of this socket using a ValueFromBuilder.
-The recommended way to do this is to attach an attribute function.
+DEPRECATED: this method no longer does anything. It will be ignored
+when executing the asset function. Please use the asset editing
+interface to perform equivalent functionality.
+
+If the socket is new, you will need to regenerate the asset first!
+
+In the past, this was used to set the value of this socket using a
+ValueFromBuilder.
 
 #### Parameters
 

--- a/app/web/src/api/sdf/dal/schema.ts
+++ b/app/web/src/api/sdf/dal/schema.ts
@@ -97,7 +97,9 @@ export const outputSocketsAndPropsFor = (
   return opts;
 };
 
-const groupedPropsFor = (schemaVariant: SchemaVariant): GroupedOptions => {
+export const groupedPropsFor = (
+  schemaVariant: SchemaVariant,
+): GroupedOptions => {
   const rootPropOptions = schemaVariant.props
     .filter(
       (p) =>
@@ -188,14 +190,24 @@ const groupedPropsFor = (schemaVariant: SchemaVariant): GroupedOptions => {
 export const inputSocketsAndPropsFor = (
   schemaVariant: SchemaVariant,
 ): GroupedOptions => {
-  const inputSocketOptions = schemaVariant.inputSockets.map((socket) => ({
+  const opts = groupedPropsFor(schemaVariant);
+  opts["Input Sockets"] = rawInputSocketsFor(schemaVariant);
+  return opts;
+};
+
+export const inputSocketsFor = (
+  schemaVariant: SchemaVariant,
+): GroupedOptions => {
+  return {
+    "Input Sockets": rawInputSocketsFor(schemaVariant),
+  };
+};
+
+const rawInputSocketsFor = (schemaVariant: SchemaVariant) => {
+  return schemaVariant.inputSockets.map((socket) => ({
     label: socket.name,
     value: `s_${socket.id}`,
   }));
-
-  const opts = groupedPropsFor(schemaVariant);
-  opts["Input Sockets"] = inputSocketOptions;
-  return opts;
 };
 
 export const findSchemaVariantForPropOrSocketId = (

--- a/app/web/src/assets/static/editor_typescript.txt
+++ b/app/web/src/assets/static/editor_typescript.txt
@@ -180,8 +180,14 @@ declare class SocketDefinitionBuilder implements ISocketDefinitionBuilder {
   setUiHidden(hidden: boolean): this;
 
   /**
-   * DEPRECATED: Set the value of this socket using a ValueFromBuilder.
-   * The recommended way to do this is to attach an attribute function.
+   * DEPRECATED: this method no longer does anything. It will be ignored
+   * when executing the asset function. Please use the asset editing
+   * interface to perform equivalent functionality.
+   *
+   * If the socket is new, you will need to regenerate the asset first!
+   *
+   * In the past, this was used to set the value of this socket using a
+   * ValueFromBuilder.
    *
    * @param {ValueFrom} valueFrom
    *
@@ -322,8 +328,14 @@ declare class MapKeyFuncBuilder implements IMapKeyFuncBuilder {
   setKey(key: string): this;
 
   /**
-   * DEPRECATED: Set the value of this socket using a ValueFromBuilder.
-   * The recommended way to do this is to attach an attribute function.
+   * DEPRECATED: this method no longer does anything. It will be ignored
+   * when executing the asset function. Please use the asset editing
+   * interface to perform equivalent functionality.
+   *
+   * If the enty is new, you will need to regenerate the asset first!
+   *
+   * In the past, this was used to set the value of this entry using a
+   * ValueFromBuilder.
    *
    * @param {ValueFrom} valueFrom
    *
@@ -583,8 +595,14 @@ declare class PropBuilder implements IPropBuilder {
   setName(name: string): this;
 
   /**
-   * DEPRECATED: Set the value of this socket using a ValueFromBuilder.
-   * The recommended way to do this is to attach an attribute function.
+   * DEPRECATED: this method no longer does anything. It will be ignored
+   * when executing the asset function. Please use the asset editing
+   * interface to perform equivalent functionality.
+   *
+   * If the prop is new, you will need to regenerate the asset first!
+   *
+   * In the past, this was used to set the value of this prop using a
+   * ValueFromBuilder.
    *
    * @param {ValueFrom} valueFrom
    *

--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -146,47 +146,47 @@
           @focus="focus"
         />
       </Stack>
-      <template v-if="ffStore.SHOW_INTRINSIC_EDITING">
-        <Stack class="p-xs" spacing="none">
-          <span class="uppercase font-bold py-3"
-            >CONFIGURE DATA PROPAGATION</span
+      <Stack class="p-xs" spacing="none">
+        <span class="uppercase font-bold py-3">CONFIGURE DATA PROPAGATION</span>
+        <p class="text-xs pb-4">
+          Choose how output sockets and props get their values.
+        </p>
+        <span class="uppercase font-bold text-sm">Output Sockets</span>
+        <ul v-if="outputSocketIntrinsics.length > 0">
+          <li
+            v-for="config in outputSocketIntrinsics"
+            :key="config.attributePrototypeId"
           >
-          <p class="text-xs pb-4">
-            Choose how output sockets and props get their value
-          </p>
-          <span class="uppercase font-bold text-sm">Output Sockets</span>
-          <ul>
-            <li
-              v-for="config in outputSocketIntrinsics"
-              :key="config.attributePrototypeId"
-            >
-              <AssetDetailIntrinsicInput
-                :schemaVariantId="schemaVariantId"
-                :isLocked="editingAsset.isLocked"
-                :data="config"
-                @change="updateOutputSocketIntrinsics"
-                @changeToUnset="changeToUnset"
-                @changeToIdentity="changeToIdentity"
-              />
-            </li>
-          </ul>
-        </Stack>
-        <Stack class="p-xs" spacing="none">
-          <span class="uppercase font-bold text-sm">Props</span>
-          <ul>
-            <li v-for="prop in configurableProps" :key="prop.id">
-              <AssetDetailIntrinsicInput
-                :schemaVariantId="schemaVariantId"
-                :isLocked="editingAsset.isLocked"
-                :data="prop"
-                @change="updatePropIntrinsics"
-                @changeToUnset="changeToUnset"
-                @changeToIdentity="changeToIdentity"
-              />
-            </li>
-          </ul>
-        </Stack>
-      </template>
+            <AssetDetailIntrinsicInput
+              :schemaVariantId="schemaVariantId"
+              :isLocked="editingAsset.isLocked"
+              :data="config"
+              @change="updateOutputSocketIntrinsics"
+              @changeToUnset="changeToUnset"
+              @changeToIdentity="changeToIdentity"
+            />
+          </li>
+        </ul>
+        <p v-else class="text-xs pb-4 pt-2">
+          No output sockets exist for asset.
+        </p>
+      </Stack>
+      <Stack class="p-xs" spacing="none">
+        <span class="uppercase font-bold text-sm">Props</span>
+        <ul v-if="configurableProps.length > 0">
+          <li v-for="prop in configurableProps" :key="prop.id">
+            <AssetDetailIntrinsicInput
+              :schemaVariantId="schemaVariantId"
+              :isLocked="editingAsset.isLocked"
+              :data="prop"
+              @change="updatePropIntrinsics"
+              @changeToUnset="changeToUnset"
+              @changeToIdentity="changeToIdentity"
+            />
+          </li>
+        </ul>
+        <p v-else class="text-xs pb-4 pt-2">No props exist for asset.</p>
+      </Stack>
     </ScrollArea>
     <div
       v-else
@@ -243,7 +243,6 @@ import {
   BindingWithBackendKindAndOutputSocket,
 } from "@/api/sdf/dal/func";
 import { useAssetStore } from "@/store/asset.store";
-import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import {
   ComponentType,
   InputSocketId,
@@ -265,7 +264,6 @@ const props = defineProps<{
 
 const assetStore = useAssetStore();
 const funcStore = useFuncStore();
-const ffStore = useFeatureFlagsStore();
 const executeAssetModalRef = ref();
 const cloneAssetModalRef = ref<InstanceType<typeof AssetNameModal>>();
 
@@ -383,6 +381,7 @@ const _configurableProps = computed(() => {
     };
     config.push(d);
   });
+  config.sort((a, b) => a.name.localeCompare(b.name));
   return config;
 });
 
@@ -433,6 +432,7 @@ const _outputSocketIntrinsics = computed(() => {
 
       bindings.push(d);
     });
+  bindings.sort((a, b) => a.socketName.localeCompare(b.socketName));
   return bindings;
 });
 

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -10,7 +10,6 @@ const FLAG_MAPPING = {
   FIRST_TIME_TUTORIAL_MODAL: "first_time_tutorial_modal",
   DEV_SLICE_REBASING: "dev-slice-rebasing",
   ADMIN_PANEL_ACCESS: "si_admin_panel_access",
-  SHOW_INTRINSIC_EDITING: "asset_detail_intrinsic_editing",
   ON_DEMAND_ASSETS: "on_demand_assets",
 };
 

--- a/bin/lang-js/src/asset_builder.ts
+++ b/bin/lang-js/src/asset_builder.ts
@@ -239,8 +239,14 @@ export class SocketDefinitionBuilder implements ISocketDefinitionBuilder {
   }
 
   /**
-   * DEPRECATED: Set the value of this socket using a ValueFromBuilder.
-   * The recommended way to do this is to attach an attribute function.
+   * DEPRECATED: this method no longer does anything. It will be ignored
+   * when executing the asset function. Please use the asset editing
+   * interface to perform equivalent functionality.
+   *
+   * If the socket is new, you will need to regenerate the asset first!
+   *
+   * In the past, this was used to set the value of this socket using a
+   * ValueFromBuilder.
    *
    * @param {ValueFrom} valueFrom
    *
@@ -411,8 +417,14 @@ export class MapKeyFuncBuilder implements IMapKeyFuncBuilder {
   }
 
   /**
-   * DEPRECATED: Set the value of this socket using a ValueFromBuilder.
-   * The recommended way to do this is to attach an attribute function.
+   * DEPRECATED: this method no longer does anything. It will be ignored
+   * when executing the asset function. Please use the asset editing
+   * interface to perform equivalent functionality.
+   *
+   * If the entry is new, you will need to regenerate the asset first!
+   *
+   * In the past, this was used to set the value of this entry using a
+   * ValueFromBuilder.
    *
    * @param {ValueFrom} valueFrom
    *
@@ -745,8 +757,14 @@ export class PropBuilder implements IPropBuilder {
   }
 
   /**
-   * DEPRECATED: Set the value of this socket using a ValueFromBuilder.
-   * The recommended way to do this is to attach an attribute function.
+   * DEPRECATED: this method no longer does anything. It will be ignored
+   * when executing the asset function. Please use the asset editing
+   * interface to perform equivalent functionality.
+   *
+   * If the prop is new, you will need to regenerate the asset first!
+   *
+   * In the past, this was used to set the value of this prop using a
+   * ValueFromBuilder.
    *
    * @param {ValueFrom} valueFrom
    *

--- a/lib/dal/tests/integration_test/schema/variant/authoring/regenerate.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/regenerate.rs
@@ -1,6 +1,15 @@
+use dal::func::argument::{FuncArgument, FuncArgumentId};
+use dal::func::binding::attribute::AttributeBinding;
+use dal::func::binding::{
+    AttributeArgumentBinding, AttributeFuncArgumentSource, AttributeFuncDestination, FuncBinding,
+};
+use dal::func::intrinsics::IntrinsicFunc;
+use dal::prop::PropPath;
 use dal::schema::variant::authoring::VariantAuthoringClient;
-use dal::{DalContext, Func, Schema, SchemaVariant};
-
+use dal::{
+    ComponentType, DalContext, Func, FuncId, OutputSocket, OutputSocketId, Prop, PropId, Schema,
+    SchemaVariant, SchemaVariantId,
+};
 use dal_test::helpers::ChangeSetTestHelpers;
 use dal_test::test;
 
@@ -78,4 +87,348 @@ async fn regenerate_variant(ctx: &mut DalContext) {
         .expect("could not list funcs for schema variant");
     // ensure the func is attached
     assert!(funcs_for_default.into_iter().any(|func| func.id == func_id));
+}
+
+#[test]
+async fn retain_bindings(ctx: &mut DalContext) {
+    let name = "Toto Wolff";
+    let description = None;
+    let link = None;
+    let category = "Mercedes AMG Petronas";
+    let color = "#00A19B";
+
+    // Create an asset with a corresponding asset func. After that, commit.
+    let schema_variant_id = {
+        let schema_variant = VariantAuthoringClient::create_schema_and_variant(
+            ctx,
+            name,
+            description.clone(),
+            link.clone(),
+            category,
+            color,
+        )
+        .await
+        .expect("unable to create schema and variant");
+        schema_variant.id()
+    };
+    let asset_func = "function main() {
+        const asset = new AssetBuilder();
+
+        const alpha_source_prop = new PropBuilder()
+            .setName(\"alpha_source_prop\")
+            .setKind(\"string\")
+            .setWidget(new PropWidgetDefinitionBuilder().setKind(\"text\").build())
+            .build();
+        asset.addProp(alpha_source_prop);
+
+        const alpha_destination_prop = new PropBuilder()
+            .setName(\"alpha_destination_prop\")
+            .setKind(\"string\")
+            .setWidget(new PropWidgetDefinitionBuilder().setKind(\"text\").build())
+            .build();
+        asset.addProp(alpha_destination_prop);
+
+        const beta_source_prop = new PropBuilder()
+            .setName(\"beta_source_prop\")
+            .setKind(\"string\")
+            .setWidget(new PropWidgetDefinitionBuilder().setKind(\"text\").build())
+            .build();
+        asset.addProp(beta_source_prop);
+
+        const beta_destination_output_socket = new SocketDefinitionBuilder()
+            .setName(\"beta_destination_output_socket\")
+            .setArity(\"one\")
+            .build();
+        asset.addOutputSocket(beta_destination_output_socket);
+
+        return asset.build();
+    }";
+    VariantAuthoringClient::save_variant_content(
+        ctx,
+        schema_variant_id,
+        name,
+        name,
+        category,
+        description,
+        link,
+        color,
+        ComponentType::Component,
+        Some(asset_func),
+    )
+    .await
+    .expect("could not save content");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit");
+
+    // Once it's all ready, regenerate and commit.
+    let schema_variant_id = VariantAuthoringClient::regenerate_variant(ctx, schema_variant_id)
+        .await
+        .expect("could not regenerate variant");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit");
+
+    // Gather all arguments needed to create our bindings.
+    let alpha_source_prop_id = Prop::find_prop_id_by_path(
+        ctx,
+        schema_variant_id,
+        &PropPath::new(["root", "domain", "alpha_source_prop"]),
+    )
+    .await
+    .expect("could not find prop id by path");
+    let alpha_destination_prop_id = Prop::find_prop_id_by_path(
+        ctx,
+        schema_variant_id,
+        &PropPath::new(["root", "domain", "alpha_destination_prop"]),
+    )
+    .await
+    .expect("could not find prop id by path");
+    let beta_source_prop_id = Prop::find_prop_id_by_path(
+        ctx,
+        schema_variant_id,
+        &PropPath::new(["root", "domain", "beta_source_prop"]),
+    )
+    .await
+    .expect("could not find prop id by path");
+    let beta_destination_output_socket_id = {
+        let beta_destination_output_socket =
+            OutputSocket::find_with_name(ctx, "beta_destination_output_socket", schema_variant_id)
+                .await
+                .expect("could not find with name")
+                .expect("no output socket found");
+        beta_destination_output_socket.id()
+    };
+    let identity_func_id = Func::find_intrinsic(ctx, IntrinsicFunc::Identity)
+        .await
+        .expect("could not find identity func");
+    let identity_func_argument_id = {
+        let identity_func_argument =
+            FuncArgument::find_by_name_for_func(ctx, "identity", identity_func_id)
+                .await
+                .expect("could not find by name for func")
+                .expect("no func argument found");
+        identity_func_argument.id
+    };
+
+    // Create the first binding and commit.
+    create_binding_simple(
+        ctx,
+        schema_variant_id,
+        alpha_source_prop_id,
+        Some(alpha_destination_prop_id),
+        None,
+        identity_func_id,
+        identity_func_argument_id,
+    )
+    .await
+    .expect("could not create binding");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit");
+
+    // Create the second binding and commit.
+    create_binding_simple(
+        ctx,
+        schema_variant_id,
+        beta_source_prop_id,
+        None,
+        Some(beta_destination_output_socket_id),
+        identity_func_id,
+        identity_func_argument_id,
+    )
+    .await
+    .expect("could not create binding");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit");
+
+    // Check that the bindings look as we expect.
+    let bindings =
+        FuncBinding::get_bindings_for_schema_variant_id(ctx, identity_func_id, schema_variant_id)
+            .await
+            .expect("could not get bindings");
+    assert_eq!(
+        2,              // expected
+        bindings.len()  // actual
+    );
+    for binding in bindings {
+        match binding {
+            FuncBinding::Attribute(mut binding) => match binding.output_location {
+                AttributeFuncDestination::Prop(prop_id) => {
+                    assert_eq!(
+                        alpha_destination_prop_id, // expected
+                        prop_id                    // actual
+                    );
+                    let argument_binding = binding
+                        .argument_bindings
+                        .pop()
+                        .expect("unexpected empty argument bindings");
+                    assert!(binding.argument_bindings.is_empty());
+                    assert_eq!(
+                        identity_func_argument_id,         // expected
+                        argument_binding.func_argument_id  // actual
+                    );
+                    assert_eq!(
+                        AttributeFuncArgumentSource::Prop(alpha_source_prop_id), // expected
+                        argument_binding.attribute_func_input_location           // actual
+                    );
+                }
+                AttributeFuncDestination::OutputSocket(output_socket_id) => {
+                    assert_eq!(
+                        beta_destination_output_socket_id, // expected
+                        output_socket_id                   // actual
+                    );
+                    let argument_binding = binding
+                        .argument_bindings
+                        .pop()
+                        .expect("unexpected empty argument bindings");
+                    assert!(binding.argument_bindings.is_empty());
+                    assert_eq!(
+                        identity_func_argument_id,         // expected
+                        argument_binding.func_argument_id  // actual
+                    );
+                    assert_eq!(
+                        AttributeFuncArgumentSource::Prop(beta_source_prop_id), // expected
+                        argument_binding.attribute_func_input_location          // actual
+                    );
+                }
+                output_location => panic!("unexpected output location: {output_location:?}"),
+            },
+            inner_binding => panic!("unexpected binding kind: {inner_binding:?}"),
+        }
+    }
+
+    // Regenerate the variant again to ensure that we have retained our bindings.
+    let schema_variant_id = VariantAuthoringClient::regenerate_variant(ctx, schema_variant_id)
+        .await
+        .expect("could not regenerate variant");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit");
+
+    // After regenerating again, we need to re-fetch our prop(s) and socket(s).
+    let alpha_source_prop_id = Prop::find_prop_id_by_path(
+        ctx,
+        schema_variant_id,
+        &PropPath::new(["root", "domain", "alpha_source_prop"]),
+    )
+    .await
+    .expect("could not find prop id by path");
+    let alpha_destination_prop_id = Prop::find_prop_id_by_path(
+        ctx,
+        schema_variant_id,
+        &PropPath::new(["root", "domain", "alpha_destination_prop"]),
+    )
+    .await
+    .expect("could not find prop id by path");
+    let beta_source_prop_id = Prop::find_prop_id_by_path(
+        ctx,
+        schema_variant_id,
+        &PropPath::new(["root", "domain", "beta_source_prop"]),
+    )
+    .await
+    .expect("could not find prop id by path");
+    let beta_destination_output_socket_id = {
+        let beta_destination_output_socket =
+            OutputSocket::find_with_name(ctx, "beta_destination_output_socket", schema_variant_id)
+                .await
+                .expect("could not find with name")
+                .expect("no output socket found");
+        beta_destination_output_socket.id()
+    };
+
+    // Check that the bindings look as we expect after regenerating again.
+    let bindings =
+        FuncBinding::get_bindings_for_schema_variant_id(ctx, identity_func_id, schema_variant_id)
+            .await
+            .expect("could not get bindings");
+    assert_eq!(
+        2,              // expected
+        bindings.len()  // actual
+    );
+    for binding in bindings {
+        match binding {
+            FuncBinding::Attribute(mut binding) => match binding.output_location {
+                AttributeFuncDestination::Prop(prop_id) => {
+                    assert_eq!(
+                        alpha_destination_prop_id, // expected
+                        prop_id                    // actual
+                    );
+                    let argument_binding = binding
+                        .argument_bindings
+                        .pop()
+                        .expect("unexpected empty argument bindings");
+                    assert!(binding.argument_bindings.is_empty());
+                    assert_eq!(
+                        identity_func_argument_id,         // expected
+                        argument_binding.func_argument_id  // actual
+                    );
+                    assert_eq!(
+                        AttributeFuncArgumentSource::Prop(alpha_source_prop_id), // expected
+                        argument_binding.attribute_func_input_location           // actual
+                    );
+                }
+                AttributeFuncDestination::OutputSocket(output_socket_id) => {
+                    assert_eq!(
+                        beta_destination_output_socket_id, // expected
+                        output_socket_id                   // actual
+                    );
+                    let argument_binding = binding
+                        .argument_bindings
+                        .pop()
+                        .expect("unexpected empty argument bindings");
+                    assert!(binding.argument_bindings.is_empty());
+                    assert_eq!(
+                        identity_func_argument_id,         // expected
+                        argument_binding.func_argument_id  // actual
+                    );
+                    assert_eq!(
+                        AttributeFuncArgumentSource::Prop(beta_source_prop_id), // expected
+                        argument_binding.attribute_func_input_location          // actual
+                    );
+                }
+                output_location => panic!("unexpected output location: {output_location:?}"),
+            },
+            inner_binding => panic!("unexpected binding kind: {inner_binding:?}"),
+        }
+    }
+}
+
+// Mimics the behavior in "v2/func/binding/create_binding" for output sockets.
+async fn create_binding_simple(
+    ctx: &DalContext,
+    schema_variant_id: SchemaVariantId,
+    source_prop_id: PropId,
+    maybe_destination_prop_id: Option<PropId>,
+    maybe_destination_output_socket_id: Option<OutputSocketId>,
+    identity_func_id: FuncId,
+    identity_func_argument_id: FuncArgumentId,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let eventual_parent =
+        AttributeBinding::assemble_eventual_parent(ctx, None, Some(schema_variant_id.into()))
+            .await?;
+    let attribute_output_location = AttributeBinding::assemble_attribute_output_location(
+        maybe_destination_prop_id.map(Into::into),
+        maybe_destination_output_socket_id.map(Into::into),
+    )?;
+
+    AttributeBinding::upsert_attribute_binding(
+        ctx,
+        identity_func_id,
+        eventual_parent,
+        attribute_output_location,
+        vec![AttributeArgumentBinding {
+            attribute_prototype_argument_id: None,
+            func_argument_id: identity_func_argument_id,
+            attribute_func_input_location: AttributeBinding::assemble_attribute_input_location(
+                Some(source_prop_id.into()),
+                None,
+                None,
+            )?,
+        }],
+    )
+    .await?;
+
+    Ok(())
 }

--- a/lib/sdf-server/src/service/v2/func.rs
+++ b/lib/sdf-server/src/service/v2/func.rs
@@ -5,12 +5,14 @@ use axum::{
     Router,
 };
 use dal::{
-    attribute::value::AttributeValueError,
+    attribute::{prototype::argument::AttributePrototypeArgumentError, value::AttributeValueError},
     func::{
         argument::FuncArgumentError, authoring::FuncAuthoringError, binding::FuncBindingError,
         runner::FuncRunnerError,
     },
-    ChangeSetError, DalContext, Func, FuncError, FuncId, WsEventError,
+    workspace_snapshot::graph::WorkspaceSnapshotGraphError,
+    ChangeSetError, DalContext, Func, FuncError, FuncId, SchemaVariantError,
+    WorkspaceSnapshotError, WsEventError,
 };
 use si_frontend_types::FuncCode;
 use si_layer_cache::LayerDbError;
@@ -142,11 +144,18 @@ impl IntoResponse for FuncAPIError {
 
             // When the authoring changes requested would result in a cycle
             Self::FuncBinding(FuncBindingError::SchemaVariant(
-                dal::SchemaVariantError::AttributePrototypeArgument(
-                    dal::attribute::prototype::argument::AttributePrototypeArgumentError::WorkspaceSnapshot(
-                        dal::WorkspaceSnapshotError::WorkspaceSnapshotGraph(
-                            dal::workspace_snapshot::graph::WorkspaceSnapshotGraphError::CreateGraphCycle,
+                SchemaVariantError::AttributePrototypeArgument(
+                    AttributePrototypeArgumentError::WorkspaceSnapshot(
+                        WorkspaceSnapshotError::WorkspaceSnapshotGraph(
+                            WorkspaceSnapshotGraphError::CreateGraphCycle,
                         ),
+                    ),
+                ),
+            ))
+            | Self::FuncBinding(FuncBindingError::AttributePrototypeArgument(
+                AttributePrototypeArgumentError::WorkspaceSnapshot(
+                    WorkspaceSnapshotError::WorkspaceSnapshotGraph(
+                        WorkspaceSnapshotGraphError::CreateGraphCycle,
                     ),
                 ),
             )) => (StatusCode::UNPROCESSABLE_ENTITY, None),

--- a/lib/vue-lib/src/design-system/forms/VormInput.vue
+++ b/lib/vue-lib/src/design-system/forms/VormInput.vue
@@ -69,6 +69,14 @@ you can pass in options as props too */
             : null
         "
         class="vorm-input__input-wrap"
+        :class="
+          clsx(
+            'vorm-input__input-wrap',
+            showCautionLines
+              ? themeClasses('bg-caution-lines-light', 'bg-caution-lines-dark')
+              : '',
+          )
+        "
       >
         <template v-if="type === 'container'">
           <slot />
@@ -285,7 +293,7 @@ import { IconNames } from "../icons/icon_set";
 import { useValidatedInput, validators } from "./helpers/form-validation";
 import { useDisabledBySelfOrParent } from "./helpers/form-disabling";
 import VormInputOption from "./VormInputOption.vue";
-import { useTheme } from "../utils/theme_tools";
+import { themeClasses, useTheme } from "../utils/theme_tools";
 import type { PropType, ComponentInternalInstance } from "vue";
 
 type InputTypes =
@@ -359,6 +367,7 @@ const props = defineProps({
   defaultValue: {}, // eslint-disable-line vue/require-prop-types
   autocomplete: { type: String },
   name: { type: String },
+  showCautionLines: Boolean,
 
   // validations
   required: Boolean,


### PR DESCRIPTION
## Description

This PR switches to the new asset details paradigm, which involves intrinsic func editing. To start, it will use the unset func and the identity func to set bindings. This PR includes several UI changes to support this includng a caution lines setting, converging on one design for the dropdowns, filtering for the dropdowns, checkboxes for the dropdown, and sorting configurable props and output sockets by name.

<img src="https://media2.giphy.com/media/sFkLsA3No8kQHYRXMm/giphy.gif"/>

## Secondary Changes

This PR also ensures that we retain func bindings when regenerating assets and switches to the new asset details panel paradigm, which replaces `setValueFrom` and it enables intrinsic func authoring for all.

The bug was caused by relying on the identity func when merging prototypes for both prop and socket output locations between two schema variants. Now, conditional logic based on the identity func has been removed because identity func bindings now work similarly to custom attribute func bindings: both involve editing the asset, but not the asset's code.

As a result of these changes, `setValueFrom` will now "no-op". The documentation and inlay hints have been updated accordingly. This does not affect existing assets as they will go through the import and export module code rather than through asset func execution. In addition, the identity-based bindings will appear in the asset details panel. However, the next time that the asset func is regenerated, `setValueFrom` will "no-op" and only the bindings in the asset details panel will be respected.

## Misc Changes

This commit also fixes tracing naming for the `regenerate_variant` function, sorting when working with the asset details panel and has some general asset details panel polish.

In addition to these changes, we also ensure that graph cycles aren't 500 errors when editing attribute bindings.