### PR TITLE
feat: Amend status codes in SDF server

### DIFF
--- a/lib/sdf-server/src/service/change_set.rs
+++ b/lib/sdf-server/src/service/change_set.rs
@@ -75,8 +75,14 @@ pub type ChangeSetResult<T> = std::result::Result<T, ChangeSetError>;
 impl IntoResponse for ChangeSetError {
     fn into_response(self) -> Response {
         let (status, error_message) = match self {
-            ChangeSetError::ActionAlreadyEnqueued(_) => {
+            ChangeSetError::ActionAlreadyEnqueued(_) | ChangeSetError::ActionPrototype(_) => {
                 (StatusCode::NOT_MODIFIED, self.to_string())
+            }
+            ChangeSetError::SchemaVariant(_) | ChangeSetError::Schema(_) => {
+                (StatusCode::UNPROCESSABLE_ENTITY, self.to_string())
+            }
+            ChangeSetError::Hyper(_) | ChangeSetError::CannotAbandonHead => {
+                (StatusCode::BAD_REQUEST, self.to_string())
             }
             ChangeSetError::ChangeSetNotFound => (StatusCode::NOT_FOUND, self.to_string()),
             ChangeSetError::DalChangeSetApply(_) => (StatusCode::CONFLICT, self.to_string()),

--- a/lib/sdf-server/src/service/component.rs
+++ b/lib/sdf-server/src/service/component.rs
@@ -118,16 +118,31 @@ impl IntoResponse for ComponentError {
             | ComponentError::NotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
             ComponentError::PropertyEditor(err) => match err {
                 PropertyEditorError::ComponentNotFound
+                | PropertyEditorError::PropertyEditorValueNotFoundByPropId(_)
                 | PropertyEditorError::SchemaVariantNotFound(_) => {
                     (StatusCode::NOT_FOUND, err.to_string())
                 }
-
+                PropertyEditorError::AttributePrototype(_)
+                | PropertyEditorError::AttributeValue(_)
+                | PropertyEditorError::BadAttributeReadContext(_)
+                | PropertyEditorError::SchemaVariant(_)
+                | PropertyEditorError::Secret(_)
+                | PropertyEditorError::SerdeJson(_)
+                | PropertyEditorError::SecretPropLeadsToStaticValue(_, _)
+                | PropertyEditorError::Validation(_)
+                | PropertyEditorError::ValueSource(_) => (StatusCode::BAD_REQUEST, err.to_string()),
+                PropertyEditorError::CycleDetected(_) => {
+                    (StatusCode::LOOP_DETECTED, err.to_string())
+                }
                 _ => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
             },
             ComponentError::SchemaVariantUpgradeSkipped => {
                 (StatusCode::NOT_MODIFIED, self.to_string())
             }
-            ComponentError::KeyAlreadyExists(_) => {
+            ComponentError::UpgradeSkippedDueToActions => {
+                (StatusCode::PRECONDITION_FAILED, self.to_string())
+            }
+            ComponentError::KeyAlreadyExists(_) | ComponentError::SerdeJson(_) => {
                 (StatusCode::UNPROCESSABLE_ENTITY, self.to_string())
             }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),

--- a/lib/sdf-server/src/service/diagram.rs
+++ b/lib/sdf-server/src/service/diagram.rs
@@ -117,7 +117,22 @@ impl IntoResponse for DiagramError {
             | DiagramError::FrameSocketNotFound(_)
             | DiagramError::EdgeNotFound
             | DiagramError::SocketNotFound => (StatusCode::NOT_FOUND, self.to_string()),
-
+            DiagramError::DuplicatedConnection => (StatusCode::NOT_MODIFIED, self.to_string()),
+            DiagramError::AttributePrototypeArgument(_)
+            | DiagramError::AttributeValue(_)
+            | DiagramError::ChangeSet(_)
+            | DiagramError::Component(_)
+            | DiagramError::AttributePrototype(_)
+            | DiagramError::Hyper(_)
+            | DiagramError::InputSocket(_)
+            | DiagramError::OutputSocket(_)
+            | DiagramError::Paste
+            | DiagramError::InvalidRequest
+            | DiagramError::InvalidSystem => (StatusCode::BAD_REQUEST, self.to_string()),
+            DiagramError::NotAuthorized => (StatusCode::FORBIDDEN, self.to_string()),
+            DiagramError::ParseFloat(_) | DiagramError::Serde(_) => {
+                (StatusCode::UNPROCESSABLE_ENTITY, self.to_string())
+            }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 

--- a/lib/sdf-server/src/service/module.rs
+++ b/lib/sdf-server/src/service/module.rs
@@ -137,7 +137,35 @@ impl IntoResponse for ModuleError {
             | ModuleError::PackageNotFound(_)
             | ModuleError::SchemaNotFoundForVariant(_)
             | ModuleError::SchemaVariantNotFound(_)
+            | ModuleError::SchemaNotFoundFromInstall(_)
             | ModuleError::WorkspaceNotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
+            ModuleError::PackageAlreadyOnDisk(_) | ModuleError::PackageAlreadyInstalled(_) => {
+                (StatusCode::NOT_MODIFIED, self.to_string())
+            }
+            ModuleError::InvalidUserSystemInit
+            | ModuleError::InvalidUser(_)
+            | ModuleError::InvalidPackageFileName(_)
+            | ModuleError::Hyper(_)
+            | ModuleError::Func(_)
+            | ModuleError::ChangeSet(_)
+            | ModuleError::SchemaVariant(_)
+            | ModuleError::PackageNameEmpty
+            | ModuleError::PackageExportEmpty
+            | ModuleError::SiPkg(_)
+            | ModuleError::Workspace(_)
+            | ModuleError::User(_)
+            | ModuleError::UlidDecode(_)
+            | ModuleError::WorkspaceSnapshot(_)
+            | ModuleError::StandardModel(_)
+            | ModuleError::Reqwest(_)
+            | ModuleError::PackageVersionEmpty
+            | ModuleError::Canonicalize(_) => (StatusCode::BAD_REQUEST, self.to_string()),
+            ModuleError::Tenancy(_) => (StatusCode::FORBIDDEN, self.to_string()),
+            ModuleError::SerdeJson(_)
+            | ModuleError::Url(_)
+            | ModuleError::ExportingImportingWithRootTenancy => {
+                (StatusCode::UNPROCESSABLE_ENTITY, self.to_string())
+            }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 

--- a/lib/sdf-server/src/service/qualification.rs
+++ b/lib/sdf-server/src/service/qualification.rs
@@ -72,9 +72,14 @@ impl IntoResponse for QualificationError {
             | QualificationError::FuncCodeNotFound(_)
             | QualificationError::FuncNotFound
             | QualificationError::SchemaNotFound(_)
-            | QualificationError::SchemaVariantNotFound => {
-                (StatusCode::NOT_FOUND, self.to_string())
-            }
+            | QualificationError::SchemaVariantNotFound
+            | QualificationError::Transactions(_) => (StatusCode::NOT_FOUND, self.to_string()),
+            QualificationError::Component(_) => (StatusCode::BAD_REQUEST, self.to_string()),
+            QualificationError::Tenancy(_) => (StatusCode::FORBIDDEN, self.to_string()),
+            QualificationError::Base64Decode(_)
+            | QualificationError::Serde(_)
+            | QualificationError::Utf8(_) => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),
+
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 

--- a/lib/sdf-server/src/service/session.rs
+++ b/lib/sdf-server/src/service/session.rs
@@ -65,16 +65,16 @@ pub type SessionResult<T> = std::result::Result<T, SessionError>;
 impl IntoResponse for SessionError {
     fn into_response(self) -> Response {
         let (status, error_code, error_message) = match self {
-            SessionError::LoginFailed => (StatusCode::CONFLICT, None, self.to_string()),
-            SessionError::InvalidWorkspace(_) => (
-                StatusCode::CONFLICT,
-                Some("WORKSPACE_NOT_INITIALIZED"),
-                self.to_string(),
-            ),
-            SessionError::WorkspacePermissions => {
-                (StatusCode::UNAUTHORIZED, None, self.to_string())
+            SessionError::WorkspacePermissions
+            | SessionError::LoginFailed
+            | SessionError::InvalidUser(_)
+            | SessionError::User(_)
+            | SessionError::InvalidWorkspace(_)
+            | SessionError::AuthApiError(_) => (StatusCode::UNAUTHORIZED, None, self.to_string()),
+            SessionError::Request(_) => (StatusCode::BAD_REQUEST, None, self.to_string()),
+            SessionError::JSONSerialize(_) | SessionError::WorkspaceNotYetMigrated(_) => {
+                (StatusCode::UNPROCESSABLE_ENTITY, None, self.to_string())
             }
-            SessionError::AuthApiError(_) => (StatusCode::UNAUTHORIZED, None, self.to_string()),
             _ => (StatusCode::INTERNAL_SERVER_ERROR, None, self.to_string()),
         };
 


### PR DESCRIPTION
Adds catches for a lot of missing/improve status 500 throws within sdf.

I've tried to leave a few groups at 500 still:
- DAL errors
- Postgres/third party connection errors
- Other things that genuinely should throw, like your workspace is broken

I'm still to do Session and Qualification, I'll follow up on those.