### PR TITLE
Only send create/delete events if the resource property is set or unset

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1571,6 +1571,15 @@ impl Component {
         }
     }
 
+    pub async fn has_resource_by_id(ctx: &DalContext, id: ComponentId) -> ComponentResult<bool> {
+        if let Some(component) = Self::try_get_by_id(ctx, id).await? {
+            if component.resource(ctx).await?.is_some() {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
     /// Returns the name of a [`Component`] for a given [`ComponentId`](Component).
     pub async fn name_by_id(ctx: &DalContext, id: ComponentId) -> ComponentResult<String> {
         let name_value_id =


### PR DESCRIPTION
This makes it so we send the ResourceCreated event anytime a resource payload is added, and ResourceDeleted event when a resource payload is removed. Before this, we triggered ResourceCreated for a Create action, and ResourceDeleted for a Delete action; but if the action fails we still send the event; and if the create has no payload, or some other action *has* a payload, we send the wrong event or don't send it.

With this code, it doesn't matter what our logic is for whether to add a resource: if there was no resource before and there is one now, it's a create; and if there was a resource before and not after, it's a delete. This way the creates and deletes will exactly match changes in the resource count, which is what we want.