### PR TITLE
temporarily ignore the problematic spans

### DIFF
--- a/component/otelcol/honeycomb-config.yaml
+++ b/component/otelcol/honeycomb-config.yaml
@@ -137,6 +137,10 @@ processors:
   filter:
     error_mode: ignore
     traces:
+      span: 
+        # temporarily ignore these
+         - name == "pinga.jobs.:workspace_id.:change_set_id.DependentValuesUpdate receive"
+         - name == "pinga.jobs.:workspace_id.:change_set_id.ComputeValidation receive"
       spanevent:
         # js-browser document-load
         - name == "connectEnd" and instrumentation_scope.name ==


### PR DESCRIPTION
We've got theories why these spans are spamming, but to save our ability to have telemetry, let's temporarily filter them out.