### PR TITLE
Add pgbouncer to forklift in tools

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
   pgbouncer:
     container_name: pgbouncer
     image: systeminit/pgbouncer:${INIT_VERSION:-stable}
-    profiles: [rebaser, pinga, sdf]
+    profiles: [rebaser, pinga, sdf, forklift]
     ports:
       - 5432:5432
     volumes:


### PR DESCRIPTION
## Description

This PR adds `pgbouncer` to forklift in tools. We did the math for tools with the configurable pool size and how many instances/replicas are running. We should be fine... in theory!

<img src="https://media1.giphy.com/media/26vUyGHlrt8dKLGgM/giphy.gif"/>