### PR TITLE
feat: Add sdf whoami endpoint accessible to user or automation tokens

### DIFF
--- a/lib/sdf-server/src/routes.rs
+++ b/lib/sdf-server/src/routes.rs
@@ -65,6 +65,7 @@ pub fn routes(state: AppState) -> Router {
         .nest("/api/module", crate::service::module::routes())
         .nest("/api/variant", crate::service::variant::routes())
         .nest("/api/v2", crate::service::v2::routes(state.clone()))
+        .nest("/api/whoami", crate::service::whoami::routes())
         .layer(CompressionLayer::new())
         // allows us to be permissive about cors from our owned subdomains
         .layer(

--- a/lib/sdf-server/src/service.rs
+++ b/lib/sdf-server/src/service.rs
@@ -23,6 +23,7 @@ pub mod secret;
 pub mod session;
 pub mod v2;
 pub mod variant;
+pub mod whoami;
 pub mod ws;
 
 /// A module containing dev routes for local development only.

--- a/lib/sdf-server/src/service/whoami.rs
+++ b/lib/sdf-server/src/service/whoami.rs
@@ -1,0 +1,38 @@
+use axum::{response::IntoResponse, routing::get, Json, Router};
+use dal::{UserPk, WorkspacePk};
+use serde::{Deserialize, Serialize};
+use si_jwt_public_key::SiJwt;
+
+use crate::{
+    extract::{AuthorizedForAutomationRole, EndpointAuthorization, ValidatedToken},
+    AppState,
+};
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/", get(whoami))
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct WhoamiResponse {
+    pub user_id: UserPk,
+    pub user_email: String,
+    pub workspace_id: WorkspacePk,
+    pub token: SiJwt,
+}
+
+async fn whoami(
+    // Just because this is the most permissive role we have right now
+    _: AuthorizedForAutomationRole,
+    ValidatedToken(token): ValidatedToken,
+    EndpointAuthorization {
+        workspace_id, user, ..
+    }: EndpointAuthorization,
+) -> impl IntoResponse {
+    Json(WhoamiResponse {
+        workspace_id,
+        user_id: user.pk(),
+        user_email: user.email().clone(),
+        token,
+    })
+}

--- a/lib/sdf-server/src/service/ws/workspace_updates.rs
+++ b/lib/sdf-server/src/service/ws/workspace_updates.rs
@@ -12,7 +12,7 @@ use tokio_util::sync::CancellationToken;
 
 use super::WsError;
 use crate::{
-    extract::{Nats, WsAuthorization},
+    extract::{EndpointAuthorization, Nats, TokenFromQueryParam},
     nats_multiplexer::NatsMultiplexerClients,
 };
 
@@ -20,7 +20,8 @@ use crate::{
 pub async fn workspace_updates(
     wsu: WebSocketUpgrade,
     Nats(nats): Nats,
-    WsAuthorization(claim): WsAuthorization,
+    _: TokenFromQueryParam, // This tells it to pull the token from the "token" param
+    auth: EndpointAuthorization,
     State(shutdown_token): State<CancellationToken>,
     State(channel_multiplexer_clients): State<NatsMultiplexerClients>,
 ) -> Result<impl IntoResponse, WsError> {
@@ -28,7 +29,7 @@ pub async fn workspace_updates(
         run_workspace_updates_proto(
             socket,
             nats,
-            claim.workspace_id(),
+            auth.workspace_id,
             channel_multiplexer_clients.ws,
             shutdown_token,
         )


### PR DESCRIPTION
This adds a "whoami" endpoint that you can hit to check your token and email (who SI thinks you are). It mainly exists to validate that we can actually authorize automation tokens for an endpoint (since all other endpoints reject automation tokens).

## Extractor Funnel

This also factors the token and authorization extractors so they always use the same code. web/automation authorization still work via extractors, they just all run through a single funnel now.

`EndpointAuthorization` is the main authorization extractor you will use (or `AccessBuilder`, which uses it), which:
  1. Extracts the access token from the `Authorization: ` header using the RawAccessToken extractor.
  2. Validates the access token and checks expiration date using the ValidatedToken extractor.
  3. Checks that the user is a member of the workspace using the WorkspaceMember extractor.
  4. Checks that the token gives the user "web" permissions using the AuthorizedRole extractor.
  5. Returns the workspace_id, user record, and the role that was authorized.

### Customization For Different Endpoints

The big reason to break this up was to allow different authorization for different endpoints, as well as to support WS endpoints using the same extractors. The `AuthorizedRole` and `RawAccessToken` extractors check if they already have a value before doing their default behavior, so you can invoke other extractors that set the value first. To wit:
- The whoami endpoint doesn't need maximal permissions (the web role), so it adds the `_: AuthorizeForAutomationRole` extractor to its endpoint function, causing endpoint validation to check for the automation role instead.
- WS endpoints add the `_: TokenFromQueryParam` extractor to the endpoint function, which retrieves the token from the "token" query parameter instead of the Authorization header.

Where appropriate, these endpoints cache their results so that if you use multiple extractors (which we do frequently) you don't pay a double or triple database access or public key decryption penalty.

This also adds `Deref` and `Into` to a lot of the extractors, which means instead of saying things like `Nats(nats): Nats` you can just say `nats: Nats` and still use the nats object like normal.

## Future

Going forward, we'll want to take some of this (RawAccessToken and ValidatedToken in particular) and move it to a common library (quite possibly repurpose `si-jwt-public-key` for it) so that the module index can use them. I started to do that, but there's a minor snarl in that it needs to be able to access the public key we grab as part of `AppState` (which isn't shared between module index and sdf). Will get back to that at a later time.