### PR TITLE
Update Rust deps that do not require code changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
  "si-std",
  "strum",
  "telemetry",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
 ]
 
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.36.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71e5a1bab60f46b0b005f4808b8ee83ef6d577608923de938403393c9a30cf8"
+checksum = "76433c4de73442daedb3a59e991d94e85c14ebfc33db53dfcd347a21cd6ef4f8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -258,6 +258,7 @@ dependencies = [
  "nkeys",
  "nuid",
  "once_cell",
+ "pin-project",
  "portable-atomic",
  "rand 0.8.5",
  "regex",
@@ -274,6 +275,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.1",
  "tokio-util",
+ "tokio-websockets",
  "tracing",
  "tryhard",
  "url",
@@ -281,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b17e44510f88a904cb3102a020d7ea11929dcddadfaff756e71112cb2cb7bd0"
+checksum = "0d226540b4ecf884b0fb4370008631ccbd9605cf82f98bb504ec8f2cee0810e8"
 dependencies = [
  "async-convert",
  "backoff",
@@ -412,7 +414,7 @@ dependencies = [
  "si-data-pg",
  "si-events",
  "telemetry",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -424,7 +426,7 @@ dependencies = [
  "si-data-nats",
  "si-events",
  "telemetry",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -435,7 +437,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "ulid",
  "url",
@@ -873,7 +875,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper 1.0.2",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -991,16 +993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bcder"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627747a6774aab38beb35990d88309481378558875a41da1a4b2e373c906ef0"
-dependencies = [
- "bytes",
- "smallvec",
-]
-
-[[package]]
 name = "bigdecimal"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,7 +1018,7 @@ dependencies = [
  "si-events",
  "telemetry",
  "telemetry-nats",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -1126,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
 dependencies = [
  "base64 0.22.1",
  "bollard-stubs",
@@ -1141,7 +1133,7 @@ dependencies = [
  "hyper 1.5.1",
  "hyper-named-pipe",
  "hyper-util",
- "hyperlocal-next",
+ "hyperlocal 0.9.1",
  "log",
  "pin-project-lite",
  "serde",
@@ -1149,7 +1141,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -1159,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.44.0-rc.2"
+version = "1.47.1-rc.27.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
 dependencies = [
  "serde",
  "serde_repr",
@@ -1214,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
 dependencies = [
  "memchr",
  "serde",
@@ -1227,7 +1219,7 @@ name = "buck2-resources"
 version = "0.1.0"
 dependencies = [
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -1515,7 +1507,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "toml",
  "tracing",
@@ -1764,7 +1756,7 @@ dependencies = [
  "futures-lite",
  "http 0.2.12",
  "hyper 0.14.31",
- "hyperlocal",
+ "hyperlocal 0.8.0",
  "remain",
  "serde",
  "serde_json",
@@ -1772,7 +1764,7 @@ dependencies = [
  "telemetry-http",
  "tempfile",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -1794,7 +1786,7 @@ dependencies = [
  "strum",
  "telemetry",
  "telemetry-utils",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
 ]
 
@@ -1822,7 +1814,7 @@ dependencies = [
  "telemetry",
  "telemetry-http",
  "telemetry-utils",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-serde",
  "tokio-util",
@@ -1856,7 +1848,7 @@ dependencies = [
  "hex",
  "iftree",
  "indexmap 2.7.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "jwt-simple",
  "lazy_static",
  "module-index-client",
@@ -1898,7 +1890,7 @@ dependencies = [
  "telemetry-nats",
  "telemetry-utils",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1933,7 +1925,7 @@ dependencies = [
  "derive_builder",
  "derive_more",
  "forklift-server",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "jwt-simple",
  "lazy_static",
  "names",
@@ -1957,7 +1949,7 @@ dependencies = [
  "sodiumoxide",
  "telemetry",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
  "tracing-opentelemetry",
@@ -2065,16 +2057,15 @@ dependencies = [
  "base64 0.22.1",
  "remain",
  "telemetry",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
 name = "deadpool"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+checksum = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed"
 dependencies = [
- "async-trait",
  "deadpool-runtime",
  "num_cpus",
  "tokio",
@@ -2082,11 +2073,13 @@ dependencies = [
 
 [[package]]
 name = "deadpool-postgres"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda39fa1cfff190d8924d447ad04fd22772c250438ca5ce1dfb3c80621c05aaa"
+checksum = "1ab8a4ea925ce79678034870834602a2980f4b88c09e97feb266496dbb4493d2"
 dependencies = [
+ "async-trait",
  "deadpool",
+ "getrandom 0.2.15",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -2108,8 +2101,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2581,6 +2587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flagset"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,7 +2658,7 @@ dependencies = [
  "si-std",
  "telemetry",
  "telemetry-nats",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
  "ulid",
@@ -2756,7 +2768,7 @@ dependencies = [
  "flume",
  "foyer-common",
  "foyer-memory",
- "fs4 0.12.0",
+ "fs4",
  "futures",
  "hashbrown 0.15.2",
  "itertools 0.13.0",
@@ -2773,16 +2785,6 @@ dependencies = [
  "tracing",
  "twox-hash",
  "zstd",
-]
-
-[[package]]
-name = "fs4"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e871a4cfa68bb224863b53149d973df1ac8d1ed2fa1d1bfc37ac1bb65dd37207"
-dependencies = [
- "rustix",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3387,7 +3389,7 @@ dependencies = [
  "http 1.2.0",
  "hyper 1.5.1",
  "hyper-util",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -3441,10 +3443,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyperlocal-next"
-version = "0.9.0"
+name = "hyperlocal"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
@@ -3816,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "krata-loopdev"
-version = "0.0.12"
+version = "0.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a22c1adad10f4e4be90192e7157b70f38a3d05b368123d693b2807749a365"
+checksum = "c0642392bab66bc87bbb956fd798b35159464066c6a35805d8b9aa09dd538047"
 dependencies = [
  "libc",
 ]
@@ -4123,7 +4125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
- "simd-adler32",
 ]
 
 [[package]]
@@ -4133,6 +4134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -4180,7 +4182,7 @@ dependencies = [
  "serde",
  "serde_json",
  "si-pkg",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "ulid",
  "url",
@@ -4216,7 +4218,7 @@ dependencies = [
  "si-settings",
  "si-std",
  "telemetry",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4284,7 +4286,7 @@ version = "0.1.0"
 dependencies = [
  "remain",
  "si-data-nats",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -4298,7 +4300,7 @@ dependencies = [
  "serde_json",
  "si-data-nats",
  "telemetry",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
 ]
@@ -4311,7 +4313,7 @@ dependencies = [
  "remain",
  "si-data-nats",
  "telemetry",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
 ]
 
@@ -4336,7 +4338,7 @@ dependencies = [
  "si-data-nats",
  "telemetry",
  "telemetry-nats",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
 ]
 
@@ -4352,7 +4354,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "time",
  "tokio",
  "tokio-util",
@@ -4373,7 +4375,7 @@ dependencies = [
  "si-data-nats",
  "si-id",
  "strum",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "ulid",
 ]
 
@@ -4559,7 +4561,7 @@ dependencies = [
  "si-hash",
  "strum",
  "tar",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -4809,16 +4811,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
-name = "pem"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
-dependencies = [
- "base64 0.22.1",
- "serde",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4839,7 +4831,7 @@ dependencies = [
  "si-events",
  "telemetry",
  "telemetry-nats",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -4859,7 +4851,7 @@ dependencies = [
  "si-data-spicedb",
  "si-events",
  "strum",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
 ]
 
@@ -4965,7 +4957,7 @@ dependencies = [
  "telemetry",
  "telemetry-nats",
  "telemetry-utils",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5174,24 +5166,23 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
  "bitflags 2.6.0",
  "chrono",
  "flate2",
  "hex",
- "lazy_static",
  "procfs-core",
  "rustix",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
  "bitflags 2.6.0",
  "chrono",
@@ -5271,7 +5262,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.0",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "socket2",
  "thiserror 2.0.6",
  "tokio",
@@ -5289,7 +5280,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.1.0",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.6",
@@ -5452,7 +5443,7 @@ dependencies = [
  "si-events",
  "telemetry",
  "telemetry-nats",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -5492,7 +5483,7 @@ dependencies = [
  "si-std",
  "telemetry",
  "telemetry-nats",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5502,9 +5493,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -5522,9 +5513,9 @@ dependencies = [
 
 [[package]]
 name = "refinery"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2783724569d96af53464d0711dff635cab7a4934df5e22e9fbc9e181523b83e"
+checksum = "0904191f0566c3d3e0091d5cc8dec22e663d77def2d247b16e7a438b188bf75d"
 dependencies = [
  "refinery-core",
  "refinery-macros",
@@ -5540,11 +5531,13 @@ dependencies = [
  "cfg-if",
  "log",
  "regex",
+ "serde",
  "siphasher 1.0.1",
  "thiserror 1.0.69",
  "time",
  "tokio",
  "tokio-postgres",
+ "toml",
  "url",
  "walkdir",
 ]
@@ -5658,7 +5651,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -5898,9 +5891,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.19"
+version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "log",
  "once_cell",
@@ -6104,7 +6097,7 @@ dependencies = [
  "strum",
  "telemetry",
  "telemetry-http",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -6280,9 +6273,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
@@ -6300,9 +6293,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6470,7 +6463,7 @@ dependencies = [
  "si-events",
  "telemetry",
  "telemetry-nats",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
 ]
@@ -6488,7 +6481,7 @@ dependencies = [
  "sodiumoxide",
  "telemetry",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
 ]
 
@@ -6503,7 +6496,7 @@ dependencies = [
  "serde",
  "serde_json",
  "telemetry",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tracing-subscriber",
 ]
@@ -6522,13 +6515,13 @@ dependencies = [
  "refinery",
  "remain",
  "reqwest",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-pemfile 2.2.0",
  "serde",
  "si-std",
  "telemetry",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
@@ -6548,7 +6541,7 @@ dependencies = [
  "spicedb-client",
  "spicedb-grpc",
  "telemetry",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tracing-subscriber",
  "url",
@@ -6570,7 +6563,7 @@ dependencies = [
  "serde_json",
  "si-id",
  "strum",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "xxhash-rust",
 ]
 
@@ -6584,7 +6577,7 @@ dependencies = [
  "krata-loopdev",
  "nix 0.26.4",
  "remain",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
  "tokio-vsock",
@@ -6610,7 +6603,7 @@ version = "0.1.0"
 dependencies = [
  "blake3",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -6635,7 +6628,7 @@ dependencies = [
  "si-events",
  "si-std",
  "telemetry",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
 ]
 
@@ -6649,9 +6642,9 @@ dependencies = [
  "bytes",
  "chrono",
  "foyer",
- "fs4 0.11.1",
+ "fs4",
  "futures",
- "miniz_oxide 0.7.4",
+ "miniz_oxide 0.8.0",
  "postcard",
  "rand 0.8.5",
  "refinery",
@@ -6669,7 +6662,7 @@ dependencies = [
  "telemetry",
  "telemetry-utils",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -6690,7 +6683,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "ulid",
  "url",
@@ -6718,7 +6711,7 @@ dependencies = [
  "si-std",
  "telemetry-utils",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
  "tracing",
@@ -6737,7 +6730,7 @@ dependencies = [
  "serde",
  "serde_json",
  "telemetry",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
 ]
@@ -6760,7 +6753,7 @@ dependencies = [
  "si-std",
  "telemetry",
  "telemetry-application",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
 ]
@@ -6772,7 +6765,7 @@ dependencies = [
  "config-file",
  "remain",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -6784,7 +6777,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -7002,7 +6995,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rust_decimal",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -7301,9 +7294,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+checksum = "948512566b1895f93b1592c7574baeb2de842f224f2aab158799ecadb8ebbb46"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7343,7 +7336,7 @@ dependencies = [
  "async-trait",
  "opentelemetry",
  "remain",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
  "tracing",
@@ -7359,7 +7352,7 @@ dependencies = [
  "opentelemetry_sdk",
  "remain",
  "telemetry",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
  "tracing-opentelemetry",
@@ -7576,6 +7569,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e78c9c330f8c85b2bae7c8368f2739157db9991235123aa1b15ef9502bfb6a"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "tokio"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7600,7 +7614,7 @@ dependencies = [
  "futures",
  "parking_lot",
  "remain",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "thread-priority",
  "tokio",
  "tokio-util",
@@ -7646,16 +7660,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres-rustls"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04fb792ccd6bbcd4bba408eb8a292f70fc4a3589e5d793626f45190e6454b6ab"
+version = "0.13.0"
+source = "git+https://github.com/jbg/tokio-postgres-rustls.git?branch=master#0cffe66df0e3fdc6b6067cf4432d1e3343c80fff"
 dependencies = [
+ "const-oid",
  "ring",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "tokio",
  "tokio-postgres",
  "tokio-rustls 0.26.1",
- "x509-certificate",
+ "x509-cert",
 ]
 
 [[package]]
@@ -7674,7 +7688,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "tokio",
 ]
 
@@ -7743,6 +7757,27 @@ dependencies = [
  "libc",
  "tokio",
  "vsock",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http 1.2.0",
+ "httparse",
+ "rand 0.8.5",
+ "ring",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.1",
+ "tokio-util",
 ]
 
 [[package]]
@@ -7835,14 +7870,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -8235,7 +8270,7 @@ dependencies = [
  "telemetry",
  "telemetry-nats",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
  "tracing",
@@ -8254,7 +8289,7 @@ dependencies = [
  "si-crypto",
  "si-data-nats",
  "si-std",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -8278,7 +8313,7 @@ dependencies = [
  "telemetry",
  "telemetry-nats",
  "telemetry-utils",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
  "ulid",
@@ -8781,22 +8816,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "x509-certificate"
-version = "0.23.1"
+name = "x509-cert"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66534846dec7a11d7c50a74b7cdb208b9a581cad890b7866430d438455847c85"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
- "bcder",
- "bytes",
- "chrono",
+ "const-oid",
  "der",
- "hex",
- "pem",
- "ring",
- "signature 2.2.0",
  "spki",
- "thiserror 1.0.69",
- "zeroize",
+ "tls_codec",
 ]
 
 [[package]]
@@ -9001,8 +9029,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "tokio-postgres-rustls"
-version = "0.13.0"
-source = "git+https://github.com/jbg/tokio-postgres-rustls.git?branch=master#0cffe66df0e3fdc6b6067cf4432d1e3343c80fff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,43 +88,43 @@ rust-version = "1.82"
 publish = false
 
 [workspace.dependencies]
-async-nats = { version = "0.36.0", features = ["service"] }
-async-openai = "0.25.0"
-async-recursion = "1.0.5"
-async-trait = "0.1.79"
-aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
-aws-sdk-firehose = "1.46.0"
+async-nats = { version = "0.38.0", features = ["service"] }
+async-openai = "0.26.0"
+async-recursion = "1.1.1"
+async-trait = "0.1.83"
+aws-config = { version = "1.5.10", features = ["behavior-version-latest"] }
+aws-sdk-firehose = "1.56.0"
 axum = { version = "0.6.20", features = [
     "macros",
     "multipart",
     "ws",
 ] } # todo: upgrade this alongside hyper/http/tokio-tungstenite
-base64 = "0.22.0"
-blake3 = "1.5.1"
-bollard = "0.16.1"
-bytes = "1.6.0"
-chrono = { version = "0.4.37", features = ["serde"] }
+base64 = "0.22.1"
+blake3 = "1.5.5"
+bollard = "0.18.1"
+bytes = "1.9.0"
+chrono = { version = "0.4.39", features = ["serde"] }
 ciborium = "0.2.2"
-clap = { version = "4.5.4", features = ["derive", "color", "env", "wrap_help"] }
+clap = { version = "4.5.23", features = ["derive", "color", "env", "wrap_help"] }
 color-eyre = "0.6.3"
-config = { version = "0.14.0", default-features = false, features = ["toml"] }
+config = { version = "0.14.1", default-features = false, features = ["toml"] }
 convert_case = "0.6.0"
-crossbeam-queue = { version = "0.3.10" }
+crossbeam-queue = { version = "0.3.11" }
 darling = "0.20.10"
-deadpool = { version = "0.10.0", features = ["rt_tokio_1"] }
-deadpool-postgres = "0.12.1"
-derive_builder = "0.20.0"
+deadpool = { version = "0.12.1", features = ["rt_tokio_1"] }
+deadpool-postgres = "0.14.0"
+derive_builder = "0.20.2"
 derive_more = "0.99.17"
 devicemapper = { version = "=0.34.1" }
 diff = "0.1.13"
 directories = "5.0.1"
 dyn-clone = "1.0.17"
-fastrace = "0.7.3"
-flate2 = "1.0.28"
-futures = "0.3.30"
-futures-lite = "2.3.0"
+fastrace = "0.7.4"
+flate2 = "1.0.35"
+futures = "0.3.31"
+futures-lite = "2.5.0"
 foyer = { version = "0.13.1", features = ["tracing", "opentelemetry_0_26"] }
-fs4 = "0.11.0"
+fs4 = "0.12.0"
 glob = "0.3.1"
 hex = "0.4.3"
 http = "0.2.12" # todo: upgrade this alongside hyper/axum/tokio-tungstenite/tower-http
@@ -138,17 +138,17 @@ hyperlocal = { version = "0.8.0", default-features = false, features = [
     "client",
 ] } # todo: using the very latest of hyper client 1.x, we _may_ be able to phase this crate
 iftree = "1.0.5"
-indexmap = { version = "2.2.6", features = ["serde", "std"] }
+indexmap = { version = "2.7.0", features = ["serde", "std"] }
 indoc = "2.0.5"
-itertools = "0.12.1"
-jwt-simple = { version = "0.12.9", default-features = false, features = [
+itertools = "0.13.0"
+jwt-simple = { version = "0.12.11", default-features = false, features = [
     "pure-rust",
 ] }
-krata-loopdev = "0.0.12"
-lazy_static = "1.4.0"
+krata-loopdev = "0.0.21"
+lazy_static = "1.5.0"
 manyhow = { version = "0.11.4", features = ["darling"] }
 mime_guess = { version = "=2.0.4" } # TODO(fnichol): 2.0.5 sets an env var in build.rs which needs to be tracked, required by reqwest
-miniz_oxide = { version = "0.7.2", features = ["simd"] }
+miniz_oxide = { version = "0.8.0", features = ["simd"] }
 names = { version = "0.14.0", default-features = false }
 nix = { version = "0.26.0", features = [
     "fs",
@@ -159,29 +159,29 @@ nix = { version = "0.26.0", features = [
 ] }
 nkeys = "0.4.0"
 num_cpus = "1.16.0"
-once_cell = "1.19.0"
+once_cell = "1.20.2"
 opentelemetry = { version = "0.26.0", features = ["trace"] }
 opentelemetry-otlp = { version = "0.26.0", features = ["metrics", "trace"] }
 opentelemetry-semantic-conventions = "0.14.0"
 opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio"] }
-ordered-float = { version = "4.4.0", features = ["serde"] }
-ouroboros = "0.18.3"
+ordered-float = { version = "4.5.0", features = ["serde"] }
+ouroboros = "0.18.4"
 parking_lot = "0.12.3"
-paste = "1.0.14"
-pathdiff = "0.2.1"
-petgraph = { version = "0.6.4", features = ["serde-1"] }
-pin-project-lite = "0.2.13"
-postcard = { version = "1.0.8", features = ["use-std"] }
-postgres-types = { version = "0.2.6", features = ["derive"] }
+paste = "1.0.15"
+pathdiff = "0.2.3"
+petgraph = { version = "0.6.5", features = ["serde-1"] }
+pin-project-lite = "0.2.15"
+postcard = { version = "1.1.1", features = ["use-std"] }
+postgres-types = { version = "0.2.8", features = ["derive"] }
 pretty_assertions_sorted = "1.2.3"
-proc-macro2 = "1.0.79"
-procfs = "0.16.0"
-quote = "1.0.35"
+proc-macro2 = "1.0.92"
+procfs = "0.17.0"
+quote = "1.0.37"
 rand = "0.8.5"
-refinery = { version = "= 0.8.12", features = ["tokio-postgres"] }
-regex = "1.10.4"
-remain = "0.2.13"
-reqwest = { version = "0.12.2", default-features = false, features = [
+refinery = { version = "0.8.14", features = ["tokio-postgres"] }
+regex = "1.11.1"
+remain = "0.2.14"
+reqwest = { version = "0.12.9", default-features = false, features = [
     "rustls-tls",
     "json",
     "multipart",
@@ -190,49 +190,49 @@ ring = "=0.17.5" # Upgrading this is possible, but a pain, so we don't want to p
 rust-s3 = { version = "0.34.0-rc4", default-features = false, features = [
     "tokio-rustls-tls",
 ] }
-rustls = { version = "0.23.18", default-features = false } # NOTE(nick,fletcher): rustls switched to "aws-lc-rs" as its default crypto provider, but we want ring (i.e. we disable the default feature for "aws-lc-rs")
-rustls-native-certs = "0.7.0"
-rustls-pemfile = { version = "2.1.1" }
-sea-orm = { version = "1.1.0", features = [
+rustls = { version = "0.23.19", default-features = false } # NOTE(nick,fletcher): rustls switched to "aws-lc-rs" as its default crypto provider, but we want ring (i.e. we disable the default feature for "aws-lc-rs")
+rustls-native-certs = "0.8.1"
+rustls-pemfile = { version = "2.2.0" }
+sea-orm = { version = "1.1.2", features = [
     "sqlx-postgres",
     "runtime-tokio-rustls",
     "macros",
     "with-chrono",
     "debug-print",
 ] }
-serde = { version = "1.0.197", features = ["derive", "rc"] }
+serde = { version = "1.0.216", features = ["derive", "rc"] }
 serde-aux = "4.5.0"
 serde_json = { version = "1.0.133", features = ["preserve_order"] }
 serde_path_to_error = { version = "0.1.16" }
-serde_with = "3.7.0"
+serde_with = "3.11.0"
 serde_yaml = "0.9.33" # NOTE(nick): this has been archived upstream
 sodiumoxide = "0.2.7"
 spicedb-client = { version = "0.1.1", features = ["tls"] }
 spicedb-grpc = "0.1.1"
-strum = { version = "0.26.2", features = ["derive"] }
-syn = { version = "2.0.55", features = ["full", "extra-traits"] }
-sysinfo = "0.32.0"
-tar = "0.4.40"
-tempfile = "3.10.1"
-test-log = { version = "0.2.15", default-features = false, features = [
+strum = { version = "0.26.3", features = ["derive"] }
+syn = { version = "2.0.90", features = ["full", "extra-traits"] }
+sysinfo = "0.33.0"
+tar = "0.4.43"
+tempfile = "3.14.0"
+test-log = { version = "0.2.16", default-features = false, features = [
     "trace",
 ] }
-thiserror = "1.0.58"
-thread-priority = "1.1.0"
-time = "0.3.36"
-tokio = { version = "1.37.0", features = ["full"] }
-tokio-postgres = { version = "0.7.10", features = [
+thiserror = "2.0.6"
+thread-priority = "1.2.0"
+time = "0.3.37"
+tokio = { version = "1.42.0", features = ["full"] }
+tokio-postgres = { version = "0.7.12", features = [
     "runtime",
     "with-chrono-0_4",
     "with-serde_json-1",
 ] }
-tokio-postgres-rustls = { version = "0.12.0" }
+tokio-postgres-rustls = { version = "0.13.0" }
 tokio-serde = { version = "0.9.0", features = ["json"] }
-tokio-stream = { version = "0.1.15", features = ["sync", "time"] }
+tokio-stream = { version = "0.1.17", features = ["sync", "time"] }
 tokio-tungstenite = "0.20.1" # todo: pinning back from 0.21.0, upgrade this alongside hyper/http/axum/tokio-tungstenite,tower-http
 tokio-util = { version = "0.7.10", features = ["codec", "rt"] }
 tokio-vsock = { version = "0.4.0" }
-toml = { version = "0.8.12" }
+toml = { version = "0.8.19" }
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.4", features = [
     "compression-br",
@@ -241,22 +241,22 @@ tower-http = { version = "0.4.4", features = [
     "cors",
     "trace",
 ] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
-tracing = { version = "0.1.40" }
+tracing = { version = "0.1.41" }
 tracing-opentelemetry = "0.27.0"
-tracing-subscriber = { version = "0.3.18", features = [
+tracing-subscriber = { version = "0.3.19", features = [
     "env-filter",
     "json",
     "std",
 ] }
 tracing-tunnel = "0.1.0"
-trybuild = { version = "1.0.99", features = ["diff"] }
+trybuild = { version = "1.0.101", features = ["diff"] }
 tryhard = "0.5.1"
-ulid = { version = "1.1.2", features = ["serde"] }
-url = { version = "2.5.0", features = ["serde"] }
-uuid = { version = "1.8.0", features = ["serde", "v4"] }
-version_check = "0.9.4"
+ulid = { version = "1.1.3", features = ["serde"] }
+url = { version = "2.5.4", features = ["serde"] }
+uuid = { version = "1.11.0", features = ["serde", "v4"] }
+version_check = "0.9.5"
 webpki-roots = { version = "0.25.4" }
-xxhash-rust = { version = "0.8.10", features = ["xxh3", "const_xxh3"] }
+xxhash-rust = { version = "0.8.12", features = ["xxh3", "const_xxh3"] }
 y-sync = { version = "0.4.0", features = ["net"] }
 yrs = { version = "0.17.4" }
 

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -31,6 +31,13 @@ git_fetch(
     visibility = [],
 )
 
+git_fetch(
+    name = "tokio-postgres-rustls-855e14009fe3bebe.git",
+    repo = "https://github.com/jbg/tokio-postgres-rustls.git",
+    rev = "0cffe66df0e3fdc6b6067cf4432d1e3343c80fff",
+    visibility = [],
+)
+
 http_archive(
     name = "addr2line-0.21.0.crate",
     sha256 = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb",
@@ -572,33 +579,33 @@ cargo.rust_library(
 
 alias(
     name = "async-nats",
-    actual = ":async-nats-0.36.0",
+    actual = ":async-nats-0.38.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "async-nats-0.36.0.crate",
-    sha256 = "f71e5a1bab60f46b0b005f4808b8ee83ef6d577608923de938403393c9a30cf8",
-    strip_prefix = "async-nats-0.36.0",
-    urls = ["https://static.crates.io/crates/async-nats/0.36.0/download"],
+    name = "async-nats-0.38.0.crate",
+    sha256 = "76433c4de73442daedb3a59e991d94e85c14ebfc33db53dfcd347a21cd6ef4f8",
+    strip_prefix = "async-nats-0.38.0",
+    urls = ["https://static.crates.io/crates/async-nats/0.38.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-nats-0.36.0",
-    srcs = [":async-nats-0.36.0.crate"],
+    name = "async-nats-0.38.0",
+    srcs = [":async-nats-0.38.0.crate"],
     crate = "async_nats",
-    crate_root = "async-nats-0.36.0.crate/src/lib.rs",
+    crate_root = "async-nats-0.38.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "async-nats-0.36.0.crate",
+        "CARGO_MANIFEST_DIR": "async-nats-0.38.0.crate",
         "CARGO_PKG_AUTHORS": "Tomasz Pietrek <tomasz@nats.io>:Casper Beyer <caspervonb@pm.me>",
         "CARGO_PKG_DESCRIPTION": "A async Rust NATS client",
         "CARGO_PKG_NAME": "async-nats",
         "CARGO_PKG_REPOSITORY": "https://github.com/nats-io/nats.rs",
-        "CARGO_PKG_VERSION": "0.36.0",
+        "CARGO_PKG_VERSION": "0.38.0",
         "CARGO_PKG_VERSION_MAJOR": "0",
-        "CARGO_PKG_VERSION_MINOR": "36",
+        "CARGO_PKG_VERSION_MINOR": "38",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     features = [
@@ -616,6 +623,7 @@ cargo.rust_library(
         ":nkeys-0.4.4",
         ":nuid-0.5.0",
         ":once_cell-1.20.2",
+        ":pin-project-1.1.7",
         ":portable-atomic-1.10.0",
         ":rand-0.8.5",
         ":regex-1.11.1",
@@ -623,7 +631,7 @@ cargo.rust_library(
         ":rustls-native-certs-0.7.3",
         ":rustls-pemfile-2.2.0",
         ":rustls-webpki-0.102.8",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_json-1.0.133",
         ":serde_nanos-0.1.4",
         ":serde_repr-0.1.19",
@@ -632,6 +640,7 @@ cargo.rust_library(
         ":tokio-1.42.0",
         ":tokio-rustls-0.26.1",
         ":tokio-util-0.7.13",
+        ":tokio-websockets-0.10.1",
         ":tracing-0.1.41",
         ":tryhard-0.5.1",
         ":url-2.5.4",
@@ -640,23 +649,23 @@ cargo.rust_library(
 
 alias(
     name = "async-openai",
-    actual = ":async-openai-0.25.0",
+    actual = ":async-openai-0.26.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "async-openai-0.25.0.crate",
-    sha256 = "1b17e44510f88a904cb3102a020d7ea11929dcddadfaff756e71112cb2cb7bd0",
-    strip_prefix = "async-openai-0.25.0",
-    urls = ["https://static.crates.io/crates/async-openai/0.25.0/download"],
+    name = "async-openai-0.26.0.crate",
+    sha256 = "0d226540b4ecf884b0fb4370008631ccbd9605cf82f98bb504ec8f2cee0810e8",
+    strip_prefix = "async-openai-0.26.0",
+    urls = ["https://static.crates.io/crates/async-openai/0.26.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "async-openai-0.25.0",
-    srcs = [":async-openai-0.25.0.crate"],
+    name = "async-openai-0.26.0",
+    srcs = [":async-openai-0.26.0.crate"],
     crate = "async_openai",
-    crate_root = "async-openai-0.25.0.crate/src/lib.rs",
+    crate_root = "async-openai-0.26.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -675,7 +684,7 @@ cargo.rust_library(
         ":reqwest-0.12.9",
         ":reqwest-eventsource-0.6.0",
         ":secrecy-0.8.0",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_json-1.0.133",
         ":thiserror-1.0.69",
         ":tokio-1.42.0",
@@ -887,7 +896,7 @@ cargo.rust_library(
     deps = [
         ":http-0.2.12",
         ":log-0.4.22",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_json-1.0.133",
         ":url-2.5.4",
         ":webpki-roots-0.25.4",
@@ -1049,7 +1058,7 @@ cargo.rust_library(
         ":log-0.4.22",
         ":quick-xml-0.30.0",
         ":rust-ini-0.19.0",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":thiserror-1.0.69",
         ":time-0.3.37",
         ":url-2.5.4",
@@ -1711,7 +1720,7 @@ cargo.rust_library(
         ":multer-2.1.0",
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.15",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_json-1.0.133",
         ":serde_path_to_error-0.1.16",
         ":serde_urlencoded-0.7.1",
@@ -1755,9 +1764,9 @@ cargo.rust_library(
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.15",
         ":rustversion-1.0.18",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":sync_wrapper-1.0.2",
-        ":tower-0.5.1",
+        ":tower-0.5.2",
         ":tower-layer-0.3.3",
         ":tower-service-0.3.3",
     ],
@@ -2063,27 +2072,6 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "bcder-0.7.4.crate",
-    sha256 = "c627747a6774aab38beb35990d88309481378558875a41da1a4b2e373c906ef0",
-    strip_prefix = "bcder-0.7.4",
-    urls = ["https://static.crates.io/crates/bcder/0.7.4/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "bcder-0.7.4",
-    srcs = [":bcder-0.7.4.crate"],
-    crate = "bcder",
-    crate_root = "bcder-0.7.4.crate/src/lib.rs",
-    edition = "2018",
-    visibility = [],
-    deps = [
-        ":bytes-1.9.0",
-        ":smallvec-1.13.2",
-    ],
-)
-
-http_archive(
     name = "bigdecimal-0.4.7.crate",
     sha256 = "7f31f3af01c5c65a07985c804d3366560e6fa7883d640a122819b14ec327482c",
     strip_prefix = "bigdecimal-0.4.7",
@@ -2120,7 +2108,7 @@ cargo.rust_library(
         ":num-bigint-0.4.6",
         ":num-integer-0.1.46",
         ":num-traits-0.2.19",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -2177,7 +2165,7 @@ cargo.rust_library(
     crate_root = "bincode-1.3.3.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
-    deps = [":serde-1.0.215"],
+    deps = [":serde-1.0.216"],
 )
 
 http_archive(
@@ -2308,7 +2296,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde-1.0.215"],
+    deps = [":serde-1.0.216"],
 )
 
 http_archive(
@@ -2553,37 +2541,44 @@ cargo.rust_library(
 
 alias(
     name = "bollard",
-    actual = ":bollard-0.16.1",
+    actual = ":bollard-0.18.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "bollard-0.16.1.crate",
-    sha256 = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c",
-    strip_prefix = "bollard-0.16.1",
-    urls = ["https://static.crates.io/crates/bollard/0.16.1/download"],
+    name = "bollard-0.18.1.crate",
+    sha256 = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30",
+    strip_prefix = "bollard-0.18.1",
+    urls = ["https://static.crates.io/crates/bollard/0.18.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "bollard-0.16.1",
-    srcs = [":bollard-0.16.1.crate"],
+    name = "bollard-0.18.1",
+    srcs = [":bollard-0.18.1.crate"],
     crate = "bollard",
-    crate_root = "bollard-0.16.1.crate/src/lib.rs",
+    crate_root = "bollard-0.18.1.crate/src/lib.rs",
     edition = "2021",
-    features = ["default"],
+    features = [
+        "default",
+        "http",
+        "hyper-named-pipe",
+        "hyper-util",
+        "hyperlocal",
+        "pipe",
+    ],
     platform = {
         "linux-arm64": dict(
-            deps = [":hyperlocal-next-0.9.0"],
+            deps = [":hyperlocal-0.9.1"],
         ),
         "linux-x86_64": dict(
-            deps = [":hyperlocal-next-0.9.0"],
+            deps = [":hyperlocal-0.9.1"],
         ),
         "macos-arm64": dict(
-            deps = [":hyperlocal-next-0.9.0"],
+            deps = [":hyperlocal-0.9.1"],
         ),
         "macos-x86_64": dict(
-            deps = [":hyperlocal-next-0.9.0"],
+            deps = [":hyperlocal-0.9.1"],
         ),
         "windows-gnu": dict(
             deps = [
@@ -2603,7 +2598,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":base64-0.22.1",
-        ":bollard-stubs-1.44.0-rc.2",
+        ":bollard-stubs-1.47.1-rc.27.3.1",
         ":bytes-1.9.0",
         ":futures-core-0.3.31",
         ":futures-util-0.3.31",
@@ -2614,12 +2609,12 @@ cargo.rust_library(
         ":hyper-util-0.1.10",
         ":log-0.4.22",
         ":pin-project-lite-0.2.15",
-        ":serde-1.0.215",
-        ":serde_derive-1.0.215",
+        ":serde-1.0.216",
+        ":serde_derive-1.0.216",
         ":serde_json-1.0.133",
         ":serde_repr-0.1.19",
         ":serde_urlencoded-0.7.1",
-        ":thiserror-1.0.69",
+        ":thiserror-2.0.6",
         ":tokio-1.42.0",
         ":tokio-util-0.7.13",
         ":url-2.5.4",
@@ -2627,22 +2622,22 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "bollard-stubs-1.44.0-rc.2.crate",
-    sha256 = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5",
-    strip_prefix = "bollard-stubs-1.44.0-rc.2",
-    urls = ["https://static.crates.io/crates/bollard-stubs/1.44.0-rc.2/download"],
+    name = "bollard-stubs-1.47.1-rc.27.3.1.crate",
+    sha256 = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da",
+    strip_prefix = "bollard-stubs-1.47.1-rc.27.3.1",
+    urls = ["https://static.crates.io/crates/bollard-stubs/1.47.1-rc.27.3.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "bollard-stubs-1.44.0-rc.2",
-    srcs = [":bollard-stubs-1.44.0-rc.2.crate"],
+    name = "bollard-stubs-1.47.1-rc.27.3.1",
+    srcs = [":bollard-stubs-1.47.1-rc.27.3.1.crate"],
     crate = "bollard_stubs",
-    crate_root = "bollard-stubs-1.44.0-rc.2.crate/src/lib.rs",
+    crate_root = "bollard-stubs-1.47.1-rc.27.3.1.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_repr-0.1.19",
         ":serde_with-3.11.0",
     ],
@@ -2701,18 +2696,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "bstr-1.11.0.crate",
-    sha256 = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22",
-    strip_prefix = "bstr-1.11.0",
-    urls = ["https://static.crates.io/crates/bstr/1.11.0/download"],
+    name = "bstr-1.11.1.crate",
+    sha256 = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8",
+    strip_prefix = "bstr-1.11.1",
+    urls = ["https://static.crates.io/crates/bstr/1.11.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "bstr-1.11.0",
-    srcs = [":bstr-1.11.0.crate"],
+    name = "bstr-1.11.1",
+    srcs = [":bstr-1.11.1.crate"],
     crate = "bstr",
-    crate_root = "bstr-1.11.0.crate/src/lib.rs",
+    crate_root = "bstr-1.11.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -2721,7 +2716,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":memchr-2.7.4",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -2772,7 +2767,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde-1.0.215"],
+    deps = [":serde-1.0.216"],
 )
 
 http_archive(
@@ -2947,7 +2942,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":num-traits-0.2.19",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -2979,7 +2974,7 @@ cargo.rust_library(
     deps = [
         ":ciborium-io-0.2.2",
         ":ciborium-ll-0.2.2",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -3433,7 +3428,7 @@ cargo.rust_library(
     deps = [
         ":nom-7.1.3",
         ":pathdiff-0.2.3",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":toml-0.8.19",
     ],
 )
@@ -3452,6 +3447,10 @@ cargo.rust_library(
     crate = "const_oid",
     crate_root = "const-oid-0.9.6.crate/src/lib.rs",
     edition = "2021",
+    features = [
+        "db",
+        "std",
+    ],
     visibility = [],
 )
 
@@ -4189,26 +4188,25 @@ cargo.rust_library(
 
 alias(
     name = "deadpool",
-    actual = ":deadpool-0.10.0",
+    actual = ":deadpool-0.12.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "deadpool-0.10.0.crate",
-    sha256 = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490",
-    strip_prefix = "deadpool-0.10.0",
-    urls = ["https://static.crates.io/crates/deadpool/0.10.0/download"],
+    name = "deadpool-0.12.1.crate",
+    sha256 = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed",
+    strip_prefix = "deadpool-0.12.1",
+    urls = ["https://static.crates.io/crates/deadpool/0.12.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "deadpool-0.10.0",
-    srcs = [":deadpool-0.10.0.crate"],
+    name = "deadpool-0.12.1",
+    srcs = [":deadpool-0.12.1.crate"],
     crate = "deadpool",
-    crate_root = "deadpool-0.10.0.crate/src/lib.rs",
-    edition = "2018",
+    crate_root = "deadpool-0.12.1.crate/src/lib.rs",
+    edition = "2021",
     features = [
-        "async-trait",
         "default",
         "managed",
         "rt_tokio_1",
@@ -4216,7 +4214,6 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":async-trait-0.1.83",
         ":deadpool-runtime-0.1.4",
         ":num_cpus-1.16.0",
         ":tokio-1.42.0",
@@ -4225,33 +4222,53 @@ cargo.rust_library(
 
 alias(
     name = "deadpool-postgres",
-    actual = ":deadpool-postgres-0.12.1",
+    actual = ":deadpool-postgres-0.14.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "deadpool-postgres-0.12.1.crate",
-    sha256 = "bda39fa1cfff190d8924d447ad04fd22772c250438ca5ce1dfb3c80621c05aaa",
-    strip_prefix = "deadpool-postgres-0.12.1",
-    urls = ["https://static.crates.io/crates/deadpool-postgres/0.12.1/download"],
+    name = "deadpool-postgres-0.14.0.crate",
+    sha256 = "1ab8a4ea925ce79678034870834602a2980f4b88c09e97feb266496dbb4493d2",
+    strip_prefix = "deadpool-postgres-0.14.0",
+    urls = ["https://static.crates.io/crates/deadpool-postgres/0.14.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "deadpool-postgres-0.12.1",
-    srcs = [":deadpool-postgres-0.12.1.crate"],
+    name = "deadpool-postgres-0.14.0",
+    srcs = [":deadpool-postgres-0.14.0.crate"],
     crate = "deadpool_postgres",
-    crate_root = "deadpool-postgres-0.12.1.crate/src/lib.rs",
-    edition = "2018",
+    crate_root = "deadpool-postgres-0.14.0.crate/src/lib.rs",
+    edition = "2021",
     features = [
         "default",
         "rt_tokio_1",
     ],
+    platform = {
+        "linux-arm64": dict(
+            deps = [":tokio-postgres-0.7.12"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":tokio-postgres-0.7.12"],
+        ),
+        "macos-arm64": dict(
+            deps = [":tokio-postgres-0.7.12"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":tokio-postgres-0.7.12"],
+        ),
+        "windows-gnu": dict(
+            deps = [":tokio-postgres-0.7.12"],
+        ),
+        "windows-msvc": dict(
+            deps = [":tokio-postgres-0.7.12"],
+        ),
+    },
     visibility = [],
     deps = [
-        ":deadpool-0.10.0",
+        ":async-trait-0.1.83",
+        ":deadpool-0.12.1",
         ":tokio-1.42.0",
-        ":tokio-postgres-0.7.12",
         ":tracing-0.1.41",
     ],
 )
@@ -4293,6 +4310,8 @@ cargo.rust_library(
     edition = "2021",
     features = [
         "alloc",
+        "derive",
+        "flagset",
         "oid",
         "pem",
         "std",
@@ -4301,8 +4320,33 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":const-oid-0.9.6",
+        ":der_derive-0.7.3",
+        ":flagset-0.4.6",
         ":pem-rfc7468-0.7.0",
         ":zeroize-1.8.1",
+    ],
+)
+
+http_archive(
+    name = "der_derive-0.7.3.crate",
+    sha256 = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18",
+    strip_prefix = "der_derive-0.7.3",
+    urls = ["https://static.crates.io/crates/der_derive/0.7.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "der_derive-0.7.3",
+    srcs = [":der_derive-0.7.3.crate"],
+    crate = "der_derive",
+    crate_root = "der_derive-0.7.3.crate/src/lib.rs",
+    edition = "2021",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.92",
+        ":quote-1.0.37",
+        ":syn-2.0.90",
     ],
 )
 
@@ -4329,7 +4373,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":powerfmt-0.2.0",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -4532,7 +4576,7 @@ cargo.rust_library(
         ":rand-0.8.5",
         ":retry-1.3.1",
         ":semver-1.0.23",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -5041,7 +5085,7 @@ cargo.rust_library(
         "use_std",
     ],
     visibility = [],
-    deps = [":serde-1.0.215"],
+    deps = [":serde-1.0.216"],
 )
 
 http_archive(
@@ -5601,6 +5645,23 @@ cargo.rust_library(
     visibility = [],
 )
 
+http_archive(
+    name = "flagset-0.4.6.crate",
+    sha256 = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec",
+    strip_prefix = "flagset-0.4.6",
+    urls = ["https://static.crates.io/crates/flagset/0.4.6/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "flagset-0.4.6",
+    srcs = [":flagset-0.4.6.crate"],
+    crate = "flagset",
+    crate_root = "flagset-0.4.6.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+)
+
 alias(
     name = "flate2",
     actual = ":flate2-1.0.35",
@@ -5805,7 +5866,7 @@ cargo.rust_library(
         ":itertools-0.13.0",
         ":parking_lot-0.12.3",
         ":pin-project-1.1.7",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -5864,7 +5925,7 @@ cargo.rust_library(
         ":parking_lot-0.12.3",
         ":paste-1.0.15",
         ":pin-project-1.1.7",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":thiserror-2.0.6",
         ":tracing-0.1.41",
     ],
@@ -5920,7 +5981,7 @@ cargo.rust_library(
         ":paste-1.0.15",
         ":pin-project-1.1.7",
         ":rand-0.8.5",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":thiserror-2.0.6",
         ":tracing-0.1.41",
         ":twox-hash-2.1.0",
@@ -5930,49 +5991,8 @@ cargo.rust_library(
 
 alias(
     name = "fs4",
-    actual = ":fs4-0.11.1",
+    actual = ":fs4-0.12.0",
     visibility = ["PUBLIC"],
-)
-
-http_archive(
-    name = "fs4-0.11.1.crate",
-    sha256 = "e871a4cfa68bb224863b53149d973df1ac8d1ed2fa1d1bfc37ac1bb65dd37207",
-    strip_prefix = "fs4-0.11.1",
-    urls = ["https://static.crates.io/crates/fs4/0.11.1/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "fs4-0.11.1",
-    srcs = [":fs4-0.11.1.crate"],
-    crate = "fs4",
-    crate_root = "fs4-0.11.1.crate/src/lib.rs",
-    edition = "2021",
-    features = [
-        "default",
-        "sync",
-    ],
-    platform = {
-        "linux-arm64": dict(
-            deps = [":rustix-0.38.42"],
-        ),
-        "linux-x86_64": dict(
-            deps = [":rustix-0.38.42"],
-        ),
-        "macos-arm64": dict(
-            deps = [":rustix-0.38.42"],
-        ),
-        "macos-x86_64": dict(
-            deps = [":rustix-0.38.42"],
-        ),
-        "windows-gnu": dict(
-            deps = [":windows-sys-0.52.0"],
-        ),
-        "windows-msvc": dict(
-            deps = [":windows-sys-0.52.0"],
-        ),
-    },
-    visibility = [],
 )
 
 http_archive(
@@ -5989,6 +6009,10 @@ cargo.rust_library(
     crate = "fs4",
     crate_root = "fs4-0.12.0.crate/src/lib.rs",
     edition = "2021",
+    features = [
+        "default",
+        "sync",
+    ],
     platform = {
         "linux-arm64": dict(
             deps = [":rustix-0.38.42"],
@@ -6556,7 +6580,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":aho-corasick-1.1.3",
-        ":bstr-1.11.0",
+        ":bstr-1.11.1",
         ":log-0.4.22",
         ":regex-automata-0.4.9",
         ":regex-syntax-0.8.5",
@@ -6861,7 +6885,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hash32-0.2.1",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":stable_deref_trait-1.2.0",
     ],
 )
@@ -7464,7 +7488,7 @@ cargo.rust_library(
         ":http-1.2.0",
         ":hyper-1.5.1",
         ":hyper-util-0.1.10",
-        ":rustls-0.23.19",
+        ":rustls-0.23.20",
         ":rustls-native-certs-0.8.1",
         ":tokio-1.42.0",
         ":tokio-rustls-0.26.1",
@@ -7562,24 +7586,25 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "hyperlocal-next-0.9.0.crate",
-    sha256 = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc",
-    strip_prefix = "hyperlocal-next-0.9.0",
-    urls = ["https://static.crates.io/crates/hyperlocal-next/0.9.0/download"],
+    name = "hyperlocal-0.9.1.crate",
+    sha256 = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7",
+    strip_prefix = "hyperlocal-0.9.1",
+    urls = ["https://static.crates.io/crates/hyperlocal/0.9.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "hyperlocal-next-0.9.0",
-    srcs = [":hyperlocal-next-0.9.0.crate"],
-    crate = "hyperlocal_next",
-    crate_root = "hyperlocal-next-0.9.0.crate/src/lib.rs",
+    name = "hyperlocal-0.9.1",
+    srcs = [":hyperlocal-0.9.1.crate"],
+    crate = "hyperlocal",
+    crate_root = "hyperlocal-0.9.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "client",
         "default",
         "http-body-util",
         "hyper-util",
+        "server",
         "tower-service",
     ],
     visibility = [],
@@ -7958,7 +7983,7 @@ cargo.rust_library(
         ":ignore-0.4.23",
         ":proc-macro2-1.0.92",
         ":quote-1.0.37",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":syn-2.0.90",
         ":toml-0.8.19",
         ":unicode-xid-0.2.6",
@@ -8040,7 +8065,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hashbrown-0.12.3",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -8074,7 +8099,7 @@ cargo.rust_library(
     deps = [
         ":equivalent-1.0.1",
         ":hashbrown-0.15.2",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -8219,12 +8244,6 @@ cargo.rust_library(
     visibility = [],
 )
 
-alias(
-    name = "itertools",
-    actual = ":itertools-0.12.1",
-    visibility = ["PUBLIC"],
-)
-
 http_archive(
     name = "itertools-0.12.1.crate",
     sha256 = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569",
@@ -8246,6 +8265,12 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [":either-1.13.0"],
+)
+
+alias(
+    name = "itertools",
+    actual = ":itertools-0.13.0",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -8378,7 +8403,7 @@ cargo.rust_library(
         ":p256-0.13.2",
         ":p384-0.13.0",
         ":rand-0.8.5",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_json-1.0.133",
         ":thiserror-2.0.6",
         ":zeroize-1.8.1",
@@ -8431,23 +8456,23 @@ cargo.rust_library(
 
 alias(
     name = "krata-loopdev",
-    actual = ":krata-loopdev-0.0.12",
+    actual = ":krata-loopdev-0.0.21",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "krata-loopdev-0.0.12.crate",
-    sha256 = "0b5a22c1adad10f4e4be90192e7157b70f38a3d05b368123d693b2807749a365",
-    strip_prefix = "krata-loopdev-0.0.12",
-    urls = ["https://static.crates.io/crates/krata-loopdev/0.0.12/download"],
+    name = "krata-loopdev-0.0.21.crate",
+    sha256 = "c0642392bab66bc87bbb956fd798b35159464066c6a35805d8b9aa09dd538047",
+    strip_prefix = "krata-loopdev-0.0.21",
+    urls = ["https://static.crates.io/crates/krata-loopdev/0.0.21/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "krata-loopdev-0.0.12",
-    srcs = [":krata-loopdev-0.0.12.crate"],
+    name = "krata-loopdev-0.0.21",
+    srcs = [":krata-loopdev-0.0.21.crate"],
     crate = "krataloopdev",
-    crate_root = "krata-loopdev-0.0.12.crate/src/lib.rs",
+    crate_root = "krata-loopdev-0.0.21.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [":libc-0.2.168"],
@@ -9657,12 +9682,6 @@ cargo.rust_library(
     visibility = [],
 )
 
-alias(
-    name = "miniz_oxide",
-    actual = ":miniz_oxide-0.7.4",
-    visibility = ["PUBLIC"],
-)
-
 http_archive(
     name = "miniz_oxide-0.7.4.crate",
     sha256 = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08",
@@ -9677,17 +9696,14 @@ cargo.rust_library(
     crate = "miniz_oxide",
     crate_root = "miniz_oxide-0.7.4.crate/src/lib.rs",
     edition = "2018",
-    features = [
-        "default",
-        "simd",
-        "simd-adler32",
-        "with-alloc",
-    ],
     visibility = [],
-    deps = [
-        ":adler-1.0.2",
-        ":simd-adler32-0.3.7",
-    ],
+    deps = [":adler-1.0.2"],
+)
+
+alias(
+    name = "miniz_oxide",
+    actual = ":miniz_oxide-0.8.0",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -9704,9 +9720,17 @@ cargo.rust_library(
     crate = "miniz_oxide",
     crate_root = "miniz_oxide-0.8.0.crate/src/lib.rs",
     edition = "2021",
-    features = ["with-alloc"],
+    features = [
+        "default",
+        "simd",
+        "simd-adler32",
+        "with-alloc",
+    ],
     visibility = [],
-    deps = [":adler2-2.0.0"],
+    deps = [
+        ":adler2-2.0.0",
+        ":simd-adler32-0.3.7",
+    ],
 )
 
 http_archive(
@@ -10883,7 +10907,7 @@ cargo.rust_library(
     deps = [
         ":num-traits-0.2.19",
         ":rand-0.8.5",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -11285,31 +11309,6 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "pem-3.0.4.crate",
-    sha256 = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae",
-    strip_prefix = "pem-3.0.4",
-    urls = ["https://static.crates.io/crates/pem/3.0.4/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "pem-3.0.4",
-    srcs = [":pem-3.0.4.crate"],
-    crate = "pem",
-    crate_root = "pem-3.0.4.crate/src/lib.rs",
-    edition = "2021",
-    features = [
-        "default",
-        "std",
-    ],
-    visibility = [],
-    deps = [
-        ":base64-0.22.1",
-        ":serde-1.0.215",
-    ],
-)
-
-http_archive(
     name = "pem-rfc7468-0.7.0.crate",
     sha256 = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412",
     strip_prefix = "pem-rfc7468-0.7.0",
@@ -11383,8 +11382,8 @@ cargo.rust_library(
     deps = [
         ":fixedbitset-0.4.2",
         ":indexmap-2.7.0",
-        ":serde-1.0.215",
-        ":serde_derive-1.0.215",
+        ":serde-1.0.216",
+        ":serde_derive-1.0.216",
     ],
 )
 
@@ -11685,7 +11684,7 @@ cargo.rust_library(
     deps = [
         ":cobs-0.2.3",
         ":heapless-0.7.17",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -11774,7 +11773,7 @@ cargo.rust_library(
     ],
     named_deps = {
         "chrono_04": ":chrono-0.4.39",
-        "serde_1": ":serde-1.0.215",
+        "serde_1": ":serde-1.0.216",
         "serde_json_1": ":serde_json-1.0.133",
     },
     visibility = [],
@@ -12057,26 +12056,26 @@ cargo.rust_library(
 
 alias(
     name = "procfs",
-    actual = ":procfs-0.16.0",
+    actual = ":procfs-0.17.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "procfs-0.16.0.crate",
-    sha256 = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4",
-    strip_prefix = "procfs-0.16.0",
-    urls = ["https://static.crates.io/crates/procfs/0.16.0/download"],
+    name = "procfs-0.17.0.crate",
+    sha256 = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f",
+    strip_prefix = "procfs-0.17.0",
+    urls = ["https://static.crates.io/crates/procfs/0.17.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "procfs-0.16.0",
-    srcs = [":procfs-0.16.0.crate"],
+    name = "procfs-0.17.0",
+    srcs = [":procfs-0.17.0.crate"],
     crate = "procfs",
-    crate_root = "procfs-0.16.0.crate/src/lib.rs",
+    crate_root = "procfs-0.17.0.crate/src/lib.rs",
     edition = "2018",
     env = {
-        "OUT_DIR": "$(location :procfs-0.16.0-build-script-run[out_dir])",
+        "OUT_DIR": "$(location :procfs-0.17.0-build-script-run[out_dir])",
     },
     features = [
         "chrono",
@@ -12089,17 +12088,16 @@ cargo.rust_library(
         ":chrono-0.4.39",
         ":flate2-1.0.35",
         ":hex-0.4.3",
-        ":lazy_static-1.5.0",
-        ":procfs-core-0.16.0",
+        ":procfs-core-0.17.0",
         ":rustix-0.38.42",
     ],
 )
 
 cargo.rust_binary(
-    name = "procfs-0.16.0-build-script-build",
-    srcs = [":procfs-0.16.0.crate"],
+    name = "procfs-0.17.0-build-script-build",
+    srcs = [":procfs-0.17.0.crate"],
     crate = "build_script_build",
-    crate_root = "procfs-0.16.0.crate/build.rs",
+    crate_root = "procfs-0.17.0.crate/build.rs",
     edition = "2018",
     features = [
         "chrono",
@@ -12110,30 +12108,30 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "procfs-0.16.0-build-script-run",
+    name = "procfs-0.17.0-build-script-run",
     package_name = "procfs",
-    buildscript_rule = ":procfs-0.16.0-build-script-build",
+    buildscript_rule = ":procfs-0.17.0-build-script-build",
     features = [
         "chrono",
         "default",
         "flate2",
     ],
-    version = "0.16.0",
+    version = "0.17.0",
 )
 
 http_archive(
-    name = "procfs-core-0.16.0.crate",
-    sha256 = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29",
-    strip_prefix = "procfs-core-0.16.0",
-    urls = ["https://static.crates.io/crates/procfs-core/0.16.0/download"],
+    name = "procfs-core-0.17.0.crate",
+    sha256 = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec",
+    strip_prefix = "procfs-core-0.17.0",
+    urls = ["https://static.crates.io/crates/procfs-core/0.17.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "procfs-core-0.16.0",
-    srcs = [":procfs-core-0.16.0.crate"],
+    name = "procfs-core-0.17.0",
+    srcs = [":procfs-core-0.17.0.crate"],
     crate = "procfs_core",
-    crate_root = "procfs-core-0.16.0.crate/src/lib.rs",
+    crate_root = "procfs-core-0.17.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "chrono",
@@ -12243,7 +12241,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":memchr-2.7.4",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -12276,7 +12274,7 @@ cargo.rust_library(
         ":bytes-1.9.0",
         ":pin-project-lite-0.2.15",
         ":rustc-hash-2.1.0",
-        ":rustls-0.23.19",
+        ":rustls-0.23.20",
         ":socket2-0.5.8",
         ":thiserror-2.0.6",
         ":tokio-1.42.0",
@@ -12308,7 +12306,7 @@ cargo.rust_library(
         ":rand-0.8.5",
         ":ring-0.17.5",
         ":rustc-hash-2.1.0",
-        ":rustls-0.23.19",
+        ":rustls-0.23.20",
         ":slab-0.4.9",
         ":thiserror-2.0.6",
         ":tinyvec-1.8.0",
@@ -12513,7 +12511,7 @@ cargo.rust_library(
     deps = [
         ":rand_chacha-0.3.1",
         ":rand_core-0.6.4",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -12608,7 +12606,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":getrandom-0.2.15",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -12695,27 +12693,28 @@ buildscript_run(
 
 alias(
     name = "refinery",
-    actual = ":refinery-0.8.12",
+    actual = ":refinery-0.8.14",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "refinery-0.8.12.crate",
-    sha256 = "a2783724569d96af53464d0711dff635cab7a4934df5e22e9fbc9e181523b83e",
-    strip_prefix = "refinery-0.8.12",
-    urls = ["https://static.crates.io/crates/refinery/0.8.12/download"],
+    name = "refinery-0.8.14.crate",
+    sha256 = "0904191f0566c3d3e0091d5cc8dec22e663d77def2d247b16e7a438b188bf75d",
+    strip_prefix = "refinery-0.8.14",
+    urls = ["https://static.crates.io/crates/refinery/0.8.14/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "refinery-0.8.12",
-    srcs = [":refinery-0.8.12.crate"],
+    name = "refinery-0.8.14",
+    srcs = [":refinery-0.8.14.crate"],
     crate = "refinery",
-    crate_root = "refinery-0.8.12.crate/src/lib.rs",
+    crate_root = "refinery-0.8.14.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
         "tokio-postgres",
+        "toml",
     ],
     visibility = [],
     deps = [
@@ -12740,8 +12739,10 @@ cargo.rust_library(
     edition = "2018",
     features = [
         "default",
+        "serde",
         "tokio",
         "tokio-postgres",
+        "toml",
     ],
     visibility = [],
     deps = [
@@ -12749,11 +12750,13 @@ cargo.rust_library(
         ":cfg-if-1.0.0",
         ":log-0.4.22",
         ":regex-1.11.1",
+        ":serde-1.0.216",
         ":siphasher-1.0.1",
         ":thiserror-1.0.69",
         ":time-0.3.37",
         ":tokio-1.42.0",
         ":tokio-postgres-0.7.12",
+        ":toml-0.8.19",
         ":url-2.5.4",
         ":walkdir-2.5.0",
     ],
@@ -13060,7 +13063,7 @@ cargo.rust_library(
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.15",
                 ":quinn-0.11.6",
-                ":rustls-0.23.19",
+                ":rustls-0.23.20",
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.10.0",
@@ -13084,7 +13087,7 @@ cargo.rust_library(
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.15",
                 ":quinn-0.11.6",
-                ":rustls-0.23.19",
+                ":rustls-0.23.20",
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.10.0",
@@ -13108,7 +13111,7 @@ cargo.rust_library(
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.15",
                 ":quinn-0.11.6",
-                ":rustls-0.23.19",
+                ":rustls-0.23.20",
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.10.0",
@@ -13132,7 +13135,7 @@ cargo.rust_library(
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.15",
                 ":quinn-0.11.6",
-                ":rustls-0.23.19",
+                ":rustls-0.23.20",
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.10.0",
@@ -13156,7 +13159,7 @@ cargo.rust_library(
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.15",
                 ":quinn-0.11.6",
-                ":rustls-0.23.19",
+                ":rustls-0.23.20",
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.10.0",
@@ -13181,7 +13184,7 @@ cargo.rust_library(
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.15",
                 ":quinn-0.11.6",
-                ":rustls-0.23.19",
+                ":rustls-0.23.20",
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.10.0",
@@ -13201,7 +13204,7 @@ cargo.rust_library(
         ":futures-util-0.3.31",
         ":http-1.2.0",
         ":mime_guess-2.0.4",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_json-1.0.133",
         ":serde_urlencoded-0.7.1",
         ":sync_wrapper-1.0.2",
@@ -14136,8 +14139,8 @@ cargo.rust_library(
         ":quick-xml-0.30.0",
         ":rustls-0.21.12",
         ":rustls-native-certs-0.6.3",
-        ":serde-1.0.215",
-        ":serde_derive-1.0.215",
+        ":serde-1.0.216",
+        ":serde_derive-1.0.216",
         ":serde_json-1.0.133",
         ":sha2-0.10.8",
         ":thiserror-1.0.69",
@@ -14175,7 +14178,7 @@ cargo.rust_library(
     deps = [
         ":arrayvec-0.7.6",
         ":num-traits-0.2.19",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -14432,23 +14435,23 @@ cargo.rust_library(
 
 alias(
     name = "rustls",
-    actual = ":rustls-0.23.19",
+    actual = ":rustls-0.23.20",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "rustls-0.23.19.crate",
-    sha256 = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1",
-    strip_prefix = "rustls-0.23.19",
-    urls = ["https://static.crates.io/crates/rustls/0.23.19/download"],
+    name = "rustls-0.23.20.crate",
+    sha256 = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b",
+    strip_prefix = "rustls-0.23.20",
+    urls = ["https://static.crates.io/crates/rustls/0.23.20/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-0.23.19",
-    srcs = [":rustls-0.23.19.crate"],
+    name = "rustls-0.23.20",
+    srcs = [":rustls-0.23.20.crate"],
     crate = "rustls",
-    crate_root = "rustls-0.23.19.crate/src/lib.rs",
+    crate_root = "rustls-0.23.20.crate/src/lib.rs",
     edition = "2021",
     features = [
         "log",
@@ -14509,12 +14512,6 @@ cargo.rust_library(
     deps = [":rustls-pemfile-1.0.4"],
 )
 
-alias(
-    name = "rustls-native-certs",
-    actual = ":rustls-native-certs-0.7.3",
-    visibility = ["PUBLIC"],
-)
-
 http_archive(
     name = "rustls-native-certs-0.7.3.crate",
     sha256 = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5",
@@ -14554,6 +14551,12 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [":rustls-pemfile-2.2.0"],
+)
+
+alias(
+    name = "rustls-native-certs",
+    actual = ":rustls-native-certs-0.8.1",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -14941,7 +14944,7 @@ cargo.rust_library(
         ":sea-orm-macros-1.1.2",
         ":sea-query-0.32.1",
         ":sea-query-binder-0.7.0",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_json-1.0.133",
         ":sqlx-0.8.2",
         ":strum-0.26.3",
@@ -15136,7 +15139,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":zeroize-1.8.1",
     ],
 )
@@ -15297,23 +15300,23 @@ buildscript_run(
 
 alias(
     name = "serde",
-    actual = ":serde-1.0.215",
+    actual = ":serde-1.0.216",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "serde-1.0.215.crate",
-    sha256 = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f",
-    strip_prefix = "serde-1.0.215",
-    urls = ["https://static.crates.io/crates/serde/1.0.215/download"],
+    name = "serde-1.0.216.crate",
+    sha256 = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e",
+    strip_prefix = "serde-1.0.216",
+    urls = ["https://static.crates.io/crates/serde/1.0.216/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde-1.0.215",
-    srcs = [":serde-1.0.215.crate"],
+    name = "serde-1.0.216",
+    srcs = [":serde-1.0.216.crate"],
     crate = "serde",
-    crate_root = "serde-1.0.215.crate/src/lib.rs",
+    crate_root = "serde-1.0.216.crate/src/lib.rs",
     edition = "2018",
     features = [
         "alloc",
@@ -15324,7 +15327,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":serde_derive-1.0.215"],
+    deps = [":serde_derive-1.0.216"],
 )
 
 alias(
@@ -15354,24 +15357,24 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":chrono-0.4.39",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_json-1.0.133",
     ],
 )
 
 http_archive(
-    name = "serde_derive-1.0.215.crate",
-    sha256 = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0",
-    strip_prefix = "serde_derive-1.0.215",
-    urls = ["https://static.crates.io/crates/serde_derive/1.0.215/download"],
+    name = "serde_derive-1.0.216.crate",
+    sha256 = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e",
+    strip_prefix = "serde_derive-1.0.216",
+    urls = ["https://static.crates.io/crates/serde_derive/1.0.216/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "serde_derive-1.0.215",
-    srcs = [":serde_derive-1.0.215.crate"],
+    name = "serde_derive-1.0.216",
+    srcs = [":serde_derive-1.0.216.crate"],
     crate = "serde_derive",
-    crate_root = "serde_derive-1.0.215.crate/src/lib.rs",
+    crate_root = "serde_derive-1.0.216.crate/src/lib.rs",
     edition = "2015",
     features = ["default"],
     proc_macro = True,
@@ -15418,7 +15421,7 @@ cargo.rust_library(
         ":itoa-1.0.14",
         ":memchr-2.7.4",
         ":ryu-1.0.18",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -15469,7 +15472,7 @@ cargo.rust_library(
     crate_root = "serde_nanos-0.1.4.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
-    deps = [":serde-1.0.215"],
+    deps = [":serde-1.0.216"],
 )
 
 alias(
@@ -15495,7 +15498,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":itoa-1.0.14",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -15538,7 +15541,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["serde"],
     visibility = [],
-    deps = [":serde-1.0.215"],
+    deps = [":serde-1.0.216"],
 )
 
 http_archive(
@@ -15560,7 +15563,7 @@ cargo.rust_library(
         ":form_urlencoded-1.2.1",
         ":itoa-1.0.14",
         ":ryu-1.0.18",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -15600,8 +15603,8 @@ cargo.rust_library(
     deps = [
         ":base64-0.22.1",
         ":hex-0.4.3",
-        ":serde-1.0.215",
-        ":serde_derive-1.0.215",
+        ":serde-1.0.216",
+        ":serde_derive-1.0.216",
         ":serde_json-1.0.133",
         ":serde_with_macros-3.11.0",
     ],
@@ -15656,7 +15659,7 @@ cargo.rust_library(
         ":indexmap-2.7.0",
         ":itoa-1.0.14",
         ":ryu-1.0.18",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":unsafe-libyaml-0.2.11",
     ],
 )
@@ -16000,7 +16003,7 @@ cargo.rust_library(
         "union",
     ],
     visibility = [],
-    deps = [":serde-1.0.215"],
+    deps = [":serde-1.0.216"],
 )
 
 http_archive(
@@ -16071,7 +16074,7 @@ cargo.rust_library(
         ":ed25519-1.5.3",
         ":libc-0.2.168",
         ":libsodium-sys-0.2.7",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -16301,9 +16304,9 @@ cargo.rust_library(
         ":paste-1.0.15",
         ":percent-encoding-2.3.1",
         ":rust_decimal-1.36.0",
-        ":rustls-0.23.19",
+        ":rustls-0.23.20",
         ":rustls-pemfile-2.2.0",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_json-1.0.133",
         ":sha2-0.10.8",
         ":smallvec-1.13.2",
@@ -16377,7 +16380,7 @@ cargo.rust_library(
         ":once_cell-1.20.2",
         ":rand-0.8.5",
         ":rust_decimal-1.36.0",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_json-1.0.133",
         ":sha2-0.10.8",
         ":smallvec-1.13.2",
@@ -16712,23 +16715,23 @@ cargo.rust_library(
 
 alias(
     name = "sysinfo",
-    actual = ":sysinfo-0.32.1",
+    actual = ":sysinfo-0.33.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "sysinfo-0.32.1.crate",
-    sha256 = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af",
-    strip_prefix = "sysinfo-0.32.1",
-    urls = ["https://static.crates.io/crates/sysinfo/0.32.1/download"],
+    name = "sysinfo-0.33.0.crate",
+    sha256 = "948512566b1895f93b1592c7574baeb2de842f224f2aab158799ecadb8ebbb46",
+    strip_prefix = "sysinfo-0.33.0",
+    urls = ["https://static.crates.io/crates/sysinfo/0.33.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sysinfo-0.32.1",
-    srcs = [":sysinfo-0.32.1.crate"],
+    name = "sysinfo-0.33.0",
+    srcs = [":sysinfo-0.33.0.crate"],
     crate = "sysinfo",
-    crate_root = "sysinfo-0.32.1.crate/src/lib.rs",
+    crate_root = "sysinfo-0.33.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "component",
@@ -17022,8 +17025,8 @@ cargo.rust_binary(
     edition = "2021",
     visibility = [],
     deps = [
-        ":async-nats-0.36.0",
-        ":async-openai-0.25.0",
+        ":async-nats-0.38.0",
+        ":async-openai-0.26.0",
         ":async-recursion-1.1.1",
         ":async-trait-0.1.83",
         ":aws-config-1.5.10",
@@ -17031,7 +17034,7 @@ cargo.rust_binary(
         ":axum-0.6.20",
         ":base64-0.22.1",
         ":blake3-1.5.5",
-        ":bollard-0.16.1",
+        ":bollard-0.18.1",
         ":bytes-1.9.0",
         ":chrono-0.4.39",
         ":ciborium-0.2.2",
@@ -17041,8 +17044,8 @@ cargo.rust_binary(
         ":convert_case-0.6.0",
         ":crossbeam-queue-0.3.11",
         ":darling-0.20.10",
-        ":deadpool-0.10.0",
-        ":deadpool-postgres-0.12.1",
+        ":deadpool-0.12.1",
+        ":deadpool-postgres-0.14.0",
         ":derive_builder-0.20.2",
         ":derive_more-0.99.18",
         ":devicemapper-0.34.1",
@@ -17052,7 +17055,7 @@ cargo.rust_binary(
         ":fastrace-0.7.4",
         ":flate2-1.0.35",
         ":foyer-0.13.1",
-        ":fs4-0.11.1",
+        ":fs4-0.12.0",
         ":futures-0.3.31",
         ":futures-lite-2.5.0",
         ":glob-0.3.1",
@@ -17063,13 +17066,13 @@ cargo.rust_binary(
         ":iftree-1.0.5",
         ":indexmap-2.7.0",
         ":indoc-2.0.5",
-        ":itertools-0.12.1",
+        ":itertools-0.13.0",
         ":jwt-simple-0.12.11",
-        ":krata-loopdev-0.0.12",
+        ":krata-loopdev-0.0.21",
         ":lazy_static-1.5.0",
         ":manyhow-0.11.4",
         ":mime_guess-2.0.4",
-        ":miniz_oxide-0.7.4",
+        ":miniz_oxide-0.8.0",
         ":names-0.14.0",
         ":nix-0.26.4",
         ":nkeys-0.4.4",
@@ -17090,20 +17093,20 @@ cargo.rust_binary(
         ":postgres-types-0.2.8",
         ":pretty_assertions_sorted-1.2.3",
         ":proc-macro2-1.0.92",
-        ":procfs-0.16.0",
+        ":procfs-0.17.0",
         ":quote-1.0.37",
         ":rand-0.8.5",
-        ":refinery-0.8.12",
+        ":refinery-0.8.14",
         ":regex-1.11.1",
         ":remain-0.2.14",
         ":reqwest-0.12.9",
         ":ring-0.17.5",
         ":rust-s3-0.34.0-rc4",
-        ":rustls-0.23.19",
-        ":rustls-native-certs-0.7.3",
+        ":rustls-0.23.20",
+        ":rustls-native-certs-0.8.1",
         ":rustls-pemfile-2.2.0",
         ":sea-orm-1.1.2",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde-aux-4.5.0",
         ":serde_json-1.0.133",
         ":serde_path_to_error-0.1.16",
@@ -17114,16 +17117,16 @@ cargo.rust_binary(
         ":spicedb-grpc-0.1.1",
         ":strum-0.26.3",
         ":syn-2.0.90",
-        ":sysinfo-0.32.1",
+        ":sysinfo-0.33.0",
         ":tar-0.4.43",
         ":tempfile-3.14.0",
         ":test-log-0.2.16",
-        ":thiserror-1.0.69",
+        ":thiserror-2.0.6",
         ":thread-priority-1.2.0",
         ":time-0.3.37",
         ":tokio-1.42.0",
         ":tokio-postgres-0.7.12",
-        ":tokio-postgres-rustls-0.12.0",
+        ":tokio-postgres-rustls-0.13.0",
         ":tokio-serde-0.9.0",
         ":tokio-stream-0.1.17",
         ":tokio-tungstenite-0.20.1",
@@ -17149,12 +17152,6 @@ cargo.rust_binary(
     ],
 )
 
-alias(
-    name = "thiserror",
-    actual = ":thiserror-1.0.69",
-    visibility = ["PUBLIC"],
-)
-
 http_archive(
     name = "thiserror-1.0.69.crate",
     sha256 = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52",
@@ -17171,6 +17168,12 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [":thiserror-impl-1.0.69"],
+)
+
+alias(
+    name = "thiserror",
+    actual = ":thiserror-2.0.6",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -17353,7 +17356,7 @@ cargo.rust_library(
         ":itoa-1.0.14",
         ":num-conv-0.1.0",
         ":powerfmt-0.2.0",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":time-core-0.1.2",
         ":time-macros-0.2.19",
     ],
@@ -17488,6 +17491,59 @@ cargo.rust_library(
     crate_root = "tinyvec_macros-0.1.1.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
+)
+
+http_archive(
+    name = "tls_codec-0.4.1.crate",
+    sha256 = "b5e78c9c330f8c85b2bae7c8368f2739157db9991235123aa1b15ef9502bfb6a",
+    strip_prefix = "tls_codec-0.4.1",
+    urls = ["https://static.crates.io/crates/tls_codec/0.4.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tls_codec-0.4.1",
+    srcs = [":tls_codec-0.4.1.crate"],
+    crate = "tls_codec",
+    crate_root = "tls_codec-0.4.1.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "derive",
+        "std",
+        "tls_codec_derive",
+    ],
+    visibility = [],
+    deps = [
+        ":tls_codec_derive-0.4.1",
+        ":zeroize-1.8.1",
+    ],
+)
+
+http_archive(
+    name = "tls_codec_derive-0.4.1.crate",
+    sha256 = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c",
+    strip_prefix = "tls_codec_derive-0.4.1",
+    urls = ["https://static.crates.io/crates/tls_codec_derive/0.4.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tls_codec_derive-0.4.1",
+    srcs = [":tls_codec_derive-0.4.1.crate"],
+    crate = "tls_codec_derive",
+    crate_root = "tls_codec_derive-0.4.1.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "std",
+    ],
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.92",
+        ":quote-1.0.37",
+        ":syn-2.0.90",
+    ],
 )
 
 alias(
@@ -17685,32 +17741,25 @@ cargo.rust_library(
 
 alias(
     name = "tokio-postgres-rustls",
-    actual = ":tokio-postgres-rustls-0.12.0",
+    actual = ":tokio-postgres-rustls-0.13.0",
     visibility = ["PUBLIC"],
 )
 
-http_archive(
-    name = "tokio-postgres-rustls-0.12.0.crate",
-    sha256 = "04fb792ccd6bbcd4bba408eb8a292f70fc4a3589e5d793626f45190e6454b6ab",
-    strip_prefix = "tokio-postgres-rustls-0.12.0",
-    urls = ["https://static.crates.io/crates/tokio-postgres-rustls/0.12.0/download"],
-    visibility = [],
-)
-
 cargo.rust_library(
-    name = "tokio-postgres-rustls-0.12.0",
-    srcs = [":tokio-postgres-rustls-0.12.0.crate"],
+    name = "tokio-postgres-rustls-0.13.0",
+    srcs = [":tokio-postgres-rustls-855e14009fe3bebe.git"],
     crate = "tokio_postgres_rustls",
-    crate_root = "tokio-postgres-rustls-0.12.0.crate/src/lib.rs",
+    crate_root = "tokio-postgres-rustls-855e14009fe3bebe/src/lib.rs",
     edition = "2018",
     visibility = [],
     deps = [
+        ":const-oid-0.9.6",
         ":ring-0.17.5",
-        ":rustls-0.23.19",
+        ":rustls-0.23.20",
         ":tokio-1.42.0",
         ":tokio-postgres-0.7.12",
         ":tokio-rustls-0.26.1",
-        ":x509-certificate-0.23.1",
+        ":x509-cert-0.2.5",
     ],
 )
 
@@ -17761,7 +17810,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":rustls-0.23.19",
+        ":rustls-0.23.20",
         ":tokio-1.42.0",
     ],
 )
@@ -17799,7 +17848,7 @@ cargo.rust_library(
         ":futures-core-0.3.31",
         ":futures-sink-0.3.31",
         ":pin-project-1.1.7",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_json-1.0.133",
     ],
 )
@@ -17946,6 +17995,44 @@ cargo.rust_library(
     ],
 )
 
+http_archive(
+    name = "tokio-websockets-0.10.1.crate",
+    sha256 = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d",
+    strip_prefix = "tokio-websockets-0.10.1",
+    urls = ["https://static.crates.io/crates/tokio-websockets/0.10.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tokio-websockets-0.10.1",
+    srcs = [":tokio-websockets-0.10.1.crate"],
+    crate = "tokio_websockets",
+    crate_root = "tokio-websockets-0.10.1.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "client",
+        "rand",
+        "ring",
+        "rustls-native-roots",
+    ],
+    visibility = [],
+    deps = [
+        ":base64-0.22.1",
+        ":bytes-1.9.0",
+        ":futures-core-0.3.31",
+        ":futures-sink-0.3.31",
+        ":http-1.2.0",
+        ":httparse-1.9.5",
+        ":rand-0.8.5",
+        ":ring-0.17.5",
+        ":rustls-native-certs-0.8.1",
+        ":rustls-pki-types-1.10.0",
+        ":tokio-1.42.0",
+        ":tokio-rustls-0.26.1",
+        ":tokio-util-0.7.13",
+    ],
+)
+
 alias(
     name = "toml",
     actual = ":toml-0.8.19",
@@ -17973,7 +18060,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_spanned-0.6.8",
         ":toml_datetime-0.6.8",
         ":toml_edit-0.22.22",
@@ -17996,7 +18083,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["serde"],
     visibility = [],
-    deps = [":serde-1.0.215"],
+    deps = [":serde-1.0.216"],
 )
 
 http_archive(
@@ -18022,7 +18109,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":indexmap-2.7.0",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_spanned-0.6.8",
         ":toml_datetime-0.6.8",
         ":winnow-0.6.20",
@@ -18166,18 +18253,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "tower-0.5.1.crate",
-    sha256 = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f",
-    strip_prefix = "tower-0.5.1",
-    urls = ["https://static.crates.io/crates/tower/0.5.1/download"],
+    name = "tower-0.5.2.crate",
+    sha256 = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9",
+    strip_prefix = "tower-0.5.2",
+    urls = ["https://static.crates.io/crates/tower/0.5.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tower-0.5.1",
-    srcs = [":tower-0.5.1.crate"],
+    name = "tower-0.5.2",
+    srcs = [":tower-0.5.2.crate"],
     crate = "tower",
-    crate_root = "tower-0.5.1.crate/src/lib.rs",
+    crate_root = "tower-0.5.2.crate/src/lib.rs",
     edition = "2018",
     features = [
         "__common",
@@ -18192,7 +18279,7 @@ cargo.rust_library(
         ":futures-core-0.3.31",
         ":futures-util-0.3.31",
         ":pin-project-lite-0.2.15",
-        ":sync_wrapper-0.1.2",
+        ":sync_wrapper-1.0.2",
         ":tower-layer-0.3.3",
         ":tower-service-0.3.3",
     ],
@@ -18482,7 +18569,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":tracing-core-0.1.33",
     ],
 )
@@ -18535,7 +18622,7 @@ cargo.rust_library(
         ":nu-ansi-term-0.46.0",
         ":once_cell-1.20.2",
         ":regex-1.11.1",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_json-1.0.133",
         ":sharded-slab-0.1.7",
         ":smallvec-1.13.2",
@@ -18573,7 +18660,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":tracing-core-0.1.33",
     ],
 )
@@ -18623,8 +18710,8 @@ cargo.rust_library(
     deps = [
         ":dissimilar-1.0.9",
         ":glob-0.3.1",
-        ":serde-1.0.215",
-        ":serde_derive-1.0.215",
+        ":serde-1.0.216",
+        ":serde_derive-1.0.216",
         ":serde_json-1.0.133",
         ":target-triple-0.1.3",
         ":termcolor-1.4.1",
@@ -18794,7 +18881,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rand-0.8.5",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -19014,7 +19101,7 @@ cargo.rust_library(
         ":form_urlencoded-1.2.1",
         ":idna-1.0.3",
         ":percent-encoding-2.3.1",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -19151,7 +19238,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":getrandom-0.2.15",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
     ],
 )
 
@@ -20069,32 +20156,26 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "x509-certificate-0.23.1.crate",
-    sha256 = "66534846dec7a11d7c50a74b7cdb208b9a581cad890b7866430d438455847c85",
-    strip_prefix = "x509-certificate-0.23.1",
-    urls = ["https://static.crates.io/crates/x509-certificate/0.23.1/download"],
+    name = "x509-cert-0.2.5.crate",
+    sha256 = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94",
+    strip_prefix = "x509-cert-0.2.5",
+    urls = ["https://static.crates.io/crates/x509-cert/0.2.5/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "x509-certificate-0.23.1",
-    srcs = [":x509-certificate-0.23.1.crate"],
-    crate = "x509_certificate",
-    crate_root = "x509-certificate-0.23.1.crate/src/lib.rs",
+    name = "x509-cert-0.2.5",
+    srcs = [":x509-cert-0.2.5.crate"],
+    crate = "x509_cert",
+    crate_root = "x509-cert-0.2.5.crate/src/lib.rs",
     edition = "2021",
+    features = ["std"],
     visibility = [],
     deps = [
-        ":bcder-0.7.4",
-        ":bytes-1.9.0",
-        ":chrono-0.4.39",
+        ":const-oid-0.9.6",
         ":der-0.7.9",
-        ":hex-0.4.3",
-        ":pem-3.0.4",
-        ":ring-0.17.5",
-        ":signature-2.2.0",
         ":spki-0.7.3",
-        ":thiserror-1.0.69",
-        ":zeroize-1.8.1",
+        ":tls_codec-0.4.1",
     ],
 )
 
@@ -20250,7 +20331,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":stable_deref_trait-1.2.0",
         ":yoke-derive-0.7.5",
         ":zerofrom-0.1.5",
@@ -20305,7 +20386,7 @@ cargo.rust_library(
     deps = [
         ":atomic_refcell-0.1.13",
         ":rand-0.7.3",
-        ":serde-1.0.215",
+        ":serde-1.0.216",
         ":serde_json-1.0.133",
         ":smallstr-0.3.0",
         ":smallvec-1.13.2",
@@ -20438,7 +20519,6 @@ cargo.rust_library(
     features = [
         "alloc",
         "default",
-        "derive",
         "zeroize_derive",
     ],
     visibility = [],

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.36.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71e5a1bab60f46b0b005f4808b8ee83ef6d577608923de938403393c9a30cf8"
+checksum = "76433c4de73442daedb3a59e991d94e85c14ebfc33db53dfcd347a21cd6ef4f8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -222,6 +222,7 @@ dependencies = [
  "nkeys",
  "nuid",
  "once_cell",
+ "pin-project",
  "portable-atomic",
  "rand 0.8.5",
  "regex",
@@ -238,6 +239,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.1",
  "tokio-util",
+ "tokio-websockets",
  "tracing",
  "tryhard",
  "url",
@@ -245,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b17e44510f88a904cb3102a020d7ea11929dcddadfaff756e71112cb2cb7bd0"
+checksum = "0d226540b4ecf884b0fb4370008631ccbd9605cf82f98bb504ec8f2cee0810e8"
 dependencies = [
  "async-convert",
  "backoff",
@@ -796,7 +798,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper 1.0.2",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -914,16 +916,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bcder"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627747a6774aab38beb35990d88309481378558875a41da1a4b2e373c906ef0"
-dependencies = [
- "bytes",
- "smallvec",
-]
-
-[[package]]
 name = "bigdecimal"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
 dependencies = [
  "base64 0.22.1",
  "bollard-stubs",
@@ -1049,7 +1041,7 @@ dependencies = [
  "hyper 1.5.1",
  "hyper-named-pipe",
  "hyper-util",
- "hyperlocal-next",
+ "hyperlocal 0.9.1",
  "log",
  "pin-project-lite",
  "serde",
@@ -1057,7 +1049,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -1067,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.44.0-rc.2"
+version = "1.47.1-rc.27.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
 dependencies = [
  "serde",
  "serde_repr",
@@ -1122,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
 dependencies = [
  "memchr",
  "serde",
@@ -1695,11 +1687,10 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "deadpool"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+checksum = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed"
 dependencies = [
- "async-trait",
  "deadpool-runtime",
  "num_cpus",
  "tokio",
@@ -1707,11 +1698,13 @@ dependencies = [
 
 [[package]]
 name = "deadpool-postgres"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda39fa1cfff190d8924d447ad04fd22772c250438ca5ce1dfb3c80621c05aaa"
+checksum = "1ab8a4ea925ce79678034870834602a2980f4b88c09e97feb266496dbb4493d2"
 dependencies = [
+ "async-trait",
  "deadpool",
+ "getrandom 0.2.15",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -1733,8 +1726,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2206,6 +2212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flagset"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2343,7 +2355,7 @@ dependencies = [
  "flume",
  "foyer-common",
  "foyer-memory",
- "fs4 0.12.0",
+ "fs4",
  "futures",
  "hashbrown 0.15.2",
  "itertools 0.13.0",
@@ -2360,16 +2372,6 @@ dependencies = [
  "tracing",
  "twox-hash",
  "zstd",
-]
-
-[[package]]
-name = "fs4"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e871a4cfa68bb224863b53149d973df1ac8d1ed2fa1d1bfc37ac1bb65dd37207"
-dependencies = [
- "rustix",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2965,7 +2967,7 @@ dependencies = [
  "http 1.2.0",
  "hyper 1.5.1",
  "hyper-util",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -3019,10 +3021,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyperlocal-next"
-version = "0.9.0"
+name = "hyperlocal"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
@@ -3394,9 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "krata-loopdev"
-version = "0.0.12"
+version = "0.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a22c1adad10f4e4be90192e7157b70f38a3d05b368123d693b2807749a365"
+checksum = "c0642392bab66bc87bbb956fd798b35159464066c6a35805d8b9aa09dd538047"
 dependencies = [
  "libc",
 ]
@@ -3701,7 +3703,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
- "simd-adler32",
 ]
 
 [[package]]
@@ -3711,6 +3712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -4205,16 +4207,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
-name = "pem"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
-dependencies = [
- "base64 0.22.1",
- "serde",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4492,24 +4484,23 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
  "bitflags 2.6.0",
  "chrono",
  "flate2",
  "hex",
- "lazy_static",
  "procfs-core",
  "rustix",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
  "bitflags 2.6.0",
  "chrono",
@@ -4589,7 +4580,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.0",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "socket2",
  "thiserror 2.0.6",
  "tokio",
@@ -4607,7 +4598,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.1.0",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.6",
@@ -4749,9 +4740,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4769,9 +4760,9 @@ dependencies = [
 
 [[package]]
 name = "refinery"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2783724569d96af53464d0711dff635cab7a4934df5e22e9fbc9e181523b83e"
+checksum = "0904191f0566c3d3e0091d5cc8dec22e663d77def2d247b16e7a438b188bf75d"
 dependencies = [
  "refinery-core",
  "refinery-macros",
@@ -4787,11 +4778,13 @@ dependencies = [
  "cfg-if",
  "log",
  "regex",
+ "serde",
  "siphasher 1.0.1",
  "thiserror 1.0.69",
  "time",
  "tokio",
  "tokio-postgres",
+ "toml",
  "url",
  "walkdir",
 ]
@@ -4905,7 +4898,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -5144,9 +5137,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.19"
+version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "log",
  "once_cell",
@@ -5449,9 +5442,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
@@ -5469,9 +5462,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5828,7 +5821,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rust_decimal",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -6127,9 +6120,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+checksum = "948512566b1895f93b1592c7574baeb2de842f224f2aab158799ecadb8ebbb46"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6249,24 +6242,24 @@ dependencies = [
  "fastrace",
  "flate2",
  "foyer",
- "fs4 0.11.1",
+ "fs4",
  "futures",
  "futures-lite",
  "glob",
  "hex",
  "http 0.2.12",
  "hyper 0.14.31",
- "hyperlocal",
+ "hyperlocal 0.8.0",
  "iftree",
  "indexmap 2.7.0",
  "indoc",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "jwt-simple",
  "krata-loopdev",
  "lazy_static",
  "manyhow",
  "mime_guess",
- "miniz_oxide 0.7.4",
+ "miniz_oxide 0.8.0",
  "names",
  "nix 0.26.4",
  "nkeys",
@@ -6296,8 +6289,8 @@ dependencies = [
  "reqwest",
  "ring",
  "rust-s3",
- "rustls 0.23.19",
- "rustls-native-certs 0.7.3",
+ "rustls 0.23.20",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "sea-orm",
  "serde",
@@ -6315,7 +6308,7 @@ dependencies = [
  "tar",
  "tempfile",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "thread-priority",
  "time",
  "tokio",
@@ -6475,6 +6468,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e78c9c330f8c85b2bae7c8368f2739157db9991235123aa1b15ef9502bfb6a"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "tokio"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6531,16 +6545,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres-rustls"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04fb792ccd6bbcd4bba408eb8a292f70fc4a3589e5d793626f45190e6454b6ab"
+version = "0.13.0"
+source = "git+https://github.com/jbg/tokio-postgres-rustls.git?branch=master#0cffe66df0e3fdc6b6067cf4432d1e3343c80fff"
 dependencies = [
+ "const-oid",
  "ring",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "tokio",
  "tokio-postgres",
  "tokio-rustls 0.26.1",
- "x509-certificate",
+ "x509-cert",
 ]
 
 [[package]]
@@ -6559,7 +6573,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "tokio",
 ]
 
@@ -6628,6 +6642,27 @@ dependencies = [
  "libc",
  "tokio",
  "vsock",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http 1.2.0",
+ "httparse",
+ "rand 0.8.5",
+ "ring",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.1",
+ "tokio-util",
 ]
 
 [[package]]
@@ -6720,14 +6755,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -7587,22 +7622,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "x509-certificate"
-version = "0.23.1"
+name = "x509-cert"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66534846dec7a11d7c50a74b7cdb208b9a581cad890b7866430d438455847c85"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
- "bcder",
- "bytes",
- "chrono",
+ "const-oid",
  "der",
- "hex",
- "pem",
- "ring",
- "signature 2.2.0",
  "spki",
- "thiserror 1.0.69",
- "zeroize",
+ "tls_codec",
 ]
 
 [[package]]
@@ -7796,8 +7824,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "tokio-postgres-rustls"
-version = "0.13.0"
-source = "git+https://github.com/jbg/tokio-postgres-rustls.git?branch=master#0cffe66df0e3fdc6b6067cf4432d1e3343c80fff"

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -28,43 +28,43 @@ rust-version = "1.82"
 publish = false
 
 [dependencies]
-async-nats = { version = "0.36.0", features = ["service"] }
-async-openai = "0.25.0"
-async-recursion = "1.0.5"
-async-trait = "0.1.79"
-aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
-aws-sdk-firehose = "1.46.0"
+async-nats = { version = "0.38.0", features = ["service"] }
+async-openai = "0.26.0"
+async-recursion = "1.1.1"
+async-trait = "0.1.83"
+aws-config = { version = "1.5.10", features = ["behavior-version-latest"] }
+aws-sdk-firehose = "1.56.0"
 axum = { version = "0.6.20", features = [
     "macros",
     "multipart",
     "ws",
 ] } # todo: upgrade this alongside hyper/http/tokio-tungstenite
-base64 = "0.22.0"
-blake3 = "1.5.1"
-bollard = "0.16.1"
-bytes = "1.6.0"
-chrono = { version = "0.4.37", features = ["serde"] }
+base64 = "0.22.1"
+blake3 = "1.5.5"
+bollard = "0.18.1"
+bytes = "1.9.0"
+chrono = { version = "0.4.39", features = ["serde"] }
 ciborium = "0.2.2"
-clap = { version = "4.5.4", features = ["derive", "color", "env", "wrap_help"] }
+clap = { version = "4.5.23", features = ["derive", "color", "env", "wrap_help"] }
 color-eyre = "0.6.3"
-config = { version = "0.14.0", default-features = false, features = ["toml"] }
+config = { version = "0.14.1", default-features = false, features = ["toml"] }
 convert_case = "0.6.0"
-crossbeam-queue = { version = "0.3.10" }
+crossbeam-queue = { version = "0.3.11" }
 darling = "0.20.10"
-deadpool = { version = "0.10.0", features = ["rt_tokio_1"] }
-deadpool-postgres = "0.12.1"
-derive_builder = "0.20.0"
+deadpool = { version = "0.12.1", features = ["rt_tokio_1"] }
+deadpool-postgres = "0.14.0"
+derive_builder = "0.20.2"
 derive_more = "0.99.17"
 devicemapper = { version = "=0.34.1" }
 diff = "0.1.13"
 directories = "5.0.1"
 dyn-clone = "1.0.17"
-fastrace = "0.7.3"
-flate2 = "1.0.28"
-futures = "0.3.30"
-futures-lite = "2.3.0"
+fastrace = "0.7.4"
+flate2 = "1.0.35"
+futures = "0.3.31"
+futures-lite = "2.5.0"
 foyer = { version = "0.13.1", features = ["tracing", "opentelemetry_0_26"] }
-fs4 = "0.11.0"
+fs4 = "0.12.0"
 glob = "0.3.1"
 hex = "0.4.3"
 http = "0.2.12" # todo: upgrade this alongside hyper/axum/tokio-tungstenite/tower-http
@@ -78,17 +78,17 @@ hyperlocal = { version = "0.8.0", default-features = false, features = [
     "client",
 ] } # todo: using the very latest of hyper client 1.x, we _may_ be able to phase this crate
 iftree = "1.0.5"
-indexmap = { version = "2.2.6", features = ["serde", "std"] }
+indexmap = { version = "2.7.0", features = ["serde", "std"] }
 indoc = "2.0.5"
-itertools = "0.12.1"
-jwt-simple = { version = "0.12.9", default-features = false, features = [
+itertools = "0.13.0"
+jwt-simple = { version = "0.12.11", default-features = false, features = [
     "pure-rust",
 ] }
-krata-loopdev = "0.0.12"
-lazy_static = "1.4.0"
+krata-loopdev = "0.0.21"
+lazy_static = "1.5.0"
 manyhow = { version = "0.11.4", features = ["darling"] }
 mime_guess = { version = "=2.0.4" } # TODO(fnichol): 2.0.5 sets an env var in build.rs which needs to be tracked, required by reqwest
-miniz_oxide = { version = "0.7.2", features = ["simd"] }
+miniz_oxide = { version = "0.8.0", features = ["simd"] }
 names = { version = "0.14.0", default-features = false }
 nix = { version = "0.26.0", features = [
     "fs",
@@ -99,29 +99,29 @@ nix = { version = "0.26.0", features = [
 ] }
 nkeys = "0.4.0"
 num_cpus = "1.16.0"
-once_cell = "1.19.0"
+once_cell = "1.20.2"
 opentelemetry = { version = "0.26.0", features = ["trace"] }
 opentelemetry-otlp = { version = "0.26.0", features = ["metrics", "trace"] }
 opentelemetry-semantic-conventions = "0.14.0"
 opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio"] }
-ordered-float = { version = "4.4.0", features = ["serde"] }
-ouroboros = "0.18.3"
+ordered-float = { version = "4.5.0", features = ["serde"] }
+ouroboros = "0.18.4"
 parking_lot = "0.12.3"
-paste = "1.0.14"
-pathdiff = "0.2.1"
-petgraph = { version = "0.6.4", features = ["serde-1"] }
-pin-project-lite = "0.2.13"
-postcard = { version = "1.0.8", features = ["use-std"] }
-postgres-types = { version = "0.2.6", features = ["derive"] }
+paste = "1.0.15"
+pathdiff = "0.2.3"
+petgraph = { version = "0.6.5", features = ["serde-1"] }
+pin-project-lite = "0.2.15"
+postcard = { version = "1.1.1", features = ["use-std"] }
+postgres-types = { version = "0.2.8", features = ["derive"] }
 pretty_assertions_sorted = "1.2.3"
-proc-macro2 = "1.0.79"
-procfs = "0.16.0"
-quote = "1.0.35"
+proc-macro2 = "1.0.92"
+procfs = "0.17.0"
+quote = "1.0.37"
 rand = "0.8.5"
-refinery = { version = "= 0.8.12", features = ["tokio-postgres"] }
-regex = "1.10.4"
-remain = "0.2.13"
-reqwest = { version = "0.12.2", default-features = false, features = [
+refinery = { version = "0.8.14", features = ["tokio-postgres"] }
+regex = "1.11.1"
+remain = "0.2.14"
+reqwest = { version = "0.12.9", default-features = false, features = [
     "rustls-tls",
     "json",
     "multipart",
@@ -130,49 +130,49 @@ ring = "=0.17.5" # Upgrading this is possible, but a pain, so we don't want to p
 rust-s3 = { version = "0.34.0-rc4", default-features = false, features = [
     "tokio-rustls-tls",
 ] }
-rustls = { version = "0.23.18", default-features = false } # NOTE(nick,fletcher): rustls switched to "aws-lc-rs" as its default crypto provider, but we want ring (i.e. we disable the default feature for "aws-lc-rs")
-rustls-native-certs = "0.7.0"
-rustls-pemfile = { version = "2.1.1" }
-sea-orm = { version = "1.1.0", features = [
+rustls = { version = "0.23.19", default-features = false } # NOTE(nick,fletcher): rustls switched to "aws-lc-rs" as its default crypto provider, but we want ring (i.e. we disable the default feature for "aws-lc-rs")
+rustls-native-certs = "0.8.1"
+rustls-pemfile = { version = "2.2.0" }
+sea-orm = { version = "1.1.2", features = [
     "sqlx-postgres",
     "runtime-tokio-rustls",
     "macros",
     "with-chrono",
     "debug-print",
 ] }
-serde = { version = "1.0.197", features = ["derive", "rc"] }
+serde = { version = "1.0.216", features = ["derive", "rc"] }
 serde-aux = "4.5.0"
 serde_json = { version = "1.0.133", features = ["preserve_order"] }
 serde_path_to_error = { version = "0.1.16" }
-serde_with = "3.7.0"
+serde_with = "3.11.0"
 serde_yaml = "0.9.33" # NOTE(nick): this has been archived upstream
 sodiumoxide = "0.2.7"
 spicedb-client = { version = "0.1.1", features = ["tls"] }
 spicedb-grpc = "0.1.1"
-strum = { version = "0.26.2", features = ["derive"] }
-syn = { version = "2.0.55", features = ["full", "extra-traits"] }
-sysinfo = "0.32.0"
-tar = "0.4.40"
-tempfile = "3.10.1"
-test-log = { version = "0.2.15", default-features = false, features = [
+strum = { version = "0.26.3", features = ["derive"] }
+syn = { version = "2.0.90", features = ["full", "extra-traits"] }
+sysinfo = "0.33.0"
+tar = "0.4.43"
+tempfile = "3.14.0"
+test-log = { version = "0.2.16", default-features = false, features = [
     "trace",
 ] }
-thiserror = "1.0.58"
-thread-priority = "1.1.0"
-time = "0.3.36"
-tokio = { version = "1.37.0", features = ["full"] }
-tokio-postgres = { version = "0.7.10", features = [
+thiserror = "2.0.6"
+thread-priority = "1.2.0"
+time = "0.3.37"
+tokio = { version = "1.42.0", features = ["full"] }
+tokio-postgres = { version = "0.7.12", features = [
     "runtime",
     "with-chrono-0_4",
     "with-serde_json-1",
 ] }
-tokio-postgres-rustls = { version = "0.12.0" }
+tokio-postgres-rustls = { version = "0.13.0" }
 tokio-serde = { version = "0.9.0", features = ["json"] }
-tokio-stream = { version = "0.1.15", features = ["sync", "time"] }
+tokio-stream = { version = "0.1.17", features = ["sync", "time"] }
 tokio-tungstenite = "0.20.1" # todo: pinning back from 0.21.0, upgrade this alongside hyper/http/axum/tokio-tungstenite,tower-http
 tokio-util = { version = "0.7.10", features = ["codec", "rt"] }
 tokio-vsock = { version = "0.4.0" }
-toml = { version = "0.8.12" }
+toml = { version = "0.8.19" }
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.4", features = [
     "compression-br",
@@ -181,22 +181,22 @@ tower-http = { version = "0.4.4", features = [
     "cors",
     "trace",
 ] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
-tracing = { version = "0.1.40" }
+tracing = { version = "0.1.41" }
 tracing-opentelemetry = "0.27.0"
-tracing-subscriber = { version = "0.3.18", features = [
+tracing-subscriber = { version = "0.3.19", features = [
     "env-filter",
     "json",
     "std",
 ] }
 tracing-tunnel = "0.1.0"
-trybuild = { version = "1.0.99", features = ["diff"] }
+trybuild = { version = "1.0.101", features = ["diff"] }
 tryhard = "0.5.1"
-ulid = { version = "1.1.2", features = ["serde"] }
-url = { version = "2.5.0", features = ["serde"] }
-uuid = { version = "1.8.0", features = ["serde", "v4"] }
-version_check = "0.9.4"
+ulid = { version = "1.1.3", features = ["serde"] }
+url = { version = "2.5.4", features = ["serde"] }
+uuid = { version = "1.11.0", features = ["serde", "v4"] }
+version_check = "0.9.5"
 webpki-roots = { version = "0.25.4" }
-xxhash-rust = { version = "0.8.10", features = ["xxh3", "const_xxh3"] }
+xxhash-rust = { version = "0.8.12", features = ["xxh3", "const_xxh3"] }
 y-sync = { version = "0.4.0", features = ["net"] }
 yrs = { version = "0.17.4" }
 


### PR DESCRIPTION
## Description

This PR updates Rust dependencies that neither require code changes nor fixup changes. This is a follow-up to #5103.

<img src="https://media3.giphy.com/media/f9r1xpjeSQOdcY8HnR/giphy.gif"/>