### PR TITLE
feat(sdf): Management APIs to update components+trigger management functionsAdd "update component properties" and "trigger management functions"

### DIFF
--- a/lib/sdf-server/src/extract.rs
+++ b/lib/sdf-server/src/extract.rs
@@ -1,6 +1,7 @@
 use axum::{http::StatusCode, Json};
 use std::fmt;
 
+pub mod change_set;
 pub mod request;
 pub mod services;
 pub mod v1;

--- a/lib/sdf-server/src/extract/change_set.rs
+++ b/lib/sdf-server/src/extract/change_set.rs
@@ -1,0 +1,103 @@
+use axum::{
+    async_trait,
+    extract::{FromRequestParts, Path},
+    http::request::Parts,
+    RequestPartsExt as _,
+};
+use dal::{ChangeSet, ChangeSetId, DalContext};
+use derive_more::{Deref, Into};
+use serde::Deserialize;
+
+use crate::app_state::AppState;
+
+use super::{bad_request, internal_error, workspace::WorkspaceAuthorization, ErrorResponse};
+
+///
+/// Gets a DalContext pointed at the TargetChangeSet.
+///
+/// This ensures the user is authorized to access the workspace, has the correct role, and
+/// that the change set is in fact a part of the workspace.
+///
+#[derive(Clone, derive_more::Deref, derive_more::Into)]
+pub struct ChangeSetDalContext(pub DalContext);
+
+#[async_trait]
+impl FromRequestParts<AppState> for ChangeSetDalContext {
+    type Rejection = ErrorResponse;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        // Get the workspace we are accessing (and authorized for)
+        let WorkspaceAuthorization {
+            mut ctx,
+            workspace_id,
+            ..
+        } = parts.extract_with_state(state).await?;
+
+        // Validate the change set id is within that workspace
+        let TargetChangeSetId(change_set_id) = parts.extract().await?;
+        let change_set = ChangeSet::find(&ctx, change_set_id)
+            .await
+            .map_err(internal_error)?;
+        if change_set.is_none_or(|change_set| change_set.workspace_id != Some(workspace_id)) {
+            return Err(internal_error("Change set not found for given workspace"));
+        }
+
+        // Update the DalContext to the given changeset.
+        ctx.update_visibility_and_snapshot_to_visibility(change_set_id)
+            .await
+            .map_err(internal_error)?;
+
+        Ok(Self(ctx))
+    }
+}
+
+/// The target change set id from the path.
+///
+/// *Not* checked to ensure it is in the workspace.
+///
+#[derive(Clone, Debug, Deref, Copy, Into)]
+struct TargetChangeSetId(pub ChangeSetId);
+
+impl TargetChangeSetId {
+    fn set(parts: &mut Parts, change_set_id: ChangeSetId) -> Result<ChangeSetId, ErrorResponse> {
+        // This must not be done twice.
+        if parts.extensions.get::<TargetChangeSetId>().is_some() {
+            return Err(internal_error("Must only specify workspace ID once"));
+        }
+
+        parts.extensions.insert(TargetChangeSetId(change_set_id));
+        Ok(change_set_id)
+    }
+}
+
+#[async_trait]
+impl<S> FromRequestParts<S> for TargetChangeSetId {
+    type Rejection = ErrorResponse;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(*parts
+            .extensions
+            .get::<TargetChangeSetId>()
+            .ok_or_else(|| internal_error("No workspace ID. Endpoints must call an extractor like TargetChangeSetIdFromPath or TargetWorkspaceFromToken to get the workspace ID."))?)
+    }
+}
+
+#[derive(Deserialize, Clone, Debug, Deref, Copy, Into)]
+pub struct TargetChangeSetIdFromPath {
+    change_set_id: ChangeSetId,
+}
+
+#[async_trait]
+impl<S> FromRequestParts<S> for TargetChangeSetIdFromPath {
+    type Rejection = ErrorResponse;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let Path(TargetChangeSetIdFromPath { change_set_id }) =
+            parts.extract().await.map_err(bad_request)?;
+        TargetChangeSetId::set(parts, change_set_id)?;
+        Ok(TargetChangeSetIdFromPath { change_set_id })
+    }
+}

--- a/lib/sdf-server/src/service/public.rs
+++ b/lib/sdf-server/src/service/public.rs
@@ -2,8 +2,10 @@ use axum::Router;
 
 use crate::AppState;
 
