### PR TITLE
Add audit events as Change Set status gets updated

### DIFF
--- a/app/web/src/api/sdf/dal/audit_log.ts
+++ b/app/web/src/api/sdf/dal/audit_log.ts
@@ -2,6 +2,7 @@ export const AUDIT_LOG_KINDS = [
   "AbandonChangeSet",
   "AddAction",
   "ApplyChangeSet",
+  "ApproveChangeSetApply",
   "CancelAction",
   "CreateChangeSet",
   "CreateComponent",
@@ -12,6 +13,9 @@ export const AUDIT_LOG_KINDS = [
   "InstallWorkspace",
   "Login",
   "PutActionOnHold",
+  "RejectChangeSetApply",
+  "ReopenChangeSet",
+  "RequestChangeSetApproval",
   "RetryAction",
   "RunAction",
   "UpdateDependentInputSocket",
@@ -21,6 +25,7 @@ export const AUDIT_LOG_KINDS = [
   "UpdatePropertyEditorValueForSecret",
   "UpdateSecret",
   "UpgradeComponent",
+  "WithdrawRequestForChangeSetApply",
 ];
 
 export const AUDIT_LOG_ENTITY_TYPES = [

--- a/lib/sdf-server/src/service/v2/change_set/approve.rs
+++ b/lib/sdf-server/src/service/v2/change_set/approve.rs
@@ -1,5 +1,6 @@
 use axum::extract::{Host, OriginalUri, Path};
 use dal::{ChangeSet, ChangeSetId, WorkspacePk, WsEvent};
+use si_events::audit_log::AuditLogKind;
 
 use super::{Error, Result};
 use crate::{
@@ -56,6 +57,13 @@ pub async fn approve(
         .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?
         .into_frontend_type(&ctx)
         .await?;
+    ctx.write_audit_log(
+        AuditLogKind::ApproveChangeSetApply {
+            from_status: old_status.into(),
+        },
+        change_set_view.name.clone(),
+    )
+    .await?;
     WsEvent::change_set_status_changed(&ctx, old_status, change_set_view)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/service/v2/change_set/cancel_approval_request.rs
+++ b/lib/sdf-server/src/service/v2/change_set/cancel_approval_request.rs
@@ -1,5 +1,6 @@
 use axum::extract::{Host, OriginalUri, Path};
 use dal::{ChangeSet, ChangeSetId, WorkspacePk, WsEvent};
+use si_events::audit_log::AuditLogKind;
 
 use super::{Error, Result};
 use crate::{
@@ -42,6 +43,13 @@ pub async fn cancel_approval_request(
         .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?
         .into_frontend_type(&ctx)
         .await?;
+    ctx.write_audit_log(
+        AuditLogKind::WithdrawRequestForChangeSetApply {
+            from_status: old_status.into(),
+        },
+        change_set_view.name.clone(),
+    )
+    .await?;
     WsEvent::change_set_status_changed(&ctx, old_status, change_set_view)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/service/v2/change_set/reject.rs
+++ b/lib/sdf-server/src/service/v2/change_set/reject.rs
@@ -1,5 +1,6 @@
 use axum::extract::{Host, OriginalUri, Path};
 use dal::{ChangeSet, ChangeSetId, WorkspacePk, WsEvent};
+use si_events::audit_log::AuditLogKind;
 
 use super::{Error, Result};
 use crate::{
@@ -42,6 +43,13 @@ pub async fn reject(
         .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?
         .into_frontend_type(&ctx)
         .await?;
+    ctx.write_audit_log(
+        AuditLogKind::RejectChangeSetApply {
+            from_status: old_status.into(),
+        },
+        change_set_view.name.clone(),
+    )
+    .await?;
     WsEvent::change_set_status_changed(&ctx, old_status, change_set_view)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/service/v2/change_set/reopen.rs
+++ b/lib/sdf-server/src/service/v2/change_set/reopen.rs
@@ -1,5 +1,6 @@
 use axum::extract::{Host, OriginalUri, Path};
 use dal::{ChangeSet, ChangeSetId, WorkspacePk, WsEvent};
+use si_events::audit_log::AuditLogKind;
 
 use super::{Error, Result};
 use crate::{
@@ -33,6 +34,14 @@ pub async fn reopen(
         .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?
         .into_frontend_type(&ctx)
         .await?;
+
+    ctx.write_audit_log(
+        AuditLogKind::ReopenChangeSet {
+            from_status: old_status.into(),
+        },
+        change_set_view.name.clone(),
+    )
+    .await?;
     WsEvent::change_set_status_changed(&ctx, old_status, change_set_view)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/si-events-rs/src/audit_log/v1.rs
+++ b/lib/si-events-rs/src/audit_log/v1.rs
@@ -2,8 +2,9 @@ use serde::{Deserialize, Serialize};
 use strum::{Display, EnumDiscriminants};
 
 use crate::{
-    ActionKind, ActionPrototypeId, Actor, AttributeValueId, ChangeSetId, ComponentId, FuncId,
-    InputSocketId, OutputSocketId, PropId, SchemaId, SchemaVariantId, SecretId, WorkspacePk,
+    ActionKind, ActionPrototypeId, Actor, AttributeValueId, ChangeSetId, ChangeSetStatus,
+    ComponentId, FuncId, InputSocketId, OutputSocketId, PropId, SchemaId, SchemaVariantId,
+    SecretId, WorkspacePk,
 };
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
@@ -18,7 +19,9 @@ pub struct AuditLogV1 {
 #[remain::sorted]
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Display, EnumDiscriminants)]
 pub enum AuditLogKindV1 {
-    AbandonChangeSet,
+    AbandonChangeSet {
+        from_status: ChangeSetStatus,
+    },
     AddAction {
         prototype_id: ActionPrototypeId,
         action_kind: ActionKind,
@@ -27,6 +30,9 @@ pub enum AuditLogKindV1 {
         func_name: String,
     },
     ApplyChangeSet,
+    ApproveChangeSetApply {
+        from_status: ChangeSetStatus,
+    },
     CancelAction {
         prototype_id: ActionPrototypeId,
         action_kind: ActionKind,
@@ -72,6 +78,16 @@ pub enum AuditLogKindV1 {
         func_id: FuncId,
         func_display_name: Option<String>,
         func_name: String,
+    },
+    RejectChangeSetApply {
+        from_status: ChangeSetStatus,
+    },
+
+    ReopenChangeSet {
+        from_status: ChangeSetStatus,
+    },
+    RequestChangeSetApproval {
+        from_status: ChangeSetStatus,
     },
     RetryAction {
         prototype_id: ActionPrototypeId,
@@ -169,5 +185,8 @@ pub enum AuditLogKindV1 {
         new_schema_variant_name: String,
         old_schema_variant_id: SchemaVariantId,
         old_schema_variant_name: String,
+    },
+    WithdrawRequestForChangeSetApply {
+        from_status: ChangeSetStatus,
     },
 }


### PR DESCRIPTION
Reused the existing Apply and Abandon Change Set events, and added new audit events for Rejection, Approval, Reopening, and Withdrawing a request, 

<div><img src="https://media0.giphy.com/media/OmTkBPi4v6nSL4SJHK/200.gif?cid=5a38a5a2k7756tsxlrkiwt3va3fj39v58tf6tnxbwaqns06i&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:168px;width:300px"/><br/>via <a href="https://giphy.com/travisband/">Travis</a> on <a href="https://giphy.com/gifs/travisband-writing-travis-dougie-payne-OmTkBPi4v6nSL4SJHK">GIPHY</a></div>