### PR TITLE
fix(layer-cache): add size hinting when inserting Rust types into caches

### DIFF
--- a/lib/dal/examples/rebase/main.rs
+++ b/lib/dal/examples/rebase/main.rs
@@ -20,7 +20,7 @@ fn load_snapshot_graph<T: DeserializeOwned>(path: &str) -> Result<T> {
 
 fn write_snapshot_graph(path: &str, graph: &WorkspaceSnapshotGraph) -> Result<()> {
     let mut file = File::create(path)?;
-    let bytes = serialize::to_vec(graph)?;
+    let (bytes, _) = serialize::to_vec(graph)?;
     file.write_all(&bytes)?;
 
     Ok(())

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -549,7 +549,7 @@ impl Workspace {
             .map(|(hash, content)| (hash, (content, "postcard".to_string())))
             .collect::<HashMap<_, _>>();
 
-        let content_store_values = serialize::to_vec(&store_values_map)?;
+        let (content_store_values, _) = serialize::to_vec(&store_values_map)?;
 
         let created_by = if let HistoryActor::User(user_pk) = ctx.history_actor() {
             let user = User::get_by_pk(ctx, *user_pk)

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -597,9 +597,7 @@ impl WorkspaceSnapshot {
 
     pub async fn serialized(&self) -> WorkspaceSnapshotResult<Vec<u8>> {
         let graph = self.working_copy().await.clone();
-        Ok(si_layer_cache::db::serialize::to_vec(
-            &WorkspaceSnapshotGraph::V4(graph),
-        )?)
+        Ok(si_layer_cache::db::serialize::to_vec(&WorkspaceSnapshotGraph::V4(graph))?.0)
     }
 
     pub fn from_bytes(bytes: &[u8]) -> WorkspaceSnapshotResult<Self> {

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -167,7 +167,7 @@ impl RebaseBatch {
     /// debugging.
     #[allow(clippy::disallowed_methods)]
     pub fn write_to_disk(&self, file_suffix: &str) {
-        let serialized = serialize::to_vec(self).expect("unable to serialize");
+        let (serialized, _) = serialize::to_vec(self).expect("unable to serialize");
         let filename = format!("{}-{}", Ulid::new(), file_suffix);
 
         let home_env = std::env::var("HOME").expect("No HOME environment variable set");

--- a/lib/dal/src/workspace_snapshot/graph/v2.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v2.rs
@@ -696,7 +696,7 @@ impl WorkspaceSnapshotGraphV2 {
     /// Write the graph to disk. This *MAY PANIC*. Use only for debugging.
     #[allow(clippy::disallowed_methods)]
     pub fn write_to_disk(&self, file_suffix: &str) {
-        let serialized = serialize::to_vec(self).expect("unable to serialize");
+        let (serialized, _) = serialize::to_vec(self).expect("unable to serialize");
         let filename = format!("{}-{}", Ulid::new(), file_suffix);
 
         let home_env = std::env::var("HOME").expect("No HOME environment variable set");

--- a/lib/dal/src/workspace_snapshot/graph/v3.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v3.rs
@@ -702,7 +702,7 @@ impl WorkspaceSnapshotGraphV3 {
     /// Write the graph to disk. This *MAY PANIC*. Use only for debugging.
     #[allow(clippy::disallowed_methods)]
     pub fn write_to_disk(&self, file_suffix: &str) {
-        let serialized = serialize::to_vec(self).expect("unable to serialize");
+        let (serialized, _) = serialize::to_vec(self).expect("unable to serialize");
         let filename = format!("{}-{}", Ulid::new(), file_suffix);
 
         let home_env = std::env::var("HOME").expect("No HOME environment variable set");

--- a/lib/dal/src/workspace_snapshot/graph/v4.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v4.rs
@@ -824,7 +824,7 @@ impl WorkspaceSnapshotGraphV4 {
     /// Write the graph to disk. This *MAY PANIC*. Use only for debugging.
     #[allow(clippy::disallowed_methods)]
     pub fn write_to_disk(&self, file_suffix: &str) {
-        let serialized = serialize::to_vec(self).expect("unable to serialize");
+        let (serialized, _) = serialize::to_vec(self).expect("unable to serialize");
         let filename = format!("{}-{}", Ulid::new(), file_suffix);
 
         let home_env = std::env::var("HOME").expect("No HOME environment variable set");

--- a/lib/dal/tests/integration_test/deserialize/mod.rs
+++ b/lib/dal/tests/integration_test/deserialize/mod.rs
@@ -228,7 +228,7 @@ async fn write_deserialization_data(ctx: &DalContext) {
     graph.cleanup_and_merkle_tree_hash().expect("hash it");
 
     let real_graph = WorkspaceSnapshotGraph::V4(graph);
-    let serialized = serialize::to_vec(&real_graph).expect("serialize");
+    let (serialized, _) = serialize::to_vec(&real_graph).expect("serialize");
 
     let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
 

--- a/lib/si-layer-cache/src/activities.rs
+++ b/lib/si-layer-cache/src/activities.rs
@@ -165,7 +165,7 @@ impl ActivityPublisher {
 
     pub(crate) async fn publish(&self, activity: &Activity) -> LayerDbResult<()> {
         let nats_subject = subject::for_activity(self.prefix(), activity);
-        let nats_payload = serialize::to_vec(&activity)?;
+        let (nats_payload, _) = serialize::to_vec(&activity)?;
         // Publish message and await confirmation from server that it has been received
         self.context
             .publish(nats_subject, nats_payload.into())

--- a/lib/si-layer-cache/src/db/cas.rs
+++ b/lib/si-layer-cache/src/db/cas.rs
@@ -45,11 +45,12 @@ where
         tenancy: Tenancy,
         actor: Actor,
     ) -> LayerDbResult<(ContentHash, PersisterStatusReader)> {
-        let postcard_value = serialize::to_vec(&value)?;
+        let (postcard_value, size_hint) = serialize::to_vec(&value)?;
         let key = ContentHash::new(&postcard_value);
         let cache_key: Arc<str> = key.to_string().into();
 
-        self.cache.insert(cache_key.clone(), value.clone());
+        self.cache
+            .insert(cache_key.clone(), value.clone(), size_hint);
 
         let event = LayeredEvent::new(
             LayeredEventKind::CasInsertion,

--- a/lib/si-layer-cache/src/db/encrypted_secret.rs
+++ b/lib/si-layer-cache/src/db/encrypted_secret.rs
@@ -50,11 +50,12 @@ where
         tenancy: Tenancy,
         actor: Actor,
     ) -> LayerDbResult<PersisterStatusReader> {
-        let postcard_value = serialize::to_vec(&value)?;
+        let (postcard_value, size_hint) = serialize::to_vec(&value)?;
 
         let cache_key: Arc<str> = key.to_string().into();
 
-        self.cache.insert(cache_key.clone(), value.clone());
+        self.cache
+            .insert(cache_key.clone(), value.clone(), size_hint);
 
         let event = LayeredEvent::new(
             LayeredEventKind::EncryptedSecretInsertion,

--- a/lib/si-layer-cache/src/db/func_run.rs
+++ b/lib/si-layer-cache/src/db/func_run.rs
@@ -220,12 +220,12 @@ impl FuncRunDb {
         tenancy: Tenancy,
         actor: Actor,
     ) -> LayerDbResult<()> {
-        let postcard_value = serialize::to_vec(&value)?;
+        let (postcard_value, size_hint) = serialize::to_vec(&value)?;
         let cache_key: Arc<str> = value.id().to_string().into();
         let sort_key: Arc<str> = value.tenancy().workspace_pk.to_string().into();
 
         self.cache
-            .insert_or_update(cache_key.clone(), value.clone());
+            .insert_or_update(cache_key.clone(), value.clone(), size_hint);
 
         let event = LayeredEvent::new(
             LayeredEventKind::FuncRunWrite,

--- a/lib/si-layer-cache/src/db/rebase_batch.rs
+++ b/lib/si-layer-cache/src/db/rebase_batch.rs
@@ -45,12 +45,12 @@ where
         actor: Actor,
     ) -> LayerDbResult<(RebaseBatchAddress, PersisterStatusReader)> {
         let value_clone = value.clone();
-        let postcard_value = serialize::to_vec(&value)?;
+        let (postcard_value, size_hint) = serialize::to_vec(&value)?;
 
         let key = RebaseBatchAddress::new(&postcard_value);
         let cache_key: Arc<str> = key.to_string().into();
 
-        self.cache.insert(cache_key.clone(), value_clone);
+        self.cache.insert(cache_key.clone(), value_clone, size_hint);
 
         let event = LayeredEvent::new(
             LayeredEventKind::RebaseBatchWrite,

--- a/lib/si-layer-cache/src/db/workspace_snapshot.rs
+++ b/lib/si-layer-cache/src/db/workspace_snapshot.rs
@@ -45,12 +45,12 @@ where
         actor: Actor,
     ) -> LayerDbResult<(WorkspaceSnapshotAddress, PersisterStatusReader)> {
         let value_clone = value.clone();
-        let postcard_value = serialize::to_vec(&value)?;
+        let (postcard_value, size_hint) = serialize::to_vec(&value)?;
 
         let key = WorkspaceSnapshotAddress::new(&postcard_value);
         let cache_key: Arc<str> = key.to_string().into();
 
-        self.cache.insert(cache_key.clone(), value_clone);
+        self.cache.insert(cache_key.clone(), value_clone, size_hint);
 
         let event = LayeredEvent::new(
             LayeredEventKind::SnapshotWrite,

--- a/lib/si-layer-cache/src/event.rs
+++ b/lib/si-layer-cache/src/event.rs
@@ -195,7 +195,7 @@ impl LayeredEventClient {
             headers.insert(NATS_HEADER_DB_NAME, event.payload.db_name.as_str());
             headers.insert(NATS_HEADER_KEY, event.payload.key.as_ref());
             headers.insert(NATS_HEADER_INSTANCE_ID, instance_id.to_string().as_str());
-            let payload = serialize::to_vec(&event)?;
+            let (payload, _) = serialize::to_vec(&event)?;
 
             let event_id = Ulid::new();
             let object_size = payload.len();

--- a/lib/si-layer-cache/tests/integration_test/db/cas.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/cas.rs
@@ -309,7 +309,7 @@ async fn stress_test() {
     for v in values {
         let big_string: Arc<String> = Arc::new(v.repeat(10_000_000));
         let cas_value = Arc::new(CasValue::String(big_string.to_string()));
-        let postcard_value =
+        let (postcard_value, _) =
             serialize::to_vec(&cas_value).expect("cannot deserialize big ass string");
         let cas_pk_string = ContentHash::new(&postcard_value).to_string();
         let ldb_slash_task = ldb_slash.clone();

--- a/lib/si-layer-cache/tests/integration_test/layer_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/layer_cache.rs
@@ -28,7 +28,9 @@ async fn make_layer_cache(db_name: &str) -> Arc<LayerCache<String>> {
 async fn empty_insert_and_get() {
     let layer_cache = make_layer_cache("empty_insert_and_get").await;
 
-    layer_cache.insert("skid row".into(), "slave to the grind".into());
+    let value = "slave to the grind";
+    let size_hint = value.len();
+    layer_cache.insert("skid row".into(), value.into(), size_hint);
 
     let skid_row: Arc<str> = "skid row".into();
 
@@ -56,7 +58,8 @@ async fn get_inserts_to_memory() {
 
     let skid_row: Arc<str> = "skid row".into();
 
-    let postcard_serialized = serialize::to_vec("slave to the grind").expect("should serialize");
+    let (postcard_serialized, _) =
+        serialize::to_vec("slave to the grind").expect("should serialize");
 
     layer_cache
         .cache()
@@ -82,7 +85,7 @@ async fn get_bulk_inserts() {
     ];
 
     for value in &values {
-        layer_cache.insert(value.clone().into(), value.to_string());
+        layer_cache.insert(value.clone().into(), value.to_string(), value.len());
     }
 
     let get_values = layer_cache


### PR DESCRIPTION
This change addresses an issue when inserting a Rust type into a Foyer cache, where the memory used by that rust variable was not being accurately calculated. Prior to this change, the `size_of_val()` would dereference one level of "smart pointers" (i.e. deref an `Arc`, or `Vec`, or `String`), but no more levels. This led to an undercount of memory for that Rust value. For example, perhaps a workspace snapshot that was 30mb in size would be incorrectly calculated as 5mb.

As determining the size of an arbitrary Rust object is surprisingly difficult, we opted to use the *uncompressed* size of serialized Postcard bytes as our "size hint" (note that Postcard adds very little extra information into the stream of bytes, so could be considered as a very close approximation) and to provide this size hint to Foyer's `with_weighter()` configuration. In our caches, when we have a `MaybeDeserialized::RawBytes` variant, the size of its Bytes is the size of that value (and so can be used directly).

<img src="https://media1.giphy.com/media/UvOaWabxo1enu/giphy.gif"/>