### PR TITLE
feat(clover, hoist): Ignore quicksight, module listing on hoist

### DIFF
--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -114,7 +114,12 @@ export async function generateSiSpecs(
 
     try {
       logger.debug(`Writing ${name}.json`);
-      await Deno.writeTextFile(`${SI_SPEC_DIR}/${name}.json`, specJson);
+      const blob = new Blob([specJson]);
+      if (blob.size > 4 * 1024 * 1024) {
+        logger.warn(`${spec.name} is bigger than 4MBs. Skipping.`);
+        continue;
+      }
+      await Deno.writeFile(`${SI_SPEC_DIR}/${name}.json`, blob.stream());
     } catch (e) {
       console.log(`Error writing to file: ${name}: ${e}`);
       continue;

--- a/bin/clover/src/pipeline-steps/removeUnneededAssets.ts
+++ b/bin/clover/src/pipeline-steps/removeUnneededAssets.ts
@@ -1,11 +1,11 @@
 import _logger from "../logger.ts";
 import _ from "npm:lodash";
 import { ExpandedPkgSpec } from "../spec/pkgs.ts";
-
+const IGNORED_CATEGORIES = ["AWS::IAM::", "AWS::QuickSight::"];
 export function removeUnneededAssets(
   specs: ExpandedPkgSpec[],
 ): ExpandedPkgSpec[] {
   return specs.filter(({ schemas: [{ variants: [variant] }] }) =>
-    !variant.cfSchema.typeName.startsWith("AWS::IAM::")
+    !IGNORED_CATEGORIES.find((c) => variant.cfSchema.typeName.startsWith(c))
   );
 }

--- a/bin/clover/src/pipeline-steps/reportDeprecatedAssets.ts
+++ b/bin/clover/src/pipeline-steps/reportDeprecatedAssets.ts
@@ -1,9 +1,6 @@
 import _logger from "../logger.ts";
 import _ from "npm:lodash";
 import { ExpandedPkgSpec } from "../spec/pkgs.ts";
-import {
-  deprecateConstructorEntries,
-} from "npm:formdata-node@4.4.1/@type/deprecateConstructorEntries.d.ts";
 const logger = _logger.ns("reportDeprecated").seal();
 
 export function reportDeprecatedAssets(


### PR DESCRIPTION
Remove quicksight modules since they were huge. Also hoist gives you the option of listing the modules before pushing
<img width="693" alt="image" src="https://github.com/user-attachments/assets/98708de9-d8b1-4984-8048-9258c002b912" />
