### PR TITLE
Update lambdas whenever `main` updates

### DIFF
--- a/component/lambda/functions/billing-set-prices.py
+++ b/component/lambda/functions/billing-set-prices.py
@@ -138,6 +138,3 @@ def lambda_handler(_event=None, _context=None):
                 },
             },
         )
-
-
-lambda_handler()

--- a/component/lambda/functions/github_lambda_loader.py
+++ b/component/lambda/functions/github_lambda_loader.py
@@ -1,0 +1,33 @@
+# From https://github.com/systeminit/si/blob/main/component/lambda/functions/github_lambda_loader.py
+import importlib, urllib.request, urllib.parse, hashlib, pathlib, os, sys, tempfile, logging
+
+logger = logging.getLogger()
+logger.setLevel("INFO")
+
+# The name of the file containing the lambda handler (defaults to <lambda_function_name>.py)
+SI_IMPORT_LAMBDA_HANDLER = os.environ.get('SI_IMPORT_LAMBDA_HANDLER', f"{os.environ['AWS_LAMBDA_FUNCTION_NAME']}.py")
+# Where to download the Python files from (e.g. https://raw.githubusercontent.com/systeminit/si/refs/heads/main/component/lambda/functions/)
+SI_LAMBDA_FUNCTIONS_URL = os.environ['SI_LAMBDA_FUNCTIONS_URL']
+# The modules to import (defaults to all of them if not specified)
+SI_IMPORT_PYTHON        = os.environ.get('SI_IMPORT_MODULES', "si_logger.py si_types.py si_redshift.py si_lago_api.py")
+
+# Create temporary directory to download modules
+with tempfile.TemporaryDirectory('github_lambda_loader') as DOWNLOADED_MODULE_DIR:
+    sys.path.append(DOWNLOADED_MODULE_DIR)
+
+    # Download referenced modules
+    def download_module_file(relative_path: str):
+        url = urllib.parse.urljoin(SI_LAMBDA_FUNCTIONS_URL, relative_path)
+        file = pathlib.Path(DOWNLOADED_MODULE_DIR, relative_path)
+        logger.debug(f"Retrieving {url} to {file} ...")
+        urllib.request.urlretrieve(url, file)
+        logger.info(f"{file}: SHA256 = {hashlib.sha256(file.read_bytes()).hexdigest()}, size: {file.stat().st_size} bytes")
+        return file
+
+    for relative_path in SI_IMPORT_PYTHON.split():
+        download_module_file(relative_path)
+    lambda_handler_module_file = download_module_file(SI_IMPORT_LAMBDA_HANDLER)
+
+    # Import lambda_handler
+    logger.info(f"Importing {lambda_handler_module_file}.lambda_handler ...")
+    lambda_handler = importlib.import_module(lambda_handler_module_file.stem).lambda_handler

--- a/component/lambda/functions/si_lago_api.py
+++ b/component/lambda/functions/si_lago_api.py
@@ -13,7 +13,7 @@ from typing import (
     Union,
     cast,
 )
-import requests  # from pip._vendor import requests
+from pip._vendor import requests
 import urllib.parse
 from si_logger import logger
 

--- a/component/lambda/functions/si_redshift.py
+++ b/component/lambda/functions/si_redshift.py
@@ -11,7 +11,10 @@ from typing import (
     overload,
 )
 import boto3
-from mypy_boto3_redshift_data import RedshiftDataAPIServiceClient
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from mypy_boto3_redshift_data import RedshiftDataAPIServiceClient
 import botocore
 import botocore.session as bc
 from botocore.client import Config

--- a/component/lambda/functions/upload-billing-hours.py
+++ b/component/lambda/functions/upload-billing-hours.py
@@ -108,6 +108,3 @@ def lambda_handler(lambda_event={}, _context=None):
             f"Uploaded {uploaded_events} events in {batch_hours}-hour batch starting {-first_hour_start} hours ago!"
         )
         last_hour_end = first_hour_start if uploaded_events > 0 else None
-
-
-lambda_handler()


### PR DESCRIPTION
This makes it so that we can deploy a new version of a lambda by updating `main`. To use it, you replace your lambda with the contents of `github_lambda_loader.py`, and it will:

1. Pulls the `si_*.py` modules from [`components/lambda/functions` on main](https://github.com/systeminit/si/tree/main/component/lambda/functions)
2. Pulls `<lambda function name>.py` from the same place (e.g. `upload-billing-hours.py`). This means different lambdas will automatically pick up the right script.
3. Imports `lambda_handler` from `<lambda function name>.py` (AWS will run this function).

We're already doing this for the `workspace_delegations_population` lambda, with a miniature version of this; this just lets us write modules.