### PR TITLE
feat: disable posthog for local runs

### DIFF
--- a/app/auth-portal/.env
+++ b/app/auth-portal/.env
@@ -4,5 +4,8 @@
 
 VITE_AUTH_API_URL=http://localhost:9001
 
-VITE_POSTHOG_PUBLIC_KEY=phc_KpehlXOqtU44B2MeW6WjqR09NxRJCYEiUReA58QcAYK
-VITE_POSTHOG_API_HOST=https://e.systeminit.com
+# POSTHOG ENV VARS (default is Production) - only enable if you need it 
+# Like to test a specific workflow or new event additions. This is intentionally
+# disabled so we don't cause too much noise + incur costs in Posthog
+#VITE_POSTHOG_PUBLIC_KEY=phc_KpehlXOqtU44B2MeW6WjqR09NxRJCYEiUReA58QcAYK
+#VITE_POSTHOG_API_HOST=https://e.systeminit.com

--- a/app/web/.env
+++ b/app/web/.env
@@ -36,9 +36,11 @@ DEV_API_PROXY_URL=http://127.0.0.1:5156
 
 
 
-# POSTHOG ENV VARS (default is Production)
-VITE_POSTHOG_PUBLIC_KEY=phc_KpehlXOqtU44B2MeW6WjqR09NxRJCYEiUReA58QcAYK
-VITE_POSTHOG_API_HOST=https://e.systeminit.com
+# POSTHOG ENV VARS (default is Production) - only enable if you need it 
+# Like to test a specific workflow or new event additions. This is intentionally
+# disabled so we don't cause too much noise + incur costs in Posthog
+#VITE_POSTHOG_PUBLIC_KEY=phc_KpehlXOqtU44B2MeW6WjqR09NxRJCYEiUReA58QcAYK
+#VITE_POSTHOG_API_HOST=https://e.systeminit.com
 
 # ENV VARIABLES FOR WS CONSOLE LOGGING
 # VITE_LOG_WS=true                      # turn on console logging for all WS events except cursor and online events

--- a/bin/auth-api/.env
+++ b/bin/auth-api/.env
@@ -30,8 +30,11 @@ AUTH0_CLIENT_SECRET=fill-in-real-key  # must set in .env.local to run auth api l
 AUTH0_M2M_CLIENT_ID=1v8ff9tKOZw0u8As4gib1HmvxefaX0nK
 AUTH0_M2M_CLIENT_SECRET=fill-in-real-key  # must set in .env.local to run auth api locally
 
-POSTHOG_PUBLIC_KEY=phc_KpehlXOqtU44B2MeW6WjqR09NxRJCYEiUReA58QcAYK
-POSTHOG_API_HOST=https://e.systeminit.com
+# POSTHOG ENV VARS (default is Production) - only enable if you need it 
+# Like to test a specific workflow or new event additions. This is intentionally
+# disabled so we don't cause too much noise + incur costs in Posthog
+#POSTHOG_PUBLIC_KEY=phc_KpehlXOqtU44B2MeW6WjqR09NxRJCYEiUReA58QcAYK
+#POSTHOG_API_HOST=https://e.systeminit.com
 
 LAGO_API_KEY=fill-in-real-key # must be set in .env.local ti run auth api locally
 


### PR DESCRIPTION
While locally running the applications we by default shouldn't push events and users into Posthog. It causes us to incur unnecessary costs within PostHog and causes noise in the Production Tenant. 

We can revisit this to maybe sample in a separate tenant or similar and have it defaulted on that that tenant instead.

See below example of soak tests causing millions of users to be created last December.
![Screenshot 2025-01-02 at 18 27 20](https://github.com/user-attachments/assets/d5e13193-1a68-4818-b594-e8883be65996)
