### PR TITLE
BUG-561: authoring pain when starting from head

### DIFF
--- a/app/web/src/components/AssetCard.vue
+++ b/app/web/src/components/AssetCard.vue
@@ -94,6 +94,7 @@
     </div>
     <!-- FIXME(nick): this probably needs to be moved and de-duped with logic in AssetListPanel -->
     <AssetContributeModal
+      v-if="contributeRequest"
       ref="contributeAssetModalRef"
       :contributeRequest="contributeRequest"
       @contribute-success="onContributeAsset"
@@ -159,7 +160,7 @@ const contributeAssetSuccessModalRef = ref<InstanceType<typeof Modal>>();
 const contributeAsset = () => contributeAssetModalRef.value?.open();
 const onContributeAsset = () => contributeAssetSuccessModalRef.value?.open();
 
-const contributeRequest = computed((): ModuleContributeRequest => {
+const contributeRequest = computed((): ModuleContributeRequest | null => {
   if (asset.value) {
     const version = dateFormat(Date.now(), "yyyyMMddkkmmss");
     return {
@@ -167,7 +168,7 @@ const contributeRequest = computed((): ModuleContributeRequest => {
       version,
       schemaVariantId: asset.value.schemaVariantId,
     };
-  } else throw new Error("cannot contribute: no asset selected");
+  } else return null;
 });
 
 const editingVersionDoesNotExist = computed<boolean>(

--- a/app/web/src/components/AssetEditor.vue
+++ b/app/web/src/components/AssetEditor.vue
@@ -79,7 +79,7 @@ const editingAsset = ref<string>(selectedAssetFuncCode.value ?? "");
 let loadAssetReqStatus: ComputedRef<ApiRequestStatus>;
 
 watch(
-  () => selectedAsset.value?.assetFuncId,
+  () => selectedAsset.value,
   () => {
     loadAssetReqStatus = funcStore.getRequestStatus(
       "FETCH_CODE",


### PR DESCRIPTION
Adding a new option to ApiRequest for a callback that will run when a new change set is created. This is a halfway elegant feature. It's not the prettiest thing, given that it is in the context of the OLD store with the original change set where the change was initiated. 

So, to resolve that, you have to go grab the correct store—which is in the midst of being activated and all the requests to build the data within the store is in flight. You have to wait for the data to arrive before interacting in some cases. I tried making that not the case here, but it really introduces unnecessary complications in other components, where you have to take into account a number of things that by default don't make sense and no one would do by nature. 