### PR TITLE
feat(clover): Add doc links to all props; don't lose documentation when regenerating

### DIFF
--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -21,6 +21,7 @@ import {
   generateOutputSocketsFromProps,
 } from "../pipeline-steps/generateOutputSocketsFromProps.ts";
 import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+import { createPolicyDocumentInputSockets } from "../pipeline-steps/createPolicyDocumentInputSockets.ts";
 
 const logger = _logger.ns("siSpecs").seal();
 const SI_SPEC_DIR = "si-specs";
@@ -64,6 +65,7 @@ export async function generateSiSpecs(
   // intrinsics
   specs = generateSubAssets(specs);
   specs = generateIntrinsicFuncs(specs);
+  specs = createPolicyDocumentInputSockets(specs);
   // don't generate input sockets until we have all of the output sockets
   specs = createInputSocketsBasedOnOutputSockets(specs);
 

--- a/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
+++ b/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
@@ -62,7 +62,7 @@ export function addDefaultPropsAndSockets(
         extraProp.metadata.propPath,
       );
 
-      schemaVariant.sockets.push(createInputSocketFromProp(regionProp, "one"));
+      schemaVariant.sockets.push(createInputSocketFromProp(regionProp));
       extraProp.entries.push(regionProp);
     }
 
@@ -93,7 +93,7 @@ export function addDefaultPropsAndSockets(
         "value": "AWS Credential",
       }];
 
