### PR TITLE
feat: add waiter to deploy pipeline for grace

### DIFF
--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -114,10 +114,18 @@ jobs:
       environment: ${{ inputs.environment }}
     secrets: inherit
 
+  sleep-between:
+    name: Wait for 5 minutes
+    needs: upgrade-and-migrate-sdf
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sleep for 5 minutes
+        run: sleep 300
+
   e2e-validation:
     needs:
       - upgrade-web
-      - upgrade-and-migrate-sdf
+      - sleep-between
     uses: ./.github/workflows/e2e-validation.yml
     with:
       environment: ${{ inputs.environment }}


### PR DESCRIPTION
Adds some grace time like we do on our service refresh to allow the services to come back before testing.

NB: I am not happy about this fix but it'll prevent the unnecessary noise