### PR TITLE
fix: up max retrys on api test to remove test flake

### DIFF
--- a/.github/workflows/run-api-test.yml
+++ b/.github/workflows/run-api-test.yml
@@ -92,9 +92,9 @@ jobs:
 
           echo "Using workspace ID: $workspace_id"
 
-          # Retry loop with 3 attempts
+          # Retry loop with 5 attempts
           n=0
-          max_retries=3
+          max_retries=5
           
           until [ $n -ge $max_retries ]
           do
@@ -115,6 +115,7 @@ jobs:
 
             n=$((n+1))
             echo "Attempt $n/$max_retries failed with exit code $exit_code! Retrying..."
+            sleep 5
           done
 
           if [ $n -ge $max_retries ]; then


### PR DESCRIPTION
Ups max potential Retrys for each API test after a deployment. We also weren't waiting between loops, so it was probably working it's way through the iterations a little too fast.

This should help ease the pressure on the system just after a deploy to remove a bit of test flake.