### PR TITLE
feat: add DVU listener for API tests

### DIFF
--- a/bin/si-api-test/binary_execution_lib.ts
+++ b/bin/si-api-test/binary_execution_lib.ts
@@ -12,6 +12,7 @@ export function parseArgs(args: string[]) {
   const parsedArgs = parse(args, {
     string: [
       "workspaceId",
+      "changeSetId",
       "userId",
       "password",
       "profile",
@@ -22,6 +23,7 @@ export function parseArgs(args: string[]) {
     ],
     alias: {
       w: "workspaceId",
+      c: "changeSetId",
       u: "userId",
       p: "password",
       t: "tests",
@@ -43,6 +45,7 @@ Usage: deno run main.ts [options]
 
 Options:
   --workspaceId, -w   Workspace ID (required)
+  --changeSetId, -c   Change Set ID (optional)
   --userId, -u        User ID (required if token not set)
   --password, -p      User password (optional)
   --tests, -t         Test names to run (comma-separated, optional)
@@ -57,6 +60,7 @@ Options:
 
   // Extract parsed arguments
   const workspaceId = parsedArgs.workspaceId;
+  const changeSetId = parsedArgs.changeSetId || undefined;
   const userId = parsedArgs.userId || undefined;
   const password = parsedArgs.password || undefined;
   const token = parsedArgs.token || undefined;
@@ -85,6 +89,7 @@ Options:
 
   return {
     workspaceId,
+    changeSetId,
     userId,
     password,
     testsToRun,

--- a/bin/si-api-test/tests/create_and_delete_component.ts
+++ b/bin/si-api-test/tests/create_and_delete_component.ts
@@ -4,11 +4,16 @@ import { runWithTemporaryChangeset } from "../test_helpers.ts";
 
 export default async function create_and_delete_component(
   sdfApiClient: SdfApiClient,
+  changeSetId: string,
 ) {
-  return runWithTemporaryChangeset(
-    sdfApiClient,
-    create_and_delete_component_inner,
-  );
+  if (changeSetId) {
+    return await create_and_delete_component_inner(sdfApiClient, changeSetId);
+  } else {
+    return runWithTemporaryChangeset(
+      sdfApiClient,
+      create_and_delete_component_inner,
+    );
+  }
 }
 
 async function create_and_delete_component_inner(

--- a/bin/si-api-test/tests/create_two_components_connect_and_propagate.ts
+++ b/bin/si-api-test/tests/create_two_components_connect_and_propagate.ts
@@ -7,11 +7,19 @@ import {
 
 export default function create_two_components_connect_and_propagate(
   sdfApiClient: SdfApiClient,
+  changeSetId: string,
 ) {
-  return runWithTemporaryChangeset(
-    sdfApiClient,
-    create_two_components_connect_and_propagate_inner,
-  );
+  if (changeSetId) {
+    return create_two_components_connect_and_propagate_inner(
+      sdfApiClient,
+      changeSetId,
+    );
+  } else {
+    return runWithTemporaryChangeset(
+      sdfApiClient,
+      create_two_components_connect_and_propagate_inner,
+    );
+  }
 }
 
 async function create_two_components_connect_and_propagate_inner(
@@ -252,5 +260,16 @@ async function create_two_components_connect_and_propagate_inner(
       destinationRegionValue.value === regionValue,
       "Expected propagated value to match source",
     );
+  });
+
+  const deleteComponentPayload = {
+    componentIds: [instanceComponentId, regionComponentId],
+    forceErase: false,
+    visibility_change_set_pk: changeSetId,
+    workspaceId: sdf.workspaceId,
+  };
+  await sdf.call({
+    route: "delete_component",
+    body: deleteComponentPayload,
   });
 }


### PR DESCRIPTION
This adds a rudimentary listener for DVU-related ws events for a specific workspace. The idea is to gather all DVU started events for a given component and watch for related finished events to ensure that we wait until they all complete. This is not an exact science and could potentially miss DVU started events if they take too long to start.

This also adds the ability to pass specific change sets into the api tests.

<img src="https://media4.giphy.com/media/UPvnFr92YskofFV2jw/giphy.gif"/>