### PR TITLE
[docs] Fix hash link to #components

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,3 +37,4 @@ We contributors to System Initiative:
 * Nick Downs (@nickryand)
 * Croxx (@MrCroxx)
 * Arne Keller (@FliegendeWurst)
+* Henry Hermes (@sandalwing)

--- a/app/docs/src/tutorials/creating-components.md
+++ b/app/docs/src/tutorials/creating-components.md
@@ -1,7 +1,7 @@
 # Creating Components
 
 This tutorial will teach you how to create new
-[Components](/reference/vocabulary#Components).
+[Components](/reference/vocabulary#components).
 
 To follow along, you should:
 

--- a/app/docs/src/tutorials/editing-components-and-contributing.md
+++ b/app/docs/src/tutorials/editing-components-and-contributing.md
@@ -1,7 +1,7 @@
 # Editing, Updating, Installing and Contributing Components
 
 This tutorial will teach you how to create new
-[Components](/reference/vocabulary#Components).
+[Components](/reference/vocabulary#components).
 
 To follow along, you should:
 

--- a/app/docs/src/tutorials/working-with-components.md
+++ b/app/docs/src/tutorials/working-with-components.md
@@ -1,6 +1,6 @@
 # Working with Components
 
-This tutorial will teach you how to work more deeply with [Components](/reference/vocabulary#Components) in System Initiative.
+This tutorial will teach you how to work more deeply with [Components](/reference/vocabulary#components) in System Initiative.
 
 To follow along, you should:
 


### PR DESCRIPTION
I noticed [this](https://docs.systeminit.com/reference/vocabulary#Components) in the docs wasn't redirecting right. This patch should fix the issue.