### PR TITLE
Add action function generation stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "serde_yaml",
+ "strum",
  "tokio",
 ]
 

--- a/bin/asset-sprayer-prompts/BUCK
+++ b/bin/asset-sprayer-prompts/BUCK
@@ -11,6 +11,7 @@ rust_binary(
         "//third-party/rust:clap",
         "//third-party/rust:color-eyre",
         "//third-party/rust:serde_yaml",
+        "//third-party/rust:strum",
         "//third-party/rust:tokio",
     ],
     srcs = glob(["src/**/*.rs"]),

--- a/bin/asset-sprayer-prompts/Cargo.toml
+++ b/bin/asset-sprayer-prompts/Cargo.toml
@@ -18,4 +18,5 @@ async-openai = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }
 serde_yaml = { workspace = true }
+strum = { workspace = true }
 tokio = { workspace = true }

--- a/bin/asset-sprayer-prompts/src/main.rs
+++ b/bin/asset-sprayer-prompts/src/main.rs
@@ -1,4 +1,10 @@
-use asset_sprayer::{config::AssetSprayerConfig, prompt::Prompt, AssetSprayer};
+use std::path::PathBuf;
+
+use asset_sprayer::{
+    config::AssetSprayerConfig,
+    prompt::{AwsCliCommand, AwsCliCommandPromptKind, Prompt},
+    AssetSprayer,
+};
 use clap::{Parser, ValueEnum};
 use color_eyre::Result;
 
@@ -8,16 +14,21 @@ const NAME: &str = "asset-sprayer-prompts";
 #[command(name = NAME, max_term_width = 100)]
 pub(crate) struct Args {
     /// The action to take with the prompt.
-    #[arg(index = 1, value_enum)]
+    #[arg(long, short = 'a', value_enum, default_value = "run")]
     pub action: Action,
-    /// The AWS command to generate an asset schema for.
+
+    /// The kind of prompt.
+    #[arg(index = 1, value_enum)]
+    pub prompt_kind: AwsCliCommandPromptKind,
+    /// The AWS command to generate a function for.
     #[arg(index = 2)]
     pub aws_command: String,
-    /// The AWS subcommand to generate an asset schema for.
+    /// The AWS subcommand to generate a function for.
     #[arg(index = 3)]
     pub aws_subcommand: String,
+
     /// Directory to load prompts from.
-    #[arg(long)]
+    #[arg(long, env = "SI_ASSET_SPRAYER_PROMPTS_DIR")]
     pub prompts_dir: Option<String>,
 }
 
@@ -30,10 +41,26 @@ pub enum Action {
     Run,
 }
 
