### PR TITLE
feat: add audit trail and posthog tracking for templates

### DIFF
--- a/lib/sdf-server/src/service/v2/management/generate_template.rs
+++ b/lib/sdf-server/src/service/v2/management/generate_template.rs
@@ -9,10 +9,11 @@ use dal::{
     ChangeSet, ChangeSetId, ComponentId, FuncId, SchemaVariantId, WorkspacePk, WsEvent,
 };
 use serde::{Deserialize, Serialize};
+use si_events::audit_log::AuditLogKind;
 
 use crate::extract::{AccessBuilder, HandlerContext, PosthogClient};
 
-use super::{ManagementApiError, ManagementApiResult};
+use super::{track, ManagementApiError, ManagementApiResult};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -34,9 +35,9 @@ pub struct GenerateTemplateResponse {
 pub async fn generate_template(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(access_builder): AccessBuilder,
-    PosthogClient(_posthog_client): PosthogClient,
-    OriginalUri(_original_uri): OriginalUri,
-    Host(_host_name): Host,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Host(host_name): Host,
     Path((_workspace_pk, change_set_id, view_id)): Path<(WorkspacePk, ChangeSetId, ViewId)>,
     Json(request): Json<GenerateTemplateRequest>,
 ) -> ManagementApiResult<ForceChangeSetResponse<GenerateTemplateResponse>> {
@@ -60,7 +61,7 @@ pub async fn generate_template(
 
     let func = FuncAuthoringClient::create_new_management_func(
         &ctx,
-        Some(request.func_name),
+        Some(request.func_name.clone()),
         new_variant.id(),
     )
     .await?;
@@ -76,7 +77,7 @@ pub async fn generate_template(
 
     let return_value = serde_json::json!({
         "status": "ok",
-        "message": format!("created {}", request.asset_name),
+        "message": format!("created {}", &request.asset_name),
         "ops": {
             "create": create_operations,
         }
@@ -110,6 +111,31 @@ pub async fn generate_template(
         .await?
         .publish_on_commit(&ctx)
         .await?;
+
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        &host_name,
+        "generate_template",
+        serde_json::json!({
+            "generated_schema_variant_id": new_variant.id,
+            "generated_prototype_id": prototype_id,
+            "generated_func_id": func.id,
+        }),
+    );
+
+    ctx.write_audit_log(
+        AuditLogKind::GenerateTemplate {
+            schema_variant_id: new_variant.id,
+            management_prototype_id: prototype_id,
+            func_id: func.id,
+            func_name: request.func_name,
+            asset_name: request.asset_name.to_owned(),
+        },
+        request.asset_name,
+    )
+    .await?;
 
     ctx.commit().await?;
 

--- a/lib/si-events-rs/src/audit_log/v1.rs
+++ b/lib/si-events-rs/src/audit_log/v1.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use si_id::ManagementPrototypeId;
 use strum::{Display, EnumDiscriminants};
 
 use crate::{
@@ -187,12 +188,31 @@ pub enum AuditLogKindV1 {
         name: String,
         version: String,
     },
+
+    GenerateTemplate {
+        schema_variant_id: SchemaVariantId,
+        management_prototype_id: ManagementPrototypeId,
+        func_id: FuncId,
+        func_name: String,
+        asset_name: String,
+    },
+
     InstallWorkspace {
         id: WorkspacePk,
         name: String,
         version: String,
     },
     Login,
+
+    ManagementOperationsComplete {
+        component_id: ComponentId,
+        prototype_id: ManagementPrototypeId,
+        func_id: FuncId,
+        func_name: String,
+        status: String,
+        message: Option<String>,
+    },
+
     OrphanComponent {
         component_id: ComponentId,
         previous_parent_id: ComponentId,
@@ -559,14 +579,36 @@ pub enum AuditLogMetadataV1 {
         name: String,
         version: String,
     },
+
+    #[serde(rename_all = "camelCase")]
+    GenerateTemplate {
+        schema_variant_id: SchemaVariantId,
+        management_prototype_id: ManagementPrototypeId,
+        func_id: FuncId,
+        func_name: String,
+        asset_name: String,
+    },
+
     #[serde(rename_all = "camelCase")]
     InstallWorkspace {
         id: WorkspacePk,
         name: String,
         version: String,
     },
+
     #[serde(rename_all = "camelCase")]
     Login,
+
+    #[serde(rename_all = "camelCase")]
+    ManagementOperationsComplete {
+        component_id: ComponentId,
+        prototype_id: ManagementPrototypeId,
+        func_id: FuncId,
+        func_name: String,
+        status: String,
+        message: Option<String>,
+    },
+
     #[serde(rename_all = "camelCase")]
     OrphanComponent {
         component_id: ComponentId,
@@ -789,7 +831,11 @@ impl AuditLogMetadataV1 {
             MetadataDiscrim::ExecuteFunc => ("Executed", Some("Function")),
             MetadataDiscrim::ExportWorkspace => ("Exported", Some("Workspace")),
             MetadataDiscrim::InstallWorkspace => ("Installed", Some("Workspace")),
+            MetadataDiscrim::GenerateTemplate => ("Generated", Some("Template")),
             MetadataDiscrim::Login => ("Authenticated", None),
+            MetadataDiscrim::ManagementOperationsComplete => {
+                ("Executed", Some("Management Operations"))
+            }
             MetadataDiscrim::OrphanComponent => ("Orphaned", Some("Component")),
             MetadataDiscrim::PutActionOnHold => ("Paused", Some("Action")),
             MetadataDiscrim::RegenerateSchemaVariant => ("Regenerated", Some("Schema Variant")),
@@ -1094,10 +1140,38 @@ impl From<Kind> for Metadata {
             Kind::ExportWorkspace { id, name, version } => {
                 Self::ExportWorkspace { id, name, version }
             }
+            Kind::GenerateTemplate {
+                schema_variant_id,
+                management_prototype_id,
+                func_id,
+                func_name,
+                asset_name,
+            } => Self::GenerateTemplate {
+                schema_variant_id,
+                management_prototype_id,
+                func_id,
+                func_name,
+                asset_name,
+            },
             Kind::InstallWorkspace { id, name, version } => {
                 Self::InstallWorkspace { id, name, version }
             }
             Kind::Login => Self::Login,
+            Kind::ManagementOperationsComplete {
+                component_id,
+                prototype_id,
+                func_id,
+                func_name,
+                status,
+                message,
+            } => Self::ManagementOperationsComplete {
+                component_id,
+                prototype_id,
+                func_id,
+                func_name,
+                status,
+                message,
+            },
             Kind::OrphanComponent {
                 component_id,
                 previous_parent_id,


### PR DESCRIPTION
Adds audit log and posthog track calls for template generation, and for the "operating" portion of management operations (functions could execute but not produce operations, so these are distinct events)