### PR TITLE
Add SDF endpoints to update AI gen prompts on the server

### DIFF
--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -47,6 +47,7 @@ pub mod layer_db_types;
 pub mod management;
 pub mod module;
 pub mod pkg;
+pub mod prompt_override;
 pub mod prop;
 pub mod property_editor;
 pub mod qualification;

--- a/lib/dal/src/migrations/U3402__prompt_overrides.sql
+++ b/lib/dal/src/migrations/U3402__prompt_overrides.sql
@@ -1,0 +1,5 @@
+CREATE TABLE prompt_overrides 
+(
+    kind                        VARCHAR(255)             NOT NULL PRIMARY KEY,
+    prompt_yaml                 TEXT                     NOT NULL
+);

--- a/lib/dal/src/prompt_override.rs
+++ b/lib/dal/src/prompt_override.rs
@@ -1,0 +1,127 @@
+use crate::{DalContext, WsEvent, WsEventResult, WsPayload};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum PromptOverrideError {
+    #[error("pg error: {0}")]
+    Pg(#[from] si_data_pg::PgError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] crate::TransactionsError),
+    #[error("ws event error: {0}")]
+    WsEvent(#[from] crate::WsEventError),
+}
+
+pub type Result<T> = std::result::Result<T, PromptOverrideError>;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptUpdatedPayload {
+    pub kind: String,
+    pub overridden: bool,
+}
+
+impl WsEvent {
+    pub async fn prompt_updated(
+        ctx: &DalContext,
+        kind: String,
+        overridden: bool,
+    ) -> WsEventResult<Self> {
+        WsEvent::new(
+            ctx,
+            WsPayload::PromptUpdated(PromptUpdatedPayload { kind, overridden }),
+        )
+        .await
+    }
+}
+
+pub struct PromptOverride;
+
+impl PromptOverride {
+    pub async fn list(ctx: &DalContext) -> Result<HashSet<String>> {
+        let rows = ctx
+            .txns()
+            .await?
+            .pg()
+            .query(
+                "
+                    SELECT kind FROM prompt_overrides
+                ",
+                &[],
+            )
+            .await?;
+        let mut result = HashSet::with_capacity(rows.len());
+        for row in rows {
+            result.insert(row.try_get(0)?);
+        }
+        Ok(result)
+    }
+
+    pub async fn get_opt(ctx: &DalContext, kind: &str) -> Result<Option<String>> {
+        match ctx
+            .txns()
+            .await?
+            .pg()
+            .query_opt(
+                "
+                    SELECT prompt_yaml FROM prompt_overrides WHERE kind = $1
+                ",
+                &[&kind],
+            )
+            .await?
+        {
+            Some(row) => Ok(Some(row.try_get(0)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn set(ctx: &DalContext, kind: &str, prompt: &str) -> Result<()> {
+        ctx.txns()
+            .await?
+            .pg()
+            .execute(
+                "
+                    INSERT INTO prompt_overrides
+                        (kind, prompt_yaml)
+                        VALUES
+                        ($1, $2)
+                    ON CONFLICT (kind) DO
+                    UPDATE SET prompt_yaml = $2
+                ",
+                &[&kind, &prompt],
+            )
+            .await?;
+
+        WsEvent::prompt_updated(ctx, kind.to_owned(), true)
+            .await?
+            .publish_immediately(ctx)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn reset(ctx: &DalContext, kind: &str) -> Result<bool> {
+        let deleted = ctx
+            .txns()
+            .await?
+            .pg()
+            .execute(
+                "
+                DELETE FROM prompt_overrides WHERE kind = $1
+            ",
+                &[&kind],
+            )
+            .await?;
+        if deleted > 0 {
+            WsEvent::prompt_updated(ctx, kind.to_owned(), false)
+                .await?
+                .publish_immediately(ctx)
+                .await?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -26,6 +26,7 @@ use crate::management::prototype::ManagementFuncExecutedPayload;
 use crate::pkg::{
     ImportWorkspaceVotePayload, WorkspaceActorPayload, WorkspaceImportApprovalActorPayload,
 };
+use crate::prompt_override::PromptUpdatedPayload;
 use crate::qualification::QualificationCheckPayload;
 use crate::schema::variant::{
     SchemaVariantClonedPayload, SchemaVariantDeletedPayload, SchemaVariantReplacedPayload,
@@ -110,6 +111,7 @@ pub enum WsPayload {
     ManagementFuncExecuted(ManagementFuncExecutedPayload),
     ModuleImported(Vec<si_frontend_types::SchemaVariant>),
     Online(OnlinePayload),
+    PromptUpdated(PromptUpdatedPayload),
     ResourceRefreshed(ComponentUpdatedPayload),
     SchemaVariantCloned(SchemaVariantClonedPayload),
     SchemaVariantCreated(frontend_types::SchemaVariant),

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -16,6 +16,7 @@ mod management;
 mod module;
 mod node_weight;
 mod pkg;
+mod prompt_overrides;
 mod prop;
 mod property_editor;
 mod qualifications;

--- a/lib/dal/tests/integration_test/prompt_overrides.rs
+++ b/lib/dal/tests/integration_test/prompt_overrides.rs
@@ -1,0 +1,72 @@
+use std::collections::HashSet;
+
+use dal::prompt_override::PromptOverride;
+use dal::DalContext;
+use dal_test::{color_eyre::Result, test};
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn update_prompt(ctx: &mut DalContext) -> Result<()> {
+    // Add prompt
+    assert_eq!(PromptOverride::list(ctx).await?, HashSet::new());
+    assert_eq!(PromptOverride::get_opt(ctx, "AssetSchema").await?, None);
+
+    // Add prompt
+    PromptOverride::set(ctx, "AssetSchema", "hi 1").await?;
+    assert_eq!(
+        PromptOverride::list(ctx).await?,
+        ["AssetSchema"].into_iter().map(ToOwned::to_owned).collect()
+    );
+    assert_eq!(
+        PromptOverride::get_opt(ctx, "AssetSchema").await?,
+        Some("hi 1".to_string())
+    );
+
+    // Update prompt
+    PromptOverride::set(ctx, "AssetSchema", "hi 2").await?;
+    assert_eq!(
+        PromptOverride::list(ctx).await?,
+        ["AssetSchema"].into_iter().map(ToOwned::to_owned).collect()
+    );
+    assert_eq!(
+        PromptOverride::get_opt(ctx, "AssetSchema").await?,
+        Some("hi 2".to_string())
+    );
+
+    // Reset prompt
+    PromptOverride::reset(ctx, "AssetSchema").await?;
+    assert_eq!(PromptOverride::list(ctx).await?, HashSet::new());
+    assert_eq!(PromptOverride::get_opt(ctx, "AssetSchema").await?, None);
+
+    // Reset prompt that doesn't exist
+    PromptOverride::reset(ctx, "AssetSchema").await?;
+    assert_eq!(PromptOverride::list(ctx).await?, HashSet::new());
+    assert_eq!(PromptOverride::get_opt(ctx, "AssetSchema").await?, None);
+
+    // Add prompt back
+    PromptOverride::set(ctx, "AssetSchema", "hi 3").await?;
+    assert_eq!(
+        PromptOverride::list(ctx).await?,
+        ["AssetSchema"].into_iter().map(ToOwned::to_owned).collect()
+    );
+    assert_eq!(
+        PromptOverride::get_opt(ctx, "AssetSchema").await?,
+        Some("hi 3".to_string())
+    );
+
+    // Add another prompt
+    PromptOverride::set(ctx, "CreateAction", "hi 3").await?;
+    assert_eq!(
+        PromptOverride::list(ctx).await?,
+        ["AssetSchema", "CreateAction"]
+            .into_iter()
+            .map(ToOwned::to_owned)
+            .collect()
+    );
+    assert_eq!(
+        PromptOverride::get_opt(ctx, "AssetSchema").await?,
+        Some("hi 3".to_string())
+    );
+
+    Ok(())
+}

--- a/lib/sdf-server/src/service/v2/admin.rs
+++ b/lib/sdf-server/src/service/v2/admin.rs
@@ -21,6 +21,7 @@ mod get_snapshot;
 mod kill_execution;
 mod list_change_sets;
 mod list_workspace_users;
+mod prompts;
 mod search_workspaces;
 mod set_concurrency_limit;
 mod set_snapshot;
@@ -187,6 +188,7 @@ pub fn v2_routes(state: AppState) -> Router<AppState> {
             "/workspaces/:workspace_pk/change_sets/:change_set_id/set_snapshot",
             post(set_snapshot::set_snapshot),
         )
+        .nest("/prompts", prompts::routes())
         .layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES))
         .route_layer(axum::middleware::from_extractor_with_state::<
             AdminAccessBuilder,

--- a/lib/sdf-server/src/service/v2/admin/prompts.rs
+++ b/lib/sdf-server/src/service/v2/admin/prompts.rs
@@ -1,0 +1,72 @@
+use asset_sprayer::prompt::AwsCliCommandPromptKind;
+use axum::{
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use dal::prompt_override::PromptOverride;
+use serde::{Deserialize, Serialize};
+use strum::IntoEnumIterator;
+use thiserror::Error;
+
+use crate::{
+    extract::{AccessBuilder, HandlerContext},
+    service::ApiError,
+    AppState,
+};
+
+mod prompt;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum PromptAPIError {
+    #[error("asset sprayer error: {0}")]
+    AssetSprayer(#[from] asset_sprayer::AssetSprayerError),
+    #[error("prompt override error: {0}")]
+    PromptOverride(#[from] dal::prompt_override::PromptOverrideError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] dal::TransactionsError),
+}
+
+pub type Result<T> = std::result::Result<T, PromptAPIError>;
+
+impl IntoResponse for PromptAPIError {
+    fn into_response(self) -> Response {
+        let err_string = self.to_string();
+
+        #[allow(clippy::match_single_binding)]
+        let (status_code, maybe_message) = match self {
+            _ => (ApiError::DEFAULT_ERROR_STATUS_CODE, None),
+        };
+
+        ApiError::new(status_code, maybe_message.unwrap_or(err_string)).into_response()
+    }
+}
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/", get(list_prompts))
+        .nest("/:prompt_kind", prompt::routes())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptListEntry {
+    pub kind: AwsCliCommandPromptKind,
+    pub overridden: bool,
+}
+
+pub async fn list_prompts(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+) -> Result<Json<Vec<PromptListEntry>>> {
+    let ctx = builder.build_head(access_builder).await?;
+    let overrides = PromptOverride::list(&ctx).await?;
+    Ok(Json(
+        AwsCliCommandPromptKind::iter()
+            .map(|kind| PromptListEntry {
+                kind,
+                overridden: overrides.contains(kind.as_ref()),
+            })
+            .collect(),
+    ))
+}

--- a/lib/sdf-server/src/service/v2/admin/prompts/prompt.rs
+++ b/lib/sdf-server/src/service/v2/admin/prompts/prompt.rs
@@ -1,0 +1,70 @@
+use asset_sprayer::prompt::AwsCliCommandPromptKind;
+use axum::{
+    extract::Path,
+    routing::{delete, get, put},
+    Json, Router,
+};
+use dal::prompt_override::PromptOverride;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    extract::{AccessBuilder, AssetSprayer, HandlerContext},
+    AppState,
+};
+
+use super::Result;
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/", get(get_prompt))
+        .route("/", put(set_prompt))
+        .route("/", delete(reset_prompt))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptValue {
+    pub kind: AwsCliCommandPromptKind,
+    pub prompt_yaml: String,
+    pub overridden: bool,
+}
+
+pub async fn get_prompt(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    AssetSprayer(asset_sprayer): AssetSprayer,
+    Path(kind): Path<AwsCliCommandPromptKind>,
+) -> Result<Json<PromptValue>> {
+    let ctx = builder.build_head(access_builder).await?;
+    let prompt_override = PromptOverride::get_opt(&ctx, kind.as_ref()).await?;
+    let overridden = prompt_override.is_some();
+    let prompt_yaml = match prompt_override {
+        Some(prompt_override) => prompt_override,
+        None => asset_sprayer.raw_prompt_yaml(&kind).await?.to_string(),
+    };
+    Ok(Json(PromptValue {
+        kind,
+        prompt_yaml,
+        overridden,
+    }))
+}
+
+pub async fn set_prompt(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    Path(kind): Path<AwsCliCommandPromptKind>,
+    prompt: String,
+) -> Result<()> {
+    let ctx = builder.build_head(access_builder).await?;
+    PromptOverride::set(&ctx, kind.as_ref(), &prompt).await?;
+    Ok(())
+}
+
+pub async fn reset_prompt(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    Path(kind): Path<AwsCliCommandPromptKind>,
+) -> Result<()> {
+    let ctx = builder.build_head(access_builder).await?;
+    PromptOverride::reset(&ctx, kind.as_ref()).await?;
+    Ok(())
+}


### PR DESCRIPTION
This allows prompts to updated (stored in SQL) on the server so that they can be iterated upon. UI forthcoming.