### PR TITLE
audit logs JSON display and other improvements

### DIFF
--- a/app/web/src/components/AuditLogCell.vue
+++ b/app/web/src/components/AuditLogCell.vue
@@ -1,0 +1,73 @@
+<template>
+  <td
+    v-tooltip="tooltip"
+    align="center"
+    :class="
+      clsx(
+        'border-x border-collapse',
+        cell.column.id === 'json' && 'w-8',
+        themeClasses('border-neutral-300', 'border-neutral-900'),
+      )
+    "
+  >
+    <IconButton
+      v-if="cell.column.id === 'json'"
+      :icon="rowExpanded ? 'collapse-row' : 'expand-row'"
+      iconTone="neutral"
+      size="xs"
+      @click="emit('toggleExpand')"
+    />
+    <FlexRender
+      v-else
+      :render="cell.column.columnDef.cell"
+      :props="cell.getContext()"
+    />
+  </td>
+</template>
+
+<script lang="ts" setup>
+import { IconButton, themeClasses } from "@si/vue-lib/design-system";
+import { FlexRender, Cell } from "@tanstack/vue-table";
+import clsx from "clsx";
+import { computed, PropType } from "vue";
+
+const props = defineProps({
+  cell: {
+    type: Object as PropType<
+      Cell<
+        {
+          actorId: string;
+          actorName: string;
+          actorEmail?: string | undefined;
+          service: string;
+          kind: string;
+          timestamp: string;
+          ip: string;
+          changeSetId: string;
+          changeSetName: string;
+        },
+        unknown
+      >
+    >,
+    required: true,
+  },
+  rowExpanded: { type: Boolean },
+});
+
+const tooltip = computed(() => {
+  if (props.cell.column.id === "json") {
+    return {
+      content: props.rowExpanded ? "Collapse Row" : "Expand Row",
+      delay: { show: 0, hide: 100 },
+      instantMove: true,
+    };
+  }
+
+  return null;
+});
+
+const emit = defineEmits<{
+  (e: "select"): void;
+  (e: "toggleExpand"): void;
+}>();
+</script>

--- a/app/web/src/components/AuditLogDrawer.vue
+++ b/app/web/src/components/AuditLogDrawer.vue
@@ -1,0 +1,45 @@
+<template>
+  <tr
+    v-show="expanded"
+    :class="
+      clsx(
+        'border',
+        themeClasses('border-neutral-300', 'border-neutral-900'),
+        Number(row.id) % 2 === 0
+          ? themeClasses(' bg-neutral-200', 'bg-neutral-700')
+          : themeClasses(' bg-neutral-100', 'bg-neutral-800'),
+      )
+    "
+  >
+    <td :colspan="colspan" class="p-0">
+      <CodeViewer showTitle title="Event Data JSON" :code="json" />
+    </td>
+  </tr>
+</template>
+
+<script setup lang="ts">
+import { themeClasses } from "@si/vue-lib/design-system";
+import { Row } from "@tanstack/vue-table";
+import { PropType } from "vue";
+import clsx from "clsx";
+import { AuditLogDisplay } from "@/store/logs.store";
+import CodeViewer from "./CodeViewer.vue";
+
+defineProps({
+  row: {
+    type: Object as PropType<Row<AuditLogDisplay>>,
+    required: true,
+  },
+  colspan: {
+    type: Number,
+    required: true,
+  },
+  json: {
+    type: String,
+    required: true,
+  },
+  expanded: {
+    type: Boolean,
+  },
+});
+</script>

--- a/app/web/src/components/layout/navbar/NavbarButton.vue
+++ b/app/web/src/components/layout/navbar/NavbarButton.vue
@@ -20,6 +20,7 @@
     @mouseleave="toggleHover"
   >
     <slot :open="isSelectedOrMenuOpen" :hovered="hovered" />
