### PR TITLE
feat(clover): generate arity=one for non-array sockets

### DIFF
--- a/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
+++ b/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
@@ -62,7 +62,7 @@ export function addDefaultPropsAndSockets(
         extraProp.metadata.propPath,
       );
 
-      schemaVariant.sockets.push(createInputSocketFromProp(regionProp, "one"));
+      schemaVariant.sockets.push(createInputSocketFromProp(regionProp));
       extraProp.entries.push(regionProp);
     }
 
@@ -93,7 +93,7 @@ export function addDefaultPropsAndSockets(
         "value": "AWS Credential",
       }];
 
-      schemaVariant.sockets.push(createInputSocketFromProp(credProp, "one"));
+      schemaVariant.sockets.push(createInputSocketFromProp(credProp));
 
       if (schemaVariant.secrets.kind !== "object") {
         console.log(

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -36,7 +36,7 @@ function addGatewayIdSocketToEC2Route(spec: ExpandedPkgSpec) {
 
   for (const prop of domain.entries) {
     if (prop.name === "GatewayId") {
-      const socket = createInputSocketFromProp(prop, "one");
+      const socket = createInputSocketFromProp(prop);
 
       const data = socket.data;
       if (data) {

--- a/bin/clover/src/pipeline-steps/createInputSocketsAcrossAssets.ts
+++ b/bin/clover/src/pipeline-steps/createInputSocketsAcrossAssets.ts
@@ -96,7 +96,7 @@ export function createInputSocketsBasedOnOutputSockets(
         fromVariants.length === 1 &&
         fromVariants[0].uniqueId === schemaVariant.uniqueId
       ) continue;
-      getOrCreateInputSocketFromProp(schemaVariant, prop, "many");
+      getOrCreateInputSocketFromProp(schemaVariant, prop);
     }
 
     // Create sockets for all Arns
@@ -104,11 +104,7 @@ export function createInputSocketsBasedOnOutputSockets(
     // wanting to connecting something like "TaskArn" or "Arn" -> "TaskRoleArn"
     for (const prop of domain.entries) {
       if (!prop.name.toLowerCase().endsWith("arn")) continue;
-      const socket = getOrCreateInputSocketFromProp(
-        schemaVariant,
-        prop,
-        "many",
-      );
+      const socket = getOrCreateInputSocketFromProp(schemaVariant, prop);
       setAnnotationOnSocket(socket, { tokens: ["Arn"] });
     }
 
@@ -146,7 +142,7 @@ export function createInputSocketsBasedOnOutputSockets(
                 bind.prop_path ===
                   propPathToString(peerProp.metadata.propPath)
               ) {
-                getOrCreateInputSocketFromProp(schemaVariant, prop, "many");
+                getOrCreateInputSocketFromProp(schemaVariant, prop);
                 setAnnotationOnSocket(socket, { tokens: [prop.name] });
               }
             }

--- a/bin/clover/src/pipeline-steps/createPolicyDocumentInputSockets.ts
+++ b/bin/clover/src/pipeline-steps/createPolicyDocumentInputSockets.ts
@@ -34,7 +34,7 @@ function createPolicyDocumentInputSocketsFromProp(
     ["string", "json"].includes(prop.kind) && name.endsWith("policydocument")
   ) {
     // Create a socket connecting to policydocument
-    const socket = getOrCreateInputSocketFromProp(variant, prop, "one");
+    const socket = getOrCreateInputSocketFromProp(variant, prop);
     setAnnotationOnSocket(socket, "policydocument");
     // Make certain it's a textarea, even if it was not json in the first place
     prop.data.widgetKind = "TextArea";

--- a/bin/clover/src/spec/sockets.ts
+++ b/bin/clover/src/spec/sockets.ts
@@ -18,8 +18,8 @@ export type ExpandedSocketSpec = Extend<SocketSpec, {
 
 export function createOutputSocketFromProp(
   prop: ExpandedPropSpec,
-  arity: SocketSpecArity = "many",
 ): ExpandedSocketSpec {
+  const arity = prop.kind === "array" ? "many" : "one";
   const socket = createSocket(prop.name, "output", arity);
   socket.data.funcUniqueId = getSiFuncId("si:identity");
   socket.inputs = [attrFuncInputSpecFromProp(prop)];
@@ -30,9 +30,9 @@ export type ConnectionAnnotation = { tokens: string[] };
 
 export function createInputSocketFromProp(
   prop: ExpandedPropSpec,
-  arity: SocketSpecArity = "many",
   extraConnectionAnnotations?: ConnectionAnnotation[],
 ): ExpandedSocketSpec {
+  const arity = prop.kind === "array" ? "many" : "one";
   const socket = createSocket(
     prop.name,
     "input",
@@ -53,13 +53,12 @@ export function createInputSocketFromProp(
 export function getOrCreateInputSocketFromProp(
   schemaVariant: ExpandedSchemaVariantSpec,
   prop: ExpandedPropSpec,
-  arity: SocketSpecArity = "many",
 ) {
   let socket = schemaVariant.sockets.find((s) =>
     s.data.kind === "input" && s.name === prop.name
   );
   if (!socket) {
-    socket ??= createInputSocketFromProp(prop, arity);
+    socket ??= createInputSocketFromProp(prop);
     schemaVariant.sockets.push(socket);
   }
   return socket;
@@ -97,7 +96,7 @@ export function setAnnotationOnSocket(
 export function createSocket(
   name: string,
   kind: SocketSpecKind,
-  arity: SocketSpecArity = "many",
+  arity: SocketSpecArity,
   extraConnectionAnnotations: ConnectionAnnotation[] = [],
 ): ExpandedSocketSpec {
   const socketId = ulid();


### PR DESCRIPTION
Most sockets are arity one (only allow one thing). This changes them to arity=one, so that other UI features (and things such as incomingConnections) will disallow multiple connections and yield the right types.

## Testing

- Validated that Tags stays arity=many
- Validated that "Subnets" and other array-typed props stay arity=many