### PR TITLE
fix: disable disk cache cleanup

### DIFF
--- a/lib/si-layer-cache/src/db.rs
+++ b/lib/si-layer-cache/src/db.rs
@@ -166,17 +166,17 @@ where
             compute_executor.clone(),
         )?;
 
-        Self::spawn_cleanup_tasks(
-            &[
-                cas_cache.disk_cache(),
-                encrypted_secret_cache.disk_cache(),
-                func_run_cache.disk_cache(),
-                func_run_log_cache.disk_cache(),
-                rebase_batch_cache.disk_cache(),
-                snapshot_cache.disk_cache(),
-            ],
-            token.clone(),
-        );
+        // Self::spawn_cleanup_tasks(
+        //     &[
+        //         cas_cache.disk_cache(),
+        //         encrypted_secret_cache.disk_cache(),
+        //         func_run_cache.disk_cache(),
+        //         func_run_log_cache.disk_cache(),
+        //         rebase_batch_cache.disk_cache(),
+        //         snapshot_cache.disk_cache(),
+        //     ],
+        //     token.clone(),
+        // );
 
         let cache_updates_task = CacheUpdatesTask::create(
             instance_id,


### PR DESCRIPTION
It seems that the `cacache` index grows more or less indefinitely, meaning our list calls get more and more expensive over time. We are going to disable this temporarily while we devise a better long-term solution.

<img src="https://media4.giphy.com/media/SmTWSTSasEZZFFVKXs/giphy.gif"/>