### PR TITLE
feat(si-data-spicedb): create initial SpiceDB Rust client

### DIFF
--- a/.ci/docker-compose.test-integration.yml
+++ b/.ci/docker-compose.test-integration.yml
@@ -10,10 +10,12 @@ services:
       # and not using the external port mapping.
       - "SI_TEST_PG_PORT=5432"
       - "SI_TEST_NATS_URL=nats"
+      - "SI_TEST_SPICEDB_URL=http://spicedb:50051"
       - "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317"
     depends_on:
       - postgres-test
       - nats
+      - spicedb
       - jaeger
       - otelcol
 
@@ -71,3 +73,13 @@ services:
     ports:
       - "4566:4566"
       - "4510-4559:4510-4559"
+
+  spicedb:
+    build: ../component/spicedb
+    environment:
+      - "SPICEDB_LOG_FORMAT=console"
+      - "SPICEDB_GRPC_PRESHARED_KEY=hobgoblin"
+      - "SPICEDB_DATASTORE_ENGINE=memory"
+      - "ZED_KEYRING_PASSWORD=orc"
+    ports:
+      - "50051:50051"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,9 +173,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e614738943d3f68c628ae3dbce7c3daffb196665f82f8c8ea6b65de73c79429"
+checksum = "998282f8f49ccd6116b0ed8a4de0fbd3151697920e7c7533416d6e25e76434a7"
 dependencies = [
  "brotli",
  "flate2",
@@ -293,6 +293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,9 +343,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.7"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8191fb3091fa0561d1379ef80333c3c7191c6f0435d986e85821bcf7acbd1126"
+checksum = "7198e6f03240fdceba36656d8be440297b6b82270325908c7381f37d826a74f6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -428,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-firehose"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "067405963a7a5a8ce3708228c8bd11805959a4873d45599076bc9238f2d2330c"
+checksum = "3f1ebf3cee2426d2aa1204ff7b6f9785004ba7d5c5b4b2187a10d5d7f7f1b75f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -450,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.44.0"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b90cfe6504115e13c41d3ea90286ede5aa14da294f3fe077027a6e83850843c"
+checksum = "0dc2faec3205d496c7e57eff685dd944203df7ce16a4116d0281c44021788a7b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -472,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.45.0"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167c0fad1f212952084137308359e8e4c4724d1c643038ce163f06de9662c1d0"
+checksum = "c93c241f52bc5e0476e259c953234dab7e2a35ee207ee202e86c0095ec4951dc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -494,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.44.0"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb5f98188ec1435b68097daa2a37d74b9d17c9caa799466338a8d1544e71b9d"
+checksum = "b259429be94a3459fa1b00c5684faee118d74f9577cc50aebadc36e507c63b5f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -590,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
+checksum = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -600,7 +606,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.1",
@@ -1125,9 +1131,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.24"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "shlex",
 ]
@@ -1208,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1218,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1939,18 +1945,18 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1960,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn 2.0.79",
@@ -2409,9 +2415,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2424,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2434,15 +2440,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2462,9 +2468,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -2481,9 +2487,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2492,21 +2498,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2605,6 +2611,25 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
+ "indexmap 2.6.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.6.0",
  "slab",
  "tokio",
@@ -2878,7 +2903,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2901,6 +2926,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -2952,7 +2978,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2970,6 +2996,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3175,6 +3214,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,9 +3230,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "0cb94a0ffd3f3ee755c20f7d8752f45cac88605a4dcf808abcff72873296ec7b"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3887,12 +3935,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"
@@ -3934,10 +3979,10 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.12.6",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -3948,8 +3993,8 @@ checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.12.6",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -4218,18 +4263,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4528,9 +4573,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
@@ -4581,7 +4626,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.3",
 ]
 
 [[package]]
@@ -4595,6 +4650,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+dependencies = [
+ "prost 0.13.3",
 ]
 
 [[package]]
@@ -4653,7 +4730,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "socket2",
  "thiserror",
  "tokio",
@@ -4670,7 +4747,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "slab",
  "thiserror",
  "tinyvec",
