### PR TITLE
chore: give test schemas stable schema ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,6 +1807,7 @@ dependencies = [
  "tokio-util",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "ulid",
  "uuid",
  "veritech-client",
  "veritech-server",

--- a/lib/dal-test/BUCK
+++ b/lib/dal-test/BUCK
@@ -41,6 +41,7 @@ rust_library(
         "//third-party/rust:tokio-util",
         "//third-party/rust:tracing-opentelemetry",
         "//third-party/rust:tracing-subscriber",
+        "//third-party/rust:ulid",
         "//third-party/rust:uuid",
     ],
     srcs = glob(["src/**/*.rs"]),

--- a/lib/dal-test/Cargo.toml
+++ b/lib/dal-test/Cargo.toml
@@ -44,6 +44,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
+ulid =  { workspace = true }
 uuid = { workspace = true }
 veritech-client = { path = "../../lib/veritech-client" }
 veritech-server = { path = "../../lib/veritech-server" }

--- a/lib/dal-test/src/test_exclusive_schemas/category_pirate.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/category_pirate.rs
@@ -1,6 +1,6 @@
-use dal::pkg::import_pkg_from_pkg;
+use dal::pkg::{import_pkg_from_pkg, ImportOptions};
 use dal::{prop::PropPath, ComponentType};
-use dal::{BuiltinsResult, DalContext, PropKind};
+use dal::{BuiltinsResult, DalContext, PropKind, SchemaId};
 use si_pkg::{
     AttrFuncInputSpec, AttrFuncInputSpecKind, PkgSpec, PropSpec, SchemaSpec, SchemaVariantSpec,
     SchemaVariantSpecData, SiPkg,
@@ -13,7 +13,10 @@ use crate::test_exclusive_schemas::{
 
 const CATEGORY: &str = "pirate";
 
-pub(crate) async fn migrate_test_exclusive_schema_pirate(ctx: &DalContext) -> BuiltinsResult<()> {
+pub(crate) async fn migrate_test_exclusive_schema_pirate(
+    ctx: &DalContext,
+    schema_id: SchemaId,
+) -> BuiltinsResult<()> {
     let mut builder = PkgSpec::builder();
 
     let schema_name = "pirate";
@@ -127,12 +130,23 @@ pub(crate) async fn migrate_test_exclusive_schema_pirate(ctx: &DalContext) -> Bu
         .build()?;
 
     let pkg = SiPkg::load_from_spec(spec)?;
-    import_pkg_from_pkg(ctx, &pkg, None).await?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }
 
-pub(crate) async fn migrate_test_exclusive_schema_pet_shop(ctx: &DalContext) -> BuiltinsResult<()> {
+pub(crate) async fn migrate_test_exclusive_schema_pet_shop(
+    ctx: &DalContext,
+    schema_id: SchemaId,
+) -> BuiltinsResult<()> {
     let mut builder = PkgSpec::builder();
 
     let schema_name = "pet_shop";
@@ -213,7 +227,15 @@ pub(crate) async fn migrate_test_exclusive_schema_pet_shop(ctx: &DalContext) -> 
         .build()?;
 
     let pkg = SiPkg::load_from_spec(spec)?;
-    import_pkg_from_pkg(ctx, &pkg, None).await?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/test_exclusive_schemas/category_validated.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/category_validated.rs
@@ -1,6 +1,6 @@
-use dal::pkg::import_pkg_from_pkg;
+use dal::pkg::{import_pkg_from_pkg, ImportOptions};
 use dal::{prop::PropPath, ComponentType};
-use dal::{BuiltinsResult, DalContext, PropKind};
+use dal::{BuiltinsResult, DalContext, PropKind, SchemaId};
 use si_pkg::{
     AttrFuncInputSpec, AttrFuncInputSpecKind, PkgSpec, PropSpec, SchemaSpec, SchemaVariantSpec,
     SchemaVariantSpecData, SiPkg,
@@ -13,6 +13,7 @@ const CATEGORY: &str = "validations";
 
 pub(crate) async fn migrate_test_exclusive_schema_bad_validations(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut builder = PkgSpec::builder();
 
@@ -81,13 +82,22 @@ pub(crate) async fn migrate_test_exclusive_schema_bad_validations(
         .build()?;
 
     let pkg = SiPkg::load_from_spec(spec)?;
-    import_pkg_from_pkg(ctx, &pkg, None).await?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }
 
 pub(crate) async fn migrate_test_exclusive_schema_validated_output(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut builder = PkgSpec::builder();
 
@@ -163,13 +173,22 @@ pub(crate) async fn migrate_test_exclusive_schema_validated_output(
         .build()?;
 
     let pkg = SiPkg::load_from_spec(spec)?;
-    import_pkg_from_pkg(ctx, &pkg, None).await?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }
 
 pub(crate) async fn migrate_test_exclusive_schema_validated_input(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut builder = PkgSpec::builder();
 
@@ -252,7 +271,15 @@ pub(crate) async fn migrate_test_exclusive_schema_validated_input(
         .build()?;
 
     let pkg = SiPkg::load_from_spec(spec)?;
-    import_pkg_from_pkg(ctx, &pkg, None).await?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/test_exclusive_schemas/dummy_secret.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/dummy_secret.rs
@@ -1,9 +1,9 @@
 use dal::func::argument::FuncArgumentKind;
 use dal::func::intrinsics::IntrinsicFunc;
-use dal::pkg::import_pkg_from_pkg;
+use dal::pkg::{import_pkg_from_pkg, ImportOptions};
 use dal::prop::{PropPath, SECRET_KIND_WIDGET_OPTION_LABEL};
 use dal::schema::variant::leaves::LeafKind;
-use dal::{BuiltinsResult, DalContext};
+use dal::{BuiltinsResult, DalContext, SchemaId};
 use si_pkg::{
     AttrFuncInputSpec, AttrFuncInputSpecKind, FuncArgumentSpec, FuncSpec, FuncSpecBackendKind,
     FuncSpecBackendResponseType, FuncSpecData, PkgSpec, PropSpec, SchemaSpec, SchemaVariantSpec,
@@ -18,11 +18,20 @@ use crate::test_exclusive_schemas::{PKG_CREATED_BY, PKG_VERSION};
 
 pub(crate) async fn migrate_test_exclusive_schema_dummy_secret(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let spec = build_dummy_secret_spec()?;
 
     let pkg = SiPkg::load_from_spec(spec)?;
-    import_pkg_from_pkg(ctx, &pkg, None).await?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/test_exclusive_schemas/fake_butane.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/fake_butane.rs
@@ -1,6 +1,6 @@
 use dal::func::argument::FuncArgumentKind;
-use dal::pkg::import_pkg_from_pkg;
-use dal::{BuiltinsResult, DalContext};
+use dal::pkg::{import_pkg_from_pkg, ImportOptions};
+use dal::{BuiltinsResult, DalContext, SchemaId};
 use dal::{ComponentType, PropKind};
 use si_pkg::{
     AttrFuncInputSpec, AttrFuncInputSpecKind, FuncArgumentSpec, FuncSpec, FuncSpecBackendKind,
@@ -15,6 +15,7 @@ use crate::test_exclusive_schemas::{
 
 pub(crate) async fn migrate_test_exclusive_schema_fake_butane(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut builder = PkgSpec::builder();
 
@@ -224,7 +225,15 @@ pub(crate) async fn migrate_test_exclusive_schema_fake_butane(
         .build()?;
 
     let pkg = SiPkg::load_from_spec(spec)?;
-    import_pkg_from_pkg(ctx, &pkg, None).await?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/test_exclusive_schemas/fake_docker_image.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/fake_docker_image.rs
@@ -1,7 +1,7 @@
-use dal::pkg::import_pkg_from_pkg;
+use dal::pkg::{import_pkg_from_pkg, ImportOptions};
 use dal::prop::PropPath;
-use dal::ComponentType;
 use dal::{BuiltinsResult, DalContext};
+use dal::{ComponentType, SchemaId};
 use si_pkg::{
     AttrFuncInputSpec, AttrFuncInputSpecKind, PkgSpec, PropSpec, PropSpecKind, PropSpecWidgetKind,
     SchemaSpec, SchemaVariantSpec, SchemaVariantSpecData, SiPkg, SocketSpecArity, SocketSpecData,
@@ -15,6 +15,7 @@ use crate::test_exclusive_schemas::{
 
 pub(crate) async fn migrate_test_exclusive_schema_fake_docker_image(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut builder = PkgSpec::builder();
 
@@ -114,7 +115,15 @@ pub(crate) async fn migrate_test_exclusive_schema_fake_docker_image(
         .build()?;
 
     let pkg = SiPkg::load_from_spec(spec)?;
-    import_pkg_from_pkg(ctx, &pkg, None).await?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/test_exclusive_schemas/fallout.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/fallout.rs
@@ -1,7 +1,7 @@
 use dal::action::prototype::ActionKind;
-use dal::pkg::import_pkg_from_pkg;
+use dal::pkg::{import_pkg_from_pkg, ImportOptions};
 use dal::prop::{PropPath, SECRET_KIND_WIDGET_OPTION_LABEL};
-use dal::{BuiltinsResult, DalContext, PropKind};
+use dal::{BuiltinsResult, DalContext, PropKind, SchemaId};
 use si_pkg::{
     ActionFuncSpec, AttrFuncInputSpec, AttrFuncInputSpecKind, FuncSpec, FuncSpecBackendKind,
     FuncSpecBackendResponseType, FuncSpecData, PkgSpec, PropSpec, PropSpecKind, PropSpecWidgetKind,
@@ -15,7 +15,10 @@ use crate::test_exclusive_schemas::{
 };
 use crate::test_exclusive_schemas::{PKG_CREATED_BY, PKG_VERSION};
 
-pub(crate) async fn migrate_test_exclusive_schema_fallout(ctx: &DalContext) -> BuiltinsResult<()> {
+pub(crate) async fn migrate_test_exclusive_schema_fallout(
+    ctx: &DalContext,
+    schema_id: SchemaId,
+) -> BuiltinsResult<()> {
     let mut fallout_builder = PkgSpec::builder();
 
     let schema_name = "fallout";
@@ -175,7 +178,15 @@ pub(crate) async fn migrate_test_exclusive_schema_fallout(ctx: &DalContext) -> B
         .build()?;
 
     let pkg = SiPkg::load_from_spec(fallout_spec)?;
-    import_pkg_from_pkg(ctx, &pkg, None).await?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/test_exclusive_schemas/katy_perry.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/katy_perry.rs
@@ -1,6 +1,6 @@
-use dal::pkg::import_pkg_from_pkg;
+use dal::pkg::{import_pkg_from_pkg, ImportOptions};
 use dal::{prop::PropPath, ComponentType};
-use dal::{BuiltinsResult, DalContext, PropKind};
+use dal::{BuiltinsResult, DalContext, PropKind, SchemaId};
 use si_pkg::{
     AttrFuncInputSpec, AttrFuncInputSpecKind, LeafInputLocation, LeafKind, PkgSpec, PropSpec,
     SchemaSpec, SchemaVariantSpec, SchemaVariantSpecData, SiPkg,
@@ -14,6 +14,7 @@ use crate::test_exclusive_schemas::{
 
 pub(crate) async fn migrate_test_exclusive_schema_katy_perry(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut kp_builder = PkgSpec::builder();
 
@@ -117,7 +118,15 @@ pub(crate) async fn migrate_test_exclusive_schema_katy_perry(
         .build()?;
 
     let pkg = SiPkg::load_from_spec(kp_spec)?;
-    import_pkg_from_pkg(ctx, &pkg, None).await?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/test_exclusive_schemas/legos/large.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/legos/large.rs
@@ -1,7 +1,7 @@
 use dal::action::prototype::ActionKind;
-use dal::pkg::import_pkg_from_pkg;
-use dal::ComponentType;
+use dal::pkg::{import_pkg_from_pkg, ImportOptions};
 use dal::{BuiltinsResult, DalContext};
+use dal::{ComponentType, SchemaId};
 use si_pkg::{
     ActionFuncSpec, PkgSpec, SchemaSpec, SchemaSpecData, SchemaVariantSpec, SchemaVariantSpecData,
     SiPkg,
@@ -15,6 +15,7 @@ use crate::test_exclusive_schemas::{
 
 pub(crate) async fn migrate_test_exclusive_schema_large_odd_lego(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut large_lego_builder = PkgSpec::builder();
 
@@ -140,14 +141,23 @@ pub(crate) async fn migrate_test_exclusive_schema_large_odd_lego(
         .schema(large_lego_schema)
         .build()?;
 
-    let large_lego_pkg = SiPkg::load_from_spec(large_lego_spec)?;
-    import_pkg_from_pkg(ctx, &large_lego_pkg, None).await?;
+    let pkg = SiPkg::load_from_spec(large_lego_spec)?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }
 
 pub(crate) async fn migrate_test_exclusive_schema_large_even_lego(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut large_lego_builder = PkgSpec::builder();
 
@@ -272,8 +282,16 @@ pub(crate) async fn migrate_test_exclusive_schema_large_even_lego(
         .schema(large_lego_schema)
         .build()?;
 
-    let large_lego_pkg = SiPkg::load_from_spec(large_lego_spec)?;
-    import_pkg_from_pkg(ctx, &large_lego_pkg, None).await?;
+    let pkg = SiPkg::load_from_spec(large_lego_spec)?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/test_exclusive_schemas/legos/medium.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/legos/medium.rs
@@ -1,7 +1,7 @@
 use dal::action::prototype::ActionKind;
-use dal::pkg::import_pkg_from_pkg;
-use dal::ComponentType;
+use dal::pkg::{import_pkg_from_pkg, ImportOptions};
 use dal::{BuiltinsResult, DalContext};
+use dal::{ComponentType, SchemaId};
 use si_pkg::SchemaSpecData;
 use si_pkg::{
     ActionFuncSpec, PkgSpec, SchemaSpec, SchemaVariantSpec, SchemaVariantSpecData, SiPkg,
@@ -15,6 +15,7 @@ use crate::test_exclusive_schemas::{
 
 pub(crate) async fn migrate_test_exclusive_schema_medium_odd_lego(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut medium_lego_builder = PkgSpec::builder();
 
@@ -136,13 +137,22 @@ pub(crate) async fn migrate_test_exclusive_schema_medium_odd_lego(
         .schema(medium_lego_schema)
         .build()?;
 
-    let medium_lego_pkg = SiPkg::load_from_spec(medium_lego_spec)?;
-    import_pkg_from_pkg(ctx, &medium_lego_pkg, None).await?;
+    let pkg = SiPkg::load_from_spec(medium_lego_spec)?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }
 pub(crate) async fn migrate_test_exclusive_schema_medium_even_lego(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut medium_lego_builder = PkgSpec::builder();
 
@@ -263,8 +273,16 @@ pub(crate) async fn migrate_test_exclusive_schema_medium_even_lego(
         .schema(medium_lego_schema)
         .build()?;
 
-    let medium_lego_pkg = SiPkg::load_from_spec(medium_lego_spec)?;
-    import_pkg_from_pkg(ctx, &medium_lego_pkg, None).await?;
+    let pkg = SiPkg::load_from_spec(medium_lego_spec)?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/test_exclusive_schemas/legos/small.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/legos/small.rs
@@ -1,7 +1,7 @@
 use dal::action::prototype::ActionKind;
-use dal::pkg::import_pkg_from_pkg;
-use dal::ComponentType;
+use dal::pkg::{import_pkg_from_pkg, ImportOptions};
 use dal::{BuiltinsResult, DalContext};
+use dal::{ComponentType, SchemaId};
 use si_pkg::{
     ActionFuncSpec, PkgSpec, SchemaSpec, SchemaVariantSpec, SchemaVariantSpecData, SiPkg,
 };
@@ -15,6 +15,7 @@ use crate::test_exclusive_schemas::{
 
 pub(crate) async fn migrate_test_exclusive_schema_small_odd_lego(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut small_lego_builder = PkgSpec::builder();
 
@@ -164,14 +165,23 @@ pub(crate) async fn migrate_test_exclusive_schema_small_odd_lego(
         .schema(small_lego_schema)
         .build()?;
 
-    let small_lego_pkg = SiPkg::load_from_spec(small_lego_spec)?;
-    import_pkg_from_pkg(ctx, &small_lego_pkg, None).await?;
+    let pkg = SiPkg::load_from_spec(small_lego_spec)?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }
 
 pub(crate) async fn migrate_test_exclusive_schema_small_even_lego(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut small_lego_builder = PkgSpec::builder();
 
@@ -288,8 +298,16 @@ pub(crate) async fn migrate_test_exclusive_schema_small_even_lego(
         .schema(small_lego_schema)
         .build()?;
 
-    let small_lego_pkg = SiPkg::load_from_spec(small_lego_spec)?;
-    import_pkg_from_pkg(ctx, &small_lego_pkg, None).await?;
+    let pkg = SiPkg::load_from_spec(small_lego_spec)?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/test_exclusive_schemas/mod.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/mod.rs
@@ -30,6 +30,7 @@ use starfield::migrate_test_exclusive_schema_etoiles;
 use starfield::migrate_test_exclusive_schema_morningstar;
 use starfield::migrate_test_exclusive_schema_private_language;
 use starfield::migrate_test_exclusive_schema_starfield;
+use std::str::FromStr;
 use swifty::migrate_test_exclusive_schema_swifty;
 
 mod category_pirate;
@@ -46,32 +47,181 @@ mod swifty;
 const PKG_VERSION: &str = "2019-06-03";
 const PKG_CREATED_BY: &str = "System Initiative";
 
+const SCHEMA_ID_STARFIELD: &str = "01JARFRNN5VV1NMM0H5M63K3PY";
+const SCHEMA_ID_PRIVATE_LANGUAGE: &str = "01JARFRNN5VV1NMM0H5M63K3PZ";
+const SCHEMA_ID_ETOILES: &str = "01JARFRNN5VV1NMM0H5M63K3Q0";
+const SCHEMA_ID_MORNINGSTAR: &str = "01JARFRNN5VV1NMM0H5M63K3Q1";
+const SCHEMA_ID_FALLOUT: &str = "01JARFRNN5VV1NMM0H5M63K3Q2";
+const SCHEMA_ID_DUMMY_SECRET: &str = "01JARFRNN5VV1NMM0H5M63K3Q3";
+const SCHEMA_ID_SWIFTY: &str = "01JARFRNN5VV1NMM0H5M63K3Q4";
+const SCHEMA_ID_KATY_PERRY: &str = "01JARFRNN5VV1NMM0H5M63K3Q5";
+const SCHEMA_ID_PIRATE: &str = "01JARFRNN5VV1NMM0H5M63K3Q6";
+const SCHEMA_ID_PET_SHOP: &str = "01JARFRNN5VV1NMM0H5M63K3Q7";
+const SCHEMA_ID_VALIDATED_INPUT: &str = "01JARFRNN5VV1NMM0H5M63K3Q8";
+const SCHEMA_ID_VALIDATED_OUTPUT: &str = "01JARFRNN5VV1NMM0H5M63K3Q9";
+const SCHEMA_ID_BAD_VALIDATIONS: &str = "01JARFRNN5VV1NMM0H5M63K3QA";
+const SCHEMA_ID_LARGE_ODD_LEGO: &str = "01JARFRNN5VV1NMM0H5M63K3QB";
+const SCHEMA_ID_LARGE_EVEN_LEGO: &str = "01JARFRNN5VV1NMM0H5M63K3QC";
+const SCHEMA_ID_MEDIUM_EVEN_LEGO: &str = "01JARFRNN5VV1NMM0H5M63K3QD";
+const SCHEMA_ID_MEDIUM_ODD_LEGO: &str = "01JARFRNN5VV1NMM0H5M63K3QE";
+const SCHEMA_ID_SMALL_ODD_LEGO: &str = "01JARFRNN5VV1NMM0H5M63K3QF";
+const SCHEMA_ID_SMALL_EVEN_LEGO: &str = "01JARFRNN5VV1NMM0H5M63K3QG";
+const SCHEMA_ID_FAKE_DOCKER_IMAGE: &str = "01JARFRNN5VV1NMM0H5M63K3QH";
+const SCHEMA_ID_FAKE_BUTANE: &str = "01JARH2BTA5DK4J9Q4Q0XH46SR";
+
+// allow expect here for the Ulid conversion. These will never panic.
+#[allow(clippy::expect_used)]
 pub(crate) async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
     migrate_test_exclusive_func_si_resource_payload_to_value(ctx).await?;
-    migrate_test_exclusive_schema_starfield(ctx).await?;
-    migrate_test_exclusive_schema_private_language(ctx).await?;
-    migrate_test_exclusive_schema_etoiles(ctx).await?;
-    migrate_test_exclusive_schema_morningstar(ctx).await?;
-    migrate_test_exclusive_schema_fallout(ctx).await?;
-    migrate_test_exclusive_schema_dummy_secret(ctx).await?;
-    migrate_test_exclusive_schema_swifty(ctx).await?;
-    migrate_test_exclusive_schema_katy_perry(ctx).await?;
-    migrate_test_exclusive_schema_pirate(ctx).await?;
-    migrate_test_exclusive_schema_pet_shop(ctx).await?;
-    migrate_test_exclusive_schema_validated_input(ctx).await?;
-    migrate_test_exclusive_schema_validated_output(ctx).await?;
-    migrate_test_exclusive_schema_bad_validations(ctx).await?;
-    migrate_test_exclusive_schema_large_odd_lego(ctx).await?;
-    migrate_test_exclusive_schema_large_even_lego(ctx).await?;
-    migrate_test_exclusive_schema_medium_even_lego(ctx).await?;
-    migrate_test_exclusive_schema_medium_odd_lego(ctx).await?;
-    migrate_test_exclusive_schema_small_odd_lego(ctx).await?;
-    migrate_test_exclusive_schema_small_even_lego(ctx).await?;
-    migrate_test_exclusive_schema_fake_docker_image(ctx).await?;
-    migrate_test_exclusive_schema_fake_butane(ctx).await?;
+    migrate_test_exclusive_schema_starfield(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_STARFIELD)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_private_language(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_PRIVATE_LANGUAGE)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_etoiles(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_ETOILES)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_morningstar(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_MORNINGSTAR)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_fallout(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_FALLOUT)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_dummy_secret(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_DUMMY_SECRET)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_swifty(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_SWIFTY)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_katy_perry(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_KATY_PERRY)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_pirate(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_PIRATE)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_pet_shop(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_PET_SHOP)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_validated_input(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_VALIDATED_INPUT)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_validated_output(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_VALIDATED_OUTPUT)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_bad_validations(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_BAD_VALIDATIONS)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_large_odd_lego(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_LARGE_ODD_LEGO)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_large_even_lego(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_LARGE_EVEN_LEGO)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_medium_even_lego(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_MEDIUM_EVEN_LEGO)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_medium_odd_lego(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_MEDIUM_ODD_LEGO)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_small_odd_lego(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_SMALL_ODD_LEGO)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_small_even_lego(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_SMALL_EVEN_LEGO)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_fake_docker_image(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_FAKE_DOCKER_IMAGE)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_fake_butane(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_FAKE_BUTANE)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
     Ok(())
 }
-
 // TODO(nick): remove this if "si:resourcePayloadToValue" becomes an instrinsic func.
 async fn migrate_test_exclusive_func_si_resource_payload_to_value(
     ctx: &DalContext,

--- a/lib/dal-test/src/test_exclusive_schemas/starfield.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/starfield.rs
@@ -1,9 +1,9 @@
 use dal::action::prototype::ActionKind;
 use dal::func::argument::FuncArgumentKind;
 use dal::func::intrinsics::IntrinsicFunc;
-use dal::pkg::import_pkg_from_pkg;
+use dal::pkg::{import_pkg_from_pkg, ImportOptions};
 use dal::prop::PropPath;
-use dal::{BuiltinsResult, DalContext, PropKind};
+use dal::{BuiltinsResult, DalContext, PropKind, SchemaId};
 use si_pkg::{
     ActionFuncSpec, AttrFuncInputSpec, AttrFuncInputSpecKind, FuncArgumentSpec, FuncSpec,
     FuncSpecBackendKind, FuncSpecBackendResponseType, FuncSpecData, PkgSpec, PropSpec, SchemaSpec,
@@ -15,6 +15,7 @@ use crate::test_exclusive_schemas::{PKG_CREATED_BY, PKG_VERSION};
 
 pub(crate) async fn migrate_test_exclusive_schema_starfield(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut starfield_builder = PkgSpec::builder();
 
@@ -411,14 +412,23 @@ pub(crate) async fn migrate_test_exclusive_schema_starfield(
         .schema(starfield_schema)
         .build()?;
 
-    let starfield_pkg = SiPkg::load_from_spec(starfield_spec)?;
-    import_pkg_from_pkg(ctx, &starfield_pkg, None).await?;
+    let pkg = SiPkg::load_from_spec(starfield_spec)?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }
 
 pub(crate) async fn migrate_test_exclusive_schema_morningstar(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut morningstar_builder = PkgSpec::builder();
     let schema_name = "morningstar";
@@ -538,13 +548,23 @@ pub(crate) async fn migrate_test_exclusive_schema_morningstar(
         .build()?;
 
     let pkg = SiPkg::load_from_spec(morningstar_spec)?;
-
-    import_pkg_from_pkg(ctx, &pkg, None).await?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }
 
-pub(crate) async fn migrate_test_exclusive_schema_etoiles(ctx: &DalContext) -> BuiltinsResult<()> {
+pub(crate) async fn migrate_test_exclusive_schema_etoiles(
+    ctx: &DalContext,
+    schema_id: SchemaId,
+) -> BuiltinsResult<()> {
     let mut etoiles_builder = PkgSpec::builder();
 
     let schema_name = "etoiles";
@@ -815,14 +835,23 @@ pub(crate) async fn migrate_test_exclusive_schema_etoiles(ctx: &DalContext) -> B
         .schema(etoiles_schema)
         .build()?;
 
-    let etoiles_pkg = SiPkg::load_from_spec(etoiles_spec)?;
-    import_pkg_from_pkg(ctx, &etoiles_pkg, None).await?;
+    let pkg = SiPkg::load_from_spec(etoiles_spec)?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }
 
 pub(crate) async fn migrate_test_exclusive_schema_private_language(
     ctx: &DalContext,
+    schema_id: SchemaId,
 ) -> BuiltinsResult<()> {
     let mut private_lang_builder = PkgSpec::builder();
 
@@ -930,8 +959,16 @@ pub(crate) async fn migrate_test_exclusive_schema_private_language(
         .schema(private_lang_schema)
         .build()?;
 
-    let private_lang_pkg = SiPkg::load_from_spec(private_lang_spec)?;
-    import_pkg_from_pkg(ctx, &private_lang_pkg, None).await?;
+    let pkg = SiPkg::load_from_spec(private_lang_spec)?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }

--- a/lib/dal-test/src/test_exclusive_schemas/swifty.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/swifty.rs
@@ -1,7 +1,7 @@
 use dal::action::prototype::ActionKind;
-use dal::pkg::import_pkg_from_pkg;
+use dal::pkg::{import_pkg_from_pkg, ImportOptions};
 use dal::{prop::PropPath, ComponentType};
-use dal::{BuiltinsResult, DalContext, PropKind};
+use dal::{BuiltinsResult, DalContext, PropKind, SchemaId};
 use si_pkg::{
     ActionFuncSpec, AttrFuncInputSpec, AttrFuncInputSpecKind, FuncSpec, FuncSpecBackendKind,
     FuncSpecBackendResponseType, FuncSpecData, LeafInputLocation, LeafKind, PkgSpec, PropSpec,
@@ -15,7 +15,10 @@ use crate::test_exclusive_schemas::{
     create_identity_func, PKG_CREATED_BY, PKG_VERSION,
 };
 
-pub(crate) async fn migrate_test_exclusive_schema_swifty(ctx: &DalContext) -> BuiltinsResult<()> {
+pub(crate) async fn migrate_test_exclusive_schema_swifty(
+    ctx: &DalContext,
+    schema_id: SchemaId,
+) -> BuiltinsResult<()> {
     let mut swifty_builder = PkgSpec::builder();
 
     let schema_name = "swifty";
@@ -186,8 +189,16 @@ pub(crate) async fn migrate_test_exclusive_schema_swifty(ctx: &DalContext) -> Bu
         .schema(swifty_schema)
         .build()?;
 
-    let swifty_pkg = SiPkg::load_from_spec(swifty_spec)?;
-    import_pkg_from_pkg(ctx, &swifty_pkg, None).await?;
+    let pkg = SiPkg::load_from_spec(swifty_spec)?;
+    import_pkg_from_pkg(
+        ctx,
+        &pkg,
+        Some(ImportOptions {
+            schema_id: Some(schema_id.into()),
+            ..Default::default()
+        }),
+    )
+    .await?;
 
     Ok(())
 }


### PR DESCRIPTION
In order to test management of other components, we need stable schema ids in our integration tests. This gives our test schemas those necessary stable ids.