### PR TITLE
Add an API test for basic authoring scenario

### DIFF
--- a/.github/workflows/run-api-test.yml
+++ b/.github/workflows/run-api-test.yml
@@ -42,9 +42,9 @@ jobs:
           echo "workspace_ids found to be $workspace_ids"
           workspace_count=$(echo "$workspace_ids" | tr ',' '\n' | wc -l)
 
-          # Validate that the number of workspace IDs matches the number of tests
-          if [ "$test_count" -ne "$workspace_count" ]; then
-              echo "Error: The number of workspace IDs ($workspace_count) does not match the number of tests ($test_count)."
+          # Validate that the number of workspace IDs is greater than or equal to the number of tests
+          if [ "$workspace_count" -lt "$test_count" ]; then
+              echo "Error: The number of workspace IDs ($workspace_count) is less than the number of tests ($test_count)."
               exit 1
           fi
 

--- a/bin/si-api-test/test_helpers.ts
+++ b/bin/si-api-test/test_helpers.ts
@@ -1,5 +1,7 @@
 import { SdfApiClient } from "./sdf_api_client.ts";
 import assert from "node:assert";
+import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
+
 
 export function sleep(ms: number) {
   const natural_ms = Math.max(0, Math.floor(ms));
@@ -87,3 +89,241 @@ export async function runWithTemporaryChangeset(
     throw err;
   }
 }
