### PR TITLE
bug: escape bad variable names in template generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6213,6 +6213,7 @@ dependencies = [
  "pretty_assertions_sorted",
  "rand 0.8.5",
  "rebaser-client",
+ "regex",
  "remain",
  "reqwest",
  "sdf-test",

--- a/lib/sdf-server/BUCK
+++ b/lib/sdf-server/BUCK
@@ -49,6 +49,7 @@ rust_library(
         "//third-party/rust:rand",
         "//third-party/rust:remain",
         "//third-party/rust:reqwest",
+        "//third-party/rust:regex",
         "//third-party/rust:serde",
         "//third-party/rust:serde_json",
         "//third-party/rust:serde_with",

--- a/lib/sdf-server/Cargo.toml
+++ b/lib/sdf-server/Cargo.toml
@@ -56,6 +56,7 @@ pathdiff = { workspace = true }
 rand = { workspace = true }
 remain = { workspace = true }
 reqwest = { workspace = true }
+regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }


### PR DESCRIPTION
Uses a regex to replace any invalid characters with valid ones, and checks that the leading character is correct.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMmZsOWRndGkzd3JhYjd2czg5bHVyM2xid28yZHp3aWl2NGk4MjVzdCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/XtX936H4lzr5fUgJOR/giphy.gif"/>