### PR TITLE
feat(si-fs): create funcs except attr and action, edit bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6613,6 +6613,8 @@ dependencies = [
  "nix 0.29.0",
  "remain",
  "reqwest",
+ "serde",
+ "serde_json",
  "si-frontend-types",
  "si-id",
  "thiserror 2.0.11",

--- a/lib/dal/src/func/binding/action.rs
+++ b/lib/dal/src/func/binding/action.rs
@@ -22,7 +22,7 @@ pub struct ActionBinding {
 }
 
 impl ActionBinding {
-    pub(crate) async fn assemble_action_bindings(
+    pub async fn assemble_action_bindings(
         ctx: &DalContext,
         func_id: FuncId,
     ) -> FuncBindingResult<Vec<FuncBinding>> {

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -260,7 +260,7 @@ impl AttributeBinding {
         Ok(bindings)
     }
 
-    pub(crate) async fn assemble_attribute_bindings(
+    pub async fn assemble_attribute_bindings(
         ctx: &DalContext,
         func_id: FuncId,
     ) -> FuncBindingResult<Vec<FuncBinding>> {

--- a/lib/dal/src/func/binding/authentication.rs
+++ b/lib/dal/src/func/binding/authentication.rs
@@ -13,7 +13,7 @@ pub struct AuthBinding {
 }
 
 impl AuthBinding {
-    pub(crate) async fn assemble_auth_bindings(
+    pub async fn assemble_auth_bindings(
         ctx: &DalContext,
         func_id: FuncId,
     ) -> FuncBindingResult<Vec<FuncBinding>> {

--- a/lib/dal/src/func/binding/leaf.rs
+++ b/lib/dal/src/func/binding/leaf.rs
@@ -26,7 +26,7 @@ pub struct LeafBinding {
 }
 
 impl LeafBinding {
-    pub(crate) async fn assemble_leaf_func_bindings(
+    pub async fn assemble_leaf_func_bindings(
         ctx: &DalContext,
         func_id: FuncId,
         leaf_kind: LeafKind,

--- a/lib/dal/src/func/binding/management.rs
+++ b/lib/dal/src/func/binding/management.rs
@@ -188,7 +188,7 @@ type Input = {{
         ))
     }
 
-    pub(crate) async fn assemble_management_bindings(
+    pub async fn assemble_management_bindings(
         ctx: &DalContext,
         func_id: FuncId,
     ) -> FuncBindingResult<Vec<FuncBinding>> {

--- a/lib/sdf-server/src/service/v2/fs.rs
+++ b/lib/sdf-server/src/service/v2/fs.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use axum::{
     extract::{Host, OriginalUri, Path, Query},
@@ -7,19 +7,36 @@ use axum::{
     Json, Router,
 };
 use dal::{
+    attribute::prototype::argument::{AttributePrototypeArgument, AttributePrototypeArgumentError},
     cached_module::CachedModule,
-    func::authoring::{FuncAuthoringClient, FuncAuthoringError},
-    pkg::{import_pkg_from_pkg, ImportOptions, PkgError},
-    schema::variant::authoring::{VariantAuthoringClient, VariantAuthoringError},
+    func::{
+        argument::{FuncArgument, FuncArgumentError},
+        authoring::{FuncAuthoringClient, FuncAuthoringError},
+        binding::{
+            action::ActionBinding, attribute::AttributeBinding, authentication::AuthBinding,
+            leaf::LeafBinding, management::ManagementBinding, EventualParent, FuncBindingError,
+        },
+        FuncKind,
+    },
+    pkg::PkgError,
+    prop::{PropError, PropPath},
+    schema::variant::{
+        authoring::{VariantAuthoringClient, VariantAuthoringError},
+        leaves::{LeafInputLocation, LeafKind},
+    },
+    socket::{input::InputSocketError, output::OutputSocketError},
     workspace::WorkspaceId,
-    ChangeSet, ChangeSetId, DalContext, FuncId, Schema, SchemaId, SchemaVariant, WsEvent,
-    WsEventError,
+    ChangeSet, ChangeSetId, DalContext, Func, FuncId, InputSocket, OutputSocket, Prop, Schema,
+    SchemaId, SchemaVariant, SchemaVariantId, WsEvent, WsEventError,
 };
 use hyper::StatusCode;
-use si_events::audit_log::AuditLogKind;
-use si_frontend_types::fs::{
-    AssetFuncs, ChangeSet as FsChangeSet, Func as FsFunc, Schema as FsSchema, SchemaAttributes,
-    SetFuncCodeRequest, VariantQuery,
+use si_events::{audit_log::AuditLogKind, ActionKind};
+use si_frontend_types::{
+    fs::{
+        self, AssetFuncs, AttributeInputFrom, AttributeOutputTo, Binding, ChangeSet as FsChangeSet,
+        Func as FsFunc, Schema as FsSchema, SchemaAttributes, SetFuncCodeRequest, VariantQuery,
+    },
+    AttributeArgumentBinding, FuncBinding,
 };
 use thiserror::Error;
 
@@ -29,13 +46,25 @@ use crate::{
 };
 
 use super::{
-    func::{get_code_response, FuncAPIError},
+    func::{
+        binding::update_binding::{
+            update_action_func_bindings, update_attribute_func_bindings, update_leaf_func_bindings,
+            update_mangement_func_bindings,
+        },
+        get_code_response, FuncAPIError,
+    },
     AccessBuilder, AppState,
 };
 
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum FsError {
+    #[error("attribute func bound to neither output socket nor prop")]
+    AttributeFuncNotBound,
+    #[error("attribute input bound to neither input socket nor prop")]
+    AttributeInputNotBound,
+    #[error("attribute prototype argument error: {0}")]
+    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
     #[error("cached module error: {0}")]
     CachedModule(#[from] dal::cached_module::CachedModuleError),
     #[error("cannot write to HEAD")]
@@ -50,18 +79,44 @@ pub enum FsError {
     FuncAlreadyUnlocked(FuncId),
     #[error("func api error: {0}")]
     FuncApi(#[from] FuncAPIError),
+    #[error("func argument error: {0}")]
+    FuncArgument(#[from] FuncArgumentError),
+    #[error("func argument not found with name: {0}")]
+    FuncArgumentNotFound(String),
     #[error("func authoring error: {0}")]
     FuncAuthoring(#[from] FuncAuthoringError),
+    #[error("func binding error: {0}")]
+    FuncBinding(#[from] FuncBindingError),
+    #[error("binding kind mismatch")]
+    FuncBindingKindMismatch,
+    #[error("func name reserved")]
+    FuncNameReserved,
+    #[error("input socket error: {0}")]
+    InputSocket(#[from] InputSocketError),
+    #[error("no input socket found named {0}")]
+    InputSocketNotFound(String),
+    #[error("output socket error: {0}")]
+    OutputSocket(#[from] OutputSocketError),
+    #[error("no output socket found named {0}")]
+    OutputSocketNotFound(String),
     #[error("pkg error: {0}")]
     Pkg(#[from] PkgError),
+    #[error("prop error: {0}")]
+    Prop(#[from] PropError),
+    #[error("prop not found at path {0}")]
+    PropNotFound(String),
     #[error("resource not found")]
     ResourceNotFound,
     #[error("schema error: {0}")]
     Schema(#[from] dal::SchemaError),
     #[error("cannot unlock schema {0}")]
     SchemaCannotUnlock(SchemaId),
+    #[error("Schema named {0} could not be found")]
+    SchemaNotFoundWithName(String),
     #[error("schema variant error: {0}")]
     SchemaVariant(#[from] dal::SchemaVariantError),
+    #[error("serde json error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
     #[error("transactions error: {0}")]
     Transactions(#[from] dal::TransactionsError),
     #[error("variant authoring error: {0}")]
@@ -92,8 +147,8 @@ pub async fn create_change_set(
     OriginalUri(_original_uri): OriginalUri,
     Host(_host_name): Host,
     Path(_workspace_id): Path<WorkspaceId>,
-    Json(request): Json<si_frontend_types::fs::CreateChangeSetRequest>,
-) -> FsResult<Json<si_frontend_types::fs::CreateChangeSetResponse>> {
+    Json(request): Json<fs::CreateChangeSetRequest>,
+) -> FsResult<Json<fs::CreateChangeSetResponse>> {
     let ctx = builder.build_head(access_builder).await?;
 
     let change_set = ChangeSet::fork_head(&ctx, request.name).await?;
@@ -121,7 +176,7 @@ pub async fn list_change_sets(
     OriginalUri(_original_uri): OriginalUri,
     Host(_host_name): Host,
     Path(_workspace_id): Path<WorkspaceId>,
-) -> FsResult<Json<si_frontend_types::fs::ListChangeSetsResponse>> {
+) -> FsResult<Json<fs::ListChangeSetsResponse>> {
     let ctx = builder.build_head(request_ctx).await?;
     let open_change_sets = ChangeSet::list_active(&ctx).await?;
 
@@ -224,7 +279,7 @@ async fn list_change_set_funcs(
 
     check_change_set(&ctx)?;
 
-    let Some(kind) = si_frontend_types::fs::kind_from_string(&kind) else {
+    let Some(kind) = fs::kind_from_string(&kind) else {
         return Ok(Json(vec![]));
     };
 
@@ -233,7 +288,8 @@ async fn list_change_set_funcs(
             .await?
             .into_iter()
             .filter(|f| kind == f.kind.into())
-            .map(dal_func_to_fs_func)
+            // We do not render bindings for the "change-set/functions" folder yet
+            .map(|f| dal_func_to_fs_func(f, 0))
             .collect(),
     ))
 }
@@ -257,33 +313,156 @@ async fn list_variant_funcs(
 
     check_change_set(&ctx)?;
 
-    let Some(kind) = si_frontend_types::fs::kind_from_string(&kind) else {
+    let Some(kind) = fs::kind_from_string(&kind) else {
         return Ok(Json(vec![]));
     };
 
     let mut funcs = vec![];
 
-    if let Some(locked_variant) = lookup_variant_for_schema(&ctx, schema_id, false).await? {
-        funcs.extend(
-            dal::SchemaVariant::all_funcs_without_intrinsics(&ctx, locked_variant.id())
+    for unlocked in [true, false] {
+        if let Some(variant) = lookup_variant_for_schema(&ctx, schema_id, unlocked).await? {
+            for func in dal::SchemaVariant::all_funcs_without_intrinsics(&ctx, variant.id())
                 .await?
                 .into_iter()
                 .filter(|f| kind == f.kind.into())
-                .map(dal_func_to_fs_func),
-        );
-    }
+            {
+                let bindings = get_bindings(&ctx, func.id, variant.id).await?;
+                let bindings_size = serde_json::to_vec_pretty(&bindings)?.len() as u64;
 
-    if let Some(unlocked_variant) = lookup_variant_for_schema(&ctx, schema_id, true).await? {
-        funcs.extend(
-            dal::SchemaVariant::all_funcs_without_intrinsics(&ctx, unlocked_variant.id())
-                .await?
-                .into_iter()
-                .filter(|f| kind == f.kind.into())
-                .map(dal_func_to_fs_func),
-        );
+                funcs.push(dal_func_to_fs_func(func, bindings_size))
+            }
+        }
     }
 
     Ok(Json(funcs))
+}
+
+async fn get_bindings(
+    ctx: &DalContext,
+    func_id: FuncId,
+    schema_variant_id: SchemaVariantId,
+) -> FsResult<fs::Bindings> {
+    let bindings =
+        get_bindings_for_func_and_schema_variant(ctx, func_id, schema_variant_id).await?;
+
+    let mut display_bindings = vec![];
+    for binding in bindings {
+        display_bindings.push(func_binding_to_fs_binding(ctx, binding).await?);
+    }
+
+    Ok(fs::Bindings {
+        bindings: display_bindings,
+    })
+}
+
+async fn func_binding_to_fs_binding(
+    ctx: &DalContext,
+    binding: FuncBinding,
+) -> FsResult<fs::Binding> {
+    Ok(match binding {
+        FuncBinding::Action { kind, .. } => Binding::Action {
+            kind: kind.unwrap_or(ActionKind::Manual),
+        },
+        FuncBinding::Attribute {
+            prop_id,
+            output_socket_id,
+            argument_bindings,
+            ..
+        } => {
+            attribute_binding_to_fs_attribute_binding(
+                ctx,
+                prop_id,
+                output_socket_id,
+                argument_bindings,
+            )
+            .await?
+        }
+        FuncBinding::Authentication { .. } => Binding::Authentication,
+        FuncBinding::CodeGeneration { inputs, .. } => Binding::CodeGeneration { inputs },
+        FuncBinding::Management {
+            managed_schemas, ..
+        } => management_binding_to_fs_management_binding(ctx, managed_schemas).await?,
+        FuncBinding::Qualification { inputs, .. } => Binding::Qualification { inputs },
+    })
+}
+
+async fn management_binding_to_fs_management_binding(
+    ctx: &DalContext,
+    managed_schemas: Option<Vec<SchemaId>>,
+) -> FsResult<Binding> {
+    Ok(if let Some(schemas) = managed_schemas {
+        let mut managed_names = vec![];
+        for managed_schema_id in schemas {
+            let schema_name =
+                match CachedModule::latest_by_schema_id(ctx, managed_schema_id).await? {
+                    Some(cached_module) => cached_module.schema_name,
+                    None => {
+                        Schema::get_by_id_or_error(ctx, managed_schema_id)
+                            .await?
+                            .name
+                    }
+                };
+            managed_names.push(schema_name);
+        }
+
+        Binding::Management {
+            managed_schemas: Some(managed_names),
+        }
+    } else {
+        Binding::Management {
+            managed_schemas: None,
+        }
+    })
+}
+
+async fn attribute_binding_to_fs_attribute_binding(
+    ctx: &DalContext,
+    prop_id: Option<dal::PropId>,
+    output_socket_id: Option<dal::OutputSocketId>,
+    argument_bindings: Vec<si_frontend_types::AttributeArgumentBinding>,
+) -> FsResult<Binding> {
+    let output_to = if let Some(prop_id) = prop_id {
+        let path = Prop::get_by_id(ctx, prop_id)
+            .await?
+            .path(ctx)
+            .await?
+            .with_replaced_sep("/");
+
+        AttributeOutputTo::Prop(path)
+    } else if let Some(output_socket_id) = output_socket_id {
+        let name = OutputSocket::get_by_id(ctx, output_socket_id)
+            .await?
+            .name()
+            .to_string();
+        AttributeOutputTo::OutputSocket(name)
+    } else {
+        return Err(FsError::AttributeFuncNotBound);
+    };
+    let mut inputs = BTreeMap::new();
+    for arg_binding in argument_bindings {
+        let func_arg_name = FuncArgument::get_by_id_or_error(ctx, arg_binding.func_argument_id)
+            .await?
+            .name;
+        let input_from = if let Some(input_prop_id) = arg_binding.prop_id {
+            let path = Prop::get_by_id(ctx, input_prop_id)
+                .await?
+                .path(ctx)
+                .await?
+                .to_string();
+            AttributeInputFrom::Prop(path)
+        } else if let Some(input_socket_id) = arg_binding.input_socket_id {
+            let name = InputSocket::get_by_id(ctx, input_socket_id)
+                .await?
+                .name()
+                .to_string();
+            AttributeInputFrom::InputSocket(name)
+        } else {
+            return Err(FsError::AttributeInputNotBound);
+        };
+
+        inputs.insert(func_arg_name, input_from);
+    }
+    Ok(Binding::Attribute { output_to, inputs })
 }
 
 async fn lookup_variant_for_schema(
@@ -342,7 +521,8 @@ pub async fn get_asset_funcs(
             let attrs = make_schema_attrs(&variant);
             result.locked_attrs_size = attrs.byte_size();
 
-            Some(dal_func_to_fs_func(asset_func))
+            // Asset funcs do not have bindings (yet)
+            Some(dal_func_to_fs_func(asset_func, 0))
         }
         None => None,
     };
@@ -354,7 +534,7 @@ pub async fn get_asset_funcs(
             let attrs = make_schema_attrs(&variant);
             result.unlocked_attrs_size = attrs.byte_size();
 
-            Some(dal_func_to_fs_func(asset_func))
+            Some(dal_func_to_fs_func(asset_func, 0))
         }
         None => None,
     };
@@ -366,7 +546,43 @@ pub async fn get_asset_funcs(
     }
 }
 
-fn dal_func_to_fs_func(func: dal::Func) -> FsFunc {
+async fn get_bindings_for_func_and_schema_variant(
+    ctx: &DalContext,
+    func_id: FuncId,
+    schema_variant_id: SchemaVariantId,
+) -> FsResult<Vec<FuncBinding>> {
+    let func = dal::Func::get_by_id_or_error(ctx, func_id).await?;
+
+    Ok(match func.kind {
+        dal::func::FuncKind::Action => {
+            ActionBinding::assemble_action_bindings(ctx, func_id).await?
+        }
+        dal::func::FuncKind::Attribute => {
+            AttributeBinding::assemble_attribute_bindings(ctx, func_id).await?
+        }
+        dal::func::FuncKind::Authentication => {
+            AuthBinding::assemble_auth_bindings(ctx, func_id).await?
+        }
+        dal::func::FuncKind::CodeGeneration => {
+            LeafBinding::assemble_leaf_func_bindings(ctx, func_id, LeafKind::CodeGeneration).await?
+        }
+        dal::func::FuncKind::Management => {
+            ManagementBinding::assemble_management_bindings(ctx, func_id).await?
+        }
+        dal::func::FuncKind::Qualification => {
+            LeafBinding::assemble_leaf_func_bindings(ctx, func_id, LeafKind::Qualification).await?
+        }
+        dal::func::FuncKind::Unknown
+        | dal::func::FuncKind::Intrinsic
+        | dal::func::FuncKind::SchemaVariantDefinition => vec![],
+    }
+    .into_iter()
+    .filter(|binding| binding.get_schema_variant() == Some(schema_variant_id))
+    .map(Into::into)
+    .collect())
+}
+
+fn dal_func_to_fs_func(func: dal::Func, bindings_size: u64) -> FsFunc {
     FsFunc {
         id: func.id,
         kind: func.kind.into(),
@@ -378,7 +594,37 @@ fn dal_func_to_fs_func(func: dal::Func) -> FsFunc {
             .map(|code| code.len())
             .unwrap_or(0) as u64,
         name: func.name,
+        bindings_size,
     }
+}
+
+async fn get_func_bindings(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(_posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    Host(_host_name): Host,
+    Path((_workspace_id, change_set_id, schema_id, func_id)): Path<(
+        WorkspaceId,
+        ChangeSetId,
+        SchemaId,
+        FuncId,
+    )>,
+    Query(variant_query): Query<VariantQuery>,
+) -> FsResult<Json<fs::Bindings>> {
+    let ctx = builder
+        .build(request_ctx.build(change_set_id.into()))
+        .await?;
+
+    check_change_set(&ctx)?;
+
+    let variant = lookup_variant_for_schema(&ctx, schema_id, variant_query.unlocked)
+        .await?
+        .ok_or(FsError::ResourceNotFound)?;
+
+    let display_bindings = get_bindings(&ctx, func_id, variant.id()).await?;
+
+    Ok(Json(display_bindings))
 }
 
 async fn get_func_code(
@@ -428,6 +674,169 @@ async fn set_func_code(
     ctx.commit().await?;
 
     Ok(())
+}
+
+async fn create_func(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(_posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    Host(_host_name): Host,
+    Path((_workspace_id, change_set_id, schema_id, kind_string)): Path<(
+        WorkspaceId,
+        ChangeSetId,
+        SchemaId,
+        String,
+    )>,
+    Json(request): Json<fs::CreateFuncRequest>,
+) -> FsResult<Json<FsFunc>> {
+    let kind = fs::kind_from_string(&kind_string).ok_or(FsError::FuncBindingKindMismatch)?;
+
+    let ctx = builder
+        .build(request_ctx.build(change_set_id.into()))
+        .await?;
+
+    check_change_set_and_not_head(&ctx).await?;
+
+    if !request.binding.kind_matches(kind) {
+        return Err(FsError::FuncBindingKindMismatch);
+    }
+
+    let name = request.name.as_str();
+
+    if dal::func::is_intrinsic(name)
+        || ["si:resourcePayloadToValue", "si:normalizeToArray"].contains(&name)
+    {
+        return Err(FsError::FuncNameReserved);
+    }
+
+    let unlocked_variant = get_or_unlock_schema(&ctx, schema_id).await?;
+
+    let (attach_audit_log, func) = match request.binding {
+        Binding::Action { kind } => {
+            let func = FuncAuthoringClient::create_new_action_func(
+                &ctx,
+                Some(request.name),
+                kind.into(),
+                unlocked_variant.id(),
+            )
+            .await?;
+            (
+                AuditLogKind::AttachActionFunc {
+                    func_id: func.id,
+                    func_display_name: func.display_name.clone(),
+                    schema_variant_id: Some(unlocked_variant.id()),
+                    component_id: None,
+                    action_kind: kind.into(),
+                },
+                func,
+            )
+        }
+        Binding::Attribute {
+            output_to: _,
+            inputs: _,
+        } => todo!(),
+        Binding::Authentication => {
+            let func = FuncAuthoringClient::create_new_auth_func(
+                &ctx,
+                Some(request.name),
+                unlocked_variant.id(),
+            )
+            .await?;
+            (
+                AuditLogKind::AttachAuthFunc {
+                    func_id: func.id,
+                    func_display_name: func.display_name.clone(),
+                    schema_variant_id: Some(unlocked_variant.id()),
+                },
+                func,
+            )
+        }
+        Binding::CodeGeneration { .. } => {
+            let func = FuncAuthoringClient::create_new_leaf_func(
+                &ctx,
+                Some(request.name),
+                LeafKind::CodeGeneration,
+                EventualParent::SchemaVariant(unlocked_variant.id()),
+                &[LeafInputLocation::Domain],
+            )
+            .await?;
+
+            (
+                AuditLogKind::AttachCodeGenFunc {
+                    func_id: func.id,
+                    func_display_name: func.display_name.clone(),
+                    schema_variant_id: Some(unlocked_variant.id()),
+                    component_id: None,
+                    subject_name: unlocked_variant.display_name().to_owned(),
+                },
+                func,
+            )
+        }
+        Binding::Management { .. } => {
+            let func = FuncAuthoringClient::create_new_management_func(
+                &ctx,
+                Some(request.name),
+                unlocked_variant.id(),
+            )
+            .await?;
+
+            (
+                AuditLogKind::AttachManagementFunc {
+                    func_id: func.id,
+                    func_display_name: func.display_name.clone(),
+                    schema_variant_id: Some(unlocked_variant.id()),
+                    component_id: None,
+                    subject_name: unlocked_variant.display_name().to_string(),
+                },
+                func,
+            )
+        }
+        Binding::Qualification { .. } => {
+            let func = FuncAuthoringClient::create_new_leaf_func(
+                &ctx,
+                Some(request.name),
+                LeafKind::Qualification,
+                EventualParent::SchemaVariant(unlocked_variant.id()),
+                &[LeafInputLocation::Domain, LeafInputLocation::Code],
+            )
+            .await?;
+            (
+                AuditLogKind::AttachQualificationFunc {
+                    func_id: func.id,
+                    func_display_name: func.display_name.clone(),
+                    schema_variant_id: Some(unlocked_variant.id()),
+                    component_id: None,
+                    subject_name: unlocked_variant.display_name().to_owned(),
+                },
+                func,
+            )
+        }
+    };
+
+    ctx.write_audit_log(
+        AuditLogKind::CreateFunc {
+            func_display_name: func.display_name.clone(),
+            func_kind: func.kind.into(),
+        },
+        func.name.clone(),
+    )
+    .await?;
+    ctx.write_audit_log(attach_audit_log, func.name.clone())
+        .await?;
+
+    let summary = func.into_frontend_type(&ctx).await?;
+    WsEvent::func_created(&ctx, summary)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    let bindings = get_bindings(&ctx, func.id, unlocked_variant.id).await?;
+    let bindings_size = serde_json::to_vec_pretty(&bindings)?.len() as u64;
+
+    ctx.commit().await?;
+
+    Ok(Json(dal_func_to_fs_func(func, bindings_size)))
 }
 
 async fn set_asset_func_code(
@@ -513,32 +922,14 @@ async fn install_schema(
     check_change_set_and_not_head(&ctx).await?;
 
     if Schema::get_by_id(&ctx, schema_id).await?.is_none() {
-        let mut uninstalled_module = CachedModule::latest_by_schema_id(&ctx, schema_id)
+        let default_variant_id = Schema::get_or_install_default_variant(&ctx, schema_id).await?;
+        let variant = SchemaVariant::get_by_id_or_error(&ctx, default_variant_id).await?;
+
+        let front_end_variant = variant.clone().into_frontend_type(&ctx, schema_id).await?;
+        WsEvent::module_imported(&ctx, vec![front_end_variant.clone()])
             .await?
-            .ok_or(FsError::ResourceNotFound)?;
-
-        let si_pkg = uninstalled_module.si_pkg(&ctx).await?;
-        import_pkg_from_pkg(
-            &ctx,
-            &si_pkg,
-            Some(ImportOptions {
-                schema_id: Some(schema_id.into()),
-                ..Default::default()
-            }),
-        )
-        .await?;
-
-        if let Some(default_variant_id) =
-            Schema::get_default_schema_variant_by_id(&ctx, schema_id).await?
-        {
-            let variant = SchemaVariant::get_by_id_or_error(&ctx, default_variant_id).await?;
-
-            let front_end_variant = variant.clone().into_frontend_type(&ctx, schema_id).await?;
-            WsEvent::module_imported(&ctx, vec![front_end_variant.clone()])
-                .await?
-                .publish_on_commit(&ctx)
-                .await?;
-        }
+            .publish_on_commit(&ctx)
+            .await?;
     }
 
     ctx.commit().await?;
@@ -636,6 +1027,44 @@ async fn set_schema_attrs(
     Ok(())
 }
 
+async fn get_or_unlock_schema(ctx: &DalContext, schema_id: SchemaId) -> FsResult<SchemaVariant> {
+    Ok(
+        match lookup_variant_for_schema(ctx, schema_id, true).await? {
+            Some(unlocked) => unlocked,
+            None => {
+                let locked_variant = lookup_variant_for_schema(ctx, schema_id, false)
+                    .await?
+                    // make a more specific error here?
+                    .ok_or(FsError::SchemaCannotUnlock(schema_id))?;
+
+                // The locked is unlocked (could be that the default is unlocked)
+                if !locked_variant.is_locked() {
+                    return Ok(locked_variant);
+                }
+
+                let unlocked_variant =
+                    VariantAuthoringClient::create_unlocked_variant_copy(ctx, locked_variant.id())
+                        .await?;
+
+                ctx.write_audit_log(
+                    AuditLogKind::UnlockSchemaVariant {
+                        schema_variant_id: unlocked_variant.id(),
+                        schema_variant_display_name: unlocked_variant.display_name().to_owned(),
+                    },
+                    locked_variant.schema(ctx).await?.name().to_owned(),
+                )
+                .await?;
+
+                WsEvent::schema_variant_created(ctx, schema_id, unlocked_variant.clone())
+                    .await?
+                    .publish_on_commit(ctx)
+                    .await?;
+                unlocked_variant
+            }
+        },
+    )
+}
+
 async fn unlock_schema(
     HandlerContext(builder): HandlerContext,
     AccessBuilder(request_ctx): AccessBuilder,
@@ -650,31 +1079,7 @@ async fn unlock_schema(
 
     check_change_set_and_not_head(&ctx).await?;
 
-    let locked_variant = lookup_variant_for_schema(&ctx, schema_id, false)
-        .await?
-        // make a more specific error here?
-        .ok_or(FsError::SchemaCannotUnlock(schema_id))?;
-
-    if !locked_variant.is_locked() {
-        return Err(FsError::SchemaCannotUnlock(schema_id));
-    }
-
-    let unlocked_variant =
-        VariantAuthoringClient::create_unlocked_variant_copy(&ctx, locked_variant.id()).await?;
-
-    ctx.write_audit_log(
-        AuditLogKind::UnlockSchemaVariant {
-            schema_variant_id: unlocked_variant.id(),
-            schema_variant_display_name: unlocked_variant.display_name().to_owned(),
-        },
-        locked_variant.schema(&ctx).await?.name().to_owned(),
-    )
-    .await?;
-
-    WsEvent::schema_variant_created(&ctx, schema_id, unlocked_variant.clone())
-        .await?
-        .publish_on_commit(&ctx)
-        .await?;
+    let unlocked_variant = get_or_unlock_schema(&ctx, schema_id).await?;
 
     let mut result = AssetFuncs {
         locked: None,
@@ -687,7 +1092,7 @@ async fn unlock_schema(
 
     let attrs = make_schema_attrs(&unlocked_variant);
     result.unlocked_attrs_size = attrs.byte_size();
-    result.unlocked = Some(dal_func_to_fs_func(asset_func));
+    result.unlocked = Some(dal_func_to_fs_func(asset_func, 0));
 
     ctx.commit().await?;
 
@@ -723,9 +1128,18 @@ async fn unlock_func(
         Some(variant) => variant,
         None => SchemaVariant::get_default_for_schema(&ctx, schema_id).await?,
     };
+    let original_variant_id = variant.id();
 
     let new_func =
         FuncAuthoringClient::create_unlocked_func_copy(&ctx, func_id, Some(variant.id())).await?;
+
+    let unlocked_variant = if variant.is_locked() {
+        lookup_variant_for_schema(&ctx, schema_id, true)
+            .await?
+            .ok_or(FsError::SchemaCannotUnlock(schema_id))?
+    } else {
+        variant
+    };
 
     let summary = new_func.into_frontend_type(&ctx).await?;
     WsEvent::func_created(&ctx, summary.clone())
@@ -737,18 +1151,362 @@ async fn unlock_func(
         AuditLogKind::UnlockFunc {
             func_id,
             func_display_name: new_func.display_name.clone(),
-            schema_variant_id: Some(variant.id()),
+            schema_variant_id: Some(original_variant_id),
             component_id: None,
             // XXX: should this be the *schema* name?
-            subject_name: Some(variant.display_name().to_owned()),
+            subject_name: Some(unlocked_variant.display_name().to_owned()),
         },
         new_func.name.clone(),
     )
     .await?;
 
+    let bindings_size = get_bindings(&ctx, new_func.id, unlocked_variant.id())
+        .await?
+        .byte_size();
+
     ctx.commit().await?;
 
-    Ok(Json(dal_func_to_fs_func(new_func)))
+    // put in real attrs size of serialized bindings
+    Ok(Json(dal_func_to_fs_func(new_func, bindings_size)))
+}
+
+async fn set_func_bindings(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(_posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    Host(_host_name): Host,
+    Path((_workspace_id, change_set_id, schema_id, func_id)): Path<(
+        WorkspaceId,
+        ChangeSetId,
+        SchemaId,
+        FuncId,
+    )>,
+    Json(request): Json<fs::Bindings>,
+) -> FsResult<()> {
+    let ctx = builder
+        .build(request_ctx.build(change_set_id.into()))
+        .await?;
+
+    check_change_set_and_not_head(&ctx).await?;
+
+    let variant = lookup_variant_for_schema(&ctx, schema_id, true)
+        .await?
+        .ok_or(FsError::ResourceNotFound)?;
+
+    let func = Func::get_by_id(&ctx, func_id)
+        .await?
+        .ok_or(FsError::ResourceNotFound)?;
+
+    if matches!(
+        func.kind,
+        FuncKind::Authentication | FuncKind::Intrinsic | FuncKind::Unknown
+    ) {
+        return Err(FsError::FuncBindingKindMismatch);
+    }
+
+    let current_bindings =
+        get_bindings_for_func_and_schema_variant(&ctx, func_id, variant.id()).await?;
+
+    let updated_bindings = request.bindings;
+
+    let mut delete_bindings = vec![];
+    let mut final_bindings = vec![];
+    for (idx, func_binding) in current_bindings.into_iter().enumerate() {
+        match updated_bindings.get(idx) {
+            Some(binding_update) => match binding_update {
+                Binding::Action { kind: update_kind } => {
+                    parse_action_bindings(&mut final_bindings, &func_binding, *update_kind)?;
+                }
+                Binding::Attribute { output_to, inputs } => {
+                    parse_attr_bindings(&ctx, &mut final_bindings, func_binding, output_to, inputs)
+                        .await?;
+                }
+                Binding::Authentication => {}
+                Binding::CodeGeneration {
+                    inputs: update_inputs,
+                } => {
+                    parse_code_gen_bindings(&mut final_bindings, func_binding, update_inputs)?;
+                }
+                Binding::Management {
+                    managed_schemas: updated_schemas,
+                } => {
+                    parse_mgmt_bindings(&ctx, &mut final_bindings, func_binding, updated_schemas)
+                        .await?;
+                }
+                Binding::Qualification {
+                    inputs: update_inputs,
+                } => {
+                    parse_qualification_bindings(&mut final_bindings, func_binding, update_inputs)?;
+                }
+            },
+            None => {
+                delete_bindings.push(func_binding);
+            }
+        }
+    }
+
+    match func.kind {
+        FuncKind::Attribute => {
+            let cycle_check_guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
+            update_attribute_func_bindings(&ctx, final_bindings).await?;
+            drop(cycle_check_guard);
+        }
+        FuncKind::Action => {
+            update_action_func_bindings(&ctx, final_bindings).await?;
+        }
+        FuncKind::CodeGeneration | FuncKind::Qualification => {
+            let cycle_check_guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
+            update_leaf_func_bindings(&ctx, final_bindings).await?;
+            drop(cycle_check_guard);
+        }
+        FuncKind::Management => {
+            update_mangement_func_bindings(&ctx, final_bindings).await?;
+        }
+        _ => return Err(FsError::FuncBindingKindMismatch),
+    }
+
+    // delete bindings that were not in the payload, create net new bindings
+
+    let func_summary = Func::get_by_id_or_error(&ctx, func_id)
+        .await?
+        .into_frontend_type(&ctx)
+        .await?;
+    WsEvent::func_updated(&ctx, func_summary.clone(), None)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    ctx.commit().await?;
+
+    Ok(())
+}
+
+fn parse_qualification_bindings(
+    final_bindings: &mut Vec<FuncBinding>,
+    func_binding: FuncBinding,
+    update_inputs: &[si_frontend_types::LeafInputLocation],
+) -> FsResult<()> {
+    let FuncBinding::Qualification {
+        schema_variant_id,
+        component_id,
+        func_id,
+        attribute_prototype_id,
+        ..
+    } = func_binding
+    else {
+        return Err(FsError::FuncBindingKindMismatch);
+    };
+
+    final_bindings.push(FuncBinding::Qualification {
+        schema_variant_id,
+        component_id,
+        func_id,
+        attribute_prototype_id,
+        inputs: update_inputs.to_owned(),
+    });
+
+    Ok(())
+}
+
+async fn parse_mgmt_bindings(
+    ctx: &DalContext,
+    final_bindings: &mut Vec<FuncBinding>,
+    func_binding: FuncBinding,
+    updated_schemas: &Option<Vec<String>>,
+) -> FsResult<()> {
+    let FuncBinding::Management {
+        schema_variant_id,
+        management_prototype_id,
+        func_id,
+        ..
+    } = func_binding
+    else {
+        return Err(FsError::FuncBindingKindMismatch);
+    };
+
+    let latest_modules: HashMap<String, _> = CachedModule::latest_modules(ctx)
+        .await?
+        .into_iter()
+        .map(|module| (module.schema_name, module.schema_id))
+        .collect();
+    let mut managed_schemas = vec![];
+    if let Some(updated_schemas) = updated_schemas {
+        for updated_schema in updated_schemas {
+            let schema_id = match latest_modules.get(updated_schema) {
+                Some(schema_id) => *schema_id,
+                None => {
+                    let Some(schema) = Schema::find_by_name(ctx, updated_schema).await? else {
+                        return Err(FsError::SchemaNotFoundWithName(updated_schema.to_owned()));
+                    };
+
+                    schema.id()
+                }
+            };
+
+            managed_schemas.push(schema_id);
+        }
+    }
+
+    final_bindings.push(FuncBinding::Management {
+        schema_variant_id,
+        management_prototype_id,
+        func_id,
+        managed_schemas: if managed_schemas.is_empty() {
+            None
+        } else {
+            Some(managed_schemas)
+        },
+    });
+
+    Ok(())
+}
+
+fn parse_code_gen_bindings(
+    final_bindings: &mut Vec<FuncBinding>,
+    func_binding: FuncBinding,
+    update_inputs: &[si_frontend_types::LeafInputLocation],
+) -> FsResult<()> {
+    let FuncBinding::CodeGeneration {
+        schema_variant_id,
+        component_id,
+        func_id,
+        attribute_prototype_id,
+        ..
+    } = func_binding
+    else {
+        return Err(FsError::FuncBindingKindMismatch);
+    };
+
+    final_bindings.push(FuncBinding::CodeGeneration {
+        schema_variant_id,
+        component_id,
+        func_id,
+        attribute_prototype_id,
+        inputs: update_inputs.to_owned(),
+    });
+
+    Ok(())
+}
+
+async fn parse_attr_bindings(
+    ctx: &DalContext,
+    final_bindings: &mut Vec<FuncBinding>,
+    func_binding: FuncBinding,
+    output_to: &AttributeOutputTo,
+    inputs: &BTreeMap<String, AttributeInputFrom>,
+) -> FsResult<()> {
+    let FuncBinding::Attribute {
+        func_id,
+        attribute_prototype_id,
+        schema_variant_id,
+        ..
+    } = func_binding
+    else {
+        return Err(FsError::FuncBindingKindMismatch);
+    };
+
+    // todo: make special errors for all 3
+    let schema_variant_id = schema_variant_id.ok_or(FsError::FuncBindingKindMismatch)?;
+    let func_id = func_id.ok_or(FsError::FuncBindingKindMismatch)?;
+    let proto_id = attribute_prototype_id.ok_or(FsError::FuncBindingKindMismatch)?;
+
+    let (prop_id, output_socket_id) = match output_to {
+        AttributeOutputTo::OutputSocket(name) => {
+            let socket = OutputSocket::find_with_name(ctx, name, schema_variant_id)
+                .await?
+                .ok_or(FsError::OutputSocketNotFound(name.to_owned()))?;
+
+            (None, Some(socket.id()))
+        }
+        AttributeOutputTo::Prop(prop_path_string) => {
+            let prop_path = PropPath::new(prop_path_string.split("/"));
+            let prop_id = Prop::find_prop_id_by_path_opt(ctx, schema_variant_id, &prop_path)
+                .await?
+                .ok_or(FsError::PropNotFound(prop_path_string.to_owned()))?;
+
+            (Some(prop_id), None)
+        }
+    };
+
+    let mut argument_bindings = vec![];
+    for (arg_name, input_from) in inputs {
+        let func_arg = FuncArgument::find_by_name_for_func(ctx, arg_name, func_id)
+            .await?
+            .ok_or(FsError::FuncArgumentNotFound(arg_name.to_owned()))?;
+
+        let apa_id =
+            AttributePrototypeArgument::find_by_func_argument_id_and_attribute_prototype_id(
+                ctx,
+                func_arg.id,
+                proto_id,
+            )
+            .await?
+            .ok_or(FsError::FuncBindingKindMismatch)?;
+
+        let (prop_id, input_socket_id) = match input_from {
+            AttributeInputFrom::InputSocket(input_socket_name) => {
+                let socket = InputSocket::find_with_name(ctx, input_socket_name, schema_variant_id)
+                    .await?
+                    .ok_or(FsError::InputSocketNotFound(input_socket_name.to_owned()))?;
+
+                (None, Some(socket.id()))
+            }
+            AttributeInputFrom::Prop(prop_path_string) => {
+                let prop_path = PropPath::new(prop_path_string.split("/"));
+                let prop_id = Prop::find_prop_id_by_path_opt(ctx, schema_variant_id, &prop_path)
+                    .await?
+                    .ok_or(FsError::PropNotFound(prop_path_string.to_owned()))?;
+
+                (Some(prop_id), None)
+            }
+        };
+
+        argument_bindings.push(AttributeArgumentBinding {
+            func_argument_id: func_arg.id,
+            attribute_prototype_argument_id: Some(apa_id),
+            prop_id,
+            input_socket_id,
+            static_value: None,
+        });
+    }
+
+    final_bindings.push(FuncBinding::Attribute {
+        func_id: Some(func_id),
+        attribute_prototype_id: Some(proto_id),
+        component_id: None,
+        schema_variant_id: Some(schema_variant_id),
+        prop_id,
+        output_socket_id,
+        argument_bindings,
+    });
+
+    Ok(())
+}
+
+fn parse_action_bindings(
+    final_bindings: &mut Vec<FuncBinding>,
+    func_binding: &FuncBinding,
+    update_kind: ActionKind,
+) -> FsResult<()> {
+    let FuncBinding::Action {
+        schema_variant_id,
+        action_prototype_id,
+        func_id,
+        ..
+    } = *func_binding
+    else {
+        return Err(FsError::FuncBindingKindMismatch);
+    };
+
+    final_bindings.push(FuncBinding::Action {
+        schema_variant_id,
+        action_prototype_id,
+        func_id,
+        kind: Some(update_kind),
+    });
+
+    Ok(())
 }
 
 pub fn fs_routes() -> Router<AppState> {
@@ -758,8 +1516,8 @@ pub fn fs_routes() -> Router<AppState> {
         .nest(
             "/change-sets/:change_set_id",
             Router::new()
-                .route("/func-code/:func_id", get(get_func_code))
-                .route("/func-code/:func_id", post(set_func_code))
+                .route("/funcs/:func_id/code", get(get_func_code))
+                .route("/funcs/:func_id/code", post(set_func_code))
                 .route("/funcs/:func_id/unlock", post(unlock_func))
                 .route("/funcs/:kind", get(list_change_set_funcs))
                 .route("/schemas", get(list_schemas))
@@ -775,7 +1533,16 @@ pub fn fs_routes() -> Router<AppState> {
                     "/schemas/:schema_id/funcs/:func_id/unlock",
                     post(unlock_func),
                 )
+                .route(
+                    "/schemas/:schema_id/funcs/:func_id/bindings",
+                    get(get_func_bindings),
+                )
+                .route(
+                    "/schemas/:schema_id/funcs/:func_id/bindings",
+                    post(set_func_bindings),
+                )
                 .route("/schemas/:schema_id/funcs/:kind", get(list_variant_funcs))
+                .route("/schemas/:schema_id/funcs/:kind/create", post(create_func))
                 .route("/schemas/:schema_id/install", post(install_schema)),
         )
 }

--- a/lib/sdf-server/src/service/v2/func/binding/update_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/update_binding.rs
@@ -25,7 +25,7 @@ use crate::{
     track,
 };
 
-async fn update_attribute_func_bindings(
+pub async fn update_attribute_func_bindings(
     ctx: &DalContext,
     bindings: Vec<FuncBinding>,
 ) -> FuncAPIResult<()> {
@@ -67,7 +67,7 @@ async fn update_attribute_func_bindings(
     Ok(())
 }
 
-async fn update_action_func_bindings(
+pub async fn update_action_func_bindings(
     ctx: &DalContext,
     bindings: Vec<FuncBinding>,
 ) -> FuncAPIResult<()> {
@@ -96,7 +96,7 @@ async fn update_action_func_bindings(
     Ok(())
 }
 
-async fn update_leaf_func_bindings(
+pub async fn update_leaf_func_bindings(
     ctx: &DalContext,
     bindings: Vec<FuncBinding>,
 ) -> FuncAPIResult<()> {
@@ -131,7 +131,7 @@ async fn update_leaf_func_bindings(
     Ok(())
 }
 
-async fn update_mangement_func_bindings(
+pub async fn update_mangement_func_bindings(
     ctx: &DalContext,
     bindings: Vec<FuncBinding>,
 ) -> FuncAPIResult<()> {

--- a/lib/si-filesystem/BUCK
+++ b/lib/si-filesystem/BUCK
@@ -10,6 +10,8 @@ rust_library(
         "//third-party/rust:nix",
         "//third-party/rust:remain",
         "//third-party/rust:reqwest",
+        "//third-party/rust:serde",
+        "//third-party/rust:serde_json",
         "//third-party/rust:thiserror",
         "//third-party/rust:tokio",
     ],

--- a/lib/si-filesystem/Cargo.toml
+++ b/lib/si-filesystem/Cargo.toml
@@ -16,5 +16,7 @@ fuser = { workspace = true }
 nix = { workspace = true }
 remain = { workspace = true }
 reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/lib/si-filesystem/src/inode_table.rs
+++ b/lib/si-filesystem/src/inode_table.rs
@@ -100,6 +100,17 @@ pub enum InodeEntryData {
     SchemaFunc {
         change_set_id: ChangeSetId,
         func_id: FuncId,
+        kind: FuncKind,
+        schema_id: SchemaId,
+        size: u64,
+        bindings_size: u64,
+        unlocked: bool,
+    },
+    SchemaFuncBindings {
+        change_set_id: ChangeSetId,
+        func_id: FuncId,
+        kind: FuncKind,
+        schema_id: SchemaId,
         size: u64,
         unlocked: bool,
     },
@@ -108,17 +119,21 @@ pub enum InodeEntryData {
         schema_id: SchemaId,
         change_set_id: ChangeSetId,
     },
-    SchemaFuncs {
+    SchemaFuncsDir {
         schema_id: SchemaId,
         change_set_id: ChangeSetId,
     },
     SchemaFuncVariantsDir {
-        locked_id: Option<FuncId>,
-        unlocked_id: Option<FuncId>,
+        kind: FuncKind,
         change_set_id: ChangeSetId,
         schema_id: SchemaId,
+        locked_id: Option<FuncId>,
+        unlocked_id: Option<FuncId>,
         locked_size: u64,
+        locked_bindings_size: u64,
         unlocked_size: u64,
+        unlocked_bindings_size: u64,
+        pending: bool,
     },
     Schemas {
         change_set_id: ChangeSetId,


### PR DESCRIPTION
Also adds a cache to the si-fs client to prevent hammering the backend
when filesystem clients make lots of syscalls.