### PR TITLE
fix(forklift?): Allow old generated audit logs to be deserialized

### DIFF
--- a/lib/si-events-rs/src/audit_log.rs
+++ b/lib/si-events-rs/src/audit_log.rs
@@ -34,7 +34,7 @@ impl AuditLog {
             entity_name,
             timestamp: Utc::now().to_rfc3339(),
             change_set_id: Some(change_set_id),
-            authentication_method,
+            authentication_method: Some(authentication_method),
         }))
     }
 }

--- a/lib/si-events-rs/src/audit_log/v1.rs
+++ b/lib/si-events-rs/src/audit_log/v1.rs
@@ -20,7 +20,7 @@ pub struct AuditLogV1 {
     pub entity_name: String,
     pub timestamp: String,
     pub change_set_id: Option<ChangeSetId>,
-    pub authentication_method: AuthenticationMethod,
+    pub authentication_method: Option<AuthenticationMethod>,
 }
 
 #[remain::sorted]


### PR DESCRIPTION
Looking into the billion-spans issue, we have a theory that something may be choking on some messages in a NATS queue that don't have the new authenticationMethod field. There are some reasons to think this might not be the issue, but it seems like a safe bet to try back-compatting the format.