### PR TITLE
fix(sdf): Graph cycles aren't a 500 when editing attribute bindings

### DIFF
--- a/lib/sdf-server/src/service/v2/func.rs
+++ b/lib/sdf-server/src/service/v2/func.rs
@@ -5,12 +5,10 @@ use axum::{
     Router,
 };
 use dal::{
-    attribute::value::AttributeValueError,
-    func::{
+    attribute::{prototype::argument::AttributePrototypeArgumentError, value::AttributeValueError}, func::{
         argument::FuncArgumentError, authoring::FuncAuthoringError, binding::FuncBindingError,
         runner::FuncRunnerError,
-    },
-    ChangeSetError, DalContext, Func, FuncError, FuncId, WsEventError,
+    }, workspace_snapshot::graph::WorkspaceSnapshotGraphError, ChangeSetError, DalContext, Func, FuncError, FuncId, SchemaVariantError, WorkspaceSnapshotError, WsEventError
 };
 use si_frontend_types::FuncCode;
 use si_layer_cache::LayerDbError;
@@ -142,11 +140,18 @@ impl IntoResponse for FuncAPIError {
 
             // When the authoring changes requested would result in a cycle
             Self::FuncBinding(FuncBindingError::SchemaVariant(
-                dal::SchemaVariantError::AttributePrototypeArgument(
-                    dal::attribute::prototype::argument::AttributePrototypeArgumentError::WorkspaceSnapshot(
-                        dal::WorkspaceSnapshotError::WorkspaceSnapshotGraph(
-                            dal::workspace_snapshot::graph::WorkspaceSnapshotGraphError::CreateGraphCycle,
+                SchemaVariantError::AttributePrototypeArgument(
+                    AttributePrototypeArgumentError::WorkspaceSnapshot(
+                        WorkspaceSnapshotError::WorkspaceSnapshotGraph(
+                            WorkspaceSnapshotGraphError::CreateGraphCycle,
                         ),
+                    ),
+                ),
+            )) 
+            | Self::FuncBinding(FuncBindingError::AttributePrototypeArgument(
+                AttributePrototypeArgumentError::WorkspaceSnapshot(
+                    WorkspaceSnapshotError::WorkspaceSnapshotGraph(
+                        WorkspaceSnapshotGraphError::CreateGraphCycle,
                     ),
                 ),
             )) => (StatusCode::UNPROCESSABLE_ENTITY, None),


### PR DESCRIPTION
We can hold off on merging this until the other intrinsics work ships

<div><img src="https://media2.giphy.com/media/LnKa2WLkd6eAM/giphy.gif?cid=5a38a5a203aaxjtabo7i2m8rf85ouufrza25vnnc2pqb95zb&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:189px;width:300px"/><br/>via <a href="https://giphy.com/gifs/spongebob-squarepants-patrick-LnKa2WLkd6eAM">GIPHY</a></div>