### PR TITLE
Add shuttle crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5941,6 +5941,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shuttle"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "naxum",
+ "remain",
+ "serde_json",
+ "si-data-nats",
+ "si-events",
+ "telemetry",
+ "telemetry-nats",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "si-crypto"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "lib/rebaser-core",
     "lib/rebaser-server",
     "lib/sdf-server",
+    "lib/shuttle",
     "lib/si-crypto",
     "lib/si-data-nats",
     "lib/si-data-pg",

--- a/lib/shuttle/BUCK
+++ b/lib/shuttle/BUCK
@@ -1,0 +1,43 @@
+load("@prelude-si//:macros.bzl", "rust_library", "rust_test")
+
+rust_library(
+    name = "shuttle",
+    deps = [
+        "//lib/naxum:naxum",
+        "//lib/si-data-nats:si-data-nats",
+        "//lib/si-events-rs:si-events",
+        "//lib/telemetry-nats-rs:telemetry-nats",
+        "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:futures",
+        "//third-party/rust:remain",
+        "//third-party/rust:thiserror",
+        "//third-party/rust:tokio-util",
+    ],
+    srcs = glob([
+        "src/**/*.rs",
+    ]),
+    extra_test_targets = [":test-integration"],
+)
+
+rust_test(
+    name = "test-integration",
+    deps = [
+        "//lib/si-data-nats:si-data-nats",
+        "//lib/si-events-rs:si-events",
+        "//lib/telemetry-nats-rs:telemetry-nats",
+        "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:serde_json",
+        "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
+        ":shuttle",
+    ],
+    crate_root = "tests/integration.rs",
+    srcs = glob([
+        "tests/**/*.rs",
+    ]),
+    env = {
+        "CARGO_PKG_NAME": "integration",
+        "RUSTC_BOOTSTRAP": "1",
+        "CI": "buildkite",
+    },
+)

--- a/lib/shuttle/Cargo.toml
+++ b/lib/shuttle/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "shuttle"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+naxum = { path = "../../lib/naxum" }
+si-data-nats = { path = "../../lib/si-data-nats" }
+si-events = { path = "../../lib/si-events-rs" }
+telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
+
+futures = { workspace = true }
+remain = { workspace = true }
+thiserror = { workspace = true }
+tokio-util = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+serde_json = { workspace = true }

--- a/lib/shuttle/src/app_state.rs
+++ b/lib/shuttle/src/app_state.rs
@@ -1,0 +1,23 @@
+use si_data_nats::{jetstream::Context, Subject};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone)]
+pub(crate) struct AppState {
+    pub(crate) context: Context,
+    pub(crate) destination_subject: Subject,
+    pub(crate) token: CancellationToken,
+}
+
+impl AppState {
+    pub(crate) fn new(
+        context: Context,
+        destination_subject: Subject,
+        token: CancellationToken,
+    ) -> Self {
+        Self {
+            context,
+            destination_subject,
+            token,
+        }
+    }
+}

