### PR TITLE
feat: don't page unless you're absolutely sure it's worth waking someone up for 

### DIFF
--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -95,7 +95,7 @@ jobs:
 
             # Run the npx task and store exit code in a variable
             npx cypress run --spec "cypress/e2e/${{ matrix.tests }}/**" || exit_code=$?
-            
+
             # Check the exit code
             if [ -z "$exit_code" ]; then
               echo "Cypress Test task succeeded!"
@@ -113,7 +113,7 @@ jobs:
 
       - name: 'Upload Cypress Recordings to Github'
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
           name: cypress-recordings-run-${{ matrix.tests }}
           path: app/web/cypress/videos/**/*.mp4
@@ -126,24 +126,42 @@ jobs:
   on-failure:
     runs-on: ubuntu-latest
     needs: cypress-tests
-    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    environment: ${{ inputs.environment }}
+    if: ${{ failure() }} && github.ref == 'refs/heads/main' }}
     steps:
-      - run: |
-          curl --location "${{ secrets.FIREHYDRANT_WEBHOOK_URL }}" \
-            --header "Content-Type: application/json" \
-            --data "{
-              \"summary\": \"E2E ${{ inputs.environment }} Tests Fail\",
-              \"body\": \"E2E Tests have failed for ${{ inputs.environment }}.\",
-              \"links\": [
-                {
-                  \"href\": \"https://github.com/systeminit/si/actions/runs/$GITHUB_RUN_ID\",
-                  \"text\": \"E2E Test Run ${{ inputs.environment }}\"
-                }
-              ],
-              \"tags\": [
-                \"service:github\"
-              ]
-            }"
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - run: |     
+          has_artifacts=false
+          # Check for marker files
+          for marker in artifacts/*/*.mp4; do
+            if [ -f "$marker" ]; then
+              echo "Artifact detected for failed test: $marker"
+              echo "Setting failure to true and breaking"
+              has_artifacts=true
+              break
+            fi
+          done
+          # If at least one valid failure marker is present, then page
+          if [ "$has_artifacts" = true ]; then
+            curl --location "${{ secrets.FIREHYDRANT_WEBHOOK_URL }}" \
+              --header "Content-Type: application/json" \
+              --data "{
+                \"summary\": \"E2E ${{ inputs.environment }} Tests Fail\",
+                \"body\": \"E2E Tests have failed for ${{ inputs.environment }}.\",
+                \"links\": [
+                  {
+                    \"href\": \"https://github.com/systeminit/si/actions/runs/$GITHUB_RUN_ID\",
+                    \"text\": \"E2E Test Run ${{ inputs.environment }}\"
+                  }
+                ],
+                \"tags\": [
+                  \"service:github\"
+                ]
+              }"
+          fi
 
       - run: |
           curl -X POST \

--- a/.github/workflows/run-api-test.yml
+++ b/.github/workflows/run-api-test.yml
@@ -88,13 +88,14 @@ jobs:
           IFS=',' read -r -a workspace_array <<< "$workspace_ids"
           
           # Pick the correct workspace ID based on the index
-          workspace_id=${workspace_array[${{ matrix.tests.index }}]}
+          workspace_id="${workspace_array[${{ matrix.tests.index }}]}"
 
           echo "Using workspace ID: $workspace_id"
 
           # Retry loop with 5 attempts
           n=0
           max_retries=5
+          exit_code=0
           
           until [ $n -ge $max_retries ]
           do
@@ -109,7 +110,7 @@ jobs:
             
             # Check the exit code
             if [ -z "$exit_code" ]; then
-              echo "Deno task succeeded!"
+              echo "Deno task succeeded [ or the orchestration failed for a totally non-valid reason ]!"
               break
             fi
 
@@ -120,32 +121,67 @@ jobs:
 
           if [ $n -ge $max_retries ]; then
             echo "All $max_retries attempts failed."
-            exit 1
+            exit_code=1
           fi
+
+          echo "last_exit_code=$exit_code" >> "$GITHUB_ENV"
+          exit "$last_exit_code"
+
+      - name: Upload artifact if exit code 53
+        if: ${{ failure() && env.last_exit_code == '53' }}
+        run: |
+          echo "Uploading marker for test ${{ matrix.tests.name }}"
+          mkdir -p artifacts/${{ matrix.tests.name }}
+          echo "failure-marker" > artifacts/${{ matrix.tests.name }}/failure-marker
+
+      - name: Upload artifacts
+        if: ${{ failure() && env.last_exit_code == '53' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.tests.name }}
+          path: artifacts/${{ matrix.tests.name }}
 
   on-failure:
     runs-on: ubuntu-latest
     needs: api-test
-    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    environment: ${{ inputs.environment }}
+    if: ${{ failure() }} && github.ref == 'refs/heads/main' }}
     steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - run: |     
+          has_artifacts=false
+          # Check for marker files
+          for marker in artifacts/*/failure-marker; do
+            if [ -f "$marker" ]; then
+              echo "Artifact detected for failed test: $marker"
+              echo "Setting failure to true and breaking"
+              has_artifacts=true
+              break
+            fi
+          done
+          # If at least one valid failure marker is present, then page
+          if [ "$has_artifacts" = true ]; then
+              curl --location "${{ secrets.FIREHYDRANT_WEBHOOK_URL }}" \
+              --header "Content-Type: application/json" \
+              --data "{
+                \"summary\": \"API ${{ inputs.environment }} Tests Fail\",
+                \"body\": \"API Tests have failed for ${{ inputs.environment }}.\",
+                \"links\": [
+                  {
+                    \"href\": \"https://github.com/systeminit/si/actions/runs/$GITHUB_RUN_ID\",
+                    \"text\": \"E2E Test Run ${{ inputs.environment }}\"
+                  }
+                ],
+                \"tags\": [
+                  \"service:github\"
+                ]
+              }" 
+          fi
       - run: |
