### PR TITLE
feat(dal,sdf): Auto-enqueue update functions for impacted components

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -2674,6 +2674,85 @@ impl Component {
         Ok(modified)
     }
 
+    /// Based on the attribute value being updated, enqueue update actions for components
+    /// impacted if they have an update action and they have a resource
+    pub async fn enqueue_relevant_update_actions(
+        ctx: &DalContext,
+        attribute_value_id: AttributeValueId,
+    ) -> ComponentResult<Vec<Action>> {
+        let mut enqueued_actions = Vec::new();
+
+        // first check the initial component
+        let component_id = AttributeValue::component_id(ctx, attribute_value_id).await?;
+        let actions = Self::enqueue_update_action_if_applicable(ctx, component_id).await?;
+        enqueued_actions.extend(actions);
+
+        // Next, calculate dependency graph to get all of the downstream components that are now also
+        // potentially needing an update action
+        // NOTE: We have no way to guarantee that a component's value will actually be different after DVU
+        // so for now, just enqueue if the value is enqueued to change. More work here is likely needed
+        let dependency_graph = DependentValueGraph::new(
+            ctx,
+            vec![DependentValueRoot::Unfinished(attribute_value_id.into())],
+        )
+        .await?;
+        for impacted_attribute_value_id in dependency_graph.all_value_ids() {
+            // check if the attribute value is in the domain tree for the component first
+            if let Some(prop_for_value) =
+                AttributeValue::prop_opt(ctx, impacted_attribute_value_id).await?
+            {
+                if prop_for_value
+                    .path(ctx)
+                    .await?
+                    .is_descendant_of(&PropPath::new(["root", "domain"]))
+                {
+                    // first get the component for this attribute value
+                    let component_id =
+                        AttributeValue::component_id(ctx, impacted_attribute_value_id).await?;
+                    let actions =
+                        Self::enqueue_update_action_if_applicable(ctx, component_id).await?;
+                    enqueued_actions.extend(actions);
+                }
+            }
+        }
+        Ok(enqueued_actions)
+    }
+
+    async fn enqueue_update_action_if_applicable(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<Vec<Action>> {
+        let mut enqueued_actions = Vec::new();
+        if Component::resource_by_id(ctx, component_id)
+            .await?
+            .is_some()
+        {
+            // then if the current component has an update action, enqueue it
+            let schema_variant_id = Component::schema_variant_id(ctx, component_id).await?;
+            let prototypes_for_variant = SchemaVariant::find_action_prototypes_by_kind(
+                ctx,
+                schema_variant_id,
+                ActionKind::Update,
+            )
+            .await?;
+
+            for prototype_id in prototypes_for_variant {
+                // don't enqueue the same action twice!
+                if Action::find_equivalent(ctx, prototype_id, Some(component_id))
+                    .await
+                    .map_err(|err| ComponentError::Action(Box::new(err)))?
+                    .is_none()
+                {
+                    let new_action = Action::new(ctx, prototype_id, Some(component_id))
+                        .await
+                        .map_err(|err| ComponentError::Action(Box::new(err)))?;
+                    enqueued_actions.push(new_action);
+                }
+            }
+        }
+        Ok(enqueued_actions)
+    }
+
     /// `AttributeValueId`s of all input sockets connected to any output socket of this component.
     async fn downstream_attribute_value_ids(
         &self,

--- a/lib/sdf-server/src/service/component.rs
+++ b/lib/sdf-server/src/service/component.rs
@@ -23,6 +23,7 @@ use dal::{
 };
 use dal::{attribute::value::AttributeValueError, component::debug::ComponentDebugViewError};
 use dal::{ChangeSetError, TransactionsError};
+use si_posthog::PosthogError;
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::task::JoinError;
@@ -82,6 +83,8 @@ pub enum ComponentError {
     NotFound(ComponentId),
     #[error(transparent)]
     ParseInt(#[from] ParseIntError),
+    #[error("posthog error: {0}")]
+    Posthog(#[from] PosthogError),
     #[error(transparent)]
     Prop(#[from] PropError),
     #[error("property editor error: {0}")]

--- a/lib/si-posthog-rs/src/api.rs
+++ b/lib/si-posthog-rs/src/api.rs
@@ -100,6 +100,7 @@ impl PosthogApiClient {
                 "{api_endpoint}/decide?v=3",
                 api_endpoint = self.api_endpoint
             ))
+            .header("Content-Type", "application/json")
             .json(&serde_json::json!(payload))
             .send()
             .await?;


### PR DESCRIPTION
For now, this is behind a feature flag as we work out the various permutations and behavior we want to see.  

When an attribute value is updated for a component, and the component has a resource AND an update function exists, enqueue it. Then, build a dependency graph, and if any downstream components with resources also have update functions, enqueue them as well.

<div><img src="https://media3.giphy.com/media/3rgXBGYrye5vSfhMdO/giphy.gif?cid=5a38a5a2g5yqf5ny33avmf698cav7iwx3pp3mb0dr1v7rvc2&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:207px;width:300px"/><br/>via <a href="https://giphy.com/thecomebackhbo/">The Comeback HBO</a> on <a href="https://giphy.com/gifs/thecomebackhbo-change-changes-ch-3rgXBGYrye5vSfhMdO">GIPHY</a></div>