### PR TITLE
fix: pgbouncer should be set by init version

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
 
   pgbouncer:
     container_name: pgbouncer
-    image: systeminit/pgbouncer:${SI_VERSION:-stable}
+    image: systeminit/pgbouncer:${INIT_VERSION:-stable}
     profiles: [rebaser, pinga, sdf]
     ports:
       - 5432:5432


### PR DESCRIPTION
Set pgbouncer based on the init version as they are more likely to be built together.