### PR TITLE
feat: split out resource_values and domain

### DIFF
--- a/bin/si-gen-cloud-control/src/commands/generateSiSpecs.ts
+++ b/bin/si-gen-cloud-control/src/commands/generateSiSpecs.ts
@@ -9,6 +9,7 @@ import {
 import { generateDefaultLeafFuncs } from "../pipeline-steps/generateLeafFuncs.ts";
 import { generateDefaultManagementFuncs } from "../pipeline-steps/generateManagementFuncs.ts";
 import { addDefaultPropsAndSockets } from "../pipeline-steps/addDefaultPropsAndSockets.ts";
+import { generateSocketsFromResourceProps } from "../pipeline-steps/generateSocketsFromResourceProps.ts";
 
 export function generateSiSpecForService(serviceName: string) {
   const cf = getServiceByName(serviceName);
@@ -35,6 +36,7 @@ export async function generateSiSpecs() {
 
   // EXECUTE PIPELINE STEPS
   specs = generateSocketsFromDomainProps(specs);
+  specs = generateSocketsFromResourceProps(specs);
   specs = addDefaultPropsAndSockets(specs);
   specs = generateAssetFuncs(specs);
   specs = generateDefaultActionFuncs(specs);

--- a/bin/si-gen-cloud-control/src/pipeline-steps/addDefaultPropsAndSockets.ts
+++ b/bin/si-gen-cloud-control/src/pipeline-steps/addDefaultPropsAndSockets.ts
@@ -46,10 +46,12 @@ export function addDefaultPropsAndSockets(specs: PkgSpec[]): PkgSpec[] {
       "string",
       extraProp.metadata.propPath,
     );
-    regionProp.data.inputs = [
-      attrFuncInputSpecFromSocket(regionSocket),
-    ];
-    regionProp.data.funcUniqueId = getSiFuncId("si:identity");
+    if (regionProp.data) {
+      regionProp.data.inputs = [
+        attrFuncInputSpecFromSocket(regionSocket),
+      ];
+      regionProp.data.funcUniqueId = getSiFuncId("si:identity");
+    }
     extraProp.entries.push(regionProp);
     domain.entries.push(extraProp);
 

--- a/bin/si-gen-cloud-control/src/pipeline-steps/generateSocketsFromResourceProps.ts
+++ b/bin/si-gen-cloud-control/src/pipeline-steps/generateSocketsFromResourceProps.ts
@@ -1,0 +1,51 @@
+import { PkgSpec } from "../bindings/PkgSpec.ts";
+import { SchemaVariantSpec } from "../bindings/SchemaVariantSpec.ts";
+import _ from "lodash";
+import { SocketSpec } from "../bindings/SocketSpec.ts";
+import { isExpandedPropSpec } from "../spec/props.ts";
+import { createSocketFromProp } from "../spec/sockets.ts";
+
+export function generateSocketsFromResourceProps(specs: PkgSpec[]): PkgSpec[] {
+  const newSpecs = [] as PkgSpec[];
+
+  for (const spec of specs) {
+    const schemaVariant = spec.schemas[0]?.variants[0];
+
+    if (!schemaVariant) {
+      console.log(
+        `Could not generate sockets for ${spec.name}: missing schema or variant`,
+      );
+      continue;
+    }
+
+    schemaVariant.sockets = [
+      ...schemaVariant.sockets,
+      ...createSocketsFromResource(schemaVariant),
+    ];
+
+    newSpecs.push(spec);
+  }
+
+  return newSpecs;
+}
+
+function createSocketsFromResource(variant: SchemaVariantSpec): SocketSpec[] {
+  const resource = variant.resourceValue;
+
+  if (resource.kind !== "object") throw "Resource prop is not object";
+
+  const sockets: SocketSpec[] = [];
+  if (resource.kind == "object") {
+    for (const prop of resource.entries) {
+      if (
+        !["array", "object"].includes(prop.kind) && isExpandedPropSpec(prop)
+      ) {
+        const socket = createSocketFromProp(prop);
+        if (socket) {
+          sockets.push(socket);
+        }
+      }
+    }
+  }
+  return sockets;
+}

--- a/bin/si-gen-cloud-control/src/spec/props.ts
+++ b/bin/si-gen-cloud-control/src/spec/props.ts
@@ -250,6 +250,9 @@ export function createObjectProp(
     uniqueId: ulid(),
     metadata: {
       propPath: [...parentPath, name],
+      createOnly: false,
+      readOnly: false,
+      writeOnly: false,
     },
   };
 
@@ -289,7 +292,6 @@ export function createScalarProp(
     kind,
     data,
     name,
-    entries: [],
     uniqueId: ulid(),
     metadata: {
       propPath: [...parentPath, name],


### PR DESCRIPTION
Changes the domain and resource_value layout

* All read-only props will be on the resource_value only
  * All output sockets will have a value like `/root/resource_value/VpcId -> VpcId`
* All other props go on the domain
  * Create- and write-only props will have a value like `Ipv4IpamPoolId -> /root/domain/Ipv4IpamPoolId`