### PR TITLE
Show current expanded row for audit dashboard

### DIFF
--- a/app/web/src/components/Workspace/WorkspaceAuditLog.vue
+++ b/app/web/src/components/Workspace/WorkspaceAuditLog.vue
@@ -134,7 +134,7 @@
             <AuditLogDrawer
               :row="row"
               :colspan="columns.length"
-              :json="JSON.stringify(logs[Number(row.id)], null, 2)"
+              :json="JSON.stringify(filteredLogs[Number(row.id)], null, 2)"
               :expanded="rowCollapseState[Number(row.id)]"
             />
             <tr class="invisible"></tr>


### PR DESCRIPTION
Now, we will show the correct row when expanding rows in the audit logs UI.