### PR TITLE
fix: allow moving components inside of their parents

### DIFF
--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -1775,7 +1775,7 @@ function endDragElements() {
 
   // do i need to resize the new parent to fit the children?
   const parentSize = viewsStore.groups[newParent?.def.id || ""];
-  if (parentSize && newParent) {
+  if (parentSize && newParent && Object.values(setParents).length > 0) {
     const newSize: Partial<Bounds> = {};
     Object.values(setParents).forEach((el) => {
       const geo =


### PR DESCRIPTION
This ensures we don't attempt to correct the size of a parent if there are not in fact new parents.