### PR TITLE
Do not filter requirements by kind and other fixes

### DIFF
--- a/app/web/src/components/Actions/ActionCard.vue
+++ b/app/web/src/components/Actions/ActionCard.vue
@@ -4,7 +4,7 @@
       clsx(
         'flex flex-row items-center text-sm relative p-2xs min-w-0 w-full border border-transparent',
         !props.noInteraction
-          ? 'cursor-pointer hover:border-action-500 dark:hover:border-action-300'
+          ? 'cursor-pointer hover:border-action-500 dark:hover:border-action-300 group/actioncard'
           : '',
         selected
           ? 'dark:bg-action-900 bg-action-100 border-action-500 dark:border-action-300'
@@ -78,8 +78,12 @@
         <span
           :class="
             clsx(
-              'text-neutral-500 dark:text-neutral-400',
-              'dark:text-action-300 text-action-500',
+              themeClasses('text-neutral-700', 'text-neutral-200'),
+              !noInteraction &&
+                themeClasses(
+                  'group-hover/actioncard:text-action-500',
+                  'group-hover/actioncard:text-action-300',
+                ),
             )
           "
         >

--- a/app/web/src/components/ApplyChangeSetButton.vue
+++ b/app/web/src/components/ApplyChangeSetButton.vue
@@ -1,6 +1,6 @@
 <template>
   <VButton
-    v-if="!changeSetsStore.headSelected"
+    v-if="!changeSetsStore.headSelected && !disableApplyButton"
     ref="applyButtonRef"
     size="md"
     tone="success"
@@ -51,6 +51,7 @@ import { useChangeSetsStore } from "@/store/change_sets.store";
 import { useStatusStore } from "@/store/status.store";
 import { useActionsStore } from "@/store/actions.store";
 import ApprovalFlowModal from "./ApprovalFlowModal.vue";
+import { ChangeSetStatus } from "@/api/sdf/dal/change_set";
 
 const actionsStore = useActionsStore();
 const changeSetsStore = useChangeSetsStore();
@@ -68,6 +69,8 @@ const approvalFlowModalRef = ref<InstanceType<typeof ApprovalFlowModal> | null>(
 const openApprovalFlowModal = () => {
   approvalFlowModalRef.value?.open();
 };
+
+const disableApplyButton = computed(() => changeSetsStore.selectedChangeSet?.status !== ChangeSetStatus.Open);
 
 const statusStoreUpdating = computed(() => {
   if (statusStore.globalStatus) {

--- a/app/web/src/components/ApprovalFlowModal.vue
+++ b/app/web/src/components/ApprovalFlowModal.vue
@@ -50,7 +50,9 @@ import { useAuthStore } from "@/store/auth.store";
 import ApprovalFlowCancelled from "@/components/toasts/ApprovalFlowCancelled.vue";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import ActionsList from "./Actions/ActionsList.vue";
+import { usePresenceStore } from "@/store/presence.store";
 
+const presenceStore = usePresenceStore();
 const changeSetsStore = useChangeSetsStore();
 const authStore = useAuthStore();
 const featureFlagsStore = useFeatureFlagsStore();
@@ -92,6 +94,7 @@ function applyButtonHandler() {
       changeSetsStore.FETCH_APPROVAL_STATUS(changeSet.value.id);
     }
 
+    presenceStore.leftDrawerOpen = false; // close the left draw for the InsetModal
     closeModalHandler();
   }
 }

--- a/app/web/src/components/ApprovalFlowModal.vue
+++ b/app/web/src/components/ApprovalFlowModal.vue
@@ -83,6 +83,15 @@ function applyButtonHandler() {
     }
   } else {
     changeSetsStore.REQUEST_CHANGE_SET_APPROVAL();
+
+    // TODO(nick): we should remove this in favor of only the WsEvent fetching. It appears that
+    // requesting the approval itself is insufficient for getting the latest approval status at
+    // the time of writing and the reason appears to be that the change set is "open" by the
+    // time the inset modal opens. Fortunately, this will work since we are the requester.
+    if (changeSet.value) {
+      changeSetsStore.FETCH_APPROVAL_STATUS(changeSet.value.id);
+    }
+
     closeModalHandler();
   }
 }

--- a/app/web/src/components/InsetApprovalModal.vue
+++ b/app/web/src/components/InsetApprovalModal.vue
@@ -159,9 +159,9 @@
       >
         <VButton
           :disabled="
-            (!featureFlagsStore.WORKSPACE_FINE_GRAINED_ACCESS_CONTROL &&
-              mode !== 'rejected') ||
-            iRejected
+            featureFlagsStore.WORKSPACE_FINE_GRAINED_ACCESS_CONTROL
+              ? iRejected
+              : mode === 'rejected'
           "
           label="Reject Request"
           tone="destructive"
@@ -169,7 +169,11 @@
           @click="rejectHandler"
         />
         <VButton
-          :disabled="mode !== 'requested' || iApproved"
+          :disabled="
+            featureFlagsStore.WORKSPACE_FINE_GRAINED_ACCESS_CONTROL
+              ? iApproved
+              : mode === 'approved'
+          "
           label="Approve Request"
           tone="success"
           icon="thumbs-up"

--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -37,10 +37,10 @@
 
   <!-- Middle Area - ModelingDiagram or InsetApprovalModal -->
   <div
-    v-if="changeSetsStore.selectedChangeSet?.status !== ChangeSetStatus.Open"
+    v-if="showInsetModal"
     :class="
       clsx(
-        'grow flex flew-row items-center justify-center',
+        'grow flex flew-row items-center justify-center p-xs',
         themeClasses('bg-shade-0', 'bg-neutral-800'),
       )
     "
@@ -162,6 +162,7 @@ import TemplateSelectionModal from "../ModelingView/TemplateSelectionModal.vue";
 import CommandModal from "./CommandModal.vue";
 import InsetApprovalModal from "../InsetApprovalModal.vue";
 import ViewDetailsPanel from "../ViewDetailsPanel.vue";
+import { watch } from "fs";
 
 const changeSetsStore = useChangeSetsStore();
 const viewsStore = useViewsStore();
@@ -173,6 +174,8 @@ const statusStore = useStatusStore();
 const funcStore = useFuncStore();
 const featureFlagsStore = useFeatureFlagsStore();
 const authStore = useAuthStore();
+
+const showInsetModal = computed(() => changeSetsStore.selectedChangeSet?.status !== ChangeSetStatus.Open);
 
 const actionsAreRunning = computed(
   () =>

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -89,6 +89,7 @@ export function useFeatureFlagsStore() {
         // You can override feature flags while working on a feature by setting them to true/false here
         // for example:
         // this.FEATURE_FLAG_NAME = false;
+        this.WORKSPACE_FINE_GRAINED_ACCESS_CONTROL = true;
       },
     }),
   )();

