### PR TITLE
Don't send geometry Ids to the frontend

### DIFF
--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -708,9 +708,11 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
                 if (!v) return;
 
                 view.viewNodes[v.id] = new DiagramViewData({
-                  ...v,
                   ...VIEW_DEFAULTS,
                   ...geo,
+                  // if geo has properties like "id" we don't want them to overwrite view props
+                  // so we spread v last
+                  ...v,
                   componentType: ComponentType.View,
                 });
               });

--- a/lib/sdf-server/src/service/v2/view/get_diagram.rs
+++ b/lib/sdf-server/src/service/v2/view/get_diagram.rs
@@ -8,6 +8,7 @@ use dal::diagram::view::{View, ViewId, ViewView};
 use dal::diagram::{Diagram, DiagramError};
 use dal::{slow_rt, ChangeSetId, ComponentId, DalContext, WorkspacePk};
 use serde::{Deserialize, Serialize};
+use si_frontend_types::RawGeometry;
 use telemetry::prelude::debug;
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -15,8 +16,8 @@ use telemetry::prelude::debug;
 pub struct GeometryResponse {
     view_id: ViewId,
     name: String,
-    components: HashMap<ComponentId, Geometry>,
-    views: HashMap<ViewId, Geometry>,
+    components: HashMap<ComponentId, RawGeometry>,
+    views: HashMap<ViewId, RawGeometry>,
 }
 
 pub async fn get_geometry(
@@ -55,10 +56,10 @@ pub async fn get_geometry(
 
         match geo_represents {
             GeometryRepresents::Component(component_id) => {
-                components.insert(component_id, geometry);
+                components.insert(component_id, geometry.into_raw());
             }
             GeometryRepresents::View(view_id) => {
-                views.insert(view_id, geometry);
+                views.insert(view_id, geometry.into_raw());
             }
         }
     }


### PR DESCRIPTION
We are overwriting the view ID with the geometry ID in some cases.

This made it so that if you added a link to a view and then merged to head, you would get errors (@keeb was seeing them).

W/ @vbustamante and @jobelenus 