+    <Icon v-if="icon" :name="icon" />
 
     <DropdownMenu v-if="slots.dropdownContent" ref="dropdownRef">
       <slot name="dropdownContent" />
@@ -34,16 +35,17 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, useSlots } from "vue";
+import { computed, ref, useSlots, PropType } from "vue";
 import { RouterLink } from "vue-router";
 import clsx from "clsx";
-import { DropdownMenu } from "@si/vue-lib/design-system";
+import { DropdownMenu, IconNames, Icon } from "@si/vue-lib/design-system";
 
 const props = defineProps({
   selected: { type: Boolean },
   tooltipText: { type: String },
   linkTo: { type: [String, Object] },
   externalLinkTo: { type: String },
+  icon: { type: String as PropType<IconNames> },
 });
 
 const dropdownRef = ref<InstanceType<typeof DropdownMenu>>();

--- a/app/web/src/components/layout/navbar/NavbarPanelCenter.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelCenter.vue
@@ -4,43 +4,39 @@
   >
     <NavbarButton
       tooltipText="Model"
+      icon="diagram"
       :selected="route.name === 'workspace-compose'"
       :linkTo="{
         name: 'workspace-compose',
         params: { changeSetId: 'auto' },
       }"
-    >
-      <Icon name="diagram" />
-    </NavbarButton>
+    />
 
     <NavbarButton
       tooltipText="Customize"
+      icon="beaker"
       :selected="route.matched.some((r) => r.name === 'workspace-lab')"
       :linkTo="{
         name: 'workspace-lab',
         params: { changeSetId: 'auto' },
       }"
-    >
-      <Icon name="beaker" />
-    </NavbarButton>
+    />
 
     <NavbarButton
       v-if="featureFlagsStore.AUDIT_PAGE"
       tooltipText="Audit"
+      icon="eye"
       :selected="route.matched.some((r) => r.name === 'workspace-audit')"
       :linkTo="{
         name: 'workspace-audit',
         params: { changeSetId: 'auto' },
       }"
-    >
-      <Icon name="eye" />
-    </NavbarButton>
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { useRoute } from "vue-router";
-import { Icon } from "@si/vue-lib/design-system";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import NavbarButton from "./NavbarButton.vue";
 

--- a/app/web/src/components/layout/navbar/NavbarPanelRight.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelRight.vue
@@ -4,17 +4,15 @@
 
     <NavbarButton
       tooltipText="Documentation"
+      icon="question-circle"
       externalLinkTo="https://docs.systeminit.com/"
-    >
-      <Icon name="question-circle" />
-    </NavbarButton>
+    />
 
     <NavbarButton
       tooltipText="Discord Community"
+      icon="logo-discord"
       externalLinkTo="https://discord.gg/system-init"
-    >
-      <Icon name="logo-discord" />
-    </NavbarButton>
+    />
 
     <WorkspaceSettingsMenu />
 
@@ -23,7 +21,6 @@
 </template>
 
 <script lang="ts" setup>
-import { Icon } from "@si/vue-lib/design-system";
 import NavbarButton from "./NavbarButton.vue";
 import Collaborators from "./Collaborators.vue";
 import WorkspaceSettingsMenu from "./WorkspaceSettingsMenu.vue";

--- a/app/web/src/components/layout/navbar/WorkspaceSettingsMenu.vue
+++ b/app/web/src/components/layout/navbar/WorkspaceSettingsMenu.vue
@@ -1,8 +1,6 @@
 <!-- eslint-disable vue/no-multiple-template-root -->
 <template>
-  <NavbarButton tooltipText="Workspace Settings">
-    <Icon name="settings" />
-
+  <NavbarButton icon="settings" tooltipText="Workspace Settings">
     <template #dropdownContent>
       <DropdownMenuItem
         icon="settings"
@@ -43,7 +41,7 @@
 </template>
 
 <script setup lang="ts">
