### PR TITLE
Split core si-id macro into multiple macros

### DIFF
--- a/lib/si-id/src/conversions.rs
+++ b/lib/si-id/src/conversions.rs
@@ -1,0 +1,25 @@
+use crate::{AttributeValueId, PropId, PropertyEditorPropId, PropertyEditorValueId};
+
+impl From<PropId> for PropertyEditorPropId {
+    fn from(prop_id: PropId) -> Self {
+        Self::from(::ulid::Ulid::from(prop_id))
+    }
+}
+
+impl From<PropertyEditorPropId> for PropId {
+    fn from(property_editor_prop_id: PropertyEditorPropId) -> Self {
+        Self::from(::ulid::Ulid::from(property_editor_prop_id))
+    }
+}
+
+impl From<AttributeValueId> for PropertyEditorValueId {
+    fn from(id: AttributeValueId) -> Self {
+        Self::from(::ulid::Ulid::from(id))
+    }
+}
+
+impl From<PropertyEditorValueId> for AttributeValueId {
+    fn from(id: PropertyEditorValueId) -> Self {
+        Self::from(::ulid::Ulid::from(id))
+    }
+}

--- a/lib/si-id/src/lib.rs
+++ b/lib/si-id/src/lib.rs
@@ -1,228 +1,47 @@
+//! Provides a centralized location for constructing identifiers for SI.
+
+#![warn(
+    bad_style,
+    clippy::missing_panics_doc,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result,
+    clippy::unwrap_used,
+    dead_code,
+    improper_ctypes,
+    missing_debug_implementations,
+    missing_docs,
+    no_mangle_generic_items,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    unconditional_recursion,
+    unreachable_pub,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
+
+#[macro_use]
+pub(crate) mod macros;
+pub(crate) mod conversions;
 pub mod ulid;
 
