### PR TITLE
build: alter Docker image multi-arch promotion for certain images

### DIFF
--- a/bin/auth-api/BUCK
+++ b/bin/auth-api/BUCK
@@ -156,5 +156,9 @@ docker_image(
     flake_lock = "//:flake.lock",
     build_deps = [
         "//bin/auth-api:auth-api",
-    ]
+    ],
+    # TODO(fnichol): revisit post 2025-02-01
+    promote_multi_arches = [
+        "amd64",
+    ],
 )

--- a/bin/module-index/BUCK
+++ b/bin/module-index/BUCK
@@ -1,8 +1,8 @@
 load(
     "@prelude-si//:macros.bzl",
     "docker_image",
-    "rust_binary",
     "nix_omnibus_pkg",
+    "rust_binary",
 )
 
 rust_binary(
@@ -29,7 +29,11 @@ docker_image(
     name = "image",
     image_name = "module-index",
     flake_lock = "//:flake.lock",
-    build_deps = ["//bin/module-index:module-index"]
+    build_deps = ["//bin/module-index:module-index"],
+    # TODO(fnichol): revisit post 2025-02-01
+    promote_multi_arches = [
+        "amd64",
+    ],
 )
 
 nix_omnibus_pkg(

--- a/prelude-si/macros/docker.bzl
+++ b/prelude-si/macros/docker.bzl
@@ -15,6 +15,7 @@ def docker_image(
         visibility = ["PUBLIC"],
         release_target = "release",
         promote_target = "promote",
+        promote_multi_arches = [],
         **kwargs):
     _docker_image(
         name = name,
@@ -36,5 +37,6 @@ def docker_image(
     _docker_image_promote(
         name = promote_target,
         image_name = "{}/{}".format(organization, kwargs.get("image_name", name)),
+        multi_arches = promote_multi_arches,
         visibility = visibility,
     )


### PR DESCRIPTION
This change changes the default machine architectures that are expected to have Docker images being built and published to Docker Hub for tag promotion (in the `si/merge-main` CI pipeline).

By default, it's expected that an ARM and an X86-64 image will be produced. In this change it's now possible to change that default assumption and to only specify the machine architectures expected to have been published. The underlying Python script and corresponding `docker_image_promote` rule already had this capability but the `docker_image` Buck2 macro wasn't able to handle this prior to this change.

This change works in concert with changes to `si-ci` which will filter out non-critical artifact builds in the `si/merge-queue` pipeline.