### PR TITLE
feat(si-pkg): allow generation of a spec without any unique info

### DIFF
--- a/bin/hoist/src/commands.rs
+++ b/bin/hoist/src/commands.rs
@@ -1,0 +1,96 @@
+use clap::Subcommand;
+use std::path::PathBuf;
+
+#[derive(Subcommand, Debug)]
+#[remain::sorted]
+pub enum Commands {
+    AnonymizeSpecs(AnonymizeSpecsArgs),
+    UploadAllSpecs(UploadAllSpecsArgs),
+    UploadSpec(UploadSpecArgs),
+    WriteAllSpecs(WriteAllSpecsArgs),
+    WriteExistingModulesSpec(WriteExistingModulesSpecArgs),
+    WriteSpec(WriteSpecArgs),
+}
+
+#[derive(clap::Args, Debug)]
+#[command(about = "Generate an anonymized version of target spec(s)")]
+pub struct AnonymizeSpecsArgs {
+    #[arg(long, short = 'o', required = true)]
+    pub out: PathBuf,
+
+    #[arg(
+        long,
+        short = 't',
+        required = true,
+        help = "Path to the directory containing specs to anonymize"
+    )]
+    pub target_dir: PathBuf,
+
+    #[arg(
+        long,
+        default_value = "100",
+        help = "Maximum number of concurrent uploads."
+    )]
+    pub max_concurrent: usize,
+}
+
+#[derive(clap::Args, Debug)]
+#[command(about = "Upload all specs in {target_dir} to the module index")]
+pub struct UploadAllSpecsArgs {
+    #[arg(
+        long,
+        short = 't',
+        required = true,
+        help = "Path to the directory containing specs to upload"
+    )]
+    pub target_dir: PathBuf,
+
+    #[arg(
+        long,
+        default_value = "100",
+        help = "Maximum number of concurrent uploads."
+    )]
+    pub max_concurrent: usize,
+}
+
+#[derive(clap::Args, Debug)]
+#[command(about = "Upload the spec {target} to the module index")]
+pub struct UploadSpecArgs {
+    #[arg(
+        long,
+        short = 't',
+        required = true,
+        help = "Path to the spec to upload"
+    )]
+    pub target: PathBuf,
+
+    #[arg(
+        long,
+        default_value = "100",
+        help = "Maximum number of concurrent uploads."
+    )]
+    pub max_concurrent: usize,
+}
+
+#[derive(clap::Args, Debug)]
+#[command(about = "Get all built-ins an write out a hashmap with their name and schema id")]
+pub struct WriteExistingModulesSpecArgs {
+    #[arg(long, short = 'o', required = true)]
+    pub out: PathBuf,
+}
+
+#[derive(clap::Args, Debug)]
+#[command(about = "Get {spec_name} from the module index and write it to {out}")]
+pub struct WriteSpecArgs {
+    #[arg(long, short = 's', required = true)]
+    pub spec_name: String,
+    #[arg(long, short = 'o', required = true)]
+    pub out: PathBuf,
+}
+
+#[derive(clap::Args, Debug)]
+#[command(about = "Get all specs from the module index and write them to {out}")]
+pub struct WriteAllSpecsArgs {
+    #[arg(long, short = 'o', required = true)]
+    pub out: PathBuf,
+}

--- a/lib/si-pkg/src/spec.rs
+++ b/lib/si-pkg/src/spec.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use chrono::{DateTime, Utc};
 use derive_builder::{Builder, UninitializedFieldError};
 use serde::{Deserialize, Serialize};
@@ -85,6 +87,14 @@ impl PkgSpec {
         self.funcs
             .iter()
             .find(|func_spec| func_spec.name.as_str() == name)
+    }
+
+    pub fn anonymize(&mut self) {
+        self.created_at = SystemTime::UNIX_EPOCH.into();
+        self.version = String::new();
+
+        self.schemas.iter_mut().for_each(|f| f.anonymize());
+        self.funcs.iter_mut().for_each(|f| f.anonymize());
     }
 }
 

--- a/lib/si-pkg/src/spec.rs
+++ b/lib/si-pkg/src/spec.rs
@@ -89,6 +89,7 @@ impl PkgSpec {
             .find(|func_spec| func_spec.name.as_str() == name)
     }
 
