### PR TITLE
fix: Restore restore_authentication to before last change to resolve 500

### DIFF
--- a/lib/sdf-server/src/service/session/restore_authentication.rs
+++ b/lib/sdf-server/src/service/session/restore_authentication.rs
@@ -3,7 +3,7 @@ use dal::{User, Workspace};
 use serde::{Deserialize, Serialize};
 
 use super::{SessionError, SessionResult};
-use crate::extract::workspace::WorkspaceAuthorization;
+use crate::extract::{v1::AccessBuilder, workspace::WorkspaceAuthorization, HandlerContext};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -13,13 +13,14 @@ pub struct RestoreAuthenticationResponse {
 }
 
 pub async fn restore_authentication(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
     WorkspaceAuthorization {
-        ctx,
-        user,
-        workspace_id,
-        ..
+        user, workspace_id, ..
     }: WorkspaceAuthorization,
 ) -> SessionResult<Json<RestoreAuthenticationResponse>> {
+    let ctx = builder.build_head(access_builder).await?;
+
     let workspace = Workspace::get_by_pk(&ctx, &workspace_id)
         .await?
         .ok_or(SessionError::InvalidWorkspace(workspace_id))?;


### PR DESCRIPTION
When you refresh, you are sent back to the auth portal.

We're getting 500 ChangeSet not in Workspace on restore_authentication, and it appears to be due to https://github.com/systeminit/si/pull/5249/files#diff-330148b6e26e474bbe8c5b90dbb8f574e97786bf077c33be74f7a9d9bf0c604cL16 .

This reverts that part of the change (we're not reverting the whole PR because there are others stacked on top of it and this may well be faster). It fixes the issue locally.