### PR TITLE
feat: add a deno workspace buck2 rule

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -1,6 +1,7 @@
 load(
     "@prelude-si//:macros.bzl",
     "alias",
+    "deno_workspace",
     "export_file",
     "nix_flake_lock",
     "pnpm_lock",
@@ -89,6 +90,17 @@ pnpm_workspace(
         "//lib/tsconfig:package.json",
         "//lib/vue-lib:package.json",
     ],
+)
+
+deno_workspace(
+    name = "deno_workspace",
+    root_config = ":deno.json",
+    packages = [
+        "//bin/lang-js:deno.json",
+        "//bin/si-gen-cloud-control:deno.json",
+        "//lib/ts-lib-deno:deno.json",
+    ],
+    visibility = ["PUBLIC"],
 )
 
 pnpm_lock(

--- a/bin/lang-js/BUCK
+++ b/bin/lang-js/BUCK
@@ -24,8 +24,6 @@ alias(
     actual = ":bin"
 )
 
-# we include si-gen-cloud-control here because the deno workspace
-# requires resolution of all members even if we don't use it
 deno_compile(
     name = "bin",
     main = "src/index.ts",
@@ -33,11 +31,7 @@ deno_compile(
     srcs = glob([
         "src/**/*.ts",
         "src/**/*.js",
-    ]) +
-    [
-        "//lib/ts-lib-deno:ts-lib-deno",
-        "//bin/si-gen-cloud-control:si-gen-cloud-control",
-    ],
+    ]) + ["//:deno_workspace"],
     permissions = [
         "allow-all",
     ],
@@ -70,11 +64,6 @@ deno_test(
         "worker-options",
     ],
 )
-
-dev_deps_srcs = {
-    "lib/eslint-config": "//lib/eslint-config:src",
-    "lib/tsconfig": "//lib/tsconfig:src",
-}
 
 nix_omnibus_pkg(
     name = "omnibus",

--- a/prelude-si/deno/BUCK
+++ b/prelude-si/deno/BUCK
@@ -17,6 +17,10 @@ export_file(
     name = "deno_test.py",
 )
 
+export_file(
+    name = "deno_workspace.py",
+)
+
 yapf_check(
     name = "check-format-python",
     srcs = glob(["**/*.py"]),

--- a/prelude-si/deno/deno_workspace.py
+++ b/prelude-si/deno/deno_workspace.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import shutil
+import sys
+from typing import List, Optional
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=
+        "Create a Deno workspace from a root config and package files")
+    parser.add_argument("--workspace_dir",
+                        required=True,
+                        help="Directory where the workspace will be created")
+    parser.add_argument("--root_config",
+                        required=True,
+                        help="Path to the root deno.json configuration file")
+    parser.add_argument("--package",
+                        action='append',
+                        required=True,
+                        help="Package files to include in the workspace")
+
+    return parser.parse_args()
+
+
+def get_target_path(pkg_file: str) -> str:
+    """Extract the target path from a package file path.
+
+    Args:
+        pkg_file: Full path to package file like 'buck-out/v2/gen/root/.../bin/lang-js/deno.json'
+
+    Returns:
+        Relative path like 'bin/lang-js/deno.json'
+    """
+    parts = pkg_file.split(os.sep)
+    try:
+        # Find 'bin' or 'lib' in the path
+        for i, part in enumerate(parts):
+            if part in ['bin', 'lib']:
+                return os.path.join(*parts[i:])
+    except:
+        return os.path.basename(pkg_file)
+    return os.path.basename(pkg_file)
+
+
+def create_workspace(workspace_dir: str, root_config: str,
+                     packages: List[str]) -> None:
+    """Create a Deno workspace with all files in the correct structure at the root level.
+
+    Args:
+        workspace_dir: Directory that will become the root
+        root_config: Path to the root deno.json configuration file
+        packages: List of package files to include in the workspace
+    """
+    os.makedirs(workspace_dir, exist_ok=True)
+
+    shutil.copy2(root_config, os.path.join(workspace_dir, "deno.json"))
+
+    for pkg_file in packages:
+        target_path = get_target_path(pkg_file)
+        target_path = target_path.replace('__deno.json__/', '')
+        dest = os.path.join(workspace_dir, target_path)
+
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+
+        try:
+            print(f"Copying {pkg_file} to {dest}")
+            shutil.copy2(pkg_file, dest)
+        except Exception as e:
+            print(f"Error copying {pkg_file} to {dest}: {e}", file=sys.stderr)
+            sys.exit(1)
+
+
+def main() -> Optional[int]:
+    try:
+        args = parse_args()
+        create_workspace(args.workspace_dir, args.root_config, args.package)
+        return 0
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prelude-si/deno/toolchain.bzl
+++ b/prelude-si/deno/toolchain.bzl
@@ -2,6 +2,7 @@ DenoToolchainInfo = provider(fields = {
     "deno_compile": provider_field(typing.Any, default = None),
     "deno_format": provider_field(typing.Any, default = None),
     "deno_test": provider_field(typing.Any, default = None),
+    "deno_workspace": provider_field(typing.Any, default = None),
 })
 
 def deno_toolchain_impl(ctx) -> list[[DefaultInfo, DenoToolchainInfo]]:
@@ -14,6 +15,7 @@ def deno_toolchain_impl(ctx) -> list[[DefaultInfo, DenoToolchainInfo]]:
             deno_compile = ctx.attrs._deno_compile,
             deno_format = ctx.attrs._deno_format,
             deno_test = ctx.attrs._deno_test,
+            deno_workspace = ctx.attrs._deno_workspace,
         ),
     ]
 
