### PR TITLE
Revert "Mint v2 tokens for regular users now that all callers can accept them"

### DIFF
--- a/bin/auth-api/src/services/auth.service.ts
+++ b/bin/auth-api/src/services/auth.service.ts
@@ -81,7 +81,20 @@ export function createSdfAuthToken(
   payload: Omit<SdfAuthTokenPayloadV2, "version">,
   options?: Omit<SignOptions, 'algorithm' | 'subject'>,
 ) {
-  return createJWT({ version: "2", ...payload }, { subject: payload.userId, ...(options ?? {}) });
+  function createPayload(): SdfAuthTokenPayload {
+    switch (payload.role) {
+      case "web":
+        // For web tokens, generate the old version until prod is able to handle new ones.
+        return { user_pk: payload.userId, workspace_pk: payload.workspaceId };
+      case "automation":
+        // Expire automation tokens quickly right now
+        return { version: "2", ...payload };
+      default:
+        return payload.role satisfies never;
+    }
+  }
+
+  return createJWT(createPayload(), { subject: payload.userId, ...(options ?? {}) });
 }
 
 export async function decodeSdfAuthToken(token: string) {


### PR DESCRIPTION
Reverts systeminit/si#5206

It looks like new sessions are using old tokens from the wrong workspaces in the web ui.