### PR TITLE
Make generator into pipeline, add asset func step

### DIFF
--- a/bin/si-gen-cloud-control/.gitignore
+++ b/bin/si-gen-cloud-control/.gitignore
@@ -1,1 +1,0 @@
-cloud-control-funcs

--- a/bin/si-gen-cloud-control/cloudformation-schema/.gitignore
+++ b/bin/si-gen-cloud-control/cloudformation-schema/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/bin/si-gen-cloud-control/deno.json
+++ b/bin/si-gen-cloud-control/deno.json
@@ -1,12 +1,15 @@
 {
   "tasks": {
-    "updateSchema": "./update-schema.sh"
+    "updateSchema": "./update-schema.sh",
+    "run": "deno run --allow-all main.ts"
   },
   "imports": {
     "@apidevtools/json-schema-ref-parser": "npm:@apidevtools/json-schema-ref-parser@^11.7.3",
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.7",
     "@std/assert": "jsr:@std/assert@1",
+    "@types/lodash": "npm:@types/lodash@^4.17.14",
     "adze": "npm:adze@^2.2.0",
-    "json-schema-typed": "npm:json-schema-typed@^8.0.1"
+    "json-schema-typed": "npm:json-schema-typed@^8.0.1",
+    "lodash": "npm:lodash@^4.17.21"
   }
 }

