### PR TITLE
feat: add basic TTL-based eviction to the disk cache

### DIFF
--- a/lib/si-layer-cache/src/disk_cache.rs
+++ b/lib/si-layer-cache/src/disk_cache.rs
@@ -1,45 +1,42 @@
 use std::sync::Arc;
 
 use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use telemetry::tracing::warn;
 
 use crate::error::LayerDbResult;
 use crate::event::LayeredEvent;
 
-#[derive(Debug, Clone)]
-pub struct CaCacheTempFile {
-    pub tempdir: Arc<tempfile::TempDir>,
-}
-
-impl CaCacheTempFile {
-    fn new(tempdir: tempfile::TempDir) -> Self {
-        Self {
-            tempdir: Arc::new(tempdir),
-        }
-    }
-}
-
-pub fn default_cacache_path() -> LayerDbResult<CaCacheTempFile> {
-    let tempdir = tempfile::tempdir()?;
-    Ok(CaCacheTempFile::new(tempdir))
-}
+const DEFAULT_CACHE_TTL_SECONDS: u64 = 60 * 60 * 24; // 24 hours
+const DEFAULT_CHECK_CACHE_TTL_SECONDS: u64 = 60 * 60; // check every hour
 
 #[derive(Clone, Debug)]
 pub struct DiskCache {
+    ttl: Duration,
+    ttl_check_interval: Duration,
     write_path: Arc<PathBuf>,
 }
 
 impl DiskCache {
-    pub fn new(dir: impl Into<PathBuf>, table_name: impl Into<String>) -> LayerDbResult<Self> {
-        let dir = dir.into();
-        let table_name_string = table_name.into();
-        let write_path = dir.join(table_name_string);
-        Ok(Self {
-            write_path: write_path.into(),
-        })
+    pub fn new(config: DiskCacheConfig) -> LayerDbResult<Self> {
+        let cache = Self {
+            ttl: config.ttl,
+            ttl_check_interval: config.ttl_check_interval,
+            write_path: config.tempdir,
+        };
+        cache.start_cleanup_task();
+        Ok(cache)
     }
 
     pub async fn get(&self, key: Arc<str>) -> LayerDbResult<Vec<u8>> {
-        let data = cacache::read(self.write_path.as_ref(), key).await?;
+        let data = cacache::read(self.write_path.as_ref(), key.clone()).await?;
+
+        // we need to ensure that recently-accessed items have up to date metadata so the TTL does
+        // not clean them up inappropriately
+        self.update_cache_entry(key.clone(), data.clone());
+
         Ok(data)
     }
 
@@ -70,5 +67,85 @@ impl DiskCache {
     pub async fn remove_from_disk(&self, event: Arc<LayeredEvent>) -> LayerDbResult<()> {
         self.remove(event.payload.key.clone()).await?;
         Ok(())
+    }
+
+    fn start_cleanup_task(&self) {
+        let me = self.clone();
+        let cache = self.write_path.clone();
+        let ttl = self.ttl;
+        let interval = self.ttl_check_interval;
+
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(interval).await;
+                for md in cacache::list_sync(cache.as_ref()).flatten() {
+                    let now = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .expect("unable to get the current time, what does this mean? How could this happen?")
+                        .as_millis();
+                    if now - md.time > ttl.as_millis() {
+                        if let Err(err) = me.remove(md.key.into()).await {
+                            warn!("unable to remove item from disk cache: {}", err);
+                        };
+                    }
+                }
+            }
+        });
+    }
+
+    fn update_cache_entry(&self, key: Arc<str>, value: Vec<u8>) {
+        let me = self.clone();
+        tokio::spawn(async move { me.insert(key, value).await });
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DiskCacheConfig {
+    pub tempdir: Arc<PathBuf>,
+    pub ttl: Duration,
+    pub ttl_check_interval: Duration,
+}
+
+impl DiskCacheConfig {
+    pub fn new(
+        dir: impl Into<PathBuf>,
+        table_name: impl Into<String>,
+        ttl: Duration,
+        ttl_check_interval: Duration,
+    ) -> Self {
+        let dir = dir.into();
+        let table_name_string = table_name.into();
+        let write_path = dir.join(table_name_string);
+        Self {
+            tempdir: write_path.into(),
+            ttl,
+            ttl_check_interval,
+        }
+    }
+
+    pub fn default_for_service(service: &str) -> Self {
+        let prefix = format!("{}-cache-", service);
+        let dir = tempfile::TempDir::with_prefix_in(prefix, "/tmp")
+            .expect("unable to create tmp dir for layerdb")
+            .into_path();
+        Self::new(
+            dir,
+            service,
+            Duration::from_secs(DEFAULT_CACHE_TTL_SECONDS),
+            Duration::from_secs(DEFAULT_CHECK_CACHE_TTL_SECONDS),
+        )
+    }
+}
+
+impl Default for DiskCacheConfig {
+    fn default() -> Self {
+        let path = tempfile::TempDir::with_prefix_in("default-cache-", "/tmp")
+            .expect("unable to create tmp dir for layerdb")
+            .into_path();
+        Self {
+            tempdir: Arc::new(path),
+            ttl: Duration::from_secs(DEFAULT_CACHE_TTL_SECONDS),
+            ttl_check_interval: Duration::from_secs(DEFAULT_CHECK_CACHE_TTL_SECONDS),
+        }
     }
 }

--- a/lib/si-layer-cache/src/layer_cache.rs
+++ b/lib/si-layer-cache/src/layer_cache.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::{collections::HashMap, fmt::Display};
 
@@ -8,7 +7,7 @@ use si_runtime::DedicatedExecutor;
 use telemetry::prelude::*;
 
 use crate::db::serialize;
-use crate::disk_cache::DiskCache;
+use crate::disk_cache::{DiskCache, DiskCacheConfig};
 use crate::error::LayerDbResult;
 use crate::memory_cache::{MemoryCache, MemoryCacheConfig};
 use crate::pg::PgLayer;
@@ -32,12 +31,12 @@ where
 {
     pub fn new(
         name: &str,
-        disk_path: impl Into<PathBuf>,
         pg_pool: PgPool,
         memory_cache_config: MemoryCacheConfig,
+        disk_cache_config: DiskCacheConfig,
         compute_executor: DedicatedExecutor,
     ) -> LayerDbResult<Self> {
-        let disk_cache = DiskCache::new(disk_path, name)?;
+        let disk_cache = DiskCache::new(disk_cache_config)?;
 
         let pg = PgLayer::new(pg_pool.clone(), name);
 

--- a/lib/si-layer-cache/src/lib.rs
+++ b/lib/si-layer-cache/src/lib.rs
@@ -36,7 +36,6 @@ pub mod persister;
 pub mod pg;
 
 pub use db::LayerDb;
-pub use disk_cache::{default_cacache_path, CaCacheTempFile};
 pub use error::LayerDbError;
 pub use pg::{default_pg_pool_config, APPLICATION_NAME, DBNAME};
 

--- a/lib/si-layer-cache/tests/integration_test/activities.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities.rs
@@ -20,10 +20,8 @@ type TestLayerDb = LayerDb<Arc<String>, Arc<String>, String, String>;
 async fn activities() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
-
-    let tempdir_slash = disk_cache_path(&tempdir, "slash");
-    let tempdir_axl = disk_cache_path(&tempdir, "axl");
+    let tempdir_slash = disk_cache_path("slash");
+    let tempdir_axl = disk_cache_path("axl");
 
     let db = setup_pg_db("activities").await;
 
@@ -87,10 +85,8 @@ async fn activities() {
 async fn activities_subscribe_partial() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
-
-    let tempdir_slash = disk_cache_path(&tempdir, "slash");
-    let tempdir_axl = disk_cache_path(&tempdir, "axl");
+    let tempdir_slash = disk_cache_path("slash");
+    let tempdir_axl = disk_cache_path("axl");
     let db = setup_pg_db("activities_subscribe_partial").await;
 
     let compute_executor = setup_compute_executor();

--- a/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
+++ b/lib/si-layer-cache/tests/integration_test/activities/rebase.rs
@@ -22,11 +22,9 @@ type TestLayerDb = LayerDb<Arc<String>, Arc<String>, String, String>;
 async fn subscribe_rebaser_requests_work_queue() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
-
-    let tempdir_slash = disk_cache_path(&tempdir, "slash");
-    let tempdir_axl = disk_cache_path(&tempdir, "axl");
-    let tempdir_duff = disk_cache_path(&tempdir, "duff");
+    let tempdir_slash = disk_cache_path("slash");
+    let tempdir_axl = disk_cache_path("axl");
+    let tempdir_duff = disk_cache_path("duff");
     let db = setup_pg_db("subscribe_rebaser_requests_work_queue").await;
     let compute_executor = setup_compute_executor();
 
@@ -156,10 +154,8 @@ async fn subscribe_rebaser_requests_work_queue() {
 async fn rebase_and_wait() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
-
-    let tempdir_slash = disk_cache_path(&tempdir, "slash");
-    let tempdir_axl = disk_cache_path(&tempdir, "axl");
+    let tempdir_slash = disk_cache_path("slash");
+    let tempdir_axl = disk_cache_path("axl");
 
     let db = setup_pg_db("rebase_and_wait").await;
 
@@ -250,11 +246,9 @@ async fn rebase_and_wait() {
 async fn rebase_requests_work_queue_stress() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
-
-    let tempdir_slash = disk_cache_path(&tempdir, "slash");
-    let tempdir_axl = disk_cache_path(&tempdir, "axl");
-    let tempdir_duff = disk_cache_path(&tempdir, "duff");
+    let tempdir_slash = disk_cache_path("slash");
+    let tempdir_axl = disk_cache_path("axl");
+    let tempdir_duff = disk_cache_path("duff");
     let db = setup_pg_db("rebase_requests_work_queue_stress").await;
     let compute_executor = setup_compute_executor();
 
@@ -417,10 +411,8 @@ async fn rebase_and_wait_stress() {
     let token = CancellationToken::new();
     let tracker = TaskTracker::new();
 
-    let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
-
-    let tempdir_slash = disk_cache_path(&tempdir, "slash");
-    let tempdir_axl = disk_cache_path(&tempdir, "axl");
+    let tempdir_slash = disk_cache_path("slash");
+    let tempdir_axl = disk_cache_path("axl");
 
     let db = setup_pg_db("rebase_and_wait_stress").await;
 

--- a/lib/si-layer-cache/tests/integration_test/db/cas.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/cas.rs
@@ -17,8 +17,7 @@ type TestLayerDb = LayerDb<CasValue, String, String, String>;
 async fn write_to_db() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-    let dbfile = disk_cache_path(&tempdir, "slash");
+    let dbfile = disk_cache_path("slash");
     let (ldb, _): (TestLayerDb, _) = LayerDb::from_services(
         dbfile,
         setup_pg_db("cas_write_to_db").await,
@@ -84,9 +83,7 @@ async fn write_to_db() {
 async fn write_and_read_many() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-
-    let dbfile = disk_cache_path(&tempdir, "slash");
+    let dbfile = disk_cache_path("slash");
 
     let (ldb, _): (TestLayerDb, _) = LayerDb::from_services(
         dbfile,
@@ -141,9 +138,7 @@ async fn write_and_read_many() {
 async fn cold_read_from_db() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-
-    let dbfile = disk_cache_path(&tempdir, "slash");
+    let dbfile = disk_cache_path("slash");
 
     let (ldb, _): (TestLayerDb, _) = LayerDb::from_services(
         dbfile,
@@ -233,10 +228,8 @@ async fn cold_read_from_db() {
 async fn writes_are_gossiped() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
-
-    let tempdir_slash = disk_cache_path(&tempdir, "slash");
-    let tempdir_axl = disk_cache_path(&tempdir, "axl");
+    let tempdir_slash = disk_cache_path("slash");
+    let tempdir_axl = disk_cache_path("axl");
 
     let db = setup_pg_db("cas_writes_are_gossiped").await;
 
@@ -356,10 +349,8 @@ async fn writes_are_gossiped() {
 async fn stress_test() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
-
-    let tempdir_slash = disk_cache_path(&tempdir, "slash");
-    let tempdir_axl = disk_cache_path(&tempdir, "axl");
+    let tempdir_slash = disk_cache_path("slash");
+    let tempdir_axl = disk_cache_path("axl");
 
     let db = setup_pg_db("stress_test").await;
 

--- a/lib/si-layer-cache/tests/integration_test/db/func_run.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/func_run.rs
@@ -22,8 +22,7 @@ type TestLayerDb = LayerDb<String, String, String, String>;
 async fn write_to_db() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-    let dbfile = disk_cache_path(&tempdir, "jesawyer");
+    let dbfile = disk_cache_path("jesawyer");
     let (ldb, _): (TestLayerDb, _) = LayerDb::from_services(
         dbfile,
         setup_pg_db("func_run_write_to_db").await,
@@ -84,8 +83,7 @@ async fn write_to_db() {
 async fn update() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-    let dbfile = disk_cache_path(&tempdir, "jesawyer");
+    let dbfile = disk_cache_path("jesawyer");
     let db = setup_pg_db("func_run_update_to_db").await;
     let (ldb, _): (TestLayerDb, _) = LayerDb::from_services(
         dbfile,
@@ -99,7 +97,7 @@ async fn update() {
     .expect("cannot create layerdb");
     ldb.pg_migrate().await.expect("migrate layer db");
 
-    let dbfile = disk_cache_path(&tempdir, "rainbow");
+    let dbfile = disk_cache_path("rainbow");
     let (ldb_remote, _): (TestLayerDb, _) = LayerDb::from_services(
         dbfile,
         db,
@@ -254,9 +252,7 @@ async fn update() {
 async fn write_and_read_many_for_workspace_id() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-
-    let dbfile = disk_cache_path(&tempdir, "fnv");
+    let dbfile = disk_cache_path("fnv");
 
     let (ldb, _): (TestLayerDb, _) = LayerDb::from_services(
         dbfile,

--- a/lib/si-layer-cache/tests/integration_test/db/func_run_log.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/func_run_log.rs
@@ -19,8 +19,7 @@ type TestLayerDb = LayerDb<String, String, String, String>;
 async fn write_to_db() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-    let dbfile = disk_cache_path(&tempdir, "esp");
+    let dbfile = disk_cache_path("esp");
     let (ldb, _): (TestLayerDb, _) = LayerDb::from_services(
         dbfile,
         setup_pg_db("func_run_log_write_to_db").await,
@@ -83,8 +82,7 @@ async fn write_to_db() {
 async fn update() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-    let dbfile = disk_cache_path(&tempdir, "sevenmarythree");
+    let dbfile = disk_cache_path("sevenmarythree");
     let db = setup_pg_db("func_run_log_update_to_db").await;
     let (ldb, _): (TestLayerDb, _) = LayerDb::from_services(
         dbfile,
@@ -98,7 +96,7 @@ async fn update() {
     .expect("cannot create layerdb");
     ldb.pg_migrate().await.expect("migrate layer db");
 
-    let dbfile = disk_cache_path(&tempdir, "tea & coffee");
+    let dbfile = disk_cache_path("tea & coffee");
     let (ldb_remote, _): (TestLayerDb, _) = LayerDb::from_services(
         dbfile,
         db,
@@ -263,9 +261,7 @@ async fn update() {
 async fn write_and_get_for_func_run_id() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-
-    let dbfile = disk_cache_path(&tempdir, "cumbersome");
+    let dbfile = disk_cache_path("cumbersome");
 
     let (ldb, _): (TestLayerDb, _) = LayerDb::from_services(
         dbfile,

--- a/lib/si-layer-cache/tests/integration_test/db/workspace_snapshot.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/workspace_snapshot.rs
@@ -17,8 +17,7 @@ type TestLayerDb = LayerDb<String, String, String, String>;
 async fn write_to_db() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-    let dbfile = disk_cache_path(&tempdir, "slash");
+    let dbfile = disk_cache_path("slash");
     let (ldb, _): (TestLayerDb, _) = LayerDb::from_services(
         dbfile,
         setup_pg_db("workspace_snapshot_write_to_db").await,
@@ -89,8 +88,7 @@ async fn write_to_db() {
 async fn evict_from_db() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-    let dbfile = disk_cache_path(&tempdir, "slash");
+    let dbfile = disk_cache_path("slash");
     let (ldb, _): (TestLayerDb, _) = LayerDb::from_services(
         dbfile,
         setup_pg_db("workspace_snapshot_evict_from_db").await,
@@ -173,10 +171,8 @@ async fn evict_from_db() {
 async fn evictions_are_gossiped() {
     let token = CancellationToken::new();
 
-    let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
-
-    let tempdir_slash = disk_cache_path(&tempdir, "slash");
-    let tempdir_axl = disk_cache_path(&tempdir, "axl");
+    let tempdir_slash = disk_cache_path("slash");
+    let tempdir_axl = disk_cache_path("axl");
 
     let db = setup_pg_db("workspace_snapshot_evictions_are_gossiped").await;
 

--- a/lib/si-layer-cache/tests/integration_test/layer_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/layer_cache.rs
@@ -1,5 +1,6 @@
 use rand::seq::SliceRandom;
 use rand::thread_rng;
+use si_layer_cache::disk_cache::DiskCacheConfig;
 use si_layer_cache::memory_cache::MemoryCacheConfig;
 use std::sync::Arc;
 
@@ -7,13 +8,11 @@ use si_layer_cache::db::serialize;
 use si_layer_cache::layer_cache::LayerCache;
 
 async fn make_layer_cache(db_name: &str) -> LayerCache<String> {
-    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
-
     let layer_cache = LayerCache::new(
         "cas",
-        tempdir.path(),
         super::setup_pg_db(db_name).await,
         MemoryCacheConfig::default(),
+        DiskCacheConfig::default(),
         super::setup_compute_executor(),
     )
     .expect("cannot create layer cache");

--- a/lib/si-layer-cache/tests/integration_test/mod.rs
+++ b/lib/si-layer-cache/tests/integration_test/mod.rs
@@ -1,9 +1,9 @@
 use buck2_resources::Buck2Resources;
 use si_data_nats::{NatsClient, NatsConfig};
 use si_data_pg::{PgPool, PgPoolConfig};
+use si_layer_cache::disk_cache::DiskCacheConfig;
 use std::env;
-use std::path::{Path, PathBuf};
-use tempfile::TempDir;
+use std::path::Path;
 
 use crate::TEST_PG_DBNAME;
 
@@ -140,6 +140,6 @@ pub fn setup_compute_executor() -> si_runtime::DedicatedExecutor {
     si_runtime::compute_executor("test").expect("failed to create executor")
 }
 
-pub fn disk_cache_path(tempdir: &TempDir, name: &str) -> PathBuf {
-    tempdir.path().join(format!("{name}-cacache"))
+pub fn disk_cache_path(table_name: &str) -> DiskCacheConfig {
+    DiskCacheConfig::default_for_service(table_name)
 }


### PR DESCRIPTION
Adds a simple, configurable TTL to disk cache items. The default behavior is to check hourly for items that have been in the cache for more than 24 hours, removing them if it finds them. 

On get, we will write the got data back to the cache to ensure that the metadata is current. This is wasteful, but should be infrequent as we should find these items in the memory cache until the next start.

<img src="https://media1.giphy.com/media/pY5xqgAYeT6J7UNIaP/giphy.gif"/>