### PR TITLE
Fix: load all components at the right time

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -1427,29 +1427,11 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
             ],
           );
 
-          realtimeStore.subscribe(
-            `${this.$id}-workspace`,
-            `workspace/${workspaceId}`,
-            [
-              {
-                eventType: "ChangeSetApplied",
-                callback: (data) => {
-                  // If the applied change set has rebased into this change set,
-                  // then refetch (i.e. there might be updates!)
-                  if (data.toRebaseChangeSetId === changeSetId) {
-                    this.FETCH_ALL_COMPONENTS();
-                  }
-                },
-              },
-            ],
-          );
-
           const actionUnsub = this.$onAction(handleStoreError);
 
           return () => {
             actionUnsub();
             realtimeStore.unsubscribe(`${this.$id}-changeset`);
-            realtimeStore.unsubscribe(`${this.$id}-workspace`);
           };
         },
       },

--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -650,14 +650,13 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
           this.recentViews.push(id);
         },
         async LIST_VIEWS(all = false) {
-          await componentsStore.FETCH_ALL_COMPONENTS();
-
           return new ApiRequest<ViewDescription[]>({
             method: "get",
             url: API_PREFIX,
             onSuccess: async (views) => {
               this.viewList = views;
               this.SORT_LIST_VIEWS();
+              await componentsStore.FETCH_ALL_COMPONENTS();
               for (const { id } of views) {
                 // assuming we're coming from "on load", we have the FETCH that gets the selectedViewId
                 if (all || id !== this.selectedViewId)
@@ -674,6 +673,7 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
           });
         },
         async FETCH_VIEW_GEOMETRY(viewId: ViewId) {
+          // requires all components to be in place!
           return new ApiRequest<{
             viewId: ViewId;
             name: string;
@@ -709,7 +709,6 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
                 ([componentId, geo]) => {
                   const node = componentsStore.allComponentsById[componentId];
                   if (!node) return;
-                  if (!view) return; // no idea why linting is complaining that i need this
                   let geometry: IRect;
                   if ("width" in node) {
                     geo.width = node.width;


### PR DESCRIPTION
After first paint, but before the data is required by other things! And don't do it twice!

Tested this against all the regressions we've been bashing away on (e.g. no blank modeling screen, no missing component on apply)
<img src="https://media4.giphy.com/media/tCb3AD2Y7xbL6co4aA/giphy.gif"/>