### PR TITLE
fixup: only test when not refreshing, otherwise it will cause grief

### DIFF
--- a/.github/workflows/prod-service-restart-cron.yml
+++ b/.github/workflows/prod-service-restart-cron.yml
@@ -5,11 +5,11 @@ on:
     - cron: "0 20 * * 1-5" # Deploys every weekday at 8pm UTC
 
 concurrency:
-  group: deploy-production
+  group: restart-production
   cancel-in-progress: false
 
 jobs:
-  deploy-production:
+  restart-production:
     uses: ./.github/workflows/deploy-service-restart.yml
     with:
       environment: production

--- a/.github/workflows/prod-test-cron.yml
+++ b/.github/workflows/prod-test-cron.yml
@@ -2,10 +2,14 @@ name: Production Crons
 
 on:
   schedule:
-    - cron: "*/15 * * * *" # Runs every 15 minutes
+    # Weekdays: Every 15 minutes except 7:45 PM and 8:00 PM UTC
+    - cron: "0-44/15 0-19 * * 1-5"  # Every 15 minutes from 12:00 AM to 7:44 PM UTC (Monday to Friday)
+    - cron: "15-59/15 20-23 * * 1-5" # Every 15 minutes from 8:15 PM to 11:59 PM UTC (Monday to Friday)
+    # Weekends: Every 15 minutes including 8:00 PM UTC
+    - cron: "*/15 * * * 6,0" # Every 15 minutes on Saturday (6) and Sunday (0)
 
-# We will wait until these tests finish before starting a deploy
-# We will also wait for a deploy to finish before starting to run tests
+# Prod deployment cron is currently disabled, but this should `not` cancel the synthetic
+# e2e runner cron
 concurrency:
   group: deploy-production
   cancel-in-progress: false


### PR DESCRIPTION
This changes things slightly so we only test during the times where we are NOT refreshing.

It should prevent the page when we know we are refreshing so things might be a little flakey. It should also prevent the clash to allow the refresh to work correctly.

p.s. I know this isn't the tidiest thing but it should tide us over and prevent pages/manual intervention