### PR TITLE
fix(dal): Allow attribute values set by dynamic funcs to be set by management funcs if the value is not controlled by an ancestor

### DIFF
--- a/lib/dal-test/src/test_exclusive_schemas/legos/small.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/legos/small.rs
@@ -438,6 +438,35 @@ pub(crate) async fn migrate_test_exclusive_schema_small_odd_lego(
         "test:removeAllCompsFromViewAndRemoveView",
     )?;
 
+    let override_values_set_by_sockets_code = r#"
+         async function main({ thisComponent, components }: Input): Promise<Output> {
+        const thisName = thisComponent.properties?.si?.name ?? "unknown";
+        const componentName = `bluey`;
+
+        return {
+            status: "ok",
+            ops: {
+                update: { self: { properties: { si: { type: "configurationFrameDown" } } } },
+                create: {
+                    [componentName]: {
+                        kind: "small odd lego",
+                properties: { 
+                    si: { name },
+                    domain: {
+                        one: `bingo`
+                        } 
+                    },
+                parent: "self"
+                    }
+                }
+            }
+        }
+    }
+    "#;
+    let override_values_set_by_sockets = build_management_func(
+        override_values_set_by_sockets_code,
+        "test:overrideValuesSetBySocket",
+    )?;
     let fn_name = "test:deleteActionSmallLego";
     let delete_action_func = build_action_func(delete_action_code, fn_name)?;
 
@@ -595,6 +624,12 @@ pub(crate) async fn migrate_test_exclusive_schema_small_odd_lego(
                         .func_unique_id(&remove_all_components_from_a_view_and_the_view.unique_id)
                         .build()?,
                 )
+                .management_func(
+                    ManagementFuncSpec::builder()
+                        .name("Override Props")
+                        .func_unique_id(&override_values_set_by_sockets.unique_id)
+                        .build()?,
+                )
                 .build()?,
         )
         .build()?;
@@ -619,6 +654,7 @@ pub(crate) async fn migrate_test_exclusive_schema_small_odd_lego(
         .func(create_view_and_component_in_view)
         .func(delete_and_erase_components)
         .func(remove_all_components_from_a_view_and_the_view)
+        .func(override_values_set_by_sockets)
         .schema(small_lego_schema)
         .build()?;
 

--- a/lib/dal/tests/integration_test/management.rs
+++ b/lib/dal/tests/integration_test/management.rs
@@ -748,6 +748,17 @@ async fn override_values_set_by_sockets(ctx: &DalContext) {
         .expect("could not get attribute value");
     let view = domain.view(ctx).await.expect("could not get view");
     assert!(view.is_some());
+
+    let one_av_id = component
+        .attribute_value_for_prop(ctx, &["root", "domain", "one"])
+        .await
+        .expect("get av for prop");
+
+    assert!(
+        !AttributeValue::is_set_by_dependent_function(ctx, one_av_id)
+            .await
+            .expect("check if dependent func")
+    );
 }
 
 #[test]


### PR DESCRIPTION
This change means that if you try to set a value from a management function, and the value would otherwise be set by another function (for example the region prop takes it's input from an input socket), we will override the value and override the default prototype.  

Tested by writing management functions that do this, and added a integration test.

<div><img src="https://media0.giphy.com/media/SqTa7KFVfBJ9b1QFPo/giphy.gif?cid=5a38a5a2n02qjmtp094c1awymz2fwqsjc5w50jny16jmbmmm&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/power/">Power</a> on <a href="https://giphy.com/gifs/power-starz-season6-episode605-SqTa7KFVfBJ9b1QFPo">GIPHY</a></div>