### PR TITLE
feat: add cfn-lint for clover asset qualifications

### DIFF
--- a/bin/clover/src/cloud-control-funcs/code-gen/awsCloudFormationLint.ts
+++ b/bin/clover/src/cloud-control-funcs/code-gen/awsCloudFormationLint.ts
@@ -1,0 +1,105 @@
+async function main(component: Input): Promise<Output> {
+  const cloudControlType = _.get(component, [
+    "domain",
+    "extra",
+    "AwsResourceType",
+  ]);
+
+  const propUsageMap = JSON.parse(component.domain.extra.PropUsageMap);
+  if (
+    !Array.isArray(propUsageMap.createOnly) ||
+    !Array.isArray(propUsageMap.updatable)
+  ) {
+    throw Error("malformed propUsageMap on resource");
+  }
+
+  const payload = _.cloneDeep(component.domain);
+
+  const propsToVisit = _.keys(payload).map((k: string) => [k]);
+
+  // Visit the prop tree, deleting values that shouldn't be used
+  while (propsToVisit.length > 0) {
+    const key = propsToVisit.pop();
+
+    console.log(`Visiting ${key}`);
+
+    let parent = payload;
+    let keyOnParent = key[0];
+    for (let i = 1; i < key.length; i++) {
+      parent = parent[key[i - 1]];
+      keyOnParent = key[i];
+    }
+
+    if (
+      !propUsageMap.createOnly.includes(keyOnParent) &&
+      !propUsageMap.updatable.includes(keyOnParent)
+    ) {
+      delete parent[keyOnParent];
+      console.log("Removing " + key);
+      continue;
+    }
+
+    const prop = parent[keyOnParent];
+
+    if (typeof prop !== "object" || Array.isArray(prop)) {
+      continue;
+    }
+
+    for (const childKey in _.keys(prop)) {
+      propsToVisit.unshift([...key, childKey]);
+    }
+  }
+
+  const cleaned = removeEmpty(payload);
+
+  const resources = {};
+  console.log('foo', component);
+  resources["cfnResource"] = {
+    Type: cloudControlType,
+    Properties: cleaned,
+  };
+  const cloudFormationPayload = {
+    AWSTemplateFormatVersion: "2010-09-09",
+    Resources: resources,
+  };
+
+  return {
+    format: "json",
+    code: JSON.stringify(cloudFormationPayload, null, 2),
+  };
+}
+
+function removeEmpty(obj: any): any {
+  if (Array.isArray(obj)) {
+    return obj
+      .filter((item) => {
+        if (item === null || item === undefined || item === "") return false;
+        if (Array.isArray(item) && item.length === 0) return false;
+        if (typeof item === "object" && Object.keys(item).length === 0) {
+          return false;
+        }
+        return true;
+      })
+      .map((item) =>
+        typeof item === "object" && item !== null ? removeEmpty(item) : item
+      );
+  }
+
+  return Object.fromEntries(
+    Object.entries(obj)
+      .filter(([_, value]) => {
+        if (value === null || value === undefined || value === "") return false;
+        if (Array.isArray(value) && value.length === 0) return false;
+        if (typeof value === "object" && Object.keys(value).length === 0) {
+          return false;
+        }
+        return true;
+      })
+      .map(([key, value]) => [
+        key,
+        typeof value === "object" && value !== null
+          ? removeEmpty(value)
+          : value,
+      ]),
+  );
+}

--- a/bin/clover/src/cloud-control-funcs/qualifications/awsCloudFormationLint.ts
+++ b/bin/clover/src/cloud-control-funcs/qualifications/awsCloudFormationLint.ts
@@ -1,0 +1,53 @@
+async function main(component: Input): Promise<Output> {
+  const codeString = component.code?.["awsCloudFormationLint"]?.code;
+  await Deno.writeTextFile("/tmp/cfn.json", codeString);
+  const args = [
+    "-f",
+    "pretty",
+  ];
+  if (component.domain?.extra?.Region) {
+    args.push("-r");
+    args.push(component.domain?.extra?.Region);
+  }
+  args.push("-t");
+  args.push("/tmp/cfn.json");
+
+  const child = await siExec.waitUntilEnd("cfn-lint", args);
+  console.log(child.stdout);
+
+  let result = "success";
+  let message = child.stdout;
+  // is an error
+  if (child.exitCode === 1) {
+    result = "failure";
+    message = `cfn-lint failed: \n\n${child.stdout}\n\n${child.stderr}`;
+  } else if (child.exitCode === 2) {
+    result = "failure";
+  // is a warning
+  } else if (child.exitCode === 4) {
+    result = "warning";
+  // is an error & warning
+  } else if (child.exitCode === 6) {
+    result = "failure";
+  // is informational
+  } else if (child.exitCode === 8) {
+    result = "warning";
+  // is an error & informational
+  } else if (child.exitCode === 10) {
+    result = "failure";
+  // is a warning & informational
+  } else if (child.exitCode === 12) {
+    result = "warning";
+  // is an error & warning & informational
+  } else if (child.exitCode === 14) {
+    result = "failure";
+  } else if (child.exitCode !== 0) {
+    result = "failure";
+    message = `cfn-lint failed: \n\n${child.stdout}\n\n${child.stderr}\n\n${child.shortMessage}`;
+  }
+
+  return {
+    result,
+    message,
+  };
+}

