### PR TITLE
fix: retry case on api tests exiting with wrong exit code

### DIFF
--- a/.github/workflows/run-api-test.yml
+++ b/.github/workflows/run-api-test.yml
@@ -121,7 +121,6 @@ jobs:
 
           if [ $n -ge $max_retries ]; then
             echo "All $max_retries attempts failed."
-            exit_code=1
           fi
 
           echo "last_exit_code=$exit_code" >> "$GITHUB_ENV"


### PR DESCRIPTION
If all the retries for the e2e tests fail, it was setting the exit code to 1, which is not the exit code we want to report on/alert from.

If all the retries fail, we want to report the exit_code of the deno task, which if it is a valid failure is 53.