### PR TITLE
Don't filter out bindings for schema variants that have components on the canvas

### DIFF
--- a/lib/sdf-server/src/service/v2/func/list_funcs.rs
+++ b/lib/sdf-server/src/service/v2/func/list_funcs.rs
@@ -54,12 +54,19 @@ async fn treat_single_function(
     // If func is unlocked or intrinsic, we always use it,
     // otherwise we return funcs that are bound to default variants
     // OR not bound to anything, OR editing variants
+    // OR bound to variants with components on the canvas
     if func.is_locked && !func.is_intrinsic() && !bindings.is_empty() {
         let mut should_hide = true;
         for binding in &bindings {
             let Some(schema_variant_id) = binding.get_schema_variant() else {
                 continue;
             };
+
+            let maybe_existing_components =
+                SchemaVariant::list_component_ids(ctx, schema_variant_id).await?;
+            if !maybe_existing_components.is_empty() {
+                should_hide = false;
+            }
 
             let schema =
                 SchemaVariant::schema_id_for_schema_variant_id(ctx, schema_variant_id).await?;


### PR DESCRIPTION
<div><img src="https://media4.giphy.com/media/550h6RQfuOuhtaDwdl/giphy.gif?cid=5a38a5a2bq78c8lrrr1byi8digrf33eohupqnkcn16ht8wtm&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/billions/">Billions</a> on <a href="https://giphy.com/gifs/billions-season-4-episode-1-showtime-550h6RQfuOuhtaDwdl">GIPHY</a></div>