### PR TITLE
fix: retrieve from memory when waiting for snapshots

### DIFF
--- a/lib/si-layer-cache/src/db/rebase_batch.rs
+++ b/lib/si-layer-cache/src/db/rebase_batch.rs
@@ -102,7 +102,7 @@ where
         let mut tried = 0;
         let read_wait = Instant::now();
         while tried < MAX_TRIES {
-            if let Some(v) = self.cache.cache().get(&key).await {
+            if let Some(v) = self.cache.cache().get_from_memory(key.clone()).await {
                 span.record("si.layer_cache.memory_cache.hit", true);
                 span.record(
                     "si.layer_cache.memory_cache.read_wait_ms",

--- a/lib/si-layer-cache/src/db/workspace_snapshot.rs
+++ b/lib/si-layer-cache/src/db/workspace_snapshot.rs
@@ -102,7 +102,7 @@ where
         let mut tried = 0;
         let read_wait = Instant::now();
         while tried < MAX_TRIES {
-            if let Some(v) = self.cache.cache().get(&key).await {
+            if let Some(v) = self.cache.cache().get_from_memory(key.clone()).await {
                 span.record("si.layer_cache.memory_cache.hit", true);
                 span.record(
                     "si.layer_cache.memory_cache.read_wait_ms",

--- a/lib/si-layer-cache/tests/integration_test/db/func_run.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/func_run.rs
@@ -46,7 +46,7 @@ async fn write_to_db() {
         .expect("failed to write to layerdb");
 
     // Are we in memory?
-    let in_memory = ldb.func_run().cache.cache().get(&key_str).await;
+    let in_memory = ldb.func_run().cache.cache().get(key_str.clone()).await;
     assert_eq!(value.id(), in_memory.expect("func run not in memory").id());
 
     // Are we in pg?
@@ -104,7 +104,7 @@ async fn update() {
         .expect("failed to write to layerdb");
 
     // Are we in memory?
-    let in_memory = ldb.func_run().cache.cache().get(&key_str).await;
+    let in_memory = ldb.func_run().cache.cache().get(key_str.clone()).await;
     assert_eq!(value.id(), in_memory.expect("func run not in memory").id());
 
     // Are we in pg?
@@ -132,7 +132,7 @@ async fn update() {
         .expect("failed to write to layerdb");
 
     // Are we in memory?
-    let in_memory = ldb.func_run().cache.cache().get(&key_str).await;
+    let in_memory = ldb.func_run().cache.cache().get(key_str.clone()).await;
     assert_eq!(
         update_func_run.state(),
         in_memory.expect("func run not in memory").state(),
@@ -155,7 +155,12 @@ async fn update() {
     let max_check_count = 10;
     let mut memory_check_count = 0;
     while memory_check_count <= max_check_count {
-        let in_memory = ldb_remote.func_run().cache.cache().get(&key_str).await;
+        let in_memory = ldb_remote
+            .func_run()
+            .cache
+            .cache()
+            .get(key_str.clone())
+            .await;
         match in_memory {
             Some(value) => {
                 assert_eq!(update_func_run.state(), value.state());

--- a/lib/si-layer-cache/tests/integration_test/db/func_run_log.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/func_run_log.rs
@@ -41,7 +41,7 @@ async fn write_to_db() {
         .expect("failed to write to layerdb");
 
     // Are we in memory?
-    let in_memory = ldb.func_run_log().cache.cache().get(&key_str).await;
+    let in_memory = ldb.func_run_log().cache.cache().get(key_str.clone()).await;
     assert_eq!(
         value.id(),
         in_memory.expect("func run log not in memory").id()
@@ -101,7 +101,7 @@ async fn update() {
         .expect("failed to write to layerdb");
 
     // Are we in memory?
-    let in_memory = ldb.func_run_log().cache.cache().get(&key_str).await;
+    let in_memory = ldb.func_run_log().cache.cache().get(key_str.clone()).await;
     assert_eq!(
         value.id(),
         in_memory.expect("func run log not in memory").id()
@@ -140,7 +140,7 @@ async fn update() {
         .expect("failed to write to layerdb");
 
     // Are we in memory?
-    let in_memory = ldb.func_run_log().cache.cache().get(&key_str).await;
+    let in_memory = ldb.func_run_log().cache.cache().get(key_str.clone()).await;
     assert_eq!(
         update_func_run_log.logs(),
         in_memory.expect("func run log not in memory").logs(),
@@ -163,7 +163,12 @@ async fn update() {
     let max_check_count = 10;
     let mut memory_check_count = 0;
     while memory_check_count <= max_check_count {
-        let in_memory = ldb_remote.func_run_log().cache.cache().get(&key_str).await;
+        let in_memory = ldb_remote
+            .func_run_log()
+            .cache
+            .cache()
+            .get(key_str.clone())
+            .await;
         match in_memory {
             Some(value) => {
                 assert_eq!(update_func_run_log.logs(), value.logs());

--- a/lib/si-layer-cache/tests/integration_test/db/workspace_snapshot.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/workspace_snapshot.rs
@@ -45,7 +45,12 @@ async fn write_to_db() {
     let key_str: Arc<str> = key.to_string().into();
 
     // Are we in memory?
-    let in_memory = ldb.workspace_snapshot().cache.cache().get(&key_str).await;
+    let in_memory = ldb
+        .workspace_snapshot()
+        .cache
+        .cache()
+        .get(key_str.clone())
+        .await;
     assert_eq!(Some(value.clone()), in_memory);
 
     // Are we in pg?
@@ -109,7 +114,12 @@ async fn evict_from_db() {
     }
 
     // Are we in memory?
-    let in_memory = ldb.workspace_snapshot().cache.cache().get(&key_str).await;
+    let in_memory = ldb
+        .workspace_snapshot()
+        .cache
+        .cache()
+        .get(key_str.clone())
+        .await;
     assert_ne!(Some(value.clone()), in_memory);
 
     assert!(
@@ -188,7 +198,7 @@ async fn evictions_are_gossiped() {
             .workspace_snapshot()
             .cache
             .cache()
-            .get(&pk_str)
+            .get(pk_str.clone())
             .await;
         match in_memory {
             Some(value) => {
@@ -241,7 +251,7 @@ async fn evictions_are_gossiped() {
             .workspace_snapshot()
             .cache
             .cache()
-            .get(&pk_str)
+            .get(pk_str.clone())
             .await;
         match in_memory {
             Some(_value) => {

--- a/lib/si-layer-cache/tests/integration_test/layer_cache.rs
+++ b/lib/si-layer-cache/tests/integration_test/layer_cache.rs
@@ -37,7 +37,7 @@ async fn empty_insert_and_get() {
     // Confirm the insert went into the memory cache
     let memory_result = layer_cache
         .cache()
-        .get(&skid_row)
+        .get(skid_row.clone())
         .await
         .expect("cannot find value in memory cache");
     assert_eq!("slave to the grind", &memory_result[..]);


### PR DESCRIPTION
The original implementation of these calls went directly to the memory cache, knowing that we were waiting for something new and it couldn't be on the disk yet. When foyer was added, this changed to go directly to the cache, meaning that we are knowingly spawning a thread that reads from disk with every attempt here, every millisecond, for up to 2000 milliseconds. This creates a TON of disk pressure and additional allocations. I _think_ this might be part of the source of our memory pressure issues, but this really leads me to believe that there is a leak internal to foyer around how they load things from the disk (maybe specifically around misses?).

Another curious thing is that I don't seem to have any traces that point to the disk misses, of which there should be many thousand.

Not that this undoes what was done earlier to move us to a just-memory cache. I would like to see how this performs in tools prod overnight at least to see if it has a significant impact on the memory allocations.