### PR TITLE
fix(dal): Ensure we re-run prototype functions when they are enqueued, even when they have no downstream dependencies

### DIFF
--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -178,6 +178,17 @@ impl DependentValueGraph {
                     &mut controlling_funcs_for_component,
                 )
                 .await?;
+            // if this attribute value is not being controlled, and has been enqueued,
+            // make sure it's added to the graph as it might not have dependencies but we know
+            // it needs to be re-ran
+
+            // For example, an output socket's AV that has no connections but is set by
+            // a dynamic function would otherwise not be executed
+
+            if current_attribute_value_controlling_value_id == current_attribute_value.id() {
+                self.inner
+                    .add_id(current_attribute_value_controlling_value_id);
+            }
 
             let value_is_for = AttributeValue::is_for(ctx, current_attribute_value.id()).await?;
 


### PR DESCRIPTION
This fixes an edge case, where if you're changing the bindings for Props/Output Sockets and the variant in question has components created that are auto-upgrading, if the existing attribute values for the binding being changed doesn't have any downstream dependencies, we were never re-executing that prototype function as we only add values to the `DependentValuesGraph` when we find downstream impacts.  This adds the independent value to the graph at the onset, ensuring it's function runs.  

This was not tested thoroughly yet, so draft mode until then and more discussion can be had. 