### PR TITLE
feat: modify schemas managed by management prototype

### DIFF
--- a/app/web/src/api/sdf/dal/func.ts
+++ b/app/web/src/api/sdf/dal/func.ts
@@ -191,6 +191,7 @@ export interface Management {
   // needed on create
   schemaVariantId: SchemaVariantId | null;
   componentId: ComponentId | null;
+  managedSchemas?: string[];
 }
 
 export interface Authentication {

--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -150,6 +150,7 @@
             <ManagementDetails
               v-if="editingFunc.kind === FuncKind.Management"
               ref="detachRef"
+              :disabled="editingFunc.isLocked"
               :funcId="editingFunc.funcId"
               :schemaVariantId="$props.schemaVariantId"
             />

--- a/app/web/src/components/FuncEditor/FuncDetails.vue
+++ b/app/web/src/components/FuncEditor/FuncDetails.vue
@@ -147,31 +147,64 @@
               </Stack>
             </TreeNode>
 
-            <ManagementDetails
+            <TreeNode
               v-if="editingFunc.kind === FuncKind.Management"
-              ref="detachRef"
-              :disabled="editingFunc.isLocked"
-              :funcId="editingFunc.funcId"
-              :schemaVariantId="$props.schemaVariantId"
-            />
+              alwaysShowArrow
+              childrenContainerClasses="border-b border-neutral-200 dark:border-neutral-600"
+              defaultOpen
+              enableGroupToggle
+              indentationSize="none"
+              label="Managed Assets"
+              labelClasses="border-b border-neutral-200 dark:border-neutral-600"
+              leftBorderSize="none"
+            >
+              <ManagementDetails
+                ref="detachRef"
+                :disabled="editingFunc.isLocked"
+                :funcId="editingFunc.funcId"
+                :schemaVariantId="$props.schemaVariantId"
+              />
+            </TreeNode>
             <ActionDetails
               v-if="editingFunc.kind === FuncKind.Action"
               ref="detachRef"
               :funcId="editingFunc.funcId"
               :schemaVariantId="$props.schemaVariantId"
             />
-            <AuthenticationDetails
+            <TreeNode
               v-if="editingFunc.kind === FuncKind.Authentication"
-              ref="detachRef"
-              :funcId="editingFunc.funcId"
-              :schemaVariantId="$props.schemaVariantId"
-            />
-            <CodeGenerationDetails
+              alwaysShowArrow
+              childrenContainerClasses="border-b border-neutral-200 dark:border-neutral-600"
+              defaultOpen
+              enableGroupToggle
+              indentationSize="none"
+              label="Function Inputs"
+              labelClasses="border-b border-neutral-200 dark:border-neutral-600"
+              leftBorderSize="none"
+            >
+              <AuthenticationDetails
+                ref="detachRef"
+                :funcId="editingFunc.funcId"
+                :schemaVariantId="$props.schemaVariantId"
+              />
+            </TreeNode>
+            <TreeNode
               v-if="editingFunc.kind === FuncKind.CodeGeneration"
-              ref="detachRef"
-              :funcId="editingFunc.funcId"
-              :schemaVariantId="$props.schemaVariantId"
-            />
+              alwaysShowArrow
+              childrenContainerClasses="border-b border-neutral-200 dark:border-neutral-600"
+              defaultOpen
+              enableGroupToggle
+              indentationSize="none"
+              label="Function Inputs"
+              labelClasses="border-b border-neutral-200 dark:border-neutral-600"
+              leftBorderSize="none"
+            >
+              <CodeGenerationDetails
+                ref="detachRef"
+                :funcId="editingFunc.funcId"
+                :schemaVariantId="$props.schemaVariantId"
+              />
+            </TreeNode>
             <QualificationDetails
               v-if="editingFunc.kind === FuncKind.Qualification"
               ref="detachRef"

--- a/app/web/src/components/FuncEditor/LeafInputs.vue
+++ b/app/web/src/components/FuncEditor/LeafInputs.vue
@@ -1,8 +1,5 @@
 <template>
   <div>
-    <h2 class="text-neutral-700 type-bold-sm dark:text-neutral-50">
-      Function inputs
-    </h2>
     <div class="flex flex-col gap-2xs py-xs">
       <VormInput
         v-if="kind === FuncBindingKind.Qualification"

--- a/app/web/src/components/FuncEditor/ManagementDetails.vue
+++ b/app/web/src/components/FuncEditor/ManagementDetails.vue
@@ -1,31 +1,94 @@
 <template>
-  <div class="p-xs flex flex-col gap-xs">
-    <div class="text-neutral-700 type-bold-sm dark:text-neutral-50">
+  <div class="p-xs flex flex-col gap-xs w-full">
+    <h2 class="text-neutral-700 type-bold-sm dark:text-neutral-50">
+      Managed assets
+    </h2>
+
+    <div class="flex flex-row gap-2xs">
+      <SelectMenu
+        v-model="selectedManagedSchemaId"
+        label="Pick an asset to manage"
+        type="dropdown"
+        :disabled="props.disabled"
+        :options="schemaOptions"
+        class="grow"
+      />
+
+      <VButton
+        icon="plus"
+        size="sm"
+        tone="success"
+        :requestStatus="updateBindingReqStatus"
+        :disabled="props.disabled"
+        @click="addSchema"
+      />
+    </div>
+
+    <ul v-if="binding?.managedSchemas">
+      <li
+        v-for="schemaId in binding.managedSchemas"
+        :key="schemaId"
+        class="flex flex-row items-center content-center gap-2xs mt-1"
+      >
+        <p class="grow text-neutral-700 type-bold-sm dark:text-neutral-50 ml-2">
+          {{ schemaNameMap[schemaId] ?? schemaId }}
+        </p>
+        <VButton
+          icon="trash"
+          size="sm"
+          :disabled="props.disabled"
+          tone="destructive"
+          @click="removeSchema(schemaId)"
+        />
+      </li>
+    </ul>
+
+    <div class="text-neutral-700 type-bold-sm dark:text-neutral-50 mt-5">
       <p class="text-sm">You can detach this function above.</p>
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
+import * as _ from "lodash-es";
 import { ref, watch, computed } from "vue";
 import { storeToRefs } from "pinia";
-import { Option } from "@/components/SelectMenu.vue";
+import { VButton } from "@si/vue-lib/design-system";
+import SelectMenu, { Option } from "@/components/SelectMenu.vue";
 import { toOptionValues } from "@/components/FuncEditor/utils";
 import { useFuncStore } from "@/store/func/funcs.store";
 import { useAssetStore } from "@/store/asset.store";
 import { FuncId } from "@/api/sdf/dal/func";
 import { SchemaVariantId } from "@/api/sdf/dal/schema";
 import { nonNullable } from "@/utils/typescriptLinter";
+import { nilId } from "@/utils/nilId";
 
 const funcStore = useFuncStore();
 const assetStore = useAssetStore();
 const { schemaVariantOptions } = storeToRefs(assetStore);
+
+const updateBindingReqStatus = funcStore.getRequestStatus("UPDATE_BINDING");
 
 const props = defineProps<{
   funcId: FuncId;
   schemaVariantId: SchemaVariantId;
   disabled?: boolean;
 }>();
+
+const noneOutput = {
+  label: "select asset to manage",
+  value: nilId(),
+};
+const selectedManagedSchemaId = ref<Option>(noneOutput);
+
+const schemaNameMap = ref<{ [key: string]: string }>({});
+
+const managerSchemaId = computed(
+  () =>
+    assetStore.variantList.find(
+      (variant) => variant.schemaVariantId === props.schemaVariantId,
+    )?.schemaId,
+);
 
 const binding = computed(() => {
   const bindings = funcStore.managementBindings[props.funcId];
@@ -34,6 +97,66 @@ const binding = computed(() => {
     .pop();
   return binding;
 });
+
+const schemaOptions = computed(() => {
+  const uninstalled: Option[] = assetStore.uninstalledVariantList.map(
+    (unin) => ({
+      label: unin.displayName ?? unin.schemaName,
+      value: unin.schemaId,
+    }),
+  );
+
+  const installed = assetStore.variantList.map((inst) => ({
+    label: inst.displayName ?? inst.schemaName,
+    value: inst.schemaId,
+  }));
+
+  const currentManagedSchemas = binding.value?.managedSchemas ?? [];
+
+  const allOptions = uninstalled.concat(installed);
+  allOptions.forEach((option) => {
+    const schemaId = option.value.toString();
+    schemaNameMap.value[schemaId] = option.label;
+  });
+
+  const filteredOptions = _.uniq(
+    allOptions.filter(
+      (opt) =>
+        typeof opt.value === "string" &&
+        opt.value !== managerSchemaId.value &&
+        !currentManagedSchemas.includes(opt.value),
+    ),
+  );
+  filteredOptions.sort((a, b) => a.label.localeCompare(b.label));
+
+  return filteredOptions;
+});
+
+const addSchema = async () => {
+  if (binding.value) {
+    const updated_binding = _.clone(binding.value);
+    if (!updated_binding.managedSchemas) {
+      updated_binding.managedSchemas = [];
+    }
+    updated_binding.managedSchemas.push(
+      selectedManagedSchemaId.value.value.toString(),
+    );
+    await funcStore.UPDATE_BINDING(props.funcId, [updated_binding]);
+  }
+};
+
+const removeSchema = async (schemaId: string) => {
+  if (binding.value) {
+    const updated_binding = _.clone(binding.value);
+    if (!updated_binding.managedSchemas) {
+      updated_binding.managedSchemas = [];
+    }
+    updated_binding.managedSchemas = updated_binding.managedSchemas.filter(
+      (id) => id !== schemaId,
+    );
+    await funcStore.UPDATE_BINDING(props.funcId, [updated_binding]);
+  }
+};
 
 const validSchemaVariantIds = computed(() => {
   const bindings = funcStore.managementBindings[props.funcId];

--- a/app/web/src/components/FuncEditor/ManagementDetails.vue
+++ b/app/web/src/components/FuncEditor/ManagementDetails.vue
@@ -51,7 +51,7 @@
 
 <script lang="ts" setup>
 import * as _ from "lodash-es";
-import { ref, watch, computed } from "vue";
+import { ref, watch, computed, toRaw } from "vue";
 import { storeToRefs } from "pinia";
 import { VButton } from "@si/vue-lib/design-system";
 import SelectMenu, { Option } from "@/components/SelectMenu.vue";
@@ -134,7 +134,7 @@ const schemaOptions = computed(() => {
 
 const addSchema = async () => {
   if (binding.value) {
-    const updated_binding = _.clone(binding.value);
+    const updated_binding = structuredClone(toRaw(binding.value));
     if (!updated_binding.managedSchemas) {
       updated_binding.managedSchemas = [];
     }

--- a/app/web/src/components/FuncEditor/ManagementDetails.vue
+++ b/app/web/src/components/FuncEditor/ManagementDetails.vue
@@ -1,24 +1,23 @@
 <template>
   <div class="p-xs flex flex-col gap-xs w-full">
-    <h2 class="text-neutral-700 type-bold-sm dark:text-neutral-50">
-      Managed assets
-    </h2>
-
     <div class="flex flex-row gap-2xs">
-      <SelectMenu
-        v-model="selectedManagedSchemaId"
-        label="Pick an asset to manage"
+      <VormInput
+        :modelValue="selectedManagedSchemaId"
+        placeholder="Pick an asset to manage"
+        size="sm"
+        noLabel
+        placeholderSelectable
         type="dropdown"
         :disabled="props.disabled"
         :options="schemaOptions"
-        class="grow"
+        @update:model-value="(newVal: string) => (selectedManagedSchemaId = newVal)"
       />
 
-      <VButton
+      <IconButton
         icon="plus"
+        class="mt-2xs"
         size="sm"
-        tone="success"
-        :requestStatus="updateBindingReqStatus"
+        iconTone="action"
         :disabled="props.disabled"
         @click="addSchema"
       />
@@ -33,19 +32,15 @@
         <p class="grow text-neutral-700 type-bold-sm dark:text-neutral-50 ml-2">
           {{ schemaNameMap[schemaId] ?? schemaId }}
         </p>
-        <VButton
+        <IconButton
           icon="trash"
           size="sm"
           :disabled="props.disabled"
-          tone="destructive"
+          iconTone="destructive"
           @click="removeSchema(schemaId)"
         />
       </li>
     </ul>
-
-    <div class="text-neutral-700 type-bold-sm dark:text-neutral-50 mt-5">
-      <p class="text-sm">You can detach this function above.</p>
-    </div>
   </div>
 </template>
 
@@ -53,21 +48,18 @@
 import * as _ from "lodash-es";
 import { ref, watch, computed, toRaw } from "vue";
 import { storeToRefs } from "pinia";
-import { VButton } from "@si/vue-lib/design-system";
-import SelectMenu, { Option } from "@/components/SelectMenu.vue";
+import { IconButton, VormInput } from "@si/vue-lib/design-system";
+import { Option } from "@/components/SelectMenu.vue";
 import { toOptionValues } from "@/components/FuncEditor/utils";
 import { useFuncStore } from "@/store/func/funcs.store";
 import { useAssetStore } from "@/store/asset.store";
 import { FuncId } from "@/api/sdf/dal/func";
 import { SchemaVariantId } from "@/api/sdf/dal/schema";
 import { nonNullable } from "@/utils/typescriptLinter";
-import { nilId } from "@/utils/nilId";
 
 const funcStore = useFuncStore();
 const assetStore = useAssetStore();
 const { schemaVariantOptions } = storeToRefs(assetStore);
-
-const updateBindingReqStatus = funcStore.getRequestStatus("UPDATE_BINDING");
 
 const props = defineProps<{
   funcId: FuncId;
@@ -75,11 +67,7 @@ const props = defineProps<{
   disabled?: boolean;
 }>();
 
-const noneOutput = {
-  label: "select asset to manage",
-  value: nilId(),
-};
-const selectedManagedSchemaId = ref<Option>(noneOutput);
+const selectedManagedSchemaId = ref("");
 
 const schemaNameMap = ref<{ [key: string]: string }>({});
 
@@ -138,9 +126,7 @@ const addSchema = async () => {
     if (!updated_binding.managedSchemas) {
       updated_binding.managedSchemas = [];
     }
-    updated_binding.managedSchemas.push(
-      selectedManagedSchemaId.value.value.toString(),
-    );
+    updated_binding.managedSchemas.push(selectedManagedSchemaId.value);
     await funcStore.UPDATE_BINDING(props.funcId, [updated_binding]);
   }
 };

--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -120,7 +120,6 @@ export const useAssetStore = (forceChangeSetId?: ChangeSetId) => {
       state: () => ({
         variantList: [] as SchemaVariant[],
         uninstalledVariantList: [] as UninstalledVariant[],
-        variantsById: {} as Record<SchemaVariantId, SchemaVariant>,
 
         executeSchemaVariantTaskId: undefined as string | undefined,
         executeSchemaVariantTaskRunning: false as boolean,

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -232,6 +232,9 @@ impl From<FuncBinding> for si_frontend_types::FuncBinding {
                 schema_variant_id: Some(mgmt.schema_variant_id.into()),
                 management_prototype_id: Some(mgmt.management_prototype_id.into()),
                 func_id: Some(mgmt.func_id.into()),
+                managed_schemas: mgmt
+                    .managed_schemas
+                    .map(|s| s.into_iter().map(Into::into).collect()),
             },
             FuncBinding::CodeGeneration(code_gen) => {
                 si_frontend_types::FuncBinding::CodeGeneration {

--- a/lib/dal/src/func/binding/management.rs
+++ b/lib/dal/src/func/binding/management.rs
@@ -85,7 +85,7 @@ impl ManagementBinding {
                                 let component_type = format!(
                                     r#"
                                 {{
-                                    kind: {name},
+                                    kind: "{name}",
                                     properties?: {sv_type},
                                     geometry?: Geometry,
                                     connect?: {{
@@ -124,18 +124,18 @@ type Output = {{
   ops?: {{
     create?: {{ [key: string]: {component_types} }},
     update?: {{ [key: string]: {{ 
-        properties?: {{ [key: string]: unknown }}, geometry?: Geometry, }},
+        properties?: {{ [key: string]: unknown }}, 
+        geometry?: Geometry, 
         connect?: {{
             add?: {{ from: string, to: {{ component: string; socket: string; }} }}[],
             remove?: {{ from: string, to: {{ component: string; socket: string; }} }}[],
         }},
-    }},
+    }} }},
     actions?: {{ [key: string]: {{
       add?: ("create" | "update" | "refresh" | "delete" | string)[];
       remove?: ("create" | "update" | "refresh" | "delete" | string)[];
     }} }}
-
-  }};
+  }},
   message?: string | null;
 }};
 type Input = {{

--- a/lib/dal/src/func/binding/management.rs
+++ b/lib/dal/src/func/binding/management.rs
@@ -3,17 +3,18 @@ use telemetry::prelude::*;
 
 use crate::{
     management::prototype::{ManagementPrototype, ManagementPrototypeId},
-    DalContext, Func, FuncId, Prop, Schema, SchemaVariant, SchemaVariantId,
+    DalContext, Func, FuncId, Prop, Schema, SchemaId, SchemaVariant, SchemaVariantId,
 };
 
 use super::{EventualParent, FuncBinding, FuncBindingResult};
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
 pub struct ManagementBinding {
-    // unique ids
     pub schema_variant_id: SchemaVariantId,
     pub management_prototype_id: ManagementPrototypeId,
     pub func_id: FuncId,
+    pub managed_schemas: Option<Vec<SchemaId>>,
 }
 
 impl ManagementBinding {
@@ -155,6 +156,16 @@ type Input = {{
         for management_prototype_id in
             ManagementPrototype::list_ids_for_func_id(ctx, func_id).await?
         {
+            let Some(prototype) =
+                ManagementPrototype::get_by_id(ctx, management_prototype_id).await?
+            else {
+                error!("Could not get bindings for func_id {func_id}");
+                continue;
+            };
+
+            let managed_schemas = prototype
+                .managed_schemas()
+                .map(|schemas| schemas.iter().map(ToOwned::to_owned).collect());
             let schema_variant_id =
                 ManagementPrototype::get_schema_variant_id(ctx, management_prototype_id).await;
             match schema_variant_id {
@@ -163,6 +174,7 @@ type Input = {{
                         schema_variant_id,
                         func_id,
                         management_prototype_id,
+                        managed_schemas,
                     }));
                 }
                 Err(err) => {
@@ -205,5 +217,39 @@ type Input = {{
         ManagementPrototype::remove(ctx, management_prototype_id).await?;
 
         Ok(EventualParent::SchemaVariant(schema_variant_id))
+    }
+
+    pub async fn update_management_binding(
+        ctx: &DalContext,
+        management_prototype_id: ManagementPrototypeId,
+        managed_schemas: Option<Vec<SchemaId>>,
+    ) -> FuncBindingResult<Vec<FuncBinding>> {
+        let func_id = ManagementPrototype::func_id(ctx, management_prototype_id).await?;
+        let Some(management_prototype) =
+            ManagementPrototype::get_by_id(ctx, management_prototype_id).await?
+        else {
+            return FuncBinding::for_func_id(ctx, func_id).await;
+        };
+
+        let schema_variant_id =
+            ManagementPrototype::get_schema_variant_id(ctx, management_prototype_id).await?;
+        let eventual_parent = EventualParent::SchemaVariant(schema_variant_id);
+        eventual_parent.error_if_locked(ctx).await?;
+        let manager_schema_id =
+            SchemaVariant::schema_id_for_schema_variant_id(ctx, schema_variant_id).await?;
+
+        management_prototype
+            .modify(ctx, |proto| {
+                proto.managed_schemas = managed_schemas.map(|schemas| {
+                    schemas
+                        .into_iter()
+                        .filter(|schema_id| schema_id != &manager_schema_id)
+                        .collect()
+                });
+                Ok(())
+            })
+            .await?;
+
+        FuncBinding::for_func_id(ctx, func_id).await
     }
 }

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -1158,7 +1158,7 @@ impl Prop {
                     let name_serialized = serde_json::to_string(&name_value)?;
                     object_type.push_str(
                         format!(
-                            "{}: {} | null | undefined;\n",
+                            "{}?: {} | null;\n",
                             &name_serialized,
                             child.ts_type(ctx).await?
                         )

--- a/lib/dal/tests/integration_test/func/authoring/binding.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding.rs
@@ -1052,6 +1052,7 @@ async fn return_the_right_bindings(ctx: &mut DalContext, nw: &WorkspaceSignup) {
                     schema_variant_id,
                     management_prototype_id,
                     func_id,
+                    ..
                 } => {
                     assert!(schema_variant_id.is_some());
                     assert!(func_id.is_some());

--- a/lib/si-frontend-types-rs/src/func.rs
+++ b/lib/si-frontend-types-rs/src/func.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use si_events::{
     ActionKind, ActionPrototypeId, AttributePrototypeArgumentId, AttributePrototypeId, ComponentId,
     FuncArgumentId, FuncBackendKind, FuncId, FuncKind, InputSocketId, ManagementPrototypeId,
-    OutputSocketId, PropId, SchemaVariantId, Timestamp,
+    OutputSocketId, PropId, SchemaId, SchemaVariantId, Timestamp,
 };
 use strum::{AsRefStr, Display, EnumIter, EnumString};
 
@@ -123,6 +123,7 @@ pub enum FuncBinding {
         schema_variant_id: Option<SchemaVariantId>,
         management_prototype_id: Option<ManagementPrototypeId>,
         func_id: Option<FuncId>,
+        managed_schemas: Option<Vec<SchemaId>>,
     },
     #[serde(rename_all = "camelCase")]
     Qualification {
@@ -135,6 +136,24 @@ pub enum FuncBinding {
         // thing that can be updated
         inputs: Vec<LeafInputLocation>,
     },
+}
+
+impl FuncBinding {
+    pub fn leaf_inputs(&self) -> Option<(AttributePrototypeId, Vec<LeafInputLocation>)> {
+        match self {
+            FuncBinding::CodeGeneration {
+                attribute_prototype_id,
+                inputs,
+                ..
+            } => attribute_prototype_id.map(|id| (id, inputs.clone())),
+            FuncBinding::Qualification {
+                attribute_prototype_id,
+                inputs,
+                ..
+            } => attribute_prototype_id.map(|id| (id, inputs.clone())),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq, Hash)]


### PR DESCRIPTION
Adds managed schemas to the management bindings, and allows you to edit them from the function editor. This makes it possible to author management functions that create, update, and connect other asset/variant types than the managing component's type.