### PR TITLE
Revert "Fix Regenerate Asset making bindings disappear"

### DIFF
--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -603,15 +603,12 @@ impl SchemaVariant {
             return Err(SchemaVariantError::SchemaVariantLocked(schema_variant_id));
         }
 
-        Self::cleanup_variant(ctx, variant).await?;
-        // Remove props/sockets/other dangling edges/nodes
-        Ok(ctx.workspace_snapshot()?.cleanup().await?)
+        Self::cleanup_variant(ctx, variant).await
     }
 
     /// Removes a schema variant from the graph, even if it is locked. You probably want to use [Self::cleanup_unlocked_variant]
     /// unless you're garbage collecting unused variants
-    /// Does not call cleanup() at the end--caller is responsible for ensuring dangling props and such are removed
-    pub(crate) async fn cleanup_variant(
+    pub async fn cleanup_variant(
         ctx: &DalContext,
         schema_variant: SchemaVariant,
     ) -> SchemaVariantResult<()> {

--- a/lib/sdf-server/src/service/variant.rs
+++ b/lib/sdf-server/src/service/variant.rs
@@ -24,8 +24,6 @@ pub mod save_variant;
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum SchemaVariantError {
-    #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] dal::attribute::prototype::AttributePrototypeError),
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
     #[error("trying to create unlocked copy for schema variant that's not the default: {0}")]
@@ -50,8 +48,6 @@ pub enum SchemaVariantError {
     NoDefaultSchemaVariantFoundForSchema(SchemaId),
     #[error("pkg error: {0}")]
     Pkg(#[from] PkgError),
-    #[error("prop error: {0}")]
-    Prop(#[from] dal::prop::PropError),
     #[error("schema error: {0}")]
     Schema(#[from] SchemaError),
     #[error("Schema name {0} already taken")]


### PR DESCRIPTION
Reverts systeminit/si#4982

In tools-prod, Regenerate Asset now emits this error:

![image](https://github.com/user-attachments/assets/d71a5a83-7b47-4383-b46f-34b6897bb4e9)

This was happening locally too, and the source was that you can't generate `FuncUpdated` events because there are dangling bindings and props from the unlocked variant that got removed. The `cleanup()` line in `cleanup_unlocked_variant()` fixed it, but doesn't seem to affect tools. Reverting so it doesn't go to prod, and will investigate.