### PR TITLE
feat: add govc to interact with vSphere

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,7 @@
         linode-cli
         flyctl
         azure-cli
+        govc
       ];
 
       buck2Derivation = {


### PR DESCRIPTION
Adds the govc binary to the nix flake, for interacting with vSphere

<img src="https://media4.giphy.com/media/FnGJfc18tDDHy/giphy.gif"/>