### PR TITLE
fix: use change set sharded store for management runs

### DIFF
--- a/app/web/src/components/ChangesPanelHistory.vue
+++ b/app/web/src/components/ChangesPanelHistory.vue
@@ -105,15 +105,14 @@ import {
   ChangeSetDetail,
   useActionsStore,
 } from "@/store/actions.store";
-import {
-  FuncRun,
-  FuncRunId,
-  ManagementHistoryItem,
-  useFuncRunsStore,
-} from "@/store/func_runs.store";
+import { FuncRun, FuncRunId, useFuncRunsStore } from "@/store/func_runs.store";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import { ChangeSet, ChangeSetStatus } from "@/api/sdf/dal/change_set";
 import { useChangeSetsStore } from "@/store/change_sets.store";
+import {
+  ManagementHistoryItem,
+  useManagementRunsStore,
+} from "@/store/management_runs.store";
 import EmptyStateCard from "./EmptyStateCard.vue";
 import ActionsList from "./Actions/ActionsList.vue";
 import FuncRunTabGroup from "./Actions/FuncRunTabGroup.vue";
@@ -121,6 +120,7 @@ import ManagementHistoryList from "./Management/ManagementHistoryList.vue";
 
 const actionsStore = useActionsStore();
 const funcRunsStore = useFuncRunsStore();
+const managementRunsStore = useManagementRunsStore();
 const changeSetsStore = useChangeSetsStore();
 const featureFlagsStore = useFeatureFlagsStore();
 
@@ -134,8 +134,7 @@ const selectedTab = ref<string | undefined>();
 
 const managementHistoryForChangeSet = computed(() =>
   changeSetsStore.selectedChangeSetId
-    ? funcRunsStore.managementRunHistory[changeSetsStore.selectedChangeSetId] ??
-      []
+    ? managementRunsStore.managementRunHistory ?? []
     : [],
 );
 

--- a/app/web/src/components/Management/ManagementHistoryCard.vue
+++ b/app/web/src/components/Management/ManagementHistoryCard.vue
@@ -48,7 +48,7 @@ import {
   TruncateWithTooltip,
   Timestamp,
 } from "@si/vue-lib/design-system";
-import { ManagementHistoryItem } from "@/store/func_runs.store";
+import { ManagementHistoryItem } from "@/store/management_runs.store";
 import StatusIndicatorIcon from "../StatusIndicatorIcon.vue";
 import FuncRunTabDropdown from "../FuncRunTabDropdown.vue";
 

--- a/app/web/src/components/Management/ManagementHistoryList.vue
+++ b/app/web/src/components/Management/ManagementHistoryList.vue
@@ -13,7 +13,8 @@
 
 <script lang="ts" setup>
 import { PropType } from "vue";
