### PR TITLE
chore(clover): Guarantee single schema, variant and that domain is object prop

### DIFF
--- a/bin/clover/README.md
+++ b/bin/clover/README.md
@@ -39,14 +39,14 @@ After that, you can diff the anonymized specs to see what your heuristic affecte
    `si-specs-old/anonymized`:
 
    ```sh
-   $ deno task run -A main.ts generate-specs && ./anonymize-specs.sh
+   $ deno task run generate-specs && ./anonymize-specs.sh
    $ cp -R si-specs si-specs-old
    ```
 
 2. **Regenerate**: Regenerate and anonymize the specs to `si-specs/anonymized`:
 
    ```sh
-   $ deno task run -A main.ts generate-specs && ./anonymize-specs.sh
+   $ deno task run generate-specs && ./anonymize-specs.sh
    ```
 
 3. **Diff**: Diff the results:

--- a/bin/clover/src/extend.ts
+++ b/bin/clover/src/extend.ts
@@ -1,0 +1,2 @@
+// Extend a type, ensuring that the overridden types extend the original
+export type Extend<T, F extends Partial<T>> = Omit<T, keyof F> & F;

--- a/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
+++ b/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
@@ -13,30 +13,9 @@ export function addDefaultPropsAndSockets(
   const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of specs) {
-    const schema = spec.schemas[0];
-
-    if (!schema) {
-      console.log(
-        `Could not generate default props and sockets for ${spec.name}: missing schema`,
-      );
-      continue;
-    }
-    const schemaVariant = schema.variants[0];
-
-    if (!schemaVariant) {
-      console.log(
-        `Could not generate default props and sockets for ${spec.name}: missing variant`,
-      );
-      continue;
-    }
-
-    const domain = schemaVariant.domain;
-    if (domain.kind !== "object") {
-      console.log(
-        `Could not generate default props and sockets for ${spec.name}: domain is not object`,
-      );
-      continue;
-    }
+    const [schema] = spec.schemas;
+    const [schemaVariant] = schema.variants;
+    const { domain } = schemaVariant;
 
     // Extra prop
     const extraProp = createObjectProp("extra", domain.metadata.propPath);

--- a/bin/clover/src/pipeline-steps/addSignatureToCategoryName.ts
+++ b/bin/clover/src/pipeline-steps/addSignatureToCategoryName.ts
@@ -10,14 +10,7 @@ export function addSignatureToCategoryName(
   const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of specs) {
-    const schema = spec.schemas[0];
-
-    if (!schema) {
-      console.log(
-        `Could not generate default props and sockets for ${spec.name}: missing schema`,
-      );
-      continue;
-    }
+    const [schema] = spec.schemas;
 
     const schemaData = schema.data;
     if (schemaData) {

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -30,13 +30,10 @@ const overrides = new Map<string, OverrideFn>([
 ]);
 
 function addGatewayIdSocketToEC2Route(spec: ExpandedPkgSpec) {
-  const schema = spec.schemas[0];
-  const variant = spec.schemas[0].variants[0];
-  const domain = variant.domain;
+  const [schema] = spec.schemas;
+  const [variant] = schema.variants;
+  const { domain } = variant;
 
-  if (!schema || !variant || !domain || domain.kind !== "object") {
-    throw new Error(`Unable to run override for ${spec.name}`);
-  }
   for (const prop of domain.entries) {
     if (prop.name === "GatewayId") {
       const socket = createInputSocketFromProp(prop, "one");

--- a/bin/clover/src/pipeline-steps/createInputSocketsAcrossAssets.ts
+++ b/bin/clover/src/pipeline-steps/createInputSocketsAcrossAssets.ts
@@ -18,22 +18,8 @@ export function createInputSocketsBasedOnOutputSockets(
 
   // Get all output sockets
   for (const spec of specs) {
-    const schema = spec.schemas[0];
-
-    if (!schema) {
-      console.log(
-        `Could not generate input sockets for ${spec.name}: missing schema`,
-      );
-      continue;
-    }
-    const schemaVariant = schema.variants[0];
-
-    if (!schemaVariant) {
-      console.log(
-        `Could not generate input sockets for ${spec.name}: missing variant`,
-      );
-      continue;
-    }
+    const [schema] = spec.schemas;
+    const [schemaVariant] = schema.variants;
 
     for (const socket of schemaVariant.sockets) {
       if (socket.data?.kind === "output") {

--- a/bin/clover/src/pipeline-steps/generateActionFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateActionFuncs.ts
@@ -13,16 +13,10 @@ export function generateDefaultActionFuncs(
   const defaultActionFuncs = createDefaultActionFuncs();
 
   for (const spec of specs) {
-    const schemaVariant = spec.schemas[0]?.variants[0];
-    const funcs = spec.funcs;
-    const actionFuncs = schemaVariant.actionFuncs;
-
-    if (!schemaVariant) {
-      console.log(
-        `Could not generate action funcs for ${spec.name}: missing schema or variant!`,
-      );
-      continue;
-    }
+    const [schema] = spec.schemas;
+    const [schemaVariant] = schema.variants;
+    const { funcs } = spec;
+    const { actionFuncs } = schemaVariant;
 
     for (const { spec: actionFunc, kind } of defaultActionFuncs) {
       funcs.push(actionFunc);

--- a/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
@@ -13,14 +13,8 @@ export function generateAssetFuncs(
   const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of specs) {
-    const schemaVariant = spec.schemas[0]?.variants[0];
-
-    if (!schemaVariant || !schemaVariant.data) {
-      console.log(
-        `Could not generate assetFunc for ${spec.name}: missing schema or variant`,
-      );
-      continue;
-    }
+    const [schema] = spec.schemas;
+    const [schemaVariant] = schema.variants;
 
     const assetFuncUniqueKey = schemaVariant.data.funcUniqueId;
     const assetFuncName = spec.name;

--- a/bin/clover/src/pipeline-steps/generateLeafFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateLeafFuncs.ts
@@ -11,14 +11,15 @@ export function generateDefaultLeafFuncs(
   const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of specs) {
-    const schemaVariant = spec.schemas[0]?.variants[0];
+    const [schema] = spec.schemas;
+    const [schemaVariant] = schema.variants;
     const funcs = spec.funcs;
     const leafFuncs = schemaVariant.leafFunctions;
     const domain_id = schemaVariant.domain.uniqueId;
 
-    if (!schemaVariant || !domain_id) {
+    if (!domain_id) {
       console.log(
-        `Could not generate action funcs for ${spec.name}: missing schema, variant, or domain id!`,
+        `Could not generate action funcs for ${spec.name}: missing domain id!`,
       );
       continue;
     }

--- a/bin/clover/src/pipeline-steps/generateManagementFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateManagementFuncs.ts
@@ -12,16 +12,10 @@ export function generateDefaultManagementFuncs(
   const defaultMgmtFuncs = createDefaultManagementFuncs();
 
   for (const spec of specs) {
-    const schemaVariant = spec.schemas[0]?.variants[0];
+    const [schema] = spec.schemas;
+    const [schemaVariant] = schema.variants;
     const funcs = spec.funcs;
     const mgmtFuncs = schemaVariant.managementFuncs;
-
-    if (!schemaVariant) {
-      console.log(
-        `Could not generate action funcs for ${spec.name}: missing schema or variant!`,
-      );
-      continue;
-    }
 
     for (const mgmtFunc of defaultMgmtFuncs) {
       funcs.push(mgmtFunc);

--- a/bin/clover/src/pipeline-steps/generateOutputSocketsFromProps.ts
+++ b/bin/clover/src/pipeline-steps/generateOutputSocketsFromProps.ts
@@ -13,14 +13,8 @@ export function generateOutputSocketsFromProps(
   const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of specs) {
-    const schemaVariant = spec.schemas[0]?.variants[0];
-
-    if (!schemaVariant) {
-      console.log(
-        `Could not generate sockets for ${spec.name}: missing schema or variant`,
-      );
-      continue;
-    }
+    const [schema] = spec.schemas;
+    const [schemaVariant] = schema.variants;
 
     schemaVariant.sockets = [
       ...schemaVariant.sockets,

--- a/bin/clover/src/pipeline-steps/generateSubAssets.ts
+++ b/bin/clover/src/pipeline-steps/generateSubAssets.ts
@@ -25,28 +25,9 @@ export function generateSubAssets(
   >;
 
   for (const spec of incomingSpecs) {
-    const schema = spec.schemas[0];
-    if (!schema) {
-      console.log(
-        `Could not generate default props and sockets for ${spec.name}: missing schema`,
-      );
-    }
-    const schemaVariant = schema.variants[0];
-
-    if (!schemaVariant) {
-      console.log(
-        `Could not generate default props and sockets for ${spec.name}: missing variant`,
-      );
-      continue;
-    }
-
-    const domain = schemaVariant.domain;
-    if (domain.kind !== "object") {
-      console.log(
-        `Could not generate default props and sockets for ${spec.name}: domain is not object`,
-      );
-      continue;
-    }
+    const [schema] = spec.schemas;
+    const [schemaVariant] = schema.variants;
+    const { domain } = schemaVariant;
 
     for (const prop of domain.entries) {
       if (prop.kind === "array" && prop.typeProp.kind === "object") {
@@ -57,7 +38,7 @@ export function generateSubAssets(
         const name = `${spec.name}::${objName}`;
         const variantId = ulid();
 
-        const newDomainWithOldIds = _.cloneDeep(domain);
+        const newDomainWithOldIds: typeof domain = _.cloneDeep(domain);
         newDomainWithOldIds.entries = prop.typeProp.entries;
 
         // recreate ["root", "domain", etc.]

--- a/bin/clover/src/pipeline-steps/updateSchemaIdsForExistingSpecs.ts
+++ b/bin/clover/src/pipeline-steps/updateSchemaIdsForExistingSpecs.ts
@@ -10,15 +10,6 @@ export function updateSchemaIdsForExistingSpecs(
   const newSpecs = [] as ExpandedPkgSpec[];
 
   for (const spec of specs) {
-    const schema = spec.schemas[0];
-
-    if (!schema) {
-      console.log(
-        `Could not generate default props and sockets for ${spec.name}: missing schema`,
-      );
-      continue;
-    }
-
     const schema_id = existing_specs[spec.name];
     if (schema_id) {
       logger.debug(`Found existing spec ${spec.name}, updating schema id`);

--- a/bin/clover/src/spec/pkgs.ts
+++ b/bin/clover/src/spec/pkgs.ts
@@ -1,26 +1,24 @@
 import { SchemaSpec } from "../bindings/SchemaSpec.ts";
 import { PkgSpec } from "../bindings/PkgSpec.ts";
 import { SchemaVariantSpec } from "../bindings/SchemaVariantSpec.ts";
-import { ExpandedPropSpec } from "./props.ts";
+import { ExpandedPropSpec, ExpandedPropSpecFor } from "./props.ts";
 import { ExpandedSocketSpec } from "./sockets.ts";
+import { Extend } from "../extend.ts";
+import { SchemaVariantSpecData } from "../bindings/SchemaVariantSpecData.ts";
 
-export type ExpandedPkgSpec = Omit<PkgSpec, "schemas"> & {
-  schemas: Array<ExpandedSchemaSpec>;
-};
+export type ExpandedPkgSpec = Extend<PkgSpec, {
+  schemas: [ExpandedSchemaSpec]; // Array of exactly one schema
+}>;
 
-export type ExpandedSchemaSpec = Omit<SchemaSpec, "variants"> & {
-  variants: Array<ExpandedSchemaVariantSpec>;
-};
+export type ExpandedSchemaSpec = Extend<SchemaSpec, {
+  variants: [ExpandedSchemaVariantSpec]; // Exactly one schema variant
+}>;
 
-export type ExpandedSchemaVariantSpec =
-  & Omit<
-    SchemaVariantSpec,
-    "sockets" | "domain" | "secrets" | "secretDefinition" | "resourceValue"
-  >
-  & {
-    sockets: ExpandedSocketSpec[];
-    domain: ExpandedPropSpec;
-    secrets: ExpandedPropSpec;
-    secretDefinition: ExpandedPropSpec | null;
-    resourceValue: ExpandedPropSpec;
-  };
+export type ExpandedSchemaVariantSpec = Extend<SchemaVariantSpec, {
+  data: NonNullable<SchemaVariantSpecData>;
+  sockets: ExpandedSocketSpec[];
+  domain: ExpandedPropSpecFor["object"];
+  secrets: ExpandedPropSpec;
+  secretDefinition: ExpandedPropSpec | null;
+  resourceValue: ExpandedPropSpec;
+}>;


### PR DESCRIPTION
We have a lot of repeated checks for there being 1 schema, 1 variant and that domain is an object prop. This ensures those things at the type level.

It also makes tooltips for individual prop types (object, string, etc.) a bunch more readable by pulling out each PropSpec kind individually (typescript then does the work ahead of time so you can just look at the props on the kind you are looking for).