### PR TITLE
fix(sdf): Ensure that Workspace Integrations exist for old workspaces

### DIFF
--- a/lib/sdf-server/src/service/session.rs
+++ b/lib/sdf-server/src/service/session.rs
@@ -5,8 +5,8 @@ use axum::{
     Router,
 };
 use dal::{
-    KeyPairError, StandardModelError, TransactionsError, UserError, UserPk, WorkspaceError,
-    WorkspacePk,
+    workspace_integrations::WorkspaceIntegrationsError, KeyPairError, StandardModelError,
+    TransactionsError, UserError, UserPk, WorkspaceError, WorkspacePk,
 };
 use serde::{Deserialize, Serialize};
 use si_data_spicedb::SpiceDbError;
@@ -54,6 +54,8 @@ pub enum SessionError {
     User(#[from] UserError),
     #[error(transparent)]
     Workspace(#[from] WorkspaceError),
+    #[error(transparent)]
+    WorkspaceIntegration(#[from] WorkspaceIntegrationsError),
     #[error("workspace {0} not yet migrated to new snapshot graph version. Migration required")]
     WorkspaceNotYetMigrated(WorkspacePk),
     #[error("invalid workspace permission: {0}")]


### PR DESCRIPTION
The original code was only creating the integrations table entry for new workspaces but we should also ensure that we do it for old workspaces as well