### PR TITLE
Ensure filters do not affect audit table contents

### DIFF
--- a/app/web/src/components/AuditLogDrawer.vue
+++ b/app/web/src/components/AuditLogDrawer.vue
@@ -12,7 +12,11 @@
     "
   >
     <td :colspan="colspan" class="p-0">
-      <CodeViewer showTitle title="Raw Event Data" :code="json" />
+      <CodeViewer
+        showTitle
+        title="Raw Event Data"
+        :code="JSON.stringify(row.original, null, 2)"
+      />
     </td>
   </tr>
 </template>
@@ -32,10 +36,6 @@ defineProps({
   },
   colspan: {
     type: Number,
-    required: true,
-  },
-  json: {
-    type: String,
     required: true,
   },
   expanded: {


### PR DESCRIPTION
## Description

This PR ensures that changing filters does not affect the contents of the inner table used in the Audit Log dashboard. This does not fully fix the performance issues observed when using filters in the Audit Log dashboard, but does improve them.

<img src="https://media4.giphy.com/media/lL2zorA5deaHun1l4o/giphy.gif"/>

## Additional Information

Now, the data for the table is only changed when the total set of Audit Log entries loaded changes. This PR takes advantage of TanStack's built-in filtering features. However, this PR does not fully take advantage of every TanStack feature at our disposal. There is likely more room for improvement.

Additionally, there is a now a distinct message for scenarios where there are no audit logs in the workspace (e.g. brand new workspace).