### PR TITLE
feat: Manage socket connections from a form

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -70,6 +70,12 @@ export interface PropertyEditorPropWidgetKindColor {
   kind: "color";
 }
 
+export interface PropertyEditorPropWidgetKindSocketConnection {
+  kind: "socketConnection";
+  options: LabelList<string>;
+  isSingleArity: boolean;
+}
+
 export type PropertyEditorPropWidgetKind =
   | PropertyEditorPropWidgetKindText
   | PropertyEditorPropWidgetKindTextArea
@@ -83,7 +89,8 @@ export type PropertyEditorPropWidgetKind =
   | PropertyEditorPropWidgetKindComboBox
   | PropertyEditorPropWidgetKindSelect
   | PropertyEditorPropWidgetKindSecret
-  | PropertyEditorPropWidgetKindColor;
+  | PropertyEditorPropWidgetKindColor
+  | PropertyEditorPropWidgetKindSocketConnection;
 
 export interface PropertyEditorProp {
   id: string;

--- a/app/web/src/components/AttributesPanel/TreeForm.vue
+++ b/app/web/src/components/AttributesPanel/TreeForm.vue
@@ -24,9 +24,9 @@
       <TreeFormItem
         v-for="tree in trees"
         :key="tree.propId"
+        :context="useAttributesPanelContext"
         :treeDef="tree"
         isRootProp
-        :context="useAttributesPanelContext"
       />
     </div>
   </div>
@@ -35,14 +35,14 @@
 <script lang="ts">
 type EventBusEvents = { toggleAllOpen: boolean };
 
-type ResetFunc = (item: TreeFormData) => void;
+type UnsetFunc = (item: TreeFormData, valToUnset?: string) => void;
 type SetValueFunc = (item: TreeFormData, newVal: string) => void;
 
 export type TreeFormContext = {
   eventBus: Emitter<EventBusEvents>;
   hoverSectionValueId: Ref<string | undefined>;
   showSectionToggles: Ref<boolean>;
-  resetValue: ResetFunc;
+  unsetValue: UnsetFunc;
   setValue: SetValueFunc;
 };
 
@@ -89,15 +89,15 @@ function onMouseLeave() {
 }
 
 const emit = defineEmits<{
-  (e: "reset", item: TreeFormData): void;
+  (e: "unsetValue", item: TreeFormData, value?: string): void;
   (e: "setValue", item: TreeFormData, value: string): void;
 }>();
 
 // EXPOSED TO CHILDREN
 const eventBus = mitt<EventBusEvents>();
 const hoverSectionValueId = ref<string>();
-const resetValue = (item: TreeFormData) => {
-  emit("reset", item);
+const unsetValue = (item: TreeFormData, value?: string) => {
+  emit("unsetValue", item, value);
 };
 const setValue = (item: TreeFormData, value: string) => {
   emit("setValue", item, value);
@@ -107,7 +107,7 @@ provide(AttributesPanelContextInjectionKey, {
   eventBus,
   hoverSectionValueId,
   showSectionToggles,
-  resetValue,
+  unsetValue,
   setValue,
 });
 </script>

--- a/app/web/src/components/ComponentConnectionsPanel.vue
+++ b/app/web/src/components/ComponentConnectionsPanel.vue
@@ -12,8 +12,8 @@
     >
       <TreeForm
         :trees="trees"
-        @reset="resetHandler"
         @setValue="setValueHandler"
+        @unsetValue="resetHandler"
       />
     </div>
   </div>
@@ -23,11 +23,21 @@
 import clsx from "clsx";
 import { themeClasses } from "@si/vue-lib/design-system";
 import { computed } from "vue";
+import * as _ from "lodash-es";
 import { PropertyEditorPropKind } from "@/api/sdf/dal/property_editor";
-import { useComponentsStore } from "@/store/components.store";
+import {
+  generateEdgeId,
+  SocketWithParent,
+  SocketWithParentAndEdge,
+  useComponentsStore,
+} from "@/store/components.store";
 import { LabelEntry, LabelList } from "@/api/sdf/dal/label_list";
 import { useViewsStore } from "@/store/views.store";
-import { DiagramViewData } from "@/components/ModelingDiagram/diagram_types";
+import {
+  DiagramSocketDef,
+  DiagramViewData,
+} from "@/components/ModelingDiagram/diagram_types";
+import { ComponentId } from "@/api/sdf/dal/component";
 import TreeForm from "./AttributesPanel/TreeForm.vue";
 import { TreeFormData, TreeFormProp } from "./AttributesPanel/TreeFormItem.vue";
 import AttributesPanelCustomInputs from "./AttributesPanel/AttributesPanelCustomInputs.vue";
@@ -35,6 +45,7 @@ import AttributesPanelCustomInputs from "./AttributesPanel/AttributesPanelCustom
 const componentsStore = useComponentsStore();
 const viewsStore = useViewsStore();
 
+// PARENTS
 const parentOptionsList = computed(() => {
   const groups = Object.values(componentsStore.groupsById);
   const list = [] as LabelList<string>;
@@ -48,6 +59,18 @@ const parentOptionsList = computed(() => {
 
   return list;
 });
+
+const currentParentNamePropValue = computed(() => ({
+  id: currentParent.value?.id,
+  propId: currentParent.value?.id,
+  value: currentParent.value?.displayName,
+  canBeSetBySocket: false,
+  isFromExternalSource: false,
+  isControlledByDynamicFunc: false,
+  isControlledByAncestor: false,
+  overridden: true,
+  ancestorManual: false,
+}));
 
 const lineageTree = computed(
   () =>
@@ -104,108 +127,247 @@ const currentParent = computed(() => {
   return componentsStore.groupsById[parentId]?.def;
 });
 
-const currentParentNamePropValue = computed(() => ({
-  id: currentParent.value?.id,
-  propId: currentParent.value?.id,
-  value: currentParent.value?.displayName,
-  canBeSetBySocket: false,
-  isFromExternalSource: false,
-  isControlledByDynamicFunc: false,
-  isControlledByAncestor: false,
-  overridden: true,
-  ancestorManual: false,
-}));
+// SOCKETS
+const treeFormItemFromSocket = (
+  socket: DiagramSocketDef,
+  componentId: ComponentId,
+  existingPeers: SocketWithParentAndEdge[],
+  possiblePeers: SocketWithParent[],
+) => {
+  const combinedId = `${componentId}-${socket.id}`;
+  const headerId = `${combinedId}-header`;
 
-// const generateMockSockets = () => {
-//   const sockets = [];
+  return {
+    propDef: {
+      id: headerId,
+      name: socket.label,
+      icon: socket.nodeSide === "left" ? "input-socket" : "output-socket",
+      kind: PropertyEditorPropKind.Object,
+      widgetKind: { kind: "header" },
+    } as TreeFormProp,
+    children: [
+      {
+        propDef: {
+          id: combinedId,
+          name: socket.label,
+          icon: "none",
+          kind: PropertyEditorPropKind.String,
+          widgetKind: {
+            kind: "socketConnection",
+            options: possiblePeers.map((peerSocket) => ({
+              label: `${peerSocket.componentName}/${peerSocket.label}`,
+              value: `${peerSocket.componentId}-${peerSocket.id}`,
+            })),
+            isSingleArity: socket.maxConnections === 1,
+          },
+        } as TreeFormProp,
+        children: [],
+        value: {
+          id: combinedId,
+          propId: combinedId,
+          value: existingPeers.map((peerSocket) => ({
+            label: `${peerSocket.componentName}/${peerSocket.label}`,
+            value: `${peerSocket.componentId}-${peerSocket.id}`,
+            isImmutable: peerSocket.edge.isInferred,
+          })),
+          canBeSetBySocket: false,
+          isFromExternalSource: false,
+          isControlledByDynamicFunc: false,
+          isControlledByAncestor: false,
+          overridden: false,
+          ancestorManual: false,
+        },
+        valueId: combinedId,
+        parentValueId:
+          socket.nodeSide === "left" ? "inputSockets" : "outputSockets",
 
-//   for (let i = 0; i < 5; i++) {
-//     sockets.push({
-//       propDef: {
-//         id: `socket${i}`,
-//         name: `example socket ${i}`,
-//         icon: "none",
-//         kind: PropertyEditorPropKind.String,
-//         widgetKind: { kind: "select" },
-//         isHidden: false,
-//         isReadonly: false,
-//       } as TreeFormProp,
-//       children: [],
-//       value: undefined,
-//       valueId: `socket${i}`,
-//       parentValueId: `socket${i}`,
-//       validation: null,
-//       propId: `socket${i}`,
-//     });
-//   }
+        validation: null,
+        propId: combinedId,
+      },
+    ],
+    value: undefined,
+    valueId: headerId,
+    parentValueId:
+      socket.nodeSide === "left" ? "inputSockets" : "outputSockets",
+    validation: null,
+    propId: headerId,
+  };
+};
 
-//   return sockets;
-// };
+const sockets = computed(() => {
+  const selectedComponent = viewsStore.selectedComponent;
 
-// const socketsTree = {
-//   propDef: {
-//     id: "sockets",
-//     name: "sockets",
-//     icon: "socket",
-//     kind: PropertyEditorPropKind.Object,
-//     widgetKind: { kind: "header" },
-//     isHidden: false,
-//     isReadonly: false,
-//   } as TreeFormProp,
-//   children: [
-//     {
-//       propDef: {
-//         id: "outputs",
-//         name: "output sockets",
-//         icon: "output-socket",
-//         kind: PropertyEditorPropKind.Object,
-//         widgetKind: { kind: "header" },
-//         isHidden: false,
-//         isReadonly: false,
-//       } as TreeFormProp,
-//       children: generateMockSockets(),
-//       value: undefined,
-//       valueId: "outputs",
-//       parentValueId: "outputs",
-//       validation: null,
-//       propId: "outputs",
-//     },
-//     {
-//       propDef: {
-//         id: "inputs",
-//         name: "input sockets",
-//         icon: "input-socket",
-//         kind: PropertyEditorPropKind.Object,
-//         widgetKind: { kind: "header" },
-//         isHidden: false,
-//         isReadonly: false,
-//       } as TreeFormProp,
-//       children: generateMockSockets(),
-//       value: undefined,
-//       valueId: "inputs",
-//       parentValueId: "inputs",
-//       validation: null,
-//       propId: "inputs",
-//     },
-//   ],
-//   value: undefined,
-//   valueId: "sockets",
-//   parentValueId: "sockets",
-//   validation: null,
-//   propId: "sockets",
-// } as TreeFormData;
+  if (
+    !selectedComponent ||
+    selectedComponent instanceof DiagramViewData ||
+    !selectedComponent.def.sockets
+  ) {
+    return { input: [], output: [] };
+  }
 
-const trees = computed(() => [lineageTree.value]);
+  const peersFunction = componentsStore.possibleAndExistingPeerSocketsFn;
+  const sockets =
+    selectedComponent.def.sockets.map((s) => {
+      const { existingPeers, possiblePeers } = peersFunction(
+        s,
+        selectedComponent.def.id,
+      );
 
-const resetHandler = (item: TreeFormData) => {
+      return treeFormItemFromSocket(
+        s,
+        selectedComponent.def.id,
+        existingPeers,
+        possiblePeers,
+      );
+    }) ?? [];
+
+  const [input, output] = _.partition(
+    sockets,
+    (s) => s.parentValueId === "inputSockets",
+  );
+
+  return { input, output };
+});
+
+const generateSocketsTree = (
+  tree: TreeFormData[],
+  direction: "input" | "output",
+) => {
+  const id = `${direction}Sockets`;
+  const directionString =
+    direction.charAt(0).toUpperCase() + direction.slice(1);
+  const name = `${tree.length} ${directionString} Socket${
+    tree.length === 1 ? "" : "s"
+  }`;
+
+  return {
+    propDef: {
+      id,
+      name,
+      icon: "socket",
+      kind: PropertyEditorPropKind.Object,
+      widgetKind: { kind: "header" },
+      isHidden: false,
+      isReadonly: false,
+    } as TreeFormProp,
+    children: tree,
+    value: undefined,
+    valueId: id,
+    parentValueId: "connections",
+    validation: null,
+    propId: id,
+  } as TreeFormData;
+};
+
+const inputSocketsTree = computed(() =>
+  generateSocketsTree(sockets.value.input, "input"),
+);
+const outputSocketsTree = computed(() =>
+  generateSocketsTree(sockets.value.output, "output"),
+);
+
+const trees = computed(() => [
+  lineageTree.value,
+  inputSocketsTree.value,
+  outputSocketsTree.value,
+]);
+
+const resetHandler = (item: TreeFormData, value?: string) => {
   if (item.propId === "parent") {
     viewsStore.SET_PARENT([item.propDef.id], null);
   }
+
+  if (!value) return;
+  const [thisComponentId, thisSocketId] = item.propId.split("-");
+  const [otherComponentId, otherSocketId] = value.split("-");
+  if (
+    !thisComponentId ||
+    !thisSocketId ||
+    !otherComponentId ||
+    !otherSocketId
+  ) {
+    return;
+  }
+
+  const [from, to] =
+    item.parentValueId === "inputSockets"
+      ? [
+          {
+            componentId: otherComponentId,
+            socketId: otherSocketId,
+          },
+          {
+            componentId: thisComponentId,
+            socketId: thisSocketId,
+          },
+        ]
+      : [
+          {
+            componentId: thisComponentId,
+            socketId: thisSocketId,
+          },
+          {
+            componentId: otherComponentId,
+            socketId: otherSocketId,
+          },
+        ];
+
+  const edgeId = generateEdgeId(
+    from.componentId,
+    to.componentId,
+    from.socketId,
+    to.socketId,
+  );
+
+  useComponentsStore().DELETE_EDGE(
+    edgeId,
+    to.socketId,
+    from.socketId,
+    to.componentId,
+    from.componentId,
+  );
 };
 
 const setValueHandler = (item: TreeFormData, value: string) => {
   if (item.propId === "parent") {
     viewsStore.SET_PARENT([item.propDef.id], value);
+    return;
   }
+
+  const [thisComponentId, thisSocketId] = item.propId.split("-");
+  const [otherComponentId, otherSocketId] = value.split("-");
+  if (
+    !thisComponentId ||
+    !thisSocketId ||
+    !otherComponentId ||
+    !otherSocketId
+  ) {
+    return;
+  }
+
+  const [from, to] =
+    item.parentValueId === "inputSockets"
+      ? [
+          {
+            componentId: otherComponentId,
+            socketId: otherSocketId,
+          },
+          {
+            componentId: thisComponentId,
+            socketId: thisSocketId,
+          },
+        ]
+      : [
+          {
+            componentId: thisComponentId,
+            socketId: thisSocketId,
+          },
+          {
+            componentId: otherComponentId,
+            socketId: otherSocketId,
+          },
+        ];
+
+  componentsStore.CREATE_COMPONENT_CONNECTION(from, to);
 };
 </script>

--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -3,10 +3,10 @@ changes, so this must be placed in a container that is sized explicitly has
 overflow hidden */
 <template>
   <div
-    class="grow h-full relative bg-neutral-50 dark:bg-neutral-900"
     :style="{
       marginLeft: presenceStore.leftResizePanelWidth === 0 ? '0' : '230px', // related to left panel drawer
     }"
+    class="grow h-full relative bg-neutral-50 dark:bg-neutral-900"
   >
     <!-- This section contains the DiagramGridBackground and other elements which should render underneath all of the components/frames/cursors -->
     <div class="absolute inset-0 overflow-hidden">
@@ -122,9 +122,9 @@ overflow hidden */
             :key="view.id"
           >
             <DiagramView
-              :view="view.def"
               :isHovered="elementIsHovered(view)"
               :isSelected="elementIsSelected(view)"
+              :view="view.def"
             />
           </template>
           <DiagramCursor

--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -1828,7 +1828,7 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
           [
             {
               eventType: "ChangeSetApplied",
-              callback: (data) => {
+              callback: async (data) => {
                 // If the applied change set has rebased into this change set,
                 // then refetch (i.e. there might be updates!)
                 if (data.toRebaseChangeSetId === changeSetId) {


### PR DESCRIPTION
This allows users to manage connections between components  that aren't on the same view.

For now, inferred edges cannot bee overriden from the form, and the socket selection input is a simple dropdown

<img width="461" alt="image" src="https://github.com/user-attachments/assets/bfd44005-dc83-4dfa-a992-df5c4de38f73">


