### PR TITLE
Solidify audit log structure in the UI

### DIFF
--- a/app/web/src/components/AuditLogCell.vue
+++ b/app/web/src/components/AuditLogCell.vue
@@ -36,11 +36,14 @@ const props = defineProps({
     type: Object as PropType<
       Cell<
         {
+          displayName: string;
           userName: string;
           userId?: string;
           userEmail?: string;
           kind: string;
           timestamp: string;
+          entityType: string;
+          entityName: string;
           changeSetId?: string;
           changeSetName?: string;
           metadata: Record<string, unknown>;

--- a/app/web/src/components/AuditLogHeader.vue
+++ b/app/web/src/components/AuditLogHeader.vue
@@ -96,10 +96,13 @@ const props = defineProps({
     type: Object as PropType<
       Header<
         {
+          displayName: string;
           userName: string;
           userId?: string;
           userEmail?: string;
           kind: string;
+          entityType: string;
+          entityName: string;
           timestamp: string;
           changeSetId?: string;
           changeSetName?: string;

--- a/app/web/src/components/Workspace/WorkspaceAuditLog.vue
+++ b/app/web/src/components/Workspace/WorkspaceAuditLog.vue
@@ -22,9 +22,7 @@
               class="flex items-center gap-2xs pr-xs whitespace-nowrap flex-none"
             >
               <div>Page</div>
-              <div class="font-bold">
-                {{ currentFilters.page }} of {{ totalPages }}
-              </div>
+              <div class="font-bold">{{ currentPage }} of {{ totalPages }}</div>
             </div>
             <IconButton
               v-tooltip="
@@ -106,11 +104,13 @@
             <tr
               :class="
                 clsx(
-                  'h-md text-sm',
-                  themeClasses(
-                    'odd:bg-neutral-200 even:bg-neutral-100',
-                    'odd:bg-neutral-700 even:bg-neutral-800',
-                  ),
+                  'h-lg text-sm',
+                  rowCollapseState[Number(row.id)]
+                    ? 'bg-action-300'
+                    : themeClasses(
+                        'odd:bg-neutral-200 even:bg-neutral-100 hover:bg-action-200',
+                        'odd:bg-neutral-700 even:bg-neutral-800 hover:bg-action-200',
+                      ),
                 )
               "
             >
@@ -157,7 +157,7 @@ import {
   createColumnHelper,
 } from "@tanstack/vue-table";
 import clsx from "clsx";
-import { h, computed, ref, withDirectives, resolveDirective } from "vue";
+import { h, computed, ref } from "vue";
 import { trackEvent } from "@/utils/tracking";
 import { AuditLogDisplay, LogFilters, useLogsStore } from "@/store/logs.store";
 import { AdminUser } from "@/store/admin.store";
@@ -213,8 +213,40 @@ const columns = [
     header: "",
     cell: "",
   },
+  columnHelper.accessor("displayName", {
+    header: "Event",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("entityType", {
+    header: "Entity Type",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("entityName", {
+    header: "Entity Name",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("changeSetName", {
+    header: "Change Set",
+    cell: (info) => info.getValue(),
+  }),
+  // TODO(nick): restore change set filtering.
+  // columnHelper.accessor("changeSetName", {
+  //   header: "Change Set",
+  //   cell: (info) =>
+  //     withDirectives(
+  //       h("div", {
+  //         innerText: info.getValue(),
+  //         class: "hover:underline cursor-pointer",
+  //       }),
+  //       [[resolveDirective("tooltip"), info.row.getValue("changeSetName")]],
+  //     ),
+  // }),
+  columnHelper.accessor("userName", {
+    header: "User",
+    cell: (info) => info.getValue(),
+  }),
   columnHelper.accessor("timestamp", {
-    header: "Timestamp",
+    header: "Time",
     cell: (info) =>
       h(Timestamp, {
         date: info.getValue(),
@@ -222,27 +254,8 @@ const columns = [
         enableDetailTooltip: true,
       }),
   }),
-  columnHelper.accessor("changeSetName", {
-    header: "Change Set",
-    cell: (info) =>
-      withDirectives(
-        h("div", {
-          innerText: info.getValue(),
-          class: "hover:underline cursor-pointer",
-        }),
-        [[resolveDirective("tooltip"), info.row.getValue("changeSetId")]],
-      ),
-  }),
   columnHelper.accessor("changeSetId", {
     header: "Change Set Id",
-    cell: (info) => info.getValue(),
-  }),
-  columnHelper.accessor("kind", {
-    header: "Kind",
-    cell: (info) => info.getValue(),
-  }),
-  columnHelper.accessor("userName", {
-    header: "User",
     cell: (info) => info.getValue(),
   }),
 ];
@@ -295,8 +308,6 @@ const toggleFilter = (id: string, filterId: string) => {
 const clearFilters = (id: string) => {
   if (id === "kind") {
     currentFilters.value.kindFilter = [];
-  } else if (id === "service") {
-    currentFilters.value.serviceFilter = [];
   } else if (id === "changeSetName") {
     currentFilters.value.changeSetFilter = [];
   } else if (id === "userName") {
@@ -327,4 +338,8 @@ const previousPage = () => {
   currentFilters.value.page--;
   loadLogs();
 };
+
+const currentPage = computed(() =>
+  totalPages.value === 0 ? 0 : currentFilters.value.page,
+);
 </script>

--- a/app/web/src/store/logs.store.ts
+++ b/app/web/src/store/logs.store.ts
@@ -12,34 +12,31 @@ export type LogFilters = {
   sortTimestampAscending: boolean;
   excludeSystemUser: boolean;
   kindFilter: string[];
-  serviceFilter: string[];
   changeSetFilter: ChangeSetId[];
   userFilter: UserId[];
 };
 
-export type AuditLog = {
-  userName?: string;
-
+interface AuditLogCommon {
+  displayName: string;
   userId?: UserId;
   userEmail?: string;
   kind: string;
+  entityType: string;
   timestamp: string;
   changeSetId?: ChangeSetId;
   changeSetName?: string;
   metadata: Record<string, unknown>;
-};
+}
 
-export type AuditLogDisplay = {
+export interface AuditLog extends AuditLogCommon {
+  userName?: string;
+  entityName?: string;
+}
+
+export interface AuditLogDisplay extends AuditLogCommon {
   userName: string;
-
-  userId?: string;
-  userEmail?: string;
-  kind: string;
-  timestamp: string;
-  changeSetId?: string;
-  changeSetName?: string;
-  metadata: Record<string, unknown>;
-};
+  entityName: string;
+}
 
 export const useLogsStore = (forceChangeSetId?: ChangeSetId) => {
   // this needs some work... but we'll probably want a way to force using HEAD
@@ -92,10 +89,13 @@ export const useLogsStore = (forceChangeSetId?: ChangeSetId) => {
                 this.logs = response.logs.map(
                   (log: AuditLog) =>
                     ({
+                      displayName: log.displayName,
                       userName: log.userName ?? "System",
                       userId: log.userId,
                       userEmail: log.userEmail,
                       kind: log.kind,
+                      entityType: log.entityType,
+                      entityName: log.entityName ?? "-",
                       metadata: log.metadata,
                       timestamp: log.timestamp,
                       changeSetId: log.changeSetId,

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -1006,8 +1006,12 @@ impl DalContext {
 
     /// Convenience wrapper around [`audit_logging::write`].
     #[instrument(name = "dal_context.write_audit_log", level = "debug", skip_all)]
-    pub async fn write_audit_log(&self, kind: AuditLogKind) -> TransactionsResult<()> {
-        Ok(audit_logging::write(self, kind).await?)
+    pub async fn write_audit_log(
+        &self,
+        kind: AuditLogKind,
+        entity_name: String,
+    ) -> TransactionsResult<()> {
+        Ok(audit_logging::write(self, kind, entity_name).await?)
     }
 
     /// Convenience wrapper around [`audit_logging::write_final_message`].

--- a/lib/dal/tests/integration_test/audit_logging.rs
+++ b/lib/dal/tests/integration_test/audit_logging.rs
@@ -28,12 +28,15 @@ async fn round_trip(ctx: &mut DalContext) {
     let component = Component::new(ctx, component_name, schema_variant_id)
         .await
         .expect("could not create component");
-    ctx.write_audit_log(AuditLogKind::CreateComponent {
-        name: component_name.to_string(),
-        component_id: component.id().into(),
-        schema_variant_id: schema_variant_id.into(),
-        schema_variant_name: schema_variant.display_name().to_string(),
-    })
+    ctx.write_audit_log(
+        AuditLogKind::CreateComponent {
+            name: component_name.to_string(),
+            component_id: component.id().into(),
+            schema_variant_id: schema_variant_id.into(),
+            schema_variant_name: schema_variant.display_name().to_string(),
+        },
+        component_name.to_string(),
+    )
     .await
     .expect("could not write audit log");
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
@@ -113,17 +116,20 @@ async fn round_trip(ctx: &mut DalContext) {
     AttributeValue::update(ctx, attribute_value_id, after_value.to_owned())
         .await
         .expect("could not update attribute value");
-    ctx.write_audit_log(AuditLogKind::UpdatePropertyEditorValue {
-        component_id: component.id().into(),
-        component_name: component_name.to_string(),
-        schema_variant_id: schema_variant_id.into(),
-        schema_variant_display_name: schema_variant.display_name().to_string(),
-        prop_id: prop.id.into(),
-        prop_name: prop.name.to_owned(),
-        attribute_value_id: attribute_value_id.into(),
-        before_value,
-        after_value,
-    })
+    ctx.write_audit_log(
+        AuditLogKind::UpdatePropertyEditorValue {
+            component_id: component.id().into(),
+            component_name: component_name.to_string(),
+            schema_variant_id: schema_variant_id.into(),
+            schema_variant_display_name: schema_variant.display_name().to_string(),
+            prop_id: prop.id.into(),
+            prop_name: prop.name.to_owned(),
+            attribute_value_id: attribute_value_id.into(),
+            before_value,
+            after_value,
+        },
+        component_name.to_string(),
+    )
     .await
     .expect("could not write audit log");
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
@@ -162,12 +168,15 @@ async fn round_trip(ctx: &mut DalContext) {
     assert_eq!(2, first_run_audit_logs.len());
 
     // Delete a component and commit. Mimic sdf by audit logging here.
-    ctx.write_audit_log(AuditLogKind::DeleteComponent {
-        name: component_name.to_string(),
-        component_id: component.id().into(),
-        schema_variant_id: schema_variant_id.into(),
-        schema_variant_name: schema_variant.display_name().to_string(),
-    })
+    ctx.write_audit_log(
+        AuditLogKind::DeleteComponent {
+            name: component_name.to_string(),
+            component_id: component.id().into(),
+            schema_variant_id: schema_variant_id.into(),
+            schema_variant_name: schema_variant.display_name().to_string(),
+        },
+        component_name.to_string(),
+    )
     .await
     .expect("could not write audit log");
     assert!(component

--- a/lib/sdf-server/src/service/component/update_property_editor_value.rs
+++ b/lib/sdf-server/src/service/component/update_property_editor_value.rs
@@ -103,32 +103,42 @@ pub async fn update_property_editor_value(
                 (None, None)
             };
 
-            ctx.write_audit_log(AuditLogKind::UpdatePropertyEditorValueForSecret {
-                component_id: request.component_id.into(),
-                component_name: component.name(&ctx).await?,
-                schema_variant_id: component_schema_variant.id().into(),
-                schema_variant_display_name: component_schema_variant.display_name().to_string(),
-                prop_id: prop.id.into(),
-                prop_name: prop.name.to_owned(),
-                attribute_value_id: request.attribute_value_id.into(),
-                before_secret_name,
-                before_secret_id,
-                after_secret_name,
-                after_secret_id,
-            })
+            ctx.write_audit_log(
+                AuditLogKind::UpdatePropertyEditorValueForSecret {
+                    component_id: request.component_id.into(),
+                    component_name: component.name(&ctx).await?,
+                    schema_variant_id: component_schema_variant.id().into(),
+                    schema_variant_display_name: component_schema_variant
+                        .display_name()
+                        .to_string(),
+                    prop_id: prop.id.into(),
+                    prop_name: prop.name.to_owned(),
+                    attribute_value_id: request.attribute_value_id.into(),
+                    before_secret_name,
+                    before_secret_id,
+                    after_secret_name,
+                    after_secret_id,
+                },
+                prop.name.to_owned(),
+            )
             .await?;
         } else {
-            ctx.write_audit_log(AuditLogKind::UpdatePropertyEditorValue {
-                component_id: request.component_id.into(),
-                component_name: component.name(&ctx).await?,
-                schema_variant_id: component_schema_variant.id().into(),
-                schema_variant_display_name: component_schema_variant.display_name().to_string(),
-                prop_id: prop.id.into(),
-                prop_name: prop.name.to_owned(),
-                attribute_value_id: request.attribute_value_id.into(),
-                before_value,
-                after_value: request.value,
-            })
+            ctx.write_audit_log(
+                AuditLogKind::UpdatePropertyEditorValue {
+                    component_id: request.component_id.into(),
+                    component_name: component.name(&ctx).await?,
+                    schema_variant_id: component_schema_variant.id().into(),
+                    schema_variant_display_name: component_schema_variant
+                        .display_name()
+                        .to_string(),
+                    prop_id: prop.id.into(),
+                    prop_name: prop.name.to_owned(),
+                    attribute_value_id: request.attribute_value_id.into(),
+                    before_value,
+                    after_value: request.value,
+                },
+                prop.name.to_owned(),
+            )
             .await?;
         }
 

--- a/lib/sdf-server/src/service/diagram/create_component.rs
+++ b/lib/sdf-server/src/service/diagram/create_component.rs
@@ -97,12 +97,15 @@ pub async fn create_component(
 
     let variant = SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
     let mut component = Component::new(&ctx, &name, variant.id()).await?;
-    ctx.write_audit_log(AuditLogKind::CreateComponent {
-        name: name.to_string(),
-        component_id: component.id().into(),
-        schema_variant_id: schema_variant_id.into(),
-        schema_variant_name: variant.display_name().to_owned(),
-    })
+    ctx.write_audit_log(
+        AuditLogKind::CreateComponent {
+            name: name.to_string(),
+            component_id: component.id().into(),
+            schema_variant_id: schema_variant_id.into(),
+            schema_variant_name: variant.display_name().to_owned(),
+        },
+        name.to_string(),
+    )
     .await?;
     let initial_geometry = component.geometry(&ctx).await?;
 

--- a/lib/sdf-server/src/service/diagram/delete_component.rs
+++ b/lib/sdf-server/src/service/diagram/delete_component.rs
@@ -157,12 +157,15 @@ async fn delete_single_component(
         component.delete(ctx).await?.is_some()
     };
 
-    ctx.write_audit_log(AuditLogKind::DeleteComponent {
-        component_id: id.into(),
-        name: component_name,
-        schema_variant_id: component_schema_variant.id().into(),
-        schema_variant_name: component_schema_variant.display_name().to_string(),
-    })
+    ctx.write_audit_log(
+        AuditLogKind::DeleteComponent {
+            component_id: id.into(),
+            name: component_name.to_owned(),
+            schema_variant_id: component_schema_variant.id().into(),
+            schema_variant_name: component_schema_variant.display_name().to_string(),
+        },
+        component_name,
+    )
     .await?;
 
     track(

--- a/lib/si-events-rs/src/audit_log.rs
+++ b/lib/si-events-rs/src/audit_log.rs
@@ -2,18 +2,21 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
 use v1::AuditLogV1;
-use v2::{AuditLogKindV2, AuditLogV2};
+use v2::AuditLogV2;
+use v3::{AuditLogKindV3, AuditLogV3};
 
 use crate::{Actor, ChangeSetId};
 
 mod v1;
 mod v2;
+mod v3;
 
-pub type AuditLogKind = AuditLogKindV2;
+pub type AuditLogKind = AuditLogKindV3;
 
 // TODO(nick): switch to something like "naxum-api-types" crate to avoid sizing issues.
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub enum AuditLog {
+    V3(Box<AuditLogV3>),
     V2(Box<AuditLogV2>),
     V1(AuditLogV1),
 }
@@ -23,10 +26,16 @@ impl AuditLog {
     ///
     /// _Note:_ [`ChangeSetId`] is required for almost all kinds of audit logging except for
     /// workspace management and authentication.
-    pub fn new(actor: Actor, kind: AuditLogKind, change_set_id: ChangeSetId) -> Self {
-        Self::V2(Box::new(AuditLogV2 {
+    pub fn new(
+        actor: Actor,
+        kind: AuditLogKind,
+        entity_name: Option<String>,
+        change_set_id: ChangeSetId,
+    ) -> Self {
+        Self::V3(Box::new(AuditLogV3 {
             actor,
             kind,
+            entity_name,
             timestamp: Utc::now().to_rfc3339(),
             change_set_id: Some(change_set_id),
         }))

--- a/lib/si-events-rs/src/audit_log/v2.rs
+++ b/lib/si-events-rs/src/audit_log/v2.rs
@@ -11,9 +11,7 @@ pub struct AuditLogV2 {
     pub change_set_id: Option<ChangeSetId>,
 }
 
-/// The kind contained within the audit log.
-///
-/// _Note:_ this does not use [`remain::sorted`] in order to match the aforementioned type.
+// NOTE(nick): this intentionally does not use "remain::sorted".
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Display)]
 pub enum AuditLogKindV2 {
     CreateComponent {

--- a/lib/si-events-rs/src/audit_log/v3.rs
+++ b/lib/si-events-rs/src/audit_log/v3.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{Actor, ChangeSetId};
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct AuditLogV3 {
+    pub actor: Actor,
+    pub kind: AuditLogKindV3,
+    pub entity_name: Option<String>,
+    pub timestamp: String,
+    pub change_set_id: Option<ChangeSetId>,
+}
+
+pub type AuditLogKindV3 = super::v2::AuditLogKindV2;


### PR DESCRIPTION
## Description

This PR solidifies the audit log structure in the UI. In order to do this, there is now an `AuditLogV3`.

> [!NOTE]
> Backwards compatibility only matters for the "beta" streams and we can reset the counter once
we switch over to the production streams.

Now, we have a display name for the event, an entity type for the event and an entity name for the event.

This PR re-orders the columns and headers as well as adds selected and hover background coloration to the rows. It does not contain fixes for the filters nor are the selected and hover colors final. In those verticals, this PR is just another step towards where we want to be.

<img src="https://media4.giphy.com/media/Va8x0BonrE3AmvGM4D/giphy.gif"/>