### PR TITLE
Feat: connections panel now has management sockets

### DIFF
--- a/app/web/src/components/ComponentConnectionsPanel.vue
+++ b/app/web/src/components/ComponentConnectionsPanel.vue
@@ -230,21 +230,19 @@ const sockets = computed(() => {
 
   const peersFunction = componentsStore.possibleAndExistingPeerSocketsFn;
   const sockets =
-    selectedComponent.def.sockets
-      .filter((s) => !s.isManagement)
-      .map((s) => {
-        const { existingPeers, possiblePeers } = peersFunction(
-          s,
-          selectedComponent.def.id,
-        );
+    selectedComponent.def.sockets.map((s) => {
+      const { existingPeers, possiblePeers } = peersFunction(
+        s,
+        selectedComponent.def.id,
+      );
 
-        return treeFormItemFromSocket(
-          s,
-          selectedComponent.def,
-          existingPeers,
-          possiblePeers,
-        );
-      }) ?? [];
+      return treeFormItemFromSocket(
+        s,
+        selectedComponent.def,
+        existingPeers,
+        possiblePeers,
+      );
+    }) ?? [];
 
   const [input, output] = _.partition(
     sockets,
@@ -303,6 +301,7 @@ const resetHandler = (item: TreeFormData, value?: string) => {
   }
 
   if (!value) return;
+
   const [thisComponentId, thisSocketId] = item.propId.split("-");
   const [otherComponentId, otherSocketId] = value.split("-");
   if (
@@ -344,7 +343,7 @@ const resetHandler = (item: TreeFormData, value?: string) => {
     to.socketId,
   );
 
-  useComponentsStore().DELETE_EDGE(
+  componentsStore.DELETE_EDGE(
     edgeId,
     to.socketId,
     from.socketId,
@@ -359,6 +358,7 @@ const setValueHandler = (item: TreeFormData, value: string) => {
     return;
   }
 
+  const isMgmt = !!value.includes("mgmt");
   const [thisComponentId, thisSocketId] = item.propId.split("-");
   const [otherComponentId, otherSocketId] = value.split("-");
   if (
@@ -393,6 +393,7 @@ const setValueHandler = (item: TreeFormData, value: string) => {
           },
         ];
 
-  componentsStore.CREATE_COMPONENT_CONNECTION(from, to);
+  if (isMgmt) componentsStore.MANAGE_COMPONENT(from, to);
+  else componentsStore.CREATE_COMPONENT_CONNECTION(from, to);
 };
 </script>

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -274,11 +274,11 @@ impl SummaryDiagramManagementEdge {
     }
 
     pub fn output_socket_id(schema_id: SchemaId) -> String {
-        format!("mgmt-output-{schema_id}")
+        format!("mgmt_output_{schema_id}")
     }
 
     pub fn input_socket_id(schema_id: SchemaId) -> String {
-        format!("mgmt-input-{schema_id}")
+        format!("mgmt_input_{schema_id}")
     }
 }
 


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/gQm37vKLwkUVjOvVmp/giphy-downsized-medium.gif"/>

Testing Steps:

1. I had the "Basic Template Pattern" mgmt component on the diagram in a separate view
2. I ensured that another component could connect its `Manager` input socket to that mgmt component.
3. I refreshed the page to make sure it would be there. I deleted the connection. And refreshed the page again
4. I made the connection and deleted it (w/o refresh) to ensure that would work.
5. I added two Tailscale Users to the diagram because they can manage one another
6. I made sure I could set and delete both output and input sockets accordingly
7. Try to create a loop in the graph, and see the error message that you can't, and you see the optimistic edge removed
8. I made sure that the dropdown did not have duplicate entries (e.g. output socket "Manage" dropdown had *both* input and output sockets in it)