### PR TITLE
feat(si-api-test): Adding the few tests we've been running to benchmark and measure performance

### DIFF
--- a/bin/si-api-test/README.md
+++ b/bin/si-api-test/README.md
@@ -36,3 +36,7 @@ local development, but not how we'll do it in GitHub actions.
 
 Add a new file into ./tests/<something>.ts and then invoke it using the --tests
 param in the binary execution
+
+## Benchmarking
+
+To run a benchmark test, specify `--tests /benchmark/{testName}` when invoking Deno. We only allow you to run a single benchmark test at a time right now.

--- a/bin/si-api-test/benchmark/abandon_all_change_sets.ts
+++ b/bin/si-api-test/benchmark/abandon_all_change_sets.ts
@@ -1,0 +1,36 @@
+// deno-lint-ignore-file no-explicit-any
+import assert from "node:assert";
+import { SdfApiClient } from "../sdf_api_client.ts";
+import {
+    sleepBetween,
+} from "../test_helpers.ts";
+
+export default async function abandon_all_change_sets(sdfApiClient: SdfApiClient) {
+    await sleepBetween(0, 750);
+    return abandon_all_change_sets_inner(sdfApiClient);
+}
+
+async function abandon_all_change_sets_inner(sdf: SdfApiClient) {
+
+    const workspaceId = sdf.workspaceId;
+    const data = await sdf.call({
+        route: "list_open_change_sets",
+        routeVars: {
+            workspaceId,
+        },
+    });
+    // loop through them and abandon each one that's not head
+    assert(data.defaultChangeSetId, "Expected headChangeSetId");
+    const changeSetsToAbandon = data.changeSets.filter((c) => c.id !== data.defaultChangeSetId);
+
+    for (const changeSet of changeSetsToAbandon) {
+        const changeSetId = changeSet.id;
+        await sdf.call({
+            route: "abandon_change_set",
+            body: {
+                changeSetId,
+            },
+        });
+    }
+
+}

--- a/bin/si-api-test/benchmark/install_modules.ts
+++ b/bin/si-api-test/benchmark/install_modules.ts
@@ -1,0 +1,64 @@
+// deno-lint-ignore-file no-explicit-any
+import { SdfApiClient } from "../sdf_api_client.ts";
+import {
+    runWithTemporaryChangeset,
+    sleepBetween,
+    createComponent,
+    installModule,
+    getSchemaVariants,
+} from "../test_helpers.ts";
+
+export default async function install_module(sdfApiClient: SdfApiClient) {
+    await sleepBetween(0, 750);
+    return runWithTemporaryChangeset(sdfApiClient, install_module_inner);
+}
+
+async function install_module_inner(sdf: SdfApiClient,
+    changeSetId: string,
+) {
+    // decide how many modules you want to install
+    const num_to_install = 5;
+
+    // get the list of builtins from the module index - note we're doing this and not hitting the schema variants route 
+    // so we can separately track install from component creation
+
+    const resp = await fetch("https://module-index.systeminit.com/builtins", {
+        "headers": {
+            "accept": "application/json, text/plain, */*",
+            "accept-language": "en-US,en;q=0.9",
+            "Cache-Control": "no-cache",
+            "User-Agent": "si.git/api-tests (support@systeminit.com)",
+        },
+        "body": null,
+        "method": "GET"
+    });
+    const builtins = await resp.json();
+
+
+    // first install n builtin modules
+    let installed = 0;
+    while (installed < num_to_install) {
+        let module_to_install = builtins.modules[installed];
+        console.log(`INSTALLING MODULE ${installed} of ${num_to_install}`);
+        await installModule(sdf, changeSetId, module_to_install.id);
+        installed++;
+    }
+    console.log(`FINISHED INSTALLING ${num_to_install} MODULES`);
+    // Now create one component for each installed module
+
+    const { schemaVariants, newCreateComponentApi } = await getSchemaVariants(
+        sdf,
+        changeSetId,
+    );
+    let num_created = 0;
+    for (const variant of schemaVariants) {
+        // create space between each one as a factor of the number being created
+        console.log(`CREATING COMPONENT ${num_created} of ${num_to_install}`);
+        await createComponent(sdf, changeSetId, variant.schemaVariantId, num_created * 450, 0, undefined, newCreateComponentApi);
+        num_created++;
+    }
+    console.log(`FINISHED CREATING ${num_created} COMPONENTS`);
+
+    // wait for dvu!
+    await sdf.waitForDVURoots(changeSetId, 2000, 300000);
+}

