### PR TITLE
feat: add metrics to layer cache hits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6110,6 +6110,7 @@ dependencies = [
  "si-std",
  "strum 0.26.3",
  "telemetry",
+ "telemetry-utils",
  "tempfile",
  "thiserror",
  "tokio",

--- a/component/deploy/userdata
+++ b/component/deploy/userdata
@@ -8,7 +8,7 @@ export INIT_VERSION=$(aws ssm get-parameter --query "Parameter.Value" --output t
 # prep attached storage
 mkfs -t xfs /dev/nvme1n1
 mkdir -p /layer_cache
-mount /dev/nvme1n1 /layer_cache
+mount -o logbsize=256k /dev/nvme1n1 /layer_cache
 
 # get build metadata
 METADATA=$(curl -Ls https://artifacts.systeminit.com/${SI_SERVICE}/${SI_VERSION}/omnibus/linux/x86_64/${SI_SERVICE}-${SI_VERSION}-omnibus-linux-x86_64.tar.gz.metadata.json)

--- a/lib/si-layer-cache/BUCK
+++ b/lib/si-layer-cache/BUCK
@@ -13,6 +13,7 @@ rust_library(
         "//lib/si-runtime-rs:si-runtime",
         "//lib/si-std:si-std",
         "//lib/telemetry-rs:telemetry",
+        "//lib/telemetry-utils-rs:telemetry-utils",
         "//third-party/rust:async-trait",
         "//third-party/rust:blake3",
         "//third-party/rust:bytes",

--- a/lib/si-layer-cache/Cargo.toml
+++ b/lib/si-layer-cache/Cargo.toml
@@ -29,6 +29,7 @@ si-runtime = { path = "../../lib/si-runtime-rs" }
 si-std = { path = "../../lib/si-std" }
 strum = { workspace = true }
 telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-utils = { path = "../../lib/telemetry-utils-rs" }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/lib/si-layer-cache/src/disk_cache.rs
+++ b/lib/si-layer-cache/src/disk_cache.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use telemetry::prelude::*;
+use telemetry_utils::metric;
 use tokio::select;
 use tokio_util::sync::CancellationToken;
 
@@ -39,7 +40,9 @@ impl DiskCache {
     }
 
     pub async fn get(&self, key: Arc<str>) -> LayerDbResult<Vec<u8>> {
-        Ok(cacache::read(self.write_path.as_ref(), key.clone()).await?)
+        let data = cacache::read(self.write_path.as_ref(), key.clone()).await?;
+        metric!(counter.layer_cache.hit.disk = 1);
+        Ok(data)
     }
 
     pub async fn contains_key(&self, key: Arc<str>) -> LayerDbResult<bool> {

--- a/lib/si-layer-cache/src/layer_cache.rs
+++ b/lib/si-layer-cache/src/layer_cache.rs
@@ -53,30 +53,16 @@ where
         Ok(())
     }
 
-    #[instrument(
-        name = "layer_cache.get",
-        level = "debug",
-        skip_all,
-        fields(
-            si.layer_cache.key = key.as_ref(),
-            si.layer_cache.layer.hit = Empty,
-        ),
-    )]
     pub async fn get(&self, key: Arc<str>) -> LayerDbResult<Option<V>> {
-        let span = current_span_for_instrument_at!("debug");
-
         Ok(match self.memory_cache.get(&key).await {
-            Some(memory_value) => {
-                span.record("si.layer_cache.layer.hit", "memory");
-                Some(memory_value)
-            }
+            Some(memory_value) => Some(memory_value),
+
             None => match self.disk_cache.get(key.clone()).await {
                 Ok(value) => {
                     let deserialized: V = serialize::from_bytes(&value[..])?;
 
                     self.memory_cache.insert(key, deserialized.clone()).await;
 
-                    span.record("si.layer_cache.layer.hit", "disk");
                     Some(deserialized)
                 }
                 Err(_) => match self.pg.get(&key).await? {
@@ -88,7 +74,6 @@ where
                             .await;
                         self.spawn_disk_cache_write_vec(key.clone(), value).await?;
 
-                        span.record("si.layer_cache.layer.hit", "disk");
                         Some(deserialized)
                     }
                     None => None,


### PR DESCRIPTION
Remove the span collection for layer cache hits, it spams way too hard to be useful. Add individual metric calls for layer cache hits in different places.

I suspect that the memory hits will be too much here, too, but we can pull them out if that's the case.

![image](https://github.com/user-attachments/assets/3b0c4176-d233-43cb-b66c-939b7ec6d61d)
