### PR TITLE
BUG-575: fix first resize on child frame

### DIFF
--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -2169,6 +2169,7 @@ function onResizeMove() {
   if (!node.size) return;
   if (!containerPointerPos.value) return;
   if (!lastMouseDownContainerPointerPos.value) return;
+
   const sizeDelta: Vector2d = {
     x: Math.round(
       (containerPointerPos.value.x -
@@ -2810,6 +2811,10 @@ function fitChildInsideParentFrame(
   createAtSize.width -= DEFAULT_GUTTER_SIZE * 6;
   createAtSize.height -= HEADER_SIZE;
   createAtSize.height -= DEFAULT_GUTTER_SIZE * 4;
+
+  // we need just a bit more padding space between the parent to fix resizability
+  createAtPosition.y += 15;
+  createAtSize.height -= 30;
 
   // enforce minimums
   createAtSize.width = Math.max(createAtSize.width, MIN_NODE_DIMENSION);


### PR DESCRIPTION
The problem was that the "fitInsideOf" size was too large/overflowing the boundary checking... make it a bit smaller and we're all set here.
<img src="https://media4.giphy.com/media/Ns2K2ajFe2TT0Fx9bM/giphy.gif"/>