### PR TITLE
feat: make foyer disk recover concurrency configurable

### DIFF
--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -67,6 +67,7 @@ url = "$SI_NATS_URL"
 [layer_db_config.cache_config]
 disk_path = "$SI_LAYER_CACHE_DISK_PATH"
 disk_admission_rate_limit = $SI_LAYER_CACHE_DISK_ADMISSION_RATE_LIMIT
+disk_recover_concurrency = $SI_LAYER_CACHE_DISK_RECOVER_CONURRENCY
 
 [audit.pg]
 user = "si"

--- a/lib/si-layer-cache/src/hybrid_cache.rs
+++ b/lib/si-layer-cache/src/hybrid_cache.rs
@@ -26,6 +26,7 @@ const DEFAULT_DISK_BUFFER_SIZE: usize = 1024 * 1024 * 128; // 128mb
 const DEFAULT_DISK_BUFFER_FLUSHERS: usize = 2;
 const DEFAULT_DISK_INDEXER_SHARDS: usize = 64;
 const DEFAULT_DISK_RECLAIMERS: usize = 2;
+const DEFAULT_DISK_RECOVER_CONCURRENCY: usize = 8;
 
 static TOTAL_SYSTEM_MEMORY_BYTES: LazyLock<u64> = LazyLock::new(|| {
     let sys = sysinfo::System::new_all();
@@ -126,6 +127,7 @@ where
                     .with_buffer_pool_size(config.disk_buffer_size)
                     .with_eviction_pickers(vec![Box::<FifoPicker>::default()])
                     .with_flushers(config.disk_buffer_flushers)
+                    .with_recover_concurrency(config.disk_recover_concurrency)
                     .with_indexer_shards(config.disk_indexer_shards)
                     .with_reclaimers(config.disk_reclaimers),
             )
@@ -208,6 +210,7 @@ pub struct CacheConfig {
     disk_indexer_shards: usize,
     disk_path: PathBuf,
     disk_reclaimers: usize,
+    disk_recover_concurrency: usize,
 }
 
 impl Default for CacheConfig {
@@ -229,6 +232,7 @@ impl Default for CacheConfig {
             disk_indexer_shards: DEFAULT_DISK_INDEXER_SHARDS,
             disk_path,
             disk_reclaimers: DEFAULT_DISK_RECLAIMERS,
+            disk_recover_concurrency: DEFAULT_DISK_RECOVER_CONCURRENCY,
         }
     }
 }


### PR DESCRIPTION
I _think_ this controls how many threads foyer spins up to read in the disk cache. This is set to the foyer default of `8`. We should tune this in tools prod to see how it impacts our startup performance