### PR TITLE
fix: nixFlakes renamed to nixVersions.stable

### DIFF
--- a/component/ci-base/Dockerfile
+++ b/component/ci-base/Dockerfile
@@ -81,7 +81,7 @@ RUN set -eux; \
         echo 'bash-prompt-prefix = (nix:$name)\040'; \
     } >"$HOME/.config/nix/nix.conf"; \
     . "$HOME/.nix-profile/etc/profile.d/nix.sh"; \
-    nix-env -iA nixpkgs.nixFlakes; \
+    nix-env -iA nixpkgs.nixVersions.stable; \
     grep 'Nix installer' "$HOME/.profile" >>"$HOME/.bashrc"; \
     \
     git config --global --add safe.directory /workdir; \


### PR DESCRIPTION
See https://buildkite.com/system-initiative/si-merge-queue/builds/3718#0192b88d-cf84-43f0-8f40-871fb2272185

<div><img src="https://media4.giphy.com/media/HxnMNAEQgHqEHcGKBb/200.gif?cid=5a38a5a2hu05j1kzbmzpzhg126j0gq3mktt8tpzjks5ob5eb&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:165px;width:300px"/></div>