### PR TITLE
fix: ensure the rootfs can be replaced

### DIFF
--- a/lib/si-firecracker/src/firecracker.rs
+++ b/lib/si-firecracker/src/firecracker.rs
@@ -94,6 +94,11 @@ impl FirecrackerJail {
     pub async fn setup(pool_size: u32) -> Result<()> {
         Self::create_scripts().await?;
 
+        // we want to work with a clean slate, but we don't necessarily care about failures here
+        for id in 0..pool_size + 1 {
+            Self::clean(id).await?;
+        }
+
         let output = Command::new("sudo")
             .arg(FIRECRACKER_SETUP_PATH)
             .arg("-j")


### PR DESCRIPTION
This will ensure that when we need to download a new rootfs image, we will completely remove the existing image by cleaning all jails and removing the existing dmsetup bits for the rootfs.

<img src="https://media3.giphy.com/media/WhfNwT4Gvr0irHxepC/giphy.gif"/>