### PR TITLE
fix(Clover): Multiple socket fixes

### DIFF
--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -60,13 +60,17 @@ export async function generateSiSpecs(
   specs = generateDefaultActionFuncs(specs);
   specs = generateDefaultLeafFuncs(specs);
   specs = generateDefaultManagementFuncs(specs);
-  specs = assetSpecificOverrides(specs);
   // subAssets should not have any of the above, but need an asset func and
   // intrinsics
   specs = generateSubAssets(specs);
   specs = generateIntrinsicFuncs(specs);
   // don't generate input sockets until we have all of the output sockets
   specs = createInputSocketsBasedOnOutputSockets(specs);
+
+  // Our overrides right now only run after the prop tree and the sockets are generated
+  specs = assetSpecificOverrides(specs);
+
+  // These need everything to be complete
   specs = generateAssetFuncs(specs);
   specs = updateSchemaIdsForExistingSpecs(existing_specs, specs);
   specs = addSignatureToCategoryName(specs);

--- a/bin/clover/src/pipeline-steps/createInputSocketsAcrossAssets.ts
+++ b/bin/clover/src/pipeline-steps/createInputSocketsAcrossAssets.ts
@@ -32,11 +32,22 @@ export function createInputSocketsBasedOnOutputSockets(
           socket.data?.connectionAnnotations,
         ) as ConnectionAnnotation[];
 
-        for (const annotations of existingAnnotations) {
-          for (const annotation of annotations.tokens) {
-            foundOutputSockets[annotation] ??= [];
-            foundOutputSockets[annotation].push(schemaVariant);
+        for (const { tokens } of existingAnnotations) {
+          if (tokens.length !== 1) {
+            throw new Error(
+              `Unexpected number of tokens on annotation for ${socket.name} on ${spec.name}`,
+            );
           }
+
+          const annotationToken = tokens[0];
+
+          // One of the annotations is always the socket name. We'll skip that one
+          if (annotationToken === socket.name) {
+            continue;
+          }
+
+          foundOutputSockets[annotationToken] ??= [];
+          foundOutputSockets[annotationToken].push(schemaVariant);
         }
       }
     }

--- a/bin/clover/src/spec/sockets.ts
+++ b/bin/clover/src/spec/sockets.ts
@@ -47,6 +47,14 @@ export function createInputSocketFromProp(
   return socket;
 }
 
+export function getSocketOnVariant(
+  variant: ExpandedSchemaVariantSpec,
+  name: string,
+  kind: SocketSpecKind,
+) {
+  return variant.sockets.find((s) => s.name === name && s.data.kind === kind);
+}
+
 export function getOrCreateInputSocketFromProp(
   schemaVariant: ExpandedSchemaVariantSpec,
   prop: ExpandedPropSpec,


### PR DESCRIPTION
- Overrides for CloudTrail::Trail sockets
- Stop creating input sockets for the same component that has the output sockets, it that's the only matching socket
- Always create output socket for `${VariantName}Name` and `${VariantName}Id`