### PR TITLE
Add custom extractor for filtering audit logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "arrayref"
@@ -173,9 +173,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998282f8f49ccd6116b0ed8a4de0fbd3151697920e7c7533416d6e25e76434a7"
+checksum = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
 dependencies = [
  "brotli",
  "flate2",
@@ -238,7 +238,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -260,7 +260,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -271,7 +271,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-firehose"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1ebf3cee2426d2aa1204ff7b6f9785004ba7d5c5b4b2187a10d5d7f7f1b75f"
+checksum = "05f36d00e1ac8e25c61443968be1e933ced6b9675c4a8022c98e0dd5dc363130"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -611,7 +611,7 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.0.1",
  "httparse",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
@@ -702,7 +702,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "itoa",
  "matchit",
  "memchr",
@@ -750,7 +750,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -855,7 +855,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -938,7 +938,7 @@ dependencies = [
  "hex",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-named-pipe",
  "hyper-util",
  "hyperlocal-next",
@@ -988,7 +988,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "syn_derive",
 ]
 
@@ -1131,9 +1131,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.28"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "shlex",
 ]
@@ -1244,7 +1244,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1480,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1584,7 +1584,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1613,7 +1613,7 @@ dependencies = [
  "futures",
  "futures-lite",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyperlocal",
  "remain",
  "serde",
@@ -1660,7 +1660,7 @@ dependencies = [
  "cyclone-core",
  "derive_builder",
  "futures",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "nix 0.27.1",
  "pin-project-lite",
  "procfs",
@@ -1763,7 +1763,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "si-events",
- "syn 2.0.79",
+ "syn 2.0.82",
  "trybuild",
 ]
 
@@ -1833,7 +1833,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1844,7 +1844,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1961,7 +1961,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1971,7 +1971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1984,7 +1984,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2144,7 +2144,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2215,7 +2215,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2353,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2493,7 +2493,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2895,9 +2895,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2919,9 +2919,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2944,7 +2944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2960,7 +2960,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -2976,9 +2976,9 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2992,7 +2992,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -3004,7 +3004,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3022,7 +3022,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3037,7 +3037,7 @@ source = "git+https://github.com/fnichol/hyperlocal.git?branch=pub-unix-stream#6
 dependencies = [
  "futures-util",
  "hex",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "pin-project",
  "tokio",
 ]
@@ -3050,7 +3050,7 @@ checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3106,7 +3106,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.79",
+ "syn 2.0.82",
  "toml",
  "unicode-xid",
 ]
