### PR TITLE
fix(dal): Ensure we're only updating what is actually impacted by component deletion

### DIFF
--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -268,6 +268,28 @@ pub async fn get_component_input_socket_value(
         AttributeValue::get_by_id(ctx, component_input_socket.attribute_value_id).await?;
     Ok(input_socket_av.view(ctx).await?)
 }
+/// Gets the [`Value`] for a specific [`Component`]'s [`InputSocket`] by the [`InputSocket`] name
+pub async fn get_component_input_socket_attribute_value(
+    ctx: &DalContext,
+    component_id: ComponentId,
+    input_socket_name: impl AsRef<str>,
+) -> Result<AttributeValue> {
+    let schema_variant_id = Component::schema_variant_id(ctx, component_id).await?;
+    let component_input_sockets =
+        ComponentInputSocket::list_for_component_id(ctx, component_id).await?;
+    let input_socket = InputSocket::find_with_name(ctx, input_socket_name, schema_variant_id)
+        .await?
+        .ok_or(eyre!("no input socket found"))?;
+    let component_input_socket = component_input_sockets
+        .into_iter()
+        .filter(|socket| socket.input_socket_id == input_socket.id())
+        .collect_vec()
+        .pop()
+        .ok_or(eyre!("no input socket match found"))?;
+    let input_socket_av =
+        AttributeValue::get_by_id(ctx, component_input_socket.attribute_value_id).await?;
+    Ok(input_socket_av)
+}
 
 /// Gets the [`Value`] for a specific [`Component`]'s [`OutputSocket`] by the [`OutputSocket`] name
 pub async fn get_component_output_socket_value(

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -26,6 +26,7 @@ use crate::{
 use petgraph::{prelude::*, visit::EdgeRef, Direction::Incoming};
 use serde::{Deserialize, Serialize};
 use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, ContentHash};
+use si_id::{AttributeValueId, ComponentId};
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -291,7 +292,7 @@ fn remove_hanging_socket_connections(
             })
             .map(|edge_ref| edge_ref.target())
         {
-            for (apa_idx, apa_weight) in graph
+            for (apa_idx, apa_weight, destination_component_id) in graph
                 .edges_directed(output_socket_index, Incoming)
                 .filter(|edge_ref| {
                     EdgeWeightKindDiscriminants::PrototypeArgumentValue
@@ -304,7 +305,11 @@ fn remove_hanging_socket_connections(
                             NodeWeight::AttributePrototypeArgument(inner) => {
                                 inner.targets().and_then(|targets| {
                                     if targets.source_component_id == component_id.into() {
-                                        Some((edge_ref.source(), node_weight))
+                                        Some((
+                                            edge_ref.source(),
+                                            node_weight,
+                                            targets.destination_component_id,
+                                        ))
                                     } else {
                                         None
                                     }
@@ -336,7 +341,15 @@ fn remove_hanging_socket_connections(
                                             _ => None,
                                         })
                                     {
-                                        affected_attribute_values.insert(id);
+                                        // check to make sure this attribute value belongs to the destination component in question
+                                        // as this will find all attribute values for the socket in question but not all need to be updated
+                                        if socket_attribute_value_belongs_to_component(
+                                            graph,
+                                            destination_component_id,
+                                            id.into(),
+                                        ) {
+                                            affected_attribute_values.insert(id);
+                                        }
                                     }
                                 },
                             );
@@ -353,6 +366,31 @@ fn remove_hanging_socket_connections(
     )?);
 
     Ok(new_updates)
+}
+
+/// Given an attribute value for an output socket, and checks that it is the attribute value
+/// for the given [`ComponentId`]
+fn socket_attribute_value_belongs_to_component(
+    graph: &WorkspaceSnapshotGraphVCurrent,
+    destination_component_id: ComponentId,
+    starting_attribute_value: AttributeValueId,
+) -> bool {
+    let Some(av_index) = graph.get_node_index_by_id_opt(starting_attribute_value) else {
+        return false;
+    };
+    if let Some(component_index) = graph
+        .edges_directed(av_index, Incoming)
+        .find(|edge_ref| {
+            EdgeWeightKindDiscriminants::SocketValue == edge_ref.weight().kind().into()
+        })
+        .map(|edge| edge.source())
+    {
+        // make sure the component id matches what we're expecting
+        if let Some(component_id) = graph.node_index_to_id(component_index) {
+            return component_id == destination_component_id.into();
+        }
+    }
+    false
 }
 
 impl CorrectTransforms for ComponentNodeWeight {

--- a/lib/dal/tests/integration_test/node_weight/component.rs
+++ b/lib/dal/tests/integration_test/node_weight/component.rs
@@ -7,9 +7,10 @@ use dal_test::expected::{
     self, apply_change_set_to_base, commit_and_update_snapshot_to_visibility,
     fork_from_head_change_set, update_visibility_and_snapshot_to_visibility, ExpectComponent,
 };
-use dal_test::helpers::connect_components_with_socket_names;
+use dal_test::helpers::{connect_components_with_socket_names, get_component_input_socket_value};
 use dal_test::test;
 use pretty_assertions_sorted::assert_eq;
+use si_events::FuncRun;
 
 #[test]
 async fn component_can_only_have_one_parent(ctx: &mut DalContext) {
@@ -182,6 +183,141 @@ async fn deleting_a_component_deletes_component_in_other_change_sets(ctx: &mut D
         .get_node_index_by_id_opt(docker_image_1.id())
         .await
         .is_none());
+}
+
+#[test]
+async fn deleting_a_connected_component_doesnt_cause_nonconnected_components_to_process(
+    ctx: &mut DalContext,
+) {
+    let docker_image_1 = ExpectComponent::create_named(ctx, "Docker Image", "docker 1").await;
+    let docker_image_1_id = docker_image_1.id();
+    let docker_image_2 = ExpectComponent::create_named(ctx, "Docker Image", "docker 2").await;
+
+    let butane_1 = ExpectComponent::create_named(ctx, "Butane", "butane 1")
+        .await
+        .component(ctx)
+        .await;
+    let butane_1_id = butane_1.id();
+    let butane_2 = ExpectComponent::create_named(ctx, "Butane", "butane 2")
+        .await
+        .component(ctx)
+        .await;
+
+    // connect both pairs of Docker -> Butane
+    connect_components_with_socket_names(
+        ctx,
+        docker_image_1.id(),
+        "Container Image",
+        butane_1.id(),
+        "Container Image",
+    )
+    .await
+    .expect("able to connect");
+    connect_components_with_socket_names(
+        ctx,
+        docker_image_2.id(),
+        "Container Image",
+        butane_2.id(),
+        "Container Image",
+    )
+    .await
+    .expect("able to connect");
+    expected::commit_and_update_snapshot_to_visibility(ctx).await;
+
+    expected::apply_change_set_to_base(ctx).await;
+    let prop_path = &["root", "domain", "systemd", "units"];
+    // open 2 new change sets
+    let cs_1 = fork_from_head_change_set(ctx).await;
+
+    // ensure this butane component has a value for the input socket
+    let butane_1_input_socket =
+        get_component_input_socket_value(ctx, butane_1_id, "Container Image")
+            .await
+            .expect("couldn't find value");
+
+    // get the attribute value id for the second butane component to check when it's function was last run
+    assert!(butane_1_input_socket.is_some());
+    let mut attribute_value_ids = butane_2
+        .attribute_values_for_prop(ctx, prop_path)
+        .await
+        .expect("couldn't find attribute values");
+    let attribute_value_id = attribute_value_ids.pop().expect("has an attribute value");
+
+    // I'm not actually looking for a qualification but there's nothing qualification specific here anyways
+    // using this to validate that this func didn't re-run unnecessarily after removing the docker image
+    // connected to the other butane component
+    let func_run_pre_delete: Option<FuncRun> = ctx
+        .layer_db()
+        .func_run()
+        .get_last_qualification_for_attribute_value_id(
+            ctx.workspace_pk().expect("has a workspace"),
+            attribute_value_id,
+        )
+        .await
+        .expect("could not get func run");
+    // remove one of the connected docker images
+    let docker = Component::get_by_id(ctx, docker_image_1_id)
+        .await
+        .expect("couldn't get component");
+    docker.delete(ctx).await.expect("couldn't delete");
+    expected::commit_and_update_snapshot_to_visibility(ctx).await;
+
+    // ensure the butane component no longer has value for that input socket
+    let butane_1_after_commit =
+        get_component_input_socket_value(ctx, butane_1_id, "Container Image")
+            .await
+            .expect("couldn't find value");
+
+    assert!(butane_1_after_commit.is_none());
+
+    // ensure the func that sets the prop for butane_2 didn't rerun (it should have the same func_run_id!)
+
+    let func_run_post_delete: Option<FuncRun> = ctx
+        .layer_db()
+        .func_run()
+        .get_last_qualification_for_attribute_value_id(
+            ctx.workspace_pk().expect("has a workspace"),
+            attribute_value_id,
+        )
+        .await
+        .expect("could not get func run");
+
+    assert_eq!(
+        func_run_post_delete.as_ref().expect("has a value").id(),
+        func_run_pre_delete.expect("has a value").id()
+    );
+
+    // before we apply, create a second fork of head
+    let cs_2 = fork_from_head_change_set(ctx).await;
+    update_visibility_and_snapshot_to_visibility(ctx, cs_1.id).await;
+
+    // now apply
+    expected::apply_change_set_to_base(ctx).await;
+
+    update_visibility_and_snapshot_to_visibility(ctx, cs_2.id).await;
+
+    //now switch to cs_2 and ensure the butane_1 component is updated correctly but the butane_2 component is as it was
+    // and we haven't re-ran the existing input socket
+    let func_run_post_apply: Option<FuncRun> = ctx
+        .layer_db()
+        .func_run()
+        .get_last_qualification_for_attribute_value_id(
+            ctx.workspace_pk().expect("has a workspace"),
+            attribute_value_id,
+        )
+        .await
+        .expect("could not get func run");
+    assert_eq!(
+        func_run_post_delete.expect("has a value").id(),
+        func_run_post_apply.expect("has a value").id()
+    );
+
+    let butane_1_after_apply =
+        get_component_input_socket_value(ctx, butane_1_id, "Container Image")
+            .await
+            .expect("couldn't find value");
+
+    assert!(butane_1_after_apply.is_none());
 }
 
 #[test]


### PR DESCRIPTION
During rebase, when we discover a component has been removed that had connections to other components, only enqueue those impacted attribute values (and not all attribute values with the same socket id, as it was before)

This ensures that when change sets are applied to head with deleted components, we do detect that values need to update in other change sets and enqueue them appropriately.

<div><img src="https://media0.giphy.com/media/WQCv56djMTCmQkySAg/giphy.gif?cid=5a38a5a24afgohpj2nbvykynniypzzh49h4qrvy9xq0jen2l&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:381px;width:300px"/><br/>via <a href="https://giphy.com/gifs/moodman-WQCv56djMTCmQkySAg">GIPHY</a></div>