### PR TITLE
Let web rebuild without rebuilding all the rust

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -44,7 +44,6 @@ groups = {
 }
 
 core_backend_targets = [
-    "//app/web:dev",
     "//bin/forklift:forklift",
     "//bin/pinga:pinga",
     "//bin/rebaser:rebaser",


### PR DESCRIPTION
`web` doesn't get much startup build time improvement from being included in the pack of rust apps, and including it in the frontend apps means restarting just web will wait for sdf and friends to build. This breaks that dependency. web still waits for sdf, so we're not losing anything in terms of dependency. Initial build likely isn't affected at all, but the web startup is fast enough that it's not worth trying to parallelize it :)

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExeDZjaTdicnFhZ21zeW5xMmJuYnRjZHBsZTc3bG83dGNyOHZwMTV5MCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/KtyTa7XH5ueJLYwmaG/giphy.gif)