-import { DropdownMenuItem, Icon } from "@si/vue-lib/design-system";
+import { DropdownMenuItem } from "@si/vue-lib/design-system";
 import { ref, computed } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import WorkspaceImportModal from "@/components/WorkspaceImportModal.vue";

--- a/bin/auth-api/README.md
+++ b/bin/auth-api/README.md
@@ -29,7 +29,7 @@ instances.
 While working on the auth stack, we still need to run it locally and configure things to point to our local auth stack:
 
 - update auth-api env vars in `bin/auth-api/.env.local`
-    - fill in `AUTH0_CLIENT_SECRET` and `AUTH0_M2M_CLIENT_SECRET` (get from 1pass)
+    - fill in `AUTH0_CLIENT_SECRET` and `AUTH0_M2M_CLIENT_SECRET` and `STRIPE_API_KEY` (get from 1pass)
     - (OPTIONAL) set auth-api redis url to a locally running redis instance (ex: `REDIS_URL=127.0.0.1:6379`) only if
       needing to test redis. Falls back to in-memory storage...
 - update web app env vars (`app/web/.env.local`) to point to local auth stack
@@ -40,8 +40,8 @@ While working on the auth stack, we still need to run it locally and configure t
 - run the backend but using the local auth stack by setting env var `SI_AUTH_API_URL=http://localhost:9001` (
   ex: `SI_AUTH_API_URL=http://localhost:9001 buck2 run dev:up`)
 - run the db migrations (`pnpm run db:reset`) locally after booting your local database
-- run the auth api `pnmp run dev` in this directory or `pnpm dev:auth-api` at the root
-- run the auth portal `pnmp run dev` in `app/auth-portal` or `pnpm dev:auth-portal` at the root
+- run the auth api `pnpm run dev` in this directory or `pnpm dev:auth-api` at the root
+- run the auth portal `pnpm run dev` in `app/auth-portal` or `pnpm dev:auth-portal` at the root
 - (or run both by running `pnpm run dev:auth` at the root)
 
 ## Deploy the Auth API to Production

--- a/lib/vue-lib/src/design-system/general/Timestamp.vue
+++ b/lib/vue-lib/src/design-system/general/Timestamp.vue
@@ -1,11 +1,18 @@
 <!-- eslint-disable vue/no-v-html -->
 <template>
-  <span class="timestamp" v-html="dateStr"></span>
+  <span
+    v-tooltip="tooltip"
+    :class="
+      clsx('timestamp', enableDetailTooltip && 'cursor-pointer hover:underline')
+    "
+    v-html="dateStr"
+  ></span>
 </template>
 
 <script lang="ts" setup>
 import * as _ from "lodash-es";
 import { computed, PropType } from "vue";
+import clsx from "clsx";
 import { TimestampSize, dateString } from "../utils/timestamp";
 
 const props = defineProps({
@@ -19,6 +26,7 @@ const props = defineProps({
     type: String as PropType<TimestampSize>,
     default: "normal",
   },
+  enableDetailTooltip: { type: Boolean },
 
   // Classes to apply to the date or time text, TODO(Wendy) - not supported for size mini or relative
   dateClasses: { type: String },
@@ -34,5 +42,15 @@ const dateStr = computed(() => {
     props.dateClasses,
     props.timeClasses,
   );
+});
+
+const tooltip = computed(() => {
+  if (!props.enableDetailTooltip) return null;
+
+  return {
+    content: props.date,
+    delay: { show: 0, hide: 100 },
+    instantMove: true,
+  };
 });
 </script>


### PR DESCRIPTION
- Each event row can now be expanded to see the raw JSON data for each event
- A button appears on the header area to collapse all rows when any rows are open
- Each timestamp cell now has a tooltip to display the raw timestamp data
- Each change set cell now has a tooltip to display the change set id
- Also fixed some typos in the auth-api README
- Posthog tracking each time a set of logs are loaded (including when the user first navigates to the Audit page)