### PR TITLE
fix: make clover tests run in CI

### DIFF
--- a/bin/clover/BUCK
+++ b/bin/clover/BUCK
@@ -41,8 +41,13 @@ deno_format(
 
 deno_test(
     name = "test-unit",
-    srcs = glob(["**/test/*.ts"]),
-    ignore = ["node_modules"],
+    srcs = glob(
+        ["**/*.ts", "**/test/*.ts"],
+        exclude = ["src/cloud-control-funcs/**/*"]
+    ),
+    ignore = [
+        "node_modules",
+    ],
     permissions = [
         "allow-all",
     ],

--- a/bin/clover/src/pipeline-steps/prettifySocketNames.ts
+++ b/bin/clover/src/pipeline-steps/prettifySocketNames.ts
@@ -23,7 +23,9 @@ export function prettifySocketNames(
     bfsPropTree([variant.domain, variant.resourceValue], (prop) => {
       if (prop.data.inputs) {
         for (const input of prop.data.inputs) {
-          input.socket_name = toSpaceCase(input.socket_name);
+          if (input.kind !== "prop") {
+            input.socket_name = toSpaceCase(input.socket_name);
+          }
         }
       }
     });

--- a/bin/clover/test/cfdb_test.ts
+++ b/bin/clover/test/cfdb_test.ts
@@ -6,8 +6,10 @@ import {
   loadCfDatabase,
 } from "../src/cfDb.ts";
 import { assertObjectMatch } from "@std/assert/object-match";
+import { dirname, fromFileUrl, join } from "@std/path";
 
-await loadCfDatabase({ path: "./test/test-files" });
+const TEST_FILES = join(dirname(fromFileUrl(import.meta.url)), "test-files");
+await loadCfDatabase({ path: TEST_FILES });
 
 Deno.test(function getByServiceNameReturnsSchema() {
   // Throws if the service does not exist

--- a/bin/clover/test/spec_test.ts
+++ b/bin/clover/test/spec_test.ts
@@ -7,6 +7,7 @@ import {
 import { generateSiSpecForService } from "../src/commands/generateSiSpecs.ts";
 import { ExpandedPropSpec } from "../src/spec/props.ts";
 import { loadCfDatabase } from "../src/cfDb.ts";
+import { dirname, fromFileUrl, join } from "@std/path";
 
 // const SET_BOOLEAN =
 //   "577a7deea25cfad0d4b2dd1e1f3d96b86b8b1578605137b8c4128d644c86964b";
@@ -17,7 +18,8 @@ import { loadCfDatabase } from "../src/cfDb.ts";
 // const SET_OBJECT =
 //   "cb9bf94739799f3a8b84bcb88495f93b27b47c31a341f8005a60ca39308909fd";
 
-await loadCfDatabase({ path: "./test/test-files" });
+const TEST_FILES = join(dirname(fromFileUrl(import.meta.url)), "test-files");
+await loadCfDatabase({ path: TEST_FILES });
 
 Deno.test(function generateServiceByName() {
   // Throws if the service does not exist


### PR DESCRIPTION
We needed to include the entirety of the source in order for the tests to be bubbled up when we figure out what changed. Also, we exclude the cc func code so we don't have to bring the types into them.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaWRzZDJ2MDB6a3p3YTY4ZHNleG4yY2psM3Y4Z2ltZ2Z3d3VtcjVocyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/gw3IWyGkC0rsazTi/giphy.gif"/>