### PR TITLE
Fix BUG-548: move the X for select box and combo box to not be on top of dropdown icon

### DIFF
--- a/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanelItem.vue
@@ -314,7 +314,12 @@
         />
         <Icon
           v-if="unsetButtonShow"
-          class="attributes-panel-item__unset-button peer"
+          :class="
+            clsx(
+              'attributes-panel-item__unset-button peer',
+              `widget-${widgetKind}`,
+            )
+          "
           name="x-circle"
           @click="unsetHandler"
         />
@@ -1662,6 +1667,11 @@ const sourceSelectMenuRef = ref<InstanceType<typeof DropdownMenu>>();
   .attributes-panel-item.--input.--focus & {
     display: block;
   }
+}
+
+.attributes-panel-item__unset-button.widget-select,
+.attributes-panel-item__unset-button.widget-comboBox {
+  right: 20px;
 }
 
 // SECRETS


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/345d3006-4108-41e1-9867-19d3f929473c)
