### PR TITLE
feat(dal): Add the ability to set an annotation on a prop in the asset builder that it's create only

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -104,6 +104,7 @@ export interface PropertyEditorProp {
   validationFormat?: string;
   defaultCanBeSetBySocket: boolean;
   isOriginSecret: boolean;
+  createOnly: boolean;
 }
 
 export interface PropertyEditorSchema {

--- a/app/web/src/assets/static/editor_typescript.txt
+++ b/app/web/src/assets/static/editor_typescript.txt
@@ -240,6 +240,7 @@ interface IPropWidgetDefinitionBuilder {
  * @example
  * const validation = new PropWidgetDefinitionBuilder()
  *  .setKind("text")
+ *  .setCreateOnly()
  *  .build()
  */
 declare class PropWidgetDefinitionBuilder implements IPropWidgetDefinitionBuilder {
@@ -271,6 +272,13 @@ declare class PropWidgetDefinitionBuilder implements IPropWidgetDefinitionBuilde
    * .setOption("us-east-2 - US East (Ohio)", "us-east-2")
    */
   addOption(key: string, value: string): this;
+  
+  /**
+   * Set this prop as create only prop. This means that when
+   * the component has a resource attached, it will be marked
+   * as uneditable in the Attributes panel
+   */
+  setCreateOnly(): this;
 
   /**
    * Build the object

--- a/app/web/src/components/AttributesPanel/TreeFormItem.vue
+++ b/app/web/src/components/AttributesPanel/TreeFormItem.vue
@@ -723,7 +723,7 @@
               themeClasses('bg-caution-lines-light', 'bg-caution-lines-dark'),
             )
           "
-          @click="openConfirmEditModal"
+          @click="openNonEditableModal"
         />
       </div>
     </div>
@@ -1268,7 +1268,7 @@ const sourceIcon = computed(() => {
 const sourceOverridden = computed(() => props.treeDef.value?.overridden);
 
 const propIsEditable = computed(() => {
-  if (isImmutableSecretProp.value) {
+  if (isImmutableSecretProp.value || isCreateOnly.value) {
     return false;
   }
   return (
@@ -1283,6 +1283,9 @@ const propControlledByParent = computed(
 );
 
 const sourceTooltip = computed(() => {
+  if (isCreateOnly.value) {
+    return `${propName.value} can only be set before resource creation`;
+  }
   if (sourceOverridden.value) {
     if (propPopulatedBySocket.value) {
       return `${propName.value} has been overriden to be set via a populated socket`;
@@ -1503,6 +1506,12 @@ const isImmutableSecretProp = computed(
     !(fullPropDef.value as PropertyEditorProp).isOriginSecret &&
     widgetKind.value === "secret",
 );
+
+const isCreateOnly = computed(
+  () =>
+    props.attributesPanel &&
+    (fullPropDef.value as PropertyEditorProp).createOnly,
+);
 const secretDefinitionIdForProp = computed(() => {
   if (props.treeDef.propDef.widgetKind.kind !== "secret") return;
   const widgetOptions = props.treeDef.propDef.widgetKind.options;
@@ -1535,6 +1544,12 @@ const confirmEditModalTitle = computed(() => {
 
   return "Are You Sure?";
 });
+
+const openNonEditableModal = () => {
+  if (!isCreateOnly.value) {
+    openConfirmEditModal();
+  }
+};
 
 const openConfirmEditModal = () => {
   if (confirmEditModalRef.value) {

--- a/bin/lang-js/src/asset_builder.ts
+++ b/bin/lang-js/src/asset_builder.ts
@@ -296,6 +296,8 @@ export interface IPropWidgetDefinitionBuilder {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   addOption(key: string, value: string): this;
 
+  setCreateOnly(): this;
+
   build(): PropWidgetDefinition;
 }
 
@@ -327,6 +329,24 @@ export class PropWidgetDefinitionBuilder
    */
   setKind(kind: PropWidgetDefinitionKind): this {
     this.propWidget.kind = kind;
+    return this;
+  }
+
+  /**
+   * Set this prop as create only prop. This means that when
+   * the component has a resource attached, it will be marked
+   * as uneditable in the Attributes panel
+   */
+  setCreateOnly(): this {
+    if (!this.propWidget.options) {
+      this.propWidget.options = [];
+    }
+
+    this.propWidget.options.push(<Option>{
+      label: "si_create_only_prop",
+      value: "true",
+    });
+
     return this;
   }
 

--- a/lib/dal-test/src/helpers/property_editor_test_view.rs
+++ b/lib/dal-test/src/helpers/property_editor_test_view.rs
@@ -57,7 +57,8 @@ impl PropEditorTestView {
             child_values,
         } = PropertyEditorValues::assemble(ctx, component_id).await?;
 
-        let PropertyEditorSchema { props, .. } = PropertyEditorSchema::assemble(ctx, sv_id).await?;
+        let PropertyEditorSchema { props, .. } =
+            PropertyEditorSchema::assemble(ctx, sv_id, false).await?;
 
         let root_view = {
             let value = values

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -99,6 +99,12 @@ pub struct WidgetOption {
     label: String,
     pub value: String,
 }
+
+impl WidgetOption {
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+}
 pub type WidgetOptions = Vec<WidgetOption>;
 
 /// An individual "field" within the tree of a [`SchemaVariant`](crate::SchemaVariant).

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -239,7 +239,7 @@ async fn prop_documentation(ctx: &mut DalContext) {
         .expect("could not commit");
 
     // Assemble property editor schema and ensure Prop Documentation is there.
-    let property_editor_schema = PropertyEditorSchema::assemble(ctx, schema_variant_id)
+    let property_editor_schema = PropertyEditorSchema::assemble(ctx, schema_variant_id, false)
         .await
         .expect("could not assemble property editor schema");
 
@@ -317,7 +317,7 @@ async fn prop_documentation(ctx: &mut DalContext) {
         .expect("could not commit");
 
     // Assemble property editor schema and ensure both Prop Documentation is there.
-    let property_editor_schema = PropertyEditorSchema::assemble(ctx, schema_variant_id)
+    let property_editor_schema = PropertyEditorSchema::assemble(ctx, schema_variant_id, false)
         .await
         .expect("could not assemble property editor schema");
 

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -31,7 +31,7 @@ async fn assemble(ctx: &DalContext) {
         .expect("could not create component");
 
     // Assemble both property editor blobs.
-    let _property_editor_schema = PropertyEditorSchema::assemble(ctx, schema_variant_id)
+    let _property_editor_schema = PropertyEditorSchema::assemble(ctx, schema_variant_id, false)
         .await
         .expect("could not assemble property editor schema");
     let _property_editor_values = PropertyEditorValues::assemble(ctx, component.id())

--- a/lib/sdf-server/src/service/component/get_property_editor_schema.rs
+++ b/lib/sdf-server/src/service/component/get_property_editor_schema.rs
@@ -24,8 +24,10 @@ pub async fn get_property_editor_schema(
 
     let schema_variant =
         Component::schema_variant_for_component_id(&ctx, request.component_id).await?;
+    let maybe_resource = Component::resource_by_id(&ctx, request.component_id).await?;
 
-    let prop_edit_schema = PropertyEditorSchema::assemble(&ctx, schema_variant.id()).await?;
+    let prop_edit_schema =
+        PropertyEditorSchema::assemble(&ctx, schema_variant.id(), maybe_resource.is_some()).await?;
 
     Ok(Json(prop_edit_schema))
 }


### PR DESCRIPTION
When this value is set, if the component has a resource associated with it, then we won't allow a user to set the value in the attribute editor

We know a VPC CidrBlock can't be modified after the resource is created. So we can change the prop definition to be:

```
    const cidrBlockProp = new PropBuilder()
        .setKind("string")
        .setName("CidrBlock")
        .setValidationFormat(Joi.string().required().regex(/^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/)(1[6-9]|2[0-8])$/).messages({
            'string.pattern.base': 'Must be a valid IPv4 CIDR with CIDR Blocks between /16 and /28'
        }))
        .setWidget(new PropWidgetDefinitionBuilder().setKind("text")
            .setCreateOnly()
            .build())
        .build();
```

Notice the `.setCreateOnly()` as part of the PropWidget

That causes the UI to react as follows (when a resource exists for the component)

![Screenshot 2025-01-21 at 23 53 19](https://github.com/user-attachments/assets/3545e807-f1bd-4beb-b32f-2dccf8af2ea1)

This value can't be overridden like a value that has been created via a socket or an attribute func so there's special casing to this