### PR TITLE
Make auth-portal something you have to manually bring up

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -302,6 +302,7 @@ si_buck2_resource(
 # Locally build and run `auth-portal` in dev mode
 si_buck2_resource(
     "//app/auth-portal:dev",
+    auto_init = False,
     allow_parallel = True,
     resource_deps = [
         "auth-api",


### PR DESCRIPTION
Right now auth-portal just sits in suspension, waiting for auth-api to come up; but that means if you don't plan to *run* auth-api, tilt shows "21/22" forever and it feels like you haven't got the whole system up!

This makes it so you have to manually bring up auth-portal after bringing up auth-api, so it doesn't show in stats :)

<img width="1019" alt="image" src="https://github.com/user-attachments/assets/ea9414fa-05e2-4fb1-b4e9-e4cda7e36b2a" />
