### PR TITLE
Protect against unforced apply without reqs met

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6141,7 +6141,10 @@ dependencies = [
 name = "sdf-test"
 version = "0.1.0"
 dependencies = [
+ "dal",
+ "dal-test",
  "rand 0.8.5",
+ "sdf-server",
  "si-data-spicedb",
 ]
 

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -333,9 +333,15 @@ export function useChangeSetsStore() {
         async APPLY_CHANGE_SET(username: string) {
           if (!this.selectedChangeSet) throw new Error("Select a change set");
           const selectedChangeSetId = this.selectedChangeSetId;
+
+          let url = BASE_API.concat([{ selectedChangeSetId }, "apply"]);
+          if (featureFlagsStore.WORKSPACE_FINE_GRAINED_ACCESS_CONTROL) {
+            url = BASE_API.concat([{ selectedChangeSetId }, "apply_v2"]);
+          }
+
           return new ApiRequest({
             method: "post",
-            url: BASE_API.concat([{ selectedChangeSetId }, "apply"]),
+            url,
             optimistic: () => {
               toast({
                 component: IncomingChangesMerging,

--- a/lib/dal-test/src/helpers/change_set.rs
+++ b/lib/dal-test/src/helpers/change_set.rs
@@ -59,19 +59,28 @@ impl ChangeSetTestHelpers {
     /// Apply Changeset To base Approvals
     pub async fn apply_change_set_to_base_approvals(ctx: &mut DalContext) -> Result<()> {
         ChangeSet::prepare_for_apply(ctx).await?;
-
-        Self::commit_and_update_snapshot_to_visibility(ctx).await?;
-
-        Self::apply_change_set_to_base_inner(ctx).await?;
+        Self::apply_change_set_to_base_approvals_without_prepare_step(ctx).await?;
         Ok(())
     }
 
     /// Force Apply Changeset To base Approvals
     pub async fn force_apply_change_set_to_base_approvals(ctx: &mut DalContext) -> Result<()> {
         ChangeSet::prepare_for_force_apply(ctx).await?;
+        Self::apply_change_set_to_base_approvals_without_prepare_step(ctx).await?;
+        Ok(())
+    }
 
+    /// Apply the change set to base for the approvals flow, but without performing the "prepare"
+    /// step.
+    ///
+    /// _Warning:_ if you do not know what to choose, use [Self::force_apply_change_set_to_base_approvals]
+    /// or [Self::apply_change_set_to_base_approvals] instead of this function. This function
+    /// should only be used if you have an alternative "prepare" workflow (e.g. testing fine grained
+    /// access control in sdf tests).
+    pub async fn apply_change_set_to_base_approvals_without_prepare_step(
+        ctx: &mut DalContext,
+    ) -> Result<()> {
         Self::commit_and_update_snapshot_to_visibility(ctx).await?;
-
         Self::apply_change_set_to_base_inner(ctx).await?;
         Ok(())
     }

--- a/lib/sdf-server/src/dal_wrapper.rs
+++ b/lib/sdf-server/src/dal_wrapper.rs
@@ -29,19 +29,27 @@
     while_true
 )]
 
-pub mod change_set_approval;
+pub mod change_set;
 
 #[allow(missing_docs)]
 #[remain::sorted]
 #[derive(Debug, thiserror::Error)]
 pub enum DalWrapperError {
+    #[error("cannot apply with unsatisfied requirements for the following entities: {0:?}")]
+    ApplyWithUnsatisfiedRequirements(
+        Vec<(si_id::EntityId, si_events::workspace_snapshot::EntityKind)>,
+    ),
     #[error("approval requirement error: {0}")]
     ApprovalRequirement(#[from] dal::approval_requirement::ApprovalRequirementError),
-    #[error("change set approval error")]
+    #[error("change set error: {0}")]
+    ChangeSet(#[from] dal::ChangeSetError),
+    #[error("change set apply error: {0}")]
+    ChangeSetApply(#[from] dal::ChangeSetApplyError),
+    #[error("change set approval error: {0}")]
     ChangeSetApproval(#[from] dal::change_set::approval::ChangeSetApprovalError),
     #[error("invalid user found")]
     InvalidUser,
-    #[error("missing applicable approval id")]
+    #[error("missing applicable approval id: {0}")]
     MissingApplicableApproval(si_id::ChangeSetApprovalId),
     #[error("permissions error: {0}")]
     Permissions(#[from] permissions::Error),

--- a/lib/sdf-server/src/service/v2/change_set.rs
+++ b/lib/sdf-server/src/service/v2/change_set.rs
@@ -13,7 +13,6 @@ use dal::{
 use reqwest::Client;
 use serde::Serialize;
 use si_data_spicedb::SpiceDbError;
-use si_events::ChangeSetStatus;
 use thiserror::Error;
 
 use crate::{middleware::WorkspacePermissionLayer, service::ApiError, AppState};
@@ -29,6 +28,7 @@ mod reopen;
 mod request_approval;
 
 // NOTE(nick): move these to the above group and remove old modules once the feature flag has been removed;
+mod apply_v2;
 mod approval_status;
 mod approve_v2;
 
@@ -41,8 +41,6 @@ pub enum Error {
     ChangeSetApply(#[from] dal::ChangeSetApplyError),
     #[error("change set approval error: {0}")]
     ChangeSetApproval(#[from] dal::change_set::approval::ChangeSetApprovalError),
-    #[error("change set not approved for apply. Current state: {0}")]
-    ChangeSetNotApprovedForApply(ChangeSetStatus),
     #[error("dal wrapper error: {0}")]
     DalWrapper(#[from] crate::dal_wrapper::DalWrapperError),
     #[error("dvu roots are not empty for change set: {0}")]
@@ -161,4 +159,5 @@ pub fn change_set_routes(state: AppState) -> Router<AppState> {
         .route("/rename", post(rename::rename))
         .route("/approval_status", get(approval_status::approval_status))
         .route("/approve_v2", post(approve_v2::approve))
+        .route("/apply_v2", post(apply_v2::apply))
 }

--- a/lib/sdf-server/src/service/v2/change_set/apply_v2.rs
+++ b/lib/sdf-server/src/service/v2/change_set/apply_v2.rs
@@ -1,0 +1,69 @@
+use axum::extract::{Host, OriginalUri, Path, State};
+use dal::{ChangeSet, ChangeSetId, WorkspacePk};
+use si_events::audit_log::AuditLogKind;
+
+use super::{post_to_webhook, ChangeSetAPIError, Result};
+use crate::{
+    dal_wrapper,
+    extract::{HandlerContext, PosthogClient},
+    service::v2::AccessBuilder,
+    track, AppState,
+};
+
+pub async fn apply(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Host(host_name): Host,
+    Path((workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
+    State(mut state): State<AppState>,
+) -> Result<()> {
+    let mut ctx = builder
+        .build(request_ctx.build(change_set_id.into()))
+        .await?;
+    let spicedb_client = state
+        .spicedb_client()
+        .ok_or(ChangeSetAPIError::SpiceDBClientNotFound)?;
+
+    // Perform the protected apply flow.
+    dal_wrapper::change_set::protected_apply_to_base_change_set(&mut ctx, spicedb_client).await?;
+
+    // Tracking, audit logging, etc.
+    {
+        let change_set_view = ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id)
+            .await?
+            .into_frontend_type(&ctx)
+            .await?;
+
+        track(
+            &posthog_client,
+            &ctx,
+            &original_uri,
+            &host_name,
+            "apply_change_set",
+            serde_json::json!({
+                "merged_change_set": change_set_id,
+            }),
+        );
+
+        ctx.write_audit_log(
+            AuditLogKind::ApplyChangeSet,
+            change_set_view.name.to_owned(),
+        )
+        .await?;
+
+        let actor = ctx.history_actor().email(&ctx).await?;
+        let change_set_url = format!("https://{}/w/{}/{}", host_name, workspace_pk, change_set_id);
+        let message = format!(
+            "{} applied change set {} to HEAD: {}",
+            actor, change_set_view.name, change_set_url
+        );
+        post_to_webhook(&ctx, workspace_pk, message.as_str()).await?;
+
+        // WS Event fires from the dal
+        ctx.commit().await?;
+    }
+
+    Ok(())
+}

--- a/lib/sdf-server/src/service/v2/change_set/approval_status.rs
+++ b/lib/sdf-server/src/service/v2/change_set/approval_status.rs
@@ -28,7 +28,7 @@ pub async fn approval_status(
         .ok_or(ChangeSetAPIError::SpiceDBClientNotFound)?;
 
     let (latest_approvals, requirements) =
-        dal_wrapper::change_set_approval::status(&ctx, spicedb_client).await?;
+        dal_wrapper::change_set::status(&ctx, spicedb_client).await?;
 
     Ok(Json(si_frontend_types::ChangeSetApprovals {
         latest_approvals,

--- a/lib/sdf-server/src/service/v2/change_set/approve_v2.rs
+++ b/lib/sdf-server/src/service/v2/change_set/approve_v2.rs
@@ -60,8 +60,7 @@ pub async fn approve(
         .spicedb_client()
         .ok_or(ChangeSetAPIError::SpiceDBClientNotFound)?;
     let approving_ids_with_hashes =
-        dal_wrapper::change_set_approval::determine_approving_ids_with_hashes(&ctx, spicedb_client)
-            .await?;
+        dal_wrapper::change_set::determine_approving_ids_with_hashes(&ctx, spicedb_client).await?;
     ChangeSetApproval::new(&ctx, request.status, approving_ids_with_hashes).await?;
 
     WsEvent::change_set_approval_status_changed(&ctx, ctx.change_set_id())

--- a/lib/sdf-server/tests/service_tests/change_set_apply.rs
+++ b/lib/sdf-server/tests/service_tests/change_set_apply.rs
@@ -1,0 +1,184 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use dal::approval_requirement::ApprovalRequirement;
+use dal::approval_requirement::ApprovalRequirementApprover;
+use dal::change_set::approval::ChangeSetApproval;
+use dal::diagram::view::View;
+use dal::DalContext;
+use dal::HistoryActor;
+use dal_test::eyre;
+use dal_test::helpers::create_component_for_default_schema_name;
+use dal_test::prelude::ChangeSetTestHelpers;
+use dal_test::sdf_test;
+use dal_test::Result;
+use indoc::indoc;
+use pretty_assertions_sorted::assert_eq;
+use sdf_server::dal_wrapper;
+use sdf_server::dal_wrapper::DalWrapperError;
+use sdf_test::helpers::SdfTestHelpers;
+use si_data_spicedb::SpiceDbClient;
+use si_events::workspace_snapshot::EntityKind;
+use si_events::ChangeSetApprovalStatus;
+use si_id::ViewId;
+
+// FIXME(nick,jacob): this must happen in the "sdf_test"'s equivalent to global setup, but not in
+// dal tests. This also should _really_ reflect the "schema.zed" file that production uses.
+async fn write_schema(client: &mut SpiceDbClient) -> Result<()> {
+    let schema = indoc! {"
+        definition user {}
+
+        definition workspace {
+          relation approver: user
+          relation owner: user
+          permission approve = approver+owner
+          permission manage = owner
+        }
+    "};
+    client.write_schema(schema).await?;
+    Ok(())
+}
+
+// NOTE(nick): this is an integration test and not a service test, but given that "sdf_test" is in
+// a weird, unused place at the time of writing, this test will live here.
+#[sdf_test]
+async fn protected_apply(ctx: &mut DalContext, spicedb_client: SpiceDbClient) -> Result<()> {
+    let mut spicedb_client = spicedb_client;
+
+    // FIXME(nick,jacob): see the comment attached to this function.
+    write_schema(&mut spicedb_client).await?;
+
+    // Cache the IDs we need.
+    let user_id = match ctx.history_actor() {
+        HistoryActor::SystemInit => return Err(eyre!("invalid user")),
+        HistoryActor::User(user_id) => *user_id,
+    };
+
+    // Create a view with a requirement and then commit.
+    let todd_view = View::new(ctx, "toddhoward").await?;
+    let todd_view_id = todd_view.id();
+    ApprovalRequirement::new_definition(
+        ctx,
+        todd_view_id,
+        1,
+        HashSet::from([ApprovalRequirementApprover::User(user_id)]),
+    )
+    .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Scenario 1: apply to HEAD and create a new change set.
+    {
+        ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+        ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
+
+        let (frontend_latest_approvals, frontend_requirements) =
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
+
+        assert!(frontend_latest_approvals.is_empty());
+        assert!(frontend_requirements.is_empty());
+    }
+
+    // Scenario 2: create a component in our new view.
+    {
+        create_component_for_default_schema_name(ctx, "starfield", "shattered space", todd_view_id)
+            .await?;
+        ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+        let (frontend_latest_approvals, mut frontend_requirements) =
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
+        frontend_requirements.sort_by_key(|r| r.entity_id);
+
+        assert!(frontend_latest_approvals.is_empty());
+        assert_eq!(
+            vec![si_frontend_types::ChangeSetApprovalRequirement {
+                entity_id: todd_view_id.into_inner().into(),
+                entity_kind: EntityKind::View,
+                required_count: 1,
+                is_satisfied: false,
+                applicable_approval_ids: Vec::new(),
+                approver_groups: HashMap::new(),
+                approver_individuals: vec![user_id],
+            },], // expected
+            frontend_requirements // actual
+        );
+    }
+
+    // Scenario 3: try to perform protected apply. This should fail in an expected manner.
+    {
+        match SdfTestHelpers::protected_apply_change_set_to_base(ctx, &mut spicedb_client).await {
+            Err(report) => match report.downcast_ref::<DalWrapperError>() {
+                Some(DalWrapperError::ApplyWithUnsatisfiedRequirements(
+                    unsatisfied_requirements,
+                )) => assert_eq!(
+                    vec![(todd_view_id.into_inner().into(), EntityKind::View)], // expected
+                    unsatisfied_requirements.to_owned()                         // actual
+                ),
+                Some(err) => return Err(eyre!("unexpected error: {err}")),
+                None => return Err(eyre!("unexpected report: {report:?}")),
+            },
+            other => return Err(eyre!("unexpected result: {other:?}")),
+        }
+    }
+
+    // Scenario 4: approve the changes.
+    {
+        let approving_ids_with_hashes =
+            dal_wrapper::change_set::determine_approving_ids_with_hashes(ctx, &mut spicedb_client)
+                .await?;
+        let approval = ChangeSetApproval::new(
+            ctx,
+            ChangeSetApprovalStatus::Approved,
+            approving_ids_with_hashes,
+        )
+        .await?;
+        ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+        let (frontend_latest_approvals, frontend_requirements) =
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
+
+        assert_eq!(
+            vec![si_frontend_types::ChangeSetApproval {
+                id: approval.id(),
+                user_id,
+                status: ChangeSetApprovalStatus::Approved,
+                is_valid: true,
+            }], // expected
+            frontend_latest_approvals // actual
+        );
+        assert_eq!(
+            vec![si_frontend_types::ChangeSetApprovalRequirement {
+                entity_id: todd_view_id.into_inner().into(),
+                entity_kind: EntityKind::View,
+                required_count: 1,
+                is_satisfied: true,
+                applicable_approval_ids: vec![approval.id()],
+                approver_groups: HashMap::new(),
+                approver_individuals: vec![user_id]
+            }], // expected
+            frontend_requirements // actual
+        );
+    }
+
+    // Scenario 5: apply the changes used the protected flow and observe that it works.
+    {
+        SdfTestHelpers::protected_apply_change_set_to_base(ctx, &mut spicedb_client).await?;
+        ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
+
+        let default_view_id = View::get_id_for_default(ctx).await?;
+        let mut view_ids: Vec<ViewId> = View::list(ctx).await?.iter().map(|v| v.id()).collect();
+        view_ids.sort();
+
+        assert_eq!(
+            vec![default_view_id, todd_view_id], // expected
+            view_ids                             // actual
+        );
+
+        let (frontend_latest_approvals, frontend_requirements) =
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
+
+        assert!(frontend_latest_approvals.is_empty());
+        assert!(frontend_requirements.is_empty());
+    }
+
+    Ok(())
+}

--- a/lib/sdf-server/tests/service_tests/change_set_approval.rs
+++ b/lib/sdf-server/tests/service_tests/change_set_approval.rs
@@ -86,11 +86,8 @@ async fn single_user_relation_existence_and_checksum_validility_permutations(
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
         let approving_ids_with_hashes =
-            dal_wrapper::change_set_approval::determine_approving_ids_with_hashes(
-                ctx,
-                &mut spicedb_client,
-            )
-            .await?;
+            dal_wrapper::change_set::determine_approving_ids_with_hashes(ctx, &mut spicedb_client)
+                .await?;
         let first_approval = ChangeSetApproval::new(
             ctx,
             ChangeSetApprovalStatus::Approved,
@@ -100,7 +97,7 @@ async fn single_user_relation_existence_and_checksum_validility_permutations(
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
         let (frontend_latest_approvals, frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
 
         assert_eq!(
             vec![si_frontend_types::ChangeSetApproval {
@@ -140,7 +137,7 @@ async fn single_user_relation_existence_and_checksum_validility_permutations(
         relation.create(&mut spicedb_client).await?;
 
         let (frontend_latest_approvals, frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
 
         assert_eq!(
             vec![si_frontend_types::ChangeSetApproval {
@@ -174,11 +171,8 @@ async fn single_user_relation_existence_and_checksum_validility_permutations(
     // requirement.
     let second_approval_id = {
         let approving_ids_with_hashes =
-            dal_wrapper::change_set_approval::determine_approving_ids_with_hashes(
-                ctx,
-                &mut spicedb_client,
-            )
-            .await?;
+            dal_wrapper::change_set::determine_approving_ids_with_hashes(ctx, &mut spicedb_client)
+                .await?;
         let second_approval = ChangeSetApproval::new(
             ctx,
             ChangeSetApprovalStatus::Approved,
@@ -188,7 +182,7 @@ async fn single_user_relation_existence_and_checksum_validility_permutations(
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
         let (mut frontend_latest_approvals, mut frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_latest_approvals.sort_by_key(|a| a.id);
         frontend_requirements
             .iter_mut()
@@ -237,7 +231,7 @@ async fn single_user_relation_existence_and_checksum_validility_permutations(
         relation.delete(&mut spicedb_client).await?;
 
         let (mut frontend_latest_approvals, frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_latest_approvals.sort_by_key(|a| a.id);
 
         assert_eq!(
@@ -280,7 +274,7 @@ async fn single_user_relation_existence_and_checksum_validility_permutations(
         relation.create(&mut spicedb_client).await?;
 
         let (mut frontend_latest_approvals, mut frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_latest_approvals.sort_by_key(|a| a.id);
         frontend_requirements
             .iter_mut()
@@ -346,7 +340,7 @@ async fn individual_approver_for_view(
     // Scenario 1: see all approvals and requirements with an "empty" workspace.
     {
         let (frontend_latest_approvals, frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
 
         assert!(frontend_latest_approvals.is_empty());
         assert!(frontend_requirements.is_empty());
@@ -372,7 +366,7 @@ async fn individual_approver_for_view(
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
         let (frontend_latest_approvals, mut frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_requirements.sort_by_key(|r| r.entity_id);
 
         assert!(frontend_latest_approvals.is_empty());
@@ -415,7 +409,7 @@ async fn individual_approver_for_view(
     let first_approval_id = {
         let first_approval_id = {
             let approving_ids_with_hashes =
-                dal_wrapper::change_set_approval::determine_approving_ids_with_hashes(
+                dal_wrapper::change_set::determine_approving_ids_with_hashes(
                     ctx,
                     &mut spicedb_client,
                 )
@@ -431,7 +425,7 @@ async fn individual_approver_for_view(
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
         let (frontend_latest_approvals, mut frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_requirements.sort_by_key(|r| r.entity_id);
 
         assert_eq!(
@@ -484,7 +478,7 @@ async fn individual_approver_for_view(
         relation.create(&mut spicedb_client).await?;
 
         let (frontend_latest_approvals, mut frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_requirements.sort_by_key(|r| r.entity_id);
 
         assert_eq!(
@@ -528,7 +522,7 @@ async fn individual_approver_for_view(
     {
         let second_approval_id = {
             let approving_ids_with_hashes =
-                dal_wrapper::change_set_approval::determine_approving_ids_with_hashes(
+                dal_wrapper::change_set::determine_approving_ids_with_hashes(
                     ctx,
                     &mut spicedb_client,
                 )
@@ -544,7 +538,7 @@ async fn individual_approver_for_view(
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
         let (mut frontend_latest_approvals, mut frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_latest_approvals.sort_by_key(|a| a.id);
         frontend_requirements.sort_by_key(|r| r.entity_id);
         frontend_requirements
@@ -600,7 +594,7 @@ async fn individual_approver_for_view(
     {
         let third_approval_id = {
             let approving_ids_with_hashes =
-                dal_wrapper::change_set_approval::determine_approving_ids_with_hashes(
+                dal_wrapper::change_set::determine_approving_ids_with_hashes(
                     ctx,
                     &mut spicedb_client,
                 )
@@ -616,7 +610,7 @@ async fn individual_approver_for_view(
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
         let (mut frontend_latest_approvals, mut frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_latest_approvals.sort_by_key(|a| a.id);
         frontend_requirements.sort_by_key(|r| r.entity_id);
         frontend_requirements
@@ -674,7 +668,7 @@ async fn individual_approver_for_view(
         ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
 
         let (frontend_latest_approvals, frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
 
         assert!(frontend_latest_approvals.is_empty());
         assert!(frontend_requirements.is_empty());
@@ -686,7 +680,7 @@ async fn individual_approver_for_view(
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
         let (frontend_latest_approvals, mut frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_requirements.sort_by_key(|r| r.entity_id);
 
         assert!(frontend_latest_approvals.is_empty());
@@ -725,7 +719,7 @@ async fn individual_approver_for_view(
     {
         let fourth_approval_id = {
             let approving_ids_with_hashes =
-                dal_wrapper::change_set_approval::determine_approving_ids_with_hashes(
+                dal_wrapper::change_set::determine_approving_ids_with_hashes(
                     ctx,
                     &mut spicedb_client,
                 )
@@ -741,7 +735,7 @@ async fn individual_approver_for_view(
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
         let (frontend_latest_approvals, mut frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_requirements.sort_by_key(|r| r.entity_id);
 
         assert_eq!(
@@ -788,7 +782,7 @@ async fn individual_approver_for_view(
     {
         let fifth_approval_id = {
             let approving_ids_with_hashes =
-                dal_wrapper::change_set_approval::determine_approving_ids_with_hashes(
+                dal_wrapper::change_set::determine_approving_ids_with_hashes(
                     ctx,
                     &mut spicedb_client,
                 )
@@ -804,7 +798,7 @@ async fn individual_approver_for_view(
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
         let (frontend_latest_approvals, mut frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_requirements.sort_by_key(|r| r.entity_id);
 
         assert_eq!(
@@ -892,7 +886,7 @@ async fn one_component_in_two_views(
         ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
 
         let (frontend_latest_approvals, frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
 
         assert!(frontend_latest_approvals.is_empty());
         assert!(frontend_requirements.is_empty());
@@ -911,7 +905,7 @@ async fn one_component_in_two_views(
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
         let (frontend_latest_approvals, mut frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_requirements.sort_by_key(|r| r.entity_id);
 
         assert!(frontend_latest_approvals.is_empty());
@@ -951,7 +945,7 @@ async fn one_component_in_two_views(
         ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
 
         let (frontend_latest_approvals, frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
 
         assert!(frontend_latest_approvals.is_empty());
         assert!(frontend_requirements.is_empty());
@@ -963,7 +957,7 @@ async fn one_component_in_two_views(
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
         let (frontend_latest_approvals, mut frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_requirements.sort_by_key(|r| r.entity_id);
 
         assert!(frontend_latest_approvals.is_empty());
@@ -1001,7 +995,7 @@ async fn one_component_in_two_views(
         ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
 
         let (frontend_latest_approvals, frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
 
         assert!(frontend_latest_approvals.is_empty());
         assert!(frontend_requirements.is_empty());
@@ -1013,7 +1007,7 @@ async fn one_component_in_two_views(
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
         let (frontend_latest_approvals, mut frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
         frontend_requirements.sort_by_key(|r| r.entity_id);
 
         assert!(frontend_latest_approvals.is_empty());
@@ -1051,7 +1045,7 @@ async fn one_component_in_two_views(
         ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
 
         let (frontend_latest_approvals, frontend_requirements) =
-            dal_wrapper::change_set_approval::status(ctx, &mut spicedb_client).await?;
+            dal_wrapper::change_set::status(ctx, &mut spicedb_client).await?;
 
         assert!(frontend_latest_approvals.is_empty());
         assert!(frontend_requirements.is_empty());

--- a/lib/sdf-server/tests/service_tests/mod.rs
+++ b/lib/sdf-server/tests/service_tests/mod.rs
@@ -1,2 +1,3 @@
+mod change_set_apply;
 mod change_set_approval;
 mod crdt;

--- a/lib/sdf-test/BUCK
+++ b/lib/sdf-test/BUCK
@@ -3,6 +3,9 @@ load("@prelude-si//:macros.bzl", "rust_library")
 rust_library(
     name = "sdf-test",
     deps = [
+        "//lib/dal:dal",
+        "//lib/dal-test:dal-test",
+        "//lib/sdf-server:sdf-server",
         "//lib/si-data-spicedb:si-data-spicedb",
         "//third-party/rust:rand",
     ],

--- a/lib/sdf-test/Cargo.toml
+++ b/lib/sdf-test/Cargo.toml
@@ -9,6 +9,9 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
+dal = { path = "../../lib/dal" }
+dal-test = { path = "../../lib/dal-test" }
+sdf-server = { path = "../../lib/sdf-server" }
 si-data-spicedb = { path = "../../lib/si-data-spicedb" }
 
 rand = { workspace = true }

--- a/lib/sdf-test/src/helpers.rs
+++ b/lib/sdf-test/src/helpers.rs
@@ -1,0 +1,33 @@
+//! This module provides [`SdfChangeSetTestHelpers`].
+
+use dal::{ChangeSet, DalContext};
+use dal_test::prelude::*;
+use sdf_server::dal_wrapper;
+
+/// This unit struct providers helper functions when [dal_test::helpers] cannot perform helper
+/// tasks alone (e.g. need to talk to SpiceDB).
+#[derive(Debug)]
+pub struct SdfTestHelpers;
+
+impl SdfTestHelpers {
+    /// Perform a change set apply, but with protections to ensure that all approval requirements
+    /// have been met.
+    pub async fn protected_apply_change_set_to_base(
+        ctx: &mut DalContext,
+        spicedb_client: &mut si_data_spicedb::Client,
+    ) -> Result<()> {
+        // First, check if all requirements have been satisfied.
+        dal_wrapper::change_set::approval_requirements_are_satisfied_or_error(ctx, spicedb_client)
+            .await?;
+
+        // We need to prepare for apply, but use the new version that skips the status check. Why?
+        // Our new approval requirements check above replaces the old status check.
+        ChangeSet::prepare_for_apply_without_status_check(ctx).await?;
+
+        // We can mostly follow the DAL test flow for applying a change set while factoring in
+        // approvals. The "mostly" part comes from the fact that we need to perform our own
+        // "prepare" step above rather than using the one from the DAL test helpers.
+        ChangeSetTestHelpers::apply_change_set_to_base_approvals_without_prepare_step(ctx).await?;
+        Ok(())
+    }
+}

--- a/lib/sdf-test/src/lib.rs
+++ b/lib/sdf-test/src/lib.rs
@@ -32,6 +32,8 @@ use si_data_spicedb::SpiceDbConfig;
 
 const ENV_VAR_SPICEDB_URL: &str = "SI_TEST_SPICEDB_URL";
 
+pub mod helpers;
+
 /// Provides a [`SpiceDbConfig`] for SDF tests.
 ///
 /// # Panics


### PR DESCRIPTION
## Description

This PR adds a new route for applying a change set with fine grained access control. This route contains new dal wrapper logic to ensure that applying a change set (unforced) only happens if all requirements have been met. There's a new integration test for this as well.

<img src="https://media1.giphy.com/media/uq4DBwnIijgmlJOHX6/giphy.gif"/>

## Other Changes

Other changes include, but are not limited to, the following:

- Split apply prepare step into two versions because sdf now handles the protection layer
- Rename the "change_set_approval" module to "change_set" in dal wrapper
- Add sdf-test helpers for mimicking protected apply behavior in the route, which is used by the new test