### PR TITLE
fix: incorrect reference for pr number in scope

### DIFF
--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: peter-evans/create-or-update-comment@v4
         id: init-comment
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.issue.number }}
           body: |
             Okay, starting a try! I\'ll update this comment once it\'s running...\n
 
@@ -36,7 +36,7 @@ jobs:
 
       - uses: peter-evans/create-or-update-comment@v4
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.issue.number }}
           comment-id: ${{ steps.init-comment.outputs.comment-id }}
           body: |
             🚀 [Try running here](${{ steps.run-build.outputs.url }})! 🚀


### PR DESCRIPTION
See [this example](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only) for usage