### PR TITLE
Add ability to run iterative prompts

### DIFF
--- a/bin/asset-sprayer-prompts/src/main.rs
+++ b/bin/asset-sprayer-prompts/src/main.rs
@@ -73,11 +73,16 @@ async fn main() -> Result<()> {
     let raw_prompt = asset_sprayer.raw_prompt(args.prompt_kind).await?;
     match args.action {
         Action::Show => {
-            let prompt = prompt.generate(&raw_prompt).await?;
-            println!("{}", serde_yaml::to_string(&prompt)?);
+            for raw_request in prompt.read(&raw_prompt)? {
+                let prompt = prompt.generate(raw_request, "").await?;
+                println!(
+                    "{}\n\n-----------------------------------\n\n",
+                    serde_yaml::to_string(&prompt)?
+                );
+            }
         }
         Action::Run => {
-            let asset_schema = asset_sprayer.run(&prompt, &raw_prompt).await?;
+            let asset_schema = asset_sprayer.run(&prompt, &raw_prompt, "").await?;
             println!("{}", asset_schema);
         }
     }

--- a/lib/asset-sprayer/prompts/aws/asset_schema.yaml
+++ b/lib/asset-sprayer/prompts/aws/asset_schema.yaml
@@ -1,93 +1,93 @@
-model: gpt-4o-mini
-temperature: 0.0
-messages:
-  - role: system
-    content: >
-      You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset schemas for use in System Initiative.
+- model: gpt-4o-mini
+  temperature: 0.0
+  messages:
+    - role: system
+      content: >
+        You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset schemas for use in System Initiative.
 
-      The user will provide the current System Initiative schema API documentation.
+        The user will provide the current System Initiative schema API documentation.
 
-      The user will provide the text of the help output from an AWS CLI command.
+        The user will provide the text of the help output from an AWS CLI command.
 
-      The user may optionally provide help text to build the schema for specific properties, which may be additional man pages, web pages, json schema, or grammars. Ensure this is used to create the proper schema for those additional properties.
+        The user may optionally provide help text to build the schema for specific properties, which may be additional man pages, web pages, json schema, or grammars. Ensure this is used to create the proper schema for those additional properties.
 
-      Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative schema.
+        Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative schema.
 
-      You will only use APIs that appear in the schema API documentation and additional text for specific properties.
+        You will only use APIs that appear in the schema API documentation and additional text for specific properties.
 
-      If the AWS documentation describes a cli option as a map with a specific set of documented keys and values, do not create a map property in the schema. Instead, create an object property where each described key described in the AWS documentation is a child property object in the schema.
+        If the AWS documentation describes a cli option as a map with a specific set of documented keys and values, do not create a map property in the schema. Instead, create an object property where each described key described in the AWS documentation is a child property object in the schema.
 
-      If you encounter a JSON Schema, you will use it to construct properties using the System Initiative API, not only as a Joi validation.
+        If you encounter a JSON Schema, you will use it to construct properties using the System Initiative API, not only as a Joi validation.
 
-      You will always include an `extra/region` property in the schema, and a corresponding input socket connected to it, using the following property and socket definition, delimited by :::'s
+        You will always include an `extra/region` property in the schema, and a corresponding input socket connected to it, using the following property and socket definition, delimited by :::'s
 
-      :::
-      const extraProp = new PropBuilder()
-        .setKind("object")
-        .setName("extra")
-        .addChild(
-          new PropBuilder()
-            .setKind("string")
-            .setName("Region")
-            .setValueFrom(
-              new ValueFromBuilder()
-                .setKind("inputSocket")
-                .setSocketName("Region")
-                .build(),
-            ).build(),
-        )
-        .build();
-
-      const regionSocket = new SocketDefinitionBuilder()
-          .setName("Region")
-          .setArity("one")
+        :::
+        const extraProp = new PropBuilder()
+          .setKind("object")
+          .setName("extra")
+          .addChild(
+            new PropBuilder()
+              .setKind("string")
+              .setName("Region")
+              .setValueFrom(
+                new ValueFromBuilder()
+                  .setKind("inputSocket")
+                  .setSocketName("Region")
+                  .build(),
+              ).build(),
+          )
           .build();
-      :::
 
-      You will make sure you include every property specified in all of the user inputs provided to create the schema when asked.
+        const regionSocket = new SocketDefinitionBuilder()
+            .setName("Region")
+            .setArity("one")
+            .build();
+        :::
 
-      You will make sure your work has every option covered in the help output or additional property documentation.
+        You will make sure you include every property specified in all of the user inputs provided to create the schema when asked.
 
-      You will make sure to include the region property in the schema.
+        You will make sure your work has every option covered in the help output or additional property documentation.
 
-      You will make sure to include the standard "AWS Credential" secret property in the schema.
+        You will make sure to include the region property in the schema.
 
-      You will make sure to use the additional text for specific properties.
+        You will make sure to include the standard "AWS Credential" secret property in the schema.
 
-      You will make sure your work has Joi validations for every option according to the help output.
+        You will make sure to use the additional text for specific properties.
 
-      You will make sure every PropBuilder has an appropriate call to `setName()`.
+        You will make sure your work has Joi validations for every option according to the help output.
 
-      You will then review your work to make sure you use only APIs described in the schema API documentation.
+        You will make sure every PropBuilder has an appropriate call to `setName()`.
 
-      You will then review your work to make sure you include any field level validations using Joi.
+        You will then review your work to make sure you use only APIs described in the schema API documentation.
 
-      You will then show the final function in its entirety, with no other explanation, as plain text. Do not wrap the code in markdown delimiters.
-  - role: user
-    content: >
-      What follows is the current System Initiative schema API documentation as markdown, between three ^ characters.
+        You will then review your work to make sure you include any field level validations using Joi.
 
-      ^^^
-      {FETCH}{SI_DOCS_URL}/reference/asset/schema.md{/FETCH}
-      ^^^
-  - role: user
-    content: >
-      What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
+        You will then show the final function in its entirety, with no other explanation, as plain text. Do not wrap the code in markdown delimiters.
+    - role: user
+      content: >
+        What follows is the current System Initiative schema API documentation as markdown, between three ^ characters.
 
-      ^^^
-      {FETCH}{SI_DOCS_URL}/reference/asset/function.md{/FETCH}
-      ^^^
-  - role: user
-    content: >
-      What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
+        ^^^
+        {FETCH}{SI_DOCS_URL}/reference/asset/schema.md{/FETCH}
+        ^^^
+    - role: user
+      content: >
+        What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
 
-      ^^^
-      {FETCH}{AWS_CLI_DOCS_URL}/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
-      ^^^
-  - role: user
-    content: >
-      Create the asset function that generates the schema.
+        ^^^
+        {FETCH}{SI_DOCS_URL}/reference/asset/function.md{/FETCH}
+        ^^^
+    - role: user
+      content: >
+        What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
 
-      Show the final function in its entirety, with no other explanation, as plain text.
+        ^^^
+        {FETCH}{AWS_CLI_DOCS_URL}/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
+        ^^^
+    - role: user
+      content: >
+        Create the asset function that generates the schema.
 
-      Do not wrap the code in markdown delimiters.
+        Show the final function in its entirety, with no other explanation, as plain text.
+
+        Do not wrap the code in markdown delimiters.

--- a/lib/asset-sprayer/prompts/aws/create_action.yaml
+++ b/lib/asset-sprayer/prompts/aws/create_action.yaml
@@ -1,468 +1,468 @@
-model: gpt-4o-mini
-temperature: 0.0
-messages:
-  - role: system
-    content: >
-      You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset functions for use in System Initiative.
+- model: gpt-4o-mini
+  temperature: 0.0
+  messages:
+    - role: system
+      content: >
+        You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset functions for use in System Initiative.
 
-      The user will provide the current System Initiative schema API documentation.
+        The user will provide the current System Initiative schema API documentation.
 
-      The user will provide the text of the help output from an AWS CLI command.
+        The user will provide the text of the help output from an AWS CLI command.
 
-      Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative asset function.
+        Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative asset function.
 
-      You will use the `--cli-input-json` argument rather than specify individual arguments on the command line.
+        You will use the `--cli-input-json` argument rather than specify individual arguments on the command line.
 
-      The variable you use to construct the arguments to `--cli-input-json` will be called `cliArguments`.
+        The variable you use to construct the arguments to `--cli-input-json` will be called `cliArguments`.
 
-      For each command line argument, you will check to see if the corresponding property has a value before inserting it into the `--cli-input-json`. For example, if the AWS CLI help text says that Tags are optional, and there are no tags in `component.properties.domain.Tags`, it should not be included in the cliArguments data structure.
+        For each command line argument, you will check to see if the corresponding property has a value before inserting it into the `--cli-input-json`. For example, if the AWS CLI help text says that Tags are optional, and there are no tags in `component.properties.domain.Tags`, it should not be included in the cliArguments data structure.
 
-      You will not set any variables that are not subsequently used in the function somewhere. For example, you will not include a line like `const domain = component.properties?.domain;` if you do not elsewhere reference the `domain` variable.
+        You will not set any variables that are not subsequently used in the function somewhere. For example, you will not include a line like `const domain = component.properties?.domain;` if you do not elsewhere reference the `domain` variable.
 
-      You will populate only the arguments that have corresponding properties as arguments to the `--cli-input-json`.
+        You will populate only the arguments that have corresponding properties as arguments to the `--cli-input-json`.
 
-      You will always check at the top of the function if the `component.properties.resource?.payload` exists, and if it does not, return an error. An example of this error follows, delimited by `:::`'s.
+        You will always check at the top of the function if the `component.properties.resource?.payload` exists, and if it does not, return an error. An example of this error follows, delimited by `:::`'s.
 
-      :::
-      if (component.properties.resource?.payload) {
-          return {
-              status: "error",
-              message: "Resource already exists",
-              payload: component.properties.resource.payload,
-          };
-      }
-      :::
+        :::
+        if (component.properties.resource?.payload) {
+            return {
+                status: "error",
+                message: "Resource already exists",
+                payload: component.properties.resource.payload,
+            };
+        }
+        :::
 
-      You will map all the command line arguments to properties in the domain tree, with the property name in PascalCase. For example, given a command line argument with kebab-case like `--queue-name`, you will map it to `component.properties?.domain?.QueueName`. The exception to this rule is the `region` property, which should always be lowercase.
+        You will map all the command line arguments to properties in the domain tree, with the property name in PascalCase. For example, given a command line argument with kebab-case like `--queue-name`, you will map it to `component.properties?.domain?.QueueName`. The exception to this rule is the `region` property, which should always be lowercase.
 
-      You will pass the region to the command if it is required, ensuring it comes from the `component.domain?.extra?.region` property.
+        You will pass the region to the command if it is required, ensuring it comes from the `component.domain?.extra?.region` property.
 
-      You will construct the response payload by examining the Output section of the AWS CLI Command help output provided by the user. It describes a JSON data structure using a plain text description language, where each field and it's type is provided as `FieldName -> (type)`, where `FieldName` maps to a output field name and `(type)` describes its type. For example, `Procedure -> (structure)` defines a JSON object, and `Description -> (string)` defines a JSON string.
+        You will construct the response payload by examining the Output section of the AWS CLI Command help output provided by the user. It describes a JSON data structure using a plain text description language, where each field and it's type is provided as `FieldName -> (type)`, where `FieldName` maps to a output field name and `(type)` describes its type. For example, `Procedure -> (structure)` defines a JSON object, and `Description -> (string)` defines a JSON string.
 
-      If the Output section JSON contains only one top level field, and its type is a `structure`, return only the value of that field. An example of an input that matches this rule follows, delimited by `:::`'s.
+        If the Output section JSON contains only one top level field, and its type is a `structure`, return only the value of that field. An example of an input that matches this rule follows, delimited by `:::`'s.
 
-      :::
-      Policy -> (structure)
+        :::
+        Policy -> (structure)
 
-        A structure containing details about the new policy.
+          A structure containing details about the new policy.
 
-        PolicyName -> (string)
-          The friendly name (not ARN) identifying the policy.
+          PolicyName -> (string)
+            The friendly name (not ARN) identifying the policy.
 
-        PolicyId -> (string)
-          The stable and unique string identifying the policy.
-      :::
+          PolicyId -> (string)
+            The stable and unique string identifying the policy.
+        :::
 
-      Here is an example of the corresponding return value of the function delimited by `:::`s:
+        Here is an example of the corresponding return value of the function delimited by `:::`s:
 
-      :::
-      const response = JSON.parse(child.stdout);
+        :::
+        const response = JSON.parse(child.stdout);
 
-      return {
-          status: "ok",
-          payload: response.Policy,
-      };
-      :::
+        return {
+            status: "ok",
+            payload: response.Policy,
+        };
+        :::
 
-      If the Output section describes anything other than a single top level field, always return the full response. If the Output section describes a single top level field, but its type is not a `structure`, always return the full response. For example, here is a single top level field that is a `(string)` not a `(structure)`, delimited by `:::`'s:
+        If the Output section describes anything other than a single top level field, always return the full response. If the Output section describes a single top level field, but its type is not a `structure`, always return the full response. For example, here is a single top level field that is a `(string)` not a `(structure)`, delimited by `:::`'s:
 
-      :::
-      QueueUrl -> (string)
-        An ID for your pants.
-      :::
+        :::
+        QueueUrl -> (string)
+          An ID for your pants.
+        :::
 
-      Here is an example of the corresponding return value of the function delimited by `:::`'s:
+        Here is an example of the corresponding return value of the function delimited by `:::`'s:
 
-      :::
-      const response = JSON.parse(child.stdout);
+        :::
+        const response = JSON.parse(child.stdout);
 
-      return {
-          status: "ok",
-          payload: response,
-      }
-      :::
+        return {
+            status: "ok",
+            payload: response,
+        }
+        :::
 
-      You will only use APIs that appear in the provided documentation.
-  - role: user
-    content: >
-      What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
+        You will only use APIs that appear in the provided documentation.
+    - role: user
+      content: >
+        What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
 
-      ^^^
-      # Asset Functions Reference
+        ^^^
+        # Asset Functions Reference
 
-      Asset functions are written in TypeScript, and executed within a sandbox
-      environment using [Firecracker](https://firecracker-microvm.github.io/).
+        Asset functions are written in TypeScript, and executed within a sandbox
+        environment using [Firecracker](https://firecracker-microvm.github.io/).
 
-      ## Asset Function Basics
+        ## Asset Function Basics
 
-      There are 5 types of asset functions:
+        There are 5 types of asset functions:
 
-      * Action
-      * Attribute
-      * Authentication
-      * Code Generation
-      * Qualification
+        * Action
+        * Attribute
+        * Authentication
+        * Code Generation
+        * Qualification
 
-      ### Executing shell commands
+        ### Executing shell commands
 
-      Functions frequently execute shell commands to interact with external services.
-      Using the [siExec API](/reference/typescript/sandbox/exec/README).
+        Functions frequently execute shell commands to interact with external services.
+        Using the [siExec API](/reference/typescript/sandbox/exec/README).
 
-      ```typescript
-      const child = siExec.waitUntilEnd("aws", [
-        "ec2",
-        "describe-hosts"
-      ]);
-      ```
+        ```typescript
+        const child = siExec.waitUntilEnd("aws", [
+          "ec2",
+          "describe-hosts"
+        ]);
+        ```
 
-      Would execute the shell command:
+        Would execute the shell command:
 
-      ```shell
-      aws ec2 describe-hosts
-      ```
+        ```shell
+        aws ec2 describe-hosts
+        ```
 
-      A more complex example from an action:
+        A more complex example from an action:
 
-      ```typescript
-      const child = await siExec.waitUntilEnd("aws", [
-          "rds",
-          "create-db-cluster",
-          "--region",
-          input?.properties?.domain?.Region || "",
-          "--cli-input-json",
-          JSON.stringify(code),
-      ]);
-      ```
+        ```typescript
+        const child = await siExec.waitUntilEnd("aws", [
+            "rds",
+            "create-db-cluster",
+            "--region",
+            input?.properties?.domain?.Region || "",
+            "--cli-input-json",
+            JSON.stringify(code),
+        ]);
+        ```
 
-      We're always adding more shell commands to the environment though Nix. [You can
-      see the current list of included commands in the source
-      code](https://github.com/systeminit/si/blob/main/flake.nix#L96).
+        We're always adding more shell commands to the environment though Nix. [You can
+        see the current list of included commands in the source
+        code](https://github.com/systeminit/si/blob/main/flake.nix#L96).
 
-      Send a PR if you need something added.
+        Send a PR if you need something added.
 
-      ### Interacting with HTTP APIs
+        ### Interacting with HTTP APIs
 
-      The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) is supported.
+        The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) is supported.
 
-      ```typescript
-      const webpage = await fetch("http://systeminit.com");
-      ```
+        ```typescript
+        const webpage = await fetch("http://systeminit.com");
+        ```
 
-      ### Using lodash
+        ### Using lodash
 
-      The [lodash API](https://lodash.com/docs/4.17.15) is available from the `_`
-      variable, which makes working with data structures in JavaScript easy.
+        The [lodash API](https://lodash.com/docs/4.17.15) is available from the `_`
+        variable, which makes working with data structures in JavaScript easy.
 
-      ```typescript
-      const result = {};
-      if (component.domain?.Sid) {
-        _.set(result, ["Sid"], component.domain.Sid);
-      }
-      ```
+        ```typescript
+        const result = {};
+        if (component.domain?.Sid) {
+          _.set(result, ["Sid"], component.domain.Sid);
+        }
+        ```
 
-      If you find yourself doing complex data manipulation, lodash is where you
-      should look first.
+        If you find yourself doing complex data manipulation, lodash is where you
+        should look first.
 
-      ### Request Storage
+        ### Request Storage
 
-      When a function has secrets as an input, it runs authentication functions before
-      it is executed. Information is then passed between functions through the Request Storage
-      API:
+        When a function has secrets as an input, it runs authentication functions before
+        it is executed. Information is then passed between functions through the Request Storage
+        API:
 
-      ```typescript
-      requestStorage.getItem("foo");
-      ```
+        ```typescript
+        requestStorage.getItem("foo");
+        ```
 
-      Or to set an item (used only in authentication functions):
+        Or to set an item (used only in authentication functions):
 
-      ```typescript
-      requestStorage.setItem("foo");
-      ```
+        ```typescript
+        requestStorage.setItem("foo");
+        ```
 
-      ## Action Functions
+        ## Action Functions
 
-      Action functions interact with external systems (such as AWS, GCP, or Azure)
-      and return resources. They are are en-queued by users in a change set, and
-      executed when applied to HEAD. The order of execution is determined
-      automatically by walking the relationships between the components.
+        Action functions interact with external systems (such as AWS, GCP, or Azure)
+        and return resources. They are are en-queued by users in a change set, and
+        executed when applied to HEAD. The order of execution is determined
+        automatically by walking the relationships between the components.
 
-      There are four types of action function:
+        There are four types of action function:
 
-      1. Functions that create a resource
-      2. Functions that refresh a resource
-      3. Functions that delete a resource
-      4. Manual functions that update or transform a resource
+        1. Functions that create a resource
+        2. Functions that refresh a resource
+        3. Functions that delete a resource
+        4. Manual functions that update or transform a resource
 
-      Create, refresh, and delete are automatically en-queued when their relevant
-      activity is taken on the diagram. Manual functions must be en-queued from the
-      actions tab of the attribute panel by the user.
+        Create, refresh, and delete are automatically en-queued when their relevant
+        activity is taken on the diagram. Manual functions must be en-queued from the
+        actions tab of the attribute panel by the user.
 
-      ### Action function arguments
+        ### Action function arguments
 
-      Action functions take an `Input` argument. It has a `properties` field which contains an object that has:
+        Action functions take an `Input` argument. It has a `properties` field which contains an object that has:
 
-      * The `si` properties
+        * The `si` properties
 
-        These are the core properties set as meta-data for the function. Name, color, etc.
+          These are the core properties set as meta-data for the function. Name, color, etc.
 
-      * The `domain` properties
+        * The `domain` properties
 
-        These are the properties specified in the schema itself.
+          These are the properties specified in the schema itself.
 
-      * The `resource` data
+        * The `resource` data
 
-        This is the output of the last action, stored as the state of the resource. It contains 3 fields:
+          This is the output of the last action, stored as the state of the resource. It contains 3 fields:
 
-        - _status_: one of "ok", "warning", or "error"
-        - _message_: an optional message
-        - _payload_: the resource payload itself
+          - _status_: one of "ok", "warning", or "error"
+          - _message_: an optional message
+          - _payload_: the resource payload itself
 
-      * The `resource_value` data
+        * The `resource_value` data
 
-        This is information pulled into the component properties from resource payload
-        data. These are properties added with the `addResourceProp()` method of a
-        components schema.
+          This is information pulled into the component properties from resource payload
+          data. These are properties added with the `addResourceProp()` method of a
+          components schema.
 
-      * Any generated `code`
+        * Any generated `code`
 
-        Generated code is available as a map, whose key is the name of the code
-        generation function that generated it.
+          Generated code is available as a map, whose key is the name of the code
+          generation function that generated it.
 
-      ### Action function return value
+        ### Action function return value
 
-      Actions return a data structure identical to the resource data above. You should be careful to
-      always return a payload, even on error - frequently, this is the last stored payload if it existed.
+        Actions return a data structure identical to the resource data above. You should be careful to
+        always return a payload, even on error - frequently, this is the last stored payload if it existed.
 
-      ```typescript
-      if (input?.properties?.resource?.payload) {
-          return {
-              status: "error",
-              message: "Resource already exists",
-              payload: input.properties.resource.payload,
-          };
-      }
-      ```
-
-      Remember that `message` is optional:
-
-      ```typescript
-      return {
-          payload: JSON.parse(child.stdout).DBCluster,
-          status: "ok"
-      };
-      ```
-
-      Payload should be returned as a JavaScript object.
-
-      ### Create action example
-
-      A create action that uses generated code, `siExec` and a secret to create an AWS EKS cluster:
-
-      ```typescript
-      async function main(component: Input): Promise<Output> {
-          if (component.properties.resource?.payload) {
-              return {
-                  status: "error",
-                  message: "Resource already exists",
-                  payload: component.properties.resource.payload,
-              };
-          }
-
-          const code = component.properties.code?.["si:genericAwsCreate"]?.code;
-          const domain = component.properties?.domain;
-
-          const child = await siExec.waitUntilEnd("aws", [
-              "eks",
-              "create-cluster",
-              "--region",
-              domain?.extra?.Region || "",
-              "--cli-input-json",
-              code || "",
-          ]);
-
-          if (child.exitCode !== 0) {
-              console.error(child.stderr);
-              return {
-                  status: "error",
-                  message: `Unable to create; AWS CLI exited with non zero code: ${child.exitCode}`,
-              };
-          }
-
-          const response = JSON.parse(child.stdout).cluster;
-
-          return {
-              resourceId: response.name,
-              status: "ok",
-          };
-      }
-      ```
-
-      ### Refresh action example
-
-      A refresh action example that uses lodash and siExec to update an AWS EKS cluster:
-
-      ```typescript
-      async function main(component: Input): Promise < Output > {
-          let name = component.properties?.si?.resourceId;
-          const resource = component.properties.resource?.payload;
-          if (!name) {
-              name = resource.name;
-          }
-          if (!name) {
-              return {
-                  status: component.properties.resource?.status ?? "error",
-                  message: "Could not refresh, no resourceId present for EKS Cluster component",
-              };
-          }
-
-          const cliArguments = { };
+        ```typescript
+        if (input?.properties?.resource?.payload) {
+            return {
+                status: "error",
+                message: "Resource already exists",
+                payload: input.properties.resource.payload,
+            };
+        }
+        ```
+
+        Remember that `message` is optional:
+
+        ```typescript
+        return {
+            payload: JSON.parse(child.stdout).DBCluster,
+            status: "ok"
+        };
+        ```
+
+        Payload should be returned as a JavaScript object.
+
+        ### Create action example
+
+        A create action that uses generated code, `siExec` and a secret to create an AWS EKS cluster:
+
+        ```typescript
+        async function main(component: Input): Promise<Output> {
+            if (component.properties.resource?.payload) {
+                return {
+                    status: "error",
+                    message: "Resource already exists",
+                    payload: component.properties.resource.payload,
+                };
+            }
+
+            const code = component.properties.code?.["si:genericAwsCreate"]?.code;
+            const domain = component.properties?.domain;
+
+            const child = await siExec.waitUntilEnd("aws", [
+                "eks",
+                "create-cluster",
+                "--region",
+                domain?.extra?.Region || "",
+                "--cli-input-json",
+                code || "",
+            ]);
+
+            if (child.exitCode !== 0) {
+                console.error(child.stderr);
+                return {
+                    status: "error",
+                    message: `Unable to create; AWS CLI exited with non zero code: ${child.exitCode}`,
+                };
+            }
+
+            const response = JSON.parse(child.stdout).cluster;
+
+            return {
+                resourceId: response.name,
+                status: "ok",
+            };
+        }
+        ```
+
+        ### Refresh action example
+
+        A refresh action example that uses lodash and siExec to update an AWS EKS cluster:
+
+        ```typescript
+        async function main(component: Input): Promise < Output > {
+            let name = component.properties?.si?.resourceId;
+            const resource = component.properties.resource?.payload;
+            if (!name) {
+                name = resource.name;
+            }
+            if (!name) {
+                return {
+                    status: component.properties.resource?.status ?? "error",
+                    message: "Could not refresh, no resourceId present for EKS Cluster component",
+                };
+            }
+
+            const cliArguments = { };
+            _.set(
+                cliArguments,
+                "name",
+                name,
+            );
+
+            const child = await siExec.waitUntilEnd("aws", [
+                "eks",
+                "describe-cluster",
+                "--region",
+                _.get(component, "properties.domain.extra.Region", ""),
+                "--cli-input-json",
+                JSON.stringify(cliArguments),
+            ]);
+
+            if (child.exitCode !== 0) {
+                console.error(child.stderr);
+                if (child.stderr.includes("ResourceNotFoundException")) {
+                    console.log("EKS Cluster not found upstream (ResourceNotFoundException) so removing the resource")
+                    return {
+                        status: "ok",
+                        payload: null,
+                    };
+                }
+                return {
+                    status: "error",
+                    payload: resource,
+                    message: `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+                };
+            }
+
+            const object = JSON.parse(child.stdout).cluster;
+            return {
+                payload: object,
+                status: "ok",
+            };
+        }
+        ```
+
+        :::warning
+        Ensure you include previous resource payload on failure!
+        :::
+
+        ### Delete action example
+
+        A delete action example that uses lodash and siExec:
+
+        ```typescript
+        async function main(component: Input): Promise<Output> {
+          const cliArguments = {};
           _.set(
-              cliArguments,
-              "name",
-              name,
+            cliArguments,
+            "PolicyArn",
+            _.get(component, "properties.resource_value.Arn"),
           );
 
           const child = await siExec.waitUntilEnd("aws", [
-              "eks",
-              "describe-cluster",
-              "--region",
-              _.get(component, "properties.domain.extra.Region", ""),
-              "--cli-input-json",
-              JSON.stringify(cliArguments),
+            "iam",
+            "delete-policy",
+            "--cli-input-json",
+            JSON.stringify(cliArguments),
           ]);
 
           if (child.exitCode !== 0) {
-              console.error(child.stderr);
-              if (child.stderr.includes("ResourceNotFoundException")) {
-                  console.log("EKS Cluster not found upstream (ResourceNotFoundException) so removing the resource")
-                  return {
-                      status: "ok",
-                      payload: null,
-                  };
-              }
+            const payload = _.get(component, "properties.resource.payload");
+            if (payload) {
               return {
-                  status: "error",
-                  payload: resource,
-                  message: `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+                status: "error",
+                payload,
+                message:
+                  `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
               };
+            } else {
+              return {
+                status: "error",
+                message:
+                  `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+              };
+            }
           }
 
-          const object = JSON.parse(child.stdout).cluster;
           return {
-              payload: object,
-              status: "ok",
+            payload: null,
+            status: "ok",
           };
-      }
-      ```
-
-      :::warning
-      Ensure you include previous resource payload on failure!
-      :::
-
-      ### Delete action example
-
-      A delete action example that uses lodash and siExec:
-
-      ```typescript
-      async function main(component: Input): Promise<Output> {
-        const cliArguments = {};
-        _.set(
-          cliArguments,
-          "PolicyArn",
-          _.get(component, "properties.resource_value.Arn"),
-        );
-
-        const child = await siExec.waitUntilEnd("aws", [
-          "iam",
-          "delete-policy",
-          "--cli-input-json",
-          JSON.stringify(cliArguments),
-        ]);
-
-        if (child.exitCode !== 0) {
-          const payload = _.get(component, "properties.resource.payload");
-          if (payload) {
-            return {
-              status: "error",
-              payload,
-              message:
-                `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
-            };
-          } else {
-            return {
-              status: "error",
-              message:
-                `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
-            };
-          }
         }
+        ```
 
-        return {
-          payload: null,
-          status: "ok",
-        };
-      }
-      ```
+        Note that the payload returned here is `null` - this ensures the resource will be removed.
 
-      Note that the payload returned here is `null` - this ensures the resource will be removed.
+        ### Manual action example
 
-      ### Manual action example
+        A manual action that updates the cluster configuration on an AWS EKS cluster, usking lodash, siExec and the AWS CLI:
 
-      A manual action that updates the cluster configuration on an AWS EKS cluster, usking lodash, siExec and the AWS CLI:
+        ```typescript
+        async function main(component: Input) {
+            const resource = component.properties.resource;
+            if (!resource) {
+                return {
+                    status: component.properties.resource?.status ?? "ok",
+                    message: component.properties.resource?.message,
+                };
+            }
 
-      ```typescript
-      async function main(component: Input) {
-          const resource = component.properties.resource;
-          if (!resource) {
-              return {
-                  status: component.properties.resource?.status ?? "ok",
-                  message: component.properties.resource?.message,
-              };
-          }
+            let json = {
+                "accessConfig": {
+                    "authenticationMode": component.properties.domain.accessConfig.authenticationMode,
+                },
+                "name": resource.name,
+            };
 
-          let json = {
-              "accessConfig": {
-                  "authenticationMode": component.properties.domain.accessConfig.authenticationMode,
-              },
-              "name": resource.name,
-          };
+            const updateResp = await siExec.waitUntilEnd("aws", [
+                "eks",
+                "update-cluster-config",
+                "--cli-input-json",
+                JSON.stringify(json),
+                "--region",
+                component.properties.domain?.extra.Region || "",
+            ]);
 
-          const updateResp = await siExec.waitUntilEnd("aws", [
-              "eks",
-              "update-cluster-config",
-              "--cli-input-json",
-              JSON.stringify(json),
-              "--region",
-              component.properties.domain?.extra.Region || "",
-          ]);
+            if (updateResp.exitCode !== 0) {
+                console.error(updateResp.stderr);
+                return {
+                    status: "error",
+                    payload: resource,
+                    message: `Unable to update the EKS Cluster Access Config, AWS CLI 2 exited with non zero code: ${updateResp.exitCode}`,
+                };
+            }
 
-          if (updateResp.exitCode !== 0) {
-              console.error(updateResp.stderr);
-              return {
-                  status: "error",
-                  payload: resource,
-                  message: `Unable to update the EKS Cluster Access Config, AWS CLI 2 exited with non zero code: ${updateResp.exitCode}`,
-              };
-          }
+            return {
+                payload: resource,
+                status: "ok"
+            };
+        }
+        ```
+        ^^^
+    - role: user
+      content: >
+        What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
 
-          return {
-              payload: resource,
-              status: "ok"
-          };
-      }
-      ```
-      ^^^
-  - role: user
-    content: >
-      What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
+        ^^^
+        {FETCH}{AWS_CLI_DOCS_URL}/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
+        ^^^
+    - role: user
+      content: >
+        Create the create action function that calls the AWS CLI command.
 
-      ^^^
-      {FETCH}{AWS_CLI_DOCS_URL}/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
-      ^^^
-  - role: user
-    content: >
-      Create the create action function that calls the AWS CLI command.
+        Show the final function in its entirety, with no other explanation, as plain text.
 
-      Show the final function in its entirety, with no other explanation, as plain text.
-
-      Do not wrap the code in markdown delimiters.
+        Do not wrap the code in markdown delimiters.

--- a/lib/asset-sprayer/prompts/aws/destroy_action.yaml
+++ b/lib/asset-sprayer/prompts/aws/destroy_action.yaml
@@ -1,399 +1,399 @@
-model: gpt-4o-mini
-temperature: 0.0
-messages:
-  - role: system
-    content: >
-      You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset functions for use in System Initiative.
+- model: gpt-4o-mini
+  temperature: 0.0
+  messages:
+    - role: system
+      content: >
+        You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset functions for use in System Initiative.
 
-      The user will provide the current System Initiative schema API documentation.
+        The user will provide the current System Initiative schema API documentation.
 
-      The user will provide the text of the help output from an AWS CLI command.
+        The user will provide the text of the help output from an AWS CLI command.
 
-      Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative asset function.
+        Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative asset function.
 
-      You will make sure to pass the region to the command if it is required.
+        You will make sure to pass the region to the command if it is required.
 
-      You will only use APIs that appear in the provided documentation.
-  - role: user
-    content: >
-      What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
+        You will only use APIs that appear in the provided documentation.
+    - role: user
+      content: >
+        What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
 
-      ^^^
-      # Asset Functions Reference
+        ^^^
+        # Asset Functions Reference
 
-      Asset functions are written in TypeScript, and executed within a sandbox
-      environment using [Firecracker](https://firecracker-microvm.github.io/).
+        Asset functions are written in TypeScript, and executed within a sandbox
+        environment using [Firecracker](https://firecracker-microvm.github.io/).
 
-      ## Asset Function Basics
+        ## Asset Function Basics
 
-      There are 5 types of asset functions:
+        There are 5 types of asset functions:
 
-      * Action
-      * Attribute
-      * Authentication
-      * Code Generation
-      * Qualification
+        * Action
+        * Attribute
+        * Authentication
+        * Code Generation
+        * Qualification
 
-      ### Executing shell commands
+        ### Executing shell commands
 
-      Functions frequently execute shell commands to interact with external services.
-      Using the [siExec API](/reference/typescript/sandbox/exec/README).
+        Functions frequently execute shell commands to interact with external services.
+        Using the [siExec API](/reference/typescript/sandbox/exec/README).
 
-      ```typescript
-      const child = siExec.waitUntilEnd("aws", [
-        "ec2",
-        "describe-hosts"
-      ]);
-      ```
+        ```typescript
+        const child = siExec.waitUntilEnd("aws", [
+          "ec2",
+          "describe-hosts"
+        ]);
+        ```
 
-      Would execute the shell command:
+        Would execute the shell command:
 
-      ```shell
-      aws ec2 describe-hosts
-      ```
+        ```shell
+        aws ec2 describe-hosts
+        ```
 
-      A more complex example from an action:
+        A more complex example from an action:
 
-      ```typescript
-      const child = await siExec.waitUntilEnd("aws", [
-          "rds",
-          "create-db-cluster",
-          "--region",
-          input?.properties?.domain?.Region || "",
-          "--cli-input-json",
-          JSON.stringify(code),
-      ]);
-      ```
+        ```typescript
+        const child = await siExec.waitUntilEnd("aws", [
+            "rds",
+            "create-db-cluster",
+            "--region",
+            input?.properties?.domain?.Region || "",
+            "--cli-input-json",
+            JSON.stringify(code),
+        ]);
+        ```
 
-      We're always adding more shell commands to the environment though Nix. [You can
-      see the current list of included commands in the source
-      code](https://github.com/systeminit/si/blob/main/flake.nix#L96).
+        We're always adding more shell commands to the environment though Nix. [You can
+        see the current list of included commands in the source
+        code](https://github.com/systeminit/si/blob/main/flake.nix#L96).
 
-      Send a PR if you need something added.
+        Send a PR if you need something added.
 
-      ### Interacting with HTTP APIs
+        ### Interacting with HTTP APIs
 
-      The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) is supported.
+        The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) is supported.
 
-      ```typescript
-      const webpage = await fetch("http://systeminit.com");
-      ```
+        ```typescript
+        const webpage = await fetch("http://systeminit.com");
+        ```
 
-      ### Using lodash
+        ### Using lodash
 
-      The [lodash API](https://lodash.com/docs/4.17.15) is available from the `_`
-      variable, which makes working with data structures in JavaScript easy.
+        The [lodash API](https://lodash.com/docs/4.17.15) is available from the `_`
+        variable, which makes working with data structures in JavaScript easy.
 
-      ```typescript
-      const result = {};
-      if (component.domain?.Sid) {
-        _.set(result, ["Sid"], component.domain.Sid);
-      }
-      ```
+        ```typescript
+        const result = {};
+        if (component.domain?.Sid) {
+          _.set(result, ["Sid"], component.domain.Sid);
+        }
+        ```
 
-      If you find yourself doing complex data manipulation, lodash is where you
-      should look first.
+        If you find yourself doing complex data manipulation, lodash is where you
+        should look first.
 
-      ### Request Storage
+        ### Request Storage
 
-      When a function has secrets as an input, it runs authentication functions before
-      it is executed. Information is then passed between functions through the Request Storage
-      API:
+        When a function has secrets as an input, it runs authentication functions before
+        it is executed. Information is then passed between functions through the Request Storage
+        API:
 
-      ```typescript
-      requestStorage.getItem("foo");
-      ```
+        ```typescript
+        requestStorage.getItem("foo");
+        ```
 
-      Or to set an item (used only in authentication functions):
+        Or to set an item (used only in authentication functions):
 
-      ```typescript
-      requestStorage.setItem("foo");
-      ```
+        ```typescript
+        requestStorage.setItem("foo");
+        ```
 
-      ## Action Functions
+        ## Action Functions
 
-      Action functions interact with external systems (such as AWS, GCP, or Azure)
-      and return resources. They are are en-queued by users in a change set, and
-      executed when applied to HEAD. The order of execution is determined
-      automatically by walking the relationships between the components.
+        Action functions interact with external systems (such as AWS, GCP, or Azure)
+        and return resources. They are are en-queued by users in a change set, and
+        executed when applied to HEAD. The order of execution is determined
+        automatically by walking the relationships between the components.
 
-      There are four types of action function:
+        There are four types of action function:
 
-      1. Functions that create a resource
-      2. Functions that refresh a resource
-      3. Functions that delete a resource
-      4. Manual functions that update or transform a resource
+        1. Functions that create a resource
+        2. Functions that refresh a resource
+        3. Functions that delete a resource
+        4. Manual functions that update or transform a resource
 
-      Create, refresh, and delete are automatically en-queued when their relevant
-      activity is taken on the diagram. Manual functions must be en-queued from the
-      actions tab of the attribute panel by the user.
+        Create, refresh, and delete are automatically en-queued when their relevant
+        activity is taken on the diagram. Manual functions must be en-queued from the
+        actions tab of the attribute panel by the user.
 
-      ### Action function arguments
+        ### Action function arguments
 
-      Action functions take an `Input` argument. It has a `properties` field which contains an object that has:
+        Action functions take an `Input` argument. It has a `properties` field which contains an object that has:
 
-      * The `si` properties
+        * The `si` properties
 
-        These are the core properties set as meta-data for the function. Name, color, etc.
+          These are the core properties set as meta-data for the function. Name, color, etc.
 
-      * The `domain` properties
+        * The `domain` properties
 
-        These are the properties specified in the schema itself.
+          These are the properties specified in the schema itself.
 
-      * The `resource` data
+        * The `resource` data
 
-        This is the output of the last action, stored as the state of the resource. It contains 3 fields:
+          This is the output of the last action, stored as the state of the resource. It contains 3 fields:
 
-        - _status_: one of "ok", "warning", or "error"
-        - _message_: an optional message
-        - _payload_: the resource payload itself
+          - _status_: one of "ok", "warning", or "error"
+          - _message_: an optional message
+          - _payload_: the resource payload itself
 
-      * The `resource_value` data
+        * The `resource_value` data
 
-        This is information pulled into the component properties from resource payload
-        data. These are properties added with the `addResourceProp()` method of a
-        components schema.
+          This is information pulled into the component properties from resource payload
+          data. These are properties added with the `addResourceProp()` method of a
+          components schema.
 
-      * Any generated `code`
+        * Any generated `code`
 
-        Generated code is available as a map, whose key is the name of the code
-        generation function that generated it.
+          Generated code is available as a map, whose key is the name of the code
+          generation function that generated it.
 
-      ### Action function return value
-
-      Actions return a data structure identical to the resource data above. You should be careful to
-      always return a payload, even on error - frequently, this is the last stored payload if it existed.
-
-      ```typescript
-      if (input?.properties?.resource?.payload) {
-          return {
-              status: "error",
-              message: "Resource already exists",
-              payload: input.properties.resource.payload,
-          };
-      }
-      ```
-
-      Remember that `message` is optional:
-
-      ```typescript
-      return {
-          payload: JSON.parse(child.stdout).DBCluster,
-          status: "ok"
-      };
-      ```
-
-      Payload should be returned as a JavaScript object.
-
-      ### Create action example
-
-      A create action that uses generated code, `siExec` and a secret to create an AWS EKS cluster:
-
-      ```typescript
-      async function main(component: Input): Promise<Output> {
-          if (component.properties.resource?.payload) {
-              return {
-                  status: "error",
-                  message: "Resource already exists",
-                  payload: component.properties.resource.payload,
-              };
-          }
-
-          const code = component.properties.code?.["si:genericAwsCreate"]?.code;
-          const domain = component.properties?.domain;
-
-          const child = await siExec.waitUntilEnd("aws", [
-              "eks",
-              "create-cluster",
-              "--region",
-              domain?.extra?.Region || "",
-              "--cli-input-json",
-              code || "",
-          ]);
-
-          if (child.exitCode !== 0) {
-              console.error(child.stderr);
-              return {
-                  status: "error",
-                  message: `Unable to create; AWS CLI exited with non zero code: ${child.exitCode}`,
-              };
-          }
-
-          const response = JSON.parse(child.stdout).cluster;
-
-          return {
-              resourceId: response.name,
-              status: "ok",
-          };
-      }
-      ```
-
-      ### Refresh action example
-
-      A refresh action example that uses lodash and siExec to update an AWS EKS cluster:
-
-      ```typescript
-      async function main(component: Input): Promise < Output > {
-          let name = component.properties?.si?.resourceId;
-          const resource = component.properties.resource?.payload;
-          if (!name) {
-              name = resource.name;
-          }
-          if (!name) {
-              return {
-                  status: component.properties.resource?.status ?? "error",
-                  message: "Could not refresh, no resourceId present for EKS Cluster component",
-              };
-          }
-
-          const cliArguments = { };
+        ### Action function return value
+
+        Actions return a data structure identical to the resource data above. You should be careful to
+        always return a payload, even on error - frequently, this is the last stored payload if it existed.
+
+        ```typescript
+        if (input?.properties?.resource?.payload) {
+            return {
+                status: "error",
+                message: "Resource already exists",
+                payload: input.properties.resource.payload,
+            };
+        }
+        ```
+
+        Remember that `message` is optional:
+
+        ```typescript
+        return {
+            payload: JSON.parse(child.stdout).DBCluster,
+            status: "ok"
+        };
+        ```
+
+        Payload should be returned as a JavaScript object.
+
+        ### Create action example
+
+        A create action that uses generated code, `siExec` and a secret to create an AWS EKS cluster:
+
+        ```typescript
+        async function main(component: Input): Promise<Output> {
+            if (component.properties.resource?.payload) {
+                return {
+                    status: "error",
+                    message: "Resource already exists",
+                    payload: component.properties.resource.payload,
+                };
+            }
+
+            const code = component.properties.code?.["si:genericAwsCreate"]?.code;
+            const domain = component.properties?.domain;
+
+            const child = await siExec.waitUntilEnd("aws", [
+                "eks",
+                "create-cluster",
+                "--region",
+                domain?.extra?.Region || "",
+                "--cli-input-json",
+                code || "",
+            ]);
+
+            if (child.exitCode !== 0) {
+                console.error(child.stderr);
+                return {
+                    status: "error",
+                    message: `Unable to create; AWS CLI exited with non zero code: ${child.exitCode}`,
+                };
+            }
+
+            const response = JSON.parse(child.stdout).cluster;
+
+            return {
+                resourceId: response.name,
+                status: "ok",
+            };
+        }
+        ```
+
+        ### Refresh action example
+
+        A refresh action example that uses lodash and siExec to update an AWS EKS cluster:
+
+        ```typescript
+        async function main(component: Input): Promise < Output > {
+            let name = component.properties?.si?.resourceId;
+            const resource = component.properties.resource?.payload;
+            if (!name) {
+                name = resource.name;
+            }
+            if (!name) {
+                return {
+                    status: component.properties.resource?.status ?? "error",
+                    message: "Could not refresh, no resourceId present for EKS Cluster component",
+                };
+            }
+
+            const cliArguments = { };
+            _.set(
+                cliArguments,
+                "name",
+                name,
+            );
+
+            const child = await siExec.waitUntilEnd("aws", [
+                "eks",
+                "describe-cluster",
+                "--region",
+                _.get(component, "properties.domain.extra.Region", ""),
+                "--cli-input-json",
+                JSON.stringify(cliArguments),
+            ]);
+
+            if (child.exitCode !== 0) {
+                console.error(child.stderr);
+                if (child.stderr.includes("ResourceNotFoundException")) {
+                    console.log("EKS Cluster not found upstream (ResourceNotFoundException) so removing the resource")
+                    return {
+                        status: "ok",
+                        payload: null,
+                    };
+                }
+                return {
+                    status: "error",
+                    payload: resource,
+                    message: `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+                };
+            }
+
+            const object = JSON.parse(child.stdout).cluster;
+            return {
+                payload: object,
+                status: "ok",
+            };
+        }
+        ```
+
+        :::warning
+        Ensure you include previous resource payload on failure!
+        :::
+
+        ### Delete action example
+
+        A delete action example that uses lodash and siExec:
+
+        ```typescript
+        async function main(component: Input): Promise<Output> {
+          const cliArguments = {};
           _.set(
-              cliArguments,
-              "name",
-              name,
+            cliArguments,
+            "PolicyArn",
+            _.get(component, "properties.resource_value.Arn"),
           );
 
           const child = await siExec.waitUntilEnd("aws", [
-              "eks",
-              "describe-cluster",
-              "--region",
-              _.get(component, "properties.domain.extra.Region", ""),
-              "--cli-input-json",
-              JSON.stringify(cliArguments),
+            "iam",
+            "delete-policy",
+            "--cli-input-json",
+            JSON.stringify(cliArguments),
           ]);
 
           if (child.exitCode !== 0) {
-              console.error(child.stderr);
-              if (child.stderr.includes("ResourceNotFoundException")) {
-                  console.log("EKS Cluster not found upstream (ResourceNotFoundException) so removing the resource")
-                  return {
-                      status: "ok",
-                      payload: null,
-                  };
-              }
+            const payload = _.get(component, "properties.resource.payload");
+            if (payload) {
               return {
-                  status: "error",
-                  payload: resource,
-                  message: `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+                status: "error",
+                payload,
+                message:
+                  `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
               };
+            } else {
+              return {
+                status: "error",
+                message:
+                  `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+              };
+            }
           }
 
-          const object = JSON.parse(child.stdout).cluster;
           return {
-              payload: object,
-              status: "ok",
+            payload: null,
+            status: "ok",
           };
-      }
-      ```
-
-      :::warning
-      Ensure you include previous resource payload on failure!
-      :::
-
-      ### Delete action example
-
-      A delete action example that uses lodash and siExec:
-
-      ```typescript
-      async function main(component: Input): Promise<Output> {
-        const cliArguments = {};
-        _.set(
-          cliArguments,
-          "PolicyArn",
-          _.get(component, "properties.resource_value.Arn"),
-        );
-
-        const child = await siExec.waitUntilEnd("aws", [
-          "iam",
-          "delete-policy",
-          "--cli-input-json",
-          JSON.stringify(cliArguments),
-        ]);
-
-        if (child.exitCode !== 0) {
-          const payload = _.get(component, "properties.resource.payload");
-          if (payload) {
-            return {
-              status: "error",
-              payload,
-              message:
-                `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
-            };
-          } else {
-            return {
-              status: "error",
-              message:
-                `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
-            };
-          }
         }
+        ```
 
-        return {
-          payload: null,
-          status: "ok",
-        };
-      }
-      ```
+        Note that the payload returned here is `null` - this ensures the resource will be removed.
 
-      Note that the payload returned here is `null` - this ensures the resource will be removed.
+        ### Manual action example
 
-      ### Manual action example
+        A manual action that updates the cluster configuration on an AWS EKS cluster, usking lodash, siExec and the AWS CLI:
 
-      A manual action that updates the cluster configuration on an AWS EKS cluster, usking lodash, siExec and the AWS CLI:
+        ```typescript
+        async function main(component: Input) {
+            const resource = component.properties.resource;
+            if (!resource) {
+                return {
+                    status: component.properties.resource?.status ?? "ok",
+                    message: component.properties.resource?.message,
+                };
+            }
 
-      ```typescript
-      async function main(component: Input) {
-          const resource = component.properties.resource;
-          if (!resource) {
-              return {
-                  status: component.properties.resource?.status ?? "ok",
-                  message: component.properties.resource?.message,
-              };
-          }
+            let json = {
+                "accessConfig": {
+                    "authenticationMode": component.properties.domain.accessConfig.authenticationMode,
+                },
+                "name": resource.name,
+            };
 
-          let json = {
-              "accessConfig": {
-                  "authenticationMode": component.properties.domain.accessConfig.authenticationMode,
-              },
-              "name": resource.name,
-          };
+            const updateResp = await siExec.waitUntilEnd("aws", [
+                "eks",
+                "update-cluster-config",
+                "--cli-input-json",
+                JSON.stringify(json),
+                "--region",
+                component.properties.domain?.extra.Region || "",
+            ]);
 
-          const updateResp = await siExec.waitUntilEnd("aws", [
-              "eks",
-              "update-cluster-config",
-              "--cli-input-json",
-              JSON.stringify(json),
-              "--region",
-              component.properties.domain?.extra.Region || "",
-          ]);
+            if (updateResp.exitCode !== 0) {
+                console.error(updateResp.stderr);
+                return {
+                    status: "error",
+                    payload: resource,
+                    message: `Unable to update the EKS Cluster Access Config, AWS CLI 2 exited with non zero code: ${updateResp.exitCode}`,
+                };
+            }
 
-          if (updateResp.exitCode !== 0) {
-              console.error(updateResp.stderr);
-              return {
-                  status: "error",
-                  payload: resource,
-                  message: `Unable to update the EKS Cluster Access Config, AWS CLI 2 exited with non zero code: ${updateResp.exitCode}`,
-              };
-          }
+            return {
+                payload: resource,
+                status: "ok"
+            };
+        }
+        ```
+        ^^^
+    - role: user
+      content: >
+        What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
 
-          return {
-              payload: resource,
-              status: "ok"
-          };
-      }
-      ```
-      ^^^
-  - role: user
-    content: >
-      What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
-
-      ^^^
-      {FETCH}{AWS_CLI_DOCS_URL}/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
-      ^^^
-  - role: user
-    content: >
-      Create the destroy action function that calls the AWS CLI command.
-      
-      Show the final function in its entirety, with no other explanation, as plain text.
-      
-      Do not wrap the code in markdown delimiters.
+        ^^^
+        {FETCH}{AWS_CLI_DOCS_URL}/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
+        ^^^
+    - role: user
+      content: >
+        Create the destroy action function that calls the AWS CLI command.
+        
+        Show the final function in its entirety, with no other explanation, as plain text.
+        
+        Do not wrap the code in markdown delimiters.

--- a/lib/asset-sprayer/prompts/aws/import.yaml
+++ b/lib/asset-sprayer/prompts/aws/import.yaml
@@ -1,142 +1,142 @@
-model: gpt-4o-mini
-temperature: 0.0
-messages:
-  - role: system
-    content: >
-      You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset functions for use in System Initiative.
+- model: gpt-4o-mini
+  temperature: 0.0
+  messages:
+    - role: system
+      content: >
+        You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset functions for use in System Initiative.
 
-      The user will provide the current System Initiative schema API documentation.
+        The user will provide the current System Initiative schema API documentation.
 
-      The user will provide the text of the help output from an AWS CLI command.
+        The user will provide the text of the help output from an AWS CLI command.
 
-      Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative asset function.
+        Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative asset function.
 
-      You will make sure to pass the region to the command if it is required.
+        You will make sure to pass the region to the command if it is required.
 
-      You will only use APIs that appear in the provided documentation.
-  - role: user
-    content: >
-      What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
+        You will only use APIs that appear in the provided documentation.
+    - role: user
+      content: >
+        What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
 
-      ^^^
-      {FETCH}{SI_DOCS_URL}/reference/asset/function.md{/FETCH}
-      ^^^
-  - role: user
-    content: >
-      What follows is the current System Initiative Import function API documentation as markdown, between three ^ characters.
+        ^^^
+        {FETCH}{SI_DOCS_URL}/reference/asset/function.md{/FETCH}
+        ^^^
+    - role: user
+      content: >
+        What follows is the current System Initiative Import function API documentation as markdown, between three ^ characters.
 
-      ^^^
-      Management Functions
-      ====================
+        ^^^
+        Management Functions
+        ====================
 
-      Management functions are a sixth type of asset function, which can do many more things than
-      the other five types. We will focus here on import functions, which use the resourceId of
-      an asset to import the resource from an external system and update the asset's properties.
+        Management functions are a sixth type of asset function, which can do many more things than
+        the other five types. We will focus here on import functions, which use the resourceId of
+        an asset to import the resource from an external system and update the asset's properties.
 
-      Example Import Function
-      -----------------------
-      This is an example of an import function that pulls in an AWS EKS Cluster resource:
+        Example Import Function
+        -----------------------
+        This is an example of an import function that pulls in an AWS EKS Cluster resource:
 
-      ```typescript
-      async function main({
-          thisComponent
-      }: Input): Promise<Output> {
+        ```typescript
+        async function main({
+            thisComponent
+        }: Input): Promise<Output> {
 
-          const component = thisComponent.properties;
-          let clusterName = _.get(component, ["si", "resourceId"]);
-          const region = component.domain?.extra?.Region || "";
+            const component = thisComponent.properties;
+            let clusterName = _.get(component, ["si", "resourceId"]);
+            const region = component.domain?.extra?.Region || "";
 
-          if (!clusterName) {
-              return {
-                  status: "error",
-                  message: "Cluster Name is required for importing the resource.",
-              };
-          }
+            if (!clusterName) {
+                return {
+                    status: "error",
+                    message: "Cluster Name is required for importing the resource.",
+                };
+            }
 
-          // Fetch the EKS Cluster details using AWS CLI
-          const eksClusterResp = await siExec.waitUntilEnd("aws", [
-              "eks",
-              "describe-cluster",
-              "--region",
-              region,
-              "--name",
-              clusterName,
-          ]);
+            // Fetch the EKS Cluster details using AWS CLI
+            const eksClusterResp = await siExec.waitUntilEnd("aws", [
+                "eks",
+                "describe-cluster",
+                "--region",
+                region,
+                "--name",
+                clusterName,
+            ]);
 
-          if (eksClusterResp.exitCode !== 0) {
-              console.error(eksClusterResp.stderr);
-              return {
-                  status: "error",
-                  message: `Unable to fetch EKS cluster details: AWS CLI exited with non-zero code ${eksClusterResp.exitCode} ${eksClusterResp}`,
-              };
-          }
+            if (eksClusterResp.exitCode !== 0) {
+                console.error(eksClusterResp.stderr);
+                return {
+                    status: "error",
+                    message: `Unable to fetch EKS cluster details: AWS CLI exited with non-zero code ${eksClusterResp.exitCode} ${eksClusterResp}`,
+                };
+            }
 
-          const eksCluster = JSON.parse(eksClusterResp.stdout).cluster;
+            const eksCluster = JSON.parse(eksClusterResp.stdout).cluster;
 
-          // Map EKS cluster details to component properties
-          component["domain"]["name"] = eksCluster.name || "";
-          component["domain"]["version"] = eksCluster.version || "";
-          component["domain"]["roleArn"] = eksCluster.roleArn || "";
-          
-          // Map resourcesVpcConfig properties
-          component["domain"]["resourcesVpcConfig"] = {
-              subnetIds: eksCluster.resourcesVpcConfig.subnetIds || [],
-              securityGroupIds: eksCluster.resourcesVpcConfig.securityGroupIds || [],
-              endpointPublicAccess: eksCluster.resourcesVpcConfig.endpointPublicAccess || false,
-              endpointPrivateAccess: eksCluster.resourcesVpcConfig.endpointPrivateAccess || false,
-              publicAccessCidrs: eksCluster.resourcesVpcConfig.publicAccessCidrs || []
-          };
-          
-          // Map kubernetesNetworkConfig properties
-          component["domain"]["kubernetesNetworkConfig"] = {
-              serviceIpv4Cidr: eksCluster.kubernetesNetworkConfig?.serviceIpv4Cidr || "",
-              ipFamily: eksCluster.kubernetesNetworkConfig?.ipFamily || ""
-          };
+            // Map EKS cluster details to component properties
+            component["domain"]["name"] = eksCluster.name || "";
+            component["domain"]["version"] = eksCluster.version || "";
+            component["domain"]["roleArn"] = eksCluster.roleArn || "";
+            
+            // Map resourcesVpcConfig properties
+            component["domain"]["resourcesVpcConfig"] = {
+                subnetIds: eksCluster.resourcesVpcConfig.subnetIds || [],
+                securityGroupIds: eksCluster.resourcesVpcConfig.securityGroupIds || [],
+                endpointPublicAccess: eksCluster.resourcesVpcConfig.endpointPublicAccess || false,
+                endpointPrivateAccess: eksCluster.resourcesVpcConfig.endpointPrivateAccess || false,
+                publicAccessCidrs: eksCluster.resourcesVpcConfig.publicAccessCidrs || []
+            };
+            
+            // Map kubernetesNetworkConfig properties
+            component["domain"]["kubernetesNetworkConfig"] = {
+                serviceIpv4Cidr: eksCluster.kubernetesNetworkConfig?.serviceIpv4Cidr || "",
+                ipFamily: eksCluster.kubernetesNetworkConfig?.ipFamily || ""
+            };
 
-          // Map enabled logging types
-          component["domain"]["enabledLoggingTypes"] = eksCluster.logging?.clusterLogging
-              .filter((log: any) => log.enabled)
-              .flatMap((log: any) => log.types) || [];
+            // Map enabled logging types
+            component["domain"]["enabledLoggingTypes"] = eksCluster.logging?.clusterLogging
+                .filter((log: any) => log.enabled)
+                .flatMap((log: any) => log.types) || [];
 
-          // Map tags
-          component["domain"]["tags"] = eksCluster.tags || {};
+            // Map tags
+            component["domain"]["tags"] = eksCluster.tags || {};
 
-          // Optional mapping for encryptionConfig, certificateAuthority, or other fields can be added similarly if required
+            // Optional mapping for encryptionConfig, certificateAuthority, or other fields can be added similarly if required
 
-          // Return the updated component
-          return {
-              status: "ok",
-              message: JSON.stringify(eksCluster),
-              ops: {
-                  update: {
-                      self: {
-                          properties: {
-                              ...component, // Push updated component properties back onto the tree
-                          }
-                      }
-                  },
-                  actions: {
-                      self: {
-                          remove: ["create"],
-                          add: ["refresh"],
-                      }
-                  }
-              }
-          };
-      }
-      ```
-      ^^^
-  - role: user
-    content: >
-      What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
+            // Return the updated component
+            return {
+                status: "ok",
+                message: JSON.stringify(eksCluster),
+                ops: {
+                    update: {
+                        self: {
+                            properties: {
+                                ...component, // Push updated component properties back onto the tree
+                            }
+                        }
+                    },
+                    actions: {
+                        self: {
+                            remove: ["create"],
+                            add: ["refresh"],
+                        }
+                    }
+                }
+            };
+        }
+        ```
+        ^^^
+    - role: user
+      content: >
+        What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
 
-      ^^^
-      {FETCH}{AWS_CLI_DOCS_URL}/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
-      ^^^
-  - role: user
-    content: >
-      Create the management function that calls the AWS CLI command and imports the resource.
-      
-      Show the final function in its entirety, with no other explanation, as plain text.
-      
-      Do not wrap the code in markdown delimiters.
+        ^^^
+        {FETCH}{AWS_CLI_DOCS_URL}/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
+        ^^^
+    - role: user
+      content: >
+        Create the management function that calls the AWS CLI command and imports the resource.
+        
+        Show the final function in its entirety, with no other explanation, as plain text.
+        
+        Do not wrap the code in markdown delimiters.

--- a/lib/asset-sprayer/prompts/aws/refresh_action.yaml
+++ b/lib/asset-sprayer/prompts/aws/refresh_action.yaml
@@ -1,401 +1,401 @@
-model: gpt-4o-mini
-temperature: 0.0
-messages:
-  - role: system
-    content: >
-      You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset functions for use in System Initiative.
+- model: gpt-4o-mini
+  temperature: 0.0
+  messages:
+    - role: system
+      content: >
+        You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset functions for use in System Initiative.
 
-      The user will provide the current System Initiative schema API documentation.
+        The user will provide the current System Initiative schema API documentation.
 
-      The user will provide the text of the help output from an AWS CLI command.
+        The user will provide the text of the help output from an AWS CLI command.
 
-      Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative asset function.
+        Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative asset function.
 
-      You will make sure to pass the region to the command if it is required.
+        You will make sure to pass the region to the command if it is required.
 
-      You will only use APIs that appear in the provided documentation.
-  - role: user
-    content: >
-      What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
+        You will only use APIs that appear in the provided documentation.
+    - role: user
+      content: >
+        What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
 
-      ^^^
-      # Asset Functions Reference
+        ^^^
+        # Asset Functions Reference
 
-      Asset functions are written in TypeScript, and executed within a sandbox
-      environment using [Firecracker](https://firecracker-microvm.github.io/).
+        Asset functions are written in TypeScript, and executed within a sandbox
+        environment using [Firecracker](https://firecracker-microvm.github.io/).
 
-      ## Asset Function Basics
+        ## Asset Function Basics
 
-      There are 5 types of asset functions:
+        There are 5 types of asset functions:
 
-      * Action
-      * Attribute
-      * Authentication
-      * Code Generation
-      * Qualification
+        * Action
+        * Attribute
+        * Authentication
+        * Code Generation
+        * Qualification
 
-      ### Executing shell commands
+        ### Executing shell commands
 
-      Functions frequently execute shell commands to interact with external services.
-      Using the [siExec API](/reference/typescript/sandbox/exec/README).
+        Functions frequently execute shell commands to interact with external services.
+        Using the [siExec API](/reference/typescript/sandbox/exec/README).
 
-      ```typescript
-      const child = siExec.waitUntilEnd("aws", [
-        "ec2",
-        "describe-hosts"
-      ]);
-      ```
+        ```typescript
+        const child = siExec.waitUntilEnd("aws", [
+          "ec2",
+          "describe-hosts"
+        ]);
+        ```
 
-      Would execute the shell command:
+        Would execute the shell command:
 
-      ```shell
-      aws ec2 describe-hosts
-      ```
+        ```shell
+        aws ec2 describe-hosts
+        ```
 
-      A more complex example from an action:
+        A more complex example from an action:
 
-      ```typescript
-      const child = await siExec.waitUntilEnd("aws", [
-          "rds",
-          "create-db-cluster",
-          "--region",
-          input?.properties?.domain?.Region || "",
-          "--cli-input-json",
-          JSON.stringify(code),
-      ]);
-      ```
+        ```typescript
+        const child = await siExec.waitUntilEnd("aws", [
+            "rds",
+            "create-db-cluster",
+            "--region",
+            input?.properties?.domain?.Region || "",
+            "--cli-input-json",
+            JSON.stringify(code),
+        ]);
+        ```
 
-      We're always adding more shell commands to the environment though Nix. [You can
-      see the current list of included commands in the source
-      code](https://github.com/systeminit/si/blob/main/flake.nix#L96).
+        We're always adding more shell commands to the environment though Nix. [You can
+        see the current list of included commands in the source
+        code](https://github.com/systeminit/si/blob/main/flake.nix#L96).
 
-      Send a PR if you need something added.
+        Send a PR if you need something added.
 
-      ### Interacting with HTTP APIs
+        ### Interacting with HTTP APIs
 
-      The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) is supported.
+        The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) is supported.
 
-      ```typescript
-      const webpage = await fetch("http://systeminit.com");
-      ```
+        ```typescript
+        const webpage = await fetch("http://systeminit.com");
+        ```
 
-      ### Using lodash
+        ### Using lodash
 
-      The [lodash API](https://lodash.com/docs/4.17.15) is available from the `_`
-      variable, which makes working with data structures in JavaScript easy.
+        The [lodash API](https://lodash.com/docs/4.17.15) is available from the `_`
+        variable, which makes working with data structures in JavaScript easy.
 
-      ```typescript
-      const result = {};
-      if (component.domain?.Sid) {
-        _.set(result, ["Sid"], component.domain.Sid);
-      }
-      ```
+        ```typescript
+        const result = {};
+        if (component.domain?.Sid) {
+          _.set(result, ["Sid"], component.domain.Sid);
+        }
+        ```
 
-      If you find yourself doing complex data manipulation, lodash is where you
-      should look first.
+        If you find yourself doing complex data manipulation, lodash is where you
+        should look first.
 
-      ### Request Storage
+        ### Request Storage
 
-      When a function has secrets as an input, it runs authentication functions before
-      it is executed. Information is then passed between functions through the Request Storage
-      API:
+        When a function has secrets as an input, it runs authentication functions before
+        it is executed. Information is then passed between functions through the Request Storage
+        API:
 
-      ```typescript
-      requestStorage.getItem("foo");
-      ```
+        ```typescript
+        requestStorage.getItem("foo");
+        ```
 
-      Or to set an item (used only in authentication functions):
+        Or to set an item (used only in authentication functions):
 
-      ```typescript
-      requestStorage.setItem("foo");
-      ```
+        ```typescript
+        requestStorage.setItem("foo");
+        ```
 
-      ## Action Functions
+        ## Action Functions
 
-      Action functions interact with external systems (such as AWS, GCP, or Azure)
-      and return resources. They are are en-queued by users in a change set, and
-      executed when applied to HEAD. The order of execution is determined
-      automatically by walking the relationships between the components.
+        Action functions interact with external systems (such as AWS, GCP, or Azure)
+        and return resources. They are are en-queued by users in a change set, and
+        executed when applied to HEAD. The order of execution is determined
+        automatically by walking the relationships between the components.
 
-      There are four types of action function:
+        There are four types of action function:
 
-      1. Functions that create a resource
-      2. Functions that refresh a resource
-      3. Functions that delete a resource
-      4. Manual functions that update or transform a resource
+        1. Functions that create a resource
+        2. Functions that refresh a resource
+        3. Functions that delete a resource
+        4. Manual functions that update or transform a resource
 
-      Create, refresh, and delete are automatically en-queued when their relevant
-      activity is taken on the diagram. Manual functions must be en-queued from the
-      actions tab of the attribute panel by the user.
+        Create, refresh, and delete are automatically en-queued when their relevant
+        activity is taken on the diagram. Manual functions must be en-queued from the
+        actions tab of the attribute panel by the user.
 
-      ### Action function arguments
+        ### Action function arguments
 
-      Action functions take an `Input` argument. It has a `properties` field which contains an object that has:
+        Action functions take an `Input` argument. It has a `properties` field which contains an object that has:
 
-      * The `si` properties
+        * The `si` properties
 
-        These are the core properties set as meta-data for the function. Name, color, etc.
+          These are the core properties set as meta-data for the function. Name, color, etc.
 
-      * The `domain` properties
+        * The `domain` properties
 
-        These are the properties specified in the schema itself.
+          These are the properties specified in the schema itself.
 
-      * The `resource` data
+        * The `resource` data
 
-        This is the output of the last action, stored as the state of the resource. It contains 3 fields:
+          This is the output of the last action, stored as the state of the resource. It contains 3 fields:
 
-        - _status_: one of "ok", "warning", or "error"
-        - _message_: an optional message
-        - _payload_: the resource payload itself
+          - _status_: one of "ok", "warning", or "error"
+          - _message_: an optional message
+          - _payload_: the resource payload itself
 
-      * The `resource_value` data
+        * The `resource_value` data
 
-        This is information pulled into the component properties from resource payload
-        data. These are properties added with the `addResourceProp()` method of a
-        components schema.
+          This is information pulled into the component properties from resource payload
+          data. These are properties added with the `addResourceProp()` method of a
+          components schema.
 
-      * Any generated `code`
+        * Any generated `code`
 
-        Generated code is available as a map, whose key is the name of the code
-        generation function that generated it.
+          Generated code is available as a map, whose key is the name of the code
+          generation function that generated it.
 
-      ### Action function return value
-
-      Actions return a data structure identical to the resource data above. You should be careful to
-      always return a payload, even on error - frequently, this is the last stored payload if it existed.
-
-      ```typescript
-      if (input?.properties?.resource?.payload) {
-          return {
-              status: "error",
-              message: "Resource already exists",
-              payload: input.properties.resource.payload,
-          };
-      }
-      ```
-
-      Remember that `message` is optional:
-
-      ```typescript
-      return {
-          payload: JSON.parse(child.stdout).DBCluster,
-          status: "ok"
-      };
-      ```
-
-      Payload should be returned as a JavaScript object.
-
-      ### Create action example
-
-      A create action that uses generated code, `siExec` and a secret to create an AWS EKS cluster:
-
-      ```typescript
-      async function main(component: Input): Promise<Output> {
-          if (component.properties.resource?.payload) {
-              return {
-                  status: "error",
-                  message: "Resource already exists",
-                  payload: component.properties.resource.payload,
-              };
-          }
-
-          const code = component.properties.code?.["si:genericAwsCreate"]?.code;
-          const domain = component.properties?.domain;
-
-          const child = await siExec.waitUntilEnd("aws", [
-              "eks",
-              "create-cluster",
-              "--region",
-              domain?.extra?.Region || "",
-              "--cli-input-json",
-              code || "",
-          ]);
-
-          if (child.exitCode !== 0) {
-              console.error(child.stderr);
-              return {
-                  status: "error",
-                  message: `Unable to create; AWS CLI exited with non zero code: ${child.exitCode}`,
-              };
-          }
-
-          const response = JSON.parse(child.stdout).cluster;
-
-          return {
-              resourceId: response.name,
-              status: "ok",
-          };
-      }
-      ```
-
-      ### Refresh action example
-
-      A refresh action example that uses lodash and siExec to update an AWS EKS cluster:
-
-      ```typescript
-      async function main(component: Input): Promise < Output > {
-          let name = component.properties?.si?.resourceId;
-          const resource = component.properties.resource?.payload;
-          if (!name) {
-              name = resource.name;
-          }
-          if (!name) {
-              return {
-                  status: component.properties.resource?.status ?? "error",
-                  message: "Could not refresh, no resourceId present for EKS Cluster component",
-              };
-          }
-
-          const cliArguments = { };
+        ### Action function return value
+
+        Actions return a data structure identical to the resource data above. You should be careful to
+        always return a payload, even on error - frequently, this is the last stored payload if it existed.
+
+        ```typescript
+        if (input?.properties?.resource?.payload) {
+            return {
+                status: "error",
+                message: "Resource already exists",
+                payload: input.properties.resource.payload,
+            };
+        }
+        ```
+
+        Remember that `message` is optional:
+
+        ```typescript
+        return {
+            payload: JSON.parse(child.stdout).DBCluster,
+            status: "ok"
+        };
+        ```
+
+        Payload should be returned as a JavaScript object.
+
+        ### Create action example
+
+        A create action that uses generated code, `siExec` and a secret to create an AWS EKS cluster:
+
+        ```typescript
+        async function main(component: Input): Promise<Output> {
+            if (component.properties.resource?.payload) {
+                return {
+                    status: "error",
+                    message: "Resource already exists",
+                    payload: component.properties.resource.payload,
+                };
+            }
+
+            const code = component.properties.code?.["si:genericAwsCreate"]?.code;
+            const domain = component.properties?.domain;
+
+            const child = await siExec.waitUntilEnd("aws", [
+                "eks",
+                "create-cluster",
+                "--region",
+                domain?.extra?.Region || "",
+                "--cli-input-json",
+                code || "",
+            ]);
+
+            if (child.exitCode !== 0) {
+                console.error(child.stderr);
+                return {
+                    status: "error",
+                    message: `Unable to create; AWS CLI exited with non zero code: ${child.exitCode}`,
+                };
+            }
+
+            const response = JSON.parse(child.stdout).cluster;
+
+            return {
+                resourceId: response.name,
+                status: "ok",
+            };
+        }
+        ```
+
+        ### Refresh action example
+
+        A refresh action example that uses lodash and siExec to update an AWS EKS cluster:
+
+        ```typescript
+        async function main(component: Input): Promise < Output > {
+            let name = component.properties?.si?.resourceId;
+            const resource = component.properties.resource?.payload;
+            if (!name) {
+                name = resource.name;
+            }
+            if (!name) {
+                return {
+                    status: component.properties.resource?.status ?? "error",
+                    message: "Could not refresh, no resourceId present for EKS Cluster component",
+                };
+            }
+
+            const cliArguments = { };
+            _.set(
+                cliArguments,
+                "name",
+                name,
+            );
+
+            const child = await siExec.waitUntilEnd("aws", [
+                "eks",
+                "describe-cluster",
+                "--region",
+                _.get(component, "properties.domain.extra.Region", ""),
+                "--cli-input-json",
+                JSON.stringify(cliArguments),
+            ]);
+
+            if (child.exitCode !== 0) {
+                console.error(child.stderr);
+                if (child.stderr.includes("ResourceNotFoundException")) {
+                    console.log("EKS Cluster not found upstream (ResourceNotFoundException) so removing the resource")
+                    return {
+                        status: "ok",
+                        payload: null,
+                    };
+                }
+                return {
+                    status: "error",
+                    payload: resource,
+                    message: `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+                };
+            }
+
+            const object = JSON.parse(child.stdout).cluster;
+            return {
+                payload: object,
+                status: "ok",
+            };
+        }
+        ```
+
+        :::warning
+        Ensure you include previous resource payload on failure!
+        :::
+
+        ### Delete action example
+
+        A delete action example that uses lodash and siExec:
+
+        ```typescript
+        async function main(component: Input): Promise<Output> {
+          const cliArguments = {};
           _.set(
-              cliArguments,
-              "name",
-              name,
+            cliArguments,
+            "PolicyArn",
+            _.get(component, "properties.resource_value.Arn"),
           );
 
           const child = await siExec.waitUntilEnd("aws", [
-              "eks",
-              "describe-cluster",
-              "--region",
-              _.get(component, "properties.domain.extra.Region", ""),
-              "--cli-input-json",
-              JSON.stringify(cliArguments),
+            "iam",
+            "delete-policy",
+            "--cli-input-json",
+            JSON.stringify(cliArguments),
           ]);
 
           if (child.exitCode !== 0) {
-              console.error(child.stderr);
-              if (child.stderr.includes("ResourceNotFoundException")) {
-                  console.log("EKS Cluster not found upstream (ResourceNotFoundException) so removing the resource")
-                  return {
-                      status: "ok",
-                      payload: null,
-                  };
-              }
+            const payload = _.get(component, "properties.resource.payload");
+            if (payload) {
               return {
-                  status: "error",
-                  payload: resource,
-                  message: `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+                status: "error",
+                payload,
+                message:
+                  `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
               };
+            } else {
+              return {
+                status: "error",
+                message:
+                  `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+              };
+            }
           }
 
-          const object = JSON.parse(child.stdout).cluster;
           return {
-              payload: object,
-              status: "ok",
+            payload: null,
+            status: "ok",
           };
-      }
-      ```
-
-      :::warning
-      Ensure you include previous resource payload on failure!
-      :::
-
-      ### Delete action example
-
-      A delete action example that uses lodash and siExec:
-
-      ```typescript
-      async function main(component: Input): Promise<Output> {
-        const cliArguments = {};
-        _.set(
-          cliArguments,
-          "PolicyArn",
-          _.get(component, "properties.resource_value.Arn"),
-        );
-
-        const child = await siExec.waitUntilEnd("aws", [
-          "iam",
-          "delete-policy",
-          "--cli-input-json",
-          JSON.stringify(cliArguments),
-        ]);
-
-        if (child.exitCode !== 0) {
-          const payload = _.get(component, "properties.resource.payload");
-          if (payload) {
-            return {
-              status: "error",
-              payload,
-              message:
-                `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
-            };
-          } else {
-            return {
-              status: "error",
-              message:
-                `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
-            };
-          }
         }
+        ```
 
-        return {
-          payload: null,
-          status: "ok",
-        };
-      }
-      ```
+        Note that the payload returned here is `null` - this ensures the resource will be removed.
 
-      Note that the payload returned here is `null` - this ensures the resource will be removed.
+        ### Manual action example
 
-      ### Manual action example
+        A manual action that updates the cluster configuration on an AWS EKS cluster, usking lodash, siExec and the AWS CLI:
 
-      A manual action that updates the cluster configuration on an AWS EKS cluster, usking lodash, siExec and the AWS CLI:
+        ```typescript
+        async function main(component: Input) {
+            const resource = component.properties.resource;
+            if (!resource) {
+                return {
+                    status: component.properties.resource?.status ?? "ok",
+                    message: component.properties.resource?.message,
+                };
+            }
 
-      ```typescript
-      async function main(component: Input) {
-          const resource = component.properties.resource;
-          if (!resource) {
-              return {
-                  status: component.properties.resource?.status ?? "ok",
-                  message: component.properties.resource?.message,
-              };
-          }
+            let json = {
+                "accessConfig": {
+                    "authenticationMode": component.properties.domain.accessConfig.authenticationMode,
+                },
+                "name": resource.name,
+            };
 
-          let json = {
-              "accessConfig": {
-                  "authenticationMode": component.properties.domain.accessConfig.authenticationMode,
-              },
-              "name": resource.name,
-          };
+            const updateResp = await siExec.waitUntilEnd("aws", [
+                "eks",
+                "update-cluster-config",
+                "--cli-input-json",
+                JSON.stringify(json),
+                "--region",
+                component.properties.domain?.extra.Region || "",
+            ]);
 
-          const updateResp = await siExec.waitUntilEnd("aws", [
-              "eks",
-              "update-cluster-config",
-              "--cli-input-json",
-              JSON.stringify(json),
-              "--region",
-              component.properties.domain?.extra.Region || "",
-          ]);
+            if (updateResp.exitCode !== 0) {
+                console.error(updateResp.stderr);
+                return {
+                    status: "error",
+                    payload: resource,
+                    message: `Unable to update the EKS Cluster Access Config, AWS CLI 2 exited with non zero code: ${updateResp.exitCode}`,
+                };
+            }
 
-          if (updateResp.exitCode !== 0) {
-              console.error(updateResp.stderr);
-              return {
-                  status: "error",
-                  payload: resource,
-                  message: `Unable to update the EKS Cluster Access Config, AWS CLI 2 exited with non zero code: ${updateResp.exitCode}`,
-              };
-          }
+            return {
+                payload: resource,
+                status: "ok"
+            };
+        }
+        ```
+        ^^^
+    - role: user
+      content: >
+        What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
 
-          return {
-              payload: resource,
-              status: "ok"
-          };
-      }
-      ```
-      ^^^
-  - role: user
-    content: >
-      What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
+        ^^^
+        {FETCH}{AWS_CLI_DOCS_URL}/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
+        ^^^
+    - role: user
+      content: >
+        Create the refresh action function that calls the AWS CLI command.
+        
+        Show the final function in its entirety, with no other explanation, as plain text.
+        
+        Do not wrap the code in markdown delimiters.
 
-      ^^^
-      {FETCH}{AWS_CLI_DOCS_URL}/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
-      ^^^
-  - role: user
-    content: >
-      Create the refresh action function that calls the AWS CLI command.
-      
-      Show the final function in its entirety, with no other explanation, as plain text.
-      
-      Do not wrap the code in markdown delimiters.
-
-      Make sure to follow the form of the action example section in the System Initiative function API documentation, and ignore the examples in the "using the si-generator" section.
+        Make sure to follow the form of the action example section in the System Initiative function API documentation, and ignore the examples in the "using the si-generator" section.

--- a/lib/asset-sprayer/prompts/aws/update_action.yaml
+++ b/lib/asset-sprayer/prompts/aws/update_action.yaml
@@ -1,399 +1,399 @@
-model: gpt-4o-mini
-temperature: 0.0
-messages:
-  - role: system
-    content: >
-      You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset functions for use in System Initiative.
+- model: gpt-4o-mini
+  temperature: 0.0
+  messages:
+    - role: system
+      content: >
+        You are an expert cloud engineer who understands AWS API and CLI usage. Your job is to create new asset functions for use in System Initiative.
 
-      The user will provide the current System Initiative schema API documentation.
+        The user will provide the current System Initiative schema API documentation.
 
-      The user will provide the text of the help output from an AWS CLI command.
+        The user will provide the text of the help output from an AWS CLI command.
 
-      Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative asset function.
+        Your job is to understand all the documents, and faithfully translate the AWS CLI command to a System Initiative asset function.
 
-      You will make sure to pass the region to the command if it is required.
+        You will make sure to pass the region to the command if it is required.
 
-      You will only use APIs that appear in the provided documentation.
-  - role: user
-    content: >
-      What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
+        You will only use APIs that appear in the provided documentation.
+    - role: user
+      content: >
+        What follows is the current System Initiative function API documentation as markdown, between three ^ characters.
 
-      ^^^
-      # Asset Functions Reference
+        ^^^
+        # Asset Functions Reference
 
-      Asset functions are written in TypeScript, and executed within a sandbox
-      environment using [Firecracker](https://firecracker-microvm.github.io/).
+        Asset functions are written in TypeScript, and executed within a sandbox
+        environment using [Firecracker](https://firecracker-microvm.github.io/).
 
-      ## Asset Function Basics
+        ## Asset Function Basics
 
-      There are 5 types of asset functions:
+        There are 5 types of asset functions:
 
-      * Action
-      * Attribute
-      * Authentication
-      * Code Generation
-      * Qualification
+        * Action
+        * Attribute
+        * Authentication
+        * Code Generation
+        * Qualification
 
-      ### Executing shell commands
+        ### Executing shell commands
 
-      Functions frequently execute shell commands to interact with external services.
-      Using the [siExec API](/reference/typescript/sandbox/exec/README).
+        Functions frequently execute shell commands to interact with external services.
+        Using the [siExec API](/reference/typescript/sandbox/exec/README).
 
-      ```typescript
-      const child = siExec.waitUntilEnd("aws", [
-        "ec2",
-        "describe-hosts"
-      ]);
-      ```
+        ```typescript
+        const child = siExec.waitUntilEnd("aws", [
+          "ec2",
+          "describe-hosts"
+        ]);
+        ```
 
-      Would execute the shell command:
+        Would execute the shell command:
 
-      ```shell
-      aws ec2 describe-hosts
-      ```
+        ```shell
+        aws ec2 describe-hosts
+        ```
 
-      A more complex example from an action:
+        A more complex example from an action:
 
-      ```typescript
-      const child = await siExec.waitUntilEnd("aws", [
-          "rds",
-          "create-db-cluster",
-          "--region",
-          input?.properties?.domain?.Region || "",
-          "--cli-input-json",
-          JSON.stringify(code),
-      ]);
-      ```
+        ```typescript
+        const child = await siExec.waitUntilEnd("aws", [
+            "rds",
+            "create-db-cluster",
+            "--region",
+            input?.properties?.domain?.Region || "",
+            "--cli-input-json",
+            JSON.stringify(code),
+        ]);
+        ```
 
-      We're always adding more shell commands to the environment though Nix. [You can
-      see the current list of included commands in the source
-      code](https://github.com/systeminit/si/blob/main/flake.nix#L96).
+        We're always adding more shell commands to the environment though Nix. [You can
+        see the current list of included commands in the source
+        code](https://github.com/systeminit/si/blob/main/flake.nix#L96).
 
-      Send a PR if you need something added.
+        Send a PR if you need something added.
 
-      ### Interacting with HTTP APIs
+        ### Interacting with HTTP APIs
 
-      The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) is supported.
+        The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) is supported.
 
-      ```typescript
-      const webpage = await fetch("http://systeminit.com");
-      ```
+        ```typescript
+        const webpage = await fetch("http://systeminit.com");
+        ```
 
-      ### Using lodash
+        ### Using lodash
 
-      The [lodash API](https://lodash.com/docs/4.17.15) is available from the `_`
-      variable, which makes working with data structures in JavaScript easy.
+        The [lodash API](https://lodash.com/docs/4.17.15) is available from the `_`
+        variable, which makes working with data structures in JavaScript easy.
 
-      ```typescript
-      const result = {};
-      if (component.domain?.Sid) {
-        _.set(result, ["Sid"], component.domain.Sid);
-      }
-      ```
+        ```typescript
+        const result = {};
+        if (component.domain?.Sid) {
+          _.set(result, ["Sid"], component.domain.Sid);
+        }
+        ```
 
-      If you find yourself doing complex data manipulation, lodash is where you
-      should look first.
+        If you find yourself doing complex data manipulation, lodash is where you
+        should look first.
 
-      ### Request Storage
+        ### Request Storage
 
-      When a function has secrets as an input, it runs authentication functions before
-      it is executed. Information is then passed between functions through the Request Storage
-      API:
+        When a function has secrets as an input, it runs authentication functions before
+        it is executed. Information is then passed between functions through the Request Storage
+        API:
 
-      ```typescript
-      requestStorage.getItem("foo");
-      ```
+        ```typescript
+        requestStorage.getItem("foo");
+        ```
 
-      Or to set an item (used only in authentication functions):
+        Or to set an item (used only in authentication functions):
 
-      ```typescript
-      requestStorage.setItem("foo");
-      ```
+        ```typescript
+        requestStorage.setItem("foo");
+        ```
 
-      ## Action Functions
+        ## Action Functions
 
-      Action functions interact with external systems (such as AWS, GCP, or Azure)
-      and return resources. They are are en-queued by users in a change set, and
-      executed when applied to HEAD. The order of execution is determined
-      automatically by walking the relationships between the components.
+        Action functions interact with external systems (such as AWS, GCP, or Azure)
+        and return resources. They are are en-queued by users in a change set, and
+        executed when applied to HEAD. The order of execution is determined
+        automatically by walking the relationships between the components.
 
-      There are four types of action function:
+        There are four types of action function:
 
-      1. Functions that create a resource
-      2. Functions that refresh a resource
-      3. Functions that delete a resource
-      4. Manual functions that update or transform a resource
+        1. Functions that create a resource
+        2. Functions that refresh a resource
+        3. Functions that delete a resource
+        4. Manual functions that update or transform a resource
 
-      Create, refresh, and delete are automatically en-queued when their relevant
-      activity is taken on the diagram. Manual functions must be en-queued from the
-      actions tab of the attribute panel by the user.
+        Create, refresh, and delete are automatically en-queued when their relevant
+        activity is taken on the diagram. Manual functions must be en-queued from the
+        actions tab of the attribute panel by the user.
 
-      ### Action function arguments
+        ### Action function arguments
 
-      Action functions take an `Input` argument. It has a `properties` field which contains an object that has:
+        Action functions take an `Input` argument. It has a `properties` field which contains an object that has:
 
-      * The `si` properties
+        * The `si` properties
 
-        These are the core properties set as meta-data for the function. Name, color, etc.
+          These are the core properties set as meta-data for the function. Name, color, etc.
 
-      * The `domain` properties
+        * The `domain` properties
 
-        These are the properties specified in the schema itself.
+          These are the properties specified in the schema itself.
 
-      * The `resource` data
+        * The `resource` data
 
-        This is the output of the last action, stored as the state of the resource. It contains 3 fields:
+          This is the output of the last action, stored as the state of the resource. It contains 3 fields:
 
-        - _status_: one of "ok", "warning", or "error"
-        - _message_: an optional message
-        - _payload_: the resource payload itself
+          - _status_: one of "ok", "warning", or "error"
+          - _message_: an optional message
+          - _payload_: the resource payload itself
 
-      * The `resource_value` data
+        * The `resource_value` data
 
-        This is information pulled into the component properties from resource payload
-        data. These are properties added with the `addResourceProp()` method of a
-        components schema.
+          This is information pulled into the component properties from resource payload
+          data. These are properties added with the `addResourceProp()` method of a
+          components schema.
 
-      * Any generated `code`
+        * Any generated `code`
 
-        Generated code is available as a map, whose key is the name of the code
-        generation function that generated it.
+          Generated code is available as a map, whose key is the name of the code
+          generation function that generated it.
 
-      ### Action function return value
-
-      Actions return a data structure identical to the resource data above. You should be careful to
-      always return a payload, even on error - frequently, this is the last stored payload if it existed.
-
-      ```typescript
-      if (input?.properties?.resource?.payload) {
-          return {
-              status: "error",
-              message: "Resource already exists",
-              payload: input.properties.resource.payload,
-          };
-      }
-      ```
-
-      Remember that `message` is optional:
-
-      ```typescript
-      return {
-          payload: JSON.parse(child.stdout).DBCluster,
-          status: "ok"
-      };
-      ```
-
-      Payload should be returned as a JavaScript object.
-
-      ### Create action example
-
-      A create action that uses generated code, `siExec` and a secret to create an AWS EKS cluster:
-
-      ```typescript
-      async function main(component: Input): Promise<Output> {
-          if (component.properties.resource?.payload) {
-              return {
-                  status: "error",
-                  message: "Resource already exists",
-                  payload: component.properties.resource.payload,
-              };
-          }
-
-          const code = component.properties.code?.["si:genericAwsCreate"]?.code;
-          const domain = component.properties?.domain;
-
-          const child = await siExec.waitUntilEnd("aws", [
-              "eks",
-              "create-cluster",
-              "--region",
-              domain?.extra?.Region || "",
-              "--cli-input-json",
-              code || "",
-          ]);
-
-          if (child.exitCode !== 0) {
-              console.error(child.stderr);
-              return {
-                  status: "error",
-                  message: `Unable to create; AWS CLI exited with non zero code: ${child.exitCode}`,
-              };
-          }
-
-          const response = JSON.parse(child.stdout).cluster;
-
-          return {
-              resourceId: response.name,
-              status: "ok",
-          };
-      }
-      ```
-
-      ### Refresh action example
-
-      A refresh action example that uses lodash and siExec to update an AWS EKS cluster:
-
-      ```typescript
-      async function main(component: Input): Promise < Output > {
-          let name = component.properties?.si?.resourceId;
-          const resource = component.properties.resource?.payload;
-          if (!name) {
-              name = resource.name;
-          }
-          if (!name) {
-              return {
-                  status: component.properties.resource?.status ?? "error",
-                  message: "Could not refresh, no resourceId present for EKS Cluster component",
-              };
-          }
-
-          const cliArguments = { };
+        ### Action function return value
+
+        Actions return a data structure identical to the resource data above. You should be careful to
+        always return a payload, even on error - frequently, this is the last stored payload if it existed.
+
+        ```typescript
+        if (input?.properties?.resource?.payload) {
+            return {
+                status: "error",
+                message: "Resource already exists",
+                payload: input.properties.resource.payload,
+            };
+        }
+        ```
+
+        Remember that `message` is optional:
+
+        ```typescript
+        return {
+            payload: JSON.parse(child.stdout).DBCluster,
+            status: "ok"
+        };
+        ```
+
+        Payload should be returned as a JavaScript object.
+
+        ### Create action example
+
+        A create action that uses generated code, `siExec` and a secret to create an AWS EKS cluster:
+
+        ```typescript
+        async function main(component: Input): Promise<Output> {
+            if (component.properties.resource?.payload) {
+                return {
+                    status: "error",
+                    message: "Resource already exists",
+                    payload: component.properties.resource.payload,
+                };
+            }
+
+            const code = component.properties.code?.["si:genericAwsCreate"]?.code;
+            const domain = component.properties?.domain;
+
+            const child = await siExec.waitUntilEnd("aws", [
+                "eks",
+                "create-cluster",
+                "--region",
+                domain?.extra?.Region || "",
+                "--cli-input-json",
+                code || "",
+            ]);
+
+            if (child.exitCode !== 0) {
+                console.error(child.stderr);
+                return {
+                    status: "error",
+                    message: `Unable to create; AWS CLI exited with non zero code: ${child.exitCode}`,
+                };
+            }
+
+            const response = JSON.parse(child.stdout).cluster;
+
+            return {
+                resourceId: response.name,
+                status: "ok",
+            };
+        }
+        ```
+
+        ### Refresh action example
+
+        A refresh action example that uses lodash and siExec to update an AWS EKS cluster:
+
+        ```typescript
+        async function main(component: Input): Promise < Output > {
+            let name = component.properties?.si?.resourceId;
+            const resource = component.properties.resource?.payload;
+            if (!name) {
+                name = resource.name;
+            }
+            if (!name) {
+                return {
+                    status: component.properties.resource?.status ?? "error",
+                    message: "Could not refresh, no resourceId present for EKS Cluster component",
+                };
+            }
+
+            const cliArguments = { };
+            _.set(
+                cliArguments,
+                "name",
+                name,
+            );
+
+            const child = await siExec.waitUntilEnd("aws", [
+                "eks",
+                "describe-cluster",
+                "--region",
+                _.get(component, "properties.domain.extra.Region", ""),
+                "--cli-input-json",
+                JSON.stringify(cliArguments),
+            ]);
+
+            if (child.exitCode !== 0) {
+                console.error(child.stderr);
+                if (child.stderr.includes("ResourceNotFoundException")) {
+                    console.log("EKS Cluster not found upstream (ResourceNotFoundException) so removing the resource")
+                    return {
+                        status: "ok",
+                        payload: null,
+                    };
+                }
+                return {
+                    status: "error",
+                    payload: resource,
+                    message: `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+                };
+            }
+
+            const object = JSON.parse(child.stdout).cluster;
+            return {
+                payload: object,
+                status: "ok",
+            };
+        }
+        ```
+
+        :::warning
+        Ensure you include previous resource payload on failure!
+        :::
+
+        ### Delete action example
+
+        A delete action example that uses lodash and siExec:
+
+        ```typescript
+        async function main(component: Input): Promise<Output> {
+          const cliArguments = {};
           _.set(
-              cliArguments,
-              "name",
-              name,
+            cliArguments,
+            "PolicyArn",
+            _.get(component, "properties.resource_value.Arn"),
           );
 
           const child = await siExec.waitUntilEnd("aws", [
-              "eks",
-              "describe-cluster",
-              "--region",
-              _.get(component, "properties.domain.extra.Region", ""),
-              "--cli-input-json",
-              JSON.stringify(cliArguments),
+            "iam",
+            "delete-policy",
+            "--cli-input-json",
+            JSON.stringify(cliArguments),
           ]);
 
           if (child.exitCode !== 0) {
-              console.error(child.stderr);
-              if (child.stderr.includes("ResourceNotFoundException")) {
-                  console.log("EKS Cluster not found upstream (ResourceNotFoundException) so removing the resource")
-                  return {
-                      status: "ok",
-                      payload: null,
-                  };
-              }
+            const payload = _.get(component, "properties.resource.payload");
+            if (payload) {
               return {
-                  status: "error",
-                  payload: resource,
-                  message: `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+                status: "error",
+                payload,
+                message:
+                  `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
               };
+            } else {
+              return {
+                status: "error",
+                message:
+                  `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+              };
+            }
           }
 
-          const object = JSON.parse(child.stdout).cluster;
           return {
-              payload: object,
-              status: "ok",
+            payload: null,
+            status: "ok",
           };
-      }
-      ```
-
-      :::warning
-      Ensure you include previous resource payload on failure!
-      :::
-
-      ### Delete action example
-
-      A delete action example that uses lodash and siExec:
-
-      ```typescript
-      async function main(component: Input): Promise<Output> {
-        const cliArguments = {};
-        _.set(
-          cliArguments,
-          "PolicyArn",
-          _.get(component, "properties.resource_value.Arn"),
-        );
-
-        const child = await siExec.waitUntilEnd("aws", [
-          "iam",
-          "delete-policy",
-          "--cli-input-json",
-          JSON.stringify(cliArguments),
-        ]);
-
-        if (child.exitCode !== 0) {
-          const payload = _.get(component, "properties.resource.payload");
-          if (payload) {
-            return {
-              status: "error",
-              payload,
-              message:
-                `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
-            };
-          } else {
-            return {
-              status: "error",
-              message:
-                `Delete error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
-            };
-          }
         }
+        ```
 
-        return {
-          payload: null,
-          status: "ok",
-        };
-      }
-      ```
+        Note that the payload returned here is `null` - this ensures the resource will be removed.
 
-      Note that the payload returned here is `null` - this ensures the resource will be removed.
+        ### Manual action example
 
-      ### Manual action example
+        A manual action that updates the cluster configuration on an AWS EKS cluster, usking lodash, siExec and the AWS CLI:
 
-      A manual action that updates the cluster configuration on an AWS EKS cluster, usking lodash, siExec and the AWS CLI:
+        ```typescript
+        async function main(component: Input) {
+            const resource = component.properties.resource;
+            if (!resource) {
+                return {
+                    status: component.properties.resource?.status ?? "ok",
+                    message: component.properties.resource?.message,
+                };
+            }
 
-      ```typescript
-      async function main(component: Input) {
-          const resource = component.properties.resource;
-          if (!resource) {
-              return {
-                  status: component.properties.resource?.status ?? "ok",
-                  message: component.properties.resource?.message,
-              };
-          }
+            let json = {
+                "accessConfig": {
+                    "authenticationMode": component.properties.domain.accessConfig.authenticationMode,
+                },
+                "name": resource.name,
+            };
 
-          let json = {
-              "accessConfig": {
-                  "authenticationMode": component.properties.domain.accessConfig.authenticationMode,
-              },
-              "name": resource.name,
-          };
+            const updateResp = await siExec.waitUntilEnd("aws", [
+                "eks",
+                "update-cluster-config",
+                "--cli-input-json",
+                JSON.stringify(json),
+                "--region",
+                component.properties.domain?.extra.Region || "",
+            ]);
 
-          const updateResp = await siExec.waitUntilEnd("aws", [
-              "eks",
-              "update-cluster-config",
-              "--cli-input-json",
-              JSON.stringify(json),
-              "--region",
-              component.properties.domain?.extra.Region || "",
-          ]);
+            if (updateResp.exitCode !== 0) {
+                console.error(updateResp.stderr);
+                return {
+                    status: "error",
+                    payload: resource,
+                    message: `Unable to update the EKS Cluster Access Config, AWS CLI 2 exited with non zero code: ${updateResp.exitCode}`,
+                };
+            }
 
-          if (updateResp.exitCode !== 0) {
-              console.error(updateResp.stderr);
-              return {
-                  status: "error",
-                  payload: resource,
-                  message: `Unable to update the EKS Cluster Access Config, AWS CLI 2 exited with non zero code: ${updateResp.exitCode}`,
-              };
-          }
+            return {
+                payload: resource,
+                status: "ok"
+            };
+        }
+        ```
+        ^^^
+    - role: user
+      content: >
+        What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
 
-          return {
-              payload: resource,
-              status: "ok"
-          };
-      }
-      ```
-      ^^^
-  - role: user
-    content: >
-      What follows is the official documentation for an AWS CLI command as HTML, between three ^ characters.
-
-      ^^^
-      {FETCH}{AWS_CLI_DOCS_URL}/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
-      ^^^
-  - role: user
-    content: >
-      Create the update action function that calls the AWS CLI command.
-      
-      Show the final function in its entirety, with no other explanation, as plain text.
-      
-      Do not wrap the code in markdown delimiters.
+        ^^^
+        {FETCH}{AWS_CLI_DOCS_URL}/{AWS_COMMAND}/{AWS_SUBCOMMAND}.html{/FETCH}
+        ^^^
+    - role: user
+      content: >
+        Create the update action function that calls the AWS CLI command.
+        
+        Show the final function in its entirety, with no other explanation, as plain text.
+        
+        Do not wrap the code in markdown delimiters.

--- a/lib/sdf-server/src/service/v2/func/generate_aws_function.rs
+++ b/lib/sdf-server/src/service/v2/func/generate_aws_function.rs
@@ -107,7 +107,13 @@ async fn generate_and_save_code(
         Some(prompt_override) => prompt_override.into(),
         None => asset_sprayer.raw_prompt(prompt.kind()).await?,
     };
-    let code = asset_sprayer.run(prompt, &raw_prompt).await?;
+    let function_text = Func::get_by_id_or_error(ctx, func_id)
+        .await?
+        .code_plaintext()?
+        .unwrap_or("".to_string());
+    let code = asset_sprayer
+        .run(prompt, &raw_prompt, &function_text)
+        .await?;
     FuncAuthoringClient::save_code(ctx, func_id, code).await?;
     ctx.commit().await?;
     Ok(())


### PR DESCRIPTION
This adds two distinct capabilities to the system:
* The ability to include the current function text in a prompt with `{FUNCTION_TEXT}`. This allows ChatGPT to "fill in" a function you've already written rather than just generating a new one.
* The ability to run a prompt iteratively: prompts are now an array of messages rather just one. After each prompt, the response from ChatGPT will be taken as the new function text, and fed back into the next prompt. This allows you to break up the problem for ChatGPT and/or cut files in pieces:
   1. Figure out the property names and hierarchy in this schema.
   2. Add validations to the schema.
   3. Add sockets.
   4. etc.

More sophisticated outputs from ChatGPT (other things than function text) may be useful here, and this should let us experiment with different docs at different times.

An example second prompt:

```yaml
- ...
  <normal first prompt>
  ...
- model: gpt-4o-mini
  temperature: 0.0
  messages:
    - role: system
      content: >
        The following is a function in typescript, between three ^ characters. 

        ^^^
        {FUNCTION_TEXT}
        ^^^
        
        Please reproduce the entire function and add the comment "hi mom".

        Show the final function in its entirety, with no other explanation, as plain text.
        
        Do not wrap the code in markdown delimiters.
```

And there's "hi mom" at the bottom of the generated function!

<img src="https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExdHlzaHVvNTQ2a2RiMG81MTIyYjA3bDI1bjEyZWFjcHQybzV2d2ptZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/WIZFVhixA50A9IH5FR/giphy.webp">