### PR TITLE
Mock audit logs for frontend

### DIFF
--- a/lib/dal/src/audit_log.rs
+++ b/lib/dal/src/audit_log.rs
@@ -1,0 +1,116 @@
+// TODO(nick): move this into its own crate.
+
+use chrono::Utc;
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use si_events::{
+    audit_log::{AuditLogKind, AuditLogService},
+    Actor,
+};
+use thiserror::Error;
+use ulid::MonotonicError;
+
+use crate::{
+    ChangeSet, ChangeSetError, ChangeSetId, DalContext, TransactionsError, Workspace,
+    WorkspaceError, WorkspacePk,
+};
+
+const LOG_COUNT: usize = 25;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum AuditLogError {
+    #[error("change set error: {0}")]
+    ChangeSet(#[from] ChangeSetError),
+    #[error("change set not found: {0}")]
+    ChangeSetNotFound(ChangeSetId),
+    #[error("monotonic error: {0}")]
+    Monotonic(#[from] MonotonicError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
+    #[error("workspace error: {0}")]
+    Workspace(#[from] WorkspaceError),
+    #[error("workspace not found: {0}")]
+    WorkspaceNotFound(WorkspacePk),
+}
+
+pub type AuditLogResult<T> = Result<T, AuditLogError>;
+
+pub async fn generate(ctx: &DalContext) -> AuditLogResult<Vec<si_frontend_types::AuditLog>> {
+    let workspace_pk = ctx.workspace_pk()?;
+    let change_set_id = ctx.change_set_id();
+
+    let workspace = Workspace::get_by_pk(ctx, &workspace_pk)
+        .await?
+        .ok_or(AuditLogError::WorkspaceNotFound(workspace_pk))?;
+    let change_set = ChangeSet::find(ctx, change_set_id)
+        .await?
+        .ok_or(AuditLogError::ChangeSetNotFound(change_set_id))?;
+
+    let mut generator = ulid::Generator::new();
+    let mut audit_logs = Vec::new();
+
+    for _ in 0..LOG_COUNT {
+        let generated = thread_rng().gen_range(0..2);
+        let (actor, actor_name, actor_email, origin_ip_address) = if generated == 1 {
+            let rand_string: String = thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(10)
+                .map(char::from)
+                .collect();
+            let name = rand_string.to_uppercase();
+            let email = format!("{rand_string}@poopcanoe.dev");
+            let user_pk = generator.generate()?;
+            (
+                Actor::User(user_pk.into()),
+                Some(name),
+                Some(email),
+                Some("127.0.0.1".to_string()),
+            )
+        } else {
+            (Actor::System, None, None, None)
+        };
+
+        let (service, kind) = match actor {
+            Actor::User(_) => {
+                let generated = thread_rng().gen_range(0..3);
+                if generated == 1 {
+                    (AuditLogService::Sdf, AuditLogKind::CreateComponent)
+                } else if generated == 2 {
+                    (AuditLogService::Sdf, AuditLogKind::DeleteComponent)
+                } else {
+                    (
+                        AuditLogService::Sdf,
+                        AuditLogKind::UpdatePropertyEditorValue,
+                    )
+                }
+            }
+            Actor::System => {
+                let generated = thread_rng().gen_range(0..2);
+                if generated == 1 {
+                    (AuditLogService::Rebaser, AuditLogKind::PerformedRebase)
+                } else {
+                    (
+                        AuditLogService::Pinga,
+                        AuditLogKind::RanDependentValuesUpdate,
+                    )
+                }
+            }
+        };
+
+        audit_logs.push(si_frontend_types::AuditLog {
+            actor,
+            actor_name,
+            actor_email,
+            service,
+            kind,
+            timestamp: Utc::now().to_rfc3339(),
+            origin_ip_address,
+            workspace_id: workspace_pk.into(),
+            workspace_name: Some(workspace.name().to_owned()),
+            change_set_id: Some(change_set_id.to_string()),
+            change_set_name: Some(change_set.name.to_owned()),
+        });
+    }
+
+    Ok(audit_logs)
+}

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -22,6 +22,7 @@ use tokio::time::Instant;
 pub mod action;
 pub mod actor_view;
 pub mod attribute;
+pub mod audit_log;
 pub mod authentication_prototype;
 pub mod billing_publish;
 pub mod builtins;

--- a/lib/dal/tests/integration_test/audit_log.rs
+++ b/lib/dal/tests/integration_test/audit_log.rs
@@ -1,0 +1,9 @@
+use dal::DalContext;
+use dal_test::test;
+
+#[test]
+async fn audit_log_generation_works(ctx: &DalContext) {
+    let _logs = dal::audit_log::generate(ctx)
+        .await
+        .expect("could not generate audit logs");
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -1,6 +1,7 @@
 mod action;
 mod asset;
 mod attribute;
+mod audit_log;
 mod change_set;
 mod component;
 mod connection;

--- a/lib/sdf-server/src/service/v2.rs
+++ b/lib/sdf-server/src/service/v2.rs
@@ -3,6 +3,7 @@ use axum::Router;
 use crate::AppState;
 
 pub mod admin;
+pub mod audit_log;
 pub mod func;
 pub mod module;
 pub mod variant;
@@ -12,7 +13,8 @@ const PREFIX: &str = "/workspaces/:workspace_id/change-sets/:change_set_id";
 pub fn routes(state: AppState) -> Router<AppState> {
     Router::new()
         .nest("/admin", admin::v2_routes(state))
-        .nest(&format!("{PREFIX}/schema-variants"), variant::v2_routes())
+        .nest(&format!("{PREFIX}/audit-logs"), audit_log::v2_routes())
         .nest(&format!("{PREFIX}/funcs"), func::v2_routes())
         .nest(&format!("{PREFIX}/modules"), module::v2_routes())
+        .nest(&format!("{PREFIX}/schema-variants"), variant::v2_routes())
 }

--- a/lib/sdf-server/src/service/v2/audit_log.rs
+++ b/lib/sdf-server/src/service/v2/audit_log.rs
@@ -1,0 +1,38 @@
+use axum::{
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use thiserror::Error;
+
+use crate::{service::ApiError, AppState};
+
+pub mod list_audit_logs;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum AuditLogError {
+    #[error("audit log error: {0}")]
+    AuditLog(#[from] dal::audit_log::AuditLogError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] dal::TransactionsError),
+}
+
+pub type AuditLogResult<T> = Result<T, AuditLogError>;
+
+impl IntoResponse for AuditLogError {
+    fn into_response(self) -> Response {
+        let err_string = self.to_string();
+
+        #[allow(clippy::match_single_binding)]
+        let (status_code, maybe_message) = match self {
+            _ => (ApiError::DEFAULT_ERROR_STATUS_CODE, None),
+        };
+
+        ApiError::new(status_code, maybe_message.unwrap_or(err_string)).into_response()
+    }
+}
+
+pub fn v2_routes() -> Router<AppState> {
+    Router::new().route("/", get(list_audit_logs::list_audit_logs))
+}

--- a/lib/sdf-server/src/service/v2/audit_log/list_audit_logs.rs
+++ b/lib/sdf-server/src/service/v2/audit_log/list_audit_logs.rs
@@ -1,0 +1,25 @@
+use axum::{
+    extract::{OriginalUri, Path},
+    Json,
+};
+use dal::{ChangeSetId, WorkspacePk};
+use si_frontend_types as frontend_types;
+
+use super::AuditLogResult;
+use crate::extract::{AccessBuilder, HandlerContext, PosthogClient};
+
+pub async fn list_audit_logs(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    PosthogClient(_posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    Path((_workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
+) -> AuditLogResult<Json<Vec<frontend_types::AuditLog>>> {
+    let ctx = builder
+        .build(access_builder.build(change_set_id.into()))
+        .await?;
+
+    let audit_logs = dal::audit_log::generate(&ctx).await?;
+
+    Ok(Json(audit_logs))
+}

--- a/lib/si-events-rs/src/audit_log.rs
+++ b/lib/si-events-rs/src/audit_log.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+
+#[remain::sorted]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub enum AuditLogService {
+    AuthApi,
+    Pinga,
+    Rebaser,
+    Sdf,
+}
+
+#[remain::sorted]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub enum AuditLogKind {
+    CreateComponent,
+    DeleteComponent,
+    PerformedRebase,
+    RanDependentValuesUpdate,
+    UpdatePropertyEditorValue,
+}

--- a/lib/si-events-rs/src/lib.rs
+++ b/lib/si-events-rs/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod audit_log;
 pub mod content_hash;
 pub mod encrypted_secret;
 pub mod merkle_tree_hash;

--- a/lib/si-frontend-types-rs/src/audit_log.rs
+++ b/lib/si-frontend-types-rs/src/audit_log.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+use si_events::{
+    audit_log::{AuditLogKind, AuditLogService},
+    Actor,
+};
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditLog {
+    pub actor: Actor,
+    pub actor_name: Option<String>,
+    pub actor_email: Option<String>,
+    pub service: AuditLogService,
+    pub kind: AuditLogKind,
+    pub timestamp: String,
+    pub origin_ip_address: Option<String>,
+    pub workspace_id: String,
+    pub workspace_name: Option<String>,
+    pub change_set_id: Option<String>,
+    pub change_set_name: Option<String>,
+}

--- a/lib/si-frontend-types-rs/src/lib.rs
+++ b/lib/si-frontend-types-rs/src/lib.rs
@@ -1,9 +1,11 @@
+mod audit_log;
 mod component;
 mod conflict;
 mod func;
 mod module;
 mod schema_variant;
 
+pub use crate::audit_log::AuditLog;
 pub use crate::component::{
     ChangeStatus, ConnectionAnnotation, DiagramSocket, DiagramSocketDirection,
     DiagramSocketNodeSide, GridPoint, Size2D, SummaryDiagramComponent,


### PR DESCRIPTION
## Description

This PR adds mocked audit logs for the frontend. Currently they are based in the `dal`, though it is likely that they will move to their own crate.

It's not in this PR, but there is a difference between a "frontend type" audit log and the audit log that will be ultimately be stored in the database. The purpose of this commit is to unlock frontend creativity by providing generated audit logs. It is not meant to reflect the structure that will ultimately be used by backend services.

<img src="https://media2.giphy.com/media/26nfp8HGGHLPGY2KQ/giphy.gif"/>