### PR TITLE
Fix: restore the ellipsis in the actions history, clean up history for no ellipsis

### DIFF
--- a/app/web/src/components/Actions/ActionCard.vue
+++ b/app/web/src/components/Actions/ActionCard.vue
@@ -179,6 +179,14 @@
       </ol>
       <p v-else class="ml-xs">None</p>
     </DropdownMenu>
+    <DetailsPanelMenuIcon
+      v-if="!props.noInteraction"
+      @click="
+        (e) => {
+          contextMenuRef?.open(e, false);
+        }
+      "
+    />
     <FuncRunTabDropdown
       v-if="!props.noInteraction && actionHistory"
       :funcRunId="actionHistory.funcRunId"
@@ -214,6 +222,7 @@ import {
   DiagramGroupData,
   DiagramNodeData,
 } from "../ModelingDiagram/diagram_types";
+import DetailsPanelMenuIcon from "../DetailsPanelMenuIcon.vue";
 
 const componentsStore = useComponentsStore();
 const actionStore = useActionsStore();

--- a/app/web/src/components/Actions/ActionsList.vue
+++ b/app/web/src/components/Actions/ActionsList.vue
@@ -81,7 +81,7 @@
     >
       <ActionCard
         :action="action"
-        :noInteraction="props.noInteraction"
+        :noInteraction="props.noInteraction || props.kind === 'history'"
         :selected="isSelected(action)"
         :slim="props.slim"
         @click="props.clickAction && props.clickAction(action, $event)"

--- a/app/web/src/components/FuncRunTabDropdown.vue
+++ b/app/web/src/components/FuncRunTabDropdown.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <DropdownMenu ref="contextMenuRef" :forceAbove="false" forceAlignRight>
+    <DropdownMenu :forceAbove="false" forceAlignRight>
       <DropdownMenuItem
         :disabled="!funcRunId"
         :onSelect="
@@ -47,27 +47,14 @@
         label="View Function"
       />
     </DropdownMenu>
-
-    <DetailsPanelMenuIcon
-      :selected="contextMenuRef?.isOpen"
-      @click="
-        (e) => {
-          contextMenuRef?.open(e, false);
-        }
-      "
-    />
   </div>
 </template>
 
 <script lang="ts" setup>
-import { ref } from "vue";
 import { DropdownMenu, DropdownMenuItem } from "@si/vue-lib/design-system";
 import { FuncRunId } from "@/store/func_runs.store";
-import DetailsPanelMenuIcon from "./DetailsPanelMenuIcon.vue";
 
-const contextMenuRef = ref<InstanceType<typeof DropdownMenu>>();
-
-const props = defineProps<{ funcRunId?: FuncRunId; showFuncView?: boolean }>();
+defineProps<{ funcRunId?: FuncRunId; showFuncView?: boolean }>();
 
 const emit = defineEmits<{
   (e: "menuClick", funcRunId: FuncRunId, tabSlug: string): void;


### PR DESCRIPTION
This got accidentally killed in `3ff15cf`
<img src="https://media4.giphy.com/media/p4aBjY7Hj63U48epm1/giphy-downsized-medium.gif"/>