### PR TITLE
feat(si-fs): support deno

### DIFF
--- a/lib/si-filesystem/src/async_wrapper.rs
+++ b/lib/si-filesystem/src/async_wrapper.rs
@@ -52,6 +52,7 @@ impl Filesystem for AsyncFuseWrapper {
         _req: &fuser::Request<'_>,
         _config: &mut fuser::KernelConfig,
     ) -> Result<(), nix::libc::c_int> {
+        self.tx.send(FilesystemCommand::HydrateChangeSets).unwrap();
         Ok(())
     }
 

--- a/lib/si-filesystem/src/client.rs
+++ b/lib/si-filesystem/src/client.rs
@@ -10,8 +10,8 @@ use si_frontend_types::{
     fs::{
         AssetFuncs, Binding, Bindings, CategoryFilter, ChangeSet, CreateChangeSetRequest,
         CreateChangeSetResponse, CreateFuncRequest, CreateSchemaRequest, CreateSchemaResponse,
-        FsApiError, Func, IdentityBindings, ListChangeSetsResponse, Schema, SchemaAttributes,
-        SetFuncBindingsRequest, SetFuncCodeRequest, VariantQuery,
+        FsApiError, Func, HydratedChangeSet, IdentityBindings, ListChangeSetsResponse, Schema,
+        SchemaAttributes, SetFuncBindingsRequest, SetFuncCodeRequest, VariantQuery,
     },
     FuncKind,
 };
@@ -357,6 +357,18 @@ impl SiFsClient {
             "{}/api/v2/workspaces/{}/fs/change-sets/{change_set_id}/{suffix}",
             self.endpoint, self.workspace_id
         )
+    }
+
+    pub async fn hydrate_change_sets(&self) -> SiFsClientResult<Vec<HydratedChangeSet>> {
+        Ok(self
+            .client
+            .get(self.fs_api_url("hydrate"))
+            .bearer_auth(&self.token)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?)
     }
 
     /// Fetches including the active change sets

--- a/lib/si-filesystem/src/command.rs
+++ b/lib/si-filesystem/src/command.rs
@@ -11,6 +11,7 @@ use crate::{FileHandle, Inode};
 #[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) enum FilesystemCommand {
+    HydrateChangeSets,
     GetAttr {
         ino: Inode,
         fh: Option<FileHandle>,
@@ -262,6 +263,7 @@ impl FilesystemCommand {
     #[allow(unused)]
     pub fn name(&self) -> &'static str {
         match self {
+            FilesystemCommand::HydrateChangeSets => "hydrate_change_sets",
             FilesystemCommand::GetAttr { .. } => "getattr",
             FilesystemCommand::ReadDir { .. } => "readdir",
             FilesystemCommand::Lookup { .. } => "lookup",
@@ -303,6 +305,7 @@ impl FilesystemCommand {
 
     pub fn error(self, errno: c_int) {
         match self {
+            FilesystemCommand::HydrateChangeSets => {}
             FilesystemCommand::GetAttr { reply, .. } => reply.error(errno),
             FilesystemCommand::ReadDir { reply, .. } => reply.error(errno),
             FilesystemCommand::Lookup { reply, .. } => reply.error(errno),

--- a/lib/si-frontend-types-rs/src/fs.rs
+++ b/lib/si-frontend-types-rs/src/fs.rs
@@ -328,3 +328,18 @@ impl CategoryFilter {
         }
     }
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct HydratedChangeSet {
+    pub name: String,
+    pub id: ChangeSetId,
+    pub funcs: Vec<Func>,
+    pub schemas: Vec<HydratedSchema>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct HydratedSchema {
+    pub schema: Schema,
+    pub asset_funcs: AssetFuncs,
+    pub funcs: Option<Vec<Func>>,
+}

--- a/lib/si-frontend-types-rs/src/func.rs
+++ b/lib/si-frontend-types-rs/src/func.rs
@@ -156,6 +156,29 @@ impl FuncBinding {
             _ => None,
         }
     }
+
+    pub fn schema_variant_id(&self) -> Option<SchemaVariantId> {
+        match self {
+            FuncBinding::Action {
+                schema_variant_id, ..
+            } => *schema_variant_id,
+            FuncBinding::Attribute {
+                schema_variant_id, ..
+            } => *schema_variant_id,
+            FuncBinding::Authentication {
+                schema_variant_id, ..
+            } => Some(*schema_variant_id),
+            FuncBinding::CodeGeneration {
+                schema_variant_id, ..
+            } => *schema_variant_id,
+            FuncBinding::Management {
+                schema_variant_id, ..
+            } => *schema_variant_id,
+            FuncBinding::Qualification {
+                schema_variant_id, ..
+            } => *schema_variant_id,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq, Hash)]


### PR DESCRIPTION
Supports deno by configuring a workspace root deno.json and a .vscode/settings.json with "deno: enable". In order to support deno we prefetch every function so we can fill out the deno.json workspaces list.

If new functions come in, or are created, *you will have to reload your deno workspace to get them parsed by the deno language server*.

`node_modules` for deno are not yet supported. They can be! But a passthrough will have to be implemented so that the node module tree can be written to disk in another folder, and mirrored in the si-filesystem system.