### PR TITLE
Coerce email_verified to a boolean in the Auth API

### DIFF
--- a/bin/auth-api/src/services/users.service.ts
+++ b/bin/auth-api/src/services/users.service.ts
@@ -209,7 +209,9 @@ function setUserDataFromAuth0Details(
       firstName: auth0Details.given_name,
       lastName: auth0Details.family_name,
       email: auth0Details.email,
-      emailVerified: auth0Details.email_verified,
+      // Coerce email_verified to a boolean in case it's anything else
+      // thanks to Auth0 and mapping SAML assertions
+      emailVerified: !!auth0Details.email_verified,
       pictureUrl: auth0Details.picture,
       // fairly certain nickname is github username when auth provider is github
       ...(auth0Details.user_id?.startsWith("github|") && {


### PR DESCRIPTION
Auth0 doesn't support email verification for Enterprise users 🙄 , so we must map a separate SAML claim to the `email_verified` user attribute in Auth0, and coerce this to a boolean in the Auth API

See here: https://community.auth0.com/t/email-verification-for-enterprise-users/28230/3 

In the Auth0 side of configuring the SAML Connection, we'll map the user's email to `email_verified` but this broke the AuthAPI as now the value on the Auth0Profile is not a bool anymore.  This fixes that. 

Note: when it comes to self-service SAML integration set up, this is something we'll need to account for when setting up SAML Connections. 

<div><img src="https://media1.giphy.com/media/d3EdJTouFN890fMnGP/giphy.gif?cid=5a38a5a2rmea5mvqh2lrvjdmuyydgcbccpl0i0wco3iuk9k9&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:270px;width:300px"/><br/>via <a href="https://giphy.com/OfflineGranny/">Offline Granny!</a> on <a href="https://giphy.com/gifs/OfflineGranny-reaction-funny-offline-granny-d3EdJTouFN890fMnGP">GIPHY</a></div>