### PR TITLE
feat: sifuncs, resource_values, paths, and input

### DIFF
--- a/bin/si-gen-cloud-control/src/spec/siFuncs.ts
+++ b/bin/si-gen-cloud-control/src/spec/siFuncs.ts
@@ -1,0 +1,105 @@
+import { FuncSpec } from "../bindings/FuncSpec.ts";
+import { FuncSpecData } from "../bindings/FuncSpecData.ts";
+import { FuncSpecBackendKind } from "../bindings/FuncSpecBackendKind.ts";
+import { FuncSpecBackendResponseType } from "../bindings/FuncSpecBackendResponseType.ts";
+import { FuncArgumentSpec } from "../bindings/FuncArgumentSpec.ts";
+import { FuncArgumentKind } from "../bindings/FuncArgumentKind.ts";
+
+interface FuncSpecInfo {
+  id: string;
+  kind: string;
+}
+
+const funcSpecs: Record<string, FuncSpecInfo> = {
+  "si:identity": {
+    id: "c6938e12287ab65f8ba8234559178413f2e2c02c44ea08384ed6687a36ec4f50",
+    kind: "identity",
+  },
+  "si:setArray": {
+    id: "51049a590fb64860f159972012ac2657c629479a244d6bcc4b1b73ba4b29f87f",
+    kind: "array",
+  },
+  "si:setBoolean": {
+    id: "577a7deea25cfad0d4b2dd1e1f3d96b86b8b1578605137b8c4128d644c86964b",
+    kind: "boolean",
+  },
+  "si:setInteger": {
+    id: "7d384b237852f20b8dec2fbd2e644ffc6bde901d7dc937bd77f50a0d57e642a9",
+    kind: "integer",
+  },
+  "si:setJson": {
+    id: "c48ahif4739799f3ab84bcb88495f93b27b47c31a341f8005a60ca39308909fd",
+    kind: "json",
+  },
+  "si:setMap": {
+    id: "dea5084fbf6e7fe8328ac725852b96f4b5869b14d0fe9dd63a285fa876772496",
+    kind: "map",
+  },
+  "si:setObject": {
+    id: "cb9bf94739799f3a8b84bcb88495f93b27b47c31a341f8005a60ca39308909fd",
+    kind: "object",
+  },
+  "si:setString": {
+    id: "bbe86d1a2b92c3e34b72a407cca424878d3466d29ca60e56a251a52a0840bfbd",
+    kind: "string",
+  },
+  "si:unset": {
+    id: "8143ff98fbe8954bb3ab89ee521335d45ba9a42b7b79289eff53b503c4392c37",
+    kind: "unset",
+  },
+  "si:validation": {
+    id: "039ff70bc7922338978ab52a39156992b7d8e3390f0ef7e99d5b6ffd43141d8a",
+    kind: "validation",
+  },
+};
+
+function createArgument(funcName: string, kind: string): FuncArgumentSpec[] {
+  if (kind === "unset") {
+    return [];
+  }
+
+  const arg: FuncArgumentSpec = {
+    // For the identity function, use "identity" as the argument name
+    name: funcName === "si:identity" ? "identity" : "value",
+    // For identity and validation functions, use "any" as the kind
+    kind: (funcName === "si:identity" || funcName === "si:validation")
+      ? "any"
+      : kind as FuncArgumentKind,
+    elementKind: (kind === "array" || kind === "map") ? "any" : null,
+    uniqueId: null,
+    deleted: false,
+  };
+
+  return [arg];
+}
+export function createSiFunc(name: string): FuncSpec {
+  const func = funcSpecs[name];
+  if (!func) {
+    throw new Error(`Unknown function: ${name}`);
+  }
+
+  const data: FuncSpecData = {
+    name,
+    displayName: null,
+    description: null,
+    handler: "",
+    codeBase64: "",
+    backendKind: func.kind as FuncSpecBackendKind,
+    responseType: func.kind as FuncSpecBackendResponseType,
+    hidden: false,
+    link: null,
+  };
+
+  return {
+    name,
+    uniqueId: func.id,
+    data,
+    deleted: false,
+    isFromBuiltin: null,
+    arguments: createArgument(name, func.kind),
+  };
+}
+
+export function getSiFuncId(kind: string): string {
+  return funcSpecs[kind].id;
+}

