### PR TITLE
feat: allow trace level to be set for API Errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5378,6 +5378,7 @@ dependencies = [
  "tokio-util",
  "tower",
  "tower-http",
+ "tracing-tunnel",
  "ulid",
  "url",
  "veritech-client",
@@ -7183,6 +7184,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-tunnel"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507bbab1fc2c9e606543558f5656b62e8014ba7e0ffa68b9484511b6871019c5"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,6 +191,7 @@ tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.4", features = ["compression-br", "compression-deflate", "compression-gzip", "cors", "trace"] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
 tracing = { version = "0.1.40" }
 tracing-opentelemetry = "0.23.0"
+tracing-tunnel = "0.1.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "std"] }
 tryhard = "0.5.1"
 ulid = { version = "1.1.2", features = ["serde"] }

--- a/lib/sdf-server/BUCK
+++ b/lib/sdf-server/BUCK
@@ -50,6 +50,7 @@ rust_library(
         "//third-party/rust:tokio-stream",
         "//third-party/rust:tokio-tungstenite",
         "//third-party/rust:tokio-util",
+        "//third-party/rust:tracing-tunnel",
         "//third-party/rust:tower",
         "//third-party/rust:tower-http",
         "//third-party/rust:ulid",

--- a/lib/sdf-server/Cargo.toml
+++ b/lib/sdf-server/Cargo.toml
@@ -57,6 +57,7 @@ tokio-tungstenite = { workspace = true }
 tokio-util = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
+tracing-tunnel = { workspace = true }
 ulid = { workspace = true }
 url = { workspace = true }
 veritech-client = { path = "../../lib/veritech-client" }

--- a/lib/sdf-server/src/service/v2/admin.rs
+++ b/lib/sdf-server/src/service/v2/admin.rs
@@ -146,7 +146,6 @@ impl IntoResponse for AdminAPIError {
             }
             _ => ApiError::DEFAULT_ERROR_STATUS_CODE,
         };
-        error!(si.error.message = ?self.to_string());
 
         ApiError::new(status_code, self).into_response()
     }

--- a/lib/sdf-server/src/service/v2/func.rs
+++ b/lib/sdf-server/src/service/v2/func.rs
@@ -160,8 +160,6 @@ impl IntoResponse for FuncAPIError {
             _ => (ApiError::DEFAULT_ERROR_STATUS_CODE, None)
         };
 
-        error!(si.error.message = ?err_string);
-
         ApiError::new(status_code, maybe_message.unwrap_or(err_string)).into_response()
     }
 }

--- a/lib/sdf-server/src/service/v2/module.rs
+++ b/lib/sdf-server/src/service/v2/module.rs
@@ -49,8 +49,6 @@ impl IntoResponse for ModulesAPIError {
             _ => ApiError::DEFAULT_ERROR_STATUS_CODE,
         };
 
-        error!(si.error.message = ?self.to_string());
-
         ApiError::new(status_code, self).into_response()
     }
 }

--- a/lib/sdf-server/src/service/v2/variant.rs
+++ b/lib/sdf-server/src/service/v2/variant.rs
@@ -49,8 +49,6 @@ impl IntoResponse for SchemaVariantsAPIError {
             _ => ApiError::DEFAULT_ERROR_STATUS_CODE,
         };
 
-        error!(si.error.message = ?self.to_string());
-
         ApiError::new(status_code, self).into_response()
     }
 }

--- a/lib/sdf-server/src/service/ws.rs
+++ b/lib/sdf-server/src/service/ws.rs
@@ -1,6 +1,4 @@
-use axum::{
-    http::StatusCode, response::IntoResponse, response::Response, routing::get, Json, Router,
-};
+use axum::{http::StatusCode, response::IntoResponse, response::Response, routing::get, Router};
 use crdt::CrdtError;
 use dal::{TransactionsError, WsEventError};
 use nats_multiplexer_client::MultiplexerClientError;
@@ -10,6 +8,8 @@ use thiserror::Error;
 use tokio::sync::TryLockError;
 
 use crate::AppState;
+
+use super::ApiError;
 
 #[remain::sorted]
 #[derive(Debug, Error)]
