### PR TITLE
Keep management connections on upgrade

### DIFF
--- a/lib/dal-test/BUCK
+++ b/lib/dal-test/BUCK
@@ -14,6 +14,7 @@ rust_library(
         "//lib/si-data-nats:si-data-nats",
         "//lib/si-data-pg:si-data-pg",
         "//lib/si-events-rs:si-events",
+        "//lib/si-id:si-id",
         "//lib/si-jwt-public-key:si-jwt-public-key",
         "//lib/si-layer-cache:si-layer-cache",
         "//lib/si-pkg:si-pkg",


### PR DESCRIPTION
This fixes the bug where management connections are removed on upgrade. Specifically:

1. Use a management function to create a component
2. Unlock and regenerate the management component (or the created component)'s schema variant.
3. (If it wasn't already unlocked) upgrade the component
4. Reload the browser.

Before this patch, all management connection from the manager to the managee were removed on step 3. (Step 4 is what reveals the fact that they are gone--we don't send wsevents about it.) This fixes it so it's retained (whichever side gets regenerated).

### Testing

Tested manually, and wrote an integration test that checks both directions.