### PR TITLE
feat: increase scrape interval into prometheus to 30s

### DIFF
--- a/component/init/configs/prometheus.yml
+++ b/component/init/configs/prometheus.yml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval: 5s
+  scrape_interval: 30s
   external_labels:
     monitor: prometheus
 scrape_configs:


### PR DESCRIPTION
Currently managed prometheus is our highest non-compute AWS bill component in each of our tooling and production accounts. 

We don't really need the 5s granularity so this should reduce the cost component by 6x by pushing the granularity to 30s.

If it turns out we need it super granular to debug something, we can either manually change it or just push it back down when needed.