### PR TITLE
chore: nix flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737717945,
-        "narHash": "sha256-ET91TMkab3PmOZnqiJQYOtSGvSTvGeHoegAv4zcTefM=",
+        "lastModified": 1739419412,
+        "narHash": "sha256-NCWZQg4DbYVFWg+MOFrxWRaVsLA7yvRWAf6o0xPR1hI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ecd26a469ac56357fd333946a99086e992452b6a",
+        "rev": "2d55b4c1531187926c2a423f6940b3b1301399b5",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737685583,
-        "narHash": "sha256-p+NVABRpGi+pT+xxf9HcLcFVxG6L+vEEy+NwzB9T0f8=",
+        "lastModified": 1739413688,
+        "narHash": "sha256-57OAXXYhOibG7Rqhhr4ecI1H8mtDJB2uj0T8rbQVGLY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "eb64cbcc8eee0fa87ebded92805280d2ec97415a",
+        "rev": "675a6427d505f140dab8c56379afb66d4f55800b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,17 @@
           darwin.apple_sdk.frameworks.CoreFoundation
         ];
 
+      # The file name of the program interpreter/dynamic linker. We're primarily
+      # interested in the Linux system values.
+      interpreterName =
+        {
+          "x86_64-linux" = "ld-linux-x86-64.so.2";
+          "aarch64-linux" = "ld-linux-aarch64.so.1";
+          "x86_64-darwin" = "/dev/null";
+          "aarch64-darwin" = "/dev/null";
+        }
+        .${system};
+
       # This isn't an exact science, but confirmed the system interpreter by
       # running `ldd /bin/sh` in Docker containers running:
       # - debian:9-slim
@@ -301,11 +312,8 @@
               # /lib64/ld-linux-x86-64.so.2 -> /nix/store/*/ld-linux-x86-64.20.2
               mkdir -p $out/lib64
               ln -sf \
-                "${pkgs.glibc}/lib/ld-linux-x86-64.so.2" \
-                "$out/lib64/ld-linux-x86-64.so.2"
-              ln -sf \
-                "${pkgs.glibc}/lib/ld-linux-aarch64.so.1" \
-                "$out/lib64/ld-linux-aarch64.so.1"
+                "${pkgs.glibc}/lib/${interpreterName}" \
+                "$out/lib64/${interpreterName}"
 
               wrapProgram $out/bin/lang-js \
                 --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath [


### PR DESCRIPTION
Upgrade the versions of whats in our nix flake, in particular to catch an updated version of cfn-lint

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdld3JoNTgyOXVzeDFmZGppNHdzbjFzbjNuamx5ajkyNGhzNjhwOWc0cyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/6F3bNKMVMR8LEOuS1y/giphy.gif"/>