### PR TITLE
Upload billing events to Lago via Lambda

### DIFF
--- a/component/lambda/functions/si_lago_api.py
+++ b/component/lambda/functions/si_lago_api.py
@@ -1,0 +1,137 @@
+from collections.abc import Iterable
+from itertools import islice
+import os
+import boto3
+import json
+from typing import Literal, NewType, TypeVar, TypedDict, Union, cast
+import requests  # from pip._vendor import requests
+import urllib.parse
+from si_logger import logger
+
+ExternalSubscriptionId = NewType("ExternalSubscriptionId", str)
+
+
+class LagoEvent(TypedDict):
+    transaction_id: str
+    external_subscription_id: ExternalSubscriptionId
+    timestamp: float
+    code: str
+    properties: dict[str, int]
+
+
+T = TypeVar("T")
+
+
+class LagoErrorResponse(TypedDict):
+    code: str
+    error_details: dict[str, dict[str, list[str]]]
+
+
+def batch(iterable: Iterable[T], n):
+    "Batch data into lists of length n. The last batch may be shorter."
+    # batched('ABCDEFG', 3) --> ABC DEF G
+    it = iter(iterable)
+    while True:
+        batch = list(islice(it, n))
+        if not batch:
+            return
+        yield batch
+
+
+class LagoHTTPError(Exception):
+    def __init__(self, *args, json, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.json = json
+
+
+class LagoApi:
+    @classmethod
+    def from_env(cls, session: boto3.Session):
+        lago_api_url = os.environ["LAGO_API_URL"]
+        lago_api_token = os.environ.get("LAGO_API_TOKEN")
+        if lago_api_token is None:
+            lago_api_token_arn = os.environ["LAGO_API_TOKEN_ARN"]
+
+            secretsmanager = session.client(service_name="secretsmanager")
+            secret = secretsmanager.get_secret_value(SecretId=lago_api_token_arn)
+            lago_api_token = json.loads(secret["SecretString"])["LAGO_API_TOKEN"]
+
+        return LagoApi(lago_api_url, lago_api_token)
+
+    def __init__(self, lago_api_url: str, lago_api_token: str):
+        self.lago_api_url = lago_api_url
+        self.lago_api_token = lago_api_token
+
+    def request(self, method: str, path: str, **kwargs):
+        response = requests.request(
+            method,
+            urllib.parse.urljoin(self.lago_api_url, path),
+            headers={"Authorization": f"Bearer {self.lago_api_token}"},
+            **kwargs,
+        )
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            raise LagoHTTPError(
+                f"{e.response.status_code} for {method} {path}: {e.response.text}",
+                json=e.response.json(),
+            ) from e
+
+        return response
+
+    def get(self, path: str):
+        return self.request("GET", path)
+
+    def delete(self, path: str):
+        return self.request("DELETE", path)
+
+    def put(self, path: str, json):
+        return self.request("PUT", path, json=json)
+
+    def post(self, path: str, json):
+        return self.request("POST", path, json=json)
+
+    def upload_events(self, events: Iterable[LagoEvent]):
+        """
+        Uploads events to Lago, batching them in groups of 100 (Lago's maximum).
+
+        If a batch fails due to an event already having been uploaded, we retry the ones that
+        try to upload each event
+        individually.
+
+        Exceptions:
+        - HTTPError: Any HTTP error response except 422 (which indicates the event already exists)
+        will be thrown.
+        """
+
+        for event_batch in batch(events, 100):
+            try:
+                self.post("/api/v1/events/batch", {"events": event_batch})
+
+            except LagoHTTPError as e:
+
+                # If the batch failed because some events were already uploaded, retry the rest
+                if [e.json.get("status"), e.json.get("code")] != [422, "validation_errors"]:
+                    raise
+
+                for error in e.json["error_details"].values():
+                    if error.get("transaction_id") != ["value_already_exist"]:
+                        raise
+
+                # Retry the events that did not fail
+                logger.warning(
+                    f"Events already existed: {[event_batch[int(i)]['transaction_id'] for i in e.json["error_details"].keys()]}"
+                )
+                retry_event_batch = [
+                    event
+                    for (i, event) in enumerate(event_batch)
+                    if str(i) not in e.json["error_details"].keys()
+                ]
+
+                if len(retry_event_batch) > 0:
+                    logger.warning(
+                        f"Reuploading remaining {len(retry_event_batch)} events."
+                    )
+
+                    # Retry the events that didn't fail. Any failure here is a real error
+                    self.post("/api/v1/events/batch", {"events": retry_event_batch})

--- a/component/lambda/functions/si_logger.py
+++ b/component/lambda/functions/si_logger.py
@@ -1,0 +1,5 @@
+import logging
+
+
+logger = logging.getLogger()
+logging.basicConfig(level=logging.INFO)

--- a/component/lambda/functions/si_redshift.py
+++ b/component/lambda/functions/si_redshift.py
@@ -1,0 +1,185 @@
+from collections.abc import Callable
+import os
+from typing import (
+    Any,
+    Generator,
+    Literal,
+    TypeVar,
+    Unpack,
+    NotRequired,
+    TypedDict,
+    overload,
+)
+import boto3
+from mypy_boto3_redshift_data import RedshiftDataAPIServiceClient
+import botocore
+import botocore.session as bc
+from botocore.client import Config
+import time
+
+
+class DatabaseConnectParams(TypedDict):
+    ClientToken: NotRequired[str]
+    ClusterIdentifier: NotRequired[str]
+    Database: NotRequired[str]
+    DbUser: NotRequired[str]
+    SecretArn: NotRequired[str]
+    WorkgroupName: NotRequired[str]
+
+
+FieldValue = int | str | float | bool | None
+
+T = TypeVar("T")
+
+
+class Redshift:
+    @classmethod
+    def from_env(
+        cls,
+        session=boto3.Session(),
+        secret_id=os.environ["LAMBDA_REDSHIFT_ACCESS"],
+        WorkgroupName="platform-app-datastore",
+        Database="data",
+    ):
+        secretsmanager = session.client(service_name="secretsmanager")
+        secret_arn = secretsmanager.get_secret_value(SecretId=secret_id)["ARN"]
+        return cls(
+            session,
+            WorkgroupName=WorkgroupName,
+            Database=Database,
+            SecretArn=secret_arn,
+        )
+
+    def __init__(
+        self,
+        session: boto3.Session,
+        wait_interval_seconds: float = 0.25,
+        **database_params: Unpack[DatabaseConnectParams],
+    ):
+        self._session = session
+        self._database_params = database_params
+        self._wait_interval_seconds = wait_interval_seconds
+        self._client = self._connect()
+
+    def query(self, Sql: str, **Parameters: object):
+        return self._query(Sql, with_headers=True, **Parameters)
+
+    def query_raw(self, Sql: str, **Parameters: object):
+        return self._query(Sql, with_headers=False, **Parameters)
+
+    def execute(self, Sql: str, **Parameters: object):
+        """
+        Executes a SQL statement, waiting for completion.
+
+        Returns only when the query status is "FINISHED".
+
+        Returns: the describe_statement response.
+
+        Raises:
+            Exception if the query failed or was aborted.
+        """
+        query_args = {}
+        if len(Parameters) > 0:
+            query_args = {
+                "Parameters": [
+                    {"name": name, "value": value}
+                    for [name, value] in Parameters.items()
+                ]
+            }
+
+        statement = self.with_client(
+            lambda client: client.execute_statement(
+                Sql=Sql, **self._database_params, **query_args  # type: ignore
+            )
+        )
+
+        while True:
+            response = self.with_client(
+                lambda client: client.describe_statement(Id=statement["Id"])
+            )
+            status = response["Status"]
+
+            if status == "FINISHED":
+                return response
+            elif status == "FAILED":
+                raise Exception(
+                    f"Query failed: {response['Error']} (Id={statement['Id']})"
+                )
+            elif status == "ABORTED":
+                raise Exception(f"Query aborted (Id={statement['Id']})")
+
+            print(
+                f"Query status: {status}. Waiting {self._wait_interval_seconds}s for completion... (Id={statement['Id']})"
+            )
+
+            time.sleep(self._wait_interval_seconds)
+
+    @overload
+    def _query(
+        self, Sql: str, with_headers: Literal[False], **Parameters: object
+    ) -> Generator[list[FieldValue], Any, None]: ...
+
+    @overload
+    def _query(
+        self, Sql: str, with_headers: Literal[True], **Parameters: object
+    ) -> Generator[dict[str, FieldValue], Any, None]: ...
+
+    def _query(self, Sql: str, with_headers: bool, **Parameters: object):
+        def to_python_value(value) -> FieldValue:
+            assert len(value) == 1
+            return None if value.get("isNull") == True else list(value.values())[0]
+
+        if len(Parameters) > 0:
+            print(f"Executing query: {Sql} with parameters {Parameters}")
+            statement = self.execute(Sql, **Parameters)
+        else:
+            print(f"Executing query: {Sql}")
+            statement = self.execute(Sql)
+
+        # Get the first page of results
+        result = self.with_client(
+            lambda client: client.get_statement_result(
+                Id=statement["Id"],
+            )
+        )
+
+        # Page through the results, yielding each one
+        column_names = [col["name"] for col in result["ColumnMetadata"]]  # type: ignore
+        while True:
+            print(f"Page with {len(result['Records'])} records")
+            for record in result["Records"]:
+                values = [to_python_value(value) for value in record]
+                yield dict(zip(column_names, values)) if with_headers else values
+
+            # If this was the last page, exit.
+            if "NextToken" not in result:
+                break
+
+            next_token: str = result["NextToken"]
+
+            print(f"Getting next page with token {next_token} ...")
+            result = self.with_client(
+                lambda client: client.get_statement_result(
+                    Id=statement["Id"], NextToken=next_token
+                )
+            )
+
+    def with_client(self, callback: Callable[["RedshiftDataAPIServiceClient"], T]) -> T:
+        """
+        Calls the callback with the Redshift client, reconnecting and retrying if the
+        connection has been lost.
+        """
+
+        try:
+            return callback(self._client)
+        except botocore.exceptions.ConnectionError as e:  # type: ignore
+            self._client = self._connect()
+            print("Re-executing after reestablishing connection")
+            return callback(self._client)
+        except Exception as e:
+            raise Exception(e)
+
+    def _connect(self):
+        return self._session.client(
+            "redshift-data", config=Config(connect_timeout=5, read_timeout=5)
+        )

--- a/component/lambda/functions/si_types.py
+++ b/component/lambda/functions/si_types.py
@@ -1,0 +1,5 @@
+from typing import NewType
+
+OwnerPk = NewType("OwnerPk", str)
+WorkspaceId = NewType("WorkspaceId", str)
+SqlTimestamp = NewType("SqlTimestamp", str)

--- a/component/lambda/functions/track_resource_counts.py
+++ b/component/lambda/functions/track_resource_counts.py
@@ -1,0 +1,164 @@
+import json
+from typing import Optional, cast
+from si_redshift import FieldValue, Redshift
+from si_types import WorkspaceId, SqlTimestamp
+
+redshift = Redshift.from_env()
+
+
+class WorkspaceResourceCountEvent:
+    @classmethod
+    def from_row(
+        cls,
+        row: list[FieldValue],
+    ):
+        return cls(*cast(tuple[WorkspaceId, int, SqlTimestamp], row))
+
+    def __init__(
+        self,
+        workspace_id: WorkspaceId,
+        resource_count: int,
+        event_timestamp: SqlTimestamp,
+    ):
+        self.workspace_id = workspace_id
+        self.resource_count = resource_count
+        self.event_timestamp = event_timestamp
+
+
+class WorkspaceResourceCounts:
+    def __init__(self, redshift: Redshift, at_time: Optional[SqlTimestamp] = None):
+        self.redshift = redshift
+        self.last_event: Optional[SqlTimestamp] = None
+        self.resource_count = dict[WorkspaceId, int]()
+        for count in self._get_workspace_resource_counts(at_time):
+            self.set(count)
+
+    def get(self, workspace_id: WorkspaceId) -> Optional[int]:
+        return self.resource_count.get(workspace_id)
+
+    def for_workspace(self, workspace_id: WorkspaceId) -> Optional[int]:
+        return self.resource_count.get(workspace_id)
+
+    def set(self, event: WorkspaceResourceCountEvent):
+        self.resource_count[event.workspace_id] = event.resource_count
+        self.last_event = event.event_timestamp
+
+    def _get_workspace_resource_counts(self, at_time: Optional[SqlTimestamp]):
+        params: dict[str, FieldValue]
+        if at_time is None:
+            where_clause = "WHERE next_event_timestamp IS NULL"
+            params = {}
+        else:
+            where_clause = """
+                WHERE next_event_timestamp <= :at_time
+                  AND (:at_time < next_event_timestamp OR next_event_timestamp IS NULL)
+            """
+            params = {"at_time": at_time}
+
+        return map(
+            WorkspaceResourceCountEvent.from_row,
+            redshift.query_raw(
+                f"""
+            SELECT workspace_id, resource_count, event_timestamp
+              FROM workspace_operations.workspace_resource_counts
+             {where_clause}
+             ORDER BY event_timestamp
+        """,
+                **params,
+            ),
+        )
+
+
+# def workspace_resource_count_history(redshift: Redshift, start_time: SqlTimestamp):
+#     return cast(Iterator[tuple[WorkspaceId, int, str]], redshift.execute())
+
+
+def insert_workspace_resource_count(
+    redshift: Redshift, event: WorkspaceResourceCountEvent
+):
+    # Insert the record (and update the old record to point at the new record's range)
+    redshift.execute(
+        """
+        BEGIN;
+
+        UPDATE workspace_operations.workspace_resource_counts
+            SET next_event_timestamp = :event_timestamp
+            WHERE workspace_id = :workspace_id AND next_event_timestamp IS NULL;
+
+        INSERT INTO workspace_operations.workspace_resource_counts
+            (workspace_id, resource_count, event_timestamp, next_event_timestamp)
+        VALUES
+            (:workspace_id, :resource_count, :event_timestamp, NULL);
+
+        COMMIT;
+    """,
+        workspace_id=event.workspace_id,
+        resource_count=str(event.resource_count),
+        event_timestamp=event.event_timestamp,
+    )
+
+
+def complete_workspace_update_events(
+    redshift: Redshift, start_time: Optional[SqlTimestamp]
+):
+    """
+    Get workspace update events that are definitely finished (i.e. we do not expect any more
+    events to show up later within the same time window).
+    """
+    end_time = cast(
+        SqlTimestamp,
+        next(
+            redshift.query_raw(
+                """
+        SELECT DATEADD(MINUTE, -15, CAST(MAX(event_timestamp) AS TIMESTAMP))
+                  FROM workspace_update_events.workspace_update_events
+    """
+            )
+        )[0],
+    )
+
+    if start_time:
+        print(f"Getting workspace_update_events from {start_time} to {end_time} ...")
+    else:
+        print(f"Getting ALL workspace_update_events up to {end_time} ...")
+
+    return map(
+        WorkspaceResourceCountEvent.from_row,
+        redshift.query_raw(
+            f"""
+            SELECT workspace_id, resource_count, event_timestamp
+            FROM workspace_update_events.workspace_update_events
+            WHERE CAST(event_timestamp AS TIMESTAMP) < :end_time
+              {"AND CAST(event_timestamp AS TIMESTAMP) >= :start_time" if start_time else ""}
+              AND resource_count IS NOT NULL
+            ORDER BY event_timestamp
+        """,
+            end_time=end_time,
+            **({"start_time": start_time} if start_time else {}),
+        ),
+    )
+
+
+def lambda_handler(_event=None, _context=None):
+    # UPDATE WORKSPACE_RESOURCE_COUNTS
+    # 1. Determine start_time based on latest workspace_resource_count.
+    # 2. Determine end_time based on latest workspace_update_event - 15 minutes.
+    # 3. Initialize workspace_resource_count from workspace_resource_counts where next_event_timestamp = NULL (last event).
+    # 4. UPDATE WORKSPACE_RESOURCE_COUNTS: for each workspace_update_event from start_time to end_time:
+    #    a. If resource_count is null or the same, skip it.
+    #    b. Update workspace_resource_count from NULL to next_event_timestamp.
+    #    c. Insert new workspace_resource_count with event_timestamp.
+
+    resource_counts = WorkspaceResourceCounts(redshift)
+
+    # Update workspace_resource_counts by adding a record each time it changes
+    for event in complete_workspace_update_events(redshift, resource_counts.last_event):
+        if event.resource_count != resource_counts.for_workspace(event.workspace_id):
+            print(f"Event: {event.event_timestamp}")
+            resource_counts.set(event)
+            insert_workspace_resource_count(redshift, event)
+
+    return {"statusCode": 200, "body": json.dumps({})}
+
+
+lambda_handler(None, None)

--- a/component/lambda/functions/upload_billing_resource_hours_to_lago.py
+++ b/component/lambda/functions/upload_billing_resource_hours_to_lago.py
@@ -1,0 +1,123 @@
+from typing import Iterator, cast
+from datetime import date, datetime, timedelta, timezone
+import itertools
+import boto3
+
+from si_redshift import Redshift
+from si_lago_api import LagoApi, ExternalSubscriptionId, LagoEvent
+from si_logger import logger
+from si_types import OwnerPk, SqlTimestamp
+
+
+session = boto3.Session()
+redshift = Redshift.from_env(session)
+lago = LagoApi.from_env(session)
+
+
+paul = OwnerPk("01GW0KXH4YJBWC7BTBAZ6ZR7EA")
+billable_metric_code = "resource-hours"
+cost_per_resource_hour = 0.007
+
+
+def get_next_uninvoiced_month():
+    # Decide what month to set price for
+    today = date.today()
+    next_uninvoiced_month = today.replace(day=1)
+    # If we're still in the grace period at the beginning of the month, we want the price for the previous month
+    if today.day < 5:
+        next_uninvoiced_month = (next_uninvoiced_month - timedelta(days=1)).replace(
+            day=1
+        )
+    return next_uninvoiced_month
+
+
+def format_event(event: tuple[ExternalSubscriptionId, SqlTimestamp, int]) -> LagoEvent:
+    [external_subscription_id, hour_start, resource_count] = event
+
+    event_time = datetime.strptime(hour_start, "%Y-%m-%d %H:%M:%S").replace(
+        tzinfo=timezone.utc
+    )
+    assert (
+        event_time.minute == 0
+        and event_time.second == 0
+        and event_time.microsecond == 0
+    )
+    return {
+        "transaction_id": f"{external_subscription_id}-{datetime.strftime(event_time, '%Y-%m-%d-%H')}",
+        "external_subscription_id": external_subscription_id,
+        "timestamp": event_time.timestamp(),
+        "code": billable_metric_code,
+        "properties": {
+            "resource_hours": resource_count,
+        },
+    }
+
+
+def lambda_handler(_event=None, _context=None):
+    #
+    # Upload events by hour
+    #
+    all_events = cast(
+        Iterator[tuple[ExternalSubscriptionId, SqlTimestamp, int]],
+        redshift.query_raw(
+            """
+            SELECT external_subscription_id, hour_start, resource_count
+              FROM workspace_operations.owner_resource_hours_with_subscriptions
+             WHERE hour_start <= (SELECT last_complete_event FROM workspace_operations.workspace_update_events_summary)
+               AND external_subscription_id IS NOT NULL
+             ORDER BY hour_start DESC
+            """
+        ),
+    )
+
+    for hour_start, hour_events in itertools.groupby(
+        all_events, lambda event: event[1]
+    ):
+        logger.info(f"Uploading events for {hour_start}")
+        for _event in hour_events:
+            pass
+        # lago.upload_events(map(format_event, hour_events))
+
+    # lago.upload_events([format_event(event) for event in all_events])
+
+    # #
+    # # Upload prices
+    # #
+    # for [owner_pk, external_subscription_id, month, is_free] in cast(
+    #     Iterator[tuple[OwnerPk, ExternalSubscriptionId, str, bool]],
+    #     redshift.query_raw(
+    #         """
+    #         SELECT
+    #             owner_billing_months.owner_pk,
+    #             external_subscription_id,
+    #             month,
+    #             is_free
+    #         FROM workspace_operations.owner_billing_months
+    #         LEFT OUTER JOIN workspace_operations.latest_owner_subscriptions ON latest_owner_subscriptions.owner_pk = owner_billing_months.owner_pk
+    #         WHERE month = :month
+    #         AND owner_billing_months.owner_pk = :owner_pk
+    #         """,
+    #         month=str(get_next_uninvoiced_month()),
+    #         owner_pk=paul,
+    #     ),
+    # ):
+    #     # TODO only do this if it's active!
+    #     json = {
+    #         "subscription": {
+    #             "plan_overrides": {
+    #                 "charges": [
+    #                     {
+    #                         "resource-hours": {
+    #                             "properties": {
+    #                                 "amount": 0.4 if is_free else cost_per_resource_hour
+    #                             }
+    #                         }
+    #                     }
+    #                 ]
+    #             }
+    #         }
+    #     }
+    #     lago.put(f"/api/v1/subscriptions/{external_subscription_id}", json)
+
+
+lambda_handler()

--- a/component/lambda/sql/billing.sql
+++ b/component/lambda/sql/billing.sql
@@ -1,0 +1,210 @@
+create external schema spectrum_schema
+from data catalog
+database 'si-prod-data'
+iam_role 'arn:aws:iam::944151301248:role/si-prod-redshift,arn:aws:iam::798856999590:role/si-prod-glue-data-bucket';
+
+CREATE TABLE IF NOT EXISTS workspace_operations.lago_resource_hours_upload_record (
+    lago_organization_id INT NOT NULL,
+    upload_start_time TIMESTAMP NOT NULL,
+    upload_end_time TIMESTAMP NOT NULL,
+    hour_start TIMESTAMP NOT NULL,
+    uploaded_records TIMESTAMP NOT NULL,
+    error TEXT,
+)
+
+-- Status of workspace_update_events ingestion, including when we consider events to be complete
+CREATE OR REPLACE VIEW workspace_operations.workspace_update_events_summary AS
+    SELECT
+        MIN(event_timestamp)::timestamp AS first_event,
+        MAX(event_timestamp)::timestamp AS last_incomplete_event,
+        last_incomplete_event - (INTERVAL '15 minutes' MINUTE) AS last_complete_event,
+        DATE_TRUNC('hour', last_complete_event) AS last_complete_hour_end,
+        last_complete_hour_end - (INTERVAL '1 hour' HOUR) AS last_complete_hour_start
+      FROM workspace_update_events.workspace_update_events
+    WITH NO SCHEMA BINDING;
+
+
+-- The resource counts for each workspace after each time it changes
+CREATE OR REPLACE VIEW workspace_operations.workspace_resource_counts_view AS
+    WITH
+        -- Get only events with actual resource_counts recorded (plus previous resource count for next step)
+        workspace_resource_count_events AS (
+            SELECT *, LAG(resource_count) OVER (PARTITION BY workspace_id ORDER BY event_timestamp) AS prev_resource_count
+            FROM workspace_update_events.workspace_update_events
+            WHERE resource_count IS NOT NULL
+        ),
+        -- Once we have only events with resource counts, get the ones where it changed (plus next_event_timestamp)
+        workspace_resource_count_change_events AS (
+            SELECT *, LEAD(event_timestamp) OVER (PARTITION BY workspace_id ORDER BY event_timestamp)
+              FROM workspace_resource_count_events
+             WHERE resource_count != prev_resource_count
+        )
+    SELECT workspace_id, event_timestamp, resource_count, next_event_timestamp
+      FROM workspace_resource_count_change_events
+    WITH NO SCHEMA BINDING;
+
+
+-- Make it so we don't have to type schema prefixes for our tables / views
+SET search_path TO workspace_operations;
+
+-- Generates a list of all hours from Sep. 2024 until now
+CREATE OR REPLACE VIEW workspace_operations.si_hours AS
+    WITH RECURSIVE hour_generator (hour_start) AS (
+        SELECT '2024-09-01 00:00:00'::timestamp
+        UNION ALL (
+            SELECT hour_start + INTERVAL '1 hour' HOUR
+            FROM hour_generator
+            WHERE hour_start < getdate()
+        )
+    )
+    SELECT hour_start FROM hour_generator;
+
+
+-- The resource counts for an owner after each time it changes
+CREATE OR REPLACE VIEW workspace_operations.owner_resource_counts AS
+    WITH
+        -- Get all times at which any workspace for an owner has changed
+        event_times AS (
+            SELECT DISTINCT owner_pk, event_timestamp
+            FROM workspace_resource_counts
+            JOIN workspace_owners USING (workspace_id)
+        ),
+        -- For each event time, get the resource count for all resources at that time
+        event_resource_counts AS (
+            SELECT event_times.owner_pk, event_times.event_timestamp, workspace_owners.workspace_id, resource_count
+            FROM event_times
+            JOIN workspace_owners USING (owner_pk)
+            JOIN workspace_resource_counts USING (workspace_id)
+            WHERE workspace_resource_counts.event_timestamp <= event_times.event_timestamp
+                AND (next_event_timestamp IS NULL OR event_times.event_timestamp < next_event_timestamp)
+        )
+    SELECT owner_pk, event_timestamp, SUM(resource_count) AS resource_count, (LEAD(event_timestamp) OVER (PARTITION BY owner_pk ORDER BY event_timestamp)) AS next_event_timestamp
+      FROM event_resource_counts
+     GROUP BY owner_pk, event_timestamp;
+
+-- Maximum resource counts for each and every hour a user has had workspaces
+CREATE OR REPLACE VIEW workspace_operations.owner_resource_hours AS
+    WITH
+        -- Get resource counts at the start of the hour
+        at_hour_start AS (
+            SELECT owner_pk, hour_start, SUM(resource_count) AS resource_count
+              FROM owner_resource_counts
+              JOIN si_hours
+                ON event_timestamp <= hour_start
+                 AND (next_event_timestamp IS NULL OR hour_start < next_event_timestamp)
+             GROUP BY owner_pk, hour_start
+        ),
+        -- Get resource counts in the middle of the hour
+        on_change AS (
+            SELECT owner_pk, DATE_TRUNC('hour', event_timestamp) AS hour_start, resource_count
+                FROM owner_resource_counts
+        )
+        SELECT owner_pk, hour_start, MAX(resource_count) AS resource_count
+            FROM (
+                (SELECT * FROM at_hour_start)
+                UNION ALL
+                (SELECT * FROM on_change)
+            )
+            GROUP BY owner_pk, hour_start;
+
+
+-- Get the latest subscription records for each owner (the ones with MAX(record_timestamp))
+CREATE OR REPLACE VIEW workspace_operations.latest_owner_subscriptions AS
+    WITH
+      -- Find the latest time we've downloaded subscription data for each owner
+      latest_subscription_record_timestamps AS (
+        SELECT owner_pk, MAX(record_timestamp) AS latest_record_timestamp FROM workspace_owner_subscriptions GROUP BY owner_pk
+      ),
+      -- If the user's subscription data has changed, we only want the latest (MAX(record_timestamp))
+      latest_subscription_records AS (
+        SELECT workspace_owner_subscriptions.*
+            FROM workspace_owner_subscriptions
+            JOIN latest_subscription_record_timestamps
+            USING (owner_pk)
+            WHERE latest_record_timestamp = record_timestamp
+      ),
+      owners AS (SELECT DISTINCT owner_pk FROM workspace_owners)
+      SELECT owners.owner_pk,
+             free_trial.external_id AS free_trial_external_subscription_id,
+             free_trial.subscription_start_date AS free_trial_start_date,
+             free_trial.subscription_end_date AS free_trial_end_date,
+             subscription.external_id AS external_subscription_id,
+             subscription.subscription_start_date,
+             subscription.subscription_end_date,
+             COALESCE(free_trial.record_timestamp, subscription.record_timestamp) AS subscription_record_timestamp
+        FROM owners
+        LEFT OUTER JOIN latest_subscription_records free_trial USING (owner_pk)
+        LEFT OUTER JOIN latest_subscription_records subscription USING (owner_pk)
+        WHERE free_trial.plan_code = 'launch_trial'
+          AND subscription.plan_code = 'launch_pay_as_you_go';
+
+
+-- Get owner_resource_hours with subscription data
+CREATE OR REPLACE VIEW workspace_operations.owner_resource_hours_with_subscriptions AS
+    WITH all_owner_resource_hours_with_subscriptions AS (
+        SELECT owner_resource_hours.*,
+            (CASE
+                WHEN hour_start >= free_trial_end_date THEN external_subscription_id
+                WHEN hour_start >= DATE_TRUNC('hour', free_trial_start_date) THEN free_trial_external_subscription_id
+                ELSE NULL
+            END) AS external_subscription_id
+        FROM owner_resource_hours
+        LEFT OUTER JOIN latest_owner_subscriptions USING (owner_pk)
+    )
+    -- Don't include data before SI launched unless it is attached to a subscription
+    SELECT * FROM all_owner_resource_hours_with_subscriptions
+     WHERE hour_start >= '2024-09-25'::timestamp OR external_subscription_id IS NOT NULL
+
+
+-- Totals and max count for the month
+CREATE OR REPLACE VIEW workspace_operations.owner_billing_months AS
+    SELECT
+        owner_pk,
+        DATE_TRUNC('month', hour_start) AS month,
+        MAX(resource_count) AS max_resource_count,
+        SUM(resource_count) AS resource_hours,
+        (MAX(resource_count) <= 100) AS is_free
+    FROM owner_resource_hours
+    GROUP BY owner_pk, DATE_TRUNC('month', hour_start);
+
+--
+-- Test queries to verify things went off correctly
+--
+
+CREATE SCHEMA workspace_verifications IF NOT EXISTS;
+
+CREATE OR REPLACE VIEW workspace_verifications.owners_with_orphaned_resource_hours AS
+    WITH
+        owner_summary AS (
+            SELECT
+                owner_pk,
+                MIN(hour_start) AS first_event,
+                MAX(hour_start) AS last_event,
+                MAX(resource_count) AS max_resource_count
+            FROM owner_resource_hours_with_subscriptions
+            GROUP BY owner_pk
+        ),
+        owner_resource_hours_without_subscriptions AS (
+            SELECT
+                owner_pk,
+                MIN(hour_start) AS first_event_without_subscription,
+                MAX(hour_start) AS last_event_without_subscription
+            FROM owner_resource_hours_with_subscriptions
+            WHERE external_subscription_id IS NULL GROUP BY owner_pk
+        )
+    SELECT
+        owner_pk,
+        first_event,
+        first_event_without_subscription,
+        last_event_without_subscription,
+        last_event,
+        max_resource_count,
+        free_trial_external_subscription_id,
+        external_subscription_id,
+        free_trial_start_date,
+        free_trial_end_date
+    FROM owner_resource_hours_without_subscriptions
+    JOIN owner_summary USING (owner_pk)
+    LEFT OUTER JOIN latest_owner_subscriptions USING (owner_pk)
+    ORDER BY first_event DESC;
+


### PR DESCRIPTION
The SQL file here captures the views and tables we've created for billing so far in Redshift. The python scripts correspond to two other lambdas:

- `upload_billing_resource_hours_to_lago.py`: uploads all billing resource counts to Lago to be counted in each user's Usage (and eventually, invoice).
- `track_resource_counts.py`: processes incoming events from SDF into a coherent table, `workspace_resource_counts`, with a row for each time a workspace's resource count changed, as well as the timespan it was active, so you can query it to find out what count a workspace had at any arbitrary time. This will be replaced with `workspace_resource_counts_view` in the SQL when I have time for testing that.
- `si_logging.py`: just sets up a common logging object.
- `si_redshift.py`: a little query module letting you do `Redshift.from_env().query("SELECT * FROM table")`; does the heavy lifting of getting our env vars and setting up the AWS client, and interpreting the results into something comprehensible. @johnrwatson wrote much of the underlying code.
- `si_lago_api.py`: handles authentication and error interpretation for the Lago API.

Copy/pasted versions of these are currently running in prod. We'll get them driven off these files after they merge.