### PR TITLE
fix(dal): respect socket arity, connection annotations, and other socket metadata when it changes from variant to variant

### DIFF
--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::{
     ActionFuncSpec, LeafFunctionSpec, ManagementFuncSpec, PropSpec, PropSpecData,
-    PropSpecWidgetKind, RootPropFuncSpec, SiPropFuncSpec, SocketSpec, SpecError,
+    PropSpecWidgetKind, RootPropFuncSpec, SiPropFuncSpec, SocketSpec, SocketSpecData, SpecError,
 };
 
 #[remain::sorted]
@@ -377,9 +377,25 @@ impl SchemaVariantSpec {
                     input_sockets,
                     output_sockets,
                 );
-
+                // If there is nothing to skip, we still need to include the data from the newer this_socket
+                // and copy it to the other_socket so we don't lose any changes here
                 if new_merge_skips.is_empty() {
-                    merged_sockets.push(other_socket.to_owned());
+                    if let (Some(this_socket_data), Some(other_socket_data)) =
+                        (this_socket.data.as_ref(), other_socket.data.as_ref())
+                    {
+                        // keep other_socket's func_unique_id, but everything else from the newer this_socket
+                        let new_data = Some(SocketSpecData {
+                            func_unique_id: other_socket_data.func_unique_id.clone(),
+                            ..this_socket_data.clone()
+                        });
+
+                        merged_sockets.push(SocketSpec {
+                            data: new_data,
+                            ..other_socket.clone()
+                        });
+                    } else {
+                        merged_sockets.push(other_socket.to_owned());
+                    }
                 } else {
                     merge_skips.extend(new_merge_skips.into_iter());
                     merged_sockets.push(this_socket.to_owned());


### PR DESCRIPTION
Before this change, if you created a variant with a socket, then modified the socket arity or connection annotations, the updates would not be reflected on regeneration. 

<div><img src="https://media1.giphy.com/media/gWyhZM3XKcyaI/giphy.gif?cid=5a38a5a2pc4u6kg6qpxcd7fyhodcp5rbfjb6qxtx9l1aeax3&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/gifs/metal-while-protractor-gWyhZM3XKcyaI">GIPHY</a></div>

Tested this manually by modifying connection annotations and arity with components on the diagram and seeing them update, and wrote an integration test for it. 