### PR TITLE
Billing: don't alert when new users race with subscription import

### DIFF
--- a/component/lambda/functions/billing-set-prices.py
+++ b/component/lambda/functions/billing-set-prices.py
@@ -45,7 +45,7 @@ class BillingSetPrices(SiLambda):
             )
 
         except LagoHTTPError as e:
-            if e.json.get("status") != 404:
+            if e.json and e.json.get("status") != 404:
                 raise
             try:
                 logging.debug(
@@ -59,7 +59,7 @@ class BillingSetPrices(SiLambda):
                 )
 
             except LagoHTTPError as e:
-                if e.json.get("status") != 404:
+                if e.json and e.json.get("status") != 404:
                     raise
 
                 try:
@@ -74,7 +74,7 @@ class BillingSetPrices(SiLambda):
                     )
 
                 except LagoHTTPError as e:
-                    if e.json.get("status") != 404:
+                    if e.json and e.json.get("status") != 404:
                         raise
 
                     logging.warning(


### PR DESCRIPTION
Right now, under the race condition where workspaces have been created for a user but their subscriptions are still being created, the subscription import lambda will trigger an error and cause an alert. This treats that situation as a new user and creates their records.

We could have fixed this by ignoring users without subscriptions in SI entirely, but then these cases would never get their subscriptions imprted and couldn't be billed. This way, they get fixed when the subscriptions appear.

This also reduces the eyestrain of output, includes progress reporting for subscription updates (which take a long time), and adds statements to tell us how many records have been processed, so that we can key alerts off of that:

```
INFO:root:Insert missing workspaces complete: 0 workspaces inserted.
INFO:root:Subscription update complete: 0 subscriptions update
```