### PR TITLE
fix: incorrectly handle io error with fail to load credential profile

### DIFF
--- a/lib/module-index-server/src/server.rs
+++ b/lib/module-index-server/src/server.rs
@@ -91,7 +91,9 @@ impl Server<(), ()> {
                     // Attempt to load from local AWS Profile
                     match AwsCredentials::from_profile(None) {
                         Ok(creds) => creds,
-                        Err(CredentialsError::ConfigNotFound) => {
+                        Err(CredentialsError::ConfigNotFound)
+                        | Err(CredentialsError::Io(_))
+                        | Err(CredentialsError::Ini(_)) => {
                             // Attempt to load from instance metadata
                             match AwsCredentials::from_instance_metadata() {
                                 Ok(creds) => creds,


### PR DESCRIPTION
Handle IO errors when loading from profile in module index.