-macro_rules! id {
-    (
-        $(#[$($attrss:tt)*])*
-        $name:ident
-    ) => {
-        $(#[$($attrss)*])*
-        #[allow(missing_docs)]
-        #[derive(
-            Eq,
-            PartialEq,
-            PartialOrd,
-            Ord,
-            Copy,
-            Clone,
-            Hash,
-            derive_more::From,
-            derive_more::Into,
-            derive_more::Display,
-            serde::Serialize,
-            serde::Deserialize,
-        )]
-        pub struct $name(::ulid::Ulid);
-
-        impl std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                f.debug_tuple(stringify!($name)).field(&self.0.to_string()).finish()
-            }
-        }
-
-        // TODO(nick): destroy this with fire.
-        impl Default for $name {
-            fn default() -> Self {
-                Self::NONE
-            }
-        }
-
-        impl $name {
-            // TODO(nick): destroy this with fire.
-            pub const NONE: Self = Self(::ulid::Ulid::nil());
-
-            /// Length of a string-encoded ID in bytes.
-            pub const ID_LEN: usize = ::ulid::ULID_LEN;
-
-            /// Generates a new key which is virtually guaranteed to be unique.
-            pub fn generate() -> Self {
-                Self(::ulid::Ulid::new())
-            }
-
-            /// Calls [`Self::generate`].
-            pub fn new() -> Self {
-                Self::generate()
-            }
-
-            /// Converts type into inner [`Ulid`](::ulid::Ulid).
-            pub fn into_inner(self) -> ::ulid::Ulid {
-                self.0
-            }
-
-            /// Creates a Crockford Base32 encoded string that represents this Ulid.
-            pub fn array_to_str<'buf>(&self, buf: &'buf mut [u8; ::ulid::ULID_LEN]) -> &'buf mut str {
-                self.0.array_to_str(buf)
-            }
-
-            pub fn array_to_str_buf() -> [u8; ::ulid::ULID_LEN] {
-                [0; ::ulid::ULID_LEN]
-            }
-
-            /// Constructs a new instance of Self from the given raw identifier.
-            ///
-            /// This function is typically used to consume ownership of the specified identifier.
-            pub fn from_raw_id(value: ::ulid::Ulid) -> Self {
-                Self(value)
-            }
-
-            /// Extracts the raw identifier.
-            ///
-            /// This function is typically used to borrow an owned idenfier.
-            pub fn as_raw_id(&self) -> ::ulid::Ulid {
-                self.0
-            }
-
-            /// Consumes this object, returning the raw underlying identifier.
-            ///
-            /// This function is typically used to transfer ownership of the underlying identifier
-            /// to the caller.
-            pub fn into_raw_id(self) -> ::ulid::Ulid {
-                self.0
-            }
-        }
-
-        impl From<$name> for String {
-            fn from(id: $name) -> Self {
-                ::ulid::Ulid::from(id.0).into()
-            }
-        }
-
-        impl<'a> From<&'a $name> for ::ulid::Ulid {
-            fn from(id: &'a $name) -> Self {
-                id.0
-            }
-        }
-
-        impl From<$name> for crate::ulid::Ulid {
-            fn from(id: $name) -> Self {
-                id.0.into()
-            }
-        }
-
-        impl<'a> From<&'a $name> for crate::ulid::Ulid {
-            fn from(id: &'a $name) -> Self {
-                id.0.into()
-            }
-        }
-
-        impl From<crate::ulid::Ulid> for $name {
-            fn from(ulid: crate::ulid::Ulid) -> Self {
-                ulid.inner().into()
-            }
-        }
-
-        impl<'a> From<&'a $name> for $name {
-            fn from(id: &'a $name) -> Self {
-                *id
-            }
-        }
-
-        impl std::str::FromStr for $name {
-            type Err = ::ulid::DecodeError;
-
-            fn from_str(s: &str) -> Result<Self, Self::Err> {
-                Ok(Self(::ulid::Ulid::from_string(s)?))
-            }
-        }
-
-        impl<'a> postgres_types::FromSql<'a> for $name {
-            fn from_sql(
-                ty: &postgres_types::Type,
-                raw: &'a [u8],
-            ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
-                let id: String = postgres_types::FromSql::from_sql(ty, raw)?;
-                Ok(Self(::ulid::Ulid::from_string(&id)?))
-            }
-
-            fn accepts(ty: &postgres_types::Type) -> bool {
-                ty == &postgres_types::Type::BPCHAR
-                    || ty.kind() == &postgres_types::Kind::Domain(postgres_types::Type::BPCHAR)
-            }
-        }
-
-        impl postgres_types::ToSql for $name {
-            fn to_sql(
-                &self,
-                ty: &postgres_types::Type,
-                out: &mut postgres_types::private::BytesMut,
-            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
-            where
-                Self: Sized,
-            {
-                postgres_types::ToSql::to_sql(&self.0.to_string(), ty, out)
-            }
-
-            fn accepts(ty: &postgres_types::Type) -> bool
-            where
-                Self: Sized,
-            {
-                ty == &postgres_types::Type::BPCHAR
-                    || ty.kind() == &postgres_types::Kind::Domain(postgres_types::Type::BPCHAR)
-            }
-
-            fn to_sql_checked(
-                &self,
-                ty: &postgres_types::Type,
-                out: &mut postgres_types::private::BytesMut,
-            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>> {
-                postgres_types::ToSql::to_sql(&self.0.to_string(), ty, out)
-            }
-        }
-    };
-}
-
-impl From<PropId> for PropertyEditorPropId {
-    fn from(prop_id: PropId) -> Self {
-        Self::from(::ulid::Ulid::from(prop_id))
-    }
-}
-
-impl From<PropertyEditorPropId> for PropId {
-    fn from(property_editor_prop_id: PropertyEditorPropId) -> Self {
-        Self::from(::ulid::Ulid::from(property_editor_prop_id))
-    }
-}
-
-impl From<AttributeValueId> for PropertyEditorValueId {
-    fn from(id: AttributeValueId) -> Self {
-        Self::from(::ulid::Ulid::from(id))
-    }
-}
-
-impl From<PropertyEditorValueId> for AttributeValueId {
-    fn from(id: PropertyEditorValueId) -> Self {
-        Self::from(::ulid::Ulid::from(id))
-    }
-}
-
-id!(ActionId);
+// Please keep these alphabetically sorted!
 id!(ActionPrototypeId);
 id!(AttributePrototypeArgumentId);
 id!(AttributePrototypeId);
-id!(AttributeValueId);
 id!(AuthenticationPrototypeId);
-id!(CachedModuleId);
-id!(ChangeSetId);
-id!(ComponentId);
 id!(DeprecatedVectorClockId);
 id!(EventSessionId);
 id!(FuncArgumentId);
 id!(FuncExecutionPk);
-id!(FuncId);
-id!(FuncRunId);
 id!(GeometryId);
 id!(HistoryEventPk);
 id!(InputSocketId);
