### PR TITLE
Revert "chore: temporarily shrink size of workspace snapshots cache"

### DIFF
--- a/lib/si-layer-cache/src/db.rs
+++ b/lib/si-layer-cache/src/db.rs
@@ -181,7 +181,7 @@ where
             cache_config
                 .clone()
                 .with_name(workspace_snapshot::CACHE_NAME)
-                .memory_usable_max_percent(20)
+                .memory_usable_max_percent(50)
                 .disk_usable_max_percent(50)
                 .with_path_join(workspace_snapshot::CACHE_NAME),
             compute_executor.clone(),


### PR DESCRIPTION
Seems that now we have a smaller mem cache, that the layer cache startup has triped in duration, likely due to additional pressure on the disks now the cache is smaller.

![Screenshot 2024-12-13 at 00 27 57](https://github.com/user-attachments/assets/6de8a52f-fdbe-452e-bd74-919a178a468e)
![Screenshot 2024-12-13 at 00 28 00](https://github.com/user-attachments/assets/d5c4ac98-2712-4362-97a8-963e981aa613)
Where the deployment happened at 3pm on the graphs

Reverting just to give us a bit more time to figure out what to do here to make it less likely that the train to prod will have issues tomorrow.