### PR TITLE
fix: delete components on head if they are not in default view

### DIFF
--- a/lib/sdf-server/src/service/diagram/delete_component.rs
+++ b/lib/sdf-server/src/service/diagram/delete_component.rs
@@ -46,6 +46,7 @@ pub async fn delete_components(
 
     let mut components = HashMap::new();
     let mut socket_map = HashMap::new();
+    let mut socket_map_head = HashMap::new();
     for component_id in request.component_ids {
         let component: Component = Component::get_by_id(&ctx, component_id).await?;
         let incoming_connections = component.incoming_connections(&ctx).await?.clone();
@@ -70,7 +71,7 @@ pub async fn delete_components(
             // to_delete=True
             let component: Component = Component::get_by_id(&ctx, component_id).await?;
             let payload = component
-                .into_frontend_type_for_default_view(&ctx, ChangeStatus::Deleted, &mut socket_map)
+                .into_frontend_type(&ctx, None, ChangeStatus::Deleted, &mut socket_map)
                 .await?;
             WsEvent::component_updated(&ctx, payload)
                 .await?
@@ -80,10 +81,11 @@ pub async fn delete_components(
             let component: Component =
                 Component::get_by_id(&base_change_set_ctx, component_id).await?;
             let payload = component
-                .into_frontend_type_for_default_view(
+                .into_frontend_type(
                     &base_change_set_ctx,
+                    None,
                     ChangeStatus::Deleted,
-                    &mut socket_map,
+                    &mut socket_map_head,
                 )
                 .await?;
             WsEvent::component_updated(&ctx, payload)


### PR DESCRIPTION
Sends a WsEvent without geometry so views are not taken into account when deleting a component.

Fixes BUG-699

To test this: create two components in a view that is not the default view. One that will have a resource (successfully get created) and one that does not (sec group and docker image were my test). Apply to head, be sure that a resource is created for the resource one. Then in a new change set, attempt to delete them. Delete should succeed. 