### PR TITLE
chore: refactor the way we send a force change set response

### DIFF
--- a/lib/sdf-server/src/service.rs
+++ b/lib/sdf-server/src/service.rs
@@ -14,6 +14,7 @@ pub mod attribute;
 pub mod change_set;
 pub mod component;
 pub mod diagram;
+pub mod force_change_set_response;
 pub mod graphviz;
 pub mod module;
 pub mod node_debug;

--- a/lib/sdf-server/src/service/component/delete_property_editor_value.rs
+++ b/lib/sdf-server/src/service/component/delete_property_editor_value.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use axum::{response::IntoResponse, Json};
+use axum::Json;
 use dal::{
     AttributeValue, AttributeValueId, ChangeSet, Component, ComponentId, PropId, Visibility,
     WsEvent,
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     extract::{AccessBuilder, HandlerContext},
-    service::component::ComponentResult,
+    service::{component::ComponentResult, force_change_set_response::ForceChangeSetResponse},
 };
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -27,7 +27,7 @@ pub async fn delete_property_editor_value(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
     Json(request): Json<DeletePropertyEditorValueRequest>,
-) -> ComponentResult<impl IntoResponse> {
+) -> ComponentResult<ForceChangeSetResponse<()>> {
     let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
@@ -46,9 +46,5 @@ pub async fn delete_property_editor_value(
 
     ctx.commit().await?;
 
-    let mut response = axum::response::Response::builder();
-    if let Some(force_change_set_id) = force_change_set_id {
-        response = response.header("force_change_set_id", force_change_set_id.to_string());
-    }
-    Ok(response.body(axum::body::Empty::new())?)
+    Ok(ForceChangeSetResponse::empty(force_change_set_id))
 }

--- a/lib/sdf-server/src/service/component/set_name.rs
+++ b/lib/sdf-server/src/service/component/set_name.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use axum::{
     extract::{Host, OriginalUri},
-    response::IntoResponse,
     Json,
 };
 use dal::{ChangeSet, Component, ComponentId, Visibility, WsEvent};
@@ -11,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use super::ComponentResult;
 use crate::{
     extract::{AccessBuilder, HandlerContext, PosthogClient},
+    service::force_change_set_response::ForceChangeSetResponse,
     track,
 };
 
@@ -34,7 +34,7 @@ pub async fn set_name(
         name,
         visibility,
     }): Json<SetNameRequest>,
