### PR TITLE
chore(ci): Temporarily silence cypress tests

### DIFF
--- a/.github/workflows/prod-test-cron.yml
+++ b/.github/workflows/prod-test-cron.yml
@@ -2,11 +2,11 @@ name: Production Crons
 
 on:
   schedule:
-      # Weekends: Every 15 minutes except 7:45 PM and 8:00 PM UTC
-      - cron: "0-44/15 0-19 * * 6,0"  # Every 15 minutes from 12:00 AM to 7:44 PM UTC (Saturday to Sunday)
-      - cron: "15-59/15 20-23 * *  6,0" # Every 15 minutes from 8:15 PM to 11:59 PM UTC (Saturday to Sunday)
-      # Weekdays: Every 15 minutes 
-      - cron: "*/15 * * * 1-5" # Every 15 minutes on Monday to Friday
+    # Weekends: Every 15 minutes except 7:45 PM and 8:00 PM UTC
+    - cron: "0-44/15 0-19 * * 6,0" # Every 15 minutes from 12:00 AM to 7:44 PM UTC (Saturday to Sunday)
+    - cron: "15-59/15 20-23 * *  6,0" # Every 15 minutes from 8:15 PM to 11:59 PM UTC (Saturday to Sunday)
+    # Weekdays: Every 15 minutes
+    - cron: "*/15 * * * 1-5" # Every 15 minutes on Monday to Friday
 
 # We will wait until these tests finish before starting a deploy
 # We will also wait for a deploy to finish before starting to run tests
@@ -15,11 +15,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  e2e-validation:
-    uses: ./.github/workflows/e2e-validation.yml
-    with:
-      environment: production
-    secrets: inherit
+  # e2e-validation:
+  #   uses: ./.github/workflows/e2e-validation.yml
+  #   with:
+  #     environment: production
+  #   secrets: inherit
   api-test:
     uses: ./.github/workflows/run-api-test.yml
     with:

--- a/.github/workflows/tools-test-cron.yml
+++ b/.github/workflows/tools-test-cron.yml
@@ -11,11 +11,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  e2e-validation:
-    uses: ./.github/workflows/e2e-validation.yml
-    with:
-      environment: tools
-    secrets: inherit
+  # e2e-validation:
+  #   uses: ./.github/workflows/e2e-validation.yml
+  #   with:
+  #     environment: tools
+  #   secrets: inherit
   api-test:
     uses: ./.github/workflows/run-api-test.yml
     with:


### PR DESCRIPTION
There's an issue with the cypress install step and we can't have this add noise to our internal alerting