+
+export const nilId = "00000000000000000000000000";
+
+// Diagram Helpers ------------------------------------------------------------
+
+
+export async function getQualificationSummary(sdf: SdfApiClient, changeSetId: string) {
+  return await sdf.call({
+    route: "qualification_summary",
+    routeVars: {
+      workspaceId: sdf.workspaceId,
+      changeSetId,
+    },
+  });
+}
+
+export async function getActions(sdf: SdfApiClient, changeSetId: string) {
+  return await sdf.call({
+    route: "action_list",
+    routeVars: {
+      workspaceId: sdf.workspaceId,
+      changeSetId,
+    },
+  });
+}
+
+export async function getFuncs(sdf: SdfApiClient, changeSetId: string) {
+  return await sdf.call({
+    route: "func_list",
+    routeVars: {
+      workspaceId: sdf.workspaceId,
+      changeSetId,
+    },
+  });
+}
+
+
+// Prop Helpers ------------------------------------------------------------
+
+
+export async function getPropertyEditor(
+  sdf: SdfApiClient,
+  changeSetId: string,
+  componentId: string,
+) {
+  const values = await sdf.call({
+    route: "get_property_values",
+    routeVars: {
+      componentId,
+      changeSetId,
+    },
+  });
+  assert(typeof values?.values === "object", "Expected prop values");
+  assert(typeof values?.childValues === "object", "Expected prop childValues:");
+
+  const schema = await sdf.call({
+    route: "get_property_schema",
+    routeVars: {
+      componentId,
+      changeSetId,
+    },
+  });
+  assert(typeof schema?.rootPropId === "string", "Expected rootPropId");
+  assert(typeof schema?.props === "object", "Expected props");
+  assert(typeof schema?.childProps === "object", "Expected childProps list");
+
+  return {
+    values,
+    schema,
+  };
+}
+
+export async function setAttributeValue(
+  sdf: SdfApiClient,
+  changeSetId: string,
+  componentId: string,
+  attributeValueId: string,
+  parentAttributeValueId: string,
+  propId: string,
+  value: unknown,
+) {
+  const updateValuePayload = {
+    visibility_change_set_pk: changeSetId,
+    componentId,
+    attributeValueId,
+    parentAttributeValueId,
+    propId,
+    value,
+    isForSecret: false,
+  };
+
+  await sdf.call({
+    route: "update_property_value",
+    body: updateValuePayload,
+  });
+}
+
+export function attributeValueIdForPropPath(
+  propPath: string,
+  propList: any[],
+  attributeValuesView: {
+    values: any[];
+    childValues: any[];
+  },
+) {
+  const prop = propList.find((p) => p.path === propPath);
+  assert(prop, `Expected to find ${propPath} prop`);
+
+  let attributeValueId;
+  let value;
+  for (const attributeValue in attributeValuesView.values) {
+    if (attributeValuesView.values[attributeValue]?.propId === prop.id) {
+      attributeValueId = attributeValue;
+      value = attributeValuesView.values[attributeValue]?.value;
+    }
+  }
+  assert(attributeValueId, "Expected source attribute value");
+
+  let parentAttributeValueId;
+  for (const attributeValue in attributeValuesView?.childValues) {
+    const avChildren = attributeValuesView?.childValues[attributeValue] ?? [];
+    if (avChildren.includes(attributeValueId)) {
+      parentAttributeValueId = attributeValue;
+    }
+  }
+  assert(parentAttributeValueId, "Expected parent of source attribute value");
+
+  return {
+    attributeValueId,
+    parentAttributeValueId,
+    propId: prop.id,
+    value,
+  };
+}
+
+
+// Schema Variant Helpers ------------------------------------------------------------
+
+export async function createAsset(
+  sdf: SdfApiClient,
+  changeSetId: string,
+  name: string,
+): Promise<string> {
+  const createAssetPayload = {
+    visibility_change_set_pk: changeSetId,
+    name,
+    color: "#AAFF00",
+  };
+
+  const createResp = await sdf.call({ route: "create_variant", body: createAssetPayload });
+  const schemaVariantId = createResp?.schemaVariantId;
+  assert(schemaVariantId, "Expected to get a schema variant id after creation");
+  return schemaVariantId;
+}
+
+export async function updateAssetCode(
+  sdf: SdfApiClient,
+  changeSetId: string,
+  schemaVariantId: string,
+  newCode: string,
+): Promise<string> {
+  // Get variant
+  const variant = await sdf.call({
+    route: "get_variant", routeVars: {
+      workspaceId: sdf.workspaceId,
+      changeSetId,
+      schemaVariantId,
+    },
+  });
+  // update variant
+  const updateVariantBody = {
+    visibility_change_set_pk: changeSetId,
+    code: newCode,
+    variant,
+  };
+
+  const saveResp = await sdf.call({
+    route: "save_variant",
+    body: updateVariantBody,
+  });
+  const success = saveResp.success;
+  assert(success, "save was successful");
+
+  const regenBody = {
+    visibility_change_set_pk: changeSetId,
+    variant,
+  };
+
+  const regenerateResp = await sdf.call({
+    route: "regenerate_variant",
+    body: regenBody,
+  });
+
+  const maybeNewId = regenerateResp.schemaVariantId;
+  assert(maybeNewId, "Expected to get a schema variant id after regenerate");
+  return maybeNewId;
+}
+
+
+// Component Helpers ------------------------------------------------------------
+
+export async function createComponent(
+  sdf: SdfApiClient,
+  changeSetId: string,
+  schemaVariantId: string,
+  x: number,
+  y: number,
+  parentId?: string,
+  newCreateComponentApi?: boolean,
+): Promise<string> {
+  const parentArgs = parentId ? { parentId } : {};
+  const payload = {
+    schemaType: newCreateComponentApi ? "installed" : undefined,
+    schemaVariantId,
+    x: x.toString(),
+    y: y.toString(),
+    visibility_change_set_pk: changeSetId,
+    workspaceId: sdf.workspaceId,
+    ...parentArgs,
+  };
+  const createResp = await sdf.call({
+    route: "create_component",
+    body: payload,
+  });
+  const componentId = createResp?.componentId;
+  assert(componentId, "Expected to get a component id after creation");
+
+  // Run side effect calls
+  await Promise.all([
+    getQualificationSummary(sdf, changeSetId),
+    getActions(sdf, changeSetId),
+    getFuncs(sdf, changeSetId),
+    getPropertyEditor(sdf, changeSetId, componentId),
+  ]);
+
+  return componentId;
+}
+

