### PR TITLE
fix: ensure already installed assets not treated as uninstalled

### DIFF
--- a/lib/sdf-server/src/service/v2/variant.rs
+++ b/lib/sdf-server/src/service/v2/variant.rs
@@ -4,7 +4,10 @@ use axum::{
     routing::{delete, get, post},
     Router,
 };
-use dal::{cached_module::CachedModuleError, ChangeSetError, SchemaVariantId, WsEventError};
+use dal::{
+    cached_module::CachedModuleError, module::ModuleError, ChangeSetError, SchemaVariantId,
+    WsEventError,
+};
 use telemetry::prelude::*;
 use thiserror::Error;
 
@@ -28,6 +31,8 @@ pub enum SchemaVariantsAPIError {
     ChangeSet(#[from] ChangeSetError),
     #[error("hyper error: {0}")]
     Http(#[from] axum::http::Error),
+    #[error("Module error: {0}")]
+    Module(#[from] ModuleError),
     #[error("schema variant error: {0}")]
     SchemaVariant(#[from] dal::SchemaVariantError),
     #[error("serde json error: {0}")]


### PR DESCRIPTION
Checks the uninstalled asset list against the modules in the graph, so that we don't show assets that are actually already installed when on demand assets is enabled.

Will not eliminate all the duplicates that show on old workspaces, but will hide all the ones that cannot be used.