--- a/deno.lock
+++ b/deno.lock
@@ -10,13 +10,17 @@
     "jsr:@deno/emit@0.46": "0.46.0",
     "jsr:@deno/graph@~0.73.1": "0.73.1",
     "jsr:@std/assert@0.223": "0.223.0",
+    "jsr:@std/assert@1": "1.0.10",
     "jsr:@std/bytes@0.223": "0.223.0",
     "jsr:@std/fmt@0.223": "0.223.0",
     "jsr:@std/fmt@~1.0.2": "1.0.3",
     "jsr:@std/fs@0.223": "0.223.0",
+    "jsr:@std/internal@^1.0.5": "1.0.5",
     "jsr:@std/io@0.223": "0.223.0",
     "jsr:@std/path@0.223": "0.223.0",
     "jsr:@std/text@~1.0.7": "1.0.9",
+    "npm:@apidevtools/json-schema-ref-parser@*": "11.7.3",
+    "npm:@apidevtools/json-schema-ref-parser@^11.7.3": "11.7.3",
     "npm:@types/debug@^4.1.7": "4.1.12",
     "npm:@types/jest@^27.4.1": "27.5.2",
     "npm:@types/js-yaml@^4.0.5": "4.0.9",
@@ -25,6 +29,8 @@
     "npm:@types/node@*": "22.5.4",
     "npm:@types/node@^18.19.59": "18.19.67",
     "npm:@typescript/vfs@^1.4.0": "1.6.0_typescript@4.9.5",
+    "npm:adze@*": "2.2.0",
+    "npm:adze@^2.2.0": "2.2.0",
     "npm:eslint@^8.57.1": "8.57.1",
     "npm:execa@^5.1.1": "5.1.1",
     "npm:fast-json-patch@^3.1.1": "3.1.1",
@@ -32,6 +38,7 @@
     "npm:joi@^17.11.0": "17.13.3",
     "npm:js-yaml@*": "4.1.0",
     "npm:js-yaml@^4.1.0": "4.1.0",
+    "npm:json-schema-typed@^8.0.1": "8.0.1",
     "npm:lodash-es@*": "4.17.21",
     "npm:lodash-es@^4.17.21": "4.17.21",
     "npm:node-fetch@2": "2.7.0",
@@ -92,6 +99,12 @@
     "@std/assert@0.223.0": {
       "integrity": "eb8d6d879d76e1cc431205bd346ed4d88dc051c6366365b1af47034b0670be24"
     },