@@ -30,6 +32,10 @@ deno_toolchain = rule(
         ),
        "_deno_test": attrs.dep(
             default = "prelude-si//deno:deno_test.py",
+            providers = [DefaultInfo],
+        ),
+       "_deno_workspace": attrs.dep(
+            default = "prelude-si//deno:deno_workspace.py",
             providers = [DefaultInfo],
         ),
     },

--- a/prelude-si/macros.bzl
+++ b/prelude-si/macros.bzl
@@ -13,6 +13,11 @@ sh_binary = _sh_binary
 test_suite = _test_suite
 
 load(
+    "@prelude-si//:deno.bzl",
+    _deno_workspace = "deno_workspace",
+)
+
+load(
     "@prelude-si//macros:docker.bzl",
     _docker_image = "docker_image",
 )
@@ -55,6 +60,8 @@ load(
     _vite_app = "vite_app",
     _workspace_node_modules = "workspace_node_modules",
 )
+
+deno_workspace = _deno_workspace
 eslint = _eslint
 ts_test = _ts_test
 node_pkg_bin = _node_pkg_bin

--- a/prelude-si/nix/nix_omnibus_pkg_build.py
+++ b/prelude-si/nix/nix_omnibus_pkg_build.py
@@ -165,7 +165,14 @@ def build_nix_package(name: str, build_context_dir: str) -> str:
             symlinks=True,
         )
 
+        # If we find a workspace dir, let's get the contents into the root
+        workspace = os.path.join(root_dir, "workspace")
+        if os.path.isdir(workspace):
+            print("--- Found a workspace dir, moving contents into root")
+            move_contents_up(workspace)
+
         print("--- Build nix package with: '{}'".format(" ".join(cmd)))
+        # Create parent directories
         subprocess.run(cmd, cwd=root_dir).check_returncode()
 
         nix_store_pkg_path = os.readlink(os.path.join(root_dir, "result"))
@@ -406,6 +413,10 @@ def compute_build_metadata(
 
     return metadata
 
+def move_contents_up(directory):
+    parent_dir = os.path.dirname(directory)
+    shutil.copytree(directory, parent_dir, dirs_exist_ok=True)
+    shutil.rmtree(directory)
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Creates a rule that takes all of the dirs declared in the workspace and make the available as buck2 output. I could not figure out how to get the contents of the `workspace` directory just into the root of the build_contents, so I added a bit to copy them up from the workspace dir into the root. 

The result here is hopefully that changes to si-gen-cloud-control won't cause a dependency chain resulting in dal builds when we really don't need them slowing down CI.

<img src="https://media2.giphy.com/media/26gsvA7sDa86fDu6s/giphy.gif"/>