### PR TITLE
Install module upgrades as editing assets

### DIFF
--- a/bin/module-index/README.md
+++ b/bin/module-index/README.md
@@ -4,15 +4,18 @@ This document contains information related to running the `module-index`.
 
 ## Running Locally with the Full Stack
 
+1. Run the system as usual, whether it's running locally or on a remote server via `buck2 run dev:up` (refer to the [DOCS](../../DOCS.md) for more information on remote development)
+1. Wait until all migrations succeed for `sdf` and all services are running and then CTRL+C
+1. _DO NOT_ run `buck2 run dev:down` as we want the goodies from the initial setup
 1. Export valid AWS credentials in your environment (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`)
-1. Modify `app/web/.env` to use the following line: `VITE_MODULE_INDEX_API_URL=http://localhost:5157` _(do not commit this change!)_
-1. Run the following command: `SI_MODULE_INDEX_URL=http://localhost:5157 buck2 run dev:up`
+1. Run your `buck2 run dev:up` command (either local or remote) with two new environment variables: `VITE_MODULE_INDEX_API_URL=http://<localhost-or-remote-instance-hostname-here>:5157` and `SI_MODULE_INDEX_URL=http://localhost:5157`
 1. Navigate to the Tilt dashboard
 1. Observe that `sdf` will fail on first boot because our local `module-index` isn't running
 1. Run `module-index` in the Tilt dashboard
 1. Restart `sdf` and observe that it starts successfully
 
-If you are editing source code, you can restart all core services, as usual.
+## Testing Changes Related to Modules
 
-> [!NOTE]
-> Running `module-index` locally does not yet work with [LocalStack](https://github.com/localstack/localstack) since credential validation requires multiple `AWS_*` variables and not just `AWS_ENDPOINT`.
+First, ensure that you have a local `module-index` running with the steps above.
+Now, create a second local workspace for your users.
+With two local workspaces, you can have two browser windows open (one per workspace) and test uploading, installing and upgrading modules.

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -42,7 +42,7 @@ pub enum PkgError {
     AttributeFuncForKeyMissingProp(import::AttrFuncContext, String),
     #[error("attribute function for prop {0} has a key {1} but prop kind is {2} not a map)")]
     AttributeFuncForKeySetOnWrongKind(PropId, String, PropKind),
-    #[error(transparent)]
+    #[error("attribute prototype error: {0}")]
     AttributePrototype(#[from] AttributePrototypeError),
     #[error("attrbute prototype argument error: {0}")]
     AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
@@ -56,9 +56,9 @@ pub enum PkgError {
     ConnectionAnnotation(#[from] ConnectionAnnotationError),
     #[error("expected data on an SiPkg node, but none found: {0}")]
     DataNotFound(String),
-    #[error(transparent)]
+    #[error("func error: {0}")]
     Func(#[from] FuncError),
-    #[error(transparent)]
+    #[error("func argument error: {0}")]
     FuncArgument(#[from] FuncArgumentError),
     #[error("func argument for {0} not found with name {1}")]
     FuncArgumentNotFoundByName(FuncId, String),
@@ -84,7 +84,7 @@ pub enum PkgError {
     MissingIntrinsicFunc(String),
     #[error("Unique id missing for node in workspace backup: {0}")]
     MissingUniqueIdForNode(String),
-    #[error(transparent)]
+    #[error("module error: {0}")]
     Module(#[from] ModuleError),
     #[error("output socket error: {0}")]
     OutputSocket(#[from] OutputSocketError),
@@ -92,11 +92,11 @@ pub enum PkgError {
     OutputSocketMissingPrototype(OutputSocketId),
     #[error("Package with that hash already installed: {0}")]
     PackageAlreadyInstalled(String),
-    #[error(transparent)]
+    #[error("si pkg error: {0}")]
     Pkg(#[from] SiPkgError),
-    #[error(transparent)]
+    #[error("pkg spec error: {0}")]
     PkgSpec(#[from] SpecError),
-    #[error(transparent)]
+    #[error("prop error: {0}")]
     Prop(#[from] PropError),
     #[error("prop {0} missing attribute prototype")]
     PropMissingPrototype(PropId),
@@ -114,7 +114,7 @@ pub enum PkgError {
     TakingOutputSocketAsInputForPropUnsupported(String, String),
     #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),
-    #[error(transparent)]
+    #[error("ulid decode error: {0}")]
     UlidDecode(#[from] ulid::DecodeError),
     #[error("url parse error: {0}")]
     Url(#[from] ParseError),
@@ -126,7 +126,7 @@ pub enum PkgError {
     WorkspaceNotFound(WorkspacePk),
     #[error("workspace pk not found on context")]
     WorkspacePkNone,
-    #[error(transparent)]
+    #[error("workspace snapshot error: {0}")]
     WorkspaceSnaphot(#[from] WorkspaceSnapshotError),
 }
 

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -305,6 +305,16 @@ impl Schema {
         Ok(())
     }
 
+    /// Returns whether or not the [`Schema`] exists locally. This works because
+    /// [`Schemas`](Schema) are unique across workspaces.
+    pub async fn exists_locally(ctx: &DalContext, id: SchemaId) -> SchemaResult<bool> {
+        Ok(ctx
+            .workspace_snapshot()?
+            .get_node_index_by_id_opt(id)
+            .await
+            .is_some())
+    }
+
     pub async fn get_by_id(ctx: &DalContext, id: SchemaId) -> SchemaResult<Option<Self>> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -1084,6 +1084,23 @@ impl SchemaVariant {
         Ok(Func::get_by_id_or_error(ctx, asset_func_id).await?)
     }
 
+    /// This method unlocks the asset [`Func`] without creating a copy.
+    ///
+    /// **Warning:** this is a somewhat dangerous as we should normally create a copy of an asset
+    /// [`Func`] when unlocking it. However, this is a special case function that should only be
+    /// used on a case-by-case basis. If unsure, create an unlocked _copy_ of the asset [`Func`].
+    pub(crate) async fn unlock_asset_func_without_copy(
+        &self,
+        ctx: &DalContext,
+    ) -> SchemaVariantResult<()> {
+        let asset_func_id = self
+            .asset_func_id
+            .ok_or(SchemaVariantError::MissingAssetFuncId(self.id))?;
+        let asset_func = Func::get_by_id_or_error(ctx, asset_func_id).await?;
+        asset_func.unsafe_unlock_without_copy(ctx).await?;
+        Ok(())
+    }
+
     pub async fn get_root_prop_id(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,

--- a/lib/sdf-server/src/service/module.rs
+++ b/lib/sdf-server/src/service/module.rs
@@ -9,8 +9,9 @@ use axum::{
 use convert_case::{Case, Casing};
 use dal::{
     pkg::PkgError as DalPkgError, ChangeSetError, ChangeSetId, DalContextBuilder, FuncError,
-    SchemaVariantError, SchemaVariantId, StandardModelError, TenancyError, TransactionsError,
-    UserError, UserPk, WorkspaceError, WorkspacePk, WorkspaceSnapshotError, WsEventError,
+    SchemaError, SchemaId, SchemaVariantError, SchemaVariantId, StandardModelError, TenancyError,
+    TransactionsError, UserError, UserPk, WorkspaceError, WorkspacePk, WorkspaceSnapshotError,
+    WsEventError,
 };
 use serde::{Deserialize, Serialize};
 use si_layer_cache::LayerDbError;
@@ -45,17 +46,17 @@ pub mod remote_module_spec;
 pub enum ModuleError {
     #[error("Could not canonicalize path: {0}")]
     Canonicalize(#[from] CanonicalFileError),
-    #[error(transparent)]
+    #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
     #[error("Changeset not found: {0}")]
     ChangeSetNotFound(ChangeSetId),
-    #[error(transparent)]
+    #[error("dal pkg error: {0}")]
     DalPkg(#[from] DalPkgError),
     #[error("Trying to export from/import into root tenancy")]
     ExportingImportingWithRootTenancy,
-    #[error("transparent")]
+    #[error("func error: {0}")]
     Func(#[from] FuncError),
-    #[error(transparent)]
+    #[error("hyper http error: {0}")]
     Hyper(#[from] hyper::http::Error),
     #[error("Invalid package file name: {0}")]
     InvalidPackageFileName(String),
@@ -67,7 +68,7 @@ pub enum ModuleError {
     IoError(#[from] std::io::Error),
     #[error("LayerDb error: {0}")]
     LayerDb(#[from] LayerDbError),
-    #[error(transparent)]
+    #[error("dal module error: {0}")]
     Module(#[from] dal::module::ModuleError),
     #[error("Module hash not be found: {0}")]
     ModuleHashNotFound(String),
@@ -89,41 +90,47 @@ pub enum ModuleError {
     PackageNotFound(String),
     #[error("Package version required")]
     PackageVersionEmpty,
-    #[error(transparent)]
+    #[error("pg error: {0}")]
     Pg(#[from] si_data_pg::PgError),
-    #[error(transparent)]
+    #[error("pg pool error: {0}")]
     PgPool(#[from] si_data_pg::PgPoolError),
-    #[error(transparent)]
+    #[error("reqwest error: {0}")]
     Reqwest(#[from] reqwest::Error),
+    #[error("schema error: {0}")]
+    Schema(#[from] SchemaError),
     #[error("schema not found for variant {0}")]
     SchemaNotFoundForVariant(SchemaVariantId),
     #[error("schema install pkg result empty: {0}")]
     SchemaNotFoundFromInstall(Ulid),
-    #[error(transparent)]
+    #[error("schema variant error: {0}")]
     SchemaVariant(#[from] SchemaVariantError),
     #[error("schema variant not found {0}")]
     SchemaVariantNotFound(SchemaVariantId),
     #[error("json serialization error: {0}")]
     SerdeJson(#[from] serde_json::Error),
-    #[error(transparent)]
+    #[error("si pkg error: {0}")]
     SiPkg(#[from] SiPkgError),
-    #[error(transparent)]
+    #[error("standard model error: {0}")]
     StandardModel(#[from] StandardModelError),
     #[error("tenancy error: {0}")]
     Tenancy(#[from] TenancyError),
     #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),
-    #[error(transparent)]
+    #[error("ulid decode error: {0}")]
     UlidDecode(#[from] ulid::DecodeError),
+    #[error(
+        "found an unlocked schema variant (schema: {1}) for a module to be installed (module: {0})"
+    )]
+    UnlockedSchemaVariantForModuleToInstall(String, SchemaId),
     #[error("Unable to parse URL: {0}")]
     Url(#[from] url::ParseError),
-    #[error("transparent")]
+    #[error("user error: {0}")]
     User(#[from] UserError),
-    #[error("transparent")]
+    #[error("workspace error: {0}")]
     Workspace(#[from] WorkspaceError),
     #[error("Could not find current workspace {0}")]
     WorkspaceNotFound(WorkspacePk),
-    #[error("transparent")]
+    #[error("workspace snapshot error: {0}")]
     WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
     #[error("could not publish websocket event: {0}")]
     WsEvent(#[from] WsEventError),


### PR DESCRIPTION
## Description

This PR installs module upgrades as editing assets in order to not clobber your local changes to a module's asset. Now, you'll be able to work with the editing asset from upstream before applying your change set. Alongside the editing asset will be its unlocked asset func so that regenerations are possible.

This commit also blocks upgrading modules when you having an editing asset for the module available. If there's an older module that does not know its core `SchemaId`, then we will install anyway, which is how things work on main today. However, those modules should not exist anymore since the `SchemaId` is now required for new modules.

The import code has been polished and modernized a bit with unused variables and code being dropped wholesale.

<img src="https://media3.giphy.com/media/FowqyyQchRvk9fN57s/giphy.gif"/>