### PR TITLE
chore: show how snapshots can be repaired

### DIFF
--- a/lib/dal/examples/rebase/main.rs
+++ b/lib/dal/examples/rebase/main.rs
@@ -1,11 +1,16 @@
 use std::{env, fs::File, io::prelude::*};
 
+use petgraph::{visit::EdgeRef, Direction::Incoming};
+use regex::bytes;
 use serde::de::DeserializeOwned;
 use si_layer_cache::db::serialize;
 
 use dal::{
-    workspace_snapshot::graph::{correct_transforms::correct_transforms, RebaseBatch},
-    WorkspaceSnapshotGraphVCurrent,
+    workspace_snapshot::{
+        graph::{correct_transforms::correct_transforms, RebaseBatch},
+        node_weight::NodeWeight,
+    },
+    WorkspaceSnapshotGraph,
 };
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + 'static>>;
@@ -20,20 +25,51 @@ fn load_snapshot_graph<T: DeserializeOwned>(path: &str) -> Result<T> {
     Ok(serialize::from_bytes(&bytes)?)
 }
 
+fn write_snapshot_graph(path: &str, graph: &WorkspaceSnapshotGraph) -> Result<()> {
+    let mut file = File::create(path)?;
+    let bytes = serialize::to_vec(graph)?;
+    file.write_all(&bytes)?;
+
+    Ok(())
+}
+
 fn main() -> Result<()> {
-    let args: Vec<String> = env::args().take(3).map(Into::into).collect();
-    let to_rebase_path = args.get(1).expect(USAGE);
-    let rebase_batch_path = args.get(2).expect(USAGE);
+    let args: Vec<String> = env::args().take(10).map(Into::into).collect();
 
-    let mut to_rebase_graph: WorkspaceSnapshotGraphVCurrent = load_snapshot_graph(to_rebase_path)?;
-    let rebase_batch: RebaseBatch = load_snapshot_graph(rebase_batch_path)?;
+    for i in 1..args.len() {
+        let to_rebase_path = args.get(i).expect(USAGE);
 
-    let corrected_transforms =
-        correct_transforms(&to_rebase_graph, rebase_batch.updates().to_vec(), false)?;
+        let mut to_rebase_graph: WorkspaceSnapshotGraph = load_snapshot_graph(to_rebase_path)?;
 
-    to_rebase_graph.perform_updates(&corrected_transforms)?;
+        let mut orphaned_component_idxs = vec![];
 
-    dbg!(to_rebase_graph.node_count());
+        for (node_weight, node_idx) in to_rebase_graph.nodes() {
+            if let NodeWeight::Component(_) = node_weight {
+                let mut has_edge_to_category = false;
+                for edge_ref in to_rebase_graph.edges_directed(node_idx, Incoming) {
+                    if let NodeWeight::Category(_) =
+                        to_rebase_graph.get_node_weight(edge_ref.source()).unwrap()
+                    {
+                        has_edge_to_category = true;
+                        break;
+                    }
+                }
+
+                if !has_edge_to_category {
+                    orphaned_component_idxs.push(node_idx);
+                }
+            }
+        }
+
+        for orphaned_idx in dbg!(orphaned_component_idxs) {
+            to_rebase_graph.remove_node(orphaned_idx);
+        }
+
+        to_rebase_graph.cleanup_and_merkle_tree_hash().unwrap();
+        let filename = format!("{}.fixed.snapshot", to_rebase_path);
+        write_snapshot_graph(&filename, &to_rebase_graph).expect("write");
+        println!("wrote {filename}");
+    }
 
     Ok(())
 }

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -104,9 +104,24 @@ impl std::ops::Deref for WorkspaceSnapshotGraph {
     }
 }
 
+impl std::ops::DerefMut for WorkspaceSnapshotGraph {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner_mut()
+    }
+}
+
 impl WorkspaceSnapshotGraph {
     /// Return a reference to the most up to date enum variant for the graph type
     pub fn inner(&self) -> &WorkspaceSnapshotGraphVCurrent {
+        match self {
+            Self::Legacy | Self::V1(_) | Self::V2(_) => {
+                unimplemented!("Attempted to access an unmigrated snapshot!")
+            }
+            Self::V3(inner) => inner,
+        }
+    }
+
+    pub fn inner_mut(&mut self) -> &mut WorkspaceSnapshotGraphVCurrent {
         match self {
             Self::Legacy | Self::V1(_) | Self::V2(_) => {
                 unimplemented!("Attempted to access an unmigrated snapshot!")


### PR DESCRIPTION
The changes to the "rebase" example here were used to repair a broken workspace in prod, so this is a good starting point if we have to do this again.