### PR TITLE
fix(dal): Don't attempt to autoconnect to the component to itself

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -2837,6 +2837,10 @@ impl Component {
 
         // loop through all components + output sockets
         for component in Self::list(ctx).await? {
+            // don't interrogate current component!
+            if component.id() == component_id {
+                continue;
+            }
             // build a map of component output sockets and values
             let output_sockets = component.output_socket_attribute_values(ctx).await?;
             for output_socket_av in output_sockets {


### PR DESCRIPTION
Saw this live in Tools Prod, autoconnect returned a graph cycle error because it matched on it's own output socket, whoops! This fixes that!