### PR TITLE
Create resource payload intrinsic if not in spec

### DIFF
--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -106,8 +106,6 @@ pub enum PkgError {
     PropNotFoundByName(String),
     #[error("prop spec structure is invalid: {0}")]
     PropSpecChildrenInvalid(String),
-    #[error("resource payload to value intrinsic func not found")]
-    ResourcePayloadToValueIntrinsicFuncNotFound,
     #[error("schema error: {0}")]
     Schema(#[from] SchemaError),
     #[error("schema variant error: {0}")]


### PR DESCRIPTION
This PR creates the resource payload to value intrinsic func (new version) if it wasn't specified in the package spec, which would have handled installation.