### PR TITLE
fix(si-fs): asset def editing improvements

### DIFF
--- a/lib/si-filesystem/src/client.rs
+++ b/lib/si-filesystem/src/client.rs
@@ -451,19 +451,28 @@ impl SiFsClient {
         .await
     }
 
+    pub async fn get_asset_func_code(
+        &self,
+        change_set_id: ChangeSetId,
+        schema_id: SchemaId,
+        unlocked: bool,
+    ) -> SiFsClientResult<String> {
+        self.get_text(
+            change_set_id,
+            self.fs_api_change_sets(&format!("schemas/{schema_id}/asset_func"), change_set_id),
+            Some(VariantQuery { unlocked }),
+        )
+        .await
+    }
     pub async fn set_asset_func_code(
         &self,
         change_set_id: ChangeSetId,
-        func_id: FuncId,
         schema_id: SchemaId,
         code: String,
     ) -> SiFsClientResult<()> {
         self.post_empty_response(
             change_set_id,
-            self.fs_api_change_sets(
-                &format!("schemas/{schema_id}/asset_func/{func_id}"),
-                change_set_id,
-            ),
+            self.fs_api_change_sets(&format!("schemas/{schema_id}/asset_func"), change_set_id),
             None::<()>,
             Some(SetFuncCodeRequest { code }),
         )

--- a/lib/si-filesystem/src/inode_table.rs
+++ b/lib/si-filesystem/src/inode_table.rs
@@ -58,7 +58,6 @@ impl InodeEntry {
 #[remain::sorted]
 pub enum InodeEntryData {
     AssetDefinitionDir {
-        func_id: FuncId,
         change_set_id: ChangeSetId,
         schema_id: SchemaId,
         size: u64,
@@ -67,9 +66,9 @@ pub enum InodeEntryData {
         unlocked: bool,
     },
     AssetFuncCode {
-        func_id: FuncId,
         change_set_id: ChangeSetId,
         schema_id: SchemaId,
+        unlocked: bool,
     },
     ChangeSet {
         change_set_id: ChangeSetId,


### PR DESCRIPTION
After more testing of editing asset definitions, I've made a few fixes.

We don't save the asset func id since after regeneration it can change.

Regeneration happens in a separate commit, so that we don't commit an incompletely assembled variant if the install fails midway through.