@@ -5047,7 +5124,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -5276,9 +5353,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
 dependencies = [
  "once_cell",
  "ring",
@@ -5381,9 +5458,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -5720,9 +5797,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9720086b3357bcb44fce40117d769a4d068c70ecfa190850a980a71755f66fcc"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5738,9 +5815,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1abbfe725f27678f4663bcacb75a83e829fd464c25d78dd038a3a29e307cec"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5870,6 +5947,22 @@ dependencies = [
  "tokio-postgres",
  "tokio-postgres-rustls",
  "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "si-data-spicedb"
+version = "0.1.0"
+dependencies = [
+ "indoc",
+ "remain",
+ "serde",
+ "si-std",
+ "spicedb-client",
+ "spicedb-grpc",
+ "telemetry",
+ "thiserror",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -6201,6 +6294,30 @@ dependencies = [
  "libc",
  "libsodium-sys",
  "serde",
+]
+
+[[package]]
+name = "spicedb-client"
+version = "0.1.1"
+source = "git+https://github.com/systeminit/spicedb-client.git?branch=si-stable#3cf3ba3482412372cee072ab3585098a8dfc1cd1"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+ "prost 0.13.3",
+ "prost-types",
+ "spicedb-grpc",
+ "thiserror",
+ "tonic 0.12.3",
+]
+
+[[package]]
+name = "spicedb-grpc"
+version = "0.1.1"
+source = "git+https://github.com/systeminit/spicedb-client.git?branch=si-stable#3cf3ba3482412372cee072ab3585098a8dfc1cd1"
+dependencies = [
+ "prost 0.13.3",
+ "prost-types",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -6973,7 +7090,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-pki-types",
  "tokio",
 ]
@@ -7103,14 +7220,40 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.12.6",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.3",
  "tokio",
  "tokio-stream",
  "tower",
@@ -7670,9 +7813,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "ef073ced962d62984fb38a36e5fdc1a2b23c9e0e1fa0689bb97afa4202ef6887"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7681,9 +7824,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "c4bfab14ef75323f4eb75fa52ee0a3fb59611977fd3240da19b2cf36ff85030e"
 dependencies = [
  "bumpalo",
  "log",
@@ -7696,9 +7839,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "65471f79c1022ffa5291d33520cbbb53b7687b01c2f8e83b57d102eed7ed479d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7708,9 +7851,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "a7bec9830f60924d9ceb3ef99d55c155be8afa76954edffbb5936ff4509474e7"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7718,9 +7861,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "4c74f6e152a76a2ad448e223b0fc0b6b5747649c3d769cc6bf45737bf97d0ed6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7731,15 +7874,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "a42f6c679374623f295a8623adfe63d9284091245c3504bde47c17a3ce2777d9"
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "44188d185b5bdcae1052d08bcbcf9091a5524038d4572cc4f4f2bb9d5554ddd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "lib/si-crypto",
     "lib/si-data-nats",
     "lib/si-data-pg",
+    "lib/si-data-spicedb",
     "lib/si-events-rs",
     "lib/si-firecracker",
     "lib/si-frontend-types-rs",
@@ -98,6 +99,7 @@ convert_case = "0.6.0"
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 crossbeam-channel = "0.5.12"
 crossbeam-queue = {version = "0.3.10"}
+darling = "0.20.10"
 deadpool = { version = "0.10.0", features = ["rt_tokio_1"] }
 deadpool-postgres = "0.12.1"
 derive_builder = "0.20.0"
@@ -123,6 +125,7 @@ itertools = "0.12.1"
 jwt-simple = { version = "0.12.9", default-features = false, features = ["pure-rust"] }
 krata-loopdev = "0.0.12"
 lazy_static = "1.4.0"
+manyhow = { version = "0.11.4", features = ["darling"] }
 mime_guess = { version = "=2.0.4" } # TODO(fnichol): 2.0.5 sets an env var in build.rs which needs to be tracked, required by reqwest
 miniz_oxide = { version = "0.7.2", features = ["simd"] }
 moka = { version = "0.12.5", features = ["future"] }
@@ -169,6 +172,8 @@ serde_url_params = "0.2.1"
 serde_with = "3.7.0"
 serde_yaml = "0.9.33" # NOTE(nick): this has been archived upstream
 sodiumoxide = "0.2.7"
+spicedb-client = "0.1.1"
+spicedb-grpc = "0.1.1"
 stream-cancel = "0.8.2"
 strum = { version = "0.26.2", features = ["derive"] }
 syn = { version = "2.0.55", features = ["full", "extra-traits"] }
@@ -192,16 +197,17 @@ tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.4", features = ["compression-br", "compression-deflate", "compression-gzip", "cors", "trace"] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
 tracing = { version = "0.1.40" }
 tracing-opentelemetry = "0.23.0"
-tracing-tunnel = "0.1.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "std"] }
+tracing-tunnel = "0.1.0"
+trybuild = { version = "1.0.99", features = ["diff"] }
 tryhard = "0.5.1"
 ulid = { version = "1.1.2", features = ["serde"] }
 url = { version = "2.5.0", features = ["serde"] }
 uuid = { version = "1.8.0", features = ["serde", "v4"] }
+version_check = "0.9.4"
 vfs = "0.12.0"
 vfs-tar = { version = "0.4.1", features = ["mmap"] }
 webpki-roots = { version = "0.25.4" }
-version_check = "0.9.4"
 xxhash-rust = { version = "0.8.10", features = ["xxh3", "const_xxh3"] }
 y-sync = { version = "0.4.0", features = ["net"] }
 yrs = { version = "0.17.4" }
@@ -214,6 +220,10 @@ hyperlocal = { git = "https://github.com/fnichol/hyperlocal.git", branch = "pub-
 # https://github.com/durch/rust-s3/pull/372
 # Note that this helps us to narrow down the number of `ring`/`rustls` versions to 1 each
 rust-s3 = { git = "https://github.com/ScuffleTV/rust-s3.git", branch = "troy/rustls" }
+# pending merging of patches upstream
+spicedb-client = { git = "https://github.com/systeminit/spicedb-client.git", branch = "si-stable" }
+# pending merging of patches upstream
+spicedb-grpc = { git = "https://github.com/systeminit/spicedb-client.git", branch = "si-stable" }
 # pending a potential merge and release of
 # https://github.com/jbg/tokio-postgres-rustls/pull/18
 tokio-postgres-rustls = { git = "https://github.com/jbg/tokio-postgres-rustls.git", branch = "master" }

--- a/lib/dal-macros/Cargo.toml
+++ b/lib/dal-macros/Cargo.toml
@@ -12,8 +12,8 @@ publish.workspace = true
 proc-macro = true
 
 [dependencies]
-darling = "0.20.10"
-manyhow = { version = "0.11.4", features = ["darling"] }
+darling = { workspace = true }
+manyhow = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
@@ -21,4 +21,4 @@ syn = { workspace = true }
 [dev-dependencies]
 dal = { path = "../dal" }
 si-events = { path = "../si-events-rs" }
-trybuild = { version = "1.0.99", features = ["diff"] }
+trybuild = { workspace = true }

--- a/lib/dal-macros/tests/ui/07-node_weight-no-discriminant-specified-fail.stderr
+++ b/lib/dal-macros/tests/ui/07-node_weight-no-discriminant-specified-fail.stderr
@@ -40,6 +40,7 @@ error[E0277]: the trait bound `TestingNodeWeight: SiVersionedNodeWeight` is not 
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SiVersionedNodeWeight` is not implemented for `TestingNodeWeight`, which is required by `for<'a> NodeInformation: From<&'a TestingNodeWeight>`
    |
    = help: the following other types implement trait `SiVersionedNodeWeight`:
+             ManagementPrototypeNodeWeight
              dal::workspace_snapshot::node_weight::InputSocketNodeWeight
              dal::workspace_snapshot::node_weight::SchemaVariantNodeWeight
    = note: required for `TestingNodeWeight` to implement `SiNodeWeight`

--- a/lib/dal-macros/tests/ui/08-node_weight-bad-node_hash-custom-code-fail.stderr
+++ b/lib/dal-macros/tests/ui/08-node_weight-bad-node_hash-custom-code-fail.stderr
@@ -28,6 +28,7 @@ error[E0277]: the trait bound `TestingNodeWeight: SiVersionedNodeWeight` is not 
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SiVersionedNodeWeight` is not implemented for `TestingNodeWeight`, which is required by `for<'a> NodeInformation: From<&'a TestingNodeWeight>`
    |
    = help: the following other types implement trait `SiVersionedNodeWeight`:
+             ManagementPrototypeNodeWeight
              dal::workspace_snapshot::node_weight::InputSocketNodeWeight
              dal::workspace_snapshot::node_weight::SchemaVariantNodeWeight
    = note: required for `TestingNodeWeight` to implement `SiNodeWeight`

--- a/lib/si-data-spicedb/BUCK
+++ b/lib/si-data-spicedb/BUCK
@@ -1,0 +1,42 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "rust_library",
+    "rust_test",
+)
+
+rust_library(
+    name = "si-data-spicedb",
+    deps = [
+        "//lib/si-std:si-std",
+        "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:remain",
+        "//third-party/rust:serde",
+        "//third-party/rust:spicedb-client",
+        "//third-party/rust:spicedb-grpc",
+        "//third-party/rust:thiserror",
+        "//third-party/rust:tokio",
+        "//third-party/rust:url",
+    ],
+    srcs = glob([
+        "src/**/*.rs",
+    ]),
+    extra_test_targets = [":test-integration"],
+)
+
+rust_test(
+    name = "test-integration",
+    deps = [
+        "//third-party/rust:indoc",
+        "//third-party/rust:tokio",
+        ":si-data-spicedb",
+    ],
+    srcs = glob([
+        "tests/**/*.rs",
+    ]),
+    crate_root = "tests/integration.rs",
+    env = {
+        "CARGO_PKG_NAME": "integration",
+        "RUSTC_BOOTSTRAP": "1",
+        "CI": "buildkite",
+    },
+)

--- a/lib/si-data-spicedb/Cargo.toml
+++ b/lib/si-data-spicedb/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "si-data-spicedb"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+remain = { workspace = true }
+serde = { workspace = true }
+si-std = { path = "../../lib/si-std" }
+spicedb-client = { workspace = true }
+spicedb-grpc = { workspace = true }
+telemetry = { path = "../../lib/telemetry-rs" }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
+
+[dev-dependencies]
+indoc = { workspace = true }

--- a/lib/si-data-spicedb/src/lib.rs
+++ b/lib/si-data-spicedb/src/lib.rs
@@ -1,0 +1,260 @@
+// #![warn(
+//     clippy::unwrap_in_result,
+//     clippy::unwrap_used,
+//     clippy::panic,
+//     clippy::missing_panics_doc,
+//     clippy::panic_in_result_fn
+// )]
+// #![allow(clippy::missing_errors_doc)]
+
+use std::{io, net::ToSocketAddrs, result, sync::Arc};
+
+use serde::{Deserialize, Serialize};
+use si_std::SensitiveString;
+use spicedb_client::SpicedbClient;
+use telemetry::prelude::*;
+use thiserror::Error;
+use url::Url;
+
+mod types;
+
+pub use types::{ReadSchemaResponse, ZedToken};
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("error connecting to spicedb at {1}: {0}")]
+    Connection(#[source] spicedb_client::result::Error, Url),
+    #[error("spicedb endpoint has no host part: {0}")]
+    EndpointNoHost(Url),
+    #[error("cannot determine spicedb endpoint port number: {0}")]
+    EndpointUnknownPort(Url),
+    #[error("error resolving ip addr for spicedb endpoint hostname: {0}")]
+    ResolveHostname(#[source] io::Error),
+    #[error("resolved hostname returned no entries")]
+    ResolveHostnameNoEntries,
+    #[error("spicedb client error: {0}")]
+    SpiceDb(#[from] spicedb_client::result::Error),
+    #[error("tokio task join error: {0}")]
+    TokioJoin(#[from] tokio::task::JoinError),
+}
+
+pub type SpiceDbError = Error;
+
+type Result<T> = result::Result<T, Error>;
+
+pub struct Client {
+    inner: SpicedbClient,
+    metadata: Arc<ConnectionMetadata>,
+}
+
+impl Client {
+    #[instrument(
+        name = "spicedb_client::new",
+        level = "debug",
+        skip_all,
+        fields(
+            db.connection_string = Empty,
+            db.system = Empty,
+            network.peer.address = Empty,
+            network.protocol.name = Empty,
+            network.transport = Empty,
+            otel.kind = SpanKind::Client.as_str(),
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+            server.address = Empty,
+            server.port = Empty,
+        ),
+    )]
+    pub async fn new(config: &SpiceDbConfig) -> Result<Self> {
+        let span = current_span_for_instrument_at!("debug");
+
+        let db_system = "spicedb";
+        let db_connection_string = config.endpoint.to_string();
+
+        let network_transport = "ip_tcp";
+        let network_protocol_name = "spicedb";
+
+        let server_port = config
+            .endpoint
+            .port_or_known_default()
+            .ok_or(Error::EndpointUnknownPort(config.endpoint.clone()))
+            .map_err(|err| span.record_err(err))?;
+
+        let server_address = match config.endpoint.host() {
+            Some(url::Host::Domain(domain)) => {
+                let domain = domain.to_owned();
+                // Resolve hostname to an IP address
+                tokio::task::spawn_blocking(move || {
+                    (format!("{domain}:{server_port}"))
+                        .to_socket_addrs()
+                        .map_err(Error::ResolveHostname)
+                        .and_then(|mut iter| iter.next().ok_or(Error::ResolveHostnameNoEntries))
+                        .map(|socket_addr| socket_addr.ip().to_string())
+                })
+                .await
+                .map_err(|err| span.record_err(err))?
+                .map_err(|err| span.record_err(err))?
+            }
+            Some(url::Host::Ipv4(addr)) => addr.to_string(),
+            Some(url::Host::Ipv6(addr)) => addr.to_string(),
+            None => return Err(span.record_err(Error::EndpointNoHost(config.endpoint.clone()))),
+        };
+
+        let metadata = ConnectionMetadata {
+            db_system,
+            db_connection_string,
+            network_peer_address: server_address.clone(),
+            network_protocol_name,
+            network_transport,
+            server_address,
+            server_port,
+        };
+
+        span.record(
+            "db.connection_string",
+            metadata.db_connection_string.as_str(),
+        );
+        span.record("db.system", metadata.db_system);
+        span.record(
+            "network.peer.address",
+            metadata.network_peer_address.as_str(),
+        );
+        span.record("network.protocol.name", metadata.network_protocol_name);
+        span.record("network.transport", metadata.network_transport);
+        span.record("server.address", metadata.server_address.as_str());
+        span.record("server.port", metadata.server_port);
+
+        let inner = SpicedbClient::from_url_and_preshared_key(
+            config.endpoint.to_string(),
+            config.preshared_key.as_str(),
+        )
+        .await
+        .map_err(|err| span.record_err(Error::Connection(err, config.endpoint.clone())))?;
+
+        span.record_ok();
+        Ok(Self {
+            inner,
+            metadata: Arc::new(metadata),
+        })
+    }
+
+    #[instrument(
+        name = "spicedb_client.read_schema",
+        level = "debug",
+        skip_all,
+        fields(
+            db.connection_string = %self.metadata.db_connection_string(),
+            db.system = %self.metadata.db_system(),
+            network.peer.address = self.metadata.network_peer_address(),
+            network.protocol.name = self.metadata.network_protocol_name(),
+            network.transport = self.metadata.network_transport(),
+            otel.kind = SpanKind::Client.as_str(),
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+            server.address = self.metadata.server_address(),
+            server.port = self.metadata.server_port(),
+        ),
+    )]
+    pub async fn read_schema(&mut self) -> Result<ReadSchemaResponse> {
+        let span = current_span_for_instrument_at!("debug");
+
+        let resp = self
+            .inner
+            .read_schema()
+            .await
+            .map_err(|err| span.record_err(Error::SpiceDb(err)))?
+            .into();
+
+        span.record_ok();
+        Ok(resp)
+    }
+
+    #[instrument(
+        name = "spicedb_client.write_schema",
+        level = "debug",
+        skip_all,
+        fields(
+            db.connection_string = %self.metadata.db_connection_string(),
+            db.system = %self.metadata.db_system(),
+            network.peer.address = self.metadata.network_peer_address(),
+            network.protocol.name = self.metadata.network_protocol_name(),
+            network.transport = self.metadata.network_transport(),
+            otel.kind = SpanKind::Client.as_str(),
+            otel.status_code = Empty,
+            otel.status_message = Empty,
+            server.address = self.metadata.server_address(),
+            server.port = self.metadata.server_port(),
+        ),
+    )]
+    pub async fn write_schema(&mut self, schema: impl ToString) -> Result<Option<ZedToken>> {
+        let span = current_span_for_instrument_at!("debug");
+
+        let resp = self
+            .inner
+            .write_schema(schema)
+            .await
+            .map_err(|err| span.record_err(Error::SpiceDb(err)))?
+            .written_at
+            .map(|value| value.into());
+
+        span.record_ok();
+        Ok(resp)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SpiceDbConfig {
+    pub endpoint: Url,
+    pub preshared_key: SensitiveString,
+}
+
+impl Default for SpiceDbConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: Url::parse("http://localhost:50051").expect("string is a valid URL"),
+            preshared_key: SensitiveString::from("hobgoblin"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ConnectionMetadata {
+    db_system: &'static str,
+    db_connection_string: String,
+    network_peer_address: String,
+    network_protocol_name: &'static str,
+    network_transport: &'static str,
+    server_address: String,
+    server_port: u16,
+}
+
+impl ConnectionMetadata {
+    pub fn db_system(&self) -> &str {
+        self.db_system
+    }
+
+    pub fn db_connection_string(&self) -> &str {
+        &self.db_connection_string
+    }
+
+    pub fn network_peer_address(&self) -> &str {
+        &self.network_peer_address
+    }
+
+    pub fn network_protocol_name(&self) -> &str {
+        self.network_protocol_name
+    }
+
+    pub fn network_transport(&self) -> &str {
+        self.network_transport
+    }
+
+    pub fn server_address(&self) -> &str {
+        &self.server_address
+    }
+
+    pub fn server_port(&self) -> u16 {
+        self.server_port
+    }
+}

--- a/lib/si-data-spicedb/src/types.rs
+++ b/lib/si-data-spicedb/src/types.rs
@@ -1,0 +1,51 @@
+use std::ops;
+
+use spicedb_grpc::authzed::api::v1;
+
+/// ZedToken is used to provide causality metadata between Write and Check requests.
+///
+/// See the authzed.api.v1.Consistency message for more information.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ZedToken(String);
+
+impl ops::Deref for ZedToken {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_str()
+    }
+}
+
+impl From<v1::ZedToken> for ZedToken {
+    fn from(value: v1::ZedToken) -> Self {
+        Self(value.token)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ReadSchemaResponse {
+    /// schema_text is the textual form of the current schema in the system
+    pub schema_text: String,
+
+    /// read_at is the ZedToken at which the schema was read.
+    read_at: Option<ZedToken>,
+}
+
+impl ReadSchemaResponse {
+    pub fn schema_text(&self) -> &str {
+        &self.schema_text
+    }
+
+    pub fn read_at(&self) -> Option<&ZedToken> {
+        self.read_at.as_ref()
+    }
+}
+
+impl From<v1::ReadSchemaResponse> for ReadSchemaResponse {
+    fn from(value: v1::ReadSchemaResponse) -> Self {
+        Self {
+            schema_text: value.schema_text,
+            read_at: value.read_at.map(|value| value.into()),
+        }
+    }
+}

--- a/lib/si-data-spicedb/tests/integration.rs
+++ b/lib/si-data-spicedb/tests/integration.rs
@@ -1,0 +1,1 @@
+mod integration_test;

--- a/lib/si-data-spicedb/tests/integration_test/mod.rs
+++ b/lib/si-data-spicedb/tests/integration_test/mod.rs
@@ -1,0 +1,52 @@
+use std::env;
+
+use indoc::indoc;
+use si_data_spicedb::{Client, SpiceDbConfig};
+
+const ENV_VAR_SPICEDB_URL: &str = "SI_TEST_SPICEDB_URL";
+
+fn spicedb_config() -> SpiceDbConfig {
+    let mut config = SpiceDbConfig::default();
+    #[allow(clippy::disallowed_methods)] // Used only in tests & so prefixed with `SI_TEST_`
+    if let Ok(value) = env::var(ENV_VAR_SPICEDB_URL) {
+        config.endpoint = value.parse().expect("failed to parse spicedb url");
+    }
+    config
+}
+
+#[tokio::test]
+async fn write_and_read_schema() {
+    let config = spicedb_config();
+
+    let mut client = Client::new(&config)
+        .await
+        .expect("failed to connect to spicedb");
+
+    let schema = indoc! {"
+        // Plan comment
+        definition plan {}
+
+        definition user {}
+
+        definition workspace {
+            relation approver: user
+            permission approve = approver
+        }
+    "};
+
+    client
+        .write_schema(schema)
+        .await
+        .expect("failed to write schema");
+
+    let response = client.read_schema().await.expect("failed to read schema");
+
+    assert!(response
+        .schema_text()
+        .lines()
+        .any(|line| line == "// Plan comment"));
+    assert!(response
+        .schema_text()
+        .lines()
+        .any(|line| line == "definition plan {}"));
+}

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -31,6 +31,13 @@ git_fetch(
     visibility = [],
 )
 
+git_fetch(
+    name = "spicedb-client-dd46daac2ba7435e.git",
+    repo = "https://github.com/systeminit/spicedb-client.git",
+    rev = "3cf3ba3482412372cee072ab3585098a8dfc1cd1",
+    visibility = [],
+)
+
 http_archive(
     name = "addr2line-0.21.0.crate",
     sha256 = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb",
@@ -101,37 +108,37 @@ cargo.rust_library(
         "linux-arm64": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
             ],
         ),
         "macos-arm64": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
             ],
         ),
         "windows-gnu": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
             ],
         ),
         "windows-msvc": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
             ],
         ),
     },
@@ -160,22 +167,22 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":once_cell-1.20.1"],
+            deps = [":once_cell-1.20.2"],
         ),
         "linux-x86_64": dict(
-            deps = [":once_cell-1.20.1"],
+            deps = [":once_cell-1.20.2"],
         ),
         "macos-arm64": dict(
-            deps = [":once_cell-1.20.1"],
+            deps = [":once_cell-1.20.2"],
         ),
         "macos-x86_64": dict(
-            deps = [":once_cell-1.20.1"],
+            deps = [":once_cell-1.20.2"],
         ),
         "windows-gnu": dict(
-            deps = [":once_cell-1.20.1"],
+            deps = [":once_cell-1.20.2"],
         ),
         "windows-msvc": dict(
-            deps = [":once_cell-1.20.1"],
+            deps = [":once_cell-1.20.2"],
         ),
     },
     visibility = [],
