### PR TITLE
Fix: we need to replace `currentRoute` in the router store as we push & replace new routes, not wait for "beforeResolve"

### DIFF
--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -214,8 +214,8 @@ onBeforeMount(async () => {
     assetStore.LOAD_SCHEMA_VARIANT_LIST(),
   ]);
   let viewId;
-  if (routeStore.currentRoute?.params.viewId)
-    viewId = routeStore.currentRoute?.params.viewId as string;
+  if (routeStore.currentRoute?.params?.viewId)
+    viewId = routeStore.currentRoute.params.viewId as string;
 
   await Promise.all([
     viewStore.FETCH_VIEW(viewId), // draws the minimal diagram, later gets all geometry and component

--- a/app/web/src/pages/WorkspaceSinglePage.vue
+++ b/app/web/src/pages/WorkspaceSinglePage.vue
@@ -196,13 +196,13 @@ function handleUrlChange() {
     const newChangeSetId =
       id === false || id === changeSetsStore.headChangeSetId ? "head" : id;
 
-    const viewId = routerStore.currentRoute?.params.viewId as
+    const viewId = routerStore.currentRoute?.params?.viewId as
       | string
       | undefined;
     if (viewId) {
       const viewStore = useViewsStore(newChangeSetId);
       if (!viewStore.viewsById[viewId]) {
-        delete routerStore.currentRoute?.params.viewId;
+        delete routerStore.currentRoute?.params?.viewId;
         const defaultView =
           viewStore.viewList.find((v) => v.id === viewId) ||
           viewStore.viewList[0];

--- a/app/web/src/store/router.store.ts
+++ b/app/web/src/store/router.store.ts
@@ -1,6 +1,9 @@
 import { defineStore } from "pinia";
 import * as _ from "lodash-es";
-import { RouteLocationNormalizedLoaded, RouteLocationRaw } from "vue-router";
+import {
+  RouteLocationNormalizedLoaded,
+  RouteLocationAsRelativeGeneric,
+} from "vue-router";
 import router from "@/router";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
 
@@ -17,24 +20,31 @@ import { ChangeSetId } from "@/api/sdf/dal/change_set";
  */
 export const useRouterStore = defineStore("router", {
   state: () => ({
-    currentRoute: null as RouteLocationNormalizedLoaded | null,
+    currentRoute: null as
+      | RouteLocationNormalizedLoaded
+      | RouteLocationAsRelativeGeneric
+      | null,
   }),
   actions: {
     replace(
       originChangeSetId: ChangeSetId | undefined,
-      location: RouteLocationRaw,
+      location: RouteLocationAsRelativeGeneric,
     ) {
       // if you're not operating on the same change set we are viewing, you can't change the router/URL
-      if (this.currentRoute?.params.changeSetId === originChangeSetId)
+      if (this.currentRoute?.params?.changeSetId === originChangeSetId) {
         router.replace(location);
+        this.currentRoute = location;
+      }
     },
     push(
       originChangeSetId: ChangeSetId | undefined,
-      location: RouteLocationRaw,
+      location: RouteLocationAsRelativeGeneric,
     ) {
       // if you're not operating on the same change set we are viewing, you can't change the router/URL
-      if (this.currentRoute?.params.changeSetId === originChangeSetId)
-        router.replace(location);
+      if (this.currentRoute?.params?.changeSetId === originChangeSetId) {
+        router.push(location);
+        this.currentRoute = location;
+      }
     },
   },
 });

--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -798,7 +798,7 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
                 route?.name === "workspace-compose-view"
               ) {
                 const params = { ...route.params };
-                delete params.viewId;
+                if ("viewId" in params) delete params.viewId;
                 routerStore.push(changeSetId, {
                   name: "workspace-compose",
                   params,


### PR DESCRIPTION
And that required some type updates and making tsc happy

The symptoms were:

- if you were switching between two views, the URL would not change
- if you were switching view 1, 2, 3, the URL would not update until the 3rd change, every time

Testing plan:

1. Switch between views and make sure that every time the URL changes