### PR TITLE
Use SpiceDB to facilitate Change Set Approvals end to end

### DIFF
--- a/app/web/src/api/sdf/dal/change_set.ts
+++ b/app/web/src/api/sdf/dal/change_set.ts
@@ -8,6 +8,8 @@ export enum ChangeSetStatus {
   Abandoned = "Abandoned",
   NeedsApproval = "NeedsApproval",
   NeedsAbandonApproval = "NeedsAbandonApproval",
+  Rejected = "Rejected",
+  Approved = "Approved",
 }
 
 export type ChangeSetId = string;
@@ -19,7 +21,12 @@ export interface ChangeSet {
   appliedAt?: IsoDateString;
   mergeRequestedAt?: IsoDateString;
   mergeRequestedByUserId?: UserId;
+  mergeRequestedByUser?: string;
   baseChangeSetId: ChangeSetId;
+  reviewedByUserId?: UserId;
+  reviewedByUser?: string;
+  reviewedAt?: IsoDateString;
+  updatedAt?: IsoDateString;
   abandonRequestedAt?: IsoDateString;
   abandonRequestedByUserId?: UserId;
 }

--- a/app/web/src/api/sdf/dal/workspace.ts
+++ b/app/web/src/api/sdf/dal/workspace.ts
@@ -11,7 +11,7 @@ export interface Workspace {
 export interface WorkspaceMetadata {
   name: string;
   id: string;
-  default_change_set_id: ChangeSetId;
-  change_sets: ChangeSet[];
+  defaultChangeSetId: ChangeSetId;
+  changeSets: ChangeSet[];
   approvers: string[];
 }

--- a/app/web/src/components/AbandonChangeSetModal.vue
+++ b/app/web/src/components/AbandonChangeSetModal.vue
@@ -1,0 +1,63 @@
+<template>
+  <!-- this modal is for the abandoning change sets -->
+  <Modal ref="modalRef" title="Abandon Change Set?">
+    <div class="text-md mb-xs">
+      Are you sure that you want to abandon change set
+      <span class="italic font-bold">
+        {{ changeSet?.name }}
+      </span>
+      and return to HEAD?
+    </div>
+    <div class="text-sm mb-sm">
+      Once abandoned, a change set cannot be recovered.
+    </div>
+    <div class="flex flex-row items-center w-full gap-sm">
+      <VButton
+        label="Cancel"
+        variant="ghost"
+        tone="warning"
+        icon="x"
+        @click="closeModalHandler"
+      />
+      <template v-if="!changeSetsStore.headSelected">
+        <VButton
+          label="Abandon Change Set"
+          tone="destructive"
+          class="flex-grow"
+          icon="trash"
+          loadingText="Abandoning Change Set"
+          @click="abandonHandler"
+        />
+      </template>
+    </div>
+  </Modal>
+</template>
+
+<script lang="ts" setup>
+import * as _ from "lodash-es";
+import { VButton, Modal } from "@si/vue-lib/design-system";
+import { computed, ref } from "vue";
+
+import { useChangeSetsStore } from "@/store/change_sets.store";
+
+const changeSetsStore = useChangeSetsStore();
+
+const modalRef = ref<InstanceType<typeof Modal> | null>(null);
+const changeSet = computed(() => changeSetsStore.selectedChangeSet);
+
+async function openModalHandler() {
+  if (changeSet?.value?.name === "HEAD") return;
+  modalRef.value?.open();
+}
+
+function closeModalHandler() {
+  modalRef.value?.close();
+}
+
+function abandonHandler() {
+  changeSetsStore.ABANDON_CHANGE_SET();
+  closeModalHandler();
+}
+
+defineExpose({ open: openModalHandler });
+</script>

--- a/app/web/src/components/ApplyChangeSetButton.vue
+++ b/app/web/src/components/ApplyChangeSetButton.vue
@@ -53,11 +53,13 @@
     </template>
 
     <ApprovalFlowModal
+      v-if="!featureFlagsStore.REBAC"
       ref="approvalFlowModalRef"
       votingKind="merge"
       @completeVoting="applyChangeSet"
     />
-    <ApprovalFlowModal2 ref="approvalFlowModal2Ref" votingKind="merge" />
+
+    <ApprovalFlowModal2 v-else ref="approvalFlowModal2Ref" votingKind="merge" />
   </VButton>
 </template>
 
@@ -114,6 +116,7 @@ const openApprovalFlowModal = () => {
 // Applies the current change set3
 const applyChangeSet = async () => {
   if (!route.name) return;
+  // if (featureFlagsStore.REBAC) return;
   const resp = await changeSetsStore.APPLY_CHANGE_SET(
     authStore.user?.email ?? "",
   );

--- a/app/web/src/components/ApprovalFlowModal.vue
+++ b/app/web/src/components/ApprovalFlowModal.vue
@@ -344,6 +344,7 @@ import { useStatusStore } from "@/store/status.store";
 import { useActionsStore } from "@/store/actions.store";
 import { useAuthStore } from "@/store/auth.store";
 import ApprovalFlowCancelled from "@/components/toasts/ApprovalFlowCancelled.vue";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 
 // If we end up adding another VotingKind, make sure to change ALL of the logic across this component that checks the votingKind prop!
 export type VotingKind = "merge" | "abandon";
@@ -354,6 +355,7 @@ const actionsStore = useActionsStore();
 const presenceStore = usePresenceStore();
 const changeSetsStore = useChangeSetsStore();
 const statusStore = useStatusStore();
+const featureFlagsStore = useFeatureFlagsStore();
 const route = useRoute();
 
 const votingModalRef = ref<InstanceType<typeof Modal> | null>(null);
@@ -506,6 +508,7 @@ async function vote(vote: string) {
 
 function openVotingModalHandler() {
   if (changeSet?.value?.name === "HEAD") return;
+  if (featureFlagsStore.REBAC) return;
   votingModalRef.value?.open();
   resetState();
   checkForUserWhoStartedVotingAndCancelIfTheyAreGone();

--- a/app/web/src/components/ApprovalPendingModal.vue
+++ b/app/web/src/components/ApprovalPendingModal.vue
@@ -2,33 +2,44 @@
   <div>
     <!-- this modal is for the voting process -->
     <Modal ref="modalRef" title="Pending Approvals" size="lg">
-      <div class="max-h-[70vh] overflow-hidden flex flex-col">
-        <div class="text-md mb-xs">
+      <div class="max-h-[70vh] overflow-hidden flex flex-col gap-xs">
+        <div class="text-md pb-xs">
           These change sets have been submitted for approval to be merged to
           HEAD. Select one to approve or reject it.
         </div>
+        <ApprovalPendingModalCard
+          v-for="changeSet in pendingChangeSets"
+          :key="changeSet.id"
+          :changeSet="changeSet"
+          @closeModal="closeModalHandler"
+        />
       </div>
     </Modal>
   </div>
 </template>
 
 <script lang="ts" setup>
-// TODO(WENDY) - this mock modal still needs code for -
-// Listing the pending approvals
-// Selecting and displaying an individual approval with Reject/Approve buttons
 import * as _ from "lodash-es";
 import { Modal } from "@si/vue-lib/design-system";
-import { ref } from "vue";
+import { ref, computed } from "vue";
+import { useChangeSetsStore } from "@/store/change_sets.store";
+import ApprovalPendingModalCard from "./ApprovalPendingModalCard.vue";
+
+const changeSetsStore = useChangeSetsStore();
 
 const modalRef = ref<InstanceType<typeof Modal> | null>(null);
+
+const pendingChangeSets = computed(
+  () => changeSetsStore.changeSetsNeedingApproval,
+);
 
 function openModalHandler() {
   modalRef.value?.open();
 }
 
-// function closeVotingModalHandler() {
-//   modalRef.value?.close();
-// }
+function closeModalHandler() {
+  modalRef.value?.close();
+}
 
 defineExpose({ open: openModalHandler });
 </script>

--- a/app/web/src/components/ApprovalPendingModalCard.vue
+++ b/app/web/src/components/ApprovalPendingModalCard.vue
@@ -1,0 +1,86 @@
+<template>
+  <div
+    :class="
+      clsx(
+        'group/pendingcard',
+        'border rounded flex flex-row gap-xs items-center p-2xs cursor-pointer',
+        themeClasses(
+          'border-neutral-200 hover:border-action-500 hover:text-action-500 text-black',
+          'border-neutral-700 hover:border-action-300 hover:text-action-300 text-white',
+        ),
+      )
+    "
+    @click="goToChangeSet(changeSet.id)"
+  >
+    <div class="group-hover/pendingcard:underline flex-1">
+      <div class="font-bold line-clamp-2">
+        {{ changeSet.name }}
+      </div>
+      <div
+        :class="
+          clsx(
+            'text-xs italic',
+            themeClasses(
+              'text-neutral-500 group-hover/pendingcard:text-action-500',
+              'text-neutral-400 group-hover/pendingcard:text-action-300',
+            ),
+          )
+        "
+      >
+        <Timestamp
+          :date="changeSet.mergeRequestedAt"
+          showTimeIfToday
+          size="extended"
+        />
+
+        by {{ changeSet.mergeRequestedByUser }}
+      </div>
+    </div>
+    <div class="flex gap-xs flex-none">
+      <VButton
+        size="xs"
+        label="Reject"
+        variant="ghost"
+        tone="destructive"
+        @click.stop="rejectChangeSet(changeSet.id)"
+      />
+      <VButton
+        size="xs"
+        tone="success"
+        class="grow"
+        label="Approve"
+        @click.stop="approveChangeSet(changeSet.id)"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import clsx from "clsx";
+import * as _ from "lodash-es";
+import { themeClasses, VButton, Timestamp } from "@si/vue-lib/design-system";
+import { PropType } from "vue";
+import { ChangeSet, ChangeSetId } from "@/api/sdf/dal/change_set";
+import { useChangeSetsStore } from "@/store/change_sets.store";
+
+const changeSetsStore = useChangeSetsStore();
+
+defineProps({
+  changeSet: { type: Object as PropType<ChangeSet>, required: true },
+});
+
+const goToChangeSet = (id: ChangeSetId) => {
+  changeSetsStore.setActiveChangeset(id);
+  emit("closeModal");
+};
+const rejectChangeSet = (id: ChangeSetId) => {
+  changeSetsStore.REJECT_CHANGE_SET_APPLY(id);
+};
+const approveChangeSet = (id: ChangeSetId) => {
+  changeSetsStore.APPROVE_CHANGE_SET_FOR_APPLY(id);
+};
+
+const emit = defineEmits<{
+  (e: "closeModal"): void;
+}>();
+</script>

--- a/app/web/src/components/NoSelectionDetailsPanel.vue
+++ b/app/web/src/components/NoSelectionDetailsPanel.vue
@@ -92,10 +92,10 @@ const pendingApprovalModalRef = ref<InstanceType<
   typeof ApprovalPendingModal
 > | null>(null);
 
-// TODO(WENDY) - Mock data we need to replace with real data!
-const userIsApprover = computed(() => true);
-const pendingApprovalCount = computed(() => 3);
-// END MOCK DATA
+const userIsApprover = computed(() => changeSetStore.currentUserIsApprover);
+const pendingApprovalCount = computed(
+  () => changeSetStore.changeSetsNeedingApproval.length,
+);
 
 const openPendingApprovalsModal = () => {
   pendingApprovalModalRef.value?.open();

--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -22,8 +22,7 @@
   <div
     v-if="
       featureFlagsStore.REBAC &&
-      changeSetsStore.selectedChangeSet?.status ===
-        ChangeSetStatus.NeedsApproval
+      changeSetsStore.selectedChangeSet?.status !== ChangeSetStatus.Open
     "
     :class="
       clsx(

--- a/app/web/src/components/layout/navbar/ChangeSetPanel.vue
+++ b/app/web/src/components/layout/navbar/ChangeSetPanel.vue
@@ -93,6 +93,7 @@
       votingKind="abandon"
       @completeVoting="changeSetsStore.ABANDON_CHANGE_SET"
     />
+    <AbandonChangeSetModal ref="abandonModalRef" />
   </div>
 </template>
 
@@ -111,6 +112,7 @@ import { useChangeSetsStore } from "@/store/change_sets.store";
 import { ChangeSetStatus } from "@/api/sdf/dal/change_set";
 import { useAuthStore } from "@/store/auth.store";
 import ApprovalFlowModal from "@/components/ApprovalFlowModal.vue";
+import AbandonChangeSetModal from "@/components/AbandonChangeSetModal.vue";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 
 const CHANGE_SET_NAME_REGEX = /^(?!head).*$/i;
@@ -139,8 +141,16 @@ const approvalFlowModalRef = ref<InstanceType<typeof ApprovalFlowModal> | null>(
   null,
 );
 
+const abandonModalRef = ref<InstanceType<typeof AbandonChangeSetModal> | null>(
+  null,
+);
+
 const openApprovalFlowModal = () => {
-  approvalFlowModalRef.value?.open();
+  if (!featureFlagsStore.REBAC) {
+    approvalFlowModalRef.value?.open();
+  } else {
+    abandonModalRef.value?.open();
+  }
 };
 
 const createModalRef = ref<InstanceType<typeof Modal>>();
@@ -182,7 +192,8 @@ function onSelectChangeSet(newVal: string) {
     if (
       changeSetsStore.changeSetsById[newVal]?.status !== ChangeSetStatus.Open &&
       changeSetsStore.changeSetsById[newVal]?.mergeRequestedByUserId !==
-        authStore.user?.pk
+        authStore.user?.pk &&
+      !featureFlagsStore.REBAC
     ) {
       return;
     }

--- a/app/web/src/components/toasts/ChangeSetStatusChanged.vue
+++ b/app/web/src/components/toasts/ChangeSetStatusChanged.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>{{ user }} has {{ command }} {{ changeSetName }}</div>
+</template>
+
+<script lang="ts" setup>
+defineProps({
+  user: { type: String, required: true },
+  changeSetName: { type: String, required: true },
+  command: { type: String, required: true },
+});
+</script>

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -3,7 +3,11 @@
 
 import { IRect } from "konva/lib/types";
 import { FuncBinding, FuncId, FuncSummary } from "@/api/sdf/dal/func";
-import { ChangeSetId } from "@/api/sdf/dal/change_set";
+import {
+  ChangeSetId,
+  ChangeSetStatus,
+  ChangeSet,
+} from "@/api/sdf/dal/change_set";
 import { ComponentId, RawComponent, RawEdge } from "@/api/sdf/dal/component";
 import {
   ComponentType,
@@ -123,6 +127,10 @@ export type WsEventPayloadMap = {
   ChangeSetAbandoned: {
     changeSetId: ChangeSetId;
     userPk: UserId;
+  };
+  ChangeSetStatusChanged: {
+    fromStatus: ChangeSetStatus;
+    changeSet: ChangeSet;
   };
   CheckedQualifications: {
     prototypeId: string;

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -275,19 +275,27 @@ impl ChangeSet {
         &self,
         ctx: &DalContext,
     ) -> ChangeSetResult<si_frontend_types::ChangeSet> {
-        let merge_requested_by_email =
+        let merge_requested_by_user =
             if let Some(merge_requested_by) = self.merge_requested_by_user_id {
-                User::get_by_pk(ctx, merge_requested_by)
-                    .await?
-                    .map(|user| user.email().clone())
+                User::get_by_pk(ctx, merge_requested_by).await?.map(|user| {
+                    if user.name().is_empty() {
+                        return user.email().clone();
+                    } else {
+                        user.name().clone()
+                    }
+                })
             } else {
                 None
             };
 
-        let reviewed_by_email = if let Some(reviewed_by) = self.reviewed_by_user_id {
-            User::get_by_pk(ctx, reviewed_by)
-                .await?
-                .map(|user| user.email().clone())
+        let reviewed_by_user = if let Some(reviewed_by) = self.reviewed_by_user_id {
+            User::get_by_pk(ctx, reviewed_by).await?.map(|user| {
+                if user.name().is_empty() {
+                    return user.email().clone();
+                } else {
+                    user.name().clone()
+                }
+            })
         } else {
             None
         };
@@ -301,10 +309,10 @@ impl ChangeSet {
             base_change_set_id: self.base_change_set_id.map(|id| id.into()),
             workspace_id: self.workspace_id.map_or("".to_owned(), |id| id.to_string()),
             merge_requested_by_user_id: self.merge_requested_by_user_id.map(|s| s.to_string()),
-            merge_requested_by_user_email: merge_requested_by_email,
+            merge_requested_by_user,
             merge_requested_at: self.merge_requested_at,
             reviewed_by_user_id: self.reviewed_by_user_id.map(|id| id.into()),
-            reviewed_by_user_email: reviewed_by_email,
+            reviewed_by_user,
             reviewed_at: self.reviewed_at,
         };
 

--- a/lib/dal/src/change_set/event.rs
+++ b/lib/dal/src/change_set/event.rs
@@ -19,18 +19,14 @@ impl WsEvent {
 
     pub async fn change_set_status_changed(
         ctx: &DalContext,
-        change_set_id: ChangeSetId,
-        user_pk: Option<UserPk>,
         from_status: ChangeSetStatus,
-        to_status: ChangeSetStatus,
+        change_set: si_frontend_types::ChangeSet,
     ) -> WsEventResult<Self> {
         WsEvent::new(
             ctx,
             WsPayload::ChangeSetStatusChanged(ChangeSetStateChangePayload {
-                change_set_id,
                 from_status,
-                to_status,
-                user_pk,
+                change_set,
             }),
         )
         .await
@@ -179,10 +175,8 @@ pub struct ChangeSetActorPayload {
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ChangeSetStateChangePayload {
-    change_set_id: ChangeSetId,
     from_status: ChangeSetStatus,
-    to_status: ChangeSetStatus,
-    user_pk: Option<UserPk>,
+    change_set: si_frontend_types::ChangeSet,
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]

--- a/lib/permissions/src/lib.rs
+++ b/lib/permissions/src/lib.rs
@@ -1,5 +1,5 @@
 use si_data_spicedb::{
-    PermissionsObject, Relationship, Relationships, SpiceDbClient, SpiceDbError, ZedToken,
+    Relationship, Relationships, SpiceDBObject, SpiceDbClient, SpiceDbError, ZedToken,
 };
 use si_events::{UserPk, WorkspacePk};
 use std::result;
@@ -57,9 +57,9 @@ pub enum Relation {
 ///     .await?;
 /// ```
 pub struct RelationBuilder {
-    object: Option<PermissionsObject>,
+    object: Option<SpiceDBObject>,
     relation: Option<Relation>,
-    subject: Option<PermissionsObject>,
+    subject: Option<SpiceDBObject>,
     zed_token: Option<ZedToken>,
 }
 
@@ -74,7 +74,7 @@ impl RelationBuilder {
     }
 
     pub fn object(mut self, object_type: ObjectType, id: impl ToString) -> Self {
-        self.object = Some(PermissionsObject::new(object_type, id));
+        self.object = Some(SpiceDBObject::new(object_type, id));
         self
     }
 
@@ -88,7 +88,7 @@ impl RelationBuilder {
     }
 
     pub fn subject(mut self, object_type: ObjectType, id: impl ToString) -> Self {
-        self.subject = Some(PermissionsObject::new(object_type, id));
+        self.subject = Some(SpiceDBObject::new(object_type, id));
         self
     }
 
@@ -130,7 +130,7 @@ impl RelationBuilder {
                 .read_relationship(Relationship::new(
                     object,
                     relation,
-                    PermissionsObject::empty(),
+                    SpiceDBObject::empty(),
                     self.zed_token.clone(),
                 ))
                 .await
@@ -181,9 +181,9 @@ impl Default for RelationBuilder {
 ///     .await?) { do_thing() }
 /// ```
 pub struct PermissionBuilder {
-    object: Option<PermissionsObject>,
+    object: Option<SpiceDBObject>,
     permission: Option<Permission>,
-    subject: Option<PermissionsObject>,
+    subject: Option<SpiceDBObject>,
     zed_token: Option<ZedToken>,
 }
 
@@ -198,7 +198,7 @@ impl PermissionBuilder {
     }
 
     pub fn object(mut self, object_type: ObjectType, id: impl ToString) -> Self {
-        self.object = Some(PermissionsObject::new(object_type, id));
+        self.object = Some(SpiceDBObject::new(object_type, id));
         self
     }
 
@@ -212,7 +212,7 @@ impl PermissionBuilder {
     }
 
     pub fn subject(mut self, object_type: ObjectType, id: impl ToString) -> Self {
-        self.subject = Some(PermissionsObject::new(object_type, id));
+        self.subject = Some(SpiceDBObject::new(object_type, id));
         self
     }
 
@@ -227,7 +227,7 @@ impl PermissionBuilder {
 
     /// Checks if the given subject has the given permission in the given object
     pub async fn has_permission(&self, client: &mut SpiceDbClient) -> Result<bool> {
-        match self.check() {
+        match self.check_has_permission() {
             Ok(perms) => Ok(client
                 .check_permissions(perms)
                 .await
@@ -236,7 +236,7 @@ impl PermissionBuilder {
         }
     }
 
-    fn check(&self) -> Result<si_data_spicedb::Permission> {
+    fn check_has_permission(&self) -> Result<si_data_spicedb::Permission> {
         match (self.object.clone(), self.permission, self.subject.clone()) {
             (Some(object), Some(permission), Some(subject)) => {
                 Ok(si_data_spicedb::Permission::new(

--- a/lib/sdf-server/src/service/v2.rs
+++ b/lib/sdf-server/src/service/v2.rs
@@ -13,11 +13,14 @@ pub mod view;
 
 const PREFIX: &str = "/workspaces/:workspace_id/change-sets/:change_set_id";
 
+// use this if you don't need to pass in the change_set id
+const CHANGE_SET_PREFIX: &str = "/workspaces/:workspace_id/change-sets";
+
 pub fn routes(state: AppState) -> Router<AppState> {
     Router::new()
         .nest("/admin", admin::v2_routes(state.clone()))
         .nest(&format!("{PREFIX}/audit-logs"), audit_log::v2_routes())
-        .nest(PREFIX, change_set::v2_routes(state.clone()))
+        .nest(CHANGE_SET_PREFIX, change_set::v2_routes(state.clone()))
         .nest(&format!("{PREFIX}/funcs"), func::v2_routes())
         .nest(&format!("{PREFIX}/modules"), module::v2_routes())
         .nest(&format!("{PREFIX}/schema-variants"), variant::v2_routes())

--- a/lib/sdf-server/src/service/v2/change_set/approve.rs
+++ b/lib/sdf-server/src/service/v2/change_set/approve.rs
@@ -51,17 +51,15 @@ pub async fn approve(
             "merged_change_set": change_set_id,
         }),
     );
-
-    WsEvent::change_set_status_changed(
-        &ctx,
-        change_set.id,
-        ChangeSet::extract_userid_from_context(&ctx).await,
-        old_status,
-        change_set.status,
-    )
-    .await?
-    .publish_on_commit(&ctx)
-    .await?;
+    let change_set_view = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+        .await?
+        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?
+        .into_frontend_type(&ctx)
+        .await?;
+    WsEvent::change_set_status_changed(&ctx, old_status, change_set_view)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
 
     ctx.commit().await?;
 

--- a/lib/sdf-server/src/service/v2/change_set/cancel_approval_request.rs
+++ b/lib/sdf-server/src/service/v2/change_set/cancel_approval_request.rs
@@ -37,16 +37,15 @@ pub async fn cancel_approval_request(
         }),
     );
 
-    WsEvent::change_set_status_changed(
-        &ctx,
-        change_set.id,
-        ChangeSet::extract_userid_from_context(&ctx).await,
-        old_status,
-        change_set.status,
-    )
-    .await?
-    .publish_on_commit(&ctx)
-    .await?;
+    let change_set_view = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+        .await?
+        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?
+        .into_frontend_type(&ctx)
+        .await?;
+    WsEvent::change_set_status_changed(&ctx, old_status, change_set_view)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
 
     ctx.commit().await?;
 

--- a/lib/sdf-server/src/service/v2/change_set/reject.rs
+++ b/lib/sdf-server/src/service/v2/change_set/reject.rs
@@ -37,16 +37,15 @@ pub async fn reject(
         }),
     );
 
-    WsEvent::change_set_status_changed(
-        &ctx,
-        change_set.id,
-        ChangeSet::extract_userid_from_context(&ctx).await,
-        old_status,
-        change_set.status,
-    )
-    .await?
-    .publish_on_commit(&ctx)
-    .await?;
+    let change_set_view = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+        .await?
+        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?
+        .into_frontend_type(&ctx)
+        .await?;
+    WsEvent::change_set_status_changed(&ctx, old_status, change_set_view)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
 
     ctx.commit().await?;
 

--- a/lib/sdf-server/src/service/v2/change_set/request_approval.rs
+++ b/lib/sdf-server/src/service/v2/change_set/request_approval.rs
@@ -37,16 +37,15 @@ pub async fn request_approval(
         }),
     );
 
-    WsEvent::change_set_status_changed(
-        &ctx,
-        change_set.id,
-        ChangeSet::extract_userid_from_context(&ctx).await,
-        old_status,
-        change_set.status,
-    )
-    .await?
-    .publish_on_commit(&ctx)
-    .await?;
+    let change_set_view = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+        .await?
+        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?
+        .into_frontend_type(&ctx)
+        .await?;
+    WsEvent::change_set_status_changed(&ctx, old_status, change_set_view)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
 
     ctx.commit().await?;
 

--- a/lib/si-data-spicedb/src/types.rs
+++ b/lib/si-data-spicedb/src/types.rs
@@ -55,12 +55,12 @@ impl From<v1::ReadSchemaResponse> for ReadSchemaResponse {
 }
 
 #[derive(Clone, Debug)]
-pub struct PermissionsObject {
+pub struct SpiceDBObject {
     r#type: String,
     id: String,
 }
 
-impl PermissionsObject {
+impl SpiceDBObject {
     pub fn new(r#type: impl ToString, id: impl ToString) -> Self {
         Self {
             id: id.to_string(),
@@ -88,17 +88,17 @@ pub type Relationships = Vec<Relationship>;
 
 #[derive(Clone, Debug)]
 pub struct Relationship {
-    object: PermissionsObject,
+    object: SpiceDBObject,
     relation: String,
-    subject: PermissionsObject,
+    subject: SpiceDBObject,
     zed_token: Option<ZedToken>,
 }
 
 impl Relationship {
     pub fn new(
-        object: PermissionsObject,
+        object: SpiceDBObject,
         relation: impl ToString,
-        subject: PermissionsObject,
+        subject: SpiceDBObject,
         zed_token: Option<ZedToken>,
     ) -> Self {
         Self {
@@ -148,7 +148,7 @@ impl Relationship {
         }
     }
 
-    pub fn object(&self) -> &PermissionsObject {
+    pub fn object(&self) -> &SpiceDBObject {
         &self.object
     }
 
@@ -156,7 +156,7 @@ impl Relationship {
         &self.relation
     }
 
-    pub fn subject(&self) -> &PermissionsObject {
+    pub fn subject(&self) -> &SpiceDBObject {
         &self.subject
     }
 
@@ -187,9 +187,9 @@ impl From<v1::Relationship> for Relationship {
             None => (String::new(), String::new()),
         };
         Relationship::new(
-            PermissionsObject::new(obj_type, obj_id),
+            SpiceDBObject::new(obj_type, obj_id),
             value.relation,
-            PermissionsObject::new(sub_type, sub_id),
+            SpiceDBObject::new(sub_type, sub_id),
             None,
         )
     }
@@ -197,17 +197,17 @@ impl From<v1::Relationship> for Relationship {
 
 #[derive(Clone, Debug)]
 pub struct Permission {
-    resource: PermissionsObject,
+    resource: SpiceDBObject,
     permission: String,
-    subject: PermissionsObject,
+    subject: SpiceDBObject,
     zed_token: Option<ZedToken>,
 }
 
 impl Permission {
     pub fn new(
-        resource: PermissionsObject,
+        resource: SpiceDBObject,
         permission: impl ToString,
-        subject: PermissionsObject,
+        subject: SpiceDBObject,
         zed_token: Option<ZedToken>,
     ) -> Self {
         Self {

--- a/lib/si-data-spicedb/tests/integration_test/mod.rs
+++ b/lib/si-data-spicedb/tests/integration_test/mod.rs
@@ -3,7 +3,7 @@ use std::env;
 use indoc::indoc;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
-use si_data_spicedb::{Client, Permission, PermissionsObject, Relationship, SpiceDbConfig};
+use si_data_spicedb::{Client, Permission, Relationship, SpiceDBObject, SpiceDbConfig};
 
 const ENV_VAR_SPICEDB_URL: &str = "SI_TEST_SPICEDB_URL";
 
@@ -82,8 +82,8 @@ async fn write_and_read_relationship() {
         .await
         .expect("failed to write schema");
 
-    let workspace_object = PermissionsObject::new("workspace", "456".to_string());
-    let user_object = PermissionsObject::new("user", "scott".to_string());
+    let workspace_object = SpiceDBObject::new("workspace", "456".to_string());
+    let user_object = SpiceDBObject::new("user", "scott".to_string());
     let mut scott_aprover_workspace =
         Relationship::new(workspace_object, "approver", user_object, None);
 
@@ -141,9 +141,9 @@ async fn check_permissions() {
         .await
         .expect("failed to write schema");
 
-    let workspace_object = PermissionsObject::new("workspace", "789".to_string());
-    let user_object = PermissionsObject::new("user", "scott".to_string());
-    let user_object2 = PermissionsObject::new("user", "fletcher".to_string());
+    let workspace_object = SpiceDBObject::new("workspace", "789".to_string());
+    let user_object = SpiceDBObject::new("user", "scott".to_string());
+    let user_object2 = SpiceDBObject::new("user", "fletcher".to_string());
     let scott_aprover_workspace = Relationship::new(
         workspace_object.clone(),
         "approver",
@@ -173,4 +173,15 @@ async fn check_permissions() {
         .check_permissions(bad_perms)
         .await
         .expect("failed to check permissions"));
+    let users = client
+        .lookup_subjects(
+            "workspace".to_string(),
+            "789".to_string(),
+            "approve".to_string(),
+            "user".to_string(),
+        )
+        .await
+        .expect("could not list subjects");
+    assert!(users.contains(&"scott".to_string()));
+    assert!(!users.contains(&"fletcher".to_string()));
 }

--- a/lib/si-frontend-types-rs/src/change_set.rs
+++ b/lib/si-frontend-types-rs/src/change_set.rs
@@ -13,9 +13,9 @@ pub struct ChangeSet {
     pub base_change_set_id: Option<ChangeSetId>,
     pub workspace_id: String,
     pub merge_requested_by_user_id: Option<String>,
-    pub merge_requested_by_user_email: Option<String>,
+    pub merge_requested_by_user: Option<String>,
     pub merge_requested_at: Option<DateTime<Utc>>,
     pub reviewed_by_user_id: Option<String>,
-    pub reviewed_by_user_email: Option<String>,
+    pub reviewed_by_user: Option<String>,
     pub reviewed_at: Option<DateTime<Utc>>,
 }


### PR DESCRIPTION
This PR includes the following changes: 
- When the `REBAC` feature flag is enabled, users will no longer see the consensus voting approval and will instead use the new approval flow that leverages SpiceDB for authorization
- Note: it is not recommended to have multiple users in the workspace with varying states of toggle
- Uses the `list_subjects` function of SpiceDB to find all users that have the permission to Approve a change set being applied (and extends an integration test for this) 
- Note: this should be refactored to follow a more ergonomic interface, but that will happen as a follow up.
- If a user is an approval, they'll be able to `Approve and Apply` a change set
- If a user is not an approver, they will be able to request approval and withdraw their request
- Non-approvers can re-open a change set before it has been applied, and only once it has been approved will they be able to apply
- Provides a way for approvers to see all change sets that need review, from anywhere. 


The way to test this locally is to add another user to your local workspace, then enable the feature flag for both users! 

<div><img src="https://media0.giphy.com/media/BtEw37CXZti8yfq3Ke/200.gif?cid=5a38a5a24xavx3wljsrv2ac7t92apzkjg5xbb0aq31kx07l1&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:198px;width:300px"/><br/>via <a href="https://giphy.com/PermissionIO/">PermissionIO</a> on <a href="https://giphy.com/gifs/PermissionIO-power-bruce-almighty-ive-got-the-BtEw37CXZti8yfq3Ke">GIPHY</a></div>

