### PR TITLE
Fetch func list on SchemaVariantReplaced/Updated

### DIFF
--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -787,6 +787,18 @@ export const useFuncStore = () => {
             },
           },
           {
+            eventType: "SchemaVariantUpdated",
+            callback: () => {
+              this.FETCH_FUNC_LIST();
+            },
+          },
+          {
+            eventType: "SchemaVariantReplaced",
+            callback: () => {
+              this.FETCH_FUNC_LIST();
+            },
+          },
+          {
             eventType: "SchemaVariantCloned",
             callback: () => {
               this.FETCH_FUNC_LIST();


### PR DESCRIPTION
SchemaVariantReplaced and SchemaVariantUpdated are fired when we click Regenerate Asset; we need to update function bindings when that happens so the asset editor will trigger.

This is a bit of an overkill hammer, but it gets the job done when the slightly more targeted https://github.com/systeminit/si/pull/4982 was causing issues. When performance becomes an issue, we may want to allow events to be sent when *bindings* are changed.

Fixes BUG-653 and BUG-660.