@@ -550,18 +557,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "async-compression-0.4.13.crate",
-    sha256 = "7e614738943d3f68c628ae3dbce7c3daffb196665f82f8c8ea6b65de73c79429",
-    strip_prefix = "async-compression-0.4.13",
-    urls = ["https://static.crates.io/crates/async-compression/0.4.13/download"],
+    name = "async-compression-0.4.14.crate",
+    sha256 = "998282f8f49ccd6116b0ed8a4de0fbd3151697920e7c7533416d6e25e76434a7",
+    strip_prefix = "async-compression-0.4.14",
+    urls = ["https://static.crates.io/crates/async-compression/0.4.14/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-compression-0.4.13",
-    srcs = [":async-compression-0.4.13.crate"],
+    name = "async-compression-0.4.14",
+    srcs = [":async-compression-0.4.14.crate"],
     crate = "async_compression",
-    crate_root = "async-compression-0.4.13.crate/src/lib.rs",
+    crate_root = "async-compression-0.4.14.crate/src/lib.rs",
     edition = "2018",
     features = [
         "brotli",
@@ -574,7 +581,7 @@ cargo.rust_library(
     deps = [
         ":brotli-7.0.0",
         ":flate2-1.0.34",
-        ":futures-core-0.3.30",
+        ":futures-core-0.3.31",
         ":memchr-2.7.4",
         ":pin-project-lite-0.2.14",
         ":tokio-1.40.0",
@@ -648,11 +655,11 @@ cargo.rust_library(
     deps = [
         ":base64-0.22.1",
         ":bytes-1.7.2",
-        ":futures-0.3.30",
+        ":futures-0.3.31",
         ":memchr-2.7.4",
         ":nkeys-0.4.4",
         ":nuid-0.5.0",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":portable-atomic-1.9.0",
         ":rand-0.8.5",
         ":regex-1.11.0",
@@ -698,7 +705,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -721,7 +728,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-stream-impl-0.3.6",
-        ":futures-core-0.3.30",
+        ":futures-core-0.3.31",
         ":pin-project-lite-0.2.14",
     ],
 )
@@ -743,7 +750,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -772,7 +779,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -798,6 +805,23 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [":num-traits-0.2.19"],
+)
+
+http_archive(
+    name = "atomic-waker-1.1.2.crate",
+    sha256 = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0",
+    strip_prefix = "atomic-waker-1.1.2",
+    urls = ["https://static.crates.io/crates/atomic-waker/1.1.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "atomic-waker-1.1.2",
+    srcs = [":atomic-waker-1.1.2.crate"],
+    crate = "atomic_waker",
+    crate_root = "atomic-waker-1.1.2.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
 )
 
 http_archive(
@@ -886,34 +910,34 @@ cargo.rust_library(
 
 alias(
     name = "aws-config",
-    actual = ":aws-config-1.5.7",
+    actual = ":aws-config-1.5.8",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "aws-config-1.5.7.crate",
-    sha256 = "8191fb3091fa0561d1379ef80333c3c7191c6f0435d986e85821bcf7acbd1126",
-    strip_prefix = "aws-config-1.5.7",
-    urls = ["https://static.crates.io/crates/aws-config/1.5.7/download"],
+    name = "aws-config-1.5.8.crate",
+    sha256 = "7198e6f03240fdceba36656d8be440297b6b82270325908c7381f37d826a74f6",
+    strip_prefix = "aws-config-1.5.8",
+    urls = ["https://static.crates.io/crates/aws-config/1.5.8/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-config-1.5.7",
-    srcs = [":aws-config-1.5.7.crate"],
+    name = "aws-config-1.5.8",
+    srcs = [":aws-config-1.5.8.crate"],
     crate = "aws_config",
-    crate_root = "aws-config-1.5.7.crate/src/lib.rs",
+    crate_root = "aws-config-1.5.8.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-config-1.5.7.crate",
+        "CARGO_MANIFEST_DIR": "aws-config-1.5.8.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK config and credential provider implementations.",
         "CARGO_PKG_NAME": "aws-config",
         "CARGO_PKG_REPOSITORY": "https://github.com/smithy-lang/smithy-rs",
-        "CARGO_PKG_VERSION": "1.5.7",
+        "CARGO_PKG_VERSION": "1.5.8",
         "CARGO_PKG_VERSION_MAJOR": "1",
         "CARGO_PKG_VERSION_MINOR": "5",
-        "CARGO_PKG_VERSION_PATCH": "7",
+        "CARGO_PKG_VERSION_PATCH": "8",
     },
     features = [
         "behavior-version-latest",
@@ -928,13 +952,13 @@ cargo.rust_library(
     deps = [
         ":aws-credential-types-1.2.1",
         ":aws-runtime-1.4.3",
-        ":aws-sdk-sso-1.44.0",
-        ":aws-sdk-ssooidc-1.45.0",
-        ":aws-sdk-sts-1.44.0",
+        ":aws-sdk-sso-1.46.0",
+        ":aws-sdk-ssooidc-1.47.0",
+        ":aws-sdk-sts-1.46.0",
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-json-0.60.7",
-        ":aws-smithy-runtime-1.7.1",
+        ":aws-smithy-runtime-1.7.2",
         ":aws-smithy-runtime-api-1.7.2",
         ":aws-smithy-types-1.2.7",
         ":aws-types-1.3.3",
@@ -1034,13 +1058,13 @@ cargo.rust_library(
         ":aws-sigv4-1.2.4",
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-http-0.60.11",
-        ":aws-smithy-runtime-1.7.1",
+        ":aws-smithy-runtime-1.7.2",
         ":aws-smithy-runtime-api-1.7.2",
         ":aws-smithy-types-1.2.7",
         ":aws-types-1.3.3",
         ":bytes-1.7.2",
         ":fastrand-2.1.1",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.14",
         ":tracing-0.1.40",
@@ -1050,33 +1074,33 @@ cargo.rust_library(
 
 alias(
     name = "aws-sdk-firehose",
-    actual = ":aws-sdk-firehose-1.49.0",
+    actual = ":aws-sdk-firehose-1.50.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "aws-sdk-firehose-1.49.0.crate",
-    sha256 = "067405963a7a5a8ce3708228c8bd11805959a4873d45599076bc9238f2d2330c",
-    strip_prefix = "aws-sdk-firehose-1.49.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-firehose/1.49.0/download"],
+    name = "aws-sdk-firehose-1.50.0.crate",
+    sha256 = "3f1ebf3cee2426d2aa1204ff7b6f9785004ba7d5c5b4b2187a10d5d7f7f1b75f",
+    strip_prefix = "aws-sdk-firehose-1.50.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-firehose/1.50.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-firehose-1.49.0",
-    srcs = [":aws-sdk-firehose-1.49.0.crate"],
+    name = "aws-sdk-firehose-1.50.0",
+    srcs = [":aws-sdk-firehose-1.50.0.crate"],
     crate = "aws_sdk_firehose",
-    crate_root = "aws-sdk-firehose-1.49.0.crate/src/lib.rs",
+    crate_root = "aws-sdk-firehose-1.50.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-firehose-1.49.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-firehose-1.50.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for Amazon Kinesis Firehose",
         "CARGO_PKG_NAME": "aws-sdk-firehose",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.49.0",
+        "CARGO_PKG_VERSION": "1.50.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "49",
+        "CARGO_PKG_VERSION_MINOR": "50",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     features = [
@@ -1091,41 +1115,41 @@ cargo.rust_library(
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-json-0.60.7",
-        ":aws-smithy-runtime-1.7.1",
+        ":aws-smithy-runtime-1.7.2",
         ":aws-smithy-runtime-api-1.7.2",
         ":aws-smithy-types-1.2.7",
         ":aws-types-1.3.3",
         ":bytes-1.7.2",
         ":http-0.2.12",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":regex-lite-0.1.6",
         ":tracing-0.1.40",
     ],
 )
 
 http_archive(
-    name = "aws-sdk-sso-1.44.0.crate",
-    sha256 = "0b90cfe6504115e13c41d3ea90286ede5aa14da294f3fe077027a6e83850843c",
-    strip_prefix = "aws-sdk-sso-1.44.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-sso/1.44.0/download"],
+    name = "aws-sdk-sso-1.46.0.crate",
+    sha256 = "0dc2faec3205d496c7e57eff685dd944203df7ce16a4116d0281c44021788a7b",
+    strip_prefix = "aws-sdk-sso-1.46.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-sso/1.46.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-sso-1.44.0",
-    srcs = [":aws-sdk-sso-1.44.0.crate"],
+    name = "aws-sdk-sso-1.46.0",
+    srcs = [":aws-sdk-sso-1.46.0.crate"],
     crate = "aws_sdk_sso",
-    crate_root = "aws-sdk-sso-1.44.0.crate/src/lib.rs",
+    crate_root = "aws-sdk-sso-1.46.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-sso-1.44.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-sso-1.46.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS Single Sign-On",
         "CARGO_PKG_NAME": "aws-sdk-sso",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.44.0",
+        "CARGO_PKG_VERSION": "1.46.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "44",
+        "CARGO_PKG_VERSION_MINOR": "46",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     visibility = [],
@@ -1135,41 +1159,41 @@ cargo.rust_library(
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-json-0.60.7",
-        ":aws-smithy-runtime-1.7.1",
+        ":aws-smithy-runtime-1.7.2",
         ":aws-smithy-runtime-api-1.7.2",
         ":aws-smithy-types-1.2.7",
         ":aws-types-1.3.3",
         ":bytes-1.7.2",
         ":http-0.2.12",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":regex-lite-0.1.6",
         ":tracing-0.1.40",
     ],
 )
 
 http_archive(
-    name = "aws-sdk-ssooidc-1.45.0.crate",
-    sha256 = "167c0fad1f212952084137308359e8e4c4724d1c643038ce163f06de9662c1d0",
-    strip_prefix = "aws-sdk-ssooidc-1.45.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-ssooidc/1.45.0/download"],
+    name = "aws-sdk-ssooidc-1.47.0.crate",
+    sha256 = "c93c241f52bc5e0476e259c953234dab7e2a35ee207ee202e86c0095ec4951dc",
+    strip_prefix = "aws-sdk-ssooidc-1.47.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-ssooidc/1.47.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-ssooidc-1.45.0",
-    srcs = [":aws-sdk-ssooidc-1.45.0.crate"],
+    name = "aws-sdk-ssooidc-1.47.0",
+    srcs = [":aws-sdk-ssooidc-1.47.0.crate"],
     crate = "aws_sdk_ssooidc",
-    crate_root = "aws-sdk-ssooidc-1.45.0.crate/src/lib.rs",
+    crate_root = "aws-sdk-ssooidc-1.47.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-ssooidc-1.45.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-ssooidc-1.47.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS SSO OIDC",
         "CARGO_PKG_NAME": "aws-sdk-ssooidc",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.45.0",
+        "CARGO_PKG_VERSION": "1.47.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "45",
+        "CARGO_PKG_VERSION_MINOR": "47",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     visibility = [],
@@ -1179,41 +1203,41 @@ cargo.rust_library(
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-json-0.60.7",
-        ":aws-smithy-runtime-1.7.1",
+        ":aws-smithy-runtime-1.7.2",
         ":aws-smithy-runtime-api-1.7.2",
         ":aws-smithy-types-1.2.7",
         ":aws-types-1.3.3",
         ":bytes-1.7.2",
         ":http-0.2.12",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":regex-lite-0.1.6",
         ":tracing-0.1.40",
     ],
 )
 
 http_archive(
-    name = "aws-sdk-sts-1.44.0.crate",
-    sha256 = "2cb5f98188ec1435b68097daa2a37d74b9d17c9caa799466338a8d1544e71b9d",
-    strip_prefix = "aws-sdk-sts-1.44.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-sts/1.44.0/download"],
+    name = "aws-sdk-sts-1.46.0.crate",
+    sha256 = "b259429be94a3459fa1b00c5684faee118d74f9577cc50aebadc36e507c63b5f",
+    strip_prefix = "aws-sdk-sts-1.46.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-sts/1.46.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-sts-1.44.0",
-    srcs = [":aws-sdk-sts-1.44.0.crate"],
+    name = "aws-sdk-sts-1.46.0",
+    srcs = [":aws-sdk-sts-1.46.0.crate"],
     crate = "aws_sdk_sts",
-    crate_root = "aws-sdk-sts-1.44.0.crate/src/lib.rs",
+    crate_root = "aws-sdk-sts-1.46.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-sts-1.44.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-sts-1.46.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS Security Token Service",
         "CARGO_PKG_NAME": "aws-sdk-sts",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.44.0",
+        "CARGO_PKG_VERSION": "1.46.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "44",
+        "CARGO_PKG_VERSION_MINOR": "46",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     visibility = [],
@@ -1224,13 +1248,13 @@ cargo.rust_library(
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-json-0.60.7",
         ":aws-smithy-query-0.60.7",
-        ":aws-smithy-runtime-1.7.1",
+        ":aws-smithy-runtime-1.7.2",
         ":aws-smithy-runtime-api-1.7.2",
         ":aws-smithy-types-1.2.7",
         ":aws-smithy-xml-0.60.9",
         ":aws-types-1.3.3",
         ":http-0.2.12",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":regex-lite-0.1.6",
         ":tracing-0.1.40",
     ],
@@ -1270,7 +1294,7 @@ cargo.rust_library(
         ":hex-0.4.3",
         ":hmac-0.12.1",
         ":http-1.1.0",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":percent-encoding-2.3.1",
         ":sha2-0.10.8",
         ":time-0.3.36",
@@ -1295,7 +1319,7 @@ cargo.rust_library(
     features = ["rt-tokio"],
     visibility = [],
     deps = [
-        ":futures-util-0.3.30",
+        ":futures-util-0.3.31",
         ":pin-project-lite-0.2.14",
         ":tokio-1.40.0",
     ],
@@ -1325,8 +1349,8 @@ cargo.rust_library(
         ":aws-smithy-types-1.2.7",
         ":bytes-1.7.2",
         ":bytes-utils-0.1.4",
-        ":futures-core-0.3.30",
-        ":once_cell-1.20.1",
+        ":futures-core-0.3.31",
+        ":once_cell-1.20.2",
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.14",
         ":pin-utils-0.1.0",
@@ -1374,18 +1398,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "aws-smithy-runtime-1.7.1.crate",
-    sha256 = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87",
-    strip_prefix = "aws-smithy-runtime-1.7.1",
-    urls = ["https://static.crates.io/crates/aws-smithy-runtime/1.7.1/download"],
+    name = "aws-smithy-runtime-1.7.2.crate",
+    sha256 = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db",
+    strip_prefix = "aws-smithy-runtime-1.7.2",
+    urls = ["https://static.crates.io/crates/aws-smithy-runtime/1.7.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-smithy-runtime-1.7.1",
-    srcs = [":aws-smithy-runtime-1.7.1.crate"],
+    name = "aws-smithy-runtime-1.7.2",
+    srcs = [":aws-smithy-runtime-1.7.2.crate"],
     crate = "aws_smithy_runtime",
-    crate_root = "aws-smithy-runtime-1.7.1.crate/src/lib.rs",
+    crate_root = "aws-smithy-runtime-1.7.2.crate/src/lib.rs",
     edition = "2021",
     features = [
         "client",
@@ -1410,7 +1434,7 @@ cargo.rust_library(
         ":h2-0.3.26",
         ":httparse-1.9.5",
         ":hyper-rustls-0.24.2",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":pin-project-lite-0.2.14",
         ":pin-utils-0.1.0",
         ":rustls-0.21.12",
@@ -1488,7 +1512,7 @@ cargo.rust_library(
         ":base64-simd-0.8.0",
         ":bytes-1.7.2",
         ":bytes-utils-0.1.4",
-        ":futures-core-0.3.30",
+        ":futures-core-0.3.31",
         ":http-0.2.12",
         ":http-body-util-0.1.2",
         ":itoa-1.0.11",
@@ -1626,7 +1650,7 @@ cargo.rust_library(
         ":base64-0.21.7",
         ":bitflags-1.3.2",
         ":bytes-1.7.2",
-        ":futures-util-0.3.30",
+        ":futures-util-0.3.31",
         ":http-0.2.12",
         ":http-body-0.4.6",
         ":hyper-0.14.30",
@@ -1669,7 +1693,7 @@ cargo.rust_library(
     deps = [
         ":async-trait-0.1.83",
         ":bytes-1.7.2",
-        ":futures-util-0.3.30",
+        ":futures-util-0.3.31",
         ":http-0.2.12",
         ":http-body-0.4.6",
         ":mime-0.3.17",
@@ -1697,7 +1721,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -1984,7 +2008,7 @@ cargo.rust_library(
         ":lazy_static-1.5.0",
         ":lazycell-1.3.0",
         ":peeking_take_while-0.1.2",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":regex-1.11.0",
         ":rustc-hash-1.1.0",
@@ -2373,8 +2397,8 @@ cargo.rust_library(
         ":base64-0.22.1",
         ":bollard-stubs-1.44.0-rc.2",
         ":bytes-1.7.2",
-        ":futures-core-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-core-0.3.31",
+        ":futures-util-0.3.31",
         ":hex-0.4.3",
         ":http-1.1.0",
         ":http-body-util-0.1.2",
@@ -2412,7 +2436,7 @@ cargo.rust_library(
     deps = [
         ":serde-1.0.210",
         ":serde_repr-0.1.19",
-        ":serde_with-3.10.0",
+        ":serde_with-3.11.0",
     ],
 )
 
@@ -2633,7 +2657,7 @@ cargo.rust_library(
     deps = [
         ":digest-0.10.7",
         ":either-1.13.0",
-        ":futures-0.3.30",
+        ":futures-0.3.31",
         ":hex-0.4.3",
         ":memmap2-0.5.10",
         ":miette-5.10.0",
@@ -2670,18 +2694,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "cc-1.1.24.crate",
-    sha256 = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938",
-    strip_prefix = "cc-1.1.24",
-    urls = ["https://static.crates.io/crates/cc/1.1.24/download"],
+    name = "cc-1.1.28.crate",
+    sha256 = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1",
+    strip_prefix = "cc-1.1.28",
+    urls = ["https://static.crates.io/crates/cc/1.1.28/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "cc-1.1.24",
-    srcs = [":cc-1.1.24.crate"],
+    name = "cc-1.1.28",
+    srcs = [":cc-1.1.28.crate"],
     crate = "cc",
-    crate_root = "cc-1.1.24.crate/src/lib.rs",
+    crate_root = "cc-1.1.28.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
     deps = [":shlex-1.3.0"],
@@ -2959,23 +2983,23 @@ buildscript_run(
 
 alias(
     name = "clap",
-    actual = ":clap-4.5.19",
+    actual = ":clap-4.5.20",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "clap-4.5.19.crate",
-    sha256 = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615",
-    strip_prefix = "clap-4.5.19",
-    urls = ["https://static.crates.io/crates/clap/4.5.19/download"],
+    name = "clap-4.5.20.crate",
+    sha256 = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8",
+    strip_prefix = "clap-4.5.20",
+    urls = ["https://static.crates.io/crates/clap/4.5.20/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap-4.5.19",
-    srcs = [":clap-4.5.19.crate"],
+    name = "clap-4.5.20",
+    srcs = [":clap-4.5.20.crate"],
     crate = "clap",
-    crate_root = "clap-4.5.19.crate/src/lib.rs",
+    crate_root = "clap-4.5.20.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -2991,24 +3015,24 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":clap_builder-4.5.19",
+        ":clap_builder-4.5.20",
         ":clap_derive-4.5.18",
     ],
 )
 
 http_archive(
-    name = "clap_builder-4.5.19.crate",
-    sha256 = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b",
-    strip_prefix = "clap_builder-4.5.19",
-    urls = ["https://static.crates.io/crates/clap_builder/4.5.19/download"],
+    name = "clap_builder-4.5.20.crate",
+    sha256 = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54",
+    strip_prefix = "clap_builder-4.5.20",
+    urls = ["https://static.crates.io/crates/clap_builder/4.5.20/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap_builder-4.5.19",
-    srcs = [":clap_builder-4.5.19.crate"],
+    name = "clap_builder-4.5.20",
+    srcs = [":clap_builder-4.5.20.crate"],
     crate = "clap_builder",
-    crate_root = "clap_builder-4.5.19.crate/src/lib.rs",
+    crate_root = "clap_builder-4.5.20.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -3049,7 +3073,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.5.0",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -3159,7 +3183,7 @@ cargo.rust_library(
         ":color-spantrace-0.2.1",
         ":eyre-0.6.12",
         ":indenter-0.3.3",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":owo-colors-3.5.0",
         ":tracing-error-0.2.0",
     ],
@@ -3181,7 +3205,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":owo-colors-3.5.0",
         ":tracing-core-0.1.32",
         ":tracing-error-0.2.0",
@@ -3445,7 +3469,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":getrandom-0.2.15",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":tiny-keccak-2.0.2",
     ],
 )
@@ -3503,13 +3527,13 @@ cargo.rust_library(
     deps = [
         ":chrono-0.4.38",
         ":flate2-1.0.34",
-        ":futures-util-0.3.30",
+        ":futures-util-0.3.31",
         ":http-0.2.12",
         ":hyper-0.14.30",
         ":log-0.4.22",
         ":mime-0.3.17",
         ":paste-1.0.15",
-        ":pin-project-1.1.5",
+        ":pin-project-1.1.6",
         ":serde-1.0.210",
         ":serde_json-1.0.125",
         ":tar-0.4.42",
@@ -3734,13 +3758,13 @@ cargo.rust_library(
         ":anes-0.1.6",
         ":cast-0.3.0",
         ":ciborium-0.2.2",
-        ":clap-4.5.19",
+        ":clap-4.5.20",
         ":criterion-plot-0.5.0",
-        ":futures-0.3.30",
+        ":futures-0.3.31",
         ":is-terminal-0.4.13",
         ":itertools-0.10.5",
         ":num-traits-0.2.19",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":oorandom-11.1.4",
         ":plotters-0.3.7",
         ":rayon-1.10.0",
@@ -4272,7 +4296,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -4331,7 +4355,7 @@ cargo.rust_library(
     deps = [
         ":fnv-1.0.7",
         ":ident_case-1.0.1",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":strsim-0.11.1",
         ":syn-2.0.79",
@@ -4569,7 +4593,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-1.0.109",
     ],
@@ -4577,75 +4601,75 @@ cargo.rust_library(
 
 alias(
     name = "derive_builder",
-    actual = ":derive_builder-0.20.1",
+    actual = ":derive_builder-0.20.2",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "derive_builder-0.20.1.crate",
-    sha256 = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b",
-    strip_prefix = "derive_builder-0.20.1",
-    urls = ["https://static.crates.io/crates/derive_builder/0.20.1/download"],
+    name = "derive_builder-0.20.2.crate",
+    sha256 = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947",
+    strip_prefix = "derive_builder-0.20.2",
+    urls = ["https://static.crates.io/crates/derive_builder/0.20.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "derive_builder-0.20.1",
-    srcs = [":derive_builder-0.20.1.crate"],
+    name = "derive_builder-0.20.2",
+    srcs = [":derive_builder-0.20.2.crate"],
     crate = "derive_builder",
-    crate_root = "derive_builder-0.20.1.crate/src/lib.rs",
+    crate_root = "derive_builder-0.20.2.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
         "std",
     ],
     visibility = [],
-    deps = [":derive_builder_macro-0.20.1"],
+    deps = [":derive_builder_macro-0.20.2"],
 )
 
 http_archive(
-    name = "derive_builder_core-0.20.1.crate",
-    sha256 = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38",
-    strip_prefix = "derive_builder_core-0.20.1",
-    urls = ["https://static.crates.io/crates/derive_builder_core/0.20.1/download"],
+    name = "derive_builder_core-0.20.2.crate",
+    sha256 = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8",
+    strip_prefix = "derive_builder_core-0.20.2",
+    urls = ["https://static.crates.io/crates/derive_builder_core/0.20.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "derive_builder_core-0.20.1",
-    srcs = [":derive_builder_core-0.20.1.crate"],
+    name = "derive_builder_core-0.20.2",
+    srcs = [":derive_builder_core-0.20.2.crate"],
     crate = "derive_builder_core",
-    crate_root = "derive_builder_core-0.20.1.crate/src/lib.rs",
+    crate_root = "derive_builder_core-0.20.2.crate/src/lib.rs",
     edition = "2018",
     features = ["lib_has_std"],
     visibility = [],
     deps = [
         ":darling-0.20.10",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
 )
 
 http_archive(
-    name = "derive_builder_macro-0.20.1.crate",
-    sha256 = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc",
-    strip_prefix = "derive_builder_macro-0.20.1",
-    urls = ["https://static.crates.io/crates/derive_builder_macro/0.20.1/download"],
+    name = "derive_builder_macro-0.20.2.crate",
+    sha256 = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c",
+    strip_prefix = "derive_builder_macro-0.20.2",
+    urls = ["https://static.crates.io/crates/derive_builder_macro/0.20.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "derive_builder_macro-0.20.1",
-    srcs = [":derive_builder_macro-0.20.1.crate"],
+    name = "derive_builder_macro-0.20.2",
+    srcs = [":derive_builder_macro-0.20.2.crate"],
     crate = "derive_builder_macro",
-    crate_root = "derive_builder_macro-0.20.1.crate/src/lib.rs",
+    crate_root = "derive_builder_macro-0.20.2.crate/src/lib.rs",
     edition = "2018",
     features = ["lib_has_std"],
     proc_macro = True,
     visibility = [],
     deps = [
-        ":derive_builder_core-0.20.1",
+        ":derive_builder_core-0.20.2",
         ":syn-2.0.79",
     ],
 )
@@ -4702,7 +4726,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":convert_case-0.4.0",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -5212,7 +5236,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":enum-ordinalize-4.3.0",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -5401,7 +5425,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -5629,7 +5653,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":indenter-0.3.3",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
     ],
 )
 
@@ -5832,23 +5856,23 @@ cargo.rust_library(
 
 alias(
     name = "futures",
-    actual = ":futures-0.3.30",
+    actual = ":futures-0.3.31",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "futures-0.3.30.crate",
-    sha256 = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0",
-    strip_prefix = "futures-0.3.30",
-    urls = ["https://static.crates.io/crates/futures/0.3.30/download"],
+    name = "futures-0.3.31.crate",
+    sha256 = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876",
+    strip_prefix = "futures-0.3.31",
+    urls = ["https://static.crates.io/crates/futures/0.3.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "futures-0.3.30",
-    srcs = [":futures-0.3.30.crate"],
+    name = "futures-0.3.31",
+    srcs = [":futures-0.3.31.crate"],
     crate = "futures",
-    crate_root = "futures-0.3.30.crate/src/lib.rs",
+    crate_root = "futures-0.3.31.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -5860,40 +5884,40 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":futures-channel-0.3.30",
-        ":futures-core-0.3.30",
-        ":futures-executor-0.3.30",
-        ":futures-io-0.3.30",
-        ":futures-sink-0.3.30",
-        ":futures-task-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-channel-0.3.31",
+        ":futures-core-0.3.31",
+        ":futures-executor-0.3.31",
+        ":futures-io-0.3.31",
+        ":futures-sink-0.3.31",
+        ":futures-task-0.3.31",
+        ":futures-util-0.3.31",
     ],
 )
 
 http_archive(
-    name = "futures-channel-0.3.30.crate",
-    sha256 = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78",
-    strip_prefix = "futures-channel-0.3.30",
-    urls = ["https://static.crates.io/crates/futures-channel/0.3.30/download"],
+    name = "futures-channel-0.3.31.crate",
+    sha256 = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10",
+    strip_prefix = "futures-channel-0.3.31",
+    urls = ["https://static.crates.io/crates/futures-channel/0.3.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "futures-channel-0.3.30",
-    srcs = [":futures-channel-0.3.30.crate"],
+    name = "futures-channel-0.3.31",
+    srcs = [":futures-channel-0.3.31.crate"],
     crate = "futures_channel",
-    crate_root = "futures-channel-0.3.30.crate/src/lib.rs",
+    crate_root = "futures-channel-0.3.31.crate/src/lib.rs",
     edition = "2018",
     env = {
-        "CARGO_MANIFEST_DIR": "futures-channel-0.3.30.crate",
+        "CARGO_MANIFEST_DIR": "futures-channel-0.3.31.crate",
         "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "Channels for asynchronous communication using futures-rs.\n",
         "CARGO_PKG_NAME": "futures-channel",
         "CARGO_PKG_REPOSITORY": "https://github.com/rust-lang/futures-rs",
-        "CARGO_PKG_VERSION": "0.3.30",
+        "CARGO_PKG_VERSION": "0.3.31",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "3",
-        "CARGO_PKG_VERSION_PATCH": "30",
+        "CARGO_PKG_VERSION_PATCH": "31",
     },
     features = [
         "alloc",
@@ -5904,35 +5928,35 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":futures-core-0.3.30",
-        ":futures-sink-0.3.30",
+        ":futures-core-0.3.31",
+        ":futures-sink-0.3.31",
     ],
 )
 
 http_archive(
-    name = "futures-core-0.3.30.crate",
-    sha256 = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d",
-    strip_prefix = "futures-core-0.3.30",
-    urls = ["https://static.crates.io/crates/futures-core/0.3.30/download"],
+    name = "futures-core-0.3.31.crate",
+    sha256 = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e",
+    strip_prefix = "futures-core-0.3.31",
+    urls = ["https://static.crates.io/crates/futures-core/0.3.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "futures-core-0.3.30",
-    srcs = [":futures-core-0.3.30.crate"],
+    name = "futures-core-0.3.31",
+    srcs = [":futures-core-0.3.31.crate"],
     crate = "futures_core",
-    crate_root = "futures-core-0.3.30.crate/src/lib.rs",
+    crate_root = "futures-core-0.3.31.crate/src/lib.rs",
     edition = "2018",
     env = {
-        "CARGO_MANIFEST_DIR": "futures-core-0.3.30.crate",
+        "CARGO_MANIFEST_DIR": "futures-core-0.3.31.crate",
         "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "The core traits and types in for the `futures` library.\n",
         "CARGO_PKG_NAME": "futures-core",
         "CARGO_PKG_REPOSITORY": "https://github.com/rust-lang/futures-rs",
-        "CARGO_PKG_VERSION": "0.3.30",
+        "CARGO_PKG_VERSION": "0.3.31",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "3",
-        "CARGO_PKG_VERSION_PATCH": "30",
+        "CARGO_PKG_VERSION_PATCH": "31",
     },
     features = [
         "alloc",
@@ -5943,18 +5967,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "futures-executor-0.3.30.crate",
-    sha256 = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d",
-    strip_prefix = "futures-executor-0.3.30",
-    urls = ["https://static.crates.io/crates/futures-executor/0.3.30/download"],
+    name = "futures-executor-0.3.31.crate",
+    sha256 = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f",
+    strip_prefix = "futures-executor-0.3.31",
+    urls = ["https://static.crates.io/crates/futures-executor/0.3.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "futures-executor-0.3.30",
-    srcs = [":futures-executor-0.3.30.crate"],
+    name = "futures-executor-0.3.31",
+    srcs = [":futures-executor-0.3.31.crate"],
     crate = "futures_executor",
-    crate_root = "futures-executor-0.3.30.crate/src/lib.rs",
+    crate_root = "futures-executor-0.3.31.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -5962,9 +5986,9 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":futures-core-0.3.30",
-        ":futures-task-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-core-0.3.31",
+        ":futures-task-0.3.31",
+        ":futures-util-0.3.31",
     ],
 )
 
@@ -5990,25 +6014,25 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":futures-core-0.3.30",
+        ":futures-core-0.3.31",
         ":lock_api-0.4.12",
         ":parking_lot-0.12.3",
     ],
 )
 
 http_archive(
-    name = "futures-io-0.3.30.crate",
-    sha256 = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1",
-    strip_prefix = "futures-io-0.3.30",
-    urls = ["https://static.crates.io/crates/futures-io/0.3.30/download"],
+    name = "futures-io-0.3.31.crate",
+    sha256 = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6",
+    strip_prefix = "futures-io-0.3.31",
+    urls = ["https://static.crates.io/crates/futures-io/0.3.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "futures-io-0.3.30",
-    srcs = [":futures-io-0.3.30.crate"],
+    name = "futures-io-0.3.31",
+    srcs = [":futures-io-0.3.31.crate"],
     crate = "futures_io",
-    crate_root = "futures-io-0.3.30.crate/src/lib.rs",
+    crate_root = "futures-io-0.3.31.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -6049,49 +6073,49 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":fastrand-2.1.1",
-        ":futures-core-0.3.30",
-        ":futures-io-0.3.30",
+        ":futures-core-0.3.31",
+        ":futures-io-0.3.31",
         ":parking-2.2.1",
         ":pin-project-lite-0.2.14",
     ],
 )
 
 http_archive(
-    name = "futures-macro-0.3.30.crate",
-    sha256 = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac",
-    strip_prefix = "futures-macro-0.3.30",
-    urls = ["https://static.crates.io/crates/futures-macro/0.3.30/download"],
+    name = "futures-macro-0.3.31.crate",
+    sha256 = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650",
+    strip_prefix = "futures-macro-0.3.31",
+    urls = ["https://static.crates.io/crates/futures-macro/0.3.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "futures-macro-0.3.30",
-    srcs = [":futures-macro-0.3.30.crate"],
+    name = "futures-macro-0.3.31",
+    srcs = [":futures-macro-0.3.31.crate"],
     crate = "futures_macro",
-    crate_root = "futures-macro-0.3.30.crate/src/lib.rs",
+    crate_root = "futures-macro-0.3.31.crate/src/lib.rs",
     edition = "2018",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
 )
 
 http_archive(
-    name = "futures-sink-0.3.30.crate",
-    sha256 = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5",
-    strip_prefix = "futures-sink-0.3.30",
-    urls = ["https://static.crates.io/crates/futures-sink/0.3.30/download"],
+    name = "futures-sink-0.3.31.crate",
+    sha256 = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7",
+    strip_prefix = "futures-sink-0.3.31",
+    urls = ["https://static.crates.io/crates/futures-sink/0.3.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "futures-sink-0.3.30",
-    srcs = [":futures-sink-0.3.30.crate"],
+    name = "futures-sink-0.3.31",
+    srcs = [":futures-sink-0.3.31.crate"],
     crate = "futures_sink",
-    crate_root = "futures-sink-0.3.30.crate/src/lib.rs",
+    crate_root = "futures-sink-0.3.31.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -6102,29 +6126,29 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "futures-task-0.3.30.crate",
-    sha256 = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004",
-    strip_prefix = "futures-task-0.3.30",
-    urls = ["https://static.crates.io/crates/futures-task/0.3.30/download"],
+    name = "futures-task-0.3.31.crate",
+    sha256 = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988",
+    strip_prefix = "futures-task-0.3.31",
+    urls = ["https://static.crates.io/crates/futures-task/0.3.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "futures-task-0.3.30",
-    srcs = [":futures-task-0.3.30.crate"],
+    name = "futures-task-0.3.31",
+    srcs = [":futures-task-0.3.31.crate"],
     crate = "futures_task",
-    crate_root = "futures-task-0.3.30.crate/src/lib.rs",
+    crate_root = "futures-task-0.3.31.crate/src/lib.rs",
     edition = "2018",
     env = {
-        "CARGO_MANIFEST_DIR": "futures-task-0.3.30.crate",
+        "CARGO_MANIFEST_DIR": "futures-task-0.3.31.crate",
         "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "Tools for working with tasks.\n",
         "CARGO_PKG_NAME": "futures-task",
         "CARGO_PKG_REPOSITORY": "https://github.com/rust-lang/futures-rs",
-        "CARGO_PKG_VERSION": "0.3.30",
+        "CARGO_PKG_VERSION": "0.3.31",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "3",
-        "CARGO_PKG_VERSION_PATCH": "30",
+        "CARGO_PKG_VERSION_PATCH": "31",
     },
     features = [
         "alloc",
@@ -6134,29 +6158,29 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "futures-util-0.3.30.crate",
-    sha256 = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48",
-    strip_prefix = "futures-util-0.3.30",
-    urls = ["https://static.crates.io/crates/futures-util/0.3.30/download"],
+    name = "futures-util-0.3.31.crate",
+    sha256 = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81",
+    strip_prefix = "futures-util-0.3.31",
+    urls = ["https://static.crates.io/crates/futures-util/0.3.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "futures-util-0.3.30",
-    srcs = [":futures-util-0.3.30.crate"],
+    name = "futures-util-0.3.31",
+    srcs = [":futures-util-0.3.31.crate"],
     crate = "futures_util",
-    crate_root = "futures-util-0.3.30.crate/src/lib.rs",
+    crate_root = "futures-util-0.3.31.crate/src/lib.rs",
     edition = "2018",
     env = {
-        "CARGO_MANIFEST_DIR": "futures-util-0.3.30.crate",
+        "CARGO_MANIFEST_DIR": "futures-util-0.3.31.crate",
         "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "Common utilities and extension traits for the futures-rs library.\n",
         "CARGO_PKG_NAME": "futures-util",
         "CARGO_PKG_REPOSITORY": "https://github.com/rust-lang/futures-rs",
-        "CARGO_PKG_VERSION": "0.3.30",
+        "CARGO_PKG_VERSION": "0.3.31",
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "3",
-        "CARGO_PKG_VERSION_PATCH": "30",
+        "CARGO_PKG_VERSION_PATCH": "31",
     },
     features = [
         "alloc",
@@ -6176,12 +6200,12 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":futures-channel-0.3.30",
-        ":futures-core-0.3.30",
-        ":futures-io-0.3.30",
-        ":futures-macro-0.3.30",
-        ":futures-sink-0.3.30",
-        ":futures-task-0.3.30",
+        ":futures-channel-0.3.31",
+        ":futures-core-0.3.31",
+        ":futures-io-0.3.31",
+        ":futures-macro-0.3.31",
+        ":futures-sink-0.3.31",
+        ":futures-task-0.3.31",
         ":memchr-2.7.4",
         ":pin-project-lite-0.2.14",
         ":pin-utils-0.1.0",
@@ -6207,7 +6231,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bytes-0.5.6",
-        ":futures-0.3.30",
+        ":futures-0.3.31",
         ":memchr-2.7.4",
         ":pin-project-0.4.30",
     ],
@@ -6464,10 +6488,40 @@ cargo.rust_library(
     deps = [
         ":bytes-1.7.2",
         ":fnv-1.0.7",
-        ":futures-core-0.3.30",
-        ":futures-sink-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-core-0.3.31",
+        ":futures-sink-0.3.31",
+        ":futures-util-0.3.31",
         ":http-0.2.12",
+        ":indexmap-2.6.0",
+        ":slab-0.4.9",
+        ":tokio-1.40.0",
+        ":tokio-util-0.7.12",
+        ":tracing-0.1.40",
+    ],
+)
+
+http_archive(
+    name = "h2-0.4.6.crate",
+    sha256 = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205",
+    strip_prefix = "h2-0.4.6",
+    urls = ["https://static.crates.io/crates/h2/0.4.6/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "h2-0.4.6",
+    srcs = [":h2-0.4.6.crate"],
+    crate = "h2",
+    crate_root = "h2-0.4.6.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":atomic-waker-1.1.2",
+        ":bytes-1.7.2",
+        ":fnv-1.0.7",
+        ":futures-core-0.3.31",
+        ":futures-sink-0.3.31",
+        ":http-1.1.0",
         ":indexmap-2.6.0",
         ":slab-0.4.9",
         ":tokio-1.40.0",
@@ -7012,7 +7066,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bytes-1.7.2",
-        ":futures-util-0.3.30",
+        ":futures-util-0.3.31",
         ":http-1.1.0",
         ":http-body-1.0.1",
         ":pin-project-lite-0.2.14",
@@ -7127,9 +7181,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bytes-1.7.2",
-        ":futures-channel-0.3.30",
-        ":futures-core-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-channel-0.3.31",
+        ":futures-core-0.3.31",
+        ":futures-util-0.3.31",
         ":h2-0.3.26",
         ":http-0.2.12",
         ":http-body-0.4.6",
@@ -7163,12 +7217,14 @@ cargo.rust_library(
         "client",
         "default",
         "http1",
+        "http2",
     ],
     visibility = [],
     deps = [
         ":bytes-1.7.2",
-        ":futures-channel-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-channel-0.3.31",
+        ":futures-util-0.3.31",
+        ":h2-0.4.6",
         ":http-1.1.0",
         ":http-body-1.0.1",
         ":httparse-1.9.5",
@@ -7234,7 +7290,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":futures-util-0.3.30",
+        ":futures-util-0.3.31",
         ":http-0.2.12",
         ":hyper-0.14.30",
         ":log-0.4.22",
@@ -7271,11 +7327,11 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":futures-util-0.3.30",
+        ":futures-util-0.3.31",
         ":http-1.1.0",
         ":hyper-1.4.1",
         ":hyper-util-0.1.9",
-        ":rustls-0.23.13",
+        ":rustls-0.23.14",
         ":tokio-1.40.0",
         ":tokio-rustls-0.26.0",
         ":tower-service-0.3.3",
@@ -7307,6 +7363,30 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "hyper-timeout-0.5.1.crate",
+    sha256 = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793",
+    strip_prefix = "hyper-timeout-0.5.1",
+    urls = ["https://static.crates.io/crates/hyper-timeout/0.5.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "hyper-timeout-0.5.1",
+    srcs = [":hyper-timeout-0.5.1.crate"],
+    crate = "hyper_timeout",
+    crate_root = "hyper-timeout-0.5.1.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":hyper-1.4.1",
+        ":hyper-util-0.1.9",
+        ":pin-project-lite-0.2.14",
+        ":tokio-1.40.0",
+        ":tower-service-0.3.3",
+    ],
+)
+
+http_archive(
     name = "hyper-util-0.1.9.crate",
     sha256 = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b",
     strip_prefix = "hyper-util-0.1.9",
@@ -7330,8 +7410,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bytes-1.7.2",
-        ":futures-channel-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-channel-0.3.31",
+        ":futures-util-0.3.31",
         ":http-1.1.0",
         ":http-body-1.0.1",
         ":hyper-1.4.1",
@@ -7362,10 +7442,10 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":futures-util-0.3.30",
+        ":futures-util-0.3.31",
         ":hex-0.4.3",
         ":hyper-0.14.30",
-        ":pin-project-1.1.5",
+        ":pin-project-1.1.6",
         ":tokio-1.40.0",
     ],
 )
@@ -7502,7 +7582,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":ignore-0.4.23",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":serde-1.0.210",
         ":syn-2.0.79",
@@ -7698,7 +7778,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -7740,7 +7820,7 @@ cargo.rust_library(
         ":fuzzy-matcher-0.3.7",
         ":fxhash-0.2.1",
         ":newline-converter-0.3.0",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":unicode-segmentation-1.12.0",
         ":unicode-width-0.1.14",
     ],
@@ -7782,7 +7862,7 @@ cargo.rust_library(
     crate_root = "is-docker-0.2.0.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
-    deps = [":once_cell-1.20.1"],
+    deps = [":once_cell-1.20.2"],
 )
 
 http_archive(
@@ -7839,7 +7919,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":is-docker-0.2.0",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
     ],
 )
 
@@ -7903,6 +7983,29 @@ cargo.rust_library(
     srcs = [":itertools-0.12.1.crate"],
     crate = "itertools",
     crate_root = "itertools-0.12.1.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "use_alloc",
+        "use_std",
+    ],
+    visibility = [],
+    deps = [":either-1.13.0"],
+)
+
+http_archive(
+    name = "itertools-0.13.0.crate",
+    sha256 = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
+    strip_prefix = "itertools-0.13.0",
+    urls = ["https://static.crates.io/crates/itertools/0.13.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "itertools-0.13.0",
+    srcs = [":itertools-0.13.0.crate"],
+    crate = "itertools",
+    crate_root = "itertools-0.13.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -8034,7 +8137,7 @@ cargo.rust_library(
     deps = [
         ":cfg-if-1.0.0",
         ":elliptic-curve-0.13.8",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":sha2-0.10.8",
         ":signature-2.2.0",
     ],
@@ -8823,7 +8926,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":darling_core-0.20.10",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
     ],
 )
@@ -8846,7 +8949,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro-utils-0.10.0",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
     ],
 )
@@ -8905,7 +9008,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -9090,7 +9193,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":miette-derive-5.10.0",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":thiserror-1.0.64",
         ":unicode-width-0.1.14",
     ],
@@ -9113,7 +9216,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -9390,8 +9493,8 @@ cargo.rust_library(
         ":crossbeam-epoch-0.9.18",
         ":crossbeam-utils-0.8.20",
         ":event-listener-5.3.1",
-        ":futures-util-0.3.30",
-        ":once_cell-1.20.1",
+        ":futures-util-0.3.31",
+        ":once_cell-1.20.2",
         ":parking_lot-0.12.3",
         ":quanta-0.12.3",
         ":smallvec-1.13.2",
@@ -9421,7 +9524,7 @@ cargo.rust_library(
     deps = [
         ":bytes-1.7.2",
         ":encoding_rs-0.8.34",
-        ":futures-util-0.3.30",
+        ":futures-util-0.3.31",
         ":http-0.2.12",
         ":httparse-1.9.5",
         ":log-0.4.22",
@@ -10025,23 +10128,23 @@ cargo.rust_library(
 
 alias(
     name = "once_cell",
-    actual = ":once_cell-1.20.1",
+    actual = ":once_cell-1.20.2",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "once_cell-1.20.1.crate",
-    sha256 = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1",
-    strip_prefix = "once_cell-1.20.1",
-    urls = ["https://static.crates.io/crates/once_cell/1.20.1/download"],
+    name = "once_cell-1.20.2.crate",
+    sha256 = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775",
+    strip_prefix = "once_cell-1.20.2",
+    urls = ["https://static.crates.io/crates/once_cell/1.20.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "once_cell-1.20.1",
-    srcs = [":once_cell-1.20.1.crate"],
+    name = "once_cell-1.20.2",
+    srcs = [":once_cell-1.20.2.crate"],
     crate = "once_cell",
-    crate_root = "once_cell-1.20.1.crate/src/lib.rs",
+    crate_root = "once_cell-1.20.2.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -10050,7 +10153,6 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":portable-atomic-1.9.0"],
 )
 
 http_archive(
@@ -10166,9 +10268,9 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":futures-core-0.3.30",
-        ":futures-sink-0.3.30",
-        ":once_cell-1.20.1",
+        ":futures-core-0.3.31",
+        ":futures-sink-0.3.31",
+        ":once_cell-1.20.2",
         ":pin-project-lite-0.2.14",
         ":thiserror-1.0.64",
         ":urlencoding-2.1.3",
@@ -10219,7 +10321,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-trait-0.1.83",
-        ":futures-core-0.3.30",
+        ":futures-core-0.3.31",
         ":http-0.2.12",
         ":opentelemetry-0.22.0",
         ":opentelemetry-proto-0.5.0",
@@ -10334,11 +10436,11 @@ cargo.rust_library(
     deps = [
         ":async-trait-0.1.83",
         ":crossbeam-channel-0.5.13",
-        ":futures-channel-0.3.30",
-        ":futures-executor-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-channel-0.3.31",
+        ":futures-executor-0.3.31",
+        ":futures-util-0.3.31",
         ":glob-0.3.1",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":opentelemetry-0.22.0",
         ":ordered-float-4.3.0",
         ":percent-encoding-2.3.1",
@@ -10526,7 +10628,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro-error-1.0.4",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -10552,7 +10654,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":itertools-0.12.1",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":proc-macro2-diagnostics-0.10.1",
         ":quote-1.0.37",
         ":syn-2.0.79",
@@ -11001,21 +11103,21 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "pin-project-1.1.5.crate",
-    sha256 = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3",
-    strip_prefix = "pin-project-1.1.5",
-    urls = ["https://static.crates.io/crates/pin-project/1.1.5/download"],
+    name = "pin-project-1.1.6.crate",
+    sha256 = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec",
+    strip_prefix = "pin-project-1.1.6",
+    urls = ["https://static.crates.io/crates/pin-project/1.1.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "pin-project-1.1.5",
-    srcs = [":pin-project-1.1.5.crate"],
+    name = "pin-project-1.1.6",
+    srcs = [":pin-project-1.1.6.crate"],
     crate = "pin_project",
-    crate_root = "pin-project-1.1.5.crate/src/lib.rs",
+    crate_root = "pin-project-1.1.6.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":pin-project-internal-1.1.5"],
+    deps = [":pin-project-internal-1.1.6"],
 )
 
 http_archive(
@@ -11035,30 +11137,30 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-1.0.109",
     ],
 )
 
 http_archive(
-    name = "pin-project-internal-1.1.5.crate",
-    sha256 = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965",
-    strip_prefix = "pin-project-internal-1.1.5",
-    urls = ["https://static.crates.io/crates/pin-project-internal/1.1.5/download"],
+    name = "pin-project-internal-1.1.6.crate",
+    sha256 = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8",
+    strip_prefix = "pin-project-internal-1.1.6",
+    urls = ["https://static.crates.io/crates/pin-project-internal/1.1.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "pin-project-internal-1.1.5",
-    srcs = [":pin-project-internal-1.1.5.crate"],
+    name = "pin-project-internal-1.1.6",
+    srcs = [":pin-project-internal-1.1.6.crate"],
     crate = "pin_project_internal",
-    crate_root = "pin-project-internal-1.1.5.crate/src/lib.rs",
+    crate_root = "pin-project-internal-1.1.6.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -11271,7 +11373,7 @@ cargo.rust_library(
         ":chrono-0.4.38",
         ":containers-api-0.8.0",
         ":flate2-1.0.34",
-        ":futures-util-0.3.30",
+        ":futures-util-0.3.31",
         ":futures_codec-0.4.1",
         ":log-0.4.22",
         ":paste-1.0.15",
@@ -11335,7 +11437,6 @@ cargo.rust_library(
     features = [
         "default",
         "fallback",
-        "require-cas",
     ],
     rustc_flags = ["@$(location :portable-atomic-1.9.0-build-script-run[rustc_flags])"],
     visibility = [],
@@ -11361,7 +11462,6 @@ cargo.rust_binary(
     features = [
         "default",
         "fallback",
-        "require-cas",
     ],
     visibility = [],
 )
@@ -11373,7 +11473,6 @@ buildscript_run(
     features = [
         "default",
         "fallback",
-        "require-cas",
     ],
     version = "1.9.0",
 )
@@ -11435,7 +11534,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.5.0",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -11646,7 +11745,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro-error-attr-1.0.4",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-1.0.109",
     ],
@@ -11696,7 +11795,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
     ],
 )
@@ -11718,7 +11817,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
     ],
 )
@@ -11744,7 +11843,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro-error-attr2-2.0.0",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -11774,7 +11873,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":smallvec-1.13.2",
     ],
@@ -11782,38 +11881,38 @@ cargo.rust_library(
 
 alias(
     name = "proc-macro2",
-    actual = ":proc-macro2-1.0.86",
+    actual = ":proc-macro2-1.0.87",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "proc-macro2-1.0.86.crate",
-    sha256 = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77",
-    strip_prefix = "proc-macro2-1.0.86",
-    urls = ["https://static.crates.io/crates/proc-macro2/1.0.86/download"],
+    name = "proc-macro2-1.0.87.crate",
+    sha256 = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a",
+    strip_prefix = "proc-macro2-1.0.87",
+    urls = ["https://static.crates.io/crates/proc-macro2/1.0.87/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "proc-macro2-1.0.86",
-    srcs = [":proc-macro2-1.0.86.crate"],
+    name = "proc-macro2-1.0.87",
+    srcs = [":proc-macro2-1.0.87.crate"],
     crate = "proc_macro2",
-    crate_root = "proc-macro2-1.0.86.crate/src/lib.rs",
+    crate_root = "proc-macro2-1.0.87.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
         "proc-macro",
     ],
-    rustc_flags = ["@$(location :proc-macro2-1.0.86-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :proc-macro2-1.0.87-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [":unicode-ident-1.0.13"],
 )
 
 cargo.rust_binary(
-    name = "proc-macro2-1.0.86-build-script-build",
-    srcs = [":proc-macro2-1.0.86.crate"],
+    name = "proc-macro2-1.0.87-build-script-build",
+    srcs = [":proc-macro2-1.0.87.crate"],
     crate = "build_script_build",
-    crate_root = "proc-macro2-1.0.86.crate/build.rs",
+    crate_root = "proc-macro2-1.0.87.crate/build.rs",
     edition = "2021",
     features = [
         "default",
@@ -11823,14 +11922,14 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "proc-macro2-1.0.86-build-script-run",
+    name = "proc-macro2-1.0.87-build-script-run",
     package_name = "proc-macro2",
-    buildscript_rule = ":proc-macro2-1.0.86-build-script-build",
+    buildscript_rule = ":proc-macro2-1.0.87-build-script-build",
     features = [
         "default",
         "proc-macro",
     ],
-    version = "1.0.86",
+    version = "1.0.87",
 )
 
 http_archive(
@@ -11854,7 +11953,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
         ":yansi-1.0.1",
@@ -11980,6 +12079,33 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "prost-0.13.3.crate",
+    sha256 = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f",
+    strip_prefix = "prost-0.13.3",
+    urls = ["https://static.crates.io/crates/prost/0.13.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "prost-0.13.3",
+    srcs = [":prost-0.13.3.crate"],
+    crate = "prost",
+    crate_root = "prost-0.13.3.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "derive",
+        "prost-derive",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":bytes-1.7.2",
+        ":prost-derive-0.13.3",
+    ],
+)
+
+http_archive(
     name = "prost-derive-0.12.6.crate",
     sha256 = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1",
     strip_prefix = "prost-derive-0.12.6",
@@ -11998,10 +12124,57 @@ cargo.rust_library(
     deps = [
         ":anyhow-1.0.89",
         ":itertools-0.12.1",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
+)
+
+http_archive(
+    name = "prost-derive-0.13.3.crate",
+    sha256 = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5",
+    strip_prefix = "prost-derive-0.13.3",
+    urls = ["https://static.crates.io/crates/prost-derive/0.13.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "prost-derive-0.13.3",
+    srcs = [":prost-derive-0.13.3.crate"],
+    crate = "prost_derive",
+    crate_root = "prost-derive-0.13.3.crate/src/lib.rs",
+    edition = "2021",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":anyhow-1.0.89",
+        ":itertools-0.13.0",
+        ":proc-macro2-1.0.87",
+        ":quote-1.0.37",
+        ":syn-2.0.79",
+    ],
+)
+
+http_archive(
+    name = "prost-types-0.13.3.crate",
+    sha256 = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670",
+    strip_prefix = "prost-types-0.13.3",
+    urls = ["https://static.crates.io/crates/prost-types/0.13.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "prost-types-0.13.3",
+    srcs = [":prost-types-0.13.3.crate"],
+    crate = "prost_types",
+    crate_root = "prost-types-0.13.3.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [":prost-0.13.3"],
 )
 
 http_archive(
@@ -12057,7 +12230,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":crossbeam-utils-0.8.20",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
     ],
 )
 
@@ -12115,7 +12288,7 @@ cargo.rust_library(
         ":bytes-1.7.2",
         ":pin-project-lite-0.2.14",
         ":rustc-hash-2.0.0",
-        ":rustls-0.23.13",
+        ":rustls-0.23.14",
         ":socket2-0.5.7",
         ":thiserror-1.0.64",
         ":tokio-1.40.0",
@@ -12147,7 +12320,7 @@ cargo.rust_library(
         ":rand-0.8.5",
         ":ring-0.17.5",
         ":rustc-hash-2.0.0",
-        ":rustls-0.23.13",
+        ":rustls-0.23.14",
         ":slab-0.4.9",
         ":thiserror-1.0.64",
         ":tinyvec-1.8.0",
@@ -12173,13 +12346,13 @@ cargo.rust_library(
     platform = {
         "windows-gnu": dict(
             deps = [
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
                 ":windows-sys-0.59.0",
             ],
         ),
         "windows-msvc": dict(
             deps = [
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
                 ":windows-sys-0.59.0",
             ],
         ),
@@ -12217,7 +12390,7 @@ cargo.rust_library(
         "proc-macro",
     ],
     visibility = [],
-    deps = [":proc-macro2-1.0.86"],
+    deps = [":proc-macro2-1.0.87"],
 )
 
 http_archive(
@@ -12606,7 +12779,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":refinery-core-0.8.14",
         ":regex-1.11.0",
@@ -12867,7 +13040,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -12913,11 +13086,11 @@ cargo.rust_library(
                 ":ipnet-2.10.1",
                 ":log-0.4.22",
                 ":mime-0.3.17",
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
-                ":rustls-0.23.13",
+                ":rustls-0.23.14",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.9.0",
                 ":tokio-1.40.0",
@@ -12935,11 +13108,11 @@ cargo.rust_library(
                 ":ipnet-2.10.1",
                 ":log-0.4.22",
                 ":mime-0.3.17",
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
-                ":rustls-0.23.13",
+                ":rustls-0.23.14",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.9.0",
                 ":tokio-1.40.0",
@@ -12957,11 +13130,11 @@ cargo.rust_library(
                 ":ipnet-2.10.1",
                 ":log-0.4.22",
                 ":mime-0.3.17",
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
-                ":rustls-0.23.13",
+                ":rustls-0.23.14",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.9.0",
                 ":tokio-1.40.0",
@@ -12979,11 +13152,11 @@ cargo.rust_library(
                 ":ipnet-2.10.1",
                 ":log-0.4.22",
                 ":mime-0.3.17",
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
-                ":rustls-0.23.13",
+                ":rustls-0.23.14",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.9.0",
                 ":tokio-1.40.0",
@@ -13001,11 +13174,11 @@ cargo.rust_library(
                 ":ipnet-2.10.1",
                 ":log-0.4.22",
                 ":mime-0.3.17",
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
-                ":rustls-0.23.13",
+                ":rustls-0.23.14",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.9.0",
                 ":tokio-1.40.0",
@@ -13024,11 +13197,11 @@ cargo.rust_library(
                 ":ipnet-2.10.1",
                 ":log-0.4.22",
                 ":mime-0.3.17",
-                ":once_cell-1.20.1",
+                ":once_cell-1.20.2",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
-                ":rustls-0.23.13",
+                ":rustls-0.23.14",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.9.0",
                 ":tokio-1.40.0",
@@ -13042,8 +13215,8 @@ cargo.rust_library(
     deps = [
         ":base64-0.22.1",
         ":bytes-1.7.2",
-        ":futures-core-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-core-0.3.31",
+        ":futures-util-0.3.31",
         ":http-1.1.0",
         ":mime_guess-2.0.4",
         ":serde-1.0.210",
@@ -13919,7 +14092,7 @@ cargo.rust_library(
         ":base64-0.21.7",
         ":bytes-1.7.2",
         ":cfg-if-1.0.0",
-        ":futures-0.3.30",
+        ":futures-0.3.31",
         ":hex-0.4.3",
         ":hmac-0.12.1",
         ":http-0.2.12",
@@ -14270,18 +14443,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "rustls-0.23.13.crate",
-    sha256 = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8",
-    strip_prefix = "rustls-0.23.13",
-    urls = ["https://static.crates.io/crates/rustls/0.23.13/download"],
+    name = "rustls-0.23.14.crate",
+    sha256 = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8",
+    strip_prefix = "rustls-0.23.14",
+    urls = ["https://static.crates.io/crates/rustls/0.23.14/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-0.23.13",
-    srcs = [":rustls-0.23.13.crate"],
+    name = "rustls-0.23.14",
+    srcs = [":rustls-0.23.14.crate"],
     crate = "rustls",
-    crate_root = "rustls-0.23.13.crate/src/lib.rs",
+    crate_root = "rustls-0.23.14.crate/src/lib.rs",
     edition = "2021",
     features = [
         "ring",
@@ -14293,7 +14466,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":ring-0.17.5",
         ":rustls-webpki-0.102.8",
         ":subtle-2.6.1",
@@ -14329,10 +14502,10 @@ cargo.rust_library(
             deps = [":security-framework-2.11.1"],
         ),
         "windows-gnu": dict(
-            deps = [":schannel-0.1.24"],
+            deps = [":schannel-0.1.26"],
         ),
         "windows-msvc": dict(
-            deps = [":schannel-0.1.24"],
+            deps = [":schannel-0.1.26"],
         ),
     },
     visibility = [],
@@ -14376,10 +14549,10 @@ cargo.rust_library(
             deps = [":security-framework-2.11.1"],
         ),
         "windows-gnu": dict(
-            deps = [":schannel-0.1.24"],
+            deps = [":schannel-0.1.26"],
         ),
         "windows-msvc": dict(
-            deps = [":schannel-0.1.24"],
+            deps = [":schannel-0.1.26"],
         ),
     },
     visibility = [],
@@ -14592,18 +14765,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "schannel-0.1.24.crate",
-    sha256 = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b",
-    strip_prefix = "schannel-0.1.24",
-    urls = ["https://static.crates.io/crates/schannel/0.1.24/download"],
+    name = "schannel-0.1.26.crate",
+    sha256 = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1",
+    strip_prefix = "schannel-0.1.26",
+    urls = ["https://static.crates.io/crates/schannel/0.1.26/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "schannel-0.1.24",
-    srcs = [":schannel-0.1.24.crate"],
+    name = "schannel-0.1.26",
+    srcs = [":schannel-0.1.26.crate"],
     crate = "schannel",
-    crate_root = "schannel-0.1.24.crate/src/lib.rs",
+    crate_root = "schannel-0.1.26.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
     deps = [":windows-sys-0.59.0"],
@@ -14666,7 +14839,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro-error2-2.0.1",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -14722,7 +14895,7 @@ cargo.rust_library(
         ":async-trait-0.1.83",
         ":bigdecimal-0.3.1",
         ":chrono-0.4.38",
-        ":futures-0.3.30",
+        ":futures-0.3.31",
         ":log-0.4.22",
         ":ouroboros-0.17.2",
         ":rust_decimal-1.36.0",
@@ -14768,7 +14941,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
         ":unicode-ident-1.0.13",
@@ -15152,7 +15325,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -15258,7 +15431,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -15335,23 +15508,23 @@ cargo.rust_library(
 
 alias(
     name = "serde_with",
-    actual = ":serde_with-3.10.0",
+    actual = ":serde_with-3.11.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde_with-3.10.0.crate",
-    sha256 = "9720086b3357bcb44fce40117d769a4d068c70ecfa190850a980a71755f66fcc",
-    strip_prefix = "serde_with-3.10.0",
-    urls = ["https://static.crates.io/crates/serde_with/3.10.0/download"],
+    name = "serde_with-3.11.0.crate",
+    sha256 = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817",
+    strip_prefix = "serde_with-3.11.0",
+    urls = ["https://static.crates.io/crates/serde_with/3.11.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_with-3.10.0",
-    srcs = [":serde_with-3.10.0.crate"],
+    name = "serde_with-3.11.0",
+    srcs = [":serde_with-3.11.0.crate"],
     crate = "serde_with",
-    crate_root = "serde_with-3.10.0.crate/src/lib.rs",
+    crate_root = "serde_with-3.11.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -15372,29 +15545,29 @@ cargo.rust_library(
         ":serde-1.0.210",
         ":serde_derive-1.0.210",
         ":serde_json-1.0.125",
-        ":serde_with_macros-3.10.0",
+        ":serde_with_macros-3.11.0",
     ],
 )
 
 http_archive(
-    name = "serde_with_macros-3.10.0.crate",
-    sha256 = "5f1abbfe725f27678f4663bcacb75a83e829fd464c25d78dd038a3a29e307cec",
-    strip_prefix = "serde_with_macros-3.10.0",
-    urls = ["https://static.crates.io/crates/serde_with_macros/3.10.0/download"],
+    name = "serde_with_macros-3.11.0.crate",
+    sha256 = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d",
+    strip_prefix = "serde_with_macros-3.11.0",
+    urls = ["https://static.crates.io/crates/serde_with_macros/3.11.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_with_macros-3.10.0",
-    srcs = [":serde_with_macros-3.10.0.crate"],
+    name = "serde_with_macros-3.11.0",
+    srcs = [":serde_with_macros-3.11.0.crate"],
     crate = "serde_with_macros",
-    crate_root = "serde_with_macros-3.10.0.crate/src/lib.rs",
+    crate_root = "serde_with_macros-3.11.0.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
         ":darling-0.20.10",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -15941,6 +16114,52 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "spicedb-client",
+    actual = ":spicedb-client-0.1.1",
+    visibility = ["PUBLIC"],
+)
+
+cargo.rust_library(
+    name = "spicedb-client-0.1.1",
+    srcs = [":spicedb-client-dd46daac2ba7435e.git"],
+    crate = "spicedb_client",
+    crate_root = "spicedb-client-dd46daac2ba7435e/spicedb-client/src/lib.rs",
+    edition = "2021",
+    features = ["default"],
+    visibility = [],
+    deps = [
+        ":bytes-1.7.2",
+        ":http-1.1.0",
+        ":prost-0.13.3",
+        ":prost-types-0.13.3",
+        ":spicedb-grpc-0.1.1",
+        ":thiserror-1.0.64",
+        ":tonic-0.12.3",
+    ],
+)
+
+alias(
+    name = "spicedb-grpc",
+    actual = ":spicedb-grpc-0.1.1",
+    visibility = ["PUBLIC"],
+)
+
+cargo.rust_library(
+    name = "spicedb-grpc-0.1.1",
+    srcs = [":spicedb-client-dd46daac2ba7435e.git"],
+    crate = "spicedb_grpc",
+    crate_root = "spicedb-client-dd46daac2ba7435e/spicedb-grpc/src/lib.rs",
+    edition = "2021",
+    features = ["default"],
+    visibility = [],
+    deps = [
+        ":prost-0.13.3",
+        ":prost-types-0.13.3",
+        ":tonic-0.12.3",
+    ],
+)
+
 http_archive(
     name = "spin-0.9.8.crate",
     sha256 = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67",
@@ -16103,17 +16322,17 @@ cargo.rust_library(
         ":crossbeam-queue-0.3.11",
         ":either-1.13.0",
         ":event-listener-2.5.3",
-        ":futures-channel-0.3.30",
-        ":futures-core-0.3.30",
+        ":futures-channel-0.3.31",
+        ":futures-core-0.3.31",
         ":futures-intrusive-0.5.0",
-        ":futures-io-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-io-0.3.31",
+        ":futures-util-0.3.31",
         ":hashlink-0.8.4",
         ":hex-0.4.3",
         ":indexmap-2.6.0",
         ":log-0.4.22",
         ":memchr-2.7.4",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":paste-1.0.15",
         ":percent-encoding-2.3.1",
         ":rust_decimal-1.36.0",
@@ -16177,10 +16396,10 @@ cargo.rust_library(
         ":chrono-0.4.38",
         ":crc-3.2.1",
         ":dotenvy-0.15.7",
-        ":futures-channel-0.3.30",
-        ":futures-core-0.3.30",
-        ":futures-io-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-channel-0.3.31",
+        ":futures-core-0.3.31",
+        ":futures-io-0.3.31",
+        ":futures-util-0.3.31",
         ":hex-0.4.3",
         ":hkdf-0.12.4",
         ":hmac-0.12.1",
@@ -16190,7 +16409,7 @@ cargo.rust_library(
         ":md-5-0.10.6",
         ":memchr-2.7.4",
         ":num-bigint-0.4.6",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":rand-0.8.5",
         ":rust_decimal-1.36.0",
         ":serde-1.0.210",
@@ -16311,8 +16530,8 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":futures-core-0.3.30",
-        ":pin-project-1.1.5",
+        ":futures-core-0.3.31",
+        ":pin-project-1.1.6",
         ":tokio-1.40.0",
     ],
 )
@@ -16421,7 +16640,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.5.0",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":rustversion-1.0.17",
         ":syn-2.0.79",
@@ -16508,7 +16727,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":unicode-ident-1.0.13",
     ],
@@ -16549,7 +16768,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":unicode-ident-1.0.13",
     ],
@@ -16591,7 +16810,7 @@ cargo.rust_library(
         "futures-core",
     ],
     visibility = [],
-    deps = [":futures-core-0.3.30"],
+    deps = [":futures-core-0.3.31"],
 )
 
 http_archive(
@@ -16727,7 +16946,7 @@ cargo.rust_library(
     deps = [
         ":cfg-if-1.0.0",
         ":fastrand-2.1.1",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
     ],
 )
 
@@ -16839,7 +17058,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -16856,8 +17075,8 @@ cargo.rust_binary(
         ":async-nats-0.36.0",
         ":async-recursion-1.1.1",
         ":async-trait-0.1.83",
-        ":aws-config-1.5.7",
-        ":aws-sdk-firehose-1.49.0",
+        ":aws-config-1.5.8",
+        ":aws-sdk-firehose-1.50.0",
         ":axum-0.6.20",
         ":base64-0.22.1",
         ":blake3-1.5.4",
@@ -16866,7 +17085,7 @@ cargo.rust_binary(
         ":cacache-13.0.0",
         ":chrono-0.4.38",
         ":ciborium-0.2.2",
-        ":clap-4.5.19",
+        ":clap-4.5.20",
         ":color-eyre-0.6.3",
         ":colored-2.1.0",
         ":comfy-table-7.1.1",
@@ -16879,14 +17098,14 @@ cargo.rust_binary(
         ":darling-0.20.10",
         ":deadpool-0.10.0",
         ":deadpool-postgres-0.12.1",
-        ":derive_builder-0.20.1",
+        ":derive_builder-0.20.2",
         ":derive_more-0.99.18",
         ":devicemapper-0.34.1",
         ":diff-0.1.13",
         ":directories-5.0.1",
         ":dyn-clone-1.0.17",
         ":flate2-1.0.34",
-        ":futures-0.3.30",
+        ":futures-0.3.31",
         ":futures-lite-2.3.0",
         ":glob-0.3.1",
         ":hex-0.4.3",
@@ -16910,7 +17129,7 @@ cargo.rust_binary(
         ":nix-0.27.1",
         ":nkeys-0.4.4",
         ":num_cpus-1.16.0",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":open-5.3.0",
         ":opentelemetry-0.22.0",
         ":opentelemetry-otlp-0.15.0",
@@ -16926,7 +17145,7 @@ cargo.rust_binary(
         ":postcard-1.0.10",
         ":postgres-types-0.2.8",
         ":pretty_assertions_sorted-1.2.3",
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":procfs-0.16.0",
         ":quote-1.0.37",
         ":rand-0.8.5",
@@ -16946,9 +17165,11 @@ cargo.rust_binary(
         ":serde_json-1.0.125",
         ":serde_path_to_error-0.1.16",
         ":serde_url_params-0.2.1",
-        ":serde_with-3.10.0",
+        ":serde_with-3.11.0",
         ":serde_yaml-0.9.34+deprecated",
         ":sodiumoxide-0.2.7",
+        ":spicedb-client-0.1.1",
+        ":spicedb-grpc-0.1.1",
         ":stream-cancel-0.8.2",
         ":strum-0.26.3",
         ":syn-2.0.79",
@@ -17030,7 +17251,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -17108,7 +17329,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":cfg-if-1.0.0",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
     ],
 )
 
@@ -17421,7 +17642,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -17479,8 +17700,8 @@ cargo.rust_library(
         ":byteorder-1.5.0",
         ":bytes-1.7.2",
         ":fallible-iterator-0.2.0",
-        ":futures-channel-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-channel-0.3.31",
+        ":futures-util-0.3.31",
         ":log-0.4.22",
         ":parking_lot-0.12.3",
         ":percent-encoding-2.3.1",
@@ -17517,7 +17738,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":futures-0.3.30",
+        ":futures-0.3.31",
         ":ring-0.17.5",
         ":rustls-0.22.4",
         ":tokio-1.40.0",
@@ -17600,7 +17821,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":rustls-0.23.13",
+        ":rustls-0.23.14",
         ":tokio-1.40.0",
     ],
 )
@@ -17635,9 +17856,9 @@ cargo.rust_library(
     deps = [
         ":bytes-1.7.2",
         ":educe-0.5.11",
-        ":futures-core-0.3.30",
-        ":futures-sink-0.3.30",
-        ":pin-project-1.1.5",
+        ":futures-core-0.3.31",
+        ":futures-sink-0.3.31",
+        ":pin-project-1.1.6",
         ":serde-1.0.210",
         ":serde_json-1.0.125",
     ],
@@ -17673,7 +17894,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":futures-core-0.3.30",
+        ":futures-core-0.3.31",
         ":pin-project-lite-0.2.14",
         ":tokio-1.40.0",
         ":tokio-util-0.7.12",
@@ -17704,7 +17925,7 @@ cargo.rust_library(
     deps = [
         ":async-stream-0.3.6",
         ":bytes-1.7.2",
-        ":futures-core-0.3.30",
+        ":futures-core-0.3.31",
         ":tokio-1.40.0",
         ":tokio-stream-0.1.16",
     ],
@@ -17738,7 +17959,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":futures-util-0.3.30",
+        ":futures-util-0.3.31",
         ":log-0.4.22",
         ":tokio-1.40.0",
         ":tungstenite-0.20.1",
@@ -17776,9 +17997,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bytes-1.7.2",
-        ":futures-core-0.3.30",
-        ":futures-sink-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-core-0.3.31",
+        ":futures-sink-0.3.31",
+        ":futures-util-0.3.31",
         ":pin-project-lite-0.2.14",
         ":tokio-1.40.0",
     ],
@@ -17807,7 +18028,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bytes-1.7.2",
-        ":futures-0.3.30",
+        ":futures-0.3.31",
         ":libc-0.2.159",
         ":tokio-1.40.0",
         ":vsock-0.3.0",
@@ -17941,8 +18162,61 @@ cargo.rust_library(
         ":hyper-0.14.30",
         ":hyper-timeout-0.4.1",
         ":percent-encoding-2.3.1",
-        ":pin-project-1.1.5",
+        ":pin-project-1.1.6",
         ":prost-0.12.6",
+        ":tokio-1.40.0",
+        ":tokio-stream-0.1.16",
+        ":tower-0.4.13",
+        ":tower-layer-0.3.3",
+        ":tower-service-0.3.3",
+        ":tracing-0.1.40",
+    ],
+)
+
+http_archive(
+    name = "tonic-0.12.3.crate",
+    sha256 = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52",
+    strip_prefix = "tonic-0.12.3",
+    urls = ["https://static.crates.io/crates/tonic/0.12.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tonic-0.12.3",
+    srcs = [":tonic-0.12.3.crate"],
+    crate = "tonic",
+    crate_root = "tonic-0.12.3.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "CARGO_MANIFEST_DIR": "tonic-0.12.3.crate",
+        "CARGO_PKG_AUTHORS": "Lucio Franco <luciofranco14@gmail.com>",
+        "CARGO_PKG_DESCRIPTION": "A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility.\n",
+        "CARGO_PKG_NAME": "tonic",
+        "CARGO_PKG_REPOSITORY": "https://github.com/hyperium/tonic",
+        "CARGO_PKG_VERSION": "0.12.3",
+        "CARGO_PKG_VERSION_MAJOR": "0",
+        "CARGO_PKG_VERSION_MINOR": "12",
+        "CARGO_PKG_VERSION_PATCH": "3",
+    },
+    features = [
+        "channel",
+        "codegen",
+        "prost",
+    ],
+    visibility = [],
+    deps = [
+        ":async-trait-0.1.83",
+        ":base64-0.22.1",
+        ":bytes-1.7.2",
+        ":http-1.1.0",
+        ":http-body-1.0.1",
+        ":http-body-util-0.1.2",
+        ":hyper-1.4.1",
+        ":hyper-timeout-0.5.1",
+        ":hyper-util-0.1.9",
+        ":percent-encoding-2.3.1",
+        ":pin-project-1.1.6",
+        ":prost-0.13.3",
         ":tokio-1.40.0",
         ":tokio-stream-0.1.16",
         ":tower-0.4.13",
@@ -18007,11 +18281,11 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":futures-core-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-core-0.3.31",
+        ":futures-util-0.3.31",
         ":hdrhistogram-7.5.4",
         ":indexmap-1.9.3",
-        ":pin-project-1.1.5",
+        ":pin-project-1.1.6",
         ":pin-project-lite-0.2.14",
         ":rand-0.8.5",
         ":slab-0.4.9",
@@ -18057,11 +18331,11 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-compression-0.4.13",
+        ":async-compression-0.4.14",
         ":bitflags-2.6.0",
         ":bytes-1.7.2",
-        ":futures-core-0.3.30",
-        ":futures-util-0.3.30",
+        ":futures-core-0.3.31",
+        ":futures-util-0.3.31",
         ":http-0.2.12",
         ":http-body-0.4.6",
         ":http-range-header-0.3.1",
@@ -18161,7 +18435,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -18188,7 +18462,7 @@ cargo.rust_library(
         "valuable",
     ],
     visibility = [],
-    deps = [":once_cell-1.20.1"],
+    deps = [":once_cell-1.20.2"],
 )
 
 http_archive(
@@ -18237,7 +18511,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":log-0.4.22",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":tracing-core-0.1.32",
     ],
 )
@@ -18281,7 +18555,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":opentelemetry-0.22.0",
         ":opentelemetry_sdk-0.22.1",
         ":smallvec-1.13.2",
@@ -18359,7 +18633,7 @@ cargo.rust_library(
     deps = [
         ":matchers-0.1.0",
         ":nu-ansi-term-0.46.0",
-        ":once_cell-1.20.1",
+        ":once_cell-1.20.2",
         ":regex-1.11.0",
         ":serde-1.0.210",
         ":serde_json-1.0.125",
@@ -18496,7 +18770,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":futures-0.3.30",
+        ":futures-0.3.31",
         ":pin-project-lite-0.2.14",
         ":tokio-1.40.0",
     ],
@@ -19157,7 +19431,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
     ],
 )
@@ -19530,7 +19804,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -19553,7 +19827,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -19748,6 +20022,7 @@ cargo.rust_library(
         "Win32_System",
         "Win32_System_Console",
         "Win32_System_IO",
+        "Win32_System_LibraryLoader",
         "Win32_System_Memory",
         "Win32_System_SystemInformation",
         "default",
@@ -20034,7 +20309,7 @@ cargo.rust_library(
     features = ["net"],
     visibility = [],
     deps = [
-        ":futures-util-0.3.30",
+        ":futures-util-0.3.31",
         ":thiserror-1.0.64",
         ":tokio-1.40.0",
         ":yrs-0.17.4",
@@ -20151,7 +20426,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],
@@ -20198,7 +20473,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.86",
+        ":proc-macro2-1.0.87",
         ":quote-1.0.37",
         ":syn-2.0.79",
     ],

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -198,9 +198,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e614738943d3f68c628ae3dbce7c3daffb196665f82f8c8ea6b65de73c79429"
+checksum = "998282f8f49ccd6116b0ed8a4de0fbd3151697920e7c7533416d6e25e76434a7"
 dependencies = [
  "brotli",
  "flate2",
@@ -318,6 +318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,9 +352,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.7"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8191fb3091fa0561d1379ef80333c3c7191c6f0435d986e85821bcf7acbd1126"
+checksum = "7198e6f03240fdceba36656d8be440297b6b82270325908c7381f37d826a74f6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -437,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-firehose"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "067405963a7a5a8ce3708228c8bd11805959a4873d45599076bc9238f2d2330c"
+checksum = "3f1ebf3cee2426d2aa1204ff7b6f9785004ba7d5c5b4b2187a10d5d7f7f1b75f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -459,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.44.0"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b90cfe6504115e13c41d3ea90286ede5aa14da294f3fe077027a6e83850843c"
+checksum = "0dc2faec3205d496c7e57eff685dd944203df7ce16a4116d0281c44021788a7b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -481,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.45.0"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167c0fad1f212952084137308359e8e4c4724d1c643038ce163f06de9662c1d0"
+checksum = "c93c241f52bc5e0476e259c953234dab7e2a35ee207ee202e86c0095ec4951dc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -503,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.44.0"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb5f98188ec1435b68097daa2a37d74b9d17c9caa799466338a8d1544e71b9d"
+checksum = "b259429be94a3459fa1b00c5684faee118d74f9577cc50aebadc36e507c63b5f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -599,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
+checksum = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -609,7 +615,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes 1.7.2",
  "fastrand",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.1",
@@ -1110,9 +1116,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.24"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "shlex",
 ]
@@ -1193,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1203,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1388,7 +1394,7 @@ dependencies = [
  "log",
  "mime",
  "paste",
- "pin-project 1.1.5",
+ "pin-project 1.1.6",
  "serde",
  "serde_json",
  "tar",
@@ -1766,18 +1772,18 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1787,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn 2.0.79",
@@ -2212,9 +2218,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2227,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2237,15 +2243,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2265,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -2284,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2295,21 +2301,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2438,6 +2444,25 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
+ "indexmap 2.6.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes 1.7.2",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.6.0",
  "slab",
  "tokio",
@@ -2711,7 +2736,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2734,6 +2759,7 @@ dependencies = [
  "bytes 1.7.2",
  "futures-channel",
  "futures-util",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -2785,7 +2811,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2803,6 +2829,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2832,7 +2871,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hyper 0.14.30",
- "pin-project 1.1.5",
+ "pin-project 1.1.6",
  "tokio",
 ]
 
@@ -3066,6 +3105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,9 +3121,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "0cb94a0ffd3f3ee755c20f7d8752f45cac88605a4dcf808abcff72873296ec7b"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3627,12 +3675,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"
@@ -3685,10 +3730,10 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.12.6",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -3699,8 +3744,8 @@ checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.12.6",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -3978,11 +4023,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
 dependencies = [
- "pin-project-internal 1.1.5",
+ "pin-project-internal 1.1.6",
 ]
 
 [[package]]
@@ -3998,9 +4043,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4286,9 +4331,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
@@ -4339,7 +4384,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes 1.7.2",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+dependencies = [
+ "bytes 1.7.2",
+ "prost-derive 0.13.3",
 ]
 
 [[package]]
@@ -4353,6 +4408,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+dependencies = [
+ "prost 0.13.3",
 ]
 
 [[package]]
@@ -4411,7 +4488,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "socket2",
  "thiserror",
  "tokio",
@@ -4428,7 +4505,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "slab",
  "thiserror",
  "tinyvec",
@@ -4732,7 +4809,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -4960,9 +5037,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
 dependencies = [
  "once_cell",
  "ring",
@@ -5065,9 +5142,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -5343,9 +5420,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9720086b3357bcb44fce40117d769a4d068c70ecfa190850a980a71755f66fcc"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5361,9 +5438,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1abbfe725f27678f4663bcacb75a83e829fd464c25d78dd038a3a29e307cec"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5558,6 +5635,30 @@ dependencies = [
  "libc",
  "libsodium-sys",
  "serde",
+]
+
+[[package]]
+name = "spicedb-client"
+version = "0.1.1"
+source = "git+https://github.com/systeminit/spicedb-client.git?branch=si-stable#3cf3ba3482412372cee072ab3585098a8dfc1cd1"
+dependencies = [
+ "bytes 1.7.2",
+ "http 1.1.0",
+ "prost 0.13.3",
+ "prost-types",
+ "spicedb-grpc",
+ "thiserror",
+ "tonic 0.12.3",
+]
+
+[[package]]
+name = "spicedb-grpc"
+version = "0.1.1"
+source = "git+https://github.com/systeminit/spicedb-client.git?branch=si-stable#3cf3ba3482412372cee072ab3585098a8dfc1cd1"
+dependencies = [
+ "prost 0.13.3",
+ "prost-types",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -5841,7 +5942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9fbf9bd71e4cf18d68a8a0951c0e5b7255920c0cd992c4ff51cddd6ef514a3"
 dependencies = [
  "futures-core",
- "pin-project 1.1.5",
+ "pin-project 1.1.6",
  "tokio",
 ]
 
@@ -6143,6 +6244,8 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "sodiumoxide",
+ "spicedb-client",
+ "spicedb-grpc",
  "stream-cancel",
  "strum 0.26.3",
  "syn 2.0.79",
@@ -6398,7 +6501,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-pki-types",
  "tokio",
 ]
@@ -6413,7 +6516,7 @@ dependencies = [
  "educe",
  "futures-core",
  "futures-sink",
- "pin-project 1.1.5",
+ "pin-project 1.1.6",
  "serde",
  "serde_json",
 ]
@@ -6528,14 +6631,40 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes 1.7.2",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
- "pin-project 1.1.5",
- "prost",
+ "pin-project 1.1.6",
+ "prost 0.12.6",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes 1.7.2",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project 1.1.6",
+ "prost 0.13.3",
  "tokio",
  "tokio-stream",
  "tower",
@@ -6554,7 +6683,7 @@ dependencies = [
  "futures-util",
  "hdrhistogram",
  "indexmap 1.9.3",
- "pin-project 1.1.5",
+ "pin-project 1.1.6",
  "pin-project-lite",
  "rand 0.8.5",
  "slab",
@@ -7035,9 +7164,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "ef073ced962d62984fb38a36e5fdc1a2b23c9e0e1fa0689bb97afa4202ef6887"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7046,9 +7175,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "c4bfab14ef75323f4eb75fa52ee0a3fb59611977fd3240da19b2cf36ff85030e"
 dependencies = [
  "bumpalo",
  "log",
@@ -7061,9 +7190,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "65471f79c1022ffa5291d33520cbbb53b7687b01c2f8e83b57d102eed7ed479d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7073,9 +7202,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "a7bec9830f60924d9ceb3ef99d55c155be8afa76954edffbb5936ff4509474e7"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7083,9 +7212,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "4c74f6e152a76a2ad448e223b0fc0b6b5747649c3d769cc6bf45737bf97d0ed6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7096,15 +7225,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "a42f6c679374623f295a8623adfe63d9284091245c3504bde47c17a3ce2777d9"
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "44188d185b5bdcae1052d08bcbcf9091a5524038d4572cc4f4f2bb9d5554ddd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -124,6 +124,8 @@ serde_url_params = "0.2.1"
 serde_with = "3.7.0"
 serde_yaml = "0.9.33" # NOTE(nick): this has been archived upstream
 sodiumoxide = "0.2.7"
+spicedb-client = "0.1.1"
+spicedb-grpc = "0.1.1"
 stream-cancel = "0.8.2"
 strum = { version = "0.26.2", features = ["derive"] }
 syn = { version = "2.0.55", features = ["full", "extra-traits"] }
@@ -147,17 +149,17 @@ tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.4", features = ["compression-br", "compression-deflate", "compression-gzip", "cors", "trace"] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
 tracing = { version = "0.1.40" }
 tracing-opentelemetry = "0.23.0"
-tracing-tunnel = "0.1.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "std"] }
+tracing-tunnel = "0.1.0"
 trybuild = { version = "1.0.99", features = ["diff"] }
 tryhard = "0.5.1"
 ulid = { version = "1.1.2", features = ["serde"] }
 url = { version = "2.5.0", features = ["serde"] }
 uuid = { version = "1.8.0", features = ["serde", "v4"] }
+version_check = "0.9.4"
 vfs = "0.12.0"
 vfs-tar = { version = "0.4.1", features = ["mmap"] }
 webpki-roots = { version = "0.25.4" }
-version_check = "0.9.4"
 xxhash-rust = { version = "0.8.10", features = ["xxh3", "const_xxh3"] }
 y-sync = { version = "0.4.0", features = ["net"] }
 yrs = { version = "0.17.4" }
@@ -170,6 +172,10 @@ hyperlocal = { git = "https://github.com/fnichol/hyperlocal.git", branch = "pub-
 # https://github.com/durch/rust-s3/pull/372
 # Note that this helps us to narrow down the number of `ring`/`rustls` versions to 1 each
 rust-s3 = { git = "https://github.com/ScuffleTV/rust-s3.git", branch = "troy/rustls" }
+# pending merging of patches upstream
+spicedb-client = { git = "https://github.com/systeminit/spicedb-client.git", branch = "si-stable" }
+# pending merging of patches upstream
+spicedb-grpc = { git = "https://github.com/systeminit/spicedb-client.git", branch = "si-stable" }
 # pending a potential merge and release of
 # https://github.com/jbg/tokio-postgres-rustls/pull/18
 tokio-postgres-rustls = { git = "https://github.com/jbg/tokio-postgres-rustls.git", branch = "master" }


### PR DESCRIPTION
This client wraps the `spicedb-client` and `spicedb-grpc` crates with instrumentation and some request/response wrapping types.

<img src="https://media0.giphy.com/media/CAlBTS57uDXoY/giphy.gif"/>