### PR TITLE
fix(sdf): Remove ManagePermissionLayer on refresh_workspace_members

### DIFF
--- a/lib/sdf-server/src/routes.rs
+++ b/lib/sdf-server/src/routes.rs
@@ -60,10 +60,7 @@ pub fn routes(state: AppState) -> Router {
             crate::service::qualification::routes(),
         )
         .nest("/api/secret", crate::service::secret::routes())
-        .nest(
-            "/api/session",
-            crate::service::session::routes(state.clone()),
-        )
+        .nest("/api/session", crate::service::session::routes())
         .nest("/api/ws", crate::service::ws::routes())
         .nest("/api/module", crate::service::module::routes())
         .nest("/api/variant", crate::service::variant::routes())

--- a/lib/sdf-server/src/service/session.rs
+++ b/lib/sdf-server/src/service/session.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use si_data_spicedb::SpiceDbError;
 use thiserror::Error;
 
-use crate::{middleware::WorkspacePermissionLayer, AppState};
+use crate::AppState;
 
 use super::ApiError;
 
@@ -82,7 +82,7 @@ impl IntoResponse for SessionError {
     }
 }
 
-pub fn routes(state: AppState) -> Router<AppState> {
+pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/connect", post(auth_connect::auth_connect))
         .route("/reconnect", get(auth_connect::auth_reconnect))
@@ -93,8 +93,6 @@ pub fn routes(state: AppState) -> Router<AppState> {
         .route("/load_workspaces", get(load_workspaces::load_workspaces))
         .route(
             "/refresh_workspace_members",
-            post(refresh_workspace_members::refresh_workspace_members).layer(
-                WorkspacePermissionLayer::new(state, permissions::Permission::Manage),
-            ),
+            post(refresh_workspace_members::refresh_workspace_members),
         )
 }

--- a/lib/sdf-server/src/service/session/refresh_workspace_members.rs
+++ b/lib/sdf-server/src/service/session/refresh_workspace_members.rs
@@ -99,18 +99,6 @@ pub async fn refresh_workspace_members(
             &posthog_client,
         )
         .await?;
-    } else {
-        track(
-            &posthog_client.0,
-            &ctx,
-            &original_uri,
-            &host_name,
-            "sync_workspace_approvers",
-            serde_json::json!({
-                "how": "/session/refresh_workspace_members",
-                "spicedb_client": "empty",
-            }),
-        );
     }
 
     let members = User::list_members_for_workspace(&ctx, request.workspace_id.clone()).await?;


### PR DESCRIPTION
This API endpoint is used more as a Webhook than it is with managing information

The AuthPortal talks to this endpoint and tells the endpoint to assemble the correct data for the wroksapce. It doesn't push that data to SDF. so if a user who doesn't have access to manage my workspace hits the endpoint, they cannot manipulate the workspace. This means we can work without this check at this time.