### PR TITLE
feat: deepen api client coverage for diagram

### DIFF
--- a/bin/si-api-test/sdf_api_client.ts
+++ b/bin/si-api-test/sdf_api_client.ts
@@ -13,12 +13,12 @@ interface API_DESCRIPTION {
 
 export const ROUTES = {
   // /api/change_set - Change Set Management ---------------------------------------------------
-  abandon_vote: {
-    path: () => "/change_set/abandon_vote",
-    method: "POST",
-  },
   abandon_change_set: {
     path: () => "/change_set/abandon_change_set",
+    method: "POST",
+  },
+  abandon_vote: {
+    path: () => "/change_set/abandon_vote",
     method: "POST",
   },
   add_action: {
@@ -75,17 +75,12 @@ export const ROUTES = {
   },
 
   // Diagram Management ---------------------------------------------------------
-  get_diagram: {
-    path: (vars: ROUTE_VARS) =>
-      `/diagram/get_diagram?visibility_change_set_pk=${vars.changeSetId}&workspaceId=${vars.workspaceId}`,
-    method: "GET",
-  },
-  set_component_position: {
-    path: () => `/diagram/set_component_position`,
+  add_components_to_view: {
+    path: () => "/diagram/add_components_to_view",
     method: "POST",
   },
-  set_component_type: {
-    path: () => `/component/set_type`,
+  delete_connection:{
+    path: () => "/diagram/delete_connection",
     method: "POST",
   },
   dvu_roots: {
@@ -93,10 +88,36 @@ export const ROUTES = {
       `/diagram/dvu_roots?visibility_change_set_pk=${vars.changeSetId}&workspaceId=${vars.workspaceId}`,
     method: "GET",
   },
+  get_all_components_and_edges: {
+    path: () => "/diagram/get_all_components_and_edges",
+    method: "GET",
+  },
+  get_diagram: {
+    path: (vars: ROUTE_VARS) =>
+      `/diagram/get_diagram?visibility_change_set_pk=${vars.changeSetId}&workspaceId=${vars.workspaceId}`,
+    method: "GET",
+  },
+  list_schemas: {
+    path: () => "/diagram/list_schemas",
+    method: "GET"
+  },
+  remove_delete_intent: {
+    path: () => "/diagram/remove_delete_intent",
+    method: "POST",
+  },
+  set_component_position: {
+    path: () => "/diagram/set_component_position",
+    method: "POST",
+  },
+  set_component_type: {
+    path: () => "/component/set_type",
+    method: "POST",
+  },
+
 
   // Component Management -------------------------------------------------------
-  delete_component: {
-    path: () => `/diagram/delete_components`,
+  delete_components: {
+    path: () => "/diagram/delete_components",
     method: "POST",
   },
   create_component: {

--- a/bin/si-api-test/tests/1-create_and_apply_across_change_sets.ts
+++ b/bin/si-api-test/tests/1-create_and_apply_across_change_sets.ts
@@ -89,7 +89,7 @@ async function cleanupHead(sdf: SdfApiClient): Promise<void> {
       workspaceId: sdf.workspaceId,
     };
     await sdf.call({
-      route: "delete_component",
+      route: "delete_components",
       body: deleteComponentPayload,
     });
     await sdf.call({

--- a/bin/si-api-test/tests/2-create_and_delete_component.ts
+++ b/bin/si-api-test/tests/2-create_and_delete_component.ts
@@ -91,7 +91,7 @@ async function create_and_delete_component_inner(
     workspaceId: sdfApiClient.workspaceId,
   };
   await sdfApiClient.call({
-    route: "delete_component",
+    route: "delete_components",
     body: deleteComponentPayload,
   });
 


### PR DESCRIPTION
Completed client coverage for diagram and added test coverage for deleting an edge into `4-create_two_components_connect_and_propagate`. Forgot how the alphabet worked in `changeset` routes, so fixed that too and renamed `deleteComponent` reference to `deleteComponents` to fit with the route. 
<div><img src="https://media1.giphy.com/media/26gYO4oCowW8bH0Ws/giphy.gif"/></div>