### PR TITLE
feat(clover): Do not generate specs for types without handlers

### DIFF
--- a/bin/clover/src/cli.ts
+++ b/bin/clover/src/cli.ts
@@ -44,6 +44,10 @@ To generate all specs containing "ECS" or "S3", you can pass some services as ar
     .option("--inferred <file:string>", "Inferred database location", {
       default: "inferred.json",
     })
+    .option(
+      "--force-update-existing-packages",
+      "Force the existing package list to be updated",
+    )
     .env(
       "SI_BEARER_TOKEN=<value:string>",
       "Auth token for interacting with the module index",

--- a/bin/clover/src/pipeline-steps/ignoreSpecsWithoutHandlers.ts
+++ b/bin/clover/src/pipeline-steps/ignoreSpecsWithoutHandlers.ts
@@ -1,0 +1,18 @@
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+import _logger from "../logger.ts";
+
+const logger = _logger.ns("assetOverrides").seal();
+
+export function ignoreSpecsWithoutHandlers(
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  return specs.filter(({ schemas: [{ variants: [variant] }] }) => {
+    if (!variant.cfSchema.handlers) {
+      logger.debug(
+        `Ignoring ${variant.cfSchema.typeName} because it has no handlers`,
+      );
+      return false;
+    }
+    return true;
+  });
+}

--- a/bin/clover/src/spec/pkgs.ts
+++ b/bin/clover/src/spec/pkgs.ts
@@ -5,6 +5,7 @@ import { ExpandedPropSpec, ExpandedPropSpecFor } from "./props.ts";
 import { ExpandedSocketSpec } from "./sockets.ts";
 import { Extend } from "../extend.ts";
 import { SchemaVariantSpecData } from "../bindings/SchemaVariantSpecData.ts";
+import { CfSchema } from "../cfDb.ts";
 
 export type ExpandedPkgSpec = Extend<PkgSpec, {
   schemas: [ExpandedSchemaSpec]; // Array of exactly one schema
@@ -21,4 +22,5 @@ export type ExpandedSchemaVariantSpec = Extend<SchemaVariantSpec, {
   secrets: ExpandedPropSpecFor["object"];
   secretDefinition: ExpandedPropSpec | null;
   resourceValue: ExpandedPropSpecFor["object"];
+  cfSchema: CfSchema;
 }>;

--- a/bin/clover/src/specUpdates.ts
+++ b/bin/clover/src/specUpdates.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import _logger from "./logger.ts";
 import _ from "npm:lodash";
 
@@ -5,67 +6,72 @@ const logger = _logger.ns("packageGen").seal();
 export const EXISTING_PACKAGES = "existing-packages/spec.json";
 
 export async function getExistingSpecs(
-  options: { moduleIndexUrl: string },
+  options: {
+    moduleIndexUrl: string;
+    forceUpdateExistingPackages?: boolean;
+  },
 ): Promise<Record<string, string>> {
   logger.debug("Getting existing specs...");
-  const args = [
-    "run",
-    "//bin/hoist:hoist",
-    "--",
-    "--endpoint",
-    options.moduleIndexUrl,
-    "write-existing-modules-spec",
-    "--out",
-    EXISTING_PACKAGES,
-  ];
-  logger.info(`Running: buck2 ${args.join(" ")}`);
-  const child = new Deno.Command(
-    "buck2",
-    {
-      args,
-      stdout: "piped",
-      stderr: "piped",
-    },
-  ).spawn();
+  if (!existsSync(EXISTING_PACKAGES) || options.forceUpdateExistingPackages) {
+    const args = [
+      "run",
+      "//bin/hoist:hoist",
+      "--",
+      "--endpoint",
+      options.moduleIndexUrl,
+      "write-existing-modules-spec",
+      "--out",
+      EXISTING_PACKAGES,
+    ];
+    logger.info(`Running: buck2 ${args.join(" ")}`);
+    const child = new Deno.Command(
+      "buck2",
+      {
+        args,
+        stdout: "piped",
+        stderr: "piped",
+      },
+    ).spawn();
 
-  // Stream stdout
-  const td = new TextDecoder();
-  const stdout = (async () => {
-    const reader = child.stdout.getReader();
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        logger.debug(td.decode(value));
+    // Stream stdout
+    const td = new TextDecoder();
+    const stdout = (async () => {
+      const reader = child.stdout.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          logger.debug(td.decode(value));
+        }
+      } finally {
+        reader.releaseLock();
       }
-    } finally {
-      reader.releaseLock();
-    }
-  })();
+    })();
 
-  // Stream stderr
-  const stderr = (async () => {
-    const reader = child.stderr.getReader();
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        logger.debug(td.decode(value));
+    // Stream stderr
+    const stderr = (async () => {
+      const reader = child.stderr.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          logger.debug(td.decode(value));
+        }
+      } finally {
+        reader.releaseLock();
       }
-    } finally {
-      reader.releaseLock();
+    })();
+
+    const status = await child.status;
+
+    if (!status.success) {
+      await stdout;
+      await stderr;
+      throw new Error(`Command failed with status: ${status.code}`);
     }
-  })();
-
-  const status = await child.status;
-
-  if (!status.success) {
-    await stdout;
-    await stderr;
-    throw new Error(`Command failed with status: ${status.code}`);
   }
 
-  const fullPath = Deno.realPathSync(EXISTING_PACKAGES);
+  const fullPath = await Deno.realPath(EXISTING_PACKAGES);
   return (await import(fullPath, {
     with: { type: "json" },
   })).default;


### PR DESCRIPTION
Some AWS resources (such as Route53 RecordSet) cannot be successfully used with cloudformation. This is inferrable by what types of `handlers` they have, showing what sort of actions you can do with them.

This PR:

* Makes it so we don't generate specs for types without create, read, update, delete or list handlers.
* Processes specs in alphabetical order so we can see what is happening
* Keeps the cfSchema around in ExpandedPkgSpec so that it can be used (but removes it at the end of generation so it doesn't bulk up the PkgSpec

## For later:

* Some types have some handlers but not others. This only handles types where we don't want to generate the asset *at all*. We will handle selectively turning off various actions / management functions based on the handlers in a separate PR.
* During this, we discovered that some sub-assets have conflicting names and were overwriting each other. This PR resolves two of those (Channel Destinations and Instance BlockDeviceMappings) but does not fix a third (TargetGroup Targets). That will have to be fixed in a separate PR.

## Testing

* Checked that the list is roughly the right number of resources not being generated (298 = the 231 top-level resources that *should* be unsupported, plus presumably 67 sub-assets)
* Spot checked that the list of unhandled assets included RecordSet and generally seemed reasonable.
* Checked that the specs we are *still* generating didn't change in any way except input sockets (we don't generate input sockets anymore if the assets they connected to no longer exist).