### PR TITLE
fix(web): as the builtins are cached and returned when we list variants, we don't need to hit the module index directly anymore.

### DIFF
--- a/app/web/src/components/modules/ModuleListPanel.vue
+++ b/app/web/src/components/modules/ModuleListPanel.vue
@@ -100,5 +100,6 @@ const filteredRemoteList = computed(() => {
 
 onMounted(() => {
   moduleStore.GET_REMOTE_MODULES_LIST({ su: true });
+  moduleStore.LIST_BUILTINS();
 });
 </script>

--- a/app/web/src/store/module.store.ts
+++ b/app/web/src/store/module.store.ts
@@ -514,7 +514,6 @@ export const useModuleStore = () => {
           ) {
             await this.LOAD_LOCAL_MODULES();
           }
-          await this.LIST_BUILTINS();
 
           realtimeStore.subscribe(this.$id, `workspace/${workspaceId}`, [
             {


### PR DESCRIPTION
We do want to it in in our module management tab though, so moving this to only run when that tab is activated

I tested this by ensuring the asset list still includes uninstalled modules that have been cached and I don't see unnecessary calls to list builtins, and seeing that we only call out to the module index when loading the internal only module management tab

<div><img src="https://media4.giphy.com/media/ZEHkIJQXaRG5YohwpS/giphy.gif?cid=5a38a5a2cfbyyavq1ylm00gbp5q8fri5k8i8s8gmi0m374i4&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/tvland/">TV Land</a> on <a href="https://giphy.com/gifs/tvland-gg-golden-girls-goldengirls-ZEHkIJQXaRG5YohwpS">GIPHY</a></div>