### PR TITLE
BUG-710: don't throw, reset copying

### DIFF
--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -2617,7 +2617,12 @@ async function triggerPasteElements() {
     throw new Error("Copy cursor must be in grid to paste element");
 
   const selectionEnclosure = currentSelectionEnclosure.value;
-  if (!selectionEnclosure) throw new Error("Couldn't get selection enclosure");
+  if (!selectionEnclosure) {
+    // Fix for BUG-710, reset when pasting across views
+    componentsStore.copyingFrom = null;
+    viewsStore.selectedComponentIds = [];
+    return;
+  }
 
   const selectionCenter = {
     x: selectionEnclosure.x + selectionEnclosure.width / 2,


### PR DESCRIPTION
The current scheme for copy & paste won't work across views... just nullifying the bad stuff here
<img src="https://media4.giphy.com/media/XtX936H4lzr5fUgJOR/giphy.gif"/>