### PR TITLE
Move otelcol back to platform group in Tiltfile

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -12,6 +12,7 @@ groups = {
     "platform": [
         "db",
         "nats",
+        "otelcol",
         "postgres",
         "spicedb",
     ],
@@ -35,7 +36,6 @@ groups = {
         "grafana",
         "jaeger",
         "loki",
-        "otelcol",
         "prometheus",
         "promtail",
     ],


### PR DESCRIPTION
While otelcol is used for telemetry, it is also a core service that the applications expect to be available. When otelcol is not started, we get a _large_ amount of error output from `sdf`, `veritech`, etc., as well as from the integration tests when only `buck2 run dev:platform` has been run with no other intervention.