### PR TITLE
feat: mgmt fns can set component type, and set parent for components

### DIFF
--- a/bin/lang-js/src/function_kinds/management.ts
+++ b/bin/lang-js/src/function_kinds/management.ts
@@ -23,15 +23,30 @@ export type ManagementFuncResult =
     | ManagementFuncResultSuccess
     | ManagementFuncResultFailure;
 
+export interface ManagmentConnect {
+  from: string,
+  to: {
+    component: string;
+    socket: string;
+  }
+}
+
 export interface ManagementOperations {
   create?: { [key: string]: {
     kind: string;
     properties?: object;
     geometry?: Geometry;
+    parent?: string;
+    connect?: ManagmentConnect[],
   } };
   update?: { [key: string]: {
     properties?: object;
     geometry?: Geometry;
+    parent?: string;
+    connect: {
+      add?: ManagmentConnect[],
+      remove?: ManagmentConnect[],
+    }
   } };
   actions?: {
     [key: string]: {

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -3423,6 +3423,8 @@ impl Component {
             ));
         }
 
+        let guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
+
         Component::add_manages_edge_to_component(
             ctx,
             manager_component_id,
@@ -3430,6 +3432,8 @@ impl Component {
             EdgeWeightKind::Manages,
         )
         .await?;
+
+        drop(guard);
 
         Ok(())
     }

--- a/lib/dal/src/func/binding/management.rs
+++ b/lib/dal/src/func/binding/management.rs
@@ -95,6 +95,7 @@ impl ManagementBinding {
                                             socket: string;
                                         }}
                                     }}[],
+                                    parent?: string,
                                 }}
                                 "#
                                 );
@@ -130,6 +131,7 @@ type Output = {{
             add?: {{ from: string, to: {{ component: string; socket: string; }} }}[],
             remove?: {{ from: string, to: {{ component: string; socket: string; }} }}[],
         }},
+        parent?: string,
     }} }},
     actions?: {{ [key: string]: {{
       add?: ("create" | "update" | "refresh" | "delete" | string)[];

--- a/lib/sdf-server/src/service/v2/management.rs
+++ b/lib/sdf-server/src/service/v2/management.rs
@@ -112,7 +112,7 @@ pub async fn run_prototype(
         let result: ManagementFuncReturn = result.try_into()?;
         if result.status == ManagementFuncStatus::Ok {
             if let Some(operations) = result.operations {
-                ManagementOperator::new(&ctx, component_id, operations, execution_result)
+                ManagementOperator::new(&ctx, component_id, operations, execution_result, None)
                     .await?
                     .operate()
                     .await?;


### PR DESCRIPTION
Adds an optional `parent` property to creates and updates returned by management functions that sets the frame parent. Also allows you to change a component into a frame by setting the `root/si/type` property of a component.

Component geometries returned and set via management functions are now all relative to the "manager" component, which gets x and y of 0.0. To place a component to the left or above the manager, use negative geometry. To the right or below, positive geometry. This allows reliably placing components inside the parent frame in any view.