--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -3,6 +3,7 @@ import { pkgSpecFromCf } from "../specPipeline.ts";
 import { generateAssetFuncs } from "../pipeline-steps/generateAssetFuncs.ts";
 import { generateDefaultActionFuncs } from "../pipeline-steps/generateActionFuncs.ts";
 import { generateDefaultLeafFuncs } from "../pipeline-steps/generateLeafFuncs.ts";
+import { generateDefaultQualificationFuncs } from "../pipeline-steps/generateQualificationFuncs.ts";
 import { generateDefaultManagementFuncs } from "../pipeline-steps/generateManagementFuncs.ts";
 import { addDefaultPropsAndSockets } from "../pipeline-steps/addDefaultPropsAndSockets.ts";
 import { generateSubAssets } from "../pipeline-steps/generateSubAssets.ts";
@@ -14,12 +15,8 @@ import { getExistingSpecs } from "../specUpdates.ts";
 
 import _logger from "../logger.ts";
 import { assetSpecificOverrides } from "../pipeline-steps/assetSpecificOverrides.ts";
-import {
-  addSignatureToCategoryName,
-} from "../pipeline-steps/addSignatureToCategoryName.ts";
-import {
-  generateOutputSocketsFromProps,
-} from "../pipeline-steps/generateOutputSocketsFromProps.ts";
+import { addSignatureToCategoryName } from "../pipeline-steps/addSignatureToCategoryName.ts";
+import { generateOutputSocketsFromProps } from "../pipeline-steps/generateOutputSocketsFromProps.ts";
 import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 import { createPolicyDocumentInputSockets } from "../pipeline-steps/createPolicyDocumentInputSockets.ts";
 
