### PR TITLE
Make code reload after AI gen

### DIFF
--- a/app/web/src/components/FuncEditor/FuncEditor.vue
+++ b/app/web/src/components/FuncEditor/FuncEditor.vue
@@ -88,7 +88,7 @@ watch(
 );
 
 watch(
-  () => selectedFuncCode.value?.funcId,
+  () => [selectedFuncCode.value?.funcId, selectedFuncCode.value?.code],
   () => {
     if (!selectedFuncCode.value) {
       return;

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -854,10 +854,9 @@ export const useFuncStore = () => {
           },
           {
             eventType: "FuncCodeSaved",
-            callback: (data, metadata) => {
+            callback: ({ generated, funcCode: { funcId } }, metadata) => {
               if (metadata.change_set_id !== selectedChangeSetId) return;
 
-              const funcId = data.funcCode.funcId;
               // TODO we update every time *any* function is generated unless you are in the
               // function editor. That's because we can't tell from here if the function is
               // the asset function editor from here (and we can't useAssetStore() because
@@ -865,7 +864,7 @@ export const useFuncStore = () => {
               // generation doesn't happen so often it's a giant problem right now.
               if (
                 (funcId === this.selectedFuncId || !this.selectedFuncId) &&
-                data.generated &&
+                generated &&
                 this.generatingFuncCode[funcId]
               ) {
                 this.FETCH_CODE(funcId);


### PR DESCRIPTION
Right now, you often (not always?) have to reload the code editor after AI generation of an action function. This makes it so that the code editor reloads when the code changes (not just the FuncId).

Performance implications are unknown, but this doesn't happen on every keystroke, so it shouldn't be a huge burden.