### PR TITLE
feat: add resourcePayloadToValue by default to all variants

### DIFF
--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -25,8 +25,8 @@ use crate::workspace_snapshot::node_weight::category_node_weight::CategoryNodeKi
 use crate::workspace_snapshot::node_weight::{FuncNodeWeight, NodeWeight, NodeWeightError};
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
-    id, implement_add_edge_to, ChangeSetId, DalContext, HelperError, Timestamp, TransactionsError,
-    WsEvent, WsEventResult, WsPayload,
+    id, implement_add_edge_to, pkg, ChangeSetId, DalContext, HelperError, Timestamp,
+    TransactionsError, WsEvent, WsEventResult, WsPayload,
 };
 
 use self::backend::{FuncBackendKind, FuncBackendResponseType};
@@ -37,6 +37,7 @@ pub mod backend;
 pub mod binding;
 pub mod intrinsics;
 mod kind;
+pub mod resource_payload_to_value;
 pub mod runner;
 pub use kind::FuncKind;
 
@@ -75,6 +76,12 @@ pub enum FuncError {
     LayerDb(#[from] si_layer_cache::LayerDbError),
     #[error("node weight error: {0}")]
     NodeWeight(#[from] NodeWeightError),
+    #[error("si pkg error: {0}")]
+    Pkg(#[from] Box<pkg::PkgError>),
+    #[error("pkg error: {0}")]
+    SiPkg(#[from] si_pkg::SiPkgError),
+    #[error("pkg spec error: {0}")]
+    Spec(#[from] si_pkg::SpecError),
     #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),
     #[error("could not acquire lock: {0}")]

--- a/lib/dal/src/func/resource_payload_to_value.rs
+++ b/lib/dal/src/func/resource_payload_to_value.rs
@@ -1,0 +1,62 @@
+use crate::{pkg::import_pkg_from_pkg, DalContext};
+use chrono::DateTime;
+use si_pkg::{
+    FuncArgumentKind, FuncArgumentSpec, FuncSpec, FuncSpecBackendKind, FuncSpecBackendResponseType,
+    FuncSpecData, PkgSpec, SiPkg,
+};
+
+use crate::func::{FuncError, FuncResult};
+
+use super::Func;
+
+pub fn build_resource_payload_to_value_pkg() -> FuncResult<PkgSpec> {
+    let payload_to_val = "async function main(arg: Input): Promise<Output> {
+  return arg.payload ?? {};
+}";
+    let fn_name = "si:resourcePayloadToValue";
+    let payload_to_val = FuncSpec::builder()
+        .name(fn_name)
+        .unique_id(fn_name)
+        .data(
+            FuncSpecData::builder()
+                .name(fn_name)
+                .code_plaintext(payload_to_val)
+                .handler("main")
+                .backend_kind(FuncSpecBackendKind::JsAttribute)
+                .response_type(FuncSpecBackendResponseType::Object)
+                .build()?,
+        )
+        .argument(
+            FuncArgumentSpec::builder()
+                .name("payload")
+                .kind(FuncArgumentKind::Object)
+                .build()?,
+        )
+        .build()?;
+
+    let mut builder = PkgSpec::builder();
+    builder.name("si-resource-payload-to-value");
+    builder.version("2024-11-22");
+    builder.created_at(DateTime::parse_from_rfc2822(
+        "Fri, 22 Nov 2024 00:00:00 EDT",
+    )?);
+    builder.created_by("System Initiative");
+    builder.func(payload_to_val);
+
+    builder
+        .build()
+        .map_err(|e| FuncError::IntrinsicSpecCreation(e.to_string()))
+}
+
+pub async fn install_resource_payload_to_value_if_missing(ctx: &DalContext) -> FuncResult<()> {
+    if Func::find_id_by_name(ctx, "si:resourcePayloadToValue")
+        .await?
+        .is_none()
+    {
+        let spec = build_resource_payload_to_value_pkg()?;
+        import_pkg_from_pkg(ctx, &SiPkg::load_from_spec(spec)?, None)
+            .await
+            .map_err(Box::new)?;
+    }
+    Ok(())
+}

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -24,6 +24,7 @@ use crate::attribute::prototype::argument::AttributePrototypeArgumentError;
 use crate::attribute::prototype::AttributePrototypeError;
 use crate::func::authoring::FuncAuthoringError;
 use crate::func::intrinsics::IntrinsicFunc;
+use crate::func::resource_payload_to_value::install_resource_payload_to_value_if_missing;
 use crate::func::runner::{FuncRunner, FuncRunnerError};
 use crate::pkg::export::PkgExporter;
 use crate::pkg::import::import_only_new_funcs;
@@ -139,6 +140,8 @@ impl VariantAuthoringClient {
         if Schema::is_name_taken(ctx, &name).await? {
             return Err(VariantAuthoringError::DuplicatedSchemaName(name));
         };
+
+        install_resource_payload_to_value_if_missing(ctx).await?;
 
         let variant_version = SchemaVariant::generate_version_string();
 


### PR DESCRIPTION
This ensure that `si:resourcePayloadToValue` is always added to new variants. This is a stub approach in favor of the more complicated effort of making this an Intrinsic function. That work as been started [here](https://github.com/systeminit/si/tree/resource_to_payload). 

Intrinsics are not installed in existing workspaces, so there are edges around managing the existing javascript function and the new intrinsic. That work is better pushed off until after the upcoming holiday.