### PR TITLE
feat: improve tracing throughout NATS-driven services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
  "regex",
  "ring",
  "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "rustls-webpki 0.102.8",
  "serde",
  "serde_json",
@@ -238,14 +238,14 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -254,24 +254,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -331,15 +331,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848d7b9b605720989929279fa644ce8f244d0ce3146fcca5b70e4eb7b3c020fc"
+checksum = "8191fb3091fa0561d1379ef80333c3c7191c6f0435d986e85821bcf7acbd1126"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-firehose"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba9a971d0843b5f5e5d811b9b3002b5eea27c26ad4bf90dd960d782000fc284"
+checksum = "067405963a7a5a8ce3708228c8bd11805959a4873d45599076bc9238f2d2330c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a9d27ed1c12b1140c47daf1bc541606c43fdafd918c4797d520db0043ceef2"
+checksum = "0b90cfe6504115e13c41d3ea90286ede5aa14da294f3fe077027a6e83850843c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.44.0"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44514a6ca967686cde1e2a1b81df6ef1883d0e3e570da8d8bc5c491dcb6fc29b"
+checksum = "167c0fad1f212952084137308359e8e4c4724d1c643038ce163f06de9662c1d0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7a4d279762a35b9df97209f6808b95d4fe78547fe2316b4d200a0283960c5a"
+checksum = "2cb5f98188ec1435b68097daa2a37d74b9d17c9caa799466338a8d1544e71b9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03701449087215b5369c7ea17fef0dd5d24cb93439ec5af0c7615f58c3f22605"
+checksum = "147100a7bea70fa20ef224a6bad700358305f5dc0f84649c53769761395b355b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -744,7 +744,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -847,7 +847,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -980,7 +980,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "syn_derive",
 ]
 
@@ -1123,9 +1123,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
 dependencies = [
  "shlex",
 ]
