### PR TITLE
feat(clover): Several input socket generation fixes

### DIFF
--- a/bin/clover/anonymize-specs.sh
+++ b/bin/clover/anonymize-specs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+POSITIONAL_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --remove-props)
+      REMOVE_PROPS=,$2
+      shift 2
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+specs_dir=${1:-si-specs}
+output_dir=$specs_dir/anonymized
+echo "Anonymizing specs to $output_dir ..."
+echo $REMOVE_PROPS
+mkdir -p $output_dir
+query=
+for spec in $specs_dir/*.json; do
+    spec_out=$output_dir/$(basename "$spec")
+    jq 'del(.version,.createdAt,.schemas[].data.defaultSchemaVariant,(.schemas[].variants[] | .version,.data.version,.data.funcUniqueId),(..|select(type == "object")|(.uniqueId,.unique_id))'$REMOVE_PROPS')' -j < "$spec" > "$spec_out"
+done

--- a/bin/clover/src/spec/props.ts
+++ b/bin/clover/src/spec/props.ts
@@ -164,9 +164,10 @@ function createPropFromCfInner(
     if (normalizedCfData.enum) {
       prop.data!.widgetKind = "ComboBox";
       for (const val of normalizedCfData.enum) {
+        const valString = val.toString();
         prop.data!.widgetOptions.push({
-          label: val,
-          value: val,
+          label: valString,
+          value: valString,
         });
       }
     } else {
@@ -426,6 +427,23 @@ export function bfsPropTree(
         break;
       }
     }
+  }
+}
+
+export function bfsExpandedPropTree(
+  props: PropSpec | PropSpec[],
+  callback: (prop: ExpandedPropSpec, parents: PropSpec[]) => unknown,
+  options?: { skipTypeProps: boolean },
+) {
+  if (!Array.isArray(props)) props = [props];
+  for (const prop of props) {
+    bfsPropTree(
+      prop,
+      (prop, parents) => {
+        if (isExpandedPropSpec(prop)) callback(prop, parents);
+      },
+      options,
+    );
   }
 }
 

--- a/bin/clover/src/spec/sockets.ts
+++ b/bin/clover/src/spec/sockets.ts
@@ -7,6 +7,7 @@ import { ExpandedPropSpec } from "./props.ts";
 import { getSiFuncId } from "./siFuncs.ts";
 import { PropSpec } from "../bindings/PropSpec.ts";
 import _ from "npm:lodash";
+import { SchemaVariantSpec } from "../bindings/SchemaVariantSpec.ts";
 
 export const SI_SEPARATOR = "\u{b}";
 
@@ -45,6 +46,23 @@ export function createInputSocketFromProp(
 
   return socket;
 }
+
+export function getOrCreateInputSocketFromProp(
+  schemaVariant: SchemaVariantSpec,
+  prop: ExpandedPropSpec,
+  arity: SocketSpecArity = "many",
+  connectionAnnotations: string[] = [],
+) {
+  let socket = schemaVariant.sockets.find((s) => s.data.kind === "input" && s.name === prop.name);
+  if (!socket) {
+    socket ??= createInputSocketFromProp(prop as ExpandedPropSpec, arity);
+    schemaVariant.sockets.push(socket);
+  }
+  for (const connectionAnnotation of connectionAnnotations) {
+    setAnnotationOnSocket(socket, { tokens: [connectionAnnotation] });
+  }
+  return socket;
+} 
 
 export function setAnnotationOnSocket(
   socket: SocketSpec,


### PR DESCRIPTION
1. Create input sockets for props if they have the same name as the output of some *other* asset. This rule already existed, but we weren't doing it if it was also an output socket on the *current* asset. Now we allow it (as long as we could also connect to some other asset besides ourselves).
2. Make sure we add annotations to sockets even if something else created the socket. This adds Arn as an annotation to a lot of sockets.
3. If a socket has the same name as an asset, but that asset has a compound identity (more than one primaryIdentifier), do *not* automatically create a socket--a single socket can't possibly do the job.