### PR TITLE
feat: delete components from management functions

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -70,6 +70,7 @@ use crate::{
 
 pub mod code;
 pub mod debug;
+pub mod delete;
 pub mod diff;
 pub mod frame;
 pub mod inferred_connection_graph;
@@ -3341,11 +3342,11 @@ impl Component {
 
     pub async fn exists_on_head(
         ctx: &DalContext,
-        component_ids: Vec<ComponentId>,
+        component_ids: &[ComponentId],
     ) -> ComponentResult<HashSet<ComponentId>> {
         let mut components = HashSet::new();
         let base_change_set_ctx = ctx.clone_with_base().await?;
-        for component_id in component_ids {
+        for &component_id in component_ids {
             let maybe_component =
                 Component::try_get_by_id(&base_change_set_ctx, component_id).await?;
             if maybe_component.is_some() {

--- a/lib/dal/src/component/delete.rs
+++ b/lib/dal/src/component/delete.rs
@@ -1,0 +1,160 @@
+use std::collections::{HashMap, HashSet};
+
+use si_events::audit_log::AuditLogKind;
+use si_id::ComponentId;
+
+use crate::{change_status::ChangeStatus, diagram::SummaryDiagramEdge, DalContext, WsEvent};
+
+use super::{Component, ComponentResult};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ComponentDeletionStatus {
+    /// The component has a resource but will be deleted by the destroy action
+    /// after applying to head
+    MarkedForDeletion,
+    /// The component was deleted in this changeset but still exists on head
+    StillExistsOnHead,
+    /// The component was deleted (either because it was safe to delete without
+    /// an action, or becuase it was force erased)
+    Deleted,
+}
+
+pub async fn delete_components(
+    ctx: &DalContext,
+    component_ids: &[ComponentId],
+    force_erase: bool,
+) -> ComponentResult<HashMap<ComponentId, ComponentDeletionStatus>> {
+    let head_components: HashSet<ComponentId> =
+        Component::exists_on_head(ctx, component_ids).await?;
+    let mut result = HashMap::new();
+
+    let mut socket_map = HashMap::new();
+    let mut socket_map_head = HashMap::new();
+    let base_change_set_ctx = ctx.clone_with_base().await?;
+
+    for &component_id in component_ids {
+        let component = Component::get_by_id(ctx, component_id).await?;
+
+        let incoming_connections = component.incoming_connections(ctx).await?;
+        let outgoing_connections = component.outgoing_connections(ctx).await?;
+
+        let status = delete_component(ctx, &component, force_erase, &head_components).await?;
+
+        for incoming_connection in incoming_connections {
+            let payload = SummaryDiagramEdge {
+                from_component_id: incoming_connection.from_component_id,
+                from_socket_id: incoming_connection.from_output_socket_id,
+                to_component_id: incoming_connection.to_component_id,
+                to_socket_id: incoming_connection.to_input_socket_id,
+                change_status: ChangeStatus::Deleted,
+                created_info: serde_json::to_value(incoming_connection.created_info)?,
+                deleted_info: serde_json::to_value(incoming_connection.deleted_info)?,
+                to_delete: true,
+                from_base_change_set: false,
+            };
+            WsEvent::connection_upserted(ctx, payload.into())
+                .await?
+                .publish_on_commit(ctx)
+                .await?;
+        }
+
+        for outgoing_connection in outgoing_connections {
+            let payload = SummaryDiagramEdge {
+                from_component_id: outgoing_connection.from_component_id,
+                from_socket_id: outgoing_connection.from_output_socket_id,
+                to_component_id: outgoing_connection.to_component_id,
+                to_socket_id: outgoing_connection.to_input_socket_id,
+                change_status: ChangeStatus::Deleted,
+                created_info: serde_json::to_value(outgoing_connection.created_info)?,
+                deleted_info: serde_json::to_value(outgoing_connection.deleted_info)?,
+                to_delete: true,
+                from_base_change_set: false,
+            };
+            WsEvent::connection_upserted(ctx, payload.into())
+                .await?
+                .publish_on_commit(ctx)
+                .await?;
+        }
+
+        match status {
+            ComponentDeletionStatus::MarkedForDeletion => {
+                let payload = component
+                    .into_frontend_type(ctx, None, ChangeStatus::Deleted, &mut socket_map)
+                    .await?;
+                WsEvent::component_updated(ctx, payload)
+                    .await?
+                    .publish_on_commit(ctx)
+                    .await?;
+            }
+            ComponentDeletionStatus::StillExistsOnHead => {
+                let component: Component =
+                    Component::get_by_id(&base_change_set_ctx, component_id).await?;
+                let payload = component
+                    .into_frontend_type(
+                        &base_change_set_ctx,
+                        None,
+                        ChangeStatus::Deleted,
+                        &mut socket_map_head,
+                    )
+                    .await?;
+                WsEvent::component_updated(ctx, payload)
+                    .await?
+                    .publish_on_commit(ctx)
+                    .await?;
+            }
+            ComponentDeletionStatus::Deleted => {
+                WsEvent::component_deleted(ctx, component_id)
+                    .await?
+                    .publish_on_commit(ctx)
+                    .await?;
+            }
+        }
+
+        result.insert(component_id, status);
+    }
+
+    Ok(result)
+}
+
+async fn delete_component(
+    ctx: &DalContext,
+    component: &Component,
+    force_erase: bool,
+    head_components: &HashSet<ComponentId>,
+) -> ComponentResult<ComponentDeletionStatus> {
+    let component_id = component.id();
+    let component_name = component.name(ctx).await?;
+    let component_schema_variant = component.schema_variant(ctx).await?;
+
+    let still_exists_on_head = head_components.contains(&component_id);
+
+    let mut status = if force_erase {
+        Component::remove(ctx, component_id).await?;
+        ComponentDeletionStatus::Deleted
+    } else {
+        // the move semantics here feel strange
+        match component.clone().delete(ctx).await? {
+            Some(_) => ComponentDeletionStatus::MarkedForDeletion,
+            None => ComponentDeletionStatus::Deleted,
+        }
+    };
+
+    if matches!(status, ComponentDeletionStatus::Deleted) && still_exists_on_head {
+        status = ComponentDeletionStatus::StillExistsOnHead;
+    }
+
+    ctx.write_audit_log(
+        AuditLogKind::DeleteComponent {
+            component_id,
+            name: component_name.to_owned(),
+            schema_variant_id: component_schema_variant.id(),
+            schema_variant_name: component_schema_variant.display_name().to_string(),
+        },
+        component_name,
+    )
+    .await?;
+
+    ctx.workspace_snapshot()?.cleanup().await?;
+
+    Ok(status)
+}

--- a/lib/dal/src/func/binding/management.rs
+++ b/lib/dal/src/func/binding/management.rs
@@ -111,7 +111,7 @@ impl ManagementBinding {
                                 let component_create_type = format!(
                                     r#"
                                 {{
-                                    kind: "{name}",
+                                    kind?: "{name}",
                                     properties?: {sv_type},
                                     geometry?: Geometry | {{ [key: string]: Geometry }},
                                     connect?: {{
@@ -166,6 +166,8 @@ type Output = {{
         }},
         parent?: string,
     }} }},
+    delete?: string[],
+    erase?: string[],
     actions?: {{ [key: string]: {{
       add?: ("create" | "update" | "refresh" | "delete" | string)[];
       remove?: ("create" | "update" | "refresh" | "delete" | string)[];


### PR DESCRIPTION
Components managed by a management component can now be deleted in a management func. Two new properties have been added to the ops return value: `delete?: string[]` and `erase?: string[]`. Delete will mark components with resources as to_delete, while erase will delete components regardless of their resource status. Components to delete or erase can be specified either by their name, or their id (available on the components input array). id will be more reliable if there is more than one managed component with the same name.