### PR TITLE
Add max deliver config to pinga (default is 1)

### DIFF
--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -119,6 +119,10 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) concurrency: Option<u32>,
 
+    /// Configures the max delivery number NATS JetStream consumer(s)
+    #[arg(long)]
+    pub(crate) max_deliver: Option<i64>,
+
     /// The path at which the layer db cache is created/used on disk [e.g. /banana/]
     #[arg(long)]
     pub(crate) layer_db_disk_path: Option<String>,
@@ -217,6 +221,9 @@ impl TryFrom<Args> for Config {
             }
             if let Some(concurrency) = args.concurrency {
                 config_map.set("concurrency_limit", i64::from(concurrency));
+            }
+            if let Some(max_deliver) = args.max_deliver {
+                config_map.set("max_deliver", max_deliver);
             }
             if let Some(layer_cache_disk_path) = args.layer_db_disk_path {
                 config_map.set("layer_db_config.disk_path", layer_cache_disk_path);

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -685,6 +685,7 @@ pub async fn pinga_server(
     let server = pinga_server::Server::from_services(
         config.instance_id(),
         config.concurrency_limit(),
+        config.max_deliver(),
         services_context,
         shutdown_token,
     )

--- a/lib/pinga-server/src/config.rs
+++ b/lib/pinga-server/src/config.rs
@@ -55,6 +55,9 @@ pub struct Config {
     #[builder(default = "default_concurrency_limit()")]
     concurrency_limit: usize,
 
+    #[builder(default = "default_max_deliver()")]
+    max_deliver: i64,
+
     #[builder(default = "random_instance_id()")]
     instance_id: String,
 
@@ -102,6 +105,11 @@ impl Config {
         self.concurrency_limit
     }
 
+    /// Gets the config's max delivery setting for NATS JetStream consumer(s).
+    pub fn max_deliver(&self) -> i64 {
+        self.max_deliver
+    }
+
     /// Gets the config's instance ID.
     pub fn instance_id(&self) -> &str {
         self.instance_id.as_ref()
@@ -123,6 +131,8 @@ pub struct ConfigFile {
     crypto: VeritechCryptoConfig,
     #[serde(default = "default_concurrency_limit")]
     concurrency_limit: usize,
+    #[serde(default = "default_max_deliver")]
+    max_deliver: i64,
     #[serde(default = "random_instance_id")]
     instance_id: String,
     #[serde(default = "default_layer_db_config")]
@@ -137,6 +147,7 @@ impl Default for ConfigFile {
             pg: Default::default(),
             nats: Default::default(),
             concurrency_limit: default_concurrency_limit(),
+            max_deliver: default_max_deliver(),
             crypto: Default::default(),
             instance_id: random_instance_id(),
             layer_db_config: default_layer_db_config(),
@@ -160,6 +171,7 @@ impl TryFrom<ConfigFile> for Config {
         config.nats(value.nats);
         config.crypto(value.crypto);
         config.concurrency_limit(value.concurrency_limit);
+        config.max_deliver(value.max_deliver);
         config.instance_id(value.instance_id);
         config.symmetric_crypto_service(value.symmetric_crypto_service.try_into()?);
         config.layer_db_config(value.layer_db_config);
@@ -181,6 +193,10 @@ fn default_symmetric_crypto_config() -> SymmetricCryptoServiceConfigFile {
 
 fn default_concurrency_limit() -> usize {
     DEFAULT_CONCURRENCY_LIMIT
+}
+
+fn default_max_deliver() -> i64 {
+    1
 }
 
 fn default_layer_db_config() -> LayerDbConfig {


### PR DESCRIPTION
## Introduction

This PR adds a configurable max delivery field to pinga, which defaults to "1".

<img src="https://media4.giphy.com/media/bpNMoPja9PwF1PAfLx/giphy.gif?cid=bd3ea57ezdlchw3e3pw2bydfq3fzvpgcx17pp64qtf0mbkjb&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>

## Description

First, why does the new configuration option default to "1"? The single naxum handler in pinga server relies on the default AckLayer and its inner logic is infallible. How is that the case? The job execution code is wrapped with an infallible wrapper.

There are two feasible ways that the handler can fail, which causes a NACK to be sent via the code in the default AckLayer... the JSON extractor can fail (error 422 on deserialization) or the subject is not a valid UTF8 string. The other extractors are fallible, but their default implementations immediately return "Ok". Therefore, either the request payload is a poison pill or the subject is invalid. In either case, we should not retry the job and we should immediately send the message to the Dead Letter Queue stream, which is already configured to handle this.

As a result of this paradigm, there is no custom backoff or increased number of max deliveries. So... why does this commit make it configurable? Due errant test behavior when adding a custom backoff and deserialization errors recently seen when pulling messages off the "PINGA_JOBS" stream, we have not confirmed whether or not the system relies on re-deliveries at the pinga-level or not. Therefore, if we discover that re-delivery is required, the max delivery should be increased accordingly with no custom backoff.

An example max delivery increase would be from 1 (default) to 60,000. WTF? WHY? Well, we have observed in live production scenarios that we can see around ~500 re-deliveries per second. Setting max deliveries to 60,000 allows for approximately 2 minutes worth of pinga trying to execute a job. This math is inadequate at best, but the point is this: if we find that we do require retries, then bump that number up.

In addition to these changes, the "initial DVU" step of the rebaser has been removed. It was added in the quiescence work, but it may actually be the cause of the poison pill messages. Working with @britmyerss revealed that it is likely unnecessary and both testing and static analysis have indicated as such.

This was tested with 201 components with the root component being a Region as a configurationDownFrame. There were VPCs, Subnets, EC2 Instances, and all kinds of nesting. Flipping the region in the root set off pinga into a frenzy and none of the errors were observed.

Fixes BUG-776