### PR TITLE
fix(dal, rebaser, pinga): If a change set is abandoned, do not process rebase requests or execute jobs. 

### DIFF
--- a/lib/dal/src/job/consumer.rs
+++ b/lib/dal/src/job/consumer.rs
@@ -15,7 +15,6 @@ use crate::billing_publish::BillingPublishError;
 use crate::diagram::DiagramError;
 use crate::prop::PropError;
 use crate::validation::ValidationError;
-use crate::FuncError;
 use crate::{
     action::prototype::ActionPrototypeError, action::ActionError,
     attribute::value::AttributeValueError,
@@ -24,6 +23,7 @@ use crate::{
     ActionPrototypeId, ComponentError, ComponentId, DalContext, DalContextBuilder,
     StandardModelError, TransactionsError, Visibility, WorkspaceSnapshotError, WsEventError,
 };
+use crate::{ChangeSetError, FuncError};
 
 #[remain::sorted]
 #[derive(Error, Debug)]
@@ -43,6 +43,8 @@ pub enum JobConsumerError {
     BillingPublish(#[from] BillingPublishError),
     #[error("Error blocking on job: {0}")]
     BlockingJob(#[from] BlockingJobError),
+    #[error("change set error: {0}")]
+    ChangeSet(#[from] ChangeSetError),
     #[error("component error: {0}")]
     Component(#[from] ComponentError),
     #[error("component {0} is destroyed")]


### PR DESCRIPTION
If it's a DVU job, we need to remove the roots so it's not enqueued again.

I will follow up with an integration test for this if it works but want to get this into Tools ASAP.

<div><img src="https://media4.giphy.com/media/iPRnsx9RzW5e0oQOsJ/200.gif?cid=5a38a5a28nv6j19pbb01ya35eur1f4ual80vlv7guhopptre&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:168px;width:300px"/><br/>via <a href="https://giphy.com/AppleTV/">Apple TV</a> on <a href="https://giphy.com/gifs/AppleTV-apple-tv-app-iPRnsx9RzW5e0oQOsJ">GIPHY</a></div>