### PR TITLE
fix: send inferred edge events after component events in mgmt fns

### DIFF
--- a/lib/sdf-server/src/service/v2/view/create_component.rs
+++ b/lib/sdf-server/src/service/v2/view/create_component.rs
@@ -183,7 +183,9 @@ pub async fn create_component(
 
     let mut maybe_inferred_edges = None;
     if let Some(frame_id) = request.parent_id {
-        maybe_inferred_edges = Frame::upsert_parent(&ctx, component.id(), frame_id).await?;
+        maybe_inferred_edges = Frame::upsert_parent(&ctx, component.id(), frame_id)
+            .await?
+            .map(|edges| edges.upserted_edges);
 
         track(
             &posthog_client,


### PR DESCRIPTION
This ensures all edge events, including inferred edge upsert and removals, happen after all component events in management funcs