### PR TITLE
Support rejection in fine grained access control

### DIFF
--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -296,10 +296,20 @@ export function useChangeSetsStore() {
 
           if (!changeSetId) throw new Error("Select a change set");
 
-          return new ApiRequest({
-            method: "post",
-            url: BASE_API.concat([{ changeSetId }, "reject"]),
-          });
+          if (featureFlagsStore.WORKSPACE_FINE_GRAINED_ACCESS_CONTROL) {
+            return new ApiRequest({
+              method: "post",
+              url: BASE_API.concat([{ changeSetId }, "approve_v2"]),
+              params: {
+                status: "Rejected",
+              },
+            });
+          } else {
+            return new ApiRequest({
+              method: "post",
+              url: BASE_API.concat([{ changeSetId }, "reject"]),
+            });
+          }
         },
         async CANCEL_APPROVAL_REQUEST() {
           if (!this.selectedChangeSet) throw new Error("Select a change set");
@@ -335,9 +345,6 @@ export function useChangeSetsStore() {
               });
             },
             _delay: 2000,
-            onSuccess: (response) => {
-              this.changeSetsById[response.changeSet.id] = response.changeSet;
-            },
             onFail: () => {
               // todo: show something!
             },

--- a/lib/si-events-rs/src/change_set_approval.rs
+++ b/lib/si-events-rs/src/change_set_approval.rs
@@ -8,4 +8,5 @@ use strum::{AsRefStr, Display, EnumString};
 )]
 pub enum ChangeSetApprovalStatus {
     Approved,
+    Rejected,
 }


### PR DESCRIPTION
## Introduction

This PR adds the ability to reject a change set with the fine grained access control feature enabled.

<img src="https://media1.giphy.com/media/l2SpUoAPo0CBOkyxq/giphy.gif"/>

## Description

Essentially, rejection is a "social" feature in the sense that it does not affect what can be done with a change set. However, in this world, we still have the ability to determine if a rejection is "stale" and what requirements it is applicable for.

How is this a one-liner change in the backend? Approval checksum calculation is automatic and the overall creation flow is already set up for different status types. In addition, when checking if requirements have been satisfied, we already check if the status is "approved", even though there was only one enum variant at the time that code was written.

That all being said, this PR introduces the ability to reject in the frontend and a corresponding integration test has been amended to double check that this works.

## Misc Changes

One additional change: remove the response payload when applying a change set in the change sets store because sdf does not return a payload.