### PR TITLE
feat: implement pgbouncer metric collection into prometheus

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -82,5 +82,16 @@ services:
     depends_on:
       - otelcol
 
+  pgbouncer-prom-exporter:
+    container_name: pgbouncer-prom-exporter
+    image: systeminit/pgbouncer-prom-exporter:${INIT_VERSION:-stable}
+    profiles: [forklift, rebaser, pinga, sdf]
+    environment:
+      - BOUNCER_ADMIN_PASSWORD=${SI_BOUNCER_ADMIN_PASSWORD}
+    ports:
+      - 9127:9127
+    depends_on:
+      - pgbouncer
+
 volumes:
   config:

--- a/component/init/configs/prometheus.yml
+++ b/component/init/configs/prometheus.yml
@@ -11,6 +11,11 @@ scrape_configs:
    static_configs:
     - targets:
       - node-exporter:9100
+ - job_name: pgbouncer_metrics
+   metrics_path: /metrics
+   static_configs:
+    - targets:
+       - pgbouncer-prom-exporter:9127
 remote_write:
   - url: $SI_PROMETHEUS_REMOTE_WRITE_URL
     sigv4:
@@ -24,4 +29,3 @@ remote_write:
       - '__address__'
       target_label: 'instance'
       replacement: '$SI_SERVICE;$SI_INSTANCE_ID'
-

--- a/component/pgbouncer-prom-exporter/BUCK
+++ b/component/pgbouncer-prom-exporter/BUCK
@@ -1,0 +1,19 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "docker_image",
+)
+
+docker_image(
+    name = "pgbouncer-prom-exporter",
+    build_args = {
+        "BASE_VERSION": "v0.9.0",
+    },
+    srcs = {
+        "docker-entrypoint.sh": ".",
+        "pgbouncer-conn-string-exporter.sh": ".",
+    },
+    run_docker_args = [
+        "--publish",
+        "9127:9127",
+    ],
+)

--- a/component/pgbouncer-prom-exporter/Dockerfile
+++ b/component/pgbouncer-prom-exporter/Dockerfile
@@ -1,0 +1,6 @@
+ARG BASE_VERSION
+FROM prometheuscommunity/pgbouncer-exporter:${BASE_VERSION}
+WORKDIR /app
+COPY ./docker-entrypoint.sh /app/
+COPY ./pgbouncer-conn-string-exporter.sh /app/
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/component/pgbouncer-prom-exporter/docker-entrypoint.sh
+++ b/component/pgbouncer-prom-exporter/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+eval $(cat /app/pgbouncer-conn-string-exporter.sh)
+/bin/pgbouncer_exporter

--- a/component/pgbouncer-prom-exporter/pgbouncer-conn-string-exporter.sh
+++ b/component/pgbouncer-prom-exporter/pgbouncer-conn-string-exporter.sh
@@ -1,0 +1,1 @@
+export PGBOUNCER_EXPORTER_CONNECTION_STRING="postgres://admin:$BOUNCER_ADMIN_PASSWORD@pgbouncer:5432/pgbouncer?sslmode=disable"


### PR DESCRIPTION
Capture those metrics and push them up to our centralised observability stack.

Tested in Tools.

Once this is merged I need to adjust the entrypoint scripts of the relevant nodes to pull the variable required for the metric ingestion. 