### PR TITLE
Billing lambda: log upload stats using INFO

### DIFF
--- a/component/lambda/functions/si_logger.py
+++ b/component/lambda/functions/si_logger.py
@@ -2,4 +2,4 @@ import logging
 
 
 logger = logging.getLogger()
-logging.basicConfig(level=logging.INFO)
+logger.setLevel("INFO")

--- a/component/lambda/functions/upload_billing_resource_hours_to_lago.py
+++ b/component/lambda/functions/upload_billing_resource_hours_to_lago.py
@@ -104,7 +104,7 @@ def lambda_handler(lambda_event={}, _context=None):
             last_hour_end = None
             break
 
-        logger.warning(
+        logger.info(
             f"Uploaded {uploaded_events} events in {batch_hours}-hour batch starting {-first_hour_start} hours ago!"
         )
         last_hour_end = first_hour_start if uploaded_events > 0 else None


### PR DESCRIPTION
We were logging it with WARN before, which seems to have been triggering some metrics.

Also makes Redshift logger only log query status every 5 seconds to stop spamming the log