### PR TITLE
fix: don't write all dvus as finished by default

### DIFF
--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -77,7 +77,6 @@ impl DependentValueGraph {
 
         let mut values = Vec::new();
         for root in roots {
-            let unfinished = !root.is_finished();
             let root_ulid: Ulid = root.into();
             // It's possible that one or more of the initial ids provided by the enqueued
             // DependentValuesUpdate job may have been removed from the snapshot between when the
@@ -100,11 +99,7 @@ impl DependentValueGraph {
                 NodeWeightDiscriminants::AttributeValue => {
                     let initial_attribute_value_id: AttributeValueId = root_ulid.into();
 
-                    if unfinished
-                        && AttributeValue::is_set_by_dependent_function(
-                            ctx,
-                            initial_attribute_value_id,
-                        )
+                    if AttributeValue::is_set_by_dependent_function(ctx, initial_attribute_value_id)
                         .await?
                     {
                         self.values_that_need_to_execute_from_prototype_function

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -1418,7 +1418,7 @@ impl WorkspaceSnapshot {
                     NodeWeight::new_finished_dependent_value_root(id, lineage_id, value_id)
                 }
                 DependentValueRoot::Unfinished(value_id) => {
-                    NodeWeight::new_finished_dependent_value_root(id, lineage_id, value_id)
+                    NodeWeight::new_dependent_value_root(id, lineage_id, value_id)
                 }
             };
 


### PR DESCRIPTION
A bug in the implementation of the component concurrency limit meant we were writing all dvu roots as "finished", but luckily still executing them (i'm not really sure how it worked!). But this broke some transform corrections related to DVUs, which was noticed when fixing the component deletion bug. This ensures we write the roots correctly and restores the component concurrency limit test.