--- a/bin/si-api-test/benchmark/one_upper.ts
+++ b/bin/si-api-test/benchmark/one_upper.ts
@@ -1,0 +1,177 @@
+// deno-lint-ignore-file no-explicit-any
+import { SdfApiClient } from "../sdf_api_client.ts";
+import {
+    runWithTemporaryChangeset,
+    sleepBetween,
+    createComponent,
+    getQualificationSummary,
+    installModule,
+    extractSchemaVariant,
+    getSchemaVariants,
+    getActions,
+    getFuncs,
+} from "../test_helpers.ts";
+
+export default async function one_upper(sdfApiClient: SdfApiClient) {
+    await sleepBetween(0, 750);
+    return runWithTemporaryChangeset(sdfApiClient, one_upper_inner);
+}
+
+function calculate_offset(initial_x: number, offset_x: number) {
+    return initial_x + offset_x
+}
+/// This test creates N chains of pairs, such that setting the attribute value on the first component
+/// in the chain should propagate through the entire chain, adding 1 at each step.
+async function one_upper_inner(sdf: SdfApiClient,
+    changeSetId: string,
+) {
+    // install requisite modules
+    const one_upper_module_with_quals = '01JKW4VKKJ0DCVHRH0HQ4D6ZG4'; // one upper with leaf funcs and validations
+    const value_passer_module_with_validation = '01JKW4VX88MJ2R1EAV73H1NRQM'; // value passwer with leaf funcs and validations
+
+    // decide whether you want qualifications/validations or not 
+    // then install the modules by the module id. 
+    await installModule(sdf, changeSetId, value_passer_module_with_validation);
+    await installModule(sdf, changeSetId, one_upper_module_with_quals);
+
+    // Edit these numbers for different amount of stress on the system
+    const num_chains = 3;
+    const num_component_pairs = 20; // note: 50 pairs actually results in 99 components as the chain ends with the value passer
+
+    const { schemaVariants, newCreateComponentApi } = await getSchemaVariants(
+        sdf,
+        changeSetId,
+    );
+
+
+    const valueVariant = await extractSchemaVariant(
+        schemaVariants,
+        "ValuePasser",
+        "KEEB",
+    );
+    const valueVariantId = valueVariant.schemaVariantId;
+    const plusOneVariant = await extractSchemaVariant(
+        schemaVariants,
+        "OneUpper",
+        "KEEB",
+    );
+    const plusOneVariantId = plusOneVariant.schemaVariantId;
+    for (let j = 0; j < num_chains; j++) {
+        let y: number;
+        // each chain is in it's own 'row'
+        y = j * 550;
+
+        // create the first component and get the attribute value Id we'll be setting after the chain is created
+        const first_value = await createComponent(sdf, changeSetId, valueVariantId, 0, y, undefined, newCreateComponentApi);
+        const sourceInputProp = valueVariant.props.find((p) =>
+            p.path === "/root/domain/input"
+        );
+
+        const sourcePropValues = await sdf.call({
+            route: "get_property_values",
+            routeVars: {
+                componentId: first_value,
+                changeSetId,
+            },
+        });
+        let sourceAttributeValue;
+        for (const attributeValue in sourcePropValues?.values) {
+            if (
+                sourcePropValues?.values[attributeValue]?.propId === sourceInputProp.id
+            ) {
+                sourceAttributeValue = attributeValue;
+            }
+        }
+        let sourceAttributeValueParent;
+        for (const attributeValue in sourcePropValues?.childValues) {
+            const avChildren = sourcePropValues?.childValues[attributeValue] ?? [];
+            if (avChildren.includes(sourceAttributeValue)) {
+                sourceAttributeValueParent = attributeValue;
+            }
+        }
+        // track the last component Id to create chains
+        let last_value_id: string | undefined;
+        last_value_id = first_value;
+        // track x position. Y stays the same for a chain but we must increment X for every pair so they're not stacked on 
+        // top of each other
+        let x: number;
+        x = 0;
+        for (let i = 1; i < num_component_pairs; i++) {
+
+            // create one-upper, which is a child of the first value passer
+            const one_upper = await createComponent(sdf, changeSetId, plusOneVariantId, x, y, last_value_id, newCreateComponentApi);
+            // offset next value passer we're creating
+            const new_coords = calculate_offset(x, 600);
+            const new_x = new_coords;
+
+            // create next value passer, no parent
+            const next_value = await createComponent(sdf, changeSetId, valueVariantId, new_x, y, undefined, newCreateComponentApi);
+
+            // connect inner one-upper to the next value passer via sockets 
+            const inputSocket = valueVariant.inputSockets.find((s) =>
+                s.name === "input"
+            );
+            const outputSocket = plusOneVariant.outputSockets.find((s) =>
+                s.name === "output"
+            );
+            const createConnectionPayload = {
+                "fromComponentId": one_upper,
+                "fromSocketId": outputSocket?.id,
+                "toComponentId": next_value,
+                "toSocketId": inputSocket?.id,
+                "visibility_change_set_pk": changeSetId,
+                "workspaceId": sdf.workspaceId,
+            };
+            await sdf.call({
+                route: "create_connection",
+                body: createConnectionPayload,
+            });
+            // put some more load on the system to see how response times are impacted by this activity
+            await Promise.all([
+                getActions(sdf, changeSetId),
+                getFuncs(sdf, changeSetId),
+                getQualificationSummary(sdf, changeSetId),
+                // note: these two below do the same thing under the covers when you don't pass in a view id
+                // choose your adventure!
+                // sdf.call({
+                //     route: "get_diagram",
+                //     routeVars: {
+                //         workspaceId: sdf.workspaceId,
+                //         changeSetId,
+                //     },
+                // }),
+                sdf.call({
+                    route: "get_all_components_and_edges",
+                    routeVars: {
+                        workspaceId: sdf.workspaceId,
+                        changeSetId,
+                    },
+                }),
+            ]);
+
+            // update values used on next loop!
+            last_value_id = next_value;
+            x = new_x;
+        }
+        // after chain is created, update attribute value for the first value passer
+        const regionValue = "1";
+        const updateValuePayload = {
+            "attributeValueId": sourceAttributeValue,
+            "parentAttributeValueId": sourceAttributeValueParent,
+            "propId": sourceInputProp.id,
+            "componentId": first_value,
+            "value": regionValue,
+            "isForSecret": false,
+            "visibility_change_set_pk": changeSetId,
+        };
+        await sdf.call({
+            route: "update_property_value",
+            body: updateValuePayload,
+        });
+
+    }
+    // after all chains are created and initial values set, wait for DVU. 
+    // this times out sometimes, but we're still able to get what we need 
+    // from telemetry
+    await sdf.waitForDVURoots(changeSetId, 2000, 300000);
+}