-      schemaVariant.sockets.push(createInputSocketFromProp(credProp, "one"));
+      schemaVariant.sockets.push(createInputSocketFromProp(credProp));
 
       if (schemaVariant.secrets.kind !== "object") {
         console.log(

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -37,7 +37,7 @@ const overrides = new Map<string, OverrideFn>([
     );
 
     if (!prop) return;
-    const socket = createInputSocketFromProp(prop, "one");
+    const socket = createInputSocketFromProp(prop);
 
     setAnnotationOnSocket(socket, { tokens: ["InternetGatewayId"] });
     setAnnotationOnSocket(socket, { tokens: ["VPNGatewayId"] });
@@ -50,7 +50,7 @@ const overrides = new Map<string, OverrideFn>([
     for (const prop of variant.domain.entries) {
       switch (prop.name) {
         case "S3BucketName": {
-          const socket = createInputSocketFromProp(prop, "one", [{
+          const socket = createInputSocketFromProp(prop, [{
             tokens: ["BucketName"],
           }]);
 
@@ -58,7 +58,7 @@ const overrides = new Map<string, OverrideFn>([
           break;
         }
         case "SnsTopicName": {
-          const socket = createInputSocketFromProp(prop, "one", [{
+          const socket = createInputSocketFromProp(prop, [{
             tokens: ["TopicName"],
           }]);
 
@@ -66,7 +66,7 @@ const overrides = new Map<string, OverrideFn>([
           break;
         }
         case "KMSKeyId": {
-          const socket = createInputSocketFromProp(prop, "one", [{
+          const socket = createInputSocketFromProp(prop, [{
             tokens: ["KeyId"],
           }]);
 

--- a/bin/clover/src/pipeline-steps/createInputSocketsAcrossAssets.ts
+++ b/bin/clover/src/pipeline-steps/createInputSocketsAcrossAssets.ts
@@ -107,7 +107,7 @@ export function createInputSocketsBasedOnOutputSockets(
         fromVariants.length === 1 &&
         fromVariants[0].uniqueId === schemaVariant.uniqueId
       ) continue;
-      getOrCreateInputSocketFromProp(schemaVariant, prop, "many");
+      getOrCreateInputSocketFromProp(schemaVariant, prop);
     }
 
     // Create sockets for all Arns
@@ -115,11 +115,7 @@ export function createInputSocketsBasedOnOutputSockets(
     // wanting to connecting something like "TaskArn" or "Arn" -> "TaskRoleArn"
     for (const prop of domain.entries) {
       if (!prop.name.toLowerCase().endsWith("arn")) continue;
-      const socket = getOrCreateInputSocketFromProp(
-        schemaVariant,
-        prop,
-        "many",
-      );
+      const socket = getOrCreateInputSocketFromProp(schemaVariant, prop);
       setAnnotationOnSocket(socket, { tokens: ["Arn"] });
     }
 
@@ -157,7 +153,7 @@ export function createInputSocketsBasedOnOutputSockets(
                 bind.prop_path ===
                   propPathToString(peerProp.metadata.propPath)
               ) {
-                getOrCreateInputSocketFromProp(schemaVariant, prop, "many");
+                getOrCreateInputSocketFromProp(schemaVariant, prop);
                 setAnnotationOnSocket(socket, { tokens: [prop.name] });
               }
             }

--- a/bin/clover/src/pipeline-steps/createPolicyDocumentInputSockets.ts
+++ b/bin/clover/src/pipeline-steps/createPolicyDocumentInputSockets.ts
@@ -1,0 +1,49 @@
+import { setAnnotationOnSocket } from "../spec/sockets.ts";
+import { ExpandedPropSpec } from "../spec/props.ts";
+import { getOrCreateInputSocketFromProp } from "../spec/sockets.ts";
+import { ExpandedPkgSpec, ExpandedSchemaVariantSpec } from "../spec/pkgs.ts";
+
+//
+// Any prop ending with PolicyDocument is considered an IAM policy document, with these properties:
+//
+// 1. It has a socket with annotation policydocument, which connects to the composable
+//    Policy Document component.
+// 2. It has type=text, widget=TextArea, so the user can copy/paste the JSON from howtos,
+//    websites, or other tools by selecting "set manually."
+//
+// TODO arrays of policies (such as in the IAM Group resource).
+// TODO *Policy (too many props that aren't really policy documents here)
+//
+export function createPolicyDocumentInputSockets(
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  for (const { schemas: [schema] } of specs) {
+    const { variants: [variant] } = schema;
+    createPolicyDocumentInputSocketsFromProp(variant, variant.domain);
+    createPolicyDocumentInputSocketsFromProp(variant, variant.resourceValue);
+  }
+  return specs;
+}
+
+function createPolicyDocumentInputSocketsFromProp(
+  variant: ExpandedSchemaVariantSpec,
+  prop: ExpandedPropSpec,
+) {
+  const name = prop.name.toLowerCase();
+  if (
+    ["string", "json"].includes(prop.kind) && name.endsWith("policydocument")
+  ) {
+    // Create a socket connecting to policydocument
+    const socket = getOrCreateInputSocketFromProp(variant, prop, "one");
+    setAnnotationOnSocket(socket, "policydocument");
+    // Make certain it's a textarea, even if it was not json in the first place
+    prop.data.widgetKind = "TextArea";
+  }
+
+  // If it's a nested object, see if any children have a policy document
+  if (prop.kind === "object") {
+    for (const childProp of prop.entries) {
+      createPolicyDocumentInputSocketsFromProp(variant, childProp);
+    }
+  }
+}

--- a/bin/clover/src/pipeline-steps/createPolicyDocumentInputSockets.ts
+++ b/bin/clover/src/pipeline-steps/createPolicyDocumentInputSockets.ts
@@ -34,7 +34,7 @@ function createPolicyDocumentInputSocketsFromProp(
     ["string", "json"].includes(prop.kind) && name.endsWith("policydocument")
   ) {
     // Create a socket connecting to policydocument
-    const socket = getOrCreateInputSocketFromProp(variant, prop, "one");
+    const socket = getOrCreateInputSocketFromProp(variant, prop);
     setAnnotationOnSocket(socket, "policydocument");
     // Make certain it's a textarea, even if it was not json in the first place
     prop.data.widgetKind = "TextArea";

--- a/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
@@ -276,9 +276,7 @@ function generateWidgetString(
     return "";
   }
 
-  const kind = widgetKind === "ComboBox"
-    ? "comboBox"
-    : widgetKind.toLowerCase();
+  const kind = `${widgetKind[0].toLowerCase()}${widgetKind.slice(1)}`;
 
   let widgetStr =
     `${indent(indentLevel)}.setWidget(new PropWidgetDefinitionBuilder()\n` +

--- a/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
@@ -52,11 +52,6 @@ export function generateAssetFuncs(
 function generateAssetCodeFromVariantSpec(
   variant: ExpandedSchemaVariantSpec,
 ): string {
-  if (variant.domain.kind !== "object") throw "Domain prop is not object";
-  if (variant.resourceValue.kind !== "object") {
-    throw "ResourceValue prop is not object";
-  }
-
   let declarations = "";
   let adds = "";
 
@@ -195,8 +190,6 @@ function generatePropBuilderString(
   prop: ExpandedPropSpec,
   indent_level: number,
 ): string {
-  const is_create_only = prop.metadata.createOnly ?? false;
-
   switch (prop.kind) {
     case "array":
     case "map": {
@@ -205,27 +198,7 @@ function generatePropBuilderString(
           generatePropBuilderString(prop.typeProp, indent_level + 1)
         }\n` +
         `${indent(indent_level)})\n`;
-
-      return `new PropBuilder()\n` +
-        `${indent(indent_level)}.setKind("${prop.kind}")\n` +
-        `${indent(indent_level)}.setName("${prop.name}")\n` +
-        `${indent(indent_level)}.setHidden(${prop.data?.hidden ?? false})\n` +
-        `${
-          generateWidgetString(
-            prop.data?.widgetKind,
-            is_create_only,
-            indent_level,
-          )
-        }` +
-        `${
-          prop.data?.defaultValue
-            ? `${indent(indent_level)}.setDefaultValue(${
-              JSON.stringify(prop.data.defaultValue)
-            })\n`
-            : ""
-        }` +
-        `${entryBlock}` +
-        `${indent(indent_level)}.build()`;
+      return generatePropBuilderStringInner(prop.kind, entryBlock);
     }
     case "object": {
       const children = prop.entries.map((p) =>
@@ -240,70 +213,55 @@ function generatePropBuilderString(
           `${indent(indent_level)})\n`;
       }
 
-      return `new PropBuilder()\n` +
-        `${indent(indent_level)}.setKind("object")\n` +
-        `${indent(indent_level)}.setName("${prop.name}")\n` +
-        `${indent(indent_level)}.setHidden(${prop.data?.hidden ?? false})\n` +
-        `${
-          generateWidgetString(
-            prop.data?.widgetKind,
-            is_create_only,
-            indent_level,
-          )
-        }` +
-        `${
-          prop.data?.defaultValue
-            ? `${indent(indent_level)}.setDefaultValue(${
-              JSON.stringify(prop.data.defaultValue)
-            })\n`
-            : ""
-        }` +
-        `${addChildBlock}` +
-        `${indent(indent_level)}.build()`;
+      return generatePropBuilderStringInner("object", addChildBlock);
     }
     case "number":
-      return `new PropBuilder()\n` +
-        `${indent(indent_level)}.setName("${prop.name}")\n` +
-        `${indent(indent_level)}.setKind("integer")\n` +
-        `${indent(indent_level)}.setHidden(${prop.data?.hidden ?? false})\n` +
-        `${
-          generateWidgetString(
-            prop.data?.widgetKind,
-            is_create_only,
-            indent_level,
-          )
-        }` +
-        `${
-          prop.data?.defaultValue
-            ? `${indent(indent_level)}.setDefaultValue(${
-              JSON.stringify(prop.data.defaultValue)
-            })\n`
-            : ""
-        }` +
-        `${indent(indent_level)}.build()`;
+      return generatePropBuilderStringInner("integer");
     case "boolean":
     case "json":
     case "string":
-      return `new PropBuilder()\n` +
-        `${indent(indent_level)}.setName("${prop.name}")\n` +
-        `${indent(indent_level)}.setKind("${prop.kind}")\n` +
-        `${indent(indent_level)}.setHidden(${prop.data?.hidden ?? false})\n` +
-        `${
-          generateWidgetString(
-            prop.data?.widgetKind,
-            is_create_only,
-            indent_level,
-            prop.data?.widgetOptions,
-          )
-        }` +
-        `${
-          prop.data?.defaultValue
-            ? `${indent(indent_level)}.setDefaultValue(${
-              JSON.stringify(prop.data.defaultValue)
-            })\n`
-            : ""
-        }` +
-        `${indent(indent_level)}.build()`;
+      return generatePropBuilderStringInner(prop.kind);
+  }
+
+  function generatePropBuilderStringInner(
+    kind: string,
+    inner: string = "",
+  ) {
+    const is_create_only = prop.metadata.createOnly ?? false;
+
+    return `new PropBuilder()\n` +
+      `${indent(indent_level)}.setName("${prop.name}")\n` +
+      `${indent(indent_level)}.setKind("${kind}")\n` +
+      `${indent(indent_level)}.setHidden(${prop.data?.hidden ?? false})\n` +
+      generateWidgetString(
+        prop.data?.widgetKind,
+        is_create_only,
+        indent_level,
+        prop.data?.widgetOptions,
+      ) +
+      (
+        prop.data?.defaultValue
+          ? `${indent(indent_level)}.setDefaultValue(${
+            JSON.stringify(prop.data.defaultValue)
+          })\n`
+          : ""
+      ) +
+      (
+        prop.data?.docLink
+          ? `${indent(indent_level)}.setDocLink(${
+            JSON.stringify(prop.data.docLink)
+          })\n`
+          : ""
+      ) +
+      (
+        prop.data?.documentation
+          ? `${indent(indent_level)}.setDocumentation(${
+            JSON.stringify(prop.data.documentation)
+          })\n`
+          : ""
+      ) +
+      inner +
+      `${indent(indent_level)}.build()`;
   }
 }
 

--- a/bin/clover/src/spec/funcs.ts
+++ b/bin/clover/src/spec/funcs.ts
@@ -8,6 +8,7 @@ import { ActionFuncSpecKind } from "../bindings/ActionFuncSpecKind.ts";
 import { LeafFunctionSpec } from "../bindings/LeafFunctionSpec.ts";
 import { LeafKind } from "../bindings/LeafKind.ts";
 import { ManagementFuncSpec } from "../bindings/ManagementFuncSpec.ts";
+import { Buffer } from "node:buffer";
 
 interface FuncSpecInfo {
   id: string;
@@ -241,7 +242,7 @@ export function createManagementFuncSpec(
 
 // Si uses a version of base64 that removes the padding at the end for some reason
 export function strippedBase64(code: string) {
-  return btoa(
-    code,
-  ).replace(/=/g, "");
+  return Buffer.from(code).toString(
+    "base64",
+  ).replace(/=*$/, "");
 }

--- a/bin/clover/src/spec/pkgs.ts
+++ b/bin/clover/src/spec/pkgs.ts
@@ -20,5 +20,5 @@ export type ExpandedSchemaVariantSpec = Extend<SchemaVariantSpec, {
   domain: ExpandedPropSpecFor["object"];
   secrets: ExpandedPropSpec;
   secretDefinition: ExpandedPropSpec | null;
-  resourceValue: ExpandedPropSpec;
+  resourceValue: ExpandedPropSpecFor["object"];
 }>;

--- a/bin/clover/src/spec/props.ts
+++ b/bin/clover/src/spec/props.ts
@@ -58,10 +58,10 @@ interface PropSpecOverrides {
   >;
   enum?: string[] | number[];
   metadata: {
-    createOnly?: boolean;
-    readOnly?: boolean;
-    writeOnly?: boolean;
-    primaryIdentifier?: boolean;
+    createOnly: boolean;
+    readOnly: boolean;
+    writeOnly: boolean;
+    primaryIdentifier: boolean;
     propPath: string[];
   };
 }
@@ -77,6 +77,7 @@ export function createPropFromCf(
   name: string,
   cfProp: CfProperty,
   onlyProperties: OnlyProperties,
+  typeName: string,
   propPath: string[],
 ): ExpandedPropSpec | undefined {
   if (!cfProp.type) {
@@ -107,6 +108,7 @@ export function createPropFromCf(
       data.name,
       data.cfProp,
       onlyProperties,
+      typeName,
       data.propPath,
       queue,
     );
@@ -128,10 +130,16 @@ export function createPropFromCf(
   return rootProp;
 }
 
+function createDocLink(typeName: string, propName: string): string | null {
+  const typeNameSnake = typeName.split("::").slice(1).join("-").toLowerCase();
+  return `https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-${typeNameSnake}.html#cfn-${typeNameSnake}-${propName.toLowerCase()}`;
+}
+
 function createPropFromCfInner(
   name: string,
   cfProp: CfProperty,
   onlyProperties: OnlyProperties,
+  typeName: string,
   propPath: string[],
   queue: CreatePropQueue,
 ): ExpandedPropSpec | undefined {
@@ -145,16 +153,16 @@ function createPropFromCfInner(
     widgetKind: null,
     widgetOptions: [],
     hidden: false,
-    docLink: null,
+    docLink: createDocLink(typeName, name),
     documentation: cfProp.description ?? null,
   };
-
   propPath.push(name);
   const partialProp: Partial<ExpandedPropSpec> = {
     name,
     data,
     uniqueId: propUniqueId,
     metadata: {
+      // cfProp,
       createOnly: onlyProperties.createOnly.includes(name),
       readOnly: onlyProperties.readOnly.includes(name),
       writeOnly: onlyProperties.writeOnly.includes(name),

--- a/bin/clover/src/spec/sockets.ts
+++ b/bin/clover/src/spec/sockets.ts
@@ -1,18 +1,21 @@
 import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
 import { AttrFuncInputSpec } from "../bindings/AttrFuncInputSpec.ts";
 import { SocketSpec } from "../bindings/SocketSpec.ts";
+import { SocketSpecData } from "../bindings/SocketSpecData.ts";
 import { SocketSpecArity } from "../bindings/SocketSpecArity.ts";
 import { SocketSpecKind } from "../bindings/SocketSpecKind.ts";
 import { ExpandedPropSpec } from "./props.ts";
 import { getSiFuncId } from "./siFuncs.ts";
 import _ from "npm:lodash";
 import { ExpandedSchemaVariantSpec } from "./pkgs.ts";
+import { Extend } from "../extend.ts";
 
 export const SI_SEPARATOR = "\u{b}";
 
-export type ExpandedSocketSpec = SocketSpec & {
-  data: NonNullable<SocketSpec["data"]>;
-};
+export type ExpandedSocketSpec = Extend<SocketSpec, {
+  data: NonNullable<SocketSpecData>;
+}>;
+
 export function createOutputSocketFromProp(
   prop: ExpandedPropSpec,
   arity: SocketSpecArity = "many",
@@ -72,8 +75,11 @@ export function getOrCreateInputSocketFromProp(
 
 export function setAnnotationOnSocket(
   socket: ExpandedSocketSpec,
-  annotation: ConnectionAnnotation,
+  annotation: string | ConnectionAnnotation,
 ) {
+  if (typeof annotation === "string") {
+    annotation = { tokens: [annotation] };
+  }
   const existingAnnotations = JSON.parse(
     socket.data.connectionAnnotations,
   ) as ConnectionAnnotation[];

--- a/bin/clover/src/spec/sockets.ts
+++ b/bin/clover/src/spec/sockets.ts
@@ -18,8 +18,8 @@ export type ExpandedSocketSpec = Extend<SocketSpec, {
 
 export function createOutputSocketFromProp(
   prop: ExpandedPropSpec,
-  arity: SocketSpecArity = "many",
 ): ExpandedSocketSpec {
+  const arity = prop.kind === "array" ? "many" : "one";
   const socket = createSocket(prop.name, "output", arity);
   socket.data.funcUniqueId = getSiFuncId("si:identity");
   socket.inputs = [attrFuncInputSpecFromProp(prop)];
@@ -30,9 +30,9 @@ export type ConnectionAnnotation = { tokens: string[] };
 
 export function createInputSocketFromProp(
   prop: ExpandedPropSpec,
-  arity: SocketSpecArity = "many",
   extraConnectionAnnotations?: ConnectionAnnotation[],
 ): ExpandedSocketSpec {
+  const arity = prop.kind === "array" ? "many" : "one";
   const socket = createSocket(
     prop.name,
     "input",
@@ -61,13 +61,12 @@ export function getSocketOnVariant(
 export function getOrCreateInputSocketFromProp(
   schemaVariant: ExpandedSchemaVariantSpec,
   prop: ExpandedPropSpec,
-  arity: SocketSpecArity = "many",
 ) {
   let socket = schemaVariant.sockets.find((s) =>
     s.data.kind === "input" && s.name === prop.name
   );
   if (!socket) {
-    socket ??= createInputSocketFromProp(prop, arity);
+    socket ??= createInputSocketFromProp(prop);
     schemaVariant.sockets.push(socket);
   }
   return socket;
@@ -105,7 +104,7 @@ export function setAnnotationOnSocket(
 export function createSocket(
   name: string,
   kind: SocketSpecKind,
-  arity: SocketSpecArity = "many",
+  arity: SocketSpecArity,
   extraConnectionAnnotations: ConnectionAnnotation[] = [],
 ): ExpandedSocketSpec {
   const socketId = ulid();

--- a/bin/clover/src/specPipeline.ts
+++ b/bin/clover/src/specPipeline.ts
@@ -8,6 +8,7 @@ import {
 } from "./spec/props.ts";
 import {
   ExpandedPkgSpec,
+  ExpandedSchemaSpec,
   ExpandedSchemaVariantSpec,
 } from "./spec/pkgs.ts";
 
@@ -109,6 +110,7 @@ function createDomainFromSrc(
     "domain",
     pruneDomainValues(src.properties, onlyProperties),
     onlyProperties,
+    src.typeName,
   );
 }
 
@@ -120,6 +122,7 @@ function createResourceValueFromSrc(
     "resource_value",
     pruneResourceValues(src.properties, onlyProperties),
     onlyProperties,
+    src.typeName,
   );
 }
 
@@ -127,10 +130,11 @@ function createRootFromProperties(
   root_name: DefaultPropType,
   properties: Record<string, CfProperty>,
   onlyProperties: OnlyProperties,
+  typeName: string,
 ) {
   const root = createDefaultProp(root_name);
   Object.entries(properties).forEach(([name, cfData]) => {
-    const newProp = createPropFromCf(name, cfData, onlyProperties, [
+    const newProp = createPropFromCf(name, cfData, onlyProperties, typeName, [
       ...root.metadata.propPath,
     ]);
 

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -258,6 +258,9 @@ si_buck2_resource(
             path = "/api/",
         ),
     ),
+    links = [
+        link("http://127.0.0.1:5156", "api"),
+    ],
     **RUST_RESOURCE_ARGS
 )
 


### PR DESCRIPTION
This PR:
* Adds doc links to all props that go to the cloudformation documentation (they go directly to the prop when the prop exists, otherwise to the page for the asset). e.g. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnetroutetableassociation.html#cfn-ec2-subnetroutetableassociation-routetableid
* Preserves documentation when regenerating assets (docs weren't in the asset function)
* Uses the modern Node API for base 64 encoding, so that we can support Unicode documentation in asset functions

## Testing

* Uploaded assets to local module index
* Regenerated the Subnet asset to ensure it regenerated, and clicked the documentation
* Clicked some doc links to make sure they went to the right assets