### PR TITLE
feat(si-fs): create action and attribute functions with mkdir

### DIFF
--- a/lib/si-filesystem/src/inode_table.rs
+++ b/lib/si-filesystem/src/inode_table.rs
@@ -1,6 +1,8 @@
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
+    io::Cursor,
     path::{Path, PathBuf},
+    sync::Arc,
     time::UNIX_EPOCH,
 };
 
@@ -27,7 +29,8 @@ pub type InodeTableResult<T> = Result<T, InodeTableError>;
 pub struct InodeEntry {
     pub ino: Inode,
     pub parent: Option<Inode>,
-    kind: FileType,
+    pub name: String,
+    pub kind: FileType,
     pub data: InodeEntryData,
     attrs: FileAttr,
     write: bool,
@@ -40,6 +43,13 @@ impl InodeEntry {
 
     pub fn attrs(&self) -> &FileAttr {
         &self.attrs
+    }
+
+    pub fn pending_buf(&self) -> Option<Arc<Cursor<Vec<u8>>>> {
+        match self.data() {
+            InodeEntryData::SchemaFuncBindingsPending { buf, .. } => Some(buf.clone()),
+            _ => None,
+        }
     }
 }
 
@@ -114,6 +124,12 @@ pub enum InodeEntryData {
         size: u64,
         unlocked: bool,
     },
+    SchemaFuncBindingsPending {
+        change_set_id: ChangeSetId,
+        schema_id: SchemaId,
+        kind: FuncKind,
+        buf: Arc<Cursor<Vec<u8>>>,
+    },
     SchemaFuncKind {
         kind: FuncKind,
         schema_id: SchemaId,
@@ -146,8 +162,8 @@ pub enum InodeEntryData {
 #[derive(Clone, Debug)]
 pub struct InodeTable {
     // This is a vec where the index to the vec is the inode number minus 1
-    path_table: Vec<PathBuf>,
-    entries_by_path: HashMap<PathBuf, InodeEntry>,
+    path_table: Vec<Option<PathBuf>>,
+    entries_by_path: BTreeMap<PathBuf, InodeEntry>,
     uid: Uid,
     gid: Gid,
 }
@@ -162,7 +178,7 @@ impl InodeTable {
     pub fn new(root_entry: InodeEntryData, uid: Uid, gid: Gid) -> Self {
         let mut table = Self {
             path_table: Vec::with_capacity(4096),
-            entries_by_path: HashMap::with_capacity(4096),
+            entries_by_path: BTreeMap::new(),
             uid,
             gid,
         };
@@ -178,16 +194,41 @@ impl InodeTable {
         table
     }
 
+    pub fn entries_by_path(&self) -> &BTreeMap<PathBuf, InodeEntry> {
+        &self.entries_by_path
+    }
+
+    pub fn direct_child_entries(&self, ino: Inode) -> InodeTableResult<Vec<InodeEntry>> {
+        let mut result = vec![];
+
+        for (_, entry) in self.entries_by_path.iter() {
+            if entry.parent != Some(ino) {
+                continue;
+            }
+            result.push(entry.clone());
+        }
+
+        Ok(result)
+    }
+
     pub fn path_for_ino(&self, ino: Inode) -> Option<&Path> {
         self.path_table
             .get(ino.as_raw().saturating_sub(1) as usize)
-            .map(|p| p.as_path())
+            .and_then(|maybe_p| maybe_p.as_ref().map(|p| p.as_path()))
     }
 
     pub fn path_buf_for_ino(&self, ino: Inode) -> Option<PathBuf> {
         self.path_table
             .get(ino.as_raw().saturating_sub(1) as usize)
             .cloned()
+            .flatten()
+    }
+
+    pub fn parent_ino(&self, ino: Inode) -> Option<Inode> {
+        self.path_buf_for_ino(ino)
+            .and_then(|path_buf| path_buf.parent().map(|path| path.to_path_buf()))
+            .and_then(|parent_path| self.entries_by_path.get(&parent_path))
+            .map(|entry| entry.ino)
     }
 
     // pub fn ino_for_path_with_parent(
@@ -206,6 +247,23 @@ impl InodeTable {
     pub fn entry_for_ino(&self, ino: Inode) -> Option<&InodeEntry> {
         self.path_for_ino(ino)
             .and_then(|path| self.entries_by_path.get(path))
+    }
+
+    pub fn pending_buf_for_file_with_parent(
+        &self,
+        parent: Inode,
+        file_name: impl AsRef<Path>,
+    ) -> InodeTableResult<Option<Arc<Cursor<Vec<u8>>>>> {
+        let path = self.make_path(Some(parent), file_name)?;
+        Ok(self
+            .ino_for_path(&path)
+            .and_then(|ino| self.pending_buf_for_ino(ino)))
+    }
+
+    pub fn pending_buf_for_ino(&self, ino: Inode) -> Option<Arc<Cursor<Vec<u8>>>> {
+        self.path_for_ino(ino)
+            .and_then(|path| self.entries_by_path.get(path))
+            .and_then(|entry| entry.pending_buf())
     }
 
     pub fn entry_mut_for_ino(&mut self, ino: Inode) -> Option<&mut InodeEntry> {
@@ -302,6 +360,36 @@ impl InodeTable {
         Ok(())
     }
 
+    pub fn invalidate_ino(&mut self, ino: Inode) -> Option<PathBuf> {
+        if let Some(parent_path) = match self
+            .path_table
+            .get_mut(ino.as_raw().saturating_sub(1) as usize)
+        {
+            Some(entry) => entry.take(),
+            None => None,
+        } {
+            self.entries_by_path.remove(&parent_path);
+
+            // Invalidate all child entries of this inode
+            for entry in self
+                .path_table
+                .iter_mut()
+                .skip(ino.as_raw().saturating_sub(1) as usize)
+            {
+                if let Some(path_buf) = entry {
+                    if path_buf.starts_with(&parent_path) {
+                        self.entries_by_path.remove(&path_buf.clone());
+                        entry.take();
+                    }
+                }
+            }
+
+            Some(parent_path)
+        } else {
+            None
+        }
+    }
+
     pub fn upsert(
         &mut self,
         path: PathBuf,
@@ -323,6 +411,11 @@ impl InodeTable {
             }
         };
 
+        let file_name = path
+            .file_name()
+            .map(|f| f.to_string_lossy().into_owned())
+            .unwrap_or("".into());
+
         let entry = self
             .entries_by_path
             .entry(path.clone())
@@ -333,6 +426,7 @@ impl InodeTable {
                 *entry = InodeEntry {
                     ino,
                     parent,
+                    name: file_name.clone(),
                     data: entry_data.to_owned(),
                     attrs,
                     write,
@@ -340,10 +434,11 @@ impl InodeTable {
                 }
             })
             .or_insert_with(|| {
-                self.path_table.push(path);
+                self.path_table.push(Some(path));
                 InodeEntry {
                     ino,
                     parent,
+                    name: file_name,
                     data: entry_data,
                     attrs,
                     write,


### PR DESCRIPTION
Call mkdir in the actions or attributes folder to create a "pending"
action or attribute function. A file "PENDING_BINDINGS_EDIT_ME.json"
will appear in the new folder. Edit that file with a correct action or
correct output location for a function, and the save will create the
pending function.

You can also configure function arguments in the bindings for attribute
functions now.