### PR TITLE
feat: management functions can add or remove actions

### DIFF
--- a/bin/lang-js/src/function_kinds/management.ts
+++ b/bin/lang-js/src/function_kinds/management.ts
@@ -21,9 +21,15 @@ export type ManagementFuncResult =
     | ManagementFuncResultFailure;
 
 export interface ManagementOperations {
-  update: { [key: string]: {
+  update?: { [key: string]: {
     properties?: object;
   } }
+  actions?: {
+    [key: string]: {
+      add?: string[],
+      remove?: string[],
+    }
+  }
 }
 
 export interface ManagementFuncResultSuccess extends ResultSuccess {

--- a/lib/dal/src/func/authoring/ts_types.rs
+++ b/lib/dal/src/func/authoring/ts_types.rs
@@ -28,25 +28,25 @@ pub(crate) fn compile_return_types(
         FuncBackendResponseType::String => "type Output = string | null;",
         FuncBackendResponseType::Integer => "type Output = number | null;",
         FuncBackendResponseType::Qualification => {
-            "type Output {
+            "type Output = {
   result: 'success' | 'warning' | 'failure';
   message?: string | null;
 }"
         }
         FuncBackendResponseType::CodeGeneration => {
-            "type Output {
+            "type Output = {
   format: string;
   code: string;
 }"
         }
         FuncBackendResponseType::Validation => {
-            "type Output {
+            "type Output = {
   valid: boolean;
   message: string;
 }"
         }
         FuncBackendResponseType::Action => {
-            "type Output {
+            "type Output = {
     resourceId?: string | null;
     status: 'ok' | 'warning' | 'error';
     payload?: { [key: string]: unknown } | null;
@@ -62,12 +62,21 @@ pub(crate) fn compile_return_types(
         FuncBackendResponseType::Unset => "type Output = undefined | null;",
         FuncBackendResponseType::Void => "type Output = void;",
         FuncBackendResponseType::Management => {
-            "type Output {
-    status: 'ok' | 'error';
-    ops?: { update: { [key: string]: { properties?: { [key: string]: unknown } } } };
-    message?: string | null;
-    }
-    type Input { thisComponent: { properties: { [key: string]: unknown } } }"
+            r#"
+type Output = {
+  status: 'ok' | 'error';
+  ops?: {
+    update?: { [key: string]: { properties?: { [key: string]: unknown } } };
+    actions?: { [key: string]: {
+      add?: ("create" | "update" | "refresh" | "delete" | string)[];
+      remove?: ("create" | "update" | "refresh" | "delete" | string)[];
+    } }
+
+  };
+  message?: string | null;
+};
+type Input = { thisComponent: { properties: { [key: string]: unknown } } };
+            "#
         }
         _ => "",
         // we no longer serve this from the backend, its static on the front end

--- a/lib/sdf-server/src/service/v2/management.rs
+++ b/lib/sdf-server/src/service/v2/management.rs
@@ -101,9 +101,10 @@ pub async fn run_prototype(
         if result.status == ManagementFuncStatus::Ok {
             if let Some(operations) = result.operations {
                 operate(&ctx, component_id, operations).await?;
-                ctx.commit().await?;
             }
         }
+
+        ctx.commit().await?;
 
         return Ok(ForceChangeSetResponse::new(
             force_change_set_id,

--- a/lib/sdf-server/src/service/v2/management.rs
+++ b/lib/sdf-server/src/service/v2/management.rs
@@ -98,9 +98,11 @@ pub async fn run_prototype(
 
     if let Some(result) = result {
         let result: ManagementFuncReturn = result.try_into()?;
-        if let Some(operations) = result.operations {
-            operate(&ctx, component_id, operations).await?;
-            ctx.commit().await?;
+        if result.status == ManagementFuncStatus::Ok {
+            if let Some(operations) = result.operations {
+                operate(&ctx, component_id, operations).await?;
+                ctx.commit().await?;
+            }
         }
 
         return Ok(ForceChangeSetResponse::new(


### PR DESCRIPTION
Adds `actions?:` to the return type of a management operation, keyed by the component id, allowing you to add or remove actions. Adding an action that does not exist is an error, but removing an action that does not exist is a no-op. Adding an already added action is a no-op, so is removing an already removed action.