### PR TITLE
fix: e2e concurrency flags

### DIFF
--- a/.github/workflows/crons.yml
+++ b/.github/workflows/crons.yml
@@ -4,11 +4,9 @@ on:
   schedule:
     - cron: '*/15 * * * *'  # Runs every 15 minutes
 
-# We want to ensure that in-progress cron runs are canceled
-# when do a deploy so they don't fail erroneously, but these
-# cannot cancel deploys
+# We will wait until these tests finish before starting a deploy
 concurrency:
-  group: e2e-tools
+  group: deploy-production
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -28,6 +28,12 @@ on:
         description: "version to deploy"
         default: "stable"
 
+# We want to ensure that in-progress cron runs against prod
+# are canceled when we do a deploy so they don't fail erroneously.
+concurrency:
+  group: e2e-${{ inputs.environment }}
+  cancel-in-progress: false
+
 jobs:
 
   invoke-and-check-cdn:
@@ -88,11 +94,6 @@ jobs:
     secrets: inherit
 
   e2e-validation:
-    # We want to ensure that in-progress cron runs against tools-prod
-    # are canceled when we do a deploy so they don't fail erroneously
-    concurrency:
-      group: e2e-${{ inputs.environment }}
-      cancel-in-progress: true
     needs:
       - upgrade-web
       - upgrade-and-migrate-sdf
@@ -102,11 +103,6 @@ jobs:
     secrets: inherit
 
   api-test:
-    # We want to ensure that in-progress cron runs against tools-prod
-    # are canceled when we do a deploy so they don't fail erroneously
-    concurrency:
-      group: api-test-${{ inputs.environment }}
-      cancel-in-progress: true
     needs:
       - upgrade-web
       - upgrade-and-migrate-sdf


### PR DESCRIPTION
This is fun. Since the crons that run against prod were set to `e2e-tools` so we were cancelling them during tools deploys :upside_down_face: . 

We set concurrency based on the environment during deploys. The result will be:

* Multiple deploys will queue and happen sequentially to ensure that deploys don't cancel each other and put us in a weird state
* Deploys will share concurrency with the crons, so we won't deploy until the tests are finished running (and tests won't start while a deploy is happening) to ensure we don't get erroneous errors