+    /// used only to create diffable specs
     pub fn anonymize(&mut self) {
         self.created_at = SystemTime::UNIX_EPOCH.into();
         self.version = String::new();

--- a/lib/si-pkg/src/spec/action_func.rs
+++ b/lib/si-pkg/src/spec/action_func.rs
@@ -52,4 +52,8 @@ impl ActionFuncSpec {
     pub fn builder() -> ActionFuncSpecBuilder {
         ActionFuncSpecBuilder::default()
     }
+
+    pub fn anonymize(&mut self) {
+        self.unique_id = None;
+    }
 }

--- a/lib/si-pkg/src/spec/attr_func_input.rs
+++ b/lib/si-pkg/src/spec/attr_func_input.rs
@@ -70,6 +70,13 @@ impl AttrFuncInputSpec {
         AttrFuncInputSpecBuilder::default()
     }
 
+    pub fn anonymize(&mut self) {
+        match self {
+            AttrFuncInputSpec::InputSocket { unique_id, .. }
+            | AttrFuncInputSpec::OutputSocket { unique_id, .. }
+            | AttrFuncInputSpec::Prop { unique_id, .. } => *unique_id = None,
+        }
+    }
     pub fn name(&self) -> &str {
         match self {
             Self::InputSocket { name, .. } => name.as_str(),

--- a/lib/si-pkg/src/spec/authentication_func.rs
+++ b/lib/si-pkg/src/spec/authentication_func.rs
@@ -26,4 +26,8 @@ impl AuthenticationFuncSpec {
     pub fn builder() -> AuthenticationFuncSpecBuilder {
         AuthenticationFuncSpecBuilder::default()
     }
+
+    pub fn anonymize(&mut self) {
+        self.unique_id = None;
+    }
 }

--- a/lib/si-pkg/src/spec/func.rs
+++ b/lib/si-pkg/src/spec/func.rs
@@ -56,6 +56,10 @@ impl FuncArgumentSpec {
     pub fn builder() -> FuncArgumentSpecBuilder {
         FuncArgumentSpecBuilder::default()
     }
+
+    pub fn anonymize(&mut self) {
+        self.unique_id = None;
+    }
 }
 
 #[remain::sorted]
@@ -199,5 +203,10 @@ impl FuncSpec {
     #[must_use]
     pub fn builder() -> FuncSpecBuilder {
         FuncSpecBuilder::default()
+    }
+
+    pub fn anonymize(&mut self) {
+        self.unique_id = String::new();
+        self.arguments.iter_mut().for_each(|f| f.anonymize());
     }
 }

--- a/lib/si-pkg/src/spec/leaf_function.rs
+++ b/lib/si-pkg/src/spec/leaf_function.rs
@@ -73,4 +73,8 @@ impl LeafFunctionSpec {
     pub fn builder() -> LeafFunctionSpecBuilder {
         LeafFunctionSpecBuilder::default()
     }
+
+    pub fn anonymize(&mut self) {
+        self.unique_id = None;
+    }
 }

--- a/lib/si-pkg/src/spec/management_func.rs
+++ b/lib/si-pkg/src/spec/management_func.rs
@@ -27,4 +27,6 @@ impl ManagementFuncSpec {
     pub fn builder() -> ManagementFuncSpecBuilder {
         ManagementFuncSpecBuilder::default()
     }
+
+    pub fn anonymize(&mut self) {}
 }

--- a/lib/si-pkg/src/spec/prop.rs
+++ b/lib/si-pkg/src/spec/prop.rs
@@ -175,6 +175,35 @@ impl PropSpec {
         PropSpecBuilder::default()
     }
 
+    pub fn anonymize(&mut self) {
+        match self {
+            PropSpec::Array {
+                type_prop,
+                unique_id,
+                ..
+            }
+            | PropSpec::Map {
+                type_prop,
+                unique_id,
+                ..
+            } => {
+                *unique_id = None;
+                type_prop.anonymize()
+            }
+            PropSpec::Object {
+                entries, unique_id, ..
+            } => {
+                *unique_id = None;
+                entries.iter_mut().for_each(|f| f.anonymize());
+            }
+            PropSpec::Boolean { unique_id, .. }
+            | PropSpec::Float { unique_id, .. }
+            | PropSpec::Json { unique_id, .. }
+            | PropSpec::Number { unique_id, .. }
+            | PropSpec::String { unique_id, .. } => *unique_id = None,
+        }
+    }
+
     pub(crate) fn to_builder_without_children(&self) -> PropSpecBuilder {
         let mut builder = PropSpec::builder();
         builder.name(self.name()).kind(self.kind());

--- a/lib/si-pkg/src/spec/schema.rs
+++ b/lib/si-pkg/src/spec/schema.rs
@@ -24,6 +24,10 @@ impl SchemaSpecData {
     pub fn builder() -> SchemaSpecDataBuilder {
         SchemaSpecDataBuilder::default()
     }
+
+    pub fn anonymize(&mut self) {
+        self.default_schema_variant = None;
+    }
 }
 
 #[derive(Builder, Clone, Debug, Deserialize, Serialize)]
@@ -52,6 +56,16 @@ impl SchemaSpec {
     #[must_use]
     pub fn builder() -> SchemaSpecBuilder {
         SchemaSpecBuilder::default()
+    }
+
+    pub fn anonymize(&mut self) {
+        self.unique_id = None;
+
+        if let Some(ref mut data) = self.data {
+            data.anonymize();
+        }
+
+        self.variants.iter_mut().for_each(|f| f.anonymize());
     }
 }
 

--- a/lib/si-pkg/src/spec/socket.rs
+++ b/lib/si-pkg/src/spec/socket.rs
@@ -73,6 +73,9 @@ impl SocketSpecData {
     pub fn builder() -> SocketSpecDataBuilder {
         SocketSpecDataBuilder::default()
     }
+    pub fn anonymize(&mut self) {
+        self.func_unique_id = None;
+    }
 }
 
 #[derive(Builder, Clone, Debug, Deserialize, Serialize)]
@@ -101,5 +104,9 @@ impl SocketSpec {
 
     pub fn kind(&self) -> Option<SocketSpecKind> {
         self.data.as_ref().map(|data| data.kind)
+    }
+    pub fn anonymize(&mut self) {
+        self.unique_id = None;
+        self.inputs.iter_mut().for_each(|f| f.anonymize())
     }
 }

--- a/lib/si-pkg/src/spec/variant.rs
+++ b/lib/si-pkg/src/spec/variant.rs
@@ -126,6 +126,11 @@ impl SchemaVariantSpecData {
     pub fn builder() -> SchemaVariantSpecDataBuilder {
         SchemaVariantSpecDataBuilder::default()
     }
+
+    pub fn anonymize(&mut self) {
+        self.func_unique_id = "".to_string();
+        self.version = "".to_string();
+    }
 }
 
 impl SchemaVariantSpecDataBuilder {
@@ -199,6 +204,29 @@ pub struct SchemaVariantSpec {
 impl SchemaVariantSpec {
     pub fn builder() -> SchemaVariantSpecBuilder {
         SchemaVariantSpecBuilder::default()
+    }
+
+    pub fn anonymize(&mut self) {
+        self.version = String::new();
+        self.unique_id = None;
+
+        if let Some(ref mut data) = self.data {
+            data.anonymize();
+        }
+
+        self.action_funcs.iter_mut().for_each(|f| f.anonymize());
+        self.auth_funcs.iter_mut().for_each(|f| f.anonymize());
+        self.leaf_functions.iter_mut().for_each(|f| f.anonymize());
+        self.management_funcs.iter_mut().for_each(|f| f.anonymize());
+
+        self.sockets.iter_mut().for_each(|f| f.anonymize());
+
+        self.domain.anonymize();
+        self.secrets.anonymize();
+        if let Some(ref mut secret_def) = self.secret_definition {
+            secret_def.anonymize()
+        };
+        self.resource_value.anonymize();
     }
 
     // This is only used when merging prototypes. If the structure of


### PR DESCRIPTION
* makes it so a PkgSpec can anonymize itself, i.e. set all unique info (dates, ids, etc.) to an empty or known value
* adds a command to hoist to let it transform specs into anonymous specs

these anonymous specs will be used for 

* generating hashes that don't include ids that can be stored in the module index to make comparison of specs more accurate
* generating diffs that ignore redundant information

```
buck2 run //bin/hoist:hoist -- anonymize-specs -t ./bin/clover/si-specs -o ./test
```

<img src="https://media4.giphy.com/media/dUkxbC3pQrRZsrTw6O/giphy-downsized-medium.gif?cid=bd3ea57eydypouxjabjvq5jkhmwslgoruzsu43tw6i5zliht&ep=v1_gifs_search&rid=giphy-downsized-medium.gif&ct=g"/>