--- a/bin/si-gen-cloud-control/si-specs/.gitignore
+++ b/bin/si-gen-cloud-control/si-specs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/bin/si-gen-cloud-control/src/cfDb.ts
+++ b/bin/si-gen-cloud-control/src/cfDb.ts
@@ -143,11 +143,14 @@ export async function loadCfDatabase(
     const fullPath = Deno.realPathSync(path);
     logger.debug("Loading database from Cloudformation schema", { fullPath });
     for (const dirEntry of Deno.readDirSync(fullPath)) {
-      const filename = `${fullPath}/${dirEntry.name}`;
-
-      if (dirEntry.name.indexOf("definition.schema") !== -1) {
+      if (
+        dirEntry.name.startsWith(".") ||
+        dirEntry.name.indexOf("definition.schema") !== -1
+      ) {
         continue;
       }
+
+      const filename = `${fullPath}/${dirEntry.name}`;
 
       const rawData = await import(filename, {
         with: { type: "json" },
@@ -158,8 +161,12 @@ export async function loadCfDatabase(
 
       const typeName: string = data.typeName;
 
-      if (!["AWS::EC2::VPC", "AWS::WAF::WebACL"].includes(typeName)) continue;
-      // if (typeName !== "AWS::EMR::Cluster") continue;
+      if (
+        ![
+          "AWS::EC2::Subnet",
+          "AWS::EC2::VPC",
+        ].includes(typeName)
+      ) continue;
 
       logger.debug(`Loaded ${typeName}`);
       try {

--- a/bin/si-gen-cloud-control/src/cli.ts
+++ b/bin/si-gen-cloud-control/src/cli.ts
@@ -1,6 +1,7 @@
 import { Command } from "@cliffy/command";
 import { fetchSchema } from "./commands/fetchSchema.ts";
-import { generateSiSpecDatabase } from "./commands/generateSiSpecDatabase.ts";
+import { generateSiSpecs } from "./commands/generateSiSpecs.ts";
+import { generateTarFromSpec } from "./commands/generateTarFromSpec.ts";
 
 export async function run() {
   const command = new Command()
@@ -20,11 +21,18 @@ export async function run() {
       await fetchSchema();
     })
     .command(
-      "generate-spec-database",
+      "generate-specs",
       "generate the si spec database from the cf database",
     )
     .action(async () => {
-      await generateSiSpecDatabase();
+      await generateSiSpecs();
+    })
+    .command(
+      "generate-tars",
+      "generate tar packages from the spec files in si-specs",
+    )
+    .action(async () => {
+      await generateTarFromSpec();
     });
 
   await command.parse(Deno.args);

--- a/bin/si-gen-cloud-control/src/commands/generateSiSpecs.ts
+++ b/bin/si-gen-cloud-control/src/commands/generateSiSpecs.ts
@@ -1,0 +1,55 @@
+import { getServiceByName, loadCfDatabase } from "../cfDb.ts";
+import { pkgSpecFromCf } from "../specPipeline.ts";
+import { PkgSpec } from "../bindings/PkgSpec.ts";
+import { generateAssetFuncs } from "../pipeline-steps/generateAssetFuncs.ts";
+import {
+  generateSocketsFromDomainProps,
+} from "../pipeline-steps/generateSocketsFromDomainProps.ts";
+
+export function generateSiSpecForService(serviceName: string) {
+  const cf = getServiceByName(serviceName);
+  return pkgSpecFromCf(cf);
+}
+
+export async function generateSiSpecs() {
+  const db = await loadCfDatabase();
+
+  let imported = 0;
+  const cfSchemas = Object.values(db);
+
+  let specs = [] as PkgSpec[];
+
+  for (const cfSchema of cfSchemas) {
+    try {
+      const pkg = pkgSpecFromCf(cfSchema);
+
+      specs.push(pkg);
+    } catch (e) {
+      console.log(`Error Building: ${cfSchema.typeName}: ${e}`);
+    }
+  }
+
+  // EXECUTE PIPELINE STEPS
+  specs = generateSocketsFromDomainProps(specs);
+  specs = generateAssetFuncs(specs);
+
+  // WRITE OUTS SPECS
+  for (const spec of specs) {
+    const specJson = JSON.stringify(spec, null, 2);
+    const name = spec.name;
+
+    try {
+      await Deno.writeTextFile(
+        `si-specs/${name}.json`,
+        specJson,
+      );
+    } catch (e) {
+      console.log(`Error writing to file: ${name}: ${e}`);
+      continue;
+    }
+
+    imported += 1;
+  }
+
+  console.log(`built ${imported} out of ${cfSchemas.length}`);
+}

--- a/bin/si-gen-cloud-control/src/commands/generateTarFromSpec.ts
+++ b/bin/si-gen-cloud-control/src/commands/generateTarFromSpec.ts
@@ -1,0 +1,47 @@
+import { CommandFailed } from "../errors.ts";
+import _logger from "../logger.ts";
+const logger = _logger.ns("generateTarFromSpec").seal();
+
+export async function generateTarFromSpec() {
+  const td = new TextDecoder();
+
+  const fullPath = Deno.realPathSync("./si-specs");
+
+  for (const dirEntry of Deno.readDirSync(fullPath)) {
+    if (
+      dirEntry.name.startsWith(".") ||
+      dirEntry.name.indexOf("definition.schema") !== -1
+    ) {
+      continue;
+    }
+
+    const pkg = dirEntry.name.split(".")[0];
+    if (!pkg) {
+      throw new Error(`Could not parse ${dirEntry.name}`);
+    }
+
+    console.log(pkg);
+
+    const child = await new Deno.Command(
+      "cargo",
+      {
+        args: [
+          "run",
+          "--example",
+          "si-pkg-json-to-tar",
+          `si-specs/${pkg}.json`,
+          `tar-packages/${pkg}.tar`,
+        ],
+      },
+    ).output();
+
+    const stdout = td.decode(child.stdout).trim();
+    logger.debug(stdout);
+    const stderr = td.decode(child.stderr).trim();
+    logger.debug(stderr);
+
+    if (!child.success) {
+      throw new CommandFailed("failed to generate tar");
+    }
+  }
+}

--- a/bin/si-gen-cloud-control/src/pipeline-steps/generateAssetFuncs.ts
+++ b/bin/si-gen-cloud-control/src/pipeline-steps/generateAssetFuncs.ts
@@ -1,0 +1,96 @@
+import { PkgSpec } from "../bindings/PkgSpec.ts";
+import type {
+  FuncSpecData,
+} from "../../../../lib/si-pkg/bindings/FuncSpecData.ts";
+import { FuncSpec } from "../../../../lib/si-pkg/bindings/FuncSpec.ts";
+import { SchemaVariantSpec } from "../bindings/SchemaVariantSpec.ts";
+import _ from "lodash";
+
+export function generateAssetFuncs(specs: PkgSpec[]): PkgSpec[] {
+  const newSpecs = [] as PkgSpec[];
+
+  for (const spec of specs) {
+    const schemaVariant = spec.schemas[0]?.variants[0];
+
+    if (!schemaVariant) {
+      console.log(
+        `Could not generate assetFunc for ${spec.name}: missing schema or variant`,
+      );
+      continue;
+    }
+
+    const assetFuncUniqueKey = schemaVariant.data.funcUniqueId;
+    const assetFuncName = spec.name;
+
+    const assetFuncCode = generateAssetCodeFromVariantSpec(schemaVariant);
+
+    const assetFuncData: FuncSpecData = {
+      name: assetFuncName,
+      displayName: null,
+      description: null,
+      handler: "main",
+      codeBase64: btoa(
+        assetFuncCode,
+      ).replace(/=/g, ""),
+      backendKind: "jsSchemaVariantDefinition",
+      responseType: "schemaVariantDefinition",
+      hidden: false,
+      link: null,
+    };
+
+    const assetFunc: FuncSpec = {
+      name: assetFuncName,
+      uniqueId: assetFuncUniqueKey,
+      data: assetFuncData,
+      deleted: false,
+      isFromBuiltin: true,
+      arguments: [],
+    };
+    spec.funcs.push(assetFunc);
+
+    newSpecs.push(spec);
+  }
+
+  return newSpecs;
+}
+
+function generateAssetCodeFromVariantSpec(variant: SchemaVariantSpec): string {
+  if (variant.domain.kind !== "object") throw "Domain prop is not object";
+
+  const queue = _.cloneDeep(variant.domain.entries);
+
+  let propDeclarations = "";
+  let propAdds = "";
+
+  while (queue.length > 0) {
+    const prop = queue.pop();
+    const varName = `${prop.name}Prop`;
+    switch (prop.kind) {
+      case "array":
+        break;
+      case "map":
+        break;
+      case "object":
+        break;
+      case "boolean":
+      case "json":
+      case "number":
+      case "string":
+        propDeclarations += `
+    const ${varName} = new PropBuilder()
+        .setKind("${prop.kind}")
+        .setName("${prop.name}")
+        .build();
+`;
+
+        propAdds += `
+      .addProp(${varName})`;
+        break;
+    }
+  }
+
+  return `function main() {${propDeclarations}
+    return new AssetBuilder()${propAdds}
+      .build();
+}`;
+}

--- a/bin/si-gen-cloud-control/src/pipeline-steps/generateSocketsFromDomainProps.ts
+++ b/bin/si-gen-cloud-control/src/pipeline-steps/generateSocketsFromDomainProps.ts
@@ -1,0 +1,48 @@
+import { PkgSpec } from "../bindings/PkgSpec.ts";
+import { SchemaVariantSpec } from "../bindings/SchemaVariantSpec.ts";
+import _ from "lodash";
+import { SocketSpec } from "../bindings/SocketSpec.ts";
+import { isExpandedPropSpec } from "../spec/props.ts";
+import { createSocketFromProp } from "../spec/sockets.ts";
+
+export function generateSocketsFromDomainProps(specs: PkgSpec[]): PkgSpec[] {
+  const newSpecs = [] as PkgSpec[];
+
+  for (const spec of specs) {
+    const schemaVariant = spec.schemas[0]?.variants[0];
+
+    if (!schemaVariant) {
+      console.log(
+        `Could not generate sockets for ${spec.name}: missing schema or variant`,
+      );
+      continue;
+    }
+
+    schemaVariant.sockets = createSocketsFromDomain(schemaVariant);
+
+    newSpecs.push(spec);
+  }
+
+  return newSpecs;
+}
+
+function createSocketsFromDomain(variant: SchemaVariantSpec): SocketSpec[] {
+  const domain = variant.domain;
+
+  if (domain.kind !== "object") throw "Domain prop is not object";
+
+  const sockets: SocketSpec[] = [];
+  if (domain.kind == "object") {
+    for (const prop of domain.entries) {
+      if (
+        !["array", "object"].includes(prop.kind) && isExpandedPropSpec(prop)
+      ) {
+        const socket = createSocketFromProp(prop);
+        if (socket) {
+          sockets.push(socket);
+        }
+      }
+    }
+  }
+  return sockets;
+}

--- a/bin/si-gen-cloud-control/src/spec/props.ts
+++ b/bin/si-gen-cloud-control/src/spec/props.ts
@@ -16,6 +16,7 @@ export type OnlyProperties = {
 export function isExpandedPropSpec(prop: PropSpec): prop is ExpandedPropSpec {
   const metadata = (prop as ExpandedPropSpec).metadata;
   return metadata &&
+    Array.isArray(metadata.propPath) &&
     typeof metadata.readOnly === "boolean" &&
     typeof metadata.writeOnly === "boolean" &&
     typeof metadata.createOnly === "boolean";

--- a/bin/si-gen-cloud-control/src/spec/sockets.ts
+++ b/bin/si-gen-cloud-control/src/spec/sockets.ts
@@ -21,8 +21,8 @@ export function createSocketFromProp(
   } else if (prop.metadata.writeOnly || prop.metadata.createOnly) {
     const socket = createSocket(prop.name, "input");
     if (socket.data) {
-      prop?.data?.inputs?.push(attrFuncInputSpecFromSocket(socket));
-      socket.data.funcUniqueId = getSiFuncId("si:identity");
+      prop.data.inputs?.push(attrFuncInputSpecFromSocket(socket));
+      prop.data.funcUniqueId = getSiFuncId("si:identity");
     }
     return socket;
   }

--- a/bin/si-gen-cloud-control/tar-packages/.gitignore
+++ b/bin/si-gen-cloud-control/tar-packages/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/bin/si-gen-cloud-control/test/spec_test.ts
+++ b/bin/si-gen-cloud-control/test/spec_test.ts
@@ -5,9 +5,7 @@ import {
   assertInstanceOf,
   assertThrows,
 } from "@std/assert";
-import {
-  generateSiSpecForService,
-} from "../src/commands/generateSiSpecDatabase.ts";
+import { generateSiSpecForService } from "../src/commands/generateSiSpecs.ts";
 import { ExpandedPropSpec } from "../src/spec/props.ts";
 import { loadCfDatabase } from "../src/cfDb.ts";
 

--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,8 @@
 {
   "workspace": [
     "./bin/lang-js",
-    "./bin/si-gen-cloud-control",
-    "./lib/ts-lib-deno"
+    "./lib/ts-lib-deno",
+    "./bin/si-gen-cloud-control"
   ],
   "imports": {
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.7",

--- a/deno.lock
+++ b/deno.lock
@@ -25,6 +25,7 @@
     "npm:@types/jest@^27.4.1": "27.5.2",
     "npm:@types/js-yaml@^4.0.5": "4.0.9",
     "npm:@types/lodash-es@^4.17.12": "4.17.12",
+    "npm:@types/lodash@^4.17.14": "4.17.14",
     "npm:@types/node-fetch@^2.6.1": "2.6.12",
     "npm:@types/node@*": "22.5.4",
     "npm:@types/node@^18.19.59": "18.19.67",
@@ -41,6 +42,7 @@
     "npm:json-schema-typed@^8.0.1": "8.0.1",
     "npm:lodash-es@*": "4.17.21",
     "npm:lodash-es@^4.17.21": "4.17.21",
+    "npm:lodash@^4.17.21": "4.17.21",
     "npm:node-fetch@2": "2.7.0",
     "npm:proper-lockfile@^4.1.2": "4.1.2",
     "npm:toml@3": "3.0.0",
@@ -545,11 +547,14 @@
     "@types/lodash-es@4.17.12": {
       "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
       "dependencies": [
-        "@types/lodash"
+        "@types/lodash@4.17.13"
       ]
     },
     "@types/lodash@4.17.13": {
       "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg=="
+    },
+    "@types/lodash@4.17.14": {
+      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A=="
     },
     "@types/mdast@4.0.4": {
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
@@ -1340,6 +1345,9 @@
     },
     "lodash.sortby@4.7.0": {
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+    },
+    "lodash@4.17.21": {
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "loupe@2.3.7": {
       "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
@@ -2302,8 +2310,10 @@
           "jsr:@cliffy/command@^1.0.0-rc.7",
           "jsr:@std/assert@1",
           "npm:@apidevtools/json-schema-ref-parser@^11.7.3",
+          "npm:@types/lodash@^4.17.14",
           "npm:adze@^2.2.0",
-          "npm:json-schema-typed@^8.0.1"
+          "npm:json-schema-typed@^8.0.1",
+          "npm:lodash@^4.17.21"
         ]
       },
       "lib/ts-lib-deno": {


### PR DESCRIPTION
- Make generator create spec files on a folder
- Add command to make specs into tars on another folder
- Change architecture a little bit so the generator can have steps added easily
- Add asset func generator step, that only generates top level props for now
- Fix issue that made generated input sockets not send values to props
- Make socket generation into its own step