### PR TITLE
feat(clover): Adding an override for the secrets manager secret

### DIFF
--- a/bin/clover/src/cloud-control-funcs/actions/awsCloudControlUpdate.ts
+++ b/bin/clover/src/cloud-control-funcs/actions/awsCloudControlUpdate.ts
@@ -49,48 +49,11 @@ async function main(component: Input): Promise<Output> {
   )?.DesiredState;
 
   // Copy secrets to desired props
-  {
-    const domain = component.properties?.domain;
-    const payload = desiredProps;
-    const propUsageMap = JSON.parse(domain.extra.PropUsageMap);
-    if (
-      !Array.isArray(propUsageMap.secrets)
-    ) {
-      throw Error("malformed propUsageMap on asset");
-    }
+  const propUsageMap = JSON.parse(
+    component.properties?.domain.extra.PropUsageMap,
+  );
 
-    for (
-      const {
-        secretKey,
-        propPath,
-      } of propUsageMap.secrets
-    ) {
-      const secret = requestStorage.getItem(secretKey);
-
-      if (!propPath?.length || propPath.length < 1) {
-        throw Error("malformed secret on propUsageMap: bad propPath");
-      }
-      if (secret) {
-        let secretParent = payload;
-        let propKey = propPath[0];
-        for (let i = 1; i < propPath.length; i++) {
-          const thisProp = secretParent[propKey];
-
-          if (!thisProp) {
-            break;
-          }
-
-          secretParent = secretParent[propKey];
-          propKey = propPath[i];
-        }
-
-        // Only add secret to payload if the codegen output has it
-        if (propKey in secretParent) {
-          secretParent[propKey] = secret;
-        }
-      }
-    }
-  }
+  addSecretsToPayload(desiredProps, propUsageMap);
 
   const desiredState = _.cloneDeep(currentState);
   _.merge(desiredState, desiredProps);
@@ -235,5 +198,54 @@ async function main(component: Input): Promise<Output> {
       payload: _.get(component, "properties.resource.payload"),
       status: "error",
     };
+  }
+}
+
+// If you change this, you should change the same func on awsCloudControlCreate.ts in this same directory
+function addSecretsToPayload(
+  payload: Record<string, any>,
+  propUsageMap: {
+    secrets: {
+      secretKey: string;
+      propPath: string[];
+    }[];
+  },
+) {
+  if (
+    !Array.isArray(propUsageMap.secrets)
+  ) {
+    throw Error("malformed propUsageMap on asset");
+  }
+
+  for (
+    const {
+      secretKey,
+      propPath,
+    } of propUsageMap.secrets
+  ) {
+    const secret = requestStorage.getItem(secretKey);
+
+    if (!propPath?.length || propPath.length < 1) {
+      throw Error("malformed secret on propUsageMap: bad propPath");
+    }
+    if (!secret) continue;
+
+    let secretParent = payload;
+    let propKey = propPath[0];
+    for (let i = 1; i < propPath.length; i++) {
+      const thisProp = secretParent[propKey];
+
+      if (!thisProp) {
+        break;
+      }
+
+      secretParent = secretParent[propKey];
+      propKey = propPath[i];
+    }
+
+    // Only add secret to payload if the codegen output has it
+    if (propKey in secretParent) {
+      secretParent[propKey] = secret;
+    }
   }
 }

--- a/bin/clover/src/cloud-control-funcs/actions/awsCloudControlUpdate.ts
+++ b/bin/clover/src/cloud-control-funcs/actions/awsCloudControlUpdate.ts
@@ -48,6 +48,50 @@ async function main(component: Input): Promise<Output> {
     component.properties.code?.["awsCloudControlUpdate"]?.code,
   )?.DesiredState;
 
+  // Copy secrets to desired props
+  {
+    const domain = component.properties?.domain;
+    const payload = desiredProps;
+    const propUsageMap = JSON.parse(domain.extra.PropUsageMap);
+    if (
+      !Array.isArray(propUsageMap.secrets)
+    ) {
+      throw Error("malformed propUsageMap on asset");
+    }
+
+    for (
+      const {
+        secretKey,
+        propPath,
+      } of propUsageMap.secrets
+    ) {
+      const secret = requestStorage.getItem(secretKey);
+
+      if (!propPath?.length || propPath.length < 1) {
+        throw Error("malformed secret on propUsageMap: bad propPath");
+      }
+      if (secret) {
+        let secretParent = payload;
+        let propKey = propPath[0];
+        for (let i = 1; i < propPath.length; i++) {
+          const thisProp = secretParent[propKey];
+
+          if (!thisProp) {
+            break;
+          }
+
+          secretParent = secretParent[propKey];
+          propKey = propPath[i];
+        }
+
+        // Only add secret to payload if the codegen output has it
+        if (propKey in secretParent) {
+          secretParent[propKey] = secret;
+        }
+      }
+    }
+  }
+
   const desiredState = _.cloneDeep(currentState);
   _.merge(desiredState, desiredProps);
   let patch;

