### PR TITLE
Fix: Change component type on views other than the default

### DIFF
--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -1230,13 +1230,13 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
                 else {
                   component.parentId = undefined;
                 }
-                componentsStore.processRawComponent(componentId);
+                componentsStore.processAndStoreRawComponent(componentId);
               });
               // if we change to no parent, we have to follow up and re-process
               Object.values(oldParentIds)
                 .filter(nonNullable)
                 .forEach((parentId) => {
-                  componentsStore.processRawComponent(parentId);
+                  componentsStore.processAndStoreRawComponent(parentId);
                 });
             },
             onFail: () => {
@@ -1245,9 +1245,11 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
                   componentsStore.rawComponentsById[componentId];
                 if (!component) return;
                 component.parentId = oldParentIds[componentId];
-                componentsStore.processRawComponent(componentId);
+                componentsStore.processAndStoreRawComponent(componentId);
                 if (component.parentId)
-                  componentsStore.processRawComponent(component.parentId);
+                  componentsStore.processAndStoreRawComponent(
+                    component.parentId,
+                  );
               });
             },
           });

--- a/lib/sdf-server/src/service/component/set_type.rs
+++ b/lib/sdf-server/src/service/component/set_type.rs
@@ -44,8 +44,9 @@ pub async fn set_type(
     let component = Component::get_by_id(&ctx, component_id).await?;
     let mut socket_map = HashMap::new();
     let payload = component
-        .into_frontend_type_for_default_view(
+        .into_frontend_type(
             &ctx,
+            None,
             component.change_status(&ctx).await?,
             &mut socket_map,
         )


### PR DESCRIPTION
Issue 1:
The set type endpoint sent the `ComponentUpdated` event with the geometry for the default views, instead of no geometry, so set_type outside of default always failed. Leading to 
Issue 2:
The nodes would disappear on change type, since we store components and groups on separate arrays in both the components and views stores. On type changes we need to move the data to the correct array.