### PR TITLE
fix(clover): Adding a text Widget override for EC2 Instance UserData

### DIFF
--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -119,7 +119,33 @@ const overrides = new Map<string, OverrideFn>([
      
      if (!prop) return;
      prop.data.widgetKind = "textarea";
-  }]
+  }],
+  [
+    "AWS::DataZone::Domain",
+    (spec: ExpandedPkgSpec) => {
+      const variant = spec.schemas[0].variants[0];
+
+      const socket = variant.sockets.find(
+        (s: ExpandedSocketSpec) => s.name === "Id" && s.data.kind === "output",
+      );
+      if (!socket) return;
+
+      setAnnotationOnSocket(socket, { tokens: ["Domain Identifier"] });
+    },
+  ],
+  [
+    "AWS::DataZone::Project",
+    (spec: ExpandedPkgSpec) => {
+      const variant = spec.schemas[0].variants[0];
+
+      const socket = variant.sockets.find(
+        (s: ExpandedSocketSpec) => s.name === "Id" && s.data.kind === "output",
+      );
+      if (!socket) return;
+
+      setAnnotationOnSocket(socket, { tokens: ["Project Identifier"] });
+    },
+  ],
 ]);
 
 function addSecretProp(

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -110,6 +110,16 @@ const overrides = new Map<string, OverrideFn>([
     "AWS::SecretsManager::Secret",
     addSecretProp("Secret String", "secretString", ["SecretString"]),
   ],
+  ["AWS::EC2::Instance", (spec: ExpandedPkgSpec) => {
+     const variant = spec.schemas[0].variants[0];
+     
+     const prop = variant.domain.entries.find((p: ExpandedPropSpec) =>
+       p.name === "UserData"
+     );
+     
+     if (!prop) return;
+     prop.data.widgetKind = "textarea";
+  }]
 ]);
 
 function addSecretProp(


### PR DESCRIPTION
This generates:

```
{
 624   │                 "name": "UserData",
 625   │                 "data": {
 626   │                   "name": "UserData",
 627   │                   "validationFormat": null,
 628   │                   "defaultValue": null,
 629   │                   "funcUniqueId": null,
 630   │                   "inputs": [],
 631   │                   "widgetKind": "textarea",
 632   │                   "widgetOptions": [],
 633   │                   "hidden": false,
 634   │                   "docLink": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-instance.html#cfn-ec2-instance-userdata",
 635   │                   "documentation": "The user data to make available to the instance."
 636   │                 },
 637   │                 "uniqueId": "01JMWFSVXC870RE0NY3JQA9JW5",
 638   │                 "kind": "string"
 639   │               },
```