--- a/lib/vue-lib/src/design-system/general/TruncateWithTooltip.vue
+++ b/lib/vue-lib/src/design-system/general/TruncateWithTooltip.vue
@@ -1,17 +1,32 @@
 <template>
-  <div ref="divRef" v-tooltip="tooltip" class="truncate">
-    <slot />
+  <div
+    ref="divRef"
+    v-tooltip="tooltip"
+    :class="clsx(!expanded && 'truncate', expandOnClick && tooltip.content && 'cursor-pointer')"
+    @click="toggleExpand"
+  >
+    <template v-if="expandableStringArray">
+      <template v-if="expanded">
+        <div v-for="s in expandableStringArray">{{ s }}</div>
+      </template>
+      <template v-else>{{ expandableStringArray.join(', ') }}</template>
+    </template>
+    <slot v-else />
   </div>
 </template>
 
 <script lang="ts" setup>
+import clsx from "clsx";
 import { ref, computed } from "vue";
 
 const props = defineProps({
   hasParentTruncateWithTooltip: { type: Boolean },
   showTooltip: { type: Boolean },
+  expandOnClick: { type: Boolean },
+  expandableStringArray: { type: Array<String> },
 });
 
+const expanded = ref(false);
 const divRef = ref<HTMLElement>();
 
 const tooltipActive = computed(() => {
@@ -27,6 +42,11 @@ const tooltip = computed(() => {
     (props.showTooltip || divRef.value.clientWidth < divRef.value.scrollWidth)
   ) {
     if (!props.hasParentTruncateWithTooltip) {
+      if (props.expandableStringArray) {
+        return {
+          content: "Click to expand",
+        };
+      }
       return {
         content: divRef.value.innerText,
       };
@@ -34,6 +54,11 @@ const tooltip = computed(() => {
   }
   return {};
 });
+
+const toggleExpand = () => {
+  if (!props.expandOnClick || !tooltip.value.content) return;
+  else expanded.value = !expanded.value;
+};
 
 defineExpose({ tooltipActive });
 </script>


### PR DESCRIPTION
## Description

This PR ensures that the InsertApprovalModel no longer filters requirements based on entity kind. Now, it shows a requirement per entity and the labelling is expanded for this feature. This is NOT the final state we want to be in due to showing potentially too many and overwhelming results for the same approver groups and individuals, but this is a step in the right direction.

This PR also ensures that the approval status data is up to date on the requester's side when requesting approvals. This is due to a potential race or missing edge case when the change set moves from an "open" to a "needsapproval" state. A corresponding "TODO" has been added to the problem area, but the current fix is sufficient in the interim.

In addition to these changes, both the requirements and actions are now scrollable. We now also show the email for a user (though truncation may not work at this time) as well as right padding for the status text (e.g. "Waiting..." which has now been capitalized to match the other states).

One final change, we now always allow users to reject the changes, even if all approvals have been met.

<img src="https://media4.giphy.com/media/UtKQmptld4nXOTBBdQ/giphy.gif"/>