### PR TITLE
fix(web): Only add favourite or default workspaces to the workspaces list

### DIFF
--- a/app/web/src/store/workspaces.store.ts
+++ b/app/web/src/store/workspaces.store.ts
@@ -31,6 +31,8 @@ type AuthApiWorkspace = {
   instanceUrl: string;
   role: "OWNER" | "EDITOR";
   token: string;
+  isDefault: boolean;
+  isFavourite: boolean;
 };
 
 export type WorkspaceImportSummary = {
@@ -105,7 +107,11 @@ export const useWorkspacesStore = () => {
           return new AuthApiRequest<AuthApiWorkspace[]>({
             url: "/workspaces",
             onSuccess: (response) => {
-              const renameIdList = _.map(response, (w) => ({
+              const filteredWorkspaces = _.filter(
+                response,
+                (w) => w.isFavourite || w.isDefault,
+              );
+              const renameIdList = _.map(filteredWorkspaces, (w) => ({
                 ...w,
                 pk: w.id,
               }));


### PR DESCRIPTION
We created 50 workspaces for the SI Camp and it has shown that the list grows to include everything.

We are going to show the most important user workspaces in that list and a user can add what is important to them from the auth portal