### PR TITLE
fix: lang-js errors not propogating correctly

### DIFF
--- a/bin/lang-js/src/function.ts
+++ b/bin/lang-js/src/function.ts
@@ -251,11 +251,15 @@ export async function runCode(
     });
 
     worker.onmessage = (event) => {
-      const { result, storage } = event.data;
+      const { result, error, storage } = event.data;
       if (storage) {
         Object.assign(rawStorage(), storage);
       }
-      resolve(result);
+      if (error) {
+        reject(error);
+      } else {
+        resolve(result);
+      }
       worker.terminate();
     };
 

--- a/bin/lang-js/src/worker.js
+++ b/bin/lang-js/src/worker.js
@@ -40,14 +40,9 @@ self.onmessage = async (event) => {
         try {
           return await run(with_arg);
         } catch (e) {
-          return {
-            err: {
-              name: e.name,
-              message: e.message
-            }
-          };
+          throw e
         }
-      })()
+       })()
     `,
   );
 
@@ -67,6 +62,12 @@ self.onmessage = async (event) => {
   } catch (e) {
     debug({ "error": e });
     clearTimeout(timeoutId);
-    throw e;
+    self.postMessage({
+      error: {
+        name: e.name ?? e,
+        message: e.message ?? e,
+      },
+      storage: rawStorage(),
+    });
   }
 };


### PR DESCRIPTION
Errors were getting swallowed here, so we weren't properly bubbling them up to the user. Now you'll see something like this on obvious failures.

![image](https://github.com/user-attachments/assets/a2bc0715-4319-4da4-b679-f1bc75e5c289)

![image](https://github.com/user-attachments/assets/95840617-88f2-48a9-8b80-b953c6276ad3)