@@ -61,6 +58,7 @@ export async function generateSiSpecs(
   specs = generateDefaultActionFuncs(specs);
   specs = generateDefaultLeafFuncs(specs);
   specs = generateDefaultManagementFuncs(specs);
+  specs = generateDefaultQualificationFuncs(specs);
   // subAssets should not have any of the above, but need an asset func and
   // intrinsics
   specs = generateSubAssets(specs);
@@ -85,10 +83,7 @@ export async function generateSiSpecs(
 
     try {
       logger.debug(`Writing ${name}.json`);
-      await Deno.writeTextFile(
-        `${SI_SPEC_DIR}/${name}.json`,
-        specJson,
-      );
+      await Deno.writeTextFile(`${SI_SPEC_DIR}/${name}.json`, specJson);
     } catch (e) {
       console.log(`Error writing to file: ${name}: ${e}`);
       continue;

--- a/bin/clover/src/pipeline-steps/generateQualificationFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateQualificationFuncs.ts
@@ -1,11 +1,11 @@
 import _ from "lodash";
 import {
-  createDefaultCodeGenFuncs,
+  createDefaultQualificationFuncs,
   createLeafFuncSpec,
 } from "../spec/funcs.ts";
 import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 
-export function generateDefaultLeafFuncs(
+export function generateDefaultQualificationFuncs(
   specs: ExpandedPkgSpec[],
 ): ExpandedPkgSpec[] {
   const newSpecs = [] as ExpandedPkgSpec[];
@@ -19,18 +19,16 @@ export function generateDefaultLeafFuncs(
 
     if (!domain_id) {
       console.log(
-        `Could not generate codegen funcs for ${spec.name}: missing domain id!`,
+        `Could not generate qualification funcs for ${spec.name}: missing domain id!`,
       );
       continue;
     }
 
-    const defaultCodeGenFuncs = createDefaultCodeGenFuncs(domain_id);
+    const defaultCodeGenFuncs = createDefaultQualificationFuncs(domain_id);
 
     for (const codeGenFunc of defaultCodeGenFuncs) {
       funcs.push(codeGenFunc);
-      leafFuncs.push(
-        createLeafFuncSpec("codeGeneration", codeGenFunc.uniqueId),
-      );
+      leafFuncs.push(createLeafFuncSpec("qualification", codeGenFunc.uniqueId));
     }
 
     newSpecs.push(spec);

--- a/bin/clover/src/spec/funcs.ts
+++ b/bin/clover/src/spec/funcs.ts
@@ -54,19 +54,26 @@ const funcSpecs: Record<string, FuncSpecInfo> = {
     path: "./src/cloud-control-funcs/actions/awsCloudControlUpdate.ts",
   },
   // Code Generation
-  "awsCloudControlCreate": {
+  awsCloudControlCreate: {
     id: "c48518d82a2db7064e7851c36636c665dce775610d08958a8a4f0c5c85cd808e",
     backendKind: "jsAttribute",
     responseType: "codeGeneration",
     displayName: "Code Gen for creating a Cloud Control Asset",
     path: "./src/cloud-control-funcs/code-gen/awsCloudControlCodeGenCreate.ts",
   },
-  "awsCloudControlUpdate": {
+  awsCloudControlUpdate: {
     id: "f170263ef3fbb0e8017b47221c5d70ae412b2eaa33e75e1a98525c9a070d60f6",
     backendKind: "jsAttribute",
     responseType: "codeGeneration",
     displayName: "Code Gen for updating a Cloud Control Asset",
     path: "./src/cloud-control-funcs/code-gen/awsCloudControlCodeGenUpdate.ts",
+  },
+  awsCloudFormationLint: {
+    id: "fdef639540613ce1639df4153f9bb5a8929e9815477eb57beb3616af48a74335",
+    backendKind: "jsAttribute",
+    responseType: "codeGeneration",
+    displayName: "Code Gen for use in validating a Cloudformation document",
+    path: "./src/cloud-control-funcs/code-gen/awsCloudFormationLint.ts",
   },
   // Management
   "Discover on AWS": {
@@ -82,6 +89,14 @@ const funcSpecs: Record<string, FuncSpecInfo> = {
     responseType: "management",
     displayName: "Import a Cloud Control Asset",
     path: "./src/cloud-control-funcs/management/awsCloudControlImport.ts",
+  },
+  // Qualification
+  awsCloudFormationLintQualification: {
+    id: "a8586fc5b4886497626fd3274c13de3f778f71b8169b3b7f20ee6db7d29b1069",
+    backendKind: "jsAttribute",
+    responseType: "qualification",
+    displayName: "Qualification for validating Cloudformation document",
+    path: "./src/cloud-control-funcs/qualifications/awsCloudFormationLint.ts",
   },
 };
 
@@ -169,15 +184,18 @@ export function createDefaultCodeGenFuncs(domain_id: string): FuncSpec[] {
   const codeGenFuncs = [
     "awsCloudControlCreate",
     "awsCloudControlUpdate",
+    "awsCloudFormationLint",
   ];
 
-  const args: FuncArgumentSpec[] = [{
-    name: "domain",
-    kind: "object",
-    elementKind: null,
-    uniqueId: domain_id,
-    deleted: false,
-  }];
+  const args: FuncArgumentSpec[] = [
+    {
+      name: "domain",
+      kind: "object",
+      elementKind: null,
+      uniqueId: domain_id,
+      deleted: false,
+    },
+  ];
 
   for (const func of codeGenFuncs) {
     const spec = funcSpecs[func];
@@ -187,12 +205,35 @@ export function createDefaultCodeGenFuncs(domain_id: string): FuncSpec[] {
   return ret;
 }
 
+export function createDefaultQualificationFuncs(domain_id: string): FuncSpec[] {
+  if (!domain_id) {
+    throw new Error("no domain id provided for qualification func!");
+  }
+
+  const ret: FuncSpec[] = [];
+  const qualificationFuncs = ["awsCloudFormationLintQualification"];
+
+  const args: FuncArgumentSpec[] = [
+    {
+      name: "domain",
+      kind: "object",
+      elementKind: null,
+      uniqueId: domain_id,
+      deleted: false,
+    },
+  ];
+
+  for (const func of qualificationFuncs) {
+    const spec = funcSpecs[func];
+    ret.push(createDefaultFuncSpec(func, spec, args));
+  }
+
+  return ret;
+}
+
 export function createDefaultManagementFuncs(): FuncSpec[] {
   const ret: FuncSpec[] = [];
-  const actionFuncs = [
-    "Discover on AWS",
-    "Import from AWS",
-  ];
+  const actionFuncs = ["Discover on AWS", "Import from AWS"];
 
   for (const func of actionFuncs) {
     const spec = funcSpecs[func];
@@ -242,7 +283,5 @@ export function createManagementFuncSpec(
 
 // Si uses a version of base64 that removes the padding at the end for some reason
 export function strippedBase64(code: string) {
-  return Buffer.from(code).toString(
-    "base64",
-  ).replace(/=*$/, "");
+  return Buffer.from(code).toString("base64").replace(/=*$/, "");
 }

--- a/flake.nix
+++ b/flake.nix
@@ -109,6 +109,9 @@
         flyctl
         azure-cli
         govc
+        (pkgs.python3.withPackages (p: with p; [
+          cfn-lint
+        ]))
       ];
 
       buck2Derivation = {


### PR DESCRIPTION
Adds support for python3 packages to the nix flake, and installs cfn-lint.

Adds the functions that we need in the clover directory, but I'm uncertain how to wire them up.