### PR TITLE
feat: on demand asset installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,6 +1698,7 @@ dependencies = [
  "itertools 0.12.1",
  "jwt-simple",
  "lazy_static",
+ "module-index-client",
  "nats-subscriber",
  "object-tree",
  "once_cell",

--- a/app/auth-portal/src/store/feature_flags.store.ts
+++ b/app/auth-portal/src/store/feature_flags.store.ts
@@ -16,6 +16,7 @@ export const useFeatureFlagsStore = () => {
         SIMPLIFIED_SIGNUP: false,
         ADMIN_PAGE: false,
         SAAS_RELEASE: false,
+        ON_DEMAND_ASSETS: false,
       }),
       onActivated() {
         posthog.onFeatureFlags((flags) => {
@@ -28,6 +29,7 @@ export const useFeatureFlagsStore = () => {
             flags.includes("edit_workspaces") || this.CREATE_WORKSPACES;
           this.ADMIN_PAGE = flags.includes("auth_portal_admin_page");
           this.SAAS_RELEASE = flags.includes("auth_portal_saas_release");
+          this.ON_DEMAND_ASSETS = flags.includes("on_demand_assets");
         });
       },
     }),

--- a/app/web/src/api/sdf/dal/schema.ts
+++ b/app/web/src/api/sdf/dal/schema.ts
@@ -43,6 +43,17 @@ export interface InputSocket {
   eligibleToSendData: boolean;
 }
 
