### PR TITLE
Orphan all children before removing old frame version on schema version upgrade

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -3092,6 +3092,11 @@ impl Component {
         // ========================================
         // Delete original component
         // ========================================
+        // Remove all children from the "old" frame before we delete it. We'll add them all to the
+        // new frame after we've deleted the old one.
+        for &child in &original_children {
+            Frame::orphan_child(ctx, child).await.map_err(Box::new)?;
+        }
 
         // Remove the original resource so that we don't queue a delete action
         original_component.clear_resource(ctx).await?;


### PR DESCRIPTION
While attempting to (re)connect the children of a frame to the newly upgraded version, we try to find the `OutputSocket` `AttributeValue`s from the old version, but this has already been removed. Rather than creating specialized (re)connect logic for the schema version upgrade scenario, we can have the existing logic treat it as a brand new parent/child relationship by orphaning the children before we remove the old version of the parent frame.