### PR TITLE
fix: spicedb entrypoint permissions must be execute

### DIFF
--- a/component/spicedb/Dockerfile
+++ b/component/spicedb/Dockerfile
@@ -13,6 +13,6 @@ FROM authzed/spicedb:v1.37.0-debug
 COPY --from=cli /usr/local/bin/zed /usr/local/bin/zed
 COPY --from=setup /tmp/schema.zed .
 COPY --from=setup /tmp/validation.yaml .
-COPY ./entrypoint.sh .
+COPY --chmod=755 ./entrypoint.sh .
 
 ENTRYPOINT ["sh", "-c", "./entrypoint.sh"]


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/EaoPSZC1r7g3oUcHmj/giphy.gif"/>