### PR TITLE
[healthcheck] added inotify check for Linux and docs around it

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,3 +34,4 @@ We contributors to System Initiative:
 * Meg Watson (@MegaWatt01)
 * John Keiser (@jkeiser)
 * Ikko Eltociear Ashimine (@eltociear)
+* Nick Downs (@nickryand)

--- a/DOCS.md
+++ b/DOCS.md
@@ -107,6 +107,26 @@ To find an acceptable limit, run the health check command.
 buck2 run dev:healthcheck
 ```
 
+## Tuning the `inotify` kernel setting (Linux Only)
+
+The local development environment sets up a high number of file watches. On Linux, this uses the `inotify` kernel subsystem. This setting
+may need to be increased in order to allow all of the `inotify` watches to be configured.
+
+> [!WARNING]
+> To tune this value, it will require sudo access.
+
+```bash
+sudo sysctl fs.inotify.max_user_watches=<new-max-user-watches-value>
+```
+
+To find an acceptable value, run the health check command.
+
+```bash
+buck2 run dev:healthcheck
+```
+
+To make this setting persistent, consult your distributions documentation.
+
 ## Dependencies
 
 For all supported platforms, there are two dependencies that must be installed, `nix` (preferably via the [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer)) and `docker`.
@@ -511,7 +531,7 @@ buck2 targets //lib/...
 > [!TIP]
 > *Ellipsis also work for other directories.*
 > *This works for the root as well, but the list at root will contain a lot of noise.*
-> 
+>
 > ```bash
 > buck2 targets ...
 > ```
@@ -697,7 +717,7 @@ aforementioned action(s) without spending too much time thinking about them.
     1. You will likely have to add the `-f/--force` flag since we are overwriting history (technically?) on the remote.
     2. Be careful when using the force flag! Try to push without using the force flag first if you are unsure.
 7. You are done! Congratulations!
-  
+
 # Core Services
 
 This section contains the paths and brief definitions of the services that run in the System Initiative software stack.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ On macOS and in WSL2 in particular, we recommend significantly increasing the fi
 
 _Please note: the new file descriptor limit may not persist to future sessions._
 
+On Linux, it may be necessary to increase the `fs.inotify.max_user_watches` kernel setting. If this setting is to low, you will see
+errors that look similar to this: `Error: ENOSPC: System limit for number of file watchers reached`.
+
 Once ready, we can build relevant services and run the entire stack locally.
 
 _Please note: if you have used SI before, the following command will delete all contents of the database.
@@ -172,4 +175,3 @@ The System Initiative software is Open Source under the [Apache License 2.0](LIC
 3. Make sure your commits Author metadata matches the name and handle you added to the file.
 
 This ensures that users, distributors, and other contributors can rely on all the software related to System Initiative being contributed under the terms of the [License](LICENSE). No contributions will be accepted without following this process.
-


### PR DESCRIPTION
I ran into `inotify` errors when trying to bring up the dev stack, in both the `web` service and the `docs` service. 

```
Error: ENOSPC: System limit for number of file watchers reached
```

This PR adds a new check to the healthcheck command and doc updates that explain it in more detail.
