### PR TITLE
feat(toolbox): use AWS_PROFILE/AWS_REGION if set when calling `awsi.sh`

### DIFF
--- a/component/toolbox/awsi.sh
+++ b/component/toolbox/awsi.sh
@@ -1,17 +1,33 @@
 #!/usr/bin/env bash
+set -eu
+
+if [[ -n "${DEBUG:-}" ]]; then set -v; fi
+if [[ -n "${TRACE:-}" ]]; then set -xv; fi
 
 # If running in Github, we don't have an interactive
 # terminal so the commands can't request user input
-if [ "$GITHUB_ACTIONS" = "true" ]; then
+if [[ "${GITHUB_ACTIONS:-}" = "true" ]]; then
   terminal="-t"
 else
   terminal="-it"
 fi
 
-docker run --rm "${terminal}" \
-  -v ~/.aws:/root/.aws \
-  -v "$(pwd)":/aws \
-  -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
-  -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
-  -e AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN}" \
-  systeminit/toolbox:stable "$*"
+args=(
+  --rm
+  "${terminal}"
+  -v ~/.aws:/root/.aws
+  -v "$(pwd)":/aws
+  -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}"
+  -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-}"
+  -e AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}"
+)
+
+if [[ -n "${AWS_PROFILE:-}" ]]; then
+  args+=(-e AWS_PROFILE="${AWS_PROFILE}")
+fi
+
+if [[ -n "${AWS_REGION:-}" ]]; then
+  args+=(-e AWS_REGION="${AWS_REGION}")
+fi
+
+docker run "${args[@]}" systeminit/toolbox:stable "$*"


### PR DESCRIPTION
This change conditionally propagates the following local environment variables into the `systeminit/toolbox` container:

- `AWS_PROFILE`
- `AWS_REGION`

If either of these variables are not present they do not get added to the `docker run` command.

In order to confirm the behavior change, several other updates are included:

- Add `set -eu` resulting in the shell script aborting if an expected environment variable is not set. To preserve the error message when you aren't authenticated, the existing `AWS_*` credential variables are still passed in as empty if not set.
- Add a `DEBUG` and `TRACE` mode to the script which add `set -v` and `set- xv` respectively when running the shell script. This helps to understand the final `docker run` command that is about to be executed (among other branching logic).

<img src="https://media2.giphy.com/media/cdNSp4L5vCU7aQrYnV/giphy.gif"/>