### PR TITLE
feat(si-fs): asset def types

### DIFF
--- a/lib/sdf-server/BUCK
+++ b/lib/sdf-server/BUCK
@@ -66,7 +66,10 @@ rust_library(
         "//third-party/rust:url",
         "//third-party/rust:y-sync",
     ],
-    srcs = glob(["src/**/*.rs"]),
+    srcs = glob([
+        "src/**/*.rs",
+        "src/service/v2/fs/editor_typescript.txt"
+    ]),
     extra_test_targets = [":test-integration"],
 )
 

--- a/lib/sdf-server/src/service/v2/fs/editor_typescript.txt
+++ b/lib/sdf-server/src/service/v2/fs/editor_typescript.txt
@@ -1,0 +1,1 @@
+../../../../../../app/web/src/assets/static/editor_typescript.txt

--- a/lib/si-filesystem/src/inode_table.rs
+++ b/lib/si-filesystem/src/inode_table.rs
@@ -63,9 +63,15 @@ pub enum InodeEntryData {
         size: u64,
         attrs_size: u64,
         bindings_size: u64,
+        types_size: u64,
         unlocked: bool,
     },
     AssetFuncCode {
+        change_set_id: ChangeSetId,
+        schema_id: SchemaId,
+        unlocked: bool,
+    },
+    AssetFuncTypes {
         change_set_id: ChangeSetId,
         schema_id: SchemaId,
         unlocked: bool,

--- a/lib/si-frontend-types-rs/src/fs.rs
+++ b/lib/si-frontend-types-rs/src/fs.rs
@@ -57,6 +57,18 @@ pub struct AssetFuncs {
     pub locked_bindings_size: u64,
     pub unlocked_attrs_size: u64,
     pub unlocked_bindings_size: u64,
+    pub types_size: u64,
+}
+
+impl AssetFuncs {
+    pub fn extend_code_sizes(&mut self, by: u64) {
+        if let Some(func) = self.locked.as_mut() {
+            func.code_size += by;
+        }
+        if let Some(func) = self.unlocked.as_mut() {
+            func.code_size += by;
+        }
+    }
 }
 
 pub fn kind_to_string(kind: FuncKind) -> String {


### PR DESCRIPTION
This adds a new file to the asset definition directories: `index.d.ts`, containing all the types for the asset builder. It inserts a triple-slash directive at the top of the asset index.ts file that references these types, so typescript language servers will pick up the types automatically. This directive will be removed from the code when the file is saved, before it is sent to the backend.
![image](https://github.com/user-attachments/assets/51bb2500-c199-4887-9151-f7381d3a1621)