-            curl --location "${{ secrets.FIREHYDRANT_WEBHOOK_URL }}" \
-            --header "Content-Type: application/json" \
-            --data "{
-              \"summary\": \"API ${{ inputs.environment }} Tests Fail\",
-              \"body\": \"API Tests have failed for ${{ inputs.environment }}.\",
-              \"links\": [
-                {
-                  \"href\": \"https://github.com/systeminit/si/actions/runs/$GITHUB_RUN_ID\",
-                  \"text\": \"E2E Test Run ${{ inputs.environment }}\"
-                }
-              ],
-              \"tags\": [
-                \"service:github\"
-              ]
-            }"
-      - run: |
-          curl -X POST \
-          --header 'Content-type: application/json' \
-          --data "{\"text\": \":si: Failed API Tests for ${{ inputs.environment }}: <https://github.com/systeminit/si/actions/runs/$GITHUB_RUN_ID|:test_tube: Link>\"}" \
-          ${{ secrets.SLACK_WEBHOOK_URL }}
+          # Always send the Internal Slack Notification if failure detected, regardless of error source
+          curl --location "${{ secrets.SLACK_WEBHOOK_URL }}" -X POST \
+            --header 'Content-type: application/json' \
+            --data "{\"text\": \":si: Failed API Tests for ${{ inputs.environment }}: <https://github.com/systeminit/si/actions/runs/$GITHUB_RUN_ID|:test_tube: Link>\"}"

--- a/bin/si-api-test/main.ts
+++ b/bin/si-api-test/main.ts
@@ -106,7 +106,7 @@ if (import.meta.main) {
   clearInterval(intervalId);
   console.log("~~ FINAL REPORT GENERATED ~~");
   await printTestReport(testReport, reportFile);
-  const exitCode = testsFailed(testReport) ? 1 : 0;
+  const exitCode = testsFailed(testReport) ? 53 : 0;
   Deno.exit(exitCode);
 }
 


### PR DESCRIPTION
I'm not particularly happy with this indirect assertion system, but logically it ties together and should hold us in good stead moving forward to prevent unnecessary pages.

It works off the premise that the only reason we should page someone from CI is:
- If we have a valid failure test result
- It's the correct environment

Previously we had a bunch of other failure scenarios which would have also paged, such as:
- NPM outage
- Github orchestration issue/infrastructure issue on their side
- Cypress results not uploading correctly in CI
- Other networking issue/blip
- Other 3rd party dependency issue

Now for every time the system wants to assert whether to page someone, the CI runner MUST have a valid failure artifact or marker pulled from the CI workflow.

`ALL` failures, regardless of cause will still post into #_alerts_internal to let us know there was an orchestration issue of some manner. Should save a lot of noise in paging people with no actionable result.

For the API tests, to assert whether the test actually failed while running our code, I made it throw exit code 53, which is a random code I devised that should not match any other orchestration failure from deno, dependencies or otherwise.

<hr />

Also fixed an issue with the Slack notification for failed tests not working because it didn't have the environment to pull the Slack token.

Developing this was a proper grind
<div><img width="476" alt="Screenshot 2024-12-09 at 23 04 05" src="https://github.com/user-attachments/assets/88e3a191-b789-44ee-a65d-44fbf670597d"></div>