--- a/bin/si-api-test/tests/7-emulate_authoring.ts
+++ b/bin/si-api-test/tests/7-emulate_authoring.ts
@@ -1,0 +1,462 @@
+// deno-lint-ignore-file no-explicit-any
+import assert from "node:assert";
+import { SdfApiClient } from "../sdf_api_client.ts";
+import {
+    runWithTemporaryChangeset,
+    sleep,
+    sleepBetween,
+    createComponent,
+    createAsset,
+    updateAssetCode,
+    nilId,
+    getQualificationSummary,
+    getPropertyEditor,
+    attributeValueIdForPropPath,
+    setAttributeValue,
+} from "../test_helpers.ts";
+import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
+
+export default async function emulate_authoring(sdfApiClient: SdfApiClient) {
+    await sleepBetween(0, 750);
+    return runWithTemporaryChangeset(sdfApiClient, emulate_authoring_inner);
+}
+
+async function emulate_authoring_inner(sdf: SdfApiClient,
+    changeSetId: string,
+) {
+    sdf.listenForDVUs();
+
+    // Create new asset
+    let schemaVariantId = await createAsset(sdf, changeSetId, "doubler");
+
+    // Update Code and Regenerate
+    schemaVariantId = await updateAssetCode(sdf, changeSetId, schemaVariantId, doublerAssetCode);
+
+    let doublerVariant = await sdf.call({
+        route: "get_variant", routeVars: {
+            workspaceId: sdf.workspaceId,
+            changeSetId,
+            schemaVariantId,
+        },
+    });
+    assert(doublerVariant?.props, "Expected props list");
+    assert(doublerVariant?.inputSockets, "Expected input sockets list");
+    assert(doublerVariant?.inputSockets.length === 0, "Expected no input sockets");
+    assert(doublerVariant?.outputSockets, "Expected output sockets list");
+    assert(doublerVariant?.outputSockets.length === 0, "Expected no output sockets");
+
+    // Add an attribute function
+    const outputProp = doublerVariant.props.find((p) => p.path === "/root/domain/doubled");
+    assert(outputProp, "Expected to find output prop");
+    let inputProp = doublerVariant.props.find((p) => p.path === "/root/domain/input");
+    assert(inputProp, "Expected to find input prop");
+    const args = [
+        {
+            name: "input",
+            kind: "string",
+            propId: inputProp.id,
+            inputSocketId: null,
+        },
+    ];
+
+    const doubleFuncId = await createAttributeFunction(sdf, changeSetId, "double", doublerVariant.id, doubleFuncCode, outputProp.id, args);
+
+
+    // create a component for the doubler
+    const doublerComponentId = await createComponent(sdf, changeSetId, doublerVariant.schemaVariantId, 0, 0, undefined, true);
+
+    // update input prop to be a number
+    const { values: doublerPropValues } = await getPropertyEditor(
+        sdf,
+        changeSetId,
+        doublerComponentId,
+    );
+
+
+    const { attributeValueId, parentAttributeValueId, propId } =
+        attributeValueIdForPropPath(
+            "/root/domain/input",
+            doublerVariant.props,
+            doublerPropValues,
+        );
+    const inputValue = "2";
+    await setAttributeValue(
+        sdf,
+        changeSetId,
+        doublerComponentId,
+        attributeValueId,
+        parentAttributeValueId,
+        propId,
+        inputValue,
+    );
+
+
+    // now add a qualification and check that the component gets it
+    const qualification = await createQualification(
+        sdf,
+        changeSetId, "doublerQualification",
+        schemaVariantId,
+        doublerQualificationCode
+    );
+
+    await sdf.waitForDVURoots(changeSetId, 2000, 60000);
+
+    // now let's check everything
+    const qualSummary = await getQualificationSummary(sdf, changeSetId);
+    assert(
+        Array.isArray(qualSummary?.components),
+        "Expected arguments list",
+    );
+    const componentQual = qualSummary?.components.find((c) => c.componentId === doublerComponentId);
+    assert(componentQual, "Expected to find qualification summary for created component");
+    assert(componentQual?.succeeded === 1, "Expected to have one qualification passing");
+    const { values: doublerValues } = await getPropertyEditor(
+        sdf,
+        changeSetId,
+        doublerComponentId,
+    );
+
+    const doubleAV =
+        attributeValueIdForPropPath(
+            "/root/domain/doubled",
+            doublerVariant.props,
+            doublerValues,
+        );
+
+    assert(doubleAV?.value === "4", `Expected doubled attribute value to be 4 but found ${doubleAV?.value}`);
+
+    // Now let's add a prop, regenerate, add an attribute func, and make sure it all works
+    schemaVariantId = await updateAssetCode(sdf, changeSetId, schemaVariantId, doublerAssetCodeAddedTripled);
+    doublerVariant = await sdf.call({
+        route: "get_variant", routeVars: {
+            workspaceId: sdf.workspaceId,
+            changeSetId,
+            schemaVariantId,
+        },
+    });
+
+
+    // Add an attribute function
+    const tripleProp = doublerVariant.props.find((p) => p.path === "/root/domain/tripled");
+    assert(tripleProp, "Expected to find output prop");
+    inputProp = doublerVariant.props.find((p) => p.path === "/root/domain/input");
+    assert(inputProp, "Expected to find input prop");
+    const triplerArgs = [
+        {
+            name: "input",
+            kind: "string",
+            propId: inputProp.id,
+            inputSocketId: null,
+        },
+    ];
+
+    const tripleFuncId = await createAttributeFunction(sdf, changeSetId, "triple", schemaVariantId, tripleFuncCode, tripleProp.id, triplerArgs);
+
+    const newDoublerVariant = await sdf.call({
+        route: "get_variant", routeVars: {
+            workspaceId: sdf.workspaceId,
+            changeSetId,
+            schemaVariantId,
+        },
+    });
+    await sdf.waitForDVURoots(changeSetId, 2000, 60000);
+
+    // Let's make sure this updated accurately on the component
+    const { values: triplerValues } = await getPropertyEditor(
+        sdf,
+        changeSetId,
+        doublerComponentId,
+    );
+
+    const tripleAV =
+        attributeValueIdForPropPath(
+            "/root/domain/tripled",
+            newDoublerVariant.props,
+            triplerValues,
+        );
+    assert(tripleAV?.value === "6", `Expected doubled attribute value to be 6  but found ${tripleAV?.value}`);
+
+}
+
+
+const doubleFuncCode = `async function main(input: Input): Promise < Output > {
+    const number = parseInt(input?.input);
+    if (!number) {
+        return String(0);      
+    }
+                
+    return String(number * 2);
+}
+`;
+
+const tripleFuncCode = `async function main(input: Input): Promise < Output > {
+    const number = parseInt(input?.input);
+    if (!number) {
+        return String(0);      
+    }
+                
+    return String(number * 3);
+}
+`;
+
+const doublerAssetCode = `function main() {
+    const asset = new AssetBuilder();
+
+    const inputProp = new PropBuilder()
+        .setName("input")
+        .setKind("string")
+        .setWidget(new PropWidgetDefinitionBuilder().setKind("text").build())
+        .build();
+    asset.addProp(inputProp);
+
+    const doublerProp = new PropBuilder()
+        .setName("doubled")
+        .setKind("string")
+        .setWidget(new PropWidgetDefinitionBuilder().setKind("text").build())
+        .build();
+
+    asset.addProp(doublerProp);
+
+    return asset.build();
+}`;
+
+const doublerAssetCodeAddedTripled = `function main() {
+    const asset = new AssetBuilder();
+
+    const inputProp = new PropBuilder()
+        .setName("input")
+        .setKind("string")
+        .setWidget(new PropWidgetDefinitionBuilder().setKind("text").build())
+        .build();
+    asset.addProp(inputProp);
+
+    const doublerProp = new PropBuilder()
+        .setName("doubled")
+        .setKind("string")
+        .setWidget(new PropWidgetDefinitionBuilder().setKind("text").build())
+        .build();
+
+    asset.addProp(doublerProp);
+
+    const triplerProp = new PropBuilder()
+        .setName("tripled")
+        .setKind("string")
+        .setWidget(new PropWidgetDefinitionBuilder().setKind("text").build())
+        .build();
+
+    asset.addProp(triplerProp);
+
+    return asset.build();
+}`;
+
+const doublerQualificationCode = `async function main(component: Input): Promise < Output > {
+
+    const doubler = component?.domain?.doubler;
+    if (doubler) {
+        const val = parseInt(doubler);
+        if (val > 0) {
+            return {
+                result: 'success',
+                message: 'Component qualified'
+            };
+        }
+    }
+
+    return {
+        result: 'failure',
+        message: 'Component not qualified'
+    };
+}`;
+
+// REQUEST HELPERS WITH VALIDATIONS
+
+async function createQualification(sdf: SdfApiClient, changeSetId: string, name: string, schemaVariantId: string, code: string) {
+    const createFuncPayload = {
+        name,
+        displayName: name,
+        description: "",
+        binding: {
+            funcId: nilId,
+            schemaVariantId,
+            bindingKind: "qualification",
+            inputs: [],
+        },
+        kind: "Qualification",
+        requestUlid: changeSetId,
+    };
+    const createFuncResp = await sdf.call({
+        route: "create_func",
+        routeVars: {
+            workspaceId: sdf.workspaceId,
+            changeSetId,
+        },
+        body: createFuncPayload,
+    });
+    // now list funcs and let's make sure we see it
+    const funcs = await sdf.call({
+        route: "func_list",
+        routeVars: {
+            workspaceId: sdf.workspaceId,
+            changeSetId,
+        },
+    });
+
+    const createdFunc = funcs.find((f) => f.name === name);
+    assert(createdFunc, "Expected to find newly created func");
+    const funcId = createdFunc.funcId;
+    const codePayload = {
+        code,
+        requestUlid: changeSetId,
+    };
+
+    // save the code
+    const updateFuncResp = await sdf.call({
+        route: "update_func_code",
+        routeVars: {
+            workspaceId: sdf.workspaceId,
+            changeSetId,
+            funcId,
+        },
+        body: codePayload,
+    });
+    return funcId;
+
+}
+
+async function createAttributeFunction(sdf: SdfApiClient, changeSetId: string, name: string, schemaVariantId: string, code: string, outputLocationId: string, funcArguments: any[]) {
+    const createFuncPayload = {
+        name,
+        displayName: name,
+        description: "",
+        binding: {
+            funcId: nilId,
+            schemaVariantId: schemaVariantId,
+            bindingKind: "attribute",
+            argumentBindings: [],
+            propId: outputLocationId,
+        },
+        kind: "Attribute",
+        requestUlid: changeSetId,
+    };
+
+    const createFuncResp = await sdf.call({
+        route: "create_func",
+        routeVars: {
+            workspaceId: sdf.workspaceId,
+            changeSetId,
+        },
+        body: createFuncPayload,
+    });
+
+    // now list funcs and let's make sure we see it
+    const funcs = await sdf.call({
+        route: "func_list",
+        routeVars: {
+            workspaceId: sdf.workspaceId,
+            changeSetId,
+        },
+    });
+
+    const createdFunc = funcs.find((f) => f.name === name);
+    assert(createdFunc, "Expected to find newly created func");
+    const funcId = createdFunc.funcId;
+    const codePayload = {
+        code,
+        requestUlid: changeSetId,
+    };
+
+    // save the code
+    const updateCodeResp = await sdf.call({
+        route: "update_func_code",
+        routeVars: {
+            workspaceId: sdf.workspaceId,
+            changeSetId,
+            funcId,
+        },
+        body: codePayload,
+    });
+
+    // create func arguments
+    let numArgs = 0;
+    for (const funcArg of funcArguments) {
+        // create the argument
+        let argPayload = {
+            created_at: new Date(),
+            updated_at: new Date(),
+            name: funcArg.name,
+            id: nilId,
+            kind: funcArg.kind,
+            requestUlid: changeSetId,
+        };
+        const createArgResp = await sdf.call({
+            route: "create_func_arg",
+            routeVars: {
+                workspaceId: sdf.workspaceId,
+                changeSetId,
+                funcId,
+            },
+            body: argPayload,
+        });
+        const args = createArgResp.arguments;
+        assert(
+            Array.isArray(createArgResp?.arguments),
+            "Expected arguments list",
+        );
+        numArgs++;
+        assert(createArgResp?.arguments.length === numArgs, `Expected ${numArgs} but found ${createArgResp?.arguments.length}`);
+        const createdArg = args.find((arg) => arg.name === funcArg.name);
+        const attributePrototypeArgumentId = createdArg.id;
+        const attributePrototypeId = createArgResp?.bindings[0].attributePrototypeId;
+        // now update the argument bindings
+
+        const bindingPayload = {
+            funcId,
+            bindings: [
+                {
+                    bindingKind: "attribute",
+                    attributePrototypeId: attributePrototypeId,
+                    funcId,
+                    propId: outputLocationId,
+                    componentId: null,
+                    outputSocketId: null,
+                    schemaVariantId,
+                    argumentBindings: [
+                        {
+                            funcArgumentId: createdArg.id,
+                            propId: funcArg.propId,
+                            attributePrototypeArgumentId: attributePrototypeArgumentId,
+                            inputSocketId: funcArg.inputSocketId,
+                        }
+                    ]
+                }
+            ]
+        }
+        const updateBindingResp = await sdf.call({
+            route: "create_func_binding",
+            routeVars: {
+                workspaceId: sdf.workspaceId,
+                changeSetId,
+                funcId,
+            },
+            body: bindingPayload,
+        });
+
+        assert(
+            Array.isArray(updateBindingResp),
+            "Expected bindings list",
+        );
+        assert(
+            Array.isArray(updateBindingResp[0].argumentBindings),
+            "Expected argument bindings list",
+        );
+        assert(
+            updateBindingResp[0].argumentBindings.length === numArgs,
+            "Expected argument bindings list",
+        );
+    }
+
+    return funcId;
+
+}
+
+


### PR DESCRIPTION
The `doubler` is now enshrined in API tests! 

This test does the following: 
- create the doubler
- Add an attribute function (that doubles a prop)
- Add a qualification
- Create a component
- Set a prop
- See that it doubles as expected
- Add another prop to the schema variant
- Add another attribute function
- See that the component auto-upgrades, and the new attribute func runs!

A bit of pain here in feature flags and adding a new test, but we'll get it figured out! 

<div><img src="https://media3.giphy.com/media/q5KSpsbhXp3lw7HxXl/giphy.gif?cid=5a38a5a2c18phxsk0a0thn8t7z5hc2tfn35uv2nlmwijd1az&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/latenightseth/">Late Night with Seth Meyers</a> on <a href="https://giphy.com/gifs/latenightseth-seth-meyers-lnsm-q5KSpsbhXp3lw7HxXl">GIPHY</a></div>