### PR TITLE
feat(clover): create input sockets for PolicyDocument props

### DIFF
--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -21,6 +21,7 @@ import {
   generateOutputSocketsFromProps,
 } from "../pipeline-steps/generateOutputSocketsFromProps.ts";
 import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+import { createPolicyDocumentInputSockets } from "../pipeline-steps/createPolicyDocumentInputSockets.ts";
 
 const logger = _logger.ns("siSpecs").seal();
 const SI_SPEC_DIR = "si-specs";
@@ -65,6 +66,7 @@ export async function generateSiSpecs(
   // intrinsics
   specs = generateSubAssets(specs);
   specs = generateIntrinsicFuncs(specs);
+  specs = createPolicyDocumentInputSockets(specs);
   // don't generate input sockets until we have all of the output sockets
   specs = createInputSocketsBasedOnOutputSockets(specs);
   specs = generateAssetFuncs(specs);

--- a/bin/clover/src/pipeline-steps/createPolicyDocumentInputSockets.ts
+++ b/bin/clover/src/pipeline-steps/createPolicyDocumentInputSockets.ts
@@ -1,0 +1,49 @@
+import { setAnnotationOnSocket } from "../spec/sockets.ts";
+import { ExpandedPropSpec } from "../spec/props.ts";
+import { getOrCreateInputSocketFromProp } from "../spec/sockets.ts";
+import { ExpandedPkgSpec, ExpandedSchemaVariantSpec } from "../spec/pkgs.ts";
+
+//
+// Any prop ending with PolicyDocument is considered an IAM policy document, with these properties:
+//
+// 1. It has a socket with annotation policydocument, which connects to the composable
+//    Policy Document component.
+// 2. It has type=text, widget=TextArea, so the user can copy/paste the JSON from howtos,
+//    websites, or other tools by selecting "set manually."
+//
+// TODO arrays of policies (such as in the IAM Group resource).
+// TODO *Policy (too many props that aren't really policy documents here)
+//
+export function createPolicyDocumentInputSockets(
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  for (const { schemas: [schema] } of specs) {
+    const { variants: [variant] } = schema;
+    createPolicyDocumentInputSocketsFromProp(variant, variant.domain);
+    createPolicyDocumentInputSocketsFromProp(variant, variant.resourceValue);
+  }
+  return specs;
+}
+
+function createPolicyDocumentInputSocketsFromProp(
+  variant: ExpandedSchemaVariantSpec,
+  prop: ExpandedPropSpec,
+) {
+  const name = prop.name.toLowerCase();
+  if (
+    ["string", "json"].includes(prop.kind) && name.endsWith("policydocument")
+  ) {
+    // Create a socket connecting to policydocument
+    const socket = getOrCreateInputSocketFromProp(variant, prop, "one");
+    setAnnotationOnSocket(socket, "policydocument");
+    // Make certain it's a textarea, even if it was not json in the first place
+    prop.data.widgetKind = "TextArea";
+  }
+
+  // If it's a nested object, see if any children have a policy document
+  if (prop.kind === "object") {
+    for (const childProp of prop.entries) {
+      createPolicyDocumentInputSocketsFromProp(variant, childProp);
+    }
+  }
+}

--- a/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
@@ -276,9 +276,7 @@ function generateWidgetString(
     return "";
   }
 
-  const kind = widgetKind === "ComboBox"
-    ? "comboBox"
-    : widgetKind.toLowerCase();
+  const kind = `${widgetKind[0].toLowerCase()}${widgetKind.slice(1)}`;
 
   let widgetStr =
     `${indent(indentLevel)}.setWidget(new PropWidgetDefinitionBuilder()\n` +

--- a/bin/clover/src/spec/pkgs.ts
+++ b/bin/clover/src/spec/pkgs.ts
@@ -20,5 +20,5 @@ export type ExpandedSchemaVariantSpec = Extend<SchemaVariantSpec, {
   domain: ExpandedPropSpecFor["object"];
   secrets: ExpandedPropSpec;
   secretDefinition: ExpandedPropSpec | null;
-  resourceValue: ExpandedPropSpec;
+  resourceValue: ExpandedPropSpecFor["object"];
 }>;

--- a/bin/clover/src/spec/sockets.ts
+++ b/bin/clover/src/spec/sockets.ts
@@ -1,18 +1,21 @@
 import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
 import { AttrFuncInputSpec } from "../bindings/AttrFuncInputSpec.ts";
 import { SocketSpec } from "../bindings/SocketSpec.ts";
+import { SocketSpecData } from "../bindings/SocketSpecData.ts";
 import { SocketSpecArity } from "../bindings/SocketSpecArity.ts";
 import { SocketSpecKind } from "../bindings/SocketSpecKind.ts";
 import { ExpandedPropSpec } from "./props.ts";
 import { getSiFuncId } from "./siFuncs.ts";
 import _ from "npm:lodash";
 import { ExpandedSchemaVariantSpec } from "./pkgs.ts";
+import { Extend } from "../extend.ts";
 
 export const SI_SEPARATOR = "\u{b}";
 
-export type ExpandedSocketSpec = SocketSpec & {
-  data: NonNullable<SocketSpec["data"]>;
-};
+export type ExpandedSocketSpec = Extend<SocketSpec, {
+  data: NonNullable<SocketSpecData>;
+}>;
+
 export function createOutputSocketFromProp(
   prop: ExpandedPropSpec,
   arity: SocketSpecArity = "many",
@@ -64,8 +67,11 @@ export function getOrCreateInputSocketFromProp(
 
 export function setAnnotationOnSocket(
   socket: ExpandedSocketSpec,
-  annotation: ConnectionAnnotation,
+  annotation: string | ConnectionAnnotation,
 ) {
+  if (typeof annotation === "string") {
+    annotation = { tokens: [annotation] };
+  }
   const existingAnnotations = JSON.parse(
     socket.data.connectionAnnotations,
   ) as ConnectionAnnotation[];


### PR DESCRIPTION
Any prop ending with PolicyDocument, which is a text or json type, will become a textare (if it isn't already) and have an input socket with type `policydocument<aws>` on it, to connect to the new Policy Document asset.

It also fixes asset functions for Clover assets with text area props (right now we generate `setWidgetKind("textarea")` when it needs to be `textArea`).

This affects:
* AWS::CodeArtifact::Domain/Repository
* AWS::DynamoDB::Table
* AWS::EC2::VerifiedAccessEndpoint/VerifiedAccessGroup/VPCEndpoint
* AWS::IAM::GroupPolicy/ManagedPolicy/Policy/Role/RolePolicy/UserPolicy
* AWS::IoT::Policy
* AWS::Logs::AccountPolicy/ResourcePolicy
* AWS::NetworkManager::CoreNetwork
* AWS::S3::BucketPolicy
* AWS::S3Express::BucketPolicy
* AWS::S3ObjectLambda::AccessPointPolicy
* AWS::S3Outposts::BucketPolicy
* AWS::SNS::TopicInlinePolicy/TopicPolicy
* AWS::SQS::QueueInlinePolicy/QueuePolicy
* AWS::XRay::ResourcePolicy

## Not Covered

This does not cover props that end with `Policy`. Many cases of this are *not* policy documents (and should not be textarea), however, so I didn't include the ones that are (there are a few) in this PR.

## Testing

* Ran regeneration function in prod and verified sockets connect
* Uploaded locally
* Validated that only the above files are affected