### PR TITLE
fix(sdf): Ensure we reload secrets when dynamically installing component

### DIFF
--- a/app/web/src/store/secrets.store.ts
+++ b/app/web/src/store/secrets.store.ts
@@ -550,6 +550,13 @@ export function useSecretsStore() {
               },
             },
             {
+              eventType: "ModuleImported",
+              callback: (schemaVariants, metadata) => {
+                if (metadata.change_set_id !== changeSetId) return;
+                this.LOAD_SECRETS();
+              },
+            },
+            {
               eventType: "SecretDeleted",
               callback: (data) => {
                 if (data.changeSetId !== changeSetId) return;

--- a/lib/sdf-server/src/service/diagram/create_component.rs
+++ b/lib/sdf-server/src/service/diagram/create_component.rs
@@ -89,10 +89,13 @@ pub async fn create_component(
                 Schema::get_or_install_default_variant(&ctx, schema_id).await?;
             }
 
-            (
-                variant_id,
-                Some(variant.into_frontend_type(&ctx, schema_id).await?),
-            )
+            let front_end_variant = variant.clone().into_frontend_type(&ctx, schema_id).await?;
+            WsEvent::module_imported(&ctx, vec![front_end_variant.clone()])
+                .await?
+                .publish_on_commit(&ctx)
+                .await?;
+
+            (variant_id, Some(front_end_variant))
         }
     };
 

--- a/lib/sdf-server/src/service/v2/view/create_component.rs
+++ b/lib/sdf-server/src/service/v2/view/create_component.rs
@@ -115,6 +115,12 @@ pub async fn create_component(
 
             let variant = SchemaVariant::get_by_id_or_error(&ctx, variant_id).await?;
 
+            let front_end_variant = variant.clone().into_frontend_type(&ctx, schema_id).await?;
+            WsEvent::module_imported(&ctx, vec![front_end_variant.clone()])
+                .await?
+                .publish_on_commit(&ctx)
+                .await?;
+
             (
                 variant_id,
                 Some(variant.into_frontend_type(&ctx, schema_id).await?),


### PR DESCRIPTION
This is a bit of a hammer but there's *currently* no way to understand that a secret has been installed as being a secret is defined internally to the module schema

This will alleviate the pain for now and will allow us to turn this feature on for users