### PR TITLE
chore(forklift): add tuning for concurrent audit log database inserts

### DIFF
--- a/lib/audit-logs/src/database/config.rs
+++ b/lib/audit-logs/src/database/config.rs
@@ -5,6 +5,8 @@ use si_data_pg::PgPoolConfig;
 pub const DBNAME: &str = "si_audit";
 const APPLICATION_NAME: &str = "si-audit";
 
+const DEFAULT_INSERT_CONCURRENCY_LIMIT: usize = 64;
+
 /// The configuration used for communicating with and setting up the audit database.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AuditDatabaseConfig {
@@ -12,6 +14,8 @@ pub struct AuditDatabaseConfig {
     ///
     /// _Note:_ this is called "pg" for ease of use with layered load configuration files.
     pub pg: PgPoolConfig,
+    /// The concurrency limit used when inserting events into the database store.
+    pub insert_concurrency_limit: usize,
 }
 
 impl Default for AuditDatabaseConfig {
@@ -22,6 +26,7 @@ impl Default for AuditDatabaseConfig {
                 application_name: APPLICATION_NAME.into(),
                 ..Default::default()
             },
+            insert_concurrency_limit: DEFAULT_INSERT_CONCURRENCY_LIMIT,
         }
     }
 }

--- a/lib/forklift-server/src/server.rs
+++ b/lib/forklift-server/src/server.rs
@@ -88,7 +88,6 @@ impl Server {
                     jetstream_context.clone(),
                     DURABLE_CONSUMER_NAME.to_string(),
                     connection_metadata.clone(),
-                    config.concurrency_limit(),
                     config.audit(),
                     token.clone(),
                 )

--- a/lib/forklift-server/src/server/app.rs
+++ b/lib/forklift-server/src/server/app.rs
@@ -32,7 +32,6 @@ pub(crate) async fn audit_logs(
     jetstream_context: Context,
     durable_consumer_name: String,
     connection_metadata: Arc<ConnectionMetadata>,
-    concurrency_limit: usize,
     audit_database_config: &AuditDatabaseConfig,
     token: CancellationToken,
 ) -> Result<Box<dyn Future<Output = io::Result<()>> + Unpin + Send>> {
@@ -40,7 +39,6 @@ pub(crate) async fn audit_logs(
         jetstream_context,
         durable_consumer_name,
         connection_metadata,
-        concurrency_limit,
         audit_database_config,
         token,
     )

--- a/lib/forklift-server/src/server/app/audit_logs.rs
+++ b/lib/forklift-server/src/server/app/audit_logs.rs
@@ -65,8 +65,7 @@ pub(crate) async fn build_and_run(
     jetstream_context: Context,
     durable_consumer_name: String,
     connection_metadata: Arc<ConnectionMetadata>,
-    concurrency_limit: usize,
-    audit_database_config: &AuditDatabaseConfig,
+    config: &AuditDatabaseConfig,
     token: CancellationToken,
 ) -> Result<Box<dyn Future<Output = io::Result<()>> + Unpin + Send>> {
     nats_dead_letter_queue::create_stream(&jetstream_context).await?;
@@ -93,7 +92,8 @@ pub(crate) async fn build_and_run(
             .await?
     };
 
-    let context = AuditDatabaseContext::from_config(audit_database_config).await?;
+    let concurrency_limit = config.insert_concurrency_limit;
+    let context = AuditDatabaseContext::from_config(config).await?;
     let state = AppState::new(context, connection_metadata.subject_prefix().is_some());
 
     // NOTE(nick,fletcher): the "NatsMakeSpan" builder defaults to "info" level logging. Bump it down, if needed.


### PR DESCRIPTION
This change adds a tunable in forklift's configuration called `insert_concurrency_limit` to control how many concurrent inserts are running.

This can be set in a `forklift.toml` with:

```toml
[audit]
insert_concurrency_limit = 4
```

Or in an environment variable with:

```sh
SI_FORKLIFT__AUDIT__INSERT_CONCURRENCY_LIMIT=4
```

Longer term, each microservice that forklift runs should have its own tunable for its own concurrency as one broad brush stroke won't be sufficient in the various environments. Additionally the name for the idea of a concurrency limit has `insert_` in it because currently we render the exact same `config.toml` template in all environments and for all services. This is one way for the moment to be very clear as to what this tunes (as read from a more "global" context).

<img src="https://media3.giphy.com/media/6fJWPMTDWEJoY/giphy.gif"/>