### PR TITLE
Report new snapshot address (not old) in billing event

### DIFF
--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -297,10 +297,6 @@ impl ChangeSet {
         ctx: &DalContext,
         workspace_snapshot_address: WorkspaceSnapshotAddress,
     ) -> ChangeSetResult<()> {
-        billing_publish::for_head_change_set_pointer_update(ctx, self)
-            .await
-            .map_err(Box::new)?;
-
         ctx.txns()
             .await?
             .pg()
@@ -311,6 +307,10 @@ impl ChangeSet {
             .await?;
 
         self.workspace_snapshot_address = workspace_snapshot_address;
+
+        billing_publish::for_head_change_set_pointer_update(ctx, self)
+            .await
+            .map_err(Box::new)?;
 
         Ok(())
     }


### PR DESCRIPTION
Right now, we're reporting the old snapshot address when we publish the "SnapshotUpdated" event, because we do it before we actually set the snapshot address. This moves the event to after, reporting the correct address.