### PR TITLE
Upsert new inferred edges on creation

### DIFF
--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -150,7 +150,7 @@ impl SummaryDiagramEdge {
         })
     }
 }
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct SummaryDiagramInferredEdge {
     pub from_component_id: ComponentId,


### PR DESCRIPTION
## Description

This PR informs the frontend of new, inferred edges on component creation. This happens when creating a component and directly placing it into a frame.

This PR also handles an edge case for mutated, inferred connections when detaching children of frames.

Example scenario: there's a grandparent up-frame, a parent down-frame and a child component or up-frame. If the parent frame has an input socket with an arity of one and both the child and grandparent have an output socket with a matching annotation, then the edge will be mutated. The parent will now have a different value at its input socket because the source side of the edge has changed.

<img src="https://media3.giphy.com/media/YqQJ6VzrKmvNm387v1/giphy.gif"/>