### PR TITLE
Fix: if no view data is received, but component exists on this view, we need to allow it to process

### DIFF
--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -1727,7 +1727,7 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
                   const componentGeo = view.components[data.component.id];
                   const thisGeo = groupGeo ?? componentGeo;
                   // I don't exist in this view, and I am not being added to this view, return
-                  if (viewId !== view.id) {
+                  if (viewId && viewId !== view.id) {
                     return;
                   }
                   const finalGeo = geometry ?? thisGeo;


### PR DESCRIPTION
We missed this case.
<img src="https://media2.giphy.com/media/fTtNMQ737dqZCkg4dk/giphy.gif"/>