### PR TITLE
Fix Regenerate Asset making bindings disappear

### DIFF
--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -603,12 +603,15 @@ impl SchemaVariant {
             return Err(SchemaVariantError::SchemaVariantLocked(schema_variant_id));
         }
 
-        Self::cleanup_variant(ctx, variant).await
+        Self::cleanup_variant(ctx, variant).await?;
+        // Remove props/sockets/other dangling edges/nodes
+        Ok(ctx.workspace_snapshot()?.cleanup().await?)
     }
 
     /// Removes a schema variant from the graph, even if it is locked. You probably want to use [Self::cleanup_unlocked_variant]
     /// unless you're garbage collecting unused variants
-    pub async fn cleanup_variant(
+    /// Does not call cleanup() at the end--caller is responsible for ensuring dangling props and such are removed
+    pub(crate) async fn cleanup_variant(
         ctx: &DalContext,
         schema_variant: SchemaVariant,
     ) -> SchemaVariantResult<()> {

--- a/lib/sdf-server/src/service/variant.rs
+++ b/lib/sdf-server/src/service/variant.rs
@@ -24,6 +24,8 @@ pub mod save_variant;
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum SchemaVariantError {
+    #[error("attribute prototype error: {0}")]
+    AttributePrototype(#[from] dal::attribute::prototype::AttributePrototypeError),
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
     #[error("trying to create unlocked copy for schema variant that's not the default: {0}")]
@@ -48,6 +50,8 @@ pub enum SchemaVariantError {
     NoDefaultSchemaVariantFoundForSchema(SchemaId),
     #[error("pkg error: {0}")]
     Pkg(#[from] PkgError),
+    #[error("prop error: {0}")]
+    Prop(#[from] dal::prop::PropError),
     #[error("schema error: {0}")]
     Schema(#[from] SchemaError),
     #[error("Schema name {0} already taken")]

--- a/lib/sdf-server/src/service/variant/regenerate_variant.rs
+++ b/lib/sdf-server/src/service/variant/regenerate_variant.rs
@@ -1,10 +1,12 @@
+use std::collections::HashSet;
+
 use axum::{
     extract::{Host, OriginalUri},
     Json,
 };
 use dal::{
-    schema::variant::authoring::VariantAuthoringClient, ChangeSet, SchemaVariant, SchemaVariantId,
-    Visibility, WsEvent,
+    schema::variant::authoring::VariantAuthoringClient, AttributePrototype, ChangeSet, DalContext,
+    Func, FuncId, Prop, SchemaVariant, SchemaVariantId, Visibility, WsEvent,
 };
 use serde::{Deserialize, Serialize};
 
@@ -100,6 +102,21 @@ pub async fn regenerate_variant(
             .await?;
     }
 
+    // Send FuncUpdated for all functions bound to the schema variant, since there may be new props/sockets (and since
+    // regenerated props/sockets now have new bindings, we need to send those too).
+    // TODO most props and sockets generally stay the same during regeneration, so maybe send fewer of these
+    for func_id in all_bound_functions(&ctx, updated_schema_variant_id).await? {
+        let func_summary = Func::get_by_id_or_error(&ctx, func_id)
+            .await?
+            .into_frontend_type(&ctx)
+            .await?;
+
+        WsEvent::func_updated(&ctx, func_summary, None)
+            .await?
+            .publish_on_commit(&ctx)
+            .await?;
+    }
+
     ctx.commit().await?;
 
     Ok(ForceChangeSetResponse::new(
@@ -108,4 +125,37 @@ pub async fn regenerate_variant(
             schema_variant_id: updated_schema_variant_id,
         },
     ))
+}
+
+async fn all_bound_functions(
+    ctx: &DalContext,
+    schema_variant_id: SchemaVariantId,
+) -> SchemaVariantResult<HashSet<FuncId>> {
+    let mut bound_func_ids = HashSet::new();
+    // Add all prop bindings
+    for prop_id in SchemaVariant::all_prop_ids(ctx, schema_variant_id).await? {
+        let ap_id = Prop::prototype_id(ctx, prop_id).await?;
+        let func_id = AttributePrototype::func_id(ctx, ap_id).await?;
+        bound_func_ids.insert(func_id);
+    }
+
+    // Add all input and output socket bindings
+    let (output_socket_ids, input_socket_ids) =
+        SchemaVariant::list_all_socket_ids(ctx, schema_variant_id).await?;
+
+    for socket_id in input_socket_ids {
+        if let Some(ap_id) = AttributePrototype::find_for_input_socket(ctx, socket_id).await? {
+            let func_id = AttributePrototype::func_id(ctx, ap_id).await?;
+            bound_func_ids.insert(func_id);
+        }
+    }
+
+    for socket_id in output_socket_ids {
+        if let Some(ap_id) = AttributePrototype::find_for_output_socket(ctx, socket_id).await? {
+            let func_id = AttributePrototype::func_id(ctx, ap_id).await?;
+            bound_func_ids.insert(func_id);
+        }
+    }
+
+    Ok(bound_func_ids)
 }


### PR DESCRIPTION
Right now, Regenerate Asset causes socket bindings to disappear, and prop bindings to stop showing their values. A reload fixes it.

This is because `SchemaVariantRegenerated` adds bindings for all props but does not send a WsEvent notifying the frontend. `SchemaVariantUpdated` has this problem for new props and sockets, as well.

Fixes BUG-653.