### PR TITLE
fix(dal): The order in which we process dependencies between components is inconsistent, so we must always check if the component is in the dependency graph before adding it as Petgraph doesn't prevent nodes with duplicate node weights from being inserted

### DIFF
--- a/lib/dal/src/action/dependency_graph.rs
+++ b/lib/dal/src/action/dependency_graph.rs
@@ -86,8 +86,10 @@ impl ActionDependencyGraph {
         // things they are feeding data into.
         for component_id in actions_by_component_id.keys().copied() {
             let component = Component::get_by_id(ctx, component_id).await?;
-            let component_index = component_dependencies.add_node(component_id);
-            component_dependencies_index_by_id.insert(component_id, component_index);
+            let component_index = component_dependencies_index_by_id
+                .entry(component_id)
+                .or_insert_with(|| component_dependencies.add_node(component_id))
+                .to_owned();
             for incoming_connection in component.incoming_connections(ctx).await? {
                 component_dependencies_index_by_id
                     .entry(incoming_connection.from_component_id)


### PR DESCRIPTION
In order to calculate the dependencies between actions, we must account for dependencies between components based on inferred connections and connections.  The issue was, if a component (A) with an enqueued action is a dependency for another component  (B) with an enqueued action, and we processed component A first, we'd end up inserting Component B into the graph, then inserting it again as it has an action enqueued. This would make the edges between the Actions all screwed up depending on what other components are in the mix.  Because Petgraph doesn't guarantee the order in which nodes are retrieved from the graph, this would sometimes be just fine, and other times, be incorrect. Fun!

<div><img src="https://media4.giphy.com/media/NusOH30J7QiJy/200.gif?cid=5a38a5a2j9iy7i6cgazhy6e56d7opuc8g27hokyg2ra7csq7&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:168px;width:300px"/><br/>via <a href="https://giphy.com/gifs/cat-memory-NusOH30J7QiJy">GIPHY</a></div>