### PR TITLE
feat(sdf, dal): Adding the ability to set a webhook url for a workspace

### DIFF
--- a/app/web/src/components/WorkspaceIntegrationsModal.vue
+++ b/app/web/src/components/WorkspaceIntegrationsModal.vue
@@ -1,0 +1,48 @@
+<template>
+  <Modal
+    ref="modalRef"
+    type="save"
+    size="sm"
+    saveLabel="Save"
+    title="Save Integrations"
+    @save="updateIntegrations"
+  >
+    <VormInput ref="labelRef" v-model="webhookUrl" label="Slack Webhook Url" />
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { Modal, VormInput } from "@si/vue-lib/design-system";
+import { ref, computed } from "vue";
+import { useWorkspacesStore } from "@/store/workspaces.store";
+
+const workspacesStore = useWorkspacesStore();
+
+const modalRef = ref<InstanceType<typeof Modal>>();
+
+const integration = computed(() => workspacesStore.getIntegrations);
+
+function open() {
+  if (
+    integration.value &&
+    integration.value.slackWebhookUrl &&
+    integration.value.slackWebhookUrl !== ""
+  ) {
+    webhookUrl.value = integration.value.slackWebhookUrl;
+  }
+  modalRef.value?.open();
+}
+
+const webhookUrl = ref("");
+
+const updateIntegrations = () => {
+  if (!webhookUrl.value || webhookUrl.value === "" || !integration.value?.pk)
+    return;
+  workspacesStore.UPDATE_INTEGRATION(integration.value?.pk, webhookUrl.value);
+
+  modalRef.value?.close();
+  webhookUrl.value = "";
+};
+
+defineExpose({ open });
+</script>

--- a/app/web/src/components/layout/navbar/WorkspaceSettingsMenu.vue
+++ b/app/web/src/components/layout/navbar/WorkspaceSettingsMenu.vue
@@ -33,11 +33,18 @@
         label="Copy Workspace Token"
         @click="copyWorkspaceToken"
       />
+      <DropdownMenuItem
+        v-if="featureFlagsStore.SLACK_WEBHOOK"
+        icon="settings"
+        label="Workspace Integrations"
+        @click="integrationsModalRef?.open()"
+      />
     </template>
   </NavbarButton>
 
   <WorkspaceImportModal ref="importModalRef" />
   <WorkspaceExportModal ref="exportModalRef" />
+  <WorkspaceIntegrationsModal ref="integrationsModalRef" />
 </template>
 
 <script setup lang="ts">
@@ -46,16 +53,21 @@ import { ref, computed } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import WorkspaceImportModal from "@/components/WorkspaceImportModal.vue";
 import WorkspaceExportModal from "@/components/WorkspaceExportModal.vue";
+import WorkspaceIntegrationsModal from "@/components/WorkspaceIntegrationsModal.vue";
 import { useWorkspacesStore } from "@/store/workspaces.store";
 import { useChangeSetsStore } from "@/store/change_sets.store";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import NavbarButton from "./NavbarButton.vue";
 
 const AUTH_PORTAL_URL = import.meta.env.VITE_AUTH_PORTAL_URL;
 const importModalRef = ref<InstanceType<typeof WorkspaceImportModal>>();
 const exportModalRef = ref<InstanceType<typeof WorkspaceExportModal>>();
+const integrationsModalRef =
+  ref<InstanceType<typeof WorkspaceIntegrationsModal>>();
 
 const workspacesStore = useWorkspacesStore();
 const changeSetStore = useChangeSetsStore();
+const featureFlagsStore = useFeatureFlagsStore();
 const router = useRouter();
 const route = useRoute();
 

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -17,6 +17,7 @@ const FLAG_MAPPING = {
   AI_GENERATOR: "ai-generator",
   REBAC: "rebac",
   OUTLINER_VIEWS: "diagram-outline-show-views",
+  SLACK_WEBHOOK: "slack_webhook",
 };
 
 type FeatureFlags = keyof typeof FLAG_MAPPING;

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -66,6 +66,7 @@ pub mod user;
 pub mod validation;
 pub mod visibility;
 pub mod workspace;
+pub mod workspace_integrations;
 pub mod workspace_snapshot;
 pub mod ws_event;
 

