### PR TITLE
Feat/fixup e2e test

### DIFF
--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cypress-tests
     environment: ${{ inputs.environment }}
-    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    if: failure()
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -145,7 +145,7 @@ jobs:
             fi
           done
           # If at least one valid failure marker is present, then page
-          if [ "$has_artifacts" = true ]; then
+          if [ "$has_artifacts" = true ] && [ "${{ github.ref_name }}" = "main" ]; then
             curl --location "${{ secrets.FIREHYDRANT_WEBHOOK_URL }}" \
               --header "Content-Type: application/json" \
               --data "{

--- a/.github/workflows/run-api-test.yml
+++ b/.github/workflows/run-api-test.yml
@@ -128,14 +128,16 @@ jobs:
           exit "$exit_code"
 
       - name: Upload artifact if exit code 53
-        if: ${{ failure() && env.last_exit_code == '53' }}
+        if: failure()
         run: |
-          echo "Uploading marker for test ${{ matrix.tests.name }}"
-          mkdir -p artifacts/${{ matrix.tests.name }}
-          echo "failure-marker" > artifacts/${{ matrix.tests.name }}/failure-marker
+          if [ "${{ env.last_exit_code }}" == "53" ]; then
+            echo "Uploading marker for test ${{ matrix.tests.name }}"
+            mkdir -p artifacts/${{ matrix.tests.name }}
+            echo "failure-marker" > artifacts/${{ matrix.tests.name }}/failure-marker
+          fi
 
       - name: Upload artifacts
-        if: ${{ failure() && env.last_exit_code == '53' }}
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.tests.name }}
@@ -145,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: api-test
     environment: ${{ inputs.environment }}
-    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    if: failure()
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -163,7 +165,7 @@ jobs:
             fi
           done
           # If at least one valid failure marker is present, then page
-          if [ "$has_artifacts" = true ]; then
+          if [ "$has_artifacts" = true ] && [ "${{ github.ref_name }}" = "main" ]; then
               curl --location "${{ secrets.FIREHYDRANT_WEBHOOK_URL }}" \
               --header "Content-Type: application/json" \
               --data "{


### PR DESCRIPTION
I'm unclear why, but this
`if: ${{ failure() && github.ref == 'refs/heads/main' }}` 

Was not triggering if there was a failure on `main`, nor when I changed it to my branch did it fire correctly. I tried both conditions individually, and they both fired correctly, so something about the && not being honoured correctly with a failure condition within the github workflow.

As a workaround I've moved the comparison logic for both e2e tests for branch into the shell, which should evaluate more accurately.

NB: the other comparison
`if: ${{ failure() && env.last_exit_code == '53' }}`
has the same bug