### PR TITLE
Tune down sdf migrations logging

### DIFF
--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -189,7 +189,7 @@ async fn import_change_set(
 
         unseen.remove(normalized_name);
 
-        info!(
+        debug!(
             "installing schema '{}' from {}",
             schema_spec.name(),
             metadata.name(),

--- a/lib/sdf-server/src/migrations.rs
+++ b/lib/sdf-server/src/migrations.rs
@@ -150,8 +150,6 @@ impl Migrator {
         builtins::func::migrate_intrinsics(&ctx)
             .await
             .map_err(MigratorError::migrate_builtins)?;
-        // info!("migrating builtin functions");
-        // builtins::func::migrate(&ctx).await?;
 
         let module_index_url = self
             .services_context
@@ -173,7 +171,7 @@ impl Migrator {
         loop {
             tokio::select! {
                 _ = interval.tick() => {
-                    info!(elapsed = instant.elapsed().as_secs_f32(), "migrating");
+                    info!(elapsed = instant.elapsed().as_secs_f32(), "migrating in progress...");
                 }
                 result = &mut install_builtins  => match result {
                     Ok(_) => {
@@ -197,9 +195,6 @@ async fn install_builtins(
     let dal = &ctx;
     let client = &module_index_client.clone();
     let modules: Vec<ModuleDetailsResponse> = module_list.modules;
-    // .into_iter()
-    // .filter(|module| module.name.contains("docker-image"))
-    // .collect();
 
     let total = modules.len();
 
@@ -237,13 +232,13 @@ async fn install_builtins(
                     Ok(_) => {
                         count += 1;
                         let elapsed = instant.elapsed().as_secs_f32();
-                        info!(
+                        debug!(
                             "pkg {pkg_name} install finished successfully and took {elapsed:.2} seconds ({count} of {total} installed)",
                             );
                     }
                     Err(PkgError::PackageAlreadyInstalled(hash)) => {
                         count += 1;
-                        warn!(%hash, "pkg {pkg_name} already installed ({count} of {total} installed)");
+                        debug!(%hash, "skipping pkg {pkg_name}: already installed ({count} of {total} installed)");
                     }
                     Err(err) => error!(?err, "pkg {pkg_name} install failed"),
                 }


### PR DESCRIPTION
## Description

This PR tunes down sdf migrations logging in three areas. In all areas, the logging is tuned to debug-level.

The first change involves logging when migrating individual modules. At the time of writing, these modules take ~0.00-0.01 seconds to migrate each. In addition, there are now over 100 modules installed, so the logging spammed is not only no longer useful, but is also particularly noisy.

The second change involves logging when modules have already been installed. Currently, this is a warning-level log and now, the message has been re-written to indicate that we are explicitly skipping the installation.

The third change involves logging when importing a schema from a module. This area is potentially the area most sensitive to change as it will also change the log level for installed modules. This is a low risk change as info-level logging should be performed at a higher level API rather than `import_change_set` as it is used in many locations and for multiple purposes. As part of this change, I looked through the usage locations and existing tracing methods should be satisfactory.

<img src="https://media2.giphy.com/media/QF5pj9FwMJ2ViBTCjy/giphy.gif"/>

## What about performance regressions?

We will still info-level log the total elapsed time, so we can track the "elapsed" field in the trace if need be. Yes, that potentially gives us a blind spot to regressions based on total module count (e.g. introducing a performance regression where the logarithmic curve in migrating each module becomes progressively slower), but we should not be relying on these logs for that kind of analysis anyway.

## Additional Change

This PR deletes some commented out and dead code. In addition, it makes the "tick" logging more clear when migrating builtins in sdf.