### PR TITLE
feat(clover): Reorder props for better UX

### DIFF
--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -36,6 +36,7 @@ import {
   reportDeprecatedAssets,
 } from "../pipeline-steps/reportDeprecatedAssets.ts";
 import { removeBadDocLinks } from "../pipeline-steps/removeBadDocLinks.ts";
+import { reorderProps } from "../pipeline-steps/reorderProps.ts";
 
 const logger = _logger.ns("siSpecs").seal();
 const SI_SPEC_DIR = "si-specs";
@@ -103,6 +104,7 @@ export async function generateSiSpecs(
   specs = pruneCfAssets(specs);
 
   // These need everything to be complete
+  specs = reorderProps(specs);
   specs = generateAssetFuncs(specs);
   specs = updateSchemaIdsForExistingSpecs(existing_specs, specs);
 

--- a/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
+++ b/bin/clover/src/pipeline-steps/addDefaultPropsAndSockets.ts
@@ -31,6 +31,7 @@ export function addDefaultPropsAndSockets(
       "extra",
       domain.metadata.propPath,
       undefined,
+      true,
     );
 
     // Create PropUsageMap
@@ -39,6 +40,7 @@ export function addDefaultPropsAndSockets(
         "PropUsageMap",
         "string",
         extraProp.metadata.propPath,
+        false,
       );
       const propUsageMap: PropUsageMap = {
         createOnly: [],
@@ -74,6 +76,7 @@ export function addDefaultPropsAndSockets(
         "Region",
         "string",
         extraProp.metadata.propPath,
+        true,
       );
 
       schemaVariant.sockets.push(createInputSocketFromProp(regionProp));
@@ -86,6 +89,7 @@ export function addDefaultPropsAndSockets(
         "AwsResourceType",
         "string",
         extraProp.metadata.propPath,
+        false,
       );
 
       typeProp.data.defaultValue = schema.name;
@@ -100,6 +104,7 @@ export function addDefaultPropsAndSockets(
         "AWS Credential",
         "string",
         extraProp.metadata.propPath,
+        true,
       );
       credProp.data.widgetKind = "Secret";
       credProp.data.widgetOptions = [{

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -111,14 +111,13 @@ const overrides = new Map<string, OverrideFn>([
     addSecretProp("Secret String", "secretString", ["SecretString"]),
   ],
   ["AWS::EC2::Instance", (spec: ExpandedPkgSpec) => {
-     const variant = spec.schemas[0].variants[0];
-     
-     const prop = variant.domain.entries.find((p: ExpandedPropSpec) =>
-       p.name === "UserData"
-     );
-     
-     if (!prop) return;
-     prop.data.widgetKind = "textarea";
+    const variant = spec.schemas[0].variants[0];
+
+    const prop = variant.domain.entries.find((p: ExpandedPropSpec) =>
+      p.name === "UserData"
+    );
+
+    prop!.data.widgetKind = "TextArea";
   }],
   [
     "AWS::DataZone::Domain",
@@ -128,9 +127,8 @@ const overrides = new Map<string, OverrideFn>([
       const socket = variant.sockets.find(
         (s: ExpandedSocketSpec) => s.name === "Id" && s.data.kind === "output",
       );
-      if (!socket) return;
 
-      setAnnotationOnSocket(socket, { tokens: ["Domain Identifier"] });
+      setAnnotationOnSocket(socket!, { tokens: ["Domain Identifier"] });
     },
   ],
   [

--- a/bin/clover/src/pipeline-steps/generateSubAssets.ts
+++ b/bin/clover/src/pipeline-steps/generateSubAssets.ts
@@ -91,9 +91,9 @@ export function generateSubAssets(
           actionFuncs: [],
           leafFunctions: [],
           managementFuncs: [],
-          resourceValue: createDefaultProp("resource_value", undefined),
+          resourceValue: createDefaultProp("resource_value", undefined, false),
           sockets: [newSpecOutputSocket],
-          secrets: createDefaultProp("secrets", undefined),
+          secrets: createDefaultProp("secrets", undefined, false),
           uniqueId: variantId,
         };
 

--- a/bin/clover/src/pipeline-steps/reorderProps.ts
+++ b/bin/clover/src/pipeline-steps/reorderProps.ts
@@ -1,0 +1,51 @@
+import _logger from "../logger.ts";
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+import { ExpandedPropSpec } from "../spec/props.ts";
+
+export function reorderProps(specs: ExpandedPkgSpec[]): ExpandedPkgSpec[] {
+  for (const { schemas: [{ variants: [variant] }] } of specs) {
+    reorderPropChildren(variant.domain);
+    reorderPropChildren(variant.resourceValue);
+  }
+  return specs;
+}
+
+function reorderPropChildren(prop: ExpandedPropSpec) {
+  switch (prop.kind) {
+    case "array":
+    case "map":
+      reorderPropChildren(prop.typeProp);
+      break;
+    case "object":
+      // Sort by:
+      // - extra always comes last
+      // - scalar types first (complex types like object/etc. go last)
+      // - required types first
+      // - then by name
+      prop.entries = prop.entries.toSorted(
+        (a, b) =>
+          compareBools(isExtraProp(a), isExtraProp(b)) ||
+          -compareBools(isScalar(a), isScalar(b)) ||
+          -compareBools(a.metadata.required, b.metadata.required) ||
+          a.name.localeCompare(b.name),
+      );
+      for (const entry of prop.entries) reorderPropChildren(entry);
+      break;
+    default:
+      break;
+  }
+}
+
+function isExtraProp(prop: ExpandedPropSpec) {
+  if (prop.metadata.propPath.length !== 3) return false;
+  const [root, domain, extra] = prop.metadata.propPath;
+  return root === "root" && domain === "domain" && extra === "extra";
+}
+
+function isScalar(prop: ExpandedPropSpec) {
+  return !["object", "array", "map"].includes(prop.kind);
+}
+
+function compareBools(a: boolean, b: boolean) {
+  return Number(a) - Number(b);
+}


### PR DESCRIPTION
The Clover package and asset functions currently order props the same as the Cloud Formation schema, which causes a few UX issues when you try to edit the attributes in SI (object props and scalar props are intermixed, and the CF schema is not well-curated and it's hard to find the props you need). This PR imposes a new order on props to fix this:

1. Scalar types always come before object props and arrays at the same level (this bunches them up so you can tell they are at the same level).
2. Required props come before optional props. This makes VpcId show up at the top of Subnet, for example.
3. The rest of props are sorted by name.

We also make sure the "extra" prop stays at the end.

![image](https://github.com/user-attachments/assets/f1f9af16-f769-4f49-917f-0de52c6ffbc8)

## Caveat

After this PR merges, Clover assets will have this order when the asset is regenerated, but *not when the asset is first used in a new workspace,* because we currently lose prop order when we upload packages to the module index--it doesn't get fixed until regenerate. This is a separate issue and will be fixed a different way.