### PR TITLE
AI Asset Generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,9 +106,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -121,43 +121,49 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayref"
@@ -172,6 +178,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asset-sprayer"
+version = "0.1.0"
+dependencies = [
+ "async-openai",
+ "dal",
+ "include_dir",
+ "remain",
+ "reqwest",
+ "serde",
+ "serde_yaml",
+ "si-std",
+ "strum 0.26.3",
+ "telemetry",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +207,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-convert"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
+dependencies = [
+ "async-trait",
 ]
 
 [[package]]
@@ -231,6 +264,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-openai"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b17e44510f88a904cb3102a020d7ea11929dcddadfaff756e71112cb2cb7bd0"
+dependencies = [
+ "async-convert",
+ "backoff",
+ "base64 0.22.1",
+ "bytes",
+ "derive_builder",
+ "eventsource-stream",
+ "futures",
+ "rand 0.8.5",
+ "reqwest",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,7 +297,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -260,7 +319,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -271,7 +330,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -357,9 +416,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.8"
+version = "1.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7198e6f03240fdceba36656d8be440297b6b82270325908c7381f37d826a74f6"
+checksum = "2d6448cfb224dd6a9b9ac734f58622dd0d4751f3589f3b777345745f46b2eb14"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -448,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-firehose"
-version = "1.51.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f36d00e1ac8e25c61443968be1e933ced6b9675c4a8022c98e0dd5dc363130"
+checksum = "0c542b9b13d39838355ba85b037135dc19eba2d3f59e4dd7642f09681b662d96"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -470,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.46.0"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc2faec3205d496c7e57eff685dd944203df7ce16a4116d0281c44021788a7b"
+checksum = "a8776850becacbd3a82a4737a9375ddb5c6832a51379f24443a98e61513f852c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -492,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.47.0"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c93c241f52bc5e0476e259c953234dab7e2a35ee207ee202e86c0095ec4951dc"
+checksum = "0007b5b8004547133319b6c4e87193eee2a0bcb3e4c18c75d09febe9dab7b383"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -514,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.46.0"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b259429be94a3459fa1b00c5684faee118d74f9577cc50aebadc36e507c63b5f"
+checksum = "9fffaa356e7f1c725908b75136d53207fa714e348f365671df14e95a60530ad3"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -537,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8db6904450bafe7473c6ca9123f88cc11089e41a025408f992db4e22d3be68"
+checksum = "5619742a0d8f253be760bfbb8e8e8368c69e3587e4637af5754e488a611499b1"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -610,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db"
+checksum = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -654,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.7"
+version = "1.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147100a7bea70fa20ef224a6bad700358305f5dc0f84649c53769761395b355b"
+checksum = "07c9cdc179e6afbf5d391ab08c85eac817b51c87e1892a5edb5f7bbdc64314b4"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -764,7 +823,21 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.15",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]
@@ -869,7 +942,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1002,7 +1075,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "syn_derive",
 ]
 
@@ -1081,9 +1154,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
 ]
@@ -1258,7 +1331,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1313,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "concurrent-queue"
@@ -1328,17 +1401,16 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
+checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
 dependencies = [
- "lazy_static",
  "nom",
  "pathdiff",
  "serde",
  "serde_json",
  "toml",
- "yaml-rust",
+ "yaml-rust2",
 ]
 
 [[package]]
@@ -1598,7 +1670,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1780,7 +1852,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "si-events",
- "syn 2.0.82",
+ "syn 2.0.85",
  "trybuild",
 ]
 
@@ -1851,7 +1923,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1862,7 +1934,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1979,7 +2051,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1989,7 +2061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2002,7 +2074,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2162,7 +2234,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2209,9 +2281,9 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -2233,7 +2305,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2300,6 +2372,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener 5.3.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
  "pin-project-lite",
 ]
 
@@ -2511,7 +2594,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2525,6 +2608,12 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2997,6 +3086,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "rustls 0.23.15",
+ "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -3124,7 +3214,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.82",
+ "syn 2.0.85",
  "toml",
  "unicode-xid",
 ]
@@ -3143,6 +3233,25 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -3187,7 +3296,16 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3376,12 +3494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3413,7 +3525,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3450,7 +3562,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3523,7 +3635,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4133,7 +4245,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4147,7 +4259,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4325,29 +4437,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -4487,7 +4599,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4619,7 +4731,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4635,9 +4747,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -4650,7 +4762,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "version_check",
  "yansi",
 ]
@@ -4711,7 +4823,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4724,7 +4836,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5077,7 +5189,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5093,9 +5205,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5149,7 +5261,7 @@ checksum = "46aef80f842736de545ada6ec65b81ee91504efd6853f4b96de7414c42ae7443"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5187,6 +5299,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.15",
+ "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -5195,13 +5308,31 @@ dependencies = [
  "sync_wrapper 1.0.1",
  "tokio",
  "tokio-rustls 0.26.0",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.26.6",
  "windows-registry",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror",
 ]
 
 [[package]]
