### PR TITLE
chore(dal): simplify tests that get schema/variants by name

### DIFF
--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -111,10 +111,9 @@ impl SchemaKey for Schema {
 }
 impl SchemaKey for str {
     async fn lookup_schema(&self, ctx: &DalContext) -> SchemaId {
-        Schema::find_by_name(ctx, self)
+        Schema::get_by_name(ctx, self)
             .await
             .expect("find schema by name")
-            .expect("schema exists")
             .id()
     }
 }

--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -72,10 +72,7 @@ pub async fn create_unlocked_variant_copy_for_schema_name(
     ctx: &DalContext,
     schema_name: impl AsRef<str>,
 ) -> Result<SchemaVariantId> {
-    let schema = Schema::find_by_name(ctx, schema_name)
-        .await?
-        .ok_or(eyre!("schema not found"))?;
-    let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id()).await?;
+    let schema_variant_id = SchemaVariant::default_id_for_schema_name(ctx, schema_name).await?;
     let unlocked_copy_sv =
         VariantAuthoringClient::create_unlocked_variant_copy(ctx, schema_variant_id)
             .await?
@@ -102,10 +99,7 @@ pub async fn create_component_for_default_schema_name(
     name: impl AsRef<str>,
     view_id: ViewId,
 ) -> Result<Component> {
-    let schema = Schema::find_by_name(ctx, schema_name)
-        .await?
-        .ok_or(eyre!("schema not found"))?;
-    let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id()).await?;
+    let schema_variant_id = SchemaVariant::default_id_for_schema_name(ctx, schema_name).await?;
 
     Ok(Component::new(ctx, name.as_ref().to_string(), schema_variant_id, view_id).await?)
 }
