### PR TITLE
chore(clover): Strongly type Clover working types (specs)

### DIFF
--- a/bin/clover/README.md
+++ b/bin/clover/README.md
@@ -1,21 +1,84 @@
-# Useful Link
+clover generates full AWS asset coverage for all resource types in the
+[Cloudformation schema](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html).
 
-- [Cloudformation resource type schema](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html)
+# Initial Setup
+
+Before you can run the schema generator, you must download the latest [Cloudformation resource type schema](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html)
+to cloudformation-schema/*.json:
+
+```sh
+$ deno task run fetch-schema
+```
+
+# Generating Assets
+
+This will fetch the current ID for each schema, and then regenerate all schemas into the
+si-specs directory.
+
+```sh
+$ deno task run generate-specs [...SCHEMA]
+```
+
+* `generate-specs` with no arguments to regenerate all specs
+* `generate-specs EC2 S3 SecurityGroup` to regenerate all EC2 and S3 schemas, plus the
+  SecurityGroup schema
+* `SI_MODULE_INDEX_URL=https://module-index/systeminit.com` to point at production
+* `SI_MODULE_INDEX_URL=http://127.0.0.1:5157` to point at your local module index. (**If you do
+  this, do NOT upload the resulting specs to production--they will have the wrong module
+  IDs.**)
+* `LOG_LEVEL=debug` (or info, warning, error) for log output
+
+## Diffing Your Changes
+
+When you have changed heuristics, you will want to look at the differences--but the specs
+contain ULIDs, which change each time. You can run `anonymize-specs.sh` runs jq to remove
+these (which will not change the specs, but create an anonymized copy in si-specs/anonymized).
+After that, you can diff the anonymized specs to see what your heuristic affected.
+
+1. **Baseline**: Before you run your new changes, generated an anonymized baseline in
+   `si-specs-old/anonymized`:
+
+   ```sh
+   $ deno task run -A main.ts generate-specs && ./anonymize-specs.sh
+   $ cp -R si-specs si-specs-old
+   ```
+
+2. **Regenerate**: Regenerate and anonymize the specs to `si-specs/anonymized`:
+
+   ```sh
+   $ deno task run -A main.ts generate-specs && ./anonymize-specs.sh
+   ```
+
+3. **Diff**: Diff the results:
+
+   ```sh
+   diff -u si-specs-old/anonymized si-specs/anonymized
+   ```
+
+4. Repeat steps 2-3 until satisfied.
+
+## Note about Asset Code changes
+
+If you are changing a lot of asset functions themselves, every package will show `codeBase64`
+changed, which is a giant blob and can get overwhelming.
+
+To exclude codeBase64, add this to anonymize-specs.sh:
+
+```sh
+$ ./anonymize-specs.sh --remove-props ".funcs[].data.codeBase64"
+```
+
+Just note that if you do this, you won't know which modules had their asset code changed!
+Don't run it all the time.
 
 # Running tests
 
 ```sh
-$ deno test -A
+$ buck2 run //bin/clover:test-unit
 ```
-
-# Updating Schema
+## Changing log output
 
 ```sh
-$ deno run -A main.ts fetch-schema
+$ env LOG_LEVEL=verbose deno test --unstable-sloppy-imports -A
 ```
 
-# Changing log output
-
-```sh
-$ env LOG_LEVEL=verbose deno test -A
-```

--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -1,6 +1,5 @@
 import { getServiceByName, loadCfDatabase } from "../cfDb.ts";
 import { pkgSpecFromCf } from "../specPipeline.ts";
-import { PkgSpec } from "../bindings/PkgSpec.ts";
 import { generateAssetFuncs } from "../pipeline-steps/generateAssetFuncs.ts";
 import { generateDefaultActionFuncs } from "../pipeline-steps/generateActionFuncs.ts";
 import { generateDefaultLeafFuncs } from "../pipeline-steps/generateLeafFuncs.ts";
@@ -21,6 +20,7 @@ import {
 import {
   generateOutputSocketsFromProps,
 } from "../pipeline-steps/generateOutputSocketsFromProps.ts";
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 
 const logger = _logger.ns("siSpecs").seal();
 const SI_SPEC_DIR = "si-specs";
@@ -30,7 +30,10 @@ export function generateSiSpecForService(serviceName: string) {
   return pkgSpecFromCf(cf);
 }
 
-export async function generateSiSpecs(moduleIndexUrl: string, services?: string[]) {
+export async function generateSiSpecs(
+  moduleIndexUrl: string,
+  services?: string[],
+) {
   if (services?.length == 0) services = undefined;
   const db = await loadCfDatabase({ services });
   const existing_specs = await getExistingSpecs(moduleIndexUrl);
@@ -39,7 +42,7 @@ export async function generateSiSpecs(moduleIndexUrl: string, services?: string[
   let importSubAssets = 0;
   const cfSchemas = Object.values(db);
 
-  let specs = [] as PkgSpec[];
+  let specs = [] as ExpandedPkgSpec[];
 
   for (const cfSchema of cfSchemas) {
     try {

--- a/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
+++ b/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
@@ -1,14 +1,16 @@
-import { PkgSpec } from "../bindings/PkgSpec.ts";
 import _ from "lodash";
 import {
   createObjectProp,
   createScalarProp,
-  isExpandedPropSpec,
+  ExpandedPropSpec,
 } from "../spec/props.ts";
 import { createInputSocketFromProp } from "../spec/sockets.ts";
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 
-export function addDefaultPropsAndSockets(specs: PkgSpec[]): PkgSpec[] {
-  const newSpecs = [] as PkgSpec[];
+export function addDefaultPropsAndSockets(
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of specs) {
     const schema = spec.schemas[0];
@@ -29,12 +31,6 @@ export function addDefaultPropsAndSockets(specs: PkgSpec[]): PkgSpec[] {
     }
 
     const domain = schemaVariant.domain;
-    if (!isExpandedPropSpec(domain)) {
-      console.log(
-        `Could not generate default props and sockets for ${spec.name}: domain has no metadata`,
-      );
-      continue;
-    }
     if (domain.kind !== "object") {
       console.log(
         `Could not generate default props and sockets for ${spec.name}: domain is not object`,
@@ -57,11 +53,11 @@ export function addDefaultPropsAndSockets(specs: PkgSpec[]): PkgSpec[] {
         updatable: [] as string[],
       };
 
-      const queue = _.cloneDeep(domain.entries);
+      const queue: ExpandedPropSpec[] = _.cloneDeep(domain.entries);
 
       while (queue.length > 0) {
         const prop = queue.pop();
-        if (!prop || !isExpandedPropSpec(prop)) break;
+        if (!prop) break;
 
         if (prop.metadata.createOnly) {
           propUsageMap.createOnly.push(prop.name);

--- a/bin/clover/src/pipeline-steps/addSignatureToCategoryName.ts
+++ b/bin/clover/src/pipeline-steps/addSignatureToCategoryName.ts
@@ -1,13 +1,13 @@
 import _logger from "../logger.ts";
-import { PkgSpec } from "../bindings/PkgSpec.ts";
 import _ from "npm:lodash";
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 
 // This exists so the frontend feature flag can ignore clover generated modules
 // It should be removed when clover assets are launched
 export function addSignatureToCategoryName(
-  specs: PkgSpec[],
-): PkgSpec[] {
-  const newSpecs = [] as PkgSpec[];
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of specs) {
     const schema = spec.schemas[0];

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -1,13 +1,14 @@
-import { PkgSpec } from "../bindings/PkgSpec.ts";
 import _ from "npm:lodash";
-import { ExpandedPropSpec } from "../spec/props.ts";
 import _logger from "../logger.ts";
 import { createInputSocketFromProp } from "../spec/sockets.ts";
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 
 const logger = _logger.ns("assetOverrides").seal();
 
-export function assetSpecificOverrides(incomingSpecs: PkgSpec[]): PkgSpec[] {
-  const newSpecs = [] as PkgSpec[];
+export function assetSpecificOverrides(
+  incomingSpecs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of incomingSpecs) {
     if (overrides.has(spec.name)) {
@@ -20,15 +21,15 @@ export function assetSpecificOverrides(incomingSpecs: PkgSpec[]): PkgSpec[] {
   return newSpecs;
 }
 
-type OverrideFn = (spec: PkgSpec) => void;
+type OverrideFn = (spec: ExpandedPkgSpec) => void;
 
 const overrides = new Map<string, OverrideFn>([
-  ["AWS::EC2::Route", (spec: PkgSpec) => {
+  ["AWS::EC2::Route", (spec: ExpandedPkgSpec) => {
     addGatewayIdSocketToEC2Route(spec);
   }],
 ]);
 
-function addGatewayIdSocketToEC2Route(spec: PkgSpec) {
+function addGatewayIdSocketToEC2Route(spec: ExpandedPkgSpec) {
   const schema = spec.schemas[0];
   const variant = spec.schemas[0].variants[0];
   const domain = variant.domain;
@@ -38,7 +39,7 @@ function addGatewayIdSocketToEC2Route(spec: PkgSpec) {
   }
   for (const prop of domain.entries) {
     if (prop.name === "GatewayId") {
-      const socket = createInputSocketFromProp(prop as ExpandedPropSpec, "one");
+      const socket = createInputSocketFromProp(prop, "one");
 
       const data = socket.data;
       if (data) {

--- a/bin/clover/src/pipeline-steps/generateActionFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateActionFuncs.ts
@@ -1,13 +1,15 @@
-import { PkgSpec } from "../bindings/PkgSpec.ts";
 import _ from "lodash";
 import {
   createActionFuncSpec,
   createDefaultActionFuncs,
 } from "../spec/funcs.ts";
 import { ActionFuncSpecKind } from "../bindings/ActionFuncSpecKind.ts";
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 
-export function generateDefaultActionFuncs(specs: PkgSpec[]): PkgSpec[] {
-  const newSpecs = [] as PkgSpec[];
+export function generateDefaultActionFuncs(
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const newSpecs = [] as ExpandedPkgSpec[];
   const defaultActionFuncs = createDefaultActionFuncs();
 
   for (const spec of specs) {

--- a/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
@@ -1,16 +1,16 @@
-import { PkgSpec } from "../bindings/PkgSpec.ts";
 import type {
   FuncSpecData,
 } from "../../../../lib/si-pkg/bindings/FuncSpecData.ts";
 import { FuncSpec } from "../../../../lib/si-pkg/bindings/FuncSpec.ts";
-import { SchemaVariantSpec } from "../bindings/SchemaVariantSpec.ts";
 import _ from "lodash";
-import { PropSpec } from "../bindings/PropSpec.ts";
 import { strippedBase64 } from "../spec/funcs.ts";
-import { CREATE_ONLY_PROP_LABEL, isExpandedPropSpec } from "../spec/props.ts";
+import { CREATE_ONLY_PROP_LABEL, ExpandedPropSpec } from "../spec/props.ts";
+import { ExpandedPkgSpec, ExpandedSchemaVariantSpec } from "../spec/pkgs.ts";
 
-export function generateAssetFuncs(specs: PkgSpec[]): PkgSpec[] {
-  const newSpecs = [] as PkgSpec[];
+export function generateAssetFuncs(
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of specs) {
     const schemaVariant = spec.schemas[0]?.variants[0];
@@ -55,7 +55,9 @@ export function generateAssetFuncs(specs: PkgSpec[]): PkgSpec[] {
   return newSpecs;
 }
 
-function generateAssetCodeFromVariantSpec(variant: SchemaVariantSpec): string {
+function generateAssetCodeFromVariantSpec(
+  variant: ExpandedSchemaVariantSpec,
+): string {
   if (variant.domain.kind !== "object") throw "Domain prop is not object";
   if (variant.resourceValue.kind !== "object") {
     throw "ResourceValue prop is not object";
@@ -186,7 +188,7 @@ function generateAssetCodeFromVariantSpec(variant: SchemaVariantSpec): string {
 }
 
 function generateSecretPropBuilderString(
-  prop: PropSpec,
+  prop: ExpandedPropSpec,
   indent_level: number,
 ): string {
   return `new SecretPropBuilder()\n` +
@@ -196,11 +198,10 @@ function generateSecretPropBuilderString(
 }
 
 function generatePropBuilderString(
-  prop: PropSpec,
+  prop: ExpandedPropSpec,
   indent_level: number,
 ): string {
-  const is_create_only =
-    (isExpandedPropSpec(prop) && prop.metadata.createOnly) ?? false;
+  const is_create_only = prop.metadata.createOnly ?? false;
 
   switch (prop.kind) {
     case "array":
@@ -316,7 +317,7 @@ function generateWidgetString(
   widgetKind: string | undefined | null,
   create_only: boolean,
   indentLevel: number,
-  options?: { label: string; value: string }[],
+  options?: { label: string; value: string }[] | null,
 ): string {
   if (!widgetKind) {
     console.log("Unable to generate widget for prop!");

--- a/bin/clover/src/pipeline-steps/generateIntrinsicFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateIntrinsicFuncs.ts
@@ -1,13 +1,15 @@
-import { PkgSpec } from "../bindings/PkgSpec.ts";
 import _ from "npm:lodash";
 import {
   createNormalizeToArray,
   createResourcePayloadToValue,
   createSiFuncs,
 } from "../spec/siFuncs.ts";
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 
-export function generateIntrinsicFuncs(specs: PkgSpec[]): PkgSpec[] {
-  const newSpecs = [] as PkgSpec[];
+export function generateIntrinsicFuncs(
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of specs) {
     const funcs = spec.funcs;

--- a/bin/clover/src/pipeline-steps/generateLeafFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateLeafFuncs.ts
@@ -1,12 +1,14 @@
-import { PkgSpec } from "../bindings/PkgSpec.ts";
 import _ from "lodash";
 import {
   createDefaultCodeGenFuncs,
   createLeafFuncSpec,
 } from "../spec/funcs.ts";
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 
-export function generateDefaultLeafFuncs(specs: PkgSpec[]): PkgSpec[] {
-  const newSpecs = [] as PkgSpec[];
+export function generateDefaultLeafFuncs(
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of specs) {
     const schemaVariant = spec.schemas[0]?.variants[0];

--- a/bin/clover/src/pipeline-steps/generateManagementFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateManagementFuncs.ts
@@ -1,12 +1,14 @@
-import { PkgSpec } from "../bindings/PkgSpec.ts";
 import _ from "lodash";
 import {
   createDefaultManagementFuncs,
   createManagementFuncSpec,
 } from "../spec/funcs.ts";
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 
-export function generateDefaultManagementFuncs(specs: PkgSpec[]): PkgSpec[] {
-  const newSpecs = [] as PkgSpec[];
+export function generateDefaultManagementFuncs(
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const newSpecs = [] as ExpandedPkgSpec[];
   const defaultMgmtFuncs = createDefaultManagementFuncs();
 
   for (const spec of specs) {

--- a/bin/clover/src/pipeline-steps/generateOutputSocketsFromProps.ts
+++ b/bin/clover/src/pipeline-steps/generateOutputSocketsFromProps.ts
@@ -1,17 +1,16 @@
-import { PkgSpec } from "../bindings/PkgSpec.ts";
-import { SchemaVariantSpec } from "../bindings/SchemaVariantSpec.ts";
 import _ from "lodash";
-import { SocketSpec } from "../bindings/SocketSpec.ts";
-import { bfsPropTree, isExpandedPropSpec } from "../spec/props.ts";
+import { bfsPropTree } from "../spec/props.ts";
 import {
   createOutputSocketFromProp,
+  ExpandedSocketSpec,
   setAnnotationOnSocket,
 } from "../spec/sockets.ts";
+import { ExpandedPkgSpec, ExpandedSchemaVariantSpec } from "../spec/pkgs.ts";
 
 export function generateOutputSocketsFromProps(
-  specs: PkgSpec[],
-): PkgSpec[] {
-  const newSpecs = [] as PkgSpec[];
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of specs) {
     const schemaVariant = spec.schemas[0]?.variants[0];
@@ -35,16 +34,16 @@ export function generateOutputSocketsFromProps(
   return newSpecs;
 }
 
-function createSocketsFromResource(variant: SchemaVariantSpec): SocketSpec[] {
+function createSocketsFromResource(
+  variant: ExpandedSchemaVariantSpec,
+): ExpandedSocketSpec[] {
   const resource = variant.resourceValue;
 
   if (resource.kind !== "object") throw "Resource prop is not object";
 
-  const sockets: SocketSpec[] = [];
+  const sockets: ExpandedSocketSpec[] = [];
   for (const prop of resource.entries) {
-    if (
-      !["array", "object"].includes(prop.kind) && isExpandedPropSpec(prop)
-    ) {
+    if (!["array", "object"].includes(prop.kind)) {
       const socket = createOutputSocketFromProp(prop);
       // if this socket is an arn, we want to make sure that all input sockets
       // that might also be arns can take this value
@@ -61,17 +60,15 @@ function createSocketsFromResource(variant: SchemaVariantSpec): SocketSpec[] {
 }
 
 function createSocketsFromPrimaryIdentifier(
-  variant: SchemaVariantSpec,
-): SocketSpec[] {
+  variant: ExpandedSchemaVariantSpec,
+): ExpandedSocketSpec[] {
   const domain = variant.domain;
 
   if (domain.kind !== "object") throw "Domain prop is not object";
 
-  const sockets: SocketSpec[] = [];
+  const sockets: ExpandedSocketSpec[] = [];
 
   bfsPropTree(domain, (prop) => {
-    if (!isExpandedPropSpec(prop)) return;
-
     // We don't check if the socket already exists before adding, since on the other func
     // we only look at resourceValue props
     if (prop.metadata.primaryIdentifier) {

--- a/bin/clover/src/pipeline-steps/generateSubAssets.ts
+++ b/bin/clover/src/pipeline-steps/generateSubAssets.ts
@@ -1,27 +1,27 @@
-import { PkgSpec } from "../bindings/PkgSpec.ts";
 import _ from "npm:lodash";
 import {
   copyPropWithNewIds,
   createDefaultProp,
   ExpandedPropSpec,
   generatePropHash,
-  isExpandedPropSpec,
 } from "../spec/props.ts";
 import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
-import { SchemaVariantSpec } from "../bindings/SchemaVariantSpec.ts";
 import { attrFuncInputSpecFromSocket } from "../spec/sockets.ts";
 import { createSocket } from "../spec/sockets.ts";
 import { attrFuncInputSpecFromProp } from "../spec/sockets.ts";
 import { getSiFuncId } from "../spec/siFuncs.ts";
 import _logger from "../logger.ts";
+import { ExpandedPkgSpec, ExpandedSchemaVariantSpec } from "../spec/pkgs.ts";
 
 const logger = _logger.ns("subAssets").seal();
 
-export function generateSubAssets(incomingSpecs: PkgSpec[]): PkgSpec[] {
-  const outgoingSpecs = [] as PkgSpec[];
+export function generateSubAssets(
+  incomingSpecs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const outgoingSpecs = [] as ExpandedPkgSpec[];
   const newSpecsByHash = {} as Record<
     string,
-    { spec: PkgSpec; names: string[] }
+    { spec: ExpandedPkgSpec; names: string[] }
   >;
 
   for (const spec of incomingSpecs) {
@@ -41,12 +41,6 @@ export function generateSubAssets(incomingSpecs: PkgSpec[]): PkgSpec[] {
     }
 
     const domain = schemaVariant.domain;
-    if (!isExpandedPropSpec(domain)) {
-      console.log(
-        `Could not generate default props and sockets for ${spec.name}: domain has no metadata`,
-      );
-      continue;
-    }
     if (domain.kind !== "object") {
       console.log(
         `Could not generate default props and sockets for ${spec.name}: domain is not object`,
@@ -103,7 +97,7 @@ export function generateSubAssets(incomingSpecs: PkgSpec[]): PkgSpec[] {
         }
 
         const variantData = _.cloneDeep(schemaVariant.data);
-        const variant: SchemaVariantSpec = {
+        const variant: ExpandedSchemaVariantSpec = {
           ...schemaVariant,
           data: {
             ...variantData,
@@ -123,7 +117,7 @@ export function generateSubAssets(incomingSpecs: PkgSpec[]): PkgSpec[] {
 
         const schemaData = _.cloneDeep(schema.data);
 
-        const newSpec: PkgSpec = {
+        const newSpec: ExpandedPkgSpec = {
           ...spec,
           name,
           description: prop.typeProp.data?.documentation ?? "",
@@ -156,7 +150,7 @@ export function generateSubAssets(incomingSpecs: PkgSpec[]): PkgSpec[] {
   // Select best name and category for each subAsset
   for (
     const { spec, names } of _.values(newSpecsByHash) as {
-      spec: PkgSpec;
+      spec: ExpandedPkgSpec;
       names: string[];
     }[]
   ) {
@@ -232,7 +226,7 @@ function fixPropPath(props: ExpandedPropSpec[], parentPath: string[]) {
   for (const prop of props) {
     prop.metadata.propPath = [...parentPath, prop.name];
     if (prop.kind === "object") {
-      fixPropPath(prop.entries as ExpandedPropSpec[], prop.metadata.propPath);
+      fixPropPath(prop.entries, prop.metadata.propPath);
     }
   }
 }

--- a/bin/clover/src/pipeline-steps/updateSchemaIdsForExistingSpecs.ts
+++ b/bin/clover/src/pipeline-steps/updateSchemaIdsForExistingSpecs.ts
@@ -1,13 +1,13 @@
 import _logger from "../logger.ts";
-import { PkgSpec } from "../bindings/PkgSpec.ts";
 import _ from "npm:lodash";
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 const logger = _logger.ns("updateExisting").seal();
 
 export function updateSchemaIdsForExistingSpecs(
   existing_specs: Record<string, string>,
-  specs: PkgSpec[],
-): PkgSpec[] {
-  const newSpecs = [] as PkgSpec[];
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of specs) {
     const schema = spec.schemas[0];

--- a/bin/clover/src/spec/pkgs.ts
+++ b/bin/clover/src/spec/pkgs.ts
@@ -1,0 +1,26 @@
+import { SchemaSpec } from "../bindings/SchemaSpec.ts";
+import { PkgSpec } from "../bindings/PkgSpec.ts";
+import { SchemaVariantSpec } from "../bindings/SchemaVariantSpec.ts";
+import { ExpandedPropSpec } from "./props.ts";
+import { ExpandedSocketSpec } from "./sockets.ts";
+
+export type ExpandedPkgSpec = Omit<PkgSpec, "schemas"> & {
+  schemas: Array<ExpandedSchemaSpec>;
+};
+
+export type ExpandedSchemaSpec = Omit<SchemaSpec, "variants"> & {
+  variants: Array<ExpandedSchemaVariantSpec>;
+};
+
+export type ExpandedSchemaVariantSpec =
+  & Omit<
+    SchemaVariantSpec,
+    "sockets" | "domain" | "secrets" | "secretDefinition" | "resourceValue"
+  >
+  & {
+    sockets: ExpandedSocketSpec[];
+    domain: ExpandedPropSpec;
+    secrets: ExpandedPropSpec;
+    secretDefinition: ExpandedPropSpec | null;
+    resourceValue: ExpandedPropSpec;
+  };

--- a/bin/clover/src/specPipeline.ts
+++ b/bin/clover/src/specPipeline.ts
@@ -1,20 +1,18 @@
 import { CfProperty, CfSchema } from "./cfDb.ts";
-import { PkgSpec } from "../../../lib/si-pkg/bindings/PkgSpec.ts";
 import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
 import {
   createDefaultProp,
   createPropFromCf,
   DefaultPropType,
-  ExpandedPropSpec,
   OnlyProperties,
 } from "./spec/props.ts";
-import { PropSpec } from "../../../lib/si-pkg/bindings/PropSpec.ts";
 import {
-  SchemaVariantSpec,
-} from "../../../lib/si-pkg/bindings/SchemaVariantSpec.ts";
-import { SchemaSpec } from "../../../lib/si-pkg/bindings/SchemaSpec.ts";
+  ExpandedPkgSpec,
+  ExpandedSchemaSpec,
+  ExpandedSchemaVariantSpec,
+} from "./spec/pkgs.ts";
 
-export function pkgSpecFromCf(src: CfSchema): PkgSpec {
+export function pkgSpecFromCf(src: CfSchema): ExpandedPkgSpec {
   const [aws, category, name] = src.typeName.split("::");
 
   if (!["AWS", "Alexa"].includes(aws) || !category || !name) {
@@ -35,13 +33,13 @@ export function pkgSpecFromCf(src: CfSchema): PkgSpec {
     primaryIdentifier: normalizeOnlyProperties(src.primaryIdentifier),
   };
 
-  const domain: PropSpec = createDomainFromSrc(src, onlyProperties);
-  const resourceValue: PropSpec = createResourceValueFromSrc(
+  const domain = createDomainFromSrc(src, onlyProperties);
+  const resourceValue = createResourceValueFromSrc(
     src,
     onlyProperties,
   );
 
-  const variant: SchemaVariantSpec = {
+  const variant: ExpandedSchemaVariantSpec = {
     version,
     data: {
       version,
@@ -68,7 +66,7 @@ export function pkgSpecFromCf(src: CfSchema): PkgSpec {
     rootPropFuncs: [],
   };
 
-  const schema: SchemaSpec = {
+  const schema: ExpandedSchemaSpec = {
     name: src.typeName,
     data: {
       name: src.typeName,
@@ -106,7 +104,7 @@ function versionFromDate(): string {
 function createDomainFromSrc(
   src: CfSchema,
   onlyProperties: OnlyProperties,
-): PropSpec {
+) {
   return createRootFromProperties(
     "domain",
     pruneDomainValues(src.properties, onlyProperties),
@@ -117,7 +115,7 @@ function createDomainFromSrc(
 function createResourceValueFromSrc(
   src: CfSchema,
   onlyProperties: OnlyProperties,
-): PropSpec {
+) {
   return createRootFromProperties(
     "resource_value",
     pruneResourceValues(src.properties, onlyProperties),
@@ -129,8 +127,8 @@ function createRootFromProperties(
   root_name: DefaultPropType,
   properties: Record<string, CfProperty>,
   onlyProperties: OnlyProperties,
-): PropSpec {
-  const root: ExpandedPropSpec = createDefaultProp(root_name);
+) {
+  const root = createDefaultProp(root_name);
   Object.entries(properties).forEach(([name, cfData]) => {
     const newProp = createPropFromCf(name, cfData, onlyProperties, [
       ...root.metadata.propPath,

--- a/bin/clover/test/cfdb_test.ts
+++ b/bin/clover/test/cfdb_test.ts
@@ -7,7 +7,7 @@ import {
 } from "../src/cfDb.ts";
 import { assertObjectMatch } from "@std/assert/object-match";
 
-await loadCfDatabase("./test/test-files");
+await loadCfDatabase({ path: "./test/test-files" });
 
 Deno.test(function getByServiceNameReturnsSchema() {
   // Throws if the service does not exist

--- a/bin/clover/test/spec_test.ts
+++ b/bin/clover/test/spec_test.ts
@@ -1,5 +1,4 @@
 import {
-  assert,
   assertEquals,
   assertExists,
   assertInstanceOf,
@@ -9,16 +8,16 @@ import { generateSiSpecForService } from "../src/commands/generateSiSpecs.ts";
 import { ExpandedPropSpec } from "../src/spec/props.ts";
 import { loadCfDatabase } from "../src/cfDb.ts";
 
-const SET_BOOLEAN =
-  "577a7deea25cfad0d4b2dd1e1f3d96b86b8b1578605137b8c4128d644c86964b";
-const SET_INTEGER =
-  "7d384b237852f20b8dec2fbd2e644ffc6bde901d7dc937bd77f50a0d57e642a9";
-const SET_MAP =
-  "dea5084fbf6e7fe8328ac725852b96f4b5869b14d0fe9dd63a285fa876772496";
-const SET_OBJECT =
-  "cb9bf94739799f3a8b84bcb88495f93b27b47c31a341f8005a60ca39308909fd";
+// const SET_BOOLEAN =
+//   "577a7deea25cfad0d4b2dd1e1f3d96b86b8b1578605137b8c4128d644c86964b";
+// const SET_INTEGER =
+//   "7d384b237852f20b8dec2fbd2e644ffc6bde901d7dc937bd77f50a0d57e642a9";
+// const SET_MAP =
+//   "dea5084fbf6e7fe8328ac725852b96f4b5869b14d0fe9dd63a285fa876772496";
+// const SET_OBJECT =
+//   "cb9bf94739799f3a8b84bcb88495f93b27b47c31a341f8005a60ca39308909fd";
 
-await loadCfDatabase("./test/test-files");
+await loadCfDatabase({ path: "./test/test-files" });
 
 Deno.test(function generateServiceByName() {
   // Throws if the service does not exist
@@ -32,7 +31,7 @@ Deno.test(function generateServiceByName() {
   assertInstanceOf(goodResult.schemas[0].variants, Array);
   assertEquals(goodResult.schemas[0].variants.length, 1);
 
-  const domain = goodResult.schemas[0].variants[0].domain as ExpandedPropSpec;
+  const domain = goodResult.schemas[0].variants[0].domain;
   assertInstanceOf(domain, Object);
   assertInstanceOf(domain.metadata.propPath, Array);
   assertEquals(domain.metadata.propPath, ["root", "domain"]);
@@ -53,20 +52,18 @@ function validateProps(prop: ExpandedPropSpec) {
     case "array":
       assertEquals(prop.data?.widgetKind, "Array");
       assertExists(prop.typeProp);
-      validateProps(prop.typeProp as ExpandedPropSpec);
+      validateProps(prop.typeProp);
       break;
     case "map":
       assertEquals(prop.data?.widgetKind, "Map");
       assertExists(prop.typeProp);
-      validateProps(prop.typeProp as ExpandedPropSpec);
+      validateProps(prop.typeProp);
       break;
     case "object":
       assertEquals(prop.data?.widgetKind, "Header");
-      if (prop.name !== "domain") {
-      }
       assertExists(prop.entries);
       Object.values(prop.entries).forEach((entry) => {
-        validateProps(entry as ExpandedPropSpec);
+        validateProps(entry);
       });
       break;
     default:


### PR DESCRIPTION
Clover is passing a bunch of PkgSpecs that it has dotted with extra cloudformation metadata, which actually contain `ExpandedPropSpec`s deep underneath. But because the PkgSpec *type* only has normal PropSpecs, we have to cast or check all props each time we look at them. The casting is dangerous (can be wrong), and the checking is unnecessary.

This PR adds an ExpandedPkgSpec that is just like PkgSpec except all props underneath are ExpandedPropSpecs. Typescript infers the types everywhere, therefore, and we can remove casts.

* Adds explicit types for everything in the pipeline. This gives us a lot more type safety, completion and editor type features, as many types showed up as "any" due to how ts-rs generates the bindings.
* Removes "type assumption" casts `as *Spec` everywhere (so we don't assume things are a certain type when they actually aren't
* Removes isExpandedPropSpec() and all calls to it, since we now know for sure that's what it is
* Gets us compiling correctly when the bindings actually load (there were a few issues that occur once the bindings get fixed to have `.ts` extensions on the imports)

While this makes us compile correctly when the si-pkg bindings are fixed, this PR does not fix them. That will come when we fix ts-rs.

### Testing

I regenerated all pkg files, and diffed them, and there are no differences.