+fn parse_args() -> Result<Args> {
+    let mut args = Args::parse();
+    if args.prompts_dir.is_none() {
+        // If we're in a localdev environment, use local prompts_dir
+        #[allow(clippy::disallowed_methods)] // for std::env::var(), this is a binary
+        if let Ok(direnv_dir) = std::env::var("DIRENV_DIR") {
+            // Check if DIRENV_DIR/lib/asset-sprayer/prompts exists
+            let prompts_dir = PathBuf::from(direnv_dir).join("lib/asset-sprayer/prompts");
+            if prompts_dir.try_exists()? {
+                args.prompts_dir = Some(prompts_dir.to_string_lossy().into());
+            }
+        }
+    }
+    Ok(args)
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    let args = Args::parse();
+    let args = parse_args()?;
 
     let asset_sprayer = AssetSprayer::new(
         async_openai::Client::new(),
@@ -41,10 +68,8 @@ async fn main() -> Result<()> {
             prompts_dir: args.prompts_dir,
         },
     );
-    let prompt = Prompt::AwsAssetSchema {
-        command: args.aws_command.clone(),
-        subcommand: args.aws_subcommand.clone(),
-    };
+    let aws_command = AwsCliCommand::new(args.aws_command, args.aws_subcommand);
+    let prompt = Prompt::AwsCliCommandPrompt(args.prompt_kind, aws_command);
     match args.action {
         Action::Show => {
             let prompt = asset_sprayer.prompt(&prompt).await?;

--- a/lib/asset-sprayer/prompts/aws/create_action.yaml
+++ b/lib/asset-sprayer/prompts/aws/create_action.yaml
@@ -1,0 +1,68 @@
+model: gpt-4o-mini
+temperature: 0.0
+messages:
+  - role: system
+    content: >
+      You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset schemas for use in System Initiative.
+
+      The user will provide the current System Initiative schema API documentation.
+
+      The user will provide the text of the help output from an AWS CLI command.
+
+      The user may optionally provide help text to build the schema for specific properties, which may be additional man pages, web pages, json schema, or grammars. Ensure this is used to create the proper schema for those additional properties.
+
+      Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative schema.
+
+      You will only use APIs that appear in the schema API documentation and additional text for specific properties.
+
+      If the AWS documentation describes a cli option as a map with a specific set of documented keys and values, do not create a map property in the schema. Instead, create an object property where each described key described in the AWS documentation is a child property object in the schema.
+
+      If you encounter a JSON Schema, you will use it to construct properties using the System Initiative API, not only as a Joi validation.
+
+      You will make sure you include every property specified in all of the user inputs provided to create the schema when asked.
+
+      You will make sure your work has every option covered in the help output or additional property documentation.
+
+      You will make sure to include the region property in the schema.
+
+      You will make sure to include the standard "AWS Credential" secret property in the schema.
+
+      You will make sure to use the additional text for specific properties.
+
+      You will make sure your work has Joi validations for every option according to the help output.
+
+      You will make sure every PropBuilder has an appropriate call to `setName()`.
+
+      You will then review your work to make sure you use only APIs described in the schema API documentation.
+
+      You will then review your work to make sure you include any field level validations using Joi.
+
+      You will then show the final function in its entirety, with no other explanation, as plain text. Do not wrap the code in markdown delimiters.
+  - role: user
+    content: >
+      What follows is the current System Initiative schema API documentation as markdown, between three ^ characters.
+
+      ^^^
+      {FETCH}https://raw.githubusercontent.com/systeminit/si/refs/heads/main/app/docs/src/reference/asset/schema.md{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
+
+      ^^^
+      {FETCH}https://raw.githubusercontent.com/systeminit/si/refs/heads/main/app/docs/src/reference/asset/function.md{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
+
+      ^^^
+      {FETCH}https://docs.aws.amazon.com/cli/latest/reference/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      Create the asset function that generates the schema.
+      
+      Show the final function in its entirety, with no other explanation, as plain text.
+      
+      Do not wrap the code in markdown delimiters.

--- a/lib/asset-sprayer/prompts/aws/delete_action.yaml
+++ b/lib/asset-sprayer/prompts/aws/delete_action.yaml
@@ -1,0 +1,68 @@
+model: gpt-4o-mini
+temperature: 0.0
+messages:
+  - role: system
+    content: >
+      You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset schemas for use in System Initiative.
+
+      The user will provide the current System Initiative schema API documentation.
+
+      The user will provide the text of the help output from an AWS CLI command.
+
+      The user may optionally provide help text to build the schema for specific properties, which may be additional man pages, web pages, json schema, or grammars. Ensure this is used to create the proper schema for those additional properties.
+
+      Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative schema.
+
+      You will only use APIs that appear in the schema API documentation and additional text for specific properties.
+
+      If the AWS documentation describes a cli option as a map with a specific set of documented keys and values, do not create a map property in the schema. Instead, create an object property where each described key described in the AWS documentation is a child property object in the schema.
+
+      If you encounter a JSON Schema, you will use it to construct properties using the System Initiative API, not only as a Joi validation.
+
+      You will make sure you include every property specified in all of the user inputs provided to create the schema when asked.
+
+      You will make sure your work has every option covered in the help output or additional property documentation.
+
+      You will make sure to include the region property in the schema.
+
+      You will make sure to include the standard "AWS Credential" secret property in the schema.
+
+      You will make sure to use the additional text for specific properties.
+
+      You will make sure your work has Joi validations for every option according to the help output.
+
+      You will make sure every PropBuilder has an appropriate call to `setName()`.
+
+      You will then review your work to make sure you use only APIs described in the schema API documentation.
+
+      You will then review your work to make sure you include any field level validations using Joi.
+
+      You will then show the final function in its entirety, with no other explanation, as plain text. Do not wrap the code in markdown delimiters.
+  - role: user
+    content: >
+      What follows is the current System Initiative schema API documentation as markdown, between three ^ characters.
+
+      ^^^
+      {FETCH}https://raw.githubusercontent.com/systeminit/si/refs/heads/main/app/docs/src/reference/asset/schema.md{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
+
+      ^^^
+      {FETCH}https://raw.githubusercontent.com/systeminit/si/refs/heads/main/app/docs/src/reference/asset/function.md{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
+
+      ^^^
+      {FETCH}https://docs.aws.amazon.com/cli/latest/reference/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      Create the asset function that generates the schema.
+      
+      Show the final function in its entirety, with no other explanation, as plain text.
+      
+      Do not wrap the code in markdown delimiters.

--- a/lib/asset-sprayer/prompts/aws/refresh_action.yaml
+++ b/lib/asset-sprayer/prompts/aws/refresh_action.yaml
@@ -1,0 +1,68 @@
+model: gpt-4o-mini
+temperature: 0.0
+messages:
+  - role: system
+    content: >
+      You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset schemas for use in System Initiative.
+
+      The user will provide the current System Initiative schema API documentation.
+
+      The user will provide the text of the help output from an AWS CLI command.
+
+      The user may optionally provide help text to build the schema for specific properties, which may be additional man pages, web pages, json schema, or grammars. Ensure this is used to create the proper schema for those additional properties.
+
+      Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative schema.
+
+      You will only use APIs that appear in the schema API documentation and additional text for specific properties.
+
+      If the AWS documentation describes a cli option as a map with a specific set of documented keys and values, do not create a map property in the schema. Instead, create an object property where each described key described in the AWS documentation is a child property object in the schema.
+
+      If you encounter a JSON Schema, you will use it to construct properties using the System Initiative API, not only as a Joi validation.
+
+      You will make sure you include every property specified in all of the user inputs provided to create the schema when asked.
+
+      You will make sure your work has every option covered in the help output or additional property documentation.
+
+      You will make sure to include the region property in the schema.
+
+      You will make sure to include the standard "AWS Credential" secret property in the schema.
+
+      You will make sure to use the additional text for specific properties.
+
+      You will make sure your work has Joi validations for every option according to the help output.
+
+      You will make sure every PropBuilder has an appropriate call to `setName()`.
+
+      You will then review your work to make sure you use only APIs described in the schema API documentation.
+
+      You will then review your work to make sure you include any field level validations using Joi.
+
+      You will then show the final function in its entirety, with no other explanation, as plain text. Do not wrap the code in markdown delimiters.
+  - role: user
+    content: >
+      What follows is the current System Initiative schema API documentation as markdown, between three ^ characters.
+
+      ^^^
+      {FETCH}https://raw.githubusercontent.com/systeminit/si/refs/heads/main/app/docs/src/reference/asset/schema.md{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
+
+      ^^^
+      {FETCH}https://raw.githubusercontent.com/systeminit/si/refs/heads/main/app/docs/src/reference/asset/function.md{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
+
+      ^^^
+      {FETCH}https://docs.aws.amazon.com/cli/latest/reference/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      Create the asset function that generates the schema.
+      
+      Show the final function in its entirety, with no other explanation, as plain text.
+      
+      Do not wrap the code in markdown delimiters.

--- a/lib/asset-sprayer/prompts/aws/update_action.yaml
+++ b/lib/asset-sprayer/prompts/aws/update_action.yaml
@@ -1,0 +1,68 @@
+model: gpt-4o-mini
+temperature: 0.0
+messages:
+  - role: system
+    content: >
+      You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset schemas for use in System Initiative.
+
+      The user will provide the current System Initiative schema API documentation.
+
+      The user will provide the text of the help output from an AWS CLI command.
+
+      The user may optionally provide help text to build the schema for specific properties, which may be additional man pages, web pages, json schema, or grammars. Ensure this is used to create the proper schema for those additional properties.
+
+      Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative schema.
+
+      You will only use APIs that appear in the schema API documentation and additional text for specific properties.
+
+      If the AWS documentation describes a cli option as a map with a specific set of documented keys and values, do not create a map property in the schema. Instead, create an object property where each described key described in the AWS documentation is a child property object in the schema.
+
+      If you encounter a JSON Schema, you will use it to construct properties using the System Initiative API, not only as a Joi validation.
+
+      You will make sure you include every property specified in all of the user inputs provided to create the schema when asked.
+
+      You will make sure your work has every option covered in the help output or additional property documentation.
+
+      You will make sure to include the region property in the schema.
+
+      You will make sure to include the standard "AWS Credential" secret property in the schema.
+
+      You will make sure to use the additional text for specific properties.
+
+      You will make sure your work has Joi validations for every option according to the help output.
+
+      You will make sure every PropBuilder has an appropriate call to `setName()`.
+
+      You will then review your work to make sure you use only APIs described in the schema API documentation.
+
+      You will then review your work to make sure you include any field level validations using Joi.
+
+      You will then show the final function in its entirety, with no other explanation, as plain text. Do not wrap the code in markdown delimiters.
+  - role: user
+    content: >
+      What follows is the current System Initiative schema API documentation as markdown, between three ^ characters.
+
+      ^^^
+      {FETCH}https://raw.githubusercontent.com/systeminit/si/refs/heads/main/app/docs/src/reference/asset/schema.md{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
+
+      ^^^
+      {FETCH}https://raw.githubusercontent.com/systeminit/si/refs/heads/main/app/docs/src/reference/asset/function.md{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
+
+      ^^^
+      {FETCH}https://docs.aws.amazon.com/cli/latest/reference/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
+      ^^^
+  - role: user
+    content: >
+      Create the asset function that generates the schema.
+      
+      Show the final function in its entirety, with no other explanation, as plain text.
+      
+      Do not wrap the code in markdown delimiters.

--- a/lib/asset-sprayer/src/lib.rs
+++ b/lib/asset-sprayer/src/lib.rs
@@ -29,7 +29,7 @@ use std::path::PathBuf;
 
 use async_openai::{config::OpenAIConfig, types::CreateChatCompletionRequest};
 use config::AssetSprayerConfig;
-use prompt::{Prompt, PromptKind};
+use prompt::Prompt;
 use telemetry::prelude::*;
 use thiserror::Error;
 
@@ -44,7 +44,7 @@ pub enum AssetSprayerError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
     #[error("Missing end {{/FETCH}} after {{FETCH}}: {0}")]
-    MissingEndFetch(PromptKind),
+    MissingEndFetch(Prompt),
     #[error("No choices were returned from the AI.")]
     NoChoices,
     #[error("OpenAI error: {0}")]
@@ -105,10 +105,10 @@ async fn test_do_ai() -> Result<()> {
     println!(
         "Done: {}",
         asset_sprayer
-            .run(&Prompt::AwsAssetSchema {
-                command: "sqs".into(),
-                subcommand: "create-queue".into()
-            })
+            .run(&Prompt::AwsCliCommandPrompt(
+                prompt::AwsCliCommandPromptKind::AssetSchema,
+                prompt::AwsCliCommand::new("sqs", "create-queue")
+            ))
             .await?
     );
     Ok(())

--- a/lib/asset-sprayer/src/prompt.rs
+++ b/lib/asset-sprayer/src/prompt.rs
@@ -5,27 +5,34 @@ use async_openai::types::{
     ChatCompletionRequestSystemMessageContent, ChatCompletionRequestUserMessage,
     ChatCompletionRequestUserMessageContent, CreateChatCompletionRequest,
 };
+use serde::{Deserialize, Serialize};
 use telemetry::prelude::*;
 
 use crate::{AssetSprayerError, Result};
 
 #[derive(Debug, Clone, strum::Display, strum::EnumDiscriminants)]
-#[strum_discriminants(name(PromptKind))]
-#[strum_discriminants(derive(strum::Display))]
 pub enum Prompt {
-    AwsAssetSchema { command: String, subcommand: String },
+    AwsCliCommandPrompt(AwsCliCommandPromptKind, AwsCliCommand),
 }
 
-impl Prompt {
-    pub fn kind(&self) -> PromptKind {
-        self.into()
-    }
+#[derive(Debug, Clone, strum::Display, strum::EnumString, strum::VariantNames)]
+pub enum AwsCliCommandPromptKind {
+    AssetSchema,
+    CreateAction,
+    DeleteAction,
+    RefreshAction,
+    UpdateAction,
+}
 
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct AwsCliCommand(pub String, pub String);
+
+impl Prompt {
     pub async fn prompt(
         &self,
         prompts_dir: &Option<PathBuf>,
     ) -> Result<CreateChatCompletionRequest> {
-        let raw_prompt = self.kind().raw_prompt(prompts_dir).await?;
+        let raw_prompt = self.raw_prompt(prompts_dir).await?;
         self.replace_prompt(raw_prompt).await
     }
 
@@ -61,12 +68,9 @@ impl Prompt {
 
     async fn replace_prompt_text(&self, text: &str) -> Result<String> {
         let text = match self {
-            Self::AwsAssetSchema {
-                command,
-                subcommand,
-            } => text
-                .replace("{AWS_COMMAND}", command)
-                .replace("{AWS_SUBCOMMAND}", subcommand),
+            Self::AwsCliCommandPrompt(_, command) => text
+                .replace("{AWS_COMMAND}", command.command())
+                .replace("{AWS_SUBCOMMAND}", command.subcommand()),
         };
         self.fetch_prompt_text(&text).await
     }
@@ -85,7 +89,7 @@ impl Prompt {
                 result.push_str(&Self::get(&text[..url_end]).await?);
                 text = &text[(url_end + "{/FETCH}".len())..];
             } else {
-                return Err(AssetSprayerError::MissingEndFetch(self.kind()));
+                return Err(AssetSprayerError::MissingEndFetch(self.clone()));
             }
         }
 
@@ -103,37 +107,73 @@ impl Prompt {
         let response = client.get(url).send().await?;
         response.error_for_status()?.text().await
     }
-}
 
-impl PromptKind {
     pub async fn raw_prompt(
         &self,
         prompts_dir: &Option<PathBuf>,
     ) -> Result<CreateChatCompletionRequest> {
-        Ok(serde_yaml::from_str(&self.yaml(prompts_dir).await?)?)
+        Ok(serde_yaml::from_str(
+            &self.raw_prompt_yaml(prompts_dir).await?,
+        )?)
     }
 
-    async fn yaml(&self, prompts_dir: &Option<PathBuf>) -> Result<Cow<'static, str>> {
+    async fn raw_prompt_yaml(&self, prompts_dir: &Option<PathBuf>) -> Result<Cow<'static, str>> {
         if let Some(ref prompts_dir) = prompts_dir {
             // Read from disk if prompts_dir is available (faster dev cycle)
-            let path = prompts_dir.join(self.yaml_relative_path());
+            let path = prompts_dir.join(self.raw_prompt_yaml_relative_path());
             info!("Loading prompt for {} from disk at {:?}", self, path);
             Ok(tokio::fs::read_to_string(path).await?.into())
         } else {
             info!("Loading embedded prompt for {}", self);
-            Ok(self.yaml_embedded().into())
+            Ok(self.raw_prompt_yaml_embedded().into())
         }
     }
 
+    fn raw_prompt_yaml_relative_path(&self) -> &str {
+        match self {
+            Self::AwsCliCommandPrompt(kind, _) => kind.yaml_relative_path(),
+        }
+    }
+
+    fn raw_prompt_yaml_embedded(&self) -> &'static str {
+        match self {
+            Self::AwsCliCommandPrompt(kind, _) => kind.yaml_embedded(),
+        }
+    }
+}
+
+impl AwsCliCommandPromptKind {
     fn yaml_relative_path(&self) -> &str {
         match self {
-            Self::AwsAssetSchema => "aws/asset_schema.yaml",
+            Self::AssetSchema => "aws/asset_schema.yaml",
+            Self::CreateAction => "aws/create_action.yaml",
+            Self::DeleteAction => "aws/delete_action.yaml",
+            Self::RefreshAction => "aws/refresh_action.yaml",
+            Self::UpdateAction => "aws/update_action.yaml",
         }
     }
 
     fn yaml_embedded(&self) -> &'static str {
         match self {
-            Self::AwsAssetSchema => include_str!("../prompts/aws/asset_schema.yaml"),
+            Self::AssetSchema => include_str!("../prompts/aws/asset_schema.yaml"),
+            Self::CreateAction => include_str!("../prompts/aws/create_action.yaml"),
+            Self::DeleteAction => include_str!("../prompts/aws/delete_action.yaml"),
+            Self::RefreshAction => include_str!("../prompts/aws/refresh_action.yaml"),
+            Self::UpdateAction => include_str!("../prompts/aws/update_action.yaml"),
         }
+    }
+}
+
+impl AwsCliCommand {
+    pub fn new(command: impl Into<String>, subcommand: impl Into<String>) -> Self {
+        Self(command.into(), subcommand.into())
+    }
+
+    pub fn command(&self) -> &str {
+        &self.0
+    }
+
+    pub fn subcommand(&self) -> &str {
+        &self.1
     }
 }


### PR DESCRIPTION
These prompts are literally identical to asset-schema at the moment. This hits the starting engine on prompt engineering and allows one to iterate on the prompt by setting `OPENAI_API_KEY` and then running:

```
buck2 run bin/asset-sprayer-prompts CreateAction sqs create-queue
buck2 run bin/asset-sprayer-prompts DeleteAction sqs delete-queue
buck2 run bin/asset-sprayer-prompts RefreshAction sqs describe-queue
buck2 run bin/asset-sprayer-prompts UpdateAction sqs update-queue
```

Iterate on the corresponding prompt in `lib/asset-sprayer/prompts/aws/create_action.yaml`, etc. and re-run. (No need to recompile each time, it'll pull it from the local directory.)