### PR TITLE
feat(web): Remove component category icons

### DIFF
--- a/app/web/src/components/AssetCard.vue
+++ b/app/web/src/components/AssetCard.vue
@@ -11,7 +11,6 @@
       }"
     >
       <div class="flex gap-xs items-center">
-        <Icon :name="getAssetIcon(asset.category)" class="shrink-0" size="lg" />
         <Stack class="" spacing="xs">
           <div
             ref="componentNameRef"
@@ -134,7 +133,6 @@ import {
 import { format as dateFormat } from "date-fns";
 import { useAssetStore } from "@/store/asset.store";
 import { SchemaVariantId, SchemaVariant } from "@/api/sdf/dal/schema";
-import { getAssetIcon } from "@/store/components.store";
 import { useModuleStore } from "@/store/module.store";
 import { ModuleContributeRequest } from "@/api/sdf/dal/module";
 import EditingPill from "./EditingPill.vue";

--- a/app/web/src/components/AssetListPanel.vue
+++ b/app/web/src/components/AssetListPanel.vue
@@ -72,7 +72,6 @@
         :key="category"
         :color="categoryColor(category)"
         :label="category"
-        :primaryIcon="getAssetIcon(category)"
         alwaysShowArrow
         clickLabelToToggle
         enableDefaultHoverClasses

--- a/app/web/src/components/AssetPalette.vue
+++ b/app/web/src/components/AssetPalette.vue
@@ -42,7 +42,6 @@
           ref="collapsibleRefs"
           :key="category.displayName"
           :label="category.displayName"
-          :primaryIcon="getAssetIcon(category.displayName)"
           :color="category.schemaVariants[0]?.variant.color || '#000'"
           enableDefaultHoverClasses
           enableGroupToggle

--- a/app/web/src/components/ComponentCard.vue
+++ b/app/web/src/components/ComponentCard.vue
@@ -16,18 +16,6 @@
     }"
   >
     <div class="flex gap-2xs items-center">
-      <Icon
-        v-if="component.def.componentType !== ComponentType.View"
-        :name="component.def.icon"
-        size="lg"
-        class="shrink-0"
-      />
-      <Icon v-else name="logo-si" size="lg" class="shrink-0" />
-      <Icon
-        :name="COMPONENT_TYPE_ICONS[component.def.componentType]"
-        size="lg"
-        class="shrink-0"
-      />
       <Stack spacing="xs" class="min-w-0">
         <div
           ref="componentNameRef"

--- a/app/web/src/components/DiagramOutline/DiagramOutlineNode.vue
+++ b/app/web/src/components/DiagramOutline/DiagramOutlineNode.vue
@@ -74,16 +74,6 @@
 
       <div v-else class="flex flex-row items-center px-xs w-full gap-1">
         <Icon
-          :name="component.def.icon"
-          size="sm"
-          :class="
-            clsx(
-              'flex-none',
-              enableGroupToggle && 'group-hover:scale-0 transition-all',
-            )
-          "
-        />
-        <Icon
           :name="COMPONENT_TYPE_ICONS[component.def.componentType]"
           size="sm"
           :class="


### PR DESCRIPTION
We only have icons for aws, butane and docker and there's no way for a user to upload their own so let's remove them for now