### PR TITLE
Centralize IDs to the new `si-id` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,7 @@ dependencies = [
  "serde_json",
  "si-data-nats",
  "si-events",
+ "si-id",
  "telemetry",
  "telemetry-nats",
  "thiserror",
@@ -1725,6 +1726,7 @@ dependencies = [
  "si-events",
  "si-frontend-types",
  "si-hash",
+ "si-id",
  "si-layer-cache",
  "si-pkg",
  "si-runtime",
@@ -4771,6 +4773,7 @@ dependencies = [
  "serde_json",
  "si-data-nats",
  "si-events",
+ "si-id",
  "telemetry",
  "telemetry-nats",
  "thiserror",
@@ -4787,6 +4790,7 @@ dependencies = [
  "serde_json",
  "si-data-nats",
  "si-events",
+ "si-id",
  "strum 0.26.3",
  "thiserror",
  "ulid",
@@ -4809,6 +4813,7 @@ dependencies = [
  "si-data-nats",
  "si-data-pg",
  "si-events",
+ "si-id",
  "si-layer-cache",
  "si-settings",
  "si-std",
@@ -5831,6 +5836,7 @@ dependencies = [
  "serde",
  "serde_json",
  "si-hash",
+ "si-id",
  "strum 0.26.3",
  "thiserror",
  "ulid",
@@ -5877,6 +5883,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "si-id"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "postgres-types",
+ "serde",
+ "ulid",
+]
+
+[[package]]
 name = "si-layer-cache"
 version = "0.1.0"
 dependencies = [
@@ -5900,6 +5916,7 @@ dependencies = [
  "si-data-nats",
  "si-data-pg",
  "si-events",
+ "si-id",
  "si-runtime",
  "si-std",
  "strum 0.26.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "lib/si-firecracker",
     "lib/si-frontend-types-rs",
     "lib/si-hash",
+    "lib/si-id",
     "lib/si-layer-cache",
     "lib/si-pkg",
     "lib/si-pool-noodle",

--- a/lib/billing-events/Cargo.toml
+++ b/lib/billing-events/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-events = { path = "../../lib/si-events-rs" }
+si-id= { path = "../../lib/si-id" }
 telemetry = { path = "../../lib/telemetry-rs" }
 telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
 thiserror = { workspace = true }

--- a/lib/billing-events/src/lib.rs
+++ b/lib/billing-events/src/lib.rs
@@ -37,8 +37,9 @@ use si_data_nats::{
 };
 use si_events::{
     ChangeSetId, ChangeSetStatus, ComponentId, FuncRunId, SchemaId, SchemaVariantId, UserPk,
-    WorkspacePk, WorkspaceSnapshotAddress,
+    WorkspaceSnapshotAddress,
 };
+use si_id::WorkspacePk;
 use telemetry::prelude::*;
 use telemetry_nats::propagation;
 use thiserror::Error;

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -51,6 +51,7 @@ si-data-pg = { path = "../../lib/si-data-pg" }
 si-events = { path = "../../lib/si-events-rs" }
 si-frontend-types = { path = "../../lib/si-frontend-types-rs" }
 si-hash = { path = "../../lib/si-hash" }
+si-id = { path = "../../lib/si-id" }
 si-layer-cache = { path = "../../lib/si-layer-cache" }
 si-pkg = { path = "../../lib/si-pkg" }
 si-runtime = { path = "../../lib/si-runtime-rs" }

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -427,7 +427,7 @@ impl DalContext {
     ) -> TransactionsResult<RequestId> {
         self.rebaser()
             .enqueue_updates_from_change_set(
-                workspace_pk.into(),
+                workspace_pk,
                 change_set_id.into(),
                 updates_address,
                 from_change_set_id.into(),
@@ -902,8 +902,7 @@ impl DalContext {
             workspace_pk: self
                 .tenancy()
                 .workspace_pk_opt()
-                .unwrap_or(WorkspacePk::NONE)
-                .into(),
+                .unwrap_or(WorkspacePk::NONE),
         }
     }
 

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -13,7 +13,7 @@ use veritech_client::{
 };
 
 use crate::label_list::ToLabelList;
-use crate::workspace::WorkspaceId;
+use crate::WorkspaceId;
 use crate::{Func, FuncId, PropKind};
 
 pub mod array;

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -26,7 +26,7 @@ use crate::attribute::prototype::argument::{
 use crate::component::socket::ComponentInputSocket;
 use crate::prop::PropError;
 use crate::schema::variant::root_prop::RootPropChild;
-use crate::workspace::WorkspaceId;
+use crate::WorkspaceId;
 use crate::{
     action::{
         prototype::{ActionPrototype, ActionPrototypeError},

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -126,7 +126,7 @@ pub use tenancy::{Tenancy, TenancyError};
 pub use timestamp::{Timestamp, TimestampError};
 pub use user::{User, UserClaim, UserError, UserPk, UserResult};
 pub use visibility::Visibility;
-pub use workspace::{Workspace, WorkspaceError, WorkspacePk, WorkspaceResult};
+pub use workspace::{Workspace, WorkspaceError, WorkspaceResult};
 pub use workspace_snapshot::graph::{
     WorkspaceSnapshotGraph, WorkspaceSnapshotGraphV3, WorkspaceSnapshotGraphVCurrent,
 };
@@ -137,6 +137,7 @@ pub use workspace_snapshot::{
 pub use workspace_snapshot::{WorkspaceSnapshot, WorkspaceSnapshotError};
 pub use ws_event::{WsEvent, WsEventError, WsEventResult, WsPayload};
 
+pub use si_id::{WorkspaceId, WorkspacePk};
 pub use si_runtime::{
     compute_executor, DedicatedExecutor, DedicatedExecutorError, DedicatedExecutorInitializeError,
     DedicatedExecutorJoinError,

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use si_data_nats::NatsError;
 use si_data_pg::{PgError, PgRow};
 use si_events::{ContentHash, WorkspaceSnapshotAddress};
+use si_id::{WorkspaceId, WorkspacePk};
 use si_layer_cache::db::serialize;
 use si_layer_cache::LayerDbError;
 use si_pkg::{
@@ -24,7 +25,7 @@ use crate::layer_db_types::ContentTypes;
 use crate::workspace_snapshot::graph::WorkspaceSnapshotGraphDiscriminants;
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
-    pk, standard_model, standard_model_accessor_ro, BuiltinsError, DalContext, HistoryActor,
+    standard_model, standard_model_accessor_ro, BuiltinsError, DalContext, HistoryActor,
     HistoryEvent, HistoryEventError, KeyPairError, StandardModelError, Tenancy, Timestamp,
     TransactionsError, User, UserError, UserPk, WorkspaceSnapshot, WorkspaceSnapshotGraph,
 };
@@ -88,25 +89,6 @@ pub enum WorkspaceError {
 }
 
 pub type WorkspaceResult<T> = Result<T, WorkspaceError>;
-
-// TODO(nick): switch to "id!" once "nilId" dies and explodes.
-pk!(WorkspacePk);
-
-// TODO(nick): switch to "id!" once "nilId" dies and explodes.
-pk!(WorkspaceId);
-
-impl From<WorkspacePk> for si_events::WorkspacePk {
-    fn from(value: WorkspacePk) -> Self {
-        let id: ulid::Ulid = value.into();
-        id.into()
-    }
-}
-
-impl From<si_events::WorkspacePk> for WorkspacePk {
-    fn from(value: si_events::WorkspacePk) -> Self {
-        Self(value.into_raw_id())
-    }
-}
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Workspace {

--- a/lib/rebaser-client/Cargo.toml
+++ b/lib/rebaser-client/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-events = { path = "../../lib/si-events-rs" }
+si-id = { path = "../../lib/si-id" }
 telemetry = { path = "../../lib/telemetry-rs" }
 telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
 thiserror = { workspace = true }

--- a/lib/rebaser-client/src/lib.rs
+++ b/lib/rebaser-client/src/lib.rs
@@ -16,7 +16,8 @@ use si_data_nats::{
     jetstream::{self, Context},
     HeaderMap, Message, NatsClient, Subject,
 };
-use si_events::{rebase_batch_address::RebaseBatchAddress, ChangeSetId, WorkspacePk};
+use si_events::{rebase_batch_address::RebaseBatchAddress, ChangeSetId};
+use si_id::WorkspacePk;
 use telemetry::prelude::*;
 use telemetry_nats::propagation;
 use thiserror::Error;

--- a/lib/rebaser-core/Cargo.toml
+++ b/lib/rebaser-core/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-events = { path = "../../lib/si-events-rs" }
+si-id = { path = "../../lib/si-id" }
 strum = { workspace = true }
 thiserror = { workspace = true }
 ulid = { workspace = true }

--- a/lib/rebaser-core/src/api_types/enqueue_updates_request/v1.rs
+++ b/lib/rebaser-core/src/api_types/enqueue_updates_request/v1.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
-use si_events::{rebase_batch_address::RebaseBatchAddress, ChangeSetId, WorkspacePk};
+use si_events::{rebase_batch_address::RebaseBatchAddress, ChangeSetId};
+use si_id::WorkspacePk;
 
 use crate::RequestId;
 

--- a/lib/rebaser-core/src/api_types/enqueue_updates_response/v1.rs
+++ b/lib/rebaser-core/src/api_types/enqueue_updates_response/v1.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
-use si_events::{rebase_batch_address::RebaseBatchAddress, ChangeSetId, WorkspacePk};
+use si_events::{rebase_batch_address::RebaseBatchAddress, ChangeSetId};
+use si_id::WorkspacePk;
 
 use crate::RequestId;
 

--- a/lib/rebaser-server/Cargo.toml
+++ b/lib/rebaser-server/Cargo.toml
@@ -22,6 +22,7 @@ si-crypto = { path = "../../lib/si-crypto" }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-data-pg = { path = "../../lib/si-data-pg" }
 si-events = { path = "../../lib/si-events-rs" }
+si-id = { path = "../../lib/si-id" }
 si-layer-cache = { path = "../../lib/si-layer-cache" }
 si-settings = { path = "../../lib/si-settings" }
 si-std = { path = "../../lib/si-std" }

--- a/lib/rebaser-server/src/change_set_processor_task.rs
+++ b/lib/rebaser-server/src/change_set_processor_task.rs
@@ -22,7 +22,8 @@ use si_data_nats::{
     async_nats::jetstream::{self, consumer::push},
     NatsClient,
 };
-use si_events::{ChangeSetId, WorkspacePk};
+use si_events::ChangeSetId;
+use si_id::WorkspacePk;
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::sync::Notify;
@@ -455,7 +456,8 @@ mod app_state {
 
     use dal::DalContextBuilder;
     use si_data_nats::NatsClient;
-    use si_events::{ChangeSetId, WorkspacePk};
+    use si_events::ChangeSetId;
+    use si_id::WorkspacePk;
     use tokio::sync::Notify;
 
     /// Application state.

--- a/lib/rebaser-server/src/handlers.rs
+++ b/lib/rebaser-server/src/handlers.rs
@@ -12,7 +12,8 @@ use si_data_nats::{
     },
     NatsClient, Subject,
 };
-use si_events::{ChangeSetId, WorkspacePk};
+use si_events::ChangeSetId;
+use si_id::WorkspacePk;
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::sync::Notify;

--- a/lib/rebaser-server/src/serial_dvu_task.rs
+++ b/lib/rebaser-server/src/serial_dvu_task.rs
@@ -1,7 +1,8 @@
 use std::{result, sync::Arc};
 
 use dal::DalContextBuilder;
-use si_events::{ChangeSetId, WorkspacePk};
+use si_events::ChangeSetId;
+use si_id::WorkspacePk;
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::sync::Notify;

--- a/lib/si-events-rs/Cargo.toml
+++ b/lib/si-events-rs/Cargo.toml
@@ -10,6 +10,7 @@ publish.workspace = true
 
 [dependencies]
 si-hash = { path = "../../lib/si-hash" }
+si-id = { path = "../../lib/si-id" }
 
 bytes = { workspace = true }
 chrono = { workspace = true }

--- a/lib/si-events-rs/src/func_run.rs
+++ b/lib/si-events-rs/src/func_run.rs
@@ -1,9 +1,10 @@
 use chrono::{DateTime, Utc};
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
+use si_id::WorkspacePk;
 use strum::{AsRefStr, Display, EnumIter, EnumString};
 
-use crate::{id, Actor, ChangeSetId, ContentHash, Tenancy, WorkspacePk};
+use crate::{id, Actor, ChangeSetId, ContentHash, Tenancy};
 
 id!(FuncRunId);
 id!(ComponentId);

--- a/lib/si-events-rs/src/tenancy.rs
+++ b/lib/si-events-rs/src/tenancy.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
+use si_id::WorkspacePk;
 
 use crate::id;
 
-id!(WorkspacePk);
 id!(ChangeSetId);
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/lib/si-events-rs/src/web_event.rs
+++ b/lib/si-events-rs/src/web_event.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use si_id::WorkspacePk;
 
-use crate::{tenancy::ChangeSetId, tenancy::WorkspacePk};
+use crate::tenancy::ChangeSetId;
 
 const DEFAULT_WEB_EVENT_VERSION: u64 = 1;
 

--- a/lib/si-id/Cargo.toml
+++ b/lib/si-id/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "si-id"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+derive_more = { workspace = true }
+postgres-types = { workspace = true }
+serde = { workspace = true }
+ulid = { workspace = true }

--- a/lib/si-id/src/lib.rs
+++ b/lib/si-id/src/lib.rs
@@ -1,56 +1,3 @@
-pub mod content_hash;
-pub mod encrypted_secret;
-pub mod merkle_tree_hash;
-pub mod rebase_batch_address;
-pub mod ulid;
-pub mod workspace_snapshot_address;
-pub mod xxhash_type;
-
-mod actor;
-mod cas;
-mod change_set_status;
-mod func;
-mod func_execution;
-mod func_run;
-mod func_run_log;
-mod resource_metadata;
-mod schema;
-mod schema_variant;
-mod socket;
-mod tenancy;
-mod timestamp;
-mod vector_clock_id;
-mod web_event;
-
-pub use crate::{
-    actor::Actor,
-    actor::UserPk,
-    cas::CasValue,
-    change_set_status::ChangeSetStatus,
-    content_hash::ContentHash,
-    encrypted_secret::EncryptedSecretKey,
-    func::{FuncArgumentId, FuncId},
-    func_execution::*,
-    func_run::{
-        ActionId, ActionKind, ActionPrototypeId, ActionResultState, AttributePrototypeArgumentId,
-        AttributePrototypeId, AttributeValueId, ComponentId, FuncBackendKind,
-        FuncBackendResponseType, FuncKind, FuncRun, FuncRunBuilder, FuncRunBuilderError, FuncRunId,
-        FuncRunState, FuncRunValue,
-    },
-    func_run_log::{FuncRunLog, FuncRunLogId, OutputLine},
-    resource_metadata::{ResourceMetadata, ResourceStatus},
-    schema::SchemaId,
-    schema_variant::{PropId, SchemaVariantId},
-    socket::{InputSocketId, OutputSocketId},
-    tenancy::ChangeSetId,
-    tenancy::Tenancy,
-    timestamp::Timestamp,
-    vector_clock_id::{VectorClockActorId, VectorClockChangeSetId, VectorClockId},
-    web_event::WebEvent,
-    workspace_snapshot_address::WorkspaceSnapshotAddress,
-};
-
-#[macro_export]
 macro_rules! id {
     (
         $(#[$($attrss:tt)*])*
@@ -66,7 +13,6 @@ macro_rules! id {
             Copy,
             Clone,
             Hash,
-            Default,
             derive_more::From,
             derive_more::Into,
             derive_more::Display,
@@ -90,44 +36,52 @@ macro_rules! id {
                 Self(::ulid::Ulid::new())
             }
 
+            /// Calls [`Self::generate`].
             pub fn new() -> Self {
                 Self::generate()
             }
 
+            /// Converts type into inner [`Ulid`](::ulid::Ulid).
+            pub fn into_inner(self) -> ::ulid::Ulid {
+                self.0
+            }
+
+            /// Creates a Crockford Base32 encoded string that represents this Ulid.
             pub fn array_to_str<'buf>(&self, buf: &'buf mut [u8; ::ulid::ULID_LEN]) -> &'buf mut str {
                 self.0.array_to_str(buf)
             }
 
-            pub fn array_to_str_buf() -> [u8; ::ulid::ULID_LEN] {
-                [0; ::ulid::ULID_LEN]
-            }
-
-            /// Constructs a new instance of Self from the given raw identifier.
-            ///
-            /// This function is typically used to consume ownership of the specified identifier.
-            pub fn from_raw_id(value: ::ulid::Ulid) -> Self {
-                Self(value)
-            }
-
-            /// Extracts the raw identifier.
-            ///
-            /// This function is typically used to borrow an owned idenfier.
-            pub fn as_raw_id(&self) -> ::ulid::Ulid {
-                self.0
-            }
-
-            /// Consumes this object, returning the raw underlying identifier.
-            ///
-            /// This function is typically used to transfer ownership of the underlying identifier
-            /// to the caller.
-            pub fn into_raw_id(self) -> ::ulid::Ulid {
-                self.0
-            }
+            /// The forbidden value of doom.
+            pub const NONE: Self = Self(::ulid::Ulid::nil());
         }
+
+        // impl From<$name> for ::si_events::ulid::Ulid {
+        //     fn from(pk: $name) -> Self {
+        //         pk.0.into()
+        //     }
+        // }
+
+        // impl<'a> From<&'a $name> for ::si_events::ulid::Ulid {
+        //     fn from(pk: &'a $name) -> Self {
+        //         pk.0.into()
+        //     }
+        // }
+
+        // impl From<::si_events::ulid::Ulid> for $name {
+        //     fn from(ulid: ::si_events::ulid::Ulid) -> Self {
+        //         ulid.inner().into()
+        //     }
+        // }
 
         impl From<$name> for String {
             fn from(id: $name) -> Self {
                 ulid::Ulid::from(id.0).into()
+            }
+        }
+
+        impl<'a> From<&'a $name> for ulid::Ulid {
+            fn from(id: &'a $name) -> Self {
+                id.0
             }
         }
 
@@ -190,3 +144,6 @@ macro_rules! id {
         }
     };
 }
+
+id!(WorkspacePk);
+id!(WorkspaceId);

--- a/lib/si-layer-cache/Cargo.toml
+++ b/lib/si-layer-cache/Cargo.toml
@@ -25,6 +25,7 @@ serde = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-data-pg = { path = "../../lib/si-data-pg" }
 si-events = { path = "../../lib/si-events-rs" }
+si-id = { path = "../../lib/si-id" }
 si-runtime = { path = "../../lib/si-runtime-rs" }
 si-std = { path = "../../lib/si-std" }
 strum = { workspace = true }

--- a/lib/si-layer-cache/src/db/func_run.rs
+++ b/lib/si-layer-cache/src/db/func_run.rs
@@ -3,8 +3,9 @@ use std::time::Duration;
 
 use si_events::{
     ActionId, ActionResultState, Actor, AttributeValueId, ContentHash, FuncRun, FuncRunId, Tenancy,
-    WebEvent, WorkspacePk,
+    WebEvent,
 };
+use si_id::WorkspacePk;
 use telemetry::prelude::*;
 
 use crate::event::LayeredEventPayload;

--- a/lib/si-layer-cache/src/nats.rs
+++ b/lib/si-layer-cache/src/nats.rs
@@ -119,7 +119,8 @@ fn nats_stream_name(prefix: Option<&str>, suffix: impl AsRef<str>) -> String {
 
 pub mod subject {
     use si_data_nats::Subject;
-    use si_events::{ChangeSetId, WorkspacePk};
+    use si_events::ChangeSetId;
+    use si_id::WorkspacePk;
 
     use crate::{
         activities::{Activity, ActivityPayloadDiscriminants},

--- a/lib/si-layer-cache/tests/integration_test/activities.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities.rs
@@ -3,7 +3,8 @@ mod rebase;
 use std::sync::Arc;
 
 use futures::StreamExt;
-use si_events::{Actor, ChangeSetId, Tenancy, WorkspacePk};
+use si_events::{Actor, ChangeSetId, Tenancy};
+use si_id::WorkspacePk;
 use si_layer_cache::{
     activities::ActivityPayloadDiscriminants, event::LayeredEventMetadata,
     memory_cache::MemoryCacheConfig, LayerDb,

--- a/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
@@ -3,9 +3,8 @@ use std::sync::{
     Arc,
 };
 
-use si_events::{
-    rebase_batch_address::RebaseBatchAddress, Actor, ChangeSetId, Tenancy, WorkspacePk,
-};
+use si_events::{rebase_batch_address::RebaseBatchAddress, Actor, ChangeSetId, Tenancy};
+use si_id::WorkspacePk;
 use si_layer_cache::{
     activities::ActivityId, event::LayeredEventMetadata, memory_cache::MemoryCacheConfig, LayerDb,
 };

--- a/lib/si-layer-cache/tests/integration_test/db/cas.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/cas.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
-use si_events::{Actor, CasValue, ChangeSetId, ContentHash, Tenancy, UserPk, WorkspacePk};
+use si_events::{Actor, CasValue, ChangeSetId, ContentHash, Tenancy, UserPk};
+use si_id::WorkspacePk;
 use si_layer_cache::{
     db::serialize, memory_cache::MemoryCacheConfig, persister::PersistStatus, LayerDb,
 };

--- a/lib/si-layer-cache/tests/integration_test/db/func_run.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/func_run.rs
@@ -5,8 +5,9 @@ use std::{sync::Arc, time::Duration};
 
 use si_events::{
     Actor, ChangeSetId, ContentHash, FuncBackendKind, FuncBackendResponseType, FuncKind, FuncRun,
-    FuncRunBuilder, FuncRunId, Tenancy, UserPk, WorkspacePk,
+    FuncRunBuilder, FuncRunId, Tenancy, UserPk,
 };
+use si_id::WorkspacePk;
 use si_layer_cache::db::serialize;
 use si_layer_cache::LayerDb;
 use tokio::time::Instant;

--- a/lib/si-layer-cache/tests/integration_test/db/func_run_log.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/func_run_log.rs
@@ -1,9 +1,8 @@
 use si_layer_cache::memory_cache::MemoryCacheConfig;
 use std::{sync::Arc, time::Duration};
 
-use si_events::{
-    Actor, ChangeSetId, FuncRunId, FuncRunLog, OutputLine, Tenancy, UserPk, WorkspacePk,
-};
+use si_events::{Actor, ChangeSetId, FuncRunId, FuncRunLog, OutputLine, Tenancy, UserPk};
+use si_id::WorkspacePk;
 use si_layer_cache::db::serialize;
 use si_layer_cache::LayerDb;
 use tokio::time::Instant;

--- a/lib/si-layer-cache/tests/integration_test/db/workspace_snapshot.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/workspace_snapshot.rs
@@ -1,7 +1,8 @@
 use si_layer_cache::memory_cache::MemoryCacheConfig;
 use std::{sync::Arc, time::Duration};
 
-use si_events::{Actor, ChangeSetId, Tenancy, UserPk, WorkspacePk};
+use si_events::{Actor, ChangeSetId, Tenancy, UserPk};
+use si_id::WorkspacePk;
 use si_layer_cache::db::serialize;
 use si_layer_cache::{persister::PersistStatus, LayerDb};
 use tokio::time::Instant;


### PR DESCRIPTION
## Description

Work in progress! Continuation of the initial efforts in [nick/3b20c5e](https://github.com/systeminit/si/tree/nick/3b20c5e).

The strategy is to move each ID one at a time to `si-id`, unlike the aforementioned branch. The new `id!` macro will contain the accursed `NONE` or "nil" value, for now, but it will eventually be culled... hopefully.