-id!(KeyPairPk);
 id!(ManagementPrototypeId);
 id!(ModuleId);
 id!(NaxumApiTypesRequestId);
@@ -230,13 +49,27 @@ id!(OutputSocketId);
 id!(PropId);
 id!(PropertyEditorPropId);
 id!(PropertyEditorValueId);
-id!(SchemaId);
-id!(SchemaVariantId);
 id!(SecretId);
 id!(StaticArgumentValueId);
-id!(UserPk);
 id!(ValidationOutputId);
 id!(ViewId);
-id!(WorkspaceId);
-id!(WorkspacePk);
 id!(WorkspaceSnapshotNodeId);
+
+// Please keep these alphabetically sorted!
+id_with_pg_types!(ActionId);
+id_with_pg_types!(CachedModuleId);
+id_with_pg_types!(ChangeSetId);
+id_with_pg_types!(ComponentId);
+id_with_pg_types!(FuncId);
+id_with_pg_types!(FuncRunId);
+id_with_pg_types!(SchemaId);
+id_with_pg_types!(UserPk);
+
+// Please keep these alphabetically sorted!
+id_with_none!(SchemaVariantId);
+
+// Please keep these alphabetically sorted!
+id_with_none_and_pg_types!(AttributeValueId);
+id_with_none_and_pg_types!(KeyPairPk);
+id_with_none_and_pg_types!(WorkspacePk);
+id_with_none_and_pg_types!(WorkspaceId);

