### PR TITLE
Fix(web,sdf,dal): Ensure Intrinsics Panel functions correctly and is reactive to changes

### DIFF
--- a/app/web/src/components/AssetDetailIntrinsicInput.vue
+++ b/app/web/src/components/AssetDetailIntrinsicInput.vue
@@ -154,12 +154,10 @@ const selectFilter = (item: DropdownFilter) => {
 
   selectedFilter.value = item;
 
-  const c = { ...display.value };
-
   if (item === "unset") {
-    emit("changeToUnset", c);
+    emit("changeToUnset", display.value);
   } else {
-    emit("changeToIdentity", c, null);
+    emit("changeToIdentity", display.value, null);
   }
 };
 

--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -508,9 +508,7 @@ const commonBindingConstruction = (
 const updatePropIntrinsics = async (data: PropDisplay) => {
   const binding = commonBindingConstruction(data);
   if (binding) {
-    const resp = await funcStore.CREATE_BINDING(identityFuncId.value, [
-      binding,
-    ]);
+    const resp = await funcStore.CREATE_BINDING(data.funcId, [binding]);
     if (!resp.result.success) {
       if (resp.result.statusCode === 422) {
         toast(
@@ -525,9 +523,7 @@ const updatePropIntrinsics = async (data: PropDisplay) => {
 const updateOutputSocketIntrinsics = async (data: IntrinsicDisplay) => {
   const binding = commonBindingConstruction(data);
   if (binding) {
-    const resp = await funcStore.CREATE_BINDING(identityFuncId.value, [
-      binding,
-    ]);
+    const resp = await funcStore.CREATE_BINDING(data.funcId, [binding]);
     if (!resp.result.success) {
       if (resp.result.statusCode === 422) {
         toast(


### PR DESCRIPTION
This change fixes a number of bugs with the intrinsics panel: 

1. Cannot destructure in AssetDetailIntrinsicInput, as we rely on the object reference (which exposed....)
2. When func bindings change, ensure we're firing func_updated to capture the func that was detached as well as attached (which exposed....)
3. ensure the funcId in the URL matches the funcId in the payload 


This was tested collaboratively: 
1. Unlock the region schema and create an editing component (that auto-upgrades as bindings change)
2. Change the region output socket to unset, see that it works (both in the UI and in the created component)
3. Change it back to a Prop and input socket (and see that it works) 
5. Change the region prop to take input from the si/root/name prop (see that it works)
6. Add a new prop, output, and input socket (see that it works)
7. Various permutations of changing these props/socket configuration - they are reactive to the changes and correctly modify the schema (and component upgrade and re-roll where necessary) as expected.