### PR TITLE
BUG-725: remove selections from head prior to applying.

### DIFF
--- a/app/web/src/components/ApplyChangeSetButton.vue
+++ b/app/web/src/components/ApplyChangeSetButton.vue
@@ -85,6 +85,7 @@ import { useActionsStore } from "@/store/actions.store";
 import { useAuthStore } from "@/store/auth.store";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import RetryApply from "@/components/toasts/RetryApply.vue";
+import { useViewsStore } from "@/store/views.store";
 import ApprovalFlowModal from "./ApprovalFlowModal.vue";
 import ApprovalFlowModal2 from "./ApprovalFlowModal2.vue";
 
@@ -121,6 +122,11 @@ const openApprovalFlowModal = () => {
 const applyChangeSet = async () => {
   if (!route.name) return;
   // if (featureFlagsStore.REBAC) return;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const viewsStore = useViewsStore(changeSetsStore.headChangeSetId!);
+  // need to clear selections prior to applying, having them is causing bugs (BUG-725)
+  viewsStore.clearSelections();
+  viewsStore.syncSelectionIntoUrl();
   const resp = await changeSetsStore.APPLY_CHANGE_SET(
     authStore.user?.email ?? "",
   );

--- a/app/web/src/components/ApprovalFlowModal2.vue
+++ b/app/web/src/components/ApprovalFlowModal2.vue
@@ -48,6 +48,7 @@ import { ChangeSetStatus } from "@/api/sdf/dal/change_set";
 import { useChangeSetsStore } from "@/store/change_sets.store";
 import { useAuthStore } from "@/store/auth.store";
 import ApprovalFlowCancelled from "@/components/toasts/ApprovalFlowCancelled.vue";
+import { useViewsStore } from "@/store/views.store";
 import ActionsList from "./Actions/ActionsList.vue";
 
 const changeSetsStore = useChangeSetsStore();
@@ -73,6 +74,11 @@ function closeModalHandler() {
 function applyButtonHandler() {
   if (userIsApprover.value) {
     if (authStore.user) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const viewsStore = useViewsStore(changeSetsStore.headChangeSetId!);
+      // need to clear selections prior to applying, having them is causing bugs (BUG-725)
+      viewsStore.clearSelections();
+      viewsStore.syncSelectionIntoUrl();
       changeSetsStore.FORCE_APPLY_CHANGE_SET(authStore.user.name);
       closeModalHandler();
     }

--- a/app/web/src/components/ComponentDetails.vue
+++ b/app/web/src/components/ComponentDetails.vue
@@ -19,20 +19,22 @@
         <Icon name="loader" size="xs" class="text-action-500 shrink-0" />
         <div class="grow truncate text-xs italic">Updating...</div>
       </div>
-      <div v-else class="flex flex-row items-center">
+      <div
+        v-else
+        :class="
+          clsx('flex flex-row items-center', showRefreshButton && 'ml-xs mb-xs')
+        "
+      >
         <DetailsPanelTimestamps
           :changeStatus="props.component.def.changeStatus"
           :created="props.component.def.createdInfo"
           :modified="props.component.def.updatedInfo"
           :deleted="props.component.def.deletedInfo"
+          :noMargin="showRefreshButton"
         />
         <div class="pr-xs shrink-0">
           <VButton
-            v-if="
-              props.component.def.hasResource &&
-              changeSetsStore.selectedChangeSetId ===
-                changeSetsStore.headChangeSetId
-            "
+            v-if="showRefreshButton"
             icon="refresh"
             size="sm"
             variant="ghost"
@@ -188,6 +190,7 @@ import {
   TabGroupItem,
   VButton,
 } from "@si/vue-lib/design-system";
+import clsx from "clsx";
 import { useComponentsStore } from "@/store/components.store";
 import { useStatusStore } from "@/store/status.store";
 import { useChangeSetsStore } from "@/store/change_sets.store";
@@ -265,6 +268,12 @@ const componentSubTabsRef = ref<InstanceType<typeof TabGroup>>();
 function onTabSelected(newTabSlug?: string) {
   viewStore.setComponentDetailsTab(newTabSlug || null);
 }
+
+const showRefreshButton = computed(
+  () =>
+    props.component.def.hasResource &&
+    changeSetsStore.selectedChangeSetId === changeSetsStore.headChangeSetId,
+);
 
 watch(
   () => viewStore.selectedComponentDetailsTab,

--- a/app/web/src/components/DetailsPanelTimestamps.vue
+++ b/app/web/src/components/DetailsPanelTimestamps.vue
@@ -1,6 +1,11 @@
 <template>
   <div
-    class="m-xs mt-0 text-xs italic text-neutral-300 grow flex flex-row justify-between"
+    :class="
+      clsx(
+        'text-xs italic text-neutral-300 grow flex flex-col justify-between',
+        !noMargin && 'm-xs mt-0',
+      )
+    "
   >
     <div
       :class="
@@ -74,10 +79,11 @@ import { ChangeStatus } from "@/api/sdf/dal/change_set";
 import { ActorAndTimestamp } from "@/api/sdf/dal/component";
 import StatusIndicatorIcon from "./StatusIndicatorIcon.vue";
 
-const props = defineProps({
+defineProps({
   changeStatus: { type: String as PropType<ChangeStatus> },
   created: { type: Object as PropType<ActorAndTimestamp>, required: true },
   modified: { type: Object as PropType<ActorAndTimestamp> },
   deleted: { type: Object as PropType<ActorAndTimestamp> },
+  noMargin: { type: Boolean },
 });
 </script>

--- a/app/web/src/pages/WorkspaceSinglePage.vue
+++ b/app/web/src/pages/WorkspaceSinglePage.vue
@@ -204,8 +204,6 @@ function handleUrlChange() {
     return;
   }
 
-  window.localStorage.setItem("tab_group_proposed_right", "actions_proposed");
-
   if (
     !changeSetId ||
     (changeSetsReqStatus.value.isSuccess &&

--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -478,6 +478,13 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
 
           this.syncSelectionIntoUrl();
         },
+        clearSelections() {
+          this.selectedEdgeId = null;
+          this.selectedComponentIds = [];
+          this.selectedComponentDetailsTab = null;
+          const key = `${changeSetId}_selected_component`;
+          window.localStorage.removeItem(key);
+        },
         syncSelectionIntoUrl() {
           let selectedIds: string[] = [];
           if (this.selectedEdgeId) {


### PR DESCRIPTION
1. A race is happening with the router where the change set applied pushes to head
2. That push brings the head stores back
3. The head stores attempt to sync selected data back into the URL
4. But the route URL has not been set to "head"
5. So the head stores sync overwrite the push to head
6. And it pushes you to the changeset you were on previously
7. Which is merged, and causes tons of breakage

<img src="https://media3.giphy.com/media/116a8zosxwA0SI/giphy.gif"/>