### PR TITLE
Write to audit logs table from forklift

### DIFF
--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -38,13 +38,11 @@ use crate::{
     user::CursorPayload, ChangeSetId, DalContext, FuncError, PropId, StandardModelError,
     TransactionsError, WorkspacePk,
 };
-use crate::{ChangeSetError, SchemaVariantError, SecretCreatedPayload, SecretUpdatedPayload};
+use crate::{SchemaVariantError, SecretCreatedPayload, SecretUpdatedPayload};
 
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum WsEventError {
-    #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetError),
     #[error("func error: {0}")]
     Func(#[from] Box<FuncError>),
     #[error("nats txn error: {0}")]


### PR DESCRIPTION
## Description

This PR ensures that we skip publishing ws events when audit logs are published for ephemeral change sets.