### PR TITLE
fix(clover): Remove the cloudformation spec generated cloudformation 

### DIFF
--- a/bin/clover/src/pipeline-steps/removeUnneededAssets.ts
+++ b/bin/clover/src/pipeline-steps/removeUnneededAssets.ts
@@ -1,7 +1,7 @@
 import _logger from "../logger.ts";
 import _ from "npm:lodash";
 import { ExpandedPkgSpec } from "../spec/pkgs.ts";
-const IGNORED_CATEGORIES = ["AWS::IAM::", "AWS::QuickSight::"];
+const IGNORED_CATEGORIES = ["AWS::IAM::", "AWS::QuickSight::", "AWS::CloudFormation::Stack"];
 export function removeUnneededAssets(
   specs: ExpandedPkgSpec[],
 ): ExpandedPkgSpec[] {


### PR DESCRIPTION
~~We have the manually curated cloudformation assets that we created to bring together the end to end scenarios~~

We are going to remove AWS::Cloudformation::Stack and replace it with our own implementation