### PR TITLE
build(buck2): impl `nix_binary` Buck2 rule to build/publish/promote

### DIFF
--- a/bin/si-fs/BUCK
+++ b/bin/si-fs/BUCK
@@ -1,5 +1,6 @@
 load(
     "@prelude-si//:macros.bzl",
+    "nix_binary",
     "rust_binary",
 )
 
@@ -15,4 +16,10 @@ rust_binary(
     ],
     srcs = glob(["src/**/*.rs"]),
     env = {"CARGO_BIN_NAME": "si-fs"},
+)
+
+nix_binary(
+    name = "binary",
+    binary_name = "si-fs",
+    build_dep = "//bin/si-fs:si-fs",
 )

--- a/bxl/dependent_targets.bxl
+++ b/bxl/dependent_targets.bxl
@@ -52,6 +52,10 @@ dependent_targets = bxl_main(
             default = False,
             doc = """Filter targets to runnable docker promotions.""",
         ),
+        "publish_binary": cli_args.bool(
+            default = False,
+            doc = """Filter targets to binary publish targets.""",
+        ),
         "publish_omnibus": cli_args.bool(
             default = False,
             doc = """Filter targets to omnibus publish targets.""",
@@ -59,10 +63,6 @@ dependent_targets = bxl_main(
         "publish_rootfs": cli_args.bool(
             default = False,
             doc = """Filter targets to rootfs publish targets.""",
-        ),
-        "releasable_binary": cli_args.bool(
-            default = False,
-            doc = """Filter targets to releasable binaries.""",
         ),
         "global_file": cli_args.list(
             cli_args.string(),
@@ -176,19 +176,15 @@ def _filter_targets(ctx: bxl.Context, targets: bxl.UnconfiguredTargetSet) -> bxl
     if ctx.cli_args.release_docker:
         has_filtered = True
         filtered = filtered + ctx.uquery().kind("docker_image_release", targets)
+    if ctx.cli_args.publish_binary:
+        has_filtered = True
+        filtered = filtered + ctx.uquery().attrregexfilter("name", "^publish-binary(-.+)?$", targets)
     if ctx.cli_args.publish_omnibus:
         has_filtered = True
         filtered = filtered + ctx.uquery().attrregexfilter("name", "^publish-omnibus(-.+)?$", targets)
     if ctx.cli_args.publish_rootfs:
         has_filtered = True
         filtered = filtered + ctx.uquery().attrregexfilter("name", "^publish-rootfs(-.+)?$", targets)
-    if ctx.cli_args.releasable_binary:
-        has_filtered = True
-        filtered = filtered + ctx.uquery().attrfilter(
-            "name",
-            "si",
-            ctx.uquery().kind("rust_binary", targets),
-        )
     if ctx.cli_args.promote_docker:
         has_filtered = True
         filtered = filtered + _filtered_promote_docker_targets(ctx, targets)

--- a/prelude-si/artifact/publish.py
+++ b/prelude-si/artifact/publish.py
@@ -44,6 +44,7 @@ class PlatformOS(BaseEnum):
 
 
 class Variant(BaseEnum):
+    Binary = "binary"
     Omnibus = "omnibus"
     Rootfs = "rootfs"
 
@@ -186,6 +187,8 @@ def artifact_name(md: ArtifactMetadata) -> str:
     prefix = f"{md.family}-{md.version}-{md.variant.value}-{md.os.value}-{md.arch.value}"
 
     match md.variant:
+        case Variant.Binary:
+            return prefix
         case Variant.Omnibus:
             return f"{prefix}.tar.gz"
         case Variant.Rootfs:

--- a/prelude-si/macros.bzl
+++ b/prelude-si/macros.bzl
@@ -31,9 +31,11 @@ rootfs = _rootfs
 
 load(
     "@prelude-si//macros:nix.bzl",
+    _nix_binary = "nix_binary",
     _nix_flake_lock = "nix_flake_lock",
     _nix_omnibus_pkg = "nix_omnibus_pkg",
 )
+nix_binary = _nix_binary
 nix_flake_lock = _nix_flake_lock
 nix_omnibus_pkg = _nix_omnibus_pkg
 

--- a/prelude-si/macros/nix.bzl
+++ b/prelude-si/macros/nix.bzl
@@ -5,6 +5,7 @@ load(
 )
 load(
     "@prelude-si//:nix.bzl",
+    _nix_binary = "nix_binary",
     _nix_flake_lock = "nix_flake_lock",
     _nix_omnibus_pkg = "nix_omnibus_pkg",
 )
@@ -21,6 +22,45 @@ def nix_flake_lock(
         nix_flake = nix_flake,
         visibility = visibility,
         **kwargs
+    )
+
+def nix_binary(
+        name,
+        binary_name,
+        source_url = "http://github.com/systeminit/si.git",
+        author = "The System Initiative <dev@systeminit.com>",
+        license = "Apache-2.0",
+        visibility = ["PUBLIC"],
+        publish_target = "publish-binary",
+        promote_target = "promote-binary",
+        artifact_destination = "s3://si-artifacts-prod",
+        artifact_cname = "artifacts.systeminit.com",
+        **kwargs):
+    _nix_binary(
+        name = name,
+        binary_name = binary_name,
+        source_url = source_url,
+        author = author,
+        license = license,
+        visibility = visibility,
+        **kwargs
+    )
+
+    _artifact_publish(
+        name = publish_target,
+        artifact = ":{}".format(name),
+        destination = artifact_destination,
+        cname = artifact_cname,
+        visibility = visibility,
+    )
+
+    _artifact_promote(
+        name = promote_target,
+        family = binary_name,
+        variant = "binary",
+        destination = artifact_destination,
+        cname = artifact_cname,
+        visibility = visibility,
     )
 
 def nix_omnibus_pkg(

--- a/prelude-si/nix/BUCK
+++ b/prelude-si/nix/BUCK
@@ -4,5 +4,9 @@ load(
 )
 
 export_file(
+    name = "nix_binary_build.py",
+)
+
+export_file(
     name = "nix_omnibus_pkg_build.py",
 )

--- a/prelude-si/nix/nix_binary_build.py
+++ b/prelude-si/nix/nix_binary_build.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""
+Builds a binary built with Nix but not dependent on Nix packages.
+"""
+import argparse
+import glob
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import json
+import sys
+from enum import Enum, EnumMeta
+import tempfile
+from typing import Any, Dict, List, Union
+
+
+# A slightly more Rust-y feeling enum
+# Thanks to: https://stackoverflow.com/a/65225753
+class MetaEnum(EnumMeta):
+
+    def __contains__(self: type[Any], member: object) -> bool:
+        try:
+            self(member)
+        except ValueError:
+            return False
+        return True
+
+
+class BaseEnum(Enum, metaclass=MetaEnum):
+    pass
+
+
+class PlatformArchitecture(BaseEnum):
+    Aarch64 = "aarch64"
+    X86_64 = "x86_64"
+
+
+class PlatformOS(BaseEnum):
+    Darwin = "darwin"
+    Linux = "linux"
+
+
+VARIANT = "binary"
+
+NIX_PKG_NAME_SUFFIX = "-standalone"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--git-info-json",
+        required=True,
+        help="Path to the Git metadata JSON file",
+    )
+    parser.add_argument(
+        "--artifact-out-file",
+        required=True,
+        help="Path to write the binary artifact file",
+    )
+    parser.add_argument(
+        "--build-metadata-out-file",
+        required=True,
+        help="Path to write the build metadata JSON file",
+    )
+    parser.add_argument(
+        "--binary-metadata-out-file",
+        required=True,
+        help="Path to write the binary metadata JSON file",
+    )
+    parser.add_argument(
+        "--build-context-dir",
+        required=True,
+        help="Path to build context directory",
+    )
+    parser.add_argument(
+        "--name",
+        required=True,
+        help="Name of binary to build",
+    )
+    parser.add_argument(
+        "--author",
+        required=True,
+        help="Author to be used in binary metadata",
+    )
+    parser.add_argument(
+        "--source-url",
+        required=True,
+        help="Source code URL to be used in binary metadata",
+    )
+    parser.add_argument(
+        "--license",
+        required=True,
+        help="Image license to be used in binary metadata",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    git_info = load_git_info(args.git_info_json)
+    architecture = detect_architecture()
+    os = detect_os()
+
+    nix_store_pkg_path = build_nix_binary(args.name, args.build_context_dir)
+    binary_metadata = compute_binary_metadata(
+        git_info,
+        args.name,
+        args.author,
+        args.source_url,
+        args.license,
+        architecture,
+        os,
+    )
+    write_binary(
+        args.name,
+        Path(args.artifact_out_file),
+        Path(nix_store_pkg_path),
+    )
+    write_json(args.binary_metadata_out_file, binary_metadata)
+
+    b3sum = compute_b3sum(args.artifact_out_file)
+    build_metadata = compute_build_metadata(
+        git_info,
+        args.name,
+        architecture,
+        os,
+        b3sum,
+    )
+    write_json(args.build_metadata_out_file, build_metadata)
+
+    return 0
+
+
+def build_nix_binary(name: str, build_context_dir: str) -> str:
+    cmd = [
+        "nix",
+        "build",
+        "--extra-experimental-features",
+        "nix-command flakes impure-derivations ca-derivations",
+        "--option",
+        "filter-syscalls",
+        "false",
+        "--print-build-logs",
+        f".#{name}{NIX_PKG_NAME_SUFFIX}",
+    ]
+
+    # We are purposefully escaping the default `$TMPDIR` location as Buck2 sets
+    # `$TMPDIR` to be under the `buck-out/` directory. Unfortunately (for us in
+    # this context), `nix build` will recursely look up the directory tree
+    # searching for a `.git/` directory so we avoid this by running our build
+    # under the system's `/tmp/` directory. Sorry folks!
+    with tempfile.TemporaryDirectory(
+            prefix="/tmp/nix_binary_build-") as tempdir:
+        root_dir = os.path.join(tempdir, "root")
+
+        # Copy build context into tempdir
+        shutil.copytree(
+            build_context_dir,
+            root_dir,
+            symlinks=True,
+        )
+
+        # If we find a workspace dir, let's get the contents into the root
+        workspace = os.path.join(root_dir, "workspace")
+        if os.path.isdir(workspace):
+            print("--- Found a workspace dir, moving contents into root")
+            move_contents_up(workspace)
+
+        print("--- Build nix package with: '{}'".format(" ".join(cmd)))
+        # Create parent directories
+        subprocess.run(cmd, cwd=root_dir).check_returncode()
+
+        nix_store_pkg_path = os.readlink(os.path.join(root_dir, "result"))
+
+    return nix_store_pkg_path
+
+
+def write_binary(name: str, out_file: Path, nix_store_pkg_path: Path):
+    src = nix_store_pkg_path.joinpath("bin", name)
+    shutil.copyfile(src, out_file)
+    shutil.copymode(src, out_file)
+
+
+def write_json(output: str, metadata: Union[Dict[str, str], List[str]]):
+    with open(output, "w") as file:
+        json.dump(metadata, file, sort_keys=True)
+
+
+# Possible machine architecture detection comes from reading the Rustup shell
+# script installer--thank you for your service!
+# See: https://github.com/rust-lang/rustup/blob/master/rustup-init.sh
+def detect_architecture() -> PlatformArchitecture:
+    machine = os.uname().machine
+
+    if (machine == "amd64" or machine == "x86_64" or machine == "x86-64"
+            or machine == "x64"):
+        return PlatformArchitecture.X86_64
+    elif (machine == "arm64" or machine == "aarch64" or machine == "arm64v8"):
+        return PlatformArchitecture.Aarch64
+    else:
+        print(
+            f"xxx Failed to determine architecure or unsupported: {machine}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+# Possible machine operating system detection comes from reading the Rustup shell
+# script installer--thank you for your service!
+# See: https://github.com/rust-lang/rustup/blob/master/rustup-init.sh
+def detect_os() -> PlatformOS:
+    platform_os = os.uname().sysname
+
+    if (platform_os == "Darwin"):
+        return PlatformOS.Darwin
+    elif (platform_os == "Linux"):
+        return PlatformOS.Linux
+    else:
+        print(
+            f"xxx Failed to determine operating system or unsupported: {platform_os}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def load_git_info(git_info_file: str) -> Dict[str, str | int | bool]:
+    with open(git_info_file) as file:
+        return json.load(file)
+
+
+def compute_binary_metadata(
+    git_info: Dict[str, str | int | bool],
+    name: str,
+    author: str,
+    source_url: str,
+    license: str,
+    architecture: PlatformArchitecture,
+    platform_os: PlatformOS,
+) -> Dict[str, str]:
+    metadata = {
+        "name": name,
+        "version": git_info.get("canonical_version"),
+        "author": author,
+        "source_url": source_url,
+        "license": license,
+        "architecture": architecture.value,
+        "os": platform_os.value,
+        "commit": git_info.get("commit_hash"),
+        "branch": git_info.get("branch"),
+    }
+
+    return metadata
+
+
+def compute_b3sum(artifact_file: str) -> str:
+    cmd = [
+        "b3sum",
+        "--no-names",
+        artifact_file,
+    ]
+    result = subprocess.run(cmd, capture_output=True)
+    # Print out stderr from process if it failed
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr.decode("ascii"))
+    result.check_returncode()
+    b3sum = result.stdout.decode("ascii").rstrip()
+
+    return b3sum
+
+
+def compute_build_metadata(
+    git_info: Dict[str, str | int | bool],
+    family: str,
+    platform_arch: PlatformArchitecture,
+    platform_os: PlatformOS,
+    b3sum: str,
+) -> Dict[str, str]:
+    metadata = {
+        "family": family,
+        "variant": VARIANT,
+        "version": git_info.get("canonical_version"),
+        "arch": platform_arch.value,
+        "os": platform_os.value,
+        "commit": git_info.get("commit_hash"),
+        "branch": git_info.get("branch"),
+        "b3sum": b3sum,
+    }
+
+    return metadata
+
+
+def move_contents_up(directory):
+    parent_dir = os.path.dirname(directory)
+    shutil.copytree(directory, parent_dir, dirs_exist_ok=True)
+    shutil.rmtree(directory)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prelude-si/nix/toolchain.bzl
+++ b/prelude-si/nix/toolchain.bzl
@@ -1,4 +1,5 @@
 NixToolchainInfo = provider(fields = {
+    "nix_binary_build": typing.Any,
     "nix_omnibus_pkg_build": typing.Any,
 })
 
@@ -9,6 +10,7 @@ def nix_toolchain_impl(ctx) -> list[[DefaultInfo, NixToolchainInfo]]:
     return [
         DefaultInfo(),
         NixToolchainInfo(
+            nix_binary_build = ctx.attrs._nix_binary_build,
             nix_omnibus_pkg_build = ctx.attrs._nix_omnibus_pkg_build,
         ),
     ]
@@ -16,6 +18,9 @@ def nix_toolchain_impl(ctx) -> list[[DefaultInfo, NixToolchainInfo]]:
 nix_toolchain = rule(
     impl = nix_toolchain_impl,
     attrs = {
+        "_nix_binary_build": attrs.dep(
+            default = "prelude-si//nix:nix_binary_build.py",
+        ),
         "_nix_omnibus_pkg_build": attrs.dep(
             default = "prelude-si//nix:nix_omnibus_pkg_build.py",
         ),


### PR DESCRIPTION
This change introduces a `nix_binary` Buck2 rule (and macro) which is used in `bin/si-fs` to build, publish, and promote a "standalone" binary of the `si-fs` FUSE filesystem daemon.

<img src="https://media3.giphy.com/media/7pLv68ItwBaHS/giphy.gif?cid=bd3ea57exngwxj22tdv9i9wlq7ysx36enhc7z867p533heh6&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>