### PR TITLE
audit log mock behind feature flag

### DIFF
--- a/app/auth-portal/src/components/WorkspaceLinkWidget.vue
+++ b/app/auth-portal/src/components/WorkspaceLinkWidget.vue
@@ -22,7 +22,7 @@
       "
     >
       <Icon name="cloud" class="flex-none" size="sm" />
-      <TruncateWithTooltip class="text-md flex-grow">
+      <TruncateWithTooltip class="text-md flex-grow py-2xs">
         <a :href="`${API_HTTP_URL}/workspaces/${workspace.id}/go`">
           {{ workspace.displayName }}
         </a>

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -48,6 +48,7 @@
     "@replit/codemirror-vim": "^6.0.11",
     "@si/ts-lib": "workspace:*",
     "@si/vue-lib": "workspace:*",
+    "@tanstack/vue-table": "^8.20.5",
     "@types/async": "^3.2.15",
     "@typescript/vfs": "^1.4.0",
     "@vueuse/head": "^1.1.15",

--- a/app/web/src/components/AuditLogHeader.vue
+++ b/app/web/src/components/AuditLogHeader.vue
@@ -1,0 +1,216 @@
+<template>
+  <th
+    ref="thRef"
+    v-tooltip="headerTooltip"
+    :colSpan="header.colSpan"
+    :class="
+      clsx(
+        'h-8 sticky top-0',
+        header.id !== 'ip' && 'cursor-pointer hover:underline',
+        themeClasses('bg-shade-0', 'bg-shade-100'),
+      )
+    "
+    @mousedown="startActive"
+    @mouseup="endActive"
+    @click.stop="onClick"
+  >
+    <div class="w-full p-xs truncate">
+      <FlexRender
+        v-if="!header.isPlaceholder"
+        :render="label"
+        :props="header.getContext()"
+      />
+      <IconButton
+        v-if="icon !== 'none'"
+        ref="iconButtonRef"
+        class="absolute right-xs top-2xs"
+        :icon="icon"
+        iconTone="neutral"
+        @click.stop="onClick"
+      />
+      <DropdownMenu
+        v-if="header.id !== 'timestamp'"
+        ref="dropdownMenuRef"
+        :items="dropdownMenuItems"
+        :anchorTo="{ $el: thRef }"
+        alignCenter
+      />
+    </div>
+  </th>
+</template>
+
+<script lang="ts" setup>
+import {
+  DropdownMenu,
+  DropdownMenuItemObjectDef,
+  IconButton,
+  themeClasses,
+} from "@si/vue-lib/design-system";
+import { FlexRender, Header } from "@tanstack/vue-table";
+import clsx from "clsx";
+import { computed, PropType, ref } from "vue";
+import { AuditLogKind, AuditLogService, LogFilters } from "@/store/logs.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
+import { AdminUser } from "@/store/admin.store";
+
+const changeSetsStore = useChangeSetsStore();
+
+const thRef = ref();
+const iconButtonRef = ref<InstanceType<typeof IconButton>>();
+const dropdownMenuRef = ref<InstanceType<typeof DropdownMenu>>();
+
+const props = defineProps({
+  header: {
+    type: Object as PropType<
+      Header<
+        {
+          actorId: string;
+          actorName: string;
+          actorEmail?: string | undefined;
+          service: string;
+          kind: string;
+          timestamp: string;
+          ip: string;
+          changeSetId: string;
+          changeSetName: string;
+        },
+        unknown
+      >
+    >,
+    required: true,
+  },
+  filters: {
+    type: Object as PropType<LogFilters>,
+    required: true,
+  },
+  users: {
+    type: Array as PropType<AdminUser[]>,
+    default: [] as AdminUser[],
+  },
+});
+
+const label = computed(() => props.header.column.columnDef.header as string);
+
+const icon = computed(() => {
+  if (props.header.id === "timestamp") {
+    if (props.filters.sortTimestampAscending) return "chevron--up";
+    else return "chevron--down";
+  } else if (selectedFilters.value.length > 0) {
+    return "filter";
+  } else {
+    return "none";
+  }
+});
+
+const filterOptions = computed(() => {
+  if (props.header.id === "kind") {
+    return Object.values(AuditLogKind).map((k) => {
+      return { label: k, value: k };
+    });
+  } else if (props.header.id === "service") {
+    return Object.values(AuditLogService).map((k) => {
+      return { label: k, value: k };
+    });
+  } else if (props.header.id === "changeSetName") {
+    return changeSetsStore.allChangeSets.map((changeSet) => {
+      return { label: changeSet.name, value: changeSet.id };
+    });
+  } else if (props.header.id === "actorName") {
+    const actors = props.users.map((user) => {
+      return { label: user.name, value: user.id };
+    });
+    actors.unshift({ label: "System", value: "System" });
+
+    return actors;
+  }
+  return [];
+});
+
+const selectedFilters = computed(() => {
+  if (props.header.id === "kind") return props.filters.kindFilter;
+  else if (props.header.id === "service") return props.filters.serviceFilter;
+  else if (props.header.id === "changeSetName")
+    return props.filters.changeSetFilter;
+  else if (props.header.id === "actorName") return props.filters.userFilter;
+  else return [];
+});
+
+const headerText = computed(() => {
+  if (label.value === "Timestamp") {
+    return `Sorting By Timestamp ${
+      props.filters.sortTimestampAscending ? "(Oldest)" : "(Newest)"
+    }`;
+  }
+  if (selectedFilters.value.length > 0) {
+    return `Filtering by ${selectedFilters.value.length} selection${
+      selectedFilters.value.length > 1 ? "s" : ""
+    }`;
+  } else return `Filter by ${label.value}`;
+});
+
+const headerTooltip = computed(() => {
+  if (props.header.id === "ip") return null;
+
+  return {
+    content: headerText.value,
+    delay: { show: 0, hide: 100 },
+    instantMove: true,
+  };
+});
+
+const dropdownMenuItems = computed(() => {
+  const items: DropdownMenuItemObjectDef[] = [];
+
+  items.push({
+    label: headerText.value,
+    header: true,
+  });
+
+  for (const k of filterOptions.value) {
+    items.push({
+      label: k.label,
+      checkable: true,
+      checked: selectedFilters.value.includes(k.value),
+      onSelect: () => {
+        emit("toggleFilter", k.value);
+      },
+    });
+  }
+
+  if (selectedFilters.value.length > 0) {
+    items.unshift({
+      label: "Clear Filters",
+      onSelect: () => {
+        emit("clearFilters");
+      },
+    });
+  }
+
+  return items;
+});
+
+const onClick = () => {
+  if (props.header.id !== "ip") {
+    dropdownMenuRef.value?.open();
+  }
+  emit("select");
+};
+
+const active = ref(false);
+
+const startActive = () => {
+  active.value = true;
+  iconButtonRef.value?.startActive();
+};
+
+const endActive = () => {
+  active.value = false;
+  iconButtonRef.value?.endActive();
+};
+
+const emit = defineEmits<{
+  (e: "select"): void;
+  (e: "clearFilters"): void;
+  (e: "toggleFilter", v: string): void;
+}>();
+</script>

