### PR TITLE
feat: management prototypes and import operations

### DIFF
--- a/bin/lang-js/src/function_kinds/management.ts
+++ b/bin/lang-js/src/function_kinds/management.ts
@@ -20,7 +20,14 @@ export type ManagementFuncResult =
     | ManagementFuncResultSuccess
     | ManagementFuncResultFailure;
 
+export interface ManagementOperations {
+  update: { [key: string]: {
+    properties?: object;
+  } }
+}
+
 export interface ManagementFuncResultSuccess extends ResultSuccess {
+  operations?: ManagementOperations,
   message?: string;
 }
 export interface ManagementFuncResultFailure extends ResultFailure { }
@@ -35,7 +42,6 @@ async function execute(
   try {
     const runner = vm.run(code);
     managementResult = await new Promise((resolve) => {
-      console.error(thisComponent);
       runner(thisComponent.properties, (resolution: Record<string, unknown>) => resolve(resolution));
     });
   } catch (err) {
@@ -45,6 +51,7 @@ async function execute(
     protocol: "result",
     status: "success",
     executionId,
+    operations: managementResult.ops as ManagementOperations | undefined,
     message: managementResult.message as string | undefined,
   };
 }

--- a/lib/cyclone-core/src/management.rs
+++ b/lib/cyclone-core/src/management.rs
@@ -18,6 +18,7 @@ pub struct ManagementRequest {
 #[serde(rename_all = "camelCase")]
 pub struct ManagementResultSuccess {
     pub execution_id: String,
+    pub operations: Option<serde_json::Value>,
     pub message: Option<String>,
     pub error: Option<String>,
 }

--- a/lib/dal-test/src/test_exclusive_schemas/mod.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/mod.rs
@@ -141,6 +141,22 @@ fn build_resource_payload_to_value_func() -> BuiltinsResult<FuncSpec> {
     Ok(resource_payload_to_value_func)
 }
 
+fn build_management_func(code: &str, fn_name: &str) -> BuiltinsResult<FuncSpec> {
+    Ok(FuncSpec::builder()
+        .name(fn_name)
+        .unique_id(fn_name)
+        .data(
+            FuncSpecData::builder()
+                .name(fn_name)
+                .code_plaintext(code)
+                .handler("main")
+                .backend_kind(FuncSpecBackendKind::Management)
+                .response_type(FuncSpecBackendResponseType::Management)
+                .build()?,
+        )
+        .build()?)
+}
+
 fn build_action_func(code: &str, fn_name: &str) -> BuiltinsResult<FuncSpec> {
     let func = FuncSpec::builder()
         .name(fn_name)

--- a/lib/dal/src/func/backend/management.rs
+++ b/lib/dal/src/func/backend/management.rs
@@ -56,9 +56,9 @@ impl FuncDispatch for FuncBackendManagement {
 }
 
 impl ExtractPayload for ManagementResultSuccess {
-    type Payload = ();
+    type Payload = ManagementResultSuccess;
 
     fn extract(self) -> FuncBackendResult<Self::Payload> {
-        Ok(())
+        Ok(self)
     }
 }

--- a/lib/dal/src/layer_db_types/content_types.rs
+++ b/lib/dal/src/layer_db_types/content_types.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use si_events::ulid::Ulid;
@@ -11,8 +13,8 @@ use crate::{
     action::ActionCompletionStatus, func::argument::FuncArgumentKind, prop::WidgetOptions,
     property_editor::schema::WidgetKind, socket::connection_annotation::ConnectionAnnotation,
     ActionPrototypeId, ComponentId, ComponentType, DalContext, FuncBackendKind,
-    FuncBackendResponseType, FuncId, PropId, PropKind, SchemaVariant, SchemaVariantId, SocketArity,
-    SocketKind, Timestamp, UserPk,
+    FuncBackendResponseType, FuncId, PropId, PropKind, SchemaId, SchemaVariant, SchemaVariantId,
+    SocketArity, SocketKind, Timestamp, UserPk,
 };
 
 #[remain::sorted]
@@ -54,6 +56,7 @@ pub enum ContentTypes {
     StaticArgumentValue(StaticArgumentValueContent),
     Validation(ValidationContent),
     OutputSocket(OutputSocketContent),
+    ManagementPrototype(ManagementPrototypeContent),
 }
 
 macro_rules! impl_into_content_types {
@@ -108,6 +111,7 @@ impl_into_content_types!(SchemaVariant);
 impl_into_content_types!(Secret);
 impl_into_content_types!(StaticArgumentValue);
 impl_into_content_types!(Validation);
+impl_into_content_types!(ManagementPrototype);
 
 // Here we've broken the Foo, FooContent convention so we need to implement
 // these traits manually
@@ -604,4 +608,16 @@ pub struct ValidationContentV1 {
     pub timestamp: Timestamp,
     pub status: ValidationStatus,
     pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, EnumDiscriminants, Serialize, Deserialize, PartialEq)]
+pub enum ManagementPrototypeContent {
+    V1(ManagementPrototypeContentV1),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct ManagementPrototypeContentV1 {
+    pub name: String,
+    pub managed_schemas: Option<HashSet<SchemaId>>,
+    pub description: Option<String>,
 }

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -43,6 +43,7 @@ pub mod jwt_key;
 pub mod key_pair;
 pub mod label_list;
 pub mod layer_db_types;
+pub mod management;
 pub mod module;
 pub mod pkg;
 pub mod prop;

--- a/lib/dal/src/management/mod.rs
+++ b/lib/dal/src/management/mod.rs
@@ -1,0 +1,220 @@
+use std::collections::{HashMap, VecDeque};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use veritech_client::ManagementResultSuccess;
+
+use crate::{
+    attribute::value::AttributeValueError,
+    prop::{PropError, PropPath},
+    AttributeValue, Component, ComponentError, ComponentId, DalContext, Prop, PropKind,
+};
+
+pub mod prototype;
+
+#[derive(Debug, Error)]
+pub enum ManagementError {
+    #[error("attribute value error: {0}")]
+    AttributeValue(#[from] AttributeValueError),
+    #[error("component error: {0}")]
+    Component(#[from] ComponentError),
+    #[error("prop error: {0}")]
+    Prop(#[from] PropError),
+}
+
+pub type ManagementResult<T> = Result<T, ManagementError>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagementUpdateOperation {
+    properties: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagementOperations {
+    update: HashMap<String, ManagementUpdateOperation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagementFuncReturn {
+    pub operations: Option<ManagementOperations>,
+    pub message: Option<String>,
+    pub error: Option<String>,
+}
+
+impl TryFrom<ManagementResultSuccess> for ManagementFuncReturn {
+    type Error = serde_json::Error;
+
+    fn try_from(value: ManagementResultSuccess) -> Result<Self, Self::Error> {
+        Ok(ManagementFuncReturn {
+            operations: match value.operations {
+                Some(ops) => serde_json::from_value(ops)?,
+                None => None,
+            },
+            message: value.message,
+            error: value.error,
+        })
+    }
+}
+
+const SELF_ID: &str = "self";
+
+pub async fn operate(
+    ctx: &DalContext,
+    manager_component_id: ComponentId,
+    operations: ManagementOperations,
+) -> ManagementResult<()> {
+    // creation should be first
+
+    for (operation_component_id, operation) in operations.update {
+        // We only support operations on self right now
+        if operation_component_id != SELF_ID {
+            continue;
+        }
+
+        if let Some(properties) = operation.properties {
+            update_component(ctx, manager_component_id, properties).await?;
+        }
+    }
+
+    Ok(())
+}
+
+// Update operations should not be able to set these props or their children
+const IGNORE_PATHS: [&[&str]; 6] = [
+    &["root", "code"],
+    &["root", "deleted_at"],
+    &["root", "qualification"],
+    &["root", "resource"],
+    &["root", "resource_value"],
+    &["root", "secrets"],
+];
+
+async fn update_component(
+    ctx: &DalContext,
+    component_id: ComponentId,
+    properties: serde_json::Value,
+) -> ManagementResult<()> {
+    let variant_id = Component::schema_variant_id(ctx, component_id).await?;
+
+    // walk the properties serde_json::Value object without recursion
+    let mut work_queue = VecDeque::new();
+    work_queue.push_back((vec!["root".to_string()], properties));
+
+    while let Some((path, current_val)) = work_queue.pop_front() {
+        let path_as_refs: Vec<_> = path.iter().map(|part| part.as_str()).collect();
+        if IGNORE_PATHS.contains(&path_as_refs.as_slice()) {
+            continue;
+        }
+
+        let Some(prop_id) =
+            Prop::find_prop_id_by_path_opt(ctx, variant_id, &PropPath::new(path.as_slice()))
+                .await?
+        else {
+            continue;
+        };
+
+        let path_attribute_value_id =
+            Component::attribute_value_for_prop_id(ctx, component_id, prop_id).await?;
+
+        if AttributeValue::is_set_by_dependent_function(ctx, path_attribute_value_id).await? {
+            continue;
+        }
+        if let serde_json::Value::Null = current_val {
+            AttributeValue::update(ctx, path_attribute_value_id, Some(current_val)).await?;
+            continue;
+        }
+
+        let prop = Prop::get_by_id_or_error(ctx, prop_id).await?;
+
+        match prop.kind {
+            PropKind::String | PropKind::Boolean | PropKind::Integer | PropKind::Json => {
+                // todo: type check!
+                let view = AttributeValue::get_by_id_or_error(ctx, path_attribute_value_id)
+                    .await?
+                    .view(ctx)
+                    .await?;
+                if Some(&current_val) != view.as_ref() {
+                    AttributeValue::update(ctx, path_attribute_value_id, Some(current_val)).await?;
+                }
+            }
+            PropKind::Object => {
+                let serde_json::Value::Object(obj) = current_val else {
+                    continue;
+                };
+
+                for (key, value) in obj {
+                    let mut new_path = path.clone();
+                    new_path.push(key);
+                    work_queue.push_back((new_path, value));
+                }
+            }
+            PropKind::Map => {
+                let serde_json::Value::Object(map) = current_val else {
+                    continue;
+                };
+
+                let map_children =
+                    AttributeValue::map_children(ctx, path_attribute_value_id).await?;
+
+                // Remove any children that are not in the new map
+                for (key, child_id) in &map_children {
+                    if !map.contains_key(key) {
+                        if AttributeValue::is_set_by_dependent_function(ctx, *child_id).await? {
+                            continue;
+                        }
+
+                        AttributeValue::remove_by_id(ctx, *child_id).await?;
+                    }
+                }
+
+                // We do not descend below a map. Instead we update the *entire*
+                // child tree of each map key
+                for (key, value) in map {
+                    match map_children.get(&key) {
+                        Some(child_id) => {
+                            if AttributeValue::is_set_by_dependent_function(ctx, *child_id).await? {
+                                continue;
+                            }
+                            let view = AttributeValue::get_by_id_or_error(ctx, *child_id)
+                                .await?
+                                .view(ctx)
+                                .await?;
+                            if Some(&value) != view.as_ref() {
+                                AttributeValue::update(ctx, *child_id, Some(value)).await?;
+                            }
+                        }
+                        None => {
+                            AttributeValue::insert(
+                                ctx,
+                                path_attribute_value_id,
+                                Some(value),
+                                Some(key),
+                            )
+                            .await?;
+                        }
+                    }
+                }
+            }
+            PropKind::Array => {
+                if matches!(current_val, serde_json::Value::Array(_)) {
+                    let view = AttributeValue::get_by_id_or_error(ctx, path_attribute_value_id)
+                        .await?
+                        .view(ctx)
+                        .await?;
+
+                    if Some(&current_val) != view.as_ref() {
+                        // Just update the entire array whole cloth
+                        AttributeValue::update(ctx, path_attribute_value_id, Some(current_val))
+                            .await?;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/lib/dal/src/management/prototype.rs
+++ b/lib/dal/src/management/prototype.rs
@@ -1,0 +1,259 @@
+//! A [`ManagementPrototype`] points to a Management [`Func`] for a schema variant
+
+use std::{collections::HashSet, sync::Arc};
+
+use serde::{Deserialize, Serialize};
+use si_events::FuncRunId;
+use thiserror::Error;
+use veritech_client::{ComponentKind, ManagementResultSuccess};
+
+use crate::{
+    func::runner::{FuncRunner, FuncRunnerError},
+    id, implement_add_edge_to,
+    layer_db_types::{ManagementPrototypeContent, ManagementPrototypeContentV1},
+    workspace_snapshot::node_weight::{traits::SiVersionedNodeWeight, NodeWeight},
+    Component, ComponentError, ComponentId, DalContext, EdgeWeightKind,
+    EdgeWeightKindDiscriminants, FuncId, HelperError, NodeWeightDiscriminants, SchemaId,
+    SchemaVariantId, TransactionsError, WorkspaceSnapshotError,
+};
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ManagementPrototypeError {
+    #[error("component error: {0}")]
+    Component(#[from] ComponentError),
+    #[error("func runner error: {0}")]
+    FuncRunner(#[from] FuncRunnerError),
+    #[error("func runner recv error")]
+    FuncRunnerRecvError,
+    #[error("helper error: {0}")]
+    Helper(#[from] HelperError),
+    #[error("layer db error: {0}")]
+    LayerDbError(#[from] si_layer_cache::LayerDbError),
+    #[error("management prototype {0} has no use edge to a function")]
+    MissingFunction(ManagementPrototypeId),
+    #[error("serde json error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
+    #[error("workspace snapshot error: {0}")]
+    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+}
+
+pub type ManagementPrototypeResult<T> = Result<T, ManagementPrototypeError>;
+
+id!(ManagementPrototypeId);
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagementPrototype {
+    pub id: ManagementPrototypeId,
+    pub managed_schemas: Option<HashSet<SchemaId>>,
+    pub name: String,
+    pub description: Option<String>,
+}
+
+impl ManagementPrototype {
+    pub async fn new(
+        ctx: &DalContext,
+        name: String,
+        description: Option<String>,
+        func_id: FuncId,
+        managed_schemas: Option<HashSet<SchemaId>>,
+    ) -> ManagementPrototypeResult<Self> {
+        let content = ManagementPrototypeContentV1 {
+            name: name.clone(),
+            managed_schemas: managed_schemas
+                .clone()
+                .map(|schemas| schemas.into_iter().map(Into::into).collect()),
+            description: description.clone(),
+        };
+
+        let (hash, _) = ctx
+            .layer_db()
+            .cas()
+            .write(
+                Arc::new(ManagementPrototypeContent::V1(content).into()),
+                None,
+                ctx.events_tenancy(),
+                ctx.events_actor(),
+            )
+            .await?;
+
+        let workspace_snapshot = ctx.workspace_snapshot()?;
+        let id = workspace_snapshot.generate_ulid().await?;
+        let lineage_id = workspace_snapshot.generate_ulid().await?;
+
+        let node_weight = NodeWeight::new_management_prototype(id, lineage_id, hash);
+        workspace_snapshot.add_or_replace_node(node_weight).await?;
+
+        Self::add_edge_to_func(ctx, id.into(), func_id, EdgeWeightKind::new_use()).await?;
+
+        Ok(ManagementPrototype {
+            id: id.into(),
+            name,
+            managed_schemas,
+            description,
+        })
+    }
+
+    pub async fn get_by_id(
+        ctx: &DalContext,
+        id: ManagementPrototypeId,
+    ) -> ManagementPrototypeResult<Option<Self>> {
+        let workspace_snapshot = ctx.workspace_snapshot()?;
+
+        let Some(idx) = workspace_snapshot.get_node_index_by_id_opt(id).await else {
+            return Ok(None);
+        };
+
+        let NodeWeight::ManagementPrototype(inner) =
+            workspace_snapshot.get_node_weight(idx).await?
+        else {
+            return Ok(None);
+        };
+
+        let content_hash = inner.content_hash();
+        let content: ManagementPrototypeContent = ctx
+            .layer_db()
+            .cas()
+            .try_read_as(&content_hash)
+            .await?
+            .ok_or(WorkspaceSnapshotError::MissingContentFromStore(id.into()))?;
+
+        let ManagementPrototypeContent::V1(content_inner) = content;
+
+        Ok(Some(Self {
+            id,
+            managed_schemas: content_inner
+                .managed_schemas
+                .map(|schemas| schemas.into_iter().map(Into::into).collect()),
+            name: content_inner.name,
+            description: content_inner.description,
+        }))
+    }
+
+    pub async fn func_id(
+        ctx: &DalContext,
+        id: ManagementPrototypeId,
+    ) -> ManagementPrototypeResult<FuncId> {
+        let workspace_snapshot = ctx.workspace_snapshot()?;
+        for node_index in workspace_snapshot
+            .outgoing_targets_for_edge_weight_kind(id, EdgeWeightKindDiscriminants::Use)
+            .await?
+        {
+            let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
+            let node_weight_id = node_weight.id();
+            if NodeWeightDiscriminants::Func == node_weight.into() {
+                return Ok(node_weight_id.into());
+            }
+        }
+
+        Err(ManagementPrototypeError::MissingFunction(id))
+    }
+
+    pub async fn execute(
+        &self,
+        ctx: &DalContext,
+        manager_component_id: ComponentId,
+    ) -> ManagementPrototypeResult<(Option<ManagementResultSuccess>, FuncRunId)> {
+        Self::execute_by_id(ctx, self.id, manager_component_id).await
+    }
+
+    pub async fn execute_by_id(
+        ctx: &DalContext,
+        id: ManagementPrototypeId,
+        manager_component_id: ComponentId,
+    ) -> ManagementPrototypeResult<(Option<ManagementResultSuccess>, FuncRunId)> {
+        let management_func_id = ManagementPrototype::func_id(ctx, id).await?;
+        let manager_component = Component::get_by_id(ctx, manager_component_id).await?;
+        let manager_component_view = manager_component.view(ctx).await?;
+
+        let args = serde_json::json!({
+            "this_component": {
+                "kind": ComponentKind::Standard,
+                "properties": manager_component_view
+            }
+        });
+
+        let result_channel =
+            FuncRunner::run_management(ctx, manager_component_id, management_func_id, args).await?;
+
+        let run_value = result_channel
+            .await
+            .map_err(|_| ManagementPrototypeError::FuncRunnerRecvError)??;
+
+        let func_run_id = run_value.func_run_id();
+        let maybe_value: Option<si_events::CasValue> =
+            run_value.value().cloned().map(|value| value.into());
+
+        let maybe_value_address = match maybe_value {
+            Some(value) => Some(
+                ctx.layer_db()
+                    .cas()
+                    .write(
+                        Arc::new(value.into()),
+                        None,
+                        ctx.events_tenancy(),
+                        ctx.events_actor(),
+                    )
+                    .await?
+                    .0,
+            ),
+            None => None,
+        };
+
+        ctx.layer_db()
+            .func_run()
+            .set_values_and_set_state_to_success(
+                func_run_id,
+                None,
+                maybe_value_address,
+                ctx.events_tenancy(),
+                ctx.events_actor(),
+            )
+            .await?;
+
+        let maybe_run_result: Option<ManagementResultSuccess> = match run_value.value() {
+            Some(value) => Some(serde_json::from_value(value.clone())?),
+            None => None,
+        };
+
+        Ok((maybe_run_result, func_run_id))
+    }
+
+    pub async fn list_for_variant_id(
+        ctx: &DalContext,
+        schema_variant_id: SchemaVariantId,
+    ) -> ManagementPrototypeResult<Vec<Self>> {
+        let workspace_snapshot = ctx.workspace_snapshot()?;
+        let mut management_prototypes = Vec::new();
+        for node_index in workspace_snapshot
+            .outgoing_targets_for_edge_weight_kind(
+                schema_variant_id,
+                EdgeWeightKindDiscriminants::ManagementPrototype,
+            )
+            .await?
+        {
+            let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
+            let node_weight_id = node_weight.id();
+            if NodeWeightDiscriminants::ManagementPrototype == node_weight.into() {
+                if let Some(management_prototype) =
+                    Self::get_by_id(ctx, node_weight_id.into()).await?
+                {
+                    management_prototypes.push(management_prototype);
+                }
+            }
+        }
+
+        Ok(management_prototypes)
+    }
+
+    implement_add_edge_to!(
+        source_id: ManagementPrototypeId,
+        destination_id: FuncId,
+        add_fn: add_edge_to_func,
+        discriminant: EdgeWeightKindDiscriminants::Use,
+        result: ManagementPrototypeResult,
+    );
+}

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -11,6 +11,7 @@ use crate::attribute::prototype::argument::{
 use crate::attribute::prototype::AttributePrototypeError;
 use crate::attribute::value::AttributeValueError;
 use crate::func::argument::FuncArgumentId;
+use crate::management::prototype::ManagementPrototypeError;
 use crate::schema::variant::SchemaVariantError;
 use crate::{
     action::prototype::ActionPrototypeError,
@@ -67,6 +68,8 @@ pub enum PkgError {
     HistoryEvent(#[from] HistoryEventError),
     #[error("input socket error: {0}")]
     InputSocket(#[from] InputSocketError),
+    #[error("management prototype error: {0}")]
+    ManagementPrototype(#[from] ManagementPrototypeError),
     #[error("Missing Func {1} for AttributePrototype {0}")]
     MissingAttributePrototypeFunc(AttributePrototypeId, FuncId),
     #[error("Func {0} missing from exported funcs")]

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -29,6 +29,7 @@ use crate::layer_db_types::{
     ContentTypeError, InputSocketContent, OutputSocketContent, SchemaVariantContent,
     SchemaVariantContentV3,
 };
+use crate::management::prototype::ManagementPrototypeId;
 use crate::module::Module;
 use crate::prop::{PropError, PropPath};
 use crate::schema::variant::root_prop::RootProp;
@@ -1252,6 +1253,13 @@ impl SchemaVariant {
         discriminant: EdgeWeightKindDiscriminants::ActionPrototype,
         result: SchemaVariantResult,
     );
+    implement_add_edge_to!(
+        source_id: SchemaVariantId,
+        destination_id: ManagementPrototypeId,
+        add_fn: add_edge_to_management_prototype,
+        discriminant: EdgeWeightKindDiscriminants::ManagementPrototype,
+        result: SchemaVariantResult,
+    );
 
     pub async fn find_action_prototypes_by_kind(
         ctx: &DalContext,
@@ -2170,6 +2178,12 @@ impl SchemaVariant {
                 }
 
                 EdgeWeightKindDiscriminants::AuthenticationPrototype => {
+                    workspace_snapshot
+                        .remove_edge(source_index, target_index, kind)
+                        .await?;
+                }
+
+                EdgeWeightKindDiscriminants::ManagementPrototype => {
                     workspace_snapshot
                         .remove_edge(source_index, target_index, kind)
                         .await?;

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -270,6 +270,10 @@ impl RootProp {
         )
         .await?;
 
+        // The `resourceId` is a prop that uniquely identifies the resource,
+        // useful for importing an existing resource from reality into the model
+        Prop::new_without_ui_optionals(ctx, "resourceId", PropKind::String, si_prop.id()).await?;
+
         Ok(si_prop.id())
     }
 

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -1621,7 +1621,8 @@ impl WorkspaceSnapshot {
                 | ContentAddressDiscriminants::Schema
                 | ContentAddressDiscriminants::SchemaVariant
                 | ContentAddressDiscriminants::Secret
-                | ContentAddressDiscriminants::ValidationPrototype => None,
+                | ContentAddressDiscriminants::ValidationPrototype
+                | ContentAddressDiscriminants::ManagementPrototype => None,
             },
 
             NodeWeight::Action(_)
@@ -1635,6 +1636,7 @@ impl WorkspaceSnapshot {
             | NodeWeight::InputSocket(_)
             | NodeWeight::Prop(_)
             | NodeWeight::SchemaVariant(_)
+            | NodeWeight::ManagementPrototype(_)
             | NodeWeight::Secret(_) => None,
         } {
             let next_node_idxs = self

--- a/lib/dal/src/workspace_snapshot/content_address.rs
+++ b/lib/dal/src/workspace_snapshot/content_address.rs
@@ -33,8 +33,9 @@ pub enum ContentAddress {
     StaticArgumentValue(ContentHash),
     ValidationOutput(ContentHash),
     // With validations moving to the props and not having prototypes anymore, this is unused
-    // TODO(victor): remove this as soon as it does not break graph (de)serialization
+    // TODO(victor): remove this when we migrate the graph next
     ValidationPrototype(ContentHash),
+    ManagementPrototype(ContentHash),
 }
 
 impl ContentAddress {
@@ -59,7 +60,8 @@ impl ContentAddress {
             | ContentAddress::Secret(id)
             | ContentAddress::StaticArgumentValue(id)
             | ContentAddress::ValidationPrototype(id)
-            | ContentAddress::ValidationOutput(id) => Some(*id),
+            | ContentAddress::ValidationOutput(id)
+            | ContentAddress::ManagementPrototype(id) => Some(*id),
         }
         .unwrap_or_default()
     }

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -6,6 +6,7 @@ use strum::EnumDiscriminants;
 
 pub mod deprecated;
 
+/// This type is postcard serialized and new enum variants *MUST* be added to the end *ONLY*.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, EnumDiscriminants)]
 #[strum_discriminants(derive(Hash, Serialize, Deserialize))]
 pub enum EdgeWeightKind {
@@ -60,6 +61,8 @@ pub enum EdgeWeightKind {
     },
     /// Edge from attribute value to validation result node
     ValidationOutput,
+    /// Edge from [`SchemaVariant`](crate::SchemaVariant) to [`ManagementPrototype`](crate::ManagementPrototype).
+    ManagementPrototype,
 }
 
 impl EdgeWeightKind {

--- a/lib/dal/src/workspace_snapshot/graph/v3.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v3.rs
@@ -747,6 +747,7 @@ impl WorkspaceSnapshotGraphV3 {
                     EdgeWeightKindDiscriminants::Root => "black",
                     EdgeWeightKindDiscriminants::Use => "black",
                     EdgeWeightKindDiscriminants::ValidationOutput => "darkcyan",
+                    EdgeWeightKindDiscriminants::ManagementPrototype => "pink",
                 };
 
                 match edgeref.weight().kind() {
@@ -791,6 +792,7 @@ impl WorkspaceSnapshotGraphV3 {
                             ContentAddressDiscriminants::StaticArgumentValue => "green",
                             ContentAddressDiscriminants::ValidationPrototype => "black",
                             ContentAddressDiscriminants::ValidationOutput => "darkcyan",
+                            ContentAddressDiscriminants::ManagementPrototype => "black",
                         };
                         (discrim.to_string(), color)
                     }
@@ -859,6 +861,9 @@ impl WorkspaceSnapshotGraphV3 {
                         format!("FinishedDependentValue\n{}", node_weight.value_id()),
                         "red",
                     ),
+                    NodeWeight::ManagementPrototype(_) => {
+                        ("ManagementPrototype".to_string(), "black")
+                    }
                 };
                 let color = color.to_string();
                 let id = node_weight.id();
@@ -1393,7 +1398,8 @@ impl WorkspaceSnapshotGraphV3 {
                     | EdgeWeightKind::Proxy
                     | EdgeWeightKind::Root
                     | EdgeWeightKind::SocketValue
-                    | EdgeWeightKind::ValidationOutput => {}
+                    | EdgeWeightKind::ValidationOutput
+                    | EdgeWeightKind::ManagementPrototype => {}
                 }
             }
         }

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -35,6 +35,7 @@ pub use dependent_value_root_node_weight::DependentValueRootNodeWeight;
 pub use func_argument_node_weight::FuncArgumentNodeWeight;
 pub use func_node_weight::FuncNodeWeight;
 pub use input_socket_node_weight::InputSocketNodeWeight;
+pub use management_prototype_node_weight::ManagementPrototypeNodeWeight;
 pub use ordering_node_weight::OrderingNodeWeight;
 pub use prop_node_weight::PropNodeWeight;
 pub use schema_variant_node_weight::SchemaVariantNodeWeight;
@@ -58,6 +59,7 @@ pub mod finished_dependent_value_root_node_weight;
 pub mod func_argument_node_weight;
 pub mod func_node_weight;
 pub mod input_socket_node_weight;
+pub mod management_prototype_node_weight;
 pub mod ordering_node_weight;
 pub mod prop_node_weight;
 pub mod schema_variant_node_weight;
@@ -127,6 +129,7 @@ pub enum NodeWeight {
     FinishedDependentValueRoot(FinishedDependentValueRootNodeWeight),
     InputSocket(InputSocketNodeWeight),
     SchemaVariant(SchemaVariantNodeWeight),
+    ManagementPrototype(ManagementPrototypeNodeWeight),
 }
 
 impl NodeWeight {
@@ -148,6 +151,7 @@ impl NodeWeight {
             NodeWeight::FinishedDependentValueRoot(weight) => weight.content_hash(),
             NodeWeight::InputSocket(weight) => weight.content_hash(),
             NodeWeight::SchemaVariant(weight) => weight.content_hash(),
+            NodeWeight::ManagementPrototype(weight) => weight.content_hash(),
         }
     }
 
@@ -169,6 +173,7 @@ impl NodeWeight {
             NodeWeight::FinishedDependentValueRoot(weight) => weight.content_store_hashes(),
             NodeWeight::InputSocket(weight) => weight.content_store_hashes(),
             NodeWeight::SchemaVariant(weight) => weight.content_store_hashes(),
+            NodeWeight::ManagementPrototype(weight) => weight.content_store_hashes(),
         }
     }
 
@@ -189,6 +194,7 @@ impl NodeWeight {
             | NodeWeight::DependentValueRoot(_)
             | NodeWeight::FinishedDependentValueRoot(_)
             | NodeWeight::InputSocket(_)
+            | NodeWeight::ManagementPrototype(_)
             | NodeWeight::SchemaVariant(_) => None,
         }
     }
@@ -211,6 +217,7 @@ impl NodeWeight {
             NodeWeight::FinishedDependentValueRoot(weight) => weight.id(),
             NodeWeight::InputSocket(weight) => weight.id(),
             NodeWeight::SchemaVariant(weight) => weight.id(),
+            NodeWeight::ManagementPrototype(weight) => weight.id(),
         }
     }
 
@@ -232,6 +239,7 @@ impl NodeWeight {
             NodeWeight::FinishedDependentValueRoot(weight) => weight.lineage_id(),
             NodeWeight::InputSocket(weight) => weight.lineage_id(),
             NodeWeight::SchemaVariant(weight) => weight.lineage_id(),
+            NodeWeight::ManagementPrototype(weight) => weight.lineage_id(),
         }
     }
 
@@ -301,6 +309,10 @@ impl NodeWeight {
                 weight.set_id(id.into());
                 weight.set_lineage_id(lineage_id);
             }
+            NodeWeight::ManagementPrototype(weight) => {
+                weight.set_id(id.into());
+                weight.set_lineage_id(lineage_id);
+            }
         }
     }
 
@@ -322,6 +334,7 @@ impl NodeWeight {
             NodeWeight::FinishedDependentValueRoot(weight) => weight.merkle_tree_hash(),
             NodeWeight::InputSocket(weight) => weight.merkle_tree_hash(),
             NodeWeight::SchemaVariant(weight) => weight.merkle_tree_hash(),
+            NodeWeight::ManagementPrototype(weight) => weight.merkle_tree_hash(),
         }
     }
 
@@ -333,14 +346,18 @@ impl NodeWeight {
             NodeWeight::FuncArgument(weight) => weight.new_content_hash(content_hash),
             NodeWeight::Prop(weight) => weight.new_content_hash(content_hash),
             NodeWeight::Secret(weight) => weight.new_content_hash(content_hash),
-            NodeWeight::InputSocket(weight) => traits::SiVersionedNodeWeight::inner_mut(weight)
-                .new_content_hash(content_hash)
-                .map_err(Box::new)
-                .map_err(Into::into),
-            NodeWeight::SchemaVariant(weight) => traits::SiVersionedNodeWeight::inner_mut(weight)
-                .new_content_hash(content_hash)
-                .map_err(Box::new)
-                .map_err(Into::into),
+            NodeWeight::InputSocket(weight) => {
+                traits::SiVersionedNodeWeight::inner_mut(weight).new_content_hash(content_hash);
+                Ok(())
+            }
+            NodeWeight::SchemaVariant(weight) => {
+                traits::SiVersionedNodeWeight::inner_mut(weight).new_content_hash(content_hash);
+                Ok(())
+            }
+            NodeWeight::ManagementPrototype(weight) => {
+                traits::SiVersionedNodeWeight::inner_mut(weight).new_content_hash(content_hash);
+                Ok(())
+            }
             NodeWeight::Action(_)
             | NodeWeight::ActionPrototype(_)
             | NodeWeight::AttributePrototypeArgument(_)
@@ -373,6 +390,7 @@ impl NodeWeight {
             NodeWeight::FinishedDependentValueRoot(weight) => weight.node_hash(),
             NodeWeight::InputSocket(weight) => weight.node_hash(),
             NodeWeight::SchemaVariant(weight) => weight.node_hash(),
+            NodeWeight::ManagementPrototype(weight) => weight.node_hash(),
         }
     }
 
@@ -394,6 +412,7 @@ impl NodeWeight {
             NodeWeight::FinishedDependentValueRoot(weight) => weight.set_merkle_tree_hash(new_hash),
             NodeWeight::InputSocket(weight) => weight.set_merkle_tree_hash(new_hash),
             NodeWeight::SchemaVariant(weight) => weight.set_merkle_tree_hash(new_hash),
+            NodeWeight::ManagementPrototype(weight) => weight.set_merkle_tree_hash(new_hash),
         }
     }
 
@@ -417,6 +436,7 @@ impl NodeWeight {
             | NodeWeight::Prop(_)
             | NodeWeight::Secret(_)
             | NodeWeight::InputSocket(_)
+            | NodeWeight::ManagementPrototype(_)
             | NodeWeight::SchemaVariant(_) => Err(NodeWeightError::CannotSetOrderOnKind),
         }
     }
@@ -449,6 +469,7 @@ impl NodeWeight {
             NodeWeight::FinishedDependentValueRoot(weight) => weight.exclusive_outgoing_edges(),
             NodeWeight::InputSocket(weight) => weight.exclusive_outgoing_edges(),
             NodeWeight::SchemaVariant(weight) => weight.exclusive_outgoing_edges(),
+            NodeWeight::ManagementPrototype(weight) => weight.exclusive_outgoing_edges(),
         }
     }
 
@@ -646,6 +667,14 @@ impl NodeWeight {
 
     pub fn new_content(id: Ulid, lineage_id: Ulid, kind: ContentAddress) -> Self {
         NodeWeight::Content(ContentNodeWeight::new(id, lineage_id, kind))
+    }
+
+    pub fn new_management_prototype(id: Ulid, lineage_id: Ulid, content_hash: ContentHash) -> Self {
+        NodeWeight::ManagementPrototype(ManagementPrototypeNodeWeight::new(
+            id,
+            lineage_id,
+            content_hash,
+        ))
     }
 
     pub fn new_action(
@@ -921,6 +950,11 @@ impl CorrectTransforms for NodeWeight {
                 updates,
                 from_different_change_set,
             ),
+            NodeWeight::ManagementPrototype(weight) => weight.correct_transforms(
+                workspace_snapshot_graph,
+                updates,
+                from_different_change_set,
+            ),
         }?;
 
         Ok(self.correct_exclusive_outgoing_edges(workspace_snapshot_graph, updates))
@@ -946,6 +980,7 @@ impl CorrectExclusiveOutgoingEdge for NodeWeight {
             NodeWeight::Secret(weight) => weight.exclusive_outgoing_edges(),
             NodeWeight::InputSocket(weight) => weight.exclusive_outgoing_edges(),
             NodeWeight::SchemaVariant(weight) => weight.exclusive_outgoing_edges(),
+            NodeWeight::ManagementPrototype(weight) => weight.exclusive_outgoing_edges(),
         }
     }
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
@@ -138,6 +138,9 @@ impl ContentNodeWeight {
                 ContentAddress::ValidationPrototype(content_hash)
             }
             ContentAddress::ValidationOutput(_) => ContentAddress::ValidationOutput(content_hash),
+            ContentAddress::ManagementPrototype(_) => {
+                ContentAddress::ManagementPrototype(content_hash)
+            }
         };
 
         self.content_address = new_address;

--- a/lib/dal/src/workspace_snapshot/node_weight/input_socket_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/input_socket_node_weight/v1.rs
@@ -48,13 +48,8 @@ impl InputSocketNodeWeightV1 {
         }
     }
 
-    pub fn new_content_hash(
-        &mut self,
-        new_content_hash: ContentHash,
-    ) -> InputSocketNodeWeightResult<()> {
+    pub fn new_content_hash(&mut self, new_content_hash: ContentHash) {
         self.content_address = ContentAddress::InputSocket(new_content_hash);
-
-        Ok(())
     }
 
     pub(crate) async fn try_upgrade_from_content_node_weight(

--- a/lib/dal/src/workspace_snapshot/node_weight/management_prototype_node_weight/mod.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/management_prototype_node_weight/mod.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+use si_events::{ulid::Ulid, ContentHash};
+use si_layer_cache::LayerDbError;
+use thiserror::Error;
+
+use super::{traits::SiVersionedNodeWeight, NodeWeightError};
+use crate::{workspace_snapshot::graph::WorkspaceSnapshotGraphError, WorkspaceSnapshotError};
+
+pub mod v1;
+
+pub use v1::ManagementPrototypeNodeWeightV1;
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum ManagementPrototypeNodeWeightError {
+    #[error("Invalid content for node weight: {0}")]
+    InvalidContentForNodeWeight(Ulid),
+    #[error("LayerDb error: {0}")]
+    LayerDb(#[from] LayerDbError),
+    #[error("NodeWeight error: {0}")]
+    NodeWeight(#[from] Box<NodeWeightError>),
+    #[error("WorkspaceSnapshot error: {0}")]
+    WorkspaceSnapshot(#[from] Box<WorkspaceSnapshotError>),
+    #[error("WorkspaceSnapshotGraph error: {0}")]
+    WorkspaceSnapshotGraph(#[from] Box<WorkspaceSnapshotGraphError>),
+}
+
+pub type ManagementPrototypeNodeWeightResult<T> = Result<T, ManagementPrototypeNodeWeightError>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ManagementPrototypeNodeWeight {
+    V1(ManagementPrototypeNodeWeightV1),
+}
+
+impl ManagementPrototypeNodeWeight {
+    pub fn new(id: Ulid, lineage_id: Ulid, content_hash: ContentHash) -> Self {
+        Self::V1(ManagementPrototypeNodeWeightV1::new(
+            id,
+            lineage_id,
+            content_hash,
+        ))
+    }
+}
+
+impl SiVersionedNodeWeight for ManagementPrototypeNodeWeight {
+    type Inner = ManagementPrototypeNodeWeightV1;
+
+    /// Return a reference to the most up to date enum variant
+    fn inner(&self) -> &ManagementPrototypeNodeWeightV1 {
+        match self {
+            ManagementPrototypeNodeWeight::V1(inner) => inner,
+        }
+    }
+
+    /// Return a mutable reference to the most up to date enum variant
+    fn inner_mut(&mut self) -> &mut ManagementPrototypeNodeWeightV1 {
+        match self {
+            ManagementPrototypeNodeWeight::V1(inner) => inner,
+        }
+    }
+}

--- a/lib/dal/src/workspace_snapshot/node_weight/management_prototype_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/management_prototype_node_weight/v1.rs
@@ -1,0 +1,83 @@
+use crate::{
+    workspace_snapshot::{
+        content_address::ContentAddress,
+        graph::LineageId,
+        node_weight::traits::{CorrectExclusiveOutgoingEdge, CorrectTransforms, SiNodeWeight},
+    },
+    NodeWeightDiscriminants, Timestamp,
+};
+use serde::{Deserialize, Serialize};
+use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ManagementPrototypeNodeWeightV1 {
+    pub id: Ulid,
+    pub lineage_id: LineageId,
+    merkle_tree_hash: MerkleTreeHash,
+    content_address: ContentAddress,
+    timestamp: Timestamp,
+}
+
+impl ManagementPrototypeNodeWeightV1 {
+    pub fn new(id: Ulid, lineage_id: Ulid, content_hash: ContentHash) -> Self {
+        Self {
+            id,
+            lineage_id,
+            merkle_tree_hash: MerkleTreeHash::default(),
+            content_address: ContentAddress::ManagementPrototype(content_hash),
+            timestamp: Timestamp::now(),
+        }
+    }
+
+    pub fn new_content_hash(&mut self, new_content_hash: ContentHash) {
+        self.content_address = ContentAddress::ManagementPrototype(new_content_hash);
+    }
+}
+
+impl SiNodeWeight for ManagementPrototypeNodeWeightV1 {
+    fn content_hash(&self) -> ContentHash {
+        self.content_address.content_hash()
+    }
+
+    fn id(&self) -> Ulid {
+        self.id
+    }
+
+    fn lineage_id(&self) -> Ulid {
+        self.lineage_id
+    }
+
+    fn merkle_tree_hash(&self) -> MerkleTreeHash {
+        self.merkle_tree_hash
+    }
+
+    fn node_hash(&self) -> ContentHash {
+        let mut content_hasher = ContentHash::hasher();
+        content_hasher.update(self.content_address.content_hash().as_bytes());
+
+        content_hasher.finalize()
+    }
+
+    fn node_weight_discriminant(&self) -> NodeWeightDiscriminants {
+        NodeWeightDiscriminants::ManagementPrototype
+    }
+
+    fn set_id(&mut self, new_id: Ulid) {
+        self.id = new_id;
+    }
+
+    fn set_lineage_id(&mut self, new_lineage_id: Ulid) {
+        self.lineage_id = new_lineage_id;
+    }
+
+    fn set_merkle_tree_hash(&mut self, new_hash: MerkleTreeHash) {
+        self.merkle_tree_hash = new_hash
+    }
+}
+
+impl CorrectTransforms for ManagementPrototypeNodeWeightV1 {}
+impl CorrectExclusiveOutgoingEdge for ManagementPrototypeNodeWeightV1 {
+    fn exclusive_outgoing_edges(&self) -> &[crate::EdgeWeightKindDiscriminants] {
+        &[]
+    }
+}

--- a/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
@@ -56,13 +56,8 @@ impl SchemaVariantNodeWeightV1 {
         self.is_locked = new_locked;
     }
 
-    pub fn new_content_hash(
-        &mut self,
-        new_content_hash: ContentHash,
-    ) -> SchemaVariantNodeWeightResult<()> {
+    pub fn new_content_hash(&mut self, new_content_hash: ContentHash) {
         self.content_address = ContentAddress::SchemaVariant(new_content_hash);
-
-        Ok(())
     }
 
     pub(crate) async fn try_upgrade_from_content_node_weight(

--- a/lib/dal/tests/integration_test/func/authoring/binding.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding.rs
@@ -495,6 +495,7 @@ async fn for_intrinsics(ctx: &mut DalContext) {
         PropPath::new(["root", "si", "protected"]),
         PropPath::new(["root", "si"]),
         PropPath::new(["root", "si", "protected"]),
+        PropPath::new(["root", "si", "resourceId"]),
         PropPath::new(["root", "secrets"]),
         PropPath::new(["root", "resource"]),
         PropPath::new(["root", "resource", "message"]),

--- a/lib/dal/tests/integration_test/func/kill_execution.rs
+++ b/lib/dal/tests/integration_test/func/kill_execution.rs
@@ -37,7 +37,7 @@ async fn kill_execution_works(ctx: &mut DalContext) {
     .await
     .expect("could new leaf func");
     let code = "async function main() {
-        const ms = 240 * 1000;
+        const ms = 480 * 1000;
         const sleep = new Promise((resolve) => setTimeout(resolve, ms));
         await sleep;
         return { payload: { \"poop\": true }, status: \"ok\" };

--- a/lib/dal/tests/integration_test/management.rs
+++ b/lib/dal/tests/integration_test/management.rs
@@ -1,0 +1,70 @@
+use dal::{
+    management::{operate, prototype::ManagementPrototype, ManagementFuncReturn},
+    AttributeValue, Component, DalContext,
+};
+use dal_test::{helpers::create_component_for_default_schema_name, test};
+
+#[test]
+async fn execute_management_func(ctx: &DalContext) {
+    let small_odd_lego =
+        create_component_for_default_schema_name(ctx, "small odd lego", "small odd lego")
+            .await
+            .expect("could not create component");
+    let variant = small_odd_lego
+        .schema_variant(ctx)
+        .await
+        .expect("get variant");
+
+    let av_id = Component::attribute_value_for_prop_by_id(
+        ctx,
+        small_odd_lego.id(),
+        &["root", "si", "resourceId"],
+    )
+    .await
+    .expect("av should exist");
+
+    AttributeValue::update(ctx, av_id, Some(serde_json::json!("import id")))
+        .await
+        .expect("able to update value");
+
+    let management_prototype = ManagementPrototype::list_for_variant_id(ctx, variant.id())
+        .await
+        .expect("get prototypes")
+        .into_iter()
+        .find(|proto| proto.name == "Import small odd lego")
+        .expect("could not find prototype");
+
+    let (result_value, _) = management_prototype
+        .execute(ctx, small_odd_lego.id())
+        .await
+        .expect("should execute management prototype func");
+
+    let result: ManagementFuncReturn = result_value
+        .expect("should have a result success")
+        .try_into()
+        .expect("should be a valid management func return");
+
+    operate(
+        ctx,
+        small_odd_lego.id(),
+        result.operations.expect("should have operations"),
+    )
+    .await
+    .expect("should operate");
+
+    let av_id = Component::attribute_value_for_prop_by_id(
+        ctx,
+        small_odd_lego.id(),
+        &["root", "domain", "two"],
+    )
+    .await
+    .expect("get four");
+
+    let two_av = AttributeValue::get_by_id_or_error(ctx, av_id)
+        .await
+        .expect("a fleetwood to my mac");
+
+    let two_value = two_av.value(ctx).await.expect("get value");
+
+    assert_eq!(Some(serde_json::json!("step")), two_value);
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -10,6 +10,7 @@ mod diagram;
 mod frame;
 mod func;
 mod input_sources;
+mod management;
 mod module;
 mod node_weight;
 mod pkg;

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -173,6 +173,7 @@ async fn all_prop_ids(ctx: &DalContext) {
         "root/si/color",
         "root/si/name",
         "root/si/protected",
+        "root/si/resourceId",
         "root/si/type",
     ];
     assert_eq!(

--- a/lib/si-pkg/pkg-complex.json
+++ b/lib/si-pkg/pkg-complex.json
@@ -72,6 +72,14 @@
           "sockets": [],
           "actionFuncs": [],
           "authFuncs": [],
+          "managementFuncs": [
+            {
+              "funcUniqueId": "dadf3f20e1abe3fa9346adac47e0e147733959bee8e24719147c61ce9b5828bf",
+              "name": "test management func",
+              "description": "test management func description",
+              "managedSchemas": ["01J9VGAA9V2YVXQM2MTSBNHAVE"]
+            }
+          ],
           "componentType": "component",
           "funcUniqueId": "dadf3f20e1abe3fa9346adac47e0e147733959bee8e24719147c61ce9b5828bf",
           "funcDescriptions": [],

--- a/lib/si-pkg/src/lib.rs
+++ b/lib/si-pkg/src/lib.rs
@@ -142,6 +142,10 @@ mod tests {
             }
         }
 
+        let management_funcs = variant.management_funcs().expect("get management funcs");
+        assert_eq!(1, management_funcs.len());
+        dbg!(management_funcs);
+
         // Ensure we get the props
         let props: Mutex<Vec<String>> = Mutex::new(Vec::new());
         variant

--- a/lib/si-pkg/src/node/management_func.rs
+++ b/lib/si-pkg/src/node/management_func.rs
@@ -1,0 +1,87 @@
+use std::{
+    collections::HashSet,
+    io::{BufRead, Write},
+};
+
+use object_tree::{
+    read_key_value_line, read_key_value_line_opt, write_key_value_line, write_key_value_line_opt,
+    GraphError, NodeChild, NodeKind, NodeWithChildren, ReadBytes, WriteBytes,
+};
+use ulid::Ulid;
+
+use crate::ManagementFuncSpec;
+
+use super::PkgNode;
+
+const KEY_FUNC_UNIQUE_ID_STR: &str = "func_unique_id";
+const KEY_NAME_STR: &str = "name";
+const KEY_DESCRIPTION_STR: &str = "description";
+const KEY_MANAGED_SCHEMAS_STR: &str = "managed_schemas";
+
+#[derive(Clone, Debug)]
+pub struct ManagementFuncNode {
+    pub func_unique_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub managed_schemas: Option<HashSet<Ulid>>,
+}
+
+impl WriteBytes for ManagementFuncNode {
+    fn write_bytes<W: Write>(&self, writer: &mut W) -> Result<(), GraphError> {
+        write_key_value_line(
+            writer,
+            KEY_FUNC_UNIQUE_ID_STR,
+            self.func_unique_id.to_string(),
+        )?;
+
+        write_key_value_line(writer, KEY_NAME_STR, &self.name)?;
+        write_key_value_line_opt(writer, KEY_DESCRIPTION_STR, self.description.as_deref())?;
+        let managed_schemas_str = match self.managed_schemas.as_ref() {
+            None => None,
+            Some(managed_schemas) => Some(serde_json::to_string(managed_schemas)?),
+        };
+        write_key_value_line_opt(writer, KEY_MANAGED_SCHEMAS_STR, managed_schemas_str)?;
+
+        Ok(())
+    }
+}
+
+impl ReadBytes for ManagementFuncNode {
+    fn read_bytes<R: BufRead>(reader: &mut R) -> Result<Option<Self>, GraphError>
+    where
+        Self: std::marker::Sized,
+    {
+        let func_unique_id = read_key_value_line(reader, KEY_FUNC_UNIQUE_ID_STR)?;
+        let name = read_key_value_line(reader, KEY_NAME_STR)?;
+        let description = read_key_value_line_opt(reader, KEY_DESCRIPTION_STR)?;
+        let managed_schemas_str = read_key_value_line_opt(reader, KEY_MANAGED_SCHEMAS_STR)?;
+        let managed_schemas = match managed_schemas_str {
+            None => None,
+            Some(managed_schemas_str) => Some(serde_json::from_str(&managed_schemas_str)?),
+        };
+
+        Ok(Some(Self {
+            func_unique_id,
+            name,
+            description,
+            managed_schemas,
+        }))
+    }
+}
+
+impl NodeChild for ManagementFuncSpec {
+    type NodeType = PkgNode;
+
+    fn as_node_with_children(&self) -> NodeWithChildren<Self::NodeType> {
+        NodeWithChildren::new(
+            NodeKind::Tree,
+            Self::NodeType::ManagementFunc(ManagementFuncNode {
+                name: self.name.to_owned(),
+                func_unique_id: self.func_unique_id.to_owned(),
+                description: self.description.to_owned(),
+                managed_schemas: self.managed_schemas.to_owned(),
+            }),
+            vec![],
+        )
+    }
+}

--- a/lib/si-pkg/src/node/mod.rs
+++ b/lib/si-pkg/src/node/mod.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use crate::node::auth_func::AuthFuncNode;
+use management_func::ManagementFuncNode;
 use object_tree::{
     read_key_value_line, read_key_value_line_opt, write_key_value_line, GraphError, NameStr,
     ReadBytes, WriteBytes,
@@ -23,6 +24,7 @@ mod edge;
 mod func;
 mod func_argument;
 mod leaf_function;
+mod management_func;
 mod map_key_func;
 mod package;
 mod position;
@@ -76,6 +78,7 @@ const NODE_KIND_EDGE: &str = "edge";
 const NODE_KIND_FUNC: &str = "func";
 const NODE_KIND_FUNC_ARGUMENT: &str = "func_argument";
 const NODE_KIND_LEAF_FUNCTION: &str = "leaf_function";
+const NODE_KIND_MANAGEMENT_FUNC: &str = "management_func";
 const NODE_KIND_MAP_KEY_FUNC: &str = "map_key_func";
 const NODE_KIND_PACKAGE: &str = "package";
 const NODE_KIND_POSITION: &str = "position";
@@ -148,6 +151,7 @@ pub enum PkgNode {
     Func(FuncNode),
     FuncArgument(FuncArgumentNode),
     LeafFunction(LeafFunctionNode),
+    ManagementFunc(ManagementFuncNode),
     MapKeyFunc(MapKeyFuncNode),
     Package(PackageNode),
     Position(PositionNode),
@@ -176,6 +180,7 @@ impl PkgNode {
     pub const FUNC_KIND_STR: &'static str = NODE_KIND_FUNC;
     pub const FUNC_ARGUMENT_KIND_STR: &'static str = NODE_KIND_FUNC_ARGUMENT;
     pub const LEAF_FUNCTION_KIND_STR: &'static str = NODE_KIND_LEAF_FUNCTION;
+    pub const MANAGEMENT_FUNC_KIND_STR: &'static str = NODE_KIND_MANAGEMENT_FUNC;
     pub const MAP_KEY_FUNC_KIND_STR: &'static str = NODE_KIND_MAP_KEY_FUNC;
     pub const PACKAGE_KIND_STR: &'static str = NODE_KIND_PACKAGE;
     pub const POSTITION_KIND_STR: &'static str = NODE_KIND_POSITION;
@@ -203,6 +208,7 @@ impl PkgNode {
             Self::Func(_) => NODE_KIND_FUNC,
             Self::FuncArgument(_) => NODE_KIND_FUNC_ARGUMENT,
             Self::LeafFunction(_) => NODE_KIND_LEAF_FUNCTION,
+            Self::ManagementFunc(_) => NODE_KIND_MANAGEMENT_FUNC,
             Self::MapKeyFunc(_) => NODE_KIND_MAP_KEY_FUNC,
             Self::Package(_) => NODE_KIND_PACKAGE,
             Self::Position(_) => NODE_KIND_POSITION,
@@ -235,6 +241,7 @@ impl NameStr for PkgNode {
             Self::Func(node) => node.name(),
             Self::FuncArgument(node) => node.name(),
             Self::LeafFunction(_) => NODE_KIND_LEAF_FUNCTION,
+            Self::ManagementFunc(_) => NODE_KIND_MANAGEMENT_FUNC,
             Self::MapKeyFunc(_) => NODE_KIND_MAP_KEY_FUNC,
             Self::Package(node) => node.name(),
             Self::Position(_) => NODE_KIND_POSITION,
@@ -270,6 +277,7 @@ impl WriteBytes for PkgNode {
             Self::Func(node) => node.write_bytes(writer)?,
             Self::FuncArgument(node) => node.write_bytes(writer)?,
             Self::LeafFunction(node) => node.write_bytes(writer)?,
+            Self::ManagementFunc(node) => node.write_bytes(writer)?,
             Self::MapKeyFunc(node) => node.write_bytes(writer)?,
             Self::Package(node) => node.write_bytes(writer)?,
             Self::Position(node) => node.write_bytes(writer)?,
@@ -322,6 +330,9 @@ impl ReadBytes for PkgNode {
             }
             NODE_KIND_LEAF_FUNCTION => {
                 LeafFunctionNode::read_bytes(reader)?.map(Self::LeafFunction)
+            }
+            NODE_KIND_MANAGEMENT_FUNC => {
+                ManagementFuncNode::read_bytes(reader)?.map(Self::ManagementFunc)
             }
             NODE_KIND_MAP_KEY_FUNC => MapKeyFuncNode::read_bytes(reader)?.map(Self::MapKeyFunc),
             NODE_KIND_PACKAGE => PackageNode::read_bytes(reader)?.map(Self::Package),

--- a/lib/si-pkg/src/node/schema_variant.rs
+++ b/lib/si-pkg/src/node/schema_variant.rs
@@ -154,6 +154,9 @@ impl NodeChild for SchemaVariantSpec {
             Box::new(SchemaVariantChild::RootPropFuncs(
                 self.root_prop_funcs.clone(),
             )) as Box<dyn NodeChild<NodeType = Self::NodeType>>,
+            Box::new(SchemaVariantChild::ManagementFuncs(
+                self.management_funcs.clone(),
+            )) as Box<dyn NodeChild<NodeType = Self::NodeType>>,
         ];
 
         if let Some(secret_definition) = self.secret_definition.clone() {

--- a/lib/si-pkg/src/node/schema_variant_child.rs
+++ b/lib/si-pkg/src/node/schema_variant_child.rs
@@ -7,8 +7,8 @@ use object_tree::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ActionFuncSpec, AuthenticationFuncSpec, LeafFunctionSpec, PropSpec, RootPropFuncSpec,
-    SiPropFuncSpec, SocketSpec,
+    ActionFuncSpec, AuthenticationFuncSpec, LeafFunctionSpec, ManagementFuncSpec, PropSpec,
+    RootPropFuncSpec, SiPropFuncSpec, SocketSpec,
 };
 
 use super::PkgNode;
@@ -17,6 +17,7 @@ const VARIANT_CHILD_TYPE_ACTION_FUNCS: &str = "action_funcs";
 const VARIANT_CHILD_TYPE_AUTH_FUNCS: &str = "auth_funcs";
 const VARIANT_CHILD_TYPE_DOMAIN: &str = "domain";
 const VARIANT_CHILD_TYPE_LEAF_FUNCTIONS: &str = "leaf_functions";
+const VARIANT_CHILD_TYPE_MANAGEMENT_FUNCS: &str = "management_funcs";
 const VARIANT_CHILD_TYPE_RESOURCE_VALUE: &str = "resource_value";
 const VARIANT_CHILD_TYPE_SI_PROP_FUNCS: &str = "si_prop_funcs";
 const VARIANT_CHILD_TYPE_SOCKETS: &str = "sockets";
@@ -34,6 +35,7 @@ pub enum SchemaVariantChild {
     AuthFuncs(Vec<AuthenticationFuncSpec>),
     Domain(PropSpec),
     LeafFunctions(Vec<LeafFunctionSpec>),
+    ManagementFuncs(Vec<ManagementFuncSpec>),
     ResourceValue(PropSpec),
     RootPropFuncs(Vec<RootPropFuncSpec>),
     SecretDefinition(PropSpec),
@@ -49,6 +51,7 @@ pub enum SchemaVariantChildNode {
     AuthFuncs,
     Domain,
     LeafFunctions,
+    ManagementFuncs,
     ResourceValue,
     RootPropFuncs,
     SecretDefinition,
@@ -64,6 +67,7 @@ impl SchemaVariantChildNode {
             Self::AuthFuncs => VARIANT_CHILD_TYPE_AUTH_FUNCS,
             Self::Domain => VARIANT_CHILD_TYPE_DOMAIN,
             Self::LeafFunctions => VARIANT_CHILD_TYPE_LEAF_FUNCTIONS,
+            Self::ManagementFuncs => VARIANT_CHILD_TYPE_MANAGEMENT_FUNCS,
             Self::ResourceValue => VARIANT_CHILD_TYPE_RESOURCE_VALUE,
             Self::RootPropFuncs => VARIANT_CHILD_TYPE_ROOT_PROP_FUNCS,
             Self::SecretDefinition => VARIANT_CHILD_TYPE_SECRET_DEFINITION,
@@ -81,6 +85,7 @@ impl NameStr for SchemaVariantChildNode {
             Self::AuthFuncs => VARIANT_CHILD_TYPE_AUTH_FUNCS,
             Self::Domain => VARIANT_CHILD_TYPE_DOMAIN,
             Self::LeafFunctions => VARIANT_CHILD_TYPE_LEAF_FUNCTIONS,
+            Self::ManagementFuncs => VARIANT_CHILD_TYPE_MANAGEMENT_FUNCS,
             Self::ResourceValue => VARIANT_CHILD_TYPE_RESOURCE_VALUE,
             Self::RootPropFuncs => VARIANT_CHILD_TYPE_ROOT_PROP_FUNCS,
             Self::SecretDefinition => VARIANT_CHILD_TYPE_SECRET_DEFINITION,
@@ -110,6 +115,7 @@ impl ReadBytes for SchemaVariantChildNode {
             VARIANT_CHILD_TYPE_AUTH_FUNCS => Self::AuthFuncs,
             VARIANT_CHILD_TYPE_DOMAIN => Self::Domain,
             VARIANT_CHILD_TYPE_LEAF_FUNCTIONS => Self::LeafFunctions,
+            VARIANT_CHILD_TYPE_MANAGEMENT_FUNCS => Self::ManagementFuncs,
             VARIANT_CHILD_TYPE_RESOURCE_VALUE => Self::ResourceValue,
             VARIANT_CHILD_TYPE_SI_PROP_FUNCS => Self::SiPropFuncs,
             VARIANT_CHILD_TYPE_ROOT_PROP_FUNCS => Self::RootPropFuncs,
@@ -230,6 +236,17 @@ impl NodeChild for SchemaVariantChild {
                     .iter()
                     .map(|prop_func| {
                         Box::new(prop_func.clone()) as Box<dyn NodeChild<NodeType = Self::NodeType>>
+                    })
+                    .collect(),
+            ),
+            Self::ManagementFuncs(management_funcs) => NodeWithChildren::new(
+                NodeKind::Tree,
+                Self::NodeType::SchemaVariantChild(SchemaVariantChildNode::ManagementFuncs),
+                management_funcs
+                    .iter()
+                    .map(|management_func| {
+                        Box::new(management_func.clone())
+                            as Box<dyn NodeChild<NodeType = Self::NodeType>>
                     })
                     .collect(),
             ),

--- a/lib/si-pkg/src/pkg.rs
+++ b/lib/si-pkg/src/pkg.rs
@@ -20,6 +20,7 @@ mod component;
 mod edge;
 mod func;
 mod leaf_function;
+mod management_func;
 mod map_key_func;
 mod position;
 mod prop;
@@ -31,8 +32,8 @@ mod variant;
 
 pub use {
     action_func::*, attr_func_input::*, attribute_value::*, auth_func::*, change_set::*,
-    component::*, edge::*, func::*, leaf_function::*, map_key_func::*, position::*, prop::*,
-    root_prop_func::*, schema::*, si_prop_func::*, socket::*, variant::*,
+    component::*, edge::*, func::*, leaf_function::*, management_func::*, map_key_func::*,
+    position::*, prop::*, root_prop_func::*, schema::*, si_prop_func::*, socket::*, variant::*,
 };
 
 use crate::{

--- a/lib/si-pkg/src/pkg/management_func.rs
+++ b/lib/si-pkg/src/pkg/management_func.rs
@@ -1,0 +1,85 @@
+use std::collections::HashSet;
+
+use object_tree::{Hash, HashedNode};
+use petgraph::prelude::*;
+use ulid::Ulid;
+
+use super::{PkgResult, SiPkgError, Source};
+
+use crate::{node::PkgNode, ManagementFuncSpec};
+
+#[derive(Clone, Debug)]
+pub struct SiPkgManagementFunc<'a> {
+    func_unique_id: String,
+    name: String,
+    description: Option<String>,
+    managed_schemas: Option<HashSet<Ulid>>,
+
+    hash: Hash,
+    source: Source<'a>,
+}
+
+impl<'a> SiPkgManagementFunc<'a> {
+    pub fn from_graph(
+        graph: &'a Graph<HashedNode<PkgNode>, ()>,
+        node_idx: NodeIndex,
+    ) -> PkgResult<Self> {
+        let hashed_node = &graph[node_idx];
+        let node = match hashed_node.inner() {
+            PkgNode::ManagementFunc(node) => node.clone(),
+            unexpected => {
+                return Err(SiPkgError::UnexpectedPkgNodeType(
+                    PkgNode::MANAGEMENT_FUNC_KIND_STR,
+                    unexpected.node_kind_str(),
+                ))
+            }
+        };
+
+        Ok(Self {
+            func_unique_id: node.func_unique_id,
+            name: node.name,
+            description: node.description,
+            managed_schemas: node.managed_schemas,
+
+            hash: hashed_node.hash(),
+            source: Source::new(graph, node_idx),
+        })
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn func_unique_id(&self) -> &str {
+        self.func_unique_id.as_str()
+    }
+
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    pub fn managed_schemas(&self) -> Option<&HashSet<Ulid>> {
+        self.managed_schemas.as_ref()
+    }
+
+    pub fn hash(&self) -> Hash {
+        self.hash
+    }
+
+    pub fn source(&self) -> &Source<'a> {
+        &self.source
+    }
+}
+
+impl<'a> TryFrom<SiPkgManagementFunc<'a>> for ManagementFuncSpec {
+    type Error = SiPkgError;
+
+    fn try_from(value: SiPkgManagementFunc<'a>) -> Result<Self, Self::Error> {
+        Ok(ManagementFuncSpec::builder()
+            .func_unique_id(value.func_unique_id())
+            .name(value.name().to_owned())
+            .description(value.description().map(ToOwned::to_owned))
+            .managed_schemas(value.managed_schemas)
+            .build()?)
+    }
+}

--- a/lib/si-pkg/src/pkg/variant.rs
+++ b/lib/si-pkg/src/pkg/variant.rs
@@ -7,8 +7,8 @@ use tokio::sync::Mutex;
 use url::Url;
 
 use super::{
-    PkgResult, SiPkgActionFunc, SiPkgError, SiPkgLeafFunction, SiPkgProp, SiPkgPropData,
-    SiPkgSiPropFunc, SiPkgSocket, Source,
+    PkgResult, SiPkgActionFunc, SiPkgError, SiPkgLeafFunction, SiPkgManagementFunc, SiPkgProp,
+    SiPkgPropData, SiPkgSiPropFunc, SiPkgSocket, Source,
 };
 
 use crate::{
@@ -184,6 +184,12 @@ impl<'a> SiPkgSchemaVariant<'a> {
         root_prop_funcs,
         SchemaVariantChildNode::RootPropFuncs,
         SiPkgRootPropFunc
+    );
+
+    impl_variant_children_from_graph!(
+        management_funcs,
+        SchemaVariantChildNode::ManagementFuncs,
+        SiPkgManagementFunc
     );
 
     fn prop_stack_from_source<I>(
@@ -439,6 +445,10 @@ impl<'a> SiPkgSchemaVariant<'a> {
 
         for si_prop_func in self.si_prop_funcs()? {
             builder.si_prop_func(si_prop_func.try_into()?);
+        }
+
+        for management_func in self.management_funcs()? {
+            builder.management_func(management_func.try_into()?);
         }
 
         self.build_prop_specs(SchemaVariantSpecPropRoot::Domain, &mut builder)

--- a/lib/si-pkg/src/spec.rs
+++ b/lib/si-pkg/src/spec.rs
@@ -12,6 +12,7 @@ mod component;
 mod edge;
 mod func;
 mod leaf_function;
+mod management_func;
 mod map_key_func;
 mod position;
 mod prop;
@@ -23,8 +24,8 @@ mod variant;
 
 pub use {
     action_func::*, attr_func_input::*, attribute_value::*, authentication_func::*, change_set::*,
-    component::*, edge::*, func::*, leaf_function::*, map_key_func::*, position::*, prop::*,
-    root_prop_func::*, schema::*, si_prop_func::*, socket::*, variant::*,
+    component::*, edge::*, func::*, leaf_function::*, management_func::*, map_key_func::*,
+    position::*, prop::*, root_prop_func::*, schema::*, si_prop_func::*, socket::*, variant::*,
 };
 
 use super::SiPkgKind;

--- a/lib/si-pkg/src/spec/management_func.rs
+++ b/lib/si-pkg/src/spec/management_func.rs
@@ -1,0 +1,31 @@
+use std::collections::HashSet;
+
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+
+use super::SpecError;
+
+#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[builder(build_fn(error = "SpecError"))]
+pub struct ManagementFuncSpec {
+    #[builder(setter(into))]
+    pub func_unique_id: String,
+
+    #[builder(setter(into))]
+    pub name: String,
+
+    #[builder(setter(into), default)]
+    pub description: Option<String>,
+
+    #[builder(setter(into), default)]
+    #[serde(default)]
+    pub managed_schemas: Option<HashSet<Ulid>>,
+}
+
+impl ManagementFuncSpec {
+    pub fn builder() -> ManagementFuncSpecBuilder {
+        ManagementFuncSpecBuilder::default()
+    }
+}

--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 
 use super::{
-    ActionFuncSpec, LeafFunctionSpec, PropSpec, PropSpecData, PropSpecWidgetKind, RootPropFuncSpec,
-    SiPropFuncSpec, SocketSpec, SpecError,
+    ActionFuncSpec, LeafFunctionSpec, ManagementFuncSpec, PropSpec, PropSpecData,
+    PropSpecWidgetKind, RootPropFuncSpec, SiPropFuncSpec, SocketSpec, SpecError,
 };
 
 #[remain::sorted]
@@ -175,6 +175,9 @@ pub struct SchemaVariantSpec {
 
     #[builder(setter(each(name = "si_prop_func"), into), default)]
     pub si_prop_funcs: Vec<SiPropFuncSpec>,
+
+    #[builder(setter(each(name = "management_func"), into), default)]
+    pub management_funcs: Vec<ManagementFuncSpec>,
 
     #[builder(private, default = "Self::default_domain()")]
     pub domain: PropSpec,
@@ -411,6 +414,7 @@ impl SchemaVariantSpec {
         schema_variant_builder.action_funcs = Some(other_spec.action_funcs.clone());
         schema_variant_builder.auth_funcs = Some(other_spec.auth_funcs.clone());
         schema_variant_builder.leaf_functions = Some(other_spec.leaf_functions.clone());
+        schema_variant_builder.management_funcs = Some(other_spec.management_funcs.clone());
 
         // These are fake root props that include all the "root prop children"
         // (domain, resource_value, etc) as entries


### PR DESCRIPTION
  - Adds /root/si/resourceId to all schema variants. A string prop that can be used by import management funcs to find the resource to import

  - Adds ManagementPrototypes to the graph with their own node weight. A management prototype points to a management func and gives the management action a name and description. It also defines a set of managed schemas, although right now components can only manage themselves. Schema Variants have a ManagementPrototype edge to their prototypes.

  - Management prototypes are part of the SiPkg. Import/export supported.

  - Adds the ability to execute a mangement prototype. ManagementFuncs return a set of MangementOperations. Right now only update is supported, and only on "self" (the managing component).

  - ManagementFuncs can update "self" by simply returning a new javascript object representing the attribute value tree for the object. Certain paths (like /root/resource and /root/resource_value) are ignored. Properties that don't match a prop in the component are ignored. An update to a value only occurs if the value has changed. Properties for attribute values that are set by dynamic functions are also ignored.

    Currently we do not descend into maps and arrays and attempt to set them piece by piece. Instead for arrays, we compare the updated array with the existing and replace the entire array if there is a difference. For maps, we iterate over the keys, and update existing keys (inserting new ones), or remove keys that are no longer present in the updated property map. This behavior needs some more testing and thought.