### PR TITLE
feat: management edges

### DIFF
--- a/app/web/src/api/sdf/dal/component.ts
+++ b/app/web/src/api/sdf/dal/component.ts
@@ -80,4 +80,5 @@ export type RawEdge = {
 export type Edge = RawEdge & {
   id: EdgeId;
   isInferred: boolean;
+  isManagement?: boolean;
 };

--- a/app/web/src/components/EdgeCard.vue
+++ b/app/web/src/components/EdgeCard.vue
@@ -3,7 +3,8 @@
     <ComponentCard :component="fromComponent" :titleCard="false" />
     <div class="_connection-label text-xs italic">
       <!-- currently output and input socket always have the same label/name -->
-      <span class="capsize">{{ fromSocket?.name }}</span>
+      <span v-if="edge?.isManagement" class="capsize">Manages</span>
+      <span v-else class="capsize">{{ fromSocket?.name }}</span>
       <!-- <div>to</div>
         <span class="capsize">{{ toSocket?.name }}</span> -->
     </div>

--- a/app/web/src/components/ModelingDiagram/DiagramEdge.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramEdge.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-group v-if="points && centerPoint && !edge.def.isInferred">
+  <v-group v-if="points && centerPoint && showEdge">
     <v-line
       :config="{
         visible: isHovered || isSelected,
@@ -161,6 +161,23 @@ const selectedComponentId = computed(
   () => componentsStore.selectedComponent?.def.id,
 );
 
+const isFromOrToSelected = computed(
+  () =>
+    props.edge.def.fromComponentId === selectedComponentId.value ||
+    props.edge.def.toComponentId === selectedComponentId.value,
+);
+const showEdge = computed(() => {
+  if (props.edge.def.isInferred) {
+    return false;
+  }
+
+  if (props.edge.def.isManagement) {
+    return isFromOrToSelected.value || props.isSelected;
+  }
+
+  return true;
+});
+
 const mainLineOpacity = computed(() => {
   if (willDeleteIfPendingEdgeCreated.value) return 0.3;
   if (isDeleted.value) return 0.75;
@@ -170,6 +187,11 @@ const mainLineOpacity = computed(() => {
   ) {
     return 0.8;
   }
+
+  if (props.edge.def.isManagement) {
+    return 0.0;
+  }
+
   return 0.1;
 });
 

--- a/app/web/src/components/ModelingDiagram/DiagramEdge.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramEdge.vue
@@ -78,6 +78,7 @@ import {
 } from "@si/vue-lib/design-system";
 import { useComponentsStore } from "@/store/components.store";
 import { isDevMode } from "@/utils/debug";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import { SELECTION_COLOR, SOCKET_SIZE } from "./diagram_constants";
 import { DiagramEdgeData } from "./diagram_types";
 import { pointAlongLinePct, pointAlongLinePx } from "./utils/math";
@@ -106,6 +107,8 @@ const { theme } = useTheme();
 
 const diagramContext = useDiagramContext();
 const { drawEdgeState } = diagramContext;
+
+const featureFlagsStore = useFeatureFlagsStore();
 
 const isDeleted = computed(
   () => props.edge.def.changeStatus === "deleted" || props.edge.def.toDelete,
@@ -171,7 +174,7 @@ const showEdge = computed(() => {
     return false;
   }
 
-  if (props.edge.def.isManagement) {
+  if (props.edge.def.isManagement && featureFlagsStore.MANAGEMENT_EDGES) {
     return isFromOrToSelected.value || props.isSelected;
   }
 

--- a/app/web/src/components/ModelingDiagram/DiagramNodeSocket.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramNodeSocket.vue
@@ -1,6 +1,23 @@
 <template>
   <v-group>
+    <v-rect
+      v-if="socket.def.isManagement"
+      :config="{
+        id: socket.uniqueKey,
+        x: 0,
+        y: props.position.y - socketSize / 2 - 1,
+        width: socketSize - 3,
+        height: socketSize - 3,
+        stroke: colors.stroke,
+        strokeWidth: isHovered ? 2 : 1,
+        fill: colors.fill,
+        rotation: 45,
+      }"
+      @mouseover="onMouseOver"
+      @mouseout="onMouseOut"
+    />
     <v-circle
+      v-else
       :config="{
         id: socket.uniqueKey,
         x: 0,
@@ -86,6 +103,7 @@ const props = defineProps<{
   nodeWidth: number;
   isHovered?: boolean;
   isSelected?: boolean;
+  isManagement?: boolean;
 }>();
 
 const emit = defineEmits(["hover:start", "hover:end"]);

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -2189,6 +2189,17 @@ const drawEdgePossibleTargetSocketKeys = computed(() => {
     if (fromSocket.def.direction === possibleToSocket.def.direction)
       return false;
 
+    const isManagedSchema =
+      possibleToSocket.def.schemaId &&
+      fromSocket.def.managedSchemas &&
+      fromSocket.def.managedSchemas.includes(possibleToSocket.def.schemaId);
+    const isSameSchema =
+      possibleToSocket.def.schemaId === fromSocket.def.schemaId;
+
+    if (fromSocket.def.isManagement && possibleToSocket.def.isManagement) {
+      return !!(isSameSchema || isManagedSchema);
+    }
+
     const [outputCAs, inputCAs] =
       fromSocket.def.direction === "output"
         ? [
@@ -2297,17 +2308,20 @@ async function endDrawEdge() {
   const fromSocketId = adjustedFrom.def.id;
   const toComponentId = adjustedTo.parent.def.id;
   const toSocketId = adjustedTo.def.id;
+  const from = {
+    componentId: fromComponentId,
+    socketId: fromSocketId,
+  };
+  const to = {
+    componentId: toComponentId,
+    socketId: toSocketId,
+  };
 
-  await componentsStore.CREATE_COMPONENT_CONNECTION(
-    {
-      componentId: fromComponentId,
-      socketId: fromSocketId,
-    },
-    {
-      componentId: toComponentId,
-      socketId: toSocketId,
-    },
-  );
+  if (adjustedFrom.def.isManagement) {
+    await componentsStore.MANAGE_COMPONENT(from, to);
+  } else {
+    await componentsStore.CREATE_COMPONENT_CONNECTION(from, to);
+  }
 }
 
 const pasteElementsActive = computed(() => {

--- a/app/web/src/components/ModelingDiagram/diagram_types.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_types.ts
@@ -69,12 +69,21 @@ abstract class DiagramNodeHasSockets extends DiagramElementData {
   layoutLeftSockets(nodeWidth: number) {
     if (!this.sockets) return { x: 0, y: 0, sockets: [] };
     const layout: DiagramSocketDataWithPosition[] = [];
+    const leftManagementSocket = this.sockets.find(
+      (s) => s.def.isManagement && s.def.nodeSide === "left",
+    );
     const sockets = _.sortBy(
-      this.sockets
-        .filter((s) => s.def.label !== "Frame")
-        .filter((s) => s.def.nodeSide === "left"),
+      this.sockets.filter(
+        (s) =>
+          s.def.label !== "Frame" &&
+          s.def.nodeSide === "left" &&
+          !s.def.isManagement,
+      ),
       (s) => s.def.label,
     );
+    if (leftManagementSocket) {
+      sockets.unshift(leftManagementSocket);
+    }
     for (const [i, socket] of sockets.entries()) {
       const y = i * SOCKET_GAP;
       const x = 15;
@@ -94,12 +103,23 @@ abstract class DiagramNodeHasSockets extends DiagramElementData {
       .filter((s) => s.def.nodeSide === "left")
       .filter((s) => s.def.label !== "Frame").length;
     const layout: DiagramSocketDataWithPosition[] = [];
+    const rightManagementSocket = this.sockets.find(
+      (s) => s.def.isManagement && s.def.nodeSide === "right",
+    );
     const sockets = _.sortBy(
-      this.sockets
-        .filter((s) => s.def.label !== "Frame")
-        .filter((s) => s.def.nodeSide === "right"),
+      this.sockets.filter(
+        (s) =>
+          s.def.label !== "Frame" &&
+          s.def.nodeSide === "right" &&
+          !s.def.isManagement,
+      ),
       (s) => s.def.label,
     );
+
+    if (rightManagementSocket) {
+      sockets.unshift(rightManagementSocket);
+    }
+
     for (const [i, socket] of sockets.entries()) {
       const y = i * SOCKET_GAP;
       const x = -nodeWidth + 15;
@@ -345,6 +365,12 @@ export type DiagramSocketDef = {
   isRequired?: boolean;
   /** which side of the node is the socket displayed on */
   nodeSide: "left" | "right"; // add top/bottom later?
+  /** is the socket a management socket */
+  isManagement?: boolean;
+  /** the schema ids managed by the socket, if a management socket, if any */
+  managedSchemas?: string[];
+  /** schema id, for management socket compatibility */
+  schemaId?: string;
 
   // color
   // shape
@@ -360,6 +386,7 @@ export type DiagramEdgeDef = {
   toSocketId: DiagramElementId;
   isBidirectional?: boolean;
   isInferred?: boolean;
+  isManagement?: boolean;
   /** change status of edge in relation to head */
   changeStatus?: ChangeStatus;
   createdAt?: Date;

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -188,11 +188,22 @@ export const getAssetIcon = (name: string) => {
 };
 
 const edgeFromRawEdge =
-  (isInferred: boolean) =>
+  ({
+    isInferred,
+    isManagement,
+  }: {
+    isInferred?: boolean;
+    isManagement?: boolean;
+  }) =>
   (e: RawEdge): Edge => {
     const edge = structuredClone(e) as Edge;
-    edge.id = `${edge.toComponentId}_${edge.toSocketId}_${edge.fromSocketId}_${edge.fromComponentId}`;
-    edge.isInferred = isInferred;
+    if (isManagement) {
+      edge.id = `mgmt-${edge.toComponentId}_${edge.fromComponentId}`;
+    } else {
+      edge.id = `${edge.toComponentId}_${edge.toSocketId}_${edge.fromSocketId}_${edge.fromComponentId}`;
+    }
+    edge.isInferred = isInferred ?? false;
+    edge.isManagement = isManagement ?? false;
     return edge;
   };
 
@@ -242,6 +253,13 @@ export const processRawComponent = (
       childIds.push(childId);
     }
   }
+
+  // insert the schema id into the socket defs, so we can match management
+  // sockets
+  component.sockets = component.sockets.map((s) => ({
+    ...s,
+    schemaId: component.schemaId,
+  }));
 
   const fullComponent = {
     ...component,
@@ -596,6 +614,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               components: RawComponent[];
               edges: RawEdge[];
               inferredEdges: RawEdge[];
+              managementEdges: RawEdge[];
             }>({
               method: "get",
               url: "diagram/get_all_components_and_edges",
@@ -612,6 +631,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
             components: RawComponent[];
             edges: RawEdge[];
             inferredEdges: RawEdge[];
+            managementEdges: RawEdge[];
           }) {
             // i want to avoid strict assignments here, so i can re-use this
             // this.rawComponentsById = _.keyBy(response.components, "id");
@@ -627,13 +647,29 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
 
             const edges =
               response.edges && response.edges.length > 0
-                ? response.edges.map(edgeFromRawEdge(false))
+                ? response.edges.map(
+                    edgeFromRawEdge({ isInferred: false, isManagement: false }),
+                  )
                 : [];
             const inferred =
               response.inferredEdges && response.inferredEdges.length > 0
-                ? response.inferredEdges.map(edgeFromRawEdge(true))
+                ? response.inferredEdges.map(
+                    edgeFromRawEdge({ isInferred: true, isManagement: false }),
+                  )
                 : [];
-            this.rawEdgesById = _.keyBy([...edges, ...inferred], "id");
+
+            const management =
+              response.managementEdges?.length > 0
+                ? response.managementEdges.map(
+                    edgeFromRawEdge({ isInferred: false, isManagement: true }),
+                  )
+                : [];
+
+            this.rawEdgesById = _.keyBy(
+              [...edges, ...inferred, ...management],
+              "id",
+            );
+
             Object.keys(this.rawEdgesById).forEach((edgeId) => {
               this.processRawEdge(edgeId);
             });
@@ -668,6 +704,51 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
             this.selectedInsertCategoryVariantId = null;
           },
 
+          async MANAGE_COMPONENT(
+            from: { componentId: ComponentNodeId; socketId: SocketId },
+            to: { componentId: ComponentNodeId; socketId: SocketId },
+          ) {
+            if (changeSetsStore.creatingChangeSet)
+              throw new Error("race, wait until the change set is created");
+            if (changeSetId === changeSetsStore.headChangeSetId)
+              changeSetsStore.creatingChangeSet = true;
+
+            const timestamp = new Date().toISOString();
+
+            const newEdge = edgeFromRawEdge({ isManagement: true })({
+              fromComponentId: from.componentId,
+              fromSocketId: from.socketId,
+              toComponentId: to.componentId,
+              toSocketId: to.socketId,
+              toDelete: false,
+              changeStatus: "added",
+              createdInfo: {
+                timestamp,
+                actor: { kind: "user", label: "You" },
+              },
+            });
+
+            return new ApiRequest({
+              method: "post",
+              url: "component/manage",
+              params: {
+                managerComponentId: from.componentId,
+                managedComponentId: to.componentId,
+                ...visibilityParams,
+              },
+              onFail: () => {
+                delete this.rawEdgesById[newEdge.id];
+              },
+              optimistic: () => {
+                this.rawEdgesById[newEdge.id] = newEdge;
+                this.processRawEdge(newEdge.id);
+                return () => {
+                  delete this.rawEdgesById[newEdge.id];
+                };
+              },
+            });
+          },
+
           async CREATE_COMPONENT_CONNECTION(
             from: { componentId: ComponentNodeId; socketId: SocketId },
             to: { componentId: ComponentNodeId; socketId: SocketId },
@@ -679,7 +760,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
 
             const timestamp = new Date().toISOString();
 
-            const newEdge = edgeFromRawEdge(false)({
+            const newEdge = edgeFromRawEdge({})({
               fromComponentId: from.componentId,
               fromSocketId: from.socketId,
               toComponentId: to.componentId,
@@ -828,23 +909,34 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
             if (changeSetId === changeSetsStore.headChangeSetId)
               changeSetsStore.creatingChangeSet = true;
 
+            const edge = this.rawEdgesById[edgeId];
+            const params = edge?.isManagement
+              ? {
+                  managedComponentId: toComponentId,
+                  managerComponentId: fromComponentId,
+                  ...visibilityParams,
+                }
+              : {
+                  fromSocketId,
+                  toSocketId,
+                  toComponentId,
+                  fromComponentId,
+                  ...visibilityParams,
+                };
+
+            const url = edge?.isManagement
+              ? "component/unmanage"
+              : "diagram/delete_connection";
+
             return new ApiRequest({
               method: "post",
-              url: "diagram/delete_connection",
+              url,
               keyRequestStatusBy: edgeId,
-              params: {
-                fromSocketId,
-                toSocketId,
-                toComponentId,
-                fromComponentId,
-                ...visibilityParams,
-              },
+              params,
               onSuccess: (response) => {
                 // this.componentDiffsById[componentId] = response.componentDiff;
               },
               optimistic: () => {
-                const edge = this.rawEdgesById[edgeId];
-
                 if (edge?.changeStatus === "added") {
                   const originalEdge = this.rawEdgesById[edgeId];
                   delete this.rawEdgesById[edgeId];
@@ -1157,7 +1249,10 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                   // don't update
                   if (metadata.change_set_id !== changeSetId) return;
 
-                  const e = edgeFromRawEdge(false)(edge);
+                  const e = edgeFromRawEdge({
+                    isManagement: edge.type === "managementEdge",
+                  })(edge);
+
                   this.rawEdgesById[e.id] = e;
                   this.processRawEdge(e.id);
                 },
@@ -1166,16 +1261,40 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                 eventType: "ConnectionDeleted",
                 callback: (edge, metadata) => {
                   if (metadata.change_set_id !== changeSetId) return;
-                  // making TS happy, we don't need this data since we're just deleting
-                  const _edge = edge as RawEdge;
-                  _edge.toDelete = true;
-                  _edge.createdInfo = {
-                    actor: { kind: "system", label: "" },
-                    timestamp: "",
-                  };
-                  const e = edgeFromRawEdge(false)(_edge);
-                  delete this.rawEdgesById[e.id];
-                  delete this.diagramEdgesById[e.id];
+
+                  let removedEdge: RawEdge;
+                  if (edge.type === "attributeValueEdge") {
+                    removedEdge = {
+                      toDelete: true,
+                      createdInfo: {
+                        actor: { kind: "system", label: "" },
+                        timestamp: "",
+                      },
+                      fromComponentId: edge.fromComponentId,
+                      toComponentId: edge.toComponentId,
+                      fromSocketId: edge.fromSocketId,
+                      toSocketId: edge.toSocketId,
+                    };
+                  } else {
+                    removedEdge = {
+                      toDelete: true,
+                      createdInfo: {
+                        actor: { kind: "system", label: "" },
+                        timestamp: "",
+                      },
+                      fromComponentId: edge.fromComponentId,
+                      toComponentId: edge.toComponentId,
+                      fromSocketId: "",
+                      toSocketId: "",
+                    };
+                  }
+
+                  const edgeId = edgeFromRawEdge({
+                    isManagement: edge.type === "managementEdge",
+                  })(removedEdge).id;
+
+                  delete this.rawEdgesById[edgeId];
+                  delete this.diagramEdgesById[edgeId];
                 },
               },
               {
@@ -1223,7 +1342,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                   if (data.changeSetId !== changeSetId) return;
                   const edges =
                     data.edges && data.edges.length > 0
-                      ? data.edges.map(edgeFromRawEdge(true))
+                      ? data.edges.map(edgeFromRawEdge({ isInferred: true }))
                       : [];
                   for (const edge of edges) {
                     this.rawEdgesById[edge.id] = edge;
@@ -1237,7 +1356,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                   if (data.changeSetId !== changeSetId) return;
                   const edges =
                     data.edges && data.edges.length > 0
-                      ? data.edges.map(edgeFromRawEdge(true))
+                      ? data.edges.map(edgeFromRawEdge({ isInferred: true }))
                       : [];
                   for (const edge of edges) {
                     delete this.rawEdgesById[edge.id];

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -12,6 +12,7 @@ const FLAG_MAPPING = {
   ADMIN_PANEL_ACCESS: "si_admin_panel_access",
   ON_DEMAND_ASSETS: "on_demand_assets",
   MANAGEMENT_FUNCTIONS: "management-functions",
+  MANAGEMENT_EDGES: "management-edges",
   AUDIT_PAGE: "audit-page",
   AI_GENERATOR: "ai-generator",
   REBAC: "rebac",
@@ -41,7 +42,9 @@ export function useFeatureFlagsStore() {
             }
           });
         });
-        // You can override feature flags while working on a feature by setting them to true here
+        // You can override feature flags while working on a feature by setting them to true/false here
+        // for example:
+        // this.MANAGEMENT_EDGES = false;
       },
     }),
   )();

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -195,13 +195,22 @@ export type WsEventPayloadMap = {
     changeSetId: string;
     edges: RawEdge[];
   };
-  ConnectionUpserted: RawEdge;
-  ConnectionDeleted: {
-    fromComponentId: string;
-    toComponentId: string;
-    fromSocketId: string;
-    toSocketId: string;
-  };
+  ConnectionUpserted: {
+    type: "attributeValueEdge" | "managementEdge";
+  } & RawEdge;
+  ConnectionDeleted:
+    | {
+        type: "attributeValueEdge";
+        fromComponentId: string;
+        toComponentId: string;
+        fromSocketId: string;
+        toSocketId: string;
+      }
+    | {
+        type: "managementEdge";
+        fromComponentId: string;
+        toComponentId: string;
+      };
   ManagementFuncExecuted: {
     managerComponentId: string;
     prototypeId: string;

--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -427,6 +427,7 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
               components: RawComponent[];
               edges: RawEdge[];
               inferredEdges: RawEdge[];
+              managementEdges: RawEdge[];
             };
           }>({
             url,

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -2635,7 +2635,7 @@ impl AttributeValue {
                 child_attribute_value_id,
                 EdgeWeightKindDiscriminants::Contain,
             )
-            .await?
+            .await
             .and_then(|weight| match weight.kind() {
                 EdgeWeightKind::Contain(key) => key.to_owned(),
                 _ => None,

--- a/lib/dal/src/management/prototype.rs
+++ b/lib/dal/src/management/prototype.rs
@@ -506,6 +506,21 @@ impl ManagementPrototype {
         Ok(schema_variant_id.into())
     }
 
+    /// Is there at least one management prototype for this schema variant?
+    pub async fn variant_has_management_prototype(
+        ctx: &DalContext,
+        schema_variant_id: SchemaVariantId,
+    ) -> ManagementPrototypeResult<bool> {
+        let workspace_snapshot = ctx.workspace_snapshot()?;
+        Ok(!workspace_snapshot
+            .outgoing_targets_for_edge_weight_kind(
+                schema_variant_id,
+                EdgeWeightKindDiscriminants::ManagementPrototype,
+            )
+            .await?
+            .is_empty())
+    }
+
     pub async fn list_for_variant_id(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -15,10 +15,9 @@ use crate::change_set::event::{
 use crate::component::{
     ComponentCreatedPayload, ComponentDeletedPayload, ComponentSetPositionPayload,
     ComponentUpdatedPayload, ComponentUpgradedPayload, ConnectionDeletedPayload,
-    InferredEdgeRemovePayload, InferredEdgeUpsertPayload,
+    ConnectionUpsertedPayload, InferredEdgeRemovePayload, InferredEdgeUpsertPayload,
 };
 use crate::diagram::view::{ViewComponentsUpdatePayload, ViewDeletedPayload, ViewWsPayload};
-use crate::diagram::SummaryDiagramEdge;
 use crate::func::runner::FuncRunLogUpdatedPayload;
 use crate::func::{
     FuncWsEventCodeSaved, FuncWsEventFuncSummary, FuncWsEventGenerating, FuncWsEventPayload,
@@ -97,7 +96,7 @@ pub enum WsPayload {
     ComponentUpdated(ComponentUpdatedPayload),
     ComponentUpgraded(ComponentUpgradedPayload),
     ConnectionDeleted(ConnectionDeletedPayload),
-    ConnectionUpserted(SummaryDiagramEdge),
+    ConnectionUpserted(ConnectionUpsertedPayload),
     Cursor(CursorPayload),
     FuncArgumentsSaved(FuncWsEventPayload),
     FuncCodeSaved(FuncWsEventCodeSaved),

--- a/lib/dal/tests/integration_test/management.rs
+++ b/lib/dal/tests/integration_test/management.rs
@@ -562,7 +562,7 @@ async fn create_component_of_same_schema(ctx: &DalContext) {
     assert_eq!(10.0, new_geometry.x);
     assert_eq!(20.0, new_geometry.y);
 
-    let managers = new_component.get_managers(ctx).await.expect("get managers");
+    let managers = new_component.managers(ctx).await.expect("get managers");
 
     assert_eq!(1, managers.len());
     assert_eq!(

--- a/lib/sdf-server/src/service/component.rs
+++ b/lib/sdf-server/src/service/component.rs
@@ -39,11 +39,13 @@ pub mod get_resource;
 pub mod insert_property_editor_value;
 pub mod json;
 pub mod list_qualifications;
+mod manage;
 pub mod refresh;
 pub mod restore_default_function;
 pub mod set_name;
 pub mod set_resource_id;
 pub mod set_type;
+mod unmanage;
 pub mod update_property_editor_value;
 mod upgrade;
 
@@ -195,4 +197,6 @@ pub fn routes() -> Router<AppState> {
         .route("/json", get(json::json))
         .route("/upgrade_component", post(upgrade::upgrade))
         .route("/conflicts", get(conflicts_for_component))
+        .route("/manage", post(manage::manage))
+        .route("/unmanage", post(unmanage::unmanage))
 }

--- a/lib/sdf-server/src/service/component/manage.rs
+++ b/lib/sdf-server/src/service/component/manage.rs
@@ -1,0 +1,64 @@
+use axum::{
+    extract::{Host, OriginalUri},
+    Json,
+};
+use dal::{ChangeSet, Component, ComponentId, Visibility, WsEvent};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    extract::{AccessBuilder, HandlerContext, PosthogClient},
+    service::force_change_set_response::ForceChangeSetResponse,
+    track,
+};
+
+use super::ComponentResult;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ManageComponentRequest {
+    pub manager_component_id: ComponentId,
+    pub managed_component_id: ComponentId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+pub async fn manage(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Host(host_name): Host,
+    Json(ManageComponentRequest {
+        manager_component_id,
+        managed_component_id,
+        visibility,
+    }): Json<ManageComponentRequest>,
+) -> ComponentResult<ForceChangeSetResponse<()>> {
+    let mut ctx = builder.build(request_ctx.build(visibility)).await?;
+    let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
+
+    let edge =
+        Component::manage_component(&ctx, manager_component_id, managed_component_id).await?;
+
+    WsEvent::connection_upserted(&ctx, edge.into())
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        &host_name,
+        "manage_component",
+        serde_json::json!({
+            "how": "/component/manage",
+            "manager_component_id": manager_component_id,
+            "managed_component_id": managed_component_id,
+        }),
+    );
+
+    ctx.commit().await?;
+
+    Ok(ForceChangeSetResponse::empty(force_change_set_id))
+}

--- a/lib/sdf-server/src/service/component/unmanage.rs
+++ b/lib/sdf-server/src/service/component/unmanage.rs
@@ -1,0 +1,63 @@
+use axum::{
+    extract::{Host, OriginalUri},
+    Json,
+};
+use dal::{ChangeSet, Component, ComponentId, Visibility, WsEvent};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    extract::{AccessBuilder, HandlerContext, PosthogClient},
+    service::force_change_set_response::ForceChangeSetResponse,
+    track,
+};
+
+use super::ComponentResult;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct UnmanageComponentRequest {
+    pub manager_component_id: ComponentId,
+    pub managed_component_id: ComponentId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+pub async fn unmanage(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Host(host_name): Host,
+    Json(UnmanageComponentRequest {
+        manager_component_id,
+        managed_component_id,
+        visibility,
+    }): Json<UnmanageComponentRequest>,
+) -> ComponentResult<ForceChangeSetResponse<()>> {
+    let mut ctx = builder.build(request_ctx.build(visibility)).await?;
+    let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
+
+    Component::unmanage_component(&ctx, manager_component_id, managed_component_id).await?;
+
+    WsEvent::manages_edge_deleted(&ctx, manager_component_id, managed_component_id)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        &host_name,
+        "unmanage_component",
+        serde_json::json!({
+            "how": "/component/unmanage",
+            "manager_component_id": manager_component_id,
+            "managed_component_id": managed_component_id,
+        }),
+    );
+
+    ctx.commit().await?;
+
+    Ok(ForceChangeSetResponse::empty(force_change_set_id))
+}

--- a/lib/sdf-server/src/service/diagram/create_connection.rs
+++ b/lib/sdf-server/src/service/diagram/create_connection.rs
@@ -77,7 +77,7 @@ pub async fn create_connection(
                 &to_component,
                 ChangeStatus::Added,
             )?;
-            WsEvent::connection_upserted(&ctx, edge)
+            WsEvent::connection_upserted(&ctx, edge.into())
                 .await?
                 .publish_on_commit(&ctx)
                 .await?;

--- a/lib/sdf-server/src/service/diagram/delete_component.rs
+++ b/lib/sdf-server/src/service/diagram/delete_component.rs
@@ -109,7 +109,7 @@ pub async fn delete_components(
                 to_delete: true,
                 from_base_change_set: false,
             };
-            WsEvent::connection_upserted(&ctx, payload)
+            WsEvent::connection_upserted(&ctx, payload.into())
                 .await?
                 .publish_on_commit(&ctx)
                 .await?;
@@ -127,7 +127,7 @@ pub async fn delete_components(
                 to_delete: true,
                 from_base_change_set: false,
             };
-            WsEvent::connection_upserted(&ctx, payload)
+            WsEvent::connection_upserted(&ctx, payload.into())
                 .await?
                 .publish_on_commit(&ctx)
                 .await?;

--- a/lib/sdf-server/src/service/diagram/delete_connection.rs
+++ b/lib/sdf-server/src/service/diagram/delete_connection.rs
@@ -86,7 +86,7 @@ pub async fn delete_connection(
     }
 
     if let Some(edge) = payload {
-        WsEvent::connection_upserted(&ctx, edge)
+        WsEvent::connection_upserted(&ctx, edge.into())
             .await?
             .publish_on_commit(&ctx)
             .await?;

--- a/lib/sdf-server/src/service/diagram/paste_component.rs
+++ b/lib/sdf-server/src/service/diagram/paste_component.rs
@@ -162,7 +162,7 @@ pub async fn paste_components(
                     to_delete: false,
                     from_base_change_set: false,
                 };
-                WsEvent::connection_upserted(&ctx, edge)
+                WsEvent::connection_upserted(&ctx, edge.into())
                     .await?
                     .publish_on_commit(&ctx)
                     .await?;

--- a/lib/sdf-server/src/service/v2/view/paste_component.rs
+++ b/lib/sdf-server/src/service/v2/view/paste_component.rs
@@ -140,7 +140,7 @@ pub async fn paste_component(
                     to_delete: false,
                     from_base_change_set: false,
                 };
-                WsEvent::connection_upserted(&ctx, edge)
+                WsEvent::connection_upserted(&ctx, edge.into())
                     .await?
                     .publish_on_commit(&ctx)
                     .await?;

--- a/lib/si-frontend-types-rs/src/component.rs
+++ b/lib/si-frontend-types-rs/src/component.rs
@@ -132,6 +132,8 @@ pub struct DiagramSocket {
     pub max_connections: Option<usize>,
     pub is_required: Option<bool>,
     pub node_side: DiagramSocketNodeSide,
+    pub is_management: Option<bool>,
+    pub managed_schemas: Option<Vec<SchemaId>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Management edges now render on the diagram, and can be drawn from one component to another, if that component is capable of managing the other. They can also be deleted.