--- a/app/web/src/components/Workspace/WorkspaceAuditLog.vue
+++ b/app/web/src/components/Workspace/WorkspaceAuditLog.vue
@@ -1,0 +1,300 @@
+<template>
+  <div
+    class="w-full h-full min-h-0 flex flex-col overflow-hidden items-center relative dark:bg-neutral-800 dark:text-shade-0 bg-neutral-50 text-neutral-900"
+  >
+    <ScrollArea>
+      <template #top>
+        <div :class="clsx('w-full flex-none')">
+          <div class="flex items-center gap-2xs p-xs">
+            <Icon name="eye" class="flex-none" />
+            <div class="flex-grow text-lg font-bold">
+              Audit Logs (this feature is not complete, mock data)
+            </div>
+            <div class="flex items-center gap-2xs pr-xs">
+              <div>Page</div>
+              <div class="font-bold">
+                {{ currentFilters.page }} of {{ totalPages }}
+              </div>
+            </div>
+            <IconButton
+              v-tooltip="
+                !canGetPreviousPage() ? 'You are on the first page.' : undefined
+              "
+              icon="double-arrow-left"
+              iconTone="shade"
+              :disabled="!canGetPreviousPage()"
+              @click="() => setPage(1)"
+            />
+            <IconButton
+              v-tooltip="
+                !canGetPreviousPage() ? 'You are on the first page.' : undefined
+              "
+              icon="chevron--left"
+              iconTone="shade"
+              :disabled="!canGetPreviousPage()"
+              @click="() => previousPage()"
+            />
+            <IconButton
+              v-tooltip="
+                !getCanNextPage() ? 'You are on the last page.' : undefined
+              "
+              icon="chevron--right"
+              iconTone="shade"
+              :disabled="!getCanNextPage()"
+              @click="() => nextPage()"
+            />
+            <IconButton
+              v-tooltip="
+                !getCanNextPage() ? 'You are on the last page.' : undefined
+              "
+              icon="double-arrow-left"
+              rotate="down"
+              iconTone="shade"
+              :disabled="!getCanNextPage()"
+              @click="() => setPage(totalPages)"
+            />
+            <!-- <span class="flex items-center gap-1">
+              | Go to page:
+              <input
+                type="number"
+                :value="goToPageNumber"
+                class="border p-1 rounded w-16"
+                @change="handleGoToPage"
+              />
+            </span> -->
+          </div>
+          <!-- <div>{{ table.getRowModel().rows.length }} Rows</div>
+        <pre>{{ JSON.stringify(table.getState().pagination, null, 2) }}</pre> -->
+          <!-- <div class="h-2" />
+      <button class="border p-2" @click="rerender">Rerender</button> -->
+        </div>
+      </template>
+      <table v-if="logLoadingRequestStatus.isSuccess" class="w-full relative">
+        <thead>
+          <tr
+            v-for="headerGroup in table.getHeaderGroups()"
+            :key="headerGroup.id"
+          >
+            <AuditLogHeader
+              v-for="header in headerGroup.headers"
+              :key="header.id"
+              :header="header"
+              :filters="currentFilters"
+              :users="users"
+              @select="onHeaderClick(header.id)"
+              @clearFilters="clearFilters(header.id)"
+              @toggleFilter="(f) => toggleFilter(header.id, f)"
+            />
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="row in table.getRowModel().rows"
+            :key="row.id"
+            :class="
+              clsx(
+                'h-md text-sm',
+                themeClasses(
+                  'odd:bg-neutral-200 even:bg-neutral-100',
+                  'odd:bg-neutral-700 even:bg-neutral-800',
+                ),
+              )
+            "
+          >
+            <td
+              v-for="cell in row.getVisibleCells()"
+              :key="cell.id"
+              align="center"
+              :class="
+                clsx(
+                  'border-x border-collapse',
+                  themeClasses('border-neutral-300', 'border-neutral-900'),
+                )
+              "
+            >
+              <FlexRender
+                :render="cell.column.columnDef.cell"
+                :props="cell.getContext()"
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <RequestStatusMessage
+        v-else
+        :requestStatus="logLoadingRequestStatus"
+        loadingMessage="Loading Logs..."
+      />
+    </ScrollArea>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import {
+  Icon,
+  IconButton,
+  RequestStatusMessage,
+  ScrollArea,
+  themeClasses,
+  Timestamp,
+} from "@si/vue-lib/design-system";
+import {
+  FlexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  useVueTable,
+  createColumnHelper,
+} from "@tanstack/vue-table";
+import clsx from "clsx";
+import { h, computed, ref } from "vue";
+import { AuditLogDisplay, LogFilters, useLogsStore } from "@/store/logs.store";
+import { AdminUser, useAdminStore } from "@/store/admin.store";
+import { useWorkspacesStore } from "@/store/workspaces.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
+import AuditLogHeader from "../AuditLogHeader.vue";
+
+const adminStore = useAdminStore();
+const workspacesStore = useWorkspacesStore();
+const changeSetsStore = useChangeSetsStore();
+
+const users = ref([] as AdminUser[]);
+
+const PAGE_SIZE = 50; // Currently this is fixed, might make it variable later
+const DEFAULT_FILTERS = {
+  page: 1,
+  pageSize: PAGE_SIZE,
+  sortTimestampAscending: false,
+  excludeSystemUser: false,
+  kindFilter: [],
+  serviceFilter: [],
+  changeSetFilter: [changeSetsStore.selectedChangeSetId],
+  userFilter: [],
+} as LogFilters;
+const currentFilters = ref({ ...DEFAULT_FILTERS });
+const logsStore = useLogsStore();
+const loadLogs = async () => {
+  logsStore.LOAD_PAGE(currentFilters.value);
+  if (workspacesStore.urlSelectedWorkspaceId) {
+    const result = await adminStore.LIST_WORKSPACE_USERS(
+      workspacesStore.urlSelectedWorkspaceId,
+    );
+    if (result?.result.success) {
+      users.value = result.result.data.users;
+      return;
+    }
+  }
+  users.value = [];
+};
+loadLogs();
+const logLoadingRequestStatus = logsStore.getRequestStatus("LOAD_PAGE");
+
+const columnHelper = createColumnHelper<AuditLogDisplay>();
+const logs = computed(() => logsStore.logs);
+const totalPages = computed(() => Math.ceil(logsStore.total / PAGE_SIZE));
+
+const columns = [
+  columnHelper.accessor("timestamp", {
+    header: "Timestamp",
+    cell: (info) => h(Timestamp, { date: info.getValue(), relative: true }),
+  }),
+  columnHelper.accessor("changeSetName", {
+    header: "Change Set",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("kind", {
+    header: "Event Kind",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("actorName", {
+    header: "Actor",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("ip", {
+    header: "Origin IP Address",
+    cell: (info) => info.getValue(),
+  }),
+  // columnHelper.accessor("service", {
+  //   header: "Service",
+  //   cell: (info) => info.getValue(),
+  // }),
+];
+
+const table = useVueTable({
+  get data() {
+    return logs.value;
+  },
+  columns,
+  getCoreRowModel: getCoreRowModel(),
+  getPaginationRowModel: getPaginationRowModel(),
+});
+table.setPageSize(PAGE_SIZE);
+
+const onHeaderClick = (id: string) => {
+  if (id === "timestamp") {
+    currentFilters.value.sortTimestampAscending =
+      !currentFilters.value.sortTimestampAscending;
+    loadLogs();
+  }
+};
+
+const toggleFilter = (id: string, filterId: string) => {
+  if (id === "kind") {
+    if (currentFilters.value.kindFilter.includes(filterId)) {
+      const i = currentFilters.value.kindFilter.indexOf(filterId);
+      currentFilters.value.kindFilter.splice(i, 1);
+    } else currentFilters.value.kindFilter.push(filterId);
+  } else if (id === "service") {
+    if (currentFilters.value.serviceFilter.includes(filterId)) {
+      const i = currentFilters.value.serviceFilter.indexOf(filterId);
+      currentFilters.value.serviceFilter.splice(i, 1);
+    } else currentFilters.value.serviceFilter.push(filterId);
+  } else if (id === "changeSetName") {
+    if (currentFilters.value.changeSetFilter.includes(filterId)) {
+      const i = currentFilters.value.changeSetFilter.indexOf(filterId);
+      currentFilters.value.changeSetFilter.splice(i, 1);
+    } else currentFilters.value.changeSetFilter.push(filterId);
+  } else if (id === "actorName") {
+    if (currentFilters.value.userFilter.includes(filterId)) {
+      const i = currentFilters.value.userFilter.indexOf(filterId);
+      currentFilters.value.userFilter.splice(i, 1);
+    } else currentFilters.value.userFilter.push(filterId);
+  }
+  loadLogs();
+};
+
+const clearFilters = (id: string) => {
+  if (id === "kind") {
+    currentFilters.value.kindFilter = [];
+  } else if (id === "service") {
+    currentFilters.value.serviceFilter = [];
+  } else if (id === "changeSetName") {
+    currentFilters.value.changeSetFilter = [];
+  } else if (id === "actorName") {
+    currentFilters.value.userFilter = [];
+  }
+  loadLogs();
+};
+
+const canGetPreviousPage = () => {
+  return currentFilters.value.page > 1;
+};
+
+const getCanNextPage = () => {
+  return currentFilters.value.page < totalPages.value;
+};
+
+const setPage = (pageNumber: number) => {
+  currentFilters.value.page = pageNumber;
+  loadLogs();
+};
+
+const nextPage = () => {
+  currentFilters.value.page++;
+  loadLogs();
+};
+
+const previousPage = () => {
+  currentFilters.value.page--;
+  loadLogs();
+};
+</script>

--- a/app/web/src/components/layout/navbar/NavbarPanelCenter.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelCenter.vue
@@ -23,13 +23,27 @@
     >
       <Icon name="beaker" />
     </NavbarButton>
+
+    <NavbarButton
+      v-if="featureFlagsStore.AUDIT_PAGE"
+      tooltipText="Audit"
+      :selected="route.matched.some((r) => r.name === 'workspace-audit')"
+      :linkTo="{
+        name: 'workspace-audit',
+        params: { changeSetId: 'auto' },
+      }"
+    >
+      <Icon name="eye" />
+    </NavbarButton>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useRoute } from "vue-router";
 import { Icon } from "@si/vue-lib/design-system";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import NavbarButton from "./NavbarButton.vue";
 
 const route = useRoute();
+const featureFlagsStore = useFeatureFlagsStore();
 </script>

--- a/app/web/src/pages/DebugPage.vue
+++ b/app/web/src/pages/DebugPage.vue
@@ -16,6 +16,15 @@
           :name="name as IconNames"
           class="cursor-pointer"
         />
+        <template v-for="(_, name) in SPINNABLE_ICONS" :key="name">
+          <Icon
+            v-for="d in ['left', 'right', 'up', 'down']"
+            :key="d"
+            v-tooltip="`${name}--${d}`"
+            :name="`${name}--${d}` as IconNames"
+            class="cursor-pointer"
+          />
+        </template>
       </div>
 
       <div class="w-full px-lg text-xl text-left">Logo Icons</div>
@@ -219,6 +228,7 @@ import {
   ICONS,
   LOGO_ICONS,
   ColorNamesArray,
+  SPINNABLE_ICONS,
 } from "@si/vue-lib/design-system";
 import { colors } from "@si/vue-lib";
 import SiLogo from "@si/vue-lib/brand-assets/si-logo-symbol.svg?component";

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -89,6 +89,11 @@ const routes: RouteRecordRaw[] = [
         ],
       },
       {
+        path: ":changeSetId/a",
+        name: "workspace-audit",
+        component: () => import("@/components/Workspace/WorkspaceAuditLog.vue"),
+      },
+      {
         path: "admin",
         name: "workspace-admin-dashboard",
         component: () =>

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -12,6 +12,7 @@ const FLAG_MAPPING = {
   ADMIN_PANEL_ACCESS: "si_admin_panel_access",
   ON_DEMAND_ASSETS: "on_demand_assets",
   MANAGEMENT_FUNCTIONS: "management-functions",
+  AUDIT_PAGE: "audit-page",
 };
 
 type FeatureFlags = keyof typeof FLAG_MAPPING;

--- a/app/web/src/store/logs.store.ts
+++ b/app/web/src/store/logs.store.ts
@@ -1,0 +1,134 @@
+import { defineStore } from "pinia";
+import * as _ from "lodash-es";
+import { ApiRequest, addStoreHooks } from "@si/vue-lib/pinia";
+import { useWorkspacesStore, WorkspacePk } from "@/store/workspaces.store";
+import { ChangeSetId } from "@/api/sdf/dal/change_set";
+import { ActorView } from "@/api/sdf/dal/history_actor";
+import { useChangeSetsStore } from "./change_sets.store";
+import { UserId } from "./auth.store";
+
+export enum AuditLogService {
+  AuthApi = "AuthApi",
+  Pinga = "Pinga",
+  Rebaser = "Rebaser",
+  Sdf = "Sdf",
+}
+
+export enum AuditLogKind {
+  CreateComponent = "CreateComponent",
+  DeleteComponent = "DeleteComponent",
+  PerformedRebase = "PerformedRebase",
+  RanAction = "RanAction",
+  RanDependentValuesUpdate = "RanDependentValuesUpdate",
+  UpdatePropertyEditorValue = "UpdatePropertyEditorValue",
+}
+
+export type LogFilters = {
+  page: number;
+  pageSize: number;
+  sortTimestampAscending: boolean;
+  excludeSystemUser: boolean;
+  kindFilter: string[];
+  serviceFilter: string[];
+  changeSetFilter: ChangeSetId[];
+  userFilter: UserId[];
+};
+
+export type AuditLog = {
+  actor: ActorView;
+  actorName: string;
+  actorEmail: string;
+  service: AuditLogService;
+  kind: AuditLogKind;
+  timestamp: string;
+  originIpAddress: string;
+  workspaceId: WorkspacePk;
+  workspaceName: string;
+  changeSetId: ChangeSetId;
+  changeSetName: string;
+};
+
+export type AuditLogDisplay = {
+  actorId: string;
+  actorName: string;
+  actorEmail?: string;
+  service: string;
+  kind: string;
+  timestamp: string;
+  ip: string;
+  changeSetId: string;
+  changeSetName: string;
+};
+
+export const useLogsStore = (forceChangeSetId?: ChangeSetId) => {
+  // this needs some work... but we'll probably want a way to force using HEAD
+  // so we can load HEAD data in some scenarios while also loading a change set?
+  let changeSetId: ChangeSetId | undefined;
+  if (forceChangeSetId) {
+    changeSetId = forceChangeSetId;
+  } else {
+    const changeSetsStore = useChangeSetsStore();
+    changeSetId = changeSetsStore.selectedChangeSetId;
+  }
+
+  const workspacesStore = useWorkspacesStore();
+  const workspaceId = workspacesStore.selectedWorkspacePk;
+  const changeSetsStore = useChangeSetsStore();
+  const selectedChangeSetId = changeSetsStore.selectedChangeSet?.id;
+
+  const API_PREFIX = [
+    "v2",
+    "workspaces",
+    { workspaceId },
+    "change-sets",
+    { selectedChangeSetId },
+    "audit-logs",
+  ];
+
+  const visibility = {
+    // changeSetId should not be empty if we are actually using this store
+    // so we can give it a bad value and let it throw an error
+    visibility_change_set_pk: changeSetId || "XXX",
+  };
+
+  return addStoreHooks(
+    workspaceId,
+    changeSetId,
+    defineStore(
+      `ws${workspaceId || "NONE"}/cs${changeSetId || "NONE"}/audit-logs`,
+      {
+        state: () => ({
+          logs: [] as AuditLogDisplay[],
+          total: 0 as number,
+        }),
+        getters: {},
+        actions: {
+          async LOAD_PAGE(filters: LogFilters) {
+            return new ApiRequest<{ logs: AuditLog[]; total: number }>({
+              url: API_PREFIX,
+              params: { ...visibility, ...filters },
+              onSuccess: (response) => {
+                this.logs = response.logs.map(
+                  (log: AuditLog) =>
+                    ({
+                      actorId: log.actor.kind ?? "System",
+                      actorName: log.actorName ?? "System",
+                      actorEmail: log.actorEmail,
+                      service: log.service,
+                      kind: log.kind,
+                      timestamp: log.timestamp,
+                      ip: log.originIpAddress ?? "System",
+                      changeSetId: log.changeSetId,
+                      changeSetName: log.changeSetName,
+                    } as AuditLogDisplay),
+                );
+                this.total = response.total;
+              },
+            });
+          },
+        },
+        onActivated() {},
+      },
+    ),
+  )();
+};

--- a/lib/dal/src/audit_log.rs
+++ b/lib/dal/src/audit_log.rs
@@ -175,7 +175,7 @@ pub fn filter_and_paginate(
     service_filter: HashSet<AuditLogService>,
     change_set_filter: HashSet<ChangeSetId>,
     user_filter: HashSet<UserPk>,
-) -> AuditLogResult<Vec<si_frontend_types::AuditLog>> {
+) -> AuditLogResult<(Vec<si_frontend_types::AuditLog>, usize)> {
     // First, filter the logs based on our chosen filters. This logic works by processing each
     // audit log and assuming each log is within our desired scope by default. The instant that a
     // log does not meet our scope, we continue!
@@ -220,8 +220,10 @@ pub fn filter_and_paginate(
         filtered_audit_logs.reverse();
     }
 
+    let total = filtered_audit_logs.len();
+
     // Finally, paginate and return.
-    Ok(paginate(filtered_audit_logs, page, page_size))
+    Ok((paginate(filtered_audit_logs, page, page_size), total))
 }
 
 fn paginate(

--- a/lib/dal/tests/integration_test/audit_log.rs
+++ b/lib/dal/tests/integration_test/audit_log.rs
@@ -8,7 +8,7 @@ async fn generation_filtering_pagination(ctx: &DalContext) {
     let audit_logs = dal::audit_log::generate(ctx, 200)
         .await
         .expect("could not generate audit logs");
-    let filtered_and_paginated_audit_logs = dal::audit_log::filter_and_paginate(
+    let (filtered_and_paginated_audit_logs, _) = dal::audit_log::filter_and_paginate(
         audit_logs,
         Some(2),
         Some(25),

--- a/lib/si-events-rs/src/audit_log.rs
+++ b/lib/si-events-rs/src/audit_log.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 
 #[remain::sorted]
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash)]
@@ -10,7 +11,19 @@ pub enum AuditLogService {
 }
 
 #[remain::sorted]
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash)]
+#[derive(
+    Clone,
+    Debug,
+    Deserialize,
+    Serialize,
+    Eq,
+    PartialEq,
+    Hash,
+    AsRefStr,
+    Display,
+    EnumIter,
+    EnumString,
+)]
 pub enum AuditLogKind {
     CreateComponent,
     DeleteComponent,

--- a/lib/vue-lib/package.json
+++ b/lib/vue-lib/package.json
@@ -46,6 +46,7 @@
     "@si/ts-lib": "workspace:*",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/line-clamp": "^0.4.2",
+    "@tanstack/vue-table": "^8.20.5",
     "@vueuse/head": "^1.1.23",
     "axios": "^1.5.0",
     "clsx": "^1.2.1",

--- a/lib/vue-lib/src/design-system/general/IconButton.vue
+++ b/lib/vue-lib/src/design-system/general/IconButton.vue
@@ -133,4 +133,6 @@ const iconShowing = computed(() => {
 const iconToneDefault = computed(() =>
   props.iconIdleTone ? props.iconIdleTone : props.iconTone,
 );
+
+defineExpose({ startActive, endActive, onHover, onEndHover });
 </script>

--- a/lib/vue-lib/src/design-system/menus/DropdownMenu.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenu.vue
@@ -108,6 +108,7 @@ const props = defineProps({
     type: String as PropType<DropdownMenuVariant>,
     default: "compact",
   },
+  alignCenter: Boolean,
 });
 
 const internalRef = ref<HTMLElement | null>(null);
@@ -271,6 +272,8 @@ function readjustMenuPosition() {
   posX.value = anchorRect.x;
   if (props.submenu) {
     posX.value = anchorRect.right;
+  } else if (props.alignCenter) {
+    posX.value = anchorRect.x + anchorRect.width / 2 - menuRect.width / 2;
   }
   // NOTE - window.innerWidth was including scrollbar width, so throwing off calc
   const windowWidth = document.documentElement.clientWidth;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       '@si/vue-lib':
         specifier: workspace:*
         version: link:../../lib/vue-lib
+      '@tanstack/vue-table':
+        specifier: ^8.20.5
+        version: 8.20.5(vue@3.4.15)
       '@types/async':
         specifier: ^3.2.15
         version: 3.2.16
@@ -786,6 +789,9 @@ importers:
       '@tailwindcss/line-clamp':
         specifier: ^0.4.2
         version: 0.4.2(tailwindcss@3.2.2)
+      '@tanstack/vue-table':
+        specifier: ^8.20.5
+        version: 8.20.5(vue@3.4.15)
       '@vueuse/head':
         specifier: ^1.1.23
         version: 1.1.23(vue@3.4.15)
@@ -4477,6 +4483,21 @@ packages:
       tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
     dependencies:
       tailwindcss: 3.2.2(postcss@8.4.21)
+    dev: false
+
+  /@tanstack/table-core@8.20.5:
+    resolution: {integrity: sha512-P9dF7XbibHph2PFRz8gfBKEXEY/HJPOhym8CHmjF8y3q5mWpKx9xtZapXQUWCgkqvsK0R46Azuz+VaxD4Xl+Tg==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /@tanstack/vue-table@8.20.5(vue@3.4.15):
+    resolution: {integrity: sha512-2xixT3BEgSDw+jOSqPt6ylO/eutDI107t2WdFMVYIZZ45UmTHLySqNriNs0+dMaKR56K5z3t+97P6VuVnI2L+Q==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      vue: '>=3.2'
+    dependencies:
+      '@tanstack/table-core': 8.20.5
+      vue: 3.4.15(typescript@4.9.5)
     dev: false
 
   /@tapjs/after-each@1.1.17(@tapjs/core@1.4.6):


### PR DESCRIPTION
![Screenshot 2024-10-18 at 6 08 39 PM](https://github.com/user-attachments/assets/e8cda3a1-9fa9-467f-836a-7d4188ae070f)

- Currently the filters for Actor and Change Set are based on the current data in the frontend. Eventually in order to filter for any possible event, we need to expand that data to include Actors who have been removed from the workspace and Change Sets which have been abandoned.
- Logs can be sorted by timestamp and filtered by everything except IP address. Would like to add filtering by IP address UI if I get the time.
- The pagination controls work, though I'd like to add UI for selecting an arbitrary page so that if there are 100's of pages you can jump to a specific one.
- The display of the data is pretty bare bones for now, will be doing improvements on that as well.