### PR TITLE
Fix: we have the workspaceId in the URL, dont need to wait & race for the fetch all workspaces call here

### DIFF
--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -31,7 +31,7 @@ const PH_TO_STORE_FLAG_LOOKUP = _.invert(FLAG_MAPPING) as Record<
 
 export function useFeatureFlagsStore() {
   const workspacesStore = useWorkspacesStore();
-  const workspacePk = workspacesStore.selectedWorkspacePk;
+  const workspacePk = workspacesStore.urlSelectedWorkspaceId;
 
   return addStoreHooks(
     undefined,


### PR DESCRIPTION
<img src="https://media2.giphy.com/media/11e9y9YLVeVxbq/giphy.gif"/>