### PR TITLE
chore: temporarily shrink size of workspace snapshots cache

### DIFF
--- a/lib/si-layer-cache/src/db.rs
+++ b/lib/si-layer-cache/src/db.rs
@@ -181,7 +181,7 @@ where
             cache_config
                 .clone()
                 .with_name(workspace_snapshot::CACHE_NAME)
-                .memory_usable_max_percent(50)
+                .memory_usable_max_percent(20)
                 .disk_usable_max_percent(50)
                 .with_path_join(workspace_snapshot::CACHE_NAME),
             compute_executor.clone(),


### PR DESCRIPTION
This will shrink the size of the workspace snapshots cache. I want to see how the cache behaves in tools prod. We currently deploy often enough that we keep resetting the cache before it hits the limit. This size should be achievable in a few hours, but still large enough to contain the largest cache size we've observed in prod so far.