### PR TITLE
build(nix): create si-fs-standalone Nix pkg for a Nix-free binary

### DIFF
--- a/bin/si-fs/BUCK
+++ b/bin/si-fs/BUCK
@@ -1,7 +1,5 @@
 load(
     "@prelude-si//:macros.bzl",
-    "docker_image",
-    "nix_omnibus_pkg",
     "rust_binary",
 )
 

--- a/flake.nix
+++ b/flake.nix
@@ -109,9 +109,10 @@
         flyctl
         azure-cli
         govc
-        (pkgs.python3.withPackages (p: with p; [
-          cfn-lint
-        ]))
+        (pkgs.python3.withPackages (p:
+          with p; [
+            cfn-lint
+          ]))
         deno
       ];
 
@@ -263,9 +264,9 @@
 
               wrapProgram $out/bin/lang-js \
                 --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath [
-                  pkgs.glibc
-                  pkgs.gcc-unwrapped.lib
-                ]}" \
+                pkgs.glibc
+                pkgs.gcc-unwrapped.lib
+              ]}" \
                 --set DENO_DIR "$out/cache" \
                 --prefix PATH : ${pkgs.lib.makeBinPath langJsExtraPkgs} \
                 --run 'cd "$(dirname "$0")"'

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,6 @@
   };
 
   outputs = {
-    self,
     nixpkgs,
     flake-utils,
     rust-overlay,
@@ -121,7 +120,11 @@
         pkgName,
         extraBuildInputs ? [],
         stdBuildPhase ? ''
-          buck2 build @//mode/release "$buck2_target" --verbose 8 --out "build/$name-$system"
+          buck2 build \
+            @//mode/release \
+            "$buck2_target" \
+            --verbose 8 \
+            --out "build/$name-$system"
         '',
         extraBuildPhase ? "",
         installPhase,
@@ -130,7 +133,7 @@
         dontAutoPatchELF ? false,
         postFixup ? "",
       }:
-        pkgs.stdenv.mkDerivation rec {
+        pkgs.stdenv.mkDerivation {
           name = pkgName;
           buck2_target = "//${pathPrefix}/${pkgName}";
           __impure = true;
@@ -157,7 +160,8 @@
           '';
           configurePhase = ''
             export LIBCLANG_PATH="${pkgs.llvmPackages.libclang.lib}/lib"
-            export BINDGEN_EXTRA_CLANG_ARGS="$(< ${pkgs.stdenv.cc}/nix-support/libc-crt1-cflags) \
+            export BINDGEN_EXTRA_CLANG_ARGS="\
+              $(< ${pkgs.stdenv.cc}/nix-support/libc-crt1-cflags) \
               $(< ${pkgs.stdenv.cc}/nix-support/libc-cflags) \
               $(< ${pkgs.stdenv.cc}/nix-support/cc-cflags) \
               $(< ${pkgs.stdenv.cc}/nix-support/libcxx-cxxflags) \
@@ -259,8 +263,12 @@
               # is where we expect it. This gets droppped into the rootfs as
               # /lib64/ld-linux-x86-64.so.2 -> /nix/store/*/ld-linux-x86-64.20.2
               mkdir -p $out/lib64
-              ln -sf ${pkgs.glibc}/lib/ld-linux-x86-64.so.2 $out/lib64/ld-linux-x86-64.so.2
-              ln -sf ${pkgs.glibc}/lib/ld-linux-aarch64.so.1 $out/lib64/ld-linux-aarch64.so.1
+              ln -sf \
+                "${pkgs.glibc}/lib/ld-linux-x86-64.so.2" \
+                "$out/lib64/ld-linux-x86-64.so.2"
+              ln -sf \
+                "${pkgs.glibc}/lib/ld-linux-aarch64.so.1" \
+                "$out/lib64/ld-linux-aarch64.so.1"
 
               wrapProgram $out/bin/lang-js \
                 --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath [
@@ -313,7 +321,8 @@
           # Env Vars so bindgen can find libclang
           shellHook = ''
             export LIBCLANG_PATH="${pkgs.llvmPackages.libclang.lib}/lib"
-            export BINDGEN_EXTRA_CLANG_ARGS="$(< ${pkgs.stdenv.cc}/nix-support/libc-crt1-cflags) \
+            export BINDGEN_EXTRA_CLANG_ARGS="\
+              $(< ${pkgs.stdenv.cc}/nix-support/libc-crt1-cflags) \
               $(< ${pkgs.stdenv.cc}/nix-support/libc-cflags) \
               $(< ${pkgs.stdenv.cc}/nix-support/cc-cflags) \
               $(< ${pkgs.stdenv.cc}/nix-support/libcxx-cxxflags) \


### PR DESCRIPTION
This change introduces a new Nix derivation helper
(`standaloneBinaryDerivation`) which uses a `binDerivation`-built
package and prepares its main binary to be runnable without the full Nix
package closure.

Note that at the moment, this very much depends on the
dynamic libraries at play and whether or not the executing system has
the correct versions. At the moment, we're targetting the `si-fs` binary
which only depends on `libc` and `libgcc`. Future work will attempt to
make these binaries more flexible and portable where possible.

<img src="https://media2.giphy.com/media/H7O4nDhobqIHqCUeHj/giphy.gif?cid=bd3ea57erh832t6adujm2h4b8nltoceggo4enk533spjt29u&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>