### PR TITLE
NO MORE COLOR PICKER BUGS

### DIFF
--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="grow relative">
-    <ScrollArea v-if="editingAsset && schemaVariantId">
+    <ScrollArea v-if="editingAsset && schemaVariantId" ref="scrollAreaRef">
       <template #top>
         <div
           class="flex flex-row items-center justify-around gap-xs p-xs border-b dark:border-neutral-600"
@@ -35,7 +35,6 @@
           title="Asset Name"
           @submit="cloneAsset"
         />
-
         <ErrorMessage
           v-for="(warning, index) in assetStore.detachmentWarnings"
           :key="warning.message"
@@ -54,13 +53,11 @@
             @click.stop="assetStore.detachmentWarnings.splice(index, 1)"
           />
         </ErrorMessage>
-
         <AssetFuncAttachModal
           ref="attachModalRef"
           :schemaVariantId="props.schemaVariantId"
         />
       </template>
-
       <Stack class="p-xs" spacing="none">
         <div>
           <ErrorMessage :requestStatus="updateAssetReqStatus" variant="block" />
@@ -76,7 +73,6 @@
           @blur="updateAsset"
           @focus="focus"
         />
-
         <VormInput
           id="displayName"
           v-model="editingAsset.displayName"
@@ -130,10 +126,11 @@
           <ColorPicker
             id="color"
             v-model="editingAsset.color"
+            :parentElement="scrollAreaRef?.scrollElement || undefined"
+            :disabled="editingAsset.isLocked"
             @change="updateAsset"
           />
         </VormInput>
-
         <VormInput
           id="link"
           v-model="editingAsset.link"
@@ -279,6 +276,8 @@ const assetStore = useAssetStore();
 const funcStore = useFuncStore();
 const executeAssetModalRef = ref();
 const cloneAssetModalRef = ref<InstanceType<typeof AssetNameModal>>();
+
+const scrollAreaRef = ref<InstanceType<typeof ScrollArea>>();
 
 // if func list is loading, its because we dont have the right data
 // and we dont want to display incorrect intrinsic data

--- a/app/web/src/components/ModelingView/TemplateSelectionModal.vue
+++ b/app/web/src/components/ModelingView/TemplateSelectionModal.vue
@@ -51,12 +51,7 @@
           label="Asset Color"
           type="container"
         >
-          <ColorPicker
-            id="asset-color"
-            v-model="assetColor"
-            insideModal
-            @change="null"
-          />
+          <ColorPicker id="asset-color" v-model="assetColor" @change="null" />
         </VormInput>
       </div>
 

--- a/lib/vue-lib/src/design-system/forms/ColorPicker.vue
+++ b/lib/vue-lib/src/design-system/forms/ColorPicker.vue
@@ -3,37 +3,61 @@
     <Teleport to="body">
       <span
         :id="id ?? 'color-picker'"
-        ref="pickerElement"
+        ref="pickerClickHitbox"
         :aria-required="required ?? false"
         :class="
           clsx(
-            'absolute h-7 px-2xs flex flex-row gap-xs items-center dark:hover:text-action-300 hover:text-action-500',
-            !disabled && 'cursor-pointer',
-            insideModal ? 'z-100' : 'z-80',
+            'z-100 absolute h-7 block',
+            !disabled && pickerInView
+              ? 'cursor-pointer'
+              : 'pointer-events-none',
           )
         "
+        @mouseover="onHover"
+        @mouseout="onEndHover"
       >
-        <span
-          class="block w-10 h-6 border rounded-md shadow-sm focus:outline-none sm:text-sm dark:color-white"
-          :style="{ backgroundColor: modelValue }"
-        ></span>
-        <span class="text-sm">{{ modelValue.toUpperCase() }}</span>
       </span>
     </Teleport>
