### PR TITLE
Track server-level tasks in the rebaser

### DIFF
--- a/lib/rebaser-server/src/app_state.rs
+++ b/lib/rebaser-server/src/app_state.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use dal::DalContextBuilder;
 use si_data_nats::{async_nats::jetstream, NatsClient};
-use tokio_util::sync::CancellationToken;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 use crate::ServerMetadata;
 
@@ -15,6 +15,7 @@ pub(crate) struct AppState {
     pub(crate) ctx_builder: DalContextBuilder,
     pub(crate) quiescent_period: Duration,
     pub(crate) token: CancellationToken,
+    pub(crate) server_tracker: TaskTracker,
 }
 
 impl AppState {
@@ -26,6 +27,7 @@ impl AppState {
         ctx_builder: DalContextBuilder,
         quiescent_period: Duration,
         token: CancellationToken,
+        server_tracker: TaskTracker,
     ) -> Self {
         Self {
             metadata,
@@ -34,6 +36,7 @@ impl AppState {
             ctx_builder,
             quiescent_period,
             token,
+            server_tracker,
         }
     }
 }

--- a/lib/rebaser-server/src/handlers.rs
+++ b/lib/rebaser-server/src/handlers.rs
@@ -87,6 +87,7 @@ pub(crate) async fn default(State(state): State<AppState>, subject: Subject) -> 
         ctx_builder,
         quiescent_period,
         token: server_token,
+        server_tracker,
     } = state;
     let subject_prefix = nats.metadata().subject_prefix();
 
@@ -140,6 +141,7 @@ pub(crate) async fn default(State(state): State<AppState>, subject: Subject) -> 
         run_notify,
         quiescent_period,
         tasks_token.clone(),
+        server_tracker,
     );
 
     let dvu_task_result = tracker.spawn(dvu_task.try_run());


### PR DESCRIPTION
## Description

This PR adds the ability to track server-level tasks in the rebaser. This is useful for spawning tasks in the change set processor that are allowed to outlive the lifetime of the processor task itself.

<img src="https://media4.giphy.com/media/Wt67TflOnf5WZStYcK/giphy.gif"/>

## Context

This PR is a continuation of the initial effort from https://github.com/systeminit/si/pull/4814.