### PR TITLE
feat: create and manage other components

### DIFF
--- a/bin/lang-js/src/component.ts
+++ b/bin/lang-js/src/component.ts
@@ -3,12 +3,14 @@ export interface Component {
   properties: Record<string, unknown>;
 }
 
+export interface Geometry {
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+}
+
 export interface ComponentWithGeometry {
   properties: Record<string, unknown>;
-  geometry: {
-    x: string,
-    y: string,
-    width?: string,
-    height?: string,
-  }
+  geometry: Geometry;
 }

--- a/lib/cyclone-client/src/client.rs
+++ b/lib/cyclone-client/src/client.rs
@@ -443,7 +443,7 @@ impl Default for ClientConfig {
 #[allow(clippy::panic, clippy::assertions_on_constants)]
 #[cfg(test)]
 mod tests {
-    use std::{env, path::Path};
+    use std::{collections::HashMap, env, path::Path};
 
     use base64::{engine::general_purpose, Engine};
     use buck2_resources::Buck2Resources;
@@ -1326,9 +1326,11 @@ mod tests {
             execution_id: "1234".to_string(),
             handler: "manage".to_string(),
             this_component: ComponentViewWithGeometry {
+                kind: None,
                 properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),
                 geometry: serde_json::json!({"x": "1", "y": "2"}),
             },
+            components: HashMap::new(),
             code_base64: base64_encode(
                 r#"function manage(input) {
                     console.log('first');
@@ -1408,9 +1410,11 @@ mod tests {
             execution_id: "1234".to_string(),
             handler: "manage".to_string(),
             this_component: ComponentViewWithGeometry {
+                kind: None,
                 properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),
                 geometry: serde_json::json!({"x": "1", "y": "2"}),
             },
+            components: HashMap::new(),
             code_base64: base64_encode(
                 r#"function manage({ thisComponent }) {
                     console.log('first');

--- a/lib/cyclone-core/src/component_view.rs
+++ b/lib/cyclone-core/src/component_view.rs
@@ -34,6 +34,8 @@ impl Default for ComponentView {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ComponentViewWithGeometry {
+    // This is not component kind. Instead it's a schema name
+    pub kind: Option<String>,
     pub properties: Value,
     pub geometry: Value,
 }
@@ -41,6 +43,7 @@ pub struct ComponentViewWithGeometry {
 impl Default for ComponentViewWithGeometry {
     fn default() -> Self {
         Self {
+            kind: None,
             properties: serde_json::json!({}),
             geometry: serde_json::json!({}),
         }

--- a/lib/cyclone-core/src/management.rs
+++ b/lib/cyclone-core/src/management.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use telemetry::prelude::*;
 use telemetry_utils::metric;
@@ -11,6 +13,7 @@ pub struct ManagementRequest {
     pub handler: String,
     pub code_base64: String,
     pub this_component: ComponentViewWithGeometry,
+    pub components: HashMap<String, ComponentViewWithGeometry>,
     pub before: Vec<BeforeFunction>,
 }
 

--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -386,7 +386,7 @@ impl ExpectComponent {
             .geometry(ctx)
             .await
             .expect("get geometry for component")
-            .raw()
+            .into_raw()
     }
 
     pub async fn view(self, ctx: &DalContext) -> Option<serde_json::Value> {

--- a/lib/dal/src/diagram/geometry.rs
+++ b/lib/dal/src/diagram/geometry.rs
@@ -61,7 +61,7 @@ impl Geometry {
         result: DiagramResult,
     );
 
-    pub fn raw(self) -> RawGeometry {
+    pub fn into_raw(self) -> RawGeometry {
         self.into()
     }
 

--- a/lib/dal/src/func/authoring/ts_types.rs
+++ b/lib/dal/src/func/authoring/ts_types.rs
@@ -61,23 +61,9 @@ pub(crate) fn compile_return_types(
         FuncBackendResponseType::Object => "type Output = any;",
         FuncBackendResponseType::Unset => "type Output = undefined | null;",
         FuncBackendResponseType::Void => "type Output = void;",
-        FuncBackendResponseType::Management => {
-            r#"
-type Output = {
-  status: 'ok' | 'error';
-  ops?: {
-    update?: { [key: string]: { properties?: { [key: string]: unknown } } };
-    actions?: { [key: string]: {
-      add?: ("create" | "update" | "refresh" | "delete" | string)[];
-      remove?: ("create" | "update" | "refresh" | "delete" | string)[];
-    } }
-
-  };
-  message?: string | null;
-};
-type Input = { thisComponent: { properties: { [key: string]: unknown } } };
-            "#
-        }
+        // All of the types for a management function are determined at "run"
+        // time when compiling binding types
+        FuncBackendResponseType::Management => "",
         _ => "",
         // we no longer serve this from the backend, its static on the front end
         //FuncBackendResponseType::SchemaVariantDefinition => SCHEMA_VARIANT_DEFINITION_TYPES

--- a/lib/dal/src/func/backend/management.rs
+++ b/lib/dal/src/func/backend/management.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use veritech_client::{
@@ -12,6 +14,7 @@ use super::ExtractPayload;
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct FuncBackendManagementArgs {
     this_component: ComponentViewWithGeometry,
+    components: HashMap<String, ComponentViewWithGeometry>,
 }
 
 #[derive(Debug)]
@@ -37,6 +40,7 @@ impl FuncDispatch for FuncBackendManagement {
             handler: handler.into(),
             code_base64: code_base64.into(),
             this_component: args.this_component,
+            components: args.components,
             before,
         };
 

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -31,8 +31,8 @@ use crate::{
     FuncError, FuncId, PropId, SchemaVariantError, SchemaVariantId,
 };
 use crate::{
-    ComponentId, InputSocketId, OutputSocketId, SchemaId, SchemaVariant, WorkspaceSnapshotError,
-    WsEventError,
+    ComponentId, InputSocketId, OutputSocketId, SchemaError, SchemaId, SchemaVariant,
+    WorkspaceSnapshotError, WsEventError,
 };
 
 pub use attribute_argument::AttributeArgumentBinding;
@@ -96,6 +96,8 @@ pub enum FuncBindingError {
     OutputSocket(#[from] OutputSocketError),
     #[error("prop error: {0}")]
     Prop(#[from] PropError),
+    #[error("schema error: {0}")]
+    Schema(#[from] SchemaError),
     #[error("schema variant error: {0}")]
     SchemaVariant(#[from] SchemaVariantError),
     #[error("serde error: {0}")]
@@ -580,7 +582,9 @@ impl FuncBinding {
                 LeafBinding::compile_leaf_func_types(ctx, func_id).await?
             }
             FuncKind::Attribute => AttributeBinding::compile_attribute_types(ctx, func_id).await?,
-            FuncKind::Management => String::new(),
+            FuncKind::Management => {
+                ManagementBinding::compile_management_types(ctx, func_id).await?
+            }
             FuncKind::Authentication
             | FuncKind::Intrinsic
             | FuncKind::SchemaVariantDefinition

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -13,7 +13,6 @@ use si_pkg::{
     SiPropFuncSpecKind, SocketSpec, SocketSpecData, SocketSpecKind, SpecError,
 };
 use telemetry::prelude::*;
-use ulid::Ulid;
 
 use crate::action::prototype::ActionPrototype;
 use crate::attribute::prototype::argument::{
@@ -519,7 +518,7 @@ impl PkgExporter {
             ManagementPrototype::list_for_variant_id(ctx, schema_variant_id).await?;
 
         for management_proto in management_prototypes {
-            let key = ManagementPrototype::func_id(ctx, management_proto.id).await?;
+            let key = ManagementPrototype::func_id(ctx, management_proto.id()).await?;
 
             let func_spec = self
                 .func_map
@@ -527,19 +526,19 @@ impl PkgExporter {
                 .ok_or(PkgError::MissingExportedFunc(key))?;
 
             let mut builder = ManagementFuncSpec::builder();
-            if let Some(description) = management_proto.description {
-                builder.description(description);
+            if let Some(description) = management_proto.description() {
+                builder.description(description.to_string());
             }
-            if let Some(managed_schemas) = management_proto.managed_schemas {
-                let managed_schemas: HashSet<Ulid> =
-                    managed_schemas.into_iter().map(Into::into).collect();
+            if let Some(managed_schemas) = management_proto.managed_schemas() {
+                let managed_schemas: HashSet<_> =
+                    managed_schemas.iter().map(|id| id.to_string()).collect();
                 builder.managed_schemas(managed_schemas);
             }
 
             specs.push(
                 builder
                     .func_unique_id(&func_spec.unique_id)
-                    .name(management_proto.name)
+                    .name(management_proto.name())
                     .build()?,
             )
         }

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -853,9 +853,13 @@ async fn import_management_func(
         management_func_spec.name().to_string(),
         management_func_spec.description().map(Into::into),
         func_id,
-        management_func_spec
-            .managed_schemas()
-            .map(|schemas| schemas.iter().map(|ulid| (*ulid).into()).collect()),
+        management_func_spec.managed_schemas().map(|schemas| {
+            schemas
+                .iter()
+                .filter_map(|ulid| Ulid::from_string(ulid).ok())
+                .map(Into::into)
+                .collect()
+        }),
         schema_variant_id,
     )
     .await?;

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -1133,7 +1133,6 @@ impl Prop {
         Self::find_prop_id_by_path(ctx, schema_variant_id, &prop_path).await
     }
 
-    #[instrument(level = "debug", skip_all)]
     #[async_recursion]
     pub async fn ts_type(&self, ctx: &DalContext) -> PropResult<String> {
         let self_path = self.path(ctx).await?;

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -65,6 +65,8 @@ pub enum EdgeWeightKind {
     ManagementPrototype,
     /// From a Geometry node to the node it represents on a view.
     Represents,
+    /// From a manager [`Component`][`crate::Component`] to a managed `Component
+    Manages,
 }
 
 impl EdgeWeightKind {

--- a/lib/dal/src/workspace_snapshot/graph/v2.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v2.rs
@@ -1233,7 +1233,8 @@ impl WorkspaceSnapshotGraphV2 {
                     | EdgeWeightKind::Root
                     | EdgeWeightKind::SocketValue
                     | EdgeWeightKind::ManagementPrototype
-                    | EdgeWeightKind::ValidationOutput => {}
+                    | EdgeWeightKind::ValidationOutput
+                    | EdgeWeightKind::Manages => {}
                 }
             }
         }

--- a/lib/dal/src/workspace_snapshot/graph/v3.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v3.rs
@@ -749,6 +749,7 @@ impl WorkspaceSnapshotGraphV3 {
                     EdgeWeightKindDiscriminants::Use => "black",
                     EdgeWeightKindDiscriminants::ValidationOutput => "darkcyan",
                     EdgeWeightKindDiscriminants::ManagementPrototype => "pink",
+                    EdgeWeightKindDiscriminants::Manages => "pink",
                 };
 
                 match edgeref.weight().kind() {
@@ -1409,7 +1410,8 @@ impl WorkspaceSnapshotGraphV3 {
                     | EdgeWeightKind::Root
                     | EdgeWeightKind::SocketValue
                     | EdgeWeightKind::ValidationOutput
-                    | EdgeWeightKind::ManagementPrototype => {}
+                    | EdgeWeightKind::ManagementPrototype
+                    | EdgeWeightKind::Manages => {}
                 }
             }
         }

--- a/lib/dal/src/workspace_snapshot/graph/v4.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v4.rs
@@ -862,6 +862,7 @@ impl WorkspaceSnapshotGraphV4 {
                     EdgeWeightKindDiscriminants::Use => "black",
                     EdgeWeightKindDiscriminants::ValidationOutput => "darkcyan",
                     EdgeWeightKindDiscriminants::ManagementPrototype => "pink",
+                    EdgeWeightKindDiscriminants::Manages => "pink",
                 };
 
                 match edgeref.weight().kind() {
@@ -1530,7 +1531,8 @@ impl WorkspaceSnapshotGraphV4 {
                     | EdgeWeightKind::Root
                     | EdgeWeightKind::SocketValue
                     | EdgeWeightKind::ValidationOutput
-                    | EdgeWeightKind::ManagementPrototype => {}
+                    | EdgeWeightKind::ManagementPrototype
+                    | EdgeWeightKind::Manages => {}
                 }
             }
         }

--- a/lib/dal/tests/integration_test/deserialize/mod.rs
+++ b/lib/dal/tests/integration_test/deserialize/mod.rs
@@ -189,6 +189,7 @@ fn make_me_one_with_everything(graph: &mut WorkspaceSnapshotGraphVCurrent) {
             EdgeWeightKindDiscriminants::ValidationOutput => EdgeWeightKind::ValidationOutput,
             EdgeWeightKindDiscriminants::ManagementPrototype => EdgeWeightKind::ManagementPrototype,
             EdgeWeightKindDiscriminants::Represents => EdgeWeightKind::Represents,
+            EdgeWeightKindDiscriminants::Manages => EdgeWeightKind::Manages,
         };
 
         let edge_weight = EdgeWeight::new(edge_weight_kind);

--- a/lib/dal/tests/integration_test/func/kill_execution.rs
+++ b/lib/dal/tests/integration_test/func/kill_execution.rs
@@ -37,7 +37,7 @@ async fn kill_execution_works(ctx: &mut DalContext) {
     .await
     .expect("could new leaf func");
     let code = "async function main() {
-        const ms = 480 * 1000;
+        const ms = 600 * 1000;
         const sleep = new Promise((resolve) => setTimeout(resolve, ms));
         await sleep;
         return { payload: { \"poop\": true }, status: \"ok\" };

--- a/lib/dal/tests/integration_test/management.rs
+++ b/lib/dal/tests/integration_test/management.rs
@@ -1,9 +1,303 @@
+use std::collections::HashMap;
+
 use dal::{
-    management::{operate, prototype::ManagementPrototype, ManagementFuncReturn},
+    management::{
+        prototype::ManagementPrototype, ManagementFuncReturn, ManagementOperator, NumericGeometry,
+    },
     AttributeValue, Component, DalContext,
 };
 use dal_test::{helpers::create_component_for_default_schema_name, test};
 use veritech_client::ManagementFuncStatus;
+
+#[test]
+async fn update_managed_components(ctx: &DalContext) {
+    let small_odd_lego =
+        create_component_for_default_schema_name(ctx, "small odd lego", "small odd lego")
+            .await
+            .expect("could not create component");
+    let small_even_lego =
+        create_component_for_default_schema_name(ctx, "small even lego", "small even lego")
+            .await
+            .expect("could not create component");
+
+    Component::manage_component(ctx, small_odd_lego.id(), small_even_lego.id())
+        .await
+        .expect("add manages edge");
+
+    let manager_variant = small_odd_lego
+        .schema_variant(ctx)
+        .await
+        .expect("get variant");
+
+    let management_prototype = ManagementPrototype::list_for_variant_id(ctx, manager_variant.id())
+        .await
+        .expect("get prototypes")
+        .into_iter()
+        .find(|proto| proto.name() == "Update")
+        .expect("could not find prototype");
+
+    let execution_result = management_prototype
+        .execute(ctx, small_odd_lego.id())
+        .await
+        .expect("should execute management prototype func");
+
+    let result: ManagementFuncReturn = execution_result
+        .result
+        .expect("should have a result success")
+        .try_into()
+        .expect("should be a valid management func return");
+
+    assert_eq!(result.status, ManagementFuncStatus::Ok);
+
+    let operations = result.operations.expect("should have operations");
+
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        execution_result.manager_component_geometry,
+        operations,
+        execution_result.managed_schema_map,
+        execution_result.placeholders,
+    )
+    .await
+    .expect("should create operator")
+    .operate()
+    .await
+    .expect("should operate");
+
+    let mut new_component = None;
+    let components = Component::list(ctx).await.expect("list components");
+    assert_eq!(2, components.len());
+    for c in components {
+        if c.name(ctx).await.expect("get name") == "small even lego managed by small odd lego" {
+            new_component = Some(c);
+            break;
+        }
+    }
+
+    let _new_component = new_component.expect("should have found the cloned component");
+}
+
+#[test]
+async fn create_component_of_other_schema(ctx: &DalContext) {
+    let small_odd_lego =
+        create_component_for_default_schema_name(ctx, "small odd lego", "small odd lego")
+            .await
+            .expect("could not create component");
+    let small_even_lego =
+        create_component_for_default_schema_name(ctx, "small even lego", "small even lego")
+            .await
+            .expect("could not create component");
+
+    let av_id = Component::attribute_value_for_prop_by_id(
+        ctx,
+        small_even_lego.id(),
+        &["root", "si", "resourceId"],
+    )
+    .await
+    .expect("av should exist");
+
+    AttributeValue::update(
+        ctx,
+        av_id,
+        Some(serde_json::json!("small even lego resource id")),
+    )
+    .await
+    .expect("able to update value");
+
+    Component::manage_component(ctx, small_odd_lego.id(), small_even_lego.id())
+        .await
+        .expect("add manages edge");
+
+    let manager_variant = small_odd_lego
+        .schema_variant(ctx)
+        .await
+        .expect("get variant");
+
+    let management_prototype = ManagementPrototype::list_for_variant_id(ctx, manager_variant.id())
+        .await
+        .expect("get prototypes")
+        .into_iter()
+        .find(|proto| proto.name() == "Clone")
+        .expect("could not find prototype");
+
+    let execution_result = management_prototype
+        .execute(ctx, small_odd_lego.id())
+        .await
+        .expect("should execute management prototype func");
+
+    let result: ManagementFuncReturn = execution_result
+        .result
+        .expect("should have a result success")
+        .try_into()
+        .expect("should be a valid management func return");
+
+    assert_eq!(result.status, ManagementFuncStatus::Ok);
+
+    let operations = result.operations.expect("should have operations");
+
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        execution_result.manager_component_geometry,
+        operations,
+        execution_result.managed_schema_map,
+        execution_result.placeholders,
+    )
+    .await
+    .expect("should create operator")
+    .operate()
+    .await
+    .expect("should operate");
+
+    let mut new_component = None;
+    let components = Component::list(ctx).await.expect("list components");
+    assert_eq!(4, components.len());
+    for c in components {
+        if c.name(ctx).await.expect("get name") == "small even lego_clone" {
+            new_component = Some(c);
+            break;
+        }
+    }
+
+    let new_component = new_component.expect("should have found the cloned component");
+    let av_id = Component::attribute_value_for_prop_by_id(
+        ctx,
+        new_component.id(),
+        &["root", "si", "resourceId"],
+    )
+    .await
+    .expect("av should exist");
+
+    let av = AttributeValue::get_by_id(ctx, av_id)
+        .await
+        .expect("get value");
+
+    assert_eq!(
+        Some(serde_json::json!("small even lego resource id")),
+        av.value(ctx).await.expect("get value")
+    );
+}
+
+#[test]
+async fn create_component_of_same_schema(ctx: &DalContext) {
+    let small_odd_lego =
+        create_component_for_default_schema_name(ctx, "small odd lego", "small odd lego")
+            .await
+            .expect("could not create component");
+    let variant = small_odd_lego
+        .schema_variant(ctx)
+        .await
+        .expect("get variant");
+
+    let management_prototype = ManagementPrototype::list_for_variant_id(ctx, variant.id())
+        .await
+        .expect("get prototypes")
+        .into_iter()
+        .find(|proto| proto.name() == "Clone")
+        .expect("could not find prototype");
+
+    let execution_result = management_prototype
+        .execute(ctx, small_odd_lego.id())
+        .await
+        .expect("should execute management prototype func");
+
+    let result: ManagementFuncReturn = execution_result
+        .result
+        .expect("should have a result success")
+        .try_into()
+        .expect("should be a valid management func return");
+
+    assert_eq!(result.status, ManagementFuncStatus::Ok);
+
+    let operations = result.operations.expect("should have operations");
+
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        execution_result.manager_component_geometry,
+        operations,
+        execution_result.managed_schema_map,
+        execution_result.placeholders,
+    )
+    .await
+    .expect("should create operator")
+    .operate()
+    .await
+    .expect("should operate");
+
+    let mut new_component = None;
+    let components = Component::list(ctx).await.expect("list components");
+    assert_eq!(2, components.len());
+    for c in components {
+        if c.name(ctx).await.expect("get name") == "small odd lego_clone" {
+            new_component = Some(c);
+            break;
+        }
+    }
+
+    let new_component = new_component.expect("should have found the cloned component");
+    let new_geometry: NumericGeometry = new_component
+        .geometry(ctx)
+        .await
+        .expect("get geometry")
+        .into_raw()
+        .into();
+
+    assert_eq!(10.0, new_geometry.x);
+    assert_eq!(20.0, new_geometry.y);
+
+    let managers = new_component.get_managers(ctx).await.expect("get managers");
+
+    assert_eq!(1, managers.len());
+    assert_eq!(
+        small_odd_lego.id(),
+        managers[0],
+        "should have the same manager"
+    );
+
+    let execution_result = management_prototype
+        .execute(ctx, small_odd_lego.id())
+        .await
+        .expect("should execute management prototype func");
+
+    let result: ManagementFuncReturn = execution_result
+        .result
+        .expect("should have a result success")
+        .try_into()
+        .expect("should be a valid management func return");
+
+    assert_eq!(result.status, ManagementFuncStatus::Ok);
+
+    let operations = result.operations.expect("should have operations");
+
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        execution_result.manager_component_geometry,
+        operations,
+        execution_result.managed_schema_map,
+        HashMap::new(),
+    )
+    .await
+    .expect("should create operator")
+    .operate()
+    .await
+    .expect("should operate");
+
+    let mut new_component_2 = None;
+
+    let components = Component::list(ctx).await.expect("list components");
+    assert_eq!(4, components.len());
+    for c in components {
+        let name = c.name(ctx).await.expect("get name");
+        if name == "small odd lego_clone_clone" {
+            new_component_2 = Some(c);
+            //break;
+        }
+    }
+    let _new_component_2 = new_component_2.expect("should have found the cloned component again");
+}
 
 #[test]
 async fn execute_management_func(ctx: &DalContext) {
@@ -32,26 +326,35 @@ async fn execute_management_func(ctx: &DalContext) {
         .await
         .expect("get prototypes")
         .into_iter()
-        .find(|proto| proto.name == "Import small odd lego")
+        .find(|proto| proto.name() == "Import small odd lego")
         .expect("could not find prototype");
 
-    let (result_value, _) = management_prototype
+    let execution_result = management_prototype
         .execute(ctx, small_odd_lego.id())
         .await
         .expect("should execute management prototype func");
 
-    let result: ManagementFuncReturn = result_value
+    let result: ManagementFuncReturn = execution_result
+        .result
         .expect("should have a result success")
         .try_into()
         .expect("should be a valid management func return");
 
     assert_eq!(result.status, ManagementFuncStatus::Ok);
 
-    operate(
+    let operations = result.operations.expect("should have operations");
+
+    ManagementOperator::new(
         ctx,
         small_odd_lego.id(),
-        result.operations.expect("should have operations"),
+        execution_result.manager_component_geometry,
+        operations,
+        execution_result.managed_schema_map,
+        execution_result.placeholders,
     )
+    .await
+    .expect("should create operator")
+    .operate()
     .await
     .expect("should operate");
 

--- a/lib/sdf-server/src/service/diagram.rs
+++ b/lib/sdf-server/src/service/diagram.rs
@@ -103,8 +103,6 @@ pub enum DiagramError {
     Schema(#[from] SchemaError),
     #[error("schema not found")]
     SchemaNotFound,
-    #[error("No schema installed after successful package import for {0}")]
-    SchemaNotInstalledAfterImport(SchemaId),
     #[error("serde error: {0}")]
     Serde(#[from] serde_json::Error),
     #[error("slow runtime error: {0}")]

--- a/lib/si-pkg/src/node/management_func.rs
+++ b/lib/si-pkg/src/node/management_func.rs
@@ -7,7 +7,6 @@ use object_tree::{
     read_key_value_line, read_key_value_line_opt, write_key_value_line, write_key_value_line_opt,
     GraphError, NodeChild, NodeKind, NodeWithChildren, ReadBytes, WriteBytes,
 };
-use ulid::Ulid;
 
 use crate::ManagementFuncSpec;
 
@@ -23,7 +22,7 @@ pub struct ManagementFuncNode {
     pub func_unique_id: String,
     pub name: String,
     pub description: Option<String>,
-    pub managed_schemas: Option<HashSet<Ulid>>,
+    pub managed_schemas: Option<HashSet<String>>,
 }
 
 impl WriteBytes for ManagementFuncNode {

--- a/lib/si-pkg/src/pkg/management_func.rs
+++ b/lib/si-pkg/src/pkg/management_func.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 
 use object_tree::{Hash, HashedNode};
 use petgraph::prelude::*;
-use ulid::Ulid;
 
 use super::{PkgResult, SiPkgError, Source};
 
@@ -13,7 +12,7 @@ pub struct SiPkgManagementFunc<'a> {
     func_unique_id: String,
     name: String,
     description: Option<String>,
-    managed_schemas: Option<HashSet<Ulid>>,
+    managed_schemas: Option<HashSet<String>>,
 
     hash: Hash,
     source: Source<'a>,
@@ -58,7 +57,7 @@ impl<'a> SiPkgManagementFunc<'a> {
         self.description.as_deref()
     }
 
-    pub fn managed_schemas(&self) -> Option<&HashSet<Ulid>> {
+    pub fn managed_schemas(&self) -> Option<&HashSet<String>> {
         self.managed_schemas.as_ref()
     }
 

--- a/lib/si-pkg/src/spec/management_func.rs
+++ b/lib/si-pkg/src/spec/management_func.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
-use ulid::Ulid;
 
 use super::SpecError;
 
@@ -21,7 +20,7 @@ pub struct ManagementFuncSpec {
 
     #[builder(setter(into), default)]
     #[serde(default)]
-    pub managed_schemas: Option<HashSet<Ulid>>,
+    pub managed_schemas: Option<HashSet<String>>,
 }
 
 impl ManagementFuncSpec {

--- a/lib/veritech-client/tests/integration.rs
+++ b/lib/veritech-client/tests/integration.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{collections::HashMap, env};
 
 use base64::{engine::general_purpose, Engine};
 use cyclone_core::{
@@ -106,13 +106,15 @@ async fn executes_simple_management_function() {
         execution_id: "1234".to_string(),
         handler: "numberOfInputs".to_string(),
         this_component: ComponentViewWithGeometry {
+            kind: None,
             properties: serde_json::json!({ "foo": "bar", "baz": "quux", "bar": "foo" }),
             geometry: serde_json::json!({"x": "1", "y": "1"}),
         },
+        components: HashMap::new(),
         code_base64: base64_encode(
             "function numberOfInputs({ thisComponent }) { 
                 const number = Object.keys(thisComponent.properties)?.length; 
-                return { status: 'ok' message: `${number}` }
+                return { status: 'ok', message: `${number}` }
              }",
         ),
         before: vec![],


### PR DESCRIPTION
Management functions can now take the components they manage as input, and they can create components, including components of other schemas. Created components are automatically "managed" by the component that creates them.