### PR TITLE
feat: add prom exporter to pgbouncer

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -57,6 +57,18 @@ services:
       init:
         condition: service_completed_successfully
 
+  pgbouncer-prom-exporter:
+    container_name: pgbouncer-prom-exporter
+    image: systeminit/pgbouncer-prom-exporter:${INIT_VERSION:-stable}
+    profiles: [rebaser, pinga, sdf]
+    ports:
+      - 9127:9127
+    volumes:
+      - config:/etc/pgbouncer-prom-exporter/
+    depends_on:
+      pgbouncer:
+        condition: service_completed_successfully
+
   vector:
     container_name: vector
     image: timberio/vector:0.X-debian

--- a/component/init/configs/pgbouncer-conn-string-exporter.sh
+++ b/component/init/configs/pgbouncer-conn-string-exporter.sh
@@ -1,0 +1,1 @@
+export PGBOUNCER_EXPORTER_CONNECTION_STRING="postgres://admin:$SI_BOUNCER_ADMIN_PASSWORD@pgbouncer:5432/pgbouncer?sslmode=disable"

--- a/component/pgbouncer-prom-exporter/BUCK
+++ b/component/pgbouncer-prom-exporter/BUCK
@@ -1,0 +1,18 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "docker_image",
+)
+
+docker_image(
+    name = "pgbouncer-prom-exporter",
+    build_args = {
+        "BASE_VERSION": "v0.9.0",
+    },
+    srcs = {
+        "docker-entrypoint.sh": ".",
+    },
+    run_docker_args = [
+        "--publish",
+        "9127:9127",
+    ],
+)

--- a/component/pgbouncer-prom-exporter/Dockerfile
+++ b/component/pgbouncer-prom-exporter/Dockerfile
@@ -1,0 +1,5 @@
+ARG BASE_VERSION
+FROM prometheuscommunity/pgbouncer-exporter:${BASE_VERSION}
+WORKDIR /app
+COPY ./docker-entrypoint.sh /app/
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/component/pgbouncer-prom-exporter/docker-entrypoint.sh
+++ b/component/pgbouncer-prom-exporter/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+eval $(cat /etc/pgbouncer-prom-exporter/pgbouncer-conn-string-exporter.sh)
+/bin/pgbouncer_exporter


### PR DESCRIPTION
Adds prom exporter to pgbouncer so we get metrics from that part of the stack, prom can then consume from :9127/metrics on each host to get the pgbouncer stats.