### PR TITLE
Bug-676: add/remove the padding for the diagram based on left drawer collapsed state

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramControls.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramControls.vue
@@ -104,7 +104,8 @@ const roundedZoomPercent = computed(() => Math.round(zoomLevel.value * 100));
 const leftPx = computed(() => {
   const minPanelWidth = 230;
   let base = 16;
-  base += presenceStore.leftResizePanelWidth - minPanelWidth;
+  if (presenceStore.leftResizePanelWidth > 0)
+    base += presenceStore.leftResizePanelWidth - minPanelWidth;
   if (presenceStore.leftDrawerOpen) base += 230;
   return base;
 });

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -5,7 +5,7 @@ overflow hidden */
   <div
     class="grow h-full relative bg-neutral-50 dark:bg-neutral-900"
     :style="{
-      marginLeft: '230px', // related to left panel drawer
+      marginLeft: presenceStore.leftResizePanelWidth === 0 ? '0' : '230px', // related to left panel drawer
     }"
   >
     <!-- This section contains the DiagramGridBackground and other elements which should render underneath all of the components/frames/cursors -->

--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -3,7 +3,10 @@
   <!-- Left Panel - views drawer and outline + asset palette -->
   <section
     class="absolute flex flex-row h-full"
-    :style="{ left: drawerLeftPos + 'px', transition: 'left 0.15s ease-out' }"
+    :style="{
+      left: drawerLeftPos + 'px',
+      transition: 'left 0.15s ease-out',
+    }"
   >
     <LeftPanelDrawer
       v-if="featureFlagsStore.OUTLINER_VIEWS"

--- a/lib/vue-lib/src/design-system/panels/ResizablePanel.vue
+++ b/lib/vue-lib/src/design-system/panels/ResizablePanel.vue
@@ -238,6 +238,12 @@ const collapseSet = (collapse: boolean) => {
   if (!collapsed.value) {
     panelOpeningFromCollapse.value = true;
     panelOpeningFromCollapseTimeout.value = window.setTimeout(() => {
+      emit("sizeSet", displaySize.value);
+      panelOpeningFromCollapse.value = false;
+    }, PANEL_COLLAPSE_HIDE_CONTENT_TIME);
+  } else {
+    panelOpeningFromCollapseTimeout.value = window.setTimeout(() => {
+      emit("sizeSet", displaySize.value);
       panelOpeningFromCollapse.value = false;
     }, PANEL_COLLAPSE_HIDE_CONTENT_TIME);
   }


### PR DESCRIPTION
I'm not entirely happy with the animation flash underneath, but this solves the worst of the problem
