### PR TITLE
feat(actions): Add "get component" management function API

### DIFF
--- a/lib/sdf-server/src/service/public/components.rs
+++ b/lib/sdf-server/src/service/public/components.rs
@@ -4,16 +4,21 @@ use axum::{
     extract::Path,
     http::StatusCode,
     response::{IntoResponse, Response},
-    routing::put,
+    routing::{get, put},
     Json, Router,
 };
 use dal::{
+    diagram::{geometry::Geometry, view::View},
+    management::prototype::ManagementPrototype,
     prop::{PropPath, PropResult, PROP_PATH_SEPARATOR},
-    AttributeValue, Component, ComponentId, Prop, PropId, SchemaVariantId, WsEvent,
+    AttributeValue, Component, ComponentError, ComponentId, DalContext, Prop, PropId,
+    SchemaVariantId, WsEvent,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use si_events::audit_log::AuditLogKind;
+use si_frontend_types::{DiagramComponentView, GeometryAndView};
+use si_id::ManagementPrototypeId;
 use thiserror::Error;
 
 use crate::extract::{change_set::ChangeSetDalContext, PosthogEventTracker};
@@ -28,6 +33,10 @@ pub enum ChangeSetsError {
     Component(#[from] dal::ComponentError),
     #[error("dal change set error: {0}")]
     DalChangeSet(#[from] dal::ChangeSetError),
+    #[error("diagram error: {0}")]
+    Diagram(#[from] dal::diagram::DiagramError),
+    #[error("prop error: {0}")]
+    ManagementPrototype(#[from] dal::management::prototype::ManagementPrototypeError),
     #[error("prop error: {0}")]
     Prop(#[from] dal::prop::PropError),
     #[error("schema variant error: {0}")]
@@ -42,7 +51,11 @@ type Result<T> = std::result::Result<T, ChangeSetsError>;
 
 impl IntoResponse for ChangeSetsError {
     fn into_response(self) -> Response {
-        (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
+        let status_code = match &self {
+            ChangeSetsError::Component(ComponentError::NotFound(_)) => StatusCode::NOT_FOUND,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        (status_code, self.to_string()).into_response()
     }
 }
 
@@ -50,34 +63,36 @@ impl IntoResponse for ChangeSetsError {
 pub fn routes() -> Router<AppState> {
     Router::new().nest(
         "/:component_id",
-        Router::new().route("/properties", put(update_component_properties)),
+        Router::new()
+            .route("/", get(get_component))
+            .route("/properties", put(update_component_properties)),
     )
 }
 
 async fn update_component_properties(
-    ChangeSetDalContext(ctx): ChangeSetDalContext,
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
     tracker: PosthogEventTracker,
-    Path(UpdateComponentPropertiesPath { component_id }): Path<UpdateComponentPropertiesPath>,
+    Path(ComponentRequestPath { component_id }): Path<ComponentRequestPath>,
     Json(payload): Json<UpdateComponentPropertiesRequest>,
 ) -> Result<Json<UpdateComponentPropertiesResponse>> {
-    tracker.track(&ctx, "update_component_properties", json!(payload));
+    tracker.track(ctx, "update_component_properties", json!(payload));
 
-    let component = Component::get_by_id(&ctx, component_id).await?;
-    let component_name = component.name(&ctx).await?;
-    let schema_variant = component.schema_variant(&ctx).await?;
+    let component = Component::get_by_id(ctx, component_id).await?;
+    let component_name = component.name(ctx).await?;
+    let schema_variant = component.schema_variant(ctx).await?;
     let schema_variant_id = schema_variant.id;
     let schema_variant_display_name = schema_variant.display_name().to_string();
-    let schema = schema_variant.schema(&ctx).await?;
+    let schema = schema_variant.schema(ctx).await?;
 
     for (key, value) in payload.domain.into_iter() {
         // Update the property
-        let prop_id = key.prop_id(&ctx, schema_variant.id).await?;
-        let prop = Prop::get_by_id(&ctx, prop_id).await?;
+        let prop_id = key.prop_id(ctx, schema_variant.id).await?;
+        let prop = Prop::get_by_id(ctx, prop_id).await?;
         let attribute_value_id =
-            Component::attribute_value_for_prop_id(&ctx, component_id, prop_id).await?;
-        let av = AttributeValue::get_by_id(&ctx, attribute_value_id).await?;
-        let before_value = av.value(&ctx).await?;
-        AttributeValue::update(&ctx, attribute_value_id, Some(value.clone())).await?;
+            Component::attribute_value_for_prop_id(ctx, component_id, prop_id).await?;
+        let av = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
+        let before_value = av.value(ctx).await?;
+        AttributeValue::update(ctx, attribute_value_id, Some(value.clone())).await?;
 
         // Log the property update
         ctx.write_audit_log(
@@ -95,14 +110,14 @@ async fn update_component_properties(
             prop.name.clone(),
         )
         .await?;
-        let parent_prop = match Prop::parent_prop_id_by_id(&ctx, prop_id).await? {
-            Some(parent_prop_id) => Some(Prop::get_by_id(&ctx, parent_prop_id).await?),
+        let parent_prop = match Prop::parent_prop_id_by_id(ctx, prop_id).await? {
+            Some(parent_prop_id) => Some(Prop::get_by_id(ctx, parent_prop_id).await?),
             None => None,
         };
 
         // Send the property update event to posthog
         tracker.track(
-            &ctx,
+            ctx,
             "property_value_updated",
             serde_json::json!({
                 "how": "/public/component/property_value_updated",
@@ -118,18 +133,10 @@ async fn update_component_properties(
     }
 
     // Send the WsEvent indicating the component was updated
-    let mut socket_map = HashMap::new();
-    let payload = component
-        .into_frontend_type(
-            &ctx,
-            None,
-            component.change_status(&ctx).await?,
-            &mut socket_map,
-        )
-        .await?;
-    WsEvent::component_updated(&ctx, payload)
+    let component = Component::get_by_id(ctx, component_id).await?;
+    WsEvent::component_updated(ctx, bare_component_response(ctx, component).await?)
         .await?
-        .publish_on_commit(&ctx)
+        .publish_on_commit(ctx)
         .await?;
 
     // Commit the changes
@@ -139,7 +146,7 @@ async fn update_component_properties(
 }
 
 #[derive(Deserialize)]
-struct UpdateComponentPropertiesPath {
+struct ComponentRequestPath {
     component_id: ComponentId,
 }
 
@@ -183,4 +190,88 @@ impl DomainPropPath {
     fn to_prop_path(&self) -> PropPath {
         PropPath::new(["root", "domain"]).join(&self.0.replace("/", PROP_PATH_SEPARATOR).into())
     }
+}
+
+async fn get_component(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+    // tracker: PosthogEventTracker,
+    Path(ComponentRequestPath { component_id }): Path<ComponentRequestPath>,
+) -> Result<Json<GetComponentResponse>> {
+    let component = Component::get_by_id(ctx, component_id).await?;
+    let domain_av_id = component.domain_prop_attribute_value(ctx).await?;
+    let domain = AttributeValue::get_by_id(ctx, domain_av_id)
+        .await?
+        .view(ctx)
+        .await?;
+
+    let mut view_data = vec![];
+    for (view_id, geometry) in Geometry::by_view_for_component_id(ctx, component_id).await? {
+        view_data.push(GeometryAndViewAndName {
+            geometry_and_view: GeometryAndView {
+                view_id,
+                geometry: geometry.into_raw(),
+            },
+            name: View::get_by_id(ctx, view_id).await?.name().to_string(),
+        });
+    }
+
+    let schema_variant_id = Component::schema_variant_id(ctx, component_id).await?;
+    let management_functions = ManagementPrototype::list_for_variant_id(ctx, schema_variant_id)
+        .await?
+        .into_iter()
+        .map(|prototype| GetComponentResponseManagementFunction {
+            management_prototype_id: prototype.id,
+            name: prototype.name,
+        })
+        .collect();
+
+    Ok(Json(GetComponentResponse {
+        component: bare_component_response(ctx, component).await?,
+        domain,
+        view_data,
+        management_functions,
+    }))
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct GetComponentResponse {
+    /// Component data
+    component: DiagramComponentView,
+    /// Domain props for this component
+    domain: Option<serde_json::Value>,
+    /// Views this component is in
+    view_data: Vec<GeometryAndViewAndName>,
+    /// Management functions available to this component
+    management_functions: Vec<GetComponentResponseManagementFunction>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct GeometryAndViewAndName {
+    #[serde(flatten)]
+    pub geometry_and_view: GeometryAndView,
+    pub name: String,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct GetComponentResponseManagementFunction {
+    management_prototype_id: ManagementPrototypeId,
+    name: String,
+}
+
+async fn bare_component_response(
+    ctx: &DalContext,
+    component: Component,
+) -> Result<DiagramComponentView> {
+    let mut socket_map = HashMap::new();
+    Ok(component
+        .into_frontend_type(
+            ctx,
+            None,
+            component.change_status(ctx).await?,
+            &mut socket_map,
+        )
+        .await?)
 }


### PR DESCRIPTION
This adds `GET /api/public/v0/components/:componentId`, which is similar (but not identical) to the mainline /api/v2/components/:componentId endpoint. This endpoints gets the data we most need to handle graceful input validation and defaults in the GitHub Action:

```typescript
{
  // The usual component data.
  component: { displayName, ... },
  // List of views this component is in.
  viewData: { viewId, name, geometry }[],
  // List of management functions associated with this component.
  managementFunctions: { managementPrototypeId, name }[],
  // Domain property values. This isn't presently used, but being able to see this is really useful debug information in logs.
  domain: <JS value of domain props>
}
```

This gives us enough information that the github action can:

* Allow the user to omit the `view` parameter when the component is in only one view
* Allow the user to omit the `managementFunction` parameter when the component only has one management function
* Specify the `view` and/or `managementFunction` parameters as *names* instead of IDs, in cases where there are multiple and disambiguation is necessary.

With this endpoint deployed locallyI was able to run the VPC template with this github action spec:

```yaml
      - uses: systeminit/actions/trigger@main
        with:
          changeSetName: Testing 123
          componentId: 01JJ4TXDYTKY91R04ET8GCM675
          domain: |
            Region: us-east-1
            BaseCidrBlock: 10.0.0.0/16
          apiToken: ${{ secrets.SI_API_TOKEN }}

          # These don't have to be specified when there's only one, but this is how you would do it by name
          # view: DEFAULT
          # managementFunction: vpcTemplateCreate
```

### Design

Philosophically, instead of creating this endpoint, we could have handled validation/search/defaulting *inside* the endpoints. But given the cycle time for updating / adding endpoints, we're focusing on building composable endpoints that can be used to build more functionality without having to go back and redeploy so frequently. This is part of why it's a private API: down the road, when we've seen a lot more use cases, we'll have a much stronger idea of what we need to compose operations and reference views/components/functions/props/etc.

### Testing

The github action has been tested using this endpoint to:

* Look up default view and management function (IDs are correct) and successfully trigger management function
* Find associated view and function by name (names are correct)
* Emits the correct names of components/views/functions in logs and errors (component name and information is correct).
* 404 when component is not found
* 401/403 when token is missing/not authorized