--- a/bin/clover/src/cloud-control-funcs/code-gen/awsCloudControlCodeGenCreate.ts
+++ b/bin/clover/src/cloud-control-funcs/code-gen/awsCloudControlCodeGenCreate.ts
@@ -13,12 +13,39 @@ async function main(component: Input): Promise<Output> {
   const propUsageMap = JSON.parse(component.domain.extra.PropUsageMap);
   if (
     !Array.isArray(propUsageMap.createOnly) ||
-    !Array.isArray(propUsageMap.updatable)
+    !Array.isArray(propUsageMap.updatable) ||
+    !Array.isArray(propUsageMap.secrets)
   ) {
     throw Error("malformed propUsageMap on resource");
   }
 
   const payload = _.cloneDeep(component.domain);
+
+  // Push secrets to payload
+  for (
+    const {
+      secretKey,
+      propPath,
+    } of propUsageMap.secrets
+  ) {
+    const secret = requestStorage.getItem(secretKey);
+
+    if (!propPath?.length || propPath.length < 1) {
+      throw Error("malformed secret on propUsageMap: bad propPath");
+    }
+    if (secret) {
+      let secretParent = payload;
+      let propKey = propPath[0];
+      for (let i = 1; i < propPath.length; i++) {
+        // Ensure key exists on payload
+        secretParent[propKey] = secretParent[propKey] ?? {};
+        secretParent = secretParent[propKey];
+        propKey = propPath[i];
+      }
+
+      secretParent[propKey] = secret;
+    }
+  }
 
   const propsToVisit = _.keys(payload).map((k: string) => [k]);
 

--- a/bin/clover/src/cloud-control-funcs/code-gen/awsCloudControlCodeGenCreate.ts
+++ b/bin/clover/src/cloud-control-funcs/code-gen/awsCloudControlCodeGenCreate.ts
@@ -21,31 +21,7 @@ async function main(component: Input): Promise<Output> {
 
   const payload = _.cloneDeep(component.domain);
 
-  // Push secrets to payload
-  for (
-    const {
-      secretKey,
-      propPath,
-    } of propUsageMap.secrets
-  ) {
-    const secret = requestStorage.getItem(secretKey);
-
-    if (!propPath?.length || propPath.length < 1) {
-      throw Error("malformed secret on propUsageMap: bad propPath");
-    }
-    if (secret) {
-      let secretParent = payload;
-      let propKey = propPath[0];
-      for (let i = 1; i < propPath.length; i++) {
-        // Ensure key exists on payload
-        secretParent[propKey] = secretParent[propKey] ?? {};
-        secretParent = secretParent[propKey];
-        propKey = propPath[i];
-      }
-
-      secretParent[propKey] = secret;
-    }
-  }
+  addSecretsToPayload(payload, propUsageMap);
 
   const propsToVisit = _.keys(payload).map((k: string) => [k]);
 
@@ -128,4 +104,40 @@ function removeEmpty(obj: any): any {
           : value,
       ]),
   );
+}
+
+// If you change this, you should change the same func on awsCloudControlCodeGenUpdate.ts in this same directory
+function addSecretsToPayload(
+  payload: Record<string, any>,
+  propUsageMap: {
+    secrets: {
+      secretKey: string;
+      propPath: string[];
+    }[];
+  },
+) {
+  for (
+    const {
+      secretKey,
+      propPath,
+    } of propUsageMap.secrets
+  ) {
+    const secret = requestStorage.getItem(secretKey);
+
+    if (!propPath?.length || propPath.length < 1) {
+      throw Error("malformed secret on propUsageMap: bad propPath");
+    }
+    if (secret) {
+      let secretParent = payload;
+      let propKey = propPath[0];
+      for (let i = 1; i < propPath.length; i++) {
+        // Ensure key exists on payload
+        secretParent[propKey] = secretParent[propKey] ?? {};
+        secretParent = secretParent[propKey];
+        propKey = propPath[i];
+      }
+
+      secretParent[propKey] = secret;
+    }
+  }
 }

