### PR TITLE
chore(rebaser): add INFO event when a processing task is starting

### DIFF
--- a/lib/naxum/src/middleware/trace/mod.rs
+++ b/lib/naxum/src/middleware/trace/mod.rs
@@ -57,17 +57,20 @@ use std::{fmt, time::Duration};
 use tracing::Level;
 
 pub use self::{
-    layer::TraceLayer, make_span::DefaultMakeSpan, on_request::DefaultOnRequest,
-    on_response::DefaultOnResponse, service::Trace,
+    layer::TraceLayer,
+    make_span::{DefaultMakeSpan, MakeSpan},
+    on_request::{DefaultOnRequest, OnRequest},
+    on_response::{DefaultOnResponse, OnResponse},
+    service::Trace,
 };
 
 use super::LatencyUnit;
 
 const DEFAULT_MESSAGE_LEVEL: Level = Level::DEBUG;
 
-struct Latency {
-    unit: LatencyUnit,
-    duration: Duration,
+pub struct Latency {
+    pub unit: LatencyUnit,
+    pub duration: Duration,
 }
 
 impl fmt::Display for Latency {


### PR DESCRIPTION
This isn't a complete solution to inspect a change set-processing task
*during* its execution, but a starting signal that we can use in tracing
to better understand the process task's lifecycle.

<img src="https://media3.giphy.com/media/5zf2M4HgjjWszLd4a5/giphy.gif"/>