### PR TITLE
A little patience never hurts

### DIFF
--- a/.github/workflows/deploy-service-restart.yml
+++ b/.github/workflows/deploy-service-restart.yml
@@ -53,9 +53,17 @@ jobs:
       service: sdf
     secrets: inherit
 
+  sleep-between:
+    name: Wait for 5 minutes
+    needs: restart-sdf
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sleep for 5 minutes
+        run: sleep 300
+
   e2e-validation:
     needs:
-      - restart-sdf
+      - sleep-between
     uses: ./.github/workflows/e2e-validation.yml
     with:
       environment: ${{ inputs.environment }}
@@ -63,7 +71,7 @@ jobs:
 
   api-test:
     needs:
-      - restart-sdf
+      - sleep-between
     uses: ./.github/workflows/run-api-test.yml
     with:
       environment: ${{ inputs.environment }}


### PR DESCRIPTION
During the service restarts we are returning the task for the restart being completed a little too quickly with no active "healthchecker" after to actually verify that the services are able to take traffic. Then we start testing and they obviously fail as the services aren't available.

This adds a little time to give the services a longer grace period before being expected to take traffic.