### PR TITLE
feat: Add more to management func types

### DIFF
--- a/bin/lang-js/src/component.ts
+++ b/bin/lang-js/src/component.ts
@@ -2,3 +2,13 @@ export interface Component {
   name: string;
   properties: Record<string, unknown>;
 }
+
+export interface ComponentWithGeometry {
+  properties: Record<string, unknown>;
+  geometry: {
+    x: string,
+    y: string,
+    width?: string,
+    height?: string,
+  }
+}

--- a/lib/cyclone-client/src/client.rs
+++ b/lib/cyclone-client/src/client.rs
@@ -448,8 +448,8 @@ mod tests {
     use base64::{engine::general_purpose, Engine};
     use buck2_resources::Buck2Resources;
     use cyclone_core::{
-        ActionRunRequest, ComponentKind, ComponentView, FunctionResult, ManagementRequest,
-        ProgressMessage, ResolverFunctionComponent, ResolverFunctionRequest,
+        ActionRunRequest, ComponentKind, ComponentView, ComponentViewWithGeometry, FunctionResult,
+        ManagementRequest, ProgressMessage, ResolverFunctionComponent, ResolverFunctionRequest,
         SchemaVariantDefinitionRequest, ValidationRequest,
     };
     use cyclone_server::{Config, ConfigBuilder, Runnable as _, Server};
@@ -1325,16 +1325,17 @@ mod tests {
         let req = ManagementRequest {
             execution_id: "1234".to_string(),
             handler: "manage".to_string(),
-            this_component: ComponentView {
+            this_component: ComponentViewWithGeometry {
                 properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),
-                kind: ComponentKind::Standard,
+                geometry: serde_json::json!({"x": "1", "y": "2"}),
             },
             code_base64: base64_encode(
                 r#"function manage(input) {
                     console.log('first');
                     console.log('second');
                     return {
-                        message: input.to,
+                        status: 'ok',
+                        message: input.thisComponent.properties.to,
                     }
                 }"#,
             ),
@@ -1406,16 +1407,17 @@ mod tests {
         let req = ManagementRequest {
             execution_id: "1234".to_string(),
             handler: "manage".to_string(),
-            this_component: ComponentView {
+            this_component: ComponentViewWithGeometry {
                 properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),
-                kind: ComponentKind::Standard,
+                geometry: serde_json::json!({"x": "1", "y": "2"}),
             },
             code_base64: base64_encode(
-                r#"function manage(input) {
+                r#"function manage({ thisComponent }) {
                     console.log('first');
                     console.log('second');
                     return {
-                        message: input.to,
+                        status: 'ok',
+                        message: thisComponent.properties.to,
                     }
                 }"#,
             ),

--- a/lib/cyclone-core/src/component_view.rs
+++ b/lib/cyclone-core/src/component_view.rs
@@ -30,3 +30,19 @@ impl Default for ComponentView {
         }
     }
 }
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentViewWithGeometry {
+    pub properties: Value,
+    pub geometry: Value,
+}
+
+impl Default for ComponentViewWithGeometry {
+    fn default() -> Self {
+        Self {
+            properties: serde_json::json!({}),
+            geometry: serde_json::json!({}),
+        }
+    }
+}

--- a/lib/cyclone-core/src/lib.rs
+++ b/lib/cyclone-core/src/lib.rs
@@ -32,10 +32,10 @@ pub use si_crypto::SensitiveStrings;
 pub use action_run::{ActionRunRequest, ActionRunResultSuccess, ResourceStatus};
 pub use before::BeforeFunction;
 pub use canonical_command::{CanonicalCommand, CanonicalCommandError};
-pub use component_view::{ComponentKind, ComponentView};
+pub use component_view::{ComponentKind, ComponentView, ComponentViewWithGeometry};
 pub use kill_execution::KillExecutionRequest;
 pub use liveness::{LivenessStatus, LivenessStatusParseError};
-pub use management::{ManagementRequest, ManagementResultSuccess};
+pub use management::{ManagementFuncStatus, ManagementRequest, ManagementResultSuccess};
 pub use progress::{
     FunctionResult, FunctionResultFailure, FunctionResultFailureError,
     FunctionResultFailureErrorKind, Message, OutputStream, ProgressMessage,

--- a/lib/cyclone-core/src/management.rs
+++ b/lib/cyclone-core/src/management.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use telemetry::prelude::*;
 use telemetry_utils::metric;
 
-use crate::{BeforeFunction, ComponentView, CycloneRequestable};
+use crate::{component_view::ComponentViewWithGeometry, BeforeFunction, CycloneRequestable};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -10,14 +10,22 @@ pub struct ManagementRequest {
     pub execution_id: String,
     pub handler: String,
     pub code_base64: String,
-    pub this_component: ComponentView,
+    pub this_component: ComponentViewWithGeometry,
     pub before: Vec<BeforeFunction>,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ManagementFuncStatus {
+    Ok,
+    Error,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ManagementResultSuccess {
     pub execution_id: String,
+    pub health: ManagementFuncStatus,
     pub operations: Option<serde_json::Value>,
     pub message: Option<String>,
     pub error: Option<String>,

--- a/lib/dal-test/src/test_exclusive_schemas/legos/small.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/legos/small.rs
@@ -55,17 +55,20 @@ pub(crate) async fn migrate_test_exclusive_schema_small_odd_lego(
         return { payload: null, status: \"ok\" };
     }";
 
-    let import_management_func_code = "async function main(thisComponent: Input): Promise<Output> {
+    let import_management_func_code =
+        "async function main({ thisComponent }: Input): Promise<Output> {
+        const thisProperties = thisComponent.properties;
         return { 
+            status: 'ok',
             ops: {
                 update: {
                     self: {
                         properties: {
                             domain: {
+                                ...thisProperties.domain
                                 two: 'step',
-                                ...thisComponent.domain
                             }
-                            ...thisComponent
+                            ...thisProperties
                         }
                     }
                 }

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1998,18 +1998,15 @@ impl AttributeValue {
             }
             None => serde_json::Value::Null,
         };
-        let total_start = std::time::Instant::now();
 
         let result_channel =
             FuncRunner::run_attribute_value(ctx, attribute_value_id, func_id, func_args)
                 .await
                 .map_err(Box::new)?;
-        info!("Getting channel took: {:?}", total_start.elapsed());
         let func_values = result_channel
             .await
             .map_err(|_| AttributeValueError::FuncRunnerSend)?
             .map_err(Box::new)?;
-        info!("Waiting for values took: {:?}", total_start.elapsed());
 
         Self::set_real_values(ctx, attribute_value_id, func_values, func).await?;
         Ok(())

--- a/lib/dal/src/func/authoring/ts_types.rs
+++ b/lib/dal/src/func/authoring/ts_types.rs
@@ -61,6 +61,14 @@ pub(crate) fn compile_return_types(
         FuncBackendResponseType::Object => "type Output = any;",
         FuncBackendResponseType::Unset => "type Output = undefined | null;",
         FuncBackendResponseType::Void => "type Output = void;",
+        FuncBackendResponseType::Management => {
+            "type Output {
+    status: 'ok' | 'error';
+    ops?: { update: { [key: string]: { properties?: { [key: string]: unknown } } } };
+    message?: string | null;
+    }
+    type Input { thisComponent: { properties: { [key: string]: unknown } } }"
+        }
         _ => "",
         // we no longer serve this from the backend, its static on the front end
         //FuncBackendResponseType::SchemaVariantDefinition => SCHEMA_VARIANT_DEFINITION_TYPES

--- a/lib/dal/src/func/backend/management.rs
+++ b/lib/dal/src/func/backend/management.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use veritech_client::{
-    BeforeFunction, ComponentView, FunctionResult, ManagementRequest, ManagementResultSuccess,
+    BeforeFunction, ComponentViewWithGeometry, FunctionResult, ManagementRequest,
+    ManagementResultSuccess,
 };
 
 use crate::func::backend::{FuncBackendResult, FuncDispatch, FuncDispatchContext};
@@ -10,7 +11,7 @@ use super::ExtractPayload;
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct FuncBackendManagementArgs {
-    this_component: ComponentView,
+    this_component: ComponentViewWithGeometry,
 }
 
 #[derive(Debug)]

--- a/lib/dal/src/management/mod.rs
+++ b/lib/dal/src/management/mod.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, VecDeque};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use veritech_client::ManagementResultSuccess;
+use veritech_client::{ManagementFuncStatus, ManagementResultSuccess};
 
 use crate::{
     attribute::value::AttributeValueError,
@@ -40,6 +40,7 @@ pub struct ManagementOperations {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ManagementFuncReturn {
+    pub status: ManagementFuncStatus,
     pub operations: Option<ManagementOperations>,
     pub message: Option<String>,
     pub error: Option<String>,
@@ -50,6 +51,7 @@ impl TryFrom<ManagementResultSuccess> for ManagementFuncReturn {
 
     fn try_from(value: ManagementResultSuccess) -> Result<Self, Self::Error> {
         Ok(ManagementFuncReturn {
+            status: value.health,
             operations: match value.operations {
                 Some(ops) => serde_json::from_value(ops)?,
                 None => None,

--- a/lib/dal/src/management/prototype.rs
+++ b/lib/dal/src/management/prototype.rs
@@ -188,11 +188,13 @@ impl ManagementPrototype {
         let management_func_id = ManagementPrototype::func_id(ctx, id).await?;
         let manager_component = Component::get_by_id(ctx, manager_component_id).await?;
         let manager_component_view = manager_component.view(ctx).await?;
+        let geometry = manager_component.geometry();
 
         let args = serde_json::json!({
             "this_component": {
                 "kind": ComponentKind::Standard,
-                "properties": manager_component_view
+                "properties": manager_component_view,
+                "geometry": geometry,
             }
         });
 

--- a/lib/dal/tests/integration_test/management.rs
+++ b/lib/dal/tests/integration_test/management.rs
@@ -3,6 +3,7 @@ use dal::{
     AttributeValue, Component, DalContext,
 };
 use dal_test::{helpers::create_component_for_default_schema_name, test};
+use veritech_client::ManagementFuncStatus;
 
 #[test]
 async fn execute_management_func(ctx: &DalContext) {
@@ -43,6 +44,8 @@ async fn execute_management_func(ctx: &DalContext) {
         .expect("should have a result success")
         .try_into()
         .expect("should be a valid management func return");
+
+    assert_eq!(result.status, ManagementFuncStatus::Ok);
 
     operate(
         ctx,

--- a/lib/veritech-client/src/lib.rs
+++ b/lib/veritech-client/src/lib.rs
@@ -15,11 +15,12 @@ use veritech_core::{
 
 pub use cyclone_core::{
     ActionRunRequest, ActionRunResultSuccess, BeforeFunction, ComponentKind, ComponentView,
-    FunctionResult, FunctionResultFailure, FunctionResultFailureErrorKind, KillExecutionRequest,
-    ManagementRequest, ManagementResultSuccess, OutputStream, ResolverFunctionComponent,
-    ResolverFunctionRequest, ResolverFunctionResponseType, ResolverFunctionResultSuccess,
-    ResourceStatus, SchemaVariantDefinitionRequest, SchemaVariantDefinitionResultSuccess,
-    SensitiveContainer, ValidationRequest, ValidationResultSuccess,
+    ComponentViewWithGeometry, FunctionResult, FunctionResultFailure,
+    FunctionResultFailureErrorKind, KillExecutionRequest, ManagementFuncStatus, ManagementRequest,
+    ManagementResultSuccess, OutputStream, ResolverFunctionComponent, ResolverFunctionRequest,
+    ResolverFunctionResponseType, ResolverFunctionResultSuccess, ResourceStatus,
+    SchemaVariantDefinitionRequest, SchemaVariantDefinitionResultSuccess, SensitiveContainer,
+    ValidationRequest, ValidationResultSuccess,
 };
 pub use veritech_core::{encrypt_value_tree, VeritechValueEncryptError};
 

--- a/lib/veritech-client/tests/integration.rs
+++ b/lib/veritech-client/tests/integration.rs
@@ -2,10 +2,10 @@ use std::env;
 
 use base64::{engine::general_purpose, Engine};
 use cyclone_core::{
-    ActionRunRequest, ComponentKind, ComponentView, FunctionResult, FunctionResultFailureErrorKind,
-    ManagementRequest, ResolverFunctionComponent, ResolverFunctionRequest,
-    ResolverFunctionResponseType, ResourceStatus, SchemaVariantDefinitionRequest,
-    ValidationRequest,
+    ActionRunRequest, ComponentKind, ComponentView, ComponentViewWithGeometry, FunctionResult,
+    FunctionResultFailureErrorKind, ManagementRequest, ResolverFunctionComponent,
+    ResolverFunctionRequest, ResolverFunctionResponseType, ResourceStatus,
+    SchemaVariantDefinitionRequest, ValidationRequest,
 };
 use si_data_nats::{NatsClient, NatsConfig};
 use test_log::test;
@@ -105,12 +105,15 @@ async fn executes_simple_management_function() {
     let request = ManagementRequest {
         execution_id: "1234".to_string(),
         handler: "numberOfInputs".to_string(),
-        this_component: ComponentView {
+        this_component: ComponentViewWithGeometry {
             properties: serde_json::json!({ "foo": "bar", "baz": "quux", "bar": "foo" }),
-            kind: ComponentKind::Standard,
+            geometry: serde_json::json!({"x": "1", "y": "1"}),
         },
         code_base64: base64_encode(
-            "function numberOfInputs(input) { const number = Object.keys(input)?.length; return { message: `${number}` } }",
+            "function numberOfInputs({ thisComponent }) { 
+                const number = Object.keys(thisComponent.properties)?.length; 
+                return { status: 'ok' message: `${number}` }
+             }",
         ),
         before: vec![],
     };


### PR DESCRIPTION
Authoring a real import has revealed some missing pieces to the management function types. This reworks it so we will be ready for the future extensions to the type (like managing multiple components, and setting geometry on the managed components) and so we can report failures in the management execution.