### PR TITLE
feat: edit schema attributes, fix size after writes

### DIFF
--- a/lib/si-filesystem/src/client.rs
+++ b/lib/si-filesystem/src/client.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use si_frontend_types::{
     fs::{
         AssetFuncs, ChangeSet, CreateChangeSetRequest, CreateChangeSetResponse, Func,
-        ListChangeSetsResponse, Schema, SetFuncCodeRequest,
+        ListChangeSetsResponse, Schema, SchemaAttributes, SetFuncCodeRequest, VariantQuery,
     },
     FuncKind,
 };
@@ -233,6 +233,41 @@ impl SiFsClient {
         self.client
             .post(self.fs_api_change_sets(&format!("schemas/{schema_id}/install"), change_set_id))
             .bearer_auth(&self.token)
+            .send()
+            .await?
+            .error_for_status()?;
+
+        Ok(())
+    }
+
+    pub async fn get_schema_attrs(
+        &self,
+        change_set_id: ChangeSetId,
+        schema_id: SchemaId,
+        unlocked: bool,
+    ) -> SiFsClientResult<SchemaAttributes> {
+        Ok(self
+            .client
+            .get(self.fs_api_change_sets(&format!("schemas/{schema_id}/attrs"), change_set_id))
+            .bearer_auth(&self.token)
+            .query(&VariantQuery { unlocked })
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?)
+    }
+
+    pub async fn set_schema_attrs(
+        &self,
+        change_set_id: ChangeSetId,
+        schema_id: SchemaId,
+        attributes: SchemaAttributes,
+    ) -> SiFsClientResult<()> {
+        self.client
+            .post(self.fs_api_change_sets(&format!("schemas/{schema_id}/attrs"), change_set_id))
+            .bearer_auth(&self.token)
+            .json(&attributes)
             .send()
             .await?
             .error_for_status()?;

--- a/lib/si-frontend-types-rs/src/fs.rs
+++ b/lib/si-frontend-types-rs/src/fs.rs
@@ -5,6 +5,8 @@
 use serde::{Deserialize, Serialize};
 use si_events::{ChangeSetId, FuncId, FuncKind, SchemaId, SchemaVariantId};
 
+use crate::ComponentType;
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ChangeSet {
     pub name: String,
@@ -46,6 +48,8 @@ pub struct Func {
 pub struct AssetFuncs {
     pub locked: Option<Func>,
     pub unlocked: Option<Func>,
+    pub locked_attrs_size: u64,
+    pub unlocked_attrs_size: u64,
 }
 
 pub fn kind_to_string(kind: FuncKind) -> String {
@@ -101,4 +105,34 @@ pub struct VariantQuery {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SetFuncCodeRequest {
     pub code: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SchemaAttributes {
+    pub category: String,
+    pub display_name: String,
+    pub description: Option<String>,
+    pub link: Option<String>,
+    pub color: String,
+    pub component_type: ComponentType,
+}
+
+impl SchemaAttributes {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(bytes)
+    }
+
+    pub fn byte_size(&self) -> u64 {
+        self.to_vec_pretty().ok().map(|vec| vec.len()).unwrap_or(0) as u64
+    }
+
+    pub fn to_vec_pretty(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec_pretty(self)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SchemaAttributesResponse {
+    pub locked: Option<SchemaAttributes>,
+    pub unlocked: Option<SchemaAttributes>,
 }


### PR DESCRIPTION
Adds an attrs.json file to the schema definition folder. Editing it on
an unlocked schema allows you to update schema attributes (like
description, link).