### PR TITLE
feat: add spicedb client relationship and permission calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5953,12 +5953,15 @@ dependencies = [
 name = "si-data-spicedb"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "indoc",
+ "rand 0.8.5",
  "remain",
  "serde",
  "si-std",
  "spicedb-client",
  "spicedb-grpc",
+ "strum 0.26.3",
  "telemetry",
  "thiserror",
  "tokio",

--- a/component/spicedb/entrypoint.sh
+++ b/component/spicedb/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-spicedb serve >>/tmp/spicedb.log 2>&1 &
+spicedb serve-testing >>/tmp/spicedb.log 2>&1 &
 tail -f /tmp/spicedb.log &
 sleep 3
 

--- a/lib/si-data-spicedb/BUCK
+++ b/lib/si-data-spicedb/BUCK
@@ -9,10 +9,12 @@ rust_library(
     deps = [
         "//lib/si-std:si-std",
         "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:futures",
         "//third-party/rust:remain",
         "//third-party/rust:serde",
         "//third-party/rust:spicedb-client",
         "//third-party/rust:spicedb-grpc",
+        "//third-party/rust:strum",
         "//third-party/rust:thiserror",
         "//third-party/rust:tokio",
         "//third-party/rust:url",
@@ -27,6 +29,7 @@ rust_test(
     name = "test-integration",
     deps = [
         "//third-party/rust:indoc",
+        "//third-party/rust:rand",
         "//third-party/rust:tokio",
         ":si-data-spicedb",
     ],

--- a/lib/si-data-spicedb/Cargo.toml
+++ b/lib/si-data-spicedb/Cargo.toml
@@ -9,11 +9,13 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
+futures = { workspace = true }
 remain = { workspace = true }
 serde = { workspace = true }
 si-std = { path = "../../lib/si-std" }
 spicedb-client = { workspace = true }
 spicedb-grpc = { workspace = true }
+strum = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
@@ -21,3 +23,4 @@ url = { workspace = true }
 
 [dev-dependencies]
 indoc = { workspace = true }
+rand = { workspace = true }

--- a/lib/si-data-spicedb/src/types.rs
+++ b/lib/si-data-spicedb/src/types.rs
@@ -1,6 +1,7 @@
 use std::ops;
 
-use spicedb_grpc::authzed::api::v1;
+use spicedb_client::builder::{RelationshipBuilder, RelationshipFilterBuilder};
+use spicedb_grpc::authzed::api::v1::{self, ObjectReference, SubjectReference};
 
 /// ZedToken is used to provide causality metadata between Write and Check requests.
 ///
@@ -47,5 +48,111 @@ impl From<v1::ReadSchemaResponse> for ReadSchemaResponse {
             schema_text: value.schema_text,
             read_at: value.read_at.map(|value| value.into()),
         }
+    }
+}
+
+pub type Relationships = Vec<Relationship>;
+#[derive(Clone, Debug)]
+pub struct Relationship(pub(crate) v1::Relationship);
+
+impl Relationship {
+    pub fn new(
+        object_type: impl ToString,
+        object_id: impl ToString,
+        relation: impl ToString,
+        subject_type: impl ToString,
+        subject_id: impl ToString,
+    ) -> Self {
+        Self(<v1::Relationship as RelationshipBuilder>::new(
+            object_type,
+            object_id,
+            relation,
+            subject_type,
+            subject_id,
+        ))
+    }
+
+    pub fn into_request(self) -> v1::ReadRelationshipsRequest {
+        let inner = self.0;
+        let mut builder = <v1::ReadRelationshipsRequest as RelationshipFilterBuilder>::new();
+
+        if let Some(resource) = inner.resource {
+            builder.resource_type(resource.object_type);
+        }
+
+        builder.relation(inner.relation);
+
+        builder
+    }
+
+    pub(crate) fn inner(self) -> v1::Relationship {
+        self.0
+    }
+
+    pub(crate) fn into_relationship_update(
+        self,
+        operation: v1::relationship_update::Operation,
+    ) -> v1::RelationshipUpdate {
+        spicedb_grpc::authzed::api::v1::RelationshipUpdate {
+            operation: operation.into(),
+            relationship: Some(self.inner()),
+        }
+    }
+}
+
+impl From<v1::Relationship> for Relationship {
+    fn from(value: v1::Relationship) -> Self {
+        Relationship(value)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Permission {
+    resource_type: String,
+    resource_id: String,
+    permission: String,
+    subject_type: String,
+    subject_id: String,
+}
+
+impl Permission {
+    pub fn new(
+        resource_type: impl ToString,
+        resource_id: impl ToString,
+        permission: impl ToString,
+        subject_type: impl ToString,
+        subject_id: impl ToString,
+    ) -> Self {
+        Self {
+            resource_type: resource_type.to_string(),
+            resource_id: resource_id.to_string(),
+            permission: permission.to_string(),
+            subject_type: subject_type.to_string(),
+            subject_id: subject_id.to_string(),
+        }
+    }
+
+    pub(crate) fn into_request(self) -> v1::CheckPermissionRequest {
+        v1::CheckPermissionRequest {
+            consistency: None,
+            resource: Some(ObjectReference {
+                object_type: self.resource_type,
+                object_id: self.resource_id,
+            }),
+            permission: self.permission,
+            subject: Some(SubjectReference {
+                object: Some(ObjectReference {
+                    object_type: self.subject_type,
+                    object_id: self.subject_id,
+                }),
+                optional_relation: "".to_string(),
+            }),
+            context: None,
+            with_tracing: false,
+        }
+    }
+
+    pub(crate) fn has_permission(permissionship: i32) -> bool {
+        i32::from(v1::check_permission_response::Permissionship::HasPermission) == permissionship
     }
 }

--- a/lib/si-data-spicedb/tests/integration_test/mod.rs
+++ b/lib/si-data-spicedb/tests/integration_test/mod.rs
@@ -1,7 +1,9 @@
 use std::env;
 
 use indoc::indoc;
-use si_data_spicedb::{Client, SpiceDbConfig};
+use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
+use si_data_spicedb::{Client, Permission, Relationship, SpiceDbConfig};
 
 const ENV_VAR_SPICEDB_URL: &str = "SI_TEST_SPICEDB_URL";
 
@@ -11,6 +13,10 @@ fn spicedb_config() -> SpiceDbConfig {
     if let Ok(value) = env::var(ENV_VAR_SPICEDB_URL) {
         config.endpoint = value.parse().expect("failed to parse spicedb url");
     }
+
+    let mut rng = thread_rng();
+    let random_string: String = (0..12).map(|_| rng.sample(Alphanumeric) as char).collect();
+    config.preshared_key = random_string.into();
     config
 }
 
@@ -49,4 +55,104 @@ async fn write_and_read_schema() {
         .schema_text()
         .lines()
         .any(|line| line == "definition plan {}"));
+}
+
+#[tokio::test]
+async fn write_and_read_relationship() {
+    let config = spicedb_config();
+
+    let mut client = Client::new(&config)
+        .await
+        .expect("failed to connect to spicedb");
+
+    let schema = indoc! {"
+        // Plan comment
+        definition plan {}
+
+        definition user {}
+
+        definition workspace {
+            relation approver: user
+            permission approve = approver
+        }
+    "};
+
+    client
+        .write_schema(schema)
+        .await
+        .expect("failed to write schema");
+
+    let scott_aprover_workspace =
+        Relationship::new("workspace", "456", "approver", "user", "scott");
+
+    client
+        .create_relationships(vec![scott_aprover_workspace.clone()])
+        .await
+        .expect("failed to create a relation");
+
+    let resp = client
+        .read_relationship(scott_aprover_workspace.clone())
+        .await
+        .expect("failed to read relation");
+
+    assert!(resp.len() == 1);
+
+    client
+        .delete_relationships(vec![scott_aprover_workspace.clone()])
+        .await
+        .expect("failed to delete relation");
+
+    let resp = client
+        .read_relationship(scott_aprover_workspace.clone())
+        .await
+        .expect("failed to read relation");
+
+    assert!(resp.is_empty());
+}
+
+#[tokio::test]
+async fn check_permissions() {
+    let config = spicedb_config();
+
+    let mut client = Client::new(&config)
+        .await
+        .expect("failed to connect to spicedb");
+
+    let schema = indoc! {"
+        // Plan comment
+        definition plan {}
+
+        definition user {}
+
+        definition workspace {
+            relation approver: user
+            permission approve = approver
+        }
+    "};
+
+    client
+        .write_schema(schema)
+        .await
+        .expect("failed to write schema");
+
+    let scott_aprover_workspace =
+        Relationship::new("workspace", "789", "approver", "user", "scott");
+
+    client
+        .create_relationships(vec![scott_aprover_workspace.clone()])
+        .await
+        .expect("failed to create a relation");
+
+    let perms = Permission::new("workspace", "789", "approver", "user", "scott");
+    let bad_perms = Permission::new("workspace", "789", "approver", "user", "fletcher");
+
+    assert!(client
+        .check_permissions(perms)
+        .await
+        .expect("failed to check permissions"));
+
+    assert!(!client
+        .check_permissions(bad_perms)
+        .await
+        .expect("failed to check permissions"));
 }


### PR DESCRIPTION
This adds crud operations for relationships and the ability to verify permissions against them.

<img src="https://media0.giphy.com/media/IgEwQ9CCHUdCF3q8v4/giphy.gif"/>