### PR TITLE
feat(si-fs): support automation tokens for si-fs

### DIFF
--- a/bin/si-fs/README.md
+++ b/bin/si-fs/README.md
@@ -3,11 +3,10 @@
 A FUSE filesystem for editing System Initiative assets in your favorite editor.
 
 1. Get your System Initiative bearer token:
-   - Open your browser's dev tools (F12)
-   - Go to the Network tab
-   - Find a request to app.systeminit.com
-   - Copy the "Authorization" header value (starts with "Bearer").
-   - Remove the "Bearer" from the token.
+   - Head to https://auth.systeminit.com/workspaces
+   - Pick the workspace you want to mount as a fuse filesystem.
+   - Click the settings "gear" icon and choose the API Tokens option.
+   - Generate an API token for use with the fuse filesystem.
    - Add the token to your env with `export SI_BEARER_TOKEN='<the token here>'` (the single quotes will ensure the base64 parses on your command line).
 
 2. Mount the filesystem:

--- a/lib/sdf-server/src/extract/change_set.rs
+++ b/lib/sdf-server/src/extract/change_set.rs
@@ -81,7 +81,7 @@ impl<S> FromRequestParts<S> for TargetChangeSetId {
         Ok(*parts
             .extensions
             .get::<TargetChangeSetId>()
-            .ok_or_else(|| internal_error("No workspace ID. Endpoints must call an extractor like TargetChangeSetIdFromPath or TargetWorkspaceFromToken to get the workspace ID."))?)
+            .ok_or_else(|| internal_error("No changeset ID. Endpoints must call an extractor like TargetChangeSetIdFromPath to get the change set ID."))?)
     }
 }
 

--- a/lib/sdf-server/src/service/v2.rs
+++ b/lib/sdf-server/src/service/v2.rs
@@ -49,7 +49,7 @@ fn workspace_routes(state: AppState) -> Router<AppState> {
                 ),
         )
         .nest("/integrations", integrations::v2_routes())
-        .nest("/fs", fs::fs_routes())
+        .nest("/fs", fs::fs_routes(state))
         .route_layer(middleware::from_extractor::<TargetWorkspaceIdFromPath>())
 }
 


### PR DESCRIPTION
The "v2/fs" route hierarchy now supports automation tokens generated in the auth portal. (Web tokens will still work since they are considered a superset of the Automation role)