### PR TITLE
fix: add no-op mode and ensure item cleanup for disk cache

### DIFF
--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -59,3 +59,4 @@ seconds_to_idle = "$SI_CACHE_EVICTION_SECONDS_TO_IDLE"
 
 [layer_db_config.disk_cache_config]
 path = "$SI_LAYER_CACHE_DISK_PATH"
+cleanup_mode = "$SI_LAYER_CACHE_CLEANUP_MODE"

--- a/lib/si-layer-cache/src/db.rs
+++ b/lib/si-layer-cache/src/db.rs
@@ -166,17 +166,17 @@ where
             compute_executor.clone(),
         )?;
 
-        //        Self::spawn_cleanup_tasks(
-        //            &[
-        //                cas_cache.disk_cache(),
-        //                encrypted_secret_cache.disk_cache(),
-        //                func_run_cache.disk_cache(),
-        //                func_run_log_cache.disk_cache(),
-        //                rebase_batch_cache.disk_cache(),
-        //                snapshot_cache.disk_cache(),
-        //            ],
-        //            token.clone(),
-        //        );
+        Self::spawn_cleanup_tasks(
+            &[
+                cas_cache.disk_cache(),
+                encrypted_secret_cache.disk_cache(),
+                func_run_cache.disk_cache(),
+                func_run_log_cache.disk_cache(),
+                rebase_batch_cache.disk_cache(),
+                snapshot_cache.disk_cache(),
+            ],
+            token.clone(),
+        );
 
         let cache_updates_task = CacheUpdatesTask::create(
             instance_id,

--- a/lib/si-layer-cache/src/disk_cache.rs
+++ b/lib/si-layer-cache/src/disk_cache.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::sync::Arc;
 
 use std::path::PathBuf;
@@ -16,6 +17,7 @@ const DEFAULT_CHECK_CACHE_TTL_SECONDS: u64 = 60 * 60; // check every hour
 
 #[derive(Clone, Debug)]
 pub struct DiskCache {
+    cleanup_mode: DiskCacheCleanupMode,
     ttl: Duration,
     ttl_check_interval: Duration,
     write_path: Arc<PathBuf>,
@@ -24,6 +26,7 @@ pub struct DiskCache {
 impl DiskCache {
     pub fn new(config: DiskCacheConfig) -> LayerDbResult<Self> {
         let cache = Self {
+            cleanup_mode: config.cleanup_mode,
             ttl: config.ttl,
             ttl_check_interval: config.ttl_check_interval,
             write_path: config.path,
@@ -56,8 +59,11 @@ impl DiskCache {
     }
 
     pub async fn remove(&self, key: Arc<str>) -> LayerDbResult<()> {
-        let maybe_metadata = cacache::metadata(self.write_path.as_ref(), key).await?;
+        let maybe_metadata = cacache::metadata(self.write_path.as_ref(), key.clone()).await?;
         if let Some(metadata) = maybe_metadata {
+            if cacache::exists(self.write_path.as_ref(), &metadata.integrity).await {
+                cacache::remove(self.write_path.as_ref(), &key.clone()).await?;
+            }
             cacache::remove_hash(self.write_path.as_ref(), &metadata.integrity).await?;
         }
         Ok(())
@@ -75,27 +81,43 @@ impl DiskCache {
     }
 
     async fn cleanup(&self) {
+        let mut would_remove = 0;
+        let mut removed = 0;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("unable to get the current time, what does this mean? How could this happen?")
+            .as_millis();
+
         for md in cacache::list_sync(self.write_path.as_ref()).flatten() {
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect(
-                    "unable to get the current time, what does this mean? How could this happen?",
-                )
-                .as_millis();
+            tokio::task::yield_now().await;
             if now - md.time > self.ttl.as_millis() {
-                if let Err(err) = self.remove(md.key.into()).await {
-                    warn!("unable to remove item from disk cache: {}", err);
-                };
+                would_remove += 1;
+                match self.cleanup_mode {
+                    DiskCacheCleanupMode::Remove => {
+                        if let Err(err) = self.remove(md.key.into()).await {
+                            warn!("unable to remove item from disk cache: {}", err);
+                            continue;
+                        };
+                        removed += 1;
+                    }
+                    DiskCacheCleanupMode::NoOp => would_remove += 1,
+                }
             }
         }
+
+        info!(
+            "Disk cache cleanup mode {} removed {} out of {} expired items",
+            self.cleanup_mode, removed, would_remove
+        );
     }
 
     pub fn start_cleanup_task(&self, cancellation_token: CancellationToken) {
         let self_clone = self.clone();
 
         info!(
-            "starting disk cache cleanup task for {}",
-            self.write_path.display()
+            "starting disk cache cleanup task for {} in {} mode",
+            self.write_path.display(),
+            self.cleanup_mode
         );
 
         tokio::spawn(async move {
@@ -119,7 +141,23 @@ impl DiskCache {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum DiskCacheCleanupMode {
+    NoOp,
+    Remove,
+}
+
+impl fmt::Display for DiskCacheCleanupMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DiskCacheCleanupMode::NoOp => write!(f, "no-op"),
+            DiskCacheCleanupMode::Remove => write!(f, "remove"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DiskCacheConfig {
+    pub cleanup_mode: DiskCacheCleanupMode,
     pub path: Arc<PathBuf>,
     pub ttl: Duration,
     pub ttl_check_interval: Duration,
@@ -127,6 +165,7 @@ pub struct DiskCacheConfig {
 
 impl DiskCacheConfig {
     pub fn new(
+        cleanup_mode: DiskCacheCleanupMode,
         dir: impl Into<PathBuf>,
         table_name: impl Into<String>,
         ttl: Duration,
@@ -136,6 +175,7 @@ impl DiskCacheConfig {
         let table_name_string = table_name.into();
         let write_path = dir.join(table_name_string);
         Self {
+            cleanup_mode,
             path: write_path.into(),
             ttl,
             ttl_check_interval,
@@ -148,6 +188,7 @@ impl DiskCacheConfig {
             .expect("unable to create tmp dir for layerdb")
             .into_path();
         Self::new(
+            DiskCacheCleanupMode::Remove,
             dir,
             service,
             Duration::from_secs(DEFAULT_CACHE_TTL_SECONDS),
@@ -162,6 +203,7 @@ impl Default for DiskCacheConfig {
             .expect("unable to create tmp dir for layerdb")
             .into_path();
         Self {
+            cleanup_mode: DiskCacheCleanupMode::Remove,
             path: Arc::new(path),
             ttl: Duration::from_secs(DEFAULT_CACHE_TTL_SECONDS),
             ttl_check_interval: Duration::from_secs(DEFAULT_CHECK_CACHE_TTL_SECONDS),

--- a/lib/si-layer-cache/tests/integration_test/disk_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/disk_cache.rs
@@ -1,12 +1,13 @@
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-use si_layer_cache::disk_cache::{DiskCache, DiskCacheConfig};
+use si_layer_cache::disk_cache::{DiskCache, DiskCacheCleanupMode, DiskCacheConfig};
 
 #[tokio::test]
 async fn new() {
     let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
     let _disk_cache: DiskCache = DiskCache::new(DiskCacheConfig::new(
+        DiskCacheCleanupMode::NoOp,
         tempdir.path(),
         "random?",
         Duration::from_secs(600),
@@ -19,6 +20,7 @@ async fn new() {
 async fn insert_and_get() {
     let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
     let disk_cache: DiskCache = DiskCache::new(DiskCacheConfig::new(
+        DiskCacheCleanupMode::NoOp,
         tempdir.path(),
         "random?",
         Duration::from_secs(600),
@@ -41,6 +43,7 @@ async fn insert_and_get() {
 async fn insert_and_remove() {
     let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
     let disk_cache: DiskCache = DiskCache::new(DiskCacheConfig::new(
+        DiskCacheCleanupMode::NoOp,
         tempdir.path(),
         "random?",
         Duration::from_secs(600),
@@ -66,6 +69,7 @@ async fn insert_and_remove() {
 async fn remove_never_inserted_object() {
     let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
     let disk_cache: DiskCache = DiskCache::new(DiskCacheConfig::new(
+        DiskCacheCleanupMode::NoOp,
         tempdir.path(),
         "random?",
         Duration::from_secs(600),
@@ -82,6 +86,7 @@ async fn remove_never_inserted_object() {
 async fn remove_ttld_item() {
     let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
     let disk_cache: DiskCache = DiskCache::new(DiskCacheConfig::new(
+        DiskCacheCleanupMode::Remove,
         tempdir.path(),
         "random?",
         Duration::from_secs(1),
@@ -100,4 +105,29 @@ async fn remove_ttld_item() {
     let item = disk_cache.get("skid row".into()).await;
     // we should not be able to get the item as it will be cleaned up
     assert!(item.is_err());
+}
+
+#[tokio::test]
+async fn noop_ttld_item() {
+    let tempdir = tempfile::TempDir::new_in("/tmp").expect("cannot create tempdir");
+    let disk_cache: DiskCache = DiskCache::new(DiskCacheConfig::new(
+        DiskCacheCleanupMode::NoOp,
+        tempdir.path(),
+        "random?",
+        Duration::from_secs(1),
+        Duration::from_secs(1),
+    ))
+    .expect("cannot create disk cache");
+    let token = CancellationToken::new();
+    disk_cache.start_cleanup_task(token.clone());
+
+    disk_cache
+        .insert("skid row".into(), b"slave to the grind".to_vec())
+        .await
+        .expect("cannot insert object");
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    let item = disk_cache.get("skid row".into()).await;
+    // we should not be able to get the item as it will be cleaned up
+    assert!(item.is_ok());
 }


### PR DESCRIPTION
* Allows the disk cache cleanup to be run in no-op for validation
* Adds a config setting for adjusting the disk cache cleanup mode
* Re-enable disk cache cleanup
* Track and report on the disk cache cleanups
* Ensure we are removing both the index and the content when we remove from the disk cache

```
2024-10-14T15:25:13.975559Z  INFO ThreadId(57) si_layer_cache::disk_cache: Disk cache cleanup mode no-op removed 0 out of 0 expired items
2024-10-14T15:26:13.984540Z  INFO ThreadId(50) si_layer_cache::disk_cache: Disk cache cleanup mode no-op removed 0 out of 368 expired items

2024-10-14T16:12:05.830532Z  INFO ThreadId(64) si_layer_cache::disk_cache: Disk cache cleanup mode remove removed 0 out of 0 expired items
2024-10-14T16:12:15.869308Z  INFO ThreadId(30) si_layer_cache::disk_cache: Disk cache cleanup mode remove removed 133 out of 133 expired items
2024-10-14T16:12:25.876136Z  INFO ThreadId(60) si_layer_cache::disk_cache: Disk cache cleanup mode remove removed 0 out of 0 expired items
```