### PR TITLE
feat(sdf): Capture a better error message from mgmt func failures

### DIFF
--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -131,6 +131,7 @@ export const useFuncStore = () => {
   const workspacesStore = useWorkspacesStore();
   const workspaceId = workspacesStore.selectedWorkspacePk;
   const authStore = useAuthStore();
+  const toast = useToast();
 
   const realtimeStore = useRealtimeStore();
 
@@ -325,6 +326,13 @@ export const useFuncStore = () => {
               { componentId },
               { viewId },
             ]),
+            onFail: (err) => {
+              if (err.response.status === 400) {
+                toast(
+                  `Error executing management function: ${err.response.data.error.message}`,
+                );
+              }
+            },
           });
         },
 
@@ -979,7 +987,6 @@ export const useFuncStore = () => {
                 };
               }
 
-              const toast = useToast();
               const toastOptions = {
                 timeout: 5000,
               };

--- a/lib/sdf-server/src/service/v2/management.rs
+++ b/lib/sdf-server/src/service/v2/management.rs
@@ -76,7 +76,13 @@ pub enum ManagementApiError {
 
 impl IntoResponse for ManagementApiError {
     fn into_response(self) -> Response {
-        ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
+        let (status_code, error_message) = match self {
+            ManagementApiError::ManagementPrototype(
+                dal::management::prototype::ManagementPrototypeError::FuncExecutionFailure(message),
+            ) => (StatusCode::BAD_REQUEST, message),
+            _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+        };
+        ApiError::new(status_code, error_message).into_response()
     }
 }
 


### PR DESCRIPTION
Before we throw a raw error as a 500 now we capture the data only and send it as a 400 with a toast

before:

![image](https://github.com/user-attachments/assets/15578b50-ecc4-4447-8ff9-49407d721fe3)

after:

![Screenshot 2025-01-28 at 21 48 06](https://github.com/user-attachments/assets/c1ed895d-82fd-4746-b2af-f9b2a34efe11)