@@ -5453,6 +5584,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5556,6 +5700,8 @@ dependencies = [
 name = "sdf-server"
 version = "0.1.0"
 dependencies = [
+ "asset-sprayer",
+ "async-openai",
  "async-trait",
  "axum",
  "base64 0.22.1",
@@ -5566,6 +5712,7 @@ dependencies = [
  "dal",
  "dal-test",
  "derive_builder",
+ "derive_more",
  "futures",
  "futures-lite",
  "hyper 0.14.31",
@@ -5628,7 +5775,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5669,7 +5816,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.82",
+ "syn 2.0.85",
  "unicode-ident",
 ]
 
@@ -5727,6 +5874,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5757,9 +5914,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
@@ -5777,13 +5934,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5837,7 +5994,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5898,7 +6055,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6288,7 +6445,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6749,7 +6906,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6784,9 +6941,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6802,7 +6959,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6965,27 +7122,27 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7079,9 +7236,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7127,7 +7284,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7445,7 +7602,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7939,7 +8096,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -7973,7 +8130,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7983,6 +8140,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"
@@ -8101,7 +8271,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8112,7 +8282,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8366,12 +8536,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "yaml-rust"
-version = "0.4.5"
+name = "yaml-rust2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+checksum = "8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8"
 dependencies = [
- "linked-hash-map",
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
 ]
 
 [[package]]
@@ -8413,7 +8585,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8433,7 +8605,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[patch.unused]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "bin/rebaser",
     "bin/sdf",
     "bin/veritech",
+    "lib/asset-sprayer",
     "lib/audit-logs",
     "lib/auth-api-client",
     "lib/billing-events",
@@ -83,6 +84,7 @@ publish = false
 
 [workspace.dependencies]
 async-nats = { version = "0.36.0", features = ["service"] }
+async-openai = "0.25.0"
 async-recursion = "1.0.5"
 async-trait = "0.1.79"
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
@@ -123,6 +125,7 @@ http = "0.2.12" # todo: upgrade this alongside hyper/axum/tokio-tungstenite/towe
 hyper = { version = "0.14.28", features = ["client", "http1", "runtime", "server"] } # todo: upgrade this alongside http/axum/tokio-tungstenite/tower-http
 hyperlocal = { version = "0.8.0", default-features = false, features = ["client"] } # todo: using the very latest of hyper client 1.x, we _may_ be able to phase this crate
 iftree = "1.0.5"
+include_dir = "0.7.4"
 indexmap = { version = "2.2.6", features = ["serde", "std"] }
 indicatif = "0.17.8"
 indoc = "2.0.5"

--- a/app/web/src/components/Ai/GenerateAwsAssetSchemaPanel.vue
+++ b/app/web/src/components/Ai/GenerateAwsAssetSchemaPanel.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="flex flex-row gap-xs items-end p-xs justify-end w-full">
+    <VormInput
+      v-model="awsCommand.cli"
+      label="CLI"
+      type="text"
+      disabled
+      :maxLength="3"
+      @enterPressed="generateAwsAssetSchema"
+    />
+    <VormInput
+      v-model="awsCommand.command"
+      label="Command"
+      type="text"
+      :disabled="generateRequestStatus.isPending"
+      @enterPressed="generateAwsAssetSchema"
+    />
+    <VormInput
+      v-model="awsCommand.subcommand"
+      label="Subcommand"
+      type="text"
+      :disabled="generateRequestStatus.isPending"
+      @enterPressed="generateAwsAssetSchema"
+    />
+    <VButton
+      v-tooltip="'Generate Schema From AWS Command'"
+      class="mb-[2px]"
+      :loading="generateRequestStatus.isPending"
+      loadingIcon="sparkles"
+      loadingText="Generating ..."
+      :requestStatus="generateRequestStatus"
+      label="Generate"
+      size="sm"
+      @click="generateAwsAssetSchema"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { reactive, PropType } from "vue";
+import { VormInput, VButton } from "@si/vue-lib/design-system";
+import { useAssetStore } from "@/store/asset.store";
+import { SchemaVariant } from "@/api/sdf/dal/schema";
+
+const assetStore = useAssetStore();
+
+const props = defineProps({
+  /** Asset we're generating for */
+  asset: { type: Object as PropType<SchemaVariant>, required: true },
+});
+
+/** The AWS command entered in the form */
+const awsCommand = reactive({
+  cli: "aws",
+  command: "sqs",
+  subcommand: "create-queue",
+});
+
+/** Status of the  */
+const generateRequestStatus = assetStore.getRequestStatus(
+  "GENERATE_AWS_ASSET_SCHEMA",
+  props.asset.schemaVariantId,
+);
+
+/** Actually trigger schema generation */
+const generateAwsAssetSchema = async () => {
+  await assetStore.GENERATE_AWS_ASSET_SCHEMA(
+    props.asset.schemaVariantId,
+    awsCommand.command,
+    awsCommand.subcommand,
+  );
+};
+</script>

--- a/app/web/src/components/AssetEditorHeader.vue
+++ b/app/web/src/components/AssetEditorHeader.vue
@@ -1,69 +1,109 @@
 <template>
-  <div class="p-xs flex flex-row gap-xs items-center">
-    <div class="flex flex-col min-w-0 flex-grow">
-      <TruncateWithTooltip
-        :showTooltip="showTooltip"
-        class="text-2xl font-bold pb-2xs flex flex-row items-center gap-xs"
-      >
-        <div
-          :class="
-            clsx(
-              'flex flex-row items-center gap-xs flex-none max-w-full',
-              selectedFunc && [
-                'cursor-pointer hover:underline',
-                themeClasses('text-action-500', 'text-action-300'),
-              ],
-            )
-          "
-          @click="onClick"
-        >
-          <NodeSkeleton :color="selectedAsset.color" size="mini" />
-          <TruncateWithTooltip ref="truncateRef1" hasParentTruncateWithTooltip>
-            {{ schemaVariantDisplayName(selectedAsset) }}
-          </TruncateWithTooltip>
-        </div>
+  <div class="flex flex-col flex-grow">
+    <!-- Main asset header -->
+    <div class="p-xs flex flex-row gap-xs items-center">
+      <div class="flex flex-col min-w-0 flex-grow">
         <TruncateWithTooltip
-          v-if="selectedFunc"
-          ref="truncateRef2"
-          hasParentTruncateWithTooltip
+          :showTooltip="showTooltip"
+          class="text-2xl font-bold pb-2xs flex flex-row items-center gap-xs"
         >
-          / {{ selectedFunc.kind }} / {{ selectedFunc.name }}
+          <div
+            :class="
+              clsx(
+                'flex flex-row items-center gap-xs flex-none max-w-full',
+                selectedFunc && [
+                  'cursor-pointer hover:underline',
+                  themeClasses('text-action-500', 'text-action-300'),
+                ],
+              )
+            "
+            @click="onClick"
+          >
+            <NodeSkeleton :color="selectedAsset.color" size="mini" />
+            <TruncateWithTooltip
+              ref="truncateRef1"
+              hasParentTruncateWithTooltip
+            >
+              {{ schemaVariantDisplayName(selectedAsset) }}
+            </TruncateWithTooltip>
+          </div>
+          <TruncateWithTooltip
+            v-if="selectedFunc"
+            ref="truncateRef2"
+            hasParentTruncateWithTooltip
+          >
+            / {{ selectedFunc.kind }} / {{ selectedFunc.name }}
+          </TruncateWithTooltip>
         </TruncateWithTooltip>
-      </TruncateWithTooltip>
-      <div
-        class="text-xs italic flex flex-row flex-wrap gap-x-lg text-neutral-600 dark:text-neutral-200 items-center"
-      >
-        <div>
-          <span class="font-bold">Asset Created At: </span>
-          <Timestamp :date="selectedAsset.created_at" size="long" />
+        <div
+          class="text-xs italic flex flex-row flex-wrap gap-x-lg text-neutral-600 dark:text-neutral-200 items-center"
+        >
+          <div>
+            <span class="font-bold">Asset Created At: </span>
+            <Timestamp :date="selectedAsset.created_at" size="long" />
+          </div>
+          <!-- TODO: Populate the created by from SDF actorHistory-->
+          <div>
+            <span class="font-bold">Created By: </span>System Initiative
+          </div>
         </div>
-        <!-- TODO: Populate the created by from SDF actorHistory-->
-        <div><span class="font-bold">Created By: </span>System Initiative</div>
       </div>
+      <EditingPill
+        v-if="!selectedAsset.isLocked"
+        class="flex-none"
+        :color="selectedAsset.color"
+      />
+      <IconButton
+        v-if="featureFlagsStore.AI_GENERATOR"
+        icon="sparkles"
+        size="lg"
+        :tooltip="
+          showAwsAssetSchemaGeneratorPanel
+            ? 'Close'
+            : 'Generate AWS Asset Schema'
+        "
+        :selected="showAwsAssetSchemaGeneratorPanel"
+        @click="toggleAwsAssetSchemaGeneratorPanel"
+      />
     </div>
-    <EditingPill
-      v-if="!selectedAsset.isLocked"
-      class="flex-none"
-      :color="selectedAsset.color"
-    />
+    <!-- openable AI generator panel extension -->
+    <Transition
+      name="expand-height"
+      enterActiveClass="transition-[height] overflow-hidden"
+      leaveActiveClass="transition-[height] overflow-hidden"
+      enterFromClass="!h-0"
+      leaveToClass="!h-0"
+      :onBeforeEnter="captureHeight"
+      :onAfterEnter="clearHeight"
+      :onBeforeLeave="captureHeight"
+      :onAfterLeave="clearHeight"
+    >
+      <div v-show="showAwsAssetSchemaGeneratorPanel" ref="transitionRef">
+        <GenerateAwsAssetSchemaPanel :asset="selectedAsset" />
+      </div>
+    </Transition>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { PropType, computed, ref } from "vue";
 import {
+  IconButton,
   Timestamp,
   themeClasses,
   TruncateWithTooltip,
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { schemaVariantDisplayName, useAssetStore } from "@/store/asset.store";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import { SchemaVariant } from "@/api/sdf/dal/schema";
 import { FuncSummary } from "@/api/sdf/dal/func";
 import EditingPill from "./EditingPill.vue";
 import NodeSkeleton from "./NodeSkeleton.vue";
+import GenerateAwsAssetSchemaPanel from "./Ai/GenerateAwsAssetSchemaPanel.vue";
 
 const assetStore = useAssetStore();
+const featureFlagsStore = useFeatureFlagsStore();
 
 const truncateRef1 = ref<InstanceType<typeof TruncateWithTooltip>>();
 const truncateRef2 = ref<InstanceType<typeof TruncateWithTooltip>>();
@@ -80,4 +120,26 @@ const onClick = () => {
 const showTooltip = computed(() => {
   return truncateRef1.value?.tooltipActive || truncateRef2.value?.tooltipActive;
 });
+
+const showAwsAssetSchemaGeneratorPanel = ref(false);
+const toggleAwsAssetSchemaGeneratorPanel = () => {
+  showAwsAssetSchemaGeneratorPanel.value =
+    !showAwsAssetSchemaGeneratorPanel.value;
+};
+
+const transitionRef = ref<HTMLDivElement>();
+
+const captureHeight = () => {
+  if (transitionRef.value) {
+    if (transitionRef.value.style.display === "none") {
+      transitionRef.value.style.removeProperty("display");
+    }
+    transitionRef.value.style.height = `${transitionRef.value.clientHeight}px`;
+  }
+};
+const clearHeight = () => {
+  if (transitionRef.value) {
+    transitionRef.value.style.height = "";
+  }
+};
 </script>

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -565,6 +565,23 @@ export const useAssetStore = (forceChangeSetId?: ChangeSetId) => {
             },
           });
         },
+
+        async GENERATE_AWS_ASSET_SCHEMA(
+          id: SchemaVariantId,
+          command: string,
+          subcommand: string,
+        ) {
+          if (changeSetStore.creatingChangeSet)
+            throw new Error("race, wait until the change set is created");
+          if (changeSetStore.headSelected)
+            changeSetStore.creatingChangeSet = true;
+
+          return new ApiRequest<SchemaVariant>({
+            url: API_PREFIX.concat([id, "generate_aws_asset_schema"]),
+            params: { command, subcommand },
+            keyRequestStatusBy: id,
+          });
+        },
       },
       async onActivated() {
         await Promise.all([

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -13,6 +13,7 @@ const FLAG_MAPPING = {
   ON_DEMAND_ASSETS: "on_demand_assets",
   MANAGEMENT_FUNCTIONS: "management-functions",
   AUDIT_PAGE: "audit-page",
+  AI_GENERATOR: "ai-generator",
 };
 
 type FeatureFlags = keyof typeof FLAG_MAPPING;

--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -202,6 +202,28 @@ pub(crate) struct Args {
     #[arg(long, env = "SI_AUTH_API_URL")]
     pub(crate) auth_api_url: Option<String>,
 
+    /// Override for the openai API key
+    #[arg(long, env = "SI_OPENAI_API_KEY")]
+    // TODO This should be a SensitiveString but if it is, it gets passed as "..."
+    // pub(crate) openai_api_key: Option<SensitiveString>,
+    pub(crate) openai_api_key: Option<String>,
+
+    /// Override for the openai API base URL
+    #[arg(long, env = "SI_OPENAI_API_BASE")]
+    pub(crate) openai_api_base: Option<String>,
+
+    /// Override for the openai org id
+    #[arg(long, env = "SI_OPENAI_ORG_ID")]
+    pub(crate) openai_org_id: Option<String>,
+
+    /// Override for the openai project id
+    #[arg(long, env = "SI_OPENAI_PROJECT_ID")]
+    pub(crate) openai_project_id: Option<String>,
+
+    /// Directory to read prompts from (localdev)
+    #[arg(long, env = "SI_ASSET_SPRAYER_PROMPTS_DIR")]
+    pub(crate) asset_sprayer_prompts_dir: Option<String>,
+
     /// Instance ID [example: 01GWEAANW5BVFK5KDRVS6DEY0F"]
     ///
     /// And instance ID is used when tracking the execution of jobs in a way that can be traced
@@ -331,6 +353,26 @@ impl TryFrom<Args> for Config {
 
             if let Some(auth_api_url) = args.auth_api_url {
                 config_map.set("auth_api_url", auth_api_url);
+            }
+
+            if let Some(openai_api_key) = args.openai_api_key {
+                config_map.set("openai.api_key", openai_api_key.to_string());
+            }
+            if let Some(openai_api_base) = args.openai_api_base {
+                config_map.set("openai.api_base", openai_api_base);
+            }
+            if let Some(openai_org_id) = args.openai_org_id {
+                config_map.set("openai.org_id", openai_org_id);
+            }
+            if let Some(openai_project_id) = args.openai_project_id {
+                config_map.set("openai.project_id", openai_project_id);
+            }
+
+            if let Some(asset_sprayer_prompts_dir) = args.asset_sprayer_prompts_dir {
+                config_map.set(
+                    "asset_sprayer.prompts_dir",
+                    asset_sprayer_prompts_dir.to_string(),
+                );
             }
 
             config_map.set("boot_feature_flags", args.features);

--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -24,6 +24,15 @@ $SI_NATS_CREDS
 """
 url = "$SI_NATS_URL"
 
+[openai]
+api_key = "$SI_OPENAI_API_KEY"
+api_base = "$SI_OPENAI_API_BASE"
+api_version = "$SI_OPENAI_API_VERSION"
+org_id = "$SI_OPENAI_ORG_ID"
+
+[asset_sprayer]
+prompts_dir = "$SI_ASSET_SPRAYER_PROMPTS_DIR"
+
 [pg]
 user = "si"
 password = "$SI_PG_PASSWORD"

--- a/lib/asset-sprayer/BUCK
+++ b/lib/asset-sprayer/BUCK
@@ -1,0 +1,22 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "asset-sprayer",
+    deps = [
+        "//lib/dal:dal",
+        "//lib/si-std:si-std",
+        "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:async-openai",
+        "//third-party/rust:remain",
+        "//third-party/rust:reqwest",
+        "//third-party/rust:serde",
+        "//third-party/rust:serde_yaml",
+        "//third-party/rust:strum",
+        "//third-party/rust:thiserror",
+        "//third-party/rust:tokio",
+    ],
+    srcs = glob([
+        "src/**/*.rs",
+        "prompts/**/*.yaml",
+    ]),
+)

--- a/lib/asset-sprayer/Cargo.toml
+++ b/lib/asset-sprayer/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "asset-sprayer"
+edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+async-openai = { workspace = true }
+dal = { path = "../../lib/dal" }
+include_dir = { workspace = true }
+remain = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+si-std = { path = "../../lib/si-std" }
+strum = { workspace = true }
+telemetry = { path = "../../lib/telemetry-rs" }
+thiserror = { workspace = true }
+tokio = { workspace = true }

--- a/lib/asset-sprayer/prompts/aws/asset_schema.yaml
+++ b/lib/asset-sprayer/prompts/aws/asset_schema.yaml
@@ -1,0 +1,68 @@
+model: gpt-4o-mini
+temperature: 0.0
+messages:
+  - role: system
+    content: >
+      You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset schemas for use in System Initiative.
+
+      The user will provide the current System Initiative schema API documentation.
+
+      The user will provide the text of the help output from an AWS CLI command.
+
+      The user may optionally provide help text to build the schema for specific properties, which may be additional man pages, web pages, json schema, or grammars. Ensure this is used to create the proper schema for those additional properties.
+
+      Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative schema.
+
+      You will only use APIs that appear in the schema API documentation and additional text for specific properties.
+
+      If the AWS documentation describes a cli option as a map with a specific set of documented keys and values, do not create a map property in the schema. Instead, create an object property where each described key described in the AWS documentation is a child property object in the schema.
+
+      If you encounter a JSON Schema, you will use it to construct properties using the System Initiative API, not only as a Joi validation.
+
+      You will make sure you include every property specified in all of the user inputs provided to create the schema when asked.
+
+      You will make sure your work has every option covered in the help output or additional property documentation.
+
+      You will make sure to include the region property in the schema.
+
+      You will make sure to include the standard "AWS Credential" secret property in the schema.
+
+      You will make sure to use the additional text for specific properties.
+
+      You will make sure your work has Joi validations for every option according to the help output.
+
+      You will make sure every PropBuilder has an appropriate call to `setName()`.
+
+      You will then review your work to make sure you use only APIs described in the schema API documentation.
+
+      You will then review your work to make sure you include any field level validations using Joi.
+
+      You will then show the final function in its entirety, with no other explanation, as plain text. Do not wrap the code in markdown delimiters.
+  - role: user
+    content: >
+      What follows is the current System Initiative schema API documentation as markdown, between three ^ characters.
+
+      ^^^
+      {FETCH}https://raw.githubusercontent.com/systeminit/si/refs/heads/main/app/docs/src/reference/asset/schema.md{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
+
+      ^^^
+      {FETCH}https://raw.githubusercontent.com/systeminit/si/refs/heads/main/app/docs/src/reference/asset/function.md{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
+
+      ^^^
+      {FETCH}https://docs.aws.amazon.com/cli/latest/reference/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      Create the asset function that generates the schema.
+      
+      Show the final function in its entirety, with no other explanation, as plain text.
+      
+      Do not wrap the code in markdown delimiters.

--- a/lib/asset-sprayer/src/config.rs
+++ b/lib/asset-sprayer/src/config.rs
@@ -1,0 +1,45 @@
+use async_openai::config::OpenAIConfig;
+use serde::{Deserialize, Serialize};
+use si_std::SensitiveString;
+use std::path::PathBuf;
+
+/// OpenAI configuration. Mirrors OpenAI configuration, but with Deserialize support.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct SIOpenAIConfig {
+    api_key: Option<SensitiveString>,
+    api_base: Option<String>,
+    org_id: Option<String>,
+    project_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct AssetSprayerConfig {
+    pub prompts_dir: Option<PathBuf>,
+}
+
+impl SIOpenAIConfig {
+    pub fn into_openai_config_opt(self) -> Option<OpenAIConfig> {
+        if self.api_key.is_none()
+            && self.api_base.is_none()
+            && self.org_id.is_none()
+            && self.project_id.is_none()
+        {
+            return None;
+        }
+
+        let mut config = OpenAIConfig::new();
+        if let Some(api_key) = self.api_key {
+            config = config.with_api_key(api_key);
+        }
+        if let Some(api_base) = self.api_base {
+            config = config.with_api_base(api_base);
+        }
+        if let Some(org_id) = self.org_id {
+            config = config.with_org_id(org_id);
+        }
+        if let Some(project_id) = self.project_id {
+            config = config.with_project_id(project_id);
+        }
+        Some(config)
+    }
+}

--- a/lib/asset-sprayer/src/lib.rs
+++ b/lib/asset-sprayer/src/lib.rs
@@ -1,0 +1,124 @@
+//! This create provides centralized support for using AI to generate assets.
+
+#![warn(
+    bad_style,
+    clippy::missing_panics_doc,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result,
+    clippy::unwrap_used,
+    dead_code,
+    improper_ctypes,
+    missing_debug_implementations,
+    // missing_docs,
+    no_mangle_generic_items,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    unconditional_recursion,
+    unreachable_pub,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
+
+use async_openai::config::OpenAIConfig;
+use config::AssetSprayerConfig;
+use prompts::{Prompt, Prompts};
+use telemetry::prelude::*;
+use thiserror::Error;
+
+pub mod config;
+pub mod prompts;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum AssetSprayerError {
+    #[error("Empty choice returned from AI.")]
+    EmptyChoice,
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Missing end {{/FETCH}} after {{FETCH}}: {0}")]
+    MissingEndFetch(Prompt),
+    #[error("No choices were returned from the AI.")]
+    NoChoices,
+    #[error("OpenAI error: {0}")]
+    OpenAI(#[from] async_openai::error::OpenAIError),
+    #[error("Reqwest error: {0}")]
+    Reqwest(#[from] reqwest::Error),
+    #[error("SerdeYaml error: {0}")]
+    SerdeYaml(#[from] serde_yaml::Error),
+    #[error("Unreachable")]
+    Unreachable,
+}
+
+pub type AssetSprayerResult<T> = Result<T, AssetSprayerError>;
+
+#[derive(Debug, Clone)]
+pub struct AssetSprayer {
+    openai_client: async_openai::Client<OpenAIConfig>,
+    prompts: Prompts,
+}
+
+impl AssetSprayer {
+    pub fn new(
+        openai_client: async_openai::Client<OpenAIConfig>,
+        config: AssetSprayerConfig,
+    ) -> Self {
+        Self {
+            openai_client,
+            prompts: Prompts::new(config.prompts_dir),
+        }
+    }
+
+    pub async fn aws_asset_schema(
+        &self,
+        aws_command: &str,
+        aws_subcommand: &str,
+    ) -> AssetSprayerResult<String> {
+        debug!(
+            "Generating asset schema for 'aws {} {}'",
+            aws_command, aws_subcommand
+        );
+        self.run(
+            Prompt::AssetSchema,
+            &[
+                ("{AWS_COMMAND}", aws_command),
+                ("{AWS_SUBCOMMAND}", aws_subcommand),
+            ],
+        )
+        .await
+    }
+
+    async fn run(&self, prompt: Prompt, replace: &[(&str, &str)]) -> AssetSprayerResult<String> {
+        let request = self.prompts.create_request(prompt, replace).await?;
+        let response = self.openai_client.chat().create(request).await?;
+        let choice = response
+            .choices
+            .into_iter()
+            .next()
+            .ok_or(AssetSprayerError::NoChoices)?;
+        let text = choice
+            .message
+            .content
+            .ok_or(AssetSprayerError::EmptyChoice)?;
+        Ok(text)
+    }
+}
+
+#[ignore = "You must have OPENAI_API_KEY set to run this test"]
+#[tokio::test]
+async fn test_do_ai() -> AssetSprayerResult<()> {
+    let asset_sprayer =
+        AssetSprayer::new(async_openai::Client::new(), AssetSprayerConfig::default());
+    println!(
+        "Done: {}",
+        asset_sprayer
+            .aws_asset_schema("sqs", "create-queue")
+            .await?
+    );
+    Ok(())
+}

--- a/lib/asset-sprayer/src/prompts.rs
+++ b/lib/asset-sprayer/src/prompts.rs
@@ -1,0 +1,150 @@
+use std::path::PathBuf;
+
+use async_openai::types::{
+    ChatCompletionRequestMessage, ChatCompletionRequestSystemMessageContent,
+    ChatCompletionRequestUserMessageContent, CreateChatCompletionRequest,
+};
+use telemetry::prelude::*;
+
+use crate::{AssetSprayerError, AssetSprayerResult};
+
+#[derive(Debug, Clone)]
+pub struct Prompts {
+    prompts_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, strum::Display)]
+pub enum Prompt {
+    AssetSchema,
+}
+
+impl Prompt {
+    fn yaml_relative_path(&self) -> &str {
+        match self {
+            Prompt::AssetSchema => "aws/asset_schema.yaml",
+        }
+    }
+
+    fn yaml_embedded(&self) -> &'static str {
+        match self {
+            Prompt::AssetSchema => include_str!("../prompts/aws/asset_schema.yaml"),
+        }
+    }
+}
+
+impl Prompts {
+    pub fn new(prompts_dir: Option<PathBuf>) -> Self {
+        Self {
+            prompts_dir: prompts_dir.map(Into::into),
+        }
+    }
+
+    pub async fn create_request(
+        &self,
+        prompt: Prompt,
+        replace: &[(&str, &str)],
+    ) -> AssetSprayerResult<CreateChatCompletionRequest> {
+        let request = self.raw_request(prompt).await?;
+        Self::replace_prompt_request(request, replace, prompt).await
+    }
+
+    async fn raw_request(&self, prompt: Prompt) -> AssetSprayerResult<CreateChatCompletionRequest> {
+        Ok(serde_yaml::from_str(&self.yaml(prompt).await?)?)
+    }
+
+    async fn yaml(&self, prompt: Prompt) -> AssetSprayerResult<String> {
+        if let Some(ref prompts_dir) = self.prompts_dir {
+            // Read from disk if prompts_dir is available (faster dev cycle)
+            let path = prompts_dir.join(prompt.yaml_relative_path());
+            info!("Loading prompt for {} from disk at {:?}", prompt, path);
+            Ok(tokio::fs::read_to_string(path).await?)
+        } else {
+            info!("Loading embedded prompt for {}", prompt);
+            Ok(prompt.yaml_embedded().to_string())
+        }
+    }
+
+    async fn replace_prompt_request(
+        request: CreateChatCompletionRequest,
+        replace: &[(&str, &str)],
+        prompt: Prompt,
+    ) -> AssetSprayerResult<CreateChatCompletionRequest> {
+        let mut request = request;
+        for message in request.messages.iter_mut() {
+            *message =
+                Self::replace_prompt_request_message(message.clone(), replace, prompt).await?;
+        }
+        Ok(request)
+    }
+
+    async fn replace_prompt_request_message(
+        message: ChatCompletionRequestMessage,
+        replace: &[(&str, &str)],
+        prompt: Prompt,
+    ) -> AssetSprayerResult<ChatCompletionRequestMessage> {
+        let mut message = message;
+        match &mut message {
+            ChatCompletionRequestMessage::User(message) => {
+                if let ChatCompletionRequestUserMessageContent::Text(text) = &mut message.content {
+                    *text = Self::replace_prompt_text(text.clone(), replace, prompt).await?;
+                }
+            }
+            ChatCompletionRequestMessage::System(message) => {
+                if let ChatCompletionRequestSystemMessageContent::Text(text) = &mut message.content
+                {
+                    *text = Self::replace_prompt_text(text.clone(), replace, prompt).await?;
+                }
+            }
+            _ => (),
+        }
+        Ok(message)
+    }
+
+    async fn replace_prompt_text(
+        text: String,
+        replace: &[(&str, &str)],
+        prompt: Prompt,
+    ) -> AssetSprayerResult<String> {
+        let mut text = text;
+
+        // Replace {KEY} with value
+        for (from, to) in replace {
+            text = text.replace(from, to);
+        }
+
+        Self::fetch_prompt_text(&text, prompt).await
+    }
+
+    async fn fetch_prompt_text(text: &str, prompt: Prompt) -> AssetSprayerResult<String> {
+        // Fetch things between {FETCH} and {/FETCH}
+        let mut result = String::new();
+        let mut text = text;
+        while let Some(fetch_start) = text.find("{FETCH}") {
+            // Copy up to {FETCH}
+            result.push_str(&text[..fetch_start]);
+            text = &text[(fetch_start + "{FETCH}".len())..];
+
+            if let Some(url_end) = text.find("{/FETCH}") {
+                // Fetch the URL between {FETCH}...{/FETCH}
+                result.push_str(&Self::get(&text[..url_end]).await?);
+                text = &text[(url_end + "{/FETCH}".len())..];
+            } else {
+                return Err(AssetSprayerError::MissingEndFetch(prompt));
+            }
+        }
+
+        // Copy the remainder of the text
+        result.push_str(text);
+
+        Ok(result)
+    }
+
+    async fn get(url: &str) -> reqwest::Result<String> {
+        info!("Fetching: {}", url);
+        let client = reqwest::ClientBuilder::new()
+            .user_agent("Wget/1.21.2")
+            .build()?;
+        let response = client.get(url).send().await?;
+        response.error_for_status()?.text().await
+    }
+}

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -1057,6 +1057,11 @@ impl SchemaVariant {
         self.asset_func_id
     }
 
+    pub fn asset_func_id_or_error(&self) -> SchemaVariantResult<FuncId> {
+        self.asset_func_id
+            .ok_or(SchemaVariantError::MissingAssetFuncId(self.id))
+    }
+
     pub fn is_builtin(&self) -> bool {
         self.is_builtin
     }
@@ -1079,10 +1084,7 @@ impl SchemaVariant {
     }
 
     pub async fn get_asset_func(&self, ctx: &DalContext) -> SchemaVariantResult<Func> {
-        let asset_func_id = self
-            .asset_func_id
-            .ok_or(SchemaVariantError::MissingAssetFuncId(self.id))?;
-
+        let asset_func_id = self.asset_func_id_or_error()?;
         Ok(Func::get_by_id_or_error(ctx, asset_func_id).await?)
     }
 

--- a/lib/sdf-server/BUCK
+++ b/lib/sdf-server/BUCK
@@ -3,6 +3,7 @@ load("@prelude-si//:macros.bzl", "rust_library")
 rust_library(
     name = "sdf-server",
     deps = [
+        "//lib/asset-sprayer:asset-sprayer",
         "//lib/buck2-resources:buck2-resources",
         "//lib/dal:dal",
         "//lib/module-index-client:module-index-client",
@@ -25,6 +26,7 @@ rust_library(
         "//lib/telemetry-http-rs:telemetry-http",
         "//lib/telemetry-rs:telemetry",
         "//lib/veritech-client:veritech-client",
+        "//third-party/rust:async-openai",
         "//third-party/rust:async-trait",
         "//third-party/rust:axum",
         "//third-party/rust:base64",
@@ -32,6 +34,7 @@ rust_library(
         "//third-party/rust:clap",
         "//third-party/rust:convert_case",
         "//third-party/rust:derive_builder",
+        "//third-party/rust:derive_more",
         "//third-party/rust:futures",
         "//third-party/rust:futures-lite",
         "//third-party/rust:hyper",
@@ -97,7 +100,7 @@ rust_test(
     ],
     crate_root = "tests/api.rs",
     srcs = glob([
-       "tests/**/*.rs",
+        "tests/**/*.rs",
     ]),
     env = {
         "CARGO_PKG_NAME": "api",

--- a/lib/sdf-server/Cargo.toml
+++ b/lib/sdf-server/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
+asset-sprayer = { path = "../../lib/asset-sprayer" }
 buck2-resources = { path = "../../lib/buck2-resources" }
 dal = { path = "../../lib/dal" }
 module-index-client = { path = "../../lib/module-index-client" }
@@ -32,6 +33,7 @@ telemetry = { path = "../../lib/telemetry-rs" }
 telemetry-http = { path = "../../lib/telemetry-http-rs" }
 veritech-client = { path = "../../lib/veritech-client" }
 
+async-openai = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 base64 = { workspace = true }
@@ -39,6 +41,7 @@ chrono = { workspace = true }
 clap = { workspace = true }
 convert_case = { workspace = true }
 derive_builder = { workspace = true }
+derive_more = { workspace = true }
 futures = { workspace = true }
 futures-lite = { workspace = true }
 hyper = { workspace = true }

--- a/lib/sdf-server/src/app.rs
+++ b/lib/sdf-server/src/app.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use asset_sprayer::AssetSprayer;
 use axum::Router;
 use dal::{JwtPublicSigningKey, ServicesContext};
 use nats_multiplexer_client::MultiplexerClient;
@@ -26,6 +27,7 @@ impl AxumApp {
         jwt_public_signing_key: JwtPublicSigningKey,
         posthog_client: PosthogClient,
         auth_api_url: impl AsRef<str>,
+        asset_sprayer: Option<AssetSprayer>,
         ws_multiplexer_client: MultiplexerClient,
         crdt_multiplexer_client: MultiplexerClient,
         create_workspace_permissions: WorkspacePermissionsMode,
@@ -39,6 +41,7 @@ impl AxumApp {
             jwt_public_signing_key,
             posthog_client,
             auth_api_url,
+            asset_sprayer,
             false,
             ws_multiplexer_client,
             crdt_multiplexer_client,
@@ -62,6 +65,7 @@ impl AxumApp {
         jwt_public_signing_key: JwtPublicSigningKey,
         posthog_client: PosthogClient,
         auth_api_url: impl AsRef<str>,
+        asset_sprayer: Option<AssetSprayer>,
         ws_multiplexer_client: MultiplexerClient,
         crdt_multiplexer_client: MultiplexerClient,
         create_workspace_permissions: WorkspacePermissionsMode,
@@ -75,6 +79,7 @@ impl AxumApp {
             jwt_public_signing_key,
             posthog_client,
             auth_api_url,
+            asset_sprayer,
             true,
             ws_multiplexer_client,
             crdt_multiplexer_client,
@@ -96,6 +101,7 @@ impl AxumApp {
         jwt_public_signing_key: JwtPublicSigningKey,
         posthog_client: PosthogClient,
         auth_api_url: impl AsRef<str>,
+        asset_sprayer: Option<AssetSprayer>,
         for_tests: bool,
         ws_multiplexer_client: MultiplexerClient,
         crdt_multiplexer_client: MultiplexerClient,
@@ -110,6 +116,7 @@ impl AxumApp {
             jwt_public_signing_key,
             posthog_client,
             auth_api_url,
+            asset_sprayer,
             for_tests,
             ws_multiplexer_client,
             crdt_multiplexer_client,

--- a/lib/sdf-server/src/app_state.rs
+++ b/lib/sdf-server/src/app_state.rs
@@ -1,5 +1,6 @@
 use std::{ops::Deref, sync::Arc};
 
+use asset_sprayer::AssetSprayer;
 use axum::extract::FromRef;
 use dal::JwtPublicSigningKey;
 use nats_multiplexer_client::MultiplexerClient;
@@ -27,6 +28,7 @@ pub struct AppState {
     jwt_public_signing_key: JwtPublicSigningKey,
     posthog_client: PosthogClient,
     auth_api_url: String, // TODO(victor) store the auth client on state instead of just the URL
+    asset_sprayer: Option<AssetSprayer>,
     for_tests: bool,
     nats_multiplexer_clients: NatsMultiplexerClients,
     create_workspace_permissions: WorkspacePermissionsMode,
@@ -43,6 +45,7 @@ impl AppState {
         jwt_public_signing_key: impl Into<JwtPublicSigningKey>,
         posthog_client: impl Into<PosthogClient>,
         auth_api_url: impl AsRef<str>,
+        asset_sprayer: Option<AssetSprayer>,
         for_tests: bool,
         ws_multiplexer_client: MultiplexerClient,
         crdt_multiplexer_client: MultiplexerClient,
@@ -57,13 +60,13 @@ impl AppState {
             crdt: Arc::new(Mutex::new(crdt_multiplexer_client)),
         };
 
-        let auth_api_url = auth_api_url.as_ref().to_string();
         Self {
             services_context: services_context.into(),
             jwt_public_signing_key: jwt_public_signing_key.into(),
             broadcast_groups: Default::default(),
             posthog_client: posthog_client.into(),
-            auth_api_url,
+            auth_api_url: auth_api_url.as_ref().to_string(),
+            asset_sprayer,
             for_tests,
             nats_multiplexer_clients,
             create_workspace_permissions,
@@ -84,6 +87,10 @@ impl AppState {
 
     pub fn auth_api_url(&self) -> &String {
         &self.auth_api_url
+    }
+
+    pub fn asset_sprayer(&self) -> Option<&AssetSprayer> {
+        self.asset_sprayer.as_ref()
     }
 
     pub fn jwt_public_signing_key(&self) -> &JwtPublicSigningKey {

--- a/lib/sdf-server/src/service/v2/variant/generate_aws_asset_schema.rs
+++ b/lib/sdf-server/src/service/v2/variant/generate_aws_asset_schema.rs
@@ -1,0 +1,94 @@
+use axum::extract::{Host, OriginalUri, Path, Query};
+use dal::{
+    schema::variant::authoring::VariantAuthoringClient, ChangeSet, ChangeSetId, SchemaVariant,
+    SchemaVariantId, WorkspacePk, WsEvent,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    extract::{AccessBuilder, AssetSprayer, HandlerContext, PosthogClient},
+    service::force_change_set_response::ForceChangeSetResponse,
+    track,
+};
+
+use super::SchemaVariantsAPIResult;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct AwsCommand {
+    pub command: String,
+    pub subcommand: String,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn generate_aws_asset_schema(
+    HandlerContext(builder): HandlerContext,
+    AssetSprayer(asset_sprayer): AssetSprayer,
+    AccessBuilder(access_builder): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Host(host_name): Host,
+    Path((_workspace_pk, change_set_id, schema_variant_id)): Path<(
+        WorkspacePk,
+        ChangeSetId,
+        SchemaVariantId,
+    )>,
+    Query(aws_command): Query<AwsCommand>,
+) -> SchemaVariantsAPIResult<ForceChangeSetResponse<()>> {
+    let mut ctx = builder
+        .build(access_builder.build(change_set_id.into()))
+        .await?;
+    let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
+
+    // Generate the code
+    let code = asset_sprayer
+        .aws_asset_schema(&aws_command.command, &aws_command.subcommand)
+        .await?;
+
+    // Update the function
+    let schema_variant = SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
+    let schema_id = SchemaVariant::schema_id_for_schema_variant_id(&ctx, schema_variant_id).await?;
+    let variant = schema_variant.into_frontend_type(&ctx, schema_id).await?;
+
+    VariantAuthoringClient::save_variant_content(
+        &ctx,
+        schema_variant_id,
+        &variant.schema_name,
+        variant.display_name.clone(),
+        variant.category.clone(),
+        variant.description.clone(),
+        variant.link.clone(),
+        variant.color.clone(),
+        variant.component_type.into(),
+        Some(code),
+    )
+    .await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        &host_name,
+        "generate_aws_asset_schema",
+        serde_json::json!({
+            "variant_id": schema_variant_id,
+            "variant_category": variant.category.clone(),
+            "variant_name": variant.schema_name.clone(),
+            "variant_display_name": variant.display_name.clone(),
+            "asset_func_id": variant.asset_func_id,
+        }),
+    );
+
+    WsEvent::schema_variant_updated(
+        &ctx,
+        schema_id,
+        SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?,
+    )
+    .await?
+    .publish_on_commit(&ctx)
+    .await?;
+
+    ctx.commit().await?;
+
+    Ok(ForceChangeSetResponse::empty(force_change_set_id))
+}

--- a/lib/si-test-macros/src/sdf_test.rs
+++ b/lib/si-test-macros/src/sdf_test.rs
@@ -381,6 +381,7 @@ impl SdfTestFnSetupExpander {
                     #jwt_public_signing_key.clone(),
                     #posthog_client,
                     "https://auth-api.systeminit.com".to_string(),
+                    None,
                     #ws_multiplexer_client,
                     #crdt_multiplexer_client,
                     ::sdf_server::WorkspacePermissionsMode::Open,

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -198,6 +198,8 @@ import Func from "./custom-icons/func.svg?raw";
 import FrameUp from "./custom-icons/frameup.svg?raw";
 import FrameDown from "./custom-icons/framedown.svg?raw";
 
+import Sparkles from "~icons/heroicons/sparkles-solid";
+
 // restricting the type here (Record<string, FunctionalComponent>) kills our IconName type below
 /* eslint sort-keys: "error" */
 export const ICONS = Object.freeze({
@@ -325,6 +327,7 @@ export const ICONS = Object.freeze({
   "sliders-vertical": SlidersVertical,
   socket: Socket,
   spacebar: MaterialSymbolsSpaceBarRounded,
+  sparkles: Sparkles,
   star: Star,
   starOutline: StarOutline,
   sun: Sun,

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -352,18 +352,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "anstream-0.6.15.crate",
-    sha256 = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526",
-    strip_prefix = "anstream-0.6.15",
-    urls = ["https://static.crates.io/crates/anstream/0.6.15/download"],
+    name = "anstream-0.6.17.crate",
+    sha256 = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338",
+    strip_prefix = "anstream-0.6.17",
+    urls = ["https://static.crates.io/crates/anstream/0.6.17/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "anstream-0.6.15",
-    srcs = [":anstream-0.6.15.crate"],
+    name = "anstream-0.6.17",
+    srcs = [":anstream-0.6.17.crate"],
     crate = "anstream",
-    crate_root = "anstream-0.6.15.crate/src/lib.rs",
+    crate_root = "anstream-0.6.17.crate/src/lib.rs",
     edition = "2021",
     features = [
         "auto",
@@ -372,36 +372,36 @@ cargo.rust_library(
     ],
     platform = {
         "windows-gnu": dict(
-            deps = [":anstyle-wincon-3.0.4"],
+            deps = [":anstyle-wincon-3.0.6"],
         ),
         "windows-msvc": dict(
-            deps = [":anstyle-wincon-3.0.4"],
+            deps = [":anstyle-wincon-3.0.6"],
         ),
     },
     visibility = [],
     deps = [
-        ":anstyle-1.0.8",
-        ":anstyle-parse-0.2.5",
-        ":anstyle-query-1.1.1",
-        ":colorchoice-1.0.2",
+        ":anstyle-1.0.9",
+        ":anstyle-parse-0.2.6",
+        ":anstyle-query-1.1.2",
+        ":colorchoice-1.0.3",
         ":is_terminal_polyfill-1.70.1",
         ":utf8parse-0.2.2",
     ],
 )
 
 http_archive(
-    name = "anstyle-1.0.8.crate",
-    sha256 = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1",
-    strip_prefix = "anstyle-1.0.8",
-    urls = ["https://static.crates.io/crates/anstyle/1.0.8/download"],
+    name = "anstyle-1.0.9.crate",
+    sha256 = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56",
+    strip_prefix = "anstyle-1.0.9",
+    urls = ["https://static.crates.io/crates/anstyle/1.0.9/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "anstyle-1.0.8",
-    srcs = [":anstyle-1.0.8.crate"],
+    name = "anstyle-1.0.9",
+    srcs = [":anstyle-1.0.9.crate"],
     crate = "anstyle",
-    crate_root = "anstyle-1.0.8.crate/src/lib.rs",
+    crate_root = "anstyle-1.0.9.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -411,18 +411,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "anstyle-parse-0.2.5.crate",
-    sha256 = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb",
-    strip_prefix = "anstyle-parse-0.2.5",
-    urls = ["https://static.crates.io/crates/anstyle-parse/0.2.5/download"],
+    name = "anstyle-parse-0.2.6.crate",
+    sha256 = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9",
+    strip_prefix = "anstyle-parse-0.2.6",
+    urls = ["https://static.crates.io/crates/anstyle-parse/0.2.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "anstyle-parse-0.2.5",
-    srcs = [":anstyle-parse-0.2.5.crate"],
+    name = "anstyle-parse-0.2.6",
+    srcs = [":anstyle-parse-0.2.6.crate"],
     crate = "anstyle_parse",
-    crate_root = "anstyle-parse-0.2.5.crate/src/lib.rs",
+    crate_root = "anstyle-parse-0.2.6.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -433,69 +433,69 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "anstyle-query-1.1.1.crate",
-    sha256 = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a",
-    strip_prefix = "anstyle-query-1.1.1",
-    urls = ["https://static.crates.io/crates/anstyle-query/1.1.1/download"],
+    name = "anstyle-query-1.1.2.crate",
+    sha256 = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c",
+    strip_prefix = "anstyle-query-1.1.2",
+    urls = ["https://static.crates.io/crates/anstyle-query/1.1.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "anstyle-query-1.1.1",
-    srcs = [":anstyle-query-1.1.1.crate"],
+    name = "anstyle-query-1.1.2",
+    srcs = [":anstyle-query-1.1.2.crate"],
     crate = "anstyle_query",
-    crate_root = "anstyle-query-1.1.1.crate/src/lib.rs",
+    crate_root = "anstyle-query-1.1.2.crate/src/lib.rs",
     edition = "2021",
     platform = {
         "windows-gnu": dict(
-            deps = [":windows-sys-0.52.0"],
+            deps = [":windows-sys-0.59.0"],
         ),
         "windows-msvc": dict(
-            deps = [":windows-sys-0.52.0"],
+            deps = [":windows-sys-0.59.0"],
         ),
     },
     visibility = [],
 )
 
 http_archive(
-    name = "anstyle-wincon-3.0.4.crate",
-    sha256 = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8",
-    strip_prefix = "anstyle-wincon-3.0.4",
-    urls = ["https://static.crates.io/crates/anstyle-wincon/3.0.4/download"],
+    name = "anstyle-wincon-3.0.6.crate",
+    sha256 = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125",
+    strip_prefix = "anstyle-wincon-3.0.6",
+    urls = ["https://static.crates.io/crates/anstyle-wincon/3.0.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "anstyle-wincon-3.0.4",
-    srcs = [":anstyle-wincon-3.0.4.crate"],
+    name = "anstyle-wincon-3.0.6",
+    srcs = [":anstyle-wincon-3.0.6.crate"],
     crate = "anstyle_wincon",
-    crate_root = "anstyle-wincon-3.0.4.crate/src/lib.rs",
+    crate_root = "anstyle-wincon-3.0.6.crate/src/lib.rs",
     edition = "2021",
     platform = {
         "windows-gnu": dict(
-            deps = [":windows-sys-0.52.0"],
+            deps = [":windows-sys-0.59.0"],
         ),
         "windows-msvc": dict(
-            deps = [":windows-sys-0.52.0"],
+            deps = [":windows-sys-0.59.0"],
         ),
     },
     visibility = [],
-    deps = [":anstyle-1.0.8"],
+    deps = [":anstyle-1.0.9"],
 )
 
 http_archive(
-    name = "anyhow-1.0.90.crate",
-    sha256 = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95",
-    strip_prefix = "anyhow-1.0.90",
-    urls = ["https://static.crates.io/crates/anyhow/1.0.90/download"],
+    name = "anyhow-1.0.91.crate",
+    sha256 = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8",
+    strip_prefix = "anyhow-1.0.91",
+    urls = ["https://static.crates.io/crates/anyhow/1.0.91/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "anyhow-1.0.90",
-    srcs = [":anyhow-1.0.90.crate"],
+    name = "anyhow-1.0.91",
+    srcs = [":anyhow-1.0.91.crate"],
     crate = "anyhow",
-    crate_root = "anyhow-1.0.90.crate/src/lib.rs",
+    crate_root = "anyhow-1.0.91.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -583,9 +583,27 @@ cargo.rust_library(
         ":flate2-1.0.34",
         ":futures-core-0.3.31",
         ":memchr-2.7.4",
-        ":pin-project-lite-0.2.14",
-        ":tokio-1.40.0",
+        ":pin-project-lite-0.2.15",
+        ":tokio-1.41.0",
     ],
+)
+
+http_archive(
+    name = "async-convert-1.0.0.crate",
+    sha256 = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae",
+    strip_prefix = "async-convert-1.0.0",
+    urls = ["https://static.crates.io/crates/async-convert/1.0.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "async-convert-1.0.0",
+    srcs = [":async-convert-1.0.0.crate"],
+    crate = "async_convert",
+    crate_root = "async-convert-1.0.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [":async-trait-0.1.83"],
 )
 
 http_archive(
@@ -610,7 +628,7 @@ cargo.rust_library(
     deps = [
         ":event-listener-5.3.1",
         ":event-listener-strategy-0.5.2",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
     ],
 )
 
@@ -654,7 +672,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":base64-0.22.1",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":futures-0.3.31",
         ":memchr-2.7.4",
         ":nkeys-0.4.4",
@@ -662,23 +680,70 @@ cargo.rust_library(
         ":once_cell-1.20.2",
         ":portable-atomic-1.9.0",
         ":rand-0.8.5",
-        ":regex-1.11.0",
+        ":regex-1.11.1",
         ":ring-0.17.5",
         ":rustls-native-certs-0.7.3",
         ":rustls-pemfile-2.2.0",
         ":rustls-webpki-0.102.8",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
         ":serde_nanos-0.1.4",
         ":serde_repr-0.1.19",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":time-0.3.36",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-rustls-0.26.0",
         ":tokio-util-0.7.12",
         ":tracing-0.1.40",
         ":tryhard-0.5.1",
         ":url-2.5.2",
+    ],
+)
+
+alias(
+    name = "async-openai",
+    actual = ":async-openai-0.25.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "async-openai-0.25.0.crate",
+    sha256 = "1b17e44510f88a904cb3102a020d7ea11929dcddadfaff756e71112cb2cb7bd0",
+    strip_prefix = "async-openai-0.25.0",
+    urls = ["https://static.crates.io/crates/async-openai/0.25.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "async-openai-0.25.0",
+    srcs = [":async-openai-0.25.0.crate"],
+    crate = "async_openai",
+    crate_root = "async-openai-0.25.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "rustls",
+    ],
+    visibility = [],
+    deps = [
+        ":async-convert-1.0.0",
+        ":backoff-0.4.0",
+        ":base64-0.22.1",
+        ":bytes-1.8.0",
+        ":derive_builder-0.20.2",
+        ":eventsource-stream-0.2.3",
+        ":futures-0.3.31",
+        ":rand-0.8.5",
+        ":reqwest-0.12.8",
+        ":reqwest-eventsource-0.6.0",
+        ":secrecy-0.8.0",
+        ":serde-1.0.213",
+        ":serde_json-1.0.125",
+        ":thiserror-1.0.65",
+        ":tokio-1.41.0",
+        ":tokio-stream-0.1.16",
+        ":tokio-util-0.7.12",
+        ":tracing-0.1.40",
     ],
 )
 
@@ -705,9 +770,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -729,7 +794,7 @@ cargo.rust_library(
     deps = [
         ":async-stream-impl-0.3.6",
         ":futures-core-0.3.31",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
     ],
 )
 
@@ -750,9 +815,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -779,9 +844,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -884,7 +949,7 @@ cargo.rust_library(
     deps = [
         ":http-0.2.12",
         ":log-0.4.22",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
         ":url-2.5.2",
         ":webpki-roots-0.25.4",
@@ -910,34 +975,34 @@ cargo.rust_library(
 
 alias(
     name = "aws-config",
-    actual = ":aws-config-1.5.8",
+    actual = ":aws-config-1.5.9",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "aws-config-1.5.8.crate",
-    sha256 = "7198e6f03240fdceba36656d8be440297b6b82270325908c7381f37d826a74f6",
-    strip_prefix = "aws-config-1.5.8",
-    urls = ["https://static.crates.io/crates/aws-config/1.5.8/download"],
+    name = "aws-config-1.5.9.crate",
+    sha256 = "2d6448cfb224dd6a9b9ac734f58622dd0d4751f3589f3b777345745f46b2eb14",
+    strip_prefix = "aws-config-1.5.9",
+    urls = ["https://static.crates.io/crates/aws-config/1.5.9/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-config-1.5.8",
-    srcs = [":aws-config-1.5.8.crate"],
+    name = "aws-config-1.5.9",
+    srcs = [":aws-config-1.5.9.crate"],
     crate = "aws_config",
-    crate_root = "aws-config-1.5.8.crate/src/lib.rs",
+    crate_root = "aws-config-1.5.9.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-config-1.5.8.crate",
+        "CARGO_MANIFEST_DIR": "aws-config-1.5.9.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK config and credential provider implementations.",
         "CARGO_PKG_NAME": "aws-config",
         "CARGO_PKG_REPOSITORY": "https://github.com/smithy-lang/smithy-rs",
-        "CARGO_PKG_VERSION": "1.5.8",
+        "CARGO_PKG_VERSION": "1.5.9",
         "CARGO_PKG_VERSION_MAJOR": "1",
         "CARGO_PKG_VERSION_MINOR": "5",
-        "CARGO_PKG_VERSION_PATCH": "8",
+        "CARGO_PKG_VERSION_PATCH": "9",
     },
     features = [
         "behavior-version-latest",
@@ -952,23 +1017,23 @@ cargo.rust_library(
     deps = [
         ":aws-credential-types-1.2.1",
         ":aws-runtime-1.4.3",
-        ":aws-sdk-sso-1.46.0",
-        ":aws-sdk-ssooidc-1.47.0",
-        ":aws-sdk-sts-1.46.0",
+        ":aws-sdk-sso-1.47.0",
+        ":aws-sdk-ssooidc-1.48.0",
+        ":aws-sdk-sts-1.47.0",
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-json-0.60.7",
-        ":aws-smithy-runtime-1.7.2",
+        ":aws-smithy-runtime-1.7.3",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.7",
+        ":aws-smithy-types-1.2.8",
         ":aws-types-1.3.3",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":fastrand-2.1.1",
         ":hex-0.4.3",
         ":http-0.2.12",
         ":ring-0.17.5",
         ":time-0.3.36",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tracing-0.1.40",
         ":url-2.5.2",
         ":zeroize-1.8.1",
@@ -994,7 +1059,7 @@ cargo.rust_library(
     deps = [
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.7",
+        ":aws-smithy-types-1.2.8",
         ":zeroize-1.8.1",
     ],
 )
@@ -1017,8 +1082,8 @@ cargo.rust_library(
         ":log-0.4.22",
         ":quick-xml-0.30.0",
         ":rust-ini-0.19.0",
-        ":serde-1.0.210",
-        ":thiserror-1.0.64",
+        ":serde-1.0.213",
+        ":thiserror-1.0.65",
         ":time-0.3.36",
         ":url-2.5.2",
     ],
@@ -1031,7 +1096,7 @@ cargo.rust_library(
     crate_root = "rust-s3-61c54947c717d042/aws-region/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":thiserror-1.0.64"],
+    deps = [":thiserror-1.0.65"],
 )
 
 http_archive(
@@ -1055,18 +1120,18 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":aws-credential-types-1.2.1",
-        ":aws-sigv4-1.2.4",
+        ":aws-sigv4-1.2.5",
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-http-0.60.11",
-        ":aws-smithy-runtime-1.7.2",
+        ":aws-smithy-runtime-1.7.3",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.7",
+        ":aws-smithy-types-1.2.8",
         ":aws-types-1.3.3",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":fastrand-2.1.1",
         ":once_cell-1.20.2",
         ":percent-encoding-2.3.1",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
         ":tracing-0.1.40",
         ":uuid-1.11.0",
     ],
@@ -1074,33 +1139,33 @@ cargo.rust_library(
 
 alias(
     name = "aws-sdk-firehose",
-    actual = ":aws-sdk-firehose-1.51.0",
+    actual = ":aws-sdk-firehose-1.52.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "aws-sdk-firehose-1.51.0.crate",
-    sha256 = "05f36d00e1ac8e25c61443968be1e933ced6b9675c4a8022c98e0dd5dc363130",
-    strip_prefix = "aws-sdk-firehose-1.51.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-firehose/1.51.0/download"],
+    name = "aws-sdk-firehose-1.52.0.crate",
+    sha256 = "0c542b9b13d39838355ba85b037135dc19eba2d3f59e4dd7642f09681b662d96",
+    strip_prefix = "aws-sdk-firehose-1.52.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-firehose/1.52.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-firehose-1.51.0",
-    srcs = [":aws-sdk-firehose-1.51.0.crate"],
+    name = "aws-sdk-firehose-1.52.0",
+    srcs = [":aws-sdk-firehose-1.52.0.crate"],
     crate = "aws_sdk_firehose",
-    crate_root = "aws-sdk-firehose-1.51.0.crate/src/lib.rs",
+    crate_root = "aws-sdk-firehose-1.52.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-firehose-1.51.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-firehose-1.52.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for Amazon Kinesis Firehose",
         "CARGO_PKG_NAME": "aws-sdk-firehose",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.51.0",
+        "CARGO_PKG_VERSION": "1.52.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "51",
+        "CARGO_PKG_VERSION_MINOR": "52",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     features = [
@@ -1115,11 +1180,11 @@ cargo.rust_library(
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-json-0.60.7",
-        ":aws-smithy-runtime-1.7.2",
+        ":aws-smithy-runtime-1.7.3",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.7",
+        ":aws-smithy-types-1.2.8",
         ":aws-types-1.3.3",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":http-0.2.12",
         ":once_cell-1.20.2",
         ":regex-lite-0.1.6",
@@ -1128,68 +1193,24 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "aws-sdk-sso-1.46.0.crate",
-    sha256 = "0dc2faec3205d496c7e57eff685dd944203df7ce16a4116d0281c44021788a7b",
-    strip_prefix = "aws-sdk-sso-1.46.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-sso/1.46.0/download"],
+    name = "aws-sdk-sso-1.47.0.crate",
+    sha256 = "a8776850becacbd3a82a4737a9375ddb5c6832a51379f24443a98e61513f852c",
+    strip_prefix = "aws-sdk-sso-1.47.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-sso/1.47.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-sso-1.46.0",
-    srcs = [":aws-sdk-sso-1.46.0.crate"],
+    name = "aws-sdk-sso-1.47.0",
+    srcs = [":aws-sdk-sso-1.47.0.crate"],
     crate = "aws_sdk_sso",
-    crate_root = "aws-sdk-sso-1.46.0.crate/src/lib.rs",
+    crate_root = "aws-sdk-sso-1.47.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-sso-1.46.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-sso-1.47.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS Single Sign-On",
         "CARGO_PKG_NAME": "aws-sdk-sso",
-        "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.46.0",
-        "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "46",
-        "CARGO_PKG_VERSION_PATCH": "0",
-    },
-    visibility = [],
-    deps = [
-        ":aws-credential-types-1.2.1",
-        ":aws-runtime-1.4.3",
-        ":aws-smithy-async-1.2.1",
-        ":aws-smithy-http-0.60.11",
-        ":aws-smithy-json-0.60.7",
-        ":aws-smithy-runtime-1.7.2",
-        ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.7",
-        ":aws-types-1.3.3",
-        ":bytes-1.7.2",
-        ":http-0.2.12",
-        ":once_cell-1.20.2",
-        ":regex-lite-0.1.6",
-        ":tracing-0.1.40",
-    ],
-)
-
-http_archive(
-    name = "aws-sdk-ssooidc-1.47.0.crate",
-    sha256 = "c93c241f52bc5e0476e259c953234dab7e2a35ee207ee202e86c0095ec4951dc",
-    strip_prefix = "aws-sdk-ssooidc-1.47.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-ssooidc/1.47.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "aws-sdk-ssooidc-1.47.0",
-    srcs = [":aws-sdk-ssooidc-1.47.0.crate"],
-    crate = "aws_sdk_ssooidc",
-    crate_root = "aws-sdk-ssooidc-1.47.0.crate/src/lib.rs",
-    edition = "2021",
-    env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-ssooidc-1.47.0.crate",
-        "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
-        "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS SSO OIDC",
-        "CARGO_PKG_NAME": "aws-sdk-ssooidc",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
         "CARGO_PKG_VERSION": "1.47.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
@@ -1203,11 +1224,11 @@ cargo.rust_library(
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-json-0.60.7",
-        ":aws-smithy-runtime-1.7.2",
+        ":aws-smithy-runtime-1.7.3",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.7",
+        ":aws-smithy-types-1.2.8",
         ":aws-types-1.3.3",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":http-0.2.12",
         ":once_cell-1.20.2",
         ":regex-lite-0.1.6",
@@ -1216,28 +1237,72 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "aws-sdk-sts-1.46.0.crate",
-    sha256 = "b259429be94a3459fa1b00c5684faee118d74f9577cc50aebadc36e507c63b5f",
-    strip_prefix = "aws-sdk-sts-1.46.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-sts/1.46.0/download"],
+    name = "aws-sdk-ssooidc-1.48.0.crate",
+    sha256 = "0007b5b8004547133319b6c4e87193eee2a0bcb3e4c18c75d09febe9dab7b383",
+    strip_prefix = "aws-sdk-ssooidc-1.48.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-ssooidc/1.48.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-sts-1.46.0",
-    srcs = [":aws-sdk-sts-1.46.0.crate"],
-    crate = "aws_sdk_sts",
-    crate_root = "aws-sdk-sts-1.46.0.crate/src/lib.rs",
+    name = "aws-sdk-ssooidc-1.48.0",
+    srcs = [":aws-sdk-ssooidc-1.48.0.crate"],
+    crate = "aws_sdk_ssooidc",
+    crate_root = "aws-sdk-ssooidc-1.48.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-sts-1.46.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-ssooidc-1.48.0.crate",
+        "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
+        "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS SSO OIDC",
+        "CARGO_PKG_NAME": "aws-sdk-ssooidc",
+        "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
+        "CARGO_PKG_VERSION": "1.48.0",
+        "CARGO_PKG_VERSION_MAJOR": "1",
+        "CARGO_PKG_VERSION_MINOR": "48",
+        "CARGO_PKG_VERSION_PATCH": "0",
+    },
+    visibility = [],
+    deps = [
+        ":aws-credential-types-1.2.1",
+        ":aws-runtime-1.4.3",
+        ":aws-smithy-async-1.2.1",
+        ":aws-smithy-http-0.60.11",
+        ":aws-smithy-json-0.60.7",
+        ":aws-smithy-runtime-1.7.3",
+        ":aws-smithy-runtime-api-1.7.2",
+        ":aws-smithy-types-1.2.8",
+        ":aws-types-1.3.3",
+        ":bytes-1.8.0",
+        ":http-0.2.12",
+        ":once_cell-1.20.2",
+        ":regex-lite-0.1.6",
+        ":tracing-0.1.40",
+    ],
+)
+
+http_archive(
+    name = "aws-sdk-sts-1.47.0.crate",
+    sha256 = "9fffaa356e7f1c725908b75136d53207fa714e348f365671df14e95a60530ad3",
+    strip_prefix = "aws-sdk-sts-1.47.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-sts/1.47.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-sdk-sts-1.47.0",
+    srcs = [":aws-sdk-sts-1.47.0.crate"],
+    crate = "aws_sdk_sts",
+    crate_root = "aws-sdk-sts-1.47.0.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "CARGO_MANIFEST_DIR": "aws-sdk-sts-1.47.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS Security Token Service",
         "CARGO_PKG_NAME": "aws-sdk-sts",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.46.0",
+        "CARGO_PKG_VERSION": "1.47.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "46",
+        "CARGO_PKG_VERSION_MINOR": "47",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     visibility = [],
@@ -1248,9 +1313,9 @@ cargo.rust_library(
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-json-0.60.7",
         ":aws-smithy-query-0.60.7",
-        ":aws-smithy-runtime-1.7.2",
+        ":aws-smithy-runtime-1.7.3",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.7",
+        ":aws-smithy-types-1.2.8",
         ":aws-smithy-xml-0.60.9",
         ":aws-types-1.3.3",
         ":http-0.2.12",
@@ -1261,18 +1326,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "aws-sigv4-1.2.4.crate",
-    sha256 = "cc8db6904450bafe7473c6ca9123f88cc11089e41a025408f992db4e22d3be68",
-    strip_prefix = "aws-sigv4-1.2.4",
-    urls = ["https://static.crates.io/crates/aws-sigv4/1.2.4/download"],
+    name = "aws-sigv4-1.2.5.crate",
+    sha256 = "5619742a0d8f253be760bfbb8e8e8368c69e3587e4637af5754e488a611499b1",
+    strip_prefix = "aws-sigv4-1.2.5",
+    urls = ["https://static.crates.io/crates/aws-sigv4/1.2.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sigv4-1.2.4",
-    srcs = [":aws-sigv4-1.2.4.crate"],
+    name = "aws-sigv4-1.2.5",
+    srcs = [":aws-sigv4-1.2.5.crate"],
     crate = "aws_sigv4",
-    crate_root = "aws-sigv4-1.2.4.crate/src/lib.rs",
+    crate_root = "aws-sigv4-1.2.5.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -1288,8 +1353,8 @@ cargo.rust_library(
         ":aws-credential-types-1.2.1",
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.7",
-        ":bytes-1.7.2",
+        ":aws-smithy-types-1.2.8",
+        ":bytes-1.8.0",
         ":form_urlencoded-1.2.1",
         ":hex-0.4.3",
         ":hmac-0.12.1",
@@ -1320,8 +1385,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":futures-util-0.3.31",
-        ":pin-project-lite-0.2.14",
-        ":tokio-1.40.0",
+        ":pin-project-lite-0.2.15",
+        ":tokio-1.41.0",
     ],
 )
 
@@ -1346,13 +1411,13 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.7",
-        ":bytes-1.7.2",
+        ":aws-smithy-types-1.2.8",
+        ":bytes-1.8.0",
         ":bytes-utils-0.1.4",
         ":futures-core-0.3.31",
         ":once_cell-1.20.2",
         ":percent-encoding-2.3.1",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
         ":pin-utils-0.1.0",
         ":tracing-0.1.40",
     ],
@@ -1373,7 +1438,7 @@ cargo.rust_library(
     crate_root = "aws-smithy-json-0.60.7.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":aws-smithy-types-1.2.7"],
+    deps = [":aws-smithy-types-1.2.8"],
 )
 
 http_archive(
@@ -1392,24 +1457,24 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":aws-smithy-types-1.2.7",
+        ":aws-smithy-types-1.2.8",
         ":urlencoding-2.1.3",
     ],
 )
 
 http_archive(
-    name = "aws-smithy-runtime-1.7.2.crate",
-    sha256 = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db",
-    strip_prefix = "aws-smithy-runtime-1.7.2",
-    urls = ["https://static.crates.io/crates/aws-smithy-runtime/1.7.2/download"],
+    name = "aws-smithy-runtime-1.7.3.crate",
+    sha256 = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2",
+    strip_prefix = "aws-smithy-runtime-1.7.3",
+    urls = ["https://static.crates.io/crates/aws-smithy-runtime/1.7.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-smithy-runtime-1.7.2",
-    srcs = [":aws-smithy-runtime-1.7.2.crate"],
+    name = "aws-smithy-runtime-1.7.3",
+    srcs = [":aws-smithy-runtime-1.7.3.crate"],
     crate = "aws_smithy_runtime",
-    crate_root = "aws-smithy-runtime-1.7.2.crate/src/lib.rs",
+    crate_root = "aws-smithy-runtime-1.7.3.crate/src/lib.rs",
     edition = "2021",
     features = [
         "client",
@@ -1428,17 +1493,17 @@ cargo.rust_library(
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-http-0.60.11",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.7",
-        ":bytes-1.7.2",
+        ":aws-smithy-types-1.2.8",
+        ":bytes-1.8.0",
         ":fastrand-2.1.1",
         ":h2-0.3.26",
         ":httparse-1.9.5",
         ":hyper-rustls-0.24.2",
         ":once_cell-1.20.2",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
         ":pin-utils-0.1.0",
         ":rustls-0.21.12",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tracing-0.1.40",
     ],
 )
@@ -1472,28 +1537,28 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":aws-smithy-async-1.2.1",
-        ":aws-smithy-types-1.2.7",
-        ":bytes-1.7.2",
-        ":pin-project-lite-0.2.14",
-        ":tokio-1.40.0",
+        ":aws-smithy-types-1.2.8",
+        ":bytes-1.8.0",
+        ":pin-project-lite-0.2.15",
+        ":tokio-1.41.0",
         ":tracing-0.1.40",
         ":zeroize-1.8.1",
     ],
 )
 
 http_archive(
-    name = "aws-smithy-types-1.2.7.crate",
-    sha256 = "147100a7bea70fa20ef224a6bad700358305f5dc0f84649c53769761395b355b",
-    strip_prefix = "aws-smithy-types-1.2.7",
-    urls = ["https://static.crates.io/crates/aws-smithy-types/1.2.7/download"],
+    name = "aws-smithy-types-1.2.8.crate",
+    sha256 = "07c9cdc179e6afbf5d391ab08c85eac817b51c87e1892a5edb5f7bbdc64314b4",
+    strip_prefix = "aws-smithy-types-1.2.8",
+    urls = ["https://static.crates.io/crates/aws-smithy-types/1.2.8/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-smithy-types-1.2.7",
-    srcs = [":aws-smithy-types-1.2.7.crate"],
+    name = "aws-smithy-types-1.2.8",
+    srcs = [":aws-smithy-types-1.2.8.crate"],
     crate = "aws_smithy_types",
-    crate_root = "aws-smithy-types-1.2.7.crate/src/lib.rs",
+    crate_root = "aws-smithy-types-1.2.8.crate/src/lib.rs",
     edition = "2021",
     features = [
         "byte-stream-poll-next",
@@ -1510,18 +1575,18 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":base64-simd-0.8.0",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":bytes-utils-0.1.4",
         ":futures-core-0.3.31",
         ":http-0.2.12",
         ":http-body-util-0.1.2",
         ":itoa-1.0.11",
         ":num-integer-0.1.46",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
         ":pin-utils-0.1.0",
         ":ryu-1.0.18",
         ":time-0.3.36",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-util-0.7.12",
     ],
 )
@@ -1575,7 +1640,7 @@ cargo.rust_library(
         ":aws-credential-types-1.2.1",
         ":aws-smithy-async-1.2.1",
         ":aws-smithy-runtime-api-1.7.2",
-        ":aws-smithy-types-1.2.7",
+        ":aws-smithy-types-1.2.8",
         ":tracing-0.1.40",
     ],
 )
@@ -1649,7 +1714,7 @@ cargo.rust_library(
         ":axum-macros-0.3.8",
         ":base64-0.21.7",
         ":bitflags-1.3.2",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":futures-util-0.3.31",
         ":http-0.2.12",
         ":http-body-0.4.6",
@@ -1660,14 +1725,14 @@ cargo.rust_library(
         ":mime-0.3.17",
         ":multer-2.1.0",
         ":percent-encoding-2.3.1",
-        ":pin-project-lite-0.2.14",
-        ":serde-1.0.210",
+        ":pin-project-lite-0.2.15",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
         ":serde_path_to_error-0.1.16",
         ":serde_urlencoded-0.7.1",
         ":sha1-0.10.6",
         ":sync_wrapper-0.1.2",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-tungstenite-0.20.1",
         ":tower-0.4.13",
         ":tower-layer-0.3.3",
@@ -1692,7 +1757,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-trait-0.1.83",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":futures-util-0.3.31",
         ":http-0.2.12",
         ":http-body-0.4.6",
@@ -1721,9 +1786,44 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
+    ],
+)
+
+http_archive(
+    name = "backoff-0.4.0.crate",
+    sha256 = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1",
+    strip_prefix = "backoff-0.4.0",
+    urls = ["https://static.crates.io/crates/backoff/0.4.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "backoff-0.4.0",
+    srcs = [":backoff-0.4.0.crate"],
+    crate = "backoff",
+    crate_root = "backoff-0.4.0.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "futures",
+        "futures-core",
+        "pin-project-lite",
+        "tokio",
+        "tokio_1",
+    ],
+    named_deps = {
+        "tokio_1": ":tokio-1.41.0",
+    },
+    visibility = [],
+    deps = [
+        ":futures-core-0.3.31",
+        ":getrandom-0.2.15",
+        ":instant-0.1.13",
+        ":pin-project-lite-0.2.15",
+        ":rand-0.8.5",
     ],
 )
 
@@ -1945,7 +2045,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":smallvec-1.13.2",
     ],
 )
@@ -2008,12 +2108,12 @@ cargo.rust_library(
         ":lazy_static-1.5.0",
         ":lazycell-1.3.0",
         ":peeking_take_while-0.1.2",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":regex-1.11.0",
+        ":regex-1.11.1",
         ":rustc-hash-1.1.0",
         ":shlex-1.3.0",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -2100,7 +2200,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde-1.0.210"],
+    deps = [":serde-1.0.213"],
 )
 
 http_archive(
@@ -2396,7 +2496,7 @@ cargo.rust_library(
     deps = [
         ":base64-0.22.1",
         ":bollard-stubs-1.44.0-rc.2",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":futures-core-0.3.31",
         ":futures-util-0.3.31",
         ":hex-0.4.3",
@@ -2405,14 +2505,14 @@ cargo.rust_library(
         ":hyper-1.5.0",
         ":hyper-util-0.1.9",
         ":log-0.4.22",
-        ":pin-project-lite-0.2.14",
-        ":serde-1.0.210",
-        ":serde_derive-1.0.210",
+        ":pin-project-lite-0.2.15",
+        ":serde-1.0.213",
+        ":serde_derive-1.0.213",
         ":serde_json-1.0.125",
         ":serde_repr-0.1.19",
         ":serde_urlencoded-0.7.1",
-        ":thiserror-1.0.64",
-        ":tokio-1.40.0",
+        ":thiserror-1.0.65",
+        ":tokio-1.41.0",
         ":tokio-util-0.7.12",
         ":url-2.5.2",
     ],
@@ -2434,7 +2534,7 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_repr-0.1.19",
         ":serde_with-3.11.0",
     ],
@@ -2513,7 +2613,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":memchr-2.7.4",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -2561,23 +2661,23 @@ cargo.rust_library(
 
 alias(
     name = "bytes",
-    actual = ":bytes-1.7.2",
+    actual = ":bytes-1.8.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "bytes-1.7.2.crate",
-    sha256 = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3",
-    strip_prefix = "bytes-1.7.2",
-    urls = ["https://static.crates.io/crates/bytes/1.7.2/download"],
+    name = "bytes-1.8.0.crate",
+    sha256 = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da",
+    strip_prefix = "bytes-1.8.0",
+    urls = ["https://static.crates.io/crates/bytes/1.8.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "bytes-1.7.2",
-    srcs = [":bytes-1.7.2.crate"],
+    name = "bytes-1.8.0",
+    srcs = [":bytes-1.8.0.crate"],
     crate = "bytes",
-    crate_root = "bytes-1.7.2.crate/src/lib.rs",
+    crate_root = "bytes-1.8.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -2585,7 +2685,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde-1.0.210"],
+    deps = [":serde-1.0.213"],
 )
 
 http_archive(
@@ -2608,7 +2708,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":either-1.13.0",
     ],
 )
@@ -2662,15 +2762,15 @@ cargo.rust_library(
         ":memmap2-0.5.10",
         ":miette-5.10.0",
         ":reflink-copy-0.1.19",
-        ":serde-1.0.210",
-        ":serde_derive-1.0.210",
+        ":serde-1.0.213",
+        ":serde_derive-1.0.213",
         ":serde_json-1.0.125",
         ":sha1-0.10.6",
         ":sha2-0.10.8",
         ":ssri-9.2.0",
         ":tempfile-3.13.0",
-        ":thiserror-1.0.64",
-        ":tokio-1.40.0",
+        ":thiserror-1.0.65",
+        ":tokio-1.41.0",
         ":tokio-stream-0.1.16",
         ":walkdir-2.5.0",
     ],
@@ -2805,7 +2905,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":num-traits-0.2.19",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -2837,7 +2937,7 @@ cargo.rust_library(
     deps = [
         ":ciborium-io-0.2.2",
         ":ciborium-ll-0.2.2",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -3046,8 +3146,8 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":anstream-0.6.15",
-        ":anstyle-1.0.8",
+        ":anstream-0.6.17",
+        ":anstyle-1.0.9",
         ":clap_lex-0.7.2",
         ":strsim-0.11.1",
         ":terminal_size-0.4.0",
@@ -3073,9 +3173,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.5.0",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -3213,18 +3313,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "colorchoice-1.0.2.crate",
-    sha256 = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0",
-    strip_prefix = "colorchoice-1.0.2",
-    urls = ["https://static.crates.io/crates/colorchoice/1.0.2/download"],
+    name = "colorchoice-1.0.3.crate",
+    sha256 = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990",
+    strip_prefix = "colorchoice-1.0.3",
+    urls = ["https://static.crates.io/crates/colorchoice/1.0.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "colorchoice-1.0.2",
-    srcs = [":colorchoice-1.0.2.crate"],
+    name = "colorchoice-1.0.3",
+    srcs = [":colorchoice-1.0.3.crate"],
     crate = "colorchoice",
-    crate_root = "colorchoice-1.0.2.crate/src/lib.rs",
+    crate_root = "colorchoice-1.0.3.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
 )
@@ -3340,31 +3440,30 @@ cargo.rust_library(
 
 alias(
     name = "config",
-    actual = ":config-0.14.0",
+    actual = ":config-0.14.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "config-0.14.0.crate",
-    sha256 = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be",
-    strip_prefix = "config-0.14.0",
-    urls = ["https://static.crates.io/crates/config/0.14.0/download"],
+    name = "config-0.14.1.crate",
+    sha256 = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf",
+    strip_prefix = "config-0.14.1",
+    urls = ["https://static.crates.io/crates/config/0.14.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "config-0.14.0",
-    srcs = [":config-0.14.0.crate"],
+    name = "config-0.14.1",
+    srcs = [":config-0.14.1.crate"],
     crate = "config",
-    crate_root = "config-0.14.0.crate/src/lib.rs",
+    crate_root = "config-0.14.1.crate/src/lib.rs",
     edition = "2018",
     features = ["toml"],
     visibility = [],
     deps = [
-        ":lazy_static-1.5.0",
         ":nom-7.1.3",
         ":pathdiff-0.2.2",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":toml-0.8.19",
     ],
 )
@@ -3533,12 +3632,12 @@ cargo.rust_library(
         ":log-0.4.22",
         ":mime-0.3.17",
         ":paste-1.0.15",
-        ":pin-project-1.1.6",
-        ":serde-1.0.210",
+        ":pin-project-1.1.7",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
         ":tar-0.4.42",
-        ":thiserror-1.0.64",
-        ":tokio-1.40.0",
+        ":thiserror-1.0.65",
+        ":tokio-1.41.0",
         ":url-2.5.2",
     ],
 )
@@ -3768,12 +3867,12 @@ cargo.rust_library(
         ":oorandom-11.1.4",
         ":plotters-0.3.7",
         ":rayon-1.10.0",
-        ":regex-1.11.0",
-        ":serde-1.0.210",
-        ":serde_derive-1.0.210",
+        ":regex-1.11.1",
+        ":serde-1.0.213",
+        ":serde_derive-1.0.213",
         ":serde_json-1.0.125",
         ":tinytemplate-1.2.1",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":walkdir-2.5.0",
     ],
 )
@@ -4296,9 +4395,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -4355,10 +4454,10 @@ cargo.rust_library(
     deps = [
         ":fnv-1.0.7",
         ":ident_case-1.0.1",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
         ":strsim-0.11.1",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -4381,7 +4480,7 @@ cargo.rust_library(
     deps = [
         ":darling_core-0.20.10",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -4401,7 +4500,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":anyhow-1.0.90",
+        ":anyhow-1.0.91",
         ":html-escape-0.2.13",
         ":nom-7.1.3",
         ":ordered-float-2.10.1",
@@ -4462,7 +4561,7 @@ cargo.rust_library(
         ":async-trait-0.1.83",
         ":deadpool-runtime-0.1.4",
         ":num_cpus-1.16.0",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
     ],
 )
 
@@ -4493,7 +4592,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":deadpool-0.10.0",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-postgres-0.7.12",
         ":tracing-0.1.40",
     ],
@@ -4515,7 +4614,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["tokio_1"],
     named_deps = {
-        "tokio_1": ":tokio-1.40.0",
+        "tokio_1": ":tokio-1.41.0",
     },
     visibility = [],
 )
@@ -4572,7 +4671,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":powerfmt-0.2.0",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -4593,7 +4692,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
         ":syn-1.0.109",
     ],
@@ -4645,9 +4744,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":darling-0.20.10",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -4670,7 +4769,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":derive_builder_core-0.20.2",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -4726,9 +4825,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":convert_case-0.4.0",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -4776,7 +4875,7 @@ cargo.rust_library(
         ":rand-0.8.5",
         ":retry-1.3.1",
         ":semver-1.0.23",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -5236,9 +5335,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":enum-ordinalize-4.3.0",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -5262,7 +5361,7 @@ cargo.rust_library(
         "use_std",
     ],
     visibility = [],
-    deps = [":serde-1.0.210"],
+    deps = [":serde-1.0.213"],
 )
 
 http_archive(
@@ -5368,18 +5467,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "encoding_rs-0.8.34.crate",
-    sha256 = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59",
-    strip_prefix = "encoding_rs-0.8.34",
-    urls = ["https://static.crates.io/crates/encoding_rs/0.8.34/download"],
+    name = "encoding_rs-0.8.35.crate",
+    sha256 = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3",
+    strip_prefix = "encoding_rs-0.8.35",
+    urls = ["https://static.crates.io/crates/encoding_rs/0.8.35/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "encoding_rs-0.8.34",
-    srcs = [":encoding_rs-0.8.34.crate"],
+    name = "encoding_rs-0.8.35",
+    srcs = [":encoding_rs-0.8.35.crate"],
     crate = "encoding_rs",
-    crate_root = "encoding_rs-0.8.34.crate/src/lib.rs",
+    crate_root = "encoding_rs-0.8.35.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -5425,9 +5524,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -5457,7 +5556,7 @@ cargo.rust_library(
         ":humantime-2.1.0",
         ":is-terminal-0.4.13",
         ":log-0.4.22",
-        ":regex-1.11.0",
+        ":regex-1.11.1",
         ":termcolor-1.4.1",
     ],
 )
@@ -5605,7 +5704,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":concurrent-queue-2.5.0",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
     ],
 )
 
@@ -5627,7 +5726,33 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":event-listener-5.3.1",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
+    ],
+)
+
+http_archive(
+    name = "eventsource-stream-0.2.3.crate",
+    sha256 = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab",
+    strip_prefix = "eventsource-stream-0.2.3",
+    urls = ["https://static.crates.io/crates/eventsource-stream/0.2.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "eventsource-stream-0.2.3",
+    srcs = [":eventsource-stream-0.2.3.crate"],
+    crate = "eventsource_stream",
+    crate_root = "eventsource-stream-0.2.3.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":futures-core-0.3.31",
+        ":nom-7.1.3",
+        ":pin-project-lite-0.2.15",
     ],
 )
 
@@ -6076,7 +6201,7 @@ cargo.rust_library(
         ":futures-core-0.3.31",
         ":futures-io-0.3.31",
         ":parking-2.2.1",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
     ],
 )
 
@@ -6097,9 +6222,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -6158,6 +6283,23 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "futures-timer-3.0.3.crate",
+    sha256 = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24",
+    strip_prefix = "futures-timer-3.0.3",
+    urls = ["https://static.crates.io/crates/futures-timer/3.0.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "futures-timer-3.0.3",
+    srcs = [":futures-timer-3.0.3.crate"],
+    crate = "futures_timer",
+    crate_root = "futures-timer-3.0.3.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+)
+
+http_archive(
     name = "futures-util-0.3.31.crate",
     sha256 = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81",
     strip_prefix = "futures-util-0.3.31",
@@ -6207,7 +6349,7 @@ cargo.rust_library(
         ":futures-sink-0.3.31",
         ":futures-task-0.3.31",
         ":memchr-2.7.4",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
         ":pin-utils-0.1.0",
         ":slab-0.4.9",
     ],
@@ -6486,7 +6628,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":fnv-1.0.7",
         ":futures-core-0.3.31",
         ":futures-sink-0.3.31",
@@ -6494,7 +6636,7 @@ cargo.rust_library(
         ":http-0.2.12",
         ":indexmap-2.6.0",
         ":slab-0.4.9",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-util-0.7.12",
         ":tracing-0.1.40",
     ],
@@ -6517,14 +6659,14 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":atomic-waker-1.1.2",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":fnv-1.0.7",
         ":futures-core-0.3.31",
         ":futures-sink-0.3.31",
         ":http-1.1.0",
         ":indexmap-2.6.0",
         ":slab-0.4.9",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-util-0.7.12",
         ":tracing-0.1.40",
     ],
@@ -6726,7 +6868,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hash32-0.2.1",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":stable_deref_trait-1.2.0",
     ],
 )
@@ -6974,7 +7116,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":fnv-1.0.7",
         ":itoa-1.0.11",
     ],
@@ -7000,7 +7142,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":fnv-1.0.7",
         ":itoa-1.0.11",
     ],
@@ -7022,9 +7164,9 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":http-0.2.12",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
     ],
 )
 
@@ -7044,7 +7186,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":http-1.1.0",
     ],
 )
@@ -7065,11 +7207,11 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":futures-util-0.3.31",
         ":http-1.1.0",
         ":http-body-1.0.1",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
     ],
 )
 
@@ -7180,7 +7322,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":futures-channel-0.3.31",
         ":futures-core-0.3.31",
         ":futures-util-0.3.31",
@@ -7190,9 +7332,9 @@ cargo.rust_library(
         ":httparse-1.9.5",
         ":httpdate-1.0.3",
         ":itoa-1.0.11",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
         ":socket2-0.5.7",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tower-service-0.3.3",
         ":tracing-0.1.40",
         ":want-0.3.1",
@@ -7221,7 +7363,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":futures-channel-0.3.31",
         ":futures-util-0.3.31",
         ":h2-0.4.6",
@@ -7229,9 +7371,9 @@ cargo.rust_library(
         ":http-body-1.0.1",
         ":httparse-1.9.5",
         ":itoa-1.0.11",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
         ":smallvec-1.13.2",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":want-0.3.1",
     ],
 )
@@ -7255,8 +7397,8 @@ cargo.rust_library(
         ":hex-0.4.3",
         ":hyper-1.5.0",
         ":hyper-util-0.1.9",
-        ":pin-project-lite-0.2.14",
-        ":tokio-1.40.0",
+        ":pin-project-lite-0.2.15",
+        ":tokio-1.41.0",
         ":tower-service-0.3.3",
         ":winapi-0.3.9",
     ],
@@ -7296,7 +7438,7 @@ cargo.rust_library(
         ":log-0.4.22",
         ":rustls-0.21.12",
         ":rustls-native-certs-0.6.3",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-rustls-0.24.1",
     ],
 )
@@ -7317,7 +7459,9 @@ cargo.rust_library(
     edition = "2021",
     features = [
         "http1",
+        "native-tokio",
         "ring",
+        "rustls-native-certs",
         "tls12",
         "webpki-roots",
         "webpki-tokio",
@@ -7332,7 +7476,8 @@ cargo.rust_library(
         ":hyper-1.5.0",
         ":hyper-util-0.1.9",
         ":rustls-0.23.15",
-        ":tokio-1.40.0",
+        ":rustls-native-certs-0.8.0",
+        ":tokio-1.41.0",
         ":tokio-rustls-0.26.0",
         ":tower-service-0.3.3",
         ":webpki-roots-0.26.6",
@@ -7356,8 +7501,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hyper-0.14.31",
-        ":pin-project-lite-0.2.14",
-        ":tokio-1.40.0",
+        ":pin-project-lite-0.2.15",
+        ":tokio-1.41.0",
         ":tokio-io-timeout-1.2.0",
     ],
 )
@@ -7380,8 +7525,8 @@ cargo.rust_library(
     deps = [
         ":hyper-1.5.0",
         ":hyper-util-0.1.9",
-        ":pin-project-lite-0.2.14",
-        ":tokio-1.40.0",
+        ":pin-project-lite-0.2.15",
+        ":tokio-1.41.0",
         ":tower-service-0.3.3",
     ],
 )
@@ -7409,15 +7554,15 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":futures-channel-0.3.31",
         ":futures-util-0.3.31",
         ":http-1.1.0",
         ":http-body-1.0.1",
         ":hyper-1.5.0",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
         ":socket2-0.5.7",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tower-service-0.3.3",
         ":tracing-0.1.40",
     ],
@@ -7445,8 +7590,8 @@ cargo.rust_library(
         ":futures-util-0.3.31",
         ":hex-0.4.3",
         ":hyper-0.14.31",
-        ":pin-project-1.1.6",
-        ":tokio-1.40.0",
+        ":pin-project-1.1.7",
+        ":tokio-1.41.0",
     ],
 )
 
@@ -7477,8 +7622,8 @@ cargo.rust_library(
         ":http-body-util-0.1.2",
         ":hyper-1.5.0",
         ":hyper-util-0.1.9",
-        ":pin-project-lite-0.2.14",
-        ":tokio-1.40.0",
+        ":pin-project-lite-0.2.15",
+        ":tokio-1.41.0",
         ":tower-service-0.3.3",
     ],
 )
@@ -7582,10 +7727,10 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":ignore-0.4.23",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":serde-1.0.210",
-        ":syn-2.0.82",
+        ":serde-1.0.213",
+        ":syn-2.0.85",
         ":toml-0.8.19",
         ":unicode-xid-0.2.6",
     ],
@@ -7622,6 +7767,53 @@ cargo.rust_library(
         ":regex-automata-0.4.8",
         ":same-file-1.0.6",
         ":walkdir-2.5.0",
+    ],
+)
+
+alias(
+    name = "include_dir",
+    actual = ":include_dir-0.7.4",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "include_dir-0.7.4.crate",
+    sha256 = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd",
+    strip_prefix = "include_dir-0.7.4",
+    urls = ["https://static.crates.io/crates/include_dir/0.7.4/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "include_dir-0.7.4",
+    srcs = [":include_dir-0.7.4.crate"],
+    crate = "include_dir",
+    crate_root = "include_dir-0.7.4.crate/src/lib.rs",
+    edition = "2021",
+    features = ["default"],
+    visibility = [],
+    deps = [":include_dir_macros-0.7.4"],
+)
+
+http_archive(
+    name = "include_dir_macros-0.7.4.crate",
+    sha256 = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75",
+    strip_prefix = "include_dir_macros-0.7.4",
+    urls = ["https://static.crates.io/crates/include_dir_macros/0.7.4/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "include_dir_macros-0.7.4",
+    srcs = [":include_dir_macros-0.7.4.crate"],
+    crate = "include_dir_macros",
+    crate_root = "include_dir_macros-0.7.4.crate/src/lib.rs",
+    edition = "2021",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.89",
+        ":quote-1.0.37",
     ],
 )
 
@@ -7666,7 +7858,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hashbrown-0.12.3",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -7700,7 +7892,7 @@ cargo.rust_library(
     deps = [
         ":equivalent-1.0.1",
         ":hashbrown-0.15.0",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -7778,9 +7970,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -7824,6 +8016,24 @@ cargo.rust_library(
         ":unicode-segmentation-1.12.0",
         ":unicode-width-0.1.14",
     ],
+)
+
+http_archive(
+    name = "instant-0.1.13.crate",
+    sha256 = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222",
+    strip_prefix = "instant-0.1.13",
+    urls = ["https://static.crates.io/crates/instant/0.1.13/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "instant-0.1.13",
+    srcs = [":instant-0.1.13.crate"],
+    crate = "instant",
+    crate_root = "instant-0.1.13.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [":cfg-if-1.0.0"],
 )
 
 http_archive(
@@ -8079,7 +8289,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":anyhow-1.0.90",
+        ":anyhow-1.0.91",
         ":binstring-0.1.1",
         ":blake2b_simd-1.0.2",
         ":coarsetime-0.1.34",
@@ -8092,9 +8302,9 @@ cargo.rust_library(
         ":p256-0.13.2",
         ":p384-0.13.0",
         ":rand-0.8.5",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":zeroize-1.8.1",
     ],
 )
@@ -8921,12 +9131,12 @@ cargo.rust_library(
     ],
     named_deps = {
         "macros": ":manyhow-macros-0.11.4",
-        "syn2": ":syn-2.0.82",
+        "syn2": ":syn-2.0.85",
     },
     visibility = [],
     deps = [
         ":darling_core-0.20.10",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
     ],
 )
@@ -8949,7 +9159,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro-utils-0.10.0",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
     ],
 )
@@ -9008,9 +9218,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -9194,7 +9404,7 @@ cargo.rust_library(
     deps = [
         ":miette-derive-5.10.0",
         ":once_cell-1.20.2",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":unicode-width-0.1.14",
     ],
 )
@@ -9216,9 +9426,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -9499,7 +9709,7 @@ cargo.rust_library(
         ":quanta-0.12.3",
         ":smallvec-1.13.2",
         ":tagptr-0.2.0",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":triomphe-0.1.11",
         ":uuid-1.11.0",
     ],
@@ -9522,8 +9732,8 @@ cargo.rust_library(
     features = ["default"],
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
-        ":encoding_rs-0.8.34",
+        ":bytes-1.8.0",
+        ":encoding_rs-0.8.35",
         ":futures-util-0.3.31",
         ":http-0.2.12",
         ":httparse-1.9.5",
@@ -10271,8 +10481,8 @@ cargo.rust_library(
         ":futures-core-0.3.31",
         ":futures-sink-0.3.31",
         ":once_cell-1.20.2",
-        ":pin-project-lite-0.2.14",
-        ":thiserror-1.0.64",
+        ":pin-project-lite-0.2.15",
+        ":thiserror-1.0.65",
         ":urlencoding-2.1.3",
     ],
 )
@@ -10328,8 +10538,8 @@ cargo.rust_library(
         ":opentelemetry-semantic-conventions-0.14.0",
         ":opentelemetry_sdk-0.22.1",
         ":prost-0.12.6",
-        ":thiserror-1.0.64",
-        ":tokio-1.40.0",
+        ":thiserror-1.0.65",
+        ":tokio-1.41.0",
         ":tonic-0.11.0",
     ],
 )
@@ -10445,8 +10655,8 @@ cargo.rust_library(
         ":ordered-float-4.4.0",
         ":percent-encoding-2.3.1",
         ":rand-0.8.5",
-        ":thiserror-1.0.64",
-        ":tokio-1.40.0",
+        ":thiserror-1.0.65",
+        ":tokio-1.41.0",
         ":tokio-stream-0.1.16",
     ],
 )
@@ -10628,9 +10838,9 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro-error-1.0.4",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -10654,10 +10864,10 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":itertools-0.12.1",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":proc-macro2-diagnostics-0.10.1",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -10960,7 +11170,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":base64-0.22.1",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -11038,8 +11248,8 @@ cargo.rust_library(
     deps = [
         ":fixedbitset-0.4.2",
         ":indexmap-2.6.0",
-        ":serde-1.0.210",
-        ":serde_derive-1.0.210",
+        ":serde-1.0.213",
+        ":serde_derive-1.0.213",
     ],
 )
 
@@ -11103,21 +11313,21 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "pin-project-1.1.6.crate",
-    sha256 = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec",
-    strip_prefix = "pin-project-1.1.6",
-    urls = ["https://static.crates.io/crates/pin-project/1.1.6/download"],
+    name = "pin-project-1.1.7.crate",
+    sha256 = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95",
+    strip_prefix = "pin-project-1.1.7",
+    urls = ["https://static.crates.io/crates/pin-project/1.1.7/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "pin-project-1.1.6",
-    srcs = [":pin-project-1.1.6.crate"],
+    name = "pin-project-1.1.7",
+    srcs = [":pin-project-1.1.7.crate"],
     crate = "pin_project",
-    crate_root = "pin-project-1.1.6.crate/src/lib.rs",
+    crate_root = "pin-project-1.1.7.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":pin-project-internal-1.1.6"],
+    deps = [":pin-project-internal-1.1.7"],
 )
 
 http_archive(
@@ -11137,54 +11347,54 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
         ":syn-1.0.109",
     ],
 )
 
 http_archive(
-    name = "pin-project-internal-1.1.6.crate",
-    sha256 = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8",
-    strip_prefix = "pin-project-internal-1.1.6",
-    urls = ["https://static.crates.io/crates/pin-project-internal/1.1.6/download"],
+    name = "pin-project-internal-1.1.7.crate",
+    sha256 = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c",
+    strip_prefix = "pin-project-internal-1.1.7",
+    urls = ["https://static.crates.io/crates/pin-project-internal/1.1.7/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "pin-project-internal-1.1.6",
-    srcs = [":pin-project-internal-1.1.6.crate"],
+    name = "pin-project-internal-1.1.7",
+    srcs = [":pin-project-internal-1.1.7.crate"],
     crate = "pin_project_internal",
-    crate_root = "pin-project-internal-1.1.6.crate/src/lib.rs",
+    crate_root = "pin-project-internal-1.1.7.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
 alias(
     name = "pin-project-lite",
-    actual = ":pin-project-lite-0.2.14",
+    actual = ":pin-project-lite-0.2.15",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "pin-project-lite-0.2.14.crate",
-    sha256 = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02",
-    strip_prefix = "pin-project-lite-0.2.14",
-    urls = ["https://static.crates.io/crates/pin-project-lite/0.2.14/download"],
+    name = "pin-project-lite-0.2.15.crate",
+    sha256 = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff",
+    strip_prefix = "pin-project-lite-0.2.15",
+    urls = ["https://static.crates.io/crates/pin-project-lite/0.2.15/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "pin-project-lite-0.2.14",
-    srcs = [":pin-project-lite-0.2.14.crate"],
+    name = "pin-project-lite-0.2.15",
+    srcs = [":pin-project-lite-0.2.15.crate"],
     crate = "pin_project_lite",
-    crate_root = "pin-project-lite-0.2.14.crate/src/lib.rs",
+    crate_root = "pin-project-lite-0.2.15.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
 )
@@ -11369,7 +11579,7 @@ cargo.rust_library(
     deps = [
         ":base64-0.13.1",
         ":byteorder-1.5.0",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":chrono-0.4.38",
         ":containers-api-0.8.0",
         ":flate2-1.0.34",
@@ -11378,11 +11588,11 @@ cargo.rust_library(
         ":log-0.4.22",
         ":paste-1.0.15",
         ":podman-api-stubs-0.9.0",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
         ":tar-0.4.42",
-        ":thiserror-1.0.64",
-        ":tokio-1.40.0",
+        ":thiserror-1.0.65",
+        ":tokio-1.41.0",
         ":url-2.5.2",
     ],
 )
@@ -11404,7 +11614,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":chrono-0.4.38",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
     ],
 )
@@ -11512,7 +11722,7 @@ cargo.rust_library(
     deps = [
         ":cobs-0.2.3",
         ":heapless-0.7.17",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -11534,9 +11744,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.5.0",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -11559,7 +11769,7 @@ cargo.rust_library(
     deps = [
         ":base64-0.22.1",
         ":byteorder-1.5.0",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":fallible-iterator-0.2.0",
         ":hmac-0.12.1",
         ":md-5-0.10.6",
@@ -11601,12 +11811,12 @@ cargo.rust_library(
     ],
     named_deps = {
         "chrono_04": ":chrono-0.4.38",
-        "serde_1": ":serde-1.0.210",
+        "serde_1": ":serde-1.0.213",
         "serde_json_1": ":serde_json-1.0.125",
     },
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":fallible-iterator-0.2.0",
         ":postgres-derive-0.4.6",
         ":postgres-protocol-0.6.7",
@@ -11745,7 +11955,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro-error-attr-1.0.4",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
         ":syn-1.0.109",
     ],
@@ -11795,7 +12005,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
     ],
 )
@@ -11817,7 +12027,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
     ],
 )
@@ -11843,9 +12053,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro-error-attr2-2.0.0",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -11873,7 +12083,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
         ":smallvec-1.13.2",
     ],
@@ -11881,38 +12091,38 @@ cargo.rust_library(
 
 alias(
     name = "proc-macro2",
-    actual = ":proc-macro2-1.0.88",
+    actual = ":proc-macro2-1.0.89",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "proc-macro2-1.0.88.crate",
-    sha256 = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9",
-    strip_prefix = "proc-macro2-1.0.88",
-    urls = ["https://static.crates.io/crates/proc-macro2/1.0.88/download"],
+    name = "proc-macro2-1.0.89.crate",
+    sha256 = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e",
+    strip_prefix = "proc-macro2-1.0.89",
+    urls = ["https://static.crates.io/crates/proc-macro2/1.0.89/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "proc-macro2-1.0.88",
-    srcs = [":proc-macro2-1.0.88.crate"],
+    name = "proc-macro2-1.0.89",
+    srcs = [":proc-macro2-1.0.89.crate"],
     crate = "proc_macro2",
-    crate_root = "proc-macro2-1.0.88.crate/src/lib.rs",
+    crate_root = "proc-macro2-1.0.89.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
         "proc-macro",
     ],
-    rustc_flags = ["@$(location :proc-macro2-1.0.88-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :proc-macro2-1.0.89-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [":unicode-ident-1.0.13"],
 )
 
 cargo.rust_binary(
-    name = "proc-macro2-1.0.88-build-script-build",
-    srcs = [":proc-macro2-1.0.88.crate"],
+    name = "proc-macro2-1.0.89-build-script-build",
+    srcs = [":proc-macro2-1.0.89.crate"],
     crate = "build_script_build",
-    crate_root = "proc-macro2-1.0.88.crate/build.rs",
+    crate_root = "proc-macro2-1.0.89.crate/build.rs",
     edition = "2021",
     features = [
         "default",
@@ -11922,14 +12132,14 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "proc-macro2-1.0.88-build-script-run",
+    name = "proc-macro2-1.0.89-build-script-run",
     package_name = "proc-macro2",
-    buildscript_rule = ":proc-macro2-1.0.88-build-script-build",
+    buildscript_rule = ":proc-macro2-1.0.89-build-script-build",
     features = [
         "default",
         "proc-macro",
     ],
-    version = "1.0.88",
+    version = "1.0.89",
 )
 
 http_archive(
@@ -11953,9 +12163,9 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
         ":yansi-1.0.1",
     ],
 )
@@ -12073,7 +12283,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":prost-derive-0.12.6",
     ],
 )
@@ -12100,7 +12310,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":prost-derive-0.13.3",
     ],
 )
@@ -12122,11 +12332,11 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":anyhow-1.0.90",
+        ":anyhow-1.0.91",
         ":itertools-0.12.1",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -12147,11 +12357,11 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":anyhow-1.0.90",
+        ":anyhow-1.0.91",
         ":itertools-0.13.0",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -12256,7 +12466,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":memchr-2.7.4",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -12285,13 +12495,13 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
-        ":pin-project-lite-0.2.14",
+        ":bytes-1.8.0",
+        ":pin-project-lite-0.2.15",
         ":rustc-hash-2.0.0",
         ":rustls-0.23.15",
         ":socket2-0.5.7",
-        ":thiserror-1.0.64",
-        ":tokio-1.40.0",
+        ":thiserror-1.0.65",
+        ":tokio-1.41.0",
         ":tracing-0.1.40",
     ],
 )
@@ -12316,13 +12526,13 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":rand-0.8.5",
         ":ring-0.17.5",
         ":rustc-hash-2.0.0",
         ":rustls-0.23.15",
         ":slab-0.4.9",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":tinyvec-1.8.0",
         ":tracing-0.1.40",
     ],
@@ -12390,7 +12600,7 @@ cargo.rust_library(
         "proc-macro",
     ],
     visibility = [],
-    deps = [":proc-macro2-1.0.88"],
+    deps = [":proc-macro2-1.0.89"],
 )
 
 http_archive(
@@ -12750,11 +12960,11 @@ cargo.rust_library(
         ":async-trait-0.1.83",
         ":cfg-if-1.0.0",
         ":log-0.4.22",
-        ":regex-1.11.0",
+        ":regex-1.11.1",
         ":siphasher-1.0.1",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":time-0.3.36",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-postgres-0.7.12",
         ":url-2.5.2",
         ":walkdir-2.5.0",
@@ -12779,11 +12989,11 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
         ":refinery-core-0.8.14",
-        ":regex-1.11.0",
-        ":syn-2.0.82",
+        ":regex-1.11.1",
+        ":syn-2.0.85",
     ],
 )
 
@@ -12821,23 +13031,23 @@ cargo.rust_library(
 
 alias(
     name = "regex",
-    actual = ":regex-1.11.0",
+    actual = ":regex-1.11.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "regex-1.11.0.crate",
-    sha256 = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8",
-    strip_prefix = "regex-1.11.0",
-    urls = ["https://static.crates.io/crates/regex/1.11.0/download"],
+    name = "regex-1.11.1.crate",
+    sha256 = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191",
+    strip_prefix = "regex-1.11.1",
+    urls = ["https://static.crates.io/crates/regex/1.11.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "regex-1.11.0",
-    srcs = [":regex-1.11.0.crate"],
+    name = "regex-1.11.1",
+    srcs = [":regex-1.11.1.crate"],
     crate = "regex",
-    crate_root = "regex-1.11.0.crate/src/lib.rs",
+    crate_root = "regex-1.11.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -13040,9 +13250,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -13073,7 +13283,9 @@ cargo.rust_library(
         "json",
         "multipart",
         "rustls-tls",
+        "rustls-tls-native-roots",
         "rustls-tls-webpki-roots",
+        "stream",
     ],
     platform = {
         "linux-arm64": dict(
@@ -13088,13 +13300,15 @@ cargo.rust_library(
                 ":mime-0.3.17",
                 ":once_cell-1.20.2",
                 ":percent-encoding-2.3.1",
-                ":pin-project-lite-0.2.14",
+                ":pin-project-lite-0.2.15",
                 ":quinn-0.11.5",
                 ":rustls-0.23.15",
+                ":rustls-native-certs-0.8.0",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.10.0",
-                ":tokio-1.40.0",
+                ":tokio-1.41.0",
                 ":tokio-rustls-0.26.0",
+                ":tokio-util-0.7.12",
                 ":webpki-roots-0.26.6",
             ],
         ),
@@ -13110,13 +13324,15 @@ cargo.rust_library(
                 ":mime-0.3.17",
                 ":once_cell-1.20.2",
                 ":percent-encoding-2.3.1",
-                ":pin-project-lite-0.2.14",
+                ":pin-project-lite-0.2.15",
                 ":quinn-0.11.5",
                 ":rustls-0.23.15",
+                ":rustls-native-certs-0.8.0",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.10.0",
-                ":tokio-1.40.0",
+                ":tokio-1.41.0",
                 ":tokio-rustls-0.26.0",
+                ":tokio-util-0.7.12",
                 ":webpki-roots-0.26.6",
             ],
         ),
@@ -13132,13 +13348,15 @@ cargo.rust_library(
                 ":mime-0.3.17",
                 ":once_cell-1.20.2",
                 ":percent-encoding-2.3.1",
-                ":pin-project-lite-0.2.14",
+                ":pin-project-lite-0.2.15",
                 ":quinn-0.11.5",
                 ":rustls-0.23.15",
+                ":rustls-native-certs-0.8.0",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.10.0",
-                ":tokio-1.40.0",
+                ":tokio-1.41.0",
                 ":tokio-rustls-0.26.0",
+                ":tokio-util-0.7.12",
                 ":webpki-roots-0.26.6",
             ],
         ),
@@ -13154,13 +13372,15 @@ cargo.rust_library(
                 ":mime-0.3.17",
                 ":once_cell-1.20.2",
                 ":percent-encoding-2.3.1",
-                ":pin-project-lite-0.2.14",
+                ":pin-project-lite-0.2.15",
                 ":quinn-0.11.5",
                 ":rustls-0.23.15",
+                ":rustls-native-certs-0.8.0",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.10.0",
-                ":tokio-1.40.0",
+                ":tokio-1.41.0",
                 ":tokio-rustls-0.26.0",
+                ":tokio-util-0.7.12",
                 ":webpki-roots-0.26.6",
             ],
         ),
@@ -13176,13 +13396,15 @@ cargo.rust_library(
                 ":mime-0.3.17",
                 ":once_cell-1.20.2",
                 ":percent-encoding-2.3.1",
-                ":pin-project-lite-0.2.14",
+                ":pin-project-lite-0.2.15",
                 ":quinn-0.11.5",
                 ":rustls-0.23.15",
+                ":rustls-native-certs-0.8.0",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.10.0",
-                ":tokio-1.40.0",
+                ":tokio-1.41.0",
                 ":tokio-rustls-0.26.0",
+                ":tokio-util-0.7.12",
                 ":webpki-roots-0.26.6",
                 ":windows-registry-0.2.0",
             ],
@@ -13199,13 +13421,15 @@ cargo.rust_library(
                 ":mime-0.3.17",
                 ":once_cell-1.20.2",
                 ":percent-encoding-2.3.1",
-                ":pin-project-lite-0.2.14",
+                ":pin-project-lite-0.2.15",
                 ":quinn-0.11.5",
                 ":rustls-0.23.15",
+                ":rustls-native-certs-0.8.0",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.10.0",
-                ":tokio-1.40.0",
+                ":tokio-1.41.0",
                 ":tokio-rustls-0.26.0",
+                ":tokio-util-0.7.12",
                 ":webpki-roots-0.26.6",
                 ":windows-registry-0.2.0",
             ],
@@ -13214,17 +13438,44 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":base64-0.22.1",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":futures-core-0.3.31",
         ":futures-util-0.3.31",
         ":http-1.1.0",
         ":mime_guess-2.0.4",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
         ":serde_urlencoded-0.7.1",
         ":sync_wrapper-1.0.1",
         ":tower-service-0.3.3",
         ":url-2.5.2",
+    ],
+)
+
+http_archive(
+    name = "reqwest-eventsource-0.6.0.crate",
+    sha256 = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde",
+    strip_prefix = "reqwest-eventsource-0.6.0",
+    urls = ["https://static.crates.io/crates/reqwest-eventsource/0.6.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "reqwest-eventsource-0.6.0",
+    srcs = [":reqwest-eventsource-0.6.0.crate"],
+    crate = "reqwest_eventsource",
+    crate_root = "reqwest-eventsource-0.6.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":eventsource-stream-0.2.3",
+        ":futures-core-0.3.31",
+        ":futures-timer-3.0.3",
+        ":mime-0.3.17",
+        ":nom-7.1.3",
+        ":pin-project-lite-0.2.15",
+        ":reqwest-0.12.8",
+        ":thiserror-1.0.65",
     ],
 )
 
@@ -14090,7 +14341,7 @@ cargo.rust_library(
         ":aws-creds-0.36.0",
         ":aws-region-0.25.4",
         ":base64-0.21.7",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":cfg-if-1.0.0",
         ":futures-0.3.31",
         ":hex-0.4.3",
@@ -14105,13 +14356,13 @@ cargo.rust_library(
         ":quick-xml-0.30.0",
         ":rustls-0.21.12",
         ":rustls-native-certs-0.6.3",
-        ":serde-1.0.210",
-        ":serde_derive-1.0.210",
+        ":serde-1.0.213",
+        ":serde_derive-1.0.213",
         ":serde_json-1.0.125",
         ":sha2-0.10.8",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":time-0.3.36",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-rustls-0.24.1",
         ":tokio-stream-0.1.16",
         ":url-2.5.2",
@@ -14145,7 +14396,7 @@ cargo.rust_library(
     deps = [
         ":arrayvec-0.7.6",
         ":num-traits-0.2.19",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -14560,6 +14811,47 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "rustls-native-certs-0.8.0.crate",
+    sha256 = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a",
+    strip_prefix = "rustls-native-certs-0.8.0",
+    urls = ["https://static.crates.io/crates/rustls-native-certs/0.8.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "rustls-native-certs-0.8.0",
+    srcs = [":rustls-native-certs-0.8.0.crate"],
+    crate = "rustls_native_certs",
+    crate_root = "rustls-native-certs-0.8.0.crate/src/lib.rs",
+    edition = "2021",
+    named_deps = {
+        "pki_types": ":rustls-pki-types-1.10.0",
+    },
+    platform = {
+        "linux-arm64": dict(
+            deps = [":openssl-probe-0.1.5"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":openssl-probe-0.1.5"],
+        ),
+        "macos-arm64": dict(
+            deps = [":security-framework-2.11.1"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":security-framework-2.11.1"],
+        ),
+        "windows-gnu": dict(
+            deps = [":schannel-0.1.26"],
+        ),
+        "windows-msvc": dict(
+            deps = [":schannel-0.1.26"],
+        ),
+    },
+    visibility = [],
+    deps = [":rustls-pemfile-2.2.0"],
+)
+
+http_archive(
     name = "rustls-pemfile-1.0.4.crate",
     sha256 = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c",
     strip_prefix = "rustls-pemfile-1.0.4",
@@ -14839,9 +15131,9 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro-error2-2.0.1",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -14902,11 +15194,11 @@ cargo.rust_library(
         ":sea-orm-macros-0.12.15",
         ":sea-query-0.30.7",
         ":sea-query-binder-0.5.0",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
         ":sqlx-0.7.4",
         ":strum-0.25.0",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":time-0.3.36",
         ":tracing-0.1.40",
         ":url-2.5.2",
@@ -14941,9 +15233,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.4.1",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
         ":unicode-ident-1.0.13",
     ],
 )
@@ -15075,6 +15367,32 @@ cargo.rust_library(
         ":generic-array-0.14.7",
         ":pkcs8-0.10.2",
         ":subtle-2.6.1",
+        ":zeroize-1.8.1",
+    ],
+)
+
+http_archive(
+    name = "secrecy-0.8.0.crate",
+    sha256 = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e",
+    strip_prefix = "secrecy-0.8.0",
+    urls = ["https://static.crates.io/crates/secrecy/0.8.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "secrecy-0.8.0",
+    srcs = [":secrecy-0.8.0.crate"],
+    crate = "secrecy",
+    crate_root = "secrecy-0.8.0.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "alloc",
+        "default",
+        "serde",
+    ],
+    visibility = [],
+    deps = [
+        ":serde-1.0.213",
         ":zeroize-1.8.1",
     ],
 )
@@ -15245,23 +15563,23 @@ buildscript_run(
 
 alias(
     name = "serde",
-    actual = ":serde-1.0.210",
+    actual = ":serde-1.0.213",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde-1.0.210.crate",
-    sha256 = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a",
-    strip_prefix = "serde-1.0.210",
-    urls = ["https://static.crates.io/crates/serde/1.0.210/download"],
+    name = "serde-1.0.213.crate",
+    sha256 = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1",
+    strip_prefix = "serde-1.0.213",
+    urls = ["https://static.crates.io/crates/serde/1.0.213/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde-1.0.210",
-    srcs = [":serde-1.0.210.crate"],
+    name = "serde-1.0.213",
+    srcs = [":serde-1.0.213.crate"],
     crate = "serde",
-    crate_root = "serde-1.0.210.crate/src/lib.rs",
+    crate_root = "serde-1.0.213.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -15272,7 +15590,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde_derive-1.0.210"],
+    deps = [":serde_derive-1.0.213"],
 )
 
 alias(
@@ -15302,32 +15620,32 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":chrono-0.4.38",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
     ],
 )
 
 http_archive(
-    name = "serde_derive-1.0.210.crate",
-    sha256 = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f",
-    strip_prefix = "serde_derive-1.0.210",
-    urls = ["https://static.crates.io/crates/serde_derive/1.0.210/download"],
+    name = "serde_derive-1.0.213.crate",
+    sha256 = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5",
+    strip_prefix = "serde_derive-1.0.213",
+    urls = ["https://static.crates.io/crates/serde_derive/1.0.213/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_derive-1.0.210",
-    srcs = [":serde_derive-1.0.210.crate"],
+    name = "serde_derive-1.0.213",
+    srcs = [":serde_derive-1.0.213.crate"],
     crate = "serde_derive",
-    crate_root = "serde_derive-1.0.210.crate/src/lib.rs",
+    crate_root = "serde_derive-1.0.213.crate/src/lib.rs",
     edition = "2015",
     features = ["default"],
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -15365,7 +15683,7 @@ cargo.rust_library(
         ":itoa-1.0.11",
         ":memchr-2.7.4",
         ":ryu-1.0.18",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -15384,7 +15702,7 @@ cargo.rust_library(
     crate_root = "serde_nanos-0.1.4.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":serde-1.0.210"],
+    deps = [":serde-1.0.213"],
 )
 
 alias(
@@ -15410,7 +15728,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":itoa-1.0.11",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -15438,8 +15756,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":percent-encoding-2.3.1",
-        ":serde-1.0.210",
-        ":thiserror-1.0.64",
+        ":serde-1.0.213",
+        ":thiserror-1.0.65",
     ],
 )
 
@@ -15460,9 +15778,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -15482,7 +15800,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["serde"],
     visibility = [],
-    deps = [":serde-1.0.210"],
+    deps = [":serde-1.0.213"],
 )
 
 alias(
@@ -15507,7 +15825,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":url-2.5.2",
     ],
 )
@@ -15531,7 +15849,7 @@ cargo.rust_library(
         ":form_urlencoded-1.2.1",
         ":itoa-1.0.11",
         ":ryu-1.0.18",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -15571,8 +15889,8 @@ cargo.rust_library(
     deps = [
         ":base64-0.22.1",
         ":hex-0.4.3",
-        ":serde-1.0.210",
-        ":serde_derive-1.0.210",
+        ":serde-1.0.213",
+        ":serde_derive-1.0.213",
         ":serde_json-1.0.125",
         ":serde_with_macros-3.11.0",
     ],
@@ -15596,9 +15914,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":darling-0.20.10",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -15627,7 +15945,7 @@ cargo.rust_library(
         ":indexmap-2.6.0",
         ":itoa-1.0.11",
         ":ryu-1.0.18",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":unsafe-libyaml-0.2.11",
     ],
 )
@@ -16139,7 +16457,7 @@ cargo.rust_library(
         ":ed25519-1.5.3",
         ":libc-0.2.161",
         ":libsodium-sys-0.2.7",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -16158,12 +16476,12 @@ cargo.rust_library(
     features = ["default"],
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":http-1.1.0",
         ":prost-0.13.3",
         ":prost-types-0.13.3",
         ":spicedb-grpc-0.1.1",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":tonic-0.12.3",
     ],
 )
@@ -16345,7 +16663,7 @@ cargo.rust_library(
         ":atoi-2.0.0",
         ":bigdecimal-0.3.1",
         ":byteorder-1.5.0",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":chrono-0.4.38",
         ":crc-3.2.1",
         ":crossbeam-queue-0.3.11",
@@ -16367,14 +16685,14 @@ cargo.rust_library(
         ":rust_decimal-1.36.0",
         ":rustls-0.21.12",
         ":rustls-pemfile-1.0.4",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
         ":sha2-0.10.8",
         ":smallvec-1.13.2",
         ":sqlformat-0.2.6",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":time-0.3.36",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-stream-0.1.16",
         ":tracing-0.1.40",
         ":url-2.5.2",
@@ -16441,13 +16759,13 @@ cargo.rust_library(
         ":once_cell-1.20.2",
         ":rand-0.8.5",
         ":rust_decimal-1.36.0",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
         ":sha2-0.10.8",
         ":smallvec-1.13.2",
         ":sqlx-core-0.7.4",
         ":stringprep-0.1.5",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":time-0.3.36",
         ":tracing-0.1.40",
         ":uuid-1.11.0",
@@ -16490,10 +16808,10 @@ cargo.rust_library(
         ":digest-0.10.7",
         ":hex-0.4.3",
         ":miette-5.10.0",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":sha-1-0.10.1",
         ":sha2-0.10.8",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":xxhash-rust-0.8.12",
     ],
 )
@@ -16560,8 +16878,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":futures-core-0.3.31",
-        ":pin-project-1.1.6",
-        ":tokio-1.40.0",
+        ":pin-project-1.1.7",
+        ":tokio-1.41.0",
     ],
 )
 
@@ -16669,10 +16987,10 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":heck-0.5.0",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
         ":rustversion-1.0.18",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -16756,7 +17074,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
         ":unicode-ident-1.0.13",
     ],
@@ -16764,23 +17082,23 @@ cargo.rust_library(
 
 alias(
     name = "syn",
-    actual = ":syn-2.0.82",
+    actual = ":syn-2.0.85",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "syn-2.0.82.crate",
-    sha256 = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021",
-    strip_prefix = "syn-2.0.82",
-    urls = ["https://static.crates.io/crates/syn/2.0.82/download"],
+    name = "syn-2.0.85.crate",
+    sha256 = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56",
+    strip_prefix = "syn-2.0.85",
+    urls = ["https://static.crates.io/crates/syn/2.0.85/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "syn-2.0.82",
-    srcs = [":syn-2.0.82.crate"],
+    name = "syn-2.0.85",
+    srcs = [":syn-2.0.85.crate"],
     crate = "syn",
-    crate_root = "syn-2.0.82.crate/src/lib.rs",
+    crate_root = "syn-2.0.85.crate/src/lib.rs",
     edition = "2021",
     features = [
         "clone-impls",
@@ -16797,7 +17115,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
         ":unicode-ident-1.0.13",
     ],
@@ -17104,9 +17422,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -17119,15 +17437,16 @@ cargo.rust_binary(
     visibility = [],
     deps = [
         ":async-nats-0.36.0",
+        ":async-openai-0.25.0",
         ":async-recursion-1.1.1",
         ":async-trait-0.1.83",
-        ":aws-config-1.5.8",
-        ":aws-sdk-firehose-1.51.0",
+        ":aws-config-1.5.9",
+        ":aws-sdk-firehose-1.52.0",
         ":axum-0.6.20",
         ":base64-0.22.1",
         ":blake3-1.5.4",
         ":bollard-0.16.1",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":cacache-13.0.0",
         ":chrono-0.4.38",
         ":ciborium-0.2.2",
@@ -17135,7 +17454,7 @@ cargo.rust_binary(
         ":color-eyre-0.6.3",
         ":colored-2.1.0",
         ":comfy-table-7.1.1",
-        ":config-0.14.0",
+        ":config-0.14.1",
         ":console-0.15.8",
         ":convert_case-0.6.0",
         ":criterion-0.5.1",
@@ -17159,6 +17478,7 @@ cargo.rust_binary(
         ":hyper-0.14.31",
         ":hyperlocal-0.8.0",
         ":iftree-1.0.5",
+        ":include_dir-0.7.4",
         ":indexmap-2.6.0",
         ":indicatif-0.17.8",
         ":indoc-2.0.5",
@@ -17186,17 +17506,17 @@ cargo.rust_binary(
         ":paste-1.0.15",
         ":pathdiff-0.2.2",
         ":petgraph-0.6.5",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
         ":podman-api-0.10.0",
         ":postcard-1.0.10",
         ":postgres-types-0.2.8",
         ":pretty_assertions_sorted-1.2.3",
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":procfs-0.16.0",
         ":quote-1.0.37",
         ":rand-0.8.5",
         ":refinery-0.8.12",
-        ":regex-1.11.0",
+        ":regex-1.11.1",
         ":remain-0.2.14",
         ":reqwest-0.12.8",
         ":ring-0.17.5",
@@ -17206,7 +17526,7 @@ cargo.rust_binary(
         ":rustls-pemfile-2.2.0",
         ":sea-orm-0.12.15",
         ":self-replace-1.5.0",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde-aux-4.5.0",
         ":serde_json-1.0.125",
         ":serde_path_to_error-0.1.16",
@@ -17219,14 +17539,14 @@ cargo.rust_binary(
         ":spicedb-grpc-0.1.1",
         ":stream-cancel-0.8.2",
         ":strum-0.26.3",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
         ":tar-0.4.42",
         ":tempfile-3.13.0",
         ":test-log-0.2.16",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":thread-priority-1.1.0",
         ":time-0.3.36",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-postgres-0.7.12",
         ":tokio-postgres-rustls-0.11.1",
         ":tokio-serde-0.9.0",
@@ -17259,48 +17579,48 @@ cargo.rust_binary(
 
 alias(
     name = "thiserror",
-    actual = ":thiserror-1.0.64",
+    actual = ":thiserror-1.0.65",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "thiserror-1.0.64.crate",
-    sha256 = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84",
-    strip_prefix = "thiserror-1.0.64",
-    urls = ["https://static.crates.io/crates/thiserror/1.0.64/download"],
+    name = "thiserror-1.0.65.crate",
+    sha256 = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5",
+    strip_prefix = "thiserror-1.0.65",
+    urls = ["https://static.crates.io/crates/thiserror/1.0.65/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "thiserror-1.0.64",
-    srcs = [":thiserror-1.0.64.crate"],
+    name = "thiserror-1.0.65",
+    srcs = [":thiserror-1.0.65.crate"],
     crate = "thiserror",
-    crate_root = "thiserror-1.0.64.crate/src/lib.rs",
+    crate_root = "thiserror-1.0.65.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":thiserror-impl-1.0.64"],
+    deps = [":thiserror-impl-1.0.65"],
 )
 
 http_archive(
-    name = "thiserror-impl-1.0.64.crate",
-    sha256 = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3",
-    strip_prefix = "thiserror-impl-1.0.64",
-    urls = ["https://static.crates.io/crates/thiserror-impl/1.0.64/download"],
+    name = "thiserror-impl-1.0.65.crate",
+    sha256 = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602",
+    strip_prefix = "thiserror-impl-1.0.65",
+    urls = ["https://static.crates.io/crates/thiserror-impl/1.0.65/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "thiserror-impl-1.0.64",
-    srcs = [":thiserror-impl-1.0.64.crate"],
+    name = "thiserror-impl-1.0.65",
+    srcs = [":thiserror-impl-1.0.65.crate"],
     crate = "thiserror_impl",
-    crate_root = "thiserror-impl-1.0.64.crate/src/lib.rs",
+    crate_root = "thiserror-impl-1.0.65.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -17416,7 +17736,7 @@ cargo.rust_library(
         ":itoa-1.0.11",
         ":num-conv-0.1.0",
         ":powerfmt-0.2.0",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":time-core-0.1.2",
         ":time-macros-0.2.18",
     ],
@@ -17504,7 +17824,7 @@ cargo.rust_library(
     edition = "2015",
     visibility = [],
     deps = [
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
     ],
 )
@@ -17551,23 +17871,23 @@ cargo.rust_library(
 
 alias(
     name = "tokio",
-    actual = ":tokio-1.40.0",
+    actual = ":tokio-1.41.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tokio-1.40.0.crate",
-    sha256 = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998",
-    strip_prefix = "tokio-1.40.0",
-    urls = ["https://static.crates.io/crates/tokio/1.40.0/download"],
+    name = "tokio-1.41.0.crate",
+    sha256 = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb",
+    strip_prefix = "tokio-1.41.0",
+    urls = ["https://static.crates.io/crates/tokio/1.41.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tokio-1.40.0",
-    srcs = [":tokio-1.40.0.crate"],
+    name = "tokio-1.41.0",
+    srcs = [":tokio-1.41.0.crate"],
     crate = "tokio",
-    crate_root = "tokio-1.40.0.crate/src/lib.rs",
+    crate_root = "tokio-1.41.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "bytes",
@@ -17642,10 +17962,10 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":mio-1.0.2",
         ":parking_lot-0.12.3",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
         ":tokio-macros-2.4.0",
         ":tracing",
     ],
@@ -17667,8 +17987,8 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":pin-project-lite-0.2.14",
-        ":tokio-1.40.0",
+        ":pin-project-lite-0.2.15",
+        ":tokio-1.41.0",
     ],
 )
 
@@ -17689,9 +18009,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -17745,7 +18065,7 @@ cargo.rust_library(
     deps = [
         ":async-trait-0.1.83",
         ":byteorder-1.5.0",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":fallible-iterator-0.2.0",
         ":futures-channel-0.3.31",
         ":futures-util-0.3.31",
@@ -17753,11 +18073,11 @@ cargo.rust_library(
         ":parking_lot-0.12.3",
         ":percent-encoding-2.3.1",
         ":phf-0.11.2",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
         ":postgres-protocol-0.6.7",
         ":postgres-types-0.2.8",
         ":rand-0.8.5",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-util-0.7.12",
         ":whoami-1.5.2",
     ],
@@ -17788,7 +18108,7 @@ cargo.rust_library(
         ":futures-0.3.31",
         ":ring-0.17.5",
         ":rustls-0.22.4",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-postgres-0.7.12",
         ":tokio-rustls-0.25.0",
         ":x509-certificate-0.23.1",
@@ -17817,7 +18137,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rustls-0.21.12",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
     ],
 )
 
@@ -17841,7 +18161,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rustls-0.22.4",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
     ],
 )
 
@@ -17869,7 +18189,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rustls-0.23.15",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
     ],
 )
 
@@ -17901,12 +18221,12 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":educe-0.5.11",
         ":futures-core-0.3.31",
         ":futures-sink-0.3.31",
-        ":pin-project-1.1.6",
-        ":serde-1.0.210",
+        ":pin-project-1.1.7",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
     ],
 )
@@ -17942,8 +18262,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":futures-core-0.3.31",
-        ":pin-project-lite-0.2.14",
-        ":tokio-1.40.0",
+        ":pin-project-lite-0.2.15",
+        ":tokio-1.41.0",
         ":tokio-util-0.7.12",
     ],
 )
@@ -17971,9 +18291,9 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":async-stream-0.3.6",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":futures-core-0.3.31",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-stream-0.1.16",
     ],
 )
@@ -18008,7 +18328,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.31",
         ":log-0.4.22",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tungstenite-0.20.1",
     ],
 )
@@ -18039,16 +18359,17 @@ cargo.rust_library(
         "futures-util",
         "hashbrown",
         "io",
+        "io-util",
         "rt",
     ],
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":futures-core-0.3.31",
         ":futures-sink-0.3.31",
         ":futures-util-0.3.31",
-        ":pin-project-lite-0.2.14",
-        ":tokio-1.40.0",
+        ":pin-project-lite-0.2.15",
+        ":tokio-1.41.0",
     ],
 )
 
@@ -18074,10 +18395,10 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":futures-0.3.31",
         ":libc-0.2.161",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":vsock-0.3.0",
     ],
 )
@@ -18109,7 +18430,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_spanned-0.6.8",
         ":toml_datetime-0.6.8",
         ":toml_edit-0.22.22",
@@ -18132,7 +18453,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["serde"],
     visibility = [],
-    deps = [":serde-1.0.210"],
+    deps = [":serde-1.0.213"],
 )
 
 http_archive(
@@ -18158,7 +18479,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":indexmap-2.6.0",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_spanned-0.6.8",
         ":toml_datetime-0.6.8",
         ":winnow-0.6.20",
@@ -18202,16 +18523,16 @@ cargo.rust_library(
         ":async-trait-0.1.83",
         ":axum-0.6.20",
         ":base64-0.21.7",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":h2-0.3.26",
         ":http-0.2.12",
         ":http-body-0.4.6",
         ":hyper-0.14.31",
         ":hyper-timeout-0.4.1",
         ":percent-encoding-2.3.1",
-        ":pin-project-1.1.6",
+        ":pin-project-1.1.7",
         ":prost-0.12.6",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-stream-0.1.16",
         ":tower-0.4.13",
         ":tower-layer-0.3.3",
@@ -18254,7 +18575,7 @@ cargo.rust_library(
     deps = [
         ":async-trait-0.1.83",
         ":base64-0.22.1",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":http-1.1.0",
         ":http-body-1.0.1",
         ":http-body-util-0.1.2",
@@ -18262,9 +18583,9 @@ cargo.rust_library(
         ":hyper-timeout-0.5.1",
         ":hyper-util-0.1.9",
         ":percent-encoding-2.3.1",
-        ":pin-project-1.1.6",
+        ":pin-project-1.1.7",
         ":prost-0.13.3",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-stream-0.1.16",
         ":tower-0.4.13",
         ":tower-layer-0.3.3",
@@ -18332,11 +18653,11 @@ cargo.rust_library(
         ":futures-util-0.3.31",
         ":hdrhistogram-7.5.4",
         ":indexmap-1.9.3",
-        ":pin-project-1.1.6",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-1.1.7",
+        ":pin-project-lite-0.2.15",
         ":rand-0.8.5",
         ":slab-0.4.9",
-        ":tokio-1.40.0",
+        ":tokio-1.41.0",
         ":tokio-util-0.7.12",
         ":tower-layer-0.3.3",
         ":tower-service-0.3.3",
@@ -18380,14 +18701,14 @@ cargo.rust_library(
     deps = [
         ":async-compression-0.4.17",
         ":bitflags-2.6.0",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":futures-core-0.3.31",
         ":futures-util-0.3.31",
         ":http-0.2.12",
         ":http-body-0.4.6",
         ":http-range-header-0.3.1",
-        ":pin-project-lite-0.2.14",
-        ":tokio-1.40.0",
+        ":pin-project-lite-0.2.15",
+        ":tokio-1.41.0",
         ":tokio-util-0.7.12",
         ":tower-layer-0.3.3",
         ":tower-service-0.3.3",
@@ -18459,7 +18780,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":log-0.4.22",
-        ":pin-project-lite-0.2.14",
+        ":pin-project-lite-0.2.15",
         ":tracing-attributes-0.1.27",
         ":tracing-core-0.1.32",
     ],
@@ -18482,9 +18803,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -18629,7 +18950,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":tracing-core-0.1.32",
     ],
 )
@@ -18681,8 +19002,8 @@ cargo.rust_library(
         ":matchers-0.1.0",
         ":nu-ansi-term-0.46.0",
         ":once_cell-1.20.2",
-        ":regex-1.11.0",
-        ":serde-1.0.210",
+        ":regex-1.11.1",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
         ":sharded-slab-0.1.7",
         ":smallvec-1.13.2",
@@ -18720,7 +19041,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":tracing-core-0.1.32",
     ],
 )
@@ -18787,8 +19108,8 @@ cargo.rust_library(
     deps = [
         ":dissimilar-1.0.9",
         ":glob-0.3.1",
-        ":serde-1.0.210",
-        ":serde_derive-1.0.210",
+        ":serde-1.0.213",
+        ":serde_derive-1.0.213",
         ":serde_json-1.0.125",
         ":target-triple-0.1.3",
         ":termcolor-1.4.1",
@@ -18819,8 +19140,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":futures-0.3.31",
-        ":pin-project-lite-0.2.14",
-        ":tokio-1.40.0",
+        ":pin-project-lite-0.2.15",
+        ":tokio-1.41.0",
     ],
 )
 
@@ -18849,14 +19170,14 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":byteorder-1.5.0",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":data-encoding-2.6.0",
         ":http-0.2.12",
         ":httparse-1.9.5",
         ":log-0.4.22",
         ":rand-0.8.5",
         ":sha1-0.10.6",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":url-2.5.2",
         ":utf-8-0.7.6",
     ],
@@ -18930,7 +19251,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rand-0.8.5",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -19170,7 +19491,7 @@ cargo.rust_library(
         ":form_urlencoded-1.2.1",
         ":idna-0.5.0",
         ":percent-encoding-2.3.1",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -19273,7 +19594,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":getrandom-0.2.15",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
     ],
 )
 
@@ -19461,7 +19782,7 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
     ],
 )
@@ -19834,9 +20155,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -19857,9 +20178,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -20225,7 +20546,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bcder-0.7.4",
-        ":bytes-1.7.2",
+        ":bytes-1.8.0",
         ":chrono-0.4.38",
         ":der-0.7.9",
         ":hex-0.4.3",
@@ -20233,7 +20554,7 @@ cargo.rust_library(
         ":ring-0.17.5",
         ":signature-2.2.0",
         ":spki-0.7.3",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
         ":zeroize-1.8.1",
     ],
 )
@@ -20340,8 +20661,8 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":futures-util-0.3.31",
-        ":thiserror-1.0.64",
-        ":tokio-1.40.0",
+        ":thiserror-1.0.65",
+        ":tokio-1.41.0",
         ":yrs-0.17.4",
     ],
 )
@@ -20392,11 +20713,11 @@ cargo.rust_library(
     deps = [
         ":atomic_refcell-0.1.13",
         ":rand-0.7.3",
-        ":serde-1.0.210",
+        ":serde-1.0.213",
         ":serde_json-1.0.125",
         ":smallstr-0.3.0",
         ":smallvec-1.13.2",
-        ":thiserror-1.0.64",
+        ":thiserror-1.0.65",
     ],
 )
 
@@ -20456,9 +20777,9 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )
 
@@ -20503,8 +20824,8 @@ cargo.rust_library(
     proc_macro = True,
     visibility = [],
     deps = [
-        ":proc-macro2-1.0.88",
+        ":proc-macro2-1.0.89",
         ":quote-1.0.37",
-        ":syn-2.0.82",
+        ":syn-2.0.85",
     ],
 )

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -140,43 +140,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "arrayref"
@@ -211,6 +211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-convert"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
+dependencies = [
+ "async-trait",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,7 +237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f71e5a1bab60f46b0b005f4808b8ee83ef6d577608923de938403393c9a30cf8"
 dependencies = [
  "base64 0.22.1",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures",
  "memchr",
  "nkeys",
@@ -256,6 +265,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-openai"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b17e44510f88a904cb3102a020d7ea11929dcddadfaff756e71112cb2cb7bd0"
+dependencies = [
+ "async-convert",
+ "backoff",
+ "base64 0.22.1",
+ "bytes 1.8.0",
+ "derive_builder",
+ "eventsource-stream",
+ "futures",
+ "rand 0.8.5",
+ "reqwest",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,7 +298,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -285,7 +320,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -296,7 +331,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -352,9 +387,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.8"
+version = "1.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7198e6f03240fdceba36656d8be440297b6b82270325908c7381f37d826a74f6"
+checksum = "2d6448cfb224dd6a9b9ac734f58622dd0d4751f3589f3b777345745f46b2eb14"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -368,7 +403,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "fastrand",
  "hex",
  "http 0.2.12",
@@ -430,7 +465,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "fastrand",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -443,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-firehose"
-version = "1.51.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f36d00e1ac8e25c61443968be1e933ced6b9675c4a8022c98e0dd5dc363130"
+checksum = "0c542b9b13d39838355ba85b037135dc19eba2d3f59e4dd7642f09681b662d96"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -456,7 +491,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -465,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.46.0"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc2faec3205d496c7e57eff685dd944203df7ce16a4116d0281c44021788a7b"
+checksum = "a8776850becacbd3a82a4737a9375ddb5c6832a51379f24443a98e61513f852c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -478,7 +513,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -487,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.47.0"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c93c241f52bc5e0476e259c953234dab7e2a35ee207ee202e86c0095ec4951dc"
+checksum = "0007b5b8004547133319b6c4e87193eee2a0bcb3e4c18c75d09febe9dab7b383"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -500,7 +535,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -509,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.46.0"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b259429be94a3459fa1b00c5684faee118d74f9577cc50aebadc36e507c63b5f"
+checksum = "9fffaa356e7f1c725908b75136d53207fa714e348f365671df14e95a60530ad3"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -532,15 +567,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8db6904450bafe7473c6ca9123f88cc11089e41a025408f992db4e22d3be68"
+checksum = "5619742a0d8f253be760bfbb8e8e8368c69e3587e4637af5754e488a611499b1"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "form_urlencoded",
  "hex",
  "hmac",
@@ -572,7 +607,7 @@ checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
@@ -605,15 +640,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db"
+checksum = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "fastrand",
  "h2 0.3.26",
  "http 0.2.12",
@@ -638,7 +673,7 @@ checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "http 0.2.12",
  "http 1.1.0",
  "pin-project-lite",
@@ -649,12 +684,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.7"
+version = "1.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147100a7bea70fa20ef224a6bad700358305f5dc0f84649c53769761395b355b"
+checksum = "07c9cdc179e6afbf5d391ab08c85eac817b51c87e1892a5edb5f7bbdc64314b4"
 dependencies = [
  "base64-simd",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
@@ -707,7 +742,7 @@ dependencies = [
  "axum-macros",
  "base64 0.21.7",
  "bitflags 1.3.2",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -740,7 +775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -759,7 +794,21 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.15",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]
@@ -823,7 +872,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627747a6774aab38beb35990d88309481378558875a41da1a4b2e373c906ef0"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "smallvec",
 ]
 
@@ -855,7 +904,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -932,7 +981,7 @@ checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
 dependencies = [
  "base64 0.22.1",
  "bollard-stubs",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-core",
  "futures-util",
  "hex",
@@ -988,7 +1037,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "syn_derive",
 ]
 
@@ -1065,9 +1114,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
 ]
@@ -1078,7 +1127,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "either",
 ]
 
@@ -1229,7 +1278,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1284,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
@@ -1323,11 +1372,10 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
+checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
 dependencies = [
- "lazy_static",
  "nom",
  "pathdiff",
  "serde",
@@ -1394,7 +1442,7 @@ dependencies = [
  "log",
  "mime",
  "paste",
- "pin-project 1.1.6",
+ "pin-project 1.1.7",
  "serde",
  "serde_json",
  "tar",
@@ -1649,7 +1697,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1673,7 +1721,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1684,7 +1732,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1788,7 +1836,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1798,7 +1846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1811,7 +1859,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1971,7 +2019,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2024,9 +2072,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -2048,7 +2096,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2115,6 +2163,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener 5.3.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
  "pin-project-lite",
 ]
 
@@ -2296,7 +2355,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2310,6 +2369,12 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2438,7 +2503,7 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -2458,7 +2523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -2652,7 +2717,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "fnv",
  "itoa",
 ]
@@ -2663,7 +2728,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "fnv",
  "itoa",
 ]
@@ -2674,7 +2739,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "http 0.2.12",
  "pin-project-lite",
 ]
@@ -2685,7 +2750,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "http 1.1.0",
 ]
 
@@ -2695,7 +2760,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
@@ -2732,7 +2797,7 @@ version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2756,7 +2821,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-channel",
  "futures-util",
  "h2 0.4.6",
@@ -2812,6 +2877,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "rustls 0.23.15",
+ "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2850,7 +2916,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
@@ -2871,7 +2937,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hyper 0.14.31",
- "pin-project 1.1.6",
+ "pin-project 1.1.7",
  "tokio",
 ]
 
@@ -2939,7 +3005,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.82",
+ "syn 2.0.85",
  "toml",
  "unicode-xid",
 ]
@@ -2958,6 +3024,25 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -3015,7 +3100,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3280,7 +3365,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3317,7 +3402,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3390,7 +3475,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3488,7 +3573,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "encoding_rs",
  "futures-util",
  "http 0.2.12",
@@ -3851,7 +3936,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3865,7 +3950,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4023,11 +4108,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
- "pin-project-internal 1.1.6",
+ "pin-project-internal 1.1.7",
 ]
 
 [[package]]
@@ -4043,20 +4128,20 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -4127,7 +4212,7 @@ checksum = "4d0ade207138f12695cb4be3b590283f1cf764c5c4909f39966c4b4b0dba7c1e"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "chrono",
  "containers-api",
  "flate2",
@@ -4183,7 +4268,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4194,7 +4279,7 @@ checksum = "acda0ebdebc28befa84bee35e651e4c5f09073d668c7aed4cf7e23c3cda84b23"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "fallible-iterator",
  "hmac",
  "md-5",
@@ -4210,7 +4295,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f66ea23a2d0e5734297357705193335e0a957696f34bed2f2faefacb2fec336f"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "chrono",
  "fallible-iterator",
  "postgres-derive",
@@ -4315,7 +4400,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4331,9 +4416,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -4346,7 +4431,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "version_check",
  "yansi",
 ]
@@ -4383,7 +4468,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "prost-derive 0.12.6",
 ]
 
@@ -4393,7 +4478,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "prost-derive 0.13.3",
 ]
 
@@ -4407,7 +4492,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4420,7 +4505,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4483,7 +4568,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -4501,7 +4586,7 @@ version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.0.0",
@@ -4700,7 +4785,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4716,9 +4801,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4772,7 +4857,7 @@ checksum = "46aef80f842736de545ada6ec65b81ee91504efd6853f4b96de7414c42ae7443"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4791,7 +4876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64 0.22.1",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-core",
  "futures-util",
  "http 1.1.0",
@@ -4810,6 +4895,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.15",
+ "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -4818,13 +4904,31 @@ dependencies = [
  "sync_wrapper 1.0.1",
  "tokio",
  "tokio-rustls 0.26.0",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.26.6",
  "windows-registry",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror",
 ]
 
 [[package]]
@@ -4865,7 +4969,7 @@ checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
 dependencies = [
  "bitvec",
  "bytecheck",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "hashbrown 0.12.3",
  "ptr_meta",
  "rend",
@@ -4926,7 +5030,7 @@ dependencies = [
  "aws-creds",
  "aws-region",
  "base64 0.21.7",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "cfg-if",
  "futures",
  "hex",
@@ -4961,7 +5065,7 @@ checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
 dependencies = [
  "arrayvec 0.7.6",
  "borsh",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "num-traits",
  "rand 0.8.5",
  "rkyv",
@@ -5075,6 +5179,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5175,7 +5292,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5216,7 +5333,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.82",
+ "syn 2.0.85",
  "unicode-ident",
 ]
 
@@ -5274,6 +5391,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5315,9 +5442,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
@@ -5335,13 +5462,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5395,7 +5522,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5456,7 +5583,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5653,7 +5780,7 @@ name = "spicedb-client"
 version = "0.1.1"
 source = "git+https://github.com/systeminit/spicedb-client.git?branch=si-stable#3cf3ba3482412372cee072ab3585098a8dfc1cd1"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "http 1.1.0",
  "prost 0.13.3",
  "prost-types",
@@ -5724,7 +5851,7 @@ dependencies = [
  "atoi",
  "bigdecimal",
  "byteorder",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -5811,7 +5938,7 @@ dependencies = [
  "bigdecimal",
  "bitflags 2.6.0",
  "byteorder",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "chrono",
  "crc",
  "digest",
@@ -5953,7 +6080,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9fbf9bd71e4cf18d68a8a0951c0e5b7255920c0cd992c4ff51cddd6ef514a3"
 dependencies = [
  "futures-core",
- "pin-project 1.1.6",
+ "pin-project 1.1.7",
  "tokio",
 ]
 
@@ -5999,7 +6126,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6034,9 +6161,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6052,7 +6179,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6158,7 +6285,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6166,6 +6293,7 @@ name = "third-party"
 version = "0.0.0"
 dependencies = [
  "async-nats",
+ "async-openai",
  "async-recursion",
  "async-trait",
  "aws-config",
@@ -6174,7 +6302,7 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "bollard",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "cacache",
  "chrono",
  "ciborium",
@@ -6206,6 +6334,7 @@ dependencies = [
  "hyper 0.14.31",
  "hyperlocal",
  "iftree",
+ "include_dir",
  "indexmap 2.6.0",
  "indicatif",
  "indoc",
@@ -6266,7 +6395,7 @@ dependencies = [
  "spicedb-grpc",
  "stream-cancel",
  "strum 0.26.3",
- "syn 2.0.82",
+ "syn 2.0.85",
  "tar",
  "tempfile",
  "test-log",
@@ -6305,22 +6434,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6414,12 +6543,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "libc",
  "mio 1.0.2",
  "parking_lot",
@@ -6448,7 +6577,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6459,7 +6588,7 @@ checksum = "3b5d3742945bc7d7f210693b0c58ae542c6fd47b17adbbda0885f3dcb34a6bdb"
 dependencies = [
  "async-trait",
  "byteorder",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "fallible-iterator",
  "futures-channel",
  "futures-util",
@@ -6530,11 +6659,11 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf600e7036b17782571dd44fa0a5cea3c82f60db5137f774a325a76a0d6852b"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "educe",
  "futures-core",
  "futures-sink",
- "pin-project 1.1.6",
+ "pin-project 1.1.7",
  "serde",
  "serde_json",
 ]
@@ -6558,7 +6687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
 dependencies = [
  "async-stream",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-core",
  "tokio",
  "tokio-stream",
@@ -6582,7 +6711,7 @@ version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-core",
  "futures-sink",
  "futures-util",
@@ -6597,7 +6726,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd"
 dependencies = [
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures",
  "libc",
  "tokio",
@@ -6648,14 +6777,14 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.21.7",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.31",
  "hyper-timeout 0.4.1",
  "percent-encoding",
- "pin-project 1.1.6",
+ "pin-project 1.1.7",
  "prost 0.12.6",
  "tokio",
  "tokio-stream",
@@ -6673,7 +6802,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -6681,7 +6810,7 @@ dependencies = [
  "hyper-timeout 0.5.1",
  "hyper-util",
  "percent-encoding",
- "pin-project 1.1.6",
+ "pin-project 1.1.7",
  "prost 0.13.3",
  "tokio",
  "tokio-stream",
@@ -6701,7 +6830,7 @@ dependencies = [
  "futures-util",
  "hdrhistogram",
  "indexmap 1.9.3",
- "pin-project 1.1.6",
+ "pin-project 1.1.7",
  "pin-project-lite",
  "rand 0.8.5",
  "slab",
@@ -6720,7 +6849,7 @@ checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "async-compression",
  "bitflags 2.6.0",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "futures-core",
  "futures-util",
  "http 0.2.12",
@@ -6766,7 +6895,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6905,7 +7034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
  "byteorder",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "data-encoding",
  "http 0.2.12",
  "httparse",
@@ -7200,7 +7329,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -7234,7 +7363,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7244,6 +7373,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"
@@ -7362,7 +7504,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7373,7 +7515,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7579,7 +7721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66534846dec7a11d7c50a74b7cdb208b9a581cad890b7866430d438455847c85"
 dependencies = [
  "bcder",
- "bytes 1.7.2",
+ "bytes 1.8.0",
  "chrono",
  "der",
  "hex",
@@ -7665,7 +7807,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7685,7 +7827,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[patch.unused]]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -29,6 +29,7 @@ publish = false
 
 [dependencies]
 async-nats = { version = "0.36.0", features = ["service"] }
+async-openai = "0.25.0"
 async-recursion = "1.0.5"
 async-trait = "0.1.79"
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
@@ -69,6 +70,7 @@ http = "0.2.12" # todo: upgrade this alongside hyper/axum/tokio-tungstenite/towe
 hyper = { version = "0.14.28", features = ["client", "http1", "runtime", "server"] } # todo: upgrade this alongside http/axum/tokio-tungstenite/tower-http
 hyperlocal = { version = "0.8.0", default-features = false, features = ["client"] } # todo: using the very latest of hyper client 1.x, we _may_ be able to phase this crate
 iftree = "1.0.5"
+include_dir = "0.7.4"
 indexmap = { version = "2.2.6", features = ["serde", "std"] }
 indicatif = "0.17.8"
 indoc = "2.0.5"


### PR DESCRIPTION
This adds a button to the asset schema code editor that lets you generate your asset schema function with AI.

https://github.com/user-attachments/assets/9cfd344e-2188-45e5-9855-cededb8ed23e

* Generation is imperfect, but passable. This turn is about hooking it up end to end so we can iterate more rapidly.
* AI generation is in the new `asset_sprayer` crate, which `sdf` calls out to to generate the code. `dal` does not depend on this.
* Locked behind the `ai-generator` feature flag, which is restricted to SI internal only
* Use `SI_OPENAI_API_KEY` when launching `buck2` to pass your API key
* Use `SI_ASSET_SPRAYER_PROMPTS_DIR=<path to your si dir>/lib/asset-sprayer/prompts` when launching `buck2` to have it load prompts from disk for faster prompt dev cycle
* Deployable using SI config files with `[openai] api_key=...` in config file