### PR TITLE
Add second cron for running e2e tests against tools production, fix deployment so we cancel running e2e tests if a deploy is kicked off

### DIFF
--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -28,14 +28,15 @@ on:
         description: "version to deploy"
         default: "stable"
 
-# We want to ensure that in-progress cron runs against prod
-# are canceled when we do a deploy so they don't fail erroneously.
+# We only one one deploy happening at a time per environment, so if one is
+# in progress, we'll wait for it to finish before starting the
+# next one.
+# Note that this will also wait for E2E tests to finish, as per the crons workflows
 concurrency:
-  group: e2e-${{ inputs.environment }}
+  group: deploy-${{ inputs.environment }}
   cancel-in-progress: false
 
 jobs:
-
   invoke-and-check-cdn:
     uses: ./.github/workflows/invoke-and-check-invalidations.yml
     with:
@@ -45,9 +46,9 @@ jobs:
   set-service-versions:
     uses: ./.github/workflows/set-service-version.yml
     strategy:
-     fail-fast: false
-     matrix:
-      service: [ "pinga", "rebaser", "sdf", "veritech", "forklift" ]
+      fail-fast: false
+      matrix:
+        service: ["pinga", "rebaser", "sdf", "veritech", "forklift"]
     with:
       environment: ${{ inputs.environment }}
       service: ${{ matrix.service }}
@@ -76,9 +77,9 @@ jobs:
       - set-service-versions
       - set-maintenance-mode
     strategy:
-     fail-fast: false
-     matrix:
-       service: [ "pinga", "rebaser", "veritech", "forklift" ]
+      fail-fast: false
+      matrix:
+        service: ["pinga", "rebaser", "veritech", "forklift"]
     uses: ./.github/workflows/upgrade-service.yml
     with:
       environment: ${{ inputs.environment }}

--- a/.github/workflows/prod-crons.yml
+++ b/.github/workflows/prod-crons.yml
@@ -1,0 +1,23 @@
+name: Production Crons
+
+on:
+  schedule:
+    - cron: "*/15 * * * *" # Runs every 15 minutes
+
+# We will wait until these tests finish before starting a deploy
+# We will also wait for a deploy to finish before starting to run tests
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  e2e-validation:
+    uses: ./.github/workflows/e2e-validation.yml
+    with:
+      environment: production
+    secrets: inherit
+  api-test:
+    uses: ./.github/workflows/run-api-test.yml
+    with:
+      environment: production
+    secrets: inherit

--- a/.github/workflows/tools-crons.yml
+++ b/.github/workflows/tools-crons.yml
@@ -1,22 +1,23 @@
-name: Crons
+name: Tools Crons
 
 on:
   schedule:
-    - cron: '*/15 * * * *'  # Runs every 15 minutes
+    - cron: "*/15 * * * *" # Runs every 15 minutes
 
 # We will wait until these tests finish before starting a deploy
+# We will also wait for a deploy to finish before starting to run tests
 concurrency:
-  group: deploy-production
+  group: deploy-tools
   cancel-in-progress: false
 
 jobs:
   e2e-validation:
     uses: ./.github/workflows/e2e-validation.yml
     with:
-      environment: production
+      environment: tools
     secrets: inherit
   api-test:
     uses: ./.github/workflows/run-api-test.yml
     with:
-      environment: production
+      environment: tools
     secrets: inherit


### PR DESCRIPTION
<div><img src="https://media2.giphy.com/media/wIAzgC4sqiGaeKMhr2/200.gif?cid=5a38a5a21hxpwrbqcbof6iqdtzr43f2uiqbkgw5ufwhdyi5l&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:171px;width:300px"/><br/>via <a href="https://giphy.com/paramountplus/">Paramount+</a> on <a href="https://giphy.com/gifs/paramountplus-season-3-paramount-icarly-wIAzgC4sqiGaeKMhr2">GIPHY</a></div>