@@ -37,18 +37,9 @@ pub mod workspace_updates;
 
 impl IntoResponse for WsError {
     fn into_response(self) -> Response {
-        let (status, error_message) = (StatusCode::INTERNAL_SERVER_ERROR, self.to_string());
+        let (status_code, error_message) = (StatusCode::INTERNAL_SERVER_ERROR, self.to_string());
 
-        let body = Json(serde_json::json!({
-            "error": {
-                "message": error_message,
-                "code": 42,
-                "statusCode": status.as_u16()
-            }
-        }));
-        error!(si.error.message = error_message);
-
-        (status, body).into_response()
+        ApiError::new(status_code, error_message).into_response()
     }
 }
 

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -16788,6 +16788,7 @@ cargo.rust_binary(
         ":tracing-0.1.40",
         ":tracing-opentelemetry-0.23.0",
         ":tracing-subscriber-0.3.18",
+        ":tracing-tunnel-0.1.0",
         ":tryhard-0.5.1",
         ":ulid-1.1.3",
         ":url-2.5.2",
@@ -18183,6 +18184,37 @@ cargo.rust_library(
         ":tracing-core-0.1.32",
         ":tracing-log-0.2.0",
         ":tracing-serde-0.1.3",
+    ],
+)
+
+alias(
+    name = "tracing-tunnel",
+    actual = ":tracing-tunnel-0.1.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "tracing-tunnel-0.1.0.crate",
+    sha256 = "507bbab1fc2c9e606543558f5656b62e8014ba7e0ffa68b9484511b6871019c5",
+    strip_prefix = "tracing-tunnel-0.1.0",
+    urls = ["https://static.crates.io/crates/tracing-tunnel/0.1.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tracing-tunnel-0.1.0",
+    srcs = [":tracing-tunnel-0.1.0.crate"],
+    crate = "tracing_tunnel",
+    crate_root = "tracing-tunnel-0.1.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":serde-1.0.210",
+        ":tracing-core-0.1.32",
     ],
 )
 

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -6095,6 +6095,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "tracing-tunnel",
  "tryhard",
  "ulid",
  "url",
@@ -6626,6 +6627,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-tunnel"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507bbab1fc2c9e606543558f5656b62e8014ba7e0ffa68b9484511b6871019c5"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -145,6 +145,7 @@ tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.4", features = ["compression-br", "compression-deflate", "compression-gzip", "cors", "trace"] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
 tracing = { version = "0.1.40" }
 tracing-opentelemetry = "0.23.0"
+tracing-tunnel = "0.1.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "std"] }
 tryhard = "0.5.1"
 ulid = { version = "1.1.2", features = ["serde"] }


### PR DESCRIPTION
This pushes all SDF APIErrors through the ApiError type so we can centralize decision making about what level to emit for different types of errors. By default, we will `WARN` on 400s and `ERROR` on 500s. It is currently unused, but `ApiErrors` can take an optional level which will force emitting at that level regardless of the status code (like if we want to throw a 500, but only have it appear as a warn in the logs). 

Note that the default `on_failure` mode still exists, so tower will always throw an error on 500s. We could disable this entirely, but it seems like it will be useful to catch things like networking issues so we can still return. The actual error types are not pushed down into this level, so we cannot do the matching here (nor do the tower devs recommend we try.

Here's an example of a `404` throwing a `WARN`.

```
2024-09-27T15:06:59.221268Z  WARN ThreadId(03) GET{http.request.method="GET" network.protocol.name="http" network.protocol.version="1.1" network.transport="tcp" url.path="/api/v2/workspaces/01J85GVH2PB85W4N3VQNM5W9K0/change-sets/01J8R13YR3MAEBVDXQAGM2ZZB9/funcs/code" url.query="id=01J8T0AD2QMA4Y3BQXAZ1ZN06S" url.domain="unknown" otel.kind="server" otel.name="GET /api/v2/workspaces/:workspace_id/change-sets/:change_set_id/funcs/code" user_agent.original="curl/8.10.1"}: sdf_server::service: err=ApiError { error: ApiErrorError { message: "The function does not exist", status_code: 404 }, level: None } self.error.status_code=404 self.error.status_code=404 self.error.message="The function does not exist"
```

<img src="https://media4.giphy.com/media/zv7iqaf7DVgjoN407s/giphy.gif"/>