### PR TITLE
fix: we need to wait a little longer during deploys

### DIFF
--- a/.github/workflows/deploy-service-restart.yml
+++ b/.github/workflows/deploy-service-restart.yml
@@ -54,12 +54,12 @@ jobs:
     secrets: inherit
 
   sleep-between:
-    name: Wait for 5 minutes
+    name: Wait for 10 minutes
     needs: restart-sdf
     runs-on: ubuntu-latest
     steps:
-      - name: Sleep for 5 minutes
-        run: sleep 300
+      - name: Sleep for 10 minutes
+        run: sleep 600
 
   e2e-validation:
     needs:

--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -115,12 +115,12 @@ jobs:
     secrets: inherit
 
   sleep-between:
-    name: Wait for 5 minutes
+    name: Wait for 10 minutes
     needs: upgrade-and-migrate-sdf
     runs-on: ubuntu-latest
     steps:
-      - name: Sleep for 5 minutes
-        run: sleep 300
+      - name: Sleep for 10 minutes
+        run: sleep 600
 
   e2e-validation:
     needs:


### PR DESCRIPTION
We have to wait a little longer in CI during the deploys as 5 minutes is really tight due to the layer cache taking a lot of time to initialise before the apps are permitted to serve. 