### PR TITLE
feat: add custom spicedb container image

### DIFF
--- a/component/spicedb/BUCK
+++ b/component/spicedb/BUCK
@@ -1,0 +1,50 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "docker_image",
+    "filegroup",
+    "shellcheck",
+    "shfmt_check",
+    "test_suite",
+)
+
+docker_image(
+    name = "spicedb",
+    srcs = {
+        "entrypoint.sh": ".",
+        "schema.zed": ".",
+    }
+)
+
+filegroup(
+  name = "src",
+  srcs = glob(["**/*"]),
+)
+
+filegroup(
+  name = "shell_srcs",
+  srcs = glob(["**/*.sh"]),
+)
+
+shfmt_check(
+    name = "check-format-shell",
+    srcs = [":shell_srcs"],
+)
+
+shellcheck(
+    name = "check-lint-shell",
+    srcs = [":shell_srcs"],
+)
+
+test_suite(
+    name = "check-format",
+    tests = [
+        ":check-format-shell",
+    ],
+)
+
+test_suite(
+    name = "check-lint",
+    tests = [
+        ":check-lint-shell",
+    ],
+)

--- a/component/spicedb/Dockerfile
+++ b/component/spicedb/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:latest AS downloader
+
+RUN apk add --no-cache wget tar
+RUN wget -O /tmp/zed.tar.gz https://github.com/authzed/zed/releases/download/v0.21.5/zed_0.21.5_linux_amd64_gnu.tar.gz
+RUN tar -xzf /tmp/zed.tar.gz -C /tmp
+RUN chmod +x /tmp/zed
+
+FROM authzed/spicedb:v1.37.0-debug
+
+COPY --from=downloader /tmp/zed /usr/local/bin/zed
+COPY ./schema.zed .
+COPY ./entrypoint.sh .
+
+ENTRYPOINT ["sh", "-c", "./entrypoint.sh"]

--- a/component/spicedb/entrypoint.sh
+++ b/component/spicedb/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -eu
+
+spicedb serve >>/tmp/spicedb.log 2>&1 &
+tail -f /tmp/spicedb.log &
+sleep 3
+
+zed context set example localhost:50051 hobgoblin --insecure
+zed schema write schema.zed
+zed schema read
+zed relationship create document:1 writer user:1
+zed permission check document:1 view user:1
+
+wait

--- a/component/spicedb/schema.zed
+++ b/component/spicedb/schema.zed
@@ -1,0 +1,9 @@
+  definition user {}
+
+  definition document {
+      relation writer: user
+      relation reader: user
+
+      permission edit = writer
+      permission view = reader + edit
+  }

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -10,13 +10,10 @@ cfg = config.parse()
 
 groups = {
     "platform": [
-        "nats",
-        "otelcol",
         "db",
+        "nats",
         "postgres",
-        "db-test",
-        "postgres-test",
-        "jaeger",
+        "spicedb",
     ],
     "backend": [
         "pinga",
@@ -30,14 +27,17 @@ groups = {
         "web",
     ],
     "testing": [
+        "db-test",
         "localstack",
-
+        "postgres-test",
     ],
     "telemetry": [
+        "grafana",
+        "jaeger",
+        "loki",
+        "otelcol",
         "prometheus",
         "promtail",
-        "grafana",
-        "loki",
     ],
 }
 
@@ -110,7 +110,7 @@ def find_group(name, groups):
 
 # Use Docker Compose to provide the platform services
 docker_compose("./docker-compose.platform.yml")
-compose_services = ["jaeger", "nats", "otelcol", "postgres", "postgres-test", "db", "db-test", "loki",  "grafana", "localstack", "promtail", "prometheus"]
+compose_services = ["jaeger", "nats", "otelcol", "postgres", "postgres-test", "db", "db-test", "loki",  "grafana", "localstack", "promtail", "prometheus", "spicedb"]
 for service in compose_services:
     if service == "jaeger":
         links = [
@@ -295,6 +295,7 @@ local_resource(
     serve_env = {"SI_FORCE_COLOR": "true"},
     allow_parallel = True,
     resource_deps = [
+        "spicedb",
         "nats",
         "otelcol",
         "pinga",

--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -174,3 +174,14 @@ services:
     image: localstack/localstack
     ports:
       - "4566:4566"
+
+  spicedb:
+    #<<: *loki-logged-service
+    build: ../component/spicedb
+    environment:
+      - "SPICEDB_LOG_FORMAT=console"
+      - "SPICEDB_GRPC_PRESHARED_KEY=hobgoblin"
+      - "SPICEDB_DATASTORE_ENGINE=memory"
+      - "ZED_KEYRING_PASSWORD=orc"
+    ports:
+      - "50051:50051"


### PR DESCRIPTION
We're planning to use SpiceDb as our authz solution. This adds it to the tilt stack. I set the container to build when starting tilt so we can add changes to `schema.zed` to validate changes as we go without having to push container images along the way. We will still build and ship images in CI.

I also reorganized the tilt file a bit. 

<img src="https://media4.giphy.com/media/kYFIiunpA2Ja2MhGy2/giphy.gif"/>