+    "@std/assert@1.0.10": {
+      "integrity": "59b5cbac5bd55459a19045d95cc7c2ff787b4f8527c0dd195078ff6f9481fbb3",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
     "@std/bytes@0.223.0": {
       "integrity": "84b75052cd8680942c397c2631318772b295019098f40aac5c36cead4cba51a8"
     },
@@ -104,17 +117,20 @@
     "@std/fs@0.223.0": {
       "integrity": "3b4b0550b2c524cbaaa5a9170c90e96cbb7354e837ad1bdaf15fc9df1ae9c31c"
     },
+    "@std/internal@1.0.5": {
+      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+    },
     "@std/io@0.223.0": {
       "integrity": "2d8c3c2ab3a515619b90da2c6ff5ea7b75a94383259ef4d02116b228393f84f1",
       "dependencies": [
-        "jsr:@std/assert",
+        "jsr:@std/assert@0.223",
         "jsr:@std/bytes"
       ]
     },
     "@std/path@0.223.0": {
       "integrity": "593963402d7e6597f5a6e620931661053572c982fc014000459edc1f93cc3989",
       "dependencies": [
-        "jsr:@std/assert"
+        "jsr:@std/assert@0.223"
       ]
     },
     "@std/text@1.0.9": {
@@ -122,6 +138,14 @@
     }
   },
   "npm": {
+    "@apidevtools/json-schema-ref-parser@11.7.3": {
+      "integrity": "sha512-WApSdLdXEBb/1FUPca2lteASewEfpjEYJ8oXZP+0gExK5qSfsEKBKcA+WjY6Q4wvXwyv0+W6Kvc372pSceib9w==",
+      "dependencies": [
+        "@jsdevtools/ono",
+        "@types/json-schema",
+        "js-yaml"
+      ]
+    },
     "@esbuild/aix-ppc64@0.21.5": {
       "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="
     },
@@ -362,6 +386,9 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
+    "@jsdevtools/ono@7.1.3": {
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
     "@nodelib/fs.scandir@2.1.5": {
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dependencies": [
@@ -512,6 +539,9 @@
     "@types/js-yaml@4.0.9": {
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="
     },
+    "@types/json-schema@7.0.15": {
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+    },
     "@types/lodash-es@4.17.12": {
       "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
       "dependencies": [
@@ -615,6 +645,14 @@
     },
     "acorn@8.14.0": {
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="
+    },
+    "adze@2.2.0": {
+      "integrity": "sha512-6QsG6nJajn0Nb2obiCXrv2THuKuERcNwVcKtSp2lalC8/x2jJi0Dv43A/xUnOhLytP7fMNqEswPVt027gXtxpg==",
+      "dependencies": [
+        "@ungap/structured-clone",
+        "date-fns",
+        "picocolors"
+      ]
     },
     "ajv@6.12.6": {
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
@@ -761,6 +799,9 @@
         "shebang-command",
         "which"
       ]
+    },
+    "date-fns@3.6.0": {
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
     },
     "debug@4.3.7": {
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
@@ -1243,6 +1284,9 @@
     },
     "json-schema-traverse@0.4.1": {
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-schema-typed@8.0.1": {
+      "integrity": "sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg=="
     },
     "json-stable-stringify-without-jsonify@1.0.1": {
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
@@ -2214,7 +2258,9 @@
     "https://deno.land/std@0.224.0/path/windows/to_file_url.ts": "40e560ee4854fe5a3d4d12976cef2f4e8914125c81b11f1108e127934ced502e",
     "https://deno.land/std@0.224.0/path/windows/to_namespaced_path.ts": "4ffa4fb6fae321448d5fe810b3ca741d84df4d7897e61ee29be961a6aac89a4c",
     "https://deno.land/std@0.224.0/testing/_test_suite.ts": "f10a8a6338b60c403f07a76f3f46bdc9f1e1a820c0a1decddeb2949f7a8a0546",
-    "https://deno.land/std@0.224.0/testing/bdd.ts": "3e4de4ff6d8f348b5574661cef9501b442046a59079e201b849d0e74120d476b"
+    "https://deno.land/std@0.224.0/testing/bdd.ts": "3e4de4ff6d8f348b5574661cef9501b442046a59079e201b849d0e74120d476b",
+    "https://deno.land/x/json_schema_typed@v8.0.0/draft_07.ts": "1d8a7c80be7b9dd80c583e471fdfec5be526a9b039d1753a9c0f9aa2e8da8be5",
+    "https://deno.land/x/ulid@v0.3.0/mod.ts": "f7ff065b66abd485051fc68af23becef6ccc7e81f7774d7fcfd894a4b2da1984"
   },
   "workspace": {
     "dependencies": [
@@ -2250,6 +2296,15 @@
             "npm:vitest@^1.0.4"
           ]
         }
+      },
+      "bin/si-gen-cloud-control": {
+        "dependencies": [
+          "jsr:@cliffy/command@^1.0.0-rc.7",
+          "jsr:@std/assert@1",
+          "npm:@apidevtools/json-schema-ref-parser@^11.7.3",
+          "npm:adze@^2.2.0",
+          "npm:json-schema-typed@^8.0.1"
+        ]
       },
       "lib/ts-lib-deno": {
         "packageJson": {


### PR DESCRIPTION
Add siFuncs and lays out the props like:

* all props go in the domain
* create- and write-only props in the domain get input sockets and related attrFuncs
* read-only props in the domain get output sockets that they are inputs to
* all read-only props go in resource_value
* they get added as inputs in the related domain prop

This means things like VpcId that come back from a resource get added to `/root/resource_value/VpcId`, then `/root/domain/VpcId` then as an output socket with the value. 

Other domain props can be set normally or via the related input socket. 

This includes setting the paths, but the path for objects and maps might be... wrong. For now. Deal with it.

![image](https://github.com/user-attachments/assets/e6bb64ab-0fac-401f-b019-043154499ca6)


<img src="https://media0.giphy.com/media/InK8B7ILps2aY/giphy.gif"/>