### PR TITLE
feat(sdf): Add automation API for "create changeset"

### DIFF
--- a/lib/sdf-server/src/extract/request.rs
+++ b/lib/sdf-server/src/extract/request.rs
@@ -16,13 +16,10 @@ use super::{internal_error, unauthorized_error, ErrorResponse};
 pub struct RequestUlidFromHeader(pub Option<Ulid>);
 
 #[async_trait]
-impl FromRequestParts<AppState> for RequestUlidFromHeader {
+impl<S> FromRequestParts<S> for RequestUlidFromHeader {
     type Rejection = ErrorResponse;
 
-    async fn from_request_parts(
-        parts: &mut Parts,
-        _state: &AppState,
-    ) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let request_ulid = parts
             .headers
             .get("X-SI-REQUEST-ULID")
@@ -134,13 +131,10 @@ impl FromRequestParts<AppState> for RawAccessToken {
 pub struct TokenFromAuthorizationHeader(pub String);
 
 #[async_trait]
-impl FromRequestParts<AppState> for TokenFromAuthorizationHeader {
+impl<S> FromRequestParts<S> for TokenFromAuthorizationHeader {
     type Rejection = ErrorResponse;
 
-    async fn from_request_parts(
-        parts: &mut Parts,
-        _state: &AppState,
-    ) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         if let Some(RawAccessToken(token)) = parts.extensions.get::<RawAccessToken>() {
             return Ok(Self(token.clone()));
         }

--- a/lib/sdf-server/src/extract/v1.rs
+++ b/lib/sdf-server/src/extract/v1.rs
@@ -1,4 +1,4 @@
-use axum::{async_trait, extract::FromRequestParts, http::request::Parts};
+use axum::{async_trait, extract::FromRequestParts, http::request::Parts, RequestPartsExt as _};
 use derive_more::{Deref, Into};
 
 use crate::app_state::AppState;
@@ -20,8 +20,8 @@ impl FromRequestParts<AppState> for AccessBuilder {
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
         // Ensure we get the workspace ID from the token
-        TargetWorkspaceIdFromToken::from_request_parts(parts, state).await?;
-        let auth = WorkspaceAuthorization::from_request_parts(parts, state).await?;
-        Ok(Self(auth.into()))
+        let _: TargetWorkspaceIdFromToken = parts.extract_with_state(state).await?;
+        let WorkspaceAuthorization { ctx, .. } = parts.extract_with_state(state).await?;
+        Ok(Self(ctx.access_builder()))
     }
 }

--- a/lib/sdf-server/src/service.rs
+++ b/lib/sdf-server/src/service.rs
@@ -18,6 +18,7 @@ pub mod force_change_set_response;
 pub mod graphviz;
 pub mod module;
 pub mod node_debug;
+pub mod public;
 pub mod qualification;
 pub mod secret;
 pub mod session;

--- a/lib/sdf-server/src/service/public.rs
+++ b/lib/sdf-server/src/service/public.rs
@@ -1,0 +1,13 @@
+use axum::Router;
+
+use crate::AppState;
+
+pub mod change_sets;
+pub mod workspaces;
+
+pub fn routes(state: AppState) -> Router<AppState> {
+    Router::new().nest(
+        "/v0",
+        Router::new().nest("/workspaces", workspaces::routes(state)),
+    )
+}

--- a/lib/sdf-server/src/service/public/change_sets.rs
+++ b/lib/sdf-server/src/service/public/change_sets.rs
@@ -1,0 +1,74 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
+use dal::{change_set::ChangeSet, WsEvent};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use si_events::audit_log::AuditLogKind;
+use thiserror::Error;
+
+use crate::extract::{workspace::WorkspaceDalContext, PosthogEventTracker};
+use crate::AppState;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ChangeSetsError {
+    #[error("dal change set error: {0}")]
+    DalChangeSet(#[from] dal::ChangeSetError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] dal::TransactionsError),
+    #[error("ws event error: {0}")]
+    WsEvent(#[from] dal::WsEventError),
+}
+
+type Result<T> = std::result::Result<T, ChangeSetsError>;
+
+impl IntoResponse for ChangeSetsError {
+    fn into_response(self) -> Response {
+        (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
+    }
+}
+
+// /api/public/workspaces/:workspace_id/change-sets
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/", post(create_change_set))
+        .nest("/:change_set_id", Router::new())
+}
+
+async fn create_change_set(
+    WorkspaceDalContext(ctx): WorkspaceDalContext,
+    tracker: PosthogEventTracker,
+    Json(payload): Json<CreateChangeSetRequest>,
+) -> Result<Json<CreateChangeSetResponse>> {
+    let change_set = ChangeSet::fork_head(&ctx, &payload.change_set_name).await?;
+
+    tracker.track(&ctx, "create_change_set", json!(payload));
+
+    ctx.write_audit_log(AuditLogKind::CreateChangeSet, payload.change_set_name)
+        .await?;
+
+    WsEvent::change_set_created(&ctx, change_set.id)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    ctx.commit_no_rebase().await?;
+
+    Ok(Json(CreateChangeSetResponse { change_set }))
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct CreateChangeSetRequest {
+    change_set_name: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct CreateChangeSetResponse {
+    change_set: ChangeSet,
+}

--- a/lib/sdf-server/src/service/public/workspaces.rs
+++ b/lib/sdf-server/src/service/public/workspaces.rs
@@ -1,0 +1,19 @@
+use axum::{middleware, Router};
+
+use crate::{
+    extract::workspace::{AuthorizedForAutomationRole, TargetWorkspaceIdFromPath},
+    AppState,
+};
+
+pub fn routes(state: AppState) -> Router<AppState> {
+    Router::new().nest(
+        "/:workspace_id",
+        Router::new()
+            .nest("/change-sets", super::change_sets::routes())
+            .route_layer(middleware::from_extractor_with_state::<
+                AuthorizedForAutomationRole,
+                AppState,
+            >(state))
+            .route_layer(middleware::from_extractor::<TargetWorkspaceIdFromPath>()),
+    )
+}

--- a/lib/sdf-server/src/service/session/restore_authentication.rs
+++ b/lib/sdf-server/src/service/session/restore_authentication.rs
@@ -3,7 +3,7 @@ use dal::{User, Workspace};
 use serde::{Deserialize, Serialize};
 
 use super::{SessionError, SessionResult};
-use crate::extract::{v1::AccessBuilder, workspace::WorkspaceAuthorization, HandlerContext};
+use crate::extract::workspace::WorkspaceAuthorization;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -13,14 +13,13 @@ pub struct RestoreAuthenticationResponse {
 }
 
 pub async fn restore_authentication(
-    HandlerContext(builder): HandlerContext,
-    AccessBuilder(access_builder): AccessBuilder,
     WorkspaceAuthorization {
-        user, workspace_id, ..
+        ctx,
+        user,
+        workspace_id,
+        ..
     }: WorkspaceAuthorization,
 ) -> SessionResult<Json<RestoreAuthenticationResponse>> {
-    let ctx = builder.build_head(access_builder).await?;
-
     let workspace = Workspace::get_by_pk(&ctx, &workspace_id)
         .await?
         .ok_or(SessionError::InvalidWorkspace(workspace_id))?;


### PR DESCRIPTION
This is a "create change set" endpoint for automation tokens (`POST /api/public/v0/workspaces/:workspace_id/change-set`). It takes `changeSetName` and is identical to the v2 create changeset api.

**Versioning**: This is designed to support a GitHub Action (which is the real public API we're shipping and supporting). The API endpoints themselves are not something we're exposing and documenting. (This is part of why `v0` is in the URL, to give a sense of semantic versioning independence.)

## The Code

This largely copies the v2 create changeset API.

It also has a couple of extractor ergonomics improvements (used in the new endpoint) that we can fold back into v2 endpoints. (I did not do the folding right now, to limit blast radius and to make this more reviewable.) Specifically:
* `WorkspaceDalContext`: Most workspace endpoints can use the WorkspaceDalContext extractor to get the DalContext, instead of extracting most of that information manually and constructing the DalContext in the endpoint code. This has the benefit of ensuring the DalContext is only given when authorization is complete, as well.
* `PosthogEventTracker`: Most endpoints have to extract and track the posthog client, original URI and host in order to send tracking events. This folds those three into one extractor. It then lets you call `tracker.track()` which will automatically include those in the posthog event.

### Example

As an example, create_change_set (the existing one) would now have this preamble:

```rust
pub async fn create_change_set(
    WorkspaceDalContext(ctx): WorkspaceDalContext,
    Json(request): Json<CreateChangeSetRequest>,
    tracker: PosthogEventTracker,
) -> ChangeSetResult<Json<CreateChangeSetResponse>> {
    let change_set = ChangeSet::fork_head(&ctx, &request.change_set_name).await?;
    ...
```

Where it currently looks like this:

```rust
pub async fn create_change_set(
    HandlerContext(builder): HandlerContext,
    AccessBuilder(access_builder): AccessBuilder,
    PosthogClient(posthog_client): PosthogClient,
    OriginalUri(original_uri): OriginalUri,
    Host(host_name): Host,
    Json(request): Json<CreateChangeSetRequest>,
) -> ChangeSetResult<Json<CreateChangeSetResponse>> {
    let ctx = builder.build_head(access_builder).await?;

    let change_set = ChangeSet::fork_head(&ctx, &request.change_set_name).await?;
    ...
```