### PR TITLE
Fix: edge not selectable

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -786,13 +786,20 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                   )
                 : [];
 
-            this.rawEdgesById = _.keyBy(
-              [...edges, ...inferred, ...management],
-              "id",
-            );
-
-            Object.keys(this.rawEdgesById).forEach((edgeId) => {
-              this.processRawEdge(edgeId);
+            const edgesToSet = [...edges, ...inferred, ...management];
+            if (options.representsAllComponents) {
+              const existingIds = Object.keys(this.rawEdgesById);
+              const allIds = Object.keys(edgesToSet);
+              const idsToDelete = existingIds.filter(
+                (id) => !allIds.includes(id),
+              );
+              idsToDelete.forEach((id) => {
+                delete this.rawEdgesById[id];
+              });
+            }
+            edgesToSet.forEach((edge) => {
+              this.rawEdgesById[edge.id] = edge;
+              this.processRawEdge(edge.id);
             });
           },
 


### PR DESCRIPTION
Can't believe that assignment to rawEdgesById didn't get noticed and cleaned up. Adding the delete pattern we used above as well, just for posterity.

Testing steps:
- we found this during John's workshop steps.
- a views edges were clobbering edges already stored