### PR TITLE
fix: eliminate temporary duplicate after install on demand

### DIFF
--- a/app/web/src/store/asset.store.ts
+++ b/app/web/src/store/asset.store.ts
@@ -712,6 +712,12 @@ export const useAssetStore = (forceChangeSetId?: ChangeSetId) => {
               if (metadata.change_set_id !== changeSetId) return;
 
               for (const variant of schemaVariants) {
+                this.uninstalledVariantList =
+                  this.uninstalledVariantList.filter(
+                    (uninstalledVariant) =>
+                      uninstalledVariant.schemaId !== variant.schemaId,
+                  );
+
                 const savedAssetIdx = this.variantList.findIndex(
                   (a) => a.schemaId === variant.schemaId,
                 );

--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -51,7 +51,6 @@ import {
 import { useComponentsStore, processRawComponent } from "./components.store";
 import { useRealtimeStore } from "./realtime/realtime.store";
 import { useWorkspacesStore } from "./workspaces.store";
-import { useAssetStore } from "./asset.store";
 import { useRouterStore } from "./router.store";
 import { useQualificationsStore } from "./qualifications.store";
 
@@ -1317,18 +1316,6 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
             },
             onSuccess: (response) => {
               delete this.pendingInsertedComponents[tempInsertId];
-              if (
-                categoryVariant.type === "uninstalled" &&
-                response.installedVariant
-              ) {
-                const assetStore = useAssetStore();
-                const installedVariant = response.installedVariant;
-                assetStore.uninstalledVariantList =
-                  assetStore.uninstalledVariantList.filter(
-                    (variant) => variant.schemaId !== installedVariant.schemaId,
-                  );
-                assetStore.schemaVariants.push(installedVariant);
-              }
             },
           });
         },


### PR DESCRIPTION
WsEvent reaction did not account for uninstalled variant list. This ensures the first install of an asset does not list the asset twice.