### PR TITLE
chore(sdf): always migrate `si_audit` database

### DIFF
--- a/lib/sdf-server/src/migrations.rs
+++ b/lib/sdf-server/src/migrations.rs
@@ -100,14 +100,9 @@ impl Migrator {
     pub async fn run_migrations(self) -> MigratorResult<()> {
         let span = current_span_for_instrument_at!("info");
 
-        // TODO(nick,john): once we have seeded the database successfully, we can replace this with
-        // error propagation.
-        if let Err(err) = self.migrate_audit_database().await {
-            warn!(
-                ?err,
-                "skipping audit database migration due to error, which is currently expected"
-            );
-        }
+        self.migrate_audit_database()
+            .await
+            .map_err(|err| span.record_err(err))?;
 
         self.migrate_layer_db_database()
             .await


### PR DESCRIPTION
This change removes the "attempt to migrate and log errors" behavior when migrating the `si_audit` database. With this change a migration is performed, identical to migrations for the `si` and `si_layer_cache` databases. When an error is encountered, it early-returns with the error.

<img src="https://media4.giphy.com/media/XI7rk6UYBM4LWp2rw0/giphy.gif"/>