### PR TITLE
Bump notice year and remove unused flake override

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,4 +2,4 @@ System Initiative
 Copyright the various System Initiative software authors.
 
 The initial developer of the software is System Initiative, Inc. (https://systeminit.com).
-Copyright 2019-2023 System Initiative, Inc. All Rights Reserved.
+Copyright 2019-2024 System Initiative, Inc. All Rights Reserved.

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,6 @@
       url = "github:oxalica/rust-overlay";
       inputs = {
         nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "flake-utils";
       };
     };
   };


### PR DESCRIPTION
## Description

This PR bumps the end date in the "NOTICE" file from "2023" to "2024". It also removes an unused flake input override since "rust-overlay" no longer uses "flake-utils".

<img src="https://media1.giphy.com/media/dW8dyJvwhI6pB4t20c/giphy.gif"/>