### PR TITLE
Fix: initial load on customize page, move to empty modeling page

### DIFF
--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -311,7 +311,6 @@ import { ComponentType } from "@/api/sdf/dal/schema";
 import { useStatusStore } from "@/store/status.store";
 import { useQualificationsStore } from "@/store/qualifications.store";
 import { nonNullable } from "@/utils/typescriptLinter";
-import { ViewId } from "@/api/sdf/dal/views";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import { DefaultMap } from "@/utils/defaultmap";
 import DiagramGridBackground from "./DiagramGridBackground.vue";
@@ -392,7 +391,6 @@ const ZOOM_PAN_FACTOR = 0.5;
 
 const props = defineProps<{
   cursors?: DiagramCursorDef[];
-  viewId: ViewId | undefined;
   readOnly?: boolean;
 }>();
 

--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -53,7 +53,6 @@
   <ModelingDiagram
     v-else
     ref="diagramRef"
-    :viewId="viewId"
     @mouseout="presenceStore.clearCursor"
     @right-click-element="onRightClickElement"
     @close-right-click-menu="closeRightClickMenu"
@@ -212,6 +211,8 @@ const onKeyDown = async (e: KeyboardEvent) => {
 onMounted(() => {
   window.addEventListener("keydown", onKeyDown);
   statusStore.FETCH_DVU_ROOTS();
+  if (!viewStore.selectedViewId && !viewStore.activatedAndFetched)
+    viewStore.FETCH_VIEW(viewId.value);
 });
 
 onBeforeUnmount(() => {

--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -182,6 +182,7 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
     changeSetId,
     defineStore(`ws${workspaceId || "NONE"}/cs${changeSetId || "NONE"}/views`, {
       state: () => ({
+        activatedAndFetched: false,
         selectedViewId: null as ViewId | null,
         outlinerViewId: null as ViewId | null,
         recentViews: new UniqueStack() as UniqueStack<ViewId>,
@@ -1590,6 +1591,7 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
             route?.name as string,
           )
         ) {
+          this.activatedAndFetched = true;
           if (route?.params.viewId) viewId = route.params.viewId as string;
           await this.FETCH_VIEW(viewId);
           // ^ selects the view


### PR DESCRIPTION
- View store doesnt FETCH_VIEW, which does a router push, on customize page.
- When we load the modeling workspace, find this state and call FETCH_VIEW
<img src="https://media2.giphy.com/media/3otPoOxjk5cwcwd5Ze/giphy.gif"/>