--- a/bin/si-api-test/main.ts
+++ b/bin/si-api-test/main.ts
@@ -37,12 +37,24 @@ if (import.meta.main) {
     token,
   });
 
-  // Dynamically load test files from the ./tests directory
   const testFiles: { [key: string]: string } = {};
-  for await (const dirEntry of Deno.readDir("./tests")) {
-    if (dirEntry.isFile && dirEntry.name.endsWith(".ts")) {
-      const testName = dirEntry.name.replace(".ts", "");
-      testFiles[testName] = `./tests/${dirEntry.name}`;
+  // Only load the specified benchmark tests if that's what you want to do!
+  const benchmarkTests = testsToRun.filter((test) => test.startsWith("benchmark/"));
+  if (benchmarkTests.length > 0) {
+    for await (const dirEntry of Deno.readDir("./benchmark")) {
+      if (dirEntry.isFile && dirEntry.name.endsWith(".ts")) {
+        const testName = `benchmark/${dirEntry.name.replace(".ts", "")}`;
+        testFiles[testName] = `./benchmark/${dirEntry.name}`;
+      }
+    }
+  } else {
+    // Otherwise, business as usual
+    // Dynamically load test files from the ./tests directory
+    for await (const dirEntry of Deno.readDir("./tests")) {
+      if (dirEntry.isFile && dirEntry.name.endsWith(".ts")) {
+        const testName = dirEntry.name.replace(".ts", "");
+        testFiles[testName] = `./tests/${dirEntry.name}`;
+      }
     }
   }
 
@@ -132,9 +144,8 @@ async function executeTest(
     testEntry.test_result = "failure";
   } finally {
     testEntry.finish_time = new Date().toISOString();
-    testEntry.test_duration = `${
-      new Date().getTime() - new Date(testEntry.start_time).getTime()
-    }ms`;
+    testEntry.test_duration = `${new Date().getTime() - new Date(testEntry.start_time).getTime()
+      }ms`;
     testEntry.test_execution_sequence = sequence;
     testReport.push(testEntry);
   }

--- a/bin/si-api-test/sdf_api_client.ts
+++ b/bin/si-api-test/sdf_api_client.ts
@@ -67,7 +67,8 @@ export const ROUTES = {
     method: "GET",
   },
   get_all_components_and_edges: {
-    path: () => "/diagram/get_all_components_and_edges",
+    path: (vars: ROUTE_VARS) =>
+      `/diagram/get_all_components_and_edges?visibility_change_set_pk=${vars.changeSetId}&workspaceId=${vars.workspaceId}`,
     method: "GET",
   },
   get_diagram: {
@@ -180,6 +181,13 @@ export const ROUTES = {
     path: (vars: ROUTE_VARS) =>
       `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/funcs/${vars.funcId}/code`,
     method: "PUT",
+  },
+
+  // Modules --------------------------------------
+
+  install_module: {
+    path: () => `/module/install_module`,
+    method: "POST",
   },
 
   // Websockets -----------------------------------------

--- a/bin/si-api-test/test_helpers.ts
+++ b/bin/si-api-test/test_helpers.ts
@@ -161,6 +161,62 @@ export async function getPropertyEditor(
   };
 }
 
+export async function installModule(
+  sdf: SdfApiClient,
+  changeSetId: string,
+  moduleId: string,
+) {
+  const installModulePayload = {
+    visibility_change_set_pk: changeSetId,
+    ids: [moduleId]
+  };
+
+  await sdf.call({
+    route: "install_module",
+    body: installModulePayload,
+  });
+}
+export function extractSchemaVariant(
+  schemaVariants: any[],
+  schemaName: string,
+  category?: string,
+) {
+  const variant = schemaVariants.find(
+    (sv) =>
+      sv.schemaName === schemaName && (!category || sv.category === category),
+  );
+
+  const awsRegionVariantId = variant?.schemaVariantId;
+  assert(
+    awsRegionVariantId,
+    `Expected to find ${schemaName} schema and variant`,
+  );
+
+  return variant;
+}
+
+export async function getSchemaVariants(sdf: SdfApiClient, changeSetId: string) {
+  let schemaVariants = await sdf.call({
+    route: "schema_variants",
+    routeVars: {
+      workspaceId: sdf.workspaceId,
+      changeSetId,
+    },
+  });
+
+  const newCreateComponentApi = Array.isArray(schemaVariants?.installed);
+  if (newCreateComponentApi) {
+    schemaVariants = schemaVariants.installed;
+  }
+
+  assert(
+    Array.isArray(schemaVariants),
+    "List schema variants should return an array",
+  );
+
+  return { schemaVariants, newCreateComponentApi };
+}
+
 export async function setAttributeValue(
   sdf: SdfApiClient,
   changeSetId: string,

--- a/bin/si-api-test/tests/1-create_and_apply_across_change_sets.ts
+++ b/bin/si-api-test/tests/1-create_and_apply_across_change_sets.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import { SdfApiClient } from "../sdf_api_client.ts";
+import { extractSchemaVariant, getSchemaVariants } from "../test_helpers.ts";
 
 export default async function create_and_and_apply_across_change_sets(
   sdfApiClient: SdfApiClient,
@@ -141,40 +142,6 @@ async function getTestSchemaVariantId(
     schemaVariantId: testResourceActionsVariant.schemaVariantId,
     newCreateComponentApi,
   };
-}
-
-function extractSchemaVariant(
-  schemaVariants: any[],
-  schemaName: string,
-  category?: string,
-) {
-  const variant = schemaVariants.find(
-    (sv) =>
-      sv.schemaName === schemaName && (!category || sv.category === category),
-  );
-
-  return variant;
-}
-
-async function getSchemaVariants(sdf: SdfApiClient, changeSetId: string) {
-  let schemaVariants = await sdf.call({
-    route: "schema_variants",
-    routeVars: {
-      workspaceId: sdf.workspaceId,
-      changeSetId,
-    },
-  });
-  const newCreateComponentApi = Array.isArray(schemaVariants?.installed);
-  if (newCreateComponentApi) {
-    schemaVariants = schemaVariants.installed;
-  }
-
-  assert(
-    Array.isArray(schemaVariants),
-    "List schema variants should return an array",
-  );
-
-  return { schemaVariants, newCreateComponentApi };
 }
 
 async function getDiagram(

--- a/bin/si-api-test/tests/5-emulate_paul_stack.ts
+++ b/bin/si-api-test/tests/5-emulate_paul_stack.ts
@@ -12,6 +12,8 @@ import {
   getQualificationSummary,
   getActions,
   getFuncs,
+  extractSchemaVariant,
+  getSchemaVariants,
 } from "../test_helpers.ts";
 import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
 
@@ -338,50 +340,6 @@ async function setComponentType(
   const res = getQualificationSummary(sdf, changeSetId);
 
   return result;
-}
-
-async function getSchemaVariants(sdf: SdfApiClient, changeSetId: string) {
-  let schemaVariants = await sdf.call({
-    route: "schema_variants",
-    routeVars: {
-      workspaceId: sdf.workspaceId,
-      changeSetId,
-    },
-  });
-
-  const newCreateComponentApi = Array.isArray(schemaVariants?.installed);
-  if (newCreateComponentApi) {
-    schemaVariants = schemaVariants.installed;
-  }
-
-  assert(
-    Array.isArray(schemaVariants),
-    "List schema variants should return an array",
-  );
-
-  return { schemaVariants, newCreateComponentApi };
-}
-
-
-
-// Data Extractors
-function extractSchemaVariant(
-  schemaVariants: any[],
-  schemaName: string,
-  category?: string,
-) {
-  const variant = schemaVariants.find(
-    (sv) =>
-      sv.schemaName === schemaName && (!category || sv.category === category),
-  );
-
-  const awsRegionVariantId = variant?.schemaVariantId;
-  assert(
-    awsRegionVariantId,
-    `Expected to find ${schemaName} schema and variant`,
-  );
-
-  return variant;
 }
 
 


### PR DESCRIPTION
The tests for benchmarking aren't really doing many assertions, so I created a separate benchmark folder to house them. We ignore this folder during end to end tests, and if you want to trigger a benchmark, invoke Deno with `--tests benchmark/{testName}`

<div><img src="https://media0.giphy.com/media/MCOMLZSvTGD1CaqQug/giphy.gif?cid=5a38a5a24wu3ykasw4lu6w9y7kfzhc4y8hd76phvh0xzaorb&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/Similarweb/">Similarweb</a> on <a href="https://giphy.com/gifs/Similarweb-valentines-day-data-similarweb-MCOMLZSvTGD1CaqQug">GIPHY</a></div>