+    <div
+      :class="
+        clsx(
+          'w-full h-full flex flex-row gap-xs px-2xs items-center select-none',
+          hoverOrOpen
+            ? themeClasses('text-action-500', 'text-action-300')
+            : themeClasses('text-shade-100', 'text-shade-0'),
+        )
+      "
+    >
+      <span
+        :class="
+          clsx(
+            'block w-10 h-6 border rounded-md shadow-sm focus:outline-none sm:text-sm',
+            hoverOrOpen
+              ? themeClasses('border-action-500', 'border-action-300')
+              : themeClasses('border-shade-100', 'border-shade-0'),
+          )
+        "
+        :style="{ backgroundColor: modelValue }"
+      ></span>
+      <span class="text-sm">{{ modelValue.toUpperCase() }}</span>
+    </div>
   </span>
 </template>
 
 <script lang="ts" setup>
-import { ref, onMounted, onBeforeUnmount } from "vue";
+import { ref, onMounted, onBeforeUnmount, computed } from "vue";
 import Picker from "vanilla-picker";
 import clsx from "clsx";
+import { themeClasses } from "../utils/theme_tools";
 
 const props = defineProps<{
   id?: string;
   required?: boolean;
   modelValue: string;
   disabled?: boolean;
-  insideModal?: boolean;
+
+  // you must pass in the scrollable container element for this to work!
+  scrollingParentElement?: HTMLElement;
 }>();
 
 const emit = defineEmits<{
@@ -47,27 +71,98 @@ const colorChanged = (color: { hex: string }) => {
   emit("change", colorHex);
 };
 
+const pickerOpen = ref(false);
+const hover = ref(false);
+
+const onHover = () => {
+  hover.value = true;
+};
+const onEndHover = () => {
+  hover.value = false;
+};
+
+const hoverOrOpen = computed(() => hover.value || pickerOpen.value);
+
 const pickerAnchorElement = ref<HTMLElement | null>(null);
-const pickerElement = ref<HTMLElement | null>(null);
+const pickerClickHitbox = ref<HTMLElement | null>(null);
 const picker = ref<Picker | null>(null);
-const positionPickerElement = () => {
-  if (pickerElement.value && pickerAnchorElement.value) {
+const positionPickerClickHitbox = () => {
+  if (pickerClickHitbox.value && pickerAnchorElement.value) {
     const rect = pickerAnchorElement.value.getBoundingClientRect();
-    pickerElement.value.style.top = `${rect.top}px`;
-    pickerElement.value.style.left = `${rect.left}px`;
+    pickerClickHitbox.value.style.top = `${rect.top}px`;
+    pickerClickHitbox.value.style.left = `${rect.left}px`;
+    pickerClickHitbox.value.style.width = `${rect.width}px`;
+    pickerInView.value = checkPickerInView();
   }
 };
-const positionPickerInterval = ref(); // TODO - this is definitely not the best way to do this
+const positionPickerInterval = ref();
+const pickerInView = ref(false);
+
+function isScrolledIntoView(container: HTMLElement, element: HTMLElement) {
+  const containerRect = container.getBoundingClientRect();
+  const elementRect = element.getBoundingClientRect();
+  return (
+    elementRect.left < containerRect.right &&
+    elementRect.right > containerRect.left &&
+    elementRect.top < containerRect.bottom &&
+    elementRect.bottom > containerRect.top
+  );
+}
+const checkPickerInView = () => {
+  if (!pickerAnchorElement.value) return false;
+  else if (!props.scrollingParentElement)
+    return true; // skip the check if no scrolling parent element set
+  else
+    return isScrolledIntoView(
+      props.scrollingParentElement,
+      pickerAnchorElement.value,
+    );
+};
 
 onMounted(() => {
-  if (!props.disabled) {
-    const p = new Picker(pickerElement.value as HTMLElement);
-    p.onDone = colorChanged;
-    picker.value = p;
-    p.setOptions({ alpha: false, popup: "left" });
-    positionPickerElement();
-    positionPickerInterval.value = setInterval(positionPickerElement, 10);
-  }
+  const p = new Picker(pickerClickHitbox.value as HTMLElement);
+  p.onDone = colorChanged;
+  picker.value = p;
+  p.setColor(props.modelValue, true);
+  p.setOptions({
+    alpha: false,
+    popup: "left",
+    onOpen: () => {
+      const goAway = () => {
+        p.hide();
+        if (pickerClickHitbox.value)
+          pickerClickHitbox.value.style.removeProperty("pointer-events");
+      };
+      if (props.disabled || !checkPickerInView() || !pickerClickHitbox.value) {
+        goAway();
+      } else {
+        pickerOpen.value = true;
+        const pickerWrapperEl = pickerClickHitbox.value.getElementsByClassName(
+          "picker_wrapper",
+        )[0] as HTMLElement;
+        if (pickerWrapperEl) {
+          const arrowEl = pickerWrapperEl.getElementsByClassName(
+            "picker_arrow",
+          )[0] as HTMLElement;
+          pickerWrapperEl.style.removeProperty("transform");
+          arrowEl.classList.remove("arrow_flipped");
+          const rect = pickerWrapperEl.getBoundingClientRect();
+          if (rect.bottom > window.innerHeight) {
+            // Too close to the bottom, flip it!
+            pickerWrapperEl.style.transform = "translateY(-100%)";
+            arrowEl.classList.add("arrow_flipped");
+          }
+          pickerWrapperEl.style.visibility = "visible";
+        } else goAway();
+      }
+    },
+    onClose: () => {
+      pickerOpen.value = false;
+      p.setColor(props.modelValue, true);
+    },
+  });
+  positionPickerClickHitbox();
+  positionPickerInterval.value = setInterval(positionPickerClickHitbox, 10);
 });
 
 onBeforeUnmount(() => {
@@ -76,6 +171,14 @@ onBeforeUnmount(() => {
 </script>
 
 <style lang="less">
+.picker_wrapper.popup.popup_left > .picker_arrow.arrow_flipped::before {
+  transform: translate(-28px, 289px) skew(-45deg);
+}
+
+.picker_wrapper.popup.layout_default.picker_wrapper {
+  visibility: hidden;
+}
+
 .picker_wrapper.popup,
 .picker_wrapper.popup .picker_arrow::before,
 .picker_wrapper.popup .picker_arrow::after {

--- a/lib/vue-lib/src/design-system/layout/ScrollArea.vue
+++ b/lib/vue-lib/src/design-system/layout/ScrollArea.vue
@@ -3,7 +3,10 @@
     <div v-if="$slots.top" class="shrink-0">
       <slot name="top" />
     </div>
-    <div class="overflow-auto flex-grow relative scroll-slot">
+    <div
+      ref="scrollDivRef"
+      class="overflow-auto flex-grow relative scroll-slot"
+    >
       <slot />
     </div>
     <div v-if="$slots.bottom" class="shrink-0">
@@ -11,3 +14,10 @@
     </div>
   </div>
 </template>
+
+<script lang="ts" setup>
+import { ref } from "vue";
+
+const scrollDivRef = ref<HTMLElement | null>(null);
+defineExpose({ scrollElement: scrollDivRef });
+</script>


### PR DESCRIPTION
![Screenshot 2025-02-05 at 10 44 43 AM](https://github.com/user-attachments/assets/aa58a37b-98c7-4587-a7f0-d2109795a94e)

This PR fixes a number of outstanding bugs with the `ColorPicker`, including -

- The `ColorPicker` selection hitbox was sometimes painting over other elements incorrectly.
- The `ColorPicker` was not properly disabled on the `AssetDetailsPanel` when an Asset was locked.
- The `ColorPicker` did not reset to the given modelValue color when closed.
- The `ColorPicker` itself could cause the application to break the window bounds if opened in the wrong spot.