### PR TITLE
Fix: BUG-735 consolidate these two events into one place and add the geo assignment

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -1385,21 +1385,6 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                 },
               },
               {
-                eventType: "ComponentUpgraded",
-                callback: (data) => {
-                  // If the component that updated wasn't in this change set,
-                  // don't update
-                  if (data.changeSetId !== changeSetId) return;
-                  // the componentIds ought to be the same, but just in case we'll delete first
-                  delete this.rawComponentsById[data.originalComponentId];
-                  delete this.allComponentsById[data.originalComponentId];
-                  delete this.nodesById[data.originalComponentId];
-                  delete this.groupsById[data.originalComponentId];
-                  this.rawComponentsById[data.component.id] = data.component;
-                  this.processAndStoreRawComponent(data.component.id, {});
-                },
-              },
-              {
                 eventType: "ResourceRefreshed",
                 callback: (data) => {
                   // If the component that updated wasn't in this change set,


### PR DESCRIPTION
This fix is explicitly for components, since their size is calculated, and not stored 😄 

Also, see my note for something to come back to in the future:
```
note: if a person added a hundred sockets to a component
and that component was a frame, it would not resize itself
and the sockets would appear outside the frame
```

I tested it:
```
function main() {
  const asset = new AssetBuilder();

  [...Array(99).keys()].forEach((i) => {
  const outputTest = new SocketDefinitionBuilder()
        .setName("Test" + i)
        .setArity("one")
        .setConnectionAnnotation("Test<string>")
        .build();
    asset.addOutputSocket(outputTest);
  })
  
  return asset.build();
}
```
<img width="193" alt="image" src="https://github.com/user-attachments/assets/df615084-1859-4e10-9219-3328c4f50cec" />