+export interface UninstalledVariant {
+  schemaId: string;
+  schemaName: string;
+  displayName: string | null;
+  category: string;
+  color: string;
+  componentType: ComponentType;
+  link: string | null;
+  description: string | null;
+}
+
 export interface SchemaVariant {
   schemaVariantId: string;
   schemaName: string;

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -302,7 +302,7 @@ import { useRealtimeStore } from "@/store/realtime/realtime.store";
 import { useChangeSetsStore } from "@/store/change_sets.store";
 import { ComponentId, EdgeId } from "@/api/sdf/dal/component";
 import { useAuthStore } from "@/store/auth.store";
-import { SchemaVariantId, ComponentType } from "@/api/sdf/dal/schema";
+import { ComponentType } from "@/api/sdf/dal/schema";
 import { useStatusStore } from "@/store/status.store";
 import { useQualificationsStore } from "@/store/qualifications.store";
 import DiagramGridBackground from "./DiagramGridBackground.vue";
@@ -2791,7 +2791,7 @@ async function triggerPasteElements() {
 
 // ELEMENT ADDITION
 const insertElementActive = computed(
-  () => !!componentsStore.selectedInsertSchemaVariantId,
+  () => !!componentsStore.selectedInsertCategoryVariantId,
 );
 
 const HEADER_SIZE = 60; // The height of the component header bar; TODO find a better way to detect this
@@ -2829,12 +2829,11 @@ async function triggerInsertElement() {
   if (!gridPointerPos.value)
     throw new Error("Cursor must be in grid to insert element");
 
-  if (!componentsStore.selectedInsertSchemaVariantId)
+  if (!componentsStore.selectedInsertCategoryVariantId)
     throw new Error("missing insert selection metadata");
 
-  const schemaVariantId =
-    componentsStore.selectedInsertSchemaVariantId as SchemaVariantId;
-  componentsStore.selectedInsertSchemaVariantId = null;
+  const insertVariantId = componentsStore.selectedInsertCategoryVariantId;
+  componentsStore.selectedInsertCategoryVariantId = null;
 
   const parentGroupId: string | undefined = cursorWithinGroupKey.value?.replace(
     "g-",
@@ -2850,12 +2849,12 @@ async function triggerInsertElement() {
     if (
       parentComponent &&
       (parentComponent.componentType !== ComponentType.AggregationFrame ||
-        schemaVariantId === parentComponent.schemaVariantId)
+        insertVariantId === parentComponent.schemaVariantId)
     ) {
       parentId = parentGroupId;
     }
     let isFrame = false;
-    const schemaVariant = componentsStore.schemaVariantsById[schemaVariantId];
+    const schemaVariant = componentsStore.schemaVariantsById[insertVariantId];
     if (schemaVariant) {
       isFrame = schemaVariant.componentType !== ComponentType.Component;
     }
@@ -2878,7 +2877,7 @@ async function triggerInsertElement() {
   // as this stands, the client will send a width/height for non-frames, that the API endpoint ignores
   // TODO: is there is a good way to determine whether this schemaID is a frame?
   componentsStore.CREATE_COMPONENT(
-    schemaVariantId,
+    insertVariantId,
     createAtPosition,
     parentId,
     createAtSize,

--- a/app/web/src/components/Workspace/WorkspaceAdminDashboard.vue
+++ b/app/web/src/components/Workspace/WorkspaceAdminDashboard.vue
@@ -7,6 +7,20 @@
         >Admin Dashboard</span
       >
       <Stack class="max-w-xl">
+        <h2 class="font-bold text-lg">UPDATE MODULE CACHE</h2>
+        <div class="flex flex-row-reverse gap-sm">
+          <VButton
+            :requestStatus="updateModuleCacheReqStatus"
+            class="flex-grow"
+            icon="plus-circle"
+            label="Update module cache"
+            loadingText="Updating module cache"
+            tone="success"
+            @click="updateModuleCache"
+          />
+        </div>
+      </Stack>
+      <Stack class="max-w-xl">
         <h2 class="font-bold text-lg">KILL FUNCTION EXECUTION</h2>
         <VormInput
           v-model="funcRunId"
@@ -48,6 +62,14 @@ onBeforeMount(async () => {
     await router.push({ name: "workspace-single" });
   }
 });
+
+const updateModuleCacheReqStatus = adminStore.getRequestStatus(
+  "UPDATE_MODULE_CACHE",
+);
+
+const updateModuleCache = async () => {
+  await adminStore.UPDATE_MODULE_CACHE();
+};
 
 const killExecutionReqStatus = adminStore.getRequestStatus("KILL_EXECUTION");
 

--- a/app/web/src/pages/auth/AuthConnectPage.vue
+++ b/app/web/src/pages/auth/AuthConnectPage.vue
@@ -50,12 +50,17 @@ const authReqStatus = authStore.getRequestStatus("AUTH_CONNECT");
 // grab the code from the URL, don't need to care about reactivity as it will not change while on the page
 const connectCode = route.query.code as string;
 const redirectPath = route.query.redirect as string;
+const onDemandAssets = route.query.onDemandAssets === "true";
 
 onMounted(async () => {
   // if no code in query, we just bail and an error will be displayed
   if (!connectCode) return;
 
-  const connectReq = await authStore.AUTH_CONNECT({ code: connectCode });
+  const connectReq = await authStore.AUTH_CONNECT({
+    code: connectCode,
+    onDemandAssets,
+  });
+
   if (connectReq.result.success) {
     const workspacePk = connectReq.result.data.workspace.pk;
 

--- a/app/web/src/store/admin.store.ts
+++ b/app/web/src/store/admin.store.ts
@@ -101,6 +101,12 @@ export const useAdminStore = () => {
             url: `${API_PREFIX}/func/runs/${funcRunId}/kill_execution`,
           });
         },
+        async UPDATE_MODULE_CACHE() {
+          return new ApiRequest<{ new_modules: object[] }>({
+            method: "post",
+            url: `${API_PREFIX}/update_module_cache`,
+          });
+        },
       },
       onActivated() {
         return () => {};

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -4,7 +4,12 @@ import * as _ from "lodash-es";
 import { addStoreHooks, ApiRequest } from "@si/vue-lib/pinia";
 import { useWorkspacesStore } from "@/store/workspaces.store";
 import { FuncId, FuncKind } from "@/api/sdf/dal/func";
-import { SchemaId, SchemaVariant, SchemaVariantId } from "@/api/sdf/dal/schema";
+import {
+  SchemaId,
+  SchemaVariant,
+  SchemaVariantId,
+  UninstalledVariant,
+} from "@/api/sdf/dal/schema";
 import { Visibility } from "@/api/sdf/dal/visibility";
 import keyedDebouncer from "@/utils/keyedDebouncer";
 import router from "@/router";
@@ -464,11 +469,14 @@ export const useAssetStore = (forceChangeSetId?: ChangeSetId) => {
         },
 
         async LOAD_SCHEMA_VARIANT_LIST() {
-          return new ApiRequest<SchemaVariant[], Visibility>({
+          return new ApiRequest<
+            { installed: SchemaVariant[]; uninstalled: UninstalledVariant[] },
+            Visibility
+          >({
             url: API_PREFIX,
             params: { ...visibility },
             onSuccess: (response) => {
-              this.variantList = response;
+              this.variantList = response.installed;
             },
           });
         },

--- a/app/web/src/store/auth.store.ts
+++ b/app/web/src/store/auth.store.ts
@@ -74,11 +74,14 @@ export const useAuthStore = defineStore("auth", {
 
     // exchanges a code from the auth portal/api to auth with sdf
     // and initializes workspace/user if necessary
-    async AUTH_CONNECT(payload: { code: string }) {
-      return new ApiRequest<LoginResponse>({
+    async AUTH_CONNECT(payload: { code: string; onDemandAssets: boolean }) {
+      return new ApiRequest<
+        LoginResponse,
+        { code: string; onDemandAssets: boolean }
+      >({
         method: "post",
         url: "/session/connect",
-        params: payload,
+        params: { ...payload },
         onSuccess: (response) => {
           this.finishUserLogin(response);
         },

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -11,6 +11,7 @@ const FLAG_MAPPING = {
   DEV_SLICE_REBASING: "dev-slice-rebasing",
   ADMIN_PANEL_ACCESS: "si_admin_panel_access",
   SHOW_INTRINSIC_EDITING: "asset_detail_intrinsic_editing",
+  ON_DEMAND_ASSETS: "on_demand_assets",
 };
 
 type FeatureFlags = keyof typeof FLAG_MAPPING;

--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -211,7 +211,7 @@ impl ExpectSchema {
     }
 
     pub async fn schema(self, ctx: &DalContext) -> Schema {
-        Schema::get_by_id(ctx, self.0)
+        Schema::get_by_id_or_error(ctx, self.0)
             .await
             .expect("get schema by id")
     }

--- a/lib/dal-test/src/helpers/change_set.rs
+++ b/lib/dal-test/src/helpers/change_set.rs
@@ -63,7 +63,7 @@ impl ChangeSetTestHelpers {
     pub async fn apply_change_set_to_base(ctx: &mut DalContext) -> Result<()> {
         // Lock all unlocked variants
         for schema_id in Schema::list_ids(ctx).await? {
-            let schema = Schema::get_by_id(ctx, schema_id).await?;
+            let schema = Schema::get_by_id_or_error(ctx, schema_id).await?;
             let Some(variant) = SchemaVariant::get_unlocked_for_schema(ctx, schema_id).await?
             else {
                 continue;

--- a/lib/dal-test/src/signup.rs
+++ b/lib/dal-test/src/signup.rs
@@ -25,7 +25,8 @@ impl WorkspaceSignup {
         user_name: impl AsRef<str>,
         user_email: impl AsRef<str>,
     ) -> color_eyre::Result<Self> {
-        let workspace = Workspace::new(ctx, WorkspacePk::generate(), workspace_name).await?;
+        let workspace =
+            Workspace::new_from_builtin(ctx, WorkspacePk::generate(), workspace_name).await?;
         let key_pair = KeyPair::new(ctx, "default").await?;
 
         let user = User::new(

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -8,6 +8,7 @@ rust_library(
     name = "dal",
     deps = [
         "//lib/billing-events:billing-events",
+        "//lib/module-index-client:module-index-client",
         "//lib/nats-subscriber:nats-subscriber",
         "//lib/object-tree:object-tree",
         "//lib/pinga-core:pinga-core",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -28,6 +28,7 @@ indexmap = { workspace = true }
 itertools = { workspace = true }
 jwt-simple = { workspace = true }
 lazy_static = { workspace = true }
+module-index-client = { path = "../../lib/module-index-client" }
 nats-subscriber = { path = "../../lib/nats-subscriber" }
 object-tree = { path = "../../lib/object-tree" }
 once_cell = { workspace = true }

--- a/lib/dal/src/builtins/func.rs
+++ b/lib/dal/src/builtins/func.rs
@@ -46,3 +46,11 @@ pub async fn migrate_intrinsics(ctx: &DalContext) -> BuiltinsResult<()> {
 
     Ok(())
 }
+
+#[instrument(skip_all)]
+pub async fn migrate_intrinsics_no_commit(ctx: &DalContext) -> BuiltinsResult<()> {
+    let intrinsics_pkg_spec = IntrinsicFunc::pkg_spec()?;
+    let intrinsics_pkg = SiPkg::load_from_spec(intrinsics_pkg_spec)?;
+    import_pkg_from_pkg(ctx, &intrinsics_pkg, None).await?;
+    Ok(())
+}

--- a/lib/dal/src/cached_module.rs
+++ b/lib/dal/src/cached_module.rs
@@ -1,0 +1,400 @@
+use std::{collections::HashMap, str::FromStr, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use itertools::Itertools;
+use postgres_types::ToSql;
+use serde::{Deserialize, Serialize};
+use telemetry::prelude::*;
+use thiserror::Error;
+use tokio::task::JoinSet;
+use ulid::Ulid;
+
+use crate::{
+    pk,
+    slow_rt::{self, SlowRuntimeError},
+    ComponentType, DalContext, SchemaId, TransactionsError,
+};
+use module_index_client::{ModuleDetailsResponse, ModuleIndexClient, ModuleIndexClientError};
+use si_data_pg::{PgError, PgRow};
+use si_pkg::{SiPkg, SiPkgError};
+
+pk!(CachedModuleId);
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum CachedModuleError {
+    #[error("join error: {0}")]
+    Join(#[from] tokio::task::JoinError),
+    #[error("module index client error: {0}")]
+    ModuleIndexClient(#[from] ModuleIndexClientError),
+    #[error("No module index url set on the services context")]
+    ModuleIndexUrlNotSet,
+    #[error("package data None")]
+    NoPackageData,
+    #[error("pg error: {0}")]
+    Pg(#[from] PgError),
+    #[error("si-pkg error: {0}")]
+    SiPkg(#[from] SiPkgError),
+    #[error("slow runtime error: {0}")]
+    SlowRuntime(#[from] SlowRuntimeError),
+    #[error("strum parse error: {0}")]
+    StrumParse(#[from] strum::ParseError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
+    #[error("url parse error: {0}")]
+    UrlParse(#[from] url::ParseError),
+}
+
+pub type CachedModuleResult<T> = Result<T, CachedModuleError>;
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CachedModule {
+    pub id: CachedModuleId,
+    pub schema_id: SchemaId,
+    pub schema_name: String,
+    pub display_name: Option<String>,
+    pub category: Option<String>,
+    pub link: Option<String>,
+    pub color: Option<String>,
+    pub description: Option<String>,
+    pub component_type: ComponentType,
+    pub latest_hash: String,
+    pub created_at: DateTime<Utc>,
+    pub package_data: Option<Vec<u8>>,
+}
+
+impl From<CachedModule> for si_frontend_types::UninstalledVariant {
+    fn from(value: CachedModule) -> Self {
+        Self {
+            schema_id: value.schema_id.into(),
+            schema_name: value.schema_name,
+            display_name: value.display_name,
+            category: value.category,
+            link: value.link,
+            color: value.color,
+            description: value.description,
+            component_type: value.component_type.into(),
+        }
+    }
+}
+
+impl TryFrom<PgRow> for CachedModule {
+    type Error = CachedModuleError;
+
+    fn try_from(row: PgRow) -> Result<Self, Self::Error> {
+        let component_type_string: String = row.try_get("component_type")?;
+        let component_type = ComponentType::from_str(&component_type_string)?;
+
+        Ok(Self {
+            id: row.try_get("id")?,
+            schema_id: row.try_get("schema_id")?,
+            schema_name: row.try_get("schema_name")?,
+            display_name: row.try_get("display_name")?,
+            category: row.try_get("category")?,
+            link: row.try_get("link")?,
+            color: row.try_get("color")?,
+            description: row.try_get("description")?,
+            component_type,
+            latest_hash: row.try_get("latest_hash")?,
+            created_at: row.try_get("created_at")?,
+            package_data: row.try_get("package_data")?,
+        })
+    }
+}
+
+impl CachedModule {
+    pub async fn si_pkg(&mut self, ctx: &DalContext) -> CachedModuleResult<SiPkg> {
+        let package_data = self.package_data(ctx).await?;
+        // slow_rt, and cache this
+        Ok(SiPkg::load_from_bytes(package_data)?)
+    }
+
+    async fn package_data(&mut self, ctx: &DalContext) -> CachedModuleResult<&[u8]> {
+        if self.package_data.is_none() {
+            let query = "SELECT package_data FROM cached_modules where id = $1";
+            let row = ctx.txns().await?.pg().query_one(query, &[&self.id]).await?;
+
+            let bytes: Option<Vec<u8>> = row.try_get("package_data")?;
+            self.package_data = bytes;
+        }
+
+        let Some(package_data) = &self.package_data else {
+            return Err(CachedModuleError::NoPackageData);
+        };
+
+        Ok(package_data.as_slice())
+    }
+
+    pub async fn find_missing_entries(
+        ctx: &DalContext,
+        hashes: Vec<String>,
+    ) -> CachedModuleResult<Vec<String>> {
+        // Constructs a list of parameters like '($1), ($2), ($3), ($4)' for
+        // each input value so they can be used as a table expression in the
+        // query, for the left join
+        let values_expr = hashes
+            .iter()
+            .enumerate()
+            .map(|(idx, _)| format!("(${})", idx + 1))
+            .join(",");
+
+        let params: Vec<_> = hashes
+            .iter()
+            .map(|hash| hash as &(dyn ToSql + Sync))
+            .collect();
+
+        let query = format!(
+            "
+            SELECT hashes.hash 
+                FROM (VALUES {values_expr}) AS hashes(hash)
+            LEFT JOIN cached_modules on cached_modules.latest_hash = hashes.hash
+            WHERE cached_modules.latest_hash IS NULL
+            "
+        );
+
+        let rows = ctx.txns().await?.pg().query(&query, &params).await?;
+
+        let mut result = vec![];
+
+        for row in rows {
+            result.push(row.try_get("hash")?);
+        }
+
+        Ok(result)
+    }
+
+    /// Calls out to the module index server to fetch the latest module set, and
+    /// updates the cache for any new builtin modules
+    pub async fn update_cached_modules(ctx: &DalContext) -> CachedModuleResult<Vec<CachedModule>> {
+        let services_context = ctx.services_context();
+        let module_index_url = services_context
+            .module_index_url()
+            .ok_or(CachedModuleError::ModuleIndexUrlNotSet)?;
+
+        let module_index_client =
+            ModuleIndexClient::unauthenticated_client(module_index_url.try_into()?);
+
+        let modules: HashMap<_, _> = module_index_client
+            .list_builtins()
+            .await?
+            .modules
+            .iter()
+            .map(|builtin| (builtin.latest_hash.to_owned(), builtin.to_owned()))
+            .collect();
+
+        let hashes: Vec<_> = modules.keys().map(ToOwned::to_owned).collect();
+        let uncached_hashes = CachedModule::find_missing_entries(ctx, hashes).await?;
+
+        let mut join_set = JoinSet::new();
+        for uncached_hash in &uncached_hashes {
+            let Some(module) = modules.get(uncached_hash).cloned() else {
+                continue;
+            };
+
+            let client = module_index_client.clone();
+            join_set.spawn(async move {
+                let module_id = module.id.to_owned();
+                Ok::<(ModuleDetailsResponse, Arc<Vec<u8>>), CachedModuleError>((
+                    module,
+                    Arc::new(
+                        client
+                            .get_builtin(Ulid::from_string(&module_id).unwrap_or_default())
+                            .await?,
+                    ),
+                ))
+            });
+        }
+
+        let mut new_modules = vec![];
+        for res in join_set.join_all().await {
+            match res {
+                Ok((module, module_bytes)) => {
+                    if let Some(new_cached_module) =
+                        Self::insert(ctx, &module, module_bytes).await?
+                    {
+                        new_modules.push(new_cached_module);
+                    }
+                }
+                Err(_) => todo!(),
+            }
+        }
+
+        if !uncached_hashes.is_empty() {
+            ctx.commit_no_rebase().await?;
+        }
+
+        Ok(new_modules)
+    }
+
+    pub async fn latest_by_schema_id(
+        ctx: &DalContext,
+        schema_id: SchemaId,
+    ) -> CachedModuleResult<Option<CachedModule>> {
+        let query = "
+            SELECT DISTINCT ON (schema_id) 
+                id,
+                schema_id,
+                schema_name,
+                display_name,
+                category,
+                link,
+                color,
+                description,
+                component_type,
+                latest_hash,
+                created_at,
+                package_data
+            FROM cached_modules
+            WHERE schema_id = $1
+            ORDER BY schema_id, created_at DESC
+        ";
+
+        let maybe_row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_opt(query, &[&schema_id])
+            .await?;
+
+        Ok(match maybe_row {
+            Some(row) => Some(row.try_into()?),
+            None => None,
+        })
+    }
+
+    pub async fn latest_modules(ctx: &DalContext) -> CachedModuleResult<Vec<CachedModule>> {
+        let query = "
+            SELECT DISTINCT ON (schema_id)
+                id,
+                schema_id,
+                schema_name,
+                display_name,
+                category,
+                link,
+                color,
+                description,
+                component_type,
+                latest_hash,
+                created_at,
+                NULL::bytea AS package_data
+            FROM cached_modules
+            ORDER BY schema_id, created_at DESC
+        ";
+
+        let rows = ctx.txns().await?.pg().query(query, &[]).await?;
+
+        let mut result = vec![];
+
+        for row in rows {
+            result.push(row.try_into()?);
+        }
+
+        Ok(result)
+    }
+
+    pub async fn insert(
+        ctx: &DalContext,
+        module_details: &ModuleDetailsResponse,
+        pkg_bytes: Arc<Vec<u8>>,
+    ) -> CachedModuleResult<Option<Self>> {
+        let bytes_clone = pkg_bytes.clone();
+        let pkg = slow_rt::spawn(async move { SiPkg::load_from_bytes(&bytes_clone) })?.await??;
+
+        let query = "
+            INSERT INTO cached_modules (
+                schema_id,
+                schema_name,
+                display_name,
+                category,
+                link,
+                color,
+                description,
+                component_type,
+                latest_hash,
+                created_at,
+                package_data
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6,
+                $7, $8, $9, $10, $11 
+            ) RETURNING
+                id,
+                schema_id,
+                schema_name,
+                display_name,
+                category,
+                link,
+                color,
+                description,
+                component_type,
+                latest_hash,
+                created_at,
+                NULL::bytea AS package_data
+        ";
+
+        let Some(schema_id) = module_details.schema_id() else {
+            warn!("builtin module {} has no schema id", module_details.id);
+            return Ok(None);
+        };
+        let schema_id: SchemaId = schema_id.into();
+
+        let Some(pkg_schema) = pkg.schemas()?.first().cloned() else {
+            warn!("builtin module {} has no schema", module_details.id);
+            return Ok(None);
+        };
+
+        let Some(pkg_variant) = pkg_schema.variants()?.first().cloned() else {
+            warn!(
+                "builtin module {} has a schema with no variant",
+                module_details.id
+            );
+            return Ok(None);
+        };
+
+        let schema_name = pkg_schema
+            .data()
+            .map(|data| data.name())
+            .unwrap_or(module_details.name.as_str());
+        let display_name = pkg_schema.data().and_then(|data| data.category_name());
+        let category = pkg_schema.data().map(|data| data.category()).unwrap_or("");
+        let link = pkg_variant
+            .data()
+            .and_then(|data| data.link().map(ToString::to_string));
+        let color = pkg_variant.data().and_then(|data| data.color());
+        let description = pkg_variant.data().and_then(|data| data.description());
+        let component_type: ComponentType = pkg_variant
+            .data()
+            .map(|data| data.component_type().into())
+            .unwrap_or_default();
+
+        info!(
+            "Updating sdf module cache for {} - {schema_name} ({category:?})",
+            module_details.name
+        );
+
+        let bytes_ref = pkg_bytes.as_slice();
+        let row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_one(
+                query,
+                &[
+                    &schema_id,
+                    &schema_name,
+                    &display_name,
+                    &category,
+                    &link,
+                    &color,
+                    &description,
+                    &component_type.to_string(),
+                    &module_details.latest_hash,
+                    &module_details.created_at,
+                    &bytes_ref,
+                ],
+            )
+            .await?;
+
+        Ok(Some(row.try_into()?))
+    }
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -25,6 +25,7 @@ pub mod attribute;
 pub mod authentication_prototype;
 pub mod billing_publish;
 pub mod builtins;
+pub mod cached_module;
 pub mod change_set;
 pub mod change_status;
 pub mod code_view;

--- a/lib/dal/src/migrations/U3301__cached_modules.sql
+++ b/lib/dal/src/migrations/U3301__cached_modules.sql
@@ -1,0 +1,18 @@
+CREATE TABLE cached_modules 
+(
+    id                          ident primary key default ident_create_v1(),
+    schema_id                   ident                    NOT NULL,
+    schema_name                 text                     NOT NULL,
+    display_name                text,
+    category                    text,
+    link                        text,
+    color                       text,
+    description                 text,
+    component_type              text                     NOT NULL,
+    latest_hash                 text                     NOT NULL,
+    created_at                  timestamp with time zone NOT NULL,
+    package_data                bytea
+);
+
+CREATE INDEX IF NOT EXISTS latest_hash_idx ON cached_modules (latest_hash);
+CREATE INDEX IF NOT EXISTS schema_id_idx ON cached_modules (schema_id);

--- a/lib/dal/src/module.rs
+++ b/lib/dal/src/module.rs
@@ -319,7 +319,7 @@ impl Module {
                     inner.content_address().into();
 
                 if inner_addr_discrim == ContentAddressDiscriminants::Schema {
-                    let schema = Schema::get_by_id(ctx, inner.id().into()).await?;
+                    let schema = Schema::get_by_id_or_error(ctx, inner.id().into()).await?;
                     all_schemas.push(schema);
                 }
             }

--- a/lib/dal/src/schema/variant/root_prop/component_type.rs
+++ b/lib/dal/src/schema/variant/root_prop/component_type.rs
@@ -23,6 +23,7 @@ use strum::{AsRefStr, Display, EnumIter, EnumString};
     Eq,
     PartialEq,
     Serialize,
+    Default,
 )]
 #[serde(rename_all = "camelCase")]
 pub enum ComponentType {
@@ -31,6 +32,7 @@ pub enum ComponentType {
     AggregationFrame,
     #[serde(alias = "Component")]
     #[strum(serialize = "Component", serialize = "component")]
+    #[default]
     Component,
     #[serde(
         alias = "ConfigurationFrameDown",

--- a/lib/dal/tests/integration_test/change_set.rs
+++ b/lib/dal/tests/integration_test/change_set.rs
@@ -150,12 +150,14 @@ async fn build_from_request_context_limits_to_workspaces_user_has_access_to(
 ) {
     let user_1 = create_user(ctx).await.expect("Unable to create user");
     let user_2 = create_user(ctx).await.expect("Unable to create user");
-    let user_1_workspace = Workspace::new(ctx, WorkspacePk::generate(), "user_1 workspace")
-        .await
-        .expect("Unable to create workspace");
-    let user_2_workspace = Workspace::new(ctx, WorkspacePk::generate(), "user_2 workspace")
-        .await
-        .expect("Unable to create workspace");
+    let user_1_workspace =
+        Workspace::new_from_builtin(ctx, WorkspacePk::generate(), "user_1 workspace")
+            .await
+            .expect("Unable to create workspace");
+    let user_2_workspace =
+        Workspace::new_from_builtin(ctx, WorkspacePk::generate(), "user_2 workspace")
+            .await
+            .expect("Unable to create workspace");
     user_1
         .associate_workspace(ctx, *user_1_workspace.pk())
         .await
@@ -200,12 +202,14 @@ async fn build_from_request_context_limits_to_change_sets_of_current_workspace(
 ) {
     let user_1 = create_user(ctx).await.expect("Unable to create user");
     let user_2 = create_user(ctx).await.expect("Unable to create user");
-    let user_1_workspace = Workspace::new(ctx, WorkspacePk::generate(), "user_1 workspace")
-        .await
-        .expect("Unable to create workspace");
-    let user_2_workspace = Workspace::new(ctx, WorkspacePk::generate(), "user_2 workspace")
-        .await
-        .expect("Unable to create workspace");
+    let user_1_workspace =
+        Workspace::new_from_builtin(ctx, WorkspacePk::generate(), "user_1 workspace")
+            .await
+            .expect("Unable to create workspace");
+    let user_2_workspace =
+        Workspace::new_from_builtin(ctx, WorkspacePk::generate(), "user_2 workspace")
+            .await
+            .expect("Unable to create workspace");
     user_1
         .associate_workspace(ctx, *user_1_workspace.pk())
         .await
@@ -250,12 +254,14 @@ async fn build_from_request_context_allows_change_set_from_workspace_with_access
 ) {
     let user_1 = create_user(ctx).await.expect("Unable to create user");
     let user_2 = create_user(ctx).await.expect("Unable to create user");
-    let user_1_workspace = Workspace::new(ctx, WorkspacePk::generate(), "user_1 workspace")
-        .await
-        .expect("Unable to create workspace");
-    let user_2_workspace = Workspace::new(ctx, WorkspacePk::generate(), "user_2 workspace")
-        .await
-        .expect("Unable to create workspace");
+    let user_1_workspace =
+        Workspace::new_from_builtin(ctx, WorkspacePk::generate(), "user_1 workspace")
+            .await
+            .expect("Unable to create workspace");
+    let user_2_workspace =
+        Workspace::new_from_builtin(ctx, WorkspacePk::generate(), "user_2 workspace")
+            .await
+            .expect("Unable to create workspace");
     user_1
         .associate_workspace(ctx, *user_1_workspace.pk())
         .await

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -168,7 +168,7 @@ async fn create_and_determine_lineage(ctx: &DalContext) {
     let schema = schemas.pop().expect("schemas are empty");
 
     // Ensure we can get it by id.
-    let found_schema = Schema::get_by_id(ctx, schema.id())
+    let found_schema = Schema::get_by_id_or_error(ctx, schema.id())
         .await
         .expect("could not get schema by id");
     assert_eq!(

--- a/lib/module-index-server/src/routes/upsert_module_route.rs
+++ b/lib/module-index-server/src/routes/upsert_module_route.rs
@@ -107,7 +107,7 @@ pub async fn upsert_module_route(
     let data = module_data.ok_or(UpsertModuleError::UploadRequiredError)?;
 
     // SiPkg using old term "package" but we are dealing with a "module"
-    let loaded_module = SiPkg::load_from_bytes(data.to_vec())?;
+    let loaded_module = SiPkg::load_from_bytes(&data)?;
     let module_metadata = loaded_module.metadata()?;
 
     info!(

--- a/lib/object-tree/src/tar/read.rs
+++ b/lib/object-tree/src/tar/read.rs
@@ -47,14 +47,14 @@ impl<T> ObjectTree<T> {
     /// - An expected file does not exist or cannot be opened
     /// - A node file fails to be correctly parsed
     /// - The resulting tree structure has no root node or multiple root nodes
-    pub fn read_from_tar<N>(tar_data: Vec<u8>) -> Result<ObjectTree<N>, TarReadError>
+    pub fn read_from_tar<N>(tar_data: &[u8]) -> Result<ObjectTree<N>, TarReadError>
     where
         N: ReadBytes,
     {
         let mut graph = Graph::new();
         let mut root_idx: Option<NodeIndex> = None;
 
-        let mut unpacked_tar = ::tar::Archive::new(tar_data.as_slice());
+        let mut unpacked_tar = ::tar::Archive::new(tar_data);
         let mut tar_data = HashMap::new();
         for maybe_tar_entry in unpacked_tar.entries()? {
             let mut tar_entry = maybe_tar_entry?;

--- a/lib/sdf-server/src/service/change_set/apply_change_set.rs
+++ b/lib/sdf-server/src/service/change_set/apply_change_set.rs
@@ -52,7 +52,7 @@ pub async fn apply_change_set(
 
     // Lock all unlocked variants
     for schema_id in Schema::list_ids(&ctx).await? {
-        let schema = Schema::get_by_id(&ctx, schema_id).await?;
+        let schema = Schema::get_by_id_or_error(&ctx, schema_id).await?;
         let Some(variant) = SchemaVariant::get_unlocked_for_schema(&ctx, schema_id).await? else {
             continue;
         };

--- a/lib/sdf-server/src/service/diagram.rs
+++ b/lib/sdf-server/src/service/diagram.rs
@@ -5,13 +5,15 @@ use axum::Router;
 use dal::attribute::prototype::argument::AttributePrototypeArgumentError;
 use dal::attribute::prototype::AttributePrototypeError;
 use dal::attribute::value::AttributeValueError;
+use dal::cached_module::CachedModuleError;
 use dal::component::ComponentError;
+use dal::pkg::PkgError;
 use dal::slow_rt::SlowRuntimeError;
 use dal::socket::input::InputSocketError;
 use dal::socket::output::OutputSocketError;
 use dal::workspace_snapshot::WorkspaceSnapshotError;
-use dal::WsEventError;
-use dal::{ChangeSetError, SchemaVariantId, StandardModelError, TransactionsError};
+use dal::{ChangeSetError, SchemaError, SchemaVariantId, StandardModelError, TransactionsError};
+use dal::{SchemaId, WsEventError};
 use std::num::ParseFloatError;
 use telemetry::prelude::*;
 use thiserror::Error;
@@ -43,6 +45,8 @@ pub enum DiagramError {
     AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
     #[error("attribute value error: {0}")]
     AttributeValue(#[from] AttributeValueError),
+    #[error("cached module error: {0}")]
+    CachedModule(#[from] CachedModuleError),
     #[error("changeset error: {0}")]
     ChangeSet(#[from] ChangeSetError),
     #[error("change set not found")]
@@ -71,14 +75,14 @@ pub enum DiagramError {
     Hyper(#[from] hyper::http::Error),
     #[error("input socket error: {0}")]
     InputSocket(#[from] InputSocketError),
-    #[error("invalid request")]
-    InvalidRequest,
-    #[error("invalid system")]
-    InvalidSystem,
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
     #[error("tokio join error: {0}")]
     Join(#[from] JoinError),
     #[error(transparent)]
     Nats(#[from] si_data_nats::NatsError),
+    #[error("no default schema variant found for schema id {0}")]
+    NoDefaultSchemaVariant(SchemaId),
     #[error("not authorized")]
     NotAuthorized,
     #[error("output socket error: {0}")]
@@ -91,8 +95,14 @@ pub enum DiagramError {
     Pg(#[from] si_data_pg::PgError),
     #[error(transparent)]
     PgPool(#[from] si_data_pg::PgPoolError),
+    #[error("pkg error: {0}")]
+    Pkg(#[from] PkgError),
+    #[error("schema error: {0}")]
+    Schema(#[from] SchemaError),
     #[error("schema not found")]
     SchemaNotFound,
+    #[error("No schema installed after successful package import for {0}")]
+    SchemaNotInstalledAfterImport(SchemaId),
     #[error("serde error: {0}")]
     Serde(#[from] serde_json::Error),
     #[error("slow runtime error: {0}")]
@@ -101,6 +111,8 @@ pub enum DiagramError {
     SocketNotFound,
     #[error(transparent)]
     StandardModel(#[from] StandardModelError),
+    #[error("No installable module found for schema id {0}")]
+    UninstalledSchemaNotFound(SchemaId),
     #[error(transparent)]
     WorkspaceSnaphot(#[from] WorkspaceSnapshotError),
     #[error("ws event error: {0}")]

--- a/lib/sdf-server/src/service/module/install_module.rs
+++ b/lib/sdf-server/src/service/module/install_module.rs
@@ -28,7 +28,6 @@ pub struct InstallModuleRequest {
     pub visibility: Visibility,
 }
 
-#[allow(clippy::panic)]
 pub async fn install_module(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
@@ -55,7 +54,7 @@ pub async fn install_module(
         let module_details = module_index_client.module_details(id).await?;
         let pkg_data = module_index_client.download_module(id).await?;
 
-        let pkg = SiPkg::load_from_bytes(pkg_data)?;
+        let pkg = SiPkg::load_from_bytes(&pkg_data)?;
 
         let (schema_id, past_module_hashes) = if pkg.schemas()?.len() > 1 {
             (None, None)

--- a/lib/sdf-server/src/service/module/remote_module_spec.rs
+++ b/lib/sdf-server/src/service/module/remote_module_spec.rs
@@ -45,7 +45,7 @@ pub async fn remote_module_spec(
         ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token);
     let pkg_data = module_index_client.download_module(request.id).await?;
 
-    let pkg = SiPkg::load_from_bytes(pkg_data)?;
+    let pkg = SiPkg::load_from_bytes(&pkg_data)?;
     let spec = pkg.to_spec().await?;
 
     track(

--- a/lib/sdf-server/src/service/v2/admin/update_module_cache.rs
+++ b/lib/sdf-server/src/service/v2/admin/update_module_cache.rs
@@ -1,0 +1,44 @@
+use serde::{Deserialize, Serialize};
+use telemetry::prelude::*;
+
+use axum::{
+    extract::{Host, OriginalUri},
+    response::Json,
+};
+use dal::cached_module::CachedModule;
+
+use super::AdminAPIResult;
+use crate::{
+    extract::{AccessBuilder, HandlerContext, PosthogClient},
+    track,
+};
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateModuleCacheResponse {
+    new_modules: Vec<CachedModule>,
+}
+
+#[instrument(name = "admin.update_module_cache", skip_all)]
+pub async fn update_module_cache(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Host(host_name): Host,
+) -> AdminAPIResult<Json<UpdateModuleCacheResponse>> {
+    let ctx = builder.build_head(access_builder).await?;
+
+    let new_modules = CachedModule::update_cached_modules(&ctx).await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        &host_name,
+        "update_module_cache",
+        serde_json::json!({ "new_modules": new_modules }),
+    );
+
+    Ok(Json(UpdateModuleCacheResponse { new_modules }))
+}

--- a/lib/sdf-server/src/service/v2/variant.rs
+++ b/lib/sdf-server/src/service/v2/variant.rs
@@ -4,7 +4,7 @@ use axum::{
     routing::{delete, get, post},
     Router,
 };
-use dal::{ChangeSetError, SchemaVariantId, WsEventError};
+use dal::{cached_module::CachedModuleError, ChangeSetError, SchemaVariantId, WsEventError};
 use telemetry::prelude::*;
 use thiserror::Error;
 
@@ -18,6 +18,8 @@ mod list_variants;
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum SchemaVariantsAPIError {
+    #[error("cached module error: {0}")]
+    CachedModule(#[from] CachedModuleError),
     #[error("cannot delete locked schema variant: {0}")]
     CannotDeleteLockedSchemaVariant(SchemaVariantId),
     #[error("cannot delete a schema variant that has attached components")]

--- a/lib/si-frontend-types-rs/src/lib.rs
+++ b/lib/si-frontend-types-rs/src/lib.rs
@@ -17,5 +17,5 @@ pub use crate::module::{
     BuiltinModules, LatestModule, ModuleContributeRequest, ModuleDetails, SyncedModules,
 };
 pub use crate::schema_variant::{
-    ComponentType, InputSocket, OutputSocket, Prop, PropKind, SchemaVariant,
+    ComponentType, InputSocket, OutputSocket, Prop, PropKind, SchemaVariant, UninstalledVariant,
 };

--- a/lib/si-frontend-types-rs/src/schema_variant.rs
+++ b/lib/si-frontend-types-rs/src/schema_variant.rs
@@ -29,6 +29,19 @@ pub struct SchemaVariant {
     pub can_contribute: bool,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UninstalledVariant {
+    pub schema_id: SchemaId,
+    pub schema_name: String,
+    pub display_name: Option<String>,
+    pub category: Option<String>,
+    pub link: Option<String>,
+    pub color: Option<String>,
+    pub description: Option<String>,
+    pub component_type: ComponentType,
+}
+
 #[remain::sorted]
 #[derive(
     AsRefStr,
@@ -68,6 +81,7 @@ pub struct OutputSocket {
     pub name: String,
     pub eligible_to_receive_data: bool,
 }
+
 #[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Prop {
@@ -79,6 +93,8 @@ pub struct Prop {
     pub eligible_to_receive_data: bool,
     pub eligible_to_send_data: bool,
 }
+
+#[remain::sorted]
 #[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum PropKind {

--- a/lib/si-pkg/examples/si-pkg-read-from-fs/main.rs
+++ b/lib/si-pkg/examples/si-pkg-read-from-fs/main.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("--- Reading object tree from dir: {path}");
     let buf = fs::read(&path).await?;
-    let pkg = SiPkg::load_from_bytes(buf)?;
+    let pkg = SiPkg::load_from_bytes(&buf)?;
 
     let (graph, _root_idx) = pkg.as_petgraph();
     println!(

--- a/lib/si-pkg/src/lib.rs
+++ b/lib/si-pkg/src/lib.rs
@@ -57,7 +57,7 @@ mod tests {
 
         let pkg_data = pkg.write_to_bytes().expect("failed to serialize pkg");
 
-        let read_pkg = SiPkg::load_from_bytes(pkg_data).expect("failed to load pkg from bytes");
+        let read_pkg = SiPkg::load_from_bytes(&pkg_data).expect("failed to load pkg from bytes");
         let metadata = read_pkg.metadata().expect("Get metadata (WorkspaceBackup)");
 
         assert_eq!(description, metadata.description());
@@ -83,7 +83,7 @@ mod tests {
 
         let pkg_data = pkg.write_to_bytes().expect("failed to serialize pkg");
 
-        let read_pkg = SiPkg::load_from_bytes(pkg_data).expect("failed to load pkg from bytes");
+        let read_pkg = SiPkg::load_from_bytes(&pkg_data).expect("failed to load pkg from bytes");
 
         assert_eq!(
             description,

--- a/lib/si-pkg/src/pkg.rs
+++ b/lib/si-pkg/src/pkg.rs
@@ -105,10 +105,10 @@ pub struct SiPkg {
 impl SiPkg {
     pub async fn load_from_file(path: impl AsRef<Path>) -> PkgResult<Self> {
         let file_data = tokio::fs::read(&path).await?;
-        Self::load_from_bytes(file_data)
+        Self::load_from_bytes(&file_data)
     }
 
-    pub fn load_from_bytes(bytes: Vec<u8>) -> PkgResult<Self> {
+    pub fn load_from_bytes(bytes: &[u8]) -> PkgResult<Self> {
         let tree: ObjectTree<PkgNode> = ObjectTree::<PkgNode>::read_from_tar(bytes)?;
 
         Ok(Self {


### PR DESCRIPTION
If the `on_demand_assets` feature flag is enabled for a user, all new workspaces created by that user will have just intrinsics installed, and assets will be installed at the moment that the component for that asset is dropped on the canvas.

On the first boot of this version, the local asset cache for sdf has to be updated manually by going to the Admin dashboard.