### PR TITLE
fix(dal): Warn instead of error during DVU when functions fail

### DIFF
--- a/lib/dal/src/job/definition/dependent_values_update.rs
+++ b/lib/dal/src/job/definition/dependent_values_update.rs
@@ -447,7 +447,7 @@ async fn execution_error(
         fallback
     };
 
-    error!(si.error.message = error_message, %attribute_value_id);
+    warn!(name = "function_execution_error", si.error.message = error_message, %attribute_value_id);
 }
 
 async fn execution_error_detail(


### PR DESCRIPTION
Turns it down to a warn event instead of an error