### PR TITLE
chore: bump foyer to 14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "array-util"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,7 +1860,7 @@ dependencies = [
  "hex",
  "iftree",
  "indexmap 2.7.1",
- "itertools",
+ "itertools 0.13.0",
  "jwt-simple",
  "lazy_static",
  "module-index-client",
@@ -1932,7 +1938,7 @@ dependencies = [
  "derive_builder",
  "derive_more",
  "forklift-server",
- "itertools",
+ "itertools 0.13.0",
  "jwt-simple",
  "lazy_static",
  "names",
@@ -2736,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "foyer"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c63beb108769d28b042829164139a5245359ccfdb4a8face928ac154e2c9ed"
+checksum = "ddac72b94b174f342300f54f6dfda93c87a4a220e2def9ee2590e3ac474b5f6d"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -2747,30 +2753,29 @@ dependencies = [
  "foyer-common",
  "foyer-memory",
  "foyer-storage",
- "futures",
  "madsim-tokio",
- "pin-project",
+ "mixtrics",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-common"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68be583b3f51bcbc6b72f40a5aea6fa6aaff10692649c08b20458bb6703f79f0"
+checksum = "3a2fec9e9293931608eb6bb4b032d05b8b45c8749ec6a0ace82bfe40ab5d68c4"
 dependencies = [
  "ahash 0.8.11",
  "bytes",
  "cfg-if",
  "fastrace",
- "futures",
- "hashbrown 0.15.2",
- "itertools",
+ "itertools 0.14.0",
  "madsim-tokio",
- "opentelemetry",
+ "mixtrics",
  "parking_lot",
  "pin-project",
  "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -2784,34 +2789,35 @@ dependencies = [
 
 [[package]]
 name = "foyer-memory"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a01e64de1452409977219fe014caa427874677aacd647bec9207d98d018bcd8"
+checksum = "5c5016e4ca89ead9045c56f10e7e4cca8068e0b114a57f9df32ad768f90f4c33"
 dependencies = [
  "ahash 0.8.11",
+ "arc-swap",
  "bitflags 2.8.0",
  "cmsketch",
  "equivalent",
  "fastrace",
  "foyer-common",
  "foyer-intrusive-collections",
- "futures",
  "hashbrown 0.15.2",
- "itertools",
+ "itertools 0.14.0",
  "madsim-tokio",
+ "mixtrics",
  "parking_lot",
- "paste",
  "pin-project",
  "serde",
  "thiserror 2.0.11",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-storage"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb89bdcdf355e8cb2b29eaa0158839f4f7c6974c6cc86f6e54e4a48a2afa5b8"
+checksum = "f6ab33a86920fddf66dae2485e37dbcaf0e56f424875d752b639df62d3f4c056"
 dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
@@ -2820,19 +2826,17 @@ dependencies = [
  "async-channel",
  "auto_enums",
  "bincode",
- "bitflags 2.8.0",
  "bytes",
  "clap",
- "either",
  "equivalent",
  "fastrace",
  "flume",
  "foyer-common",
  "foyer-memory",
  "fs4",
- "futures",
- "hashbrown 0.15.2",
- "itertools",
+ "futures-core",
+ "futures-util",
+ "itertools 0.14.0",
  "libc",
  "lz4",
  "madsim-tokio",
@@ -2840,9 +2844,10 @@ dependencies = [
  "parking_lot",
  "paste",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.9.0",
  "serde",
  "thiserror 2.0.11",
+ "tokio",
  "tracing",
  "twox-hash",
  "zstd",
@@ -3861,6 +3866,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4245,6 +4259,17 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mixtrics"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4d2b55cea00ffba84e3df1e875d9190331e2f3bba2ee3bdd3abcc739639a71"
+dependencies = [
+ "itertools 0.14.0",
+ "opentelemetry",
+ "parking_lot",
 ]
 
 [[package]]
@@ -5330,7 +5355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -6863,6 +6888,7 @@ dependencies = [
  "fs4",
  "futures",
  "miniz_oxide 0.8.4",
+ "mixtrics",
  "postcard",
  "rand 0.8.5",
  "refinery",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ dyn-clone = "1.0.17"
 env_logger = "0.11.6"
 fastrace = "0.7.4"
 flate2 = "1.0.35"
-foyer = { version = "0.13.1", features = ["tracing", "opentelemetry_0_26"] }
+foyer = { version = "0.14.1", features = ["tracing"] }
 fs4 = "0.12.0"
 fuser = { version = "0.15.1", default-features = false }
 futures = "0.3.31"
@@ -163,6 +163,7 @@ log = "0.4"
 manyhow = { version = "0.11.4", features = ["darling"] }
 mime_guess = { version = "=2.0.4" } # TODO(fnichol): 2.0.5 sets an env var in build.rs which needs to be tracked, required by reqwest
 miniz_oxide = { version = "0.8.0", features = ["simd"] }
+mixtrics = { version = "0.0.3", features = ["opentelemetry_0_26"] }
 monostate = "0.1.13"
 names = { version = "0.14.0", default-features = false }
 nix = { version = "0.29.0", features = [

--- a/lib/si-layer-cache/BUCK
+++ b/lib/si-layer-cache/BUCK
@@ -23,6 +23,7 @@ rust_library(
         "//third-party/rust:fs4",
         "//third-party/rust:futures",
         "//third-party/rust:miniz_oxide",
+        "//third-party/rust:mixtrics",
         "//third-party/rust:postcard",
         "//third-party/rust:refinery",
         "//third-party/rust:remain",

--- a/lib/si-layer-cache/Cargo.toml
+++ b/lib/si-layer-cache/Cargo.toml
@@ -26,6 +26,7 @@ foyer = { workspace = true }
 fs4 = { workspace = true }
 futures = { workspace = true }
 miniz_oxide = { workspace = true }
+mixtrics = { workspace = true }
 postcard = { workspace = true }
 refinery = { workspace = true }
 remain = { workspace = true }

--- a/lib/si-layer-cache/src/hybrid_cache.rs
+++ b/lib/si-layer-cache/src/hybrid_cache.rs
@@ -1,8 +1,8 @@
-use foyer::opentelemetry_0_26::OpenTelemetryMetricsRegistry;
 use foyer::{
     DirectFsDeviceOptions, Engine, FifoPicker, HybridCache, HybridCacheBuilder, LargeEngineOptions,
     RateLimitPicker, RecoverMode, TokioRuntimeOptions,
 };
+use mixtrics::registry::opentelemetry_0_26::OpenTelemetryMetricsRegistry;
 use std::cmp::max;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
@@ -106,7 +106,9 @@ where
 
         let cache: HybridCache<Arc<str>, MaybeDeserialized<V>> = HybridCacheBuilder::new()
             .with_name(cache_name)
-            .with_metrics_registry(OpenTelemetryMetricsRegistry::new(global::meter(cache_name)))
+            .with_metrics_registry(Box::new(OpenTelemetryMetricsRegistry::new(global::meter(
+                cache_name,
+            ))))
             .memory(memory_cache_capacity_bytes)
             .with_weighter(
                 |_key: &Arc<str>, value: &MaybeDeserialized<V>| match value {

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -454,6 +454,23 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "arc-swap-1.7.1.crate",
+    sha256 = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457",
+    strip_prefix = "arc-swap-1.7.1",
+    urls = ["https://static.crates.io/crates/arc-swap/1.7.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "arc-swap-1.7.1",
+    srcs = [":arc-swap-1.7.1.crate"],
+    crate = "arc_swap",
+    crate_root = "arc-swap-1.7.1.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+)
+
+http_archive(
     name = "array-util-1.0.2.crate",
     sha256 = "7e509844de8f09b90a2c3444684a2b6695f4071360e13d2fda0af9f749cc2ed6",
     strip_prefix = "array-util-1.0.2",
@@ -5947,31 +5964,47 @@ cargo.rust_library(
 
 alias(
     name = "foyer",
-    actual = ":foyer-0.13.1",
+    actual = ":foyer-0.14.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "foyer-0.13.1.crate",
-    sha256 = "19c63beb108769d28b042829164139a5245359ccfdb4a8face928ac154e2c9ed",
-    strip_prefix = "foyer-0.13.1",
-    urls = ["https://static.crates.io/crates/foyer/0.13.1/download"],
+    name = "foyer-0.14.1.crate",
+    sha256 = "ddac72b94b174f342300f54f6dfda93c87a4a220e2def9ee2590e3ac474b5f6d",
+    strip_prefix = "foyer-0.14.1",
+    urls = ["https://static.crates.io/crates/foyer/0.14.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "foyer-0.13.1",
-    srcs = [":foyer-0.13.1.crate"],
+    name = "foyer-0.14.1",
+    srcs = [":foyer-0.14.1.crate"],
     crate = "foyer",
-    crate_root = "foyer-0.13.1.crate/src/lib.rs",
+    crate_root = "foyer-0.14.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
-        "opentelemetry_0_26",
         "tracing",
     ],
-    named_deps = {
-        "tokio": ":madsim-tokio-0.2.30",
+    platform = {
+        "linux-arm64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "macos-arm64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "windows-gnu": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "windows-msvc": dict(
+            deps = [":tokio-1.43.0"],
+        ),
     },
     visibility = [],
     deps = [
@@ -5979,36 +6012,48 @@ cargo.rust_library(
         ":anyhow-1.0.95",
         ":equivalent-1.0.1",
         ":fastrace-0.7.6",
-        ":foyer-common-0.13.1",
-        ":foyer-memory-0.13.1",
-        ":foyer-storage-0.13.1",
-        ":futures-0.3.31",
-        ":pin-project-1.1.9",
+        ":foyer-common-0.14.1",
+        ":foyer-memory-0.14.1",
+        ":foyer-storage-0.14.1",
+        ":mixtrics-0.0.3",
         ":tracing-0.1.41",
     ],
 )
 
 http_archive(
-    name = "foyer-common-0.13.1.crate",
-    sha256 = "68be583b3f51bcbc6b72f40a5aea6fa6aaff10692649c08b20458bb6703f79f0",
-    strip_prefix = "foyer-common-0.13.1",
-    urls = ["https://static.crates.io/crates/foyer-common/0.13.1/download"],
+    name = "foyer-common-0.14.1.crate",
+    sha256 = "3a2fec9e9293931608eb6bb4b032d05b8b45c8749ec6a0ace82bfe40ab5d68c4",
+    strip_prefix = "foyer-common-0.14.1",
+    urls = ["https://static.crates.io/crates/foyer-common/0.14.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "foyer-common-0.13.1",
-    srcs = [":foyer-common-0.13.1.crate"],
+    name = "foyer-common-0.14.1",
+    srcs = [":foyer-common-0.14.1.crate"],
     crate = "foyer_common",
-    crate_root = "foyer-common-0.13.1.crate/src/lib.rs",
+    crate_root = "foyer-common-0.14.1.crate/src/lib.rs",
     edition = "2021",
-    features = [
-        "opentelemetry_0_26",
-        "tracing",
-    ],
-    named_deps = {
-        "opentelemetry_0_26": ":opentelemetry-0.26.0",
-        "tokio": ":madsim-tokio-0.2.30",
+    features = ["tracing"],
+    platform = {
+        "linux-arm64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "macos-arm64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "windows-gnu": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "windows-msvc": dict(
+            deps = [":tokio-1.43.0"],
+        ),
     },
     visibility = [],
     deps = [
@@ -6016,9 +6061,8 @@ cargo.rust_library(
         ":bytes-1.10.0",
         ":cfg-if-1.0.0",
         ":fastrace-0.7.6",
-        ":futures-0.3.31",
-        ":hashbrown-0.15.2",
-        ":itertools-0.13.0",
+        ":itertools-0.14.0",
+        ":mixtrics-0.0.3",
         ":parking_lot-0.12.3",
         ":pin-project-1.1.9",
         ":serde-1.0.217",
@@ -6048,37 +6092,56 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "foyer-memory-0.13.1.crate",
-    sha256 = "0a01e64de1452409977219fe014caa427874677aacd647bec9207d98d018bcd8",
-    strip_prefix = "foyer-memory-0.13.1",
-    urls = ["https://static.crates.io/crates/foyer-memory/0.13.1/download"],
+    name = "foyer-memory-0.14.1.crate",
+    sha256 = "5c5016e4ca89ead9045c56f10e7e4cca8068e0b114a57f9df32ad768f90f4c33",
+    strip_prefix = "foyer-memory-0.14.1",
+    urls = ["https://static.crates.io/crates/foyer-memory/0.14.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "foyer-memory-0.13.1",
-    srcs = [":foyer-memory-0.13.1.crate"],
+    name = "foyer-memory-0.14.1",
+    srcs = [":foyer-memory-0.14.1.crate"],
     crate = "foyer_memory",
-    crate_root = "foyer-memory-0.13.1.crate/src/lib.rs",
+    crate_root = "foyer-memory-0.14.1.crate/src/lib.rs",
     edition = "2021",
     features = ["tracing"],
     named_deps = {
         "intrusive_collections": ":foyer-intrusive-collections-0.10.0-dev",
-        "tokio": ":madsim-tokio-0.2.30",
+    },
+    platform = {
+        "linux-arm64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "macos-arm64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "windows-gnu": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "windows-msvc": dict(
+            deps = [":tokio-1.43.0"],
+        ),
     },
     visibility = [],
     deps = [
         ":ahash-0.8.11",
+        ":arc-swap-1.7.1",
         ":bitflags-2.8.0",
         ":cmsketch-0.2.1",
         ":equivalent-1.0.1",
         ":fastrace-0.7.6",
-        ":foyer-common-0.13.1",
-        ":futures-0.3.31",
+        ":foyer-common-0.14.1",
         ":hashbrown-0.15.2",
-        ":itertools-0.13.0",
+        ":itertools-0.14.0",
+        ":mixtrics-0.0.3",
         ":parking_lot-0.12.3",
-        ":paste-1.0.15",
         ":pin-project-1.1.9",
         ":serde-1.0.217",
         ":thiserror-2.0.11",
@@ -6087,25 +6150,42 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "foyer-storage-0.13.1.crate",
-    sha256 = "9fb89bdcdf355e8cb2b29eaa0158839f4f7c6974c6cc86f6e54e4a48a2afa5b8",
-    strip_prefix = "foyer-storage-0.13.1",
-    urls = ["https://static.crates.io/crates/foyer-storage/0.13.1/download"],
+    name = "foyer-storage-0.14.1.crate",
+    sha256 = "f6ab33a86920fddf66dae2485e37dbcaf0e56f424875d752b639df62d3f4c056",
+    strip_prefix = "foyer-storage-0.14.1",
+    urls = ["https://static.crates.io/crates/foyer-storage/0.14.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "foyer-storage-0.13.1",
-    srcs = [":foyer-storage-0.13.1.crate"],
+    name = "foyer-storage-0.14.1",
+    srcs = [":foyer-storage-0.14.1.crate"],
     crate = "foyer_storage",
-    crate_root = "foyer-storage-0.13.1.crate/src/lib.rs",
+    crate_root = "foyer-storage-0.14.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
         "tracing",
     ],
-    named_deps = {
-        "tokio": ":madsim-tokio-0.2.30",
+    platform = {
+        "linux-arm64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "macos-arm64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "windows-gnu": dict(
+            deps = [":tokio-1.43.0"],
+        ),
+        "windows-msvc": dict(
+            deps = [":tokio-1.43.0"],
+        ),
     },
     visibility = [],
     deps = [
@@ -6116,26 +6196,24 @@ cargo.rust_library(
         ":async-channel-2.3.1",
         ":auto_enums-0.8.7",
         ":bincode-1.3.3",
-        ":bitflags-2.8.0",
         ":bytes-1.10.0",
         ":clap-4.5.28",
-        ":either-1.13.0",
         ":equivalent-1.0.1",
         ":fastrace-0.7.6",
         ":flume-0.11.1",
-        ":foyer-common-0.13.1",
-        ":foyer-memory-0.13.1",
+        ":foyer-common-0.14.1",
+        ":foyer-memory-0.14.1",
         ":fs4-0.12.0",
-        ":futures-0.3.31",
-        ":hashbrown-0.15.2",
-        ":itertools-0.13.0",
+        ":futures-core-0.3.31",
+        ":futures-util-0.3.31",
+        ":itertools-0.14.0",
         ":libc-0.2.169",
         ":lz4-1.28.1",
         ":ordered_hash_map-0.4.0",
         ":parking_lot-0.12.3",
         ":paste-1.0.15",
         ":pin-project-1.1.9",
-        ":rand-0.8.5",
+        ":rand-0.9.0",
         ":serde-1.0.217",
         ":thiserror-2.0.11",
         ":tracing-0.1.41",
@@ -8541,6 +8619,29 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "itertools-0.14.0.crate",
+    sha256 = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285",
+    strip_prefix = "itertools-0.14.0",
+    urls = ["https://static.crates.io/crates/itertools/0.14.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "itertools-0.14.0",
+    srcs = [":itertools-0.14.0.crate"],
+    crate = "itertools",
+    crate_root = "itertools-0.14.0.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "use_alloc",
+        "use_std",
+    ],
+    visibility = [],
+    deps = [":either-1.13.0"],
+)
+
+http_archive(
     name = "itoa-1.0.14.crate",
     sha256 = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674",
     strip_prefix = "itoa-1.0.14",
@@ -9564,33 +9665,6 @@ cxx_library(
     visibility = [],
 )
 
-http_archive(
-    name = "madsim-tokio-0.2.30.crate",
-    sha256 = "7d3eb2acc57c82d21d699119b859e2df70a91dbdb84734885a1e72be83bdecb5",
-    strip_prefix = "madsim-tokio-0.2.30",
-    urls = ["https://static.crates.io/crates/madsim-tokio/0.2.30/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "madsim-tokio-0.2.30",
-    srcs = [":madsim-tokio-0.2.30.crate"],
-    crate = "madsim_tokio",
-    crate_root = "madsim-tokio-0.2.30.crate/src/lib.rs",
-    edition = "2021",
-    features = [
-        "fs",
-        "macros",
-        "rt",
-        "rt-multi-thread",
-        "signal",
-        "sync",
-        "time",
-    ],
-    visibility = [],
-    deps = [":tokio-1.43.0"],
-)
-
 alias(
     name = "manyhow",
     actual = ":manyhow-0.11.4",
@@ -10003,6 +10077,40 @@ cargo.rust_library(
         ),
     },
     visibility = [],
+)
+
+alias(
+    name = "mixtrics",
+    actual = ":mixtrics-0.0.3",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "mixtrics-0.0.3.crate",
+    sha256 = "ff4d2b55cea00ffba84e3df1e875d9190331e2f3bba2ee3bdd3abcc739639a71",
+    strip_prefix = "mixtrics-0.0.3",
+    urls = ["https://static.crates.io/crates/mixtrics/0.0.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "mixtrics-0.0.3",
+    srcs = [":mixtrics-0.0.3.crate"],
+    crate = "mixtrics",
+    crate_root = "mixtrics-0.0.3.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "opentelemetry_0_26",
+    ],
+    named_deps = {
+        "opentelemetry_0_26": ":opentelemetry-0.26.0",
+    },
+    visibility = [],
+    deps = [
+        ":itertools-0.14.0",
+        ":parking_lot-0.12.3",
+    ],
 )
 
 alias(
@@ -17410,7 +17518,7 @@ cargo.rust_binary(
         ":env_logger-0.11.6",
         ":fastrace-0.7.6",
         ":flate2-1.0.35",
-        ":foyer-0.13.1",
+        ":foyer-0.14.1",
         ":fs4-0.12.0",
         ":fuser-0.15.1",
         ":futures-0.3.31",
@@ -17432,6 +17540,7 @@ cargo.rust_binary(
         ":manyhow-0.11.4",
         ":mime_guess-2.0.4",
         ":miniz_oxide-0.8.4",
+        ":mixtrics-0.0.3",
         ":monostate-0.1.13",
         ":names-0.14.0",
         ":nix-0.29.0",

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -155,6 +155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "array-util"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "foyer"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c63beb108769d28b042829164139a5245359ccfdb4a8face928ac154e2c9ed"
+checksum = "ddac72b94b174f342300f54f6dfda93c87a4a220e2def9ee2590e3ac474b5f6d"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -2331,30 +2337,29 @@ dependencies = [
  "foyer-common",
  "foyer-memory",
  "foyer-storage",
- "futures",
  "madsim-tokio",
- "pin-project",
+ "mixtrics",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-common"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68be583b3f51bcbc6b72f40a5aea6fa6aaff10692649c08b20458bb6703f79f0"
+checksum = "3a2fec9e9293931608eb6bb4b032d05b8b45c8749ec6a0ace82bfe40ab5d68c4"
 dependencies = [
  "ahash 0.8.11",
  "bytes",
  "cfg-if",
  "fastrace",
- "futures",
- "hashbrown 0.15.2",
- "itertools",
+ "itertools 0.14.0",
  "madsim-tokio",
- "opentelemetry",
+ "mixtrics",
  "parking_lot",
  "pin-project",
  "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -2368,34 +2373,35 @@ dependencies = [
 
 [[package]]
 name = "foyer-memory"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a01e64de1452409977219fe014caa427874677aacd647bec9207d98d018bcd8"
+checksum = "5c5016e4ca89ead9045c56f10e7e4cca8068e0b114a57f9df32ad768f90f4c33"
 dependencies = [
  "ahash 0.8.11",
+ "arc-swap",
  "bitflags 2.8.0",
  "cmsketch",
  "equivalent",
  "fastrace",
  "foyer-common",
  "foyer-intrusive-collections",
- "futures",
  "hashbrown 0.15.2",
- "itertools",
+ "itertools 0.14.0",
  "madsim-tokio",
+ "mixtrics",
  "parking_lot",
- "paste",
  "pin-project",
  "serde",
  "thiserror 2.0.11",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-storage"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb89bdcdf355e8cb2b29eaa0158839f4f7c6974c6cc86f6e54e4a48a2afa5b8"
+checksum = "f6ab33a86920fddf66dae2485e37dbcaf0e56f424875d752b639df62d3f4c056"
 dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
@@ -2404,19 +2410,17 @@ dependencies = [
  "async-channel",
  "auto_enums",
  "bincode",
- "bitflags 2.8.0",
  "bytes",
  "clap",
- "either",
  "equivalent",
  "fastrace",
  "flume",
  "foyer-common",
  "foyer-memory",
  "fs4",
- "futures",
- "hashbrown 0.15.2",
- "itertools",
+ "futures-core",
+ "futures-util",
+ "itertools 0.14.0",
  "libc",
  "lz4",
  "madsim-tokio",
@@ -2424,9 +2428,10 @@ dependencies = [
  "parking_lot",
  "paste",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.9.0",
  "serde",
  "thiserror 2.0.11",
+ "tokio",
  "tracing",
  "twox-hash",
  "zstd",
@@ -3415,6 +3420,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3799,6 +3813,17 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mixtrics"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4d2b55cea00ffba84e3df1e875d9190331e2f3bba2ee3bdd3abcc739639a71"
+dependencies = [
+ "itertools 0.14.0",
+ "opentelemetry",
+ "parking_lot",
 ]
 
 [[package]]
@@ -4624,7 +4649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -6378,7 +6403,7 @@ dependencies = [
  "indexmap 2.7.1",
  "indicatif",
  "indoc",
- "itertools",
+ "itertools 0.13.0",
  "jwt-simple",
  "krata-loopdev",
  "lazy_static",
@@ -6386,6 +6411,7 @@ dependencies = [
  "manyhow",
  "mime_guess",
  "miniz_oxide 0.8.4",
+ "mixtrics",
  "monostate",
  "names",
  "nix 0.29.0",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -68,7 +68,7 @@ dyn-clone = "1.0.17"
 env_logger = "0.11.6"
 fastrace = "0.7.4"
 flate2 = "1.0.35"
-foyer = { version = "0.13.1", features = ["tracing", "opentelemetry_0_26"] }
+foyer = { version = "0.14.1", features = ["tracing"] }
 fs4 = "0.12.0"
 fuser = { version = "0.15.1", default-features = false }
 futures = "0.3.31"
@@ -99,6 +99,7 @@ log = "0.4"
 manyhow = { version = "0.11.4", features = ["darling"] }
 mime_guess = { version = "=2.0.4" } # TODO(fnichol): 2.0.5 sets an env var in build.rs which needs to be tracked, required by reqwest
 miniz_oxide = { version = "0.8.0", features = ["simd"] }
+mixtrics = { version = "0.0.3", features = ["opentelemetry_0_26"] }
 monostate = "0.1.13"
 names = { version = "0.14.0", default-features = false }
 nix = { version = "0.29.0", features = [


### PR DESCRIPTION
I don't have definitive evidence, but I suspect this change will help with the memory pressures we have not been able to resolve. Specifically, [this change](https://github.com/foyer-rs/foyer/commit/170a4108b5dcccbfbcfe0912bcd36eb0eef6dd78).

> fix: fix memory leak caused by circle reference count

This has some interesting implications around how the disk cache works and make me wonder if we'll be writing to it as often. The ideal situation here is that we'll be caching old entries without busting our memory limit and flushing all entries when stopping the service.

Note that they broke out the metrics collection to a separate crate, so I brought that in here.