-import { FuncRunId, ManagementHistoryItem } from "@/store/func_runs.store";
+import { FuncRunId } from "@/store/func_runs.store";
+import { ManagementHistoryItem } from "@/store/management_runs.store";
 import ManagementHistoryCard from "./ManagementHistoryCard.vue";
 
 const props = defineProps({

--- a/app/web/src/components/ManagementRunPrototype.vue
+++ b/app/web/src/components/ManagementRunPrototype.vue
@@ -23,18 +23,6 @@
       @viewFunc="onClickView"
       @menuClick="(id, slug) => emit('showLatestRunTab', id, slug)"
     />
-
-    <!-- <div
-      :class="
-        clsx(
-          'ml-auto mr-2xs hover:underline font-bold select-none cursor-pointer',
-          themeClasses('text-action-500', 'text-action-300'),
-        )
-      "
-      @click.stop="onClickView"
-    >
-      view
-    </div> -->
   </li>
 </template>
 
@@ -54,7 +42,8 @@ import {
   MgmtPrototypeResult,
 } from "@/store/func/funcs.store";
 import { useComponentsStore } from "@/store/components.store";
-import { FuncRunId, useFuncRunsStore } from "@/store/func_runs.store";
+import { FuncRunId } from "@/store/func_runs.store";
+import { useManagementRunsStore } from "@/store/management_runs.store";
 import {
   DiagramGroupData,
   DiagramNodeData,
@@ -63,10 +52,10 @@ import StatusIndicatorIcon from "./StatusIndicatorIcon.vue";
 import FuncRunTabDropdown from "./FuncRunTabDropdown.vue";
 
 const funcStore = useFuncStore();
-const funcRunStore = useFuncRunsStore();
 const componentsStore = useComponentsStore();
 const router = useRouter();
 const toast = useToast();
+const managementRunsStore = useManagementRunsStore();
 
 const lastExecution = ref<MgmtPrototypeResult | undefined>(undefined);
 
@@ -87,14 +76,14 @@ const request = funcStore.getRequestStatus(
 );
 
 onMounted(() => {
-  funcRunStore.GET_LATEST_FOR_MGMT_PROTO_AND_COMPONENT(
+  managementRunsStore.GET_LATEST_FOR_MGMT_PROTO_AND_COMPONENT(
     props.prototype.managementPrototypeId,
     props.component.def.id,
   );
 });
 
 const latestRunId = computed(() =>
-  funcRunStore.latestManagementRun(
+  managementRunsStore.latestManagementRun(
     props.prototype.managementPrototypeId,
     props.component.def.id,
   ),

--- a/app/web/src/store/management_runs.store.ts
+++ b/app/web/src/store/management_runs.store.ts
@@ -1,0 +1,132 @@
+import { addStoreHooks, ApiRequest } from "@si/vue-lib/pinia";
+import { defineStore } from "pinia";
+import { ComponentId } from "@/api/sdf/dal/component";
+import { ActionResultState } from "@/api/sdf/dal/action";
+import { useWorkspacesStore } from "./workspaces.store";
+import { useChangeSetsStore } from "./change_sets.store";
+import handleStoreError from "./errors";
+import { useRealtimeStore } from "./realtime/realtime.store";
+import { useFeatureFlagsStore } from "./feature_flags.store";
+import { FuncRun, FuncRunId, useFuncRunsStore } from "./func_runs.store";
+
+export interface ManagementHistoryItem {
+  funcRunId: FuncRunId;
+  name: string;
+  funcId: string;
+  originatingChangeSetName: string;
+  updatedAt: string;
+  resourceResult?: string;
+  codeExecuted?: string;
+  logs?: string;
+  arguments?: string;
+  componentName: string;
+  schemaName: string;
+  status: ActionResultState;
+}
+
+export const useManagementRunsStore = () => {
+  const workspacesStore = useWorkspacesStore();
+  const workspaceId = workspacesStore.selectedWorkspacePk;
+
+  const changeSetsStore = useChangeSetsStore();
+  const changeSetId = changeSetsStore.selectedChangeSetId;
+  const featureFlagsStore = useFeatureFlagsStore();
+  const funcRunsStore = useFuncRunsStore();
+
+  const API_PREFIX = `v2/workspaces/${workspaceId}/change-sets/${changeSetId}`;
+
+  return addStoreHooks(
+    workspaceId,
+    changeSetId,
+    defineStore(`ws${workspaceId || "NONE"}/cs${changeSetId}/management_runs`, {
+      state: () => ({
+        managementRunByPrototypeAndComponentId: {} as {
+          [key: string]: FuncRunId;
+        },
+        managementRunHistory: [] as ManagementHistoryItem[],
+      }),
+      getters: {
+        latestManagementRun:
+          (state) => (prototypeId: string, componentId: ComponentId) =>
+            state.managementRunByPrototypeAndComponentId[
+              `${prototypeId}-${componentId}`
+            ],
+      },
+      actions: {
+        async GET_MANAGEMENT_RUN_HISTORY() {
+          if (!featureFlagsStore.MANAGEMENT_FUNCTIONS) return;
+          return new ApiRequest<ManagementHistoryItem[]>({
+            url: `${API_PREFIX}/management/history`,
+            headers: { accept: "application/json" },
+            params: {
+              visibility_change_set_pk: changeSetsStore.selectedChangeSetId,
+            },
+            onSuccess: (response) => {
+              this.managementRunHistory = response;
+            },
+          });
+        },
+
+        async GET_LATEST_FOR_MGMT_PROTO_AND_COMPONENT(
+          prototypeId: string,
+          componentId: ComponentId,
+        ) {
+          return new ApiRequest<FuncRun | null>({
+            url: `${API_PREFIX}/management/prototype/${prototypeId}/${componentId}/latest`,
+            headers: { accept: "application/json" },
+            params: {
+              visibility_change_set_pk: changeSetsStore.selectedChangeSetId,
+            },
+            onSuccess: (funcRun) => {
+              if (funcRun) {
+                this.setLatestManagementRun(
+                  prototypeId,
+                  componentId,
+                  funcRun.id,
+                );
+                funcRunsStore.funcRuns[funcRun.id] = funcRun;
+              }
+            },
+          });
+        },
+
+        setLatestManagementRun(
+          prototypeId: string,
+          componentId: string,
+          funcRunId: string,
+        ) {
+          this.managementRunByPrototypeAndComponentId[
+            `${prototypeId}-${componentId}`
+          ] = funcRunId;
+        },
+      },
+      onActivated() {
+        const actionUnsub = this.$onAction(handleStoreError);
+        const realtimeStore = useRealtimeStore();
+
+        this.GET_MANAGEMENT_RUN_HISTORY();
+
+        const changeSetId = changeSetsStore.selectedChangeSetId;
+        realtimeStore.subscribe(this.$id, `changeset/${changeSetId}`, [
+          {
+            eventType: "ManagementFuncExecuted",
+            callback: (payload) => {
+              this.setLatestManagementRun(
+                payload.prototypeId,
+                payload.managerComponentId,
+                payload.funcRunId,
+              );
+
+              this.GET_MANAGEMENT_RUN_HISTORY();
+            },
+          },
+        ]);
+
+        return () => {
+          actionUnsub();
+          realtimeStore.unsubscribe(this.$id);
+        };
+      },
+    }),
+  )();
+};


### PR DESCRIPTION
Some reactivity issues and a bug when fetching history were a consequence of using the FuncRuns pinia store, which is not namespaced to the change set. This moves the management functionality over to its own, change set specific store, which resolves these issues.

Fixes BUG-664