### PR TITLE
fix: amend logic in toolbox to handle situation where CDN has zero invalidations so far

### DIFF
--- a/component/toolbox/scripts/supporting-funcs/cloudfront-funcs.sh
+++ b/component/toolbox/scripts/supporting-funcs/cloudfront-funcs.sh
@@ -27,7 +27,7 @@ track_invalidations() {
     # Get the list of invalidations that are still in progress
     active_invalidations=$(aws cloudfront list-invalidations --distribution-id "$distribution_id" --query "InvalidationList.Items[?Status=='InProgress'].Id" --output text)
 
-    if [ -z "$active_invalidations" ]; then
+    if [[ -z "$active_invalidations" || "$active_invalidations" == "None" ]]; then
       return
     else
       echo "$distribution_id: Active invalidation $active_invalidations | [current time: $SECONDS / timeout: $end_time]"


### PR DESCRIPTION
We are failing to exit if an invalidation has never happened on a new CDN.

This handles that case.

<hr/>

Tested against tools prod, which is in the same situation. Two CDNs one of which is a spike CDN that has never had an invalidation.