### PR TITLE
fix(web): Small turn to expose the prop path in the intrinsics panel

### DIFF
--- a/app/web/src/components/AssetDetailIntrinsicInput.vue
+++ b/app/web/src/components/AssetDetailIntrinsicInput.vue
@@ -3,6 +3,7 @@
     v-if="display"
     :id="id"
     v-model="display.value"
+    :labelTooltip="tooltipValue"
     :label="label"
     :options="optionsForIntrinsicDisplay"
     compact
@@ -95,8 +96,13 @@ const id = computed<string>(() => {
 
 const label = computed<string>(() => {
   if ("socketName" in props.data) return props.data.socketName;
-  if ("name" in props.data) return props.data.name;
+  if ("name" in props.data) return props.data.path.replace("/root", "");
   return "N/A";
+});
+
+const tooltipValue = computed<string>(() => {
+  if ("name" in props.data) return props.data.path;
+  return "";
 });
 
 watch(

--- a/lib/vue-lib/src/design-system/forms/VormInput.vue
+++ b/lib/vue-lib/src/design-system/forms/VormInput.vue
@@ -24,6 +24,15 @@ you can pass in options as props too */
   >
     <label
       v-if="!noLabel"
+      v-tooltip="
+        compact
+          ? {
+              content: labelTooltip,
+              theme: 'instant-show',
+              placement: 'left',
+            }
+          : null
+      "
       :class="clsx('vorm-input__label', !inlineLabel && 'pb-xs block')"
       :for="formInputId"
     >
@@ -382,6 +391,7 @@ const props = defineProps({
   inlineLabel: { type: Boolean },
   instructions: String,
   placeholder: String,
+  labelTooltip: String, // Only works for compact!
 
   iconRight: { type: String as PropType<IconNames>, required: false },
   iconRightRotate: {


### PR DESCRIPTION
This is a stop gap solution until we redesign that panel. This is going to be useful in the interim

![Screenshot 2025-01-29 at 00 19 40](https://github.com/user-attachments/assets/d255eceb-bae9-4b5f-a61b-c29ac2750628)
