### PR TITLE
feat(mgmt): Allow management functions to connect their input to their progeny

### DIFF
--- a/lib/cyclone-client/src/client.rs
+++ b/lib/cyclone-client/src/client.rs
@@ -450,7 +450,7 @@ mod tests {
     use cyclone_core::{
         ActionRunRequest, ComponentKind, ComponentView, ComponentViewWithGeometry, FunctionResult,
         ManagementRequest, ProgressMessage, ResolverFunctionComponent, ResolverFunctionRequest,
-        SchemaVariantDefinitionRequest, ValidationRequest,
+        SchemaVariantDefinitionRequest, ThisComponent, ValidationRequest,
     };
     use cyclone_server::{Config, ConfigBuilder, Runnable as _, Server};
     use futures::StreamExt;
@@ -1376,10 +1376,13 @@ mod tests {
             execution_id: "1234".to_string(),
             handler: "manage".to_string(),
             current_view: "DEFAULT".to_string(),
-            this_component: ComponentViewWithGeometry {
-                kind: None,
-                properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),
-                geometry: serde_json::json!({"x": "1", "y": "2"}),
+            this_component: ThisComponent {
+                component: ComponentViewWithGeometry {
+                    kind: None,
+                    properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),
+                    geometry: serde_json::json!({"x": "1", "y": "2"}),
+                },
+                incoming_connections: serde_json::json!({}),
             },
             components: HashMap::new(),
             variant_socket_map: HashMap::new(),
@@ -1468,10 +1471,13 @@ mod tests {
             execution_id: "1234".to_string(),
             handler: "manage".to_string(),
             current_view: "DEFAULT".to_string(),
-            this_component: ComponentViewWithGeometry {
-                kind: None,
-                properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),
-                geometry: serde_json::json!({"x": "1", "y": "2"}),
+            this_component: ThisComponent {
+                component: ComponentViewWithGeometry {
+                    kind: None,
+                    properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),
+                    geometry: serde_json::json!({"x": "1", "y": "2"}),
+                },
+                incoming_connections: serde_json::json!({}),
             },
             components: HashMap::new(),
             variant_socket_map: HashMap::new(),

--- a/lib/cyclone-core/src/component_view.rs
+++ b/lib/cyclone-core/src/component_view.rs
@@ -49,3 +49,21 @@ impl Default for ComponentViewWithGeometry {
         }
     }
 }
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct ThisComponent {
+    #[serde(flatten)]
+    pub component: ComponentViewWithGeometry,
+    pub incoming_connections: Value,
+}
+
+impl Default for ThisComponent {
+    fn default() -> Self {
+        Self {
+            component: Default::default(),
+            incoming_connections: serde_json::json!({}),
+        }
+    }
+}

--- a/lib/cyclone-core/src/lib.rs
+++ b/lib/cyclone-core/src/lib.rs
@@ -32,7 +32,7 @@ pub use si_crypto::SensitiveStrings;
 pub use action_run::{ActionRunRequest, ActionRunResultSuccess, ResourceStatus};
 pub use before::BeforeFunction;
 pub use canonical_command::{CanonicalCommand, CanonicalCommandError};
-pub use component_view::{ComponentKind, ComponentView, ComponentViewWithGeometry};
+pub use component_view::{ComponentKind, ComponentView, ComponentViewWithGeometry, ThisComponent};
 pub use kill_execution::KillExecutionRequest;
 pub use liveness::{LivenessStatus, LivenessStatusParseError};
 pub use management::{ManagementFuncStatus, ManagementRequest, ManagementResultSuccess};

--- a/lib/cyclone-core/src/management.rs
+++ b/lib/cyclone-core/src/management.rs
@@ -4,7 +4,10 @@ use serde::{Deserialize, Serialize};
 use telemetry::prelude::*;
 use telemetry_utils::metric;
 
