### PR TITLE
feat: add catch in converge for non-unique si-names of components

### DIFF
--- a/lib/sdf-server/src/service/v2/management/generate_template.rs
+++ b/lib/sdf-server/src/service/v2/management/generate_template.rs
@@ -176,6 +176,17 @@ pub async fn generate_template(
     }
     component_sync_code.push_str(
         r#"
+
+    // Check for duplicate si names in the abscene of component idempotency keys
+    const seenNames = new Set<string>();
+    for (const spec of specs) {
+        const name = _.get(spec, ["properties", "si", "name"]);
+        if (seenNames.has(name)) {
+            throw new Error(`Duplicate properties.si.name found: "${name}", please regenerate the template after fixing the duplicate names or modify the id references in the management function`);
+        }
+        seenNames.add(name);
+    }
+
     return template.converge(currentView, thisComponent, components, specs);
 }
 "#,


### PR DESCRIPTION
In the generated template function, check if the SI name's of the components are unique, to avoid a bit of a messy user experience if this isn't the case.

I tried to put this in the converge function, but it didn't seem right as the complexity is more hidden to the user. At least with this they can read the code that ensures uniqueness and what it's running the check against.

This is a bit of a patch/hotfix whilst we implement genuinely unique idempotency keys for each component.

it looks like this on failure of the condition:
[
![Screenshot 2025-01-30 at 23 55 47](https://github.com/user-attachments/assets/6e7094f5-8aee-4914-b4d5-b015b1a9eb62)
](url)