### PR TITLE
feat(clover): Fix last typescript errors

### DIFF
--- a/bin/clover/src/cfDb.ts
+++ b/bin/clover/src/cfDb.ts
@@ -4,7 +4,6 @@ import {
 import $RefParser from "npm:@apidevtools/json-schema-ref-parser";
 import _logger from "./logger.ts";
 import { ServiceMissing } from "./errors.ts";
-import { JSONSchemaObject } from "@apidevtools/json-schema-ref-parser";
 import _ from "npm:lodash";
 
 const logger = _logger.ns("cfDb").seal();
@@ -60,7 +59,7 @@ export function normalizePropertyType(prop: CfProperty): CfProperty {
     return { ...prop, type: "object" };
   }
 
-  if (!prop.type || !Array.isArray(prop.type)) {
+  if (!prop.type || !Array.isArray(prop.type) || typeof prop.type === "string") {
     return prop;
   }
   const nonStringType = prop.type.find((t) => t !== "string");
@@ -314,7 +313,7 @@ export async function loadCfDatabase(
         const expandedSchema = await $RefParser.dereference(data, {
           dereference: {
             circular: "ignore",
-            onDereference: (path: string, ref: JSONSchemaObject) => {
+            onDereference: (path: string, ref: JSONSchema.Object) => {
               const name = path.split("/").pop();
               ref.title = ref.title ?? name;
             },


### PR DESCRIPTION
This clears out the two remaining clover typescript errors in my Problems tab.

1. JSONSchemaObject is now JSONSchema.Object in the upstream.
2. Typescript doesn't realize that !Array.isArray(prop.type) means "prop.type is not a string" and therefore it doesn't narrow the type down to just the boolean one. This causes some errors because it worries that some of the props from other types might be around and don't match the result.