### PR TITLE
BUG-768: only show child frames in the diagram outliner when an ancestor is in the view

### DIFF
--- a/app/web/src/components/DiagramOutline/DiagramOutlineNode.vue
+++ b/app/web/src/components/DiagramOutline/DiagramOutlineNode.vue
@@ -306,14 +306,32 @@ const inView = computed(() =>
   viewComponentIds.value.includes(props.component.def.id),
 );
 
+const allChildren = (component: DiagramGroupData): ComponentId[] => {
+  const ids: ComponentId[] = [];
+  component.def.childIds?.forEach((id) => {
+    ids.push(id);
+    const c = componentsStore.allComponentsById[id];
+    if (c) ids.push(...allChildren(c));
+  });
+  return ids;
+};
+
 // show child frames not in view, but not components
 const childComponents = computed(() => {
   const children =
     componentsStore.componentsByParentId[props.component.def.id] || [];
   return children.filter((c) => {
-    if (!c.def.isGroup && !viewComponentIds.value.includes(c.def.id))
-      return false;
-    return true;
+    if (viewComponentIds.value.includes(c.def.id)) {
+      return true;
+    } else {
+      if (!c.def.isGroup) return false;
+      else {
+        const childIds = allChildren(c);
+        if (childIds.some((id) => viewComponentIds.value.includes(id)))
+          return true;
+        return false;
+      }
+    }
   });
 });
 


### PR DESCRIPTION
Currently the diagram outliner shows all ancestors that are frames even if they are not in the current view. Thats not the intention.

Testing steps, easier to use pictures, but the basic setup is:
![image](https://github.com/user-attachments/assets/f2c96adb-1f4c-41dd-b798-d9f7435d8ba4)
![image](https://github.com/user-attachments/assets/fd240e5c-4886-4a10-8418-6abf16fc05b8)

- have a child of region (VPC outside frame) in TEST that has **no children** in DEFAULT... it should not show in DEFAULT outliner (primary bug)
- have children of region (generic frame, VPC inside frame) in TEST that **have** children in DEFAULT (key pair, ec2 instance)... it should show in DEFAULT outliner (this _was_ working, but needed to make sure the fix to above didn't break this)
- make sure that everything else in both views looks right/didn't break (e.g. root components, frames with no children)