### PR TITLE
fix(clover): fix doc links for nested props

### DIFF
--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -30,6 +30,8 @@ import { PkgSpec } from "../bindings/PkgSpec.ts";
 import { ignoreSpecsWithoutHandlers } from "../pipeline-steps/ignoreSpecsWithoutHandlers.ts";
 import { SchemaVariantSpec } from "../bindings/SchemaVariantSpec.ts";
 import { SchemaSpec } from "../bindings/SchemaSpec.ts";
+import { bfsPropTree, ExpandedPropSpec } from "../spec/props.ts";
+import { PropSpec } from "../bindings/PropSpec.ts";
 
 const logger = _logger.ns("siSpecs").seal();
 const SI_SPEC_DIR = "si-specs";
@@ -135,9 +137,24 @@ function unexpandSchema(
     variants: expanded.variants.map(unexpandVariant),
   };
 }
+
 function unexpandVariant(
   expanded: ExpandedSchemaVariantSpec,
 ): SchemaVariantSpec {
   const { cfSchema: _, ...variant } = expanded;
+  bfsPropTree([
+    variant.domain,
+    variant.resourceValue,
+    variant.secrets,
+    variant.secretDefinition,
+  ], unexpandProperty);
   return variant;
+}
+
+function unexpandProperty(expanded: ExpandedPropSpec): PropSpec {
+  const deleteable = expanded as Partial<ExpandedPropSpec>;
+  delete deleteable.metadata;
+  delete deleteable.joiValidation;
+  delete deleteable.cfProp;
+  return expanded;
 }

--- a/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
+++ b/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
@@ -18,7 +18,11 @@ export function addDefaultPropsAndSockets(
     const { domain } = schemaVariant;
 
     // Extra prop
-    const extraProp = createObjectProp("extra", domain.metadata.propPath);
+    const extraProp = createObjectProp(
+      "extra",
+      domain.metadata.propPath,
+      undefined,
+    );
 
     // Create PropUsageMap
     {

--- a/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
+++ b/bin/clover/src/pipeline-steps/generateAssetFuncs.ts
@@ -268,9 +268,6 @@ function generatePropBuilderString(
       ) +
       inner +
       `${indent(indent_level)}.build()`;
-    // Now that we've emitted it, we don't need prop.joiValidation anymore. Don't bother
-    // putting it in the spec (we already have validationFormat).
-    delete prop.joiValidation;
     return result;
   }
 }

--- a/bin/clover/src/pipeline-steps/generateSubAssets.ts
+++ b/bin/clover/src/pipeline-steps/generateSubAssets.ts
@@ -91,9 +91,9 @@ export function generateSubAssets(
           actionFuncs: [],
           leafFunctions: [],
           managementFuncs: [],
-          resourceValue: createDefaultProp("resource_value"),
+          resourceValue: createDefaultProp("resource_value", undefined),
           sockets: [newSpecOutputSocket],
-          secrets: createDefaultProp("secrets"),
+          secrets: createDefaultProp("secrets", undefined),
           uniqueId: variantId,
         };
 

--- a/bin/clover/src/specPipeline.ts
+++ b/bin/clover/src/specPipeline.ts
@@ -50,7 +50,7 @@ export function pkgSpecFromCf(cfSchema: CfSchema): ExpandedPkgSpec {
     version,
     data: {
       version,
-      link: createDocLink(cfSchema),
+      link: createDocLink(cfSchema, undefined),
       color: "#FF9900",
       displayName: name,
       componentType: "component",


### PR DESCRIPTION
This fixes the doc links we create for props that are part of nested definitions. In Cloud Formation, nested object definitions are placed in their own pages.

We had code trying to make this work, but it relied on `$ref`, which is stripped from most props during dereferencing. This code populates a "defName" into every prop with the name of its containing definition before the dereferencing happens.

## Testing

* Diffed output, verified that only docLink changed
* Spot checked modified docLink, verified that old link failed and new link succeeded