### PR TITLE
feat: management functions understand views

### DIFF
--- a/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
+++ b/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
@@ -433,10 +433,12 @@ const rightClickMenuItems = computed(() => {
 
 const runManagementFunc = async (prototype: MgmtPrototype) => {
   if (!selectedComponent.value) return;
+  if (!viewStore.selectedViewId) return;
 
   const result = await funcStore.RUN_MGMT_PROTOTYPE(
     prototype.managementPrototypeId,
     selectedComponent.value.def.id,
+    viewStore.selectedViewId,
   );
 
   if (result.result.success && result.result.data.message) {

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -31,6 +31,7 @@ import { useAssetStore } from "@/store/asset.store";
 import { SchemaVariant, SchemaVariantId } from "@/api/sdf/dal/schema";
 import { DefaultMap } from "@/utils/defaultmap";
 import { ComponentId } from "@/api/sdf/dal/component";
+import { ViewId } from "@/api/sdf/dal/views";
 import { useChangeSetsStore } from "../change_sets.store";
 import { useRealtimeStore } from "../realtime/realtime.store";
 import { useComponentsStore } from "../components.store";
@@ -287,6 +288,7 @@ export const useFuncStore = () => {
         async RUN_MGMT_PROTOTYPE(
           prototypeId: ManagementPrototypeId,
           componentId: ComponentId,
+          viewId: ViewId,
         ) {
           return new ApiRequest<MgmtPrototypeResult>({
             method: "post",
@@ -296,6 +298,7 @@ export const useFuncStore = () => {
               "prototype",
               { prototypeId },
               { componentId },
+              { viewId },
             ]),
           });
         },

--- a/bin/lang-js/src/component.ts
+++ b/bin/lang-js/src/component.ts
@@ -4,13 +4,13 @@ export interface Component {
 }
 
 export interface Geometry {
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
   width?: number;
   height?: number;
 }
 
 export interface ComponentWithGeometry {
   properties: Record<string, unknown>;
-  geometry: Geometry;
+  geometry: { [key: string]: Geometry };
 }

--- a/bin/lang-js/src/function_kinds/management.ts
+++ b/bin/lang-js/src/function_kinds/management.ts
@@ -13,6 +13,7 @@ import { RequestCtx } from "../request";
 const debug = Debug("langJs:management");
 
 export interface ManagementFunc extends Func {
+  currentView: string;
   thisComponent: ComponentWithGeometry;
   components: {
     [key: string]: ComponentWithGeometry;
@@ -20,8 +21,8 @@ export interface ManagementFunc extends Func {
 }
 
 export type ManagementFuncResult =
-    | ManagementFuncResultSuccess
-    | ManagementFuncResultFailure;
+  | ManagementFuncResultSuccess
+  | ManagementFuncResultFailure;
 
 export interface ManagmentConnect {
   from: string,
@@ -32,22 +33,26 @@ export interface ManagmentConnect {
 }
 
 export interface ManagementOperations {
-  create?: { [key: string]: {
-    kind: string;
-    properties?: object;
-    geometry?: Geometry;
-    parent?: string;
-    connect?: ManagmentConnect[],
-  } };
-  update?: { [key: string]: {
-    properties?: object;
-    geometry?: Geometry;
-    parent?: string;
-    connect: {
-      add?: ManagmentConnect[],
-      remove?: ManagmentConnect[],
+  create?: {
+    [key: string]: {
+      kind: string;
+      properties?: object;
+      geometry?: Geometry;
+      parent?: string;
+      connect?: ManagmentConnect[],
     }
-  } };
+  };
+  update?: {
+    [key: string]: {
+      properties?: object;
+      geometry?: { [key: string]: Geometry };
+      parent?: string;
+      connect: {
+        add?: ManagmentConnect[],
+        remove?: ManagmentConnect[],
+      }
+    }
+  };
   actions?: {
     [key: string]: {
       add?: string[],
@@ -66,14 +71,14 @@ export interface ManagementFuncResultFailure extends ResultFailure { }
 async function execute(
   vm: NodeVM,
   { executionId }: RequestCtx,
-  { thisComponent, components }: ManagementFunc,
+  { thisComponent, components, currentView }: ManagementFunc,
   code: string,
 ): Promise<ManagementFuncResult> {
   let managementResult: Record<string, unknown> | undefined | null;
   try {
     const runner = vm.run(code);
     managementResult = await new Promise((resolve) => {
-      runner({ thisComponent, components }, (resolution: Record<string, unknown>) => resolve(resolution));
+      runner({ thisComponent, components, currentView }, (resolution: Record<string, unknown>) => resolve(resolution));
     });
   } catch (err) {
     return failureExecution(err as Error, executionId);

--- a/lib/cyclone-client/src/client.rs
+++ b/lib/cyclone-client/src/client.rs
@@ -1325,6 +1325,7 @@ mod tests {
         let req = ManagementRequest {
             execution_id: "1234".to_string(),
             handler: "manage".to_string(),
+            current_view: "DEFAULT".to_string(),
             this_component: ComponentViewWithGeometry {
                 kind: None,
                 properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),
@@ -1409,6 +1410,7 @@ mod tests {
         let req = ManagementRequest {
             execution_id: "1234".to_string(),
             handler: "manage".to_string(),
+            current_view: "DEFAULT".to_string(),
             this_component: ComponentViewWithGeometry {
                 kind: None,
                 properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),

--- a/lib/cyclone-core/src/management.rs
+++ b/lib/cyclone-core/src/management.rs
@@ -12,6 +12,7 @@ pub struct ManagementRequest {
     pub execution_id: String,
     pub handler: String,
     pub code_base64: String,
+    pub current_view: String,
     pub this_component: ComponentViewWithGeometry,
     pub components: HashMap<String, ComponentViewWithGeometry>,
     pub before: Vec<BeforeFunction>,

--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -880,4 +880,8 @@ impl ExpectView {
         let name = generate_fake_name();
         View::new(ctx, name).await.expect("create view")
     }
+
+    pub async fn create_with_name(ctx: &DalContext, name: &str) -> View {
+        View::new(ctx, name).await.expect("create view")
+    }
 }

--- a/lib/dal/src/diagram/geometry.rs
+++ b/lib/dal/src/diagram/geometry.rs
@@ -62,20 +62,20 @@ impl Geometry {
         self.id
     }
 
-    pub fn x(&self) -> &isize {
-        &self.x
+    pub fn x(&self) -> isize {
+        self.x
     }
 
-    pub fn y(&self) -> &isize {
-        &self.y
+    pub fn y(&self) -> isize {
+        self.y
     }
 
-    pub fn width(&self) -> Option<&isize> {
-        self.width.as_ref()
+    pub fn width(&self) -> Option<isize> {
+        self.width
     }
 
-    pub fn height(&self) -> Option<&isize> {
-        self.height.as_ref()
+    pub fn height(&self) -> Option<isize> {
+        self.height
     }
 
     fn assemble(node_weight: GeometryNodeWeight, content: GeometryContent) -> Self {

--- a/lib/dal/src/func/backend/management.rs
+++ b/lib/dal/src/func/backend/management.rs
@@ -15,6 +15,7 @@ use super::ExtractPayload;
 pub struct FuncBackendManagementArgs {
     this_component: ComponentViewWithGeometry,
     components: HashMap<String, ComponentViewWithGeometry>,
+    current_view: String,
 }
 
 #[derive(Debug)]
@@ -41,6 +42,7 @@ impl FuncDispatch for FuncBackendManagement {
             code_base64: code_base64.into(),
             this_component: args.this_component,
             components: args.components,
+            current_view: args.current_view,
             before,
         };
 

--- a/lib/dal/src/schema/variant/root_prop/component_type.rs
+++ b/lib/dal/src/schema/variant/root_prop/component_type.rs
@@ -106,4 +106,11 @@ impl ComponentType {
             Self::ConfigurationFrameUp => "Configuration Frame (up)",
         }
     }
+
+    pub fn is_frame(&self) -> bool {
+        matches!(
+            self,
+            Self::AggregationFrame | Self::ConfigurationFrameDown | Self::ConfigurationFrameUp
+        )
+    }
 }

--- a/lib/dal/tests/integration_test/secret.rs
+++ b/lib/dal/tests/integration_test/secret.rs
@@ -314,8 +314,8 @@ async fn copy_paste_component_with_secrets_being_used(ctx: &mut DalContext, nw: 
                 ctx,
                 default_view_id,
                 RawGeometry {
-                    x: *geometry.x(),
-                    y: *geometry.y(),
+                    x: geometry.x(),
+                    y: geometry.y(),
                     width: None,
                     height: None,
                 },
@@ -340,8 +340,8 @@ async fn copy_paste_component_with_secrets_being_used(ctx: &mut DalContext, nw: 
             ctx,
             default_view_id,
             RawGeometry {
-                x: *user_component_geometry.x(),
-                y: *user_component_geometry.y(),
+                x: user_component_geometry.x(),
+                y: user_component_geometry.y(),
                 width: None,
                 height: None,
             },

--- a/lib/sdf-server/src/service/diagram/create_component.rs
+++ b/lib/sdf-server/src/service/diagram/create_component.rs
@@ -132,8 +132,8 @@ pub async fn create_component(
                 view_id,
                 x,
                 y,
-                width.or_else(|| initial_geometry.width().copied()),
-                height.or_else(|| initial_geometry.height().copied()),
+                width.or_else(|| initial_geometry.width()),
+                height.or_else(|| initial_geometry.height()),
             )
             .await?;
     } else {

--- a/lib/sdf-server/src/service/diagram/set_component_position.rs
+++ b/lib/sdf-server/src/service/diagram/set_component_position.rs
@@ -126,8 +126,8 @@ pub async fn set_component_position(
 
             if component_type != ComponentType::Component {
                 size = (
-                    new_geometry.width.or_else(|| geometry.width().copied()),
-                    new_geometry.height.or_else(|| geometry.height().copied()),
+                    new_geometry.width.or_else(|| geometry.width()),
+                    new_geometry.height.or_else(|| geometry.height()),
                 );
             }
 

--- a/lib/sdf-server/src/service/v2/view/create_component.rs
+++ b/lib/sdf-server/src/service/v2/view/create_component.rs
@@ -161,8 +161,8 @@ pub async fn create_component(
                 view_id,
                 x,
                 y,
-                width.or_else(|| initial_geometry.width().copied()),
-                height.or_else(|| initial_geometry.height().copied()),
+                width.or_else(|| initial_geometry.width()),
+                height.or_else(|| initial_geometry.height()),
             )
             .await?;
     } else {

--- a/lib/sdf-server/src/service/v2/view/set_component_geometry.rs
+++ b/lib/sdf-server/src/service/v2/view/set_component_geometry.rs
@@ -49,12 +49,8 @@ pub async fn set_component_geometry(
         let new_geometry_cache = new_geometry.clone();
 
         let (width, height) = (
-            new_geometry
-                .width
-                .or_else(|| current_geometry.width().copied()),
-            new_geometry
-                .height
-                .or_else(|| current_geometry.height().copied()),
+            new_geometry.width.or_else(|| current_geometry.width()),
+            new_geometry.height.or_else(|| current_geometry.height()),
         );
 
         component

--- a/lib/veritech-client/tests/integration.rs
+++ b/lib/veritech-client/tests/integration.rs
@@ -105,6 +105,7 @@ async fn executes_simple_management_function() {
     let request = ManagementRequest {
         execution_id: "1234".to_string(),
         handler: "numberOfInputs".to_string(),
+        current_view: "DEFAULT".to_string(),
         this_component: ComponentViewWithGeometry {
             kind: None,
             properties: serde_json::json!({ "foo": "bar", "baz": "quux", "bar": "foo" }),


### PR DESCRIPTION
Management funcs are now run in the context of a view. They can only create components in that view. But they can manage components in other views. The position of created components is relative to the manager component, but the position specified in updates is absolute.

If a manager component is in more than one view, a the "play" button will open a dropdown allowing you to select the view to run the function in.

This also makes position (x,y) optional, allowing you to update just the size of a component.