@@ -1206,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1216,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1229,14 +1229,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1576,7 +1576,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1699,7 +1699,6 @@ dependencies = [
  "jwt-simple",
  "lazy_static",
  "module-index-client",
- "nats-subscriber",
  "object-tree",
  "once_cell",
  "paste",
@@ -1810,7 +1809,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1821,7 +1820,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1938,7 +1937,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1948,7 +1947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1961,7 +1960,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2115,7 +2114,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2186,7 +2185,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2314,9 +2313,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.0",
@@ -2363,6 +2362,7 @@ dependencies = [
  "si-data-nats",
  "si-settings",
  "telemetry",
+ "telemetry-nats",
  "thiserror",
  "tokio-util",
  "ulid",
@@ -2463,7 +2463,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2554,8 +2554,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2822,9 +2822,9 @@ checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -2944,9 +2944,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2957,7 +2957,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
@@ -3038,7 +3037,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.77",
+ "syn 2.0.79",
  "toml",
  "unicode-xid",
 ]
@@ -3053,7 +3052,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -3101,7 +3100,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3188,9 +3187,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -3226,9 +3225,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libloading"
@@ -3331,7 +3330,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3404,7 +3403,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3690,9 +3689,9 @@ dependencies = [
 
 [[package]]
 name = "nkeys"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de02c883c178998da8d0c9816a88ef7ef5c58314dd1585c97a4a5679f3ab337"
+checksum = "9f49e787f4c61cbd0f9320b31cc26e58719f6aa5068e34697dd3aea361412fe3"
 dependencies = [
  "data-encoding",
  "ed25519 2.2.3",
@@ -3834,9 +3833,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -3916,7 +3918,7 @@ dependencies = [
  "glob",
  "once_cell",
  "opentelemetry",
- "ordered-float 4.2.2",
+ "ordered-float 4.3.0",
  "percent-encoding",
  "rand 0.8.5",
  "thiserror",
@@ -3950,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
+checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
 dependencies = [
  "num-traits",
 ]
@@ -3999,7 +4001,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4013,7 +4015,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4177,7 +4179,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4231,12 +4233,12 @@ dependencies = [
  "si-std",
  "stream-cancel",
  "telemetry",
+ "telemetry-nats",
  "telemetry-utils",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
  "ulid",
  "veritech-client",
 ]
@@ -4264,9 +4266,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plotters"
@@ -4298,9 +4300,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "postcard"
@@ -4324,7 +4326,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4438,6 +4440,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4454,7 +4478,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "version_check",
  "yansi",
 ]
@@ -4505,7 +4529,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4739,6 +4763,7 @@ dependencies = [
  "si-data-nats",
  "si-events",
  "telemetry",
+ "telemetry-nats",
  "thiserror",
 ]
 
@@ -4779,20 +4804,20 @@ dependencies = [
  "si-settings",
  "si-std",
  "telemetry",
+ "telemetry-nats",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
  "ulid",
  "veritech-client",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4848,7 +4873,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4864,14 +4889,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4885,13 +4910,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4908,9 +4933,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remain"
@@ -4920,7 +4945,7 @@ checksum = "46aef80f842736de545ada6ec65b81ee91504efd6853f4b96de7414c42ae7443"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4934,9 +4959,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4958,7 +4983,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.13",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5217,7 +5242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -5234,19 +5259,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -5389,15 +5413,15 @@ dependencies = [
 
 [[package]]
 name = "sea-bae"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd3534a9978d0aa7edd2808dc1f8f31c4d0ecd31ddf71d997b3c98e9f3c9114"
+checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5438,7 +5462,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.77",
+ "syn 2.0.79",
  "unicode-ident",
 ]
 
@@ -5510,9 +5534,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5552,7 +5576,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5595,14 +5619,14 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -5631,9 +5655,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "9720086b3357bcb44fce40117d769a4d068c70ecfa190850a980a71755f66fcc"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5649,14 +5673,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+checksum = "5f1abbfe725f27678f4663bcacb75a83e829fd464c25d78dd038a3a29e307cec"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5771,7 +5795,7 @@ dependencies = [
  "remain",
  "reqwest",
  "rustls 0.22.4",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "serde",
  "si-std",
  "telemetry",
@@ -6004,7 +6028,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6052,9 +6076,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simdutf8"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -6441,7 +6465,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6476,9 +6500,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6494,7 +6518,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6526,9 +6550,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+checksum = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020"
 dependencies = [
  "filetime",
  "libc",
@@ -6591,6 +6615,7 @@ dependencies = [
 name = "telemetry-nats"
 version = "0.1.0"
 dependencies = [
+ "naxum",
  "si-data-nats",
  "telemetry",
  "tracing-opentelemetry",
@@ -6602,9 +6627,9 @@ version = "0.1.0"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -6624,12 +6649,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
 dependencies = [
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6650,27 +6675,27 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6812,7 +6837,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6991,9 +7016,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.5.0",
  "serde",
@@ -7104,7 +7129,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -7289,9 +7314,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-segmentation"
@@ -7584,7 +7609,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -7618,7 +7643,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7746,7 +7771,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -7757,7 +7782,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -7940,9 +7965,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -8058,7 +8083,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -8078,7 +8103,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[patch.unused]]

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -9,7 +9,6 @@ rust_library(
     deps = [
         "//lib/billing-events:billing-events",
         "//lib/module-index-client:module-index-client",
-        "//lib/nats-subscriber:nats-subscriber",
         "//lib/object-tree:object-tree",
         "//lib/pinga-core:pinga-core",
         "//lib/rebaser-client:rebaser-client",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -29,7 +29,6 @@ itertools = { workspace = true }
 jwt-simple = { workspace = true }
 lazy_static = { workspace = true }
 module-index-client = { path = "../../lib/module-index-client" }
-nats-subscriber = { path = "../../lib/nats-subscriber" }
 object-tree = { path = "../../lib/object-tree" }
 once_cell = { workspace = true }
 paste = { workspace = true }

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -415,7 +415,7 @@ impl AttributeValue {
     }
 
     #[instrument(
-        name = "attribute_value.update", 
+        name = "attribute_value.update",
         level = "info",
         skip_all,
         fields(
@@ -506,7 +506,14 @@ impl AttributeValue {
         .into())
     }
 
-    #[instrument(level = "info" skip(ctx, read_lock))]
+    #[instrument(
+        name = "attribute_value.execute_prototype_function",
+        level = "info",
+        skip_all,
+        fields(
+            si.attribute_value.id = %attribute_value_id,
+        ),
+    )]
     pub async fn execute_prototype_function(
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
@@ -1902,7 +1909,7 @@ impl AttributeValue {
     }
 
     #[instrument(
-        name = "attribute_value.set_value", 
+        name = "attribute_value.set_value",
         level = "info",
         skip_all,
         fields(

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -394,8 +394,8 @@ pub trait FuncDispatch: std::fmt::Debug {
 
     #[instrument(
         name = "funcdispatch.execute",
-        skip_all,
         level = "debug",
+        skip_all,
         fields(
             otel.kind = SpanKind::Client.as_str(),
             otel.status_code = Empty,
@@ -409,7 +409,7 @@ pub trait FuncDispatch: std::fmt::Debug {
     where
         <Self::Output as ExtractPayload>::Payload: Serialize,
     {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         // NOTE(nick,wendy): why is a debug output of "self" a valid backend?
         let backend = format!("{:?}", &self);
@@ -460,8 +460,8 @@ pub trait FuncBackend {
 
     #[instrument(
         name = "funcbackend.execute",
-        skip_all,
         level = "debug",
+        skip_all,
         fields(
             otel.kind = SpanKind::Client.as_str(),
             otel.status_code = Empty,
@@ -472,7 +472,7 @@ pub trait FuncBackend {
     async fn execute(
         self: Box<Self>,
     ) -> FuncBackendResult<(Option<serde_json::Value>, Option<serde_json::Value>)> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let value = self.inline().await?;
 

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -188,6 +188,8 @@ impl FuncRunner {
         args: serde_json::Value,
         component_id: ComponentId,
     ) -> FuncRunnerResult<(FuncRunId, FuncRunnerValueChannel)> {
+        let span = current_span_for_instrument_at!("debug");
+
         // Prepares the function for execution.
         //
         // Note: this function is internal so we can record early-returning errors in span metadata
@@ -285,8 +287,6 @@ impl FuncRunner {
             })
         }
 
-        let span = Span::current();
-
         let runner = prepare(ctx, func, args, component_id, &span)
             .await
             .map_err(|err| span.record_err(err))?;
@@ -327,6 +327,8 @@ impl FuncRunner {
         ctx: &DalContext,
         func: &Func,
     ) -> FuncRunnerResult<FuncRunnerValueChannel> {
+        let span = current_span_for_instrument_at!("debug");
+
         // Prepares the function for execution.
         //
         // Note: this function is internal so we can record early-returning errors in span metadata
@@ -440,8 +442,6 @@ impl FuncRunner {
             })
         }
 
-        let span = Span::current();
-
         let runner = prepare(ctx, func, &span)
             .await
             .map_err(|err| span.record_err(err))?;
@@ -483,6 +483,8 @@ impl FuncRunner {
         value: Option<serde_json::Value>,
         validation_format: String,
     ) -> FuncRunnerResult<FuncRunnerValueChannel> {
+        let span = current_span_for_instrument_at!("debug");
+
         // Prepares the function for execution.
         //
         // Note: this function is internal so we can record early-returning errors in span metadata
@@ -625,8 +627,6 @@ impl FuncRunner {
             })
         }
 
-        let span = Span::current();
-
         let runner = prepare(ctx, attribute_value_id, value, validation_format, &span)
             .await
             .map_err(|err| span.record_err(err))?;
@@ -666,6 +666,8 @@ impl FuncRunner {
         func_id: FuncId,
         args: serde_json::Value,
     ) -> FuncRunnerResult<FuncRunnerValueChannel> {
+        let span = current_span_for_instrument_at!("info");
+
         // Prepares the function for execution.
         //
         // Note: this function is internal so we can record early-returning errors in span metadata
@@ -805,8 +807,6 @@ impl FuncRunner {
             })
         }
 
-        let span = Span::current();
-
         let runner = prepare(ctx, attribute_value_id, func_id, args, &span)
             .await
             .map_err(|err| span.record_err(err))?;
@@ -850,6 +850,8 @@ impl FuncRunner {
         func_id: FuncId,
         args: serde_json::Value,
     ) -> FuncRunnerResult<FuncRunnerValueChannel> {
+        let span = current_span_for_instrument_at!("debug");
+
         // Prepares the function for execution.
         //
         // Note: this function is internal so we can record early-returning errors in span metadata
@@ -1026,8 +1028,6 @@ impl FuncRunner {
             })
         }
 
-        let span = Span::current();
-
         let runner = prepare(ctx, action_prototype_id, component_id, func_id, args, &span)
             .await
             .map_err(|err| span.record_err(err))?;
@@ -1044,7 +1044,7 @@ impl FuncRunner {
         fields(job.id = Empty, si.func_run.id = Empty)
     )]
     pub async fn kill_execution(ctx: &DalContext, func_run_id: FuncRunId) -> FuncRunnerResult<()> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("info");
 
         if !span.is_disabled() {
             let mut id_buf = FuncRunId::array_to_str_buf();
@@ -1469,13 +1469,14 @@ impl FuncRunnerExecutionTask {
 
     #[instrument(
         name = "func_runner.execution_task.run",
-        level = "debug",
+        level = "info",
         parent = &self.parent_span,
         skip_all,
         fields()
     )]
     async fn run(self) {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("info");
+
         let parent_span = self.parent_span.clone();
 
         if let Err(err) = self

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -447,6 +447,8 @@ impl WorkspaceSnapshot {
         &self,
         ctx: &DalContext,
     ) -> WorkspaceSnapshotResult<WorkspaceSnapshotAddress> {
+        let span = current_span_for_instrument_at!("debug");
+
         // Pull out the working copy and clean it up.
         let new_address = {
             // Everything needs to be pulled out here so we can throw it into
@@ -477,7 +479,7 @@ impl WorkspaceSnapshot {
             })?
             .await??;
 
-            Span::current().record("si.workspace_snapshot.address", new_address.to_string());
+            span.record("si.workspace_snapshot.address", new_address.to_string());
 
             new_address
         };

--- a/lib/forklift-server/BUCK
+++ b/lib/forklift-server/BUCK
@@ -8,6 +8,7 @@ rust_library(
         "//lib/naxum:naxum",
         "//lib/si-data-nats:si-data-nats",
         "//lib/si-settings:si-settings",
+        "//lib/telemetry-nats-rs:telemetry-nats",
         "//lib/telemetry-rs:telemetry",
         "//third-party/rust:derive_builder",
         "//third-party/rust:remain",

--- a/lib/forklift-server/Cargo.toml
+++ b/lib/forklift-server/Cargo.toml
@@ -11,15 +11,15 @@ publish.workspace = true
 [dependencies]
 billing-events = { path = "../../lib/billing-events" }
 data-warehouse-stream-client = { path = "../../lib/data-warehouse-stream-client" }
-naxum = { path = "../../lib/naxum" }
-si-data-nats = { path = "../../lib/si-data-nats" }
-si-settings = { path = "../../lib/si-settings" }
-telemetry = { path = "../../lib/telemetry-rs" }
-
 derive_builder = { workspace = true }
+naxum = { path = "../../lib/naxum" }
 remain = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+si-data-nats = { path = "../../lib/si-data-nats" }
+si-settings = { path = "../../lib/si-settings" }
+telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
 thiserror = { workspace = true }
 tokio-util = { workspace = true }
 ulid = { workspace = true }

--- a/lib/forklift-server/src/handlers.rs
+++ b/lib/forklift-server/src/handlers.rs
@@ -25,7 +25,7 @@ type HandlerResult<T> = Result<T, HandlerError>;
 impl IntoResponse for HandlerError {
     fn into_response(self) -> Response {
         error!(si.error.message = ?self, "failed to process message");
-        Response::internal_server_error()
+        Response::default_internal_server_error()
     }
 }
 

--- a/lib/nats-subscriber/src/builder.rs
+++ b/lib/nats-subscriber/src/builder.rs
@@ -61,7 +61,9 @@ impl<T> SubscriberBuilder<T> {
                 .map_err(SubscriberError::NatsSubscribe)?
         };
 
-        let make_span = NatsMakeSpan::new().level(self.span_level);
+        let make_span = NatsMakeSpan::builder(nats.metadata_clone())
+            .level(self.span_level)
+            .build();
 
         Ok(Subscriber {
             inner,

--- a/lib/nats-subscriber/src/lib.rs
+++ b/lib/nats-subscriber/src/lib.rs
@@ -171,7 +171,7 @@ where
                     }
                 };
 
-                let process_span = this.make_span.make_span(&msg, this.subject);
+                let process_span = this.make_span.span_from_core_message(&msg);
 
                 let (msg, _metadata) = msg.into_parts();
 

--- a/lib/naxum/examples/graceful-shutdown/main.rs
+++ b/lib/naxum/examples/graceful-shutdown/main.rs
@@ -1,7 +1,7 @@
 use std::{env, error, str, time::Duration};
 
 use async_nats::jetstream;
-use naxum::{handler::Handler, middleware::ack::AckLayer, ServiceExt};
+use naxum::{handler::Handler, middleware::ack::AckLayer, Message, ServiceExt};
 use tokio::{
     signal::unix::{self, SignalKind},
     time,
@@ -22,7 +22,7 @@ const DEFAULT_TRACING_DIRECTIVES: &str = "graceful_shutdown=trace,naxum=debug,in
 #[derive(Clone, Debug)]
 struct AppState {}
 
-async fn default(msg: async_nats::Message) -> naxum::response::Result<()> {
+async fn default(msg: Message<async_nats::Message>) -> naxum::response::Result<()> {
     info!(subject = msg.subject.as_str(), "processing message");
 
     let payload = str::from_utf8(&msg.payload).expect("TODO");

--- a/lib/naxum/examples/nats-core-subscriber/main.rs
+++ b/lib/naxum/examples/nats-core-subscriber/main.rs
@@ -2,7 +2,7 @@ use std::{convert::Infallible, env, error, str, time::Duration};
 
 use futures::StreamExt;
 use naxum::{
-    extract::State, handler::Handler, middleware::trace::TraceLayer, BoxError, ServiceExt,
+    extract::State, handler::Handler, middleware::trace::TraceLayer, BoxError, Message, ServiceExt,
 };
 use tokio::{
     signal::unix::{self, SignalKind},
@@ -26,7 +26,7 @@ struct AppState {}
 
 async fn default(
     State(_state): State<AppState>,
-    msg: async_nats::Message,
+    msg: Message<async_nats::Message>,
 ) -> naxum::response::Result<()> {
     info!(subject = msg.subject.as_str(), "processing message");
 

--- a/lib/naxum/examples/nats-js-acker/main.rs
+++ b/lib/naxum/examples/nats-js-acker/main.rs
@@ -12,7 +12,7 @@ use naxum::{
     handler::Handler,
     middleware::{ack::AckLayer, trace::TraceLayer},
     response::{IntoResponse, Response},
-    BoxError, ServiceExt,
+    BoxError, Message, ServiceExt,
 };
 use thiserror::Error;
 use tokio::{
@@ -51,11 +51,14 @@ enum AppError {
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         error!(error = ?self, "failed to process message");
-        Response::internal_server_error()
+        Response::default_internal_server_error()
     }
 }
 
-async fn default(State(state): State<AppState>, msg: async_nats::Message) -> Result<(), AppError> {
+async fn default(
+    State(state): State<AppState>,
+    msg: Message<async_nats::Message>,
+) -> Result<(), AppError> {
     info!(subject = msg.subject.as_str(), headers = ?msg.headers, "processing message");
 
     // Introduce some simulated "work" time

--- a/lib/naxum/examples/nats-js-consumer/main.rs
+++ b/lib/naxum/examples/nats-js-consumer/main.rs
@@ -2,7 +2,7 @@ use std::{env, error, str, time::Duration};
 
 use async_nats::jetstream;
 use naxum::{
-    extract::State, handler::Handler, middleware::trace::TraceLayer, BoxError, ServiceExt,
+    extract::State, handler::Handler, middleware::trace::TraceLayer, BoxError, Message, ServiceExt,
 };
 use tokio::{
     signal::unix::{self, SignalKind},
@@ -26,7 +26,7 @@ struct AppState {}
 
 async fn default(
     State(_state): State<AppState>,
-    msg: jetstream::Message,
+    msg: Message<jetstream::Message>,
 ) -> naxum::response::Result<()> {
     info!(subject = msg.subject.as_str(), "processing message");
 

--- a/lib/naxum/src/body.rs
+++ b/lib/naxum/src/body.rs
@@ -1,0 +1,89 @@
+use std::borrow::Cow;
+
+use bytes::Bytes;
+
+pub mod inner;
+
+#[derive(Debug)]
+pub struct Body(Bytes);
+
+impl Body {
+    pub fn new<B>(body: B) -> Self
+    where
+        B: inner::Body,
+    {
+        Self(body.into())
+    }
+
+    pub const fn empty() -> Self {
+        Self(Bytes::new())
+    }
+}
+
+impl Default for Body {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl From<()> for Body {
+    fn from(_: ()) -> Self {
+        Self::empty()
+    }
+}
+
+impl From<&'static [u8]> for Body {
+    fn from(value: &'static [u8]) -> Self {
+        Self(Bytes::from(value))
+    }
+}
+
+impl From<Cow<'static, [u8]>> for Body {
+    fn from(value: Cow<'static, [u8]>) -> Self {
+        match value {
+            Cow::Borrowed(value) => Self(Bytes::from(value)),
+            Cow::Owned(value) => Self(Bytes::from(value)),
+        }
+    }
+}
+
+impl From<Vec<u8>> for Body {
+    fn from(value: Vec<u8>) -> Self {
+        Self(Bytes::from(value))
+    }
+}
+
+impl From<&'static str> for Body {
+    fn from(value: &'static str) -> Self {
+        Self(Bytes::from(value))
+    }
+}
+
+impl From<Cow<'static, str>> for Body {
+    fn from(value: Cow<'static, str>) -> Self {
+        match value {
+            Cow::Borrowed(value) => Self(Bytes::from(value)),
+            Cow::Owned(value) => Self(Bytes::from(value)),
+        }
+    }
+}
+
+impl From<String> for Body {
+    fn from(value: String) -> Self {
+        Self(Bytes::from(value))
+    }
+}
+
+impl From<Bytes> for Body {
+    fn from(value: Bytes) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Body> for Bytes {
+    fn from(value: Body) -> Self {
+        value.0
+    }
+}
+
+impl inner::Body for Body {}

--- a/lib/naxum/src/body/inner.rs
+++ b/lib/naxum/src/body/inner.rs
@@ -1,0 +1,3 @@
+use bytes::Bytes;
+
+pub trait Body: Into<Bytes> {}

--- a/lib/naxum/src/extract/matched_subject.rs
+++ b/lib/naxum/src/extract/matched_subject.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+
+use async_nats::Subject;
+use async_trait::async_trait;
+
+use crate::Head;
+
+use super::{
+    rejection::{MatchedSubjectMissing, MatchedSubjectRejection},
+    FromMessageHead,
+};
+
+#[derive(Clone, Debug)]
+pub struct MatchedSubject(pub(crate) Arc<str>);
+
+impl MatchedSubject {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<Subject> for MatchedSubject {
+    fn from(value: Subject) -> Self {
+        Self(value.to_string().into())
+    }
+}
+
+impl From<&Subject> for MatchedSubject {
+    fn from(value: &Subject) -> Self {
+        Self(value.to_string().into())
+    }
+}
+
+impl From<String> for MatchedSubject {
+    fn from(value: String) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<&str> for MatchedSubject {
+    fn from(value: &str) -> Self {
+        Self(value.into())
+    }
+}
+
+#[async_trait]
+impl<S> FromMessageHead<S> for MatchedSubject {
+    type Rejection = MatchedSubjectRejection;
+
+    async fn from_message_head(head: &mut Head, _state: &S) -> Result<Self, Self::Rejection> {
+        let matched_subject = head
+            .extensions
+            .get::<Self>()
+            .ok_or(MatchedSubjectRejection::MatchedSubjectMissing(
+                MatchedSubjectMissing,
+            ))?
+            .clone();
+
+        Ok(matched_subject)
+    }
+}

--- a/lib/naxum/src/extract/message_parts.rs
+++ b/lib/naxum/src/extract/message_parts.rs
@@ -6,8 +6,7 @@ use bytes::Bytes;
 
 use crate::{
     extract::rejection::InvalidUtf8,
-    message::{Extensions, Head},
-    MessageHead,
+    message::{Extensions, Head, Message, MessageHead},
 };
 
 use super::{
@@ -16,14 +15,14 @@ use super::{
 };
 
 #[async_trait]
-impl<S, R> FromMessage<S, R> for R
+impl<S, R> FromMessage<S, R> for Message<R>
 where
     S: Send + Sync,
     R: MessageHead + Send,
 {
     type Rejection = Infallible;
 
-    async fn from_message(req: R, _state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_message(req: Message<R>, _state: &S) -> Result<Self, Self::Rejection> {
         Ok(req)
     }
 }
@@ -100,7 +99,7 @@ where
 {
     type Rejection = Infallible;
 
-    async fn from_message(req: R, _state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_message(req: Message<R>, _state: &S) -> Result<Self, Self::Rejection> {
         Ok(req.into_parts().1)
     }
 }
@@ -113,7 +112,7 @@ where
 {
     type Rejection = StringRejection;
 
-    async fn from_message(req: R, state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_message(req: Message<R>, state: &S) -> Result<Self, Self::Rejection> {
         let bytes = Bytes::from_message(req, state).await.unwrap();
         let string = str::from_utf8(&bytes)
             .map_err(InvalidUtf8::from_err)?

--- a/lib/naxum/src/extract/rejection.rs
+++ b/lib/naxum/src/extract/rejection.rs
@@ -21,7 +21,7 @@ impl InvalidUtf8 {
 impl IntoResponse for InvalidUtf8 {
     fn into_response(self) -> Response {
         // TODO: log rejection
-        Response::internal_server_error()
+        Response::default_internal_server_error()
     }
 }
 
@@ -108,5 +108,23 @@ composite_rejection! {
         JsonDataError,
         JsonSyntaxError,
         // MissingJsonContentType,
+    }
+}
+
+define_rejection! {
+    #[status_code = 500]
+    #[body = "No matched subject found"]
+    /// Rejection type for [`MatchedSubject`](super::MatchedSubject).
+    ///
+    /// This rejection is used if no matched subject could be found.
+    pub struct MatchedSubjectMissing;
+}
+
+composite_rejection! {
+    /// Rejection type for [`MatchedSubject`](super::MatchedSubject).
+    ///
+    /// Contains one vaiant for each way the extractor can fail.
+    pub enum MatchedSubjectRejection {
+        MatchedSubjectMissing,
     }
 }

--- a/lib/naxum/src/handler/service.rs
+++ b/lib/naxum/src/handler/service.rs
@@ -8,7 +8,11 @@ use std::{
 use futures::FutureExt;
 use tower::Service;
 
-use crate::{make_service::IntoMakeService, response::Response, MessageHead};
+use crate::{
+    make_service::IntoMakeService,
+    message::{Message, MessageHead},
+    response::Response,
+};
 
 use super::Handler;
 
@@ -59,7 +63,7 @@ where
     }
 }
 
-impl<H, T, S, R> Service<R> for HandlerService<H, T, S, R>
+impl<H, T, S, R> Service<Message<R>> for HandlerService<H, T, S, R>
 where
     H: Handler<T, S, R> + Clone + Send + 'static,
     S: Clone + Send + Sync,
@@ -76,7 +80,7 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: R) -> Self::Future {
+    fn call(&mut self, req: Message<R>) -> Self::Future {
         let handler = self.handler.clone();
         let future = Handler::call(handler, req, self.state.clone());
         let future = future.map(Ok as _);

--- a/lib/naxum/src/json.rs
+++ b/lib/naxum/src/json.rs
@@ -7,7 +7,7 @@ use crate::{
         rejection::{JsonDataError, JsonRejection, JsonSyntaxError},
         FromMessage,
     },
-    MessageHead,
+    message::{Message, MessageHead},
 };
 
 #[derive(Clone, Copy, Default, Debug)]
@@ -23,7 +23,7 @@ where
 {
     type Rejection = JsonRejection;
 
-    async fn from_message(req: R, state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_message(req: Message<R>, state: &S) -> Result<Self, Self::Rejection> {
         let bytes = Bytes::from_message(req, state)
             .await
             .expect("from_message is infallible");

--- a/lib/naxum/src/lib.rs
+++ b/lib/naxum/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 pub(crate) mod macros;
 
+pub mod body;
 mod cancellation;
 mod error;
 pub mod error_handling;
@@ -18,13 +19,14 @@ pub use self::cancellation::wait_on_cancelled;
 pub use self::error::Error;
 pub use self::json::Json;
 pub use self::make_service::IntoMakeService;
-pub use self::message::{Head, MessageHead};
+pub use self::message::{Extensions, Head, HeadRef, Message, MessageHead};
 pub use self::serve::{serve, serve_with_incoming_limit};
 pub use self::service_ext::ServiceExt;
 
 pub use async_nats::StatusCode;
 pub use async_trait::async_trait;
 pub use tower::ServiceBuilder;
+pub use tower::ServiceExt as TowerServiceExt;
 
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/lib/naxum/src/macros.rs
+++ b/lib/naxum/src/macros.rs
@@ -227,3 +227,24 @@ macro_rules! all_the_tuples {
         $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15], T16);
     };
 }
+
+macro_rules! all_the_tuples_no_last_special_case {
+    ($name:ident) => {
+        $name!(T1);
+        $name!(T1, T2);
+        $name!(T1, T2, T3);
+        $name!(T1, T2, T3, T4);
+        $name!(T1, T2, T3, T4, T5);
+        $name!(T1, T2, T3, T4, T5, T6);
+        $name!(T1, T2, T3, T4, T5, T6, T7);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);
+    };
+}

--- a/lib/naxum/src/message.rs
+++ b/lib/naxum/src/message.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt};
+use std::{error, fmt, ops};
 
 use async_nats::{HeaderMap, StatusCode, Subject};
 use bytes::Bytes;
@@ -8,6 +8,144 @@ mod extensions;
 pub use extensions::Extensions;
 
 use crate::response::{IntoResponse, Response};
+
+#[derive(Clone)]
+pub struct Message<T> {
+    inner: T,
+    extensions: Extensions,
+}
+
+impl<T> Message<T>
+where
+    T: MessageHead,
+{
+    #[inline]
+    pub(crate) fn new(inner: T) -> Self {
+        Self {
+            inner,
+            extensions: Extensions::new(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn new_with_extensions(inner: T, extensions: Extensions) -> Self {
+        Self { inner, extensions }
+    }
+
+    #[inline]
+    pub fn from_parts(head: Head, payload: Bytes) -> Result<Self, FromPartsError> {
+        let (inner, extensions) = T::from_head_and_payload(head, payload)?;
+
+        Ok(Self::new_with_extensions(inner, extensions))
+    }
+
+    #[inline]
+    pub fn subject(&self) -> &Subject {
+        self.inner.subject()
+    }
+
+    #[inline]
+    pub fn reply(&self) -> Option<&Subject> {
+        self.inner.reply()
+    }
+
+    #[inline]
+    pub fn headers(&self) -> Option<&HeaderMap> {
+        self.inner.headers()
+    }
+
+    #[inline]
+    pub fn status(&self) -> Option<StatusCode> {
+        self.inner.status()
+    }
+
+    #[inline]
+    pub fn description(&self) -> Option<&str> {
+        self.inner.description()
+    }
+
+    #[inline]
+    pub fn length(&self) -> usize {
+        self.inner.length()
+    }
+
+    #[inline]
+    pub fn payload_length(&self) -> usize {
+        self.inner.payload_length()
+    }
+    #[inline]
+    pub fn extensions(&self) -> &Extensions {
+        &self.extensions
+    }
+
+    #[inline]
+    pub fn extensions_mut(&mut self) -> &mut Extensions {
+        &mut self.extensions
+    }
+
+    pub fn head(&self) -> HeadRef<'_> {
+        HeadRef {
+            subject: self.subject(),
+            reply: self.reply(),
+            headers: self.headers(),
+            status: self.status(),
+            description: self.description(),
+            length: self.length(),
+            payload_length: self.payload_length(),
+            extensions: self.extensions(),
+        }
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    #[inline]
+    pub fn split(self) -> (T, Extensions) {
+        (self.inner, self.extensions)
+    }
+
+    #[inline]
+    pub fn into_parts(self) -> (Head, Bytes) {
+        let (mut head, payload) = self.inner.into_head_and_payload();
+        head.extensions.extend(self.extensions);
+
+        (head, payload)
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Message<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Message")
+            .field("parts", &self.extensions)
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl<T> ops::Deref for Message<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> ops::DerefMut for Message<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<T> From<T> for Message<T>
+where
+    T: MessageHead,
+{
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FromPartsError(&'static str);
@@ -22,7 +160,7 @@ impl error::Error for FromPartsError {}
 
 impl IntoResponse for FromPartsError {
     fn into_response(self) -> Response {
-        Response::internal_server_error()
+        Response::default_internal_server_error()
     }
 }
 
@@ -39,14 +177,23 @@ pub trait MessageHead {
     /// Optional Status of the message. Used mostly for internal handling.
     fn status(&self) -> Option<StatusCode>;
 
+    /// Optional status description.
+    fn description(&self) -> Option<&str>;
+
     /// Length of message in bytes.
     fn length(&self) -> usize;
 
-    fn from_parts(head: Head, payload: Bytes) -> Result<Self, FromPartsError>
+    /// Length of message's payload in bytes.
+    fn payload_length(&self) -> usize;
+
+    fn from_head_and_payload(
+        head: Head,
+        payload: Bytes,
+    ) -> Result<(Self, Extensions), FromPartsError>
     where
         Self: Sized;
 
-    fn into_parts(self) -> (Head, Bytes);
+    fn into_head_and_payload(self) -> (Head, Bytes);
 }
 
 impl MessageHead for async_nats::Message {
@@ -66,11 +213,22 @@ impl MessageHead for async_nats::Message {
         self.status
     }
 
+    fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
     fn length(&self) -> usize {
         self.length
     }
 
-    fn from_parts(head: Head, payload: Bytes) -> Result<Self, FromPartsError> {
+    fn payload_length(&self) -> usize {
+        self.payload.len()
+    }
+
+    fn from_head_and_payload(
+        head: Head,
+        payload: Bytes,
+    ) -> Result<(Self, Extensions), FromPartsError> {
         let Head {
             subject,
             reply,
@@ -78,20 +236,24 @@ impl MessageHead for async_nats::Message {
             status,
             description,
             length,
-            extensions: _,
+            extensions,
         } = head;
-        Ok(Self {
-            subject,
-            reply,
-            payload,
-            headers,
-            status,
-            description,
-            length,
-        })
+
+        Ok((
+            Self {
+                subject,
+                reply,
+                payload,
+                headers,
+                status,
+                description,
+                length,
+            },
+            extensions,
+        ))
     }
 
-    fn into_parts(self) -> (Head, Bytes) {
+    fn into_head_and_payload(self) -> (Head, Bytes) {
         let Self {
             subject,
             reply,
@@ -134,11 +296,22 @@ impl MessageHead for async_nats::jetstream::Message {
         self.message.status
     }
 
+    fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
     fn length(&self) -> usize {
         self.message.length
     }
 
-    fn from_parts(head: Head, payload: Bytes) -> Result<Self, FromPartsError> {
+    fn payload_length(&self) -> usize {
+        self.message.payload.len()
+    }
+
+    fn from_head_and_payload(
+        head: Head,
+        payload: Bytes,
+    ) -> Result<(Self, Extensions), FromPartsError> {
         let Head {
             subject,
             reply,
@@ -162,10 +335,11 @@ impl MessageHead for async_nats::jetstream::Message {
             .ok_or(FromPartsError(
                 "jetstream context not found in message head extensions",
             ))?;
-        Ok(Self { message, context })
+
+        Ok((Self { message, context }, extensions))
     }
 
-    fn into_parts(self) -> (Head, Bytes) {
+    fn into_head_and_payload(self) -> (Head, Bytes) {
         let Self { message, context } = self;
         let async_nats::Message {
             subject,
@@ -217,4 +391,31 @@ pub struct Head {
 
     /// The message's extensions
     pub extensions: Extensions,
+}
+
+#[derive(Clone, Debug)]
+pub struct HeadRef<'a> {
+    /// Subject to which message is published to.
+    pub subject: &'a Subject,
+
+    /// Optional reply subject to which response can be published by a subscriber or consumer.
+    pub reply: Option<&'a Subject>,
+
+    /// Optional headers.
+    pub headers: Option<&'a HeaderMap>,
+
+    /// Optional Status of the message. Used mostly for internal handling.
+    pub status: Option<StatusCode>,
+
+    /// Optional status description.
+    pub description: Option<&'a str>,
+
+    /// Length of message in bytes.
+    pub length: usize,
+
+    /// Length of message's payload in bytes.
+    pub payload_length: usize,
+
+    /// The message's extensions
+    pub extensions: &'a Extensions,
 }

--- a/lib/naxum/src/middleware.rs
+++ b/lib/naxum/src/middleware.rs
@@ -1,5 +1,6 @@
 pub mod ack;
 pub mod delay;
+pub mod matched_subject;
 pub mod post_process;
 pub mod trace;
 

--- a/lib/naxum/src/middleware/ack/future.rs
+++ b/lib/naxum/src/middleware/ack/future.rs
@@ -9,12 +9,12 @@ use pin_project_lite::pin_project;
 use tokio_util::sync::DropGuard;
 use tower::Service;
 
-use crate::response::Response;
+use crate::{message::Message, response::Response};
 
 pin_project! {
     pub struct ResponseFuture<S>
     where
-        S: Service<async_nats::Message>,
+        S: Service<Message<async_nats::Message>>,
     {
         #[pin]
         pub(crate) inner: S::Future,
@@ -38,7 +38,7 @@ pub(crate) enum State<T, E> {
 
 impl<S> Future for ResponseFuture<S>
 where
-    S: Service<async_nats::Message, Response = Response>,
+    S: Service<Message<async_nats::Message>, Response = Response>,
 {
     type Output = Result<S::Response, S::Error>;
 

--- a/lib/naxum/src/middleware/matched_subject/for_subject.rs
+++ b/lib/naxum/src/middleware/matched_subject/for_subject.rs
@@ -1,0 +1,24 @@
+use crate::{Message, MessageHead};
+
+pub trait ForSubject<R>
+where
+    R: MessageHead,
+{
+    fn call(&mut self, req: &mut Message<R>);
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DefaultForSubject {}
+
+impl DefaultForSubject {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<R> ForSubject<R> for DefaultForSubject
+where
+    R: MessageHead,
+{
+    fn call(&mut self, _req: &mut Message<R>) {}
+}

--- a/lib/naxum/src/middleware/matched_subject/layer.rs
+++ b/lib/naxum/src/middleware/matched_subject/layer.rs
@@ -1,0 +1,47 @@
+use tower::Layer;
+
+use super::{DefaultForSubject, MatchedSubject};
+
+pub struct MatchedSubjectLayer<ForSubject = DefaultForSubject> {
+    pub(crate) for_subject: ForSubject,
+}
+
+impl Default for MatchedSubjectLayer {
+    fn default() -> Self {
+        Self {
+            for_subject: Default::default(),
+        }
+    }
+}
+
+impl MatchedSubjectLayer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<ForSubject> MatchedSubjectLayer<ForSubject> {
+    pub fn for_subject<NewForSubject>(
+        self,
+        new_for_subject: NewForSubject,
+    ) -> MatchedSubjectLayer<NewForSubject> {
+        let Self { for_subject: _ } = self;
+        MatchedSubjectLayer {
+            for_subject: new_for_subject,
+        }
+    }
+}
+
+impl<S, ForSubject> Layer<S> for MatchedSubjectLayer<ForSubject>
+where
+    ForSubject: Clone,
+{
+    type Service = MatchedSubject<S, ForSubject>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MatchedSubject {
+            inner,
+            for_subject: self.for_subject.clone(),
+        }
+    }
+}

--- a/lib/naxum/src/middleware/matched_subject/mod.rs
+++ b/lib/naxum/src/middleware/matched_subject/mod.rs
@@ -1,0 +1,9 @@
+mod for_subject;
+mod layer;
+mod service;
+
+pub use self::{
+    for_subject::{DefaultForSubject, ForSubject},
+    layer::MatchedSubjectLayer,
+    service::MatchedSubject,
+};

--- a/lib/naxum/src/middleware/matched_subject/service.rs
+++ b/lib/naxum/src/middleware/matched_subject/service.rs
@@ -1,0 +1,58 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tower::Service;
+
+use crate::{Message, MessageHead};
+
+use super::{DefaultForSubject, ForSubject, MatchedSubjectLayer};
+
+#[derive(Clone, Copy, Debug)]
+pub struct MatchedSubject<S, ForSubject = DefaultForSubject> {
+    pub(crate) inner: S,
+    pub(crate) for_subject: ForSubject,
+}
+
+impl<S> MatchedSubject<S> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            for_subject: DefaultForSubject::default(),
+        }
+    }
+
+    pub fn layer() -> MatchedSubjectLayer {
+        MatchedSubjectLayer::new()
+    }
+}
+
+impl<S, ForSubjectT, R> Service<Message<R>> for MatchedSubject<S, ForSubjectT>
+where
+    S: Service<Message<R>> + Clone + Send + 'static,
+    S::Future: Send,
+    ForSubjectT: ForSubject<R>,
+    R: MessageHead + Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Message<R>) -> Self::Future {
+        self.for_subject.call(&mut req);
+
+        let clone = self.inner.clone();
+        // Take the service that was ready
+        //
+        // See documentation for [`Service`] trait
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        Box::pin(async move { inner.call(req).await })
+    }
+}

--- a/lib/naxum/src/middleware/post_process/future.rs
+++ b/lib/naxum/src/middleware/post_process/future.rs
@@ -9,12 +9,12 @@ use futures::future::BoxFuture;
 use pin_project_lite::pin_project;
 use tower::Service;
 
-use crate::response::Response;
+use crate::{message::Message, response::Response};
 
 pin_project! {
     pub struct ResponseFuture<S>
     where
-        S: Service<jetstream::Message>,
+        S: Service<Message<jetstream::Message>>,
     {
         #[pin]
         pub(crate) inner: S::Future,
@@ -37,7 +37,7 @@ pub(crate) enum State<T, E> {
 
 impl<S> Future for ResponseFuture<S>
 where
-    S: Service<jetstream::Message, Response = Response>,
+    S: Service<Message<jetstream::Message>, Response = Response>,
 {
     type Output = Result<S::Response, S::Error>;
 

--- a/lib/naxum/src/middleware/trace/body.rs
+++ b/lib/naxum/src/middleware/trace/body.rs
@@ -1,0 +1,23 @@
+use std::time::Instant;
+
+use bytes::Bytes;
+use tracing::Span;
+
+use crate::body::inner;
+
+pub struct ResponseBody<B> {
+    pub(crate) inner: B,
+    pub(crate) _start: Instant,
+    pub(crate) _span: Span,
+}
+
+impl<B> From<ResponseBody<B>> for Bytes
+where
+    B: inner::Body,
+{
+    fn from(value: ResponseBody<B>) -> Self {
+        value.inner.into()
+    }
+}
+
+impl<B> inner::Body for ResponseBody<B> where B: inner::Body {}

--- a/lib/naxum/src/middleware/trace/make_span.rs
+++ b/lib/naxum/src/middleware/trace/make_span.rs
@@ -1,15 +1,15 @@
 use tracing::{Level, Span};
 
-use crate::MessageHead;
+use crate::message::{Message, MessageHead};
 
 use super::DEFAULT_MESSAGE_LEVEL;
 
 pub trait MakeSpan<R> {
-    fn make_span(&mut self, req: &R) -> Span;
+    fn make_span(&mut self, req: &Message<R>) -> Span;
 }
 
 impl<R> MakeSpan<R> for Span {
-    fn make_span(&mut self, _req: &R) -> Span {
+    fn make_span(&mut self, _req: &Message<R>) -> Span {
         self.clone()
     }
 }
@@ -18,7 +18,7 @@ impl<F, R> MakeSpan<R> for F
 where
     F: FnMut(&R) -> Span,
 {
-    fn make_span(&mut self, req: &R) -> Span {
+    fn make_span(&mut self, req: &Message<R>) -> Span {
         self(req)
     }
 }
@@ -58,7 +58,7 @@ impl<R> MakeSpan<R> for DefaultMakeSpan
 where
     R: MessageHead,
 {
-    fn make_span(&mut self, req: &R) -> Span {
+    fn make_span(&mut self, req: &Message<R>) -> Span {
         let reply = req.reply().map(|r| r.as_str()).unwrap_or_default();
         let status = req.status().map(|s| s.as_u16()).unwrap_or_default();
 

--- a/lib/naxum/src/middleware/trace/mod.rs
+++ b/lib/naxum/src/middleware/trace/mod.rs
@@ -45,6 +45,7 @@ macro_rules! event_dynamic_lvl {
     };
 }
 
+mod body;
 mod future;
 mod layer;
 mod make_span;
@@ -57,6 +58,7 @@ use std::{fmt, time::Duration};
 use tracing::Level;
 
 pub use self::{
+    body::ResponseBody,
     layer::TraceLayer,
     make_span::{DefaultMakeSpan, MakeSpan},
     on_request::{DefaultOnRequest, OnRequest},

--- a/lib/naxum/src/middleware/trace/on_request.rs
+++ b/lib/naxum/src/middleware/trace/on_request.rs
@@ -1,20 +1,22 @@
 use tracing::{Level, Span};
 
+use crate::message::Message;
+
 use super::DEFAULT_MESSAGE_LEVEL;
 
 pub trait OnRequest<R> {
-    fn on_request(&mut self, req: &R, span: &Span);
+    fn on_request(&mut self, req: &Message<R>, span: &Span);
 }
 
 impl<R> OnRequest<R> for () {
-    fn on_request(&mut self, _req: &R, _span: &Span) {}
+    fn on_request(&mut self, _req: &Message<R>, _span: &Span) {}
 }
 
 impl<R, F> OnRequest<R> for F
 where
     F: FnMut(&R, &Span),
 {
-    fn on_request(&mut self, req: &R, span: &Span) {
+    fn on_request(&mut self, req: &Message<R>, span: &Span) {
         self(req, span)
     }
 }
@@ -44,7 +46,7 @@ impl DefaultOnRequest {
 }
 
 impl<R> OnRequest<R> for DefaultOnRequest {
-    fn on_request(&mut self, _req: &R, _span: &Span) {
+    fn on_request(&mut self, _req: &Message<R>, _span: &Span) {
         event_dynamic_lvl!(self.level, "started processing message");
     }
 }

--- a/lib/naxum/src/middleware/trace/on_response.rs
+++ b/lib/naxum/src/middleware/trace/on_response.rs
@@ -9,20 +9,20 @@ use crate::{
 
 use super::DEFAULT_MESSAGE_LEVEL;
 
-pub trait OnResponse {
-    fn on_response(self, response: &Response, latency: Duration, span: &Span);
+pub trait OnResponse<B> {
+    fn on_response(self, response: &Response<B>, latency: Duration, span: &Span);
 }
 
-impl OnResponse for () {
+impl<B> OnResponse<B> for () {
     #[inline]
-    fn on_response(self, _response: &Response, _latency: Duration, _span: &Span) {}
+    fn on_response(self, _response: &Response<B>, _latency: Duration, _span: &Span) {}
 }
 
-impl<F> OnResponse for F
+impl<B, F> OnResponse<B> for F
 where
-    F: FnOnce(&Response, Duration, &Span),
+    F: FnOnce(&Response<B>, Duration, &Span),
 {
-    fn on_response(self, response: &Response, latency: Duration, span: &Span) {
+    fn on_response(self, response: &Response<B>, latency: Duration, span: &Span) {
         self(response, latency, span)
     }
 }
@@ -58,8 +58,8 @@ impl DefaultOnResponse {
     }
 }
 
-impl OnResponse for DefaultOnResponse {
-    fn on_response(self, _response: &Response, latency: Duration, _span: &Span) {
+impl<B> OnResponse<B> for DefaultOnResponse {
+    fn on_response(self, _response: &Response<B>, latency: Duration, _span: &Span) {
         let latency = Latency {
             unit: self.latency_unit,
             duration: latency,

--- a/lib/naxum/src/response.rs
+++ b/lib/naxum/src/response.rs
@@ -1,43 +1,15 @@
+use crate::body::Body;
+
+pub mod inner;
 mod into_response;
+mod into_response_parts;
 
-use async_nats::StatusCode;
+pub use self::{
+    into_response::IntoResponse,
+    into_response_parts::{IntoResponseParts, ResponseParts},
+};
 
-pub use self::into_response::IntoResponse;
-
-#[derive(Clone, Copy, Debug, Default)]
-pub struct Response {
-    status: StatusCode,
-}
-
-impl Response {
-    pub fn ok() -> Self {
-        Self {
-            status: StatusCode::from_u16(200).expect("status code is in valid range"),
-        }
-    }
-
-    pub fn bad_request() -> Self {
-        Self {
-            status: StatusCode::from_u16(400).expect("status code is in valid range"),
-        }
-    }
-
-    pub fn internal_server_error() -> Self {
-        Self {
-            status: StatusCode::from_u16(500).expect("status code is in valid range"),
-        }
-    }
-
-    pub fn service_unavailable() -> Self {
-        Self {
-            status: StatusCode::from_u16(503).expect("status code is in valid range"),
-        }
-    }
-
-    pub fn status(self) -> StatusCode {
-        self.status
-    }
-}
+pub type Response<T = Body> = inner::Response<T>;
 
 pub type Result<T, E = ErrorResponse> = std::result::Result<T, E>;
 
@@ -61,7 +33,6 @@ where
     T: IntoResponse,
 {
     fn from(value: T) -> Self {
-        #[allow(clippy::unit_arg)]
         Self(value.into_response())
     }
 }

--- a/lib/naxum/src/response/inner.rs
+++ b/lib/naxum/src/response/inner.rs
@@ -1,0 +1,152 @@
+use std::fmt;
+
+use async_nats::StatusCode;
+
+#[derive(Clone)]
+pub struct Response<T> {
+    head: Parts,
+    body: T,
+}
+
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct Parts {
+    pub status: StatusCode,
+}
+
+impl<T> Response<T> {
+    #[inline]
+    pub fn new(body: T) -> Self {
+        Self {
+            head: Parts::new(),
+            body,
+        }
+    }
+
+    #[inline]
+    pub fn from_parts(parts: Parts, body: T) -> Self {
+        Self { head: parts, body }
+    }
+
+    #[inline]
+    pub fn status(&self) -> StatusCode {
+        self.head.status
+    }
+
+    #[inline]
+    pub fn status_mut(&mut self) -> &mut StatusCode {
+        &mut self.head.status
+    }
+
+    #[inline]
+    pub fn body(&self) -> &T {
+        &self.body
+    }
+
+    #[inline]
+    pub fn body_mut(&mut self) -> &mut T {
+        &mut self.body
+    }
+
+    #[inline]
+    pub fn into_body(self) -> T {
+        self.body
+    }
+
+    #[inline]
+    pub fn into_parts(self) -> (Parts, T) {
+        (self.head, self.body)
+    }
+
+    #[inline]
+    pub fn map<F, U>(self, f: F) -> Response<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        Response {
+            head: self.head,
+            body: f(self.body),
+        }
+    }
+}
+
+impl<T> Response<T> {
+    pub fn default_internal_server_error() -> Self
+    where
+        T: Default,
+    {
+        Self {
+            head: Parts {
+                status: StatusCode::from_u16(500).expect("status code is in valid range"),
+            },
+            body: T::default(),
+        }
+    }
+
+    pub fn default_ok() -> Self
+    where
+        T: Default,
+    {
+        Self {
+            head: Parts {
+                status: StatusCode::from_u16(200).expect("status code is in valid range"),
+            },
+            body: T::default(),
+        }
+    }
+
+    pub fn default_bad_request() -> Self
+    where
+        T: Default,
+    {
+        Self {
+            head: Parts {
+                status: StatusCode::from_u16(400).expect("status code is in valid range"),
+            },
+            body: T::default(),
+        }
+    }
+
+    pub fn default_service_unavailable() -> Self
+    where
+        T: Default,
+    {
+        Self {
+            head: Parts {
+                status: StatusCode::from_u16(503).expect("status code is in valid range"),
+            },
+            body: T::default(),
+        }
+    }
+}
+
+impl<T: Default> Default for Response<T> {
+    #[inline]
+    fn default() -> Self {
+        Response::new(T::default())
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Response<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Response")
+            .field("status", &self.status())
+            .finish()
+    }
+}
+
+impl Parts {
+    fn new() -> Self {
+        Self {
+            status: StatusCode::default(),
+        }
+    }
+}
+
+impl fmt::Debug for Parts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Parts")
+            .field("status", &self.status)
+            .finish()
+    }
+}

--- a/lib/naxum/src/response/into_response_parts.rs
+++ b/lib/naxum/src/response/into_response_parts.rs
@@ -1,0 +1,68 @@
+use std::convert::Infallible;
+
+use super::{IntoResponse, Response};
+
+pub trait IntoResponseParts {
+    type Error: IntoResponse;
+
+    fn into_response_parts(self, res: ResponseParts) -> Result<ResponseParts, Self::Error>;
+}
+
+impl<T> IntoResponseParts for Option<T>
+where
+    T: IntoResponseParts,
+{
+    type Error = T::Error;
+
+    fn into_response_parts(self, res: ResponseParts) -> Result<ResponseParts, Self::Error> {
+        if let Some(inner) = self {
+            inner.into_response_parts(res)
+        } else {
+            Ok(res)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ResponseParts {
+    pub(crate) res: Response,
+}
+
+impl ResponseParts {}
+
+macro_rules! impl_into_response_parts {
+    ( $($ty:ident),* $(,)? ) => {
+        #[allow(non_snake_case)]
+        impl<$($ty,)*> IntoResponseParts for ($($ty,)*)
+        where
+            $( $ty: IntoResponseParts, )*
+        {
+            type Error = Response;
+
+            fn into_response_parts(self, res: ResponseParts) -> Result<ResponseParts, Self::Error> {
+                let ($($ty,)*) = self;
+
+                $(
+                    let res = match $ty.into_response_parts(res) {
+                        Ok(res) => res,
+                        Err(err) => {
+                            return Err(err.into_response());
+                        }
+                    };
+                )*
+
+                Ok(res)
+            }
+        }
+    };
+}
+
+all_the_tuples_no_last_special_case!(impl_into_response_parts);
+
+impl IntoResponseParts for () {
+    type Error = Infallible;
+
+    fn into_response_parts(self, res: ResponseParts) -> Result<ResponseParts, Self::Error> {
+        Ok(res)
+    }
+}

--- a/lib/naxum/src/service_ext.rs
+++ b/lib/naxum/src/service_ext.rs
@@ -1,8 +1,8 @@
 use tower::Service;
 
-use crate::{error_handling::HandleError, make_service::IntoMakeService};
+use crate::{error_handling::HandleError, make_service::IntoMakeService, message::Message};
 
-pub trait ServiceExt<R>: Service<R> + Sized {
+pub trait ServiceExt<R>: Service<Message<R>> + Sized {
     fn into_make_service(self) -> IntoMakeService<Self>;
 
     fn handle_error<F, T>(self, f: F) -> HandleError<Self, F, T> {
@@ -12,7 +12,7 @@ pub trait ServiceExt<R>: Service<R> + Sized {
 
 impl<S, R> ServiceExt<R> for S
 where
-    S: Service<R> + Sized,
+    S: Service<Message<R>> + Sized,
 {
     fn into_make_service(self) -> IntoMakeService<Self> {
         IntoMakeService::new(self)

--- a/lib/pinga-server/BUCK
+++ b/lib/pinga-server/BUCK
@@ -15,6 +15,7 @@ rust_library(
         "//lib/si-layer-cache:si-layer-cache",
         "//lib/si-settings:si-settings",
         "//lib/si-std:si-std",
+        "//lib/telemetry-nats-rs:telemetry-nats",
         "//lib/telemetry-rs:telemetry",
         "//lib/telemetry-utils-rs:telemetry-utils",
         "//lib/veritech-client:veritech-client",
@@ -28,7 +29,6 @@ rust_library(
         "//third-party/rust:tokio",
         "//third-party/rust:tokio-stream",
         "//third-party/rust:tokio-util",
-        "//third-party/rust:tower",
         "//third-party/rust:ulid",
     ],
     srcs = glob([

--- a/lib/pinga-server/Cargo.toml
+++ b/lib/pinga-server/Cargo.toml
@@ -28,11 +28,11 @@ si-settings = { path = "../../lib/si-settings" }
 si-std = { path = "../../lib/si-std" }
 stream-cancel = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
 telemetry-utils = { path = "../../lib/telemetry-utils-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
-tower = { workspace = true }
 ulid = { workspace = true }
 veritech-client = { path = "../../lib/veritech-client" }

--- a/lib/rebaser-client/BUCK
+++ b/lib/rebaser-client/BUCK
@@ -6,6 +6,7 @@ rust_library(
         "//lib/rebaser-core:rebaser-core",
         "//lib/si-data-nats:si-data-nats",
         "//lib/si-events-rs:si-events",
+        "//lib/telemetry-nats-rs:telemetry-nats",
         "//lib/telemetry-rs:telemetry",
         "//third-party/rust:futures",
         "//third-party/rust:pin-project-lite",

--- a/lib/rebaser-client/Cargo.toml
+++ b/lib/rebaser-client/Cargo.toml
@@ -18,4 +18,5 @@ serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-events = { path = "../../lib/si-events-rs" }
 telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
 thiserror = { workspace = true }

--- a/lib/rebaser-server/BUCK
+++ b/lib/rebaser-server/BUCK
@@ -15,6 +15,7 @@ rust_library(
         "//lib/si-layer-cache:si-layer-cache",
         "//lib/si-settings:si-settings",
         "//lib/si-std:si-std",
+        "//lib/telemetry-nats-rs:telemetry-nats",
         "//lib/telemetry-rs:telemetry",
         "//lib/veritech-client:veritech-client",
         "//third-party/rust:derive_builder",
@@ -25,7 +26,6 @@ rust_library(
         "//third-party/rust:tokio",
         "//third-party/rust:tokio-stream",
         "//third-party/rust:tokio-util",
-        "//third-party/rust:tower",
         "//third-party/rust:ulid",
     ],
     srcs = glob([

--- a/lib/rebaser-server/Cargo.toml
+++ b/lib/rebaser-server/Cargo.toml
@@ -26,10 +26,10 @@ si-layer-cache = { path = "../../lib/si-layer-cache" }
 si-settings = { path = "../../lib/si-settings" }
 si-std = { path = "../../lib/si-std" }
 telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
-tower = { workspace = true }
 ulid = { workspace = true }
 veritech-client = { path = "../../lib/veritech-client" }

--- a/lib/rebaser-server/src/extract.rs
+++ b/lib/rebaser-server/src/extract.rs
@@ -7,7 +7,7 @@
 use naxum::{
     async_trait, composite_rejection, define_rejection,
     extract::{FromMessage, FromMessageHead},
-    Head, MessageHead,
+    Head, Message, MessageHead,
 };
 use rebaser_core::{
     api_types::{ApiVersionsWrapper, ApiWrapper},
@@ -169,7 +169,7 @@ where
 {
     type Rejection = ApiTypesNegotiateRejection;
 
-    async fn from_message(req: R, state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_message(req: Message<R>, state: &S) -> Result<Self, Self::Rejection> {
         let (mut head, payload) = req.into_parts();
         let ContentInfo(content_info) = ContentInfo::from_message_head(&mut head, state).await?;
 

--- a/lib/rebaser-server/src/handlers.rs
+++ b/lib/rebaser-server/src/handlers.rs
@@ -63,17 +63,17 @@ impl IntoResponse for HandlerError {
         match self {
             HandlerError::SubjectParse(_, _) => {
                 warn!(si.error.message = ?self, "subject parse error");
-                Response::bad_request()
+                Response::default_bad_request()
             }
             // While propagated as an `Err`, a task being interupted is expected behavior and is
             // not an error (rather we use `Err` to ensure the task persists in the stream)
             HandlerError::TaskInterrupted(subject) => {
                 debug!(subject, "task interrupted");
-                Response::service_unavailable()
+                Response::default_service_unavailable()
             }
             _ => {
                 error!(si.error.message = ?self, "failed to process message");
-                Response::internal_server_error()
+                Response::default_internal_server_error()
             }
         }
     }

--- a/lib/rebaser-server/src/rebase.rs
+++ b/lib/rebaser-server/src/rebase.rs
@@ -56,7 +56,7 @@ pub async fn perform_rebase(
     ctx: &mut DalContext,
     request: &EnqueueUpdatesRequest,
 ) -> RebaseResult<RebaseStatus> {
-    let span = Span::current();
+    let span = current_span_for_instrument_at!("info");
 
     let start = Instant::now();
     let workspace = get_workspace(ctx).await?;

--- a/lib/sdf-server/src/service/v2/admin/set_concurrency_limit.rs
+++ b/lib/sdf-server/src/service/v2/admin/set_concurrency_limit.rs
@@ -24,7 +24,15 @@ pub struct SetComponentConcurrencyLimitResponse {
     pub concurrency_limit: Option<i32>,
 }
 
-#[instrument(name = "admin.set_component_concurrency_limit", skip_all)]
+#[instrument(
+    name = "admin.set_component_concurrency_limit",
+    level = "info",
+    skip_all,
+    fields(
+        si.workspace.id = %workspace_pk,
+        si.workspace.concurrency_limit = Empty,
+    ),
+)]
 pub async fn set_concurrency_limit(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(access_builder): AccessBuilder,
@@ -34,8 +42,8 @@ pub async fn set_concurrency_limit(
     Path(workspace_pk): Path<WorkspacePk>,
     Json(request): Json<SetComponentConcurrencyLimitRequest>,
 ) -> AdminAPIResult<Json<SetComponentConcurrencyLimitResponse>> {
-    let span = Span::current();
-    span.record("si.workspace.id", workspace_pk.to_string());
+    let span = current_span_for_instrument_at!("info");
+
     span.record(
         "si.workspace.concurrency_limit",
         request

--- a/lib/sdf-server/src/service/v2/admin/set_snapshot.rs
+++ b/lib/sdf-server/src/service/v2/admin/set_snapshot.rs
@@ -20,7 +20,16 @@ pub struct SetSnapshotResponse {
     workspace_snapshot_address: WorkspaceSnapshotAddress,
 }
 
-#[instrument(name = "admin.set_snapshot", skip_all)]
+#[instrument(
+    name = "admin.set_snapshot",
+    level = "info",
+    skip_all,
+    fields(
+        si.change_set.id = %change_set_id,
+        si.workspace.id = %workspace_pk,
+        si.workspace_snapshot.address = Empty,
+    ),
+)]
 pub async fn set_snapshot(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(access_builder): AccessBuilder,
@@ -30,9 +39,7 @@ pub async fn set_snapshot(
     Path((workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
     mut multipart: Multipart,
 ) -> AdminAPIResult<Json<SetSnapshotResponse>> {
-    let span = Span::current();
-    span.record("si.workspace.id", workspace_pk.to_string());
-    span.record("si.change_set.id", change_set_id.to_string());
+    let span = current_span_for_instrument_at!("info");
 
     let ctx = builder.build_head(access_builder).await?;
 
@@ -63,7 +70,7 @@ pub async fn set_snapshot(
     .await??;
 
     span.record(
-        "workspace_snapshot_address",
+        "si.workspace_snapshot.address",
         workspace_snapshot_address.to_string(),
     );
 

--- a/lib/si-data-nats/examples/nats-subscribe/main.rs
+++ b/lib/si-data-nats/examples/nats-subscribe/main.rs
@@ -94,7 +94,8 @@ async fn run() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
     )
 )]
 fn process_message(message: Message, count: u32, sub: &Subscriber) {
-    let span = Span::current();
+    let span = current_span_for_instrument_at!("debug");
+
     span.follows_from(sub.span());
 
     span.record(

--- a/lib/si-data-nats/src/jetstream/context.rs
+++ b/lib/si-data-nats/src/jetstream/context.rs
@@ -147,7 +147,7 @@ impl Context {
         subject: S,
         payload: Bytes,
     ) -> Result<PublishAckFuture, PublishError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.to_subject();
         span.record("messaging.destination.name", subject.as_str());
@@ -225,7 +225,7 @@ impl Context {
         headers: async_nats::header::HeaderMap,
         payload: Bytes,
     ) -> Result<PublishAckFuture, PublishError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.to_subject();
         span.record("messaging.destination.name", subject.as_str());
@@ -303,7 +303,7 @@ impl Context {
         subject: S,
         publish: Publish,
     ) -> Result<PublishAckFuture, PublishError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.to_subject();
         span.record("messaging.destination.name", subject.as_str());
@@ -346,7 +346,7 @@ impl Context {
         )
     )]
     pub async fn query_account(&self) -> Result<Account, AccountError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let account = self
             .inner
@@ -417,7 +417,7 @@ impl Context {
     where
         Config: From<S>,
     {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let stream = self
             .inner
@@ -480,7 +480,7 @@ impl Context {
         &self,
         stream: T,
     ) -> Result<Stream<()>, GetStreamError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let stream = self
             .inner
@@ -535,7 +535,7 @@ impl Context {
         )
     )]
     pub async fn get_stream<T: AsRef<str>>(&self, stream: T) -> Result<Stream, GetStreamError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let stream = self
             .inner
@@ -607,7 +607,7 @@ impl Context {
     where
         S: Into<Config>,
     {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let stream_config = stream_config.into();
         trace!(?stream_config);
@@ -668,7 +668,7 @@ impl Context {
         &self,
         stream: T,
     ) -> Result<async_nats::jetstream::stream::DeleteStatus, DeleteStreamError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let status = self
             .inner
@@ -738,7 +738,7 @@ impl Context {
     where
         S: Borrow<Config>,
     {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let info = self
             .inner
@@ -796,7 +796,7 @@ impl Context {
         &self,
         subject: T,
     ) -> Result<String, GetStreamByNameError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.into();
         span.record("messaging.destination.name", subject.as_str());
@@ -907,7 +907,7 @@ impl Context {
         &self,
         bucket: T,
     ) -> Result<async_nats::jetstream::kv::Store, KeyValueError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let store = self
             .inner
@@ -969,7 +969,7 @@ impl Context {
         &self,
         config: async_nats::jetstream::kv::Config,
     ) -> Result<async_nats::jetstream::kv::Store, CreateKeyValueError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let store = self
             .inner
@@ -1031,7 +1031,7 @@ impl Context {
         &self,
         bucket: T,
     ) -> Result<async_nats::jetstream::stream::DeleteStatus, KeyValueError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let status = self
             .inner
@@ -1102,7 +1102,7 @@ impl Context {
         S: AsRef<str>,
         C: AsRef<str>,
     {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let consumer = self
             .inner
@@ -1167,7 +1167,7 @@ impl Context {
         consumer: C,
         stream: S,
     ) -> Result<DeleteStatus, ConsumerError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let status = self
             .inner
@@ -1236,7 +1236,7 @@ impl Context {
         config: C,
         stream: S,
     ) -> Result<Consumer<C>, ConsumerError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let consumer = self
             .inner
@@ -1304,7 +1304,7 @@ impl Context {
         T: ?Sized + Serialize,
         V: DeserializeOwned,
     {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.to_subject();
         span.record("messaging.destination.name", subject.as_str());
@@ -1371,7 +1371,7 @@ impl Context {
         &self,
         config: async_nats::jetstream::object_store::Config,
     ) -> Result<async_nats::jetstream::object_store::ObjectStore, CreateObjectStoreError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let store = self
             .inner
@@ -1427,7 +1427,7 @@ impl Context {
         &self,
         bucket_name: T,
     ) -> Result<async_nats::jetstream::object_store::ObjectStore, ObjectStoreError> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let store = self
             .inner
@@ -1483,7 +1483,7 @@ impl Context {
         &self,
         bucket_name: T,
     ) -> Result<(), DeleteObjectStore> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         self.inner
             .delete_object_store(bucket_name)

--- a/lib/si-data-nats/src/lib.rs
+++ b/lib/si-data-nats/src/lib.rs
@@ -108,7 +108,7 @@ impl Client {
         (self.inner, self.metadata)
     }
 
-    #[instrument(name = "client.new", skip_all, level = "debug")]
+    #[instrument(name = "nats_client::new", skip_all, level = "debug")]
     pub async fn new(config: &NatsConfig) -> Result<Self> {
         let mut options = ConnectOptions::default();
 
@@ -183,7 +183,7 @@ impl Client {
     /// # }
     /// ```
     #[instrument(
-        name = "client.publish",
+        name = "nats_client.publish",
         skip_all,
         level = "debug",
         fields(
@@ -210,7 +210,7 @@ impl Client {
         )
     )]
     pub async fn publish(&self, subject: impl ToSubject, payload: Bytes) -> Result<()> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.to_subject();
         span.record("messaging.destination.name", subject.as_str());
@@ -250,7 +250,7 @@ impl Client {
     /// # }
     /// ```
     #[instrument(
-        name = "client.publish_with_headers",
+        name = "nats_client.publish_with_headers",
         skip_all,
         level = "debug",
         fields(
@@ -282,7 +282,7 @@ impl Client {
         headers: HeaderMap,
         payload: Bytes,
     ) -> Result<()> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.to_subject();
         span.record("messaging.destination.name", subject.as_str());
@@ -318,7 +318,7 @@ impl Client {
     /// # }
     /// ```
     #[instrument(
-        name = "client.publish_with_reply",
+        name = "nats_client.publish_with_reply",
         skip_all,
         level = "debug",
         fields(
@@ -350,7 +350,7 @@ impl Client {
         reply: impl ToSubject,
         payload: Bytes,
     ) -> Result<()> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.to_subject();
         span.record("messaging.destination.name", subject.as_str());
@@ -395,7 +395,7 @@ impl Client {
     /// # }
     /// ```
     #[instrument(
-        name = "client.publish_with_reply_and_headers",
+        name = "nats_client.publish_with_reply_and_headers",
         skip_all,
         level = "debug",
         fields(
@@ -428,7 +428,7 @@ impl Client {
         headers: HeaderMap,
         payload: Bytes,
     ) -> Result<()> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.to_subject();
         span.record("messaging.destination.name", subject.as_str());
@@ -462,7 +462,7 @@ impl Client {
     /// # }
     /// ```
     #[instrument(
-        name = "client.request",
+        name = "nats_client.request",
         skip_all,
         level = "debug",
         fields(
@@ -490,7 +490,7 @@ impl Client {
         )
     )]
     pub async fn request(&self, subject: impl ToSubject, payload: Bytes) -> Result<Message> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.to_subject();
         span.record("messaging.destination.name", subject.as_str());
@@ -529,7 +529,7 @@ impl Client {
     /// # }
     /// ```
     #[instrument(
-        name = "client.request_with_headers",
+        name = "nats_client.request_with_headers",
         skip_all,
         level = "debug",
         fields(
@@ -562,7 +562,7 @@ impl Client {
         headers: HeaderMap,
         payload: Bytes,
     ) -> Result<Message> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.to_subject();
         span.record("messaging.destination.name", subject.as_str());
@@ -599,7 +599,7 @@ impl Client {
     /// # }
     /// ```
     #[instrument(
-        name = "client.send_request",
+        name = "nats_client.send_request",
         skip_all,
         level = "debug",
         fields(
@@ -627,7 +627,7 @@ impl Client {
         )
     )]
     pub async fn send_request(&self, subject: impl ToSubject, request: Request) -> Result<Message> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.to_subject();
         span.record("messaging.destination.name", subject.as_str());
@@ -691,7 +691,7 @@ impl Client {
     /// # }
     /// ```
     #[instrument(
-        name = "client.subscribe",
+        name = "nats_client.subscribe",
         skip_all,
         level = "debug",
         fields(
@@ -716,7 +716,7 @@ impl Client {
         )
     )]
     pub async fn subscribe(&self, subject: impl ToSubject) -> Result<Subscriber> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.to_subject();
         span.record("messaging.destination.name", subject.as_str());
@@ -760,7 +760,7 @@ impl Client {
     /// # }
     /// ```
     #[instrument(
-        name = "client.queue_subscribe",
+        name = "nats_client.queue_subscribe",
         skip_all,
         level = "debug",
         fields(
@@ -790,7 +790,7 @@ impl Client {
         subject: impl ToSubject,
         queue_group: String,
     ) -> Result<Subscriber> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let subject = subject.to_subject();
         span.record("messaging.destination.name", subject.as_str());
@@ -831,7 +831,7 @@ impl Client {
     /// # }
     /// ```
     #[instrument(
-        name = "client.flush",
+        name = "nats_client.flush",
         skip_all,
         level = "debug",
         fields(
@@ -853,7 +853,7 @@ impl Client {
         )
     )]
     pub async fn flush(&self) -> Result<()> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         self.inner
             .flush()
@@ -888,7 +888,7 @@ impl Client {
 // API extensions
 impl Client {
     #[instrument(
-        name = "client.transaction",
+        name = "nats_client.transaction",
         skip_all,
         level = "debug",
         fields(
@@ -955,7 +955,7 @@ impl Client {
     /// # }
     /// ```
     #[instrument(
-        name = "client::connect_with_options",
+        name = "nats_client::connect_with_options",
         skip_all,
         level = "debug",
         fields(
@@ -993,7 +993,7 @@ impl Client {
         let network_protocol_name = "nats";
         let network_transport = "ip_tcp";
 
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
         span.record("messaging.system", messaging_system);
         span.record("messaging.url", messaging_url.as_str());
         span.record("network.protocol.name", network_protocol_name);
@@ -1058,6 +1058,11 @@ impl Client {
     /// Gets a reference to the client's metadata.
     pub fn metadata(&self) -> &ConnectionMetadata {
         self.metadata.as_ref()
+    }
+
+    /// Gets a cloned copy of the client's metadata.
+    pub fn metadata_clone(&self) -> Arc<ConnectionMetadata> {
+        self.metadata.clone()
     }
 }
 
@@ -1164,7 +1169,7 @@ impl NatsTxn {
     }
 
     #[instrument(
-        name = "transaction.publish",
+        name = "nats_txn.publish",
         skip_all,
         level = "debug",
         fields(
@@ -1178,7 +1183,7 @@ impl NatsTxn {
     where
         T: Serialize + Debug,
     {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
         span.follows_from(&self.tx_span);
 
         let subject = subject.to_subject();
@@ -1192,7 +1197,7 @@ impl NatsTxn {
     }
 
     #[instrument(
-        name = "transaction.publish_immediately",
+        name = "nats_txn.publish_immediately",
         skip_all,
         level = "debug",
         fields(
@@ -1206,7 +1211,7 @@ impl NatsTxn {
     where
         T: Serialize + Debug,
     {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
         span.follows_from(&self.tx_span);
 
         let subject = subject.to_subject();
@@ -1224,7 +1229,7 @@ impl NatsTxn {
     }
 
     #[instrument(
-        name = "transaction.commit_into_conn",
+        name = "nats_txn.commit_into_conn",
         skip_all,
         level = "debug",
         fields(
@@ -1234,7 +1239,7 @@ impl NatsTxn {
         )
     )]
     pub async fn commit_into_conn(self) -> Result<Client> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
         span.follows_from(&self.tx_span);
 
         let mut pending_publish = self.pending_publish.lock_owned().await;
@@ -1255,7 +1260,7 @@ impl NatsTxn {
     }
 
     #[instrument(
-        name = "transaction.commit",
+        name = "nats_txn.commit",
         skip_all,
         level = "debug",
         fields(
@@ -1268,7 +1273,7 @@ impl NatsTxn {
     }
 
     #[instrument(
-        name = "transaction.rollback_into_conn",
+        name = "nats_txn.rollback_into_conn",
         skip_all,
         level = "debug",
         fields(
@@ -1278,7 +1283,7 @@ impl NatsTxn {
         )
     )]
     pub async fn rollback_into_conn(self) -> Result<Client> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
         span.follows_from(&self.tx_span);
 
         // Nothing much to do, we want to drop the pending publishes which happens when this
@@ -1292,7 +1297,7 @@ impl NatsTxn {
     }
 
     #[instrument(
-        name = "transaction.rollback",
+        name = "nats_txn.rollback",
         skip_all,
         level = "debug",
         fields(

--- a/lib/si-data-nats/src/message.rs
+++ b/lib/si-data-nats/src/message.rs
@@ -76,6 +76,10 @@ impl Message {
         self.inner
     }
 
+    pub fn as_inner(&self) -> &InnerMessage {
+        &self.inner
+    }
+
     /// Get a reference to the connection metadata.
     pub fn metadata(&self) -> Arc<ConnectionMetadata> {
         self.metadata.clone()

--- a/lib/si-data-nats/src/subscriber.rs
+++ b/lib/si-data-nats/src/subscriber.rs
@@ -93,7 +93,7 @@ impl Subscriber {
         )
     )]
     pub async fn unsubscribe(mut self) -> Result<()> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
         span.follows_from(&self.sub_span);
 
         self.inner
@@ -160,7 +160,7 @@ impl Subscriber {
         )
     )]
     pub async fn unsubscribe_after(&mut self, unsub_after: u64) -> Result<()> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
         span.follows_from(&self.sub_span);
 
         self.inner

--- a/lib/si-layer-cache/src/db/rebase_batch.rs
+++ b/lib/si-layer-cache/src/db/rebase_batch.rs
@@ -94,7 +94,7 @@ where
         &self,
         key: &RebaseBatchAddress,
     ) -> LayerDbResult<Option<Arc<V>>> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let key: Arc<str> = key.to_string().into();
         const MAX_TRIES: i32 = 2000;

--- a/lib/si-layer-cache/src/db/serialize.rs
+++ b/lib/si-layer-cache/src/db/serialize.rs
@@ -16,11 +16,13 @@ pub fn to_vec<T>(value: &T) -> LayerDbResult<Vec<u8>>
 where
     T: Serialize + ?Sized,
 {
+    let span = current_span_for_instrument_at!("debug");
+
     let serialized = postcard::to_stdvec(value)?;
     // 1 is the best speed, 6 is default, 9 is best compression but may be too slow
     let compressed = miniz_oxide::deflate::compress_to_vec(&serialized, 1);
 
-    Span::current().record("bytes.size", compressed.len());
+    span.record("bytes.size", compressed.len());
 
     Ok(compressed)
 }

--- a/lib/si-layer-cache/src/db/workspace_snapshot.rs
+++ b/lib/si-layer-cache/src/db/workspace_snapshot.rs
@@ -94,7 +94,7 @@ where
         &self,
         key: &WorkspaceSnapshotAddress,
     ) -> LayerDbResult<Option<Arc<V>>> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         let key: Arc<str> = key.to_string().into();
         const MAX_TRIES: i32 = 2000;

--- a/lib/si-layer-cache/src/layer_cache.rs
+++ b/lib/si-layer-cache/src/layer_cache.rs
@@ -64,7 +64,7 @@ where
         ),
     )]
     pub async fn get(&self, key: Arc<str>) -> LayerDbResult<Option<V>> {
-        let span = Span::current();
+        let span = current_span_for_instrument_at!("debug");
 
         Ok(match self.memory_cache.get(&key).await {
             Some(memory_value) => {

--- a/lib/telemetry-nats-rs/BUCK
+++ b/lib/telemetry-nats-rs/BUCK
@@ -3,6 +3,7 @@ load("@prelude-si//:macros.bzl", "rust_library")
 rust_library(
     name = "telemetry-nats",
     deps = [
+        "//lib/naxum:naxum",
         "//lib/si-data-nats:si-data-nats",
         "//lib/telemetry-rs:telemetry",
         "//third-party/rust:tracing-opentelemetry",

--- a/lib/telemetry-nats-rs/Cargo.toml
+++ b/lib/telemetry-nats-rs/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
+naxum = { path = "../../lib/naxum" }
 si-data-nats = { path = "../../lib/si-data-nats" }
 telemetry = { path = "../../lib/telemetry-rs" }
 tracing-opentelemetry = { workspace = true }

--- a/lib/telemetry-nats-rs/src/lib.rs
+++ b/lib/telemetry-nats-rs/src/lib.rs
@@ -13,6 +13,8 @@
 
 pub mod headers;
 mod make_span;
+mod on_response;
 pub mod propagation;
 
-pub use make_span::NatsMakeSpan;
+pub use make_span::{NatsMakeSpan, ParentSpan};
+pub use on_response::NatsOnResponse;

--- a/lib/telemetry-nats-rs/src/make_span.rs
+++ b/lib/telemetry-nats-rs/src/make_span.rs
@@ -1,36 +1,93 @@
-use si_data_nats::{header, Message, Subject};
+use std::sync::Arc;
+
+use naxum::{
+    extract::MatchedSubject, middleware::trace::MakeSpan, Extensions, HeadRef, Message, MessageHead,
+};
+use si_data_nats::{header, ConnectionMetadata};
 use telemetry::prelude::*;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::{headers::CORRELATION_ID, propagation::extract_opentelemetry_context};
 
+/// Marker type which informs [`NatsMakeSpan`] to skip OpenTelemetry propagation header extraction.
+#[derive(Clone, Debug)]
+pub struct ParentSpan(Span);
+
+impl ParentSpan {
+    /// Creates a new ParentSpan with the given [`Span`].
+    pub fn new(span: Span) -> Self {
+        Self(span)
+    }
+
+    /// Consumes into the inner [`Span`].
+    pub fn into_inner(self) -> Span {
+        self.0
+    }
+
+    /// Returns a reference to the [`Span`].
+    pub fn as_span(&self) -> &Span {
+        &self.0
+    }
+}
+
 /// Generates [`Span`]s from incoming NATS messages on a subscription.
 #[derive(Clone, Debug)]
 pub struct NatsMakeSpan {
     level: Level,
+    metadata: Arc<ConnectionMetadata>,
 }
 
-impl Default for NatsMakeSpan {
-    #[inline]
-    fn default() -> Self {
-        Self { level: Level::INFO }
-    }
+pub struct NatsMakeSpanBuilder {
+    level: Level,
+    connection_metadata: Arc<ConnectionMetadata>,
 }
 
-impl NatsMakeSpan {
-    /// Creates a new `NatsMakeSpan`.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
+impl NatsMakeSpanBuilder {
     /// Sets the [`Level`] used for the tracing [`Span`].
     pub fn level(mut self, level: Level) -> Self {
         self.level = level;
         self
     }
 
+    /// Builds and returns a new [`NatsMakeSpan`].
+    pub fn build(self) -> NatsMakeSpan {
+        NatsMakeSpan {
+            level: self.level,
+            metadata: self.connection_metadata,
+        }
+    }
+}
+
+impl NatsMakeSpan {
+    /// Creates a new `NatsMakeSpan` builder.
+    pub fn builder(connection_metadata: Arc<ConnectionMetadata>) -> NatsMakeSpanBuilder {
+        NatsMakeSpanBuilder {
+            level: Level::INFO,
+            connection_metadata,
+        }
+    }
+
     /// Generate a [`Span`] from a message.
-    pub fn make_span(&mut self, message: &Message, sub_subject: &Subject) -> Span {
+    //
+    // TODO(fnichol): Method is `pub` exclusively for `lib/nats-subscriber`. If and when that crate
+    // can be retired, this should be deleted
+    pub fn span_from_core_message(&mut self, message: &si_data_nats::Message) -> Span {
+        let extensions = Extensions::new();
+        let head_ref = HeadRef {
+            subject: message.subject(),
+            reply: message.reply(),
+            headers: message.headers(),
+            status: message.status(),
+            description: message.description(),
+            length: message.length(),
+            payload_length: message.payload().len(),
+            extensions: &extensions,
+        };
+
+        self.span_from_head(head_ref)
+    }
+
+    fn span_from_head(&mut self, head: HeadRef<'_>) -> Span {
         enum InnerLevel {
             Error,
             Warn,
@@ -50,55 +107,125 @@ impl NatsMakeSpan {
             }
         }
 
-        let metadata = message.metadata();
+        let parent_span = head.extensions.get::<ParentSpan>().map(|s| s.as_span());
+        let matched_subject = head
+            .extensions
+            .get::<MatchedSubject>()
+            .map(|ms| ms.as_str());
 
         // This ugly macro is needed, unfortunately, because `tracing::span!` required the level
         // argument to be static. Meaning we can't just pass `self.level` and a dynamic name.
         macro_rules! inner {
             ($level:expr, $name:expr) => {
-                ::telemetry::tracing::span!(
-                    $level,
-                    $name,
+                match parent_span {
+                    Some(parent_span) => {
+                        ::telemetry::tracing::span!(
+                            parent: parent_span,
+                            $level,
+                            $name,
 
-                    // Messaging attributes
-                    //
-                    // See: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#messaging-attributes
+                            // Messaging attributes
+                            //
+                            // See: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#messaging-attributes
 
-                    messaging.client_id = metadata.messaging_client_id(),
-                    messaging.destination.name = sub_subject.as_str(),
-                    messaging.message.body.size = message.payload().len(),
-                    messaging.message.conversation_id = Empty,
-                    messaging.message.envelope.size = message.length(),
-                    messaging.nats.server.id = metadata.messaging_nats_server_id(),
-                    messaging.nats.server.name = metadata.messaging_nats_server_name(),
-                    messaging.nats.server.version = metadata.messaging_nats_server_version(),
-                    messaging.operation = MessagingOperation::Receive.as_str(),
-                    messaging.system = metadata.messaging_system(),
-                    messaging.url = metadata.messaging_url(),
-                    network.peer.address = metadata.network_peer_address(),
-                    network.protocol.name = metadata.network_protocol_name(),
-                    network.protocol.version = metadata.network_protocol_version(),
-                    network.transport = metadata.network_transport(),
-                    server.address = metadata.server_address(),
-                    server.port = metadata.server_port(),
+                            messaging.client_id = self.metadata.messaging_client_id(),
+                            messaging.destination.name = head.subject.as_str(),
+                            messaging.message.body.size = head.payload_length,
+                            messaging.message.conversation_id = Empty,
+                            messaging.message.correlation.id = Empty,
+                            messaging.message.envelope.size = head.length,
+                            messaging.message.id = Empty,
+                            messaging.nats.message.status = Empty,
+                            messaging.nats.server.id = self.metadata.messaging_nats_server_id(),
+                            messaging.nats.server.name = self.metadata.messaging_nats_server_name(),
+                            messaging.nats.server.version = self.metadata.messaging_nats_server_version(),
+                            messaging.operation = MessagingOperation::Receive.as_str(),
+                            messaging.system = self.metadata.messaging_system(),
+                            messaging.url = self.metadata.messaging_url(),
+                            network.peer.address = self.metadata.network_peer_address(),
+                            network.protocol.name = self.metadata.network_protocol_name(),
+                            network.protocol.version = self.metadata.network_protocol_version(),
+                            network.transport = self.metadata.network_transport(),
+                            server.address = self.metadata.server_address(),
+                            server.port = self.metadata.server_port(),
 
-                    // Set special `otel.*` fields which tracing-opentelemetry will use when
-                    // transmitting traces via OpenTelemetry protocol
-                    //
-                    // See:
-                    // https://docs.rs/tracing-opentelemetry/0.22.0/tracing_opentelemetry/#special-fields
-                    //
+                            // Set special `otel.*` fields which tracing-opentelemetry will use when
+                            // transmitting traces via OpenTelemetry protocol
+                            //
+                            // See:
+                            // https://docs.rs/tracing-opentelemetry/0.22.0/tracing_opentelemetry/#special-fields
+                            //
 
-                    otel.kind = SpanKind::Consumer.as_str(),
-                    otel.name = Empty,
-                    // Default for OpenTelemetry status is `Unset` which should map to an empty/unset
-                    // tracing value.
-                    //
-                    // See: https://docs.rs/opentelemetry/0.21.0/opentelemetry/trace/enum.Status.html
-                    otel.status_code = Empty,
-                    // Only set if status_code == Error
-                    otel.status_message = Empty,
-                )
+                            otel.kind = SpanKind::Consumer.as_str(),
+                            otel.name = Empty,
+                            // Default for OpenTelemetry status is `Unset` which should map to an empty/unset
+                            // tracing value.
+                            //
+                            // See: https://docs.rs/opentelemetry/0.21.0/opentelemetry/trace/enum.Status.html
+                            otel.status_code = Empty,
+                            // Only set if status_code == Error
+                            otel.status_message = Empty,
+
+                            // System Initiative attributes
+
+                            si.change_set.id = Empty,
+                            si.workspace.id = Empty,
+                        )
+                    }
+                    None => {
+                        ::telemetry::tracing::span!(
+                            $level,
+                            $name,
+
+                            // Messaging attributes
+                            //
+                            // See: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#messaging-attributes
+
+                            messaging.client_id = self.metadata.messaging_client_id(),
+                            messaging.destination.name = head.subject.as_str(),
+                            messaging.message.body.size = head.payload_length,
+                            messaging.message.conversation_id = Empty,
+                            messaging.message.correlation.id = Empty,
+                            messaging.message.envelope.size = head.length,
+                            messaging.message.id = Empty,
+                            messaging.nats.message.status = Empty,
+                            messaging.nats.server.id = self.metadata.messaging_nats_server_id(),
+                            messaging.nats.server.name = self.metadata.messaging_nats_server_name(),
+                            messaging.nats.server.version = self.metadata.messaging_nats_server_version(),
+                            messaging.operation = MessagingOperation::Receive.as_str(),
+                            messaging.system = self.metadata.messaging_system(),
+                            messaging.url = self.metadata.messaging_url(),
+                            network.peer.address = self.metadata.network_peer_address(),
+                            network.protocol.name = self.metadata.network_protocol_name(),
+                            network.protocol.version = self.metadata.network_protocol_version(),
+                            network.transport = self.metadata.network_transport(),
+                            server.address = self.metadata.server_address(),
+                            server.port = self.metadata.server_port(),
+
+                            // Set special `otel.*` fields which tracing-opentelemetry will use when
+                            // transmitting traces via OpenTelemetry protocol
+                            //
+                            // See:
+                            // https://docs.rs/tracing-opentelemetry/0.22.0/tracing_opentelemetry/#special-fields
+                            //
+
+                            otel.kind = SpanKind::Consumer.as_str(),
+                            otel.name = Empty,
+                            // Default for OpenTelemetry status is `Unset` which should map to an empty/unset
+                            // tracing value.
+                            //
+                            // See: https://docs.rs/opentelemetry/0.21.0/opentelemetry/trace/enum.Status.html
+                            otel.status_code = Empty,
+                            // Only set if status_code == Error
+                            otel.status_message = Empty,
+
+                            // System Initiative attributes
+
+                            si.change_set.id = Empty,
+                            si.workspace.id = Empty,
+                        )
+                    }
+                }
             };
         }
 
@@ -112,9 +239,19 @@ impl NatsMakeSpan {
 
         span.record(
             "otel.name",
-            format!("{} {}", sub_subject, MessagingOperation::Receive.as_str()),
+            match matched_subject {
+                Some(matched_subject) => {
+                    format!("{matched_subject} {}", MessagingOperation::Receive.as_str())
+                }
+                None => format!(
+                    "{} {}",
+                    head.subject.as_str(),
+                    MessagingOperation::Receive.as_str()
+                ),
+            },
         );
-        if let Some(headers) = message.headers() {
+
+        if let Some(headers) = head.headers {
             if let Some(message_id) = headers.get(header::NATS_MESSAGE_ID) {
                 span.record("messaging.message.id", message_id.as_str());
             }
@@ -123,11 +260,22 @@ impl NatsMakeSpan {
                 span.record("messaging.message.correlation.id", correlation_id.as_str());
             }
 
-            // Extract OpenTelemetry parent span metadata from the request headers (if it exists) and
-            // associate it with this request span
-            span.set_parent(extract_opentelemetry_context(headers));
+            if parent_span.is_none() {
+                // Extract OpenTelemetry parent span metadata from the message headers (if it
+                // exists) and associate it with this request span
+                span.set_parent(extract_opentelemetry_context(headers));
+            }
         }
 
         span
+    }
+}
+
+impl<R> MakeSpan<R> for NatsMakeSpan
+where
+    R: MessageHead,
+{
+    fn make_span(&mut self, req: &Message<R>) -> Span {
+        self.span_from_head(req.head())
     }
 }

--- a/lib/telemetry-nats-rs/src/on_response.rs
+++ b/lib/telemetry-nats-rs/src/on_response.rs
@@ -1,0 +1,113 @@
+use std::{fmt, time::Duration};
+
+use naxum::{
+    middleware::{trace::OnResponse, LatencyUnit},
+    response::Response,
+};
+use telemetry::{prelude::*, OtelStatusCode};
+
+/// An implementation of [`OnResponse`] to update span fields for NATS responses.
+#[derive(Clone, Debug)]
+pub struct NatsOnResponse {
+    level: Level,
+    latency_unit: LatencyUnit,
+}
+
+impl Default for NatsOnResponse {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            level: Level::DEBUG,
+            latency_unit: LatencyUnit::Millis,
+        }
+    }
+}
+
+impl NatsOnResponse {
+    /// Creates a new `NatsOnResponse`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the [`Level`] used for the tracing [`Span`].
+    pub fn level(mut self, level: Level) -> Self {
+        self.level = level;
+        self
+    }
+}
+
+impl<B> OnResponse<B> for NatsOnResponse {
+    fn on_response(self, response: &Response<B>, latency: Duration, span: &Span) {
+        let status = response.status();
+        span.record("messaging.nats.message.status", status.as_u16());
+
+        // In OpenTelemetry HTTP spans, only HTTP/5xx errors should set an `ERROR` value for
+        // `otel.status_code` (except for other errors such as transient/network errors).
+        //
+        // > Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+        // > unless there was another error (e.g., network error receiving the response body; or
+        // > 3xx codes with max redirects exceeded), in which case status MUST be set to Error.
+        //
+        // > For HTTP status codes in the 4xx range span status MUST be left unset in case of
+        // > SpanKind.SERVER and MUST be set to Error in case of SpanKind.CLIENT.
+        //
+        // In the case of NATS, we'll follow the same principle...
+        //
+        // See: <https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status>
+        if status.is_server_error() {
+            span.record("otel.status_code", OtelStatusCode::Error.as_str());
+        }
+
+        macro_rules! inner_event {
+            ($level:expr, $($tt:tt)*) => {
+                match $level {
+                    ::telemetry::tracing::Level::ERROR => {
+                        ::telemetry::tracing::error!($($tt)*);
+                    }
+                    ::telemetry::tracing::Level::WARN => {
+                        ::telemetry::tracing::warn!($($tt)*);
+                    }
+                    ::telemetry::tracing::Level::INFO => {
+                        ::telemetry::tracing::info!($($tt)*);
+                    }
+                    ::telemetry::tracing::Level::DEBUG => {
+                        ::telemetry::tracing::debug!($($tt)*);
+                    }
+                    ::telemetry::tracing::Level::TRACE => {
+                        ::telemetry::tracing::trace!($($tt)*);
+                    }
+                }
+            };
+        }
+
+        let latency = Latency {
+            unit: self.latency_unit,
+            duration: latency,
+        };
+
+        inner_event!(
+            self.level,
+            %latency,
+            status = status.as_u16(),
+            "finished processing request",
+        );
+    }
+}
+
+// From `tower_http::trace`
+struct Latency {
+    unit: LatencyUnit,
+    duration: Duration,
+}
+
+impl fmt::Display for Latency {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.unit {
+            LatencyUnit::Seconds => write!(f, "{} s", self.duration.as_secs_f64()),
+            LatencyUnit::Millis => write!(f, "{} ms", self.duration.as_millis()),
+            LatencyUnit::Micros => write!(f, "{} μs", self.duration.as_micros()),
+            LatencyUnit::Nanos => write!(f, "{} ns", self.duration.as_nanos()),
+            _ => write!(f, "{:?} (unknown)", self.duration),
+        }
+    }
+}

--- a/lib/telemetry-rs/src/lib.rs
+++ b/lib/telemetry-rs/src/lib.rs
@@ -27,7 +27,9 @@ pub use tracing;
 use tracing::warn;
 
 pub mod prelude {
-    pub use super::{MessagingOperation, SpanExt, SpanKind, SpanKindExt};
+    pub use super::{
+        current_span_for_instrument_at, MessagingOperation, SpanExt, SpanKind, SpanKindExt,
+    };
     pub use tracing::{
         self, debug, debug_span, enabled, error, error_span, event, event_enabled, field::Empty,
         info, info_span, instrument, span, span_enabled, trace, trace_span, warn, warn_span,
@@ -521,4 +523,43 @@ impl IntoAppModules for &[&'static str] {
     fn into_app_modules(self) -> Vec<Cow<'static, str>> {
         self.iter().map(|e| Cow::Borrowed(*e)).collect()
     }
+}
+
+#[macro_export]
+macro_rules! current_span_for_instrument_at {
+    ("error") => {
+        if enabled!(Level::ERROR) {
+            Span::current()
+        } else {
+            Span::none()
+        }
+    };
+    ("warn") => {
+        if enabled!(Level::WARN) {
+            Span::current()
+        } else {
+            Span::none()
+        }
+    };
+    ("info") => {
+        if enabled!(Level::INFO) {
+            Span::current()
+        } else {
+            Span::none()
+        }
+    };
+    ("debug") => {
+        if enabled!(Level::DEBUG) {
+            Span::current()
+        } else {
+            Span::none()
+        }
+    };
+    ("trace") => {
+        if enabled!(Level::TRACE) {
+            Span::current()
+        } else {
+            Span::none()
+        }
+    };
 }

--- a/lib/veritech-client/src/lib.rs
+++ b/lib/veritech-client/src/lib.rs
@@ -69,7 +69,15 @@ impl Client {
         self.nats.metadata().subject_prefix()
     }
 
-    #[instrument(name = "client.execute_action_run", level = "info", skip_all)]
+    #[instrument(
+        name = "veritech_client.execute_action_run",
+        level = "info",
+        skip_all,
+        fields(
+            si.change_set.id = change_set_id,
+            si.workspace.id = workspace_id,
+        ),
+    )]
     pub async fn execute_action_run(
         &self,
         output_tx: mpsc::Sender<OutputStream>,
@@ -91,7 +99,15 @@ impl Client {
         .await
     }
 
-    #[instrument(name = "client.execute_resolver_function", level = "info", skip_all)]
+    #[instrument(
+        name = "veritech_client.execute_resolver_function",
+        level = "info",
+        skip_all,
+        fields(
+            si.change_set.id = change_set_id,
+            si.workspace.id = workspace_id,
+        ),
+    )]
     pub async fn execute_resolver_function(
         &self,
         output_tx: mpsc::Sender<OutputStream>,
@@ -114,9 +130,13 @@ impl Client {
     }
 
     #[instrument(
-        name = "client.execute_schema_variant_definition",
+        name = "veritech_client.execute_schema_variant_definition",
         level = "info",
-        skip_all
+        skip_all,
+        fields(
+            si.change_set.id = change_set_id,
+            si.workspace.id = workspace_id,
+        ),
     )]
     pub async fn execute_schema_variant_definition(
         &self,
@@ -139,7 +159,15 @@ impl Client {
         .await
     }
 
-    #[instrument(name = "client.execute_validation", level = "info", skip_all)]
+    #[instrument(
+        name = "veritech_client.execute_validation",
+        level = "info",
+        skip_all,
+        fields(
+            si.change_set.id = change_set_id,
+            si.workspace.id = workspace_id,
+        ),
+    )]
     pub async fn execute_validation(
         &self,
         output_tx: mpsc::Sender<OutputStream>,
@@ -161,7 +189,12 @@ impl Client {
         .await
     }
 
-    #[instrument(name = "client.kill_execution", level = "info", skip_all)]
+    #[instrument(
+        name = "veritech_client.kill_execution",
+        level = "info",
+        skip_all,
+        fields()
+    )]
     pub async fn kill_execution(
         &self,
         request: &KillExecutionRequest,

--- a/lib/veritech-server/src/handlers/kill.rs
+++ b/lib/veritech-server/src/handlers/kill.rs
@@ -58,7 +58,7 @@ async fn kill_execution_request_task(
 
 #[instrument(name = "veritech.kill_execution_request", level = "info", skip_all)]
 async fn kill_execution_request(state: &KillAppState, execution_id: String) -> HandlerResult<()> {
-    let span = Span::current();
+    let span = current_span_for_instrument_at!("info");
 
     // NOTE(nick): in the instances of multiple veritechs, only one will have the kill sender.
     // Right now, we are returning a formal error here. We may want to reconsider this.

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -101,37 +101,37 @@ cargo.rust_library(
         "linux-arm64": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
             ],
         ),
         "macos-arm64": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
             ],
         ),
         "windows-gnu": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
             ],
         ),
         "windows-msvc": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
             ],
         ),
     },
@@ -160,22 +160,22 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":once_cell-1.19.0"],
+            deps = [":once_cell-1.20.1"],
         ),
         "linux-x86_64": dict(
-            deps = [":once_cell-1.19.0"],
+            deps = [":once_cell-1.20.1"],
         ),
         "macos-arm64": dict(
-            deps = [":once_cell-1.19.0"],
+            deps = [":once_cell-1.20.1"],
         ),
         "macos-x86_64": dict(
-            deps = [":once_cell-1.19.0"],
+            deps = [":once_cell-1.20.1"],
         ),
         "windows-gnu": dict(
-            deps = [":once_cell-1.19.0"],
+            deps = [":once_cell-1.20.1"],
         ),
         "windows-msvc": dict(
-            deps = [":once_cell-1.19.0"],
+            deps = [":once_cell-1.20.1"],
         ),
     },
     visibility = [],
@@ -573,7 +573,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":brotli-6.0.0",
-        ":flate2-1.0.33",
+        ":flate2-1.0.34",
         ":futures-core-0.3.30",
         ":memchr-2.7.4",
         ":pin-project-lite-0.2.14",
@@ -650,21 +650,21 @@ cargo.rust_library(
         ":bytes-1.7.2",
         ":futures-0.3.30",
         ":memchr-2.7.4",
-        ":nkeys-0.4.3",
+        ":nkeys-0.4.4",
         ":nuid-0.5.0",
-        ":once_cell-1.19.0",
-        ":portable-atomic-1.7.0",
+        ":once_cell-1.20.1",
+        ":portable-atomic-1.9.0",
         ":rand-0.8.5",
-        ":regex-1.10.6",
+        ":regex-1.11.0",
         ":ring-0.17.5",
         ":rustls-native-certs-0.7.3",
-        ":rustls-pemfile-2.1.3",
+        ":rustls-pemfile-2.2.0",
         ":rustls-webpki-0.102.8",
         ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":serde_nanos-0.1.4",
         ":serde_repr-0.1.19",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":time-0.3.36",
         ":tokio-1.40.0",
         ":tokio-rustls-0.26.0",
@@ -700,81 +700,81 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
 http_archive(
-    name = "async-stream-0.3.5.crate",
-    sha256 = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51",
-    strip_prefix = "async-stream-0.3.5",
-    urls = ["https://static.crates.io/crates/async-stream/0.3.5/download"],
+    name = "async-stream-0.3.6.crate",
+    sha256 = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476",
+    strip_prefix = "async-stream-0.3.6",
+    urls = ["https://static.crates.io/crates/async-stream/0.3.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-stream-0.3.5",
-    srcs = [":async-stream-0.3.5.crate"],
+    name = "async-stream-0.3.6",
+    srcs = [":async-stream-0.3.6.crate"],
     crate = "async_stream",
-    crate_root = "async-stream-0.3.5.crate/src/lib.rs",
-    edition = "2018",
+    crate_root = "async-stream-0.3.6.crate/src/lib.rs",
+    edition = "2021",
     visibility = [],
     deps = [
-        ":async-stream-impl-0.3.5",
+        ":async-stream-impl-0.3.6",
         ":futures-core-0.3.30",
         ":pin-project-lite-0.2.14",
     ],
 )
 
 http_archive(
-    name = "async-stream-impl-0.3.5.crate",
-    sha256 = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193",
-    strip_prefix = "async-stream-impl-0.3.5",
-    urls = ["https://static.crates.io/crates/async-stream-impl/0.3.5/download"],
+    name = "async-stream-impl-0.3.6.crate",
+    sha256 = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d",
+    strip_prefix = "async-stream-impl-0.3.6",
+    urls = ["https://static.crates.io/crates/async-stream-impl/0.3.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-stream-impl-0.3.5",
-    srcs = [":async-stream-impl-0.3.5.crate"],
+    name = "async-stream-impl-0.3.6",
+    srcs = [":async-stream-impl-0.3.6.crate"],
     crate = "async_stream_impl",
-    crate_root = "async-stream-impl-0.3.5.crate/src/lib.rs",
-    edition = "2018",
-    proc_macro = True,
-    visibility = [],
-    deps = [
-        ":proc-macro2-1.0.86",
-        ":quote-1.0.37",
-        ":syn-2.0.77",
-    ],
-)
-
-alias(
-    name = "async-trait",
-    actual = ":async-trait-0.1.82",
-    visibility = ["PUBLIC"],
-)
-
-http_archive(
-    name = "async-trait-0.1.82.crate",
-    sha256 = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1",
-    strip_prefix = "async-trait-0.1.82",
-    urls = ["https://static.crates.io/crates/async-trait/0.1.82/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "async-trait-0.1.82",
-    srcs = [":async-trait-0.1.82.crate"],
-    crate = "async_trait",
-    crate_root = "async-trait-0.1.82.crate/src/lib.rs",
+    crate_root = "async-stream-impl-0.3.6.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
+    ],
+)
+
+alias(
+    name = "async-trait",
+    actual = ":async-trait-0.1.83",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "async-trait-0.1.83.crate",
+    sha256 = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd",
+    strip_prefix = "async-trait-0.1.83",
+    urls = ["https://static.crates.io/crates/async-trait/0.1.83/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "async-trait-0.1.83",
+    srcs = [":async-trait-0.1.83.crate"],
+    crate = "async_trait",
+    crate_root = "async-trait-0.1.83.crate/src/lib.rs",
+    edition = "2021",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.86",
+        ":quote-1.0.37",
+        ":syn-2.0.79",
     ],
 )
 
@@ -868,52 +868,52 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "autocfg-1.3.0.crate",
-    sha256 = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0",
-    strip_prefix = "autocfg-1.3.0",
-    urls = ["https://static.crates.io/crates/autocfg/1.3.0/download"],
+    name = "autocfg-1.4.0.crate",
+    sha256 = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26",
+    strip_prefix = "autocfg-1.4.0",
+    urls = ["https://static.crates.io/crates/autocfg/1.4.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "autocfg-1.3.0",
-    srcs = [":autocfg-1.3.0.crate"],
+    name = "autocfg-1.4.0",
+    srcs = [":autocfg-1.4.0.crate"],
     crate = "autocfg",
-    crate_root = "autocfg-1.3.0.crate/src/lib.rs",
+    crate_root = "autocfg-1.4.0.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
 )
 
 alias(
     name = "aws-config",
-    actual = ":aws-config-1.5.6",
+    actual = ":aws-config-1.5.7",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "aws-config-1.5.6.crate",
-    sha256 = "848d7b9b605720989929279fa644ce8f244d0ce3146fcca5b70e4eb7b3c020fc",
-    strip_prefix = "aws-config-1.5.6",
-    urls = ["https://static.crates.io/crates/aws-config/1.5.6/download"],
+    name = "aws-config-1.5.7.crate",
+    sha256 = "8191fb3091fa0561d1379ef80333c3c7191c6f0435d986e85821bcf7acbd1126",
+    strip_prefix = "aws-config-1.5.7",
+    urls = ["https://static.crates.io/crates/aws-config/1.5.7/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-config-1.5.6",
-    srcs = [":aws-config-1.5.6.crate"],
+    name = "aws-config-1.5.7",
+    srcs = [":aws-config-1.5.7.crate"],
     crate = "aws_config",
-    crate_root = "aws-config-1.5.6.crate/src/lib.rs",
+    crate_root = "aws-config-1.5.7.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-config-1.5.6.crate",
+        "CARGO_MANIFEST_DIR": "aws-config-1.5.7.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK config and credential provider implementations.",
         "CARGO_PKG_NAME": "aws-config",
         "CARGO_PKG_REPOSITORY": "https://github.com/smithy-lang/smithy-rs",
-        "CARGO_PKG_VERSION": "1.5.6",
+        "CARGO_PKG_VERSION": "1.5.7",
         "CARGO_PKG_VERSION_MAJOR": "1",
         "CARGO_PKG_VERSION_MINOR": "5",
-        "CARGO_PKG_VERSION_PATCH": "6",
+        "CARGO_PKG_VERSION_PATCH": "7",
     },
     features = [
         "behavior-version-latest",
@@ -928,15 +928,15 @@ cargo.rust_library(
     deps = [
         ":aws-credential-types-1.2.1",
         ":aws-runtime-1.4.3",
-        ":aws-sdk-sso-1.43.0",
-        ":aws-sdk-ssooidc-1.44.0",
-        ":aws-sdk-sts-1.43.0",
+        ":aws-sdk-sso-1.44.0",
+        ":aws-sdk-ssooidc-1.45.0",
+        ":aws-sdk-sts-1.44.0",
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-json-0.60.7",
         ":aws-smithy-runtime-1.7.1",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.6",
+        ":aws-smithy-types-1.2.7",
         ":aws-types-1.3.3",
         ":bytes-1.7.2",
         ":fastrand-2.1.1",
@@ -970,7 +970,7 @@ cargo.rust_library(
     deps = [
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.6",
+        ":aws-smithy-types-1.2.7",
         ":zeroize-1.8.1",
     ],
 )
@@ -994,7 +994,7 @@ cargo.rust_library(
         ":quick-xml-0.30.0",
         ":rust-ini-0.19.0",
         ":serde-1.0.210",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":time-0.3.36",
         ":url-2.5.2",
     ],
@@ -1007,7 +1007,7 @@ cargo.rust_library(
     crate_root = "rust-s3-61c54947c717d042/aws-region/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":thiserror-1.0.63"],
+    deps = [":thiserror-1.0.64"],
 )
 
 http_archive(
@@ -1036,11 +1036,11 @@ cargo.rust_library(
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-runtime-1.7.1",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.6",
+        ":aws-smithy-types-1.2.7",
         ":aws-types-1.3.3",
         ":bytes-1.7.2",
         ":fastrand-2.1.1",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.14",
         ":tracing-0.1.40",
@@ -1050,33 +1050,33 @@ cargo.rust_library(
 
 alias(
     name = "aws-sdk-firehose",
-    actual = ":aws-sdk-firehose-1.48.0",
+    actual = ":aws-sdk-firehose-1.49.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "aws-sdk-firehose-1.48.0.crate",
-    sha256 = "4ba9a971d0843b5f5e5d811b9b3002b5eea27c26ad4bf90dd960d782000fc284",
-    strip_prefix = "aws-sdk-firehose-1.48.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-firehose/1.48.0/download"],
+    name = "aws-sdk-firehose-1.49.0.crate",
+    sha256 = "067405963a7a5a8ce3708228c8bd11805959a4873d45599076bc9238f2d2330c",
+    strip_prefix = "aws-sdk-firehose-1.49.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-firehose/1.49.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-firehose-1.48.0",
-    srcs = [":aws-sdk-firehose-1.48.0.crate"],
+    name = "aws-sdk-firehose-1.49.0",
+    srcs = [":aws-sdk-firehose-1.49.0.crate"],
     crate = "aws_sdk_firehose",
-    crate_root = "aws-sdk-firehose-1.48.0.crate/src/lib.rs",
+    crate_root = "aws-sdk-firehose-1.49.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-firehose-1.48.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-firehose-1.49.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for Amazon Kinesis Firehose",
         "CARGO_PKG_NAME": "aws-sdk-firehose",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.48.0",
+        "CARGO_PKG_VERSION": "1.49.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "48",
+        "CARGO_PKG_VERSION_MINOR": "49",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     features = [
@@ -1093,79 +1093,35 @@ cargo.rust_library(
         ":aws-smithy-json-0.60.7",
         ":aws-smithy-runtime-1.7.1",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.6",
+        ":aws-smithy-types-1.2.7",
         ":aws-types-1.3.3",
         ":bytes-1.7.2",
         ":http-0.2.12",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":regex-lite-0.1.6",
         ":tracing-0.1.40",
     ],
 )
 
 http_archive(
-    name = "aws-sdk-sso-1.43.0.crate",
-    sha256 = "70a9d27ed1c12b1140c47daf1bc541606c43fdafd918c4797d520db0043ceef2",
-    strip_prefix = "aws-sdk-sso-1.43.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-sso/1.43.0/download"],
+    name = "aws-sdk-sso-1.44.0.crate",
+    sha256 = "0b90cfe6504115e13c41d3ea90286ede5aa14da294f3fe077027a6e83850843c",
+    strip_prefix = "aws-sdk-sso-1.44.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-sso/1.44.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-sso-1.43.0",
-    srcs = [":aws-sdk-sso-1.43.0.crate"],
+    name = "aws-sdk-sso-1.44.0",
+    srcs = [":aws-sdk-sso-1.44.0.crate"],
     crate = "aws_sdk_sso",
-    crate_root = "aws-sdk-sso-1.43.0.crate/src/lib.rs",
+    crate_root = "aws-sdk-sso-1.44.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-sso-1.43.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-sso-1.44.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS Single Sign-On",
         "CARGO_PKG_NAME": "aws-sdk-sso",
-        "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.43.0",
-        "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "43",
-        "CARGO_PKG_VERSION_PATCH": "0",
-    },
-    visibility = [],
-    deps = [
-        ":aws-credential-types-1.2.1",
-        ":aws-runtime-1.4.3",
-        ":aws-smithy-async-1.2.1",
-        ":aws-smithy-http-0.60.11",
-        ":aws-smithy-json-0.60.7",
-        ":aws-smithy-runtime-1.7.1",
-        ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.6",
-        ":aws-types-1.3.3",
-        ":bytes-1.7.2",
-        ":http-0.2.12",
-        ":once_cell-1.19.0",
-        ":regex-lite-0.1.6",
-        ":tracing-0.1.40",
-    ],
-)
-
-http_archive(
-    name = "aws-sdk-ssooidc-1.44.0.crate",
-    sha256 = "44514a6ca967686cde1e2a1b81df6ef1883d0e3e570da8d8bc5c491dcb6fc29b",
-    strip_prefix = "aws-sdk-ssooidc-1.44.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-ssooidc/1.44.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "aws-sdk-ssooidc-1.44.0",
-    srcs = [":aws-sdk-ssooidc-1.44.0.crate"],
-    crate = "aws_sdk_ssooidc",
-    crate_root = "aws-sdk-ssooidc-1.44.0.crate/src/lib.rs",
-    edition = "2021",
-    env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-ssooidc-1.44.0.crate",
-        "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
-        "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS SSO OIDC",
-        "CARGO_PKG_NAME": "aws-sdk-ssooidc",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
         "CARGO_PKG_VERSION": "1.44.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
@@ -1181,39 +1137,83 @@ cargo.rust_library(
         ":aws-smithy-json-0.60.7",
         ":aws-smithy-runtime-1.7.1",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.6",
+        ":aws-smithy-types-1.2.7",
         ":aws-types-1.3.3",
         ":bytes-1.7.2",
         ":http-0.2.12",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":regex-lite-0.1.6",
         ":tracing-0.1.40",
     ],
 )
 
 http_archive(
-    name = "aws-sdk-sts-1.43.0.crate",
-    sha256 = "cd7a4d279762a35b9df97209f6808b95d4fe78547fe2316b4d200a0283960c5a",
-    strip_prefix = "aws-sdk-sts-1.43.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-sts/1.43.0/download"],
+    name = "aws-sdk-ssooidc-1.45.0.crate",
+    sha256 = "167c0fad1f212952084137308359e8e4c4724d1c643038ce163f06de9662c1d0",
+    strip_prefix = "aws-sdk-ssooidc-1.45.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-ssooidc/1.45.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-sts-1.43.0",
-    srcs = [":aws-sdk-sts-1.43.0.crate"],
-    crate = "aws_sdk_sts",
-    crate_root = "aws-sdk-sts-1.43.0.crate/src/lib.rs",
+    name = "aws-sdk-ssooidc-1.45.0",
+    srcs = [":aws-sdk-ssooidc-1.45.0.crate"],
+    crate = "aws_sdk_ssooidc",
+    crate_root = "aws-sdk-ssooidc-1.45.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-sts-1.43.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-ssooidc-1.45.0.crate",
+        "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
+        "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS SSO OIDC",
+        "CARGO_PKG_NAME": "aws-sdk-ssooidc",
+        "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
+        "CARGO_PKG_VERSION": "1.45.0",
+        "CARGO_PKG_VERSION_MAJOR": "1",
+        "CARGO_PKG_VERSION_MINOR": "45",
+        "CARGO_PKG_VERSION_PATCH": "0",
+    },
+    visibility = [],
+    deps = [
+        ":aws-credential-types-1.2.1",
+        ":aws-runtime-1.4.3",
+        ":aws-smithy-async-1.2.1",
+        ":aws-smithy-http-0.60.11",
+        ":aws-smithy-json-0.60.7",
+        ":aws-smithy-runtime-1.7.1",
+        ":aws-smithy-runtime-api-1.7.2",
+        ":aws-smithy-types-1.2.7",
+        ":aws-types-1.3.3",
+        ":bytes-1.7.2",
+        ":http-0.2.12",
+        ":once_cell-1.20.1",
+        ":regex-lite-0.1.6",
+        ":tracing-0.1.40",
+    ],
+)
+
+http_archive(
+    name = "aws-sdk-sts-1.44.0.crate",
+    sha256 = "2cb5f98188ec1435b68097daa2a37d74b9d17c9caa799466338a8d1544e71b9d",
+    strip_prefix = "aws-sdk-sts-1.44.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-sts/1.44.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-sdk-sts-1.44.0",
+    srcs = [":aws-sdk-sts-1.44.0.crate"],
+    crate = "aws_sdk_sts",
+    crate_root = "aws-sdk-sts-1.44.0.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "CARGO_MANIFEST_DIR": "aws-sdk-sts-1.44.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS Security Token Service",
         "CARGO_PKG_NAME": "aws-sdk-sts",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.43.0",
+        "CARGO_PKG_VERSION": "1.44.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "43",
+        "CARGO_PKG_VERSION_MINOR": "44",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     visibility = [],
@@ -1226,11 +1226,11 @@ cargo.rust_library(
         ":aws-smithy-query-0.60.7",
         ":aws-smithy-runtime-1.7.1",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.6",
+        ":aws-smithy-types-1.2.7",
         ":aws-smithy-xml-0.60.9",
         ":aws-types-1.3.3",
         ":http-0.2.12",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":regex-lite-0.1.6",
         ":tracing-0.1.40",
     ],
@@ -1264,13 +1264,13 @@ cargo.rust_library(
         ":aws-credential-types-1.2.1",
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.6",
+        ":aws-smithy-types-1.2.7",
         ":bytes-1.7.2",
         ":form_urlencoded-1.2.1",
         ":hex-0.4.3",
         ":hmac-0.12.1",
         ":http-1.1.0",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":percent-encoding-2.3.1",
         ":sha2-0.10.8",
         ":time-0.3.36",
@@ -1322,11 +1322,11 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.6",
+        ":aws-smithy-types-1.2.7",
         ":bytes-1.7.2",
         ":bytes-utils-0.1.4",
         ":futures-core-0.3.30",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.14",
         ":pin-utils-0.1.0",
@@ -1349,7 +1349,7 @@ cargo.rust_library(
     crate_root = "aws-smithy-json-0.60.7.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":aws-smithy-types-1.2.6"],
+    deps = [":aws-smithy-types-1.2.7"],
 )
 
 http_archive(
@@ -1368,7 +1368,7 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":aws-smithy-types-1.2.6",
+        ":aws-smithy-types-1.2.7",
         ":urlencoding-2.1.3",
     ],
 )
@@ -1404,13 +1404,13 @@ cargo.rust_library(
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.6",
+        ":aws-smithy-types-1.2.7",
         ":bytes-1.7.2",
         ":fastrand-2.1.1",
         ":h2-0.3.26",
-        ":httparse-1.9.4",
+        ":httparse-1.9.5",
         ":hyper-rustls-0.24.2",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":pin-project-lite-0.2.14",
         ":pin-utils-0.1.0",
         ":rustls-0.21.12",
@@ -1448,7 +1448,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":aws-smithy-async-1.2.1",
-        ":aws-smithy-types-1.2.6",
+        ":aws-smithy-types-1.2.7",
         ":bytes-1.7.2",
         ":pin-project-lite-0.2.14",
         ":tokio-1.40.0",
@@ -1458,18 +1458,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "aws-smithy-types-1.2.6.crate",
-    sha256 = "03701449087215b5369c7ea17fef0dd5d24cb93439ec5af0c7615f58c3f22605",
-    strip_prefix = "aws-smithy-types-1.2.6",
-    urls = ["https://static.crates.io/crates/aws-smithy-types/1.2.6/download"],
+    name = "aws-smithy-types-1.2.7.crate",
+    sha256 = "147100a7bea70fa20ef224a6bad700358305f5dc0f84649c53769761395b355b",
+    strip_prefix = "aws-smithy-types-1.2.7",
+    urls = ["https://static.crates.io/crates/aws-smithy-types/1.2.7/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-smithy-types-1.2.6",
-    srcs = [":aws-smithy-types-1.2.6.crate"],
+    name = "aws-smithy-types-1.2.7",
+    srcs = [":aws-smithy-types-1.2.7.crate"],
     crate = "aws_smithy_types",
-    crate_root = "aws-smithy-types-1.2.6.crate/src/lib.rs",
+    crate_root = "aws-smithy-types-1.2.7.crate/src/lib.rs",
     edition = "2021",
     features = [
         "byte-stream-poll-next",
@@ -1551,7 +1551,7 @@ cargo.rust_library(
         ":aws-credential-types-1.2.1",
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.6",
+        ":aws-smithy-types-1.2.7",
         ":tracing-0.1.40",
     ],
 )
@@ -1620,7 +1620,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.82",
+        ":async-trait-0.1.83",
         ":axum-core-0.3.4",
         ":axum-macros-0.3.8",
         ":base64-0.21.7",
@@ -1667,7 +1667,7 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":async-trait-0.1.82",
+        ":async-trait-0.1.83",
         ":bytes-1.7.2",
         ":futures-util-0.3.30",
         ":http-0.2.12",
@@ -1699,7 +1699,7 @@ cargo.rust_library(
         ":heck-0.4.1",
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -1726,7 +1726,7 @@ cargo.rust_library(
         "linux-arm64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -1734,7 +1734,7 @@ cargo.rust_library(
         "linux-x86_64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -1742,7 +1742,7 @@ cargo.rust_library(
         "macos-arm64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -1750,7 +1750,7 @@ cargo.rust_library(
         "macos-x86_64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -1758,7 +1758,7 @@ cargo.rust_library(
         "windows-gnu": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -1986,10 +1986,10 @@ cargo.rust_library(
         ":peeking_take_while-0.1.2",
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":regex-1.10.6",
+        ":regex-1.11.0",
         ":rustc-hash-1.1.0",
         ":shlex-1.3.0",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -2379,7 +2379,7 @@ cargo.rust_library(
         ":http-1.1.0",
         ":http-body-util-0.1.2",
         ":hyper-1.4.1",
-        ":hyper-util-0.1.8",
+        ":hyper-util-0.1.9",
         ":log-0.4.22",
         ":pin-project-lite-0.2.14",
         ":serde-1.0.210",
@@ -2387,7 +2387,7 @@ cargo.rust_library(
         ":serde_json-1.0.125",
         ":serde_repr-0.1.19",
         ":serde_urlencoded-0.7.1",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":tokio-1.40.0",
         ":tokio-util-0.7.12",
         ":url-2.5.2",
@@ -2412,7 +2412,7 @@ cargo.rust_library(
     deps = [
         ":serde-1.0.210",
         ":serde_repr-0.1.19",
-        ":serde_with-3.9.0",
+        ":serde_with-3.10.0",
     ],
 )
 
@@ -2623,10 +2623,10 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
     },
     visibility = [],
@@ -2644,8 +2644,8 @@ cargo.rust_library(
         ":sha1-0.10.6",
         ":sha2-0.10.8",
         ":ssri-9.2.0",
-        ":tempfile-3.12.0",
-        ":thiserror-1.0.63",
+        ":tempfile-3.13.0",
+        ":thiserror-1.0.64",
         ":tokio-1.40.0",
         ":tokio-stream-0.1.16",
         ":walkdir-2.5.0",
@@ -2670,18 +2670,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "cc-1.1.21.crate",
-    sha256 = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0",
-    strip_prefix = "cc-1.1.21",
-    urls = ["https://static.crates.io/crates/cc/1.1.21/download"],
+    name = "cc-1.1.24.crate",
+    sha256 = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938",
+    strip_prefix = "cc-1.1.24",
+    urls = ["https://static.crates.io/crates/cc/1.1.24/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "cc-1.1.21",
-    srcs = [":cc-1.1.21.crate"],
+    name = "cc-1.1.24",
+    srcs = [":cc-1.1.24.crate"],
     crate = "cc",
-    crate_root = "cc-1.1.21.crate/src/lib.rs",
+    crate_root = "cc-1.1.24.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
     deps = [":shlex-1.3.0"],
@@ -2900,7 +2900,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":glob-0.3.1",
-        ":libc-0.2.158",
+        ":libc-0.2.159",
         ":libloading-0.8.5",
     ],
 )
@@ -2959,23 +2959,23 @@ buildscript_run(
 
 alias(
     name = "clap",
-    actual = ":clap-4.5.17",
+    actual = ":clap-4.5.19",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "clap-4.5.17.crate",
-    sha256 = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac",
-    strip_prefix = "clap-4.5.17",
-    urls = ["https://static.crates.io/crates/clap/4.5.17/download"],
+    name = "clap-4.5.19.crate",
+    sha256 = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615",
+    strip_prefix = "clap-4.5.19",
+    urls = ["https://static.crates.io/crates/clap/4.5.19/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap-4.5.17",
-    srcs = [":clap-4.5.17.crate"],
+    name = "clap-4.5.19",
+    srcs = [":clap-4.5.19.crate"],
     crate = "clap",
-    crate_root = "clap-4.5.17.crate/src/lib.rs",
+    crate_root = "clap-4.5.19.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -2991,24 +2991,24 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":clap_builder-4.5.17",
-        ":clap_derive-4.5.13",
+        ":clap_builder-4.5.19",
+        ":clap_derive-4.5.18",
     ],
 )
 
 http_archive(
-    name = "clap_builder-4.5.17.crate",
-    sha256 = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73",
-    strip_prefix = "clap_builder-4.5.17",
-    urls = ["https://static.crates.io/crates/clap_builder/4.5.17/download"],
+    name = "clap_builder-4.5.19.crate",
+    sha256 = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b",
+    strip_prefix = "clap_builder-4.5.19",
+    urls = ["https://static.crates.io/crates/clap_builder/4.5.19/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap_builder-4.5.17",
-    srcs = [":clap_builder-4.5.17.crate"],
+    name = "clap_builder-4.5.19",
+    srcs = [":clap_builder-4.5.19.crate"],
     crate = "clap_builder",
-    crate_root = "clap_builder-4.5.17.crate/src/lib.rs",
+    crate_root = "clap_builder-4.5.19.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -3026,23 +3026,23 @@ cargo.rust_library(
         ":anstyle-1.0.8",
         ":clap_lex-0.7.2",
         ":strsim-0.11.1",
-        ":terminal_size-0.3.0",
+        ":terminal_size-0.4.0",
     ],
 )
 
 http_archive(
-    name = "clap_derive-4.5.13.crate",
-    sha256 = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0",
-    strip_prefix = "clap_derive-4.5.13",
-    urls = ["https://static.crates.io/crates/clap_derive/4.5.13/download"],
+    name = "clap_derive-4.5.18.crate",
+    sha256 = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab",
+    strip_prefix = "clap_derive-4.5.18",
+    urls = ["https://static.crates.io/crates/clap_derive/4.5.18/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap_derive-4.5.13",
-    srcs = [":clap_derive-4.5.13.crate"],
+    name = "clap_derive-4.5.18",
+    srcs = [":clap_derive-4.5.18.crate"],
     crate = "clap_derive",
-    crate_root = "clap_derive-4.5.13.crate/src/lib.rs",
+    crate_root = "clap_derive-4.5.18.crate/src/lib.rs",
     edition = "2021",
     features = ["default"],
     proc_macro = True,
@@ -3051,7 +3051,7 @@ cargo.rust_library(
         ":heck-0.5.0",
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -3088,22 +3088,22 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "windows-gnu": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "windows-msvc": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
     },
     visibility = [],
@@ -3159,7 +3159,7 @@ cargo.rust_library(
         ":color-spantrace-0.2.1",
         ":eyre-0.6.12",
         ":indenter-0.3.3",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":owo-colors-3.5.0",
         ":tracing-error-0.2.0",
     ],
@@ -3181,7 +3181,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":owo-colors-3.5.0",
         ":tracing-core-0.1.32",
         ":tracing-error-0.2.0",
@@ -3387,7 +3387,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":lazy_static-1.5.0",
-        ":libc-0.2.158",
+        ":libc-0.2.159",
         ":unicode-width-0.1.14",
     ],
 )
@@ -3445,7 +3445,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":getrandom-0.2.15",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":tiny-keccak-2.0.2",
     ],
 )
@@ -3502,7 +3502,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":chrono-0.4.38",
-        ":flate2-1.0.33",
+        ":flate2-1.0.34",
         ":futures-util-0.3.30",
         ":http-0.2.12",
         ":hyper-0.14.30",
@@ -3512,8 +3512,8 @@ cargo.rust_library(
         ":pin-project-1.1.5",
         ":serde-1.0.210",
         ":serde_json-1.0.125",
-        ":tar-0.4.41",
-        ":thiserror-1.0.63",
+        ":tar-0.4.42",
+        ":thiserror-1.0.64",
         ":tokio-1.40.0",
         ":url-2.5.2",
     ],
@@ -3581,7 +3581,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":core-foundation-sys-0.8.7",
-        ":libc-0.2.158",
+        ":libc-0.2.159",
     ],
 )
 
@@ -3622,10 +3622,10 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
     },
     visibility = [],
@@ -3734,17 +3734,17 @@ cargo.rust_library(
         ":anes-0.1.6",
         ":cast-0.3.0",
         ":ciborium-0.2.2",
-        ":clap-4.5.17",
+        ":clap-4.5.19",
         ":criterion-plot-0.5.0",
         ":futures-0.3.30",
         ":is-terminal-0.4.13",
         ":itertools-0.10.5",
         ":num-traits-0.2.19",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":oorandom-11.1.4",
         ":plotters-0.3.7",
         ":rayon-1.10.0",
-        ":regex-1.10.6",
+        ":regex-1.11.0",
         ":serde-1.0.210",
         ":serde_derive-1.0.210",
         ":serde_json-1.0.125",
@@ -3944,7 +3944,7 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":mio-0.8.11",
                 ":signal-hook-0.3.17",
                 ":signal-hook-mio-0.2.4",
@@ -3952,7 +3952,7 @@ cargo.rust_library(
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":mio-0.8.11",
                 ":signal-hook-0.3.17",
                 ":signal-hook-mio-0.2.4",
@@ -3960,7 +3960,7 @@ cargo.rust_library(
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":mio-0.8.11",
                 ":signal-hook-0.3.17",
                 ":signal-hook-mio-0.2.4",
@@ -3968,7 +3968,7 @@ cargo.rust_library(
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":mio-0.8.11",
                 ":signal-hook-0.3.17",
                 ":signal-hook-mio-0.2.4",
@@ -4011,16 +4011,16 @@ cargo.rust_library(
     features = ["windows"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "windows-gnu": dict(
             deps = [
@@ -4274,7 +4274,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -4328,7 +4328,7 @@ cargo.rust_library(
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
         ":strsim-0.11.1",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -4351,7 +4351,7 @@ cargo.rust_library(
     deps = [
         ":darling_core-0.20.10",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -4429,7 +4429,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.82",
+        ":async-trait-0.1.83",
         ":deadpool-runtime-0.1.4",
         ":num_cpus-1.16.0",
         ":tokio-1.40.0",
@@ -4617,7 +4617,7 @@ cargo.rust_library(
         ":darling-0.20.10",
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -4640,7 +4640,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":derive_builder_core-0.20.1",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -4698,7 +4698,7 @@ cargo.rust_library(
         ":convert_case-0.4.0",
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -4936,16 +4936,16 @@ cargo.rust_library(
     edition = "2015",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.48.0"],
@@ -5191,7 +5191,7 @@ cargo.rust_library(
         ":enum-ordinalize-4.3.0",
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -5380,7 +5380,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -5410,7 +5410,7 @@ cargo.rust_library(
         ":humantime-2.1.0",
         ":is-terminal-0.4.13",
         ":log-0.4.22",
-        ":regex-1.10.6",
+        ":regex-1.11.0",
         ":termcolor-1.4.1",
     ],
 )
@@ -5449,16 +5449,16 @@ cargo.rust_library(
     features = ["std"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -5606,7 +5606,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":indenter-0.3.3",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
     ],
 )
 
@@ -5691,16 +5691,16 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.59.0"],
@@ -5732,23 +5732,23 @@ cargo.rust_library(
 
 alias(
     name = "flate2",
-    actual = ":flate2-1.0.33",
+    actual = ":flate2-1.0.34",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "flate2-1.0.33.crate",
-    sha256 = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253",
-    strip_prefix = "flate2-1.0.33",
-    urls = ["https://static.crates.io/crates/flate2/1.0.33/download"],
+    name = "flate2-1.0.34.crate",
+    sha256 = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0",
+    strip_prefix = "flate2-1.0.34",
+    urls = ["https://static.crates.io/crates/flate2/1.0.34/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "flate2-1.0.33",
-    srcs = [":flate2-1.0.33.crate"],
+    name = "flate2-1.0.34",
+    srcs = [":flate2-1.0.34.crate"],
     crate = "flate2",
-    crate_root = "flate2-1.0.33.crate/src/lib.rs",
+    crate_root = "flate2-1.0.34.crate/src/lib.rs",
     edition = "2018",
     features = [
         "any_impl",
@@ -6052,7 +6052,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -6273,16 +6273,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
     },
     visibility = [],
@@ -6312,16 +6312,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
     },
     visibility = [],
@@ -6395,8 +6395,8 @@ cargo.rust_library(
         ":aho-corasick-1.1.3",
         ":bstr-1.10.0",
         ":log-0.4.22",
-        ":regex-automata-0.4.7",
-        ":regex-syntax-0.8.4",
+        ":regex-automata-0.4.8",
+        ":regex-syntax-0.8.5",
     ],
 )
 
@@ -6998,18 +6998,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "httparse-1.9.4.crate",
-    sha256 = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9",
-    strip_prefix = "httparse-1.9.4",
-    urls = ["https://static.crates.io/crates/httparse/1.9.4/download"],
+    name = "httparse-1.9.5.crate",
+    sha256 = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946",
+    strip_prefix = "httparse-1.9.5",
+    urls = ["https://static.crates.io/crates/httparse/1.9.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "httparse-1.9.4",
-    srcs = [":httparse-1.9.4.crate"],
+    name = "httparse-1.9.5",
+    srcs = [":httparse-1.9.5.crate"],
     crate = "httparse",
-    crate_root = "httparse-1.9.4.crate/src/lib.rs",
+    crate_root = "httparse-1.9.5.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -7094,7 +7094,7 @@ cargo.rust_library(
         ":h2-0.3.26",
         ":http-0.2.12",
         ":http-body-0.4.6",
-        ":httparse-1.9.4",
+        ":httparse-1.9.5",
         ":httpdate-1.0.3",
         ":itoa-1.0.11",
         ":pin-project-lite-0.2.14",
@@ -7132,7 +7132,7 @@ cargo.rust_library(
         ":futures-util-0.3.30",
         ":http-1.1.0",
         ":http-body-1.0.1",
-        ":httparse-1.9.4",
+        ":httparse-1.9.5",
         ":itoa-1.0.11",
         ":pin-project-lite-0.2.14",
         ":smallvec-1.13.2",
@@ -7159,7 +7159,7 @@ cargo.rust_library(
     deps = [
         ":hex-0.4.3",
         ":hyper-1.4.1",
-        ":hyper-util-0.1.8",
+        ":hyper-util-0.1.9",
         ":pin-project-lite-0.2.14",
         ":tokio-1.40.0",
         ":tower-service-0.3.3",
@@ -7228,14 +7228,14 @@ cargo.rust_library(
         "webpki-tokio",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.8.0",
+        "pki_types": ":rustls-pki-types-1.9.0",
     },
     visibility = [],
     deps = [
         ":futures-util-0.3.30",
         ":http-1.1.0",
         ":hyper-1.4.1",
-        ":hyper-util-0.1.8",
+        ":hyper-util-0.1.9",
         ":rustls-0.23.13",
         ":tokio-1.40.0",
         ":tokio-rustls-0.26.0",
@@ -7268,18 +7268,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "hyper-util-0.1.8.crate",
-    sha256 = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba",
-    strip_prefix = "hyper-util-0.1.8",
-    urls = ["https://static.crates.io/crates/hyper-util/0.1.8/download"],
+    name = "hyper-util-0.1.9.crate",
+    sha256 = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b",
+    strip_prefix = "hyper-util-0.1.9",
+    urls = ["https://static.crates.io/crates/hyper-util/0.1.9/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "hyper-util-0.1.8",
-    srcs = [":hyper-util-0.1.8.crate"],
+    name = "hyper-util-0.1.9",
+    srcs = [":hyper-util-0.1.9.crate"],
     crate = "hyper_util",
-    crate_root = "hyper-util-0.1.8.crate/src/lib.rs",
+    crate_root = "hyper-util-0.1.9.crate/src/lib.rs",
     edition = "2021",
     features = [
         "client",
@@ -7299,7 +7299,6 @@ cargo.rust_library(
         ":pin-project-lite-0.2.14",
         ":socket2-0.5.7",
         ":tokio-1.40.0",
-        ":tower-0.4.13",
         ":tower-service-0.3.3",
         ":tracing-0.1.40",
     ],
@@ -7358,7 +7357,7 @@ cargo.rust_library(
         ":hex-0.4.3",
         ":http-body-util-0.1.2",
         ":hyper-1.4.1",
-        ":hyper-util-0.1.8",
+        ":hyper-util-0.1.9",
         ":pin-project-lite-0.2.14",
         ":tokio-1.40.0",
         ":tower-service-0.3.3",
@@ -7467,7 +7466,7 @@ cargo.rust_library(
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
         ":serde-1.0.210",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
         ":toml-0.8.19",
         ":unicode-xid-0.2.6",
     ],
@@ -7501,7 +7500,7 @@ cargo.rust_library(
         ":globset-0.4.15",
         ":log-0.4.22",
         ":memchr-2.7.4",
-        ":regex-automata-0.4.7",
+        ":regex-automata-0.4.8",
         ":same-file-1.0.6",
         ":walkdir-2.5.0",
     ],
@@ -7614,7 +7613,7 @@ cargo.rust_library(
     deps = [
         ":console-0.15.8",
         ":number_prefix-0.4.0",
-        ":portable-atomic-1.7.0",
+        ":portable-atomic-1.9.0",
         ":unicode-width-0.1.14",
     ],
 )
@@ -7662,7 +7661,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -7702,7 +7701,7 @@ cargo.rust_library(
         ":fuzzy-matcher-0.3.7",
         ":fxhash-0.2.1",
         ":newline-converter-0.3.0",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":unicode-segmentation-1.12.0",
         ":unicode-width-0.1.14",
     ],
@@ -7744,7 +7743,7 @@ cargo.rust_library(
     crate_root = "is-docker-0.2.0.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
-    deps = [":once_cell-1.19.0"],
+    deps = [":once_cell-1.20.1"],
 )
 
 http_archive(
@@ -7763,16 +7762,16 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -7801,7 +7800,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":is-docker-0.2.0",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
     ],
 )
 
@@ -7947,30 +7946,30 @@ cargo.rust_library(
         ":hmac-sha1-compact-1.1.4",
         ":hmac-sha256-1.1.7",
         ":hmac-sha512-1.1.5",
-        ":k256-0.13.3",
+        ":k256-0.13.4",
         ":p256-0.13.2",
         ":p384-0.13.0",
         ":rand-0.8.5",
         ":serde-1.0.210",
         ":serde_json-1.0.125",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":zeroize-1.8.1",
     ],
 )
 
 http_archive(
-    name = "k256-0.13.3.crate",
-    sha256 = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b",
-    strip_prefix = "k256-0.13.3",
-    urls = ["https://static.crates.io/crates/k256/0.13.3/download"],
+    name = "k256-0.13.4.crate",
+    sha256 = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b",
+    strip_prefix = "k256-0.13.4",
+    urls = ["https://static.crates.io/crates/k256/0.13.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "k256-0.13.3",
-    srcs = [":k256-0.13.3.crate"],
+    name = "k256-0.13.4",
+    srcs = [":k256-0.13.4.crate"],
     crate = "k256",
-    crate_root = "k256-0.13.3.crate/src/lib.rs",
+    crate_root = "k256-0.13.4.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -7996,7 +7995,7 @@ cargo.rust_library(
     deps = [
         ":cfg-if-1.0.0",
         ":elliptic-curve-0.13.8",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":sha2-0.10.8",
         ":signature-2.2.0",
     ],
@@ -8023,7 +8022,7 @@ cargo.rust_library(
     crate_root = "krata-loopdev-0.0.12.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":libc-0.2.158"],
+    deps = [":libc-0.2.159"],
 )
 
 alias(
@@ -8072,33 +8071,33 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "libc-0.2.158.crate",
-    sha256 = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439",
-    strip_prefix = "libc-0.2.158",
-    urls = ["https://static.crates.io/crates/libc/0.2.158/download"],
+    name = "libc-0.2.159.crate",
+    sha256 = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5",
+    strip_prefix = "libc-0.2.159",
+    urls = ["https://static.crates.io/crates/libc/0.2.159/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "libc-0.2.158",
-    srcs = [":libc-0.2.158.crate"],
+    name = "libc-0.2.159",
+    srcs = [":libc-0.2.159.crate"],
     crate = "libc",
-    crate_root = "libc-0.2.158.crate/src/lib.rs",
+    crate_root = "libc-0.2.159.crate/src/lib.rs",
     edition = "2015",
     features = [
         "default",
         "extra_traits",
         "std",
     ],
-    rustc_flags = ["@$(location :libc-0.2.158-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :libc-0.2.159-build-script-run[rustc_flags])"],
     visibility = [],
 )
 
 cargo.rust_binary(
-    name = "libc-0.2.158-build-script-build",
-    srcs = [":libc-0.2.158.crate"],
+    name = "libc-0.2.159-build-script-build",
+    srcs = [":libc-0.2.159.crate"],
     crate = "build_script_build",
-    crate_root = "libc-0.2.158.crate/build.rs",
+    crate_root = "libc-0.2.159.crate/build.rs",
     edition = "2015",
     features = [
         "default",
@@ -8109,15 +8108,15 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "libc-0.2.158-build-script-run",
+    name = "libc-0.2.159-build-script-run",
     package_name = "libc",
-    buildscript_rule = ":libc-0.2.158-build-script-build",
+    buildscript_rule = ":libc-0.2.159-build-script-build",
     features = [
         "default",
         "extra_traits",
         "std",
     ],
-    version = "0.2.158",
+    version = "0.2.159",
 )
 
 http_archive(
@@ -8428,7 +8427,7 @@ cargo.rust_library(
     edition = "2015",
     visibility = [],
     deps = [
-        ":libc-0.2.158",
+        ":libc-0.2.159",
         ":libsodium-sys-0.2.7-libsodium",
     ],
 )
@@ -8806,7 +8805,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -8894,16 +8893,16 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
     },
     visibility = [],
@@ -8926,16 +8925,16 @@ cargo.rust_library(
     features = ["stable_deref_trait"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
     },
     visibility = [],
@@ -8989,8 +8988,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":miette-derive-5.10.0",
-        ":once_cell-1.19.0",
-        ":thiserror-1.0.63",
+        ":once_cell-1.20.1",
+        ":thiserror-1.0.64",
         ":unicode-width-0.1.14",
     ],
 )
@@ -9014,7 +9013,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -9187,16 +9186,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.48.0"],
@@ -9230,16 +9229,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -9284,18 +9283,18 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-lock-3.4.0",
-        ":async-trait-0.1.82",
+        ":async-trait-0.1.83",
         ":crossbeam-channel-0.5.13",
         ":crossbeam-epoch-0.9.18",
         ":crossbeam-utils-0.8.20",
         ":event-listener-5.3.1",
         ":futures-util-0.3.30",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":parking_lot-0.12.3",
         ":quanta-0.12.3",
         ":smallvec-1.13.2",
         ":tagptr-0.2.0",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":triomphe-0.1.11",
         ":uuid-1.10.0",
     ],
@@ -9322,7 +9321,7 @@ cargo.rust_library(
         ":encoding_rs-0.8.34",
         ":futures-util-0.3.30",
         ":http-0.2.12",
-        ":httparse-1.9.4",
+        ":httparse-1.9.5",
         ":log-0.4.22",
         ":memchr-2.7.4",
         ":mime-0.3.17",
@@ -9486,7 +9485,7 @@ cargo.rust_library(
     deps = [
         ":bitflags-1.3.2",
         ":cfg-if-1.0.0",
-        ":libc-0.2.158",
+        ":libc-0.2.159",
     ],
 )
 
@@ -9525,29 +9524,29 @@ cargo.rust_library(
     deps = [
         ":bitflags-2.6.0",
         ":cfg-if-1.0.0",
-        ":libc-0.2.158",
+        ":libc-0.2.159",
     ],
 )
 
 alias(
     name = "nkeys",
-    actual = ":nkeys-0.4.3",
+    actual = ":nkeys-0.4.4",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "nkeys-0.4.3.crate",
-    sha256 = "2de02c883c178998da8d0c9816a88ef7ef5c58314dd1585c97a4a5679f3ab337",
-    strip_prefix = "nkeys-0.4.3",
-    urls = ["https://static.crates.io/crates/nkeys/0.4.3/download"],
+    name = "nkeys-0.4.4.crate",
+    sha256 = "9f49e787f4c61cbd0f9320b31cc26e58719f6aa5068e34697dd3aea361412fe3",
+    strip_prefix = "nkeys-0.4.4",
+    urls = ["https://static.crates.io/crates/nkeys/0.4.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "nkeys-0.4.3",
-    srcs = [":nkeys-0.4.3.crate"],
+    name = "nkeys-0.4.4",
+    srcs = [":nkeys-0.4.4.crate"],
     crate = "nkeys",
-    crate_root = "nkeys-0.4.3.crate/src/lib.rs",
+    crate_root = "nkeys-0.4.4.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [
@@ -9820,7 +9819,7 @@ cargo.rust_binary(
         "std",
     ],
     visibility = [],
-    deps = [":autocfg-1.3.0"],
+    deps = [":autocfg-1.4.0"],
 )
 
 buildscript_run(
@@ -9858,16 +9857,16 @@ cargo.rust_library(
     edition = "2015",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
     },
     visibility = [],
@@ -9924,23 +9923,23 @@ cargo.rust_library(
 
 alias(
     name = "once_cell",
-    actual = ":once_cell-1.19.0",
+    actual = ":once_cell-1.20.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "once_cell-1.19.0.crate",
-    sha256 = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
-    strip_prefix = "once_cell-1.19.0",
-    urls = ["https://static.crates.io/crates/once_cell/1.19.0/download"],
+    name = "once_cell-1.20.1.crate",
+    sha256 = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1",
+    strip_prefix = "once_cell-1.20.1",
+    urls = ["https://static.crates.io/crates/once_cell/1.20.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "once_cell-1.19.0",
-    srcs = [":once_cell-1.19.0.crate"],
+    name = "once_cell-1.20.1",
+    srcs = [":once_cell-1.20.1.crate"],
     crate = "once_cell",
-    crate_root = "once_cell-1.19.0.crate/src/lib.rs",
+    crate_root = "once_cell-1.20.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -9949,6 +9948,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
+    deps = [":portable-atomic-1.9.0"],
 )
 
 http_archive(
@@ -9992,26 +9992,26 @@ cargo.rust_library(
         "linux-arm64": dict(
             deps = [
                 ":is-wsl-0.4.0",
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":pathdiff-0.2.1",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
                 ":is-wsl-0.4.0",
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":pathdiff-0.2.1",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":pathdiff-0.2.1",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":pathdiff-0.2.1",
             ],
         ),
@@ -10066,9 +10066,9 @@ cargo.rust_library(
     deps = [
         ":futures-core-0.3.30",
         ":futures-sink-0.3.30",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":pin-project-lite-0.2.14",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":urlencoding-2.1.3",
     ],
 )
@@ -10116,7 +10116,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.82",
+        ":async-trait-0.1.83",
         ":futures-core-0.3.30",
         ":http-0.2.12",
         ":opentelemetry-0.22.0",
@@ -10124,7 +10124,7 @@ cargo.rust_library(
         ":opentelemetry-semantic-conventions-0.14.0",
         ":opentelemetry_sdk-0.22.1",
         ":prost-0.12.6",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":tokio-1.40.0",
         ":tonic-0.11.0",
     ],
@@ -10230,18 +10230,18 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.82",
+        ":async-trait-0.1.83",
         ":crossbeam-channel-0.5.13",
         ":futures-channel-0.3.30",
         ":futures-executor-0.3.30",
         ":futures-util-0.3.30",
         ":glob-0.3.1",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":opentelemetry-0.22.0",
-        ":ordered-float-4.2.2",
+        ":ordered-float-4.3.0",
         ":percent-encoding-2.3.1",
         ":rand-0.8.5",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":tokio-1.40.0",
         ":tokio-stream-0.1.16",
     ],
@@ -10305,18 +10305,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "ordered-float-4.2.2.crate",
-    sha256 = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6",
-    strip_prefix = "ordered-float-4.2.2",
-    urls = ["https://static.crates.io/crates/ordered-float/4.2.2/download"],
+    name = "ordered-float-4.3.0.crate",
+    sha256 = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537",
+    strip_prefix = "ordered-float-4.3.0",
+    urls = ["https://static.crates.io/crates/ordered-float/4.3.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "ordered-float-4.2.2",
-    srcs = [":ordered-float-4.2.2.crate"],
+    name = "ordered-float-4.3.0",
+    srcs = [":ordered-float-4.3.0.crate"],
     crate = "ordered_float",
-    crate_root = "ordered-float-4.2.2.crate/src/lib.rs",
+    crate_root = "ordered-float-4.3.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -10426,7 +10426,7 @@ cargo.rust_library(
         ":proc-macro-error-1.0.4",
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -10453,7 +10453,7 @@ cargo.rust_library(
         ":proc-macro2-1.0.86",
         ":proc-macro2-diagnostics-0.10.1",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -10646,16 +10646,16 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "windows-gnu": dict(
             deps = [":windows-targets-0.52.6"],
@@ -10958,7 +10958,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -11058,19 +11058,19 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "pkg-config-0.3.30.crate",
-    sha256 = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec",
-    strip_prefix = "pkg-config-0.3.30",
-    urls = ["https://static.crates.io/crates/pkg-config/0.3.30/download"],
+    name = "pkg-config-0.3.31.crate",
+    sha256 = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2",
+    strip_prefix = "pkg-config-0.3.31",
+    urls = ["https://static.crates.io/crates/pkg-config/0.3.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "pkg-config-0.3.30",
-    srcs = [":pkg-config-0.3.30.crate"],
+    name = "pkg-config-0.3.31",
+    srcs = [":pkg-config-0.3.31.crate"],
     crate = "pkg_config",
-    crate_root = "pkg-config-0.3.30.crate/src/lib.rs",
-    edition = "2015",
+    crate_root = "pkg-config-0.3.31.crate/src/lib.rs",
+    edition = "2018",
     visibility = [],
 )
 
@@ -11168,7 +11168,7 @@ cargo.rust_library(
         ":bytes-1.7.2",
         ":chrono-0.4.38",
         ":containers-api-0.8.0",
-        ":flate2-1.0.33",
+        ":flate2-1.0.34",
         ":futures-util-0.3.30",
         ":futures_codec-0.4.1",
         ":log-0.4.22",
@@ -11176,8 +11176,8 @@ cargo.rust_library(
         ":podman-api-stubs-0.9.0",
         ":serde-1.0.210",
         ":serde_json-1.0.125",
-        ":tar-0.4.41",
-        ":thiserror-1.0.63",
+        ":tar-0.4.42",
+        ":thiserror-1.0.64",
         ":tokio-1.40.0",
         ":url-2.5.2",
     ],
@@ -11206,71 +11206,74 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "portable-atomic-1.7.0.crate",
-    sha256 = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265",
-    strip_prefix = "portable-atomic-1.7.0",
-    urls = ["https://static.crates.io/crates/portable-atomic/1.7.0/download"],
+    name = "portable-atomic-1.9.0.crate",
+    sha256 = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2",
+    strip_prefix = "portable-atomic-1.9.0",
+    urls = ["https://static.crates.io/crates/portable-atomic/1.9.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "portable-atomic-1.7.0",
-    srcs = [":portable-atomic-1.7.0.crate"],
+    name = "portable-atomic-1.9.0",
+    srcs = [":portable-atomic-1.9.0.crate"],
     crate = "portable_atomic",
-    crate_root = "portable-atomic-1.7.0.crate/src/lib.rs",
+    crate_root = "portable-atomic-1.9.0.crate/src/lib.rs",
     edition = "2018",
     env = {
-        "CARGO_MANIFEST_DIR": "portable-atomic-1.7.0.crate",
+        "CARGO_MANIFEST_DIR": "portable-atomic-1.9.0.crate",
         "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "Portable atomic types including support for 128-bit atomics, atomic float, etc.\n",
         "CARGO_PKG_NAME": "portable-atomic",
         "CARGO_PKG_REPOSITORY": "https://github.com/taiki-e/portable-atomic",
-        "CARGO_PKG_VERSION": "1.7.0",
+        "CARGO_PKG_VERSION": "1.9.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "7",
+        "CARGO_PKG_VERSION_MINOR": "9",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     features = [
         "default",
         "fallback",
+        "require-cas",
     ],
-    rustc_flags = ["@$(location :portable-atomic-1.7.0-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :portable-atomic-1.9.0-build-script-run[rustc_flags])"],
     visibility = [],
 )
 
 cargo.rust_binary(
-    name = "portable-atomic-1.7.0-build-script-build",
-    srcs = [":portable-atomic-1.7.0.crate"],
+    name = "portable-atomic-1.9.0-build-script-build",
+    srcs = [":portable-atomic-1.9.0.crate"],
     crate = "build_script_build",
-    crate_root = "portable-atomic-1.7.0.crate/build.rs",
+    crate_root = "portable-atomic-1.9.0.crate/build.rs",
     edition = "2018",
     env = {
-        "CARGO_MANIFEST_DIR": "portable-atomic-1.7.0.crate",
+        "CARGO_MANIFEST_DIR": "portable-atomic-1.9.0.crate",
         "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "Portable atomic types including support for 128-bit atomics, atomic float, etc.\n",
         "CARGO_PKG_NAME": "portable-atomic",
         "CARGO_PKG_REPOSITORY": "https://github.com/taiki-e/portable-atomic",
-        "CARGO_PKG_VERSION": "1.7.0",
+        "CARGO_PKG_VERSION": "1.9.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "7",
+        "CARGO_PKG_VERSION_MINOR": "9",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     features = [
         "default",
         "fallback",
+        "require-cas",
     ],
     visibility = [],
 )
 
 buildscript_run(
-    name = "portable-atomic-1.7.0-build-script-run",
+    name = "portable-atomic-1.9.0-build-script-run",
     package_name = "portable-atomic",
-    buildscript_rule = ":portable-atomic-1.7.0-build-script-build",
+    buildscript_rule = ":portable-atomic-1.9.0-build-script-build",
     features = [
         "default",
         "fallback",
+        "require-cas",
     ],
-    version = "1.7.0",
+    version = "1.9.0",
 )
 
 alias(
@@ -11332,7 +11335,7 @@ cargo.rust_library(
         ":heck-0.5.0",
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -11596,6 +11599,55 @@ cargo.rust_library(
     ],
 )
 
+http_archive(
+    name = "proc-macro-error-attr2-2.0.0.crate",
+    sha256 = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5",
+    strip_prefix = "proc-macro-error-attr2-2.0.0",
+    urls = ["https://static.crates.io/crates/proc-macro-error-attr2/2.0.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "proc-macro-error-attr2-2.0.0",
+    srcs = [":proc-macro-error-attr2-2.0.0.crate"],
+    crate = "proc_macro_error_attr2",
+    crate_root = "proc-macro-error-attr2-2.0.0.crate/src/lib.rs",
+    edition = "2021",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.86",
+        ":quote-1.0.37",
+    ],
+)
+
+http_archive(
+    name = "proc-macro-error2-2.0.1.crate",
+    sha256 = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802",
+    strip_prefix = "proc-macro-error2-2.0.1",
+    urls = ["https://static.crates.io/crates/proc-macro-error2/2.0.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "proc-macro-error2-2.0.1",
+    srcs = [":proc-macro-error2-2.0.1.crate"],
+    crate = "proc_macro_error2",
+    crate_root = "proc-macro-error2-2.0.1.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "syn-error",
+    ],
+    visibility = [],
+    deps = [
+        ":proc-macro-error-attr2-2.0.0",
+        ":proc-macro2-1.0.86",
+        ":quote-1.0.37",
+        ":syn-2.0.79",
+    ],
+)
+
 alias(
     name = "proc-macro2",
     actual = ":proc-macro2-1.0.86",
@@ -11672,7 +11724,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
         ":yansi-1.0.1",
     ],
 )
@@ -11709,7 +11761,7 @@ cargo.rust_library(
     deps = [
         ":bitflags-2.6.0",
         ":chrono-0.4.38",
-        ":flate2-1.0.33",
+        ":flate2-1.0.34",
         ":hex-0.4.3",
         ":lazy_static-1.5.0",
         ":procfs-core-0.16.0",
@@ -11816,7 +11868,7 @@ cargo.rust_library(
         ":itertools-0.12.1",
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -11840,20 +11892,20 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":raw-cpuid-11.1.0",
             ],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":raw-cpuid-11.1.0",
             ],
         ),
@@ -11873,7 +11925,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":crossbeam-utils-0.8.20",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
     ],
 )
 
@@ -11933,7 +11985,7 @@ cargo.rust_library(
         ":rustc-hash-2.0.0",
         ":rustls-0.23.13",
         ":socket2-0.5.7",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":tokio-1.40.0",
         ":tracing-0.1.40",
     ],
@@ -11965,7 +12017,7 @@ cargo.rust_library(
         ":rustc-hash-2.0.0",
         ":rustls-0.23.13",
         ":slab-0.4.9",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":tinyvec-1.8.0",
         ":tracing-0.1.40",
     ],
@@ -11989,20 +12041,20 @@ cargo.rust_library(
     platform = {
         "windows-gnu": dict(
             deps = [
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
                 ":windows-sys-0.59.0",
             ],
         ),
         "windows-msvc": dict(
             deps = [
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
                 ":windows-sys-0.59.0",
             ],
         ),
     },
     visibility = [],
     deps = [
-        ":libc-0.2.158",
+        ":libc-0.2.159",
         ":socket2-0.5.7",
         ":tracing-0.1.40",
     ],
@@ -12065,25 +12117,25 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":rand_chacha-0.2.2",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":rand_chacha-0.2.2",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":rand_chacha-0.2.2",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":rand_chacha-0.2.2",
             ],
         ),
@@ -12130,16 +12182,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
     },
     visibility = [],
@@ -12390,12 +12442,12 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.82",
+        ":async-trait-0.1.83",
         ":cfg-if-1.0.0",
         ":log-0.4.22",
-        ":regex-1.10.6",
+        ":regex-1.11.0",
         ":siphasher-1.0.1",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":time-0.3.36",
         ":tokio-1.40.0",
         ":tokio-postgres-0.7.12",
@@ -12425,8 +12477,8 @@ cargo.rust_library(
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
         ":refinery-core-0.8.14",
-        ":regex-1.10.6",
-        ":syn-2.0.77",
+        ":regex-1.11.0",
+        ":syn-2.0.79",
     ],
 )
 
@@ -12464,23 +12516,23 @@ cargo.rust_library(
 
 alias(
     name = "regex",
-    actual = ":regex-1.10.6",
+    actual = ":regex-1.11.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "regex-1.10.6.crate",
-    sha256 = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619",
-    strip_prefix = "regex-1.10.6",
-    urls = ["https://static.crates.io/crates/regex/1.10.6/download"],
+    name = "regex-1.11.0.crate",
+    sha256 = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8",
+    strip_prefix = "regex-1.11.0",
+    urls = ["https://static.crates.io/crates/regex/1.11.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "regex-1.10.6",
-    srcs = [":regex-1.10.6.crate"],
+    name = "regex-1.11.0",
+    srcs = [":regex-1.11.0.crate"],
     crate = "regex",
-    crate_root = "regex-1.10.6.crate/src/lib.rs",
+    crate_root = "regex-1.11.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -12505,8 +12557,8 @@ cargo.rust_library(
     deps = [
         ":aho-corasick-1.1.3",
         ":memchr-2.7.4",
-        ":regex-automata-0.4.7",
-        ":regex-syntax-0.8.4",
+        ":regex-automata-0.4.8",
+        ":regex-syntax-0.8.5",
     ],
 )
 
@@ -12534,18 +12586,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "regex-automata-0.4.7.crate",
-    sha256 = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df",
-    strip_prefix = "regex-automata-0.4.7",
-    urls = ["https://static.crates.io/crates/regex-automata/0.4.7/download"],
+    name = "regex-automata-0.4.8.crate",
+    sha256 = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3",
+    strip_prefix = "regex-automata-0.4.8",
+    urls = ["https://static.crates.io/crates/regex-automata/0.4.8/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "regex-automata-0.4.7",
-    srcs = [":regex-automata-0.4.7.crate"],
+    name = "regex-automata-0.4.8",
+    srcs = [":regex-automata-0.4.8.crate"],
     crate = "regex_automata",
-    crate_root = "regex-automata-0.4.7.crate/src/lib.rs",
+    crate_root = "regex-automata-0.4.8.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -12577,7 +12629,7 @@ cargo.rust_library(
     deps = [
         ":aho-corasick-1.1.3",
         ":memchr-2.7.4",
-        ":regex-syntax-0.8.4",
+        ":regex-syntax-0.8.5",
     ],
 )
 
@@ -12632,18 +12684,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "regex-syntax-0.8.4.crate",
-    sha256 = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b",
-    strip_prefix = "regex-syntax-0.8.4",
-    urls = ["https://static.crates.io/crates/regex-syntax/0.8.4/download"],
+    name = "regex-syntax-0.8.5.crate",
+    sha256 = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c",
+    strip_prefix = "regex-syntax-0.8.5",
+    urls = ["https://static.crates.io/crates/regex-syntax/0.8.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "regex-syntax-0.8.4",
-    srcs = [":regex-syntax-0.8.4.crate"],
+    name = "regex-syntax-0.8.5",
+    srcs = [":regex-syntax-0.8.5.crate"],
     crate = "regex_syntax",
-    crate_root = "regex-syntax-0.8.4.crate/src/lib.rs",
+    crate_root = "regex-syntax-0.8.5.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -12685,29 +12737,29 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
 alias(
     name = "reqwest",
-    actual = ":reqwest-0.12.7",
+    actual = ":reqwest-0.12.8",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "reqwest-0.12.7.crate",
-    sha256 = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63",
-    strip_prefix = "reqwest-0.12.7",
-    urls = ["https://static.crates.io/crates/reqwest/0.12.7/download"],
+    name = "reqwest-0.12.8.crate",
+    sha256 = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b",
+    strip_prefix = "reqwest-0.12.8",
+    urls = ["https://static.crates.io/crates/reqwest/0.12.8/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "reqwest-0.12.7",
-    srcs = [":reqwest-0.12.7.crate"],
+    name = "reqwest-0.12.8",
+    srcs = [":reqwest-0.12.8.crate"],
     crate = "reqwest",
-    crate_root = "reqwest-0.12.7.crate/src/lib.rs",
+    crate_root = "reqwest-0.12.8.crate/src/lib.rs",
     edition = "2021",
     features = [
         "__rustls",
@@ -12725,17 +12777,17 @@ cargo.rust_library(
                 ":http-body-util-0.1.2",
                 ":hyper-1.4.1",
                 ":hyper-rustls-0.27.3",
-                ":hyper-util-0.1.8",
+                ":hyper-util-0.1.9",
                 ":ipnet-2.10.0",
                 ":log-0.4.22",
                 ":mime-0.3.17",
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
                 ":rustls-0.23.13",
-                ":rustls-pemfile-2.1.3",
-                ":rustls-pki-types-1.8.0",
+                ":rustls-pemfile-2.2.0",
+                ":rustls-pki-types-1.9.0",
                 ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
                 ":webpki-roots-0.26.6",
@@ -12747,17 +12799,17 @@ cargo.rust_library(
                 ":http-body-util-0.1.2",
                 ":hyper-1.4.1",
                 ":hyper-rustls-0.27.3",
-                ":hyper-util-0.1.8",
+                ":hyper-util-0.1.9",
                 ":ipnet-2.10.0",
                 ":log-0.4.22",
                 ":mime-0.3.17",
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
                 ":rustls-0.23.13",
-                ":rustls-pemfile-2.1.3",
-                ":rustls-pki-types-1.8.0",
+                ":rustls-pemfile-2.2.0",
+                ":rustls-pki-types-1.9.0",
                 ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
                 ":webpki-roots-0.26.6",
@@ -12769,17 +12821,17 @@ cargo.rust_library(
                 ":http-body-util-0.1.2",
                 ":hyper-1.4.1",
                 ":hyper-rustls-0.27.3",
-                ":hyper-util-0.1.8",
+                ":hyper-util-0.1.9",
                 ":ipnet-2.10.0",
                 ":log-0.4.22",
                 ":mime-0.3.17",
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
                 ":rustls-0.23.13",
-                ":rustls-pemfile-2.1.3",
-                ":rustls-pki-types-1.8.0",
+                ":rustls-pemfile-2.2.0",
+                ":rustls-pki-types-1.9.0",
                 ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
                 ":webpki-roots-0.26.6",
@@ -12791,17 +12843,17 @@ cargo.rust_library(
                 ":http-body-util-0.1.2",
                 ":hyper-1.4.1",
                 ":hyper-rustls-0.27.3",
-                ":hyper-util-0.1.8",
+                ":hyper-util-0.1.9",
                 ":ipnet-2.10.0",
                 ":log-0.4.22",
                 ":mime-0.3.17",
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
                 ":rustls-0.23.13",
-                ":rustls-pemfile-2.1.3",
-                ":rustls-pki-types-1.8.0",
+                ":rustls-pemfile-2.2.0",
+                ":rustls-pki-types-1.9.0",
                 ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
                 ":webpki-roots-0.26.6",
@@ -12813,17 +12865,17 @@ cargo.rust_library(
                 ":http-body-util-0.1.2",
                 ":hyper-1.4.1",
                 ":hyper-rustls-0.27.3",
-                ":hyper-util-0.1.8",
+                ":hyper-util-0.1.9",
                 ":ipnet-2.10.0",
                 ":log-0.4.22",
                 ":mime-0.3.17",
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
                 ":rustls-0.23.13",
-                ":rustls-pemfile-2.1.3",
-                ":rustls-pki-types-1.8.0",
+                ":rustls-pemfile-2.2.0",
+                ":rustls-pki-types-1.9.0",
                 ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
                 ":webpki-roots-0.26.6",
@@ -12836,17 +12888,17 @@ cargo.rust_library(
                 ":http-body-util-0.1.2",
                 ":hyper-1.4.1",
                 ":hyper-rustls-0.27.3",
-                ":hyper-util-0.1.8",
+                ":hyper-util-0.1.9",
                 ":ipnet-2.10.0",
                 ":log-0.4.22",
                 ":mime-0.3.17",
-                ":once_cell-1.19.0",
+                ":once_cell-1.20.1",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
                 ":rustls-0.23.13",
-                ":rustls-pemfile-2.1.3",
-                ":rustls-pki-types-1.8.0",
+                ":rustls-pemfile-2.2.0",
+                ":rustls-pki-types-1.9.0",
                 ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
                 ":webpki-roots-0.26.6",
@@ -13057,7 +13109,7 @@ cargo.rust_library(
                 "RING_CORE_PREFIX": "ring_core_0_17_5_",
             },
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":ring-0.17.5-ring-c-asm-elf-aarch64",
                 ":ring-0.17.5-ring-c-asm-elf-aarch64",
                 ":spin-0.9.8",
@@ -13068,7 +13120,7 @@ cargo.rust_library(
                 "RING_CORE_PREFIX": "ring_core_0_17_5_",
             },
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":ring-0.17.5-ring-c-asm-elf-x86_84",
                 ":ring-0.17.5-ring-c-asm-elf-x86_84",
                 ":spin-0.9.8",
@@ -13729,7 +13781,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.82",
+        ":async-trait-0.1.83",
         ":aws-creds-0.36.0",
         ":aws-region-0.25.4",
         ":base64-0.21.7",
@@ -13752,7 +13804,7 @@ cargo.rust_library(
         ":serde_derive-1.0.210",
         ":serde_json-1.0.125",
         ":sha2-0.10.8",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":time-0.3.36",
         ":tokio-1.40.0",
         ":tokio-rustls-0.24.1",
@@ -13930,7 +13982,7 @@ cargo.rust_library(
                 "libc_errno": ":errno-0.3.9",
             },
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":linux-raw-sys-0.4.14",
             ],
         ),
@@ -13939,7 +13991,7 @@ cargo.rust_library(
                 "libc_errno": ":errno-0.3.9",
             },
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":linux-raw-sys-0.4.14",
             ],
         ),
@@ -13947,13 +13999,13 @@ cargo.rust_library(
             named_deps = {
                 "libc_errno": ":errno-0.3.9",
             },
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
             named_deps = {
                 "libc_errno": ":errno-0.3.9",
             },
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "windows-gnu": dict(
             named_deps = {
@@ -14073,7 +14125,7 @@ cargo.rust_library(
         "tls12",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.8.0",
+        "pki_types": ":rustls-pki-types-1.9.0",
     },
     visibility = [],
     deps = [
@@ -14105,11 +14157,11 @@ cargo.rust_library(
         "tls12",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.8.0",
+        "pki_types": ":rustls-pki-types-1.9.0",
     },
     visibility = [],
     deps = [
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":ring-0.17.5",
         ":rustls-webpki-0.102.8",
         ":subtle-2.6.1",
@@ -14176,7 +14228,7 @@ cargo.rust_library(
     crate_root = "rustls-native-certs-0.7.3.crate/src/lib.rs",
     edition = "2021",
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.8.0",
+        "pki_types": ":rustls-pki-types-1.9.0",
     },
     platform = {
         "linux-arm64": dict(
@@ -14199,7 +14251,7 @@ cargo.rust_library(
         ),
     },
     visibility = [],
-    deps = [":rustls-pemfile-2.1.3"],
+    deps = [":rustls-pemfile-2.2.0"],
 )
 
 http_archive(
@@ -14222,48 +14274,47 @@ cargo.rust_library(
 
 alias(
     name = "rustls-pemfile",
-    actual = ":rustls-pemfile-2.1.3",
+    actual = ":rustls-pemfile-2.2.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "rustls-pemfile-2.1.3.crate",
-    sha256 = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425",
-    strip_prefix = "rustls-pemfile-2.1.3",
-    urls = ["https://static.crates.io/crates/rustls-pemfile/2.1.3/download"],
+    name = "rustls-pemfile-2.2.0.crate",
+    sha256 = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50",
+    strip_prefix = "rustls-pemfile-2.2.0",
+    urls = ["https://static.crates.io/crates/rustls-pemfile/2.2.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-pemfile-2.1.3",
-    srcs = [":rustls-pemfile-2.1.3.crate"],
+    name = "rustls-pemfile-2.2.0",
+    srcs = [":rustls-pemfile-2.2.0.crate"],
     crate = "rustls_pemfile",
-    crate_root = "rustls-pemfile-2.1.3.crate/src/lib.rs",
+    crate_root = "rustls-pemfile-2.2.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
         "std",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.8.0",
+        "pki_types": ":rustls-pki-types-1.9.0",
     },
     visibility = [],
-    deps = [":base64-0.22.1"],
 )
 
 http_archive(
-    name = "rustls-pki-types-1.8.0.crate",
-    sha256 = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0",
-    strip_prefix = "rustls-pki-types-1.8.0",
-    urls = ["https://static.crates.io/crates/rustls-pki-types/1.8.0/download"],
+    name = "rustls-pki-types-1.9.0.crate",
+    sha256 = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55",
+    strip_prefix = "rustls-pki-types-1.9.0",
+    urls = ["https://static.crates.io/crates/rustls-pki-types/1.9.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-pki-types-1.8.0",
-    srcs = [":rustls-pki-types-1.8.0.crate"],
+    name = "rustls-pki-types-1.9.0",
+    srcs = [":rustls-pki-types-1.9.0.crate"],
     crate = "rustls_pki_types",
-    crate_root = "rustls-pki-types-1.8.0.crate/src/lib.rs",
+    crate_root = "rustls-pki-types-1.9.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -14320,7 +14371,7 @@ cargo.rust_library(
         "std",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.8.0",
+        "pki_types": ":rustls-pki-types-1.9.0",
     },
     visibility = [],
     deps = [
@@ -14465,27 +14516,27 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "sea-bae-0.2.0.crate",
-    sha256 = "3bd3534a9978d0aa7edd2808dc1f8f31c4d0ecd31ddf71d997b3c98e9f3c9114",
-    strip_prefix = "sea-bae-0.2.0",
-    urls = ["https://static.crates.io/crates/sea-bae/0.2.0/download"],
+    name = "sea-bae-0.2.1.crate",
+    sha256 = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25",
+    strip_prefix = "sea-bae-0.2.1",
+    urls = ["https://static.crates.io/crates/sea-bae/0.2.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sea-bae-0.2.0",
-    srcs = [":sea-bae-0.2.0.crate"],
+    name = "sea-bae-0.2.1",
+    srcs = [":sea-bae-0.2.1.crate"],
     crate = "sea_bae",
-    crate_root = "sea-bae-0.2.0.crate/src/lib.rs",
+    crate_root = "sea-bae-0.2.1.crate/src/lib.rs",
     edition = "2018",
     proc_macro = True,
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro-error-1.0.4",
+        ":proc-macro-error2-2.0.1",
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -14535,8 +14586,8 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-stream-0.3.5",
-        ":async-trait-0.1.82",
+        ":async-stream-0.3.6",
+        ":async-trait-0.1.83",
         ":bigdecimal-0.3.1",
         ":chrono-0.4.38",
         ":futures-0.3.30",
@@ -14550,7 +14601,7 @@ cargo.rust_library(
         ":serde_json-1.0.125",
         ":sqlx-0.7.4",
         ":strum-0.25.0",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":time-0.3.36",
         ":tracing-0.1.40",
         ":url-2.5.2",
@@ -14579,7 +14630,7 @@ cargo.rust_library(
         "strum",
     ],
     named_deps = {
-        "bae": ":sea-bae-0.2.0",
+        "bae": ":sea-bae-0.2.1",
     },
     proc_macro = True,
     visibility = [],
@@ -14587,7 +14638,7 @@ cargo.rust_library(
         ":heck-0.4.1",
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
         ":unicode-ident-1.0.13",
     ],
 )
@@ -14749,24 +14800,24 @@ cargo.rust_library(
         ":bitflags-2.6.0",
         ":core-foundation-0.9.4",
         ":core-foundation-sys-0.8.7",
-        ":libc-0.2.158",
-        ":security-framework-sys-2.11.1",
+        ":libc-0.2.159",
+        ":security-framework-sys-2.12.0",
     ],
 )
 
 http_archive(
-    name = "security-framework-sys-2.11.1.crate",
-    sha256 = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf",
-    strip_prefix = "security-framework-sys-2.11.1",
-    urls = ["https://static.crates.io/crates/security-framework-sys/2.11.1/download"],
+    name = "security-framework-sys-2.12.0.crate",
+    sha256 = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6",
+    strip_prefix = "security-framework-sys-2.12.0",
+    urls = ["https://static.crates.io/crates/security-framework-sys/2.12.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "security-framework-sys-2.11.1",
-    srcs = [":security-framework-sys-2.11.1.crate"],
+    name = "security-framework-sys-2.12.0",
+    srcs = [":security-framework-sys-2.12.0.crate"],
     crate = "security_framework_sys",
-    crate_root = "security-framework-sys-2.11.1.crate/src/lib.rs",
+    crate_root = "security-framework-sys-2.12.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "OSX_10_10",
@@ -14777,7 +14828,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":core-foundation-sys-0.8.7",
-        ":libc-0.2.158",
+        ":libc-0.2.159",
     ],
 )
 
@@ -14816,7 +14867,7 @@ cargo.rust_library(
         ),
     },
     visibility = [],
-    deps = [":tempfile-3.12.0"],
+    deps = [":tempfile-3.13.0"],
 )
 
 http_archive(
@@ -14971,7 +15022,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -15077,23 +15128,23 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
 http_archive(
-    name = "serde_spanned-0.6.7.crate",
-    sha256 = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d",
-    strip_prefix = "serde_spanned-0.6.7",
-    urls = ["https://static.crates.io/crates/serde_spanned/0.6.7/download"],
+    name = "serde_spanned-0.6.8.crate",
+    sha256 = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1",
+    strip_prefix = "serde_spanned-0.6.8",
+    urls = ["https://static.crates.io/crates/serde_spanned/0.6.8/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_spanned-0.6.7",
-    srcs = [":serde_spanned-0.6.7.crate"],
+    name = "serde_spanned-0.6.8",
+    srcs = [":serde_spanned-0.6.8.crate"],
     crate = "serde_spanned",
-    crate_root = "serde_spanned-0.6.7.crate/src/lib.rs",
+    crate_root = "serde_spanned-0.6.8.crate/src/lib.rs",
     edition = "2021",
     features = ["serde"],
     visibility = [],
@@ -15152,23 +15203,23 @@ cargo.rust_library(
 
 alias(
     name = "serde_with",
-    actual = ":serde_with-3.9.0",
+    actual = ":serde_with-3.10.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde_with-3.9.0.crate",
-    sha256 = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857",
-    strip_prefix = "serde_with-3.9.0",
-    urls = ["https://static.crates.io/crates/serde_with/3.9.0/download"],
+    name = "serde_with-3.10.0.crate",
+    sha256 = "9720086b3357bcb44fce40117d769a4d068c70ecfa190850a980a71755f66fcc",
+    strip_prefix = "serde_with-3.10.0",
+    urls = ["https://static.crates.io/crates/serde_with/3.10.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_with-3.9.0",
-    srcs = [":serde_with-3.9.0.crate"],
+    name = "serde_with-3.10.0",
+    srcs = [":serde_with-3.10.0.crate"],
     crate = "serde_with",
-    crate_root = "serde_with-3.9.0.crate/src/lib.rs",
+    crate_root = "serde_with-3.10.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -15189,23 +15240,23 @@ cargo.rust_library(
         ":serde-1.0.210",
         ":serde_derive-1.0.210",
         ":serde_json-1.0.125",
-        ":serde_with_macros-3.9.0",
+        ":serde_with_macros-3.10.0",
     ],
 )
 
 http_archive(
-    name = "serde_with_macros-3.9.0.crate",
-    sha256 = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350",
-    strip_prefix = "serde_with_macros-3.9.0",
-    urls = ["https://static.crates.io/crates/serde_with_macros/3.9.0/download"],
+    name = "serde_with_macros-3.10.0.crate",
+    sha256 = "5f1abbfe725f27678f4663bcacb75a83e829fd464c25d78dd038a3a29e307cec",
+    strip_prefix = "serde_with_macros-3.10.0",
+    urls = ["https://static.crates.io/crates/serde_with_macros/3.10.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_with_macros-3.9.0",
-    srcs = [":serde_with_macros-3.9.0.crate"],
+    name = "serde_with_macros-3.10.0",
+    srcs = [":serde_with_macros-3.10.0.crate"],
     crate = "serde_with_macros",
-    crate_root = "serde_with_macros-3.9.0.crate/src/lib.rs",
+    crate_root = "serde_with_macros-3.10.0.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
@@ -15213,7 +15264,7 @@ cargo.rust_library(
         ":darling-0.20.10",
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -15443,7 +15494,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":libc-0.2.158",
+        ":libc-0.2.159",
         ":signal-hook-registry-1.4.2",
     ],
 )
@@ -15471,7 +15522,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":libc-0.2.158",
+        ":libc-0.2.159",
         ":signal-hook-0.3.17",
     ],
 )
@@ -15491,7 +15542,7 @@ cargo.rust_library(
     crate_root = "signal-hook-registry-1.4.2.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
-    deps = [":libc-0.2.158"],
+    deps = [":libc-0.2.159"],
 )
 
 http_archive(
@@ -15703,16 +15754,16 @@ cargo.rust_library(
     features = ["all"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -15752,7 +15803,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":ed25519-1.5.3",
-        ":libc-0.2.158",
+        ":libc-0.2.159",
         ":libsodium-sys-0.2.7",
         ":serde-1.0.210",
     ],
@@ -15930,7 +15981,7 @@ cargo.rust_library(
         ":indexmap-2.5.0",
         ":log-0.4.22",
         ":memchr-2.7.4",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":paste-1.0.15",
         ":percent-encoding-2.3.1",
         ":rust_decimal-1.36.0",
@@ -15941,7 +15992,7 @@ cargo.rust_library(
         ":sha2-0.10.8",
         ":smallvec-1.13.2",
         ":sqlformat-0.2.6",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":time-0.3.36",
         ":tokio-1.40.0",
         ":tokio-stream-0.1.16",
@@ -16007,7 +16058,7 @@ cargo.rust_library(
         ":md-5-0.10.6",
         ":memchr-2.7.4",
         ":num-bigint-0.4.6",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":rand-0.8.5",
         ":rust_decimal-1.36.0",
         ":serde-1.0.210",
@@ -16016,7 +16067,7 @@ cargo.rust_library(
         ":smallvec-1.13.2",
         ":sqlx-core-0.7.4",
         ":stringprep-0.1.5",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":time-0.3.36",
         ":tracing-0.1.40",
         ":uuid-1.10.0",
@@ -16062,7 +16113,7 @@ cargo.rust_library(
         ":serde-1.0.210",
         ":sha-1-0.10.1",
         ":sha2-0.10.8",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":xxhash-rust-0.8.12",
     ],
 )
@@ -16152,7 +16203,7 @@ cargo.rust_library(
     deps = [
         ":unicode-bidi-0.3.15",
         ":unicode-normalization-0.1.24",
-        ":unicode-properties-0.1.2",
+        ":unicode-properties-0.1.3",
     ],
 )
 
@@ -16241,7 +16292,7 @@ cargo.rust_library(
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
         ":rustversion-1.0.17",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -16333,23 +16384,23 @@ cargo.rust_library(
 
 alias(
     name = "syn",
-    actual = ":syn-2.0.77",
+    actual = ":syn-2.0.79",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "syn-2.0.77.crate",
-    sha256 = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed",
-    strip_prefix = "syn-2.0.77",
-    urls = ["https://static.crates.io/crates/syn/2.0.77/download"],
+    name = "syn-2.0.79.crate",
+    sha256 = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590",
+    strip_prefix = "syn-2.0.79",
+    urls = ["https://static.crates.io/crates/syn/2.0.79/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "syn-2.0.77",
-    srcs = [":syn-2.0.77.crate"],
+    name = "syn-2.0.79",
+    srcs = [":syn-2.0.79.crate"],
     crate = "syn",
-    crate_root = "syn-2.0.77.crate/src/lib.rs",
+    crate_root = "syn-2.0.79.crate/src/lib.rs",
     edition = "2021",
     features = [
         "clone-impls",
@@ -16430,23 +16481,23 @@ cargo.rust_library(
 
 alias(
     name = "tar",
-    actual = ":tar-0.4.41",
+    actual = ":tar-0.4.42",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tar-0.4.41.crate",
-    sha256 = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909",
-    strip_prefix = "tar-0.4.41",
-    urls = ["https://static.crates.io/crates/tar/0.4.41/download"],
+    name = "tar-0.4.42.crate",
+    sha256 = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020",
+    strip_prefix = "tar-0.4.42",
+    urls = ["https://static.crates.io/crates/tar/0.4.42/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tar-0.4.41",
-    srcs = [":tar-0.4.41.crate"],
+    name = "tar-0.4.42",
+    srcs = [":tar-0.4.42.crate"],
     crate = "tar",
-    crate_root = "tar-0.4.41.crate/src/lib.rs",
+    crate_root = "tar-0.4.42.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -16455,25 +16506,25 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":xattr-1.3.1",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":xattr-1.3.1",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":xattr-1.3.1",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":xattr-1.3.1",
             ],
         ),
@@ -16502,23 +16553,23 @@ cargo.rust_library(
 
 alias(
     name = "tempfile",
-    actual = ":tempfile-3.12.0",
+    actual = ":tempfile-3.13.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tempfile-3.12.0.crate",
-    sha256 = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64",
-    strip_prefix = "tempfile-3.12.0",
-    urls = ["https://static.crates.io/crates/tempfile/3.12.0/download"],
+    name = "tempfile-3.13.0.crate",
+    sha256 = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b",
+    strip_prefix = "tempfile-3.13.0",
+    urls = ["https://static.crates.io/crates/tempfile/3.13.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tempfile-3.12.0",
-    srcs = [":tempfile-3.12.0.crate"],
+    name = "tempfile-3.13.0",
+    srcs = [":tempfile-3.13.0.crate"],
     crate = "tempfile",
-    crate_root = "tempfile-3.12.0.crate/src/lib.rs",
+    crate_root = "tempfile-3.13.0.crate/src/lib.rs",
     edition = "2021",
     platform = {
         "linux-arm64": dict(
@@ -16544,7 +16595,7 @@ cargo.rust_library(
     deps = [
         ":cfg-if-1.0.0",
         ":fastrand-2.1.1",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
     ],
 )
 
@@ -16574,18 +16625,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "terminal_size-0.3.0.crate",
-    sha256 = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7",
-    strip_prefix = "terminal_size-0.3.0",
-    urls = ["https://static.crates.io/crates/terminal_size/0.3.0/download"],
+    name = "terminal_size-0.4.0.crate",
+    sha256 = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef",
+    strip_prefix = "terminal_size-0.4.0",
+    urls = ["https://static.crates.io/crates/terminal_size/0.4.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "terminal_size-0.3.0",
-    srcs = [":terminal_size-0.3.0.crate"],
+    name = "terminal_size-0.4.0",
+    srcs = [":terminal_size-0.4.0.crate"],
     crate = "terminal_size",
-    crate_root = "terminal_size-0.3.0.crate/src/lib.rs",
+    crate_root = "terminal_size-0.4.0.crate/src/lib.rs",
     edition = "2021",
     platform = {
         "linux-arm64": dict(
@@ -16601,10 +16652,10 @@ cargo.rust_library(
             deps = [":rustix-0.38.37"],
         ),
         "windows-gnu": dict(
-            deps = [":windows-sys-0.48.0"],
+            deps = [":windows-sys-0.59.0"],
         ),
         "windows-msvc": dict(
-            deps = [":windows-sys-0.48.0"],
+            deps = [":windows-sys-0.59.0"],
         ),
     },
     visibility = [],
@@ -16658,7 +16709,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -16672,9 +16723,9 @@ cargo.rust_binary(
     deps = [
         ":async-nats-0.36.0",
         ":async-recursion-1.1.1",
-        ":async-trait-0.1.82",
-        ":aws-config-1.5.6",
-        ":aws-sdk-firehose-1.48.0",
+        ":async-trait-0.1.83",
+        ":aws-config-1.5.7",
+        ":aws-sdk-firehose-1.49.0",
         ":axum-0.6.20",
         ":base64-0.22.1",
         ":blake3-1.5.4",
@@ -16683,7 +16734,7 @@ cargo.rust_binary(
         ":cacache-13.0.0",
         ":chrono-0.4.38",
         ":ciborium-0.2.2",
-        ":clap-4.5.17",
+        ":clap-4.5.19",
         ":color-eyre-0.6.3",
         ":colored-2.1.0",
         ":comfy-table-7.1.1",
@@ -16701,7 +16752,7 @@ cargo.rust_binary(
         ":diff-0.1.13",
         ":directories-5.0.1",
         ":dyn-clone-1.0.17",
-        ":flate2-1.0.33",
+        ":flate2-1.0.34",
         ":futures-0.3.30",
         ":futures-lite-2.3.0",
         ":glob-0.3.1",
@@ -16723,9 +16774,9 @@ cargo.rust_binary(
         ":moka-0.12.8",
         ":names-0.14.0",
         ":nix-0.27.1",
-        ":nkeys-0.4.3",
+        ":nkeys-0.4.4",
         ":num_cpus-1.16.0",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":open-5.3.0",
         ":opentelemetry-0.22.0",
         ":opentelemetry-otlp-0.15.0",
@@ -16746,14 +16797,14 @@ cargo.rust_binary(
         ":quote-1.0.37",
         ":rand-0.8.5",
         ":refinery-0.8.12",
-        ":regex-1.10.6",
+        ":regex-1.11.0",
         ":remain-0.2.14",
-        ":reqwest-0.12.7",
+        ":reqwest-0.12.8",
         ":ring-0.17.5",
         ":rust-s3-0.34.0-rc4",
         ":rustls-0.22.4",
         ":rustls-native-certs-0.7.3",
-        ":rustls-pemfile-2.1.3",
+        ":rustls-pemfile-2.2.0",
         ":sea-orm-0.12.15",
         ":self-replace-1.5.0",
         ":serde-1.0.210",
@@ -16761,16 +16812,16 @@ cargo.rust_binary(
         ":serde_json-1.0.125",
         ":serde_path_to_error-0.1.16",
         ":serde_url_params-0.2.1",
-        ":serde_with-3.9.0",
+        ":serde_with-3.10.0",
         ":serde_yaml-0.9.34+deprecated",
         ":sodiumoxide-0.2.7",
         ":stream-cancel-0.8.2",
         ":strum-0.26.3",
-        ":syn-2.0.77",
-        ":tar-0.4.41",
-        ":tempfile-3.12.0",
+        ":syn-2.0.79",
+        ":tar-0.4.42",
+        ":tempfile-3.13.0",
         ":test-log-0.2.16",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":thread-priority-1.1.0",
         ":time-0.3.36",
         ":tokio-1.40.0",
@@ -16805,48 +16856,48 @@ cargo.rust_binary(
 
 alias(
     name = "thiserror",
-    actual = ":thiserror-1.0.63",
+    actual = ":thiserror-1.0.64",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "thiserror-1.0.63.crate",
-    sha256 = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724",
-    strip_prefix = "thiserror-1.0.63",
-    urls = ["https://static.crates.io/crates/thiserror/1.0.63/download"],
+    name = "thiserror-1.0.64.crate",
+    sha256 = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84",
+    strip_prefix = "thiserror-1.0.64",
+    urls = ["https://static.crates.io/crates/thiserror/1.0.64/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "thiserror-1.0.63",
-    srcs = [":thiserror-1.0.63.crate"],
+    name = "thiserror-1.0.64",
+    srcs = [":thiserror-1.0.64.crate"],
     crate = "thiserror",
-    crate_root = "thiserror-1.0.63.crate/src/lib.rs",
+    crate_root = "thiserror-1.0.64.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":thiserror-impl-1.0.63"],
+    deps = [":thiserror-impl-1.0.64"],
 )
 
 http_archive(
-    name = "thiserror-impl-1.0.63.crate",
-    sha256 = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261",
-    strip_prefix = "thiserror-impl-1.0.63",
-    urls = ["https://static.crates.io/crates/thiserror-impl/1.0.63/download"],
+    name = "thiserror-impl-1.0.64.crate",
+    sha256 = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3",
+    strip_prefix = "thiserror-impl-1.0.64",
+    urls = ["https://static.crates.io/crates/thiserror-impl/1.0.64/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "thiserror-impl-1.0.63",
-    srcs = [":thiserror-impl-1.0.63.crate"],
+    name = "thiserror-impl-1.0.64",
+    srcs = [":thiserror-impl-1.0.64.crate"],
     crate = "thiserror_impl",
-    crate_root = "thiserror-impl-1.0.63.crate/src/lib.rs",
+    crate_root = "thiserror-impl-1.0.64.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -16872,26 +16923,26 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.158"],
+            deps = [":libc-0.2.159"],
         ),
         "windows-gnu": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":winapi-0.3.9",
             ],
         ),
         "windows-msvc": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":winapi-0.3.9",
             ],
         ),
@@ -16922,7 +16973,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":cfg-if-1.0.0",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
     ],
 )
 
@@ -17143,28 +17194,28 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.7",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.7",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.7",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.158",
+                ":libc-0.2.159",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.7",
             ],
@@ -17237,7 +17288,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -17289,7 +17340,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":async-trait-0.1.82",
+        ":async-trait-0.1.83",
         ":byteorder-1.5.0",
         ":bytes-1.7.2",
         ":fallible-iterator-0.2.0",
@@ -17382,7 +17433,7 @@ cargo.rust_library(
     crate_root = "tokio-rustls-0.25.0.crate/src/lib.rs",
     edition = "2021",
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.8.0",
+        "pki_types": ":rustls-pki-types-1.9.0",
     },
     visibility = [],
     deps = [
@@ -17410,7 +17461,7 @@ cargo.rust_library(
         "tls12",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.8.0",
+        "pki_types": ":rustls-pki-types-1.9.0",
     },
     visibility = [],
     deps = [
@@ -17516,7 +17567,7 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":async-stream-0.3.5",
+        ":async-stream-0.3.6",
         ":bytes-1.7.2",
         ":futures-core-0.3.30",
         ":tokio-1.40.0",
@@ -17622,7 +17673,7 @@ cargo.rust_library(
     deps = [
         ":bytes-1.7.2",
         ":futures-0.3.30",
-        ":libc-0.2.158",
+        ":libc-0.2.159",
         ":tokio-1.40.0",
         ":vsock-0.3.0",
     ],
@@ -17656,9 +17707,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":serde-1.0.210",
-        ":serde_spanned-0.6.7",
+        ":serde_spanned-0.6.8",
         ":toml_datetime-0.6.8",
-        ":toml_edit-0.22.21",
+        ":toml_edit-0.22.22",
     ],
 )
 
@@ -17682,18 +17733,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "toml_edit-0.22.21.crate",
-    sha256 = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf",
-    strip_prefix = "toml_edit-0.22.21",
-    urls = ["https://static.crates.io/crates/toml_edit/0.22.21/download"],
+    name = "toml_edit-0.22.22.crate",
+    sha256 = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5",
+    strip_prefix = "toml_edit-0.22.22",
+    urls = ["https://static.crates.io/crates/toml_edit/0.22.22/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "toml_edit-0.22.21",
-    srcs = [":toml_edit-0.22.21.crate"],
+    name = "toml_edit-0.22.22",
+    srcs = [":toml_edit-0.22.22.crate"],
     crate = "toml_edit",
-    crate_root = "toml_edit-0.22.21.crate/src/lib.rs",
+    crate_root = "toml_edit-0.22.22.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -17705,9 +17756,9 @@ cargo.rust_library(
     deps = [
         ":indexmap-2.5.0",
         ":serde-1.0.210",
-        ":serde_spanned-0.6.7",
+        ":serde_spanned-0.6.8",
         ":toml_datetime-0.6.8",
-        ":winnow-0.6.18",
+        ":winnow-0.6.20",
     ],
 )
 
@@ -17744,8 +17795,8 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-stream-0.3.5",
-        ":async-trait-0.1.82",
+        ":async-stream-0.3.6",
+        ":async-trait-0.1.83",
         ":axum-0.6.20",
         ":base64-0.21.7",
         ":bytes-1.7.2",
@@ -17977,7 +18028,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -18002,7 +18053,7 @@ cargo.rust_library(
         "valuable",
     ],
     visibility = [],
-    deps = [":once_cell-1.19.0"],
+    deps = [":once_cell-1.20.1"],
 )
 
 http_archive(
@@ -18051,7 +18102,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":log-0.4.22",
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":tracing-core-0.1.32",
     ],
 )
@@ -18095,7 +18146,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":once_cell-1.19.0",
+        ":once_cell-1.20.1",
         ":opentelemetry-0.22.0",
         ":opentelemetry_sdk-0.22.1",
         ":smallvec-1.13.2",
@@ -18173,8 +18224,8 @@ cargo.rust_library(
     deps = [
         ":matchers-0.1.0",
         ":nu-ansi-term-0.46.0",
-        ":once_cell-1.19.0",
-        ":regex-1.10.6",
+        ":once_cell-1.20.1",
+        ":regex-1.11.0",
         ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":sharded-slab-0.1.7",
@@ -18308,11 +18359,11 @@ cargo.rust_library(
         ":bytes-1.7.2",
         ":data-encoding-2.6.0",
         ":http-0.2.12",
-        ":httparse-1.9.4",
+        ":httparse-1.9.5",
         ":log-0.4.22",
         ":rand-0.8.5",
         ":sha1-0.10.6",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":url-2.5.2",
         ":utf-8-0.7.6",
     ],
@@ -18487,18 +18538,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "unicode-properties-0.1.2.crate",
-    sha256 = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524",
-    strip_prefix = "unicode-properties-0.1.2",
-    urls = ["https://static.crates.io/crates/unicode-properties/0.1.2/download"],
+    name = "unicode-properties-0.1.3.crate",
+    sha256 = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0",
+    strip_prefix = "unicode-properties-0.1.3",
+    urls = ["https://static.crates.io/crates/unicode-properties/0.1.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "unicode-properties-0.1.2",
-    srcs = [":unicode-properties-0.1.2.crate"],
+    name = "unicode-properties-0.1.3",
+    srcs = [":unicode-properties-0.1.3.crate"],
     crate = "unicode_properties",
-    crate_root = "unicode-properties-0.1.2.crate/src/lib.rs",
+    crate_root = "unicode-properties-0.1.3.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -18886,7 +18937,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":libc-0.2.158",
+        ":libc-0.2.159",
         ":nix-0.24.3",
     ],
 )
@@ -19022,7 +19073,7 @@ cargo.rust_library(
     crate_root = "webpki-roots-0.26.6.crate/src/lib.rs",
     edition = "2018",
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.8.0",
+        "pki_types": ":rustls-pki-types-1.9.0",
     },
     visibility = [],
 )
@@ -19310,7 +19361,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -19333,7 +19384,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -19659,18 +19710,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "winnow-0.6.18.crate",
-    sha256 = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f",
-    strip_prefix = "winnow-0.6.18",
-    urls = ["https://static.crates.io/crates/winnow/0.6.18/download"],
+    name = "winnow-0.6.20.crate",
+    sha256 = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b",
+    strip_prefix = "winnow-0.6.20",
+    urls = ["https://static.crates.io/crates/winnow/0.6.20/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "winnow-0.6.18",
-    srcs = [":winnow-0.6.18.crate"],
+    name = "winnow-0.6.20",
+    srcs = [":winnow-0.6.20.crate"],
     crate = "winnow",
-    crate_root = "winnow-0.6.18.crate/src/lib.rs",
+    crate_root = "winnow-0.6.20.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -19706,7 +19757,7 @@ cargo.rust_library(
         ":ring-0.17.5",
         ":signature-2.2.0",
         ":spki-0.7.3",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":zeroize-1.8.1",
     ],
 )
@@ -19813,7 +19864,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":futures-util-0.3.30",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
         ":tokio-1.40.0",
         ":yrs-0.17.4",
     ],
@@ -19869,7 +19920,7 @@ cargo.rust_library(
         ":serde_json-1.0.125",
         ":smallstr-0.3.0",
         ":smallvec-1.13.2",
-        ":thiserror-1.0.63",
+        ":thiserror-1.0.64",
     ],
 )
 
@@ -19931,7 +19982,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )
 
@@ -19978,6 +20029,6 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.86",
         ":quote-1.0.37",
-        ":syn-2.0.77",
+        ":syn-2.0.79",
     ],
 )

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -239,7 +239,7 @@ dependencies = [
  "regex",
  "ring",
  "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "rustls-webpki 0.102.8",
  "serde",
  "serde_json",
@@ -263,14 +263,14 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -279,24 +279,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -340,15 +340,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848d7b9b605720989929279fa644ce8f244d0ce3146fcca5b70e4eb7b3c020fc"
+checksum = "8191fb3091fa0561d1379ef80333c3c7191c6f0435d986e85821bcf7acbd1126"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -437,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-firehose"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba9a971d0843b5f5e5d811b9b3002b5eea27c26ad4bf90dd960d782000fc284"
+checksum = "067405963a7a5a8ce3708228c8bd11805959a4873d45599076bc9238f2d2330c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a9d27ed1c12b1140c47daf1bc541606c43fdafd918c4797d520db0043ceef2"
+checksum = "0b90cfe6504115e13c41d3ea90286ede5aa14da294f3fe077027a6e83850843c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.44.0"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44514a6ca967686cde1e2a1b81df6ef1883d0e3e570da8d8bc5c491dcb6fc29b"
+checksum = "167c0fad1f212952084137308359e8e4c4724d1c643038ce163f06de9662c1d0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7a4d279762a35b9df97209f6808b95d4fe78547fe2316b4d200a0283960c5a"
+checksum = "2cb5f98188ec1435b68097daa2a37d74b9d17c9caa799466338a8d1544e71b9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -643,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03701449087215b5369c7ea17fef0dd5d24cb93439ec5af0c7615f58c3f22605"
+checksum = "147100a7bea70fa20ef224a6bad700358305f5dc0f84649c53769761395b355b"
 dependencies = [
  "base64-simd",
  "bytes 1.7.2",
@@ -753,7 +753,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -849,7 +849,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -982,7 +982,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "syn_derive",
 ]
 
@@ -1110,9 +1110,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
 dependencies = [
  "shlex",
 ]
@@ -1193,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1203,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1216,14 +1216,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1643,7 +1643,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1667,7 +1667,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1678,7 +1678,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1782,7 +1782,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1792,7 +1792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1805,7 +1805,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1959,7 +1959,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2036,7 +2036,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2164,9 +2164,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.0",
@@ -2284,7 +2284,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2405,8 +2405,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2673,9 +2673,9 @@ checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -2795,9 +2795,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes 1.7.2",
  "futures-channel",
@@ -2808,7 +2808,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
@@ -2889,7 +2888,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.77",
+ "syn 2.0.79",
  "toml",
  "unicode-xid",
 ]
@@ -2904,7 +2903,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -2965,7 +2964,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3097,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -3135,9 +3134,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libloading"
@@ -3234,7 +3233,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3307,7 +3306,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3460,9 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "nkeys"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de02c883c178998da8d0c9816a88ef7ef5c58314dd1585c97a4a5679f3ab337"
+checksum = "9f49e787f4c61cbd0f9320b31cc26e58719f6aa5068e34697dd3aea361412fe3"
 dependencies = [
  "data-encoding",
  "ed25519 2.2.3",
@@ -3592,9 +3591,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -3685,7 +3687,7 @@ dependencies = [
  "glob",
  "once_cell",
  "opentelemetry",
- "ordered-float 4.2.2",
+ "ordered-float 4.3.0",
  "percent-encoding",
  "rand 0.8.5",
  "thiserror",
@@ -3719,9 +3721,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
+checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
 dependencies = [
  "num-traits",
 ]
@@ -3768,7 +3770,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3782,7 +3784,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3966,7 +3968,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4004,9 +4006,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plotters"
@@ -4074,9 +4076,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "postcard"
@@ -4100,7 +4102,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4214,6 +4216,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4230,7 +4254,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "version_check",
  "yansi",
 ]
@@ -4281,7 +4305,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4494,9 +4518,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4552,7 +4576,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4568,14 +4592,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4589,13 +4613,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4612,9 +4636,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remain"
@@ -4624,7 +4648,7 @@ checksum = "46aef80f842736de545ada6ec65b81ee91504efd6853f4b96de7414c42ae7443"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4638,9 +4662,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64 0.22.1",
  "bytes 1.7.2",
@@ -4662,7 +4686,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.13",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4920,7 +4944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -4937,19 +4961,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -5020,15 +5043,15 @@ dependencies = [
 
 [[package]]
 name = "sea-bae"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd3534a9978d0aa7edd2808dc1f8f31c4d0ecd31ddf71d997b3c98e9f3c9114"
+checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5069,7 +5092,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.77",
+ "syn 2.0.79",
  "unicode-ident",
 ]
 
@@ -5141,9 +5164,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5194,7 +5217,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5237,14 +5260,14 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -5273,9 +5296,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "9720086b3357bcb44fce40117d769a4d068c70ecfa190850a980a71755f66fcc"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5291,14 +5314,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+checksum = "5f1abbfe725f27678f4663bcacb75a83e829fd464c25d78dd038a3a29e307cec"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5428,9 +5451,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simdutf8"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5817,7 +5840,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5852,9 +5875,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5870,7 +5893,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5902,9 +5925,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+checksum = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020"
 dependencies = [
  "filetime",
  "libc",
@@ -5922,9 +5945,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -5944,12 +5967,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
 dependencies = [
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5970,7 +5993,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6060,7 +6083,7 @@ dependencies = [
  "rust-s3",
  "rustls 0.22.4",
  "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "sea-orm",
  "self-replace",
  "serde",
@@ -6073,7 +6096,7 @@ dependencies = [
  "sodiumoxide",
  "stream-cancel",
  "strum 0.26.3",
- "syn 2.0.77",
+ "syn 2.0.79",
  "tar",
  "tempfile",
  "test-log",
@@ -6111,22 +6134,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6254,7 +6277,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6433,9 +6456,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.5.0",
  "serde",
@@ -6546,7 +6569,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6731,9 +6754,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6967,7 +6990,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -7001,7 +7024,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7129,7 +7152,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -7140,7 +7163,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -7323,9 +7346,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -7432,7 +7455,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -7452,7 +7475,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[patch.unused]]


### PR DESCRIPTION
This change drastically improves the quality and fidelity of tracing across all services, but primarily in NATS-driven services and the Postgres client.

Naxum changes:

- Adds first class `Extensions` support to incoming messages which can be used in middleware to populate and consume items.
- Introduces a message wrapper type of `naxum::Message<R>` which handles common combining and decomposition as well as manages `Extensions`. Adds a `HeadRef<'_>` type on a `naxum::Message` via a `head` method.
- Introduces a `Body` trait to responses and a default body implementation. This allows middlewares to map their own response body types and ensures that their contents can be sent up the middleware stack. This change was the most important feature to unlock proper `Trace` middleware behavior.
- Adds a `MatchedSubject` middleware which can be used to set a "matched subject" value in a message's `Extensions`. This is very similar to Axum's `MatchedPath` extractor which retains path values such as `/api/:workspace_id/:user_id`. Currently this middleware provides its user the ability to set a `Extensions` value which can be extracted later.
- Adds a `MatchedSubject` extractor, fetching the value set prior in a `MatchedSubject` middleware.

Other changes:

- Fixes major instrumented span bug present in `si_data_nats`, `si_data_pg`, and `si_layer_cache` where fields would be over-ridden (including the span's `otel.name`) if a method was instrumented at a more verbose level than what was currently set. For example, a Postgres client call to `pg.query` which might be instrumented at `DEBUG` but is being ran at an `INFO` level had `span.record()` code which was *assuming* that `Span::current()` would be the `query` method's `Span`. In this example, that would not be the case and rather the first `INFO` level `Span` up the call stack would be found and all `span.record()` calls would be set there. This change introduces a new `current_span_for_instrument_at` macro that can be used in these crates to replace direct calls to `Span::current()` to automatically disable a `Span` and capture all `span.record()` calls rather than propagating them up the call stack. This was a *huge* find and explains literally years of problems!!
- Improves `telemetry_nats::NatsMakeSpan` whch can be used with Naxum's `Trace` middleware. Adds connection metadata, pre-allocates fields for SI workspace and change set IDs, adds a `ParentSpan` as in `telemetry_http` to override distributed propagation.
- Adds support to set the `otel.name` field to use a `MatchedSubject` if present in `Extensions`.
- Introduces a `telemetry_nats::NatsOnResponse` which can be used Naxum's `Trace` middleware. Records the message status (similar to an HTTP response status) and record `otel.status_code` if appropriate.
- Injects trace propagation headers when sending messages to Veritech, Pinga, and Rebaser (client-side) and relying on the `telemetry_nats::NatsMakeSpan` to extract server-side.
- Fixes visual connecting spans between Pinga jobs and Veritech function calls due to internal `tokio::spawn` calls not passing in their parent span.
- Adds an `INFO` span for each DVU job managed in a Rebaser's `SerialDvuTask`, allowing for per-execution timings.

<img src="https://media1.giphy.com/media/3q3QK6KyDVUBzih7hB/giphy.gif"/>