### PR TITLE
fix(sdf): Don't send 500 on schema variant deletion precondition failure

### DIFF
--- a/lib/sdf-server/src/service/v2/variant.rs
+++ b/lib/sdf-server/src/service/v2/variant.rs
@@ -44,6 +44,9 @@ impl IntoResponse for SchemaVariantsAPIError {
             Self::Transactions(dal::TransactionsError::BadWorkspaceAndChangeSet) => {
                 StatusCode::FORBIDDEN
             }
+            Self::CannotDeleteVariantWithComponents | Self::CannotDeleteLockedSchemaVariant(_) => {
+                StatusCode::PRECONDITION_FAILED
+            }
             // When a graph node cannot be found for a schema variant, it is not found
             Self::SchemaVariant(dal::SchemaVariantError::NotFound(_)) => StatusCode::NOT_FOUND,
             _ => ApiError::DEFAULT_ERROR_STATUS_CODE,


### PR DESCRIPTION
Deleting won't happen as there are nodes on the graph connected to the variant - it's not really a 500 more of a 412

![image](https://github.com/user-attachments/assets/1c405286-f394-480d-9085-a3da39405568)


The user already gets notified of this with messages like:

<img width="410" alt="Screenshot 2024-09-29 at 22 34 25" src="https://github.com/user-attachments/assets/45d5bdd8-7b6c-4da5-a422-9bb02848dcc2">
