### PR TITLE
fix(web): Ensure we can always promote / reject builtins

### DIFF
--- a/app/web/src/components/modules/ModuleListPanel.vue
+++ b/app/web/src/components/modules/ModuleListPanel.vue
@@ -11,12 +11,12 @@
     />
 
     <ModuleList
-      label="Local / Installed"
-      :modules="filteredLocalModules"
-      :loading="loadLocalModulesReqStatus"
-      loadingMessage="Loading local modules..."
+      label="Builtin List"
+      :modules="filteredBuiltins"
+      :loading="loadBuiltinsReqStatus"
+      loadingMessage="Loading builtins..."
       :textSearch="textSearch"
-      noModulesMessage="No modules installed"
+      noModulesMessage="No builtins found"
     />
 
     <ModuleList
@@ -38,18 +38,17 @@ import ModuleList from "./ModuleList.vue";
 import SidebarSubpanelTitle from "../SidebarSubpanelTitle.vue";
 
 const moduleStore = useModuleStore();
-const loadLocalModulesReqStatus =
-  moduleStore.getRequestStatus("LOAD_LOCAL_MODULES");
+const loadBuiltinsReqStatus = moduleStore.getRequestStatus("LIST_BUILTINS");
 const searchRemoteModulesReqStatus = moduleStore.getRequestStatus(
   "GET_REMOTE_MODULES_LIST",
 );
 
 const textSearch = ref("");
 
-const filteredLocalModules = computed(() => {
-  if (!textSearch.value) return moduleStore.localModules;
+const filteredBuiltins = computed(() => {
+  if (!textSearch.value) return moduleStore.builtins;
 
-  return _.filter(moduleStore.localModules, (m) =>
+  return _.filter(moduleStore.builtins, (m) =>
     m.name.toLowerCase().includes(textSearch.value.toLowerCase()),
   );
 });

--- a/app/web/src/store/module.store.ts
+++ b/app/web/src/store/module.store.ts
@@ -186,6 +186,7 @@ export const useModuleStore = () => {
               (m) => m.hash,
             );
           },
+          builtins: (state) => _.values(state.builtinsSearchResults),
           builtinModuleSummaryByHash: (state) =>
             _.keyBy(state.builtinsSearchResults, (m) => m.hash),
           builtinModuleDetailsByHash: (state) =>


### PR DESCRIPTION
When on an on-demand installation workspace, we lost the ability to promote / reject the builtins as we no longer had all of the modules installed anymore

We have replaced the modules list with the ability to see builtins - this is something we have feature flagged for SI cohort at this time