### PR TITLE
fix: disk cache removal types swapped

### DIFF
--- a/lib/si-layer-cache/src/disk_cache.rs
+++ b/lib/si-layer-cache/src/disk_cache.rs
@@ -62,9 +62,9 @@ impl DiskCache {
         let maybe_metadata = cacache::metadata(self.write_path.as_ref(), key.clone()).await?;
         if let Some(metadata) = maybe_metadata {
             if cacache::exists(self.write_path.as_ref(), &metadata.integrity).await {
-                cacache::remove(self.write_path.as_ref(), &key.clone()).await?;
+                cacache::remove_hash(self.write_path.as_ref(), &metadata.integrity).await?;
             }
-            cacache::remove_hash(self.write_path.as_ref(), &metadata.integrity).await?;
+            cacache::remove(self.write_path.as_ref(), &key.clone()).await?;
         }
         Ok(())
     }


### PR DESCRIPTION
`remove_hash()` removes the content, which is checked by `.exists()`.

`remove()` removes the index, which is checked by `.metadata()`.

<img src="https://media4.giphy.com/media/xUNd9WfYEbADMhVN4Y/giphy-downsized-medium.gif"/>