### PR TITLE
Feat/deploy prod via api call

### DIFF
--- a/.github/workflows/deploy-after-wait.yml
+++ b/.github/workflows/deploy-after-wait.yml
@@ -1,0 +1,46 @@
+name: deploy-after-wait
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        required: true
+        description: "Where to deploy to"
+        default: "tools"
+        options:
+          - tools
+          - production
+      wait_duration:
+        type: string
+        required: true
+        description: "How long to wait before deploying"
+        default: "300" # 5 minutes
+
+jobs:
+  wait:
+    name: wait
+    runs-on: ubuntu-latest
+    steps:
+      - name: wait
+        run: |
+          echo "Sleeping for ${{ inputs.wait_duration }}"
+          sleep ${{ inputs.wait_duration }}
+
+  deploy:
+    uses: ./.github/workflows/deploy-stack.yml
+    needs: wait
+    with:
+      environment: ${{ inputs.environment }}
+      version: stable
+    secrets: inherit
+
+  on-failure:
+    runs-on: ubuntu-latest
+    needs: deploy
+    if: failure()
+    steps:
+      - run: |
+          curl -X POST \
+            -H 'Content-type: application/json' \
+            --data "{\"text\": \":si: Deployment to ${{ inputs.environment }} failed: <https://github.com/systeminit/si/actions/runs/$GITHUB_RUN_ID|:ship: Link>\"}" ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/set-maintenance-mode.yml
+++ b/.github/workflows/set-maintenance-mode.yml
@@ -27,4 +27,3 @@ jobs:
       - name: Toggle maintenance
         run: |
           component/toolbox/awsi.sh toggle-maintenance -p pull-from-env -r us-east-1 -s sdf -m y -a y
-          sleep 120 # FIXME(nick,johnwatson): derisking just in case. Please remove after the deployment using this.


### PR DESCRIPTION
Adds a basic deployment wrapper allow us to trigger a deploying via webhook from a runbook, but giving us a bit of time to get the message out to customers that the product will be going into maintenance.