### PR TITLE
fix: jail memory size incorrectly increaed

### DIFF
--- a/lib/si-firecracker/src/scripts/prepare_jailer.sh
+++ b/lib/si-firecracker/src/scripts/prepare_jailer.sh
@@ -193,7 +193,7 @@ cat << EOF
   ],
   "machine-config": {
     "vcpu_count": 4,
-    "mem_size_mib": 1024
+    "mem_size_mib": 512
   },
   "network-interfaces": [{
     "iface_id": "1",


### PR DESCRIPTION
This was increased incorrectly [here](https://github.com/systeminit/si/commit/8ebad96e11d37628e691fa3e6894cf8a8baf37e2).  This was part of the deno work. I increased this for local development as I thought the issues I was seeing were OOM-related, but did not set this back in the PR. I've tested this locally and everything seems to run smoothly. 

<img src="https://media3.giphy.com/media/UcVesAccMWjRpeFrK8/giphy.gif"/>