### PR TITLE
feat: add rudimentary authz schema and validation

### DIFF
--- a/component/spicedb/BUCK
+++ b/component/spicedb/BUCK
@@ -12,6 +12,7 @@ docker_image(
     srcs = {
         "entrypoint.sh": ".",
         "schema.zed": ".",
+        "validation.yaml": ".",
     }
 )
 

--- a/component/spicedb/Dockerfile
+++ b/component/spicedb/Dockerfile
@@ -1,14 +1,22 @@
-FROM alpine:latest AS downloader
+FROM alpine:latest AS setup
 
-RUN apk add --no-cache wget tar
-RUN wget -O /tmp/zed.tar.gz https://github.com/authzed/zed/releases/download/v0.21.5/zed_0.21.5_linux_amd64_gnu.tar.gz
-RUN tar -xzf /tmp/zed.tar.gz -C /tmp
-RUN chmod +x /tmp/zed
+RUN apk add --no-cache wget tar yq && \
+    wget -O /tmp/zed.tar.gz https://github.com/authzed/zed/releases/download/v0.21.5/zed_0.21.5_linux_amd64_gnu.tar.gz && \
+    tar -xzf /tmp/zed.tar.gz -C /tmp && \
+    chmod +x /tmp/zed
+
+COPY ./schema.zed /tmp/schema.zed
+COPY ./validation.yaml /tmp/validation.yaml
+
+# stub the schema file into the validation.yaml
+RUN sed -i '/<<SCHEMA>>/r /tmp/schema.zed' /tmp/validation.yaml && \
+    sed -i '/<<SCHEMA>>/d' /tmp/validation.yaml
 
 FROM authzed/spicedb:v1.37.0-debug
 
-COPY --from=downloader /tmp/zed /usr/local/bin/zed
-COPY ./schema.zed .
+COPY --from=setup /tmp/zed /usr/local/bin/zed
+COPY --from=setup /tmp/schema.zed .
+COPY --from=setup /tmp/validation.yaml .
 COPY ./entrypoint.sh .
 
 ENTRYPOINT ["sh", "-c", "./entrypoint.sh"]

--- a/component/spicedb/entrypoint.sh
+++ b/component/spicedb/entrypoint.sh
@@ -8,7 +8,6 @@ sleep 3
 zed context set example localhost:50051 hobgoblin --insecure
 zed schema write schema.zed
 zed schema read
-zed relationship create document:1 writer user:1
-zed permission check document:1 view user:1
+zed validate validation.yaml
 
 wait

--- a/component/spicedb/schema.zed
+++ b/component/spicedb/schema.zed
@@ -1,9 +1,6 @@
   definition user {}
 
-  definition document {
-      relation writer: user
-      relation reader: user
-
-      permission edit = writer
-      permission view = reader + edit
+  definition workspace {
+      relation approver: user
+      permission approve = approver
   }

--- a/component/spicedb/validation.yaml
+++ b/component/spicedb/validation.yaml
@@ -1,0 +1,13 @@
+schema: |-
+  <<SCHEMA>>
+relationships: |-
+  workspace:123#approver@user:scott
+assertions:
+  assertTrue:
+  - workspace:123#approve@user:scott
+  assertFalse:
+  - workspace:123#approve@user:fletcher
+validation:
+  workspace:123#approve:
+    - "[user:scott] is <workspace:123#approver>"
+


### PR DESCRIPTION
This adds a super basic approval schema and way to validate it by setting assertions and validations in a yaml file. The container will be built when tilt is up and the validations will run automatically. 

```
Success! - 1 relationships loaded, 2 assertions run, 1 expected relations validated
```