### PR TITLE
fix: bump vite to accommodate CVE-2025-24010

### DIFF
--- a/app/auth-portal/package.json
+++ b/app/auth-portal/package.json
@@ -44,7 +44,7 @@
     "rollup-plugin-visualizer": "^5.12.0",
     "typescript": "^4.9.5",
     "unplugin-icons": "^0.17.4",
-    "vite": "^5.4.10",
+    "vite": "^5.4.12",
     "vite-plugin-checker": "^0.6.4",
     "vite-plugin-markdown": "^2.2.0",
     "vite-svg-loader": "^3.4.0",

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -121,7 +121,7 @@
     "eslint": "^8.57.1",
     "graphology-types": "^0.24.7",
     "unplugin-icons": "^0.17.4",
-    "vite": "^5.4.10",
+    "vite": "^5.4.12",
     "vite-plugin-checker": "^0.6.4",
     "vite-svg-loader": "^3.4.0",
     "vue-tsc": "^1.8.27"

--- a/lib/vue-lib/package.json
+++ b/lib/vue-lib/package.json
@@ -82,7 +82,7 @@
     "tailwindcss": "^3.2.2",
     "typescript": "^4.9.5",
     "unplugin-icons": "^0.17.4",
-    "vite": "^5.4.10",
+    "vite": "^5.4.12",
     "vite-svg-loader": "^3.4.0",
     "vue-tsc": "^1.8.27"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
         version: 1.177.0
       vite-ssg:
         specifier: ^0.23.8
-        version: 0.23.8(vite@5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue-router@4.4.5(vue@3.5.12(typescript@4.9.5)))(vue@3.5.12(typescript@4.9.5))
+        version: 0.23.8(vite@5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue-router@4.4.5(vue@3.5.12(typescript@4.9.5)))(vue@3.5.12(typescript@4.9.5))
       vue:
         specifier: ^3.5.12
         version: 3.5.12(typescript@4.9.5)
@@ -76,7 +76,7 @@ importers:
         version: 18.19.59
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.1.4(vite@5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.12(typescript@4.9.5))
+        version: 5.1.4(vite@5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.12(typescript@4.9.5))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -93,14 +93,14 @@ importers:
         specifier: ^0.17.4
         version: 0.17.4(@vue/compiler-sfc@3.5.13)(vue-template-compiler@2.7.14)
       vite:
-        specifier: ^5.4.10
-        version: 5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
+        specifier: ^5.4.12
+        version: 5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
       vite-plugin-checker:
         specifier: ^0.6.4
-        version: 0.6.4(eslint@8.57.1)(optionator@0.9.4)(typescript@4.9.5)(vite@5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue-tsc@1.8.27(typescript@4.9.5))
+        version: 0.6.4(eslint@8.57.1)(optionator@0.9.4)(typescript@4.9.5)(vite@5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue-tsc@1.8.27(typescript@4.9.5))
       vite-plugin-markdown:
         specifier: ^2.2.0
-        version: 2.2.0(vite@5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))
+        version: 2.2.0(vite@5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))
       vite-svg-loader:
         specifier: ^3.4.0
         version: 3.6.0
@@ -405,13 +405,13 @@ importers:
         version: 2023.10.5
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.1.4(vite@5.4.10(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))(vue@3.5.12(typescript@4.9.5))
+        version: 5.1.4(vite@5.4.14(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))(vue@3.5.12(typescript@4.9.5))
       cypress:
         specifier: ^13.8.1
         version: 13.13.2
       cypress-vite:
         specifier: ^1.5.0
