### PR TITLE
Ensure all Geometry for a View are removed when removing a View

### DIFF
--- a/lib/dal/src/workspace_snapshot/node_weight/view_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/view_node_weight/v1.rs
@@ -99,7 +99,6 @@ impl CorrectTransforms for ViewNodeWeightV1 {
 
         if let Some(view_removal_update_idx) = maybe_view_removal_update_idx {
             let view_node_index = workspace_snapshot_graph.get_node_index_by_id(self.id())?;
-            dbg!(&updates);
 
             // Make sure that any pre-existing Geometry has a removal in the set of updates.
             for (_edge_weight, _source, destination) in workspace_snapshot_graph

--- a/lib/si-frontend-types-rs/src/component.rs
+++ b/lib/si-frontend-types-rs/src/component.rs
@@ -23,7 +23,7 @@ pub struct GridPoint {
     pub y: isize,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct RawGeometry {
     pub x: isize,


### PR DESCRIPTION
Because of the edge directionality, removing the `DiagramObject` for a `View` is insufficient to also remove all `Geometry` that represent that `DiagramObject`/`View`. To account for this, we now use the source of all `Represents` edges pointing at the `DiagramObject` to explicitly remove the `Geometry` that represent the `DiagramObject`/`View`.

Additionally, when we check to see if we would be orphaning anything by removing a `View`, if we encounter a `Geometry` that has no `Represents` edge, we ignore it and move on, as it's not representing anything to orphan.