### PR TITLE
fix: spawn one cleanup task per distinct disk cache

### DIFF
--- a/lib/si-layer-cache/tests/integration_test/disk_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/disk_cache.rs
@@ -1,4 +1,5 @@
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 
 use si_layer_cache::disk_cache::{DiskCache, DiskCacheConfig};
 
@@ -87,6 +88,8 @@ async fn remove_ttld_item() {
         Duration::from_secs(1),
     ))
     .expect("cannot create disk cache");
+    let token = CancellationToken::new();
+    disk_cache.start_cleanup_task(token.clone());
 
     disk_cache
         .insert("skid row".into(), b"slave to the grind".to_vec())


### PR DESCRIPTION
Currently, every 3600 seconds, 10s of thousands of disk cache tasks will attempt to evict stale files, exhausting CPU. Let's stop the disk cache eviction feature from spawning one long running eviction task per layer cache event. Instead spawn just one per distinct disk cache (as defined by the write path).