### PR TITLE
feat: add remainder of changset routes to API client

### DIFF
--- a/bin/si-api-test/sdf_api_client.ts
+++ b/bin/si-api-test/sdf_api_client.ts
@@ -12,23 +12,62 @@ interface API_DESCRIPTION {
 }
 
 export const ROUTES = {
-  // Change Set Management ------------------------------------------------------
-  apply_change_set: {
-    path: () => "/change_set/apply_change_set",
-    method: "POST",
-  },
-  create_change_set: {
-    path: () => "/change_set/create_change_set",
+  // /api/change_set - Change Set Management ---------------------------------------------------
+  abandon_vote: {
+    path: () => "/change_set/abandon_vote",
     method: "POST",
   },
   abandon_change_set: {
     path: () => "/change_set/abandon_change_set",
     method: "POST",
   },
-  open_change_sets: {
+  add_action: {
+    path: () => "/change_set/add_action", 
+    method: "POST",
+  },
+  apply_change_set: {
+    path: () => "/change_set/apply_change_set",
+    method: "POST",
+  },
+  begin_abandon_approval_process: {
+    path: () => "/change_set/begin_abandon_approval_process",
+    method: "POST",
+  },
+  begin_approval_process: {
+    path: () => "/change_set/begin_approval_process",
+    method: "POST",
+  },
+  cancel_abandon_approval_process: {
+    path: () => "/change_set/cancel_abandon_approval_process",
+    method: "POST",
+  },
+  cancel_approval_process: {
+    path: () => "/change_set/cancel_approval_process",
+    method: "POST",
+  },
+  create_change_set: {
+    path: () => "/change_set/create_change_set",
+    method: "POST",
+  },
+  list_open_change_sets: {
     path: () => "/change_set/list_open_change_sets",
     method: "GET",
   },
+  merge_vote: {
+    path: () => "/change_set/merge_vote",
+    method: "POST",
+  },
+  rebase_on_base: {
+    path: () => "/change_set/rebase_on_base",
+    method: "POST",
+  },
+  status_with_base: {
+    path: () => "/change_set/status_with_base",
+    method: "POST",
+  },
+
+  // V2/Workspaces  ---------------------------------------------------------
+  // TODO(MegaWatt01): come back to properly format this hanging route
   schema_variants: {
     path: (vars: ROUTE_VARS) =>
       `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/schema-variants`,

--- a/bin/si-api-test/tests/6-get_head_changeset.ts
+++ b/bin/si-api-test/tests/6-get_head_changeset.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import { SdfApiClient } from "../sdf_api_client.ts";
 
 export default async function get_head_changeset(sdfApiClient: SdfApiClient) {
-  const data = await sdfApiClient.call({ route: "open_change_sets" });
+  const data = await sdfApiClient.call({ route: "list_open_change_sets" });
 
   assert(data.headChangeSetId, "Expected headChangeSetId");
   const head = data.changeSets.find((c) => c.id === data.headChangeSetId);


### PR DESCRIPTION
Adds a bit of missing client coverage for the change_set set of routes for the API tests. Renames one reference that was mis-mapped to the route name. Bit of a simple one with no real functional impact but it should be a step in the right direction. 


<div><img src="https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGx2dWpjZmt1aWR0YzlyaXhpcjB1cTl4M2tsY2lzOTV6dW14YmdjaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/14mgxYFJHXGmoo/giphy.gif"/></div>