### PR TITLE
chore(dal): Use ChangeSet::get_by_id() anywhere change set is already required

### DIFF
--- a/lib/dal-test/src/expand_helpers.rs
+++ b/lib/dal-test/src/expand_helpers.rs
@@ -33,10 +33,9 @@ pub async fn create_change_set_and_update_ctx(
     ctx: &mut DalContext,
     base_change_set_id: ChangeSetId,
 ) {
-    let base_change_set = ChangeSet::find(ctx, base_change_set_id)
+    let base_change_set = ChangeSet::get_by_id(ctx, base_change_set_id)
         .await
-        .expect("could not perform find change set")
-        .expect("no change set found");
+        .expect("could not find change set");
     let workspace_snapshot_address = base_change_set.workspace_snapshot_address;
     let change_set = ChangeSet::new(
         ctx,

--- a/lib/dal-test/src/helpers/change_set.rs
+++ b/lib/dal-test/src/helpers/change_set.rs
@@ -163,9 +163,7 @@ impl ChangeSetTestHelpers {
 
     /// Abandons the current [`ChangeSet`].
     pub async fn abandon_change_set(ctx: &mut DalContext) -> Result<()> {
-        let mut abandonment_change_set = ChangeSet::find(ctx, ctx.change_set_id())
-            .await?
-            .ok_or(eyre!("change set not found by id: {}", ctx.change_set_id()))?;
+        let mut abandonment_change_set = ChangeSet::get_by_id(ctx, ctx.change_set_id()).await?;
         abandonment_change_set.abandon(ctx).await?;
         Ok(())
     }

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -36,7 +36,7 @@ use crate::layer_db_types::ContentTypes;
 use crate::slow_rt::SlowRuntimeError;
 use crate::workspace_snapshot::graph::{RebaseBatch, WorkspaceSnapshotGraph};
 use crate::workspace_snapshot::DependentValueRoot;
-use crate::{audit_logging, slow_rt, EncryptedSecret, Workspace, WorkspaceError};
+use crate::{audit_logging, slow_rt, ChangeSetError, EncryptedSecret, Workspace, WorkspaceError};
 use crate::{
     change_set::{ChangeSet, ChangeSetId},
     job::{
@@ -407,10 +407,7 @@ impl DalContext {
     /// Note: This does not guarantee that the [`ChangeSetId`] is contained within the [`WorkspacePk`]
     /// for the current [`DalContext`]
     pub async fn update_snapshot_to_visibility(&mut self) -> TransactionsResult<()> {
-        let change_set = ChangeSet::find_across_workspaces(self, self.change_set_id())
-            .await
-            .map_err(|err| TransactionsError::ChangeSet(err.to_string()))?
-            .ok_or(TransactionsError::ChangeSetNotFound(self.change_set_id()))?;
+        let change_set = ChangeSet::get_by_id_across_workspaces(self, self.change_set_id()).await?;
 
         let workspace_snapshot = WorkspaceSnapshot::find_for_change_set(self, change_set.id)
             .await
@@ -1353,9 +1350,7 @@ pub enum TransactionsError {
     #[error("Bad Workspace & Change Set")]
     BadWorkspaceAndChangeSet,
     #[error("change set error: {0}")]
-    ChangeSet(String),
-    #[error("change set not found for change set id: {0}")]
-    ChangeSetNotFound(ChangeSetId),
+    ChangeSet(#[from] Box<ChangeSetError>),
     #[error("change set not set on DalContext")]
     ChangeSetNotSet,
     #[error("job queue processor error: {0}")]
@@ -1406,7 +1401,13 @@ pub type TransactionsResult<T> = Result<T, TransactionsError>;
 
 impl From<WorkspaceError> for TransactionsError {
     fn from(err: WorkspaceError) -> Self {
-        TransactionsError::Workspace(Box::new(err))
+        Box::new(err).into()
+    }
+}
+
+impl From<ChangeSetError> for TransactionsError {
+    fn from(err: ChangeSetError) -> Self {
+        Box::new(err).into()
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/migrator.rs
+++ b/lib/dal/src/workspace_snapshot/migrator.rs
@@ -87,9 +87,7 @@ impl SnapshotGraphMigrator {
         info!("Migrating {} snapshot(s)", open_change_sets.len(),);
 
         for change_set in open_change_sets {
-            let mut change_set = ChangeSet::find_across_workspaces(ctx, change_set.id)
-                .await?
-                .ok_or(ChangeSetError::ChangeSetNotFound(change_set.id))?;
+            let mut change_set = ChangeSet::get_by_id_across_workspaces(ctx, change_set.id).await?;
             if change_set.workspace_id.is_none() || change_set.status == ChangeSetStatus::Failed {
                 // These are broken/garbage change sets generated during migrations of the
                 // "universal" workspace/change set. They're not actually accessible via normal

--- a/lib/dal/tests/integration_test/change_set.rs
+++ b/lib/dal/tests/integration_test/change_set.rs
@@ -319,12 +319,9 @@ async fn cannot_find_change_set_across_workspaces(
     assert!(user_2_change_set_unfound.is_none());
 
     // But if we search for the change set across all workspaces, we find it
-    let user_2_change_set_found_harshly =
-        ChangeSet::find_across_workspaces(&user_1_dal_context, user_2_change_set.id)
-            .await
-            .expect("could not find change set");
-
-    assert!(user_2_change_set_found_harshly.is_some());
+    ChangeSet::get_by_id_across_workspaces(&user_1_dal_context, user_2_change_set.id)
+        .await
+        .expect("could not find change set");
 }
 
 #[test]
@@ -402,10 +399,9 @@ async fn change_set_approval_flow(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update");
     // request approval
-    let mut change_set = ChangeSet::find(ctx, new_change_set.id)
+    let mut change_set = ChangeSet::get_by_id(ctx, new_change_set.id)
         .await
-        .expect("could not find change set")
-        .expect("change set is some");
+        .expect("could not find change set");
 
     change_set
         .request_change_set_approval(ctx)
@@ -415,10 +411,9 @@ async fn change_set_approval_flow(ctx: &mut DalContext) {
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update");
-    let mut change_set = ChangeSet::find(ctx, new_change_set.id)
+    let mut change_set = ChangeSet::get_by_id(ctx, new_change_set.id)
         .await
-        .expect("could not find change set")
-        .expect("change set is some");
+        .expect("could not find change set");
 
     // make sure everything looks right
     assert_eq!(change_set.status, ChangeSetStatus::NeedsApproval);
@@ -435,10 +430,9 @@ async fn change_set_approval_flow(ctx: &mut DalContext) {
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update");
-    let mut change_set = ChangeSet::find(ctx, new_change_set.id)
+    let mut change_set = ChangeSet::get_by_id(ctx, new_change_set.id)
         .await
-        .expect("could not find change set")
-        .expect("change set is some");
+        .expect("could not find change set");
     assert_eq!(change_set.status, ChangeSetStatus::Rejected);
     assert!(change_set.merge_requested_at.is_some());
     assert_eq!(change_set.merge_requested_by_user_id, current_user);
@@ -457,10 +451,9 @@ async fn change_set_approval_flow(ctx: &mut DalContext) {
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update");
-    let mut change_set = ChangeSet::find(ctx, new_change_set.id)
+    let mut change_set = ChangeSet::get_by_id(ctx, new_change_set.id)
         .await
-        .expect("could not find change set")
-        .expect("change set is some");
+        .expect("could not find change set");
     assert_eq!(change_set.status, ChangeSetStatus::Open);
     assert_eq!(change_set.merge_requested_at, None);
     assert_eq!(change_set.merge_requested_by_user_id, None);
@@ -476,10 +469,9 @@ async fn change_set_approval_flow(ctx: &mut DalContext) {
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update");
-    let mut change_set = ChangeSet::find(ctx, new_change_set.id)
+    let mut change_set = ChangeSet::get_by_id(ctx, new_change_set.id)
         .await
-        .expect("could not find change set")
-        .expect("change set is some");
+        .expect("could not find change set");
 
     // make sure everything looks right
     assert_eq!(change_set.status, ChangeSetStatus::NeedsApproval);
@@ -497,10 +489,9 @@ async fn change_set_approval_flow(ctx: &mut DalContext) {
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update");
-    let change_set = ChangeSet::find(ctx, new_change_set.id)
+    let change_set = ChangeSet::get_by_id(ctx, new_change_set.id)
         .await
-        .expect("could not find change set")
-        .expect("change set is some");
+        .expect("could not find change set");
 
     // make sure everything looks right
     assert_eq!(change_set.status, ChangeSetStatus::Approved);

--- a/lib/rebaser-server/src/change_set_processor_task.rs
+++ b/lib/rebaser-server/src/change_set_processor_task.rs
@@ -404,9 +404,8 @@ mod handlers {
 
             if let Some(workspace) = Workspace::get_by_pk(&ctx, &workspace_id).await? {
                 if workspace.default_change_set_id() == ctx.visibility().change_set_id {
-                    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
-                        .await?
-                        .ok_or(RebaseError::MissingChangeSet(change_set_id))?;
+                    let mut change_set =
+                        ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id).await?;
                     if WorkspaceSnapshot::dispatch_actions(&ctx).await? {
                         // Write out the snapshot to get the new address/id.
                         let new_snapshot_id = ctx

--- a/lib/rebaser-server/src/rebase.rs
+++ b/lib/rebaser-server/src/rebase.rs
@@ -26,8 +26,6 @@ pub(crate) enum RebaseError {
     ChangeSet(#[from] ChangeSetError),
     #[error("layerdb error: {0}")]
     LayerDb(#[from] LayerDbError),
-    #[error("missing change set")]
-    MissingChangeSet(ChangeSetId),
     #[error("missing rebase batch {0}")]
     MissingRebaseBatch(RebaseBatchAddress),
     #[error("pending events error: {0}")]
@@ -74,9 +72,7 @@ pub async fn perform_rebase(
     let updating_head = request.change_set_id == workspace.default_change_set_id();
 
     // Gather everything we need to detect conflicts and updates from the inbound message.
-    let mut to_rebase_change_set = ChangeSet::find(ctx, request.change_set_id)
-        .await?
-        .ok_or(RebaseError::MissingChangeSet(request.change_set_id))?;
+    let mut to_rebase_change_set = ChangeSet::get_by_id(ctx, request.change_set_id).await?;
     let to_rebase_workspace_snapshot_address = to_rebase_change_set.workspace_snapshot_address;
     debug!("before snapshot fetch and parse: {:?}", start.elapsed());
     let to_rebase_workspace_snapshot =

--- a/lib/sdf-server/src/service/change_set.rs
+++ b/lib/sdf-server/src/service/change_set.rs
@@ -42,8 +42,6 @@ pub enum ChangeSetError {
     ActionPrototype(#[from] ActionPrototypeError),
     #[error("cannot abandon head change set")]
     CannotAbandonHead,
-    #[error("change set not found")]
-    ChangeSetNotFound,
     #[error("component error: {0}")]
     Component(#[from] ComponentError),
     #[error("dal change set error: {0}")]
@@ -80,7 +78,9 @@ impl IntoResponse for ChangeSetError {
             ChangeSetError::ActionAlreadyEnqueued(_) => {
                 (StatusCode::NOT_MODIFIED, self.to_string())
             }
-            ChangeSetError::ChangeSetNotFound => (StatusCode::NOT_FOUND, self.to_string()),
+            ChangeSetError::DalChangeSet(DalChangeSetError::ChangeSetNotFound(..)) => {
+                (StatusCode::NOT_FOUND, self.to_string())
+            }
             ChangeSetError::DalChangeSetApply(_) => (StatusCode::CONFLICT, self.to_string()),
             ChangeSetError::DvuRootsNotEmpty(_) => (
                 StatusCode::PRECONDITION_REQUIRED,

--- a/lib/sdf-server/src/service/change_set/abandon_change_set.rs
+++ b/lib/sdf-server/src/service/change_set/abandon_change_set.rs
@@ -38,9 +38,7 @@ pub async fn abandon_change_set(
     if maybe_head_changeset == request.change_set_id {
         return Err(ChangeSetError::CannotAbandonHead);
     }
-    let mut change_set = ChangeSet::find(&ctx, request.change_set_id)
-        .await?
-        .ok_or(ChangeSetError::ChangeSetNotFound)?;
+    let mut change_set = ChangeSet::get_by_id(&ctx, request.change_set_id).await?;
     let old_status = change_set.status;
     ctx.update_visibility_and_snapshot_to_visibility(change_set.id)
         .await?;

--- a/lib/sdf-server/src/service/change_set/abandon_vote.rs
+++ b/lib/sdf-server/src/service/change_set/abandon_vote.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     extract::{v1::AccessBuilder, HandlerContext, PosthogClient},
-    service::change_set::{ChangeSetError, ChangeSetResult},
+    service::change_set::ChangeSetResult,
     track,
 };
 
@@ -29,9 +29,7 @@ pub async fn abandon_vote(
 ) -> ChangeSetResult<Json<()>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let mut change_set = ChangeSet::find(&ctx, ctx.change_set_id())
-        .await?
-        .ok_or(ChangeSetError::ChangeSetNotFound)?;
+    let mut change_set = ChangeSet::get_by_id(&ctx, ctx.change_set_id()).await?;
     change_set.abandon_vote(&ctx, request.vote.clone()).await?;
 
     track(

--- a/lib/sdf-server/src/service/change_set/begin_abandon_approval_process.rs
+++ b/lib/sdf-server/src/service/change_set/begin_abandon_approval_process.rs
@@ -38,9 +38,7 @@ pub async fn begin_abandon_approval_process(
     if maybe_head_changeset == request.visibility.change_set_id {
         return Err(ChangeSetError::CannotAbandonHead);
     }
-    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
-        .await?
-        .ok_or(ChangeSetError::ChangeSetNotFound)?;
+    let mut change_set = ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id).await?;
 
     change_set.begin_abandon_approval_flow(&ctx).await?;
 
@@ -69,9 +67,7 @@ pub async fn cancel_abandon_approval_process(
 ) -> ChangeSetResult<Json<()>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let mut change_set = ChangeSet::find(&ctx, ctx.change_set_id())
-        .await?
-        .ok_or(ChangeSetError::ChangeSetNotFound)?;
+    let mut change_set = ChangeSet::get_by_id(&ctx, ctx.change_set_id()).await?;
     change_set.cancel_abandon_approval_flow(&ctx).await?;
 
     track(

--- a/lib/sdf-server/src/service/change_set/begin_approval_process.rs
+++ b/lib/sdf-server/src/service/change_set/begin_approval_process.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     extract::{v1::AccessBuilder, HandlerContext, PosthogClient},
-    service::change_set::{ChangeSetError, ChangeSetResult},
+    service::change_set::ChangeSetResult,
     track,
 };
 
@@ -35,9 +35,7 @@ pub async fn begin_approval_process(
 ) -> ChangeSetResult<Json<()>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
-        .await?
-        .ok_or(ChangeSetError::ChangeSetNotFound)?;
+    let mut change_set = ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id).await?;
     change_set.begin_approval_flow(&ctx).await?;
 
     track(
@@ -67,9 +65,7 @@ pub async fn cancel_approval_process(
 ) -> ChangeSetResult<Json<()>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
-        .await?
-        .ok_or(ChangeSetError::ChangeSetNotFound)?;
+    let mut change_set = ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id).await?;
     change_set.cancel_approval_flow(&ctx).await?;
 
     track(

--- a/lib/sdf-server/src/service/change_set/merge_vote.rs
+++ b/lib/sdf-server/src/service/change_set/merge_vote.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     extract::{v1::AccessBuilder, HandlerContext, PosthogClient},
-    service::change_set::{ChangeSetError, ChangeSetResult},
+    service::change_set::ChangeSetResult,
     track,
 };
 
@@ -29,9 +29,7 @@ pub async fn merge_vote(
 ) -> ChangeSetResult<Json<()>> {
     let ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
-        .await?
-        .ok_or(ChangeSetError::ChangeSetNotFound)?;
+    let mut change_set = ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id).await?;
     change_set.merge_vote(&ctx, request.vote.clone()).await?;
 
     track(

--- a/lib/sdf-server/src/service/change_set/rebase_on_base.rs
+++ b/lib/sdf-server/src/service/change_set/rebase_on_base.rs
@@ -36,15 +36,9 @@ pub async fn rebase_on_base(
 ) -> ChangeSetResult<Json<RebaseOnBaseResponse>> {
     let ctx: dal::DalContext = builder.build(request_ctx.build(request.visibility)).await?;
 
-    let change_set = ChangeSet::find(&ctx, request.visibility.change_set_id)
-        .await?
-        .ok_or(dal::ChangeSetError::ChangeSetNotFound(
-            request.visibility.change_set_id,
-        ))?;
+    let change_set = ChangeSet::get_by_id(&ctx, request.visibility.change_set_id).await?;
     let base_change_set = if let Some(base_change_set_id) = change_set.base_change_set_id {
-        ChangeSet::find(&ctx, base_change_set_id)
-            .await?
-            .ok_or(dal::ChangeSetError::ChangeSetNotFound(base_change_set_id))?
+        ChangeSet::get_by_id(&ctx, base_change_set_id).await?
     } else {
         return Err(dal::ChangeSetError::NoBaseChangeSet(ctx.change_set_id()).into());
     };

--- a/lib/sdf-server/src/service/change_set/status_with_base.rs
+++ b/lib/sdf-server/src/service/change_set/status_with_base.rs
@@ -27,11 +27,7 @@ pub async fn status_with_base(
 ) -> ChangeSetResult<Json<StatusWithBaseResponse>> {
     let _ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
-    // let change_set = ChangeSet::find(&ctx, request.visibility.change_set_id)
-    //     .await?
-    //     .ok_or(dal::ChangeSetError::ChangeSetNotFound(
-    //         request.visibility.change_set_id,
-    //     ))?;
+    // let change_set = ChangeSet::get_by_id(&ctx, request.visibility.change_set_id).await?;
     // let cs_workspace_snapshot = WorkspaceSnapshot::find_for_change_set(&ctx, change_set.id).await?;
     // let cs_vector_clock_id = cs_workspace_snapshot
     //     .max_recently_seen_clock_id(Some(change_set.id))
@@ -40,9 +36,7 @@ pub async fn status_with_base(
     //         change_set.id,
     //     ))?;
     // let base_change_set = if let Some(base_change_set_id) = change_set.base_change_set_id {
-    //     ChangeSet::find(&ctx, base_change_set_id)
-    //         .await?
-    //         .ok_or(dal::ChangeSetError::ChangeSetNotFound(base_change_set_id))?
+    //     ChangeSet::get_by_id(&ctx, base_change_set_id).await?
     // } else {
     //     return Err(dal::ChangeSetError::NoBaseChangeSet(request.visibility.change_set_id).into());
     // };

--- a/lib/sdf-server/src/service/diagram.rs
+++ b/lib/sdf-server/src/service/diagram.rs
@@ -53,8 +53,6 @@ pub enum DiagramError {
     CachedModule(#[from] CachedModuleError),
     #[error("changeset error: {0}")]
     ChangeSet(#[from] ChangeSetError),
-    #[error("change set not found")]
-    ChangeSetNotFound,
     #[error("component error: {0}")]
     Component(#[from] ComponentError),
     #[error("component not found")]
@@ -135,7 +133,6 @@ impl IntoResponse for DiagramError {
 
         let status_code = match self {
             DiagramError::SchemaNotFound
-            | DiagramError::ChangeSetNotFound
             | DiagramError::ComponentNotFound
             | DiagramError::FrameSocketNotFound(_)
             | DiagramError::EdgeNotFound

--- a/lib/sdf-server/src/service/module.rs
+++ b/lib/sdf-server/src/service/module.rs
@@ -8,8 +8,8 @@ use axum::{
 };
 use convert_case::{Case, Casing};
 use dal::{
-    pkg::PkgError as DalPkgError, ChangeSetError, ChangeSetId, DalContextBuilder, FuncError,
-    SchemaError, SchemaId, SchemaVariantError, SchemaVariantId, StandardModelError, TenancyError,
+    pkg::PkgError as DalPkgError, ChangeSetError, DalContextBuilder, FuncError, SchemaError,
+    SchemaId, SchemaVariantError, SchemaVariantId, StandardModelError, TenancyError,
     TransactionsError, UserError, UserPk, WorkspaceError, WorkspacePk, WorkspaceSnapshotError,
     WsEventError,
 };
@@ -41,8 +41,6 @@ pub enum ModuleError {
     Canonicalize(#[from] CanonicalFileError),
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
-    #[error("Changeset not found: {0}")]
-    ChangeSetNotFound(ChangeSetId),
     #[error("dal pkg error: {0}")]
     DalPkg(#[from] DalPkgError),
     #[error("Trying to export from/import into root tenancy")]
@@ -134,8 +132,7 @@ pub type ModuleResult<T> = Result<T, ModuleError>;
 impl IntoResponse for ModuleError {
     fn into_response(self) -> Response {
         let (status_code, error_message) = match self {
-            ModuleError::ChangeSetNotFound(_)
-            | ModuleError::ModuleHashNotFound(_)
+            ModuleError::ModuleHashNotFound(_)
             | ModuleError::PackageNotFound(_)
             | ModuleError::SchemaNotFoundForVariant(_)
             | ModuleError::SchemaVariantNotFound(_)

--- a/lib/sdf-server/src/service/v2/admin.rs
+++ b/lib/sdf-server/src/service/v2/admin.rs
@@ -49,8 +49,6 @@ pub enum AdminAPIError {
     CachedModule(#[from] CachedModuleError),
     #[error("change set error: {0}")]
     ChangeSet(#[from] dal::ChangeSetError),
-    #[error("change set {0} not found")]
-    ChangeSetNotFound(ChangeSetId),
     #[error("func runner error: {0}")]
     FuncRunner(#[from] FuncRunnerError),
     #[error("layer db error: {0}")]

--- a/lib/sdf-server/src/service/v2/admin/get_snapshot.rs
+++ b/lib/sdf-server/src/service/v2/admin/get_snapshot.rs
@@ -21,9 +21,7 @@ pub async fn get_snapshot(
 ) -> AdminAPIResult<Response<Body>> {
     ctx.update_tenancy(Tenancy::new(workspace_id));
 
-    let change_set = ChangeSet::find(&ctx, change_set_id)
-        .await?
-        .ok_or(AdminAPIError::ChangeSetNotFound(change_set_id))?;
+    let change_set = ChangeSet::get_by_id(&ctx, change_set_id).await?;
 
     let snap_addr = change_set.workspace_snapshot_address;
 

--- a/lib/sdf-server/src/service/v2/admin/set_snapshot.rs
+++ b/lib/sdf-server/src/service/v2/admin/set_snapshot.rs
@@ -44,9 +44,7 @@ pub async fn set_snapshot(
 
     let span = current_span_for_instrument_at!("info");
 
-    let mut change_set = ChangeSet::find(&ctx, change_set_id)
-        .await?
-        .ok_or(AdminAPIError::ChangeSetNotFound(change_set_id))?;
+    let mut change_set = ChangeSet::get_by_id(&ctx, change_set_id).await?;
 
     let snapshot_data = Arc::new(
         multipart

--- a/lib/sdf-server/src/service/v2/audit_log.rs
+++ b/lib/sdf-server/src/service/v2/audit_log.rs
@@ -3,7 +3,7 @@ use axum::{
     routing::get,
     Router,
 };
-use si_events::{ChangeSetId, UserPk};
+use si_events::UserPk;
 use thiserror::Error;
 
 use crate::{service::ApiError, AppState};
@@ -13,8 +13,6 @@ mod list_audit_logs;
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum AuditLogError {
-    #[error("change set not found for id: {0}")]
-    ChangeSetNotFound(ChangeSetId),
     #[error("dal audit logging error: {0}")]
     DalAuditLogging(#[from] dal::audit_logging::AuditLoggingError),
     #[error("dal change set error: {0}")]

--- a/lib/sdf-server/src/service/v2/audit_log/list_audit_logs.rs
+++ b/lib/sdf-server/src/service/v2/audit_log/list_audit_logs.rs
@@ -114,9 +114,7 @@ impl Assembler {
                     if let Some(change_set) = self.change_set_cache.get(&change_set_id) {
                         change_set.name.to_owned()
                     } else {
-                        let change_set = ChangeSet::find(ctx, change_set_id)
-                            .await?
-                            .ok_or(AuditLogError::ChangeSetNotFound(change_set_id))?;
+                        let change_set = ChangeSet::get_by_id(ctx, change_set_id).await?;
                         let found_data = change_set.name.to_owned();
                         self.change_set_cache.insert(change_set_id, change_set);
                         found_data

--- a/lib/sdf-server/src/service/v2/change_set.rs
+++ b/lib/sdf-server/src/service/v2/change_set.rs
@@ -36,8 +36,6 @@ pub enum Error {
     ChangeSetApply(#[from] dal::ChangeSetApplyError),
     #[error("change set not approved for apply. Current state: {0}")]
     ChangeSetNotApprovedForApply(ChangeSetStatus),
-    #[error("change set not found: {0}")]
-    ChangeSetNotFound(ChangeSetId),
     #[error("dvu roots are not empty for change set: {0}")]
     DvuRootsNotEmpty(ChangeSetId),
     #[error("func error: {0}")]

--- a/lib/sdf-server/src/service/v2/change_set/approve.rs
+++ b/lib/sdf-server/src/service/v2/change_set/approve.rs
@@ -37,9 +37,7 @@ pub async fn approve(
         return Err(Error::DvuRootsNotEmpty(ctx.change_set_id()));
     }
 
-    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
-        .await?
-        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?;
+    let mut change_set = ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id).await?;
     let old_status = change_set.status;
     change_set.approve_change_set_for_apply(&ctx).await?;
 
@@ -53,9 +51,8 @@ pub async fn approve(
             "merged_change_set": change_set_id,
         }),
     );
-    let change_set_view = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+    let change_set_view = ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id)
         .await?
-        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?
         .into_frontend_type(&ctx)
         .await?;
     ctx.write_audit_log(

--- a/lib/sdf-server/src/service/v2/change_set/cancel_approval_request.rs
+++ b/lib/sdf-server/src/service/v2/change_set/cancel_approval_request.rs
@@ -2,7 +2,7 @@ use axum::extract::{Host, OriginalUri, Path};
 use dal::{ChangeSet, ChangeSetId, WorkspacePk, WsEvent};
 use si_events::audit_log::AuditLogKind;
 
-use super::{post_to_webhook, Error, Result};
+use super::{post_to_webhook, Result};
 use crate::{
     extract::{HandlerContext, PosthogClient},
     service::v2::AccessBuilder,
@@ -21,9 +21,7 @@ pub async fn cancel_approval_request(
         .build(request_ctx.build(change_set_id.into()))
         .await?;
 
-    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
-        .await?
-        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?;
+    let mut change_set = ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id).await?;
     let old_status = change_set.status;
 
     change_set.reopen_change_set(&ctx).await?;
@@ -39,9 +37,8 @@ pub async fn cancel_approval_request(
         }),
     );
 
-    let change_set_view = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+    let change_set_view = ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id)
         .await?
-        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?
         .into_frontend_type(&ctx)
         .await?;
     ctx.write_audit_log(

--- a/lib/sdf-server/src/service/v2/change_set/force_apply.rs
+++ b/lib/sdf-server/src/service/v2/change_set/force_apply.rs
@@ -2,7 +2,7 @@ use axum::extract::{Host, OriginalUri, Path};
 use dal::{ChangeSet, ChangeSetId, WorkspacePk};
 use si_events::audit_log::AuditLogKind;
 
-use super::{Error, Result};
+use super::Result;
 use crate::{
     extract::{HandlerContext, PosthogClient},
     service::v2::AccessBuilder,
@@ -20,9 +20,7 @@ pub async fn force_apply(
     let mut ctx = builder
         .build(request_ctx.build(change_set_id.into()))
         .await?;
-    let change_set = ChangeSet::find(&ctx, change_set_id)
-        .await?
-        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?;
+    let change_set = ChangeSet::get_by_id(&ctx, change_set_id).await?;
     let old_status = change_set.status;
     ChangeSet::prepare_for_force_apply(&ctx).await?;
     ctx.write_audit_log(
@@ -48,9 +46,7 @@ pub async fn force_apply(
         }),
     );
 
-    let change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
-        .await?
-        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?;
+    let change_set = ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id).await?;
 
     ctx.write_audit_log(AuditLogKind::ApplyChangeSet, change_set.name)
         .await?;

--- a/lib/sdf-server/src/service/v2/change_set/reject.rs
+++ b/lib/sdf-server/src/service/v2/change_set/reject.rs
@@ -2,7 +2,7 @@ use axum::extract::{Host, OriginalUri, Path};
 use dal::{ChangeSet, ChangeSetId, WorkspacePk, WsEvent};
 use si_events::audit_log::AuditLogKind;
 
-use super::{post_to_webhook, Error, Result};
+use super::{post_to_webhook, Result};
 use crate::{
     extract::{HandlerContext, PosthogClient},
     service::v2::AccessBuilder,
@@ -21,9 +21,7 @@ pub async fn reject(
         .build(request_ctx.build(change_set_id.into()))
         .await?;
 
-    let mut change_set = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
-        .await?
-        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?;
+    let mut change_set = ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id).await?;
     let old_status = change_set.status;
 
     change_set.reject_change_set_for_apply(&ctx).await?;
@@ -39,9 +37,8 @@ pub async fn reject(
         }),
     );
 
-    let change_set_view = ChangeSet::find(&ctx, ctx.visibility().change_set_id)
+    let change_set_view = ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id)
         .await?
-        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?
         .into_frontend_type(&ctx)
         .await?;
     ctx.write_audit_log(

--- a/lib/sdf-server/src/service/v2/change_set/rename.rs
+++ b/lib/sdf-server/src/service/v2/change_set/rename.rs
@@ -5,7 +5,7 @@ use axum::{
 use dal::{ChangeSet, ChangeSetId, WorkspacePk};
 use serde::Deserialize;
 
-use super::{Error, Result};
+use super::Result;
 use crate::{
     extract::{HandlerContext, PosthogClient},
     service::v2::AccessBuilder,
@@ -31,9 +31,7 @@ pub async fn rename(
         .build(request_ctx.build(change_set_id.into()))
         .await?;
 
-    ChangeSet::find(&ctx, ctx.visibility().change_set_id)
-        .await?
-        .ok_or(Error::ChangeSetNotFound(ctx.change_set_id()))?;
+    ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id).await?;
 
     ChangeSet::rename_change_set(&ctx, change_set_id, &request.new_name).await?;
 


### PR DESCRIPTION
This adds a ChangeSet::get_by_id() that calls ChangeSet::find() and yields ChangeSetNotFound if it fails. It replaces all callers that were doing exactly the same thing (and removes the ChangeSetNotFound error from many of their error enums).

I also moved DefaultChangeSetNotFound to workspace's `default_change_set()` method while I was at it; that is only called in one place, and was also a rote replacement.

Wanted this while writing an endpoint, but it seems worth breaking out. This is entirely a textual replacement of callers (no change in behavior).