### PR TITLE
feat: Add button to create an "automation token" and use it in SDF API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,7 +1878,6 @@ dependencies = [
  "si-frontend-types",
  "si-hash",
  "si-id",
- "si-jwt-public-key",
  "si-layer-cache",
  "si-pkg",
  "si-runtime",
@@ -4236,6 +4235,27 @@ dependencies = [
  "serde",
  "serde_json",
  "ulid",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d208407d7552cd041d8cdb69a1bc3303e029c598738177a3d87082004dc0e1e"
+dependencies = [
+ "monostate-impl",
+ "serde",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ce64b975ed4f123575d11afd9491f2e37bbd5813fbfbc0f09ae1fbddea74e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6623,6 +6643,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "jwt-simple",
+ "monostate",
  "remain",
  "serde",
  "si-events",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ lazy_static = "1.5.0"
 manyhow = { version = "0.11.4", features = ["darling"] }
 mime_guess = { version = "=2.0.4" } # TODO(fnichol): 2.0.5 sets an env var in build.rs which needs to be tracked, required by reqwest
 miniz_oxide = { version = "0.8.0", features = ["simd"] }
+monostate = "0.1.13"
 names = { version = "0.14.0", default-features = false }
 nix = { version = "0.26.0", features = [
     "fs",

--- a/app/auth-portal/src/pages/WorkspaceDetailsPage.vue
+++ b/app/auth-portal/src/pages/WorkspaceDetailsPage.vue
@@ -37,6 +37,18 @@
           </div>
         </template>
         <IconButton
+          v-if="featureFlagsStore.AUTOMATION_API"
+          tooltip="Create API Token for Automation"
+          tooltipPlacement="top"
+          :icon="'clipboard-copy'"
+          size="lg"
+          class="flex-none"
+          iconTone="warning"
+          :iconIdleTone="draftWorkspace.isFavourite ? 'warning' : 'shade'"
+          iconBgActiveTone="action"
+          @click="createAutomationToken()"
+        />
+        <IconButton
           :tooltip="
             draftWorkspace.isFavourite ? 'Remove Favourite' : 'Add Favourite'
           "
@@ -254,10 +266,12 @@ import { useWorkspacesStore, WorkspaceId } from "@/store/workspaces.store";
 import { tracker } from "@/lib/posthog";
 import { API_HTTP_URL } from "@/store/api";
 import MemberListItem from "@/components/MemberListItem.vue";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 
 const authStore = useAuthStore();
 const workspacesStore = useWorkspacesStore();
 const router = useRouter();
+const featureFlagsStore = useFeatureFlagsStore();
 
 const props = defineProps({
   workspaceId: { type: String as PropType<WorkspaceId>, required: true },
@@ -426,6 +440,17 @@ const favouriteWorkspace = async (isFavourite: boolean) => {
   await workspacesStore.SET_FAVOURITE(props.workspaceId, isFavourite);
 
   draftWorkspace.isFavourite = isFavourite;
+};
+
+const createAutomationToken = async () => {
+  if (!props.workspaceId) return;
+
+  const { result } = await workspacesStore.CREATE_AUTOMATION_TOKEN(
+    props.workspaceId,
+  );
+  if (result.success) {
+    await navigator.clipboard.writeText(result.data.token);
+  }
 };
 
 const deleteWorkspace = async () => {

--- a/app/auth-portal/src/store/feature_flags.store.ts
+++ b/app/auth-portal/src/store/feature_flags.store.ts
@@ -12,12 +12,14 @@ export const useFeatureFlagsStore = () => {
         ADMIN_PAGE: false,
         ON_DEMAND_ASSETS: false,
         CHANGE_USER_ROLE: false,
+        AUTOMATION_API: false,
       }),
       onActivated() {
         posthog.onFeatureFlags((flags) => {
           this.ADMIN_PAGE = flags.includes("auth_portal_admin_page");
           this.ON_DEMAND_ASSETS = flags.includes("on_demand_assets");
           this.CHANGE_USER_ROLE = flags.includes("change_user_role");
+          this.AUTOMATION_API = flags.includes("automation_api");
         });
       },
     }),

--- a/app/auth-portal/src/store/workspaces.store.ts
+++ b/app/auth-portal/src/store/workspaces.store.ts
@@ -218,6 +218,13 @@ export const useWorkspacesStore = defineStore("workspaces", {
       });
     },
 
+    async CREATE_AUTOMATION_TOKEN(workspaceId: WorkspaceId) {
+      return new ApiRequest<{ token: string }>({
+        method: "post",
+        url: `/workspaces/${workspaceId}/createAutomationToken`,
+      });
+    },
+
     async CHANGE_MEMBERSHIP(
       workspaceId: WorkspaceId,
       userId: UserId,

--- a/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
+++ b/app/web/src/components/Workspace/WorkspaceCustomizeAssets.vue
@@ -172,6 +172,7 @@ const funcStore = useFuncStore();
 const moduleStore = useModuleStore();
 
 const selectedVariantId = computed(() => assetStore.selectedVariantId);
+
 const selectedFuncId = computed(() => funcStore.selectedFuncId);
 const loadAssetsRequestStatus = assetStore.getRequestStatus(
   "LOAD_SCHEMA_VARIANT_LIST",

--- a/bin/auth-api/README.md
+++ b/bin/auth-api/README.md
@@ -36,6 +36,7 @@ instances.
 While working on the auth stack, we still need to run it locally and configure things to point to our local auth stack:
 
 - update auth-api env vars in `bin/auth-api/.env.local`
+    - if you don't have .env.local yet, copy the `auth api local dev .env.local` key into the `.env.local` file.
     - fill in `AUTH0_CLIENT_SECRET` and `AUTH0_M2M_CLIENT_SECRET` and `STRIPE_API_KEY` (get from 1pass)
     - (OPTIONAL) set auth-api redis url to a locally running redis instance (ex: `REDIS_URL=127.0.0.1:6379`) only if
       needing to test redis. Falls back to in-memory storage...
@@ -44,12 +45,14 @@ While working on the auth stack, we still need to run it locally and configure t
     VITE_AUTH_API_URL=http://localhost:9001
     VITE_AUTH_PORTAL_URL=http://localhost:9000
   ```
-- run the backend but using the local auth stack by setting env var `SI_AUTH_API_URL=http://localhost:9001` (
-  ex: `SI_AUTH_API_URL=http://localhost:9001 buck2 run dev:up`)
-- run the db migrations (`pnpm run db:reset`) locally after booting your local database
+- run the db migrations (`pnpm run db:reset`) locally after booting your local database (run `buck2 dev:stop` and then `buck2 dev` and hope nobody connects in the meantime!).
 - run the auth api `pnpm run dev` in this directory or `pnpm dev:auth-api` at the root
 - run the auth portal `pnpm run dev` in `app/auth-portal` or `pnpm dev:auth-portal` at the root
-- (or run both by running `pnpm run dev:auth` at the root)
+- (or run both by running `pnpm run dev:auth` at the root, but running them separately gives you nice console output)
+- Run the backend, but pointing at your shiny new auth API:
+  ```bash
+  SI_AUTH_API_URL=http://localhost:9001 SI_CREATE_WORKSPACE_PERMISSIONS=open buck2 run dev
+  ```
 
 ## Deploy the Auth API to Production
 

--- a/bin/auth-api/src/routes/auth.routes.ts
+++ b/bin/auth-api/src/routes/auth.routes.ts
@@ -74,7 +74,11 @@ router.post("/auth/login", async (ctx) => {
     throw new ApiError("Forbidden", "You do not have access to that workspace");
   }
 
-  const token = createSdfAuthToken(user.id, workspaceId);
+  const token = createSdfAuthToken({
+    userId: user.id,
+    workspaceId,
+    role: "web",
+  });
 
   ctx.body = { token };
 });

--- a/bin/auth-api/src/routes/workspace.routes.ts
+++ b/bin/auth-api/src/routes/workspace.routes.ts
@@ -69,19 +69,21 @@ async function extractOwnWorkspaceIdParam(ctx: CustomRouteContext) {
   return workspace;
 }
 
-async function isWorkspaceOwner(ctx: CustomRouteContext) {
+async function authorizeWorkspaceRoute(ctx: CustomRouteContext, role?: RoleType) {
   const workspace = await extractWorkspaceIdParam(ctx);
-
   const authUser = extractAuthUser(ctx);
-  const memberRole = await userRoleForWorkspace(authUser.id, workspace.id);
-  if (memberRole !== RoleType.OWNER) {
-    throw new ApiError(
-      "Forbidden",
-      "You do not have the correct permisison to edit this workspace",
-    );
+
+  if (role) {
+    const memberRole = await userRoleForWorkspace(authUser.id, workspace.id);
+    if (memberRole !== role) {
+      throw new ApiError(
+        "Forbidden",
+        "You do not have the correct permission to edit this workspace",
+      );
+    }
   }
 
-  return true;
+  return { authUser, workspace };
 }
 
 router.get("/workspaces/:workspaceId", async (ctx) => {
@@ -141,10 +143,7 @@ router.post("/workspaces/new", async (ctx) => {
 });
 
 router.patch("/workspaces/:workspaceId", async (ctx) => {
-  const authUser = extractAuthUser(ctx);
-  await isWorkspaceOwner(ctx);
-
-  const workspace = await extractOwnWorkspaceIdParam(ctx);
+  const { authUser, workspace } = await authorizeWorkspaceRoute(ctx, RoleType.OWNER);
 
   const reqBody = validate(
     ctx.request.body,
@@ -181,9 +180,7 @@ export type Member = {
   signupAt: Date | null;
 };
 router.get("/workspace/:workspaceId/members", async (ctx) => {
-  extractAuthUser(ctx);
-
-  const workspace = await extractOwnWorkspaceIdParam(ctx);
+  const { workspace } = await authorizeWorkspaceRoute(ctx);
 
   const members: Member[] = [];
   const workspaceMembers = await getWorkspaceMembers(workspace.id);
@@ -202,11 +199,7 @@ router.get("/workspace/:workspaceId/members", async (ctx) => {
 });
 
 router.post("/workspace/:workspaceId/membership", async (ctx) => {
-  // user must be logged in
-  const authUser = extractAuthUser(ctx);
-  await isWorkspaceOwner(ctx);
-
-  const workspace = await extractOwnWorkspaceIdParam(ctx);
+  const { authUser, workspace } = await authorizeWorkspaceRoute(ctx, RoleType.OWNER);
 
   const reqBody = validate(
     ctx.request.body,
@@ -241,11 +234,7 @@ router.post("/workspace/:workspaceId/membership", async (ctx) => {
 });
 
 router.post("/workspace/:workspaceId/members", async (ctx) => {
-  // user must be logged in
-  const authUser = extractAuthUser(ctx);
-  await isWorkspaceOwner(ctx);
-
-  const workspace = await extractOwnWorkspaceIdParam(ctx);
+  const { authUser, workspace } = await authorizeWorkspaceRoute(ctx, RoleType.OWNER);
 
   const reqBody = validate(
     ctx.request.body,
@@ -273,11 +262,7 @@ router.post("/workspace/:workspaceId/members", async (ctx) => {
 });
 
 router.delete("/workspace/:workspaceId/members", async (ctx) => {
-  // user must be logged in
-  const authUser = extractAuthUser(ctx);
-  await isWorkspaceOwner(ctx);
-
-  const workspace = await extractOwnWorkspaceIdParam(ctx);
+  const { authUser, workspace } = await authorizeWorkspaceRoute(ctx, RoleType.OWNER);
 
   const reqBody = validate(
     ctx.request.body,
@@ -310,9 +295,7 @@ router.delete("/workspace/:workspaceId/members", async (ctx) => {
 });
 
 router.patch("/workspaces/:workspaceId/setDefault", async (ctx) => {
-  const authUser = extractAuthUser(ctx);
-
-  const workspace = await extractWorkspaceIdParam(ctx);
+  const { authUser, workspace } = await authorizeWorkspaceRoute(ctx);
 
   tracker.trackEvent(authUser, "set_default_workspace", {
     defaultWorkspaceSetBy: authUser.email,
@@ -327,9 +310,7 @@ router.patch("/workspaces/:workspaceId/setDefault", async (ctx) => {
 });
 
 router.patch("/workspaces/:workspaceId/favourite", async (ctx) => {
-  const authUser = extractAuthUser(ctx);
-
-  const workspace = await extractWorkspaceIdParam(ctx);
+  const { authUser, workspace } = await authorizeWorkspaceRoute(ctx);
 
   const reqBody = validate(
     ctx.request.body,
@@ -366,16 +347,15 @@ router.patch("/workspaces/:workspaceId/favourite", async (ctx) => {
 });
 
 router.get("/workspaces/:workspaceId/go", async (ctx) => {
-  const workspace = await extractOwnWorkspaceIdParam(ctx);
+  const { authUser, workspace } = await authorizeWorkspaceRoute(ctx);
 
+  // TODO check this in all endpoints?
   if (workspace.quarantinedAt !== null) {
     throw new ApiError(
       "Unauthorized",
       `This workspace (ID ${workspace.id}) is quarantined. Contact SI support`,
     );
   }
-
-  const authUser = extractAuthUser(ctx);
 
   // we require the user to have verified their email before they can log into a workspace
   if (!authUser.emailVerified) {
@@ -424,6 +404,20 @@ router.get("/workspaces/:workspaceId/go", async (ctx) => {
   ctx.redirect(redirectUrl);
 });
 
+router.post("/workspaces/:workspaceId/createAutomationToken", async (ctx) => {
+  const { authUser, workspace } = await authorizeWorkspaceRoute(ctx, RoleType.OWNER);
+
+  const token = createSdfAuthToken({
+    userId: authUser.id,
+    workspaceId: workspace.id,
+    role: "automation",
+  }, {
+    expiresIn: "1 day",
+  });
+
+  ctx.body = { token };
+});
+
 router.post("/complete-auth-connect", async (ctx) => {
   const reqBody = validate(
     ctx.request.body,
@@ -441,7 +435,11 @@ router.post("/complete-auth-connect", async (ctx) => {
   const user = await getUserById(connectPayload.userId);
   if (!user) throw new ApiError("Conflict", "User no longer exists");
 
-  const token = createSdfAuthToken(user.id, workspace.id);
+  const token = createSdfAuthToken({
+    userId: user.id,
+    workspaceId: workspace.id,
+    role: "web",
+  });
 
   ctx.body = {
     user,

--- a/bin/auth-api/src/services/auth.service.ts
+++ b/bin/auth-api/src/services/auth.service.ts
@@ -1,5 +1,5 @@
 import { User, Workspace } from "@prisma/client";
-import { JwtPayload } from "jsonwebtoken";
+import { JwtPayload, SignOptions } from "jsonwebtoken";
 import * as Koa from "koa";
 import { nanoid } from "nanoid";
 import _ from "lodash";
@@ -8,8 +8,8 @@ import { ApiError } from "../lib/api-error";
 import { setCache } from "../lib/cache";
 import { createJWT, verifyJWT } from "../lib/jwt";
 import { tryCatch } from "../lib/try-catch";
-import { getUserById } from "./users.service";
-import { getWorkspaceById } from "./workspaces.service";
+import { getUserById, UserId } from "./users.service";
+import { getWorkspaceById, WorkspaceId } from "./workspaces.service";
 import { posthog } from "../lib/posthog";
 
 export const SI_COOKIE_NAME = "si-auth";
@@ -48,23 +48,45 @@ export async function decodeAuthToken(token: string) {
 
 // Auth tokens used for communication between the user's browser and SDF
 // and between that SDF instance and this auth api if necessary
-type SdfAuthTokenData = {
+export type SdfAuthTokenPayload = SdfAuthTokenPayloadV1 | SdfAuthTokenPayloadV2;
+export type SdfAuthTokenRole = "web" | "automation";
+
+interface SdfAuthTokenPayloadV2 {
+  version: "2";
+  userId: UserId;
+  workspaceId: WorkspaceId;
+  role: SdfAuthTokenRole;
+}
+
+// Old auth token versions
+interface SdfAuthTokenPayloadV1 {
   user_pk: string;
   workspace_pk: string;
-};
+}
 
-// will figure out what we want to pass in here...
-export function createSdfAuthToken(userId: string, workspaceId: string) {
-  const payload: SdfAuthTokenData = {
-    user_pk: userId,
-    workspace_pk: workspaceId,
-  };
-  // can add more metadata, expiry, etc...
-  return createJWT(payload, { subject: userId });
+// Pass a V2 token in.
+export function createSdfAuthToken(
+  payload: Omit<SdfAuthTokenPayloadV2, "version">,
+  options?: Omit<SignOptions, 'algorithm' | 'subject'>,
+) {
+  function createPayload(): SdfAuthTokenPayload {
+    switch (payload.role) {
+      case "web":
+        // For web tokens, generate the old version until prod is able to handle new ones.
+        return { user_pk: payload.userId, workspace_pk: payload.workspaceId };
+      case "automation":
+        // Expire automation tokens quickly right now
+        return { version: "2", ...payload };
+      default:
+        return payload.role satisfies never;
+    }
+  }
+
+  return createJWT(createPayload(), { subject: payload.userId, ...(options ?? {}) });
 }
 
 export async function decodeSdfAuthToken(token: string) {
-  return verifyJWT(token) as SdfAuthTokenData & JwtPayload;
+  return verifyJWT(token) as SdfAuthTokenPayload & JwtPayload;
 }
 
 function wipeAuthCookie(ctx: Koa.Context) {

--- a/bin/auth-api/test/auth-routes.test.ts
+++ b/bin/auth-api/test/auth-routes.test.ts
@@ -90,13 +90,24 @@ t.test('Auth routes', async () => {
     });
 
     t.test('verify sdf auth token succeeds for whoami', async () => {
-      const authData = await decodeAuthToken(validToken);
-      const user = await getUserById(authData.userId);
+      const { userId } = await decodeAuthToken(validToken);
+      const user = await getUserById(userId);
       if (!user) {
         t.bailout("User Fetch has failed");
       }
-      const workspace = await createWorkspace(user!, InstanceEnvType.SI, "https://app.systeminit.com", `${user!.nickname}'s Testing Workspace`, false);
-      const sdfToken = createSdfAuthToken(authData.userId, workspace.id);
+      const workspace = await createWorkspace(
+        user!,
+        InstanceEnvType.SI,
+        "https://app.systeminit.com",
+        `${user!.nickname}'s Testing Workspace`,
+        false,
+        "",
+      );
+      const sdfToken = createSdfAuthToken({
+        userId,
+        workspaceId: workspace.id,
+        role: "web",
+      });
       await request.get('/whoami')
         .set('cookie', `si-auth=${sdfToken}`)
         .expectOk()

--- a/bin/auth-api/test/helpers/dummy-factory.ts
+++ b/bin/auth-api/test/helpers/dummy-factory.ts
@@ -52,7 +52,14 @@ export async function createDummyUser(options?: {
     await saveTosAgreement(user, LATEST_TOS_VERSION_ID, '1.2.3.4');
   }
 
-  const workspace = await createWorkspace(user, InstanceEnvType.SI, "https://app.systeminit.com", `${user.nickname}'s Testing Workspace`, false);
+  const workspace = await createWorkspace(
+    user,
+    InstanceEnvType.SI,
+    "https://app.systeminit.com",
+    `${user.nickname}'s Testing Workspace`,
+    false,
+    "",
+  );
 
   return { user, workspace };
 }

--- a/bin/auth-api/test/workspace-routes.test.ts
+++ b/bin/auth-api/test/workspace-routes.test.ts
@@ -180,8 +180,8 @@ t.test('Workspace routes', async () => {
           const token = res.body.token;
           const decoded = await decodeSdfAuthToken(token);
           // check the token includes the user and workspace ids
-          expect(decoded.user_pk).to.equal(user.id);
-          expect(decoded.workspace_pk).to.equal(workspace.id);
+          expect(decoded.userId).to.equal(user.id);
+          expect(decoded.workspaceId).to.equal(workspace.id);
         });
     });
 

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -24,7 +24,6 @@ rust_library(
         "//lib/si-frontend-types-rs:si-frontend-types",
         "//lib/si-hash:si-hash",
         "//lib/si-id:si-id",
-        "//lib/si-jwt-public-key:si-jwt-public-key",
         "//lib/si-layer-cache:si-layer-cache",
         "//lib/si-pkg:si-pkg",
         "//lib/si-runtime-rs:si-runtime",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -25,7 +25,6 @@ si-data-pg = { path = "../../lib/si-data-pg" }
 si-events = { path = "../../lib/si-events-rs" }
 si-frontend-types = { path = "../../lib/si-frontend-types-rs" }
 si-hash = { path = "../../lib/si-hash" }
-si-jwt-public-key = { path = "../../lib/si-jwt-public-key" }
 si-id = { path = "../../lib/si-id" }
 si-layer-cache = { path = "../../lib/si-layer-cache" }
 si-pkg = { path = "../../lib/si-pkg" }

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -1108,12 +1108,6 @@ impl AccessBuilder {
     }
 }
 
-impl From<DalContext> for AccessBuilder {
-    fn from(ctx: DalContext) -> Self {
-        Self::new(ctx.tenancy, ctx.history_actor)
-    }
-}
-
 /// A builder for a [`DalContext`].
 #[derive(Clone)]
 pub struct DalContextBuilder {

--- a/lib/dal/src/job/definition/action.rs
+++ b/lib/dal/src/job/definition/action.rs
@@ -49,7 +49,7 @@ pub struct ActionJob {
 
 impl ActionJob {
     pub fn new(ctx: &DalContext, id: ActionId) -> Box<Self> {
-        let access_builder = AccessBuilder::from(ctx.clone());
+        let access_builder = ctx.access_builder();
         let visibility = *ctx.visibility();
 
         Box::new(Self {

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -124,7 +124,7 @@ pub use standard_connection::{HelperError, HelperResult};
 pub use standard_model::{StandardModel, StandardModelError, StandardModelResult};
 pub use tenancy::{Tenancy, TenancyError};
 pub use timestamp::{Timestamp, TimestampError};
-pub use user::{User, UserClaim, UserError, UserPk, UserResult};
+pub use user::{User, UserError, UserPk, UserResult};
 pub use visibility::Visibility;
 pub use workspace::{Workspace, WorkspaceError, WorkspacePk, WorkspaceResult};
 pub use workspace_snapshot::graph::{WorkspaceSnapshotGraph, WorkspaceSnapshotGraphVCurrent};

--- a/lib/module-index-server/src/routes/list_modules_route.rs
+++ b/lib/module-index-server/src/routes/list_modules_route.rs
@@ -67,7 +67,7 @@ pub async fn list_module_route(
         .filter(si_module::Column::RejectedAt.is_null())
         .filter(si_module::Column::Kind.eq(kind.to_db_kind()));
     let query = if !su {
-        let user_id = user_claim.user_pk.to_string();
+        let user_id = user_claim.user_id().to_string();
         query.filter(si_module::Column::OwnerUserId.eq(user_id))
     } else {
         query

--- a/lib/module-index-server/src/routes/upsert_module_route.rs
+++ b/lib/module-index-server/src/routes/upsert_module_route.rs
@@ -188,7 +188,7 @@ pub async fn upsert_module_route(
     let new_module = si_module::ActiveModel {
         name: Set(module_metadata.name().to_owned()),
         description: Set(Some(module_metadata.description().to_owned())),
-        owner_user_id: Set(user_claim.user_pk.to_string()),
+        owner_user_id: Set(user_claim.user_id().to_string()),
         owner_display_name: Set(Some(module_metadata.created_by().to_owned())),
         latest_hash: Set(module_metadata.hash().to_string()),
         // maybe use db's `CLOCK_TIMESTAMP()`?

--- a/lib/module-index-server/src/routes/upsert_workspace_route.rs
+++ b/lib/module-index-server/src/routes/upsert_workspace_route.rs
@@ -83,7 +83,7 @@ pub async fn upsert_workspace_route(
     let new_module = si_module::ActiveModel {
         name: Set(export_metadata.name.to_owned()),
         description: Set(Some(export_metadata.description.to_owned())),
-        owner_user_id: Set(user_claim.user_pk.to_string()),
+        owner_user_id: Set(user_claim.user_id().to_string()),
         owner_display_name: Set(Some(export_metadata.created_by.to_owned())),
         latest_hash: Set(hash.to_string()),
         latest_hash_created_at: Set(DateTime::<FixedOffset>::from_naive_utc_and_offset(

--- a/lib/sdf-server/src/service/v2/func/generate_aws_function.rs
+++ b/lib/sdf-server/src/service/v2/func/generate_aws_function.rs
@@ -29,8 +29,8 @@ pub struct GenerateAwsFunctionQuery {
 #[allow(clippy::too_many_arguments)]
 pub async fn generate_aws_function(
     HandlerContext(builder): HandlerContext,
-    AssetSprayer(asset_sprayer): AssetSprayer,
     AccessBuilder(access_builder): AccessBuilder,
+    AssetSprayer(asset_sprayer): AssetSprayer,
     PosthogClient(posthog_client): PosthogClient,
     OriginalUri(original_uri): OriginalUri,
     Host(host_name): Host,

--- a/lib/sdf-server/src/service/ws/crdt.rs
+++ b/lib/sdf-server/src/service/ws/crdt.rs
@@ -71,7 +71,7 @@ pub async fn crdt(
     State(broadcast_groups): State<BroadcastGroups>,
     State(nats_multiplexer_clients): State<NatsMultiplexerClients>,
 ) -> Result<impl IntoResponse, WsError> {
-    let workspace_pk = claim.workspace_pk;
+    let workspace_pk = claim.workspace_id();
     let channel_name = Subject::from(format!("crdt.{workspace_pk}.{id}"));
 
     let receiver = nats_multiplexer_clients

--- a/lib/sdf-server/src/service/ws/workspace_updates.rs
+++ b/lib/sdf-server/src/service/ws/workspace_updates.rs
@@ -28,7 +28,7 @@ pub async fn workspace_updates(
         run_workspace_updates_proto(
             socket,
             nats,
-            claim.workspace_pk,
+            claim.workspace_id(),
             channel_multiplexer_clients.ws,
             shutdown_token,
         )

--- a/lib/si-jwt-public-key/BUCK
+++ b/lib/si-jwt-public-key/BUCK
@@ -12,6 +12,7 @@ rust_library(
         "//lib/telemetry-rs:telemetry",
         "//third-party/rust:base64",
         "//third-party/rust:jwt-simple",
+        "//third-party/rust:monostate",
         "//third-party/rust:remain",
         "//third-party/rust:serde",
         "//third-party/rust:thiserror",

--- a/lib/si-jwt-public-key/Cargo.toml
+++ b/lib/si-jwt-public-key/Cargo.toml
@@ -19,3 +19,4 @@ remain = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+monostate = { workspace = true }

--- a/lib/si-jwt-public-key/src/lib.rs
+++ b/lib/si-jwt-public-key/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use base64::{engine::general_purpose, Engine};
 use jwt_simple::{common::VerificationOptions, prelude::*};
+use monostate::MustBe;
 use serde::{Deserialize, Serialize};
 use telemetry::prelude::*;
 use thiserror::Error;
@@ -77,10 +78,77 @@ impl JwtConfig {
     }
 }
 
+/** Role indicating what permissions the user should have */
+#[derive(Deserialize, Serialize, Debug, Copy, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum SiJwtClaimRole {
+    Web,
+    Automation,
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
-pub struct SiJwtClaims {
-    pub user_pk: UserPk,
-    pub workspace_pk: WorkspacePk,
+#[serde(untagged)]
+pub enum SiJwtClaims {
+    V2(SiJwtClaimsV2),
+    #[serde(rename_all = "snake_case")]
+    V1(SiJwtClaimsV1),
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SiJwtClaimsV2 {
+    version: MustBe!("2"),
+    user_id: UserPk,
+    workspace_id: WorkspacePk,
+    role: SiJwtClaimRole,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct SiJwtClaimsV1 {
+    user_pk: UserPk,
+    workspace_pk: WorkspacePk,
+}
+
+impl SiJwtClaims {
+    pub fn user_id(&self) -> UserPk {
+        match self {
+            Self::V2(SiJwtClaimsV2 { user_id, .. }) => *user_id,
+            Self::V1(SiJwtClaimsV1 { user_pk, .. }) => *user_pk,
+        }
+    }
+
+    pub fn workspace_id(&self) -> WorkspacePk {
+        match self {
+            Self::V2(SiJwtClaimsV2 { workspace_id, .. }) => *workspace_id,
+            Self::V1(SiJwtClaimsV1 { workspace_pk, .. }) => *workspace_pk,
+        }
+    }
+
+    pub fn authorized_for(&self, required_role: SiJwtClaimRole) -> bool {
+        let role = match self {
+            Self::V2(SiJwtClaimsV2 { role, .. }) => *role,
+            Self::V1(SiJwtClaimsV1 { .. }) => SiJwtClaimRole::Web,
+        };
+        role == required_role
+    }
+
+    pub fn for_web(user_id: UserPk, workspace_id: WorkspacePk) -> Self {
+        Self::V2(SiJwtClaimsV2 {
+            version: MustBe!("2"),
+            user_id,
+            workspace_id,
+            role: SiJwtClaimRole::Web,
+        })
+    }
+
+    pub async fn from_bearer_token(
+        public_key: JwtPublicSigningKeyChain,
+        token: impl AsRef<str>,
+    ) -> JwtKeyResult<SiJwtClaims> {
+        let claims = validate_bearer_token(public_key, token).await?;
+        Ok(claims.custom)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
@@ -177,12 +245,11 @@ pub async fn validate_bearer_token(
     public_key: JwtPublicSigningKeyChain,
     bearer_token: impl AsRef<str>,
 ) -> JwtKeyResult<JWTClaims<SiJwtClaims>> {
-    let bearer_token = bearer_token.as_ref();
-    let token = if let Some(token) = bearer_token.strip_prefix("Bearer ") {
-        token.to_string()
-    } else {
-        return Err(JwtPublicSigningKeyError::BearerToken);
-    };
+    let token = bearer_token
+        .as_ref()
+        .strip_prefix("Bearer ")
+        .ok_or(JwtPublicSigningKeyError::BearerToken)?
+        .to_string();
 
     let claims =
         tokio::task::spawn_blocking(move || public_key.verify_token(&token, None)).await??;
@@ -194,162 +261,170 @@ pub async fn validate_bearer_token(
 mod tests {
     use super::*;
 
+    // TODO test these with V2 and V1
+
+    fn v1_and_v2_claims() -> impl IntoIterator<Item = SiJwtClaims> {
+        [
+            SiJwtClaims::V1(SiJwtClaimsV1 {
+                user_pk: UserPk::generate(),
+                workspace_pk: WorkspacePk::generate(),
+            }),
+            SiJwtClaims::V2(SiJwtClaimsV2 {
+                version: MustBe!("2"),
+                user_id: UserPk::generate(),
+                workspace_id: WorkspacePk::generate(),
+                role: SiJwtClaimRole::Web,
+            }),
+        ]
+    }
+
     #[tokio::test]
     async fn validate_with_primary_rs256() {
-        println!("generating key...");
-        let key_pair = RS256KeyPair::generate(2048).expect("generate key pair");
-        println!("done");
+        for si_claim in v1_and_v2_claims() {
+            println!("generating key...");
+            let key_pair = RS256KeyPair::generate(2048).expect("generate key pair");
+            println!("done");
 
-        let pub_key = key_pair.public_key();
-        let pub_key_pem = pub_key.to_pem().expect("get pub key pem");
-        let pub_key_base64 = general_purpose::STANDARD.encode(pub_key_pem);
+            let pub_key = key_pair.public_key();
+            let pub_key_pem = pub_key.to_pem().expect("get pub key pem");
+            let pub_key_base64 = general_purpose::STANDARD.encode(pub_key_pem);
 
-        let si_claim = SiJwtClaims {
-            user_pk: UserPk::generate(),
-            workspace_pk: WorkspacePk::generate(),
-        };
+            let claims = JWTClaims {
+                issued_at: None,
+                expires_at: None,
+                invalid_before: None,
+                issuer: None,
+                subject: None,
+                audiences: None,
+                jwt_id: None,
+                nonce: None,
+                custom: si_claim.clone(),
+            };
 
-        let claims = JWTClaims {
-            issued_at: None,
-            expires_at: None,
-            invalid_before: None,
-            issuer: None,
-            subject: None,
-            audiences: None,
-            jwt_id: None,
-            nonce: None,
-            custom: si_claim.clone(),
-        };
+            let signed = key_pair.sign(claims).expect("sign the key");
+            let bearer_token = format!("Bearer {signed}");
 
-        let signed = key_pair.sign(claims).expect("sign the key");
-        let bearer_token = format!("Bearer {signed}");
+            let primary_cfg = JwtConfig {
+                key_file: None,
+                key_base64: Some(pub_key_base64),
+                algo: JwtAlgo::RS256,
+            };
 
-        let primary_cfg = JwtConfig {
-            key_file: None,
-            key_base64: Some(pub_key_base64),
-            algo: JwtAlgo::RS256,
-        };
+            let key_chain = JwtPublicSigningKeyChain::from_config(primary_cfg, None)
+                .await
+                .expect("make key chain");
 
-        let key_chain = JwtPublicSigningKeyChain::from_config(primary_cfg, None)
-            .await
-            .expect("make key chain");
+            let claims = validate_bearer_token(key_chain, &bearer_token)
+                .await
+                .expect("should validate");
 
-        let claims = validate_bearer_token(key_chain, &bearer_token)
-            .await
-            .expect("shoudl validate");
-
-        assert_eq!(si_claim, claims.custom);
+            assert_eq!(si_claim, claims.custom);
+        }
     }
 
     #[tokio::test]
     async fn validate_with_primary_es256() {
-        println!("generating key...");
-        let key_pair = ES256KeyPair::generate();
-        let key_pair_2 = ES256KeyPair::generate();
-        println!("done");
+        for si_claim in v1_and_v2_claims() {
+            println!("generating key...");
+            let key_pair = ES256KeyPair::generate();
+            let key_pair_2 = ES256KeyPair::generate();
+            println!("done");
 
-        let pub_key = key_pair.public_key();
-        let pub_key_pem = pub_key.to_pem().expect("get pub key pem");
-        let pub_key_base64 = general_purpose::STANDARD.encode(pub_key_pem);
+            let pub_key = key_pair.public_key();
+            let pub_key_pem = pub_key.to_pem().expect("get pub key pem");
+            let pub_key_base64 = general_purpose::STANDARD.encode(pub_key_pem);
 
-        let si_claim = SiJwtClaims {
-            user_pk: UserPk::generate(),
-            workspace_pk: WorkspacePk::generate(),
-        };
+            let claims = JWTClaims {
+                issued_at: None,
+                expires_at: None,
+                invalid_before: None,
+                issuer: None,
+                subject: None,
+                audiences: None,
+                jwt_id: None,
+                nonce: None,
+                custom: si_claim.clone(),
+            };
 
-        let claims = JWTClaims {
-            issued_at: None,
-            expires_at: None,
-            invalid_before: None,
-            issuer: None,
-            subject: None,
-            audiences: None,
-            jwt_id: None,
-            nonce: None,
-            custom: si_claim.clone(),
-        };
+            let signed = key_pair.sign(claims.clone()).expect("sign the key");
+            let bearer_token = format!("Bearer {signed}");
 
-        let signed = key_pair.sign(claims.clone()).expect("sign the key");
-        let bearer_token = format!("Bearer {signed}");
+            let primary_cfg = JwtConfig {
+                key_file: None,
+                key_base64: Some(pub_key_base64),
+                algo: JwtAlgo::ES256,
+            };
 
-        let primary_cfg = JwtConfig {
-            key_file: None,
-            key_base64: Some(pub_key_base64),
-            algo: JwtAlgo::ES256,
-        };
+            let key_chain = JwtPublicSigningKeyChain::from_config(primary_cfg, None)
+                .await
+                .expect("make key chain");
 
-        let key_chain = JwtPublicSigningKeyChain::from_config(primary_cfg, None)
-            .await
-            .expect("make key chain");
+            let claims = validate_bearer_token(key_chain.clone(), &bearer_token)
+                .await
+                .expect("should validate");
 
-        let claims = validate_bearer_token(key_chain.clone(), &bearer_token)
-            .await
-            .expect("shoudl validate");
+            assert_eq!(si_claim, claims.custom);
 
-        assert_eq!(si_claim, claims.custom);
-
-        // Just confirm it fails with the wrong key
-        let signed_bad = key_pair_2.sign(claims).expect("sign the key");
-        let bearer_bad = format!("Bearer {signed_bad}");
-        let result = validate_bearer_token(key_chain, &bearer_bad).await;
-        assert!(result.is_err());
+            // Just confirm it fails with the wrong key
+            let signed_bad = key_pair_2.sign(claims).expect("sign the key");
+            let bearer_bad = format!("Bearer {signed_bad}");
+            let result = validate_bearer_token(key_chain, &bearer_bad).await;
+            assert!(result.is_err());
+        }
     }
 
     #[tokio::test]
     async fn validate_with_secondary_rs256() {
-        println!("generating keys...");
-        let key_pair_es256 = ES256KeyPair::generate();
-        let key_pair_rs256 = RS256KeyPair::generate(2048).expect("generate rs256 key");
-        println!("done");
+        for si_claim in v1_and_v2_claims() {
+            println!("generating keys...");
+            let key_pair_es256 = ES256KeyPair::generate();
+            let key_pair_rs256 = RS256KeyPair::generate(2048).expect("generate rs256 key");
+            println!("done");
 
-        let pub_key_es256 = key_pair_es256.public_key();
-        let pub_key_pem = pub_key_es256.to_pem().expect("get pub key pem");
-        let pub_key_base64_es256 = general_purpose::STANDARD.encode(pub_key_pem);
+            let pub_key_es256 = key_pair_es256.public_key();
+            let pub_key_pem = pub_key_es256.to_pem().expect("get pub key pem");
+            let pub_key_base64_es256 = general_purpose::STANDARD.encode(pub_key_pem);
 
-        let pub_key_rs256 = key_pair_rs256.public_key();
-        let pub_key_pem = pub_key_rs256.to_pem().expect("get pub key pem");
-        let pub_key_base64_rs256 = general_purpose::STANDARD.encode(pub_key_pem);
+            let pub_key_rs256 = key_pair_rs256.public_key();
+            let pub_key_pem = pub_key_rs256.to_pem().expect("get pub key pem");
+            let pub_key_base64_rs256 = general_purpose::STANDARD.encode(pub_key_pem);
 
-        let si_claim = SiJwtClaims {
-            user_pk: UserPk::generate(),
-            workspace_pk: WorkspacePk::generate(),
-        };
+            let claims = JWTClaims {
+                issued_at: None,
+                expires_at: None,
+                invalid_before: None,
+                issuer: None,
+                subject: None,
+                audiences: None,
+                jwt_id: None,
+                nonce: None,
+                custom: si_claim.clone(),
+            };
 
-        let claims = JWTClaims {
-            issued_at: None,
-            expires_at: None,
-            invalid_before: None,
-            issuer: None,
-            subject: None,
-            audiences: None,
-            jwt_id: None,
-            nonce: None,
-            custom: si_claim.clone(),
-        };
+            let signed = key_pair_rs256.sign(claims.clone()).expect("sign the key");
+            let bearer_token = format!("Bearer {signed}");
 
-        let signed = key_pair_rs256.sign(claims.clone()).expect("sign the key");
-        let bearer_token = format!("Bearer {signed}");
+            let primary_cfg = JwtConfig {
+                key_file: None,
+                key_base64: Some(pub_key_base64_es256),
+                algo: JwtAlgo::ES256,
+            };
 
-        let primary_cfg = JwtConfig {
-            key_file: None,
-            key_base64: Some(pub_key_base64_es256),
-            algo: JwtAlgo::ES256,
-        };
+            let secondary_cfg = JwtConfig {
+                key_file: None,
+                key_base64: Some(pub_key_base64_rs256),
+                algo: JwtAlgo::RS256,
+            };
 
-        let secondary_cfg = JwtConfig {
-            key_file: None,
-            key_base64: Some(pub_key_base64_rs256),
-            algo: JwtAlgo::RS256,
-        };
+            let key_chain = JwtPublicSigningKeyChain::from_config(primary_cfg, Some(secondary_cfg))
+                .await
+                .expect("make key chain");
 
-        let key_chain = JwtPublicSigningKeyChain::from_config(primary_cfg, Some(secondary_cfg))
-            .await
-            .expect("make key chain");
+            let claims = validate_bearer_token(key_chain.clone(), &bearer_token)
+                .await
+                .expect("should validate");
 
-        let claims = validate_bearer_token(key_chain.clone(), &bearer_token)
-            .await
-            .expect("shoudl validate");
-
-        assert_eq!(si_claim, claims.custom);
+            assert_eq!(si_claim, claims.custom);
+        }
     }
 }

--- a/lib/vue-lib/src/pinia/pinia_api_tools.ts
+++ b/lib/vue-lib/src/pinia/pinia_api_tools.ts
@@ -107,12 +107,16 @@ export class ApiRequest<
   // we use a getter to get the result so that we can add further type restrictions
   // ie, checking success guarantees data is present
   get result():
-    | { success: true; data: Response }
+    | {
+        success: true;
+        data: Response;
+      }
     | {
         success: false;
         err: Error;
         errBody?: any;
         statusCode?: number | undefined;
+        data?: Response extends undefined ? never : undefined;
       } {
     /* eslint-disable @typescript-eslint/no-non-null-assertion */
     if (this.rawSuccess === undefined)

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -9796,6 +9796,56 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "monostate",
+    actual = ":monostate-0.1.13",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "monostate-0.1.13.crate",
+    sha256 = "0d208407d7552cd041d8cdb69a1bc3303e029c598738177a3d87082004dc0e1e",
+    strip_prefix = "monostate-0.1.13",
+    urls = ["https://static.crates.io/crates/monostate/0.1.13/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "monostate-0.1.13",
+    srcs = [":monostate-0.1.13.crate"],
+    crate = "monostate",
+    crate_root = "monostate-0.1.13.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":monostate-impl-0.1.13",
+        ":serde-1.0.216",
+    ],
+)
+
+http_archive(
+    name = "monostate-impl-0.1.13.crate",
+    sha256 = "a7ce64b975ed4f123575d11afd9491f2e37bbd5813fbfbc0f09ae1fbddea74e0",
+    strip_prefix = "monostate-impl-0.1.13",
+    urls = ["https://static.crates.io/crates/monostate-impl/0.1.13/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "monostate-impl-0.1.13",
+    srcs = [":monostate-impl-0.1.13.crate"],
+    crate = "monostate_impl",
+    crate_root = "monostate-impl-0.1.13.crate/src/lib.rs",
+    edition = "2021",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.92",
+        ":quote-1.0.37",
+        ":syn-2.0.90",
+    ],
+)
+
 http_archive(
     name = "multer-2.1.0.crate",
     sha256 = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2",


### PR DESCRIPTION
This adds the ability to create "automation tokens" intended for use with API clients in hands-free contexts like github.

* "Create API Token" button on Manage Workspace to generate a token and copy it to your buffer. This is *not* intended as a final UI; just a way to get this usable.
  ![image](https://github.com/user-attachments/assets/543e5976-c19f-4245-a343-640713c29b33)
* Automation tokens:
  - Not revocable
  - Have an expiration of 1 day (which SDF does not appear to honor)
  - Are rejected by all SDF and module-index endpoints
* Token format for existing users has not yet changed, to ensure we don't interrupt service. All services will be rolled out with the ability to handle the both the old token format and the new one, but only automation tokens will be minted with the new format until the next deployment.
* Automation tokens are initially heavily restricted to a very small set of permissions. We may open it up to things we deem safe for automation.

### Testing

I have tested:

* Old and new format for user tokens both work when:
  - Creating a new workspace from the auth portal.
  - Installing components in a fresh workspace (installing new modules from a local module-index server).
  - Multiplayer and creating / moving components around.
  - Hitting the SDF and local module-index server.
* Tokens generated by the old Auth API allow access to workspaces as well.
* Automation tokens are rejected by the SDF API as well as the module-index API.

Automated tests: added tests for the new token formats. There is no new coverage in the SDF, DAL or auth api automated tests.

It is critical we ensure SDF and module-index are working after deploy in preprod. I have not tested the new tokens against preprod or prod module-index / SDF, because that requires private keys from those environments to create the tokens.

### Deployment

auth api, SDF, and module-index will all have to be deployed. It doesn't matter what order they are deployed in, but all need to be deployed to ensure the new code is generating and accepting tokens correctly to ensure service doesn't get interrupted.

### Caveats

* Tokens have a 1 day expiration date, but SDF does *not* honor it. jwt.io indicates the token should be expired. Something to be aware of: I don't expect many people to create these tokens yet until they, you know, do something, so I'll address this soon after.

### Quickstart

You too can have your API requests denied due to lack of permission:
1. Run the auth api and portal locally (see instructions in `bin/auth-api/README.md`).
2. Create a new workspace.
3. Click the "Generate Automation Token" button (see image above). Key is now in your buffer.
4. Hit `curl -H "Authorization: Bearer $MY_AUTH_API_TOKEN" http://localhost:5156/api/v2/workspaces/01JF8X1BCPAFTFR18J24JHQGBE/integrations`

See your very own 401 saying you don't have a `web` role.

![token](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWRkOGk0M3d4cXdyNjM4aXFvcHgzenVkMjRjZzhscXdkb2t0ODlmayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/lAce6rIFOcqPu/giphy.webp)