-        version: 1.5.0(vite@5.4.10(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))
+        version: 1.5.0(vite@5.4.14(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -422,11 +422,11 @@ importers:
         specifier: ^0.17.4
         version: 0.17.4(@vue/compiler-sfc@3.5.13)(vue-template-compiler@2.7.14)
       vite:
-        specifier: ^5.4.10
-        version: 5.4.10(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0)
+        specifier: ^5.4.12
+        version: 5.4.14(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0)
       vite-plugin-checker:
         specifier: ^0.6.4
-        version: 0.6.4(eslint@8.57.1)(optionator@0.9.4)(typescript@4.9.5)(vite@5.4.10(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))(vue-tsc@1.8.27(typescript@4.9.5))
+        version: 0.6.4(eslint@8.57.1)(optionator@0.9.4)(typescript@4.9.5)(vite@5.4.14(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))(vue-tsc@1.8.27(typescript@4.9.5))
       vite-svg-loader:
         specifier: ^3.4.0
         version: 3.6.0
@@ -829,8 +829,8 @@ importers:
         specifier: ^0.17.4
         version: 0.17.4(@vue/compiler-sfc@3.5.13)(vue-template-compiler@2.7.14)
       vite:
-        specifier: ^5.4.10
-        version: 5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
+        specifier: ^5.4.12
+        version: 5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
       vite-svg-loader:
         specifier: ^3.4.0
         version: 3.6.0
@@ -10383,8 +10383,8 @@ packages:
   vite-svg-loader@3.6.0:
     resolution: {integrity: sha512-bZJffcgCREW57kNkgMhuNqeDznWXyQwJ3wKrRhHLMMzwDnP5jr3vXW3cqsmquRR7VTP5mLdKj1/zzPPooGUuPw==}
 
-  vite@5.4.10:
-    resolution: {integrity: sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==}
+  vite@5.4.14:
+    resolution: {integrity: sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -13933,14 +13933,14 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue@5.1.4(vite@5.4.10(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))(vue@3.5.12(typescript@4.9.5))':
+  '@vitejs/plugin-vue@5.1.4(vite@5.4.14(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))(vue@3.5.12(typescript@4.9.5))':
     dependencies:
-      vite: 5.4.10(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0)
+      vite: 5.4.14(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0)
       vue: 3.5.12(typescript@4.9.5)
 
-  '@vitejs/plugin-vue@5.1.4(vite@5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.12(typescript@4.9.5))':
+  '@vitejs/plugin-vue@5.1.4(vite@5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.12(typescript@4.9.5))':
     dependencies:
-      vite: 5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
+      vite: 5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
       vue: 3.5.12(typescript@4.9.5)
 
   '@volar/language-core@1.11.1':
@@ -15613,11 +15613,11 @@ snapshots:
 
   cyclist@1.0.1: {}
 
-  cypress-vite@1.5.0(vite@5.4.10(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0)):
+  cypress-vite@1.5.0(vite@5.4.14(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0)):
     dependencies:
       chokidar: 3.5.3
       debug: 4.3.4
-      vite: 5.4.10(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0)
+      vite: 5.4.14(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -22446,7 +22446,7 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite-plugin-checker@0.6.4(eslint@8.57.1)(optionator@0.9.4)(typescript@4.9.5)(vite@5.4.10(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))(vue-tsc@1.8.27(typescript@4.9.5)):
+  vite-plugin-checker@0.6.4(eslint@8.57.1)(optionator@0.9.4)(typescript@4.9.5)(vite@5.4.14(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))(vue-tsc@1.8.27(typescript@4.9.5)):
     dependencies:
       '@babel/code-frame': 7.22.10
       ansi-escapes: 4.3.2
@@ -22459,7 +22459,7 @@ snapshots:
       semver: 7.5.4
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
-      vite: 5.4.10(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0)
+      vite: 5.4.14(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.7
@@ -22470,7 +22470,7 @@ snapshots:
       typescript: 4.9.5
       vue-tsc: 1.8.27(typescript@4.9.5)
 
-  vite-plugin-checker@0.6.4(eslint@8.57.1)(optionator@0.9.4)(typescript@4.9.5)(vite@5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue-tsc@1.8.27(typescript@4.9.5)):
+  vite-plugin-checker@0.6.4(eslint@8.57.1)(optionator@0.9.4)(typescript@4.9.5)(vite@5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue-tsc@1.8.27(typescript@4.9.5)):
     dependencies:
       '@babel/code-frame': 7.22.10
       ansi-escapes: 4.3.2
@@ -22483,7 +22483,7 @@ snapshots:
       semver: 7.5.4
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
-      vite: 5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
+      vite: 5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.7
@@ -22494,15 +22494,15 @@ snapshots:
       typescript: 4.9.5
       vue-tsc: 1.8.27(typescript@4.9.5)
 
-  vite-plugin-markdown@2.2.0(vite@5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)):
+  vite-plugin-markdown@2.2.0(vite@5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)):
     dependencies:
       domhandler: 4.3.1
       front-matter: 4.0.2
       htmlparser2: 6.1.0
       markdown-it: 12.3.2
-      vite: 5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
+      vite: 5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
 
-  vite-ssg@0.23.8(vite@5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue-router@4.4.5(vue@3.5.12(typescript@4.9.5)))(vue@3.5.12(typescript@4.9.5)):
+  vite-ssg@0.23.8(vite@5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue-router@4.4.5(vue@3.5.12(typescript@4.9.5)))(vue@3.5.12(typescript@4.9.5)):
     dependencies:
       '@unhead/dom': 1.11.10
       '@unhead/vue': 1.11.10(vue@3.5.12(typescript@4.9.5))
@@ -22512,7 +22512,7 @@ snapshots:
       jsdom: 24.1.3
       kolorist: 1.8.0
       prettier: 3.3.3
-      vite: 5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
+      vite: 5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
       vue: 3.5.12(typescript@4.9.5)
       yargs: 17.7.2
     optionalDependencies:
@@ -22528,10 +22528,10 @@ snapshots:
       '@vue/compiler-sfc': 3.2.47
       svgo: 2.8.0
 
-  vite@5.4.10(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0):
+  vite@5.4.14(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.47
+      postcss: 8.4.49
       rollup: 4.24.2
     optionalDependencies:
       '@types/node': 18.19.59
@@ -22539,10 +22539,10 @@ snapshots:
       less: 4.1.3
       terser: 5.24.0
 
-  vite@5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0):
+  vite@5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.47
+      postcss: 8.4.49
       rollup: 4.24.2
     optionalDependencies:
       '@types/node': 18.19.59
@@ -22562,7 +22562,7 @@ snapshots:
       '@shikijs/core': 1.10.1
       '@shikijs/transformers': 1.10.1
       '@types/markdown-it': 13.0.8
-      '@vitejs/plugin-vue': 5.1.4(vite@5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.12(typescript@4.9.5))
+      '@vitejs/plugin-vue': 5.1.4(vite@5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.12(typescript@4.9.5))
       '@vue/devtools-api': 7.3.5
       '@vueuse/core': 10.11.0(vue@3.5.12(typescript@4.9.5))
       '@vueuse/integrations': 10.11.0(axios@1.7.7)(focus-trap@7.5.4)(jwt-decode@3.1.2)(vue@3.5.12(typescript@4.9.5))
@@ -22570,7 +22570,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 6.3.0
       shiki: 1.10.1
-      vite: 5.4.10(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
+      vite: 5.4.14(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
       vue: 3.5.12(typescript@4.9.5)
     optionalDependencies:
       postcss: 8.4.49


### PR DESCRIPTION
Mitigates https://github.com/systeminit/si/security/dependabot/377

<div><img src="https://media2.giphy.com/media/tHIRLHtNwxpjIFqPdV/giphy.gif?cid=5a38a5a277z1mtnais4oxbi9bfokne2maojgnu4rdhdekksc&amp;ep=v1_gifs_trending&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/></div>

We don't use the development server in production (obviously), but it's nice to tidy up

<hr/>

Tested a dev server for create/update/delete a key pair in AWS. Everything went smoothly