-pub mod change_sets;
-pub mod workspaces;
+mod change_sets;
+mod components;
+mod management;
+mod workspaces;
 
 pub fn routes(state: AppState) -> Router<AppState> {
     Router::new().nest(

--- a/lib/sdf-server/src/service/public/components.rs
+++ b/lib/sdf-server/src/service/public/components.rs
@@ -1,0 +1,186 @@
+use std::collections::HashMap;
+
+use axum::{
+    extract::Path,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::put,
+    Json, Router,
+};
+use dal::{
+    prop::{PropPath, PropResult, PROP_PATH_SEPARATOR},
+    AttributeValue, Component, ComponentId, Prop, PropId, SchemaVariantId, WsEvent,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use si_events::audit_log::AuditLogKind;
+use thiserror::Error;
+
+use crate::extract::{change_set::ChangeSetDalContext, PosthogEventTracker};
+use crate::AppState;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ChangeSetsError {
+    #[error("attribute value error: {0}")]
+    AttributeValue(#[from] dal::attribute::value::AttributeValueError),
+    #[error("component error: {0}")]
+    Component(#[from] dal::ComponentError),
+    #[error("dal change set error: {0}")]
+    DalChangeSet(#[from] dal::ChangeSetError),
+    #[error("prop error: {0}")]
+    Prop(#[from] dal::prop::PropError),
+    #[error("schema variant error: {0}")]
+    SchemaVariant(#[from] dal::SchemaVariantError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] dal::TransactionsError),
+    #[error("ws event error: {0}")]
+    WsEvent(#[from] dal::WsEventError),
+}
+
+type Result<T> = std::result::Result<T, ChangeSetsError>;
+
+impl IntoResponse for ChangeSetsError {
+    fn into_response(self) -> Response {
+        (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
+    }
+}
+
+// /api/public/workspaces/:workspace_id/change-sets/:change_set_id/components
+pub fn routes() -> Router<AppState> {
+    Router::new().nest(
+        "/:component_id",
+        Router::new().route("/properties", put(update_component_properties)),
+    )
+}
+
+async fn update_component_properties(
+    ChangeSetDalContext(ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    Path(UpdateComponentPropertiesPath { component_id }): Path<UpdateComponentPropertiesPath>,
+    Json(payload): Json<UpdateComponentPropertiesRequest>,
+) -> Result<Json<UpdateComponentPropertiesResponse>> {
+    tracker.track(&ctx, "update_component_properties", json!(payload));
+
+    let component = Component::get_by_id(&ctx, component_id).await?;
+    let component_name = component.name(&ctx).await?;
+    let schema_variant = component.schema_variant(&ctx).await?;
+    let schema_variant_id = schema_variant.id;
+    let schema_variant_display_name = schema_variant.display_name().to_string();
+    let schema = schema_variant.schema(&ctx).await?;
+
+    for (key, value) in payload.domain.into_iter() {
+        // Update the property
+        let prop_id = key.prop_id(&ctx, schema_variant.id).await?;
+        let prop = Prop::get_by_id(&ctx, prop_id).await?;
+        let attribute_value_id =
+            Component::attribute_value_for_prop_id(&ctx, component_id, prop_id).await?;
+        let av = AttributeValue::get_by_id(&ctx, attribute_value_id).await?;
+        let before_value = av.value(&ctx).await?;
+        AttributeValue::update(&ctx, attribute_value_id, Some(value.clone())).await?;
+
+        // Log the property update
+        ctx.write_audit_log(
+            AuditLogKind::UpdatePropertyEditorValue {
+                component_id,
+                component_name: component_name.clone(),
+                schema_variant_id,
+                schema_variant_display_name: schema_variant_display_name.clone(),
+                prop_id,
+                prop_name: prop.name.clone(),
+                attribute_value_id,
+                before_value,
+                after_value: Some(value),
+            },
+            prop.name.clone(),
+        )
+        .await?;
+        let parent_prop = match Prop::parent_prop_id_by_id(&ctx, prop_id).await? {
+            Some(parent_prop_id) => Some(Prop::get_by_id(&ctx, parent_prop_id).await?),
+            None => None,
+        };
+
+        // Send the property update event to posthog
+        tracker.track(
+            &ctx,
+            "property_value_updated",
+            serde_json::json!({
+                "how": "/public/component/property_value_updated",
+                "component_id": component_id,
+                "component_schema_name": schema.name(),
+                "prop_id": prop_id,
+                "prop_name": prop.name,
+                "parent_prop_id": parent_prop.as_ref().map(|prop| prop.id),
+                "parent_prop_name": parent_prop.as_ref().map(|prop| prop.name.clone()),
+                "change_set_id": ctx.change_set_id(),
+            }),
+        );
+    }
+
+    // Send the WsEvent indicating the component was updated
+    let mut socket_map = HashMap::new();
+    let payload = component
+        .into_frontend_type(
+            &ctx,
+            None,
+            component.change_status(&ctx).await?,
+            &mut socket_map,
+        )
+        .await?;
+    WsEvent::component_updated(&ctx, payload)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    // Commit the changes
+    ctx.commit().await?;
+
+    Ok(Json(UpdateComponentPropertiesResponse {}))
+}
+
+#[derive(Deserialize)]
+struct UpdateComponentPropertiesPath {
+    component_id: ComponentId,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct UpdateComponentPropertiesRequest {
+    domain: HashMap<ComponentPropKey, serde_json::Value>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct UpdateComponentPropertiesResponse {}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(untagged)]
+enum ComponentPropKey {
+    PropId(PropId),
+    PropPath(DomainPropPath),
+}
+
+impl ComponentPropKey {
+    async fn prop_id(
+        &self,
+        ctx: &dal::DalContext,
+        schema_variant_id: SchemaVariantId,
+    ) -> PropResult<PropId> {
+        match self {
+            ComponentPropKey::PropId(prop_id) => Ok(*prop_id),
+            ComponentPropKey::PropPath(path) => {
+                Prop::find_prop_id_by_path(ctx, schema_variant_id, &path.to_prop_path()).await
+            }
+        }
+    }
+}
+
+// A prop path, starting from root/domain, with / instead of PROP_PATH_SEPARATOR as its separator
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+struct DomainPropPath(String);
+
+impl DomainPropPath {
+    fn to_prop_path(&self) -> PropPath {
+        PropPath::new(["root", "domain"]).join(&self.0.replace("/", PROP_PATH_SEPARATOR).into())
+    }
+}

--- a/lib/sdf-server/src/service/public/management.rs
+++ b/lib/sdf-server/src/service/public/management.rs
@@ -1,0 +1,184 @@
+use axum::{
+    extract::Path,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use si_events::audit_log::AuditLogKind;
+use thiserror::Error;
+use veritech_client::ManagementFuncStatus;
+
+use crate::extract::{change_set::ChangeSetDalContext, PosthogEventTracker};
+use crate::AppState;
+
+use dal::{
+    diagram::view::ViewId,
+    management::{
+        prototype::{ManagementPrototype, ManagementPrototypeId},
+        ManagementFuncReturn, ManagementOperator,
+    },
+    schema::variant::authoring::VariantAuthoringError,
+    ComponentId, Func, FuncError, WsEvent,
+};
+
+// /api/public/workspaces/:workspace_id/change-sets/:change_set_id/components
+pub fn routes() -> Router<AppState> {
+    Router::new().nest(
+        "/prototype/:management_prototype_id",
+        Router::new().route("/:component_id/:view_id", post(run_prototype)),
+    )
+}
+
+async fn run_prototype(
+    ChangeSetDalContext(ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    Path(RunPrototypePath {
+        management_prototype_id: prototype_id,
+        component_id,
+        view_id,
+    }): Path<RunPrototypePath>,
+    Json(request): Json<RunPrototypeRequest>,
+) -> Result<Json<RunPrototypeResponse>> {
+    // TODO check that this is a valid prototypeId
+    let mut execution_result =
+        ManagementPrototype::execute_by_id(&ctx, prototype_id, component_id, view_id.into())
+            .await?;
+
+    tracker.track(
+        &ctx,
+        "run_prototype",
+        serde_json::json!({
+            "how": "/public/management/run_prototype",
+            "view_id": view_id,
+            "prototype_id": prototype_id,
+            "component_id": component_id,
+        }),
+    );
+
+    if let Some(result) = execution_result.result.take() {
+        let ManagementFuncReturn {
+            status,
+            message,
+            operations,
+            ..
+        } = result.try_into()?;
+        let mut created_component_ids = None;
+        if status == ManagementFuncStatus::Ok {
+            if let Some(operations) = operations {
+                created_component_ids = ManagementOperator::new(
+                    &ctx,
+                    component_id,
+                    operations,
+                    execution_result,
+                    Some(view_id),
+                )
+                .await?
+                .operate()
+                .await?;
+            }
+        }
+
+        let func_id = ManagementPrototype::func_id(&ctx, prototype_id).await?;
+        let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+
+        WsEvent::management_operations_complete(
+            &ctx,
+            request.request_ulid,
+            func.name.clone(),
+            message.clone(),
+            status,
+            created_component_ids,
+        )
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+        ctx.write_audit_log(
+            AuditLogKind::ManagementOperationsComplete {
+                component_id,
+                prototype_id,
+                func_id,
+                func_name: func.name.clone(),
+                status: match status {
+                    ManagementFuncStatus::Ok => "ok",
+                    ManagementFuncStatus::Error => "error",
+                }
+                .to_string(),
+                message: message.clone(),
+            },
+            func.name,
+        )
+        .await?;
+
+        ctx.commit().await?;
+
+        return Ok(Json(RunPrototypeResponse { status, message }));
+    }
+
+    Err(ManagementApiError::ManagementPrototypeExecutionFailure(
+        prototype_id,
+    ))
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunPrototypeRequest {
+    request_ulid: Option<ulid::Ulid>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunPrototypeResponse {
+    status: ManagementFuncStatus,
+    message: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RunPrototypePath {
+    management_prototype_id: ManagementPrototypeId,
+    component_id: ComponentId,
+    view_id: ViewId,
+}
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+enum ManagementApiError {
+    #[error("change set error: {0}")]
+    ChangeSet(#[from] dal::ChangeSetError),
+    #[error("func error: {0}")]
+    Func(#[from] FuncError),
+    #[error("func api error: {0}")]
+    FuncAPI(#[from] crate::service::v2::func::FuncAPIError),
+    #[error("func authoring error: {0}")]
+    FuncAuthoring(#[from] dal::func::authoring::FuncAuthoringError),
+    #[error("hyper error: {0}")]
+    Http(#[from] axum::http::Error),
+    #[error("layer db error: {0}")]
+    LayerDb(#[from] si_layer_cache::LayerDbError),
+    #[error("management error: {0}")]
+    Management(#[from] dal::management::ManagementError),
+    #[error("management prototype error: {0}")]
+    ManagementPrototype(#[from] dal::management::prototype::ManagementPrototypeError),
+    #[error("management prototype execution failure: {0}")]
+    ManagementPrototypeExecutionFailure(ManagementPrototypeId),
+    #[error("schema variant error: {0}")]
+    SchemaVariant(#[from] dal::SchemaVariantError),
+    #[error("serde json error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] dal::TransactionsError),
+    #[error("variant authoring error: {0}")]
+    VariantAuthoring(#[from] VariantAuthoringError),
+    #[error("ws event error: {0}")]
+    WsEvent(#[from] dal::WsEventError),
+}
+
+type Result<T> = std::result::Result<T, ManagementApiError>;
+
+impl IntoResponse for ManagementApiError {
+    fn into_response(self) -> Response {
+        (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
+    }
+}


### PR DESCRIPTION
This adds two management API endpoints:

* Component update: PUT /api/public/v0/workspaces/:workspace_id/change-sets/:change_set_id/components/:component_id/properties
  Lets you pass a set of properties with either `{ "propId": <value> }` or `{ "<prop name/path>": <value> }`, and sets those properties to the given values.

  This is patchy at the top level in that it will only set properties you specify at the top level, but it will replace the entire value of anything you set. So if you have a property like `{ a: { b: 1, c: 2 } }` and you POST with `{ "a": { b: 10 } }`, then `c` will be reset to its default value. But if you set `{ "a/b": 10 }`, then `c` will retain its value.

  The final interface is something we intend to experiment with; this gets us to where we have some flexibility writing the github action.
* Trigger management function: this is an exact analog of the normal endpoint to trigger a management function. You pass the view, component and prototype id (in the same format). I have copied the endpoint itself. This interface will likely evolve to support the github action over time as well, but our initial plan is to have you pass these IDs yourself.

This puts us in spitting distance of a useful management-function-triggering github action (apply changeset and the action itself are the remaining items before we can really put it into practice).

### Code

I also found an extractor pattern that lets us use some of our extractors more easily (`parts.extract()` instead of `extract_with_state()`), and applied it where it could be. Doesn't affect more than a few callers.

![management!](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExeG1kM3FiaTk1cm00NmF5M3VudXNicHJqaDZsZnNsMDh6cm8xYTUyayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/U1bCix41cllqYDdSFQ/giphy.gif)