### PR TITLE
Order sockets and props in binding dropdowns alphabetically

### DIFF
--- a/app/web/src/api/sdf/dal/schema.ts
+++ b/app/web/src/api/sdf/dal/schema.ts
@@ -71,10 +71,12 @@ export interface SchemaVariant {
 }
 
 export const outputSocketsAndPropsFor = (schemaVariant: SchemaVariant) => {
-  const socketOptions = schemaVariant.outputSockets.map((socket) => ({
-    label: `Output Socket: ${socket.name}`,
-    value: `s_${socket.id}`,
-  }));
+  const socketOptions = schemaVariant.outputSockets
+    .map((socket) => ({
+      label: `Output Socket: ${socket.name}`,
+      value: `s_${socket.id}`,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
 
   // output
   const propOptions = schemaVariant.props
@@ -82,7 +84,8 @@ export const outputSocketsAndPropsFor = (schemaVariant: SchemaVariant) => {
     .map((p) => ({
       label: `Attribute: ${p.path}`,
       value: `p_${p.id}`,
-    }));
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
   return { socketOptions, propOptions };
 };
 
@@ -97,7 +100,8 @@ export const inputSocketsAndPropsFor = (schemaVariant: SchemaVariant) => {
     .map((p) => ({
       label: `Attribute: ${p.path}`,
       value: `p_${p.id}`,
-    }));
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
 
   return { socketOptions, propOptions };
 };


### PR DESCRIPTION
These dropdowns get awful big, and having a random order makes it *very* hard to find the attribute or socket I want.

![image](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMW9nNTg3MHJrY29zOWFyM2U2bms4cm15N2E5NGhvNDBzZnNkMmdwNCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/QTdvQnZ6MoZjyN3shL/giphy.gif)

After:
![image](https://github.com/user-attachments/assets/df888fae-f3ae-4e52-b6f6-e963a4e64a60)

Before:
![image](https://github.com/user-attachments/assets/fcae6c68-bc61-45e9-83a2-1dd746f9af75)
