### PR TITLE
feat: remove tests from the deploy on main cron

### DIFF
--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -114,6 +114,7 @@ jobs:
     secrets: inherit
 
   sleep-between:
+    if: ${{ inputs.environment != 'tools' }}
     name: Wait for 10 minutes
     needs: upgrade-and-migrate-sdf
     runs-on: ubuntu-latest
@@ -121,16 +122,18 @@ jobs:
       - name: Sleep for 10 minutes
         run: sleep 600
 
-  # e2e-validation:
-  #   needs:
-  #     - upgrade-web
-  #     - sleep-between
-  #   uses: ./.github/workflows/e2e-validation.yml
-  #   with:
-  #     environment: ${{ inputs.environment }}
-  #   secrets: inherit
+  e2e-validation:
+    if: ${{ inputs.environment != 'tools' }}
+    needs:
+      - upgrade-web
+      - sleep-between
+    uses: ./.github/workflows/e2e-validation.yml
+    with:
+      environment: ${{ inputs.environment }}
+    secrets: inherit
 
   api-test:
+    if: ${{ inputs.environment != 'tools' }}
     needs:
       - upgrade-web
       - sleep-between

--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: define-test-matrix
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         tests: ${{ fromJSON(needs.define-test-matrix.outputs.tests) }}
     steps:
@@ -59,11 +59,11 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Install Cypress
+      - name: Install Deps
         working-directory: app/web
         run: |
           pnpm i
-          pnpm install cypress
+          npx cypress install
 
       - name: install uuid
         run: |

--- a/.github/workflows/prod-test-cron.yml
+++ b/.github/workflows/prod-test-cron.yml
@@ -15,11 +15,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # e2e-validation:
-  #   uses: ./.github/workflows/e2e-validation.yml
-  #   with:
-  #     environment: production
-  #   secrets: inherit
+  e2e-validation:
+    uses: ./.github/workflows/e2e-validation.yml
+    with:
+      environment: production
+    secrets: inherit
   api-test:
     uses: ./.github/workflows/run-api-test.yml
     with:

--- a/.github/workflows/run-api-test.yml
+++ b/.github/workflows/run-api-test.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: define-test-matrix
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         tests: ${{ fromJSON(needs.define-test-matrix.outputs.tests) }}
     env:

--- a/.github/workflows/tools-test-cron.yml
+++ b/.github/workflows/tools-test-cron.yml
@@ -11,11 +11,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # e2e-validation:
-  #   uses: ./.github/workflows/e2e-validation.yml
-  #   with:
-  #     environment: tools
-  #   secrets: inherit
+  e2e-validation:
+    uses: ./.github/workflows/e2e-validation.yml
+    with:
+      environment: tools
+    secrets: inherit
   api-test:
     uses: ./.github/workflows/run-api-test.yml
     with:


### PR DESCRIPTION
- Only test if we're deploying to prod. The Cron for tools will catch any issues post-merge anyway. This should allow us to ship to tools faster and prevent unnecessary queueing
- Re-enable the cypress tests and fix the binary issue there
- Change the test failure strategy to fail_fast, i.e. if literally any subtask fails, immediately fail and page/alert