-use crate::{component_view::ComponentViewWithGeometry, BeforeFunction, CycloneRequestable};
+use crate::{
+    component_view::{ComponentViewWithGeometry, ThisComponent},
+    BeforeFunction, CycloneRequestable,
+};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -13,7 +16,7 @@ pub struct ManagementRequest {
     pub handler: String,
     pub code_base64: String,
     pub current_view: String,
-    pub this_component: ComponentViewWithGeometry,
+    pub this_component: ThisComponent,
     pub components: HashMap<String, ComponentViewWithGeometry>,
     pub variant_socket_map: HashMap<String, usize>,
     pub before: Vec<BeforeFunction>,

--- a/lib/dal/src/func/backend/management.rs
+++ b/lib/dal/src/func/backend/management.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use veritech_client::{
     BeforeFunction, ComponentViewWithGeometry, FunctionResult, ManagementRequest,
-    ManagementResultSuccess,
+    ManagementResultSuccess, ThisComponent,
 };
 
 use crate::func::backend::{FuncBackendResult, FuncDispatch, FuncDispatchContext};
@@ -13,7 +13,7 @@ use super::ExtractPayload;
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct FuncBackendManagementArgs {
-    this_component: ComponentViewWithGeometry,
+    this_component: ThisComponent,
     components: HashMap<String, ComponentViewWithGeometry>,
     current_view: String,
     variant_socket_map: HashMap<String, usize>,

--- a/lib/dal/src/func/binding/management.rs
+++ b/lib/dal/src/func/binding/management.rs
@@ -5,7 +5,7 @@ use telemetry::prelude::*;
 
 use crate::{
     management::prototype::{ManagementPrototype, ManagementPrototypeId},
-    DalContext, Func, FuncId, Prop, Schema, SchemaId, SchemaVariant, SchemaVariantId,
+    DalContext, Func, FuncId, Prop, Schema, SchemaId, SchemaVariant, SchemaVariantId, SocketArity,
 };
 
 use super::{EventualParent, FuncBinding, FuncBindingResult};
@@ -18,6 +18,11 @@ pub struct ManagementBinding {
     pub func_id: FuncId,
     pub managed_schemas: Option<Vec<SchemaId>>,
 }
+
+const INCOMING_CONNECTION_TYPE: &str = "{ component: string, socket: string; value: any }";
+const DEFAULT_THIS_COMPONENT_IFACE: &str = "object";
+const DEFAULT_THIS_INCOMING_CONNECTIONS: &str = "object";
+const DEFAULT_COMPONENT_TYPES: &str = "object";
 
 impl ManagementBinding {
     #[instrument(
@@ -52,46 +57,47 @@ impl ManagementBinding {
         ctx: &DalContext,
         func_id: FuncId,
     ) -> FuncBindingResult<String> {
-        let default_this_component = "object".to_string();
-        let default_component_types = "object".to_string();
         let default_types = (
-            default_this_component,
-            default_component_types.to_owned(),
-            default_component_types.to_owned(),
+            DEFAULT_THIS_COMPONENT_IFACE.to_owned(),
+            DEFAULT_THIS_INCOMING_CONNECTIONS.to_owned(),
+            DEFAULT_COMPONENT_TYPES.to_owned(),
+            DEFAULT_COMPONENT_TYPES.to_owned(),
         );
 
-        let (this_component_iface, component_create_type, component_input_type) =
-            match ManagementPrototype::prototype_id_for_func_id(ctx, func_id).await? {
-                Some(prototype_id) => {
-                    match ManagementPrototype::get_by_id(ctx, prototype_id).await? {
-                        Some(prototype) => {
-                            let variant_id =
-                                ManagementPrototype::get_schema_variant_id(ctx, prototype_id)
-                                    .await?;
-                            let root_prop = Prop::get_by_id(
-                                ctx,
-                                SchemaVariant::get_root_prop_id(ctx, variant_id).await?,
-                            )
-                            .await?;
+        let (
+            this_component_iface,
+            this_incoming_connections,
+            component_create_type,
+            component_input_type,
+        ) = match ManagementPrototype::prototype_id_for_func_id(ctx, func_id).await? {
+            Some(prototype_id) => match ManagementPrototype::get_by_id(ctx, prototype_id).await? {
+                Some(prototype) => {
+                    let variant_id =
+                        ManagementPrototype::get_schema_variant_id(ctx, prototype_id).await?;
+                    let root_prop = Prop::get_by_id(
+                        ctx,
+                        SchemaVariant::get_root_prop_id(ctx, variant_id).await?,
+                    )
+                    .await?;
 
-                            let (_, reverse_map) = prototype.managed_schemas_map(ctx).await?;
+                    let (_, reverse_map) = prototype.managed_schemas_map(ctx).await?;
 
-                            let mut component_create_types = vec![];
-                            let mut component_update_types = vec![];
-                            for (schema_id, name) in reverse_map {
-                                let variant_id =
-                                    Schema::get_or_install_default_variant(ctx, schema_id).await?;
+                    let mut component_create_types = vec![];
+                    let mut component_update_types = vec![];
+                    for (schema_id, name) in reverse_map {
+                        let variant_id =
+                            Schema::get_or_install_default_variant(ctx, schema_id).await?;
 
-                                let root_prop = Prop::get_by_id(
-                                    ctx,
-                                    SchemaVariant::get_root_prop_id(ctx, variant_id).await?,
-                                )
-                                .await?;
+                        let root_prop = Prop::get_by_id(
+                            ctx,
+                            SchemaVariant::get_root_prop_id(ctx, variant_id).await?,
+                        )
+                        .await?;
 
-                                let sv_type = root_prop.ts_type(ctx).await?;
+                        let sv_type = root_prop.ts_type(ctx).await?;
 
-                                let component_update_type = format!(
-                                    r#"
+                        let component_update_type = format!(
+                            r#"
                                 {{
                                     kind: "{name}",
                                     properties?: {sv_type},
@@ -106,43 +112,51 @@ impl ManagementBinding {
                                     parent?: string,
                                 }}
                                 "#
-                                );
+                        );
 
-                                let component_create_type = format!(
-                                    r#"
+                        let component_create_type = format!(
+                            r#"
                                 {{
                                     kind?: "{name}",
                                     properties?: {sv_type},
                                     geometry?: Geometry | {{ [key: string]: Geometry }},
-                                    connect?: {{
-                                        from: string,
-                                        to: {{
-                                            component: string;
-                                            socket: string;
-                                        }}
-                                    }}[],
+                                    connect?: Connection[],
                                     parent?: string,
                                 }}
                                 "#
-                                );
-                                component_create_types.push(component_create_type);
-                                component_update_types.push(component_update_type);
-                            }
-
-                            let component_create_type = component_create_types.join("|\n");
-                            let component_input_type = component_update_types.join("|\n");
-
-                            (
-                                root_prop.ts_type(ctx).await?,
-                                component_create_type,
-                                component_input_type,
-                            )
-                        }
-                        None => default_types,
+                        );
+                        component_create_types.push(component_create_type);
+                        component_update_types.push(component_update_type);
                     }
+
+                    let component_create_type = component_create_types.join("|\n");
+                    let component_input_type = component_update_types.join("|\n");
+
+                    let mut this_incoming_connections = "    {\n".to_string();
+                    let this_component_iface = root_prop.ts_type(ctx).await?;
+                    for input_socket in SchemaVariant::list_all_sockets(ctx, variant_id).await?.1 {
+                        let name = input_socket.name();
+                        let type_qualifier = match input_socket.arity() {
+                            SocketArity::One => " | undefined",
+                            SocketArity::Many => "[]",
+                        };
+                        this_incoming_connections.push_str(&format!(
+                            "      {name}: {INCOMING_CONNECTION_TYPE}{type_qualifier},\n"
+                        ));
+                    }
+                    this_incoming_connections.push_str("    }\n");
+
+                    (
+                        this_component_iface,
+                        this_incoming_connections,
+                        component_create_type,
+                        component_input_type,
+                    )
                 }
                 None => default_types,
-            };
+            },
+            None => default_types,
+        };
 
         Ok(format!(
             r#"
@@ -152,6 +166,21 @@ type Geometry = {{
     width?: number,
     height?: number,
 }};
+type Connection =
+    | {{
+        from: string,
+        to: {{
+            component: string,
+            socket: string,
+        }},
+    }}
+    | {{
+        from: {{
+            component: string,
+            socket: string,
+        }},
+        to: string,
+    }};
 type Output = {{
   status: 'ok' | 'error';
   ops?: {{
@@ -161,8 +190,8 @@ type Output = {{
         properties?: {{ [key: string]: unknown }}, 
         geometry?: {{ [key: string]: Geometry }}, 
         connect?: {{
-            add?: {{ from: string, to: {{ component: string; socket: string; }} }}[],
-            remove?: {{ from: string, to: {{ component: string; socket: string; }} }}[],
+            add?: Connection[],
+            remove?: Connection[],
         }},
         parent?: string,
     }} }},
@@ -177,13 +206,14 @@ type Output = {{
   message?: string | null;
 }};
 type Input = {{
-   currentView: string, 
-    thisComponent: {{
-        properties: {this_component_iface},
-        geometry: {{ [key: string]: Geometry }},
-    }},
-    components: {{ [key: string]: {component_input_type} }},
-    variantSocketMap: Record<string, number>,
+  currentView: string, 
+  thisComponent: {{
+    properties: {this_component_iface},
+    geometry: {{ [key: string]: Geometry }},
+    incomingConnections: {this_incoming_connections},
+  }},
+  components: {{ [key: string]: {component_input_type} }},
+  variantSocketMap: Record<string, number>,
 }};"#
         ))
     }

--- a/lib/dal/src/management/generator.rs
+++ b/lib/dal/src/management/generator.rs
@@ -4,8 +4,8 @@ use si_frontend_types::RawGeometry;
 use si_id::{ComponentId, SchemaId, ViewId};
 
 use crate::management::{
-    ConnectionIdentifier, ManagementConnection, ManagementCreateGeometry,
-    ManagementCreateOperation, ManagementGeometry, IGNORE_PATHS,
+    ManagementConnection, ManagementCreateGeometry, ManagementCreateOperation, ManagementGeometry,
+    SocketRef, IGNORE_PATHS,
 };
 use crate::prop::PropPath;
 use crate::{AttributeValue, Component, DalContext, InputSocket, OutputSocket, Prop, PropKind};
@@ -146,9 +146,9 @@ pub async fn generate_template(
                 if let Some(to_placeholder) =
                     placeholders_by_component_id.get(&conn.to_component_id)
                 {
-                    connections.push(ManagementConnection {
+                    connections.push(ManagementConnection::Output {
                         from: conn.from_socket_name,
-                        to: ConnectionIdentifier {
+                        to: SocketRef {
                             component: to_placeholder.to_owned(),
                             socket: conn.to_socket_name,
                         },

--- a/lib/veritech-client/src/lib.rs
+++ b/lib/veritech-client/src/lib.rs
@@ -20,7 +20,7 @@ pub use cyclone_core::{
     ManagementResultSuccess, OutputStream, ResolverFunctionComponent, ResolverFunctionRequest,
     ResolverFunctionResponseType, ResolverFunctionResultSuccess, ResourceStatus,
     SchemaVariantDefinitionRequest, SchemaVariantDefinitionResultSuccess, SensitiveContainer,
-    ValidationRequest, ValidationResultSuccess,
+    ThisComponent, ValidationRequest, ValidationResultSuccess,
 };
 pub use veritech_core::{encrypt_value_tree, VeritechValueEncryptError};
 

--- a/lib/veritech-client/tests/integration.rs
+++ b/lib/veritech-client/tests/integration.rs
@@ -5,7 +5,7 @@ use cyclone_core::{
     ActionRunRequest, ComponentKind, ComponentView, ComponentViewWithGeometry, FunctionResult,
     FunctionResultFailureErrorKind, ManagementRequest, ResolverFunctionComponent,
     ResolverFunctionRequest, ResolverFunctionResponseType, ResourceStatus,
-    SchemaVariantDefinitionRequest, ValidationRequest,
+    SchemaVariantDefinitionRequest, ThisComponent, ValidationRequest,
 };
 use si_data_nats::{NatsClient, NatsConfig};
 use test_log::test;
@@ -106,10 +106,13 @@ async fn executes_simple_management_function() {
         execution_id: "1234".to_string(),
         handler: "numberOfInputs".to_string(),
         current_view: "DEFAULT".to_string(),
-        this_component: ComponentViewWithGeometry {
-            kind: None,
-            properties: serde_json::json!({ "foo": "bar", "baz": "quux", "bar": "foo" }),
-            geometry: serde_json::json!({"x": "1", "y": "1"}),
+        this_component: ThisComponent {
+            component: ComponentViewWithGeometry {
+                kind: None,
+                properties: serde_json::json!({ "foo": "bar", "baz": "quux", "bar": "foo" }),
+                geometry: serde_json::json!({"x": "1", "y": "1"}),
+            },
+            incoming_connections: serde_json::json!({}),
         },
         components: HashMap::new(),
         variant_socket_map: HashMap::new(),

--- a/lib/veritech-core/src/lib.rs
+++ b/lib/veritech-core/src/lib.rs
@@ -153,7 +153,7 @@ impl GetNatsSubjectFor for ValidationRequest {
 pub enum VeritechRequest {
     ActionRun(ActionRunRequest),
     KillExecution(KillExecutionRequest),
-    Management(ManagementRequest),
+    Management(Box<ManagementRequest>),
     Resolver(ResolverFunctionRequest), // Resolvers are JsAttribute functions
     SchemaVariantDefinition(SchemaVariantDefinitionRequest),
     Validation(ValidationRequest),
@@ -180,7 +180,7 @@ impl VeritechRequest {
                 Self::KillExecution(serde_json::from_slice(payload)?)
             }
             NATS_MANAGEMENT_DEFAULT_SUBJECT_SUFFIX => {
-                Self::Management(serde_json::from_slice(payload)?)
+                Self::Management(Box::new(serde_json::from_slice(payload)?))
             }
             NATS_RESOLVER_FUNCTION_DEFAULT_SUBJECT_SUFFIX => {
                 Self::Resolver(serde_json::from_slice(payload)?)

--- a/lib/veritech-server/src/handlers.rs
+++ b/lib/veritech-server/src/handlers.rs
@@ -138,7 +138,7 @@ pub async fn process_request(
             dispatch_request(state, request, reply_subject).await?
         }
         VeritechRequest::Management(request) => {
-            dispatch_request(state, request, reply_subject).await?
+            dispatch_request(state, *request, reply_subject).await?
         }
         VeritechRequest::Resolver(request) => {
             dispatch_request(state, request, reply_subject).await?


### PR DESCRIPTION
This allows your management function to pass on its input connections to any components it creates or manages. It adds three basic functionalities to achieve this:

1. **Reading your input sockets:** `thisComponent` now has a new `incomingConnections` property, containing all incoming connections for each input socket, with `component` and `socket` for each one.
2. **Connecting input sockets:** `ops.create.<component>.connect` now supports input sockets in addition to output sockets (just specify `{ from: { component, socket }, to: string }`). (`ops.update.<component>.connect.add/remove` support this as well.)
3. **Connecting to non-managed components:** You can now connect sockets to arbitrary components by component ID. If `component` is set to a ULID, it will connect to that component (managed and created components are still supported).

![image](https://github.com/user-attachments/assets/2d454f69-1de7-4928-ac05-da1fe493a423)

## Example

This management function creates a VPC and connects its "AWS Credentials" and Region inputs to the same ones hooked up to the management component itself:

```ts
async function main({ thisComponent: Input): Promise<Output> {
    return {
        status: "ok",
        ops: {
            create: {
                MyVpc: {
                    kind: "VPC",
                    connect: [
                        {
                            from: thisComponent.incomingConnections["AWS Credential"],
                            to: "AWS Credential",
                        },
                        {
                            from: thisComponent.incomingConnections.Region,
                            to: "Region",
                        },
                    ]
                }
            }
        }
    }
}
```

## For Later

There are some things we could do to make this easier to use in another turn:

* **Support undefined/array in from:** The recommended pattern for single-arity sockets like Region is to just shove Region into `ops.create.connect[].from` like in the example. However, if the user does not hook up the socket, the error message is confusing (can't deserialize undefined). We should make connect treat `from: undefined` as "don't connect anything here" so the user doesn't have to. We should also let it support `from: <array>`, so you can directly shove arity-many sockets in here and have that work too.
* **Pass output socket connections:** Output sockets, while less useful, seem perfectly doable here and probably should happen for parity.
* **Mirror incomingConnections on create:** If we allowed you to specify `incomingConnections: { <socket>: { component; socket } }` on ops.create[] instead of just `connect`, it would improve the experience:
  - It would let you write `incomingConnections: { Region }` instead of `connect: [ { from: Region, to: "Region" } ]`.
  - Components with all the same input sockets (very common) could write `{ incomingConnections }` instead of `{ connect: [ { from: Region, to: "Region" }, { from: AWSCredential, to: "AWS Credential" } ] }`.
  - If we then allowed incomingConnections to ignore extra sockets, you could use incomingConnections even more places.
* **inferred:** We should pass inferred connections, but add `inferred: true` so that you can decide whether to connect based on that or not.
* **Error case:** When you have two connections to a socket with arity="one", we pass you the first one instead of telling you there is an error.
* **Name bikeshed:** `connections.input` might work better for this (incoming is a mouthful to say and type; less capitals is nice; it gives an obvious place to hang output connections). `sockets.input` maybe too.

## Testing

This still needs regression tests, but we'd like to get this up quickly for John (I'll fast follow today). What I've tested:

1. Check that we get the right incomingConnections:
   - For 0, 1, N connections
   - For arity: one and arity: many
   - Inferred connections
   - Error message if there are multiple connections and arity: one
   - Right value for connections with secrets, strings, object and array typed data
2. Check that we can create and remove connections from ops.reate.connect and ops.update.connect.add/remove:
   - Referencing existing managed components
   - Referencing other components being added in ops.create
   - Referencing external component ids
   - Referencing sockets whose names are different than the other side of the connection
