### PR TITLE
Fix intrinsics dropdown

### DIFF
--- a/app/web/src/components/AssetDetailIntrinsicInput.vue
+++ b/app/web/src/components/AssetDetailIntrinsicInput.vue
@@ -46,7 +46,7 @@
         :selected="contextMenuRef?.isOpen"
         @click="
           (e) => {
-            contextMenuRef?.open(e, false);
+            if (!props.isLocked) contextMenuRef?.open(e, false);
           }
         "
       />

--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -146,47 +146,59 @@
           @focus="focus"
         />
       </Stack>
-      <Stack class="p-xs" spacing="none">
-        <span class="uppercase font-bold py-3">CONFIGURE DATA PROPAGATION</span>
-        <p class="text-xs pb-4">
-          Choose how output sockets and props get their values.
-        </p>
-        <span class="uppercase font-bold text-sm">Output Sockets</span>
-        <ul v-if="outputSocketIntrinsics.length > 0">
-          <li
-            v-for="config in outputSocketIntrinsics"
-            :key="config.attributePrototypeId"
+      <Stack v-if="funcListRequest.isPending" class="p-xs" spacing="none">
+        <span class="uppercase font-bold py-3">
+          CONFIGURE DATA PROPAGATION
+        </span>
+        <div class="flex justify-center">
+          <Icon size="lg" name="loader" />
+        </div>
+      </Stack>
+      <div v-else>
+        <Stack class="p-xs" spacing="none">
+          <span class="uppercase font-bold py-3"
+            >CONFIGURE DATA PROPAGATION</span
           >
-            <AssetDetailIntrinsicInput
-              :schemaVariantId="schemaVariantId"
-              :isLocked="editingAsset.isLocked"
-              :data="config"
-              @change="updateOutputSocketIntrinsics"
-              @changeToUnset="changeToUnset"
-              @changeToIdentity="changeToIdentity"
-            />
-          </li>
-        </ul>
-        <p v-else class="text-xs pb-4 pt-2">
-          No output sockets exist for asset.
-        </p>
-      </Stack>
-      <Stack class="p-xs" spacing="none">
-        <span class="uppercase font-bold text-sm">Props</span>
-        <ul v-if="configurableProps.length > 0">
-          <li v-for="prop in configurableProps" :key="prop.id">
-            <AssetDetailIntrinsicInput
-              :schemaVariantId="schemaVariantId"
-              :isLocked="editingAsset.isLocked"
-              :data="prop"
-              @change="updatePropIntrinsics"
-              @changeToUnset="changeToUnset"
-              @changeToIdentity="changeToIdentity"
-            />
-          </li>
-        </ul>
-        <p v-else class="text-xs pb-4 pt-2">No props exist for asset.</p>
-      </Stack>
+          <p class="text-xs pb-4">
+            Choose how output sockets and props get their values.
+          </p>
+          <span class="uppercase font-bold text-sm">Output Sockets</span>
+          <ul v-if="outputSocketIntrinsics.length > 0">
+            <li
+              v-for="config in outputSocketIntrinsics"
+              :key="config.attributePrototypeId"
+            >
+              <AssetDetailIntrinsicInput
+                :schemaVariantId="schemaVariantId"
+                :isLocked="editingAsset.isLocked"
+                :data="config"
+                @change="updateOutputSocketIntrinsics"
+                @changeToUnset="changeToUnset"
+                @changeToIdentity="changeToIdentity"
+              />
+            </li>
+          </ul>
+          <p v-else class="text-xs pb-4 pt-2">
+            No output sockets exist for asset.
+          </p>
+        </Stack>
+        <Stack class="p-xs" spacing="none">
+          <span class="uppercase font-bold text-sm">Props</span>
+          <ul v-if="configurableProps.length > 0">
+            <li v-for="prop in configurableProps" :key="prop.id">
+              <AssetDetailIntrinsicInput
+                :schemaVariantId="schemaVariantId"
+                :isLocked="editingAsset.isLocked"
+                :data="prop"
+                @change="updatePropIntrinsics"
+                @changeToUnset="changeToUnset"
+                @changeToIdentity="changeToIdentity"
+              />
+            </li>
+          </ul>
+          <p v-else class="text-xs pb-4 pt-2">No props exist for asset.</p>
+        </Stack>
+      </div>
     </ScrollArea>
     <div
       v-else
@@ -225,6 +237,7 @@ import {
   Stack,
   VButton,
   VormInput,
+  Icon,
 } from "@si/vue-lib/design-system";
 import * as _ from "lodash-es";
 import { useToast } from "vue-toastification";
@@ -266,6 +279,10 @@ const assetStore = useAssetStore();
 const funcStore = useFuncStore();
 const executeAssetModalRef = ref();
 const cloneAssetModalRef = ref<InstanceType<typeof AssetNameModal>>();
+
+// if func list is loading, its because we dont have the right data
+// and we dont want to display incorrect intrinsic data
+const funcListRequest = funcStore.getRequestStatus("FETCH_FUNC_LIST");
 
 const focusedFormField = ref<string | undefined>();
 const focus = (evt: Event) => {

--- a/lib/vue-lib/src/design-system/forms/VormInput.vue
+++ b/lib/vue-lib/src/design-system/forms/VormInput.vue
@@ -719,18 +719,17 @@ function onSelectChange(event: Event) {
   // TODO: a little extra handling to grab the actual vue child and use its bound value
   // rather than event.target.value as this will allow us to preserve any weird value types
 
-  const childIndex = (event?.target as any)?.selectedIndex;
-  const selectedOption = childInputOptions.value[childIndex];
-  const newSelectedValue = selectedOption?.exposed?.optionValue;
+  const newSelectedValue = [...(event?.target as any).selectedOptions].pop()
+    ?.value;
   // fallback to event.target.value for cases where the VormInputOption has no bound value
   // for example `VormInputOption yes`
 
   // console.log(childIndex, selectedOption, newSelectedValue);
-  setNewValue(
+  const newVal =
     newSelectedValue === undefined
       ? (event?.target as any)?.value
-      : newSelectedValue,
-  );
+      : newSelectedValue;
+  setNewValue(newVal);
 }
 
 function fixOptionSelection() {


### PR DESCRIPTION
Addresses three problems:

1. The VormInput child registration was not coming back in the expected order, so the value that was set was not the one the user actually selected. I'm not sure exactly why we were looking at indexes, rather than using the value in the target. I attempt to keep multi-select/checkboxes working, but I don't see any examples in the app to test against.
2. The "flashing" we were seeing was due to WsEvent `SchemaVariantUpdated` firing before `FuncUpdated`. The latter updates the bindings struct, so the former was resetting the form based on the prior saved value. The fix is to optimistically change the bindings data structure.
3. When you unlock a function the prop/socket display is wrong. It is wrong because the new SchemaVariant that comes into being does not send/include binding data in the payload. Which means we we need to call `FETCH_FUNC_LIST` to get the data... so we will display a loader while that request is in flight which prevents incorrect intrinsic data from showing up.