### PR TITLE
feat(clover): Add top-level doc links

### DIFF
--- a/bin/clover/src/pipeline-steps/generateSubAssets.ts
+++ b/bin/clover/src/pipeline-steps/generateSubAssets.ts
@@ -84,6 +84,7 @@ export function generateSubAssets(
             ...variantData,
             displayName: name,
             funcUniqueId: ulid(),
+            link: prop.typeProp.data?.docLink,
             description: prop.typeProp.data?.documentation ?? "",
           },
           domain: newDomain,

--- a/bin/clover/src/specPipeline.ts
+++ b/bin/clover/src/specPipeline.ts
@@ -1,6 +1,6 @@
 import { CfProperty, CfSchema } from "./cfDb.ts";
 import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
-import { createDefaultPropFromCf, OnlyProperties } from "./spec/props.ts";
+import { createDefaultPropFromCf, createDocLink, OnlyProperties } from "./spec/props.ts";
 import {
   ExpandedPkgSpec,
   ExpandedSchemaSpec,
@@ -46,7 +46,7 @@ export function pkgSpecFromCf(src: CfSchema): ExpandedPkgSpec {
     version,
     data: {
       version,
-      link: null,
+      link: createDocLink(src),
       color: "#b64017",
       displayName: name,
       componentType: "component",


### PR DESCRIPTION
This PR:

* Adds top-level documentation links for all schemas (including sub-assets)
* Fixes links to many props that referenced definitions (these get their own pages in AWS).

![image](https://github.com/user-attachments/assets/9fe28632-6aff-4eec-9288-aaf853a78f15)

## Unfixed

There are still at least some props that are under referenced definitions which don't link to the sub-page. I suspect it's because of how often things like oneOf/anyOf are used when $ref is used (we don't support $ref there). Future turn.

## Testing

* Regenerated and diffed all assets to make sure doc links generally looked right
* Loaded up an asset, looked at the doc link
