### PR TITLE
fix: schemas should be created with lineage_id == id 

### DIFF
--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -149,9 +149,10 @@ impl Schema {
 
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        let lineage_id = workspace_snapshot.generate_ulid().await?;
+        // Lineage id has to match id here, otherwise every new schema will be
+        // treated as a new node, even though it has the same id
         let node_weight =
-            NodeWeight::new_content(id.into(), lineage_id, ContentAddress::Schema(hash));
+            NodeWeight::new_content(id.into(), id.into(), ContentAddress::Schema(hash));
 
         workspace_snapshot.add_or_replace_node(node_weight).await?;
 

--- a/lib/dal/src/workspace_snapshot/graph/v4.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v4.rs
@@ -1631,7 +1631,7 @@ impl WorkspaceSnapshotGraphV4 {
                     if let (Some(source_idx), Some(destination_idx)) = (source_idx, destination_idx)
                     {
                         if let EdgeWeightKind::Use { is_default: true } = edge_weight.kind() {
-                            ensure_only_one_default_use_edge(self, source_idx)?;
+                            ensure_only_one_default_use_edge(self, source_idx, destination_idx)?;
                         }
 
                         self.add_edge_inner(
@@ -1781,6 +1781,7 @@ fn prop_node_indexes_for_node_index(
 fn ensure_only_one_default_use_edge(
     graph: &mut WorkspaceSnapshotGraphV4,
     source_idx: NodeIndex,
+    destination_idx: NodeIndex,
 ) -> WorkspaceSnapshotGraphResult<()> {
     let existing_default_targets: Vec<NodeIndex> = graph
         .edges_directed(source_idx, Outgoing)
@@ -1788,7 +1789,7 @@ fn ensure_only_one_default_use_edge(
             matches!(
                 edge_ref.weight().kind(),
                 EdgeWeightKind::Use { is_default: true }
-            )
+            ) && edge_ref.target() != destination_idx
         })
         .map(|edge_ref| edge_ref.target())
         .collect();


### PR DESCRIPTION
On demand asset installation can produce identical Schema nodes by id, but they will have different lineage ids. Since the lineage ids are different, we will treat them as new nodes on the graph. The idempotency of our updates usually means this is fine. But the interaction with the code to ensure there is only one default edge caused an issue.

This fixes both, by ensuring new schemas are always created with the lineage id equal to the schema id. This will ensure we compare the nodes instead of treating the schema node as a new node.

It also ensures that if a new edge update comes in that sets a schema variant to the default, but that variant is already default, we preserve that default.