@@ -3169,7 +3169,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3230,9 +3230,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb94a0ffd3f3ee755c20f7d8752f45cac88605a4dcf808abcff72873296ec7b"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3303,9 +3303,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libloading"
@@ -3395,7 +3395,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3432,7 +3432,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3505,7 +3505,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3603,7 +3603,7 @@ dependencies = [
  "chrono",
  "derive_builder",
  "futures",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "jwt-simple",
  "module-index-types",
  "refinery",
@@ -4017,7 +4017,7 @@ dependencies = [
  "glob",
  "once_cell",
  "opentelemetry",
- "ordered-float 4.3.0",
+ "ordered-float 4.4.0",
  "percent-encoding",
  "rand 0.8.5",
  "thiserror",
@@ -4051,9 +4051,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
+checksum = "83e7ccb95e240b7c9506a3d544f10d935e142cc90b0a1d56954fb44d89ad6b97"
 dependencies = [
  "num-traits",
 ]
@@ -4100,7 +4100,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4114,7 +4114,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4196,9 +4196,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+checksum = "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361"
 
 [[package]]
 name = "peeking_take_while"
@@ -4292,7 +4292,7 @@ checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4439,7 +4439,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4571,7 +4571,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4587,9 +4587,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -4602,7 +4602,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "version_check",
  "yansi",
 ]
@@ -4663,7 +4663,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4676,7 +4676,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4744,7 +4744,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "socket2",
  "thiserror",
  "tokio",
@@ -4761,7 +4761,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.0.0",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "slab",
  "thiserror",
  "tinyvec",
@@ -5029,7 +5029,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5101,7 +5101,7 @@ checksum = "46aef80f842736de545ada6ec65b81ee91504efd6853f4b96de7414c42ae7443"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5126,7 +5126,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "ipnet",
@@ -5138,7 +5138,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -5262,7 +5262,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls 0.24.2",
  "log",
  "maybe-async",
@@ -5367,9 +5367,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.14"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "once_cell",
  "ring",
@@ -5424,9 +5424,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
@@ -5451,9 +5451,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"
@@ -5520,7 +5520,7 @@ dependencies = [
  "derive_builder",
  "futures",
  "futures-lite",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "module-index-client",
  "names",
  "nats-multiplexer",
@@ -5537,6 +5537,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_qs",
  "serde_url_params",
  "serde_with",
  "si-crypto",
@@ -5579,7 +5580,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5620,7 +5621,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.79",
+ "syn 2.0.82",
  "unicode-ident",
 ]
 
@@ -5734,7 +5735,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5770,6 +5771,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5777,7 +5789,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5838,7 +5850,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6205,7 +6217,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6666,7 +6678,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6701,9 +6713,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6719,7 +6731,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6770,6 +6782,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
+
+[[package]]
 name = "telemetry"
 version = "0.1.0"
 dependencies = [
@@ -6805,7 +6823,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "remain",
  "telemetry",
  "tower-http",
@@ -6876,7 +6894,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6896,7 +6914,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -7038,7 +7056,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -7109,7 +7127,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
 ]
@@ -7242,7 +7260,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
@@ -7267,7 +7285,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-timeout 0.5.1",
  "hyper-util",
  "percent-encoding",
@@ -7356,7 +7374,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -7463,15 +7481,16 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "207aa50d36c4be8d8c6ea829478be44a372c6a77669937bb39c698e52f1491e8"
+checksum = "8dcd332a5496c026f1e14b7f3d2b7bd98e509660c04239c58b0ba38a12daded4"
 dependencies = [
  "dissimilar",
  "glob",
  "serde",
  "serde_derive",
  "serde_json",
+ "target-triple",
  "termcolor",
  "toml",
 ]
@@ -7526,12 +7545,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
@@ -7634,9 +7650,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
  "serde",
@@ -7832,9 +7848,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef073ced962d62984fb38a36e5fdc1a2b23c9e0e1fa0689bb97afa4202ef6887"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7843,24 +7859,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4bfab14ef75323f4eb75fa52ee0a3fb59611977fd3240da19b2cf36ff85030e"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65471f79c1022ffa5291d33520cbbb53b7687b01c2f8e83b57d102eed7ed479d"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7870,9 +7886,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7bec9830f60924d9ceb3ef99d55c155be8afa76954edffbb5936ff4509474e7"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7880,28 +7896,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c74f6e152a76a2ad448e223b0fc0b6b5747649c3d769cc6bf45737bf97d0ed6"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42f6c679374623f295a8623adfe63d9284091245c3504bde47c17a3ce2777d9"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44188d185b5bdcae1052d08bcbcf9091a5524038d4572cc4f4f2bb9d5554ddd9"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8014,7 +8030,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -8025,7 +8041,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -8326,7 +8342,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -8346,10 +8362,10 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[patch.unused]]
 name = "tokio-postgres-rustls"
-version = "0.12.0"
-source = "git+https://github.com/jbg/tokio-postgres-rustls.git?branch=master#21f4d0eaae8b4d4be335ec0767e7891f38bd0cc9"
+version = "0.13.0"
+source = "git+https://github.com/jbg/tokio-postgres-rustls.git?branch=master#0cffe66df0e3fdc6b6067cf4432d1e3343c80fff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ serde = { version = "1.0.197", features = ["derive", "rc"] }
 serde-aux = "4.5.0"
 serde_json = { version = "=1.0.125", features = ["preserve_order"] }
 serde_path_to_error = { version = "0.1.16" }
+serde_qs = "0.13.0"
 serde_url_params = "0.2.1"
 serde_with = "3.7.0"
 serde_yaml = "0.9.33" # NOTE(nick): this has been archived upstream

--- a/lib/dal/src/audit_log.rs
+++ b/lib/dal/src/audit_log.rs
@@ -220,6 +220,8 @@ pub fn filter_and_paginate(
         filtered_audit_logs.reverse();
     }
 
+    // Count the number of audit logs after filtering, but before pagination. We need this so that
+    // the frontend can know how many pages exists when paginating data.
     let total = filtered_audit_logs.len();
 
     // Finally, paginate and return.

--- a/lib/sdf-server/BUCK
+++ b/lib/sdf-server/BUCK
@@ -44,6 +44,7 @@ rust_library(
         "//third-party/rust:reqwest",
         "//third-party/rust:serde",
         "//third-party/rust:serde_json",
+        "//third-party/rust:serde_qs",
         "//third-party/rust:serde_with",
         "//third-party/rust:sodiumoxide",
         "//third-party/rust:strum",

--- a/lib/sdf-server/Cargo.toml
+++ b/lib/sdf-server/Cargo.toml
@@ -9,34 +9,14 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
-async-trait = { workspace = true }
-axum = { workspace = true }
-base64 = { workspace = true }
 buck2-resources = { path = "../../lib/buck2-resources" }
-chrono = { workspace = true }
-clap = { workspace = true }
-convert_case = { workspace = true }
 dal = { path = "../../lib/dal" }
-derive_builder = { workspace = true }
-futures = { workspace = true }
-futures-lite = { workspace = true }
-hyper = { workspace = true }
 module-index-client = { path = "../../lib/module-index-client" }
-names = { workspace = true }
 nats-multiplexer = { path = "../../lib/nats-multiplexer" }
 nats-multiplexer-client = { path = "../../lib/nats-multiplexer-client" }
 nats-subscriber = { path = "../../lib/nats-subscriber" }
-nix = { workspace = true }
-once_cell = { workspace = true }
-pathdiff = { workspace = true }
 permissions = { path = "../../lib/permissions" }
-rand = { workspace = true }
 rebaser-client = { path = "../../lib/rebaser-client" }
-remain = { workspace = true }
-reqwest = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-serde_with = { workspace = true }
 si-crypto = { path = "../../lib/si-crypto" }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-data-pg = { path = "../../lib/si-data-pg" }
@@ -48,10 +28,33 @@ si-pkg = { path = "../../lib/si-pkg" }
 si-posthog = { path = "../../lib/si-posthog-rs" }
 si-settings = { path = "../../lib/si-settings" }
 si-std = { path = "../../lib/si-std" }
-sodiumoxide = { workspace = true }
-strum = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
 telemetry-http = { path = "../../lib/telemetry-http-rs" }
+veritech-client = { path = "../../lib/veritech-client" }
+
+async-trait = { workspace = true }
+axum = { workspace = true }
+base64 = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+convert_case = { workspace = true }
+derive_builder = { workspace = true }
+futures = { workspace = true }
+futures-lite = { workspace = true }
+hyper = { workspace = true }
+names = { workspace = true }
+nix = { workspace = true }
+once_cell = { workspace = true }
+pathdiff = { workspace = true }
+rand = { workspace = true }
+remain = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_qs = { workspace = true }
+serde_with = { workspace = true }
+sodiumoxide = { workspace = true }
+strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
@@ -62,11 +65,11 @@ tower-http = { workspace = true }
 tracing-tunnel = { workspace = true }
 ulid = { workspace = true }
 url = { workspace = true }
-veritech-client = { path = "../../lib/veritech-client" }
 y-sync = { workspace = true }
 
 [dev-dependencies]
 dal-test = { path = "../../lib/dal-test" }
+
 pretty_assertions_sorted = { workspace = true }
 serde_url_params = { workspace = true }
 tokio-util = { workspace = true }

--- a/lib/sdf-server/src/service/v2/audit_log/list_audit_logs.rs
+++ b/lib/sdf-server/src/service/v2/audit_log/list_audit_logs.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use axum::{
-    extract::{OriginalUri, Path, Query},
+    extract::{OriginalUri, Path},
     Json,
 };
 use dal::{ChangeSetId, WorkspacePk};
@@ -13,7 +13,7 @@ use si_events::{
 use si_frontend_types as frontend_types;
 
 use super::AuditLogResult;
-use crate::extract::{AccessBuilder, HandlerContext, PosthogClient};
+use crate::extract::{AccessBuilder, HandlerContext, PosthogClient, QueryWithVecParams};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -41,7 +41,7 @@ pub async fn list_audit_logs(
     PosthogClient(_posthog_client): PosthogClient,
     OriginalUri(_original_uri): OriginalUri,
     Path((_workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
-    Query(request): Query<ListAuditLogsRequest>,
+    QueryWithVecParams(request): QueryWithVecParams<ListAuditLogsRequest>,
 ) -> AuditLogResult<Json<ListAuditLogsResponse>> {
     let ctx = builder
         .build(access_builder.build(change_set_id.into()))
@@ -76,6 +76,7 @@ pub async fn list_audit_logs(
             None => HashSet::new(),
         },
     )?;
+
     Ok(Json(ListAuditLogsResponse {
         logs: filtered_and_paginated_audit_logs,
         total,

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -484,18 +484,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "anyhow-1.0.89.crate",
-    sha256 = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6",
-    strip_prefix = "anyhow-1.0.89",
-    urls = ["https://static.crates.io/crates/anyhow/1.0.89/download"],
+    name = "anyhow-1.0.90.crate",
+    sha256 = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95",
+    strip_prefix = "anyhow-1.0.90",
+    urls = ["https://static.crates.io/crates/anyhow/1.0.90/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "anyhow-1.0.89",
-    srcs = [":anyhow-1.0.89.crate"],
+    name = "anyhow-1.0.90",
+    srcs = [":anyhow-1.0.90.crate"],
     crate = "anyhow",
-    crate_root = "anyhow-1.0.89.crate/src/lib.rs",
+    crate_root = "anyhow-1.0.90.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -557,18 +557,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "async-compression-0.4.14.crate",
-    sha256 = "998282f8f49ccd6116b0ed8a4de0fbd3151697920e7c7533416d6e25e76434a7",
-    strip_prefix = "async-compression-0.4.14",
-    urls = ["https://static.crates.io/crates/async-compression/0.4.14/download"],
+    name = "async-compression-0.4.17.crate",
+    sha256 = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857",
+    strip_prefix = "async-compression-0.4.17",
+    urls = ["https://static.crates.io/crates/async-compression/0.4.17/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-compression-0.4.14",
-    srcs = [":async-compression-0.4.14.crate"],
+    name = "async-compression-0.4.17",
+    srcs = [":async-compression-0.4.17.crate"],
     crate = "async_compression",
-    crate_root = "async-compression-0.4.14.crate/src/lib.rs",
+    crate_root = "async-compression-0.4.17.crate/src/lib.rs",
     edition = "2018",
     features = [
         "brotli",
@@ -705,9 +705,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -750,9 +750,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -779,9 +779,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -1068,39 +1068,39 @@ cargo.rust_library(
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.14",
         ":tracing-0.1.40",
-        ":uuid-1.10.0",
+        ":uuid-1.11.0",
     ],
 )
 
 alias(
     name = "aws-sdk-firehose",
-    actual = ":aws-sdk-firehose-1.50.0",
+    actual = ":aws-sdk-firehose-1.51.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "aws-sdk-firehose-1.50.0.crate",
-    sha256 = "3f1ebf3cee2426d2aa1204ff7b6f9785004ba7d5c5b4b2187a10d5d7f7f1b75f",
-    strip_prefix = "aws-sdk-firehose-1.50.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-firehose/1.50.0/download"],
+    name = "aws-sdk-firehose-1.51.0.crate",
+    sha256 = "05f36d00e1ac8e25c61443968be1e933ced6b9675c4a8022c98e0dd5dc363130",
+    strip_prefix = "aws-sdk-firehose-1.51.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-firehose/1.51.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-firehose-1.50.0",
-    srcs = [":aws-sdk-firehose-1.50.0.crate"],
+    name = "aws-sdk-firehose-1.51.0",
+    srcs = [":aws-sdk-firehose-1.51.0.crate"],
     crate = "aws_sdk_firehose",
-    crate_root = "aws-sdk-firehose-1.50.0.crate/src/lib.rs",
+    crate_root = "aws-sdk-firehose-1.51.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-firehose-1.50.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-firehose-1.51.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for Amazon Kinesis Firehose",
         "CARGO_PKG_NAME": "aws-sdk-firehose",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.50.0",
+        "CARGO_PKG_VERSION": "1.51.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "50",
+        "CARGO_PKG_VERSION_MINOR": "51",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     features = [
@@ -1421,7 +1421,7 @@ cargo.rust_library(
         "http_02x": ":http-0.2.12",
         "http_body_04x": ":http-body-0.4.6",
         "http_body_1x": ":http-body-1.0.1",
-        "hyper_0_14": ":hyper-0.14.30",
+        "hyper_0_14": ":hyper-0.14.31",
     },
     visibility = [],
     deps = [
@@ -1653,7 +1653,7 @@ cargo.rust_library(
         ":futures-util-0.3.31",
         ":http-0.2.12",
         ":http-body-0.4.6",
-        ":hyper-0.14.30",
+        ":hyper-0.14.31",
         ":itoa-1.0.11",
         ":matchit-0.7.3",
         ":memchr-2.7.4",
@@ -1721,9 +1721,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -1750,7 +1750,7 @@ cargo.rust_library(
         "linux-arm64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -1758,7 +1758,7 @@ cargo.rust_library(
         "linux-x86_64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -1766,7 +1766,7 @@ cargo.rust_library(
         "macos-arm64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -1774,7 +1774,7 @@ cargo.rust_library(
         "macos-x86_64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -1782,7 +1782,7 @@ cargo.rust_library(
         "windows-gnu": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -2008,12 +2008,12 @@ cargo.rust_library(
         ":lazy_static-1.5.0",
         ":lazycell-1.3.0",
         ":peeking_take_while-0.1.2",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
         ":regex-1.11.0",
         ":rustc-hash-1.1.0",
         ":shlex-1.3.0",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -2402,7 +2402,7 @@ cargo.rust_library(
         ":hex-0.4.3",
         ":http-1.1.0",
         ":http-body-util-0.1.2",
-        ":hyper-1.4.1",
+        ":hyper-1.5.0",
         ":hyper-util-0.1.9",
         ":log-0.4.22",
         ":pin-project-lite-0.2.14",
@@ -2647,10 +2647,10 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
     },
     visibility = [],
@@ -2694,18 +2694,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "cc-1.1.28.crate",
-    sha256 = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1",
-    strip_prefix = "cc-1.1.28",
-    urls = ["https://static.crates.io/crates/cc/1.1.28/download"],
+    name = "cc-1.1.31.crate",
+    sha256 = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f",
+    strip_prefix = "cc-1.1.31",
+    urls = ["https://static.crates.io/crates/cc/1.1.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "cc-1.1.28",
-    srcs = [":cc-1.1.28.crate"],
+    name = "cc-1.1.31",
+    srcs = [":cc-1.1.31.crate"],
     crate = "cc",
-    crate_root = "cc-1.1.28.crate/src/lib.rs",
+    crate_root = "cc-1.1.31.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
     deps = [":shlex-1.3.0"],
@@ -2924,7 +2924,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":glob-0.3.1",
-        ":libc-0.2.159",
+        ":libc-0.2.161",
         ":libloading-0.8.5",
     ],
 )
@@ -3073,9 +3073,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.5.0",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -3112,22 +3112,22 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "windows-gnu": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "windows-msvc": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
     },
     visibility = [],
@@ -3363,7 +3363,7 @@ cargo.rust_library(
     deps = [
         ":lazy_static-1.5.0",
         ":nom-7.1.3",
-        ":pathdiff-0.2.1",
+        ":pathdiff-0.2.2",
         ":serde-1.0.210",
         ":toml-0.8.19",
     ],
@@ -3411,7 +3411,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":lazy_static-1.5.0",
-        ":libc-0.2.159",
+        ":libc-0.2.161",
         ":unicode-width-0.1.14",
     ],
 )
@@ -3529,7 +3529,7 @@ cargo.rust_library(
         ":flate2-1.0.34",
         ":futures-util-0.3.31",
         ":http-0.2.12",
-        ":hyper-0.14.30",
+        ":hyper-0.14.31",
         ":log-0.4.22",
         ":mime-0.3.17",
         ":paste-1.0.15",
@@ -3605,7 +3605,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":core-foundation-sys-0.8.7",
-        ":libc-0.2.159",
+        ":libc-0.2.161",
     ],
 )
 
@@ -3646,10 +3646,10 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
     },
     visibility = [],
@@ -3968,7 +3968,7 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":mio-0.8.11",
                 ":signal-hook-0.3.17",
                 ":signal-hook-mio-0.2.4",
@@ -3976,7 +3976,7 @@ cargo.rust_library(
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":mio-0.8.11",
                 ":signal-hook-0.3.17",
                 ":signal-hook-mio-0.2.4",
@@ -3984,7 +3984,7 @@ cargo.rust_library(
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":mio-0.8.11",
                 ":signal-hook-0.3.17",
                 ":signal-hook-mio-0.2.4",
@@ -3992,7 +3992,7 @@ cargo.rust_library(
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":mio-0.8.11",
                 ":signal-hook-0.3.17",
                 ":signal-hook-mio-0.2.4",
@@ -4035,16 +4035,16 @@ cargo.rust_library(
     features = ["windows"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "windows-gnu": dict(
             deps = [
@@ -4296,9 +4296,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -4355,10 +4355,10 @@ cargo.rust_library(
     deps = [
         ":fnv-1.0.7",
         ":ident_case-1.0.1",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
         ":strsim-0.11.1",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -4381,7 +4381,7 @@ cargo.rust_library(
     deps = [
         ":darling_core-0.20.10",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -4401,7 +4401,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":anyhow-1.0.89",
+        ":anyhow-1.0.90",
         ":html-escape-0.2.13",
         ":nom-7.1.3",
         ":ordered-float-2.10.1",
@@ -4593,7 +4593,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
         ":syn-1.0.109",
     ],
@@ -4645,9 +4645,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":darling-0.20.10",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -4670,7 +4670,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":derive_builder_core-0.20.2",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -4726,9 +4726,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":convert_case-0.4.0",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -4966,16 +4966,16 @@ cargo.rust_library(
     edition = "2015",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.48.0"],
@@ -5236,9 +5236,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":enum-ordinalize-4.3.0",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -5425,9 +5425,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -5496,16 +5496,16 @@ cargo.rust_library(
     features = ["std"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -5738,16 +5738,16 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.59.0"],
@@ -6097,9 +6097,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -6320,16 +6320,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
     },
     visibility = [],
@@ -6359,16 +6359,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
     },
     visibility = [],
@@ -7147,23 +7147,23 @@ cargo.rust_library(
 
 alias(
     name = "hyper",
-    actual = ":hyper-0.14.30",
+    actual = ":hyper-0.14.31",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "hyper-0.14.30.crate",
-    sha256 = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9",
-    strip_prefix = "hyper-0.14.30",
-    urls = ["https://static.crates.io/crates/hyper/0.14.30/download"],
+    name = "hyper-0.14.31.crate",
+    sha256 = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85",
+    strip_prefix = "hyper-0.14.31",
+    urls = ["https://static.crates.io/crates/hyper/0.14.31/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "hyper-0.14.30",
-    srcs = [":hyper-0.14.30.crate"],
+    name = "hyper-0.14.31",
+    srcs = [":hyper-0.14.31.crate"],
     crate = "hyper",
-    crate_root = "hyper-0.14.30.crate/src/lib.rs",
+    crate_root = "hyper-0.14.31.crate/src/lib.rs",
     edition = "2018",
     features = [
         "client",
@@ -7200,18 +7200,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "hyper-1.4.1.crate",
-    sha256 = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05",
-    strip_prefix = "hyper-1.4.1",
-    urls = ["https://static.crates.io/crates/hyper/1.4.1/download"],
+    name = "hyper-1.5.0.crate",
+    sha256 = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a",
+    strip_prefix = "hyper-1.5.0",
+    urls = ["https://static.crates.io/crates/hyper/1.5.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "hyper-1.4.1",
-    srcs = [":hyper-1.4.1.crate"],
+    name = "hyper-1.5.0",
+    srcs = [":hyper-1.5.0.crate"],
     crate = "hyper",
-    crate_root = "hyper-1.4.1.crate/src/lib.rs",
+    crate_root = "hyper-1.5.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "client",
@@ -7253,7 +7253,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hex-0.4.3",
-        ":hyper-1.4.1",
+        ":hyper-1.5.0",
         ":hyper-util-0.1.9",
         ":pin-project-lite-0.2.14",
         ":tokio-1.40.0",
@@ -7292,7 +7292,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.31",
         ":http-0.2.12",
-        ":hyper-0.14.30",
+        ":hyper-0.14.31",
         ":log-0.4.22",
         ":rustls-0.21.12",
         ":rustls-native-certs-0.6.3",
@@ -7323,15 +7323,15 @@ cargo.rust_library(
         "webpki-tokio",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.9.0",
+        "pki_types": ":rustls-pki-types-1.10.0",
     },
     visibility = [],
     deps = [
         ":futures-util-0.3.31",
         ":http-1.1.0",
-        ":hyper-1.4.1",
+        ":hyper-1.5.0",
         ":hyper-util-0.1.9",
-        ":rustls-0.23.14",
+        ":rustls-0.23.15",
         ":tokio-1.40.0",
         ":tokio-rustls-0.26.0",
         ":tower-service-0.3.3",
@@ -7355,7 +7355,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":hyper-0.14.30",
+        ":hyper-0.14.31",
         ":pin-project-lite-0.2.14",
         ":tokio-1.40.0",
         ":tokio-io-timeout-1.2.0",
@@ -7378,7 +7378,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":hyper-1.4.1",
+        ":hyper-1.5.0",
         ":hyper-util-0.1.9",
         ":pin-project-lite-0.2.14",
         ":tokio-1.40.0",
@@ -7414,7 +7414,7 @@ cargo.rust_library(
         ":futures-util-0.3.31",
         ":http-1.1.0",
         ":http-body-1.0.1",
-        ":hyper-1.4.1",
+        ":hyper-1.5.0",
         ":pin-project-lite-0.2.14",
         ":socket2-0.5.7",
         ":tokio-1.40.0",
@@ -7444,7 +7444,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.31",
         ":hex-0.4.3",
-        ":hyper-0.14.30",
+        ":hyper-0.14.31",
         ":pin-project-1.1.6",
         ":tokio-1.40.0",
     ],
@@ -7475,7 +7475,7 @@ cargo.rust_library(
     deps = [
         ":hex-0.4.3",
         ":http-body-util-0.1.2",
-        ":hyper-1.4.1",
+        ":hyper-1.5.0",
         ":hyper-util-0.1.9",
         ":pin-project-lite-0.2.14",
         ":tokio-1.40.0",
@@ -7582,10 +7582,10 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":ignore-0.4.23",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
         ":serde-1.0.210",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
         ":toml-0.8.19",
         ":unicode-xid-0.2.6",
     ],
@@ -7778,9 +7778,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -7881,16 +7881,16 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -8079,7 +8079,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":anyhow-1.0.89",
+        ":anyhow-1.0.90",
         ":binstring-0.1.1",
         ":blake2b_simd-1.0.2",
         ":coarsetime-0.1.34",
@@ -8164,7 +8164,7 @@ cargo.rust_library(
     crate_root = "krata-loopdev-0.0.12.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":libc-0.2.159"],
+    deps = [":libc-0.2.161"],
 )
 
 alias(
@@ -8213,33 +8213,33 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "libc-0.2.159.crate",
-    sha256 = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5",
-    strip_prefix = "libc-0.2.159",
-    urls = ["https://static.crates.io/crates/libc/0.2.159/download"],
+    name = "libc-0.2.161.crate",
+    sha256 = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1",
+    strip_prefix = "libc-0.2.161",
+    urls = ["https://static.crates.io/crates/libc/0.2.161/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "libc-0.2.159",
-    srcs = [":libc-0.2.159.crate"],
+    name = "libc-0.2.161",
+    srcs = [":libc-0.2.161.crate"],
     crate = "libc",
-    crate_root = "libc-0.2.159.crate/src/lib.rs",
+    crate_root = "libc-0.2.161.crate/src/lib.rs",
     edition = "2015",
     features = [
         "default",
         "extra_traits",
         "std",
     ],
-    rustc_flags = ["@$(location :libc-0.2.159-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :libc-0.2.161-build-script-run[rustc_flags])"],
     visibility = [],
 )
 
 cargo.rust_binary(
-    name = "libc-0.2.159-build-script-build",
-    srcs = [":libc-0.2.159.crate"],
+    name = "libc-0.2.161-build-script-build",
+    srcs = [":libc-0.2.161.crate"],
     crate = "build_script_build",
-    crate_root = "libc-0.2.159.crate/build.rs",
+    crate_root = "libc-0.2.161.crate/build.rs",
     edition = "2015",
     features = [
         "default",
@@ -8250,15 +8250,15 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "libc-0.2.159-build-script-run",
+    name = "libc-0.2.161-build-script-run",
     package_name = "libc",
-    buildscript_rule = ":libc-0.2.159-build-script-build",
+    buildscript_rule = ":libc-0.2.161-build-script-build",
     features = [
         "default",
         "extra_traits",
         "std",
     ],
-    version = "0.2.159",
+    version = "0.2.161",
 )
 
 http_archive(
@@ -8569,7 +8569,7 @@ cargo.rust_library(
     edition = "2015",
     visibility = [],
     deps = [
-        ":libc-0.2.159",
+        ":libc-0.2.161",
         ":libsodium-sys-0.2.7-libsodium",
     ],
 )
@@ -8921,12 +8921,12 @@ cargo.rust_library(
     ],
     named_deps = {
         "macros": ":manyhow-macros-0.11.4",
-        "syn2": ":syn-2.0.79",
+        "syn2": ":syn-2.0.82",
     },
     visibility = [],
     deps = [
         ":darling_core-0.20.10",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
     ],
 )
@@ -8949,7 +8949,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro-utils-0.10.0",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
     ],
 )
@@ -9008,9 +9008,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -9098,16 +9098,16 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
     },
     visibility = [],
@@ -9130,16 +9130,16 @@ cargo.rust_library(
     features = ["stable_deref_trait"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
     },
     visibility = [],
@@ -9216,9 +9216,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -9269,7 +9269,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":mime-0.3.17",
-        ":unicase-2.7.0",
+        ":unicase-2.8.0",
     ],
 )
 
@@ -9284,7 +9284,7 @@ cargo.rust_binary(
         "rev-mappings",
     ],
     visibility = [],
-    deps = [":unicase-2.7.0"],
+    deps = [":unicase-2.8.0"],
 )
 
 buildscript_run(
@@ -9391,16 +9391,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.48.0"],
@@ -9434,16 +9434,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -9501,7 +9501,7 @@ cargo.rust_library(
         ":tagptr-0.2.0",
         ":thiserror-1.0.64",
         ":triomphe-0.1.11",
-        ":uuid-1.10.0",
+        ":uuid-1.11.0",
     ],
 )
 
@@ -9690,7 +9690,7 @@ cargo.rust_library(
     deps = [
         ":bitflags-1.3.2",
         ":cfg-if-1.0.0",
-        ":libc-0.2.159",
+        ":libc-0.2.161",
     ],
 )
 
@@ -9729,7 +9729,7 @@ cargo.rust_library(
     deps = [
         ":bitflags-2.6.0",
         ":cfg-if-1.0.0",
-        ":libc-0.2.159",
+        ":libc-0.2.161",
     ],
 )
 
@@ -10062,16 +10062,16 @@ cargo.rust_library(
     edition = "2015",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
     },
     visibility = [],
@@ -10196,27 +10196,27 @@ cargo.rust_library(
         "linux-arm64": dict(
             deps = [
                 ":is-wsl-0.4.0",
-                ":libc-0.2.159",
-                ":pathdiff-0.2.1",
+                ":libc-0.2.161",
+                ":pathdiff-0.2.2",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
                 ":is-wsl-0.4.0",
-                ":libc-0.2.159",
-                ":pathdiff-0.2.1",
+                ":libc-0.2.161",
+                ":pathdiff-0.2.2",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.159",
-                ":pathdiff-0.2.1",
+                ":libc-0.2.161",
+                ":pathdiff-0.2.2",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.159",
-                ":pathdiff-0.2.1",
+                ":libc-0.2.161",
+                ":pathdiff-0.2.2",
             ],
         ),
     },
@@ -10442,7 +10442,7 @@ cargo.rust_library(
         ":glob-0.3.1",
         ":once_cell-1.20.2",
         ":opentelemetry-0.22.0",
-        ":ordered-float-4.3.0",
+        ":ordered-float-4.4.0",
         ":percent-encoding-2.3.1",
         ":rand-0.8.5",
         ":thiserror-1.0.64",
@@ -10509,18 +10509,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "ordered-float-4.3.0.crate",
-    sha256 = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537",
-    strip_prefix = "ordered-float-4.3.0",
-    urls = ["https://static.crates.io/crates/ordered-float/4.3.0/download"],
+    name = "ordered-float-4.4.0.crate",
+    sha256 = "83e7ccb95e240b7c9506a3d544f10d935e142cc90b0a1d56954fb44d89ad6b97",
+    strip_prefix = "ordered-float-4.4.0",
+    urls = ["https://static.crates.io/crates/ordered-float/4.4.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "ordered-float-4.3.0",
-    srcs = [":ordered-float-4.3.0.crate"],
+    name = "ordered-float-4.4.0",
+    srcs = [":ordered-float-4.4.0.crate"],
     crate = "ordered_float",
-    crate_root = "ordered-float-4.3.0.crate/src/lib.rs",
+    crate_root = "ordered-float-4.4.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -10628,9 +10628,9 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro-error-1.0.4",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -10654,10 +10654,10 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":itertools-0.12.1",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":proc-macro2-diagnostics-0.10.1",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -10850,16 +10850,16 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "windows-gnu": dict(
             deps = [":windows-targets-0.52.6"],
@@ -10901,23 +10901,23 @@ cargo.rust_library(
 
 alias(
     name = "pathdiff",
-    actual = ":pathdiff-0.2.1",
+    actual = ":pathdiff-0.2.2",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "pathdiff-0.2.1.crate",
-    sha256 = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd",
-    strip_prefix = "pathdiff-0.2.1",
-    urls = ["https://static.crates.io/crates/pathdiff/0.2.1/download"],
+    name = "pathdiff-0.2.2.crate",
+    sha256 = "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361",
+    strip_prefix = "pathdiff-0.2.2",
+    urls = ["https://static.crates.io/crates/pathdiff/0.2.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "pathdiff-0.2.1",
-    srcs = [":pathdiff-0.2.1.crate"],
+    name = "pathdiff-0.2.2",
+    srcs = [":pathdiff-0.2.2.crate"],
     crate = "pathdiff",
-    crate_root = "pathdiff-0.2.1.crate/src/lib.rs",
+    crate_root = "pathdiff-0.2.2.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
 )
@@ -11137,7 +11137,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
         ":syn-1.0.109",
     ],
@@ -11160,9 +11160,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -11534,9 +11534,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.5.0",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -11745,7 +11745,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro-error-attr-1.0.4",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
         ":syn-1.0.109",
     ],
@@ -11795,7 +11795,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
     ],
 )
@@ -11817,7 +11817,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
     ],
 )
@@ -11843,9 +11843,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro-error-attr2-2.0.0",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -11873,7 +11873,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
         ":smallvec-1.13.2",
     ],
@@ -11881,38 +11881,38 @@ cargo.rust_library(
 
 alias(
     name = "proc-macro2",
-    actual = ":proc-macro2-1.0.87",
+    actual = ":proc-macro2-1.0.88",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "proc-macro2-1.0.87.crate",
-    sha256 = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a",
-    strip_prefix = "proc-macro2-1.0.87",
-    urls = ["https://static.crates.io/crates/proc-macro2/1.0.87/download"],
+    name = "proc-macro2-1.0.88.crate",
+    sha256 = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9",
+    strip_prefix = "proc-macro2-1.0.88",
+    urls = ["https://static.crates.io/crates/proc-macro2/1.0.88/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "proc-macro2-1.0.87",
-    srcs = [":proc-macro2-1.0.87.crate"],
+    name = "proc-macro2-1.0.88",
+    srcs = [":proc-macro2-1.0.88.crate"],
     crate = "proc_macro2",
-    crate_root = "proc-macro2-1.0.87.crate/src/lib.rs",
+    crate_root = "proc-macro2-1.0.88.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
         "proc-macro",
     ],
-    rustc_flags = ["@$(location :proc-macro2-1.0.87-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :proc-macro2-1.0.88-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [":unicode-ident-1.0.13"],
 )
 
 cargo.rust_binary(
-    name = "proc-macro2-1.0.87-build-script-build",
-    srcs = [":proc-macro2-1.0.87.crate"],
+    name = "proc-macro2-1.0.88-build-script-build",
+    srcs = [":proc-macro2-1.0.88.crate"],
     crate = "build_script_build",
-    crate_root = "proc-macro2-1.0.87.crate/build.rs",
+    crate_root = "proc-macro2-1.0.88.crate/build.rs",
     edition = "2021",
     features = [
         "default",
@@ -11922,14 +11922,14 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "proc-macro2-1.0.87-build-script-run",
+    name = "proc-macro2-1.0.88-build-script-run",
     package_name = "proc-macro2",
-    buildscript_rule = ":proc-macro2-1.0.87-build-script-build",
+    buildscript_rule = ":proc-macro2-1.0.88-build-script-build",
     features = [
         "default",
         "proc-macro",
     ],
-    version = "1.0.87",
+    version = "1.0.88",
 )
 
 http_archive(
@@ -11953,9 +11953,9 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
         ":yansi-1.0.1",
     ],
 )
@@ -12122,11 +12122,11 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":anyhow-1.0.89",
+        ":anyhow-1.0.90",
         ":itertools-0.12.1",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -12147,11 +12147,11 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":anyhow-1.0.89",
+        ":anyhow-1.0.90",
         ":itertools-0.13.0",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -12197,20 +12197,20 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":raw-cpuid-11.2.0",
             ],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":raw-cpuid-11.2.0",
             ],
         ),
@@ -12288,7 +12288,7 @@ cargo.rust_library(
         ":bytes-1.7.2",
         ":pin-project-lite-0.2.14",
         ":rustc-hash-2.0.0",
-        ":rustls-0.23.14",
+        ":rustls-0.23.15",
         ":socket2-0.5.7",
         ":thiserror-1.0.64",
         ":tokio-1.40.0",
@@ -12320,7 +12320,7 @@ cargo.rust_library(
         ":rand-0.8.5",
         ":ring-0.17.5",
         ":rustc-hash-2.0.0",
-        ":rustls-0.23.14",
+        ":rustls-0.23.15",
         ":slab-0.4.9",
         ":thiserror-1.0.64",
         ":tinyvec-1.8.0",
@@ -12359,7 +12359,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":libc-0.2.159",
+        ":libc-0.2.161",
         ":socket2-0.5.7",
         ":tracing-0.1.40",
     ],
@@ -12390,7 +12390,7 @@ cargo.rust_library(
         "proc-macro",
     ],
     visibility = [],
-    deps = [":proc-macro2-1.0.87"],
+    deps = [":proc-macro2-1.0.88"],
 )
 
 http_archive(
@@ -12422,25 +12422,25 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":rand_chacha-0.2.2",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":rand_chacha-0.2.2",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":rand_chacha-0.2.2",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":rand_chacha-0.2.2",
             ],
         ),
@@ -12487,16 +12487,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
     },
     visibility = [],
@@ -12779,11 +12779,11 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
         ":refinery-core-0.8.14",
         ":regex-1.11.0",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -13040,9 +13040,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -13080,7 +13080,7 @@ cargo.rust_library(
             deps = [
                 ":http-body-1.0.1",
                 ":http-body-util-0.1.2",
-                ":hyper-1.4.1",
+                ":hyper-1.5.0",
                 ":hyper-rustls-0.27.3",
                 ":hyper-util-0.1.9",
                 ":ipnet-2.10.1",
@@ -13090,9 +13090,9 @@ cargo.rust_library(
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
-                ":rustls-0.23.14",
+                ":rustls-0.23.15",
                 ":rustls-pemfile-2.2.0",
-                ":rustls-pki-types-1.9.0",
+                ":rustls-pki-types-1.10.0",
                 ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
                 ":webpki-roots-0.26.6",
@@ -13102,7 +13102,7 @@ cargo.rust_library(
             deps = [
                 ":http-body-1.0.1",
                 ":http-body-util-0.1.2",
-                ":hyper-1.4.1",
+                ":hyper-1.5.0",
                 ":hyper-rustls-0.27.3",
                 ":hyper-util-0.1.9",
                 ":ipnet-2.10.1",
@@ -13112,9 +13112,9 @@ cargo.rust_library(
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
-                ":rustls-0.23.14",
+                ":rustls-0.23.15",
                 ":rustls-pemfile-2.2.0",
-                ":rustls-pki-types-1.9.0",
+                ":rustls-pki-types-1.10.0",
                 ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
                 ":webpki-roots-0.26.6",
@@ -13124,7 +13124,7 @@ cargo.rust_library(
             deps = [
                 ":http-body-1.0.1",
                 ":http-body-util-0.1.2",
-                ":hyper-1.4.1",
+                ":hyper-1.5.0",
                 ":hyper-rustls-0.27.3",
                 ":hyper-util-0.1.9",
                 ":ipnet-2.10.1",
@@ -13134,9 +13134,9 @@ cargo.rust_library(
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
-                ":rustls-0.23.14",
+                ":rustls-0.23.15",
                 ":rustls-pemfile-2.2.0",
-                ":rustls-pki-types-1.9.0",
+                ":rustls-pki-types-1.10.0",
                 ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
                 ":webpki-roots-0.26.6",
@@ -13146,7 +13146,7 @@ cargo.rust_library(
             deps = [
                 ":http-body-1.0.1",
                 ":http-body-util-0.1.2",
-                ":hyper-1.4.1",
+                ":hyper-1.5.0",
                 ":hyper-rustls-0.27.3",
                 ":hyper-util-0.1.9",
                 ":ipnet-2.10.1",
@@ -13156,9 +13156,9 @@ cargo.rust_library(
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
-                ":rustls-0.23.14",
+                ":rustls-0.23.15",
                 ":rustls-pemfile-2.2.0",
-                ":rustls-pki-types-1.9.0",
+                ":rustls-pki-types-1.10.0",
                 ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
                 ":webpki-roots-0.26.6",
@@ -13168,7 +13168,7 @@ cargo.rust_library(
             deps = [
                 ":http-body-1.0.1",
                 ":http-body-util-0.1.2",
-                ":hyper-1.4.1",
+                ":hyper-1.5.0",
                 ":hyper-rustls-0.27.3",
                 ":hyper-util-0.1.9",
                 ":ipnet-2.10.1",
@@ -13178,9 +13178,9 @@ cargo.rust_library(
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
-                ":rustls-0.23.14",
+                ":rustls-0.23.15",
                 ":rustls-pemfile-2.2.0",
-                ":rustls-pki-types-1.9.0",
+                ":rustls-pki-types-1.10.0",
                 ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
                 ":webpki-roots-0.26.6",
@@ -13191,7 +13191,7 @@ cargo.rust_library(
             deps = [
                 ":http-body-1.0.1",
                 ":http-body-util-0.1.2",
-                ":hyper-1.4.1",
+                ":hyper-1.5.0",
                 ":hyper-rustls-0.27.3",
                 ":hyper-util-0.1.9",
                 ":ipnet-2.10.1",
@@ -13201,9 +13201,9 @@ cargo.rust_library(
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.14",
                 ":quinn-0.11.5",
-                ":rustls-0.23.14",
+                ":rustls-0.23.15",
                 ":rustls-pemfile-2.2.0",
-                ":rustls-pki-types-1.9.0",
+                ":rustls-pki-types-1.10.0",
                 ":tokio-1.40.0",
                 ":tokio-rustls-0.26.0",
                 ":webpki-roots-0.26.6",
@@ -13414,7 +13414,7 @@ cargo.rust_library(
                 "RING_CORE_PREFIX": "ring_core_0_17_5_",
             },
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":ring-0.17.5-ring-c-asm-elf-aarch64",
                 ":ring-0.17.5-ring-c-asm-elf-aarch64",
                 ":spin-0.9.8",
@@ -13425,7 +13425,7 @@ cargo.rust_library(
                 "RING_CORE_PREFIX": "ring_core_0_17_5_",
             },
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":ring-0.17.5-ring-c-asm-elf-x86_84",
                 ":ring-0.17.5-ring-c-asm-elf-x86_84",
                 ":spin-0.9.8",
@@ -14096,7 +14096,7 @@ cargo.rust_library(
         ":hex-0.4.3",
         ":hmac-0.12.1",
         ":http-0.2.12",
-        ":hyper-0.14.30",
+        ":hyper-0.14.31",
         ":hyper-rustls-0.24.2",
         ":log-0.4.22",
         ":maybe-async-0.2.10",
@@ -14287,7 +14287,7 @@ cargo.rust_library(
                 "libc_errno": ":errno-0.3.9",
             },
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":linux-raw-sys-0.4.14",
             ],
         ),
@@ -14296,7 +14296,7 @@ cargo.rust_library(
                 "libc_errno": ":errno-0.3.9",
             },
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":linux-raw-sys-0.4.14",
             ],
         ),
@@ -14304,13 +14304,13 @@ cargo.rust_library(
             named_deps = {
                 "libc_errno": ":errno-0.3.9",
             },
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
             named_deps = {
                 "libc_errno": ":errno-0.3.9",
             },
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "windows-gnu": dict(
             named_deps = {
@@ -14430,7 +14430,7 @@ cargo.rust_library(
         "tls12",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.9.0",
+        "pki_types": ":rustls-pki-types-1.10.0",
     },
     visibility = [],
     deps = [
@@ -14443,18 +14443,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "rustls-0.23.14.crate",
-    sha256 = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8",
-    strip_prefix = "rustls-0.23.14",
-    urls = ["https://static.crates.io/crates/rustls/0.23.14/download"],
+    name = "rustls-0.23.15.crate",
+    sha256 = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993",
+    strip_prefix = "rustls-0.23.15",
+    urls = ["https://static.crates.io/crates/rustls/0.23.15/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-0.23.14",
-    srcs = [":rustls-0.23.14.crate"],
+    name = "rustls-0.23.15",
+    srcs = [":rustls-0.23.15.crate"],
     crate = "rustls",
-    crate_root = "rustls-0.23.14.crate/src/lib.rs",
+    crate_root = "rustls-0.23.15.crate/src/lib.rs",
     edition = "2021",
     features = [
         "ring",
@@ -14462,7 +14462,7 @@ cargo.rust_library(
         "tls12",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.9.0",
+        "pki_types": ":rustls-pki-types-1.10.0",
     },
     visibility = [],
     deps = [
@@ -14533,7 +14533,7 @@ cargo.rust_library(
     crate_root = "rustls-native-certs-0.7.3.crate/src/lib.rs",
     edition = "2021",
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.9.0",
+        "pki_types": ":rustls-pki-types-1.10.0",
     },
     platform = {
         "linux-arm64": dict(
@@ -14602,24 +14602,24 @@ cargo.rust_library(
         "std",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.9.0",
+        "pki_types": ":rustls-pki-types-1.10.0",
     },
     visibility = [],
 )
 
 http_archive(
-    name = "rustls-pki-types-1.9.0.crate",
-    sha256 = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55",
-    strip_prefix = "rustls-pki-types-1.9.0",
-    urls = ["https://static.crates.io/crates/rustls-pki-types/1.9.0/download"],
+    name = "rustls-pki-types-1.10.0.crate",
+    sha256 = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b",
+    strip_prefix = "rustls-pki-types-1.10.0",
+    urls = ["https://static.crates.io/crates/rustls-pki-types/1.10.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-pki-types-1.9.0",
-    srcs = [":rustls-pki-types-1.9.0.crate"],
+    name = "rustls-pki-types-1.10.0",
+    srcs = [":rustls-pki-types-1.10.0.crate"],
     crate = "rustls_pki_types",
-    crate_root = "rustls-pki-types-1.9.0.crate/src/lib.rs",
+    crate_root = "rustls-pki-types-1.10.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -14676,7 +14676,7 @@ cargo.rust_library(
         "std",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.9.0",
+        "pki_types": ":rustls-pki-types-1.10.0",
     },
     visibility = [],
     deps = [
@@ -14686,40 +14686,40 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "rustversion-1.0.17.crate",
-    sha256 = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6",
-    strip_prefix = "rustversion-1.0.17",
-    urls = ["https://static.crates.io/crates/rustversion/1.0.17/download"],
+    name = "rustversion-1.0.18.crate",
+    sha256 = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248",
+    strip_prefix = "rustversion-1.0.18",
+    urls = ["https://static.crates.io/crates/rustversion/1.0.18/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustversion-1.0.17",
-    srcs = [":rustversion-1.0.17.crate"],
+    name = "rustversion-1.0.18",
+    srcs = [":rustversion-1.0.18.crate"],
     crate = "rustversion",
-    crate_root = "rustversion-1.0.17.crate/src/lib.rs",
+    crate_root = "rustversion-1.0.18.crate/src/lib.rs",
     edition = "2018",
     env = {
-        "OUT_DIR": "$(location :rustversion-1.0.17-build-script-run[out_dir])",
+        "OUT_DIR": "$(location :rustversion-1.0.18-build-script-run[out_dir])",
     },
     proc_macro = True,
     visibility = [],
 )
 
 cargo.rust_binary(
-    name = "rustversion-1.0.17-build-script-build",
-    srcs = [":rustversion-1.0.17.crate"],
+    name = "rustversion-1.0.18-build-script-build",
+    srcs = [":rustversion-1.0.18.crate"],
     crate = "build_script_build",
-    crate_root = "rustversion-1.0.17.crate/build/build.rs",
+    crate_root = "rustversion-1.0.18.crate/build/build.rs",
     edition = "2018",
     visibility = [],
 )
 
 buildscript_run(
-    name = "rustversion-1.0.17-build-script-run",
+    name = "rustversion-1.0.18-build-script-run",
     package_name = "rustversion",
-    buildscript_rule = ":rustversion-1.0.17-build-script-build",
-    version = "1.0.17",
+    buildscript_rule = ":rustversion-1.0.18-build-script-build",
+    version = "1.0.18",
 )
 
 http_archive(
@@ -14839,9 +14839,9 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro-error2-2.0.1",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -14910,7 +14910,7 @@ cargo.rust_library(
         ":time-0.3.36",
         ":tracing-0.1.40",
         ":url-2.5.2",
-        ":uuid-1.10.0",
+        ":uuid-1.11.0",
     ],
 )
 
@@ -14941,9 +14941,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
         ":unicode-ident-1.0.13",
     ],
 )
@@ -14994,7 +14994,7 @@ cargo.rust_library(
         ":rust_decimal-1.36.0",
         ":serde_json-1.0.125",
         ":time-0.3.36",
-        ":uuid-1.10.0",
+        ":uuid-1.11.0",
     ],
 )
 
@@ -15039,7 +15039,7 @@ cargo.rust_library(
         ":serde_json-1.0.125",
         ":sqlx-0.7.4",
         ":time-0.3.36",
-        ":uuid-1.10.0",
+        ":uuid-1.11.0",
     ],
 )
 
@@ -15105,7 +15105,7 @@ cargo.rust_library(
         ":bitflags-2.6.0",
         ":core-foundation-0.9.4",
         ":core-foundation-sys-0.8.7",
-        ":libc-0.2.159",
+        ":libc-0.2.161",
         ":security-framework-sys-2.12.0",
     ],
 )
@@ -15133,7 +15133,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":core-foundation-sys-0.8.7",
-        ":libc-0.2.159",
+        ":libc-0.2.161",
     ],
 )
 
@@ -15325,9 +15325,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -15414,6 +15414,35 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "serde_qs",
+    actual = ":serde_qs-0.13.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "serde_qs-0.13.0.crate",
+    sha256 = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6",
+    strip_prefix = "serde_qs-0.13.0",
+    urls = ["https://static.crates.io/crates/serde_qs/0.13.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "serde_qs-0.13.0",
+    srcs = [":serde_qs-0.13.0.crate"],
+    crate = "serde_qs",
+    crate_root = "serde_qs-0.13.0.crate/src/lib.rs",
+    edition = "2018",
+    features = ["default"],
+    visibility = [],
+    deps = [
+        ":percent-encoding-2.3.1",
+        ":serde-1.0.210",
+        ":thiserror-1.0.64",
+    ],
+)
+
 http_archive(
     name = "serde_repr-0.1.19.crate",
     sha256 = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9",
@@ -15431,9 +15460,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -15567,9 +15596,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":darling-0.20.10",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -15799,7 +15828,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":libc-0.2.159",
+        ":libc-0.2.161",
         ":signal-hook-registry-1.4.2",
     ],
 )
@@ -15827,7 +15856,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":libc-0.2.159",
+        ":libc-0.2.161",
         ":signal-hook-0.3.17",
     ],
 )
@@ -15847,7 +15876,7 @@ cargo.rust_library(
     crate_root = "signal-hook-registry-1.4.2.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
-    deps = [":libc-0.2.159"],
+    deps = [":libc-0.2.161"],
 )
 
 http_archive(
@@ -16059,16 +16088,16 @@ cargo.rust_library(
     features = ["all"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -16108,7 +16137,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":ed25519-1.5.3",
-        ":libc-0.2.159",
+        ":libc-0.2.161",
         ":libsodium-sys-0.2.7",
         ":serde-1.0.210",
     ],
@@ -16349,7 +16378,7 @@ cargo.rust_library(
         ":tokio-stream-0.1.16",
         ":tracing-0.1.40",
         ":url-2.5.2",
-        ":uuid-1.10.0",
+        ":uuid-1.11.0",
         ":webpki-roots-0.25.4",
     ],
 )
@@ -16421,7 +16450,7 @@ cargo.rust_library(
         ":thiserror-1.0.64",
         ":time-0.3.36",
         ":tracing-0.1.40",
-        ":uuid-1.10.0",
+        ":uuid-1.11.0",
         ":whoami-1.5.2",
     ],
 )
@@ -16640,10 +16669,10 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.5.0",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":rustversion-1.0.17",
-        ":syn-2.0.79",
+        ":rustversion-1.0.18",
+        ":syn-2.0.82",
     ],
 )
 
@@ -16727,7 +16756,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
         ":unicode-ident-1.0.13",
     ],
@@ -16735,23 +16764,23 @@ cargo.rust_library(
 
 alias(
     name = "syn",
-    actual = ":syn-2.0.79",
+    actual = ":syn-2.0.82",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "syn-2.0.79.crate",
-    sha256 = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590",
-    strip_prefix = "syn-2.0.79",
-    urls = ["https://static.crates.io/crates/syn/2.0.79/download"],
+    name = "syn-2.0.82.crate",
+    sha256 = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021",
+    strip_prefix = "syn-2.0.82",
+    urls = ["https://static.crates.io/crates/syn/2.0.82/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "syn-2.0.79",
-    srcs = [":syn-2.0.79.crate"],
+    name = "syn-2.0.82",
+    srcs = [":syn-2.0.82.crate"],
     crate = "syn",
-    crate_root = "syn-2.0.79.crate/src/lib.rs",
+    crate_root = "syn-2.0.82.crate/src/lib.rs",
     edition = "2021",
     features = [
         "clone-impls",
@@ -16768,7 +16797,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
         ":unicode-ident-1.0.13",
     ],
@@ -16857,25 +16886,25 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":xattr-1.3.1",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":xattr-1.3.1",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":xattr-1.3.1",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":xattr-1.3.1",
             ],
         ),
@@ -16900,6 +16929,23 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [":nom-7.1.3"],
+)
+
+http_archive(
+    name = "target-triple-0.1.3.crate",
+    sha256 = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078",
+    strip_prefix = "target-triple-0.1.3",
+    urls = ["https://static.crates.io/crates/target-triple/0.1.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "target-triple-0.1.3",
+    srcs = [":target-triple-0.1.3.crate"],
+    crate = "target_triple",
+    crate_root = "target-triple-0.1.3.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
 )
 
 alias(
@@ -17058,9 +17104,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -17076,7 +17122,7 @@ cargo.rust_binary(
         ":async-recursion-1.1.1",
         ":async-trait-0.1.83",
         ":aws-config-1.5.8",
-        ":aws-sdk-firehose-1.50.0",
+        ":aws-sdk-firehose-1.51.0",
         ":axum-0.6.20",
         ":base64-0.22.1",
         ":blake3-1.5.4",
@@ -17110,7 +17156,7 @@ cargo.rust_binary(
         ":glob-0.3.1",
         ":hex-0.4.3",
         ":http-0.2.12",
-        ":hyper-0.14.30",
+        ":hyper-0.14.31",
         ":hyperlocal-0.8.0",
         ":iftree-1.0.5",
         ":indexmap-2.6.0",
@@ -17138,14 +17184,14 @@ cargo.rust_binary(
         ":ouroboros-0.18.4",
         ":parking_lot-0.12.3",
         ":paste-1.0.15",
-        ":pathdiff-0.2.1",
+        ":pathdiff-0.2.2",
         ":petgraph-0.6.5",
         ":pin-project-lite-0.2.14",
         ":podman-api-0.10.0",
         ":postcard-1.0.10",
         ":postgres-types-0.2.8",
         ":pretty_assertions_sorted-1.2.3",
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":procfs-0.16.0",
         ":quote-1.0.37",
         ":rand-0.8.5",
@@ -17164,6 +17210,7 @@ cargo.rust_binary(
         ":serde-aux-4.5.0",
         ":serde_json-1.0.125",
         ":serde_path_to_error-0.1.16",
+        ":serde_qs-0.13.0",
         ":serde_url_params-0.2.1",
         ":serde_with-3.11.0",
         ":serde_yaml-0.9.34+deprecated",
@@ -17172,7 +17219,7 @@ cargo.rust_binary(
         ":spicedb-grpc-0.1.1",
         ":stream-cancel-0.8.2",
         ":strum-0.26.3",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
         ":tar-0.4.42",
         ":tempfile-3.13.0",
         ":test-log-0.2.16",
@@ -17195,11 +17242,11 @@ cargo.rust_binary(
         ":tracing-opentelemetry-0.23.0",
         ":tracing-subscriber-0.3.18",
         ":tracing-tunnel-0.1.0",
-        ":trybuild-1.0.99",
+        ":trybuild-1.0.101",
         ":tryhard-0.5.1",
         ":ulid-1.1.3",
         ":url-2.5.2",
-        ":uuid-1.10.0",
+        ":uuid-1.11.0",
         ":version_check-0.9.5",
         ":vfs-0.12.0",
         ":vfs-tar-0.4.1",
@@ -17251,9 +17298,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -17279,26 +17326,26 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.159"],
+            deps = [":libc-0.2.161"],
         ),
         "windows-gnu": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":winapi-0.3.9",
             ],
         ),
         "windows-msvc": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":winapi-0.3.9",
             ],
         ),
@@ -17308,7 +17355,7 @@ cargo.rust_library(
         ":bitflags-2.6.0",
         ":cfg-if-1.0.0",
         ":log-0.4.22",
-        ":rustversion-1.0.17",
+        ":rustversion-1.0.18",
     ],
 )
 
@@ -17550,28 +17597,28 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.7",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.7",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.7",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.159",
+                ":libc-0.2.161",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.7",
             ],
@@ -17642,9 +17689,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -17789,7 +17836,7 @@ cargo.rust_library(
     crate_root = "tokio-rustls-0.25.0.crate/src/lib.rs",
     edition = "2021",
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.9.0",
+        "pki_types": ":rustls-pki-types-1.10.0",
     },
     visibility = [],
     deps = [
@@ -17817,11 +17864,11 @@ cargo.rust_library(
         "tls12",
     ],
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.9.0",
+        "pki_types": ":rustls-pki-types-1.10.0",
     },
     visibility = [],
     deps = [
-        ":rustls-0.23.14",
+        ":rustls-0.23.15",
         ":tokio-1.40.0",
     ],
 )
@@ -18029,7 +18076,7 @@ cargo.rust_library(
     deps = [
         ":bytes-1.7.2",
         ":futures-0.3.31",
-        ":libc-0.2.159",
+        ":libc-0.2.161",
         ":tokio-1.40.0",
         ":vsock-0.3.0",
     ],
@@ -18159,7 +18206,7 @@ cargo.rust_library(
         ":h2-0.3.26",
         ":http-0.2.12",
         ":http-body-0.4.6",
-        ":hyper-0.14.30",
+        ":hyper-0.14.31",
         ":hyper-timeout-0.4.1",
         ":percent-encoding-2.3.1",
         ":pin-project-1.1.6",
@@ -18211,7 +18258,7 @@ cargo.rust_library(
         ":http-1.1.0",
         ":http-body-1.0.1",
         ":http-body-util-0.1.2",
-        ":hyper-1.4.1",
+        ":hyper-1.5.0",
         ":hyper-timeout-0.5.1",
         ":hyper-util-0.1.9",
         ":percent-encoding-2.3.1",
@@ -18331,7 +18378,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-compression-0.4.14",
+        ":async-compression-0.4.17",
         ":bitflags-2.6.0",
         ":bytes-1.7.2",
         ":futures-core-0.3.31",
@@ -18435,9 +18482,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -18714,23 +18761,23 @@ cargo.rust_library(
 
 alias(
     name = "trybuild",
-    actual = ":trybuild-1.0.99",
+    actual = ":trybuild-1.0.101",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "trybuild-1.0.99.crate",
-    sha256 = "207aa50d36c4be8d8c6ea829478be44a372c6a77669937bb39c698e52f1491e8",
-    strip_prefix = "trybuild-1.0.99",
-    urls = ["https://static.crates.io/crates/trybuild/1.0.99/download"],
+    name = "trybuild-1.0.101.crate",
+    sha256 = "8dcd332a5496c026f1e14b7f3d2b7bd98e509660c04239c58b0ba38a12daded4",
+    strip_prefix = "trybuild-1.0.101",
+    urls = ["https://static.crates.io/crates/trybuild/1.0.101/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "trybuild-1.0.99",
-    srcs = [":trybuild-1.0.99.crate"],
+    name = "trybuild-1.0.101",
+    srcs = [":trybuild-1.0.101.crate"],
     crate = "trybuild",
-    crate_root = "trybuild-1.0.99.crate/src/lib.rs",
+    crate_root = "trybuild-1.0.101.crate/src/lib.rs",
     edition = "2021",
     features = [
         "diff",
@@ -18743,6 +18790,7 @@ cargo.rust_library(
         ":serde-1.0.210",
         ":serde_derive-1.0.210",
         ":serde_json-1.0.125",
+        ":target-triple-0.1.3",
         ":termcolor-1.4.1",
         ":toml-0.8.19",
     ],
@@ -18887,38 +18935,20 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "unicase-2.7.0.crate",
-    sha256 = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89",
-    strip_prefix = "unicase-2.7.0",
-    urls = ["https://static.crates.io/crates/unicase/2.7.0/download"],
+    name = "unicase-2.8.0.crate",
+    sha256 = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df",
+    strip_prefix = "unicase-2.8.0",
+    urls = ["https://static.crates.io/crates/unicase/2.8.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "unicase-2.7.0",
-    srcs = [":unicase-2.7.0.crate"],
+    name = "unicase-2.8.0",
+    srcs = [":unicase-2.8.0.crate"],
     crate = "unicase",
-    crate_root = "unicase-2.7.0.crate/src/lib.rs",
-    edition = "2015",
-    rustc_flags = ["@$(location :unicase-2.7.0-build-script-run[rustc_flags])"],
+    crate_root = "unicase-2.8.0.crate/src/lib.rs",
+    edition = "2018",
     visibility = [],
-)
-
-cargo.rust_binary(
-    name = "unicase-2.7.0-build-script-build",
-    srcs = [":unicase-2.7.0.crate"],
-    crate = "build_script_build",
-    crate_root = "unicase-2.7.0.crate/build.rs",
-    edition = "2015",
-    visibility = [],
-    deps = [":version_check-0.9.5"],
-)
-
-buildscript_run(
-    name = "unicase-2.7.0-build-script-run",
-    package_name = "unicase",
-    buildscript_rule = ":unicase-2.7.0-build-script-build",
-    version = "2.7.0",
 )
 
 http_archive(
@@ -19215,23 +19245,23 @@ cargo.rust_library(
 
 alias(
     name = "uuid",
-    actual = ":uuid-1.10.0",
+    actual = ":uuid-1.11.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "uuid-1.10.0.crate",
-    sha256 = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314",
-    strip_prefix = "uuid-1.10.0",
-    urls = ["https://static.crates.io/crates/uuid/1.10.0/download"],
+    name = "uuid-1.11.0.crate",
+    sha256 = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a",
+    strip_prefix = "uuid-1.11.0",
+    urls = ["https://static.crates.io/crates/uuid/1.11.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "uuid-1.10.0",
-    srcs = [":uuid-1.10.0.crate"],
+    name = "uuid-1.11.0",
+    srcs = [":uuid-1.11.0.crate"],
     crate = "uuid",
-    crate_root = "uuid-1.10.0.crate/src/lib.rs",
+    crate_root = "uuid-1.11.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -19382,7 +19412,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":libc-0.2.159",
+        ":libc-0.2.161",
         ":nix-0.24.3",
     ],
 )
@@ -19431,7 +19461,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
     ],
 )
@@ -19518,7 +19548,7 @@ cargo.rust_library(
     crate_root = "webpki-roots-0.26.6.crate/src/lib.rs",
     edition = "2018",
     named_deps = {
-        "pki_types": ":rustls-pki-types-1.9.0",
+        "pki_types": ":rustls-pki-types-1.10.0",
     },
     visibility = [],
 )
@@ -19804,9 +19834,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -19827,9 +19857,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -20426,9 +20456,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )
 
@@ -20473,8 +20503,8 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.87",
+        ":proc-macro2-1.0.88",
         ":quote-1.0.37",
-        ":syn-2.0.79",
+        ":syn-2.0.82",
     ],
 )

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "arrayref"
@@ -198,9 +198,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998282f8f49ccd6116b0ed8a4de0fbd3151697920e7c7533416d6e25e76434a7"
+checksum = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
 dependencies = [
  "brotli",
  "flate2",
@@ -263,7 +263,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -285,7 +285,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -296,7 +296,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-firehose"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1ebf3cee2426d2aa1204ff7b6f9785004ba7d5c5b4b2187a10d5d7f7f1b75f"
+checksum = "05f36d00e1ac8e25c61443968be1e933ced6b9675c4a8022c98e0dd5dc363130"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -620,7 +620,7 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.0.1",
  "httparse",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
@@ -711,7 +711,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "itoa",
  "matchit",
  "memchr",
@@ -759,7 +759,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -855,7 +855,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -938,7 +938,7 @@ dependencies = [
  "hex",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-named-pipe",
  "hyper-util",
  "hyperlocal-next",
@@ -988,7 +988,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "syn_derive",
 ]
 
@@ -1116,9 +1116,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.28"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "shlex",
 ]
@@ -1229,7 +1229,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1389,7 +1389,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyperlocal",
  "log",
  "mime",
@@ -1507,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1649,7 +1649,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1673,7 +1673,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1684,7 +1684,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1788,7 +1788,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1798,7 +1798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1811,7 +1811,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1971,7 +1971,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2048,7 +2048,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2186,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2296,7 +2296,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2728,9 +2728,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes 1.7.2",
  "futures-channel",
@@ -2752,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes 1.7.2",
  "futures-channel",
@@ -2777,7 +2777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2793,7 +2793,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -2809,9 +2809,9 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2825,7 +2825,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2837,7 +2837,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2855,7 +2855,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2870,7 +2870,7 @@ source = "git+https://github.com/fnichol/hyperlocal.git?branch=pub-unix-stream#6
 dependencies = [
  "futures-util",
  "hex",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "pin-project 1.1.6",
  "tokio",
 ]
@@ -2883,7 +2883,7 @@ checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2939,7 +2939,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.79",
+ "syn 2.0.82",
  "toml",
  "unicode-xid",
 ]
@@ -3015,7 +3015,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3121,9 +3121,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb94a0ffd3f3ee755c20f7d8752f45cac88605a4dcf808abcff72873296ec7b"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3194,9 +3194,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libloading"
@@ -3280,7 +3280,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3317,7 +3317,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3390,7 +3390,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3768,7 +3768,7 @@ dependencies = [
  "glob",
  "once_cell",
  "opentelemetry",
- "ordered-float 4.3.0",
+ "ordered-float 4.4.0",
  "percent-encoding",
  "rand 0.8.5",
  "thiserror",
@@ -3802,9 +3802,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
+checksum = "83e7ccb95e240b7c9506a3d544f10d935e142cc90b0a1d56954fb44d89ad6b97"
 dependencies = [
  "num-traits",
 ]
@@ -3851,7 +3851,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3865,7 +3865,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3947,9 +3947,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+checksum = "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361"
 
 [[package]]
 name = "peeking_take_while"
@@ -4049,7 +4049,7 @@ checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4183,7 +4183,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4315,7 +4315,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4331,9 +4331,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -4346,7 +4346,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "version_check",
  "yansi",
 ]
@@ -4407,7 +4407,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4420,7 +4420,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4488,7 +4488,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "socket2",
  "thiserror",
  "tokio",
@@ -4505,7 +4505,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.0.0",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "slab",
  "thiserror",
  "tinyvec",
@@ -4700,7 +4700,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4772,7 +4772,7 @@ checksum = "46aef80f842736de545ada6ec65b81ee91504efd6853f4b96de7414c42ae7443"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4797,7 +4797,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "ipnet",
@@ -4809,7 +4809,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -4932,7 +4932,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls 0.24.2",
  "log",
  "maybe-async",
@@ -5037,9 +5037,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.14"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "once_cell",
  "ring",
@@ -5094,9 +5094,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
@@ -5121,9 +5121,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"
@@ -5175,7 +5175,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5216,7 +5216,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.79",
+ "syn 2.0.82",
  "unicode-ident",
 ]
 
@@ -5341,7 +5341,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5377,6 +5377,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5384,7 +5395,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5445,7 +5456,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5988,7 +5999,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6023,9 +6034,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6041,7 +6052,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6090,6 +6101,12 @@ checksum = "7262f48c9ef16eb92e4ba069d4992dd27b793f816fb82012a860190d93ec882d"
 dependencies = [
  "nom",
 ]
+
+[[package]]
+name = "target-triple"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 
 [[package]]
 name = "tempfile"
@@ -6141,7 +6158,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6186,7 +6203,7 @@ dependencies = [
  "glob",
  "hex",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyperlocal",
  "iftree",
  "indexmap 2.6.0",
@@ -6240,6 +6257,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "serde_path_to_error",
+ "serde_qs",
  "serde_url_params",
  "serde_with",
  "serde_yaml",
@@ -6248,7 +6266,7 @@ dependencies = [
  "spicedb-grpc",
  "stream-cancel",
  "strum 0.26.3",
- "syn 2.0.79",
+ "syn 2.0.82",
  "tar",
  "tempfile",
  "test-log",
@@ -6302,7 +6320,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6430,7 +6448,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6501,7 +6519,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
 ]
@@ -6634,7 +6652,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project 1.1.6",
@@ -6659,7 +6677,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-timeout 0.5.1",
  "hyper-util",
  "percent-encoding",
@@ -6748,7 +6766,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -6855,15 +6873,16 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "207aa50d36c4be8d8c6ea829478be44a372c6a77669937bb39c698e52f1491e8"
+checksum = "8dcd332a5496c026f1e14b7f3d2b7bd98e509660c04239c58b0ba38a12daded4"
 dependencies = [
  "dissimilar",
  "glob",
  "serde",
  "serde_derive",
  "serde_json",
+ "target-triple",
  "termcolor",
  "toml",
 ]
@@ -6918,12 +6937,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
@@ -7026,9 +7042,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
  "serde",
@@ -7164,9 +7180,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef073ced962d62984fb38a36e5fdc1a2b23c9e0e1fa0689bb97afa4202ef6887"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7175,24 +7191,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4bfab14ef75323f4eb75fa52ee0a3fb59611977fd3240da19b2cf36ff85030e"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65471f79c1022ffa5291d33520cbbb53b7687b01c2f8e83b57d102eed7ed479d"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7202,9 +7218,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7bec9830f60924d9ceb3ef99d55c155be8afa76954edffbb5936ff4509474e7"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7212,28 +7228,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c74f6e152a76a2ad448e223b0fc0b6b5747649c3d769cc6bf45737bf97d0ed6"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42f6c679374623f295a8623adfe63d9284091245c3504bde47c17a3ce2777d9"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44188d185b5bdcae1052d08bcbcf9091a5524038d4572cc4f4f2bb9d5554ddd9"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7346,7 +7362,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -7357,7 +7373,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -7649,7 +7665,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -7669,10 +7685,10 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[patch.unused]]
 name = "tokio-postgres-rustls"
-version = "0.12.0"
-source = "git+https://github.com/jbg/tokio-postgres-rustls.git?branch=master#21f4d0eaae8b4d4be335ec0767e7891f38bd0cc9"
+version = "0.13.0"
+source = "git+https://github.com/jbg/tokio-postgres-rustls.git?branch=master#0cffe66df0e3fdc6b6067cf4432d1e3343c80fff"

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -120,6 +120,7 @@ serde = { version = "1.0.197", features = ["derive", "rc"] }
 serde-aux = "4.5.0"
 serde_json = { version = "=1.0.125", features = ["preserve_order"] }
 serde_path_to_error = { version = "0.1.16" }
+serde_qs = "0.13.0"
 serde_url_params = "0.2.1"
 serde_with = "3.7.0"
 serde_yaml = "0.9.33" # NOTE(nick): this has been archived upstream

--- a/third-party/rust/fixups/target-triple/fixups.toml
+++ b/third-party/rust/fixups/target-triple/fixups.toml
@@ -1,0 +1,1 @@
+buildscript = []


### PR DESCRIPTION
## Description

This PR adds a custom extractor for filtering audit logs. Generally, it handles array notated query string parameters, which is likely the first time we needed to do so in `sdf`.

<img src="https://media2.giphy.com/media/7NDtOJnhq2QKgPAWMM/giphy.gif"/>