### PR TITLE
feat: start lang-js with cyclone

### DIFF
--- a/bin/lang-js/src/function.ts
+++ b/bin/lang-js/src/function.ts
@@ -92,7 +92,6 @@ export interface OutputLine {
 }
 
 export async function executeFunction(
-  kind: FunctionKind,
   request: Request,
   timeout: number,
 ) {
@@ -105,7 +104,7 @@ export async function executeFunction(
 
   // TODO Create Func types instead of casting request objs
   let result;
-  switch (kind) {
+  switch (request.kind) {
     case FunctionKind.ActionRun:
       result = await executor(
         ctx,
@@ -169,7 +168,7 @@ export async function executeFunction(
       );
       break;
     default:
-      throw Error(`Unknown Kind variant: ${kind}`);
+      throw Error(`Unknown Kind variant: ${request.kind}`);
   }
 
   console.log(JSON.stringify(result));

--- a/bin/lang-js/src/request.ts
+++ b/bin/lang-js/src/request.ts
@@ -3,6 +3,7 @@ import { BeforeFunc } from "./function_kinds/before.ts";
 import { JoiValidationFunc } from "./function_kinds/joi_validation.ts";
 import { ResolverFunc } from "./function_kinds/resolver_function.ts";
 import { ManagementFunc } from "./function_kinds/management.ts";
+import { FunctionKind } from "./function.ts";
 import {
   SchemaVariantDefinitionFunc,
 } from "./function_kinds/schema_variant_definition.ts";
@@ -19,6 +20,7 @@ export type Request =
   & AnyFunction
   & RequestCtx
   & {
+    kind: FunctionKind;
     before?: BeforeFunc[];
     timeout?: number;
   };

--- a/deno.lock
+++ b/deno.lock
@@ -353,11 +353,8 @@
     "@types/lodash-es@4.17.12": {
       "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
       "dependencies": [
-        "@types/lodash@4.17.13"
+        "@types/lodash"
       ]
-    },
-    "@types/lodash@4.17.13": {
-      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg=="
     },
     "@types/lodash@4.17.14": {
       "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A=="
@@ -455,8 +452,8 @@
     "date-fns@3.6.0": {
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
     },
-    "debug@4.3.7": {
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+    "debug@4.4.0": {
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dependencies": [
         "ms"
       ]
@@ -632,8 +629,8 @@
     "fast-levenshtein@2.0.6": {
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
-    "fastq@1.17.1": {
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+    "fastq@1.19.0": {
+      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
       "dependencies": [
         "reusify"
       ]
@@ -732,8 +729,8 @@
     "ignore@5.3.2": {
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
     },
-    "import-fresh@3.3.0": {
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+    "import-fresh@3.3.1": {
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dependencies": [
         "parent-module",
         "resolve-from"

--- a/lib/cyclone-core/src/action_run.rs
+++ b/lib/cyclone-core/src/action_run.rs
@@ -42,6 +42,10 @@ impl CycloneRequestable for ActionRunRequest {
         &self.execution_id
     }
 
+    fn kind(&self) -> &str {
+        "actionRun"
+    }
+
     fn websocket_path(&self) -> &str {
         "/execute/command"
     }

--- a/lib/cyclone-core/src/kill_execution.rs
+++ b/lib/cyclone-core/src/kill_execution.rs
@@ -15,6 +15,10 @@ impl CycloneRequestable for KillExecutionRequest {
         &self.execution_id
     }
 
+    fn kind(&self) -> &str {
+        ""
+    }
+
     fn websocket_path(&self) -> &str {
         ""
     }

--- a/lib/cyclone-core/src/management.rs
+++ b/lib/cyclone-core/src/management.rs
@@ -46,6 +46,10 @@ impl CycloneRequestable for ManagementRequest {
         &self.execution_id
     }
 
+    fn kind(&self) -> &str {
+        "management"
+    }
+
     fn websocket_path(&self) -> &str {
         "/execute/management"
     }

--- a/lib/cyclone-core/src/request.rs
+++ b/lib/cyclone-core/src/request.rs
@@ -38,6 +38,7 @@ pub trait CycloneRequestable {
     type Response;
 
     fn execution_id(&self) -> &str;
+    fn kind(&self) -> &str;
     fn websocket_path(&self) -> &str;
     fn inc_run_metric(&self);
     fn dec_run_metric(&self);

--- a/lib/cyclone-core/src/resolver_function.rs
+++ b/lib/cyclone-core/src/resolver_function.rs
@@ -62,6 +62,10 @@ impl CycloneRequestable for ResolverFunctionRequest {
         &self.execution_id
     }
 
+    fn kind(&self) -> &str {
+        "resolverfunction"
+    }
+
     fn websocket_path(&self) -> &str {
         "/execute/resolver"
     }

--- a/lib/cyclone-core/src/schema_variant_definition.rs
+++ b/lib/cyclone-core/src/schema_variant_definition.rs
@@ -29,6 +29,10 @@ impl CycloneRequestable for SchemaVariantDefinitionRequest {
         &self.execution_id
     }
 
+    fn kind(&self) -> &str {
+        "schemaVariantDefinition"
+    }
+
     fn websocket_path(&self) -> &str {
         "/execute/schema_variant_definition"
     }

--- a/lib/cyclone-core/src/validation.rs
+++ b/lib/cyclone-core/src/validation.rs
@@ -28,6 +28,10 @@ impl CycloneRequestable for ValidationRequest {
         &self.execution_id
     }
 
+    fn kind(&self) -> &str {
+        "validation"
+    }
+
     fn websocket_path(&self) -> &str {
         "/execute/validation"
     }

--- a/lib/cyclone-server/src/handlers.rs
+++ b/lib/cyclone-server/src/handlers.rs
@@ -1,7 +1,6 @@
 use std::{
     fmt,
     marker::{PhantomData, Unpin},
-    path::PathBuf,
     sync::Arc,
 };
 
@@ -30,10 +29,7 @@ use crate::{
         LangServerActionRunResultSuccess, LangServerResolverFunctionResultSuccess,
         LangServerValidationResultSuccess,
     },
-    state::{
-        LangServerFunctionTimeout, LangServerPath, LangServerProcessTimeout, TelemetryLevel,
-        WatchKeepalive,
-    },
+    state::{LangServerChild, LangServerProcessTimeout, WatchKeepalive},
     watch,
 };
 
@@ -100,155 +96,120 @@ pub async fn ws_execute_ping(
 
 pub async fn ws_execute_resolver(
     wsu: WebSocketUpgrade,
-    State(lang_server_path): State<LangServerPath>,
-    State(telemetry_level): State<TelemetryLevel>,
-    State(lang_server_function_timeout): State<LangServerFunctionTimeout>,
     State(lang_server_process_timeout): State<LangServerProcessTimeout>,
+    State(child): State<LangServerChild>,
     limit_request_guard: LimitRequestGuard,
     Extension(request_span): Extension<ParentSpan>,
 ) -> impl IntoResponse {
-    let lang_server_path = lang_server_path.as_path().to_path_buf();
-    let telemetry_level = telemetry_level.is_debug_or_lower().await;
     wsu.on_upgrade(move |socket| {
         let request: PhantomData<ResolverFunctionRequest> = PhantomData;
         let lang_server_success: PhantomData<LangServerResolverFunctionResultSuccess> = PhantomData;
         let success: PhantomData<ResolverFunctionResultSuccess> = PhantomData;
         handle_socket(
             socket,
-            lang_server_path,
-            telemetry_level,
-            lang_server_function_timeout.inner(),
             lang_server_process_timeout.inner(),
             limit_request_guard,
-            "resolverfunction".to_owned(),
             request,
             lang_server_success,
             success,
             request_span.into_inner(),
+            child,
         )
     })
 }
 
 pub async fn ws_execute_validation(
     wsu: WebSocketUpgrade,
-    State(lang_server_path): State<LangServerPath>,
-    State(telemetry_level): State<TelemetryLevel>,
-    State(lang_server_function_timeout): State<LangServerFunctionTimeout>,
     State(lang_server_process_timeout): State<LangServerProcessTimeout>,
+    State(child): State<LangServerChild>,
     limit_request_guard: LimitRequestGuard,
     Extension(request_span): Extension<ParentSpan>,
 ) -> impl IntoResponse {
-    let lang_server_path = lang_server_path.as_path().to_path_buf();
-    let telemetry_level = telemetry_level.is_debug_or_lower().await;
     wsu.on_upgrade(move |socket| {
         let request: PhantomData<ValidationRequest> = PhantomData;
         let lang_server_success: PhantomData<LangServerValidationResultSuccess> = PhantomData;
         let success: PhantomData<ValidationResultSuccess> = PhantomData;
         handle_socket(
             socket,
-            lang_server_path,
-            telemetry_level,
-            lang_server_function_timeout.inner(),
             lang_server_process_timeout.inner(),
             limit_request_guard,
-            "validation".to_owned(),
             request,
             lang_server_success,
             success,
             request_span.into_inner(),
+            child,
         )
     })
 }
 
 pub async fn ws_execute_action_run(
     wsu: WebSocketUpgrade,
-    State(lang_server_path): State<LangServerPath>,
-    State(telemetry_level): State<TelemetryLevel>,
-    State(lang_server_function_timeout): State<LangServerFunctionTimeout>,
     State(lang_server_process_timeout): State<LangServerProcessTimeout>,
+    State(child): State<LangServerChild>,
     limit_request_guard: LimitRequestGuard,
     Extension(request_span): Extension<ParentSpan>,
 ) -> impl IntoResponse {
-    let lang_server_path = lang_server_path.as_path().to_path_buf();
-    let telemetry_level = telemetry_level.is_debug_or_lower().await;
     wsu.on_upgrade(move |socket| {
         let request: PhantomData<ActionRunRequest> = PhantomData;
         let lang_server_success: PhantomData<LangServerActionRunResultSuccess> = PhantomData;
         let success: PhantomData<ActionRunResultSuccess> = PhantomData;
         handle_socket(
             socket,
-            lang_server_path,
-            telemetry_level,
-            lang_server_function_timeout.inner(),
             lang_server_process_timeout.inner(),
             limit_request_guard,
-            "actionRun".to_owned(),
             request,
             lang_server_success,
             success,
             request_span.into_inner(),
+            child,
         )
     })
 }
 
 pub async fn ws_execute_schema_variant_definition(
     wsu: WebSocketUpgrade,
-    State(lang_server_path): State<LangServerPath>,
-    State(telemetry_level): State<TelemetryLevel>,
-    State(lang_server_function_timeout): State<LangServerFunctionTimeout>,
     State(lang_server_process_timeout): State<LangServerProcessTimeout>,
+    State(child): State<LangServerChild>,
     limit_request_guard: LimitRequestGuard,
     Extension(request_span): Extension<ParentSpan>,
 ) -> impl IntoResponse {
-    let lang_server_path = lang_server_path.as_path().to_path_buf();
-    let telemetry_level = telemetry_level.is_debug_or_lower().await;
     wsu.on_upgrade(move |socket| {
         let request: PhantomData<SchemaVariantDefinitionRequest> = PhantomData;
         let lang_server_success: PhantomData<SchemaVariantDefinitionResultSuccess> = PhantomData;
         let success: PhantomData<SchemaVariantDefinitionResultSuccess> = PhantomData;
         handle_socket(
             socket,
-            lang_server_path,
-            telemetry_level,
-            lang_server_function_timeout.inner(),
             lang_server_process_timeout.inner(),
             limit_request_guard,
-            "schemaVariantDefinition".to_owned(),
             request,
             lang_server_success,
             success,
             request_span.into_inner(),
+            child,
         )
     })
 }
 
 pub async fn ws_execute_management(
     wsu: WebSocketUpgrade,
-    State(lang_server_path): State<LangServerPath>,
-    State(telemetry_level): State<TelemetryLevel>,
-    State(lang_server_function_timeout): State<LangServerFunctionTimeout>,
     State(lang_server_process_timeout): State<LangServerProcessTimeout>,
+    State(child): State<LangServerChild>,
     limit_request_guard: LimitRequestGuard,
     Extension(request_span): Extension<ParentSpan>,
 ) -> impl IntoResponse {
-    let lang_server_path = lang_server_path.as_path().to_path_buf();
-    let telemetry_level = telemetry_level.is_debug_or_lower().await;
     wsu.on_upgrade(move |socket| {
         let request: PhantomData<ManagementRequest> = PhantomData;
         let lang_server_success: PhantomData<ManagementResultSuccess> = PhantomData;
         let success: PhantomData<ManagementResultSuccess> = PhantomData;
         handle_socket(
             socket,
-            lang_server_path,
-            telemetry_level,
-            lang_server_function_timeout.inner(),
             lang_server_process_timeout.inner(),
             limit_request_guard,
-            "management".to_owned(),
             request,
             lang_server_success,
             success,
             request_span.into_inner(),
+            child,
         )
     })
 }
@@ -263,30 +224,22 @@ pub async fn ws_execute_management(
 #[allow(clippy::too_many_arguments)]
 async fn handle_socket<Request, LangServerSuccess, Success>(
     mut socket: WebSocket,
-    lang_server_path: PathBuf,
-    lang_server_debugging: bool,
-    lang_server_function_timeout: Option<usize>,
     lang_server_process_timeout: Option<u64>,
     _limit_request_guard: LimitRequestGuard,
-    sub_command: String,
     _request_marker: PhantomData<Request>,
     _lang_server_success_marker: PhantomData<LangServerSuccess>,
     success_marker: PhantomData<Success>,
     request_span: Span,
+    child: LangServerChild,
 ) where
     Request: Serialize + DeserializeOwned + Unpin + fmt::Debug + CycloneRequestable,
     Success: Serialize + Unpin + fmt::Debug,
     LangServerSuccess: Serialize + DeserializeOwned + Unpin + fmt::Debug + Into<Success>,
 {
     let proto = {
-        let execution: Execution<Request, LangServerSuccess, Success> = execution::new(
-            lang_server_path,
-            lang_server_debugging,
-            lang_server_function_timeout,
-            lang_server_process_timeout,
-            sub_command,
-        );
-        match execution.start(&mut socket).await {
+        let execution: Execution<Request, LangServerSuccess, Success> =
+            execution::new(lang_server_process_timeout);
+        match execution.start(child, &mut socket).await {
             Ok(started) => started,
             Err(err) => {
                 warn!(si.error.message = ?err, "failed to start protocol");


### PR DESCRIPTION
Instead of starting lang-js at the time we execute a function, we will start it when cyclone starts. This should helps us churn through functions more quickly when pool is full as we won't have to incur the ~80ms lang-js startup time.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZGtjcTdjc2Jnb3l4aGttaTVhenc1OHZvbnNhY29wZWY3dG8zMHV1ciZlcD12MV9naWZzX3NlYXJjaCZjdD1n/5zf2M4HgjjWszLd4a5/giphy.gif"/>