### PR TITLE
Fix frames ordering and parentage

### DIFF
--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -2614,7 +2614,10 @@ const groups = computed(() => {
 
       // if being dragged (or ancestor being dragged), bump up to front, but maintain order within that frame
       // TODO change this to being position comparisons not parentage
-      if (dragElementsActive.value) {
+      if (
+        dragElementsActive.value ||
+        componentsStore.selectedComponentIds.length > 0
+      ) {
         if (
           _.intersection(
             [g.def.componentId, ...(g.def.ancestorIds || [])],

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -1438,6 +1438,8 @@ const findChildrenByBoundingBox = (
 
   const components: (DiagramGroupData | DiagramNodeData)[] = [];
   const process = ([id, elRect]: [ComponentId, IRect]) => {
+    // i do not fit inside myself
+    if (el.def.id === id) return;
     const _r = { ...elRect };
     _r.x -= _r.width / 2;
     if (rectContainsAnother(rect, _r)) {
@@ -1603,6 +1605,8 @@ function endDragElements() {
 
   const nonChildElements = currentSelectionMovableElements.value.filter(
     (component) => {
+      if (draggedChildren.value.length === 0) return true;
+
       const idx = draggedChildren.value.findIndex(
         (child) => child.def.id === component.def.id,
       );
@@ -1626,6 +1630,9 @@ function endDragElements() {
     if (component.def.parentId && detach) setParents.push(component.def.id);
 
     if (!component.def.parentId && newParent?.def.id)
+      setParents.push(component.def.id);
+
+    if (component.def.parentId !== newParent?.def.id)
       setParents.push(component.def.id);
   });
 


### PR DESCRIPTION
Currently, you can take a frame and drag it over another frame, which hides it. (This was always possible before too). But now when you move the frame "on top" of it, the "lower/hidden" frame comes for the ride, because its "inside" the other one... So I at least put a fix to bring it to the top when its selected so you can move it.

There is one more potential step to take, ordering frames based on their bounding box (e.g. smaller frames on top)

<img src="https://media4.giphy.com/media/AvMJCeu1EMmhG/giphy.gif"/>