### PR TITLE
Use get_child_av_ids_in_order for view() algorithm

### DIFF
--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -684,7 +684,7 @@ impl ExpectAttributeValue {
     }
 
     pub async fn attribute_value(self, ctx: &DalContext) -> AttributeValue {
-        dal::AttributeValue::get_by_id_or_error(ctx, self.0)
+        dal::AttributeValue::get_by_id(ctx, self.0)
             .await
             .expect("get prop value by id failed")
     }
@@ -757,9 +757,7 @@ impl ExpectProp {
     }
 
     pub async fn prop(self, ctx: &DalContext) -> Prop {
-        Prop::get_by_id_or_error(ctx, self.0)
-            .await
-            .expect("get prop by id")
+        Prop::get_by_id(ctx, self.0).await.expect("get prop by id")
     }
 
     pub async fn direct_single_child(self, ctx: &DalContext) -> ExpectProp {

--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -221,7 +221,7 @@ pub async fn get_component_input_socket_value(
         .pop()
         .ok_or(eyre!("no input socket match found"))?;
     let input_socket_av =
-        AttributeValue::get_by_id_or_error(ctx, component_input_socket.attribute_value_id).await?;
+        AttributeValue::get_by_id(ctx, component_input_socket.attribute_value_id).await?;
     Ok(input_socket_av.view(ctx).await?)
 }
 
@@ -244,7 +244,7 @@ pub async fn get_component_output_socket_value(
         .pop()
         .ok_or(eyre!("no input socket match found"))?;
     let output_socket_av =
-        AttributeValue::get_by_id_or_error(ctx, component_output_socket.attribute_value_id).await?;
+        AttributeValue::get_by_id(ctx, component_output_socket.attribute_value_id).await?;
     Ok(output_socket_av.view(ctx).await?)
 }
 /// Update the [`Value`] for a specific [`AttributeValue`] for the given [`Component`](ComponentId) by the [`PropPath`]
@@ -279,7 +279,7 @@ pub async fn get_attribute_value_for_component(
         .ok_or(eyre!("unexpected, no attribute values found for prop"))?;
     assert!(attribute_value_ids.is_empty());
 
-    let attribute_value = AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
+    let attribute_value = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
 
     let value = attribute_value.view(ctx).await?;
     Ok(value)
@@ -318,7 +318,7 @@ pub async fn fetch_resource_last_synced_value(
         return Err(eyre!("unexpected: more than one attribute value found"));
     }
 
-    let last_synced_value = AttributeValue::get_by_id_or_error(ctx, attribute_value_id)
+    let last_synced_value = AttributeValue::get_by_id(ctx, attribute_value_id)
         .await?
         .view(ctx)
         .await?;

--- a/lib/dal-test/src/helpers/property_editor_test_view.rs
+++ b/lib/dal-test/src/helpers/property_editor_test_view.rs
@@ -107,8 +107,7 @@ impl PropEditorTestView {
                 .get(child_id)
                 .ok_or(eyre!("could not get value for child"))?
                 .clone();
-            let real_prop =
-                Prop::get_by_id_or_error(ctx, value.prop_id.into_inner().into()).await?;
+            let real_prop = Prop::get_by_id(ctx, value.prop_id.into_inner().into()).await?;
             if real_prop.hidden {
                 continue;
             }

--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -179,7 +179,7 @@ impl AttributePrototypeDebugView {
                             .await?
                         {
                             let attribute_value =
-                                AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
+                                AttributeValue::get_by_id(ctx, attribute_value_id).await?;
                             let prop_path =
                                 AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
                             let view = attribute_value.view(ctx).await?.unwrap_or(Value::Null);
@@ -205,7 +205,7 @@ impl AttributePrototypeDebugView {
                             .await?
                         {
                             let attribute_value =
-                                AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
+                                AttributeValue::get_by_id(ctx, attribute_value_id).await?;
                             let attribute_value_path =
                                 AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
 
@@ -233,7 +233,7 @@ impl AttributePrototypeDebugView {
                             .await?
                         {
                             let attribute_value =
-                                AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
+                                AttributeValue::get_by_id(ctx, attribute_value_id).await?;
                             let attribute_value_path =
                                 AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
 
@@ -283,8 +283,7 @@ impl AttributePrototypeDebugView {
                     let attribute_value_path =
                         AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
                     let output_av =
-                        AttributeValue::get_by_id_or_error(ctx, output_match.attribute_value_id)
-                            .await?;
+                        AttributeValue::get_by_id(ctx, output_match.attribute_value_id).await?;
                     let value_view = output_av.view(ctx).await?.unwrap_or(Value::Null);
                     let input_func = AttributePrototype::func_id(ctx, prototype_id).await?;
                     if let Some(func_argument) =

--- a/lib/dal/src/attribute/value/debug.rs
+++ b/lib/dal/src/attribute/value/debug.rs
@@ -80,13 +80,13 @@ impl AttributeDebugView {
         key: Option<String>,
         parent_id: Option<AttributeValueId>,
     ) -> AttributeDebugViewResult<AttributeDebugView> {
-        let attribute_value = AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
+        let attribute_value = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
         let prototype_id = AttributeValue::prototype_id(ctx, attribute_value_id).await?;
         let value_is_for = AttributeValue::is_for(ctx, attribute_value_id).await?;
 
-        let prop_id = AttributeValue::prop_id_for_id_or_error(ctx, attribute_value_id).await?;
+        let prop_id = AttributeValue::prop_id(ctx, attribute_value_id).await?;
 
-        let prop = Prop::get_by_id_or_error(ctx, prop_id).await?;
+        let prop = Prop::get_by_id(ctx, prop_id).await?;
         let path = AttributeValue::get_path_for_id(ctx, attribute_value_id)
             .await?
             .unwrap_or_else(String::new);

--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -225,7 +225,7 @@ impl DependentValueGraph {
 
             match value_is_for {
                 ValueIsFor::Prop(prop_id) => {
-                    let prop = Prop::get_by_id_or_error(ctx, prop_id).await?;
+                    let prop = Prop::get_by_id(ctx, prop_id).await?;
                     if prop.kind == PropKind::Object {
                         // The children of an object might themselves be the
                         // input to another function, so we have to add them to

--- a/lib/dal/src/attribute/value/is_for.rs
+++ b/lib/dal/src/attribute/value/is_for.rs
@@ -78,7 +78,7 @@ impl ValueIsFor {
                 format!("Input Socket: {}", socket.name())
             }
             ValueIsFor::Prop(prop_id) => {
-                let prop = Prop::get_by_id_or_error(ctx, *prop_id).await?;
+                let prop = Prop::get_by_id(ctx, *prop_id).await?;
                 format!("Prop: {}", prop.path(ctx).await?.with_replaced_sep("."))
             }
         })

--- a/lib/dal/src/code_view.rs
+++ b/lib/dal/src/code_view.rs
@@ -76,7 +76,7 @@ impl CodeView {
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
     ) -> Result<Option<Self>, CodeViewError> {
-        let attribute_value = AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
+        let attribute_value = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
         let code_view_name = match attribute_value.key(ctx).await? {
             Some(key) => key,
             None => return Ok(None),

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -397,7 +397,7 @@ impl Component {
         for value_id in Component::attribute_values_for_prop_id(ctx, id, root_prop_id).await? {
             let value_component_id = AttributeValue::component_id(ctx, value_id).await?;
             if value_component_id == id {
-                let root_value = AttributeValue::get_by_id_or_error(ctx, value_id).await?;
+                let root_value = AttributeValue::get_by_id(ctx, value_id).await?;
                 return Ok(root_value.view(ctx).await?);
             }
         }
@@ -676,7 +676,7 @@ impl Component {
         // component. If so, attempt to copy it over.
         let mut value_q = VecDeque::from([(old_root_id, None, None)]);
         while let Some((old_av_id, old_key_or_index, new_parent_id)) = value_q.pop_front() {
-            let old_av = AttributeValue::get_by_id_or_error(ctx, old_av_id).await?;
+            let old_av = AttributeValue::get_by_id(ctx, old_av_id).await?;
 
             let maybe_old_component_prototype_id =
                 AttributeValue::component_prototype_id(ctx, old_av_id).await?;
@@ -694,8 +694,8 @@ impl Component {
                 continue;
             };
 
-            let new_prop = Prop::get_by_id_or_error(ctx, new_prop_id).await?;
-            let old_prop = Prop::get_by_id_or_error(ctx, old_prop_id).await?;
+            let new_prop = Prop::get_by_id(ctx, new_prop_id).await?;
+            let old_prop = Prop::get_by_id(ctx, old_prop_id).await?;
 
             // Prop kinds could have changed for the same prop. We could
             // try and coerce values, but it's safer to just skip.  Even if
@@ -1627,7 +1627,7 @@ impl Component {
     ) -> ComponentResult<Option<ResourceData>> {
         let value_id = Self::attribute_value_for_prop_by_id(ctx, id, &["root", "resource"]).await?;
 
-        let av = AttributeValue::get_by_id_or_error(ctx, value_id).await?;
+        let av = AttributeValue::get_by_id(ctx, value_id).await?;
 
         match av.view(ctx).await? {
             Some(serde_value) => {
@@ -1651,7 +1651,7 @@ impl Component {
         let name_value_id =
             Self::attribute_value_for_prop_by_id(ctx, id, &["root", "si", "name"]).await?;
 
-        let name_av = AttributeValue::get_by_id_or_error(ctx, name_value_id).await?;
+        let name_av = AttributeValue::get_by_id(ctx, name_value_id).await?;
 
         Ok(match name_av.view(ctx).await? {
             Some(serde_value) => serde_json::from_value(serde_value)?,
@@ -1674,8 +1674,7 @@ impl Component {
             let resource_id_value_id =
                 Self::attribute_value_for_prop_id(ctx, self.id, prop_id).await?;
 
-            let resource_id_av =
-                AttributeValue::get_by_id_or_error(ctx, resource_id_value_id).await?;
+            let resource_id_av = AttributeValue::get_by_id(ctx, resource_id_value_id).await?;
 
             Ok(match resource_id_av.view(ctx).await? {
                 Some(serde_value) => serde_json::from_value(serde_value)?,
@@ -1690,7 +1689,7 @@ impl Component {
         let color_value_id = self
             .attribute_value_for_prop(ctx, &["root", "si", "color"])
             .await?;
-        let color_av = AttributeValue::get_by_id_or_error(ctx, color_value_id).await?;
+        let color_av = AttributeValue::get_by_id(ctx, color_value_id).await?;
 
         Ok(match color_av.view(ctx).await? {
             Some(serde_value) => Some(serde_json::from_value(serde_value)?),
@@ -1706,7 +1705,7 @@ impl Component {
         let type_value_id =
             Self::attribute_value_for_prop_by_id(ctx, component_id, &["root", "si", "type"])
                 .await?;
-        let type_value = AttributeValue::get_by_id_or_error(ctx, type_value_id)
+        let type_value = AttributeValue::get_by_id(ctx, type_value_id)
             .await?
             .view(ctx)
             .await?

--- a/lib/dal/src/component/qualification.rs
+++ b/lib/dal/src/component/qualification.rs
@@ -24,16 +24,7 @@ impl Component {
         let qualification_map_value_id =
             Self::find_qualification_map_attribute_value_id(ctx, component_id).await?;
 
-        let qualification_av_ids =
-            AttributeValue::get_child_av_ids_in_order(ctx, qualification_map_value_id).await?;
-
-        let mut avs = vec![];
-        for av_id in qualification_av_ids {
-            let attribute_value = AttributeValue::get_by_id_or_error(ctx, av_id).await?;
-            avs.push(attribute_value);
-        }
-
-        Ok(avs)
+        Ok(AttributeValue::get_child_avs_in_order(ctx, qualification_map_value_id).await?)
     }
     pub async fn list_qualification_statuses(
         ctx: &DalContext,

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -97,8 +97,7 @@ impl AttributeBinding {
             AttributePrototype::eventual_parent(ctx, attribute_prototype_id).await?;
         let output_location = match eventual_parent {
             AttributePrototypeEventualParent::Component(_, attribute_value_id) => {
-                let prop_id =
-                    AttributeValue::prop_id_for_id_or_error(ctx, attribute_value_id).await?;
+                let prop_id = AttributeValue::prop_id(ctx, attribute_value_id).await?;
                 AttributeFuncDestination::Prop(prop_id)
             }
             AttributePrototypeEventualParent::SchemaVariantFromOutputSocket(
@@ -741,7 +740,7 @@ impl AttributeBinding {
                     if let AttributeFuncArgumentSource::Prop(prop_id) =
                         arg.attribute_func_input_location
                     {
-                        let prop = Prop::get_by_id_or_error(ctx, prop_id).await?;
+                        let prop = Prop::get_by_id(ctx, prop_id).await?;
                         let ts_type = prop.ts_type(ctx).await?;
 
                         if let std::collections::hash_map::Entry::Vacant(e) =
@@ -759,7 +758,7 @@ impl AttributeBinding {
                     let output_type = if let AttributeFuncDestination::Prop(output_prop_id) =
                         attribute.output_location
                     {
-                        Prop::get_by_id_or_error(ctx, output_prop_id)
+                        Prop::get_by_id(ctx, output_prop_id)
                             .await?
                             .ts_type(ctx)
                             .await?

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -1465,7 +1465,7 @@ impl FuncRunner {
                             Self::auth_funcs_for_secret_child_prop_id(ctx, secret_child_prop_id)
                                 .await?;
                         let attribute_value =
-                            AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
+                            AttributeValue::get_by_id(ctx, attribute_value_id).await?;
                         let maybe_value = attribute_value.value(ctx).await?;
 
                         // NOTE(nick): in the future, we could likely run auth funcs without secret inputs without
@@ -1516,7 +1516,7 @@ impl FuncRunner {
         ctx: &DalContext,
         secret_child_prop_id: PropId,
     ) -> FuncRunnerResult<Vec<Func>> {
-        let secret_child_prop = Prop::get_by_id_or_error(ctx, secret_child_prop_id).await?;
+        let secret_child_prop = Prop::get_by_id(ctx, secret_child_prop_id).await?;
 
         let secret_definition_name = secret_child_prop
             .widget_options

--- a/lib/dal/src/input_sources.rs
+++ b/lib/dal/src/input_sources.rs
@@ -140,7 +140,7 @@ impl InputSources {
         schema_variant_id: SchemaVariantId,
     ) -> InputSourcesResult<Vec<InputSourceProp>> {
         let root_prop_id = SchemaVariant::get_root_prop_id(ctx, schema_variant_id).await?;
-        let root_prop = Prop::get_by_id_or_error(ctx, root_prop_id).await?;
+        let root_prop = Prop::get_by_id(ctx, root_prop_id).await?;
 
         let mut work_queue = VecDeque::new();
         work_queue.push_back(root_prop);

--- a/lib/dal/src/job/definition/compute_validation.rs
+++ b/lib/dal/src/job/definition/compute_validation.rs
@@ -101,7 +101,7 @@ impl JobConsumer for ComputeValidation {
                 continue;
             }
 
-            let value = AttributeValue::get_by_id_or_error(ctx, av_id)
+            let value = AttributeValue::get_by_id(ctx, av_id)
                 .await?
                 .value(ctx)
                 .await?;

--- a/lib/dal/src/management/mod.rs
+++ b/lib/dal/src/management/mod.rs
@@ -324,12 +324,12 @@ async fn update_component(
             continue;
         }
 
-        let prop = Prop::get_by_id_or_error(ctx, prop_id).await?;
+        let prop = Prop::get_by_id(ctx, prop_id).await?;
 
         match prop.kind {
             PropKind::String | PropKind::Boolean | PropKind::Integer | PropKind::Json => {
                 // todo: type check!
-                let view = AttributeValue::get_by_id_or_error(ctx, path_attribute_value_id)
+                let view = AttributeValue::get_by_id(ctx, path_attribute_value_id)
                     .await?
                     .view(ctx)
                     .await?;
@@ -375,7 +375,7 @@ async fn update_component(
                             if AttributeValue::is_set_by_dependent_function(ctx, *child_id).await? {
                                 continue;
                             }
-                            let view = AttributeValue::get_by_id_or_error(ctx, *child_id)
+                            let view = AttributeValue::get_by_id(ctx, *child_id)
                                 .await?
                                 .view(ctx)
                                 .await?;
@@ -397,7 +397,7 @@ async fn update_component(
             }
             PropKind::Array => {
                 if matches!(current_val, serde_json::Value::Array(_)) {
-                    let view = AttributeValue::get_by_id_or_error(ctx, path_attribute_value_id)
+                    let view = AttributeValue::get_by_id(ctx, path_attribute_value_id)
                         .await?
                         .view(ctx)
                         .await?;

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -613,7 +613,7 @@ impl PkgExporter {
         if let Some(root_prop_id) =
             Prop::find_prop_id_by_path_opt(ctx, variant_id, &prop_path).await?
         {
-            root_prop = Prop::get_by_id_or_error(ctx, root_prop_id).await?
+            root_prop = Prop::get_by_id(ctx, root_prop_id).await?
         } else if is_optional_prop {
             return Ok(());
         } else {
@@ -635,7 +635,7 @@ impl PkgExporter {
         let mut traversal_stack: Vec<TraversalStackEntry> = Vec::new();
 
         while let Some((prop_id, parent_prop_id)) = stack.pop() {
-            let child_prop = Prop::get_by_id_or_error(ctx, prop_id).await?;
+            let child_prop = Prop::get_by_id(ctx, prop_id).await?;
             let mut builder = PropSpec::builder();
 
             builder.unique_id(prop_id);
@@ -849,7 +849,7 @@ impl PkgExporter {
                         // attribute function on the component.
                     },
                     crate::attribute::prototype::argument::value_source::ValueSource::Prop(prop_id) =>{
-                        let prop = Prop::get_by_id_or_error(ctx, prop_id)
+                        let prop = Prop::get_by_id(ctx, prop_id)
                             .await?
                             .path(ctx)
                             .await?;

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -1472,7 +1472,7 @@ async fn get_prototype_for_context(
                 key.to_owned().expect("check above ensures this is some"),
             ))?,
         };
-        let map_prop = Prop::get_by_id_or_error(ctx, map_prop_id).await?;
+        let map_prop = Prop::get_by_id(ctx, map_prop_id).await?;
 
         if map_prop.kind != PropKind::Map {
             return Err(PkgError::AttributeFuncForKeySetOnWrongKind(

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -719,7 +719,7 @@ impl Prop {
         Ok(result)
     }
 
-    pub async fn get_by_id_or_error(ctx: &DalContext, id: PropId) -> PropResult<Self> {
+    pub async fn get_by_id(ctx: &DalContext, id: PropId) -> PropResult<Self> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let ulid: ::si_events::ulid::Ulid = id.into();
         let node_index = workspace_snapshot.get_node_index_by_id(ulid).await?;
@@ -870,7 +870,7 @@ impl Prop {
         path: &PropPath,
     ) -> PropResult<Self> {
         let prop_id = Self::find_prop_id_by_path(ctx, schema_variant_id, path).await?;
-        Self::get_by_id_or_error(ctx, prop_id).await
+        Self::get_by_id(ctx, prop_id).await
     }
 
     implement_add_edge_to!(
@@ -990,7 +990,7 @@ impl Prop {
     ) -> PropResult<()> {
         let value = serde_json::to_value(value)?;
 
-        let prop = Self::get_by_id_or_error(ctx, prop_id).await?;
+        let prop = Self::get_by_id(ctx, prop_id).await?;
         if !prop.kind.is_scalar() {
             return Err(PropError::SetDefaultForNonScalar(prop_id, prop.kind));
         }
@@ -1117,7 +1117,7 @@ impl Prop {
 
         let mut ordered_child_props = Vec::with_capacity(child_prop_ids.len());
         for child_prop_id in child_prop_ids {
-            ordered_child_props.push(Self::get_by_id_or_error(ctx, child_prop_id).await?)
+            ordered_child_props.push(Self::get_by_id(ctx, child_prop_id).await?)
         }
 
         Ok(ordered_child_props)
@@ -1152,12 +1152,12 @@ impl Prop {
             PropKind::String => "string".to_string(),
             PropKind::Array => {
                 let element_prop_id = Self::element_prop_id(ctx, self.id).await?;
-                let element_prop = Self::get_by_id_or_error(ctx, element_prop_id).await?;
+                let element_prop = Self::get_by_id(ctx, element_prop_id).await?;
                 format!("{}[]", element_prop.ts_type(ctx).await?)
             }
             PropKind::Map => {
                 let element_prop_id = Self::element_prop_id(ctx, self.id).await?;
-                let element_prop = Self::get_by_id_or_error(ctx, element_prop_id).await?;
+                let element_prop = Self::get_by_id(ctx, element_prop_id).await?;
                 format!("Record<string, {}>", element_prop.ts_type(ctx).await?)
             }
             PropKind::Object => {

--- a/lib/dal/src/property_editor/schema.rs
+++ b/lib/dal/src/property_editor/schema.rs
@@ -31,7 +31,7 @@ impl PropertyEditorSchema {
         // Get the root prop and load it into the work queue.
         let root_prop_id =
             Prop::find_prop_id_by_path(ctx, schema_variant_id, &PropPath::new(["root"])).await?;
-        let root_prop = Prop::get_by_id_or_error(ctx, root_prop_id).await?;
+        let root_prop = Prop::get_by_id(ctx, root_prop_id).await?;
         let root_property_editor_prop = builder.build(ctx, root_prop).await?;
         let root_property_editor_prop_id = root_property_editor_prop.id;
         props.insert(root_property_editor_prop_id, root_property_editor_prop);

--- a/lib/dal/src/property_editor/values.rs
+++ b/lib/dal/src/property_editor/values.rs
@@ -53,8 +53,8 @@ impl PropertyEditorValues {
         // Get the root attribute value and load it into the work queue.
         let root_av_id = Component::root_attribute_value_id(ctx, component_id).await?;
         let root_value_id = PropertyEditorValueId::from(root_av_id);
-        let root_prop_id = AttributeValue::prop_id_for_id_or_error(ctx, root_av_id).await?;
-        let root_av = AttributeValue::get_by_id_or_error(ctx, root_av_id).await?;
+        let root_prop_id = AttributeValue::prop_id(ctx, root_av_id).await?;
+        let root_av = AttributeValue::get_by_id(ctx, root_av_id).await?;
 
         let validation = ValidationOutputNode::find_for_attribute_value_id(ctx, root_av_id)
             .await?
@@ -99,7 +99,7 @@ impl PropertyEditorValues {
 
                 // NOTE(nick): we already have the node weight, but I believe we still want to use "get_by_id" to
                 // get the content from the store. Perhaps, there's a more efficient way that we can do this.
-                let prop_id = AttributeValue::prop_id_for_id_or_error(ctx, av_id).await?;
+                let prop_id = AttributeValue::prop_id(ctx, av_id).await?;
                 let value_id = PropertyEditorValueId::from(av_id);
 
                 let sockets_for_av =
@@ -130,7 +130,7 @@ impl PropertyEditorValues {
                     .map(|node| node.validation);
 
                 // Get the value
-                let mut value = AttributeValue::get_by_id_or_error(ctx, av_id)
+                let mut value = AttributeValue::get_by_id(ctx, av_id)
                     .await?
                     .value_or_default(ctx, prop_id)
                     .await?;
@@ -289,7 +289,7 @@ impl PropertyEditorValue {
 
     /// Returns the [`Prop`](crate::Prop) corresponding to the "prop_id" field.
     pub async fn prop(&self, ctx: &DalContext) -> PropertyEditorResult<Prop> {
-        let prop = Prop::get_by_id_or_error(ctx, self.prop_id.into()).await?;
+        let prop = Prop::get_by_id(ctx, self.prop_id.into()).await?;
         Ok(prop)
     }
 }

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -270,9 +270,9 @@ impl QualificationView {
                 status = QualificationSubCheckStatus::Failure;
                 fail_counter += 1;
 
-                let prop_id = AttributeValue::prop_id_for_id_or_error(ctx, av_id).await?;
+                let prop_id = AttributeValue::prop_id(ctx, av_id).await?;
 
-                let prop = Prop::get_by_id_or_error(ctx, prop_id).await?;
+                let prop = Prop::get_by_id(ctx, prop_id).await?;
 
                 output.push(QualificationOutputStreamView {
                     stream: "stdout".to_owned(),

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -640,7 +640,7 @@ impl Secret {
             let all_connected_attribute_values =
                 Prop::all_attribute_values_everywhere_for_prop_id(ctx, secret_prop_id).await?;
             for connected_av in all_connected_attribute_values {
-                let av = AttributeValue::get_by_id_or_error(ctx, connected_av).await?;
+                let av = AttributeValue::get_by_id(ctx, connected_av).await?;
                 if let Some(val) = av.value(ctx).await? {
                     if val == secret_details {
                         let connected_component =

--- a/lib/dal/src/socket/debug.rs
+++ b/lib/dal/src/socket/debug.rs
@@ -72,7 +72,7 @@ impl SocketDebugView {
 
         let prototype_debug_view =
             AttributePrototypeDebugView::new(ctx, attribute_value_id).await?;
-        let attribute_value = AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
+        let attribute_value = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
         let output_socket =
             OutputSocket::get_by_id(ctx, component_output_socket.output_socket_id).await?;
         let connection_annotations = output_socket
@@ -119,7 +119,7 @@ impl SocketDebugView {
         let prototype_debug_view =
             AttributePrototypeDebugView::new(ctx, component_input_socket.attribute_value_id)
                 .await?;
-        let attribute_value = AttributeValue::get_by_id_or_error(ctx, attribute_value_id).await?;
+        let attribute_value = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
         let input_socket =
             InputSocket::get_by_id(ctx, component_input_socket.input_socket_id).await?;
         let connection_annotations = input_socket

--- a/lib/dal/src/validation.rs
+++ b/lib/dal/src/validation.rs
@@ -20,7 +20,7 @@ use crate::workspace_snapshot::node_weight::{NodeWeight, NodeWeightError};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
     id, schema::variant::SchemaVariantError, AttributeValue, AttributeValueId, ChangeSetError,
-    Component, ComponentId, FuncError, HistoryEventError, Prop, Timestamp,
+    Component, ComponentId, FuncError, HistoryEventError, Timestamp,
 };
 use crate::{ComponentError, DalContext, TransactionsError};
 
@@ -253,17 +253,10 @@ impl ValidationOutput {
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
     ) -> ValidationResult<Option<String>> {
-        Ok(
-            if let Some(prop_id) = AttributeValue::prop_id_for_id(ctx, attribute_value_id)
-                .await
-                .map_err(Box::new)?
-            {
-                let prop = Prop::get_by_id_or_error(ctx, prop_id).await?;
-                prop.validation_format
-            } else {
-                None
-            },
-        )
+        Ok(AttributeValue::prop_opt(ctx, attribute_value_id)
+            .await
+            .map_err(Box::new)?
+            .and_then(|prop| prop.validation_format))
     }
 
     /// If an attribute value is for a [Prop](Prop) that has a `validation_format`, run a validation

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -329,7 +329,7 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) {
     .await
     .expect("able to set universe value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, rigid_designator_value_id)
+    let view = AttributeValue::get_by_id(ctx, rigid_designator_value_id)
         .await
         .expect("get av")
         .view(ctx)
@@ -343,14 +343,13 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let naming_and_necessity_view =
-        AttributeValue::get_by_id_or_error(ctx, naming_and_necessity_value_id)
-            .await
-            .expect("able to get attribute value for `naming_and_necessity_value_id`")
-            .view(ctx)
-            .await
-            .expect("able to get view for `naming_and_necessity_value_id`")
-            .expect("naming and necessity has a value");
+    let naming_and_necessity_view = AttributeValue::get_by_id(ctx, naming_and_necessity_value_id)
+        .await
+        .expect("able to get attribute value for `naming_and_necessity_value_id`")
+        .view(ctx)
+        .await
+        .expect("able to get view for `naming_and_necessity_value_id`")
+        .expect("naming and necessity has a value");
 
     // hesperus is phosphorus (the attr func on naming_and_necessity_value_id will return
     // phosphorus if it receives hesperus)
@@ -367,7 +366,7 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) {
         .copied()
         .expect("a value exists for the root prop");
 
-    let root_value = AttributeValue::get_by_id_or_error(ctx, root_value_id)
+    let root_value = AttributeValue::get_by_id(ctx, root_value_id)
         .await
         .expect("able to get the value for the root prop attriburte value id");
 
@@ -506,7 +505,7 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
     .await
     .expect("able to set universe value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, possible_world_a_value_id)
+    let view = AttributeValue::get_by_id(ctx, possible_world_a_value_id)
         .await
         .expect("get av")
         .view(ctx)
@@ -522,14 +521,13 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let naming_and_necessity_view =
-        AttributeValue::get_by_id_or_error(ctx, naming_and_necessity_value_id)
-            .await
-            .expect("able to get attribute value for `naming_and_necessity_value_id`")
-            .view(ctx)
-            .await
-            .expect("able to get view for `naming_and_necessity_value_id`")
-            .expect("naming and necessity has a value");
+    let naming_and_necessity_view = AttributeValue::get_by_id(ctx, naming_and_necessity_value_id)
+        .await
+        .expect("able to get attribute value for `naming_and_necessity_value_id`")
+        .view(ctx)
+        .await
+        .expect("able to get view for `naming_and_necessity_value_id`")
+        .expect("naming and necessity has a value");
 
     // hesperus is phosphorus (the attr func on naming_and_necessity_value_id will return
     // phosphorus if it receives hesperus)
@@ -546,7 +544,7 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) {
         .copied()
         .expect("a value exists for the root prop");
 
-    let root_value = AttributeValue::get_by_id_or_error(ctx, root_value_id)
+    let root_value = AttributeValue::get_by_id(ctx, root_value_id)
         .await
         .expect("able to get the value for the root prop attriburte value id");
 
@@ -684,7 +682,7 @@ async fn set_the_universe(ctx: &mut DalContext) {
         .await
         .expect("able to set universe value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, universe_value_id)
+    let view = AttributeValue::get_by_id(ctx, universe_value_id)
         .await
         .expect("get av")
         .view(ctx)
@@ -698,7 +696,7 @@ async fn set_the_universe(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, universe_value_id)
+    let view = AttributeValue::get_by_id(ctx, universe_value_id)
         .await
         .expect("get av")
         .view(ctx)

--- a/lib/dal/tests/integration_test/component/delete.rs
+++ b/lib/dal/tests/integration_test/component/delete.rs
@@ -259,7 +259,7 @@ async fn delete_updates_downstream_components(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -303,7 +303,7 @@ async fn delete_updates_downstream_components(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -423,7 +423,7 @@ async fn delete_undo_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -470,7 +470,7 @@ async fn delete_undo_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -515,7 +515,7 @@ async fn delete_undo_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -545,7 +545,7 @@ async fn delete_undo_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)

--- a/lib/dal/tests/integration_test/component/property_order.rs
+++ b/lib/dal/tests/integration_test/component/property_order.rs
@@ -27,7 +27,7 @@ async fn attribute_value_names(
     let av_id = prop.attribute_value(ctx).await.id();
     let mut result = vec![];
     for child_av_id in AttributeValue::get_child_av_ids_in_order(ctx, av_id).await? {
-        let prop = AttributeValue::prop_for_id_or_error(ctx, child_av_id).await?;
+        let prop = AttributeValue::prop(ctx, child_av_id).await?;
         result.push(prop.name);
     }
     Ok(result)

--- a/lib/dal/tests/integration_test/component/upgrade.rs
+++ b/lib/dal/tests/integration_test/component/upgrade.rs
@@ -565,7 +565,7 @@ async fn upgrade_array_of_objects(ctx: &mut DalContext) {
             .expect("unable to get reference av id")
             .to_owned();
 
-        let prop_id = AttributeValue::prop_id_for_id_or_error(ctx, av_id)
+        let prop_id = AttributeValue::prop_id(ctx, av_id)
             .await
             .expect("get prop_id for attribute value");
 
@@ -641,7 +641,7 @@ async fn upgrade_array_of_objects(ctx: &mut DalContext) {
             .expect("unable to get reference av id")
             .to_owned();
 
-        let prop_id = AttributeValue::prop_id_for_id_or_error(ctx, av_id)
+        let prop_id = AttributeValue::prop_id(ctx, av_id)
             .await
             .expect("get prop_id for attribute value");
 

--- a/lib/dal/tests/integration_test/connection.rs
+++ b/lib/dal/tests/integration_test/connection.rs
@@ -342,7 +342,7 @@ async fn connect_and_disconnect_components_explicit_connection(ctx: &mut DalCont
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -384,7 +384,7 @@ async fn connect_and_disconnect_components_explicit_connection(ctx: &mut DalCont
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -426,7 +426,7 @@ async fn connect_and_disconnect_components_explicit_connection(ctx: &mut DalCont
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -606,7 +606,7 @@ async fn remove_connection(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -643,7 +643,7 @@ async fn remove_connection(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)

--- a/lib/dal/tests/integration_test/dependent_values_update.rs
+++ b/lib/dal/tests/integration_test/dependent_values_update.rs
@@ -134,7 +134,7 @@ async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -179,7 +179,7 @@ async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -300,7 +300,7 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -343,7 +343,7 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)
@@ -386,7 +386,7 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id_or_error(ctx, units_value_id)
+    let view = AttributeValue::get_by_id(ctx, units_value_id)
         .await
         .expect("value exists")
         .view(ctx)

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -552,7 +552,7 @@ async fn output_sockets_can_have_both(ctx: &mut DalContext) {
         .into_iter()
         .next()
         .expect("got av");
-    let odd_component_1_mat_view = AttributeValue::get_by_id_or_error(ctx, odd_component_1_av)
+    let odd_component_1_mat_view = AttributeValue::get_by_id(ctx, odd_component_1_av)
         .await
         .expect("got av")
         .view(ctx)
@@ -570,7 +570,7 @@ async fn output_sockets_can_have_both(ctx: &mut DalContext) {
         .into_iter()
         .next()
         .expect("got av");
-    let odd_component_2_mat_view = AttributeValue::get_by_id_or_error(ctx, odd_component_2_av)
+    let odd_component_2_mat_view = AttributeValue::get_by_id(ctx, odd_component_2_av)
         .await
         .expect("got av")
         .view(ctx)
@@ -3297,7 +3297,7 @@ async fn frames_and_secrets(ctx: &mut DalContext, nw: &WorkspaceSignup) {
         .expect("could not get attribute values")
         .pop()
         .expect("has a value");
-        let component_secret_value = AttributeValue::get_by_id_or_error(ctx, component_secret_av)
+        let component_secret_value = AttributeValue::get_by_id(ctx, component_secret_av)
             .await
             .expect("could not get attribute value by id")
             .value(ctx)
@@ -3378,7 +3378,7 @@ async fn frames_and_secrets(ctx: &mut DalContext, nw: &WorkspaceSignup) {
         .expect("could not get attribute values")
         .pop()
         .expect("has a value");
-        let component_secret_value = AttributeValue::get_by_id_or_error(ctx, component_secret_av)
+        let component_secret_value = AttributeValue::get_by_id(ctx, component_secret_av)
             .await
             .expect("could not get attribute value by id")
             .value(ctx)

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -89,7 +89,7 @@ async fn get_ts_type_from_root(ctx: &mut DalContext) {
     let root_prop_id = SchemaVariant::get_root_prop_id(ctx, schema_variant_id)
         .await
         .expect("could not get root prop id");
-    let root_prop = Prop::get_by_id_or_error(ctx, root_prop_id)
+    let root_prop = Prop::get_by_id(ctx, root_prop_id)
         .await
         .expect("could not get prop by id");
 

--- a/lib/dal/tests/integration_test/func/authoring.rs
+++ b/lib/dal/tests/integration_test/func/authoring.rs
@@ -110,7 +110,7 @@ async fn create_unlocked_copy_attribute_func(ctx: &mut DalContext) {
     let AttributeFuncDestination::Prop(prop_output) = output_location else {
         panic!("output location is wrong");
     };
-    let prop_name = Prop::get_by_id_or_error(ctx, prop_output)
+    let prop_name = Prop::get_by_id(ctx, prop_output)
         .await
         .expect("prop exists");
     assert_eq!(
@@ -207,7 +207,7 @@ async fn create_unlocked_copy_attribute_func(ctx: &mut DalContext) {
         panic!("output location is wrong");
     };
     // prop name is galaxies
-    let prop_name = Prop::get_by_id_or_error(ctx, prop_output)
+    let prop_name = Prop::get_by_id(ctx, prop_output)
         .await
         .expect("prop exists");
     assert_eq!(

--- a/lib/dal/tests/integration_test/func/authoring/binding.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding.rs
@@ -582,7 +582,7 @@ async fn for_intrinsics(ctx: &mut DalContext) {
                     let AttributeFuncDestination::Prop(prop_id) = binding.output_location else {
                         panic!("Non-Prop is set to unset, which is unexpected!")
                     };
-                    let prop = Prop::get_by_id_or_error(ctx, prop_id)
+                    let prop = Prop::get_by_id(ctx, prop_id)
                         .await
                         .expect("couldn't get prop");
                     let path = prop.path(ctx).await.expect("could not get prop path");
@@ -613,7 +613,7 @@ async fn for_intrinsics(ctx: &mut DalContext) {
                 assert_eq!(2, attribute_bindings.len());
                 for binding in attribute_bindings {
                     if let AttributeFuncDestination::Prop(prop_id) = binding.output_location {
-                        let prop = Prop::get_by_id_or_error(ctx, prop_id)
+                        let prop = Prop::get_by_id(ctx, prop_id)
                             .await
                             .expect("couldn't get prop");
                         let path = prop.path(ctx).await.expect("bad");
@@ -631,7 +631,7 @@ async fn for_intrinsics(ctx: &mut DalContext) {
                                 else {
                                     panic!("Non-Prop is set to unset, which is unexpected!")
                                 };
-                                let prop = Prop::get_by_id_or_error(ctx, prop_id)
+                                let prop = Prop::get_by_id(ctx, prop_id)
                                     .await
                                     .expect("couldn't get prop");
                                 let path = prop

--- a/lib/dal/tests/integration_test/management.rs
+++ b/lib/dal/tests/integration_test/management.rs
@@ -63,7 +63,7 @@ async fn execute_management_func(ctx: &DalContext) {
     .await
     .expect("get four");
 
-    let two_av = AttributeValue::get_by_id_or_error(ctx, av_id)
+    let two_av = AttributeValue::get_by_id(ctx, av_id)
         .await
         .expect("a fleetwood to my mac");
 

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -61,7 +61,7 @@ async fn verify_prop_used_as_input_flag(ctx: &DalContext) {
     ];
 
     for container_prop_path in &container_props {
-        let container_prop = Prop::get_by_id_or_error(
+        let container_prop = Prop::get_by_id(
             ctx,
             Prop::find_prop_id_by_path(
                 ctx,
@@ -82,7 +82,7 @@ async fn verify_prop_used_as_input_flag(ctx: &DalContext) {
     }
 
     for item_prop_path in &item_props {
-        let item_prop = Prop::get_by_id_or_error(
+        let item_prop = Prop::get_by_id(
             ctx,
             Prop::find_prop_id_by_path(
                 ctx,

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -122,7 +122,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
         AttributeValue::get_child_av_ids_in_order(ctx, parrot_names_value_id)
             .await
             .expect("get the vec of child ids");
-    let parrot_names_third_item = AttributeValue::get_by_id_or_error(
+    let parrot_names_third_item = AttributeValue::get_by_id(
         ctx,
         *parrot_names_child_ids
             .get(2)
@@ -142,7 +142,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
     let treasure_child_ids = AttributeValue::get_child_av_ids_in_order(ctx, treasure_map_value_id)
         .await
         .expect("get the vec of child ids");
-    let treasure_second_item = AttributeValue::get_by_id_or_error(
+    let treasure_second_item = AttributeValue::get_by_id(
         ctx,
         *treasure_child_ids
             .get(1)
@@ -191,7 +191,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
     // Check that the items around the removed item are correct
 
     // Get the second item in the array
-    let parrot_names_second_item = AttributeValue::get_by_id_or_error(
+    let parrot_names_second_item = AttributeValue::get_by_id(
         ctx,
         *parrot_names_child_ids
             .get(1)
@@ -208,7 +208,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
     assert_eq!(parrot_names_second_item_value, Some("samantha".into()));
 
     // Get the third item in the array
-    let parrot_names_third_item = AttributeValue::get_by_id_or_error(
+    let parrot_names_third_item = AttributeValue::get_by_id(
         ctx,
         *parrot_names_child_ids
             .get(2)
@@ -242,7 +242,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
     // Check that the items around the removed item are correct
 
     // Get the first item in the treasure map
-    let treasure_first_item = AttributeValue::get_by_id_or_error(
+    let treasure_first_item = AttributeValue::get_by_id(
         ctx,
         *treasure_child_ids
             .first()
@@ -267,7 +267,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
     assert_eq!(treasure_first_item_key, Some("ohio".to_string()));
 
     // Get the second item in the treasure map
-    let treasure_second_item = AttributeValue::get_by_id_or_error(
+    let treasure_second_item = AttributeValue::get_by_id(
         ctx,
         *treasure_child_ids
             .get(1)
@@ -311,7 +311,7 @@ async fn override_value_then_reset(ctx: &mut DalContext) {
         .pop()
         .expect("there should only be one value id");
 
-    let prop_id = AttributeValue::prop_id_for_id_or_error(ctx, av_id)
+    let prop_id = AttributeValue::prop_id(ctx, av_id)
         .await
         .expect("get prop_id for attribute value");
 
@@ -411,7 +411,7 @@ async fn override_array_then_reset(ctx: &mut DalContext) {
         .pop()
         .expect("there should only be one value id");
 
-    let prop_id = AttributeValue::prop_id_for_id_or_error(ctx, av_id)
+    let prop_id = AttributeValue::prop_id(ctx, av_id)
         .await
         .expect("get prop_id for attribute value");
 
@@ -507,7 +507,7 @@ async fn prop_can_be_set_by_socket(ctx: &mut DalContext) {
         .pop()
         .expect("there should only be one value id");
 
-    let prop_id = AttributeValue::prop_id_for_id_or_error(ctx, av_id)
+    let prop_id = AttributeValue::prop_id(ctx, av_id)
         .await
         .expect("get prop_id for attribute value");
 
@@ -588,7 +588,7 @@ async fn values_controlled_by_ancestor(ctx: &mut DalContext) {
         .pop()
         .expect("there should only be one value id");
 
-    let parrots_prop_id = AttributeValue::prop_id_for_id_or_error(ctx, parrots_av_id)
+    let parrots_prop_id = AttributeValue::prop_id(ctx, parrots_av_id)
         .await
         .expect("get prop_id for attribute value");
 
@@ -676,7 +676,7 @@ async fn values_controlled_by_ancestor(ctx: &mut DalContext) {
 
         let parrot_entry_av_id = parrot_entry_avs.pop().expect("there should a value id");
 
-        let parrot_entry_prop_id = AttributeValue::prop_id_for_id_or_error(ctx, parrot_entry_av_id)
+        let parrot_entry_prop_id = AttributeValue::prop_id(ctx, parrot_entry_av_id)
             .await
             .expect("get prop_id for attribute value");
 

--- a/lib/dal/tests/integration_test/resource_metadata.rs
+++ b/lib/dal/tests/integration_test/resource_metadata.rs
@@ -162,7 +162,7 @@ async fn list(ctx: &mut DalContext, nw: &WorkspaceSignup) {
         .expect("should be able to find avs for last synced")
         .pop()
         .expect("should have an av for last synced");
-    let last_synced_value = AttributeValue::get_by_id_or_error(ctx, last_synced_av_id)
+    let last_synced_value = AttributeValue::get_by_id(ctx, last_synced_av_id)
         .await
         .expect("should be able to get last synced av")
         .view(ctx)

--- a/lib/dal/tests/integration_test/secret/with_actions.rs
+++ b/lib/dal/tests/integration_test/secret/with_actions.rs
@@ -198,7 +198,7 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
         .pop()
         .expect("should have an av for last synced");
 
-    let last_synced_value = AttributeValue::get_by_id_or_error(ctx, last_synced_av_id)
+    let last_synced_value = AttributeValue::get_by_id(ctx, last_synced_av_id)
         .await
         .expect("should be able to get last synced av")
         .view(ctx)

--- a/lib/sdf-server/src/service/component/update_property_editor_value.rs
+++ b/lib/sdf-server/src/service/component/update_property_editor_value.rs
@@ -61,15 +61,11 @@ pub async fn update_property_editor_value(
     let component = Component::get_by_id(&ctx, request.component_id).await?;
     {
         let component_schema = component.schema(&ctx).await?;
-        let prop = Prop::get_by_id_or_error(&ctx, request.prop_id).await?;
+        let prop = Prop::get_by_id(&ctx, request.prop_id).await?;
 
         // In this context, there will always be a parent attribute value id
         let parent_prop = if let Some(att_val_id) = request.parent_attribute_value_id {
-            if let Some(prop_id) = AttributeValue::prop_id_for_id(&ctx, att_val_id).await? {
-                Some(Prop::get_by_id_or_error(&ctx, prop_id).await?)
-            } else {
-                None
-            }
+            AttributeValue::prop_opt(&ctx, att_val_id).await?
         } else {
             None
         };


### PR DESCRIPTION
The view() algorithm was already walking object avs in prop order. This just uses the common function to do the walk. At the same time, this gives prop_id_or_error the good function name prop_id; and the old prop_id becomes prop_id_opt. (This matches how many other dal modules do it.)

AttributeValue::get_child_av_ids_in_order no longer calls prop_opt (and errors if there is no prop). The only places that now call AttributeValue::prop_opt are:

- AttributeValue::set_values_from_func_run_value
- component/update_property_editor_value

These functions fail the tests if you attempt to toss errors when an AV has no prop. I haven't yet investigated why.