### PR TITLE
fix: amend minor typo in dependency for deploy pipeline

### DIFF
--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -134,7 +134,7 @@ jobs:
   api-test:
     needs:
       - upgrade-web
-      - upgrade-and-migrate-sdf
+      - sleep-between
     uses: ./.github/workflows/run-api-test.yml
     with:
       environment: ${{ inputs.environment }}


### PR DESCRIPTION
The API test stage was not waiting like I wanted so it was testing way too early. This fixes that problem and should stabilise false alerts.