### PR TITLE
Fix two flake-y tests by waiting for actions

### DIFF
--- a/lib/sdf-server/tests/service_tests/change_set_apply.rs
+++ b/lib/sdf-server/tests/service_tests/change_set_apply.rs
@@ -172,6 +172,7 @@ async fn protected_apply(ctx: &mut DalContext, spicedb_client: SpiceDbClient) ->
     // Scenario 5: apply the changes used the protected flow and observe that it works.
     {
         SdfTestHelpers::protected_apply_change_set_to_base(ctx, &mut spicedb_client).await?;
+        ChangeSetTestHelpers::wait_for_actions_to_run(ctx).await?;
         ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
 
         let default_view_id = View::get_id_for_default(ctx).await?;

--- a/lib/sdf-server/tests/service_tests/change_set_approval.rs
+++ b/lib/sdf-server/tests/service_tests/change_set_approval.rs
@@ -1039,6 +1039,7 @@ async fn one_component_in_two_views(
     // Scenario 3: apply to HEAD and create a new change set (skip approvals).
     {
         ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+        ChangeSetTestHelpers::wait_for_actions_to_run(ctx).await?;
         ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
 
         let (frontend_latest_approvals, frontend_requirements) =
@@ -1089,6 +1090,7 @@ async fn one_component_in_two_views(
     // Scenario 5: apply to HEAD and create a new change set (skip approvals).
     {
         ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+        ChangeSetTestHelpers::wait_for_actions_to_run(ctx).await?;
         ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
 
         let (frontend_latest_approvals, frontend_requirements) =
@@ -1139,6 +1141,7 @@ async fn one_component_in_two_views(
     // Scenario 7: apply to HEAD and create a new change set (skip approvals).
     {
         ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+        ChangeSetTestHelpers::wait_for_actions_to_run(ctx).await?;
         ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
 
         let (frontend_latest_approvals, frontend_requirements) =


### PR DESCRIPTION
This PR fixes two flake-y tests by waiting for actions to run related to "Starfield". Interestingly, this should have only started happening after #5451, which was reverted by #5478 and is intended to come back on "main" after #5485 is approved and merged.

That being said, this can happen for a number of reasons, but the key takeaway is that we should be waiting for actions to run whenver possible in our tests.