### PR TITLE
chore(tilt): Only rebuild individual service on Restart in tilt

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -23,6 +23,7 @@ groups = {
         "rebaser",
         "sdf",
         "veritech",
+        "rust-initial-build",
     ],
     "frontend": [
         "auth-portal",
@@ -43,25 +44,12 @@ groups = {
     ],
 }
 
-core_backend_targets = [
-    "//bin/forklift:forklift",
-    "//bin/pinga:pinga",
-    "//bin/rebaser:rebaser",
-    "//bin/sdf:sdf",
-    "//bin/veritech:veritech",
-]
-
-# Add "all" group as a sorted set of all services
-_all = {}
-for group_values in groups.values():
-    for value in group_values:
-        _all.update({value: True})
-groups.update({"all": sorted(_all.keys())})
-
 # Parse the CLI args to enable group names and/or individual service names
 enabled_resources = []
 for arg in cfg.get("to-run", []):
-    if arg in groups:
+    if arg == "all":
+        enabled_resources += [service for services in groups.values() for service in services]
+    elif arg in groups:
         enabled_resources += groups[arg]
     else:
         enabled_resources.append(arg)
@@ -78,7 +66,7 @@ RUST_RESOURCE_ARGS = {
 # ("config.define_string") arguments with the argument call (i.e. it thinks "--foo bar" is one
 # argument rather than having argument "--foo" be passed value "bar"). Thus, we use two booleans to
 # get around this. If we get both, greedily choose the standard mode.
-def mode_and_targets(cfg, targets):
+def buck2_mode_and_targets(targets):
     targets_str = " ".join(targets)
 
     if cfg.get("standard-rustc-build-mode", False):
@@ -89,6 +77,21 @@ def mode_and_targets(cfg, targets):
         return "@//mode/debug {}".format(targets_str)
 
     return "@//mode/release {}".format(targets_str)
+
+def buck2_build_deps(build_targets):
+    return [
+        dep
+        for build_target in build_targets
+        for dep in str(
+            local(
+                "buck2 uquery \"inputs(deps('{}'))\"".format(build_target),
+                quiet = True,
+            ),
+        ).splitlines()
+    ]
+
+def resource_labels(name):
+    return [group for group in groups if group != "all" and name in groups[group]]
 
 def si_buck2_resource(
         target,
@@ -102,34 +105,24 @@ def si_buck2_resource(
     if name == None:
         name = target.split("/")[-1].split(":")[0]
 
-    if target in core_backend_targets:
-        build_targets = core_backend_targets
-    else:
-        build_targets = [target]
-
     # Get Buck2 build command
-    cmd = "buck2 build {}".format(mode_and_targets(cfg, build_targets))
+    mode_and_targets = buck2_mode_and_targets([target])
+    cmd = "buck2 build {}".format(mode_and_targets)
 
     # Get Buck2 run command
-    mode_and_target = mode_and_targets(cfg, [target])
-    serve_cmd = "buck2 run {}".format(mode_and_target)
+    serve_cmd = "buck2 run {}".format(mode_and_targets)
     if buck2_serve_args != None:
         serve_cmd += " -- {}".format(buck2_serve_args)
-    if tee and mode_and_target != target:
+    if tee and mode_and_targets != target:
         # TODO different resources currently tee differently depending on mode. Seems like copypasta
         # error but ask around to see if it's intended.
         serve_cmd += " | tee /tmp/si-logs/{}".format(name)
 
     # Compute Buck2 source inputs to populate Tilt local_resource/deps
-    deps = str(
-        local(
-            "buck2 uquery \"inputs(deps('{}'))\"".format(target),
-            quiet = True,
-        ),
-    ).splitlines()
+    deps = buck2_build_deps([target])
 
     # Lookup group and add to labels
-    group_names = [group for group in groups if group != "all" and name in groups[group]]
+    group_names = resource_labels(name)
 
     print("local_resource(")
     print("    name       = \"{}\"".format(name))
@@ -161,51 +154,43 @@ def si_buck2_resource(
 # - https://docs.tilt.dev/api.html#api.allow_k8s_contexts
 allow_k8s_contexts(k8s_context())
 
-def find_group(name, groups):
-    for group, names in groups.items():
-        if name in names:
-            return group
-    return "all"
-
 # Use Docker Compose to provide the platform services
 docker_compose("./docker-compose.platform.yml")
-compose_services = [
-    "db",
-    "db-test",
-    "grafana",
-    "jaeger",
-    "localstack",
-    "loki",
-    "nats",
-    "otelcol",
-    "postgres",
-    "postgres-test",
-    "prometheus",
-    "promtail",
-    "spicedb",
-]
-for service in compose_services:
-    if service == "jaeger":
-        links = [
-            link("http://localhost:16686", "jaeger-ui"),
-        ]
-    elif service == "grafana":
-        links = [
+compose_services = {
+    "db": {},
+    "db-test": {},
+    "grafana": {
+        "links": [
             link("http://localhost:3000", "grafana-ui"),
-        ]
-    elif service == "localstack":
-        links = [
+        ],
+    },
+    "jaeger": {
+        "links": [
+            link("http://localhost:16686", "jaeger-ui"),
+        ],
+    },
+    "localstack": {
+        "links": [
             link("http://localhost:4566", "localstack-api"),
-        ]
-    else:
-        links = []
-
-    dc_resource(service, links = links, labels = [find_group(service, groups)])
+        ],
+    },
+    "loki": {},
+    "nats": {},
+    "otelcol": {},
+    "postgres": {},
+    "postgres-test": {},
+    "prometheus": {},
+    "promtail": {},
+    "spicedb": {},
+}
+for service, kwargs in compose_services.items():
+    dc_resource(service, labels = resource_labels(service), **kwargs)
 
 # Locally build and run `rebaser`
 si_buck2_resource(
     "//bin/rebaser:rebaser",
     resource_deps = [
+        "rust-initial-build",
         "nats",
         "otelcol",
         "postgres",
@@ -217,6 +202,7 @@ si_buck2_resource(
 si_buck2_resource(
     "//bin/forklift:forklift",
     resource_deps = [
+        "rust-initial-build",
         "nats",
         "otelcol",
     ],
@@ -227,6 +213,7 @@ si_buck2_resource(
 si_buck2_resource(
     "//bin/pinga:pinga",
     resource_deps = [
+        "rust-initial-build",
         "nats",
         "otelcol",
         "veritech",
@@ -243,6 +230,7 @@ si_buck2_resource(
     #
     # NB: BUCK2 MUST RUN AS ROOT OR THIS WILL NOT WORK
     resource_deps = [
+        "rust-initial-build",
         "nats",
         "otelcol",
     ],
@@ -253,6 +241,7 @@ si_buck2_resource(
 si_buck2_resource(
     "//bin/sdf:sdf",
     resource_deps = [
+        "rust-initial-build",
         "spicedb",
         "nats",
         "otelcol",
@@ -354,4 +343,20 @@ si_buck2_resource(
     links = [
         link("http://127.0.0.1:9000", "auth"),
     ],
+)
+
+rust_build_targets = [
+    "//bin/forklift:forklift",
+    "//bin/pinga:pinga",
+    "//bin/rebaser:rebaser",
+    "//bin/sdf:sdf",
+    "//bin/veritech:veritech",
+]
+local_resource(
+    "rust-initial-build",
+    allow_parallel = True,
+    labels = resource_labels("rust-initial-build"),
+    cmd = "buck2 build {}".format(buck2_mode_and_targets(rust_build_targets)),
+    deps = buck2_build_deps(rust_build_targets),
+    **RUST_RESOURCE_ARGS,
 )


### PR DESCRIPTION
This makes it so when you click the little Restart button next to rebaser, forklift, pinga, veritech, or sdf, they will only rebuild what is necessary for *themselves* to restart. This speeds up restart.

At the same time, we preserve the new "build everything in a single command for performance" on tilt startup by creating a new "rust-backend-build" resource, which those 5 services all depend on. On startup, they will wait for this; but on restart, this won't be retriggered (this is how tilt works in general, inter-service dependencies only matter on startup).

The net effect is to speed up service rebuilds without slowing down initial startup.

<IMG SRC="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNGQyMmllNmNzYzkwcDZwenpqZjFuY2c1bjVmdzNxbmw1bDR6OGpjZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/20NQduJrwiY1uHVixC/giphy.gif">