### PR TITLE
Remove optional parameters from service.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "remain",
  "reqwest",
  "serde",
+ "serde_with",
  "serde_yaml",
  "si-std",
  "strum 0.26.3",

--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -26,12 +26,6 @@ url = "$SI_NATS_URL"
 
 [openai]
 api_key = "$SI_OPENAI_API_KEY"
-api_base = "$SI_OPENAI_API_BASE"
-api_version = "$SI_OPENAI_API_VERSION"
-org_id = "$SI_OPENAI_ORG_ID"
-
-[asset_sprayer]
-prompts_dir = "$SI_ASSET_SPRAYER_PROMPTS_DIR"
 
 [pg]
 user = "si"

--- a/lib/asset-sprayer/BUCK
+++ b/lib/asset-sprayer/BUCK
@@ -10,6 +10,7 @@ rust_library(
         "//third-party/rust:remain",
         "//third-party/rust:reqwest",
         "//third-party/rust:serde",
+        "//third-party/rust:serde_with",
         "//third-party/rust:serde_yaml",
         "//third-party/rust:strum",
         "//third-party/rust:thiserror",

--- a/lib/asset-sprayer/Cargo.toml
+++ b/lib/asset-sprayer/Cargo.toml
@@ -15,6 +15,7 @@ include_dir = { workspace = true }
 remain = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
+serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 si-std = { path = "../../lib/si-std" }
 strum = { workspace = true }

--- a/lib/asset-sprayer/src/config.rs
+++ b/lib/asset-sprayer/src/config.rs
@@ -1,20 +1,27 @@
 use async_openai::config::OpenAIConfig;
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, NoneAsEmptyString};
 use si_std::SensitiveString;
-use std::path::PathBuf;
 
 /// OpenAI configuration. Mirrors OpenAI configuration, but with Deserialize support.
+#[serde_as]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct SIOpenAIConfig {
+    #[serde_as(as = "NoneAsEmptyString")]
     api_key: Option<SensitiveString>,
+    #[serde_as(as = "NoneAsEmptyString")]
     api_base: Option<String>,
+    #[serde_as(as = "NoneAsEmptyString")]
     org_id: Option<String>,
+    #[serde_as(as = "NoneAsEmptyString")]
     project_id: Option<String>,
 }
 
+#[serde_as]
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct AssetSprayerConfig {
-    pub prompts_dir: Option<PathBuf>,
+    #[serde_as(as = "NoneAsEmptyString")]
+    pub prompts_dir: Option<String>,
 }
 
 impl SIOpenAIConfig {

--- a/lib/asset-sprayer/src/lib.rs
+++ b/lib/asset-sprayer/src/lib.rs
@@ -70,7 +70,7 @@ impl AssetSprayer {
     ) -> Self {
         Self {
             openai_client,
-            prompts: Prompts::new(config.prompts_dir),
+            prompts: Prompts::new(config.prompts_dir.map(Into::into)),
         }
     }
 

--- a/lib/si-settings/BUCK
+++ b/lib/si-settings/BUCK
@@ -6,9 +6,9 @@ rust_library(
     name = "si-settings",
     deps = [
         "//lib/config-file:config-file",
+        "//lib/si-std:si-std",
         "//third-party/rust:remain",
         "//third-party/rust:serde",
-        "//third-party/rust:serde_with",
         "//third-party/rust:thiserror",
     ],
     srcs = glob(["src/**/*.rs"]),


### PR DESCRIPTION
We don't use these in any production environment, and this will get us where we can deploy.