### PR TITLE
feat: stream hoist logs, simplify update process

### DIFF
--- a/bin/clover/src/pipeline-steps/updateSchemaIdsForExistingSpecs.ts
+++ b/bin/clover/src/pipeline-steps/updateSchemaIdsForExistingSpecs.ts
@@ -3,7 +3,7 @@ import { PkgSpec } from "../bindings/PkgSpec.ts";
 import _ from "npm:lodash";
 
 export function updateSchemaIdsForExistingSpecs(
-  existing_specs: Record<string, PkgSpec>,
+  existing_specs: Record<string, string>,
   specs: PkgSpec[],
 ): PkgSpec[] {
   const newSpecs = [] as PkgSpec[];
@@ -18,9 +18,9 @@ export function updateSchemaIdsForExistingSpecs(
       continue;
     }
 
-    const existing_spec = existing_specs[spec.name];
-    if (existing_spec) {
-      spec.schemas[0].uniqueId = existing_spec.schemas[0].uniqueId;
+    const schema_id = existing_specs[spec.name];
+    if (schema_id) {
+      spec.schemas[0].uniqueId = schema_id;
     }
     newSpecs.push(spec);
   }

--- a/bin/clover/src/specUpdates.ts
+++ b/bin/clover/src/specUpdates.ts
@@ -1,16 +1,14 @@
 import _logger from "./logger.ts";
 import _ from "npm:lodash";
 import { PkgSpec } from "./bindings/PkgSpec.ts";
-import { emptyDirectory } from "./util.ts";
 
 const logger = _logger.ns("packageGen").seal();
-export const EXISTING_PACKAGES = "existing-packages";
+export const EXISTING_PACKAGES = "existing-packages/spec.json";
 
 export async function getExistingSpecs(): Promise<Record<string, PkgSpec>> {
-  await emptyDirectory(EXISTING_PACKAGES);
   logger.debug("Getting existing specs...");
   const td = new TextDecoder();
-  const child = await new Deno.Command(
+  const child = new Deno.Command(
     "buck2",
     {
       args: [
@@ -19,33 +17,51 @@ export async function getExistingSpecs(): Promise<Record<string, PkgSpec>> {
         "--",
         "--endpoint",
         "http://0.0.0.0:5157",
-        "write-all-specs",
+        "write-existing-modules-spec",
         "--out",
         EXISTING_PACKAGES,
       ],
+      stdout: "piped",
+      stderr: "piped",
     },
-  ).output();
+  ).spawn();
 
-  const stdout = td.decode(child.stdout).trim();
-  logger.debug(stdout);
-  const stderr = td.decode(child.stderr).trim();
-  logger.debug(stderr);
+  // Stream stdout
+  (async () => {
+    const reader = child.stdout.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        logger.debug(td.decode(value));
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  })();
 
-  const fullPath = Deno.realPathSync(EXISTING_PACKAGES);
+  // Stream stderr
+  (async () => {
+    const reader = child.stderr.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        logger.debug(td.decode(value));
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  })();
 
-  const existing_specs: Record<string, PkgSpec> = {};
+  const status = await child.status;
 
-  for (const dirEntry of Deno.readDirSync(fullPath)) {
-    if (!dirEntry.name.includes(".json")) continue;
-
-    const filename = `${fullPath}/${dirEntry.name}`;
-
-    const rawData = await import(filename, {
-      with: { type: "json" },
-    });
-    const existing_spec = rawData.default as PkgSpec;
-    existing_specs[existing_spec.name] = existing_spec;
+  if (!status.success) {
+    throw new Error(`Command failed with status: ${status.code}`);
   }
 
-  return existing_specs;
+  const fullPath = Deno.realPathSync(EXISTING_PACKAGES);
+  return (await import(fullPath, {
+    with: { type: "json" },
+  })).default;
 }


### PR DESCRIPTION
* stream logs from hoist when we use it in clover to check for updates
* add to hoist the ability to generate simple name:schema_id map to make the upgrade process much simpler
* get latest _builtins_ instead of latest modules because @stack72 said to


<img src="https://media1.giphy.com/media/6F3bNKMVMR8LEOuS1y/giphy.gif"/>