### PR TITLE
feat(module-index, hoist): rate limiting and parallelization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,7 @@ reqwest = { version = "0.12.9", default-features = false, features = [
 ring = "=0.17.5" # Upgrading this is possible, but a pain, so we don't want to pick up every new minor version (see: https://github.com/facebook/buck2/commit/91af40b66960d003067c3d241595fb53d1e636c8)
 rust-s3 = { version = "0.34.0-rc4", default-features = false, features = [
     "tokio-rustls-tls",
+    "fail-on-err"
 ] }
 rustls = { version = "0.23.19", default-features = false } # NOTE(nick,fletcher): rustls switched to "aws-lc-rs" as its default crypto provider, but we want ring (i.e. we disable the default feature for "aws-lc-rs")
 rustls-native-certs = "0.8.1"

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -14284,6 +14284,7 @@ cargo.rust_library(
     crate_root = "rust-s3-61c54947c717d042/s3/src/lib.rs",
     edition = "2018",
     features = [
+        "fail-on-err",
         "futures",
         "hyper",
         "hyper-rustls",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -134,6 +134,7 @@ reqwest = { version = "0.12.9", default-features = false, features = [
 ring = "=0.17.5" # Upgrading this is possible, but a pain, so we don't want to pick up every new minor version (see: https://github.com/facebook/buck2/commit/91af40b66960d003067c3d241595fb53d1e636c8)
 rust-s3 = { version = "0.34.0-rc4", default-features = false, features = [
     "tokio-rustls-tls",
+    "fail-on-err"
 ] }
 rustls = { version = "0.23.19", default-features = false } # NOTE(nick,fletcher): rustls switched to "aws-lc-rs" as its default crypto provider, but we want ring (i.e. we disable the default feature for "aws-lc-rs")
 rustls-native-certs = "0.8.1"


### PR DESCRIPTION
Hoist:

* download and upload in threads to make it go _fast_

Module Index:

* add a rate limit configuration for requests to the module index to ensure we don't crush the database or S3 when doing mass uploads or downloads

Hoist downloads ~1800 packages from module index without knocking it over

```bash
❯ time buck2 run //bin/hoist:hoist -- --endpoint http://0.0.0.0:5157 write-all-specs -o .pkgs
File changed: root//.pkgs/AWS::EC2::IPAMAllocation.json
File changed: root//.pkgs/AWS::IoT::ThingType.json
File changed: root//.pkgs/AWS::SageMaker::CodeRepository.json
1831 additional file change events
Build ID: 22ce2f63-447e-4158-a8f5-794ad1a85dbf
Network: Up: 0B  Down: 0B
Command: run.                                                                                                                                                           
Time elapsed: 0.0s
BUILD SUCCEEDED
  [▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸▸] 1838/1838 (0s)
✨ All downloads complete!                                                                                                                                               
buck2 run //bin/hoist:hoist -- --endpoint http://0.0.0.0:5157 write-all-specs  94.84s user 10.51s system 571% cpu 18.419 total
```

<img src="https://media4.giphy.com/media/yXVO50FJIJMSQ/giphy.gif"/>