### PR TITLE
Get the change set for audit log published events

### DIFF
--- a/lib/dal/src/audit_logging.rs
+++ b/lib/dal/src/audit_logging.rs
@@ -463,7 +463,9 @@ pub struct AuditLogsPublishedPayload {
 
 impl WsEvent {
     pub async fn audit_logs_published(ctx: &DalContext) -> WsEventResult<Self> {
-        let change_set = ctx.change_set()?;
+        let change_set = ChangeSet::find(ctx, ctx.change_set_id())
+            .await?
+            .ok_or(ChangeSetError::ChangeSetNotFound(ctx.change_set_id()))?;
         WsEvent::new(
             ctx,
             WsPayload::AuditLogsPublished(AuditLogsPublishedPayload {

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -39,11 +39,13 @@ use crate::{
     user::CursorPayload, ChangeSetId, DalContext, FuncError, PropId, StandardModelError,
     TransactionsError, WorkspacePk,
 };
-use crate::{SchemaVariantError, SecretCreatedPayload, SecretUpdatedPayload};
+use crate::{ChangeSetError, SchemaVariantError, SecretCreatedPayload, SecretUpdatedPayload};
 
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum WsEventError {
+    #[error("change set error: {0}")]
+    ChangeSet(#[from] ChangeSetError),
     #[error("func error: {0}")]
     Func(#[from] Box<FuncError>),
     #[error("nats txn error: {0}")]


### PR DESCRIPTION
This PR ensures that we get the change set when preparing audit log publish events. We do not want to rely on the reference as it will only be stored when updating the visibility.