### PR TITLE
fix(sdf, web): Protect against deleting last view

### DIFF
--- a/app/web/src/components/ViewCard.vue
+++ b/app/web/src/components/ViewCard.vue
@@ -88,6 +88,7 @@
       />
       <DropdownMenuItem
         label="Delete View"
+        :disabled="viewsStore.viewListCount === 1"
         icon="trash"
         :onSelect="() => deleteView(view)"
       />

--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -260,6 +260,9 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
             ? state.selectedComponentIds[0]
             : null;
         },
+        viewListCount: (state) => {
+          return state.viewList.length;
+        },
         selectedComponent():
           | DiagramNodeData
           | DiagramGroupData

--- a/lib/dal/src/diagram/view.rs
+++ b/lib/dal/src/diagram/view.rs
@@ -210,7 +210,14 @@ impl View {
         }
 
         let Some(default_view) = maybe_default_view else {
-            return Err(DiagramError::DefaultViewNotFound);
+            let mut current_views = Self::list(ctx).await?;
+            current_views.sort_by_key(|f| f.id);
+            // We should get the view with the lowest ID and return that!
+            if let Some(view) = current_views.first() {
+                return Ok(view.id);
+            } else {
+                return Err(DiagramError::DefaultViewNotFound);
+            }
         };
 
         Ok(default_view.into())

--- a/lib/dal/src/workspace_snapshot/graph/v4/diagram/view.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v4/diagram/view.rs
@@ -81,23 +81,27 @@ impl ViewExt for WorkspaceSnapshotGraphV4 {
             ));
         }
 
+        let mut edge_idxs_to_remove = Vec::new();
+        let mut view_geometry_idxs = Vec::new();
         // We need to explicitly remove the DiagramObject for the View as it will have more
         // incoming edges than just the one from the View.
-        let diagram_object_idx = self.get_edge_weight_kind_target_idx(
+        if let Some(diagram_object_idx) = self.get_edge_weight_kind_target_idx_opt(
             view_node_idx,
             Direction::Outgoing,
             EdgeWeightKindDiscriminants::DiagramObject,
-        )?;
-        let mut edge_idxs_to_remove = Vec::new();
-        let mut view_geometry_idxs = Vec::new();
-        for diagram_object_edgeref in self.edges_directed(diagram_object_idx, Direction::Incoming) {
-            edge_idxs_to_remove.push(diagram_object_edgeref.id());
-            if EdgeWeightKindDiscriminants::Represents
-                == diagram_object_edgeref.weight().kind().into()
+        )? {
+            for diagram_object_edgeref in
+                self.edges_directed(diagram_object_idx, Direction::Incoming)
             {
-                view_geometry_idxs.push(diagram_object_edgeref.source());
+                edge_idxs_to_remove.push(diagram_object_edgeref.id());
+                if EdgeWeightKindDiscriminants::Represents
+                    == diagram_object_edgeref.weight().kind().into()
+                {
+                    view_geometry_idxs.push(diagram_object_edgeref.source());
+                }
             }
         }
+
         for view_edgeref in self.edges_directed(view_node_idx, Direction::Incoming) {
             edge_idxs_to_remove.push(view_edgeref.id());
         }

--- a/lib/sdf-server/src/service/v2/view/remove_view.rs
+++ b/lib/sdf-server/src/service/v2/view/remove_view.rs
@@ -12,7 +12,7 @@ use crate::{
     track,
 };
 
-use super::ViewResult;
+use super::{ViewError, ViewResult};
 
 pub async fn remove_view(
     HandlerContext(builder): HandlerContext,
@@ -27,6 +27,11 @@ pub async fn remove_view(
         .await?;
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
+
+    let current_view_list = View::list(&ctx).await?;
+    if current_view_list.len() == 1 {
+        return Err(ViewError::CantDeleteOnlyView());
+    }
 
     let view = View::get_by_id(&ctx, view_id).await?;
     View::remove(&ctx, view_id).await?;


### PR DESCRIPTION
There was no protection to stop a user from deleting ALL views. We now check to see if there's at least 1 view available before allowing a deletion to proceed