### PR TITLE
fix: reduce lockfile update in langjs

### DIFF
--- a/bin/lang-js/src/transpile.ts
+++ b/bin/lang-js/src/transpile.ts
@@ -26,7 +26,7 @@ export function bundleCode(code: string): Promise<string> {
     try {
       release = await lock("/tmp/lang-js-transpile", {
         stale: 30000,
-        updateInterval: 1000,
+        updateInterval: 100,
         retries: {
           retries: 60,
           minTimeout: 100,


### PR DESCRIPTION
This is adding time to func runs as we now wait a second per beforefunc executed

<img src="https://media2.giphy.com/media/3o6nURyS2InUh6jbnq/giphy.gif"/>