-) -> ComponentResult<impl IntoResponse> {
+) -> ComponentResult<ForceChangeSetResponse<()>> {
     let mut ctx = builder.build(request_ctx.build(visibility)).await?;
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
@@ -66,9 +66,5 @@ pub async fn set_name(
 
     ctx.commit().await?;
 
-    let mut response = axum::response::Response::builder();
-    if let Some(force_change_set_id) = force_change_set_id {
-        response = response.header("force_change_set_id", force_change_set_id.to_string());
-    }
-    Ok(response.body(axum::body::Empty::new())?)
+    Ok(ForceChangeSetResponse::empty(force_change_set_id))
 }

--- a/lib/sdf-server/src/service/component/update_property_editor_value.rs
+++ b/lib/sdf-server/src/service/component/update_property_editor_value.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use axum::{
     extract::{Host, OriginalUri},
-    response::IntoResponse,
     Json,
 };
 use dal::{
@@ -14,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use super::ComponentResult;
 use crate::{
     extract::{AccessBuilder, HandlerContext, PosthogClient},
+    service::force_change_set_response::ForceChangeSetResponse,
     track,
 };
 
@@ -38,7 +38,7 @@ pub async fn update_property_editor_value(
     OriginalUri(original_uri): OriginalUri,
     Host(host_name): Host,
     Json(request): Json<UpdatePropertyEditorValueRequest>,
-) -> ComponentResult<impl IntoResponse> {
+) -> ComponentResult<ForceChangeSetResponse<()>> {
     let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
@@ -104,9 +104,5 @@ pub async fn update_property_editor_value(
 
     ctx.commit().await?;
 
-    let mut response = axum::response::Response::builder();
-    if let Some(force_change_set_id) = force_change_set_id {
-        response = response.header("force_change_set_id", force_change_set_id.to_string());
-    }
-    Ok(response.body(axum::body::Empty::new())?)
+    Ok(ForceChangeSetResponse::empty(force_change_set_id))
 }

--- a/lib/sdf-server/src/service/diagram/paste_component.rs
+++ b/lib/sdf-server/src/service/diagram/paste_component.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use axum::{
     extract::{Host, OriginalUri},
     http::uri::Uri,
-    response::IntoResponse,
     Json,
 };
 use dal::{
@@ -17,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use super::{DiagramError, DiagramResult};
 use crate::{
     extract::{AccessBuilder, HandlerContext, PosthogClient},
+    service::force_change_set_response::ForceChangeSetResponse,
     track,
 };
 
@@ -73,7 +73,7 @@ pub async fn paste_components(
     OriginalUri(original_uri): OriginalUri,
     Host(host_name): Host,
     Json(request): Json<PasteComponentsRequest>,
-) -> DiagramResult<impl IntoResponse> {
+) -> DiagramResult<ForceChangeSetResponse<()>> {
     let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
@@ -171,9 +171,5 @@ pub async fn paste_components(
 
     ctx.commit().await?;
 
-    let mut response = axum::response::Response::builder();
-    if let Some(force_change_set_id) = force_change_set_id {
-        response = response.header("force_change_set_id", force_change_set_id.to_string());
-    }
-    Ok(response.body(axum::body::Empty::new())?)
+    Ok(ForceChangeSetResponse::empty(force_change_set_id))
 }

--- a/lib/sdf-server/src/service/force_change_set_response.rs
+++ b/lib/sdf-server/src/service/force_change_set_response.rs
@@ -1,0 +1,89 @@
+use axum::{
+    http::{HeaderName, HeaderValue},
+    response::{IntoResponse, Response},
+};
+use dal::ChangeSetId;
+use hyper::{header, HeaderMap, StatusCode};
+use serde::Serialize;
+use tokio_util::bytes::{BufMut, BytesMut};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ForceChangeSetResponse<T>
+where
+    T: Serialize,
+{
+    force_change_set_id: Option<ChangeSetId>,
+    response: Option<T>,
+}
+
+impl<T> ForceChangeSetResponse<T>
+where
+    T: Serialize,
+{
+    pub fn new(force_change_set_id: Option<ChangeSetId>, response: T) -> Self {
+        Self {
+            force_change_set_id,
+            response: Some(response),
+        }
+    }
+
+    pub fn empty(force_change_set_id: Option<ChangeSetId>) -> Self {
+        Self {
+            force_change_set_id,
+            response: None,
+        }
+    }
+}
+
+const APPLICATION_JSON: &str = "application/json";
+const TEXT_PLAIN_UTF_8: &str = "text/plain; charset=utf-8";
+const FORCE_CHANGE_SET_HEADER: &str = "force_change_set_id";
+
+impl<T> IntoResponse for ForceChangeSetResponse<T>
+where
+    T: Serialize,
+{
+    fn into_response(self) -> Response {
+        let mut headers = HeaderMap::new();
+
+        if let Some(force_change_set_id) = self.force_change_set_id {
+            headers.insert(
+                HeaderName::from_static(FORCE_CHANGE_SET_HEADER),
+                match HeaderValue::from_str(&force_change_set_id.to_string()) {
+                    Ok(header_value) => header_value,
+                    Err(err) => {
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            [(header::CONTENT_TYPE, TEXT_PLAIN_UTF_8)],
+                            err.to_string(),
+                        )
+                            .into_response();
+                    }
+                },
+            );
+        }
+
+        match self.response {
+            Some(response) => {
+                let mut buf = BytesMut::with_capacity(128).writer();
+                match serde_json::to_writer(&mut buf, &response) {
+                    Ok(()) => {
+                        headers.insert(
+                            header::CONTENT_TYPE,
+                            HeaderValue::from_static(APPLICATION_JSON),
+                        );
+
+                        (headers, buf.into_inner().freeze()).into_response()
+                    }
+                    Err(err) => (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        [(header::CONTENT_TYPE, TEXT_PLAIN_UTF_8)],
+                        err.to_string(),
+                    )
+                        .into_response(),
+                }
+            }
+            None => (headers, ()).into_response(),
+        }
+    }
+}

--- a/lib/sdf-server/src/service/secret/update_secret.rs
+++ b/lib/sdf-server/src/service/secret/update_secret.rs
@@ -1,4 +1,4 @@
-use axum::{response::IntoResponse, Json};
+use axum::Json;
 use dal::{
     key_pair::KeyPairPk, ChangeSet, Secret, SecretAlgorithm, SecretId, SecretVersion, SecretView,
     Visibility, WsEvent,
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use super::SecretResult;
 use crate::extract::{AccessBuilder, HandlerContext};
+use crate::service::force_change_set_response::ForceChangeSetResponse;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -34,7 +35,7 @@ pub async fn update_secret(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_tx): AccessBuilder,
     Json(request): Json<UpdateSecretRequest>,
-) -> SecretResult<impl IntoResponse> {
+) -> SecretResult<ForceChangeSetResponse<SecretView>> {
     let mut ctx = builder.build(request_tx.build(request.visibility)).await?;
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
@@ -65,12 +66,8 @@ pub async fn update_secret(
 
     ctx.commit().await?;
 
-    let mut response = axum::response::Response::builder();
-    if let Some(force_change_set_id) = force_change_set_id {
-        response = response.header("force_change_set_id", force_change_set_id.to_string());
-    }
-
-    Ok(response.body(serde_json::to_string(
-        &SecretView::from_secret(&ctx, secret).await?,
-    )?)?)
+    Ok(ForceChangeSetResponse::new(
+        force_change_set_id,
+        SecretView::from_secret(&ctx, secret).await?,
+    ))
 }

--- a/lib/sdf-server/src/service/v2/func/binding/create_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/create_binding.rs
@@ -1,6 +1,5 @@
 use axum::{
     extract::{Host, OriginalUri, Path},
-    response::IntoResponse,
     Json,
 };
 use dal::{
@@ -15,7 +14,10 @@ use si_frontend_types as frontend_types;
 
 use crate::{
     extract::{AccessBuilder, HandlerContext, PosthogClient},
-    service::v2::func::{FuncAPIError, FuncAPIResult},
+    service::{
+        force_change_set_response::ForceChangeSetResponse,
+        v2::func::{FuncAPIError, FuncAPIResult},
+    },
     track,
 };
 
@@ -27,7 +29,7 @@ pub async fn create_binding(
     Host(host_name): Host,
     Path((_workspace_pk, change_set_id, func_id)): Path<(WorkspacePk, ChangeSetId, FuncId)>,
     Json(request): Json<frontend_types::FuncBindings>,
-) -> FuncAPIResult<impl IntoResponse> {
+) -> FuncAPIResult<ForceChangeSetResponse<Vec<si_frontend_types::FuncBinding>>> {
     let mut ctx = builder
         .build(access_builder.build(change_set_id.into()))
         .await?;
@@ -304,11 +306,5 @@ pub async fn create_binding(
 
     ctx.commit().await?;
 
-    let mut response = axum::response::Response::builder();
-    response = response.header("Content-Type", "application/json");
-    if let Some(force_change_set_id) = force_change_set_id {
-        response = response.header("force_change_set_id", force_change_set_id.to_string());
-    }
-
-    Ok(response.body(serde_json::to_string(&bindings)?)?)
+    Ok(ForceChangeSetResponse::new(force_change_set_id, bindings))
 }

--- a/lib/sdf-server/src/service/v2/func/binding/delete_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/delete_binding.rs
@@ -1,11 +1,13 @@
 use crate::{
     extract::{AccessBuilder, HandlerContext, PosthogClient},
-    service::v2::func::{FuncAPIError, FuncAPIResult},
+    service::{
+        force_change_set_response::ForceChangeSetResponse,
+        v2::func::{FuncAPIError, FuncAPIResult},
+    },
     track,
 };
 use axum::{
     extract::{Host, OriginalUri, Path},
-    response::IntoResponse,
     Json,
 };
 use dal::func::FuncKind;
@@ -26,7 +28,7 @@ pub async fn delete_binding(
     Host(host_name): Host,
     Path((_workspace_pk, change_set_id, func_id)): Path<(WorkspacePk, ChangeSetId, FuncId)>,
     Json(request): Json<frontend_types::FuncBindings>,
-) -> FuncAPIResult<impl IntoResponse> {
+) -> FuncAPIResult<ForceChangeSetResponse<Vec<frontend_types::FuncBinding>>> {
     let mut ctx = builder
         .build(access_builder.build(change_set_id.into()))
         .await?;
@@ -142,10 +144,5 @@ pub async fn delete_binding(
         .await?;
     ctx.commit().await?;
 
-    let mut response = axum::response::Response::builder();
-    response = response.header("Content-Type", "application/json");
-    if let Some(force_change_set_id) = force_change_set_id {
-        response = response.header("force_change_set_id", force_change_set_id.to_string());
-    }
-    Ok(response.body(serde_json::to_string(&binding)?)?)
+    Ok(ForceChangeSetResponse::new(force_change_set_id, binding))
 }

--- a/lib/sdf-server/src/service/v2/func/binding/update_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/update_binding.rs
@@ -1,6 +1,5 @@
 use axum::{
     extract::{Host, OriginalUri, Path},
-    response::IntoResponse,
     Json,
 };
 use dal::{
@@ -15,7 +14,10 @@ use si_frontend_types as frontend_types;
 
 use crate::{
     extract::{AccessBuilder, HandlerContext, PosthogClient},
-    service::v2::func::{FuncAPIError, FuncAPIResult},
+    service::{
+        force_change_set_response::ForceChangeSetResponse,
+        v2::func::{FuncAPIError, FuncAPIResult},
+    },
     track,
 };
 
@@ -27,7 +29,7 @@ pub async fn update_binding(
     Host(host_name): Host,
     Path((_workspace_pk, change_set_id, func_id)): Path<(WorkspacePk, ChangeSetId, FuncId)>,
     Json(request): Json<frontend_types::FuncBindings>,
-) -> FuncAPIResult<impl IntoResponse> {
+) -> FuncAPIResult<ForceChangeSetResponse<Vec<frontend_types::FuncBinding>>> {
     let mut ctx = builder
         .build(access_builder.build(change_set_id.into()))
         .await?;
@@ -184,10 +186,5 @@ pub async fn update_binding(
 
     ctx.commit().await?;
 
-    let mut response = axum::response::Response::builder();
-    response = response.header("Content-Type", "application/json");
-    if let Some(force_change_set_id) = force_change_set_id {
-        response = response.header("force_change_set_id", force_change_set_id.to_string());
-    }
-    Ok(response.body(serde_json::to_string(&binding)?)?)
+    Ok(ForceChangeSetResponse::new(force_change_set_id, binding))
 }

--- a/lib/sdf-server/src/service/v2/func/create_unlocked_copy.rs
+++ b/lib/sdf-server/src/service/v2/func/create_unlocked_copy.rs
@@ -1,6 +1,5 @@
 use axum::{
     extract::{Host, OriginalUri, Path},
-    response::IntoResponse,
     Json,
 };
 use dal::{
@@ -13,6 +12,7 @@ use si_frontend_types::{FuncCode, FuncSummary};
 use super::{get_code_response, FuncAPIError, FuncAPIResult};
 use crate::{
     extract::{AccessBuilder, HandlerContext, PosthogClient},
+    service::force_change_set_response::ForceChangeSetResponse,
     track,
 };
 
@@ -36,7 +36,7 @@ pub async fn create_unlocked_copy(
     Host(host_name): Host,
     Path((_workspace_pk, change_set_id, func_id)): Path<(WorkspacePk, ChangeSetId, FuncId)>,
     Json(request): Json<UnlockFuncRequest>,
-) -> FuncAPIResult<impl IntoResponse> {
+) -> FuncAPIResult<ForceChangeSetResponse<CreateFuncResponse>> {
     let mut ctx = builder
         .build(access_builder.build(change_set_id.into()))
         .await?;
@@ -75,14 +75,8 @@ pub async fn create_unlocked_copy(
 
     ctx.commit().await?;
 
-    let mut response = axum::response::Response::builder();
-    response = response.header("Content-Type", "application/json");
-    if let Some(force_change_set_id) = force_change_set_id {
-        response = response.header("force_change_set_id", force_change_set_id.to_string());
-    }
-
-    Ok(response.body(serde_json::to_string(&CreateFuncResponse {
-        summary,
-        code,
-    })?)?)
+    Ok(ForceChangeSetResponse::new(
+        force_change_set_id,
+        CreateFuncResponse { summary, code },
+    ))
 }

--- a/lib/sdf-server/src/service/v2/func/save_code.rs
+++ b/lib/sdf-server/src/service/v2/func/save_code.rs
@@ -1,6 +1,5 @@
 use axum::{
     extract::{Host, OriginalUri, Path},
-    response::IntoResponse,
     Json,
 };
 use dal::{
@@ -12,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use super::{get_code_response, FuncAPIResult};
 use crate::{
     extract::{AccessBuilder, HandlerContext, PosthogClient},
+    service::force_change_set_response::ForceChangeSetResponse,
     track,
 };
 
@@ -29,7 +29,7 @@ pub async fn save_code(
     Host(host_name): Host,
     Path((_workspace_pk, change_set_id, func_id)): Path<(WorkspacePk, ChangeSetId, FuncId)>,
     Json(request): Json<SaveCodeRequest>,
-) -> FuncAPIResult<impl IntoResponse> {
+) -> FuncAPIResult<ForceChangeSetResponse<()>> {
     let mut ctx = builder
         .build(access_builder.build(change_set_id.into()))
         .await?;
@@ -59,10 +59,5 @@ pub async fn save_code(
 
     ctx.commit().await?;
 
-    let mut response = axum::response::Response::builder();
-    response = response.header("Content-Type", "application/json");
-    if let Some(force_change_set_id) = force_change_set_id {
-        response = response.header("force_change_set_id", force_change_set_id.to_string());
-    }
-    Ok(response.body(axum::body::Empty::new())?)
+    Ok(ForceChangeSetResponse::empty(force_change_set_id))
 }

--- a/lib/sdf-server/src/service/variant.rs
+++ b/lib/sdf-server/src/service/variant.rs
@@ -50,6 +50,8 @@ pub enum SchemaVariantError {
     Pkg(#[from] PkgError),
     #[error("schema error: {0}")]
     Schema(#[from] SchemaError),
+    #[error("Schema name {0} already taken")]
+    SchemaNameAlreadyTaken(String),
     #[error("schema variant asset func not found: {0}")]
     SchemaVariantAssetNotFound(SchemaVariantId),
     #[error("json serialization error: {0}")]
@@ -91,6 +93,10 @@ impl IntoResponse for SchemaVariantError {
             SchemaVariantError::VariantAuthoring(VariantAuthoringError::FuncExecutionFailure(
                 message,
             )) => (StatusCode::UNPROCESSABLE_ENTITY, message),
+            SchemaVariantError::SchemaNameAlreadyTaken(name) => (
+                StatusCode::CONFLICT,
+                format!("Schema name {name} already in use"),
+            ),
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 

--- a/lib/sdf-server/src/service/variant/save_variant.rs
+++ b/lib/sdf-server/src/service/variant/save_variant.rs
@@ -1,6 +1,5 @@
 use axum::{
     extract::{Host, OriginalUri},
-    response::IntoResponse,
     Json,
 };
 use dal::{
@@ -11,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     extract::{AccessBuilder, HandlerContext, PosthogClient},
-    service::variant::SchemaVariantResult,
+    service::{force_change_set_response::ForceChangeSetResponse, variant::SchemaVariantResult},
     track,
 };
 
@@ -41,7 +40,7 @@ pub async fn save_variant(
         code,
         visibility,
     }): Json<SaveVariantRequest>,
-) -> SchemaVariantResult<impl IntoResponse> {
+) -> SchemaVariantResult<ForceChangeSetResponse<SaveVariantResponse>> {
     let mut ctx = builder.build(request_ctx.build(visibility)).await?;
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
@@ -94,13 +93,8 @@ pub async fn save_variant(
 
     ctx.commit().await?;
 
-    let mut response = axum::response::Response::builder();
-    response = response.header("Content-Type", "application/json");
-    if let Some(force_change_set_id) = force_change_set_id {
-        response = response.header("force_change_set_id", force_change_set_id.to_string());
-    }
-
-    Ok(response.body(serde_json::to_string(&SaveVariantResponse {
-        success: true,
-    })?)?)
+    Ok(ForceChangeSetResponse::new(
+        force_change_set_id,
+        SaveVariantResponse { success: true },
+    ))
 }


### PR DESCRIPTION
Instead of constructing an axum Response by hand and adding the force_change_set_id header manually, this introduces a new response type for our sdf routes that handles the header automatically in its implementation of the IntoResponse trait: ForceChangeSetResponse<T>. Use it anywhere you need to notify the frontend that the change set has changed.