### PR TITLE
auth-api: Deny automation tokens the ability to access the auth api

### DIFF
--- a/bin/auth-api/src/custom-state.ts
+++ b/bin/auth-api/src/custom-state.ts
@@ -1,15 +1,19 @@
 import Router from '@koa/router';
 import Koa from 'koa';
-import { Workspace } from '@prisma/client';
+import { AuthToken, Workspace } from '@prisma/client';
 import { UserWithTosStatus } from "./services/users.service";
+import { AuthTokenData } from './services/auth.service';
 
 // types for the things we add to our koa ctx
 export type CustomAppContext = {
 };
 export type CustomAppState = {
   clientIp: string,
+  token?: AuthTokenData,
   authUser?: UserWithTosStatus,
   authWorkspace?: Workspace,
+  // For automation tokens, we look this up so we can check if they're revoked
+  authToken?: AuthToken,
 };
 
 export type CustomRouteContext = Koa.ParameterizedContext<

--- a/bin/auth-api/src/main.ts
+++ b/bin/auth-api/src/main.ts
@@ -9,10 +9,10 @@ import chalk from 'chalk';
 import cors from '@koa/cors';
 
 import { PrismaClient } from "@prisma/client";
-import { router, routesLoaded } from "./routes";
+import { router, automationApiRouter, routesLoaded } from "./routes";
 import { ApiError, errorHandlingMiddleware } from "./lib/api-error";
 import { httpRequestLoggingMiddleware } from "./lib/request-logger";
-import { loadAuthMiddleware } from "./services/auth.service";
+import { loadAuthMiddleware, requireWebTokenMiddleware } from "./services/auth.service";
 import { detectClientIp } from "./lib/client-ip";
 import { CustomAppContext, CustomAppState } from "./custom-state";
 
@@ -31,9 +31,9 @@ app.use(httpRequestLoggingMiddleware);
 app.use(errorHandlingMiddleware);
 app.use(bodyParser());
 app.use(loadAuthMiddleware);
-
 // routes - must be last after all middlewares
-app.use(router.routes());
+app.use(automationApiRouter.routes());
+app.use(router.use(requireWebTokenMiddleware).routes());
 
 // catch-all middelware after routes handles no route match (404)
 app.use((_ctx, _next) => {

--- a/bin/auth-api/src/routes/index.ts
+++ b/bin/auth-api/src/routes/index.ts
@@ -45,10 +45,11 @@ export function extractAdminAuthUser(ctx: CustomRouteContext) {
 
 // we initialize and export the router immediately
 // but we'll add routes to it here and in each routes file
-export const router = new Router<CustomAppState, CustomAppContext>();
 export type CustomRouter = Router<CustomAppState, CustomAppContext>;
+export const router = new Router<CustomAppState, CustomAppContext>();
+export const automationApiRouter = new Router<CustomAppState, CustomAppContext>();
 
-router.get("/", async (ctx) => {
+automationApiRouter.get("/", async (ctx) => {
   // TODO: add something which checks redis and postgres connections are working
   ctx.body = { systemStatus: "ok" };
 });

--- a/bin/auth-api/src/routes/user.routes.ts
+++ b/bin/auth-api/src/routes/user.routes.ts
@@ -30,9 +30,11 @@ import {
   updateCustomerDetails,
 } from "../lib/lago";
 import { checkCustomerPaymentMethodSet } from "../lib/stripe";
-import { extractAdminAuthUser, extractAuthUser, router } from ".";
+import {
+  automationApiRouter, extractAdminAuthUser, extractAuthUser, router,
+} from ".";
 
-router.get("/whoami", async (ctx) => {
+automationApiRouter.get("/whoami", async (ctx) => {
   // user must be logged in
   if (!ctx.state.authUser) {
     throw new ApiError("Unauthorized", "You are not logged in");
@@ -40,6 +42,7 @@ router.get("/whoami", async (ctx) => {
 
   ctx.body = {
     user: ctx.state.authUser,
+    authToken: ctx.state.authToken,
   };
 });
 


### PR DESCRIPTION
Right now, automation tokens can do anything the user can in the authentication api. This is because SDF tokens are given the same level of access as auth tokens (we do this so that sdf can talk to the auth api on the user's behalf by just forwarding on the SDF token).

This PR:
* Requires a "web authorized" token for all auth api routes except / and /whoami. This means includes SDF web tokens, auth api tokens, and v2 tokens with role = web, and *excludes* v2 tokens with role = automation.
* Allows automation API access to the `/` and `/whoami` endpoints, but if a token is passed, it checks for token revocation and throws 401 Unauthorized if the token has been revoked. This is necessary for the next PR, which will check for token revocation. Since the auth api must be deployed first, it is a separate PR.
* Adds `authToken` to the output of the whoami endpoint. This allows a token to get its own name.

### Approach

This adds a new middleware to check for the web token, and adds it to the main router, applying it consistently to all routes. To make `/` not check this, `/` is handled in a separate router object which does not have the middleware.

Just as before, the middleware will not throw if there is no token--each individual endpoint already checks whether there is a token, looking for `ctx.authUser` and `ctx.authWorkspace`, both of which will only exist in ctx if the token was found. There are a few endpoints (particularly the login and logout flows) which do not require the token, and these endpoints still work correctly despite using the new middleware.

For the revocation check, the existing authentication middleware now goes one extra step: if the token being used is an automation token, it checks whether it was revoked and reports a 401.

### Testing

* Session / authentication flow:
  * Login, logut and refresh in SDF
  * Login and logout in the auth portal
  * Going to a new workspace from auth portal
  * Going to an existing workspace from auth portal
  * New user first login / create account
* Testing that auth portal still works across a broad range of endpoints:
  * creation of workspaces
  * going to existing workspaces
  * updating a workspace name
  * adding API tokens to a workspace
* Auth API with curl:
  * / and /whoami give 200 for both web and automation tokens
  * / and /whoami yield 401 for revoked automation tokens
  * /whoami yields the authToken for automation tokens
  * /whoami does not yield the authToken property for web tokens (since it doesn't exist)

I've tried to minimize the damage, but this is a change which affects all authentication API endpoints. Suggestions are welcomed for expanding the test repertoire.