### PR TITLE
feat: mgmt fns can create views, create components in views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,6 +1939,7 @@ dependencies = [
  "si-data-nats",
  "si-data-pg",
  "si-events",
+ "si-id",
  "si-jwt-public-key",
  "si-layer-cache",
  "si-pkg",

--- a/bin/lang-js/src/function_kinds/management.ts
+++ b/bin/lang-js/src/function_kinds/management.ts
@@ -32,16 +32,18 @@ export interface ManagmentConnect {
   }
 }
 
+export interface ManagementCreate {
+  [key: string]: {
+    kind: string;
+    properties?: object;
+    geometry?: Geometry | { [key: string]: Geometry };
+    parent?: string;
+    connect?: ManagmentConnect[],
+  }
+}
+
 export interface ManagementOperations {
-  create?: {
-    [key: string]: {
-      kind: string;
-      properties?: object;
-      geometry?: Geometry;
-      parent?: string;
-      connect?: ManagmentConnect[],
-    }
-  };
+  create?: ManagementCreate,
   update?: {
     [key: string]: {
       properties?: object;

--- a/lib/dal-test/Cargo.toml
+++ b/lib/dal-test/Cargo.toml
@@ -20,6 +20,7 @@ si-crypto = { path = "../../lib/si-crypto" }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-data-pg = { path = "../../lib/si-data-pg" }
 si-events = { path = "../../lib/si-events-rs" }
+si-id = { path = "../../lib/si-id" }
 si-jwt-public-key = { path = "../../lib/si-jwt-public-key" }
 si-layer-cache = { path = "../../lib/si-layer-cache" }
 si-pkg = { path = "../../lib/si-pkg" }

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -101,6 +101,7 @@ rust_test(
         "//lib/pending-events:pending-events",
         "//lib/rebaser-server:rebaser-server",
         "//lib/si-events-rs:si-events",
+        "//lib/si-id:si-id",
         "//lib/si-frontend-types-rs:si-frontend-types",
         "//lib/si-layer-cache:si-layer-cache",
         "//lib/si-pkg:si-pkg",

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1487,7 +1487,7 @@ impl Component {
         view_id: ViewId,
     ) -> ComponentResult<Geometry> {
         let mut geometry_pre = self.geometry(ctx, view_id).await?;
-        if geometry_pre.clone().into_raw() != raw_geometry {
+        if geometry_pre.into_raw() != raw_geometry {
             geometry_pre
                 .update(ctx, raw_geometry)
                 .await
@@ -3594,7 +3594,7 @@ impl Component {
 
             Some(GeometryAndView {
                 view_id,
-                geometry: geometry.clone().into_raw(),
+                geometry: geometry.into_raw(),
             })
         } else {
             None

--- a/lib/dal/src/diagram/view.rs
+++ b/lib/dal/src/diagram/view.rs
@@ -378,7 +378,7 @@ impl View {
         view_id: ViewId,
     ) -> DiagramResult<Geometry> {
         let mut geometry_pre = self.geometry(ctx, view_id).await?;
-        if geometry_pre.clone().into_raw() != raw_geometry {
+        if geometry_pre.into_raw() != raw_geometry {
             geometry_pre.update(ctx, raw_geometry).await?;
         }
 

--- a/lib/dal/src/func/binding/management.rs
+++ b/lib/dal/src/func/binding/management.rs
@@ -113,7 +113,7 @@ impl ManagementBinding {
                                 {{
                                     kind: "{name}",
                                     properties?: {sv_type},
-                                    geometry?: Geometry,
+                                    geometry?: Geometry | {{ [key: string]: Geometry }},
                                     connect?: {{
                                         from: string,
                                         to: {{
@@ -155,6 +155,7 @@ type Geometry = {{
 type Output = {{
   status: 'ok' | 'error';
   ops?: {{
+    views?: {{ create: string[]; }},
     create?: {{ [key: string]: {component_create_type} }},
     update?: {{ [key: string]: {{ 
         properties?: {{ [key: string]: unknown }}, 

--- a/lib/dal/src/management/generator.rs
+++ b/lib/dal/src/management/generator.rs
@@ -4,8 +4,8 @@ use si_frontend_types::RawGeometry;
 use si_id::{ComponentId, SchemaId, ViewId};
 
 use crate::management::{
-    ConnectionIdentifier, ManagementConnection, ManagementCreateOperation, ManagementGeometry,
-    IGNORE_PATHS,
+    ConnectionIdentifier, ManagementConnection, ManagementCreateGeometry,
+    ManagementCreateOperation, ManagementGeometry, IGNORE_PATHS,
 };
 use crate::prop::PropPath;
 use crate::{AttributeValue, Component, DalContext, InputSocket, OutputSocket, Prop, PropKind};
@@ -191,7 +191,7 @@ pub async fn generate_template(
         let create = ManagementCreateOperation {
             kind: Some(kind),
             properties,
-            geometry,
+            geometry: geometry.map(ManagementCreateGeometry::CurrentView),
             connect,
             parent,
         };

--- a/lib/dal/tests/integration_test/management/generator.rs
+++ b/lib/dal/tests/integration_test/management/generator.rs
@@ -62,13 +62,7 @@ async fn calculates_top_and_center(ctx: &DalContext) {
         .expect("set geo for left lego");
 
     let mut geometries = HashMap::new();
-    for geo in [
-        center_geo.clone(),
-        left_geo,
-        right_geo,
-        btm_geo.clone(),
-        top_geo.clone(),
-    ] {
+    for geo in [center_geo, left_geo, right_geo, btm_geo, top_geo] {
         geometries.insert(ComponentId::generate(), geo.into_raw());
     }
 


### PR DESCRIPTION
The return type for management functions has been extended to support creating views, and creating new components in views other than the current view.

The "geometry" property on a create can now *either* be a plain geometry object, which will create the component in the current view, or it can be a map of view names to geometries, which will create the component in the specified view with that geometry.

Additionally, you can add to your ops return an object like so:

```
ops: {
  views: {
    create: ["view a", "view b", "view c"]
  }
}
```

to create new views in a mangement function. The views will be available for create and update operations in the management func itself.