@@ -117,9 +111,7 @@ pub async fn create_component_for_unlocked_schema_name_on_default_view(
     schema_name: impl AsRef<str>,
     name: impl AsRef<str>,
 ) -> Result<Component> {
-    let schema = Schema::find_by_name(ctx, schema_name)
-        .await?
-        .ok_or(eyre!("schema not found"))?;
+    let schema = Schema::get_by_name(ctx, schema_name).await?;
     let schema_variant_id = SchemaVariant::get_unlocked_for_schema(ctx, schema.id())
         .await?
         .ok_or(eyre!("no unlocked schema variant for schema name"))?;
@@ -142,10 +134,7 @@ pub async fn create_component_for_schema_name_with_type_on_default_view(
     name: impl AsRef<str>,
     component_type: ComponentType,
 ) -> Result<Component> {
-    let schema = Schema::find_by_name(ctx, schema_name)
-        .await?
-        .ok_or(eyre!("schema not found"))?;
-    let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id()).await?;
+    let schema_variant_id = SchemaVariant::default_id_for_schema_name(ctx, schema_name).await?;
 
     let view_id = ExpectView::get_id_for_default(ctx).await;
 

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -3680,7 +3680,7 @@ impl Component {
         let schema_variant = self.schema_variant(ctx).await?;
         let schema = self.schema(ctx).await?;
         let default_schema_variant_id =
-            SchemaVariant::get_default_id_for_schema(ctx, schema.id()).await?;
+            SchemaVariant::default_id_for_schema(ctx, schema.id()).await?;
 
         let newest_schema_variant_id =
             match SchemaVariant::get_unlocked_for_schema(ctx, schema.id()).await? {

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -485,7 +485,7 @@ impl FuncBinding {
                     }
                     None => {
                         let default_for_schema =
-                            SchemaVariant::get_default_id_for_schema(ctx, schema).await?;
+                            SchemaVariant::default_id_for_schema(ctx, schema).await?;
 
                         schema_default_map.insert(schema, default_for_schema);
 

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -105,7 +105,7 @@ impl PkgExporter {
         let mut funcs = vec![];
         let schema_is_builtin = schema.is_builtin();
 
-        let default_variant = SchemaVariant::get_default_for_schema(ctx, schema.id()).await?;
+        let default_variant = SchemaVariant::default_for_schema(ctx, schema.id()).await?;
 
         let mut schema_spec_builder = SchemaSpec::builder();
         schema_spec_builder.name(schema.name());

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -897,7 +897,7 @@ impl SchemaVariant {
         let mut schema_variant_ids = Vec::new();
 
         for schema_id in Schema::list_ids(ctx).await? {
-            schema_variant_ids.push(Self::get_default_id_for_schema(ctx, schema_id).await?);
+            schema_variant_ids.push(Self::default_id_for_schema(ctx, schema_id).await?);
         }
 
         Ok(schema_variant_ids)
@@ -940,7 +940,7 @@ impl SchemaVariant {
                 .is_none())
     }
 
-    pub async fn get_latest_for_schema(
+    pub async fn latest_for_schema(
         ctx: &DalContext,
         schema_id: SchemaId,
     ) -> SchemaVariantResult<Option<Self>> {
@@ -951,7 +951,7 @@ impl SchemaVariant {
         Ok(variants.last().cloned())
     }
 
-    pub async fn get_default_for_schema(
+    pub async fn default_for_schema(
         ctx: &DalContext,
         schema_id: SchemaId,
     ) -> SchemaVariantResult<Self> {
@@ -961,7 +961,7 @@ impl SchemaVariant {
         Self::get_by_id_or_error(ctx, default_schema_variant_id).await
     }
 
-    pub async fn get_default_id_for_schema(
+    pub async fn default_id_for_schema(
         ctx: &DalContext,
         schema_id: SchemaId,
     ) -> SchemaVariantResult<SchemaVariantId> {
@@ -969,6 +969,23 @@ impl SchemaVariant {
             Schema::get_default_schema_variant_by_id_or_error(ctx, schema_id).await?;
         Ok(default_schema_variant_id)
     }
+
+    pub async fn default_for_schema_name(
+        ctx: &DalContext,
+        name: impl AsRef<str>,
+    ) -> SchemaVariantResult<Self> {
+        let schema_id = Schema::get_by_name(ctx, name).await?.id();
+        Self::default_for_schema(ctx, schema_id).await
+    }
+
+    pub async fn default_id_for_schema_name(
+        ctx: &DalContext,
+        name: impl AsRef<str>,
+    ) -> SchemaVariantResult<SchemaVariantId> {
+        let schema_id = Schema::get_by_name(ctx, name).await?.id();
+        Self::default_id_for_schema(ctx, schema_id).await
+    }
+
     pub async fn list_for_schema(
         ctx: &DalContext,
         schema_id: SchemaId,
@@ -1082,7 +1099,7 @@ impl SchemaVariant {
     ) -> SchemaVariantResult<bool> {
         let schema_id = Self::schema_id_for_schema_variant_id(ctx, id).await?;
 
-        Ok(Self::get_default_id_for_schema(ctx, schema_id).await? == id)
+        Ok(Self::default_id_for_schema(ctx, schema_id).await? == id)
     }
 
     pub async fn is_default(&self, ctx: &DalContext) -> SchemaVariantResult<bool> {
@@ -2379,7 +2396,7 @@ impl SchemaVariant {
         let mut schema_variants = HashMap::new();
 
         for schema_id in Schema::list_ids(ctx).await? {
-            let default_schema_variant = Self::get_default_for_schema(ctx, schema_id).await?;
+            let default_schema_variant = Self::default_for_schema(ctx, schema_id).await?;
             if !default_schema_variant.ui_hidden() {
                 schema_variants.insert(
                     default_schema_variant.id,

--- a/lib/dal/src/schema/variant/metadata_view.rs
+++ b/lib/dal/src/schema/variant/metadata_view.rs
@@ -32,7 +32,7 @@ impl SchemaVariantMetadataView {
         let schemas = Schema::list(ctx).await?;
         for schema in schemas {
             let default_schema_variant =
-                SchemaVariant::get_default_for_schema(ctx, schema.id()).await?;
+                SchemaVariant::default_for_schema(ctx, schema.id()).await?;
             views.push(SchemaVariantMetadataView {
                 id: schema.id,
                 default_schema_variant_id: default_schema_variant.id,

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -5,9 +5,8 @@ use pretty_assertions_sorted::assert_eq;
 
 #[test]
 async fn find_for_prop(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "swifty")
+    let schema = Schema::get_by_name(ctx, "swifty")
         .await
-        .expect("unable to get schema")
         .expect("schema not found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)

--- a/lib/dal/tests/integration_test/audit_logging.rs
+++ b/lib/dal/tests/integration_test/audit_logging.rs
@@ -24,9 +24,8 @@ async fn round_trip(ctx: &mut DalContext, audit_database_context: AuditDatabaseC
     let context = audit_database_context;
 
     // Collect schema information.
-    let schema = Schema::find_by_name(ctx, "swifty")
+    let schema = Schema::get_by_name(ctx, "swifty")
         .await
-        .expect("could not perform find by name")
         .expect("schema not found by name");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)

--- a/lib/dal/tests/integration_test/component/delete.rs
+++ b/lib/dal/tests/integration_test/component/delete.rs
@@ -160,9 +160,8 @@ async fn delete_on_already_to_delete_does_not_enqueue_destroy_action(ctx: &mut D
 #[test]
 async fn delete_updates_downstream_components(ctx: &mut DalContext) {
     // Get the source schema variant id.
-    let docker_image_schema = Schema::find_by_name(ctx, "Docker Image")
+    let docker_image_schema = Schema::get_by_name(ctx, "Docker Image")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let mut docker_image_schema_variants =
         SchemaVariant::list_for_schema(ctx, docker_image_schema.id())
@@ -174,9 +173,8 @@ async fn delete_updates_downstream_components(ctx: &mut DalContext) {
     let docker_image_schema_variant_id = docker_image_schema_variant.id();
 
     // Get the destination schema variant id.
-    let butane_schema = Schema::find_by_name(ctx, "Butane")
+    let butane_schema = Schema::get_by_name(ctx, "Butane")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let mut butane_schema_variants = SchemaVariant::list_for_schema(ctx, butane_schema.id())
         .await
@@ -334,9 +332,8 @@ async fn delete_updates_downstream_components(ctx: &mut DalContext) {
 #[test]
 async fn delete_undo_updates_inputs(ctx: &mut DalContext) {
     // Get the source schema variant id.
-    let docker_image_schema = Schema::find_by_name(ctx, "Docker Image")
+    let docker_image_schema = Schema::get_by_name(ctx, "Docker Image")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let mut docker_image_schema_variants =
         SchemaVariant::list_for_schema(ctx, docker_image_schema.id())
@@ -348,9 +345,8 @@ async fn delete_undo_updates_inputs(ctx: &mut DalContext) {
     let docker_image_schema_variant_id = docker_image_schema_variant.id();
 
     // Get the destination schema variant id.
-    let butane_schema = Schema::find_by_name(ctx, "Butane")
+    let butane_schema = Schema::get_by_name(ctx, "Butane")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let mut butane_schema_variants = SchemaVariant::list_for_schema(ctx, butane_schema.id())
         .await

--- a/lib/dal/tests/integration_test/connection.rs
+++ b/lib/dal/tests/integration_test/connection.rs
@@ -274,9 +274,8 @@ async fn make_chain_remove_middle(ctx: &mut DalContext) {
 #[test]
 async fn connect_and_disconnect_components_explicit_connection(ctx: &mut DalContext) {
     // Get the source schema variant id.
-    let docker_image_schema = Schema::find_by_name(ctx, "Docker Image")
+    let docker_image_schema = Schema::get_by_name(ctx, "Docker Image")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let mut docker_image_schema_variants =
         SchemaVariant::list_for_schema(ctx, docker_image_schema.id())
@@ -288,9 +287,8 @@ async fn connect_and_disconnect_components_explicit_connection(ctx: &mut DalCont
     let docker_image_schema_variant_id = docker_image_schema_variant.id();
 
     // Get the destination schema variant id.
-    let butane_schema = Schema::find_by_name(ctx, "Butane")
+    let butane_schema = Schema::get_by_name(ctx, "Butane")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let mut butane_schema_variants = SchemaVariant::list_for_schema(ctx, butane_schema.id())
         .await
@@ -548,9 +546,8 @@ async fn connect_to_one_destination_with_multiple_candidates_of_same_schema_vari
 #[test]
 async fn remove_connection(ctx: &mut DalContext) {
     // Get the source schema variant id.
-    let docker_image_schema = Schema::find_by_name(ctx, "Docker Image")
+    let docker_image_schema = Schema::get_by_name(ctx, "Docker Image")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let mut docker_image_schema_variants =
         SchemaVariant::list_for_schema(ctx, docker_image_schema.id())
@@ -562,9 +559,8 @@ async fn remove_connection(ctx: &mut DalContext) {
     let docker_image_schema_variant_id = docker_image_schema_variant.id();
 
     // Get the destination schema variant id.
-    let butane_schema = Schema::find_by_name(ctx, "Butane")
+    let butane_schema = Schema::get_by_name(ctx, "Butane")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let mut butane_schema_variants = SchemaVariant::list_for_schema(ctx, butane_schema.id())
         .await

--- a/lib/dal/tests/integration_test/dependent_values_update.rs
+++ b/lib/dal/tests/integration_test/dependent_values_update.rs
@@ -13,9 +13,8 @@ use veritech_client::ResourceStatus;
 #[test]
 async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
     // Get the source schema variant id.
-    let docker_image_schema = Schema::find_by_name(ctx, "Docker Image")
+    let docker_image_schema = Schema::get_by_name(ctx, "Docker Image")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let mut docker_image_schema_variants =
         SchemaVariant::list_for_schema(ctx, docker_image_schema.id())
@@ -27,9 +26,8 @@ async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
     let docker_image_schema_variant_id = docker_image_schema_variant.id();
 
     // Get the destination schema variant id.
-    let butane_schema = Schema::find_by_name(ctx, "Butane")
+    let butane_schema = Schema::get_by_name(ctx, "Butane")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let mut butane_schema_variants = SchemaVariant::list_for_schema(ctx, butane_schema.id())
         .await
@@ -207,9 +205,8 @@ async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
 #[test]
 async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
     // Get the source schema variant id.
-    let docker_image_schema = Schema::find_by_name(ctx, "Docker Image")
+    let docker_image_schema = Schema::get_by_name(ctx, "Docker Image")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let mut docker_image_schema_variants =
         SchemaVariant::list_for_schema(ctx, docker_image_schema.id())
@@ -221,9 +218,8 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
     let docker_image_schema_variant_id = docker_image_schema_variant.id();
 
     // Get the destination schema variant id.
-    let butane_schema = Schema::find_by_name(ctx, "Butane")
+    let butane_schema = Schema::get_by_name(ctx, "Butane")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let mut butane_schema_variants = SchemaVariant::list_for_schema(ctx, butane_schema.id())
         .await

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -126,13 +126,11 @@ async fn frames_and_connections(ctx: &mut DalContext) {
 
 #[test]
 async fn convert_component_to_frame_and_attach_no_nesting(ctx: &mut DalContext) {
-    let starfield_schema = Schema::find_by_name(ctx, "starfield")
+    let starfield_schema = Schema::get_by_name(ctx, "starfield")
         .await
-        .expect("could not perform find by name")
         .expect("schema not found by name");
-    let fallout_schema = Schema::find_by_name(ctx, "fallout")
+    let fallout_schema = Schema::get_by_name(ctx, "fallout")
         .await
-        .expect("could not perform find by name")
         .expect("schema not found by name");
 
     // Create components using the test exclusive schemas. Neither of them should be frames.
@@ -232,13 +230,11 @@ async fn convert_component_to_frame_and_attach_no_nesting(ctx: &mut DalContext) 
 
 #[test]
 async fn simple_frames(ctx: &mut DalContext) {
-    let swifty_schema = Schema::find_by_name(ctx, "swifty")
+    let swifty_schema = Schema::get_by_name(ctx, "swifty")
         .await
-        .expect("could not perform find by name")
         .expect("schema not found by name");
-    let fallout_schema = Schema::find_by_name(ctx, "fallout")
+    let fallout_schema = Schema::get_by_name(ctx, "fallout")
         .await
-        .expect("could not perform find by name")
         .expect("schema not found by name");
 
     // Collect schema variants.
@@ -1910,13 +1906,11 @@ async fn up_frames_multiple_children_moves_and_deletes(ctx: &mut DalContext) {
 
 #[test]
 async fn multiple_frames_with_complex_connections_no_nesting(ctx: &mut DalContext) {
-    let swifty_schema = Schema::find_by_name(ctx, "swifty")
+    let swifty_schema = Schema::get_by_name(ctx, "swifty")
         .await
-        .expect("could not perform find by name")
         .expect("schema not found by name");
-    let fallout_schema = Schema::find_by_name(ctx, "fallout")
+    let fallout_schema = Schema::get_by_name(ctx, "fallout")
         .await
-        .expect("could not perform find by name")
         .expect("schema not found by name");
 
     // Collect schema variants.

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -9,11 +9,10 @@ mod authoring;
 
 #[test]
 async fn summary(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "starfield")
+    let schema = Schema::get_by_name(ctx, "starfield")
         .await
-        .expect("could not find schema")
         .expect("schema not found");
-    let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+    let schema_variant_id = SchemaVariant::default_id_for_schema(ctx, schema.id())
         .await
         .expect("no schema variant found");
 
@@ -75,9 +74,8 @@ async fn duplicate(ctx: &mut DalContext) {
 
 #[test]
 async fn get_ts_type_from_root(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "starfield")
+    let schema = Schema::get_by_name(ctx, "starfield")
         .await
-        .expect("could not perform find by name")
         .expect("schema not found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)

--- a/lib/dal/tests/integration_test/func/authoring/binding.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding.rs
@@ -144,9 +144,8 @@ async fn get_bindings_for_latest_schema_variants(ctx: &mut DalContext) {
 
 #[test]
 async fn for_action(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "swifty")
+    let schema = Schema::get_by_name(ctx, "swifty")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)
@@ -177,9 +176,8 @@ async fn for_action(ctx: &mut DalContext) {
 
 #[test]
 async fn for_qualification(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "dummy-secret")
+    let schema = Schema::get_by_name(ctx, "dummy-secret")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)
@@ -212,9 +210,8 @@ async fn for_qualification(ctx: &mut DalContext) {
 
 #[test]
 async fn for_code_generation(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "katy perry")
+    let schema = Schema::get_by_name(ctx, "katy perry")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)
@@ -245,9 +242,8 @@ async fn for_code_generation(ctx: &mut DalContext) {
 
 #[test]
 async fn for_authentication(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "dummy-secret")
+    let schema = Schema::get_by_name(ctx, "dummy-secret")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)
@@ -286,9 +282,8 @@ async fn for_attribute_with_prop_input(ctx: &mut DalContext) {
         .pop()
         .expect("got the binding");
 
-    let schema = Schema::find_by_name(ctx, "starfield")
+    let schema = Schema::get_by_name(ctx, "starfield")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)
@@ -395,9 +390,8 @@ async fn for_attribute_with_input_socket_input(ctx: &mut DalContext) {
         .pop()
         .expect("got the binding");
 
-    let schema = Schema::find_by_name(ctx, "starfield")
+    let schema = Schema::get_by_name(ctx, "starfield")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)
@@ -480,9 +474,8 @@ async fn for_attribute_with_input_socket_input(ctx: &mut DalContext) {
 
 #[test]
 async fn for_intrinsics(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "starfield")
+    let schema = Schema::get_by_name(ctx, "starfield")
         .await
-        .expect("unable to get schema")
         .expect("schema not found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)
@@ -688,9 +681,8 @@ async fn for_intrinsics(ctx: &mut DalContext) {
 
 #[test]
 async fn code_gen_cannot_create_cycle(ctx: &mut DalContext) {
-    let _schema = Schema::find_by_name(ctx, "katy perry")
+    let _schema = Schema::get_by_name(ctx, "katy perry")
         .await
-        .expect("could not perform find by name")
         .expect("no schema found");
     let schema_variant_id = create_unlocked_variant_copy_for_schema_name(ctx, "katy perry")
         .await

--- a/lib/dal/tests/integration_test/func/authoring/binding/action.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding/action.rs
@@ -5,7 +5,7 @@ use dal::func::authoring::FuncAuthoringClient;
 use dal::func::binding::action::ActionBinding;
 use dal::func::binding::FuncBinding;
 use dal::schema::variant::authoring::VariantAuthoringClient;
-use dal::{DalContext, Func, Schema, SchemaVariant};
+use dal::{DalContext, Func, SchemaVariant};
 use dal_test::helpers::{
     create_component_for_unlocked_schema_name_on_default_view, ChangeSetTestHelpers,
 };
@@ -13,11 +13,7 @@ use dal_test::test;
 
 #[test]
 async fn attach_multiple_action_funcs(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "katy perry")
-        .await
-        .expect("unable to find by name")
-        .expect("no schema found");
-    let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+    let schema_variant_id = SchemaVariant::default_id_for_schema_name(ctx, "katy perry")
         .await
         .expect("unable to get default schema variant");
 
@@ -74,11 +70,7 @@ async fn attach_multiple_action_funcs(ctx: &mut DalContext) {
 
 #[test]
 async fn error_when_attaching_an_exisiting_type(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "fallout")
-        .await
-        .expect("unable to find by name")
-        .expect("no schema found");
-    let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+    let schema_variant_id = SchemaVariant::default_id_for_schema_name(ctx, "fallout")
         .await
         .expect("unable to get default schema variant");
     let func_id = Func::find_id_by_name(ctx, "test:createActionFallout")
@@ -131,11 +123,7 @@ async fn detach_attach_then_delete_action_func_while_enqueued(ctx: &mut DalConte
                 .expect("could get hold status");
         true
     }
-    let schema = Schema::find_by_name(ctx, "starfield")
-        .await
-        .expect("unable to find by name")
-        .expect("no schema found");
-    let old_schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+    let old_schema_variant_id = SchemaVariant::default_id_for_schema_name(ctx, "starfield")
         .await
         .expect("unable to get default schema variant");
 

--- a/lib/dal/tests/integration_test/func/authoring/binding/attribute.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding/attribute.rs
@@ -45,9 +45,8 @@ async fn create_attribute_prototype_with_attribute_prototype_argument(ctx: &mut 
     );
 
     // Cache the variables we need.
-    let schema = Schema::find_by_name(ctx, "starfield")
+    let schema = Schema::get_by_name(ctx, "starfield")
         .await
-        .expect("could not execute find schema")
         .expect("schema not found");
     let schema_variant_id = SchemaVariant::get_unlocked_for_schema(ctx, schema.id())
         .await
@@ -828,11 +827,7 @@ async fn detach_attribute_func(ctx: &mut DalContext) {
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("commit and update snapshot");
-    let schema = Schema::find_by_name(ctx, "starfield")
-        .await
-        .expect("unable to find by name")
-        .expect("no schema found");
-    let default_schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+    let default_schema_variant_id = SchemaVariant::default_id_for_schema_name(ctx, "starfield")
         .await
         .expect("unable to get default schema variant");
 

--- a/lib/dal/tests/integration_test/func/authoring/binding/authentication.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding/authentication.rs
@@ -7,11 +7,7 @@ use dal_test::test;
 
 #[test]
 async fn attach_multiple_auth_funcs_with_creation(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "katy perry")
-        .await
-        .expect("unable to find by name")
-        .expect("no schema found");
-    let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+    let schema_variant_id = SchemaVariant::default_id_for_schema_name(ctx, "katy perry")
         .await
         .expect("unable to get default schema variant");
 
@@ -67,11 +63,7 @@ async fn attach_multiple_auth_funcs_with_creation(ctx: &mut DalContext) {
 
 #[test]
 async fn detach_auth_func(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "dummy-secret")
-        .await
-        .expect("unable to find by name")
-        .expect("no schema found");
-    let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+    let schema_variant_id = SchemaVariant::default_id_for_schema_name(ctx, "dummy-secret")
         .await
         .expect("unable to get default schema variant");
 
@@ -117,12 +109,11 @@ async fn edit_auth_func(ctx: &mut DalContext) {
         .await
         .expect("could not fork head");
     // find the variant we know is default and attached to this func already
-    let schema = Schema::find_by_name(ctx, "dummy-secret")
+    let schema = Schema::get_by_name(ctx, "dummy-secret")
         .await
-        .expect("unable to find by name")
         .expect("no schema found");
 
-    let schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+    let schema_variant_id = SchemaVariant::default_id_for_schema(ctx, schema.id())
         .await
         .expect("unable to get default schema variant");
     // Cache the total number of funcs before continuing.
@@ -206,7 +197,7 @@ async fn edit_auth_func(ctx: &mut DalContext) {
     );
 
     //ensure new schema variant is locked and default
-    let maybe_locked_schema_variant_id = SchemaVariant::get_default_id_for_schema(ctx, schema.id())
+    let maybe_locked_schema_variant_id = SchemaVariant::default_id_for_schema(ctx, schema.id())
         .await
         .expect("unable to get default schema variant");
     let maybe_locked_schema_variant =

--- a/lib/dal/tests/integration_test/func/authoring/create_func.rs
+++ b/lib/dal/tests/integration_test/func/authoring/create_func.rs
@@ -15,12 +15,10 @@ use dal_test::test;
 
 #[test]
 async fn create_qualification_with_schema_variant(ctx: &mut DalContext) {
-    let maybe_swifty_schema = Schema::find_by_name(ctx, "swifty")
+    let swifty_schema = Schema::get_by_name(ctx, "swifty")
         .await
         .expect("unable to get schema");
-    assert!(maybe_swifty_schema.is_some());
 
-    let swifty_schema = maybe_swifty_schema.unwrap();
     let maybe_sv_id = swifty_schema
         .get_default_schema_variant_id(ctx)
         .await
@@ -90,12 +88,10 @@ async fn create_qualification_with_schema_variant(ctx: &mut DalContext) {
 
 #[test]
 async fn create_codegen_with_schema_variant(ctx: &mut DalContext) {
-    let maybe_swifty_schema = Schema::find_by_name(ctx, "swifty")
+    let swifty_schema = Schema::get_by_name(ctx, "swifty")
         .await
         .expect("unable to get schema");
-    assert!(maybe_swifty_schema.is_some());
 
-    let swifty_schema = maybe_swifty_schema.unwrap();
     let maybe_sv_id = swifty_schema
         .get_default_schema_variant_id(ctx)
         .await
@@ -153,9 +149,8 @@ async fn create_codegen_with_schema_variant(ctx: &mut DalContext) {
 
 #[test]
 async fn create_attribute_override_dynamic_func_for_prop(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "swifty")
+    let schema = Schema::get_by_name(ctx, "swifty")
         .await
-        .expect("unable to find schema by name")
         .expect("schema not found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)
@@ -230,9 +225,8 @@ async fn create_attribute_override_dynamic_func_for_prop(ctx: &mut DalContext) {
 
 #[test]
 async fn create_attribute_override_dynamic_func_for_output_socket(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "swifty")
+    let schema = Schema::get_by_name(ctx, "swifty")
         .await
-        .expect("unable to find schema by name")
         .expect("schema not found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)
@@ -304,12 +298,10 @@ async fn create_attribute_override_dynamic_func_for_output_socket(ctx: &mut DalC
 
 #[test]
 async fn create_action_with_schema_variant(ctx: &mut DalContext) {
-    let maybe_swifty_schema = Schema::find_by_name(ctx, "small even lego")
+    let swifty_schema = Schema::get_by_name(ctx, "small even lego")
         .await
         .expect("unable to get schema");
-    assert!(maybe_swifty_schema.is_some());
 
-    let swifty_schema = maybe_swifty_schema.unwrap();
     let maybe_sv_id = swifty_schema
         .get_default_schema_variant_id(ctx)
         .await

--- a/lib/dal/tests/integration_test/func/authoring/save_func/attribute.rs
+++ b/lib/dal/tests/integration_test/func/authoring/save_func/attribute.rs
@@ -35,9 +35,8 @@ async fn create_attribute_prototype_with_attribute_prototype_argument(ctx: &mut 
     );
 
     // Cache the variables we need.
-    let schema = Schema::find_by_name(ctx, "starfield")
+    let schema = Schema::get_by_name(ctx, "starfield")
         .await
-        .expect("could not find schema")
         .expect("schema not found");
     let schema_variant_id = SchemaVariant::get_unlocked_for_schema(ctx, schema.id())
         .await

--- a/lib/dal/tests/integration_test/module.rs
+++ b/lib/dal/tests/integration_test/module.rs
@@ -75,9 +75,8 @@ async fn get_fallout_module(ctx: &DalContext) {
 
 #[test]
 async fn module_export_simple(ctx: &mut DalContext) {
-    let schema = Schema::find_by_name(ctx, "dummy-secret")
+    let schema = Schema::get_by_name(ctx, "dummy-secret")
         .await
-        .expect("unable to get schema")
         .expect("schema not found");
 
     let default_schema_variant = schema
@@ -169,9 +168,8 @@ async fn module_export_simple(ctx: &mut DalContext) {
 
 #[test]
 async fn prepare_contribution_works(ctx: &DalContext) {
-    let schema = Schema::find_by_name(ctx, "swifty")
+    let schema = Schema::get_by_name(ctx, "swifty")
         .await
-        .expect("could not find by name")
         .expect("schema not found");
     let name = "Paul's Test Pkg With Extra Spaces At The End    ";
     let version = "    Version With Spaces At The Beginning 2019-06-03";

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -109,9 +109,8 @@ async fn verify_prop_used_as_input_flag(ctx: &DalContext) {
 
 #[test]
 async fn ordered_child_props(ctx: &DalContext) {
-    let schema = Schema::find_by_name(ctx, "starfield")
+    let schema = Schema::get_by_name(ctx, "starfield")
         .await
-        .expect("could not perform find by name")
         .expect("schema not found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -106,9 +106,8 @@ async fn list_root_si_child_props(ctx: &DalContext) {
 
 #[test]
 async fn all_prop_ids(ctx: &DalContext) {
-    let schema = Schema::find_by_name(ctx, "starfield")
+    let schema = Schema::get_by_name(ctx, "starfield")
         .await
-        .expect("unable to get schema")
         .expect("schema not found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)
@@ -187,9 +186,8 @@ async fn all_prop_ids(ctx: &DalContext) {
 
 #[test]
 async fn all_funcs(ctx: &DalContext) {
-    let schema = Schema::find_by_name(ctx, "swifty")
+    let schema = Schema::get_by_name(ctx, "swifty")
         .await
-        .expect("unable to get schema")
         .expect("schema not found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)
@@ -216,9 +214,8 @@ async fn all_funcs(ctx: &DalContext) {
     );
     assert_eq!(expected, actual);
 
-    let schema = Schema::find_by_name(ctx, "starfield")
+    let schema = Schema::get_by_name(ctx, "starfield")
         .await
-        .expect("unable to get schema")
         .expect("schema not found");
     let schema_variant_id = schema
         .get_default_schema_variant_id(ctx)

--- a/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
@@ -11,9 +11,8 @@ async fn clone_variant(ctx: &mut DalContext) {
         .await
         .expect("could not update visibility");
 
-    let schema = Schema::find_by_name(ctx, "dummy-secret")
+    let schema = Schema::get_by_name(ctx, "dummy-secret")
         .await
-        .expect("unable to get schema")
         .expect("schema not found");
 
     let default_schema_variant = schema

--- a/lib/dal/tests/integration_test/schema/variant/authoring/save_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/save_variant.rs
@@ -129,9 +129,8 @@ async fn unlock_and_save_variant(ctx: &mut DalContext) {
         .await
         .expect("could not update visibility");
 
-    let schema = Schema::find_by_name(ctx, "dummy-secret")
+    let schema = Schema::get_by_name(ctx, "dummy-secret")
         .await
-        .expect("unable to get schema")
         .expect("schema not found");
     let default_schema_variant = schema
         .get_default_schema_variant_id(ctx)
@@ -231,9 +230,8 @@ async fn unlock_and_save_variant(ctx: &mut DalContext) {
         .expect("could not apply to head");
 
     // check head and make sure everything looks good
-    let schema = Schema::find_by_name(ctx, "dummy-secret")
+    let schema = Schema::get_by_name(ctx, "dummy-secret")
         .await
-        .expect("unable to get schema")
         .expect("schema not found");
     let default_schema_variant = schema
         .get_default_schema_variant_id(ctx)

--- a/lib/dal/tests/integration_test/schema/variant/view.rs
+++ b/lib/dal/tests/integration_test/schema/variant/view.rs
@@ -24,13 +24,10 @@ async fn list_schema_variant_definition_views(ctx: &DalContext) {
 
 #[test]
 async fn get_schema_variant(ctx: &DalContext) {
-    let maybe_swifty_schema = Schema::find_by_name(ctx, "swifty")
+    let swifty_schema = Schema::get_by_name(ctx, "swifty")
         .await
         .expect("unable to get schema");
 
-    assert!(maybe_swifty_schema.is_some());
-
-    let swifty_schema = maybe_swifty_schema.unwrap();
     let maybe_sv_id = swifty_schema
         .get_default_schema_variant_id(ctx)
         .await

--- a/lib/sdf-server/src/service/component/upgrade.rs
+++ b/lib/sdf-server/src/service/component/upgrade.rs
@@ -45,7 +45,7 @@ pub async fn upgrade(
     let upgrade_target_variant =
         match SchemaVariant::get_unlocked_for_schema(&ctx, schema.id()).await? {
             Some(unlocked_variant) => unlocked_variant,
-            None => SchemaVariant::get_default_for_schema(&ctx, schema.id()).await?,
+            None => SchemaVariant::default_for_schema(&ctx, schema.id()).await?,
         };
 
     // This is just a check to see if someone has made a request incorrectly!

--- a/lib/sdf-server/src/service/v2/func/list_funcs.rs
+++ b/lib/sdf-server/src/service/v2/func/list_funcs.rs
@@ -77,8 +77,7 @@ async fn treat_single_function(
                     should_hide = false;
                 }
             } else {
-                let default_for_schema =
-                    SchemaVariant::get_default_id_for_schema(ctx, schema).await?;
+                let default_for_schema = SchemaVariant::default_id_for_schema(ctx, schema).await?;
 
                 schema_default_map.insert(schema, default_for_schema);
 


### PR DESCRIPTION
Separating this PR for a few ergonomics changes for tests:

* Make Schema::find_by_name() error if schema is not found since all callers return an error themselves. This eliminates an unnecessary .expect() (Also rename to get_by_name())
* Add SchemaVariant::default_by_schema_name() since that is a primary use case in tests (we almost never need the schema itself). Did not change all tests to use, just regenerate.rs for now since it's not a purely search-and-replace)
* Use color_eyre errors in regenerate.rs to ergonomicize the tests (so we don't expect() all the time). Not doing this globally across all tests as it changes too many lines at once and isn't *quite* seach-and-replaceable

regenerate.rs tests are reduced by 15-20% with no changes; have very few expect()s breaking the flow; and many statements reduce to a single line now that the expect is gone.

## Risk Mitigation

* No behavior change.
* Only one change outside of tests: si-fs no longer has its own bespoke error when the schema is not found by name. The error message still lists the name of the schema not found.
* All tests still pass.