--- a/bin/clover/src/cloud-control-funcs/code-gen/awsCloudControlCodeGenUpdate.ts
+++ b/bin/clover/src/cloud-control-funcs/code-gen/awsCloudControlCodeGenUpdate.ts
@@ -13,12 +13,39 @@ async function main(component: Input): Promise<Output> {
   const propUsageMap = JSON.parse(component.domain.extra.PropUsageMap);
   if (
     !Array.isArray(propUsageMap.createOnly) ||
-    !Array.isArray(propUsageMap.updatable)
+    !Array.isArray(propUsageMap.updatable) ||
+    !Array.isArray(propUsageMap.secrets)
   ) {
     throw Error("malformed propUsageMap on resource");
   }
 
   const payload = _.cloneDeep(component.domain);
+
+  // Push secrets to payload
+  for (
+    const {
+      secretKey,
+      propPath,
+    } of propUsageMap.secrets
+  ) {
+    const secret = requestStorage.getItem(secretKey);
+
+    if (!propPath?.length || propPath.length < 1) {
+      throw Error("malformed secret on propUsageMap: bad propPath");
+    }
+    if (secret) {
+      let secretParent = payload;
+      let propKey = propPath[0];
+      for (let i = 1; i < propPath.length; i++) {
+        // Ensure key exists on payload
+        secretParent[propKey] = secretParent[propKey] ?? {};
+        secretParent = secretParent[propKey];
+        propKey = propPath[i];
+      }
+
+      secretParent[propKey] = secret;
+    }
+  }
 
   const propsToVisit = _.keys(payload).map((k: string) => [k]);
 

--- a/bin/clover/src/cloud-control-funcs/code-gen/awsCloudControlCodeGenUpdate.ts
+++ b/bin/clover/src/cloud-control-funcs/code-gen/awsCloudControlCodeGenUpdate.ts
@@ -21,31 +21,7 @@ async function main(component: Input): Promise<Output> {
 
   const payload = _.cloneDeep(component.domain);
 
-  // Push secrets to payload
-  for (
-    const {
-      secretKey,
-      propPath,
-    } of propUsageMap.secrets
-  ) {
-    const secret = requestStorage.getItem(secretKey);
-
-    if (!propPath?.length || propPath.length < 1) {
-      throw Error("malformed secret on propUsageMap: bad propPath");
-    }
-    if (secret) {
-      let secretParent = payload;
-      let propKey = propPath[0];
-      for (let i = 1; i < propPath.length; i++) {
-        // Ensure key exists on payload
-        secretParent[propKey] = secretParent[propKey] ?? {};
-        secretParent = secretParent[propKey];
-        propKey = propPath[i];
-      }
-
-      secretParent[propKey] = secret;
-    }
-  }
+  addSecretsToPayload(payload, propUsageMap);
 
   const propsToVisit = _.keys(payload).map((k: string) => [k]);
 
@@ -127,4 +103,40 @@ function removeEmpty(obj: any): any {
           : value,
       ]),
   );
+}
+
+// If you change this, you should change the same func on awsCloudControlCodeGenCreate.ts in this same directory
+function addSecretsToPayload(
+  payload: Record<string, any>,
+  propUsageMap: {
+    secrets: {
+      secretKey: string;
+      propPath: string[];
+    }[];
+  },
+) {
+  for (
+    const {
+      secretKey,
+      propPath,
+    } of propUsageMap.secrets
+  ) {
+    const secret = requestStorage.getItem(secretKey);
+
+    if (!propPath?.length || propPath.length < 1) {
+      throw Error("malformed secret on propUsageMap: bad propPath");
+    }
+    if (secret) {
+      let secretParent = payload;
+      let propKey = propPath[0];
+      for (let i = 1; i < propPath.length; i++) {
+        // Ensure key exists on payload
+        secretParent[propKey] = secretParent[propKey] ?? {};
+        secretParent = secretParent[propKey];
+        propKey = propPath[i];
+      }
+
+      secretParent[propKey] = secret;
+    }
+  }
 }

--- a/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
+++ b/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
@@ -7,6 +7,15 @@ import {
 import { createInputSocketFromProp } from "../spec/sockets.ts";
 import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 
+export interface PropUsageMap {
+  createOnly: string[];
+  updatable: string[];
+  secrets: {
+    secretKey: string;
+    propPath: string[];
+  }[];
+}
+
 export function addDefaultPropsAndSockets(
   specs: ExpandedPkgSpec[],
 ): ExpandedPkgSpec[] {
@@ -27,9 +36,10 @@ export function addDefaultPropsAndSockets(
         "string",
         extraProp.metadata.propPath,
       );
-      const propUsageMap = {
-        createOnly: [] as string[],
-        updatable: [] as string[],
+      const propUsageMap: PropUsageMap = {
+        createOnly: [],
+        updatable: [],
+        secrets: [],
       };
 
       const queue: ExpandedPropSpec[] = _.cloneDeep(domain.entries);

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -93,7 +93,7 @@ const overrides = new Map<string, OverrideFn>([
   ],
   ["ContainerDefinitions Secrets", (spec: ExpandedPkgSpec) => {
     const variant = spec.schemas[0].variants[0];
-    
+
     const prop = variant.domain.entries.find((p: ExpandedPropSpec) =>
       p.name === "ValueFrom"
     );


### PR DESCRIPTION
This is the first part of this work. We now need to ensure that we can use this prop as part of the payload we send to AWS
This isn't specific to SecretManager:;Secret, this is a pattern that we will need to replicate with other assets like KmsKey and RDS DBInstance USername/Password