### PR TITLE
feat(clover): allow for schema-specific overrides

### DIFF
--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -15,6 +15,7 @@ import { updateSchemaIdsForExistingSpecs } from "../pipeline-steps/updateSchemaI
 import { getExistingSpecs } from "../specUpdates.ts";
 
 import _logger from "../logger.ts";
+import { assetSpecificOverrides } from "../pipeline-steps/assetSpecificOverrides.ts";
 
 const logger = _logger.ns("siSpecs").seal();
 const SI_SPEC_DIR = "si-specs";
@@ -49,10 +50,12 @@ export async function generateSiSpecs() {
   specs = generateDefaultActionFuncs(specs);
   specs = generateDefaultLeafFuncs(specs);
   specs = generateDefaultManagementFuncs(specs);
+  specs = assetSpecificOverrides(specs);
   // subAssets should not have any of the above, but need an asset func and
   // intrinsics
   specs = generateSubAssets(specs);
   specs = generateIntrinsicFuncs(specs);
+  // don't generate input sockets until we have all of the output sockets
   specs = createInputSocketsBasedOnOutputSockets(specs);
   specs = generateAssetFuncs(specs);
   specs = updateSchemaIdsForExistingSpecs(existing_specs, specs);

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -1,0 +1,54 @@
+import { PkgSpec } from "../bindings/PkgSpec.ts";
+import _ from "npm:lodash";
+import { ExpandedPropSpec } from "../spec/props.ts";
+import _logger from "../logger.ts";
+import { createInputSocketFromProp } from "../spec/sockets.ts";
+
+const logger = _logger.ns("assetOverrides").seal();
+
+export function assetSpecificOverrides(incomingSpecs: PkgSpec[]): PkgSpec[] {
+  const newSpecs = [] as PkgSpec[];
+
+  for (const spec of incomingSpecs) {
+    if (overrides.has(spec.name)) {
+      logger.debug(`Running override for ${spec.name}`);
+      overrides.get(spec.name)?.(spec);
+    }
+    newSpecs.push(spec);
+  }
+
+  return newSpecs;
+}
+
+type OverrideFn = (spec: PkgSpec) => void;
+
+const overrides = new Map<string, OverrideFn>([
+  ["AWS::EC2::Route", (spec: PkgSpec) => {
+    addGatewayIdSocketToEC2Route(spec);
+  }],
+]);
+
+function addGatewayIdSocketToEC2Route(spec: PkgSpec) {
+  const schema = spec.schemas[0];
+  const variant = spec.schemas[0].variants[0];
+  const domain = variant.domain;
+
+  if (!schema || !variant || !domain || domain.kind !== "object") {
+    throw new Error(`Unable to run override for ${spec.name}`);
+  }
+  for (const prop of domain.entries) {
+    if (prop.name === "GatewayId") {
+      const socket = createInputSocketFromProp(prop as ExpandedPropSpec, "one");
+
+      const data = socket.data;
+      if (data) {
+        const annotation = JSON.parse(data.connectionAnnotations);
+        annotation.push({ tokens: ["InternetGatewayId"] });
+        annotation.push({ tokens: ["VPNGatewayId"] });
+        data.connectionAnnotations = JSON.stringify(annotation);
+      }
+
+      variant.sockets.push(socket);
+    }
+  }
+}

--- a/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
@@ -119,10 +119,22 @@ function generateAssetCodeFromVariantSpec(variant: SchemaVariantSpec): string {
 
       const varName = `${socket.name}Socket`.replace(" ", "");
 
+      type AnnotationItem = {
+        tokens: string[];
+      };
+      const annotations = JSON.parse(
+        data.connectionAnnotations,
+      ) as AnnotationItem[];
+
       socketDeclarations +=
         `${indent(1)}const ${varName} = new SocketDefinitionBuilder()\n` +
         `${indent(2)}.setName("${socket.name}")\n` +
         `${indent(2)}.setArity("${data.arity}")\n` +
+        annotations.map((item: AnnotationItem) =>
+          `${indent(2)}.setConnectionAnnotation("${item.tokens.join("<")}${
+            ">".repeat(item.tokens.length - 1)
+          }")`
+        ).join("\n") + "\n" +
         `${indent(2)}.build();\n\n`;
 
       switch (data.kind) {


### PR DESCRIPTION
Adds the capability to do per-schema overrides for special cases. 

EC2 Routes need a `GatewayId`, but it could be either a `VPNGatewayId` of `InternetGatewayId`.

Also adds generating connection annotations in the asset builder func

![image](https://github.com/user-attachments/assets/9908762d-f861-4408-8209-c4c927ab1944)


```typescript
    const GatewayIdSocket = new SocketDefinitionBuilder()
        .setName("GatewayId")
        .setArity("one")
        .setConnectionAnnotation("GatewayId")
        .setConnectionAnnotation("test<InternetGatewayId>")
        .setConnectionAnnotation("test<cats<VPNGatewayId>>")
        .setConnectionAnnotation("VPNGatewayId")
        .build();
```