### PR TITLE
fix(auth-portal): Ensure a user must be email verified before proceeding

### DIFF
--- a/app/auth-portal/src/pages/BillingPage.vue
+++ b/app/auth-portal/src/pages/BillingPage.vue
@@ -163,7 +163,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as _ from "lodash-es";
-import { computed, ref, watch } from "vue";
+import { computed, ref, watch, onMounted } from "vue";
 import {
   ErrorMessage,
   Icon,
@@ -173,12 +173,14 @@ import {
   VormInput,
   VButton,
 } from "@si/vue-lib/design-system";
+import { useRouter } from "vue-router";
 import { useHead } from "@vueuse/head";
 import { useAuthStore, BillingDetails } from "@/store/auth.store";
 import { ALLOWED_INPUT_REGEX } from "@/lib/validations";
 
 const { validationMethods } = useValidatedInputGroup();
 const authStore = useAuthStore();
+const router = useRouter();
 
 const loadBillingDetailsReqStatus = authStore.getRequestStatus(
   "LOAD_BILLING_DETAILS",
@@ -484,4 +486,10 @@ const countryOptions: CountryOption[] = [
   { value: "ZM", label: "Zambia" },
   { value: "ZW", label: "Zimbabwe" },
 ];
+
+onMounted(() => {
+  if (!user.value || !user.value?.emailVerified) {
+    return router.push({ name: "profile" });
+  }
+});
 </script>

--- a/app/auth-portal/src/pages/WorkspaceAuthTokensPage.vue
+++ b/app/auth-portal/src/pages/WorkspaceAuthTokensPage.vue
@@ -122,7 +122,7 @@
 
 <script lang="ts" setup>
 import * as _ from "lodash-es";
-import { computed, ref } from "vue";
+import { computed, ref, onMounted } from "vue";
 import {
   VormInput,
   Stack,
@@ -136,7 +136,9 @@ import {
 import { useAsyncState, useIntervalFn } from "@vueuse/core";
 import { apiData } from "@si/vue-lib/pinia";
 import { useHead } from "@vueuse/head";
+import { useRouter } from "vue-router";
 import { useWorkspacesStore, WorkspaceId } from "@/store/workspaces.store";
+import { useAuthStore } from "@/store/auth.store";
 import WorkspacePageHeader from "@/components/WorkspacePageHeader.vue";
 import { AuthToken, useAuthTokensApi } from "@/store/authTokens.store";
 import AuthTokenList from "@/components/AuthTokenList.vue";
@@ -145,6 +147,8 @@ import { ALLOWED_INPUT_REGEX } from "@/lib/validations";
 useHead({ title: "API Tokens" });
 
 const workspacesStore = useWorkspacesStore();
+const router = useRouter();
+const authStore = useAuthStore();
 const api = useAuthTokensApi();
 
 const props = defineProps<{
@@ -264,4 +268,12 @@ const revokeToken = (id: string) => {
     authTokens.state.value[id].revokedAt = new Date();
   }
 };
+
+const user = computed(() => authStore.user);
+
+onMounted(() => {
+  if (!user.value || !user.value?.emailVerified) {
+    return router.push({ name: "profile" });
+  }
+});
 </script>

--- a/app/auth-portal/src/pages/WorkspaceDetailsPage.vue
+++ b/app/auth-portal/src/pages/WorkspaceDetailsPage.vue
@@ -234,7 +234,7 @@
 
 <script lang="ts" setup>
 import * as _ from "lodash-es";
-import { computed, PropType, reactive, ref, watch } from "vue";
+import { computed, PropType, reactive, ref, watch, onMounted } from "vue";
 import {
   Icon,
   VormInput,
@@ -249,6 +249,7 @@ import clsx from "clsx";
 import { useHead } from "@vueuse/head";
 import { useRouter } from "vue-router";
 import { useWorkspacesStore, WorkspaceId } from "@/store/workspaces.store";
+import { useAuthStore } from "@/store/auth.store";
 import { tracker } from "@/lib/posthog";
 import { API_HTTP_URL } from "@/store/api";
 import MemberListItem from "@/components/MemberListItem.vue";
@@ -257,6 +258,7 @@ import { ALLOWED_INPUT_REGEX } from "@/lib/validations";
 
 const workspacesStore = useWorkspacesStore();
 const router = useRouter();
+const authStore = useAuthStore();
 
 const props = defineProps({
   workspaceId: { type: String as PropType<WorkspaceId>, required: true },
@@ -477,4 +479,12 @@ const createWorkspaceTypeDropdownOptions = [
   { label: "Local Dev Instance", value: "local" },
   { label: "Remote URL", value: "url" },
 ];
+
+const user = computed(() => authStore.user);
+
+onMounted(() => {
+  if (!user.value || !user.value?.emailVerified) {
+    return router.push({ name: "profile" });
+  }
+});
 </script>

--- a/app/auth-portal/src/pages/WorkspacesPage.vue
+++ b/app/auth-portal/src/pages/WorkspacesPage.vue
@@ -150,7 +150,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, watch, ref } from "vue";
+import { computed, watch, ref, onMounted } from "vue";
 import {
   Icon,
   Timestamp,
@@ -217,6 +217,11 @@ watch(
   },
   { immediate: true },
 );
+onMounted(() => {
+  if (!user.value || !user.value?.emailVerified) {
+    return router.push({ name: "profile" });
+  }
+});
 
 const workspaceCount = computed(() => workspaces.value.length);
 const workspaceTitle = computed(() => {

--- a/bin/auth-api/src/routes/index.ts
+++ b/bin/auth-api/src/routes/index.ts
@@ -16,10 +16,14 @@ const __dirname = getThisDirname(import.meta.url);
 // to centralize error handling and make TS happier when dealing with params
 
 /// Return auth user and fail if not present
-export function extractAuthUser(ctx: CustomRouteContext) {
+export function extractAuthUser(ctx: CustomRouteContext, requiresEmailVerified = false) {
   const authUser = ctx.state.authUser;
   if (!authUser) {
     throw new ApiError("Unauthorized", "You are not logged in");
+  }
+
+  if (requiresEmailVerified && !authUser.emailVerified) {
+    throw new ApiError("Unauthorized", "You must verify your email");
   }
 
   if (authUser.quarantinedAt !== null) {


### PR DESCRIPTION
Before this commit, if you were an unverified email user you could bypass the check for email verification and create a new workspace. This prevents this.

We redirect an unverified user to the profile page if they try and hit workspaces, workspace details or billing

We also prevent these API calls in the UI by checking that the email is verified on specific routes we want to protect