### PR TITLE
feat(ENG-2745): actions can set resourceId

### DIFF
--- a/lib/cyclone-core/src/action_run.rs
+++ b/lib/cyclone-core/src/action_run.rs
@@ -27,6 +27,7 @@ pub enum ResourceStatus {
 #[serde(rename_all = "camelCase")]
 pub struct ActionRunResultSuccess {
     pub execution_id: String,
+    pub resource_id: Option<String>,
     pub payload: Option<serde_json::Value>,
     pub status: ResourceStatus,
     pub message: Option<String>,

--- a/lib/cyclone-server/src/result/action_run.rs
+++ b/lib/cyclone-server/src/result/action_run.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 pub struct LangServerActionRunResultSuccess {
     pub execution_id: String,
     #[serde(default)]
+    pub resource_id: Option<String>,
+    #[serde(default)]
     pub payload: Option<serde_json::Value>,
     pub health: ResourceStatus,
     #[serde(default)]
@@ -21,6 +23,7 @@ impl From<LangServerActionRunResultSuccess> for ActionRunResultSuccess {
     fn from(value: LangServerActionRunResultSuccess) -> Self {
         Self {
             execution_id: value.execution_id,
+            resource_id: value.resource_id,
             error: value.error,
             status: value.health,
             message: value.message,

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1548,7 +1548,13 @@ impl Component {
     ) -> ComponentResult<()> {
         let path = ["root", "si", "resourceId"];
         let sv_id = Self::schema_variant_id(ctx, self.id).await?;
-        let resource_prop_id = Prop::find_prop_id_by_path(ctx, sv_id, &PropPath::new(path)).await?;
+
+        let Some(resource_prop_id) =
+            Prop::find_prop_id_by_path_opt(ctx, sv_id, &PropPath::new(path)).await?
+        else {
+            return Ok(());
+        };
+
         // If the name prop is controlled by an identity or other function,
         // don't override the prototype here
         if Prop::is_set_by_dependent_function(ctx, resource_prop_id).await? {

--- a/lib/dal/src/func/authoring/ts_types.rs
+++ b/lib/dal/src/func/authoring/ts_types.rs
@@ -47,6 +47,7 @@ pub(crate) fn compile_return_types(
         }
         FuncBackendResponseType::Action => {
             "type Output {
+    resourceId?: string | null;
     status: 'ok' | 'warning' | 'error';
     payload?: { [key: string]: unknown } | null;
     message?: string | null;

--- a/lib/dal/src/func/backend/js_action.rs
+++ b/lib/dal/src/func/backend/js_action.rs
@@ -90,6 +90,7 @@ impl FuncDispatch for FuncBackendJsAction {
 
                 FunctionResult::Success(Self::Output {
                     execution_id: failure.execution_id().to_owned(),
+                    resource_id: None,
                     payload: self
                         .request
                         .args


### PR DESCRIPTION
Actions can now return a resourceId which will set the /root/si/resourceId prop (if it exists on the component). This enables creates that set resourceId instead of the payload, allowing the refresh to set the resource payload.