### PR TITLE
feat: move layer cache to external db param

### DIFF
--- a/component/init/configs/pgbouncer.ini
+++ b/component/init/configs/pgbouncer.ini
@@ -1,6 +1,6 @@
 [databases]
 $SI_PG_DB=host=$SI_PG_HOST port=5432 dbname=$SI_PG_DB user=si
-$SI_LAYER_CACHE_DBNAME=host=$SI_PG_HOST port=5432 dbname=$SI_LAYER_CACHE_DBNAME user=si
+$SI_LAYER_CACHE_DBNAME=host=$SI_PG_HOST_LAYER_CACHE port=5432 dbname=$SI_LAYER_CACHE_DBNAME user=si
 $SI_AUDIT_DBNAME=host=$SI_PG_HOST port=5432 dbname=$SI_AUDIT_DBNAME user=si
 
 [pgbouncer]


### PR DESCRIPTION
Moves the pgbouncer configuration off the default database which is grouped together, into another param to allow me to test out moving the layer-cache into another RDS/db

In tools I've seeded this param + will seed in prod if it works or will revert