--- a/lib/si-id/src/macros.rs
+++ b/lib/si-id/src/macros.rs
@@ -1,0 +1,303 @@
+/// The primary macro used for creating IDs for SI.
+macro_rules! id {
+    (
+        $(#[$($attrs:tt)*])*
+        $name:ident
+    ) => {
+        do_not_use_directly_id_inner!(
+            $(#[$($attrs)*])*
+            $name
+        );
+    };
+}
+
+/// Provides PostgreSQL type conversion implementations in addition to standard [`id!`] functionality.
+macro_rules! id_with_pg_types {
+    (
+        $(#[$($attrs:tt)*])*
+        $name:ident
+    ) => {
+        do_not_use_directly_id_inner!(
+            $(#[$($attrs)*])*
+            $name
+        );
+
+        impl<'a> postgres_types::FromSql<'a> for $name {
+            fn from_sql(
+                ty: &postgres_types::Type,
+                raw: &'a [u8],
+            ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+                let id: String = postgres_types::FromSql::from_sql(ty, raw)?;
+                Ok(Self(::ulid::Ulid::from_string(&id)?))
+            }
+
+            fn accepts(ty: &postgres_types::Type) -> bool {
+                ty == &postgres_types::Type::BPCHAR
+                    || ty.kind() == &postgres_types::Kind::Domain(postgres_types::Type::BPCHAR)
+            }
+        }
+
+        impl postgres_types::ToSql for $name {
+            fn to_sql(
+                &self,
+                ty: &postgres_types::Type,
+                out: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+            where
+                Self: Sized,
+            {
+                postgres_types::ToSql::to_sql(&self.0.to_string(), ty, out)
+            }
+
+            fn accepts(ty: &postgres_types::Type) -> bool
+            where
+                Self: Sized,
+            {
+                ty == &postgres_types::Type::BPCHAR
+                    || ty.kind() == &postgres_types::Kind::Domain(postgres_types::Type::BPCHAR)
+            }
+
+            fn to_sql_checked(
+                &self,
+                ty: &postgres_types::Type,
+                out: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>> {
+                postgres_types::ToSql::to_sql(&self.0.to_string(), ty, out)
+            }
+        }
+    };
+}
+
+/// **Deprecated:** this macro provides additional functionality for using the "nil" ID on top of the standard `id!`
+/// macro.
+///
+/// This absolutely should not be used for any new IDs. Nick will be mad. No, I'm not writing this in third
+/// person, why do you ask?
+macro_rules! id_with_none {
+    (
+        $(#[$($attrs:tt)*])*
+        $name:ident
+    ) => {
+        do_not_use_directly_id_inner!(
+            $(#[$($attrs)*])*
+            $name
+        );
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::NONE
+            }
+        }
+
+        impl $name {
+            /// The "nil" value for this ID.
+            pub const NONE: Self = Self(::ulid::Ulid::nil());
+        }
+    };
+}
+
+/// **Deprecated:** this macro provides additional functionality for using the "nil" ID on top of the standard `id!`
+/// macro. It also adds support for PostgreSQL type conversions.
+///
+/// This absolutely should not be used for any new IDs. Nick will be mad. No, I'm not writing this in third person, why
+/// do you ask?
+macro_rules! id_with_none_and_pg_types {
+    (
+        $(#[$($attrs:tt)*])*
+        $name:ident
+    ) => {
+        do_not_use_directly_id_inner!(
+            $(#[$($attrs)*])*
+            $name
+        );
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::NONE
+            }
+        }
+
+        impl $name {
+            /// The "nil" value for this ID.
+            pub const NONE: Self = Self(::ulid::Ulid::nil());
+        }
+
+        impl<'a> postgres_types::FromSql<'a> for $name {
+            fn from_sql(
+                ty: &postgres_types::Type,
+                raw: &'a [u8],
+            ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+                let id: String = postgres_types::FromSql::from_sql(ty, raw)?;
+                Ok(Self(::ulid::Ulid::from_string(&id)?))
+            }
+
+            fn accepts(ty: &postgres_types::Type) -> bool {
+                ty == &postgres_types::Type::BPCHAR
+                    || ty.kind() == &postgres_types::Kind::Domain(postgres_types::Type::BPCHAR)
+            }
+        }
+
+        impl postgres_types::ToSql for $name {
+            fn to_sql(
+                &self,
+                ty: &postgres_types::Type,
+                out: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+            where
+                Self: Sized,
+            {
+                postgres_types::ToSql::to_sql(&self.0.to_string(), ty, out)
+            }
+
+            fn accepts(ty: &postgres_types::Type) -> bool
+            where
+                Self: Sized,
+            {
+                ty == &postgres_types::Type::BPCHAR
+                    || ty.kind() == &postgres_types::Kind::Domain(postgres_types::Type::BPCHAR)
+            }
+
+            fn to_sql_checked(
+                &self,
+                ty: &postgres_types::Type,
+                out: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>> {
+                postgres_types::ToSql::to_sql(&self.0.to_string(), ty, out)
+            }
+        }
+    };
+}
+
+// NOTE(nick,jacob): this is a bit messy, but it would be complicated/tricky to scope this properly until stable
+// Rust provides the ability to use normal visibility modifiers in front of a "macro_rules!" definition. Some escape
+// hatches include, but are not limited to, creating a "si-id-macros" crate with mixed usages of "macro_export" and
+// "macro_use"... or using the "macro-vis" crate (https://github.com/kestrer/macro-vis). At the time of writing,
+// pursuing an escape hatch or different solution is unlikely to be worth it.
+#[allow(missing_docs)]
+macro_rules! do_not_use_directly_id_inner {
+    (
+        $(#[$($attrss:tt)*])*
+        $name:ident
+    ) => {
+        $(#[$($attrss)*])*
+        #[allow(missing_docs)]
+        #[derive(
+            Eq,
+            PartialEq,
+            PartialOrd,
+            Ord,
+            Copy,
+            Clone,
+            Hash,
+            derive_more::From,
+            derive_more::Into,
+            derive_more::Display,
+            serde::Serialize,
+            serde::Deserialize,
+        )]
+        pub struct $name(::ulid::Ulid);
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_tuple(stringify!($name)).field(&self.0.to_string()).finish()
+            }
+        }
+
+        impl $name {
+            /// Length of a string-encoded ID in bytes.
+            pub const ID_LEN: usize = ::ulid::ULID_LEN;
+
+            /// Generates a new key which is virtually guaranteed to be unique.
+            pub fn generate() -> Self {
+                Self(::ulid::Ulid::new())
+            }
+
+            /// Calls [`Self::generate`].
+            #[allow(clippy::new_without_default)]
+            pub fn new() -> Self {
+                Self::generate()
+            }
+
+            /// Converts type into inner [`Ulid`](::ulid::Ulid).
+            pub fn into_inner(self) -> ::ulid::Ulid {
+                self.0
+            }
+
+            /// Creates a Crockford Base32 encoded string that represents this Ulid.
+            pub fn array_to_str<'buf>(&self, buf: &'buf mut [u8; ::ulid::ULID_LEN]) -> &'buf mut str {
+                self.0.array_to_str(buf)
+            }
+
+            /// Converts the ID into a byte array.
+            pub fn array_to_str_buf() -> [u8; ::ulid::ULID_LEN] {
+                [0; ::ulid::ULID_LEN]
+            }
+
+            /// Constructs a new instance of Self from the given raw identifier.
+            ///
+            /// This function is typically used to consume ownership of the specified identifier.
+            pub fn from_raw_id(value: ::ulid::Ulid) -> Self {
+                Self(value)
+            }
+
+            /// Extracts the raw identifier.
+            ///
+            /// This function is typically used to borrow an owned idenfier.
+            pub fn as_raw_id(&self) -> ::ulid::Ulid {
+                self.0
+            }
+
+            /// Consumes this object, returning the raw underlying identifier.
+            ///
+            /// This function is typically used to transfer ownership of the underlying identifier
+            /// to the caller.
+            pub fn into_raw_id(self) -> ::ulid::Ulid {
+                self.0
+            }
+        }
+
+        impl From<$name> for String {
+            fn from(id: $name) -> Self {
+                ::ulid::Ulid::from(id.0).into()
+            }
+        }
+
+        impl<'a> From<&'a $name> for ::ulid::Ulid {
+            fn from(id: &'a $name) -> Self {
+                id.0
+            }
+        }
+
+        impl From<$name> for crate::ulid::Ulid {
+            fn from(id: $name) -> Self {
+                id.0.into()
+            }
+        }
+
+        impl<'a> From<&'a $name> for crate::ulid::Ulid {
+            fn from(id: &'a $name) -> Self {
+                id.0.into()
+            }
+        }
+
+        impl From<crate::ulid::Ulid> for $name {
+            fn from(ulid: crate::ulid::Ulid) -> Self {
+                ulid.inner().into()
+            }
+        }
+
+        impl<'a> From<&'a $name> for $name {
+            fn from(id: &'a $name) -> Self {
+                *id
+            }
+        }
+
+        impl std::str::FromStr for $name {
+            type Err = ::ulid::DecodeError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Ok(Self(::ulid::Ulid::from_string(s)?))
+            }
+        }
+    };
+}

--- a/lib/si-id/src/ulid.rs
+++ b/lib/si-id/src/ulid.rs
@@ -1,3 +1,5 @@
+//! Provides a wrapper for [`::ulid::Ulid`] for common visitor and conversion patterns.
+
 pub use ulid::DecodeError;
 pub use ulid::ULID_LEN;
 
@@ -6,18 +8,22 @@ use ulid::Ulid as CoreUlid;
 /// Size is the size in bytes, len is the string length
 const ULID_SIZE: usize = 16;
 
+/// A wrapper around [`::ulid::Ulid`] for common visitor and conversion patterns.
 #[derive(Eq, PartialEq, Copy, Clone, Hash, Default, PartialOrd, Ord)]
 pub struct Ulid(CoreUlid);
 
 impl Ulid {
+    #[allow(missing_docs)]
     pub fn new() -> Self {
         Self(CoreUlid::new())
     }
 
+    /// Provides the inner [`::ulid::Ulid`].
     pub fn inner(&self) -> CoreUlid {
         self.0
     }
 
+    /// Constructs a [`Ulid`] from a string that represents a [`::ulid::Ulid`].
     pub fn from_string(encoded: &str) -> Result<Self, DecodeError> {
         match CoreUlid::from_string(encoded) {
             Ok(ulid) => Ok(ulid.into()),
@@ -25,6 +31,7 @@ impl Ulid {
         }
     }
 }
+
 struct UlidVisitor;
 
 impl<'de> ::serde::de::Visitor<'de> for UlidVisitor {


### PR DESCRIPTION
## Description

This PR splits the core si-id macro into four macros and is a follow-up to #5093.

The macros are based on the existence of PostgreSQL conversion implementations and the "nil" ID. The macros using "nil" should not be used by any new IDs and exist for backwards compatibility.

<img src="https://media0.giphy.com/media/3ofT5HzCfEl6r3NvKo/giphy.gif"/>

## Additional Changes

- All macros have moved into their own module
- All conversions between IDs have been moved into their own module
- Our standard set of lints for new crates have been added to "si-id" (along with resolutions to failed lints)

## Potential Future Work

The below list has been carried over and modified from from #5093:

- Migrate all IDs in "si-layer-cache" (currently not reliant on a macro)
- Migrate all IDs in "module-index-server" (currently not reliant on a macro)
- Clean-up ID call sites (e.g. reduce "pub use" statements, but we may not actually want this)
- Remove all usages of the third party ulid crate and go through "si-id" (we may not actually want this)