### PR TITLE
feat(clover): add Joi validations

### DIFF
--- a/bin/clover/src/cfDb.ts
+++ b/bin/clover/src/cfDb.ts
@@ -41,21 +41,14 @@ export type CfProperty =
 
 type CfBooleanProperty = JSONSchema.Boolean;
 
-type CfStringProperty = Extend<JSONSchema.String, {
-  format?:
-    | "date-time"
-    | "json-pointer"
-    | "string"
-    | "timestamp"
-    | "uri";
-}>;
+type CfStringProperty = JSONSchema.String;
 
 type CfNumberProperty = JSONSchema.Number & {
-  format?: "double" | "int64";
+  format?: string;
 };
 
 type CfIntegerProperty = JSONSchema.Integer & {
-  format?: "double" | "int64";
+  format?: string;
 };
 
 type CfArrayProperty = Extend<JSONSchema.Array, {

--- a/bin/clover/src/cfDb.ts
+++ b/bin/clover/src/cfDb.ts
@@ -5,15 +5,86 @@ import $RefParser from "npm:@apidevtools/json-schema-ref-parser";
 import _logger from "./logger.ts";
 import { ServiceMissing } from "./errors.ts";
 import _ from "npm:lodash";
+import { Extend } from "./extend.ts";
 
 const logger = _logger.ns("cfDb").seal();
 
 type JSONPointer = string;
 
-interface CfPropertyStatic {
-  description?: string;
-  title?: string;
-}
+const CF_PROPERTY_TYPES = [
+  "boolean",
+  "string",
+  "number",
+  "integer",
+  "object",
+  "array",
+  "json",
+] as const;
+export type CfPropertyType = typeof CF_PROPERTY_TYPES[number];
+
+export type CfProperty =
+  | Extend<CfBooleanProperty, { type: "boolean" }>
+  | Extend<CfStringProperty, { type: "string" }>
+  | Extend<CfNumberProperty, { type: "number" }>
+  | Extend<CfIntegerProperty, { type: "integer" }>
+  | Extend<CfArrayProperty, { type: "array" }>
+  | CfObjectProperty // We may infer object-ness if type is undefined but other props are there
+  | Omit<JSONSchema.String, "type"> & { type: "json" }
+  | CfMultiTypeProperty
+  // Then we have this mess of array typed properties
+  | Extend<JSONSchema.Interface, {
+    type: ["string", CfPropertyType] | [
+      CfPropertyType,
+      "string",
+    ];
+  }>;
+
+type CfBooleanProperty = JSONSchema.Boolean;
+
+type CfStringProperty = Extend<JSONSchema.String, {
+  format?:
+    | "date-time"
+    | "json-pointer"
+    | "string"
+    | "timestamp"
+    | "uri";
+}>;
+
+type CfNumberProperty = JSONSchema.Number & {
+  format?: "double" | "int64";
+};
+
+type CfIntegerProperty = JSONSchema.Integer & {
+  format?: "double" | "int64";
+};
+
+type CfArrayProperty = Extend<JSONSchema.Array, {
+  // For properties of type array, defines the data structure of each array item.
+  // Contains a single schema. A list of schemas is not allowed.
+  items: CfProperty;
+  // For properties of type array, set to true to specify that the order in which array items are specified must be honored, and that changing the order of the array will indicate a change in the property.
+  // The default is true.
+  insertionOrder?: boolean;
+}>;
+
+type CfObjectProperty = Extend<JSONSchema.Object, {
+  properties?: Record<string, CfProperty>;
+  // e.g. patternProperties: { "^[a-z]+": { type: "string" } }
+  patternProperties?: Record<string, CfProperty>;
+  // Any properties that are required if this property is specified.
+  dependencies?: Record<string, string[]>;
+  oneOf?: CfObjectProperty[];
+  anyOf?: CfObjectProperty[];
+  allOf?: CfObjectProperty[];
+}>;
+
+type CfMultiTypeProperty =
+  & Pick<JSONSchema.Interface, "$ref" | "$comment" | "title" | "description">
+  & {
+    type?: undefined;
+    oneOf?: CfProperty[];
+    anyOf?: CfProperty[];
+  };
 
 type StringPair =
   | ["string", "object"]
@@ -26,85 +97,74 @@ type StringPair =
   | ["string", "array"]
   | ["integer", "string"];
 
-export type CfProperty =
-  & ({
-    "type":
-      | "boolean"
-      | "json" // Cf does not really have this, but we can use it to differentiate between json and normal text
-      | StringPair;
-  } | {
-    "type": "string";
-    "enum"?: string[];
-  } | {
-    "type": "number" | "integer";
-    "enum"?: number[];
-  } | {
-    "type": "array";
-    "items": CfProperty;
-  } | {
-    "type": "object";
-    "properties"?: Record<string, CfProperty>;
-    "patternProperties"?: Record<string, CfProperty>;
-  } | {
-    "type": undefined;
-    "oneOf"?: CfProperty[]; // TODO: this should be a qualification
-    "anyOf"?: CfProperty[]; // TODO: this should be a qualification
-    "properties"?: Record<string, CfProperty>;
-    "patternProperties"?: Record<string, CfProperty>;
-    "$ref"?: string;
-  })
-  & CfPropertyStatic;
+export function normalizeProperty(
+  prop: CfProperty,
+): CfProperty {
+  const normalizedCfData = normalizePropertyType(prop);
+  return normalizeAnyOfAndOneOfTypes(normalizedCfData);
+}
 
-export function normalizePropertyType(prop: CfProperty): CfProperty {
-  // Some props have no type but we can duck type them to objects
-  if (!prop.type && (prop.properties || prop.patternProperties)) {
-    return { ...prop, type: "object" };
-  }
+function normalizePropertyType(
+  prop: CfProperty,
+): CfProperty {
+  // If it already has a single type, return the prop as-is
+  if (typeof prop.type === "string") return prop;
 
-  // If the type is not an array, the type is fine. The type === string here is redundant, but does type guarding for the rest of the function
-  if (
-    !prop.type || !Array.isArray(prop.type) || typeof prop.type === "string"
-  ) {
+  // Infer type when there is none.
+  if (prop.type === undefined) {
+    // Some props have no type but we can duck type them to objects
+    if (isCfObjectProperty(prop)) {
+      return { ...prop, type: "object" } as CfObjectProperty;
+    }
+
+    // TODO we really need to look inside the ref here rather than assuming string ...
+    if (prop.$ref) {
+      return { ...prop, type: "string" } as CfProperty;
+    }
+
+    // If it's a multi-type thing, return it--we don't really handle these yet.
     return prop;
   }
+
+  // The only remaining possible type is array.
 
   // If the cf type is an array, it's always string+something, and we use that something
   // to guess the best type we should use
   const nonStringType = prop.type.find((t) => t !== "string");
 
+  let type: CfPropertyType;
   switch (nonStringType) {
     case "boolean":
-      return { ...prop, type: "boolean" };
     case "integer":
     case "number":
-      return { ...prop, type: "integer" };
+      type = nonStringType;
+      break;
     case "object":
       // If it's an object we make it a json type, which will become a string type + textArea widget
-      return { ...prop, type: "json" };
+      type = "json";
+      break;
     case "array": {
       // When we get something that is string/array, the items object should already there
-      const finalProp = { ...prop, type: "array" } as Extract<CfProperty, {
-        type: "array";
-      }>;
-      if (!finalProp.items) {
+      if (!("items" in prop)) {
         throw new Error("array typed prop includes array but has no items");
       }
-
-      return finalProp;
+      type = "array";
+      break;
     }
     default:
       console.log(prop);
       throw new Error("unhandled array type");
   }
+  return { ...prop, type } as CfProperty;
 }
 
-export function normalizeAnyOfAndOneOfTypes(prop: CfProperty): CfProperty {
-  if (prop.type) {
-    return prop;
-  }
+function normalizeAnyOfAndOneOfTypes(
+  prop: CfProperty,
+): CfProperty {
+  if (prop.type) return prop;
 
   if (prop.oneOf) {
-    const newProp: Extract<CfProperty, { type: "object" }> = {
+    const newProp: CfObjectProperty = {
       description: prop.description,
       type: "object",
       properties: {},
@@ -115,10 +175,7 @@ export function normalizeAnyOfAndOneOfTypes(prop: CfProperty): CfProperty {
         throw new Error("unexpected oneOf");
       }
 
-      if (
-        (ofMember.type === undefined || ofMember.type === "object") &&
-        ofMember.properties
-      ) {
+      if (ofMember.type === "object" && ofMember.properties) {
         for (const title of _.keys(ofMember.properties)) {
           newProp.properties[title] = ofMember.properties[title];
         }
@@ -159,20 +216,24 @@ export function normalizeAnyOfAndOneOfTypes(prop: CfProperty): CfProperty {
     const properties = {} as Record<string, CfProperty>;
 
     for (const ofMember of prop.anyOf) {
-      if (!ofMember.type && ofMember.properties) {
-        isObject = true;
+      if (!isCfObjectProperty(ofMember)) {
+        isObject = false;
+        break;
+      }
+      isObject = true;
 
-        if (!ofMember.title) {
-          console.log(prop);
-          throw new Error("anyOf of objects without title");
-        }
+      if (!ofMember.title) {
+        console.log(prop);
+        throw new Error("anyOf of objects without title");
+      }
+
+      if (ofMember.properties) {
+        isObject = true;
 
         properties[ofMember.title] = {
           ...ofMember.properties[ofMember.title],
         };
-      } else if (
-        ofMember.type === "object" && ofMember.patternProperties
-      ) {
+      } else if (ofMember.patternProperties) {
         isObject = true;
 
         if (!ofMember.title) {
@@ -181,9 +242,6 @@ export function normalizeAnyOfAndOneOfTypes(prop: CfProperty): CfProperty {
         }
 
         properties[ofMember.title] = ofMember;
-      } else {
-        isObject = false;
-        break;
       }
     }
 
@@ -202,6 +260,12 @@ export function normalizeAnyOfAndOneOfTypes(prop: CfProperty): CfProperty {
   }
 
   return prop;
+}
+
+// Tells whether this can be treated like an object (even if it doesn't have type = object)
+function isCfObjectProperty(prop: CfProperty): prop is CfObjectProperty {
+  return prop.type === "object" || "properties" in prop ||
+    "patternProperties" in prop;
 }
 
 export interface CfSchema extends JSONSchema.Interface {
@@ -234,6 +298,7 @@ export interface CfSchema extends JSONSchema.Interface {
       definitions: JSONSchema.Interface["definitions"];
     }
   >;
+  definitions?: Record<string, CfProperty>;
   properties: Record<string, CfProperty>;
   readOnlyProperties?: JSONPointer[];
   writeOnlyProperties?: JSONPointer[];

--- a/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
@@ -229,7 +229,7 @@ function generatePropBuilderString(
   ) {
     const is_create_only = prop.metadata.createOnly ?? false;
 
-    return `new PropBuilder()\n` +
+    const result = `new PropBuilder()\n` +
       `${indent(indent_level)}.setName("${prop.name}")\n` +
       `${indent(indent_level)}.setKind("${kind}")\n` +
       `${indent(indent_level)}.setHidden(${prop.data?.hidden ?? false})\n` +
@@ -244,6 +244,13 @@ function generatePropBuilderString(
           ? `${indent(indent_level)}.setDefaultValue(${
             JSON.stringify(prop.data.defaultValue)
           })\n`
+          : ""
+      ) +
+      (
+        prop.joiValidation
+          ? `${
+            indent(indent_level)
+          }.setValidationFormat(${prop.joiValidation})\n`
           : ""
       ) +
       (
@@ -262,6 +269,10 @@ function generatePropBuilderString(
       ) +
       inner +
       `${indent(indent_level)}.build()`;
+    // Now that we've emitted it, we don't need prop.joiValidation anymore. Don't bother
+    // putting it in the spec (we already have validationFormat).
+    delete prop.joiValidation;
+    return result;
   }
 }
 

--- a/bin/clover/src/spec/props.ts
+++ b/bin/clover/src/spec/props.ts
@@ -4,6 +4,7 @@ import { PropSpec } from "../bindings/PropSpec.ts";
 import { PropSpecData } from "../bindings/PropSpecData.ts";
 import { PropSpecWidgetKind } from "../bindings/PropSpecWidgetKind.ts";
 import _ from "npm:lodash";
+import ImportedJoi from "joi";
 import { Extend } from "../extend.ts";
 const { createHash } = await import("node:crypto");
 
@@ -60,6 +61,7 @@ interface PropSpecOverrides {
     primaryIdentifier: boolean;
     propPath: string[];
   };
+  joiValidation?: string;
 }
 
 type CreatePropQueue = {
@@ -175,17 +177,16 @@ function createPropFromCfInner(
     cfProp.title = name;
   }
 
-  const normalizedCfData = normalizeProperty(cfProp);
+  const normalizedCfProp = normalizeProperty(cfProp);
 
   if (
-    normalizedCfData.type === "integer" ||
-    normalizedCfData.type === "number"
+    normalizedCfProp.type === "integer" || normalizedCfProp.type === "number"
   ) {
     const prop = partialProp as ExpandedPropSpecFor["number"];
     prop.kind = "number";
-    if (normalizedCfData.enum) {
+    if (normalizedCfProp.enum) {
       prop.data.widgetKind = "ComboBox";
-      for (const val of normalizedCfData.enum) {
+      for (const val of normalizedCfProp.enum) {
         const valString = val.toString();
         prop.data.widgetOptions!.push({
           label: valString,
@@ -196,19 +197,55 @@ function createPropFromCfInner(
       prop.data.widgetKind = "Text";
     }
 
+    // Add validation
+    let validation = "";
+    if (normalizedCfProp.type === "integer") {
+      validation += ".integer()";
+    }
+    if (normalizedCfProp.minimum !== undefined) {
+      validation += `.min(${normalizedCfProp.minimum})`;
+    }
+    if (normalizedCfProp.maximum !== undefined) {
+      validation += `.max(${normalizedCfProp.maximum})`;
+    }
+    if (normalizedCfProp.exclusiveMinimum !== undefined) {
+      validation += `.greater(${normalizedCfProp.exclusiveMinimum})`;
+    }
+    if (normalizedCfProp.exclusiveMaximum !== undefined) {
+      validation += `.less(${normalizedCfProp.exclusiveMaximum})`;
+    }
+    if (normalizedCfProp.multipleOf !== undefined) {
+      validation += `.multiple(${normalizedCfProp.multipleOf})`;
+    }
+    switch (normalizedCfProp.format) {
+      case "int64":
+      case "double":
+        // These formats are inherent to JS
+        break;
+      case undefined:
+        break;
+      default:
+        throw new Error(
+          `Unsupported number format: ${normalizedCfProp.format}`,
+        );
+    }
+    if (validation) {
+      setJoiValidation(prop, `Joi.number()${validation}`);
+    }
+
     return prop;
-  } else if (normalizedCfData.type === "boolean") {
+  } else if (normalizedCfProp.type === "boolean") {
     const prop = partialProp as Extract<ExpandedPropSpec, { kind: "boolean" }>;
     prop.kind = "boolean";
     prop.data.widgetKind = "Checkbox";
 
     return prop;
-  } else if (normalizedCfData.type === "string") {
+  } else if (normalizedCfProp.type === "string") {
     const prop = partialProp as Extract<ExpandedPropSpec, { kind: "string" }>;
     prop.kind = "string";
-    if (normalizedCfData.enum) {
+    if (normalizedCfProp.enum) {
       prop.data.widgetKind = "ComboBox";
-      for (const val of normalizedCfData.enum) {
+      for (const val of normalizedCfProp.enum) {
         prop.data.widgetOptions!.push({
           label: val,
           value: val,
@@ -218,14 +255,84 @@ function createPropFromCfInner(
       prop.data.widgetKind = "Text";
     }
 
+    // Add validation
+    if (
+      normalizedCfProp.format === "date-time" ||
+      normalizedCfProp.format === "timestamp"
+    ) {
+      prop.joiValidation = "Joi.date().iso()";
+    } else {
+      let validation = "";
+
+      // https://json-schema.org/understanding-json-schema/reference/type#built-in-formats
+      switch (normalizedCfProp.format) {
+        case "uri":
+          validation += ".uri()";
+          break;
+        case "json-pointer":
+          // https://tools.ietf.org/html/rfc6901
+          // We don't validate the whole thing there, but we at least check that it starts with slash!
+          validation += `.pattern(/^\\//)`;
+          break;
+        case "string":
+          // This seems meaningless (actually, the two fields that use it, QuickSight::DataSet::CreatedAt
+          // and QuickSight::DataSet::LastUpdatedAt, are both number types in the actual API, so
+          // it's not clear why these are strings in the first place)
+          break;
+        // This is a special case (and seems likely wrong), but may as well support it
+        case "(^arn:[a-z\\d-]+:rekognition:[a-z\\d-]+:\\d{12}:collection\\/([a-zA-Z0-9_.\\-]+){1,255})":
+          validation += `.pattern(new RegExp(${
+            JSON.stringify(normalizedCfProp.format)
+          }))`;
+          break;
+        case undefined:
+          break;
+        default:
+          throw new Error(
+            `Unsupported format: ${normalizedCfProp.format}`,
+          );
+      }
+      if (normalizedCfProp.minLength !== undefined) {
+        validation += `.min(${normalizedCfProp.minLength})`;
+      }
+      if (normalizedCfProp.maxLength !== undefined) {
+        validation += `.max(${normalizedCfProp.maxLength})`;
+      }
+      if (normalizedCfProp.pattern !== undefined) {
+        if (
+          !shouldIgnorePattern(typeName, normalizedCfProp.pattern)
+        ) {
+          validation += `.pattern(new RegExp(${
+            JSON.stringify(normalizedCfProp.pattern)
+          }))`;
+        }
+      }
+      if (validation) {
+        try {
+          setJoiValidation(prop, `Joi.string()${validation}`);
+        } catch (e) {
+          if (normalizedCfProp.pattern !== undefined) {
+            console.log(
+              `If this is a regex syntax error, add this to IGNORE_PATTERNS:
+                ${JSON.stringify(typeName)}: [ ${
+                JSON.stringify(normalizedCfProp.pattern)
+              }, ],
+              `,
+            );
+          }
+          throw e;
+        }
+      }
+    }
     return prop;
-  } else if (normalizedCfData.type === "json") {
+  } else if (normalizedCfProp.type === "json") {
+    // TODO if this is gonna be json we should really check that it's valid json ...
     const prop = partialProp as Extract<ExpandedPropSpec, { kind: "string" }>;
     prop.kind = "string";
     prop.data.widgetKind = "TextArea";
 
     return prop;
-  } else if (normalizedCfData.type === "array") {
+  } else if (normalizedCfProp.type === "array") {
     const prop = partialProp as Extract<ExpandedPropSpec, { kind: "array" }>;
     prop.kind = "array";
     prop.data.widgetKind = "Array";
@@ -235,18 +342,18 @@ function createPropFromCfInner(
         prop.typeProp = data;
       },
       name: `${name}Item`,
-      cfProp: normalizedCfData.items,
+      cfProp: normalizedCfProp.items,
       propPath: _.clone(propPath),
     });
 
     return prop;
-  } else if (normalizedCfData.type === "object") {
-    if (normalizedCfData.patternProperties) {
+  } else if (normalizedCfProp.type === "object") {
+    if (normalizedCfProp.patternProperties) {
       const prop = partialProp as Extract<ExpandedPropSpec, { kind: "map" }>;
       prop.kind = "map";
       prop.data.widgetKind = "Map";
 
-      const patternProps = Object.entries(normalizedCfData.patternProperties);
+      const patternProps = Object.entries(normalizedCfProp.patternProperties);
 
       let cfProp;
       if (patternProps.length === 1) {
@@ -276,13 +383,13 @@ function createPropFromCfInner(
       });
 
       return prop;
-    } else if (normalizedCfData.properties) {
+    } else if (normalizedCfProp.properties) {
       const prop = partialProp as Extract<ExpandedPropSpec, { kind: "object" }>;
       prop.kind = "object";
       prop.data.widgetKind = "Header";
       prop.entries = [];
 
-      Object.entries(normalizedCfData.properties).forEach(
+      Object.entries(normalizedCfProp.properties).forEach(
         ([objName, objProp]) => {
           queue.push({
             addTo: (data: ExpandedPropSpec) => {
@@ -304,17 +411,68 @@ function createPropFromCfInner(
     }
   }
 
-  if (!normalizedCfData.type && normalizedCfData.description == "") {
+  if (!normalizedCfProp.type && normalizedCfProp.description == "") {
     return undefined;
   }
 
-  if (!normalizedCfData.type && normalizedCfData.title) {
+  if (!normalizedCfProp.type && normalizedCfProp.title) {
     return undefined;
   }
 
   // console.log(cfProp);
-  console.log(normalizedCfData);
+  console.log(normalizedCfProp);
   throw new Error(`no matching kind in prop with path: ${propPath}`);
+}
+
+function setJoiValidation(prop: ExpandedPropSpec, joiValidation: string) {
+  prop.joiValidation = joiValidation;
+  // Used in the eval() below
+  // deno-lint-ignore no-unused-vars
+  const Joi = ImportedJoi;
+  try {
+    prop.data.validationFormat = JSON.stringify(eval(joiValidation).describe());
+  } catch (e) {
+    console.error(joiValidation);
+    throw e;
+  }
+}
+
+// Some patterns in cloudformation are broken and need to be ignored
+const IGNORE_PATTERNS = {
+  "AWS::Amplify::App": ["(?s).+", "(?s).*"],
+  "AWS::Amplify::Branch": ["(?s).+", "(?s).*"],
+  "AWS::Amplify::Domain": ["(?s).+", "(?s).*"],
+  "AWS::AppFlow::Flow": [
+    "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*",
+  ],
+  "AWS::CloudFormation::GuardHook": [
+    "^(?!(?i)aws)[A-Za-z0-9]{2,64}::[A-Za-z0-9]{2,64}::[A-Za-z0-9]{2,64}$",
+  ],
+  "AWS::CloudFormation::LambdaHook": [
+    "^(?!(?i)aws)[A-Za-z0-9]{2,64}::[A-Za-z0-9]{2,64}::[A-Za-z0-9]{2,64}$",
+  ],
+  "AWS::CloudTrail::Dashboard": ["(?s).*"],
+  "AWS::FinSpace::Environment": [
+    "^[a-zA-Z-0-9-:\\/]*{1,1000}$",
+    "^[a-zA-Z-0-9-:\\/.]*{1,1000}$",
+  ],
+  "AWS::GameLift::GameServerGroup": ["[ -퟿-�𐀀-􏿿\r\n\t]*"],
+  "AWS::Invoicing::InvoiceUnit": ["^(?! )[\\p{L}\\p{N}\\p{Z}-_]*(?<! )$"],
+  "AWS::OpsWorksCM::Server": [
+    "(?s)\\s*-----BEGIN CERTIFICATE-----.+-----END CERTIFICATE-----\\s*",
+    "(?ms)\\s*^-----BEGIN (?-s:.*)PRIVATE KEY-----$.*?^-----END (?-s:.*)PRIVATE KEY-----$\\s*",
+    "(?s).*",
+  ],
+  "AWS::SageMaker::FeatureGroup": [
+    "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\t]*",
+  ],
+} as Record<string, string[]>;
+
+function shouldIgnorePattern(
+  typeName: string,
+  pattern: string,
+): boolean {
+  return IGNORE_PATTERNS[typeName]?.indexOf(pattern) >= 0;
 }
 
 function setCreateOnlyProp(data: ExpandedPropSpec["data"]) {

--- a/bin/clover/src/spec/props.ts
+++ b/bin/clover/src/spec/props.ts
@@ -1,8 +1,4 @@
-import {
-  CfProperty,
-  normalizeAnyOfAndOneOfTypes,
-  normalizePropertyType,
-} from "../cfDb.ts";
+import { CfProperty, normalizeProperty } from "../cfDb.ts";
 import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
 import { PropSpec } from "../bindings/PropSpec.ts";
 import { PropSpecData } from "../bindings/PropSpecData.ts";
@@ -179,12 +175,7 @@ function createPropFromCfInner(
     cfProp.title = name;
   }
 
-  let normalizedCfData = normalizePropertyType(cfProp);
-  normalizedCfData = normalizeAnyOfAndOneOfTypes(normalizedCfData);
-
-  if (!normalizedCfData.type && normalizedCfData.$ref) {
-    normalizedCfData = { ...normalizedCfData, type: "string" };
-  }
+  const normalizedCfData = normalizeProperty(cfProp);
 
   if (
     normalizedCfData.type === "integer" ||

--- a/deno.lock
+++ b/deno.lock
@@ -56,6 +56,7 @@
     "npm:json-schema-typed@^8.0.1": "8.0.1",
     "npm:lodash-es@4.17.21": "4.17.21",
     "npm:lodash-es@^4.17.21": "4.17.21",
+    "npm:lodash@*": "4.17.21",
     "npm:lodash@4.17.21": "4.17.21",
     "npm:lodash@^4.17.21": "4.17.21",
     "npm:node-domexception@1.0.0": "1.0.0",


### PR DESCRIPTION
This PR adds Joi validations for scalars:
- number: minimum, maximum, exclusiveMinimum, exclusiveMaximum, multipleOf
- string: minLength, maxLength, pattern, format: date-time/timestamp/uri

It does this by:
1. prop.joiValidationGenerating the Joi validation expression (`Joi.string().max(255).pattern(new RegExp("^arn:"))`) based on the type and validation criteria on the property. If there are no modifiers besides the type (like string / number / boolean), validation is not generated. This is stuffed in prop.joiValidation, which will be used by the asset function generator later.
2. prop.data.validationFormat: We then eval() the joiValidation Calling it in the generator with `eval()`, calling `describe()` on the resulting Joi object and encoding that to JSON before putting it into package spec format.
3. Asset function: when generating the asset function for a prop with joiValidation, we add a `setValidationFormat(<prop.joiValidation>)` builder call to the PropBuilder, and prop.joiValidation is deleted to make sure we don't dump it unnecessarily into the PkgSpec we upload.

## Testing

- Uploaded AWS::ECR::Repository locally and set RepositoryName to a single character. Watched validation go red.
- Did Regenerate Asset and updated said component. Validation still red!