### PR TITLE
feat(clover): Allow generation of just specific specs with argument

### DIFF
--- a/bin/clover/src/cfDb.ts
+++ b/bin/clover/src/cfDb.ts
@@ -246,10 +246,15 @@ export interface CfSchema extends JSONSchema.Interface {
 
 type CfDb = Record<string, CfSchema>;
 const DB: CfDb = {};
+const DEFAULT_PATH = "./cloudformation-schema";
 
 export async function loadCfDatabase(
-  path: string = "./cloudformation-schema",
+  { path, services }: {
+    path?: string,
+    services?: string[],
+  }
 ): Promise<CfDb> {
+  path ??= DEFAULT_PATH;
   if (Object.keys(DB).length === 0) {
     const fullPath = Deno.realPathSync(path);
     logger.debug("Loading database from Cloudformation schema", { fullPath });
@@ -272,42 +277,7 @@ export async function loadCfDatabase(
 
       const typeName: string = data.typeName;
 
-      if (
-        false &&
-        ![
-          "AWS::EC2::Subnet",
-          "AWS::EC2::SecurityGroup",
-          "AWS::EC2::SecurityGroupIngress",
-          "AWS::EC2::SecurityGroupEgress",
-          "AWS::EC2::SecurityGroupVpcAssociation",
-          "AWS::EC2::Instance",
-          "AWS::EC2::KeyPair",
-          "AWS::EC2::VPC",
-          "AWS::EC2::Subnet",
-          "AWS::EC2::Route",
-          "AWS::EC2::RouteTable",
-          "AWS::EC2::SubnetRouteTableAssociation",
-          "AWS::EC2::NatGateway",
-          "AWS::EC2::InternetGateway",
-          "AWS::EC2::EIP",
-          "AWS::EC2::EIPAssociation",
-          "AWS::EC2::VPCGatewayAttachment",
-          "AWS::ElasticLoadBalancingV2::LoadBalancer",
-          "AWS::ElasticLoadBalancingV2::Listener",
-          "AWS::ElasticLoadBalancingV2::ListenerRule",
-          "AWS::ElasticLoadBalancingV2::TargetGroup",
-          "AWS::ECS::CapacityProvider",
-          "AWS::ECS::Cluster",
-          "AWS::ECS::Service",
-          "AWS::ECS::ClusterCapacityProviderAssociations",
-          "AWS::ECS::TaskDefinition",
-          "AWS::IAM::Policy",
-          "AWS::IAM::Role",
-          "AWS::IAM::InstanceProfile",
-          "AWS::IAM::RolePolicy",
-          "AWS::IAM::ManagedPolicy",
-        ].includes(typeName)
-      ) continue;
+      if (services && !services.some((service) => typeName.match(service))) continue;
 
       logger.debug(`Loaded ${typeName}`);
       try {

--- a/bin/clover/src/cli.ts
+++ b/bin/clover/src/cli.ts
@@ -3,38 +3,57 @@ import { fetchSchema } from "./commands/fetchSchema.ts";
 import { generateSiSpecs } from "./commands/generateSiSpecs.ts";
 import { generateTarFromSpec } from "./commands/generateTarFromSpec.ts";
 
+const DEFAULT_MODULE_INDEX_URL = "http://0.0.0.0:5157";
+
 export async function run() {
   const command = new Command()
     .name("clover")
     .version("0.1.0")
     .description("Asset Pipeline for AWS Cloud Control")
-    .env("LOG_LEVEL=<value:string>", "Set the log level; defaults to info")
+    .globalEnv(
+      "LOG_LEVEL=<value:string>",
+      "Set the log level; defaults to info"
+    )
     .action(() => {
       command.showHelp();
       Deno.exit(1);
     })
     .command(
       "fetch-schema",
-      "fetch cloudformation schema from aws",
+      "Getch cloudformation schema from aws.",
     )
     .action(async () => {
       await fetchSchema();
     })
     .command(
-      "generate-specs",
-      "generate the si spec database from the cf database",
+      "generate-specs [...services:string]",
+      `Generate the si spec database from the cf database.
+
+To generate all specs:
+
+  clover generate-specs
+
+To generate all specs containing "ECS" or "S3", you can pass some services as arguments:
+
+  clover generate-specs ECS S3
+`
     )
     .env(
       "SI_BEARER_TOKEN=<value:string>",
       "Auth token for interacting with the module index",
       { required: true },
     )
-    .action(async () => {
-      await generateSiSpecs();
+    .env(
+      "SI_MODULE_INDEX_URL=<value:string>",
+      "Set the module index url; defaults to http://0.0.0.0:5157",
+      { prefix: "SI_" }
+    )
+    .action(async ({ moduleIndexUrl }, ...services: string[]) => {
+      await generateSiSpecs(moduleIndexUrl ?? DEFAULT_MODULE_INDEX_URL, services);
     })
     .command(
       "generate-tars",
-      "generate tar packages from the spec files in si-specs",
+      "Generate tar packages from the spec files in si-specs",
     )
     .action(async () => {
       await generateTarFromSpec();

--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -30,9 +30,10 @@ export function generateSiSpecForService(serviceName: string) {
   return pkgSpecFromCf(cf);
 }
 
-export async function generateSiSpecs() {
-  const db = await loadCfDatabase();
-  const existing_specs = await getExistingSpecs();
+export async function generateSiSpecs(moduleIndexUrl: string, services?: string[]) {
+  if (services?.length == 0) services = undefined;
+  const db = await loadCfDatabase({ services });
+  const existing_specs = await getExistingSpecs(moduleIndexUrl);
 
   let imported = 0;
   let importSubAssets = 0;


### PR DESCRIPTION
Allows you to add arguments to `generate-specs` to restrict which services will be run.

```
# Generates all specs
deno run task generate-specs
# Generates all ECS and S3 specs
deno run task generate-specs ECS S3
```

And gets rid of the hardcoded list of specs.

It also adds `SI_MODULE_INDEX_URL` environment variable support so you can point at an arbitrary module index server. Defaults to what it did before. Probably should default to something else, however :)