### PR TITLE
feat(clover): Colons on category names and deprecation reporting

### DIFF
--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -32,6 +32,9 @@ import { bfsPropTree, ExpandedPropSpec } from "../spec/props.ts";
 import { PropSpec } from "../bindings/PropSpec.ts";
 import { pruneCfAssets } from "../pipeline-steps/pruneCfAssets.ts";
 import { removeUnneededAssets } from "../pipeline-steps/removeUnneededAssets.ts";
+import {
+  reportDeprecatedAssets,
+} from "../pipeline-steps/reportDeprecatedAssets.ts";
 
 const logger = _logger.ns("siSpecs").seal();
 const SI_SPEC_DIR = "si-specs";
@@ -99,6 +102,9 @@ export async function generateSiSpecs(
   // These need everything to be complete
   specs = generateAssetFuncs(specs);
   specs = updateSchemaIdsForExistingSpecs(existing_specs, specs);
+
+  // Reporting steps
+  reportDeprecatedAssets(existing_specs, specs);
 
   // WRITE OUTS SPECS
   await emptyDirectory(SI_SPEC_DIR);

--- a/bin/clover/src/pipeline-steps/reportDeprecatedAssets.ts
+++ b/bin/clover/src/pipeline-steps/reportDeprecatedAssets.ts
@@ -1,0 +1,34 @@
+import _logger from "../logger.ts";
+import _ from "npm:lodash";
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+import {
+  deprecateConstructorEntries,
+} from "npm:formdata-node@4.4.1/@type/deprecateConstructorEntries.d.ts";
+const logger = _logger.ns("reportDeprecated").seal();
+
+export function reportDeprecatedAssets(
+  existing_specs: Record<string, string>,
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const deprecatedSpecs = _.clone(existing_specs);
+
+  for (const spec of specs) {
+    if (deprecatedSpecs[spec.name]) {
+      logger.debug(`Found existing spec ${spec.name}`);
+      delete deprecatedSpecs[spec.name];
+    }
+  }
+
+  const deprecatedSpecNames = _.keys(deprecatedSpecs);
+  if (deprecatedSpecNames.length) {
+    logger.warn(
+      `${deprecatedSpecNames.length} asset(s) haven't been generated but are on module index. They've been saved to existing-packages/deprecatedSpecs.json`,
+    );
+    Deno.writeTextFileSync(
+      "existing-packages/deprecatedSpecs.json",
+      JSON.stringify(deprecatedSpecs, null, 2),
+    );
+  }
+
+  return specs;
+}

--- a/bin/clover/src/specPipeline.ts
+++ b/bin/clover/src/specPipeline.ts
@@ -12,9 +12,9 @@ import {
 } from "./spec/pkgs.ts";
 
 export function pkgSpecFromCf(cfSchema: CfSchema): ExpandedPkgSpec {
-  const [aws, category, name] = cfSchema.typeName.split("::");
+  const [metaCategory, category, name] = cfSchema.typeName.split("::");
 
-  if (!["AWS", "Alexa"].includes(aws) || !category || !name) {
+  if (!["AWS", "Alexa"].includes(metaCategory) || !category || !name) {
     throw `Bad typeName: ${cfSchema.typeName}`;
   }
 
@@ -78,7 +78,7 @@ export function pkgSpecFromCf(cfSchema: CfSchema): ExpandedPkgSpec {
     name: cfSchema.typeName,
     data: {
       name: cfSchema.typeName,
-      category: `AWS ${category}`,
+      category: `${metaCategory}::${category}`,
       categoryName: null,
       uiHidden: false,
       defaultSchemaVariant: variantUniqueKey,


### PR DESCRIPTION
Adds "::" to category names and adds a warning log on the clover generator when it notices that the module index has specs that are not generated anymore, meaning they've probably been removed by AWS

<img src="https://media1.tenor.com/m/-1l5zsQ5354AAAAC/lit-old-lady.gif">