### PR TITLE
fix: remove concurrency indicator from cron

### DIFF
--- a/.github/workflows/prod-deploy-cron.yml
+++ b/.github/workflows/prod-deploy-cron.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     - cron: "45 14 * * 1-5" # Deploys every weekday at 3pm UTC
 
-concurrency:
-  group: deploy-production
-  cancel-in-progress: false
-
 jobs:
   deploy-production:
     uses: ./.github/workflows/deploy-stack.yml


### PR DESCRIPTION
You can't have a downstream workflow with the same concurrency indicator as the parent caller. Remove it from the caller (cron).

<img src="https://media3.giphy.com/media/9tZG8iM4BhW427FynU/giphy.gif?cid=5a38a5a2263qjm2if0cztq8oub7saqokz014129w8t9g75di&ep=v1_gifs_search&rid=giphy.gif&ct=g"></img>