### PR TITLE
feat(web): Show resource_value props in AttributePanel

### DIFF
--- a/app/web/src/components/AttributesPanel/AttributesPanel.vue
+++ b/app/web/src/components/AttributesPanel/AttributesPanel.vue
@@ -58,6 +58,14 @@
         isRootProp
         :context="useAttributesPanelContext"
       />
+      <TreeFormItem
+        v-if="resourceValueTree && resourceValueTree.children.length"
+        attributesPanel
+        :treeDef="resourceValueTree"
+        isRootProp
+        startClosed
+        :context="useAttributesPanelContext"
+      />
     </div>
 
     <div v-if="SHOW_DEBUG_TREE" class="mt-xl">
@@ -124,6 +132,7 @@ const loadSchemaReqStatus = attributesStore.getRequestStatus(
 
 const domainTree = computed(() => attributesStore.domainTree);
 const secretsTree = computed(() => attributesStore.secretsTree);
+const resourceValueTree = computed(() => attributesStore.resourceValueTree);
 
 const showSectionToggles = ref(false);
 function onMouseMove(e: PointerEvent) {

--- a/app/web/src/components/AttributesPanel/TreeFormItem.vue
+++ b/app/web/src/components/AttributesPanel/TreeFormItem.vue
@@ -971,6 +971,7 @@ const props = defineProps({
   level: { type: Number, default: 0 },
   isRootProp: { type: Boolean, default: false },
   context: { type: Function, required: true },
+  startClosed: { type: Boolean },
 
   // Only set this boolean to true if this TreeFormItem is part of AttributesPanel
   attributesPanel: { type: Boolean },
@@ -989,7 +990,7 @@ const headerMainLabelTooltip = computed(() => {
   } else return {};
 });
 
-const isOpen = ref(true); // ref(props.attributeDef.children.length > 0);
+const isOpen = ref(!props.startClosed); // ref(props.attributeDef.children.length > 0);
 const showValidationDetails = ref(false);
 
 const shouldBeHidden = (item: AttributeTreeItem | TreeFormData) => {

--- a/app/web/src/store/component_attributes.store.ts
+++ b/app/web/src/store/component_attributes.store.ts
@@ -173,6 +173,13 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
               (c) => c.propDef.name === "secrets",
             );
           },
+          resourceValueTree(): AttributeTreeItem | undefined {
+            if (!this.attributesTree) return undefined;
+            return _.find(
+              this.attributesTree.children,
+              (c) => c.propDef.name === "resource_value",
+            );
+          },
           siTreeByPropName(): Record<string, AttributeTreeItem> | undefined {
             if (!this.attributesTree) return undefined;
             const siTree = _.find(

--- a/lib/dal/src/property_editor/schema.rs
+++ b/lib/dal/src/property_editor/schema.rs
@@ -46,9 +46,9 @@ impl PropertyEditorSchema {
 
                 for child_prop in child_props {
                     // Skip anything at and under "/root/secret_definition",
-                    // also skip hidden props
-                    if (prop_id == root_prop_id && child_prop.name == "secret_definition")
-                        || child_prop.hidden
+                    // also skip hidden props EXCEPT /root/resource_value
+                    if prop_id == root_prop_id && child_prop.name == "secret_definition"
+                        || (child_prop.hidden && child_prop.name != "resource_value")
                     {
                         continue;
                     }


### PR DESCRIPTION
If a component has resource_value props, then we are going to show them on the attributes panel. 

the panel will be closed by default and the user can expand it. The panel won't even show if there are no child_props of the resource_value prop

**Existing Component:**

![Screenshot 2025-01-26 at 00 39 05](https://github.com/user-attachments/assets/ac1a068b-fc74-4ccc-b84e-a2980af865b6)

**component with resource_value props**

![Screenshot 2025-01-26 at 00 28 45](https://github.com/user-attachments/assets/bd55591a-37c7-444c-a55d-4c72cbcc0637)

Notice the value can't be set - as it's set via an attribute func - this is the functionality we want. This panel will be collapsed by default so not to take any extra space