### PR TITLE
BUG-769: ensure components that have been removed are removed from the store

### DIFF
--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -858,7 +858,9 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
               }
             },
             onSuccess: (response) => {
-              componentsStore.SET_COMPONENTS_FROM_VIEW(response.diagram);
+              componentsStore.SET_COMPONENTS_FROM_VIEW(response.diagram, {
+                representsAllComponents: false,
+              });
 
               // remove invalid component IDs from the selection
               const validComponentIds = _.intersection(


### PR DESCRIPTION
Components that don't have a delete action that runs or are erased suffer from this problem.

Testing steps:

1. In default view: create a cred with secret, region, choose a region, key pair, set a name and instance, connect to key pair.
2. Apply to HEAD, ensure that resources are created.
3. Create a second view
4. Add a VPC to that view, set the CIDR, parent it to the Region
5. Apply to HEAD, ensure that resources are created.
6. Create a changeset
7. Erase the VPC
8. Go back to the DEFAULT view
9. The VPC is still in the diagram outliner
10. Hit apply
11. The VPC leaves the diagram outliner (the fix)