### PR TITLE
Adds V2 routes for change set approval and apply

### DIFF
--- a/app/web/src/api/sdf/dal/workspace.ts
+++ b/app/web/src/api/sdf/dal/workspace.ts
@@ -1,7 +1,17 @@
+import { ChangeSetId, ChangeSet } from "./change_set";
+
 export interface Workspace {
   pk: string;
   name: string;
   created_at: IsoDateString;
   updated_at: IsoDateString;
   token: string;
+}
+
+export interface WorkspaceMetadata {
+  name: string;
+  id: string;
+  default_change_set_id: ChangeSetId;
+  change_sets: ChangeSet[];
+  approvers: string[];
 }

--- a/lib/dal/src/change_set/event.rs
+++ b/lib/dal/src/change_set/event.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{ChangeSetId, DalContext, UserPk, WsEvent, WsEventResult, WsPayload};
+use crate::{ChangeSetId, ChangeSetStatus, DalContext, UserPk, WsEvent, WsEventResult, WsPayload};
 
 impl WsEvent {
     pub async fn change_set_written(
@@ -15,6 +15,25 @@ impl WsEvent {
         change_set_id: ChangeSetId,
     ) -> WsEventResult<Self> {
         WsEvent::new(ctx, WsPayload::ChangeSetCreated(change_set_id)).await
+    }
+
+    pub async fn change_set_status_changed(
+        ctx: &DalContext,
+        change_set_id: ChangeSetId,
+        user_pk: Option<UserPk>,
+        from_status: ChangeSetStatus,
+        to_status: ChangeSetStatus,
+    ) -> WsEventResult<Self> {
+        WsEvent::new(
+            ctx,
+            WsPayload::ChangeSetStatusChanged(ChangeSetStateChangePayload {
+                change_set_id,
+                from_status,
+                to_status,
+                user_pk,
+            }),
+        )
+        .await
     }
 
     pub async fn change_set_abandoned(
@@ -155,6 +174,14 @@ impl WsEvent {
 #[serde(rename_all = "camelCase")]
 pub struct ChangeSetActorPayload {
     change_set_id: ChangeSetId,
+    user_pk: Option<UserPk>,
+}
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeSetStateChangePayload {
+    change_set_id: ChangeSetId,
+    from_status: ChangeSetStatus,
+    to_status: ChangeSetStatus,
     user_pk: Option<UserPk>,
 }
 

--- a/lib/dal/src/change_set/status.rs
+++ b/lib/dal/src/change_set/status.rs
@@ -13,16 +13,19 @@ pub enum ChangeSetStatus {
     Abandoned,
     /// Applied this changeset to its parent
     Applied,
-    /// TODO appears to be unused
-    Closed,
-    /// TODO appears to be unused
+    /// Approved by relevant parties and ready to be applied
+    Approved,
+    /// Migration of Workspace Snapshot for this change set failed
     Failed,
     /// Planned to be abandoned but needs approval first
+    /// todo(brit): Remove once rebac is done
     NeedsAbandonApproval,
     /// Planned to be applied but needs approval first
     NeedsApproval,
-    /// Normal state: potentially usable
+    /// Available for user's to modify
     Open,
+    /// Request to apply was rejected
+    Rejected,
 }
 
 impl From<si_events::ChangeSetStatus> for ChangeSetStatus {
@@ -30,13 +33,14 @@ impl From<si_events::ChangeSetStatus> for ChangeSetStatus {
         match value {
             si_events::ChangeSetStatus::Abandoned => Self::Abandoned,
             si_events::ChangeSetStatus::Applied => Self::Applied,
-            si_events::ChangeSetStatus::Closed => Self::Closed,
             si_events::ChangeSetStatus::Failed => Self::Failed,
             si_events::ChangeSetStatus::NeedsAbandonApproval => {
                 ChangeSetStatus::NeedsAbandonApproval
             }
             si_events::ChangeSetStatus::NeedsApproval => Self::NeedsApproval,
             si_events::ChangeSetStatus::Open => Self::Open,
+            si_events::ChangeSetStatus::Approved => Self::Approved,
+            si_events::ChangeSetStatus::Rejected => Self::Rejected,
         }
     }
 }
@@ -46,11 +50,12 @@ impl From<ChangeSetStatus> for si_events::ChangeSetStatus {
         match value {
             ChangeSetStatus::Abandoned => Self::Abandoned,
             ChangeSetStatus::Applied => Self::Applied,
-            ChangeSetStatus::Closed => Self::Closed,
             ChangeSetStatus::Failed => Self::Failed,
             ChangeSetStatus::NeedsAbandonApproval => Self::NeedsAbandonApproval,
             ChangeSetStatus::NeedsApproval => Self::NeedsApproval,
             ChangeSetStatus::Open => Self::Open,
+            ChangeSetStatus::Approved => Self::Approved,
+            ChangeSetStatus::Rejected => Self::Rejected,
         }
     }
 }

--- a/lib/dal/src/change_set/view.rs
+++ b/lib/dal/src/change_set/view.rs
@@ -27,7 +27,7 @@ pub struct ChangeSetView {
 impl OpenChangeSetsView {
     pub async fn assemble(ctx: &DalContext) -> ChangeSetResult<Self> {
         // List all open change sets and assemble them into individual views.
-        let open_change_sets = ChangeSet::list_open(ctx).await?;
+        let open_change_sets = ChangeSet::list_active(ctx).await?;
         let mut views = Vec::with_capacity(open_change_sets.len());
         for change_set in open_change_sets {
             views.push(ChangeSetView {

--- a/lib/dal/src/func/binding/action.rs
+++ b/lib/dal/src/func/binding/action.rs
@@ -58,7 +58,6 @@ impl ActionBinding {
         let func_id = ActionPrototype::func_id(ctx, action_prototype_id).await?;
         let func = Func::get_by_id_or_error(ctx, func_id).await?; // delete and recreate the prototype
 
-        //brit todo: there might be existing actions enqueued, we should find them and reassociate the prototype?
         ActionPrototype::remove(ctx, action_prototype_id).await?;
         ActionPrototype::new(
             ctx,

--- a/lib/dal/src/migrations/U3002__change_set_approvers.sql
+++ b/lib/dal/src/migrations/U3002__change_set_approvers.sql
@@ -1,0 +1,3 @@
+ALTER TABLE change_set_pointers ADD COLUMN reviewed_by_user_id ident;
+ALTER TABLE change_set_pointers ADD COLUMN reviewed_at TIMESTAMPTZ;
+ALTER TABLE change_set_pointers ADD COLUMN merge_requested_at TIMESTAMPTZ;

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -496,7 +496,7 @@ impl Workspace {
         let mut content_hashes = vec![];
         let mut change_sets: HashMap<Ulid, Vec<WorkspaceExportChangeSetV0>> = HashMap::new();
         let mut default_change_set_base = Ulid::nil();
-        for change_set in ChangeSet::list_open(ctx).await? {
+        for change_set in ChangeSet::list_active(ctx).await? {
             let snap = WorkspaceSnapshot::find_for_change_set(ctx, change_set.id).await?;
 
             // From root, get every value from every node, store with hash
@@ -592,7 +592,7 @@ impl Workspace {
         } = workspace_data.into_latest();
 
         // ABANDON PREVIOUS CHANGESETS
-        for mut change_set in ChangeSet::list_open(ctx).await? {
+        for mut change_set in ChangeSet::list_active(ctx).await? {
             change_set.abandon(ctx).await?;
         }
 

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -9,6 +9,7 @@ use ulid::Ulid;
 
 use crate::change_set::event::{
     ChangeSetActorPayload, ChangeSetAppliedPayload, ChangeSetMergeVotePayload,
+    ChangeSetStateChangePayload,
 };
 use crate::component::{
     ComponentCreatedPayload, ComponentDeletedPayload, ComponentSetPositionPayload,
@@ -80,6 +81,7 @@ pub enum WsPayload {
     ChangeSetCanceled(ChangeSetId),
     ChangeSetCreated(ChangeSetId),
     ChangeSetMergeVote(ChangeSetMergeVotePayload),
+    ChangeSetStatusChanged(ChangeSetStateChangePayload),
     ChangeSetWritten(ChangeSetId),
     CheckedQualifications(QualificationCheckPayload),
     ComponentCreated(ComponentCreatedPayload),

--- a/lib/dal/tests/integration_test/change_set.rs
+++ b/lib/dal/tests/integration_test/change_set.rs
@@ -3,8 +3,12 @@ use dal::{
     context::TransactionsErrorDiscriminants, DalContext, DalContextBuilder, HistoryActor,
     RequestContext, Workspace, WorkspacePk,
 };
-use dal_test::helpers::{create_user, ChangeSetTestHelpers};
+use dal::{ChangeSet, ChangeSetStatus, Component};
+use dal_test::helpers::{
+    create_component_for_default_schema_name, create_user, ChangeSetTestHelpers,
+};
 use dal_test::test;
+use itertools::Itertools;
 use pretty_assertions_sorted::assert_eq;
 use std::collections::HashSet;
 
@@ -301,4 +305,170 @@ async fn build_from_request_context_allows_change_set_from_workspace_with_access
         dbg!(e);
     }
     assert!(builder_result.is_ok());
+}
+
+#[test]
+async fn change_set_approval_flow(ctx: &mut DalContext) {
+    // create a new change set
+    let new_change_set = ChangeSetTestHelpers::fork_from_head_change_set(ctx)
+        .await
+        .expect("could not fork head");
+    let current_user = ChangeSet::extract_userid_from_context(ctx).await;
+
+    // do something in it
+    let component = create_component_for_default_schema_name(ctx, "small odd lego", "small")
+        .await
+        .expect("could not create component");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update");
+    // request approval
+    let mut change_set = ChangeSet::find(ctx, new_change_set.id)
+        .await
+        .expect("could not find change set")
+        .expect("change set is some");
+
+    change_set
+        .request_change_set_approval(ctx)
+        .await
+        .expect("could not request approval");
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update");
+    let mut change_set = ChangeSet::find(ctx, new_change_set.id)
+        .await
+        .expect("could not find change set")
+        .expect("change set is some");
+
+    // make sure everything looks right
+    assert_eq!(change_set.status, ChangeSetStatus::NeedsApproval);
+    assert!(change_set.merge_requested_at.is_some());
+    assert_eq!(change_set.merge_requested_by_user_id, current_user);
+    assert_eq!(change_set.reviewed_at, None);
+    assert_eq!(change_set.reviewed_by_user_id, None);
+
+    // let's reject it
+    change_set
+        .reject_change_set_for_apply(ctx)
+        .await
+        .expect("could not reject change set");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update");
+    let mut change_set = ChangeSet::find(ctx, new_change_set.id)
+        .await
+        .expect("could not find change set")
+        .expect("change set is some");
+    assert_eq!(change_set.status, ChangeSetStatus::Rejected);
+    assert!(change_set.merge_requested_at.is_some());
+    assert_eq!(change_set.merge_requested_by_user_id, current_user);
+    assert!(change_set.reviewed_at.is_some());
+    assert_eq!(change_set.reviewed_by_user_id, current_user);
+
+    // let's see if we can apply now, it should fail because the change set has not been approved
+    let apply_result = ChangeSetTestHelpers::apply_change_set_to_base_approvals(ctx).await;
+    assert!(apply_result.is_err());
+
+    // now let's re-open it
+    change_set
+        .reopen_change_set(ctx)
+        .await
+        .expect("could not update status");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update");
+    let mut change_set = ChangeSet::find(ctx, new_change_set.id)
+        .await
+        .expect("could not find change set")
+        .expect("change set is some");
+    assert_eq!(change_set.status, ChangeSetStatus::Open);
+    assert_eq!(change_set.merge_requested_at, None);
+    assert_eq!(change_set.merge_requested_by_user_id, None);
+    assert_eq!(change_set.reviewed_at, None);
+    assert_eq!(change_set.reviewed_by_user_id, None);
+
+    // now let's request approval again
+    change_set
+        .request_change_set_approval(ctx)
+        .await
+        .expect("could not request approval");
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update");
+    let mut change_set = ChangeSet::find(ctx, new_change_set.id)
+        .await
+        .expect("could not find change set")
+        .expect("change set is some");
+
+    // make sure everything looks right
+    assert_eq!(change_set.status, ChangeSetStatus::NeedsApproval);
+    assert!(change_set.merge_requested_at.is_some());
+    assert_eq!(change_set.merge_requested_by_user_id, current_user);
+    assert_eq!(change_set.reviewed_at, None);
+    assert_eq!(change_set.reviewed_by_user_id, None);
+
+    // this time we will approve
+    change_set
+        .approve_change_set_for_apply(ctx)
+        .await
+        .expect("could not approve");
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update");
+    let change_set = ChangeSet::find(ctx, new_change_set.id)
+        .await
+        .expect("could not find change set")
+        .expect("change set is some");
+
+    // make sure everything looks right
+    assert_eq!(change_set.status, ChangeSetStatus::Approved);
+    assert!(change_set.merge_requested_at.is_some());
+    assert_eq!(change_set.merge_requested_by_user_id, current_user);
+    assert!(change_set.reviewed_at.is_some());
+    assert_eq!(change_set.reviewed_by_user_id, current_user);
+
+    // now let's apply it!
+
+    ChangeSetTestHelpers::apply_change_set_to_base_approvals(ctx)
+        .await
+        .expect("could not apply to head");
+
+    // should have one component
+    let mut components = Component::list(ctx)
+        .await
+        .expect("could not list components");
+    assert_eq!(components.len(), 1);
+    let only_component = components.pop().expect("has one in there");
+    assert_eq!(only_component.id(), component.id());
+
+    // now let's create another change set and ensure force_apply works as expected
+    let _new_change_set = ChangeSetTestHelpers::fork_from_head_change_set(ctx)
+        .await
+        .expect("could not fork head");
+
+    // do something in it
+    let second_component = create_component_for_default_schema_name(ctx, "small odd lego", "small")
+        .await
+        .expect("could not create component");
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update");
+    // force apply
+    ChangeSetTestHelpers::force_apply_change_set_to_base_approvals(ctx)
+        .await
+        .expect("could not force apply change set");
+    // should have two components now
+    let components = Component::list(ctx)
+        .await
+        .expect("could not list components");
+    assert_eq!(components.len(), 2);
+    let component_ids = [component.id(), second_component.id()];
+    let components = components
+        .into_iter()
+        .filter(|comp| component_ids.contains(&comp.id()))
+        .collect_vec();
+    assert_eq!(components.len(), 2);
 }

--- a/lib/rebaser-server/src/rebase.rs
+++ b/lib/rebaser-server/src/rebase.rs
@@ -146,7 +146,10 @@ pub async fn perform_rebase(
     }
 
     if updating_head && *workspace.pk() != WorkspacePk::NONE {
-        let all_open_change_sets = ChangeSet::list_open(ctx).await?;
+        //todo(brit): what do we want to do about change sets that haven't
+        // been applied yet, but are approved? (like gh merge-queue)
+        // should we 'unapprove' them?
+        let all_open_change_sets = ChangeSet::list_active(ctx).await?;
         for target_change_set in all_open_change_sets.into_iter().filter(|cs| {
             cs.id != workspace.default_change_set_id()
                 && cs.id != to_rebase_change_set.id

--- a/lib/sdf-server/src/service/v2.rs
+++ b/lib/sdf-server/src/service/v2.rs
@@ -15,9 +15,9 @@ const PREFIX: &str = "/workspaces/:workspace_id/change-sets/:change_set_id";
 
 pub fn routes(state: AppState) -> Router<AppState> {
     Router::new()
-        .nest("/admin", admin::v2_routes(state))
+        .nest("/admin", admin::v2_routes(state.clone()))
         .nest(&format!("{PREFIX}/audit-logs"), audit_log::v2_routes())
-        .nest(&format!("{PREFIX}/change-sets"), change_set::v2_routes())
+        .nest("{PREFIX}", change_set::v2_routes(state.clone()))
         .nest(&format!("{PREFIX}/funcs"), func::v2_routes())
         .nest(&format!("{PREFIX}/modules"), module::v2_routes())
         .nest(&format!("{PREFIX}/schema-variants"), variant::v2_routes())

--- a/lib/sdf-server/src/service/v2/change_set.rs
+++ b/lib/sdf-server/src/service/v2/change_set.rs
@@ -1,30 +1,56 @@
 use std::result;
 
-use axum::{http::StatusCode, response::IntoResponse, routing::post, Router};
-use dal::ChangeSetId;
+use axum::{
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Router,
+};
+use dal::{ChangeSetId, ChangeSetStatus, WsEventError};
 use thiserror::Error;
 
-use crate::{service::ApiError, AppState};
+use crate::{middleware::WorkspacePermissionLayer, service::ApiError, AppState};
 
 mod apply;
+mod approve;
+mod cancel_approval_request;
+mod force_apply;
+mod list;
+mod reject;
+mod reopen;
+mod request_approval;
 
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("change set error: {0}")]
+    ChangeSet(#[from] dal::ChangeSetError),
     #[error("change set apply error: {0}")]
     ChangeSetApply(#[from] dal::ChangeSetApplyError),
+    #[error("change set not approved for apply. Current state: {0}")]
+    ChangeSetNotApprovedForApply(ChangeSetStatus),
+    #[error("change set not found: {0}")]
+    ChangeSetNotFound(ChangeSetId),
     #[error("dvu roots are not empty for change set: {0}")]
     DvuRootsNotEmpty(ChangeSetId),
     #[error("func error: {0}")]
     Func(#[from] dal::FuncError),
+    #[error("permissions error: {0}")]
+    Permissions(#[from] permissions::Error),
     #[error("schema error: {0}")]
     Schema(#[from] dal::SchemaError),
     #[error("schema variant error: {0}")]
     SchemaVariant(#[from] dal::SchemaVariantError),
+    #[error("spicedb not found")]
+    SpiceDBNotFound,
     #[error("transactions error: {0}")]
     Transactions(#[from] dal::TransactionsError),
+    #[error("found an unexpected number of open change sets matching default change set (should be one, found {0:?})")]
+    UnexpectedNumberOfOpenChangeSetsMatchingDefaultChangeSet(Vec<ChangeSetId>),
     #[error("workspace snapshot error: {0}")]
     WorkspaceSnapshot(#[from] dal::WorkspaceSnapshotError),
+    #[error("ws event error: {0}")]
+    WsEvent(#[from] WsEventError),
 }
 
 impl IntoResponse for Error {
@@ -46,6 +72,39 @@ pub type ChangeSetAPIError = Error;
 
 type Result<T> = result::Result<T, Error>;
 
-pub fn v2_routes() -> Router<AppState> {
-    Router::new().route("/apply", post(apply::apply))
+pub fn v2_routes(state: AppState) -> Router<AppState> {
+    Router::new()
+        .route("/apply", post(apply::apply))
+        .route(
+            "/request_approval",
+            post(request_approval::request_approval),
+        )
+        .route(
+            "/approve",
+            post(approve::approve).layer(WorkspacePermissionLayer::new(
+                state.clone(),
+                permissions::Permission::Approve,
+            )),
+        )
+        .route(
+            "/reject",
+            post(reject::reject).layer(WorkspacePermissionLayer::new(
+                state.clone(),
+                permissions::Permission::Approve,
+            )),
+        )
+        .route(
+            "/cancel_approval_request",
+            post(cancel_approval_request::cancel_approval_request),
+        )
+        // Consider how we make it editable again after it's been rejected
+        .route("/reopen", post(reopen::reopen))
+        .route("/list", get(list::list_actionable))
+        .route(
+            "/force_apply",
+            post(force_apply::force_apply).layer(WorkspacePermissionLayer::new(
+                state.clone(),
+                permissions::Permission::Approve,
+            )),
+        )
 }

--- a/lib/sdf-server/src/service/v2/change_set/approve.rs
+++ b/lib/sdf-server/src/service/v2/change_set/approve.rs
@@ -1,0 +1,69 @@
+use axum::extract::{Host, OriginalUri, Path};
+use dal::{ChangeSet, ChangeSetId, WorkspacePk, WsEvent};
+
+use super::{Error, Result};
+use crate::{
+    extract::{AccessBuilder, HandlerContext, PosthogClient},
+    track,
+};
+
+pub async fn approve(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Host(host_name): Host,
+    Path((_workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
+) -> Result<()> {
+    let ctx = builder
+        .build(request_ctx.build(change_set_id.into()))
+        .await?;
+
+    // Ensure that DVU roots are empty before continuing?
+    // todo(brit): maybe we can get away without this. Ex: Approve a PR before tests finish
+    if !ctx
+        .workspace_snapshot()?
+        .get_dependent_value_roots()
+        .await?
+        .is_empty()
+    {
+        // TODO(nick): we should consider requiring this check in integration tests too. Why did I
+        // not do this at the time of writing? Tests have multiple ways to call "apply", whether
+        // its via helpers or through the change set methods directly. In addition, they test
+        // for success and failure, not solely for success. We should still do this, but not within
+        // the PR corresponding to when this message was written.
+        return Err(Error::DvuRootsNotEmpty(ctx.change_set_id()));
+    }
+
+    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+        .await?
+        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?;
+    let old_status = change_set.status;
+    change_set.approve_change_set_for_apply(&ctx).await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        &host_name,
+        "approve_change_set_apply",
+        serde_json::json!({
+            "merged_change_set": change_set_id,
+        }),
+    );
+
+    WsEvent::change_set_status_changed(
+        &ctx,
+        change_set.id,
+        ChangeSet::extract_userid_from_context(&ctx).await,
+        old_status,
+        change_set.status,
+    )
+    .await?
+    .publish_on_commit(&ctx)
+    .await?;
+
+    ctx.commit().await?;
+
+    Ok(())
+}

--- a/lib/sdf-server/src/service/v2/change_set/cancel_approval_request.rs
+++ b/lib/sdf-server/src/service/v2/change_set/cancel_approval_request.rs
@@ -1,13 +1,13 @@
 use axum::extract::{Host, OriginalUri, Path};
-use dal::{ChangeSet, ChangeSetId, WorkspacePk};
+use dal::{ChangeSet, ChangeSetId, WorkspacePk, WsEvent};
 
-use super::Result;
+use super::{Error, Result};
 use crate::{
     extract::{AccessBuilder, HandlerContext, PosthogClient},
     track,
 };
 
-pub async fn apply(
+pub async fn cancel_approval_request(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
     PosthogClient(posthog_client): PosthogClient,
@@ -15,29 +15,39 @@ pub async fn apply(
     Host(host_name): Host,
     Path((_workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
 ) -> Result<()> {
-    let mut ctx = builder
+    let ctx = builder
         .build(request_ctx.build(change_set_id.into()))
         .await?;
 
-    ChangeSet::prepare_for_apply(&ctx).await?;
+    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+        .await?
+        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?;
+    let old_status = change_set.status;
 
-    // We need to run a commit before apply so changes get saved
-    ctx.commit().await?;
-
-    ChangeSet::apply_to_base_change_set(&mut ctx).await?;
+    change_set.reopen_change_set(&ctx).await?;
 
     track(
         &posthog_client,
         &ctx,
         &original_uri,
         &host_name,
-        "apply_change_set",
+        "approve_change_set_apply",
         serde_json::json!({
             "merged_change_set": change_set_id,
         }),
     );
 
-    // WS Event fires from the dal
+    WsEvent::change_set_status_changed(
+        &ctx,
+        change_set.id,
+        ChangeSet::extract_userid_from_context(&ctx).await,
+        old_status,
+        change_set.status,
+    )
+    .await?
+    .publish_on_commit(&ctx)
+    .await?;
+
     ctx.commit().await?;
 
     Ok(())

--- a/lib/sdf-server/src/service/v2/change_set/list.rs
+++ b/lib/sdf-server/src/service/v2/change_set/list.rs
@@ -1,0 +1,82 @@
+use axum::{
+    extract::{Host, OriginalUri, Path, State},
+    Json,
+};
+use dal::{ChangeSet, ChangeSetId, WorkspacePk};
+use permissions::{ObjectType, Relation, RelationBuilder};
+
+use super::{AppState, Error, Result};
+use crate::{
+    extract::{AccessBuilder, HandlerContext, PosthogClient},
+    track,
+};
+
+pub async fn list_actionable(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Host(host_name): Host,
+    State(mut state): State<AppState>,
+    Path(workspace_pk): Path<WorkspacePk>,
+) -> Result<Json<si_frontend_types::WorkspaceMetadata>> {
+    let ctx = builder.build_head(request_ctx).await?;
+
+    // List all actionable change sets and assemble them into individual views.
+    let open_change_sets = ChangeSet::list_active(&ctx).await?;
+    let mut views = Vec::with_capacity(open_change_sets.len());
+    for change_set in open_change_sets {
+        views.push(change_set.into_frontend_type(&ctx).await?);
+    }
+    let client = state.spicedb_client().ok_or(Error::SpiceDBNotFound)?;
+    let existing_approvers = RelationBuilder::new()
+        .object(ObjectType::Workspace, workspace_pk)
+        .relation(Relation::Approver)
+        .read(client)
+        .await?;
+
+    let existing_approver_ids: Vec<String> = existing_approvers
+        .into_iter()
+        .map(|w| w.subject().id().to_string())
+        .collect();
+
+    // Ensure that we find exactly one change set view that matches the open change sets found.
+    let head_change_set_id = ctx.get_workspace_default_change_set_id().await?;
+    let maybe_head_change_set_id: Vec<ChangeSetId> = views
+        .iter()
+        .filter_map(|v| {
+            if v.id == head_change_set_id.into() {
+                Some(head_change_set_id)
+            } else {
+                None
+            }
+        })
+        .collect();
+    if maybe_head_change_set_id.len() != 1 {
+        return Err(
+            Error::UnexpectedNumberOfOpenChangeSetsMatchingDefaultChangeSet(
+                maybe_head_change_set_id,
+            ),
+        );
+    }
+    let workspace = &ctx.get_workspace().await?;
+    let workspace_view = si_frontend_types::WorkspaceMetadata {
+        name: workspace.name().to_string(),
+        id: workspace.pk().to_string(),
+        default_change_set_id: head_change_set_id.into(),
+        change_sets: views,
+        approvers: existing_approver_ids,
+    };
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        &host_name,
+        "list",
+        serde_json::json!({
+            "workspace_id": workspace_pk,
+        }),
+    );
+
+    Ok(Json(workspace_view))
+}

--- a/lib/sdf-server/src/service/v2/change_set/reject.rs
+++ b/lib/sdf-server/src/service/v2/change_set/reject.rs
@@ -1,0 +1,54 @@
+use axum::extract::{Host, OriginalUri, Path};
+use dal::{ChangeSet, ChangeSetId, WorkspacePk, WsEvent};
+
+use super::{Error, Result};
+use crate::{
+    extract::{AccessBuilder, HandlerContext, PosthogClient},
+    track,
+};
+
+pub async fn reject(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Host(host_name): Host,
+    Path((_workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
+) -> Result<()> {
+    let ctx = builder
+        .build(request_ctx.build(change_set_id.into()))
+        .await?;
+
+    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+        .await?
+        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?;
+    let old_status = change_set.status;
+
+    change_set.reject_change_set_for_apply(&ctx).await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        &host_name,
+        "reject_change_set_apply",
+        serde_json::json!({
+            "change_set": change_set_id,
+        }),
+    );
+
+    WsEvent::change_set_status_changed(
+        &ctx,
+        change_set.id,
+        ChangeSet::extract_userid_from_context(&ctx).await,
+        old_status,
+        change_set.status,
+    )
+    .await?
+    .publish_on_commit(&ctx)
+    .await?;
+
+    ctx.commit().await?;
+
+    Ok(())
+}

--- a/lib/sdf-server/src/service/v2/change_set/reopen.rs
+++ b/lib/sdf-server/src/service/v2/change_set/reopen.rs
@@ -1,0 +1,56 @@
+use axum::extract::{Host, OriginalUri, Path};
+use dal::{ChangeSet, ChangeSetId, WorkspacePk, WsEvent};
+
+use super::{Error, Result};
+use crate::{
+    extract::{AccessBuilder, HandlerContext, PosthogClient},
+    track,
+};
+
+pub async fn reopen(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Host(host_name): Host,
+    Path((_workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
+) -> Result<()> {
+    let ctx = builder
+        .build(request_ctx.build(change_set_id.into()))
+        .await?;
+
+    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+        .await?
+        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?;
+    let old_status = change_set.status;
+
+    //todo(brit): should we guard against re-opening abandoned change sets?
+    // this might be helpful if we don't...
+    change_set.reopen_change_set(&ctx).await?;
+
+    WsEvent::change_set_status_changed(
+        &ctx,
+        change_set.id,
+        ChangeSet::extract_userid_from_context(&ctx).await,
+        old_status,
+        change_set.status,
+    )
+    .await?
+    .publish_on_commit(&ctx)
+    .await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        &host_name,
+        "reject_change_set_apply",
+        serde_json::json!({
+            "change_set": change_set_id,
+        }),
+    );
+
+    ctx.commit().await?;
+
+    Ok(())
+}

--- a/lib/sdf-server/src/service/v2/change_set/request_approval.rs
+++ b/lib/sdf-server/src/service/v2/change_set/request_approval.rs
@@ -1,0 +1,54 @@
+use axum::extract::{Host, OriginalUri, Path};
+use dal::{ChangeSet, ChangeSetId, WorkspacePk, WsEvent};
+
+use super::{Error, Result};
+use crate::{
+    extract::{AccessBuilder, HandlerContext, PosthogClient},
+    track,
+};
+
+pub async fn request_approval(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Host(host_name): Host,
+    Path((_workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
+) -> Result<()> {
+    let ctx = builder
+        .build(request_ctx.build(change_set_id.into()))
+        .await?;
+
+    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+        .await?
+        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?;
+    let old_status = change_set.status;
+
+    change_set.request_change_set_approval(&ctx).await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        &host_name,
+        "request_change_set_approval",
+        serde_json::json!({
+            "change_set": change_set_id,
+        }),
+    );
+
+    WsEvent::change_set_status_changed(
+        &ctx,
+        change_set.id,
+        ChangeSet::extract_userid_from_context(&ctx).await,
+        old_status,
+        change_set.status,
+    )
+    .await?
+    .publish_on_commit(&ctx)
+    .await?;
+
+    ctx.commit().await?;
+
+    Ok(())
+}

--- a/lib/si-events-rs/src/change_set_status.rs
+++ b/lib/si-events-rs/src/change_set_status.rs
@@ -8,9 +8,10 @@ use strum::{AsRefStr, Display, EnumString};
 pub enum ChangeSetStatus {
     Abandoned,
     Applied,
-    Closed,
+    Approved,
     Failed,
     NeedsAbandonApproval,
     NeedsApproval,
     Open,
+    Rejected,
 }

--- a/lib/si-frontend-types-rs/src/change_set.rs
+++ b/lib/si-frontend-types-rs/src/change_set.rs
@@ -1,0 +1,21 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use si_events::{ChangeSetId, ChangeSetStatus};
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeSet {
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub name: String,
+    pub id: ChangeSetId,
+    pub status: ChangeSetStatus,
+    pub base_change_set_id: Option<ChangeSetId>,
+    pub workspace_id: String,
+    pub merge_requested_by_user_id: Option<String>,
+    pub merge_requested_by_user_email: Option<String>,
+    pub merge_requested_at: Option<DateTime<Utc>>,
+    pub reviewed_by_user_id: Option<String>,
+    pub reviewed_by_user_email: Option<String>,
+    pub reviewed_at: Option<DateTime<Utc>>,
+}

--- a/lib/si-frontend-types-rs/src/lib.rs
+++ b/lib/si-frontend-types-rs/src/lib.rs
@@ -1,11 +1,14 @@
 mod audit_log;
+mod change_set;
 mod component;
 mod conflict;
 mod func;
 mod module;
 mod schema_variant;
+mod workspace;
 
 pub use crate::audit_log::AuditLog;
+pub use crate::change_set::ChangeSet;
 pub use crate::component::{
     ChangeStatus, ConnectionAnnotation, DiagramSocket, DiagramSocketDirection,
     DiagramSocketNodeSide, GridPoint, Size2D, SummaryDiagramComponent,
@@ -21,3 +24,4 @@ pub use crate::module::{
 pub use crate::schema_variant::{
     ComponentType, InputSocket, OutputSocket, Prop, PropKind, SchemaVariant, UninstalledVariant,
 };
+pub use crate::workspace::WorkspaceMetadata;

--- a/lib/si-frontend-types-rs/src/workspace.rs
+++ b/lib/si-frontend-types-rs/src/workspace.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+use si_events::ChangeSetId;
+
+use crate::change_set::ChangeSet;
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceMetadata {
+    pub name: String,
+    pub id: String,
+    pub default_change_set_id: ChangeSetId,
+    pub change_sets: Vec<ChangeSet>,
+    /// list of user ids that are approvers for this workspace
+    pub approvers: Vec<String>,
+}


### PR DESCRIPTION
- Adds new structs for Frontend Types
- Adds endpoint for each action taken on a change set (Request approval, approve, reject, cancel request, reopen, apply, force apply)
- Adds new endpoints to `change_sets.store` (nothing is calling them, but was helping me click test)
- Adds new integration test for the overall flow

<div><img src="https://media4.giphy.com/media/gremU0LQdTvpna46kv/giphy.gif?cid=5a38a5a2yrjd9ia1yelijru9j51nh0xj7l65pgpd50ct8h2d&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/Amsterdenim/">Amsterdenim</a> on <a href="https://giphy.com/gifs/Amsterdenim-approved-stamp-stamped-gremU0LQdTvpna46kv">GIPHY</a></div>