### PR TITLE
fix(web): wait for all components to be loaded into the components.store before hydrating each view's geometry mapping lazily

### DIFF
--- a/app/web/src/components/LeftPanelDrawer.vue
+++ b/app/web/src/components/LeftPanelDrawer.vue
@@ -118,8 +118,9 @@ const create = async () => {
   } else {
     const resp = await viewStore.CREATE_VIEW(viewName.value);
     if (resp.result.success) {
-      viewStore.selectView(resp.result.data.id);
       modalRef.value?.close();
+      viewStore.selectView(resp.result.data.id);
+
       viewName.value = "";
     } else if (resp.result.statusCode === 409) {
       labelRef.value?.setError(


### PR DESCRIPTION
Also calculate socket info when components are moved to/copied to a view so edges render

<div><img src="https://media0.giphy.com/media/a5MFvAwc6GPf2/giphy.gif?cid=5a38a5a2wcxsy1ff3db3uj1yhymycmshs56luxtq6n0r8wtu&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/pusheen/">Pusheen</a> on <a href="https://giphy.com/gifs/cat-cartoon-move-a5MFvAwc6GPf2">GIPHY</a></div>