--- a/lib/shuttle/src/handlers.rs
+++ b/lib/shuttle/src/handlers.rs
@@ -1,0 +1,51 @@
+use naxum::{
+    extract::State,
+    response::{IntoResponse, Response},
+    Message,
+};
+use si_data_nats::async_nats::{self, jetstream};
+use telemetry::tracing::error;
+use telemetry_nats::propagation;
+use thiserror::Error;
+
+use crate::{app_state::AppState, FINAL_MESSAGE_HEADER_KEY};
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub(crate) enum HandlerError {
+    #[error("error publishing message: {0}")]
+    NatsPublish(#[from] async_nats::jetstream::context::PublishError),
+}
+
+type HandlerResult<T> = std::result::Result<T, HandlerError>;
+
+pub(crate) async fn default(
+    State(state): State<AppState>,
+    msg: Message<jetstream::Message>,
+) -> HandlerResult<()> {
+    if let Some(headers) = msg.headers() {
+        if headers.get(FINAL_MESSAGE_HEADER_KEY).is_some() {
+            state.token.cancel();
+            return Ok(());
+        }
+    }
+
+    let ack = state
+        .context
+        .publish_with_headers(
+            state.destination_subject,
+            propagation::empty_injected_headers(),
+            msg.payload.to_owned(),
+        )
+        .await?;
+    ack.await?;
+
+    Ok(())
+}
+
+impl IntoResponse for HandlerError {
+    fn into_response(self) -> Response {
+        error!(si.error.message = ?self, "failed to process message");
+        Response::default_internal_server_error()
+    }
+}

--- a/lib/shuttle/src/lib.rs
+++ b/lib/shuttle/src/lib.rs
@@ -1,0 +1,214 @@
+//! This crate provides an opinionated [`naxum`] server that "shuttles" (consumes on a source stream and publishes to a
+//! destination subject) NATS JetStream stream messages to another subject until a "final message" (a message with
+//! [`FINAL_MESSAGE_HEADER_KEY`] in its headers) is seen.
+
+#![warn(
+    bad_style,
+    clippy::missing_panics_doc,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result,
+    clippy::unwrap_used,
+    dead_code,
+    improper_ctypes,
+    missing_debug_implementations,
+    missing_docs,
+    no_mangle_generic_items,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    unconditional_recursion,
+    unreachable_pub,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
+
+use std::{future::IntoFuture, io};
+
+use futures::Future;
+use middleware::DeleteMessageOnSuccess;
+use naxum::{
+    handler::Handler,
+    middleware::{post_process::PostProcessLayer, trace::TraceLayer},
+    response::{IntoResponse, Response},
+    ServiceBuilder, ServiceExt, TowerServiceExt,
+};
+use si_data_nats::{
+    async_nats::{
+        self,
+        jetstream::{
+            consumer::StreamErrorKind, context::RequestErrorKind, stream::ConsumerErrorKind,
+        },
+    },
+    jetstream, Subject,
+};
+use si_data_nats::{jetstream::Context, NatsClient};
+use si_events::ulid::Ulid;
+use telemetry::prelude::*;
+use telemetry::tracing::error;
+use thiserror::Error;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+
+mod app_state;
+mod handlers;
+mod middleware;
+
+/// The header key used to indicate to a running shuttle instance that it has consumed everything
+/// and can shut down. The header value and message body are ignored.
+pub const FINAL_MESSAGE_HEADER_KEY: &str = "X-Final-Message";
+
+#[allow(missing_docs)]
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ShuttleError {
+    #[error("async nats consumer error: {0}")]
+    AsyncNatsConsumer(#[from] async_nats::error::Error<ConsumerErrorKind>),
+    #[error("async nats request error: {0}")]
+    AsyncNatsRequest(#[from] async_nats::error::Error<RequestErrorKind>),
+    #[error("async nats stream error: {0}")]
+    AsyncNatsStream(#[from] async_nats::error::Error<StreamErrorKind>),
+    #[error("naxum error: {0}")]
+    Naxum(#[source] io::Error),
+}
+
+type Result<T> = std::result::Result<T, ShuttleError>;
+
+/// A running, opinionated [`naxum`] server that "shuttles" messages from a limits-based stream to
+/// another given subject.
+pub struct Shuttle {
+    source_subject: Subject,
+    destination_subject: Subject,
+    shutdown_cleanup_toolkit: ShuttleShutdownCleanupToolkit,
+    inner: Box<dyn Future<Output = io::Result<()>> + Unpin + Send>,
+}
+
+impl std::fmt::Debug for Shuttle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Shuttle")
+            .field("source_subject", &self.source_subject)
+            .field("destination_subject", &self.destination_subject)
+            .field("shutdown_cleanup_toolkit", &self.shutdown_cleanup_toolkit)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Shuttle {
+    /// Creates a new running [`Shuttle`] instance.
+    #[instrument(
+        name = "shuttle.new",
+        level = "trace",
+        skip_all,
+        fields(source_subject, destination_subject)
+    )]
+    pub async fn new(
+        nats: NatsClient,
+        tracker: TaskTracker,
+        token: CancellationToken,
+        limits_based_source_stream: async_nats::jetstream::stream::Stream,
+        source_subject: Subject,
+        destination_subject: Subject,
+    ) -> Result<Self> {
+        let deliver_subject = nats.new_inbox();
+        let connection_metadata = nats.metadata_clone();
+        let context = jetstream::new(nats);
+
+        let consumer_name = format!("shuttle-{}", Ulid::new());
+        let source_stream_name = limits_based_source_stream
+            .get_info()
+            .await?
+            .config
+            .name
+            .to_owned();
+
+        let incoming = {
+            limits_based_source_stream
+                .create_consumer(async_nats::jetstream::consumer::push::OrderedConfig {
+                    name: Some(consumer_name.to_owned()),
+                    deliver_subject,
+                    filter_subject: source_subject.to_string(),
+                    ..Default::default()
+                })
+                .await?
+                .messages()
+                .await?
+        };
+
+        let state = crate::app_state::AppState::new(
+            context.clone(),
+            destination_subject.clone(),
+            token.clone(),
+        );
+
+        let app = ServiceBuilder::new()
+            .layer(
+                TraceLayer::new()
+                    .make_span_with(
+                        telemetry_nats::NatsMakeSpan::builder(connection_metadata).build(),
+                    )
+                    .on_response(telemetry_nats::NatsOnResponse::new()),
+            )
+            .layer(
+                PostProcessLayer::new()
+                    .on_success(DeleteMessageOnSuccess::new(limits_based_source_stream)),
+            )
+            .service(crate::handlers::default.with_state(state))
+            .map_response(Response::into_response);
+
+        let inner = naxum::serve(incoming, app.into_make_service())
+            .with_graceful_shutdown(naxum::wait_on_cancelled(token));
+
+        Ok(Self {
+            source_subject,
+            destination_subject,
+            shutdown_cleanup_toolkit: ShuttleShutdownCleanupToolkit {
+                consumer_name,
+                source_stream_name,
+                context,
+                tracker,
+            },
+            inner: Box::new(inner.into_future()),
+        })
+    }
+
+    /// Fallibly awaits the inner naxum task.
+    #[instrument(name = "shuttle.try_run", level = "trace", skip_all)]
+    pub async fn try_run(self) -> Result<()> {
+        self.inner.await.map_err(ShuttleError::Naxum)?;
+        trace!(%self.source_subject, %self.destination_subject, "shuttle inner loop exited, now performing cleanup");
+        self.shutdown_cleanup_toolkit.spawn_cleanup_task()?;
+        trace!(%self.source_subject, %self.destination_subject, "shuttle main loop shutdown complete");
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ShuttleShutdownCleanupToolkit {
+    consumer_name: String,
+    source_stream_name: String,
+    context: Context,
+    tracker: TaskTracker,
+}
+
+impl ShuttleShutdownCleanupToolkit {
+    #[instrument(
+        name = "shuttle.shutdown_cleanup_toolkit.spawn_cleanup_task",
+        level = "trace",
+        skip_all
+    )]
+    pub(crate) fn spawn_cleanup_task(self) -> Result<()> {
+        self.tracker.spawn(async move {
+            if let Err(err) = self
+                .context
+                .delete_consumer_from_stream(self.consumer_name, self.source_stream_name)
+                .await
+            {
+                error!(?err, "error deleting consumer from stream");
+            }
+        });
+        Ok(())
+    }
+}

--- a/lib/shuttle/src/middleware.rs
+++ b/lib/shuttle/src/middleware.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+use naxum::middleware::post_process;
+use si_data_nats::async_nats;
+use telemetry::prelude::*;
+
+#[derive(Clone, Debug)]
+pub(crate) struct DeleteMessageOnSuccess {
+    stream: async_nats::jetstream::stream::Stream,
+}
+
+impl DeleteMessageOnSuccess {
+    pub(crate) fn new(stream: async_nats::jetstream::stream::Stream) -> Self {
+        Self { stream }
+    }
+}
+
+impl post_process::OnSuccess for DeleteMessageOnSuccess {
+    fn call(
+        &mut self,
+        head: Arc<naxum::Head>,
+        info: Arc<post_process::Info>,
+    ) -> BoxFuture<'static, ()> {
+        let stream = self.stream.clone();
+
+        Box::pin(async move {
+            trace!("deleting message on success");
+            if let Err(err) = stream.delete_message(info.stream_sequence).await {
+                warn!(
+                    si.error.message = ?err,
+                    subject = head.subject.as_str(),
+                    "failed to delete the message",
+                );
+            }
+        })
+    }
+}

--- a/lib/shuttle/tests/integration.rs
+++ b/lib/shuttle/tests/integration.rs
@@ -1,0 +1,140 @@
+use std::env;
+use std::error;
+use std::time::Duration;
+
+use shuttle::Shuttle;
+use shuttle::FINAL_MESSAGE_HEADER_KEY;
+use si_data_nats::async_nats::jetstream::stream::Config;
+use si_data_nats::jetstream;
+use si_data_nats::jetstream::Context;
+use si_data_nats::NatsClient;
+use si_data_nats::NatsConfig;
+use si_data_nats::Subject;
+use si_events::ulid::Ulid;
+use telemetry::prelude::*;
+use telemetry_nats::propagation;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+const MESSAGE_COUNT: u64 = 100;
+
+async fn setup_nats() -> std::result::Result<(NatsClient, Context), Box<dyn error::Error>> {
+    let mut config = NatsConfig::default();
+
+    #[allow(clippy::disallowed_methods)]
+    if let Ok(url) = env::var("NATS_URL") {
+        config.url = url;
+    } else if let Ok(url) = env::var("SI_TEST_NATS_URL") {
+        config.url = url;
+    } else {
+        config.url = "nats://localhost:4222".to_owned();
+    }
+
+    let client = NatsClient::new(&config).await?;
+    let context = jetstream::new(client.clone());
+
+    Ok((client, context))
+}
+
+#[tokio::test]
+async fn integration() -> std::result::Result<(), Box<dyn error::Error>> {
+    let (client, context) = setup_nats().await?;
+
+    // Get a new set of streams for every test execution.
+    let prefix = Ulid::new();
+
+    // Create both streams.
+    let (source_stream, destination_stream) = {
+        let source_subject = Subject::from(format!("{}.shuttle.test.source.>", prefix));
+        let source_stream_name = format!("SHUTTLE_TEST_SOURCE_{}", prefix);
+        let destination_subject = Subject::from(format!("{}.shuttle.test.destination.>", prefix));
+        let destination_stream_name = format!("SHUTTLE_TEST_DESTINATION_{}", prefix);
+
+        let source_stream = context
+            .get_or_create_stream(Config {
+                name: source_stream_name.to_string(),
+                subjects: vec![source_subject.to_string()],
+                ..Default::default()
+            })
+            .await?;
+        let destination_stream = context
+            .get_or_create_stream(Config {
+                name: destination_stream_name.to_string(),
+                subjects: vec![destination_subject.to_string()],
+                ..Default::default()
+            })
+            .await?;
+
+        (source_stream, destination_stream)
+    };
+
+    // Spawn the shuttle instance using a tracker.
+    let tracker = TaskTracker::new();
+    let tracker_clone = tracker.clone();
+    let source_stream_clone = source_stream.clone();
+    tracker.spawn(async move {
+        match Shuttle::new(
+            client,
+            tracker_clone,
+            CancellationToken::new(),
+            source_stream_clone,
+            Subject::from(format!("{}.shuttle.test.source.some.inner.*", prefix)),
+            Subject::from(format!(
+                "{}.shuttle.test.destination.some.inner.messages",
+                prefix
+            )),
+        )
+        .await
+        {
+            Ok(shuttle) => {
+                if let Err(err) = shuttle.try_run().await {
+                    error!(?err, "error running shuttle instance");
+                }
+            }
+            Err(err) => {
+                error!(?err, "error creating shuttle instance")
+            }
+        }
+    });
+
+    // Publish messages on the source stream to ensure that shuttle works.
+    {
+        let data_setup_subject = Subject::from(format!(
+            "{}.shuttle.test.source.some.inner.messages",
+            prefix
+        ));
+
+        // Publish many messages to be shuttled.
+        for index in 0..MESSAGE_COUNT {
+            let ack = context
+                .publish_with_headers(
+                    data_setup_subject.to_owned(),
+                    propagation::empty_injected_headers(),
+                    index.to_string().into(),
+                )
+                .await?;
+            ack.await?;
+        }
+
+        // Publish the final message.
+        let mut headers = propagation::empty_injected_headers();
+        headers.insert(FINAL_MESSAGE_HEADER_KEY, "");
+        let ack = context
+            .publish_with_headers(data_setup_subject, headers, serde_json::to_vec("")?.into())
+            .await?;
+        ack.await?;
+    }
+
+    // Close the tracker and wait for all tasks to close.
+    tracker.close();
+    tokio::time::timeout(Duration::from_secs(5), tracker.wait()).await?;
+
+    // Now that everything has shut down, confirm that shuttle did its job.
+    assert_eq!(0, source_stream.get_info().await?.state.messages);
+    assert_eq!(
+        MESSAGE_COUNT,
+        destination_stream.get_info().await?.state.messages
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

This PR provides "shuttle", a new crate and service that "shuttles" or "forwards" messages from a limits-based NATS JetStream stream to a given NATS subject.

<img src="https://media2.giphy.com/media/NRWFU8lq7hCXS/giphy.gif"/>

## Context

This is needed for the pending events architecture and audit logging work in order for the rebaser to drain pending events and publish them to appropriate subjects.

Relevant PRs: #4814, #4852, #4854