### PR TITLE
fix: frames can manage children,  connection events sent after component events in management operator

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -2630,7 +2630,11 @@ impl AttributeValue {
     ) -> AttributeValueResult<Option<String>> {
         Ok(ctx
             .workspace_snapshot()?
-            .find_edge(parent_attribute_value_id, child_attribute_value_id)
+            .find_edge(
+                parent_attribute_value_id,
+                child_attribute_value_id,
+                EdgeWeightKindDiscriminants::Contain,
+            )
             .await?
             .and_then(|weight| match weight.kind() {
                 EdgeWeightKind::Contain(key) => key.to_owned(),

--- a/lib/dal/src/workspace_snapshot/graph/tests/detect_updates.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/detect_updates.rs
@@ -71,7 +71,7 @@ mod test {
                 ContentAddress::Component(ContentHash::from("Component B")),
             ))
             .expect("Unable to add Component B");
-        let _new_onto_root_component_edge_index = base_graph
+        base_graph
             .add_edge(
                 base_graph.root(),
                 EdgeWeight::new(EdgeWeightKind::new_use()),


### PR DESCRIPTION
In order for frames to manage children, we had to allow parallel edges
in our graph. There should be no problem here, nothing we do should
break on parallel edges.

Also, we need to ensure we send the connection WsEvents *after*
component WsEvents so that the frontend knows about all components
before getting connection messages.