### PR TITLE
Mint v2 tokens for regular users now that all callers can accept them

### DIFF
--- a/bin/auth-api/src/services/auth.service.ts
+++ b/bin/auth-api/src/services/auth.service.ts
@@ -81,20 +81,7 @@ export function createSdfAuthToken(
   payload: Omit<SdfAuthTokenPayloadV2, "version">,
   options?: Omit<SignOptions, 'algorithm' | 'subject'>,
 ) {
-  function createPayload(): SdfAuthTokenPayload {
-    switch (payload.role) {
-      case "web":
-        // For web tokens, generate the old version until prod is able to handle new ones.
-        return { user_pk: payload.userId, workspace_pk: payload.workspaceId };
-      case "automation":
-        // Expire automation tokens quickly right now
-        return { version: "2", ...payload };
-      default:
-        return payload.role satisfies never;
-    }
-  }
-
-  return createJWT(createPayload(), { subject: payload.userId, ...(options ?? {}) });
+  return createJWT({ version: "2", ...payload }, { subject: payload.userId, ...(options ?? {}) });
 }
 
 export async function decodeSdfAuthToken(token: string) {


### PR DESCRIPTION
This just ties up a loose end: we were minting old v1 tokens for web users to ensure backwards compatibility during the upgrade. That's been working for a few weeks, so now we can switch to new-style tokens.

Testing: We already have unit tests that we're handling the v2 tokens correctly, and I've run the entire stack locally once again to make sure the module index, web app and SDF all work correctly.

This will require a deploy of the auth api, but nothing else. Existing tokens will continue to work, as well (this doesn't deprecate them or anything).