### PR TITLE
Add filtering and pagination to fake audit logs

### DIFF
--- a/lib/dal/src/audit_log.rs
+++ b/lib/dal/src/audit_log.rs
@@ -1,10 +1,12 @@
 // TODO(nick): move this into its own crate.
 
+use std::{collections::HashSet, str::FromStr};
+
 use chrono::Utc;
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use rand::{thread_rng, Rng};
 use si_events::{
     audit_log::{AuditLogKind, AuditLogService},
-    Actor,
+    Actor, UserPk,
 };
 use thiserror::Error;
 use ulid::MonotonicError;
@@ -13,8 +15,6 @@ use crate::{
     ChangeSet, ChangeSetError, ChangeSetId, DalContext, TransactionsError, Workspace,
     WorkspaceError, WorkspacePk,
 };
-
-const LOG_COUNT: usize = 25;
 
 #[remain::sorted]
 #[derive(Debug, Error)]
@@ -27,6 +27,8 @@ pub enum AuditLogError {
     Monotonic(#[from] MonotonicError),
     #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),
+    #[error("ulid decode error: {0}")]
+    UlidDecode(#[from] ulid::DecodeError),
     #[error("workspace error: {0}")]
     Workspace(#[from] WorkspaceError),
     #[error("workspace not found: {0}")]
@@ -35,66 +37,113 @@ pub enum AuditLogError {
 
 pub type AuditLogResult<T> = Result<T, AuditLogError>;
 
-pub async fn generate(ctx: &DalContext) -> AuditLogResult<Vec<si_frontend_types::AuditLog>> {
+/// Generate somewhat believable, but fake [`si_frontend_types::AuditLogs`](si_frontend_types::AuditLog).
+pub async fn generate(
+    ctx: &DalContext,
+    generation_count: usize,
+) -> AuditLogResult<Vec<si_frontend_types::AuditLog>> {
     let workspace_pk = ctx.workspace_pk()?;
-    let change_set_id = ctx.change_set_id();
-
     let workspace = Workspace::get_by_pk(ctx, &workspace_pk)
         .await?
         .ok_or(AuditLogError::WorkspaceNotFound(workspace_pk))?;
-    let change_set = ChangeSet::find(ctx, change_set_id)
+
+    let current_change_set_id = ctx.change_set_id();
+    let current_change_set = ChangeSet::find(ctx, current_change_set_id)
         .await?
-        .ok_or(AuditLogError::ChangeSetNotFound(change_set_id))?;
+        .ok_or(AuditLogError::ChangeSetNotFound(current_change_set_id))?;
+
+    let head_change_set_id = workspace.default_change_set_id();
+    let head_change_set = ChangeSet::find(ctx, head_change_set_id)
+        .await?
+        .ok_or(AuditLogError::ChangeSetNotFound(current_change_set_id))?;
 
     let mut generator = ulid::Generator::new();
+    let user_max = (generator.generate()?, "Max Verstappen", "max@siandrbr.dev");
+    let user_charles = (
+        generator.generate()?,
+        "Charles LeClerc",
+        "charles@ferrarisi.org",
+    );
+    let user_lewis = (
+        generator.generate()?,
+        "Lewis Hamilton",
+        "lewis@mbamgpetronas+si.com",
+    );
+
     let mut audit_logs = Vec::new();
 
-    for _ in 0..LOG_COUNT {
-        let generated = thread_rng().gen_range(0..2);
-        let (actor, actor_name, actor_email, origin_ip_address) = if generated == 1 {
-            let rand_string: String = thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(10)
-                .map(char::from)
-                .collect();
-            let name = rand_string.to_uppercase();
-            let email = format!("{rand_string}@poopcanoe.dev");
-            let user_pk = generator.generate()?;
-            (
-                Actor::User(user_pk.into()),
-                Some(name),
-                Some(email),
-                Some("127.0.0.1".to_string()),
-            )
-        } else {
-            (Actor::System, None, None, None)
+    for _ in 0..generation_count {
+        let (actor, actor_name, actor_email, origin_ip_address) = match dice_roll(2) {
+            1 => match dice_roll(3) {
+                1 => (
+                    Actor::User(user_max.0.into()),
+                    Some(user_max.1.to_owned()),
+                    Some(user_max.2.to_owned()),
+                    Some("127.0.0.1".to_string()),
+                ),
+                2 => (
+                    Actor::User(user_charles.0.into()),
+                    Some(user_charles.1.to_owned()),
+                    Some(user_charles.2.to_owned()),
+                    Some("127.0.0.1".to_string()),
+                ),
+                _ => (
+                    Actor::User(user_lewis.0.into()),
+                    Some(user_lewis.1.to_owned()),
+                    Some(user_lewis.2.to_owned()),
+                    Some("127.0.0.1".to_string()),
+                ),
+            },
+            _ => (Actor::System, None, None, None),
         };
 
-        let (service, kind) = match actor {
-            Actor::User(_) => {
-                let generated = thread_rng().gen_range(0..3);
-                if generated == 1 {
-                    (AuditLogService::Sdf, AuditLogKind::CreateComponent)
-                } else if generated == 2 {
-                    (AuditLogService::Sdf, AuditLogKind::DeleteComponent)
-                } else {
-                    (
-                        AuditLogService::Sdf,
-                        AuditLogKind::UpdatePropertyEditorValue,
-                    )
-                }
-            }
-            Actor::System => {
-                let generated = thread_rng().gen_range(0..2);
-                if generated == 1 {
-                    (AuditLogService::Rebaser, AuditLogKind::PerformedRebase)
-                } else {
-                    (
-                        AuditLogService::Pinga,
-                        AuditLogKind::RanDependentValuesUpdate,
-                    )
-                }
-            }
+        let (service, kind, change_set_id, change_set_name) = match actor {
+            Actor::User(_) => match dice_roll(2) {
+                1 => (
+                    AuditLogService::Sdf,
+                    AuditLogKind::CreateComponent,
+                    current_change_set_id,
+                    current_change_set.name.to_owned(),
+                ),
+                2 => (
+                    AuditLogService::Sdf,
+                    AuditLogKind::DeleteComponent,
+                    current_change_set_id,
+                    current_change_set.name.to_owned(),
+                ),
+                _ => (
+                    AuditLogService::Sdf,
+                    AuditLogKind::UpdatePropertyEditorValue,
+                    current_change_set_id,
+                    current_change_set.name.to_owned(),
+                ),
+            },
+            Actor::System => match dice_roll(4) {
+                1 => (
+                    AuditLogService::Rebaser,
+                    AuditLogKind::PerformedRebase,
+                    head_change_set_id,
+                    head_change_set.name.to_owned(),
+                ),
+                2 => (
+                    AuditLogService::Rebaser,
+                    AuditLogKind::PerformedRebase,
+                    current_change_set_id,
+                    current_change_set.name.to_owned(),
+                ),
+                3 => (
+                    AuditLogService::Pinga,
+                    AuditLogKind::RanAction,
+                    head_change_set_id,
+                    head_change_set.name.to_owned(),
+                ),
+                _ => (
+                    AuditLogService::Pinga,
+                    AuditLogKind::RanDependentValuesUpdate,
+                    current_change_set_id,
+                    current_change_set.name.to_owned(),
+                ),
+            },
         };
 
         audit_logs.push(si_frontend_types::AuditLog {
@@ -108,9 +157,94 @@ pub async fn generate(ctx: &DalContext) -> AuditLogResult<Vec<si_frontend_types:
             workspace_id: workspace_pk.into(),
             workspace_name: Some(workspace.name().to_owned()),
             change_set_id: Some(change_set_id.to_string()),
-            change_set_name: Some(change_set.name.to_owned()),
+            change_set_name: Some(change_set_name),
         });
     }
 
     Ok(audit_logs)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn filter_and_paginate(
+    audit_logs: Vec<si_frontend_types::AuditLog>,
+    page: Option<usize>,
+    page_size: Option<usize>,
+    sort_timestamp_ascending: Option<bool>,
+    exclude_system_user: Option<bool>,
+    kind_filter: HashSet<AuditLogKind>,
+    service_filter: HashSet<AuditLogService>,
+    change_set_filter: HashSet<ChangeSetId>,
+    user_filter: HashSet<UserPk>,
+) -> AuditLogResult<Vec<si_frontend_types::AuditLog>> {
+    // First, filter the logs based on our chosen filters. This logic works by processing each
+    // audit log and assuming each log is within our desired scope by default. The instant that a
+    // log does not meet our scope, we continue!
+    let mut filtered_audit_logs = Vec::new();
+    for audit_log in audit_logs {
+        if !kind_filter.is_empty() && !kind_filter.contains(&audit_log.kind) {
+            continue;
+        }
+
+        if !service_filter.is_empty() && !service_filter.contains(&audit_log.service) {
+            continue;
+        }
+
+        if let Some(change_set_id) = &audit_log.change_set_id {
+            if !change_set_filter.is_empty()
+                && !change_set_filter.contains(&ChangeSetId::from_str(change_set_id)?)
+            {
+                continue;
+            }
+        } else if !change_set_filter.is_empty() {
+            continue;
+        }
+
+        match &audit_log.actor {
+            Actor::User(user_pk) => {
+                if !user_filter.is_empty() && !user_filter.contains(user_pk) {
+                    continue;
+                }
+            }
+            Actor::System => {
+                if let Some(true) = exclude_system_user {
+                    continue;
+                }
+            }
+        }
+
+        filtered_audit_logs.push(audit_log);
+    }
+
+    // After filtering, perform the sort.
+    if let Some(true) = sort_timestamp_ascending {
+        filtered_audit_logs.reverse();
+    }
+
+    // Finally, paginate and return.
+    Ok(paginate(filtered_audit_logs, page, page_size))
+}
+
+fn paginate(
+    logs: Vec<si_frontend_types::AuditLog>,
+    page: Option<usize>,
+    page_size: Option<usize>,
+) -> Vec<si_frontend_types::AuditLog> {
+    if let Some(page_size) = page_size {
+        let target_page = page.unwrap_or(1);
+
+        let mut current_page = 1;
+        for chunk in logs.chunks(page_size) {
+            if current_page == target_page {
+                return chunk.to_vec();
+            }
+            current_page += 1;
+        }
+        logs
+    } else {
+        logs
+    }
+}
+
+fn dice_roll(faces: usize) -> usize {
+    thread_rng().gen_range(0..faces)
 }

--- a/lib/dal/tests/integration_test/audit_log.rs
+++ b/lib/dal/tests/integration_test/audit_log.rs
@@ -1,9 +1,27 @@
+use std::collections::HashSet;
+
 use dal::DalContext;
 use dal_test::test;
 
 #[test]
-async fn audit_log_generation_works(ctx: &DalContext) {
-    let _logs = dal::audit_log::generate(ctx)
+async fn generation_filtering_pagination(ctx: &DalContext) {
+    let audit_logs = dal::audit_log::generate(ctx, 200)
         .await
         .expect("could not generate audit logs");
+    let filtered_and_paginated_audit_logs = dal::audit_log::filter_and_paginate(
+        audit_logs,
+        Some(2),
+        Some(25),
+        None,
+        None,
+        HashSet::new(),
+        HashSet::new(),
+        HashSet::new(),
+        HashSet::new(),
+    )
+    .expect("could not filter and paginate");
+    assert_eq!(
+        25,                                      // expected
+        filtered_and_paginated_audit_logs.len()  // actual
+    )
 }

--- a/lib/sdf-server/src/service/v2/audit_log/list_audit_logs.rs
+++ b/lib/sdf-server/src/service/v2/audit_log/list_audit_logs.rs
@@ -1,12 +1,32 @@
+use std::collections::HashSet;
+
 use axum::{
     extract::{OriginalUri, Path},
     Json,
 };
 use dal::{ChangeSetId, WorkspacePk};
+use serde::{Deserialize, Serialize};
+use si_events::{
+    audit_log::{AuditLogKind, AuditLogService},
+    UserPk,
+};
 use si_frontend_types as frontend_types;
 
 use super::AuditLogResult;
 use crate::extract::{AccessBuilder, HandlerContext, PosthogClient};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListAuditLogsRequest {
+    page: Option<usize>,
+    page_size: Option<usize>,
+    sort_timestamp_ascending: Option<bool>,
+    exclude_system_user: Option<bool>,
+    kind_filter: HashSet<AuditLogKind>,
+    service_filter: HashSet<AuditLogService>,
+    change_set_filter: HashSet<ChangeSetId>,
+    user_filter: HashSet<UserPk>,
+}
 
 pub async fn list_audit_logs(
     HandlerContext(builder): HandlerContext,
@@ -14,12 +34,29 @@ pub async fn list_audit_logs(
     PosthogClient(_posthog_client): PosthogClient,
     OriginalUri(_original_uri): OriginalUri,
     Path((_workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
+    Json(request): Json<ListAuditLogsRequest>,
 ) -> AuditLogResult<Json<Vec<frontend_types::AuditLog>>> {
     let ctx = builder
         .build(access_builder.build(change_set_id.into()))
         .await?;
 
-    let audit_logs = dal::audit_log::generate(&ctx).await?;
+    // NOTE(nick): right now, we just generate a ton of logs and then apply our filters. This is
+    // obviously wasteful, but this will be driven with real data, real queries and real database
+    // goodies in the future.
+    let audit_logs = dal::audit_log::generate(&ctx, 200).await?;
 
-    Ok(Json(audit_logs))
+    // NOTE(nick): this will be replaced with real queries.
+    let filtered_and_paginated_audit_logs = dal::audit_log::filter_and_paginate(
+        audit_logs,
+        request.page,
+        request.page_size,
+        request.sort_timestamp_ascending,
+        request.exclude_system_user,
+        request.kind_filter,
+        request.service_filter,
+        request.change_set_filter,
+        request.user_filter,
+    )?;
+
+    Ok(Json(filtered_and_paginated_audit_logs))
 }

--- a/lib/si-events-rs/src/audit_log.rs
+++ b/lib/si-events-rs/src/audit_log.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[remain::sorted]
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash)]
 pub enum AuditLogService {
     AuthApi,
     Pinga,
@@ -10,11 +10,12 @@ pub enum AuditLogService {
 }
 
 #[remain::sorted]
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash)]
 pub enum AuditLogKind {
     CreateComponent,
     DeleteComponent,
     PerformedRebase,
+    RanAction,
     RanDependentValuesUpdate,
     UpdatePropertyEditorValue,
 }


### PR DESCRIPTION
## Description

This PR adds filtering and pagination to fake audit logs that were first introduced in commit 51f424a.

It performs a "second pass" filtering and pagination run on a generated list of audit logs. Not only that, but this PR also polishes audit log generation log, standardizes users and makes random number generation easier to follow.

<img src="https://media2.giphy.com/media/xT1R9L0kbNKPwGm25i/giphy.gif"/>