### PR TITLE
fix(clover): ensure that we send an object out of CloudFormation Resource Socket

### DIFF
--- a/bin/clover/src/cloud-control-funcs/attribute/awsCloudControlCfAssetAttr.ts
+++ b/bin/clover/src/cloud-control-funcs/attribute/awsCloudControlCfAssetAttr.ts
@@ -6,5 +6,5 @@ async function main(input: Input): Promise<Output> {
     "Type": input.cfnType,
     "Properties": properties,
   };
-  return JSON.stringify(result);
+  return result;
 }

--- a/bin/clover/src/pipeline-steps/removeUnneededAssets.ts
+++ b/bin/clover/src/pipeline-steps/removeUnneededAssets.ts
@@ -5,6 +5,7 @@ const IGNORED_CATEGORIES = [
   "AWS::IAM::",
   "AWS::QuickSight::",
   "AWS::CloudFormation::Stack",
+  "AWS::CloudFormation::StackSet"
 ];
 export function removeUnneededAssets(
   specs: ExpandedPkgSpec[],


### PR DESCRIPTION
We don't want a string - we want the object

Also removes StackSet to go with Stack - neither work with our templates and we will remove them for now