--- a/lib/dal/src/migrations/U3410__workspace_integration.sql
+++ b/lib/dal/src/migrations/U3410__workspace_integration.sql
@@ -1,0 +1,11 @@
+CREATE TABLE workspace_integrations
+(
+    pk                          ident primary key default ident_create_v1(),
+    slack_webhook_url           text NULL,
+    workspace_pk                ident NOT NULL
+);
+CREATE UNIQUE INDEX ON workspace_integrations (pk);
+CREATE UNIQUE INDEX ON workspace_integrations (workspace_pk);
+CREATE UNIQUE INDEX ON workspace_integrations (slack_webhook_url, workspace_pk);
+CREATE INDEX ON workspace_integrations (slack_webhook_url);
+CREATE INDEX ON workspace_integrations (workspace_pk);

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -21,6 +21,7 @@ use crate::builtins::func::migrate_intrinsics_no_commit;
 use crate::change_set::{ChangeSet, ChangeSetError, ChangeSetId};
 use crate::feature_flags::FeatureFlag;
 use crate::layer_db_types::ContentTypes;
+use crate::workspace_integrations::{WorkspaceIntegration, WorkspaceIntegrationsError};
 use crate::workspace_snapshot::graph::WorkspaceSnapshotGraphDiscriminants;
 use crate::workspace_snapshot::WorkspaceSnapshotError;
 use crate::{
@@ -84,6 +85,8 @@ pub enum WorkspaceError {
     Transactions(#[from] TransactionsError),
     #[error(transparent)]
     User(#[from] UserError),
+    #[error("workspace integration error: {0}")]
+    WorkspaceIntegration(#[from] WorkspaceIntegrationsError),
     #[error("workspace not found: {0}")]
     WorkspaceNotFound(WorkspacePk),
     #[error("workspace snapshot error: {0}")]
@@ -366,6 +369,9 @@ impl Workspace {
             &serde_json::json![{ "visibility": ctx.visibility() }],
         )
         .await?;
+
+        // Create an entry in the workspace integrations table by default
+        WorkspaceIntegration::new(ctx, None).await?;
 
         Ok(workspace)
     }

--- a/lib/dal/src/workspace_integrations.rs
+++ b/lib/dal/src/workspace_integrations.rs
@@ -1,0 +1,126 @@
+use crate::{workspace::WorkspaceId, DalContext, TransactionsError};
+use serde::{Deserialize, Serialize};
+use si_data_pg::{PgError, PgRow};
+use thiserror::Error;
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum WorkspaceIntegrationsError {
+    #[error(transparent)]
+    Pg(#[from] PgError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
+}
+
+pub type WorkspaceIntegrationsResult<T> = Result<T, WorkspaceIntegrationsError>;
+
+pub use si_id::WorkspaceIntegrationId;
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceIntegration {
+    pk: WorkspaceIntegrationId,
+    workspace_pk: WorkspaceId,
+    slack_webhook_url: Option<String>,
+}
+
+impl TryFrom<PgRow> for WorkspaceIntegration {
+    type Error = WorkspaceIntegrationsError;
+
+    fn try_from(row: PgRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            pk: row.try_get("pk")?,
+            workspace_pk: row.try_get("workspace_pk")?,
+            slack_webhook_url: row.try_get("slack_webhook_url")?,
+        })
+    }
+}
+
+impl WorkspaceIntegration {
+    pub fn pk(&self) -> &WorkspaceIntegrationId {
+        &self.pk
+    }
+
+    pub fn slack_webhook_url(&self) -> Option<String> {
+        self.slack_webhook_url.clone()
+    }
+
+    pub async fn update_webhook_url(
+        &mut self,
+        ctx: &DalContext,
+        webhook_url: String,
+    ) -> WorkspaceIntegrationsResult<()> {
+        ctx.txns()
+            .await?
+            .pg()
+            .query_none(
+                "UPDATE workspace_integrations SET slack_webhook_url = $2 WHERE pk = $1",
+                &[&self.pk, &webhook_url],
+            )
+            .await?;
+        self.slack_webhook_url = Some(webhook_url);
+
+        Ok(())
+    }
+
+    pub async fn new(
+        ctx: &DalContext,
+        webhook_url: Option<String>,
+    ) -> WorkspaceIntegrationsResult<Self> {
+        let workspace_pk = ctx.workspace_pk()?;
+
+        let row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_one(
+                "INSERT INTO workspace_integrations (workspace_pk, slack_webhook_url) VALUES ($1, $2)  RETURNING *",
+                &[&workspace_pk, &webhook_url],
+            )
+            .await?;
+
+        let workspace_integration = Self::try_from(row)?;
+
+        Ok(workspace_integration)
+    }
+
+    pub async fn get_integrations_for_workspace_pk(
+        ctx: &DalContext,
+    ) -> WorkspaceIntegrationsResult<Option<Self>> {
+        let workspace_pk = ctx.workspace_pk()?;
+
+        let maybe_row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_opt(
+                "SELECT * FROM workspace_integrations AS w WHERE workspace_pk = $1",
+                &[&workspace_pk],
+            )
+            .await?;
+        let maybe_workspace_integration = match maybe_row {
+            Some(found) => Some(Self::try_from(found)?),
+            None => None,
+        };
+        Ok(maybe_workspace_integration)
+    }
+
+    pub async fn get_by_pk(
+        ctx: &DalContext,
+        workspace_integration_id: WorkspaceIntegrationId,
+    ) -> WorkspaceIntegrationsResult<Option<Self>> {
+        let maybe_row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_opt(
+                "SELECT * FROM workspace_integrations AS w WHERE pk = $1",
+                &[&workspace_integration_id],
+            )
+            .await?;
+        let maybe_workspace_integration = match maybe_row {
+            Some(found) => Some(Self::try_from(found)?),
+            None => None,
+        };
+        Ok(maybe_workspace_integration)
+    }
+}

--- a/lib/sdf-server/src/service/v2.rs
+++ b/lib/sdf-server/src/service/v2.rs
@@ -6,6 +6,7 @@ pub mod admin;
 pub mod audit_log;
 pub mod change_set;
 pub mod func;
+pub mod integrations;
 pub mod management;
 pub mod module;
 pub mod variant;
@@ -15,6 +16,8 @@ const PREFIX: &str = "/workspaces/:workspace_id/change-sets/:change_set_id";
 
 // use this if you don't need to pass in the change_set id
 const CHANGE_SET_PREFIX: &str = "/workspaces/:workspace_id/change-sets";
+
+const INTEGRATIONS_PREFIX: &str = "/workspaces/:workspace_id";
 
 pub fn routes(state: AppState) -> Router<AppState> {
     Router::new()
@@ -26,4 +29,8 @@ pub fn routes(state: AppState) -> Router<AppState> {
         .nest(&format!("{PREFIX}/schema-variants"), variant::v2_routes())
         .nest(&format!("{PREFIX}/management"), management::v2_routes())
         .nest(&format!("{PREFIX}/views"), view::v2_routes())
+        .nest(
+            &format!("{INTEGRATIONS_PREFIX}/integrations"),
+            integrations::v2_routes(),
+        )
 }

--- a/lib/sdf-server/src/service/v2/change_set/approve.rs
+++ b/lib/sdf-server/src/service/v2/change_set/approve.rs
@@ -2,7 +2,7 @@ use axum::extract::{Host, OriginalUri, Path};
 use dal::{ChangeSet, ChangeSetId, WorkspacePk, WsEvent};
 use si_events::audit_log::AuditLogKind;
 
-use super::{Error, Result};
+use super::{post_to_webhook, Error, Result};
 use crate::{
     extract::{AccessBuilder, HandlerContext, PosthogClient},
     track,
@@ -14,7 +14,7 @@ pub async fn approve(
     PosthogClient(posthog_client): PosthogClient,
     OriginalUri(original_uri): OriginalUri,
     Host(host_name): Host,
-    Path((_workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
+    Path((workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
 ) -> Result<()> {
     let ctx = builder
         .build(request_ctx.build(change_set_id.into()))
@@ -64,6 +64,17 @@ pub async fn approve(
         change_set_view.name.clone(),
     )
     .await?;
+
+    let actor = ctx.history_actor().email(&ctx).await?;
+    let change_set_url = format!("https://{}/w/{}/{}", host_name, workspace_pk, change_set_id);
+    let message = format!(
+        "{} approved merge of change set {}: {}",
+        actor,
+        change_set_view.name.clone(),
+        change_set_url
+    );
+    post_to_webhook(&ctx, workspace_pk, message.as_str()).await?;
+
     WsEvent::change_set_status_changed(&ctx, old_status, change_set_view)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/service/v2/change_set/reject.rs
+++ b/lib/sdf-server/src/service/v2/change_set/reject.rs
@@ -2,7 +2,7 @@ use axum::extract::{Host, OriginalUri, Path};
 use dal::{ChangeSet, ChangeSetId, WorkspacePk, WsEvent};
 use si_events::audit_log::AuditLogKind;
 
-use super::{Error, Result};
+use super::{post_to_webhook, Error, Result};
 use crate::{
     extract::{AccessBuilder, HandlerContext, PosthogClient},
     track,
@@ -14,7 +14,7 @@ pub async fn reject(
     PosthogClient(posthog_client): PosthogClient,
     OriginalUri(original_uri): OriginalUri,
     Host(host_name): Host,
-    Path((_workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
+    Path((workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
 ) -> Result<()> {
     let ctx = builder
         .build(request_ctx.build(change_set_id.into()))
@@ -50,6 +50,17 @@ pub async fn reject(
         change_set_view.name.clone(),
     )
     .await?;
+
+    let actor = ctx.history_actor().email(&ctx).await?;
+    let change_set_url = format!("https://{}/w/{}/{}", host_name, workspace_pk, change_set_id);
+    let message = format!(
+        "{} rejected merge of change set {}: {}",
+        actor,
+        change_set_view.name.clone(),
+        change_set_url
+    );
+    post_to_webhook(&ctx, workspace_pk, message.as_str()).await?;
+
     WsEvent::change_set_status_changed(&ctx, old_status, change_set_view)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/service/v2/integrations.rs
+++ b/lib/sdf-server/src/service/v2/integrations.rs
@@ -1,0 +1,42 @@
+use axum::{
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Router,
+};
+use hyper::StatusCode;
+use thiserror::Error;
+
+use crate::{service::ApiError, AppState};
+
+pub mod get_integrations;
+pub mod update_integration;
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum IntegrationsError {
+    #[error("integration with id {0} not found")]
+    IntegrationNotFound(dal::workspace_integrations::WorkspaceIntegrationId),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] dal::TransactionsError),
+    #[error("workspace integration error: {0}")]
+    WorkspaceIntegrations(#[from] dal::workspace_integrations::WorkspaceIntegrationsError),
+}
+
+pub type IntegrationsResult<T> = Result<T, IntegrationsError>;
+
+impl IntoResponse for IntegrationsError {
+    fn into_response(self) -> Response {
+        let (status_code, error_message) = (StatusCode::INTERNAL_SERVER_ERROR, self.to_string());
+
+        ApiError::new(status_code, error_message).into_response()
+    }
+}
+
+pub fn v2_routes() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/:workspace_integration_id",
+            post(update_integration::update_integration),
+        )
+        .route("/", get(get_integrations::get_integration))
+}

--- a/lib/sdf-server/src/service/v2/integrations/get_integrations.rs
+++ b/lib/sdf-server/src/service/v2/integrations/get_integrations.rs
@@ -1,0 +1,27 @@
+use crate::extract::{AccessBuilder, HandlerContext, PosthogClient};
+use axum::extract::{Host, OriginalUri};
+use axum::Json;
+use dal::workspace_integrations::WorkspaceIntegration;
+use serde::{Deserialize, Serialize};
+
+use super::IntegrationsResult;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetIntegrationResponse {
+    pub integration: Option<WorkspaceIntegration>,
+}
+
+pub async fn get_integration(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    PosthogClient(_posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    Host(_host_name): Host,
+) -> IntegrationsResult<Json<GetIntegrationResponse>> {
+    let ctx = builder.build_head(access_builder).await?;
+
+    let integration = WorkspaceIntegration::get_integrations_for_workspace_pk(&ctx).await?;
+
+    Ok(Json(GetIntegrationResponse { integration }))
+}

--- a/lib/sdf-server/src/service/v2/integrations/update_integration.rs
+++ b/lib/sdf-server/src/service/v2/integrations/update_integration.rs
@@ -1,0 +1,45 @@
+use crate::extract::{AccessBuilder, HandlerContext, PosthogClient};
+use axum::extract::{Host, OriginalUri, Path};
+use axum::Json;
+use dal::workspace_integrations::{WorkspaceIntegration, WorkspaceIntegrationId};
+use dal::WorkspacePk;
+use serde::{Deserialize, Serialize};
+
+use super::{IntegrationsError, IntegrationsResult};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateIntegrationRequest {
+    slack_webhook_url: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateIntegrationResponse {
+    pub integration: WorkspaceIntegration,
+}
+
+pub async fn update_integration(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    PosthogClient(_posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    Host(_host_name): Host,
+    Path((_workspace_pk, workspace_integration_id)): Path<(WorkspacePk, WorkspaceIntegrationId)>,
+    Json(request): Json<UpdateIntegrationRequest>,
+) -> IntegrationsResult<Json<UpdateIntegrationResponse>> {
+    let ctx = builder.build_head(access_builder).await?;
+
+    let mut integration = WorkspaceIntegration::get_by_pk(&ctx, workspace_integration_id)
+        .await?
+        .ok_or(IntegrationsError::IntegrationNotFound(
+            workspace_integration_id,
+        ))?;
+
+    if let Some(webhook_url) = request.slack_webhook_url {
+        integration.update_webhook_url(&ctx, webhook_url).await?;
+    }
+    ctx.commit().await?;
+
+    Ok(Json(UpdateIntegrationResponse { integration }))
+}

--- a/lib/si-id/src/lib.rs
+++ b/lib/si-id/src/lib.rs
@@ -64,6 +64,7 @@ id_with_pg_types!(FuncId);
 id_with_pg_types!(FuncRunId);
 id_with_pg_types!(SchemaId);
 id_with_pg_types!(UserPk);
+id_with_pg_types!(WorkspaceIntegrationId);
 
 // Please keep these alphabetically sorted!
 id_with_none!(SchemaVariantId);


### PR DESCRIPTION
We currently only post to that webhook from the change set approval flow but we want to make this more of an opt-in to what you can / can't to