### PR TITLE
feat(sdf): Preserve prop order when uploading packages to the module index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6922,6 +6922,7 @@ dependencies = [
  "chrono",
  "derive_builder",
  "indexmap 2.7.1",
+ "itertools 0.13.0",
  "object-tree",
  "petgraph",
  "remain",

--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -334,6 +334,7 @@ impl ExpectSchemaVariant {
         .id
         .into();
         variant.update_asset_func(ctx, asset_func).await;
+        variant.regenerate(ctx).await;
         variant
     }
 
@@ -688,6 +689,10 @@ impl ExpectComponentProp {
         ExpectProp(self.1)
     }
 
+    pub async fn name(self, ctx: &DalContext) -> String {
+        self.prop().name(ctx).await
+    }
+
     pub async fn attribute_value(self, ctx: &DalContext) -> ExpectAttributeValue {
         let prop_values = ExpectPropertyEditorValues::assemble(ctx, self.0).await;
         let attribute_value_id = prop_values
@@ -977,6 +982,16 @@ impl ExpectAttributeValue {
             .await
             .expect("remove prop value by id failed")
     }
+
+    pub async fn prop(self, ctx: &DalContext) -> ExpectComponentProp {
+        let component_id = AttributeValue::component_id(ctx, self.0)
+            .await
+            .expect("get component id");
+        let prop_id = AttributeValue::prop_id(ctx, self.0)
+            .await
+            .expect("get prop id");
+        ExpectComponentProp(component_id, prop_id)
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deref, AsRef, AsMut, From, Into)]
@@ -995,6 +1010,27 @@ impl ExpectProp {
 
     pub async fn prop(self, ctx: &DalContext) -> Prop {
         Prop::get_by_id(ctx, self.0).await.expect("get prop by id")
+    }
+
+    pub async fn name(self, ctx: &DalContext) -> String {
+        self.prop(ctx).await.name
+    }
+
+    pub async fn children(self, ctx: &DalContext) -> Vec<ExpectProp> {
+        Prop::direct_child_prop_ids_ordered(ctx, self.0)
+            .await
+            .expect("get direct child prop ids ordered")
+            .into_iter()
+            .map(Into::into)
+            .collect()
+    }
+
+    pub async fn child_names(self, ctx: &DalContext) -> Vec<String> {
+        let mut result = vec![];
+        for child in self.children(ctx).await {
+            result.push(child.name(ctx).await);
+        }
+        result
     }
 
     pub async fn direct_single_child(self, ctx: &DalContext) -> ExpectProp {

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -627,7 +627,7 @@ impl PkgExporter {
         }
 
         let mut stack: Vec<(PropId, Option<PropId>)> = Vec::new();
-        for child_tree_node in Prop::direct_child_prop_ids_unordered(ctx, root_prop.id()).await? {
+        for child_tree_node in Prop::direct_child_prop_ids_ordered(ctx, root_prop.id()).await? {
             stack.push((child_tree_node, None));
         }
 
@@ -680,8 +680,7 @@ impl PkgExporter {
                 parent_prop_id,
             });
 
-            for child_tree_node in Prop::direct_child_prop_ids_unordered(ctx, child_prop.id).await?
-            {
+            for child_tree_node in Prop::direct_child_prop_ids_ordered(ctx, child_prop.id).await? {
                 stack.push((child_tree_node, Some(prop_id)));
             }
         }

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -1092,6 +1092,8 @@ impl Prop {
         }
         Ok(prop)
     }
+
+    // Gets child props, in order
     pub async fn direct_child_prop_ids_ordered(
         ctx: &DalContext,
         prop_id: PropId,
@@ -1102,6 +1104,7 @@ impl Prop {
             .await?
         {
             Some(child_ulids) => Ok(child_ulids.into_iter().map(Into::into).collect()),
+            // All props are either ordered, or have no children.
             None => Ok(vec![]),
         }
     }

--- a/lib/dal/tests/integration_test/pkg/mod.rs
+++ b/lib/dal/tests/integration_test/pkg/mod.rs
@@ -1,12 +1,18 @@
 use dal::pkg::export::PkgExporter;
 use dal::pkg::{import_pkg_from_pkg, ImportOptions};
+use dal::prop::PropPath;
 use dal::schema::variant::authoring::VariantAuthoringClient;
-use dal::{DalContext, FuncBackendKind, FuncBackendResponseType};
-use dal_test::test;
+use dal::{
+    AttributeValue, AttributeValueId, Component, ComponentId, DalContext, FuncBackendKind,
+    FuncBackendResponseType, Prop, PropId, SchemaVariant, SchemaVariantId,
+};
+use dal_test::expected::ExpectSchemaVariant;
+use dal_test::helpers::create_component_for_schema_variant_on_default_view;
+use dal_test::{test, Result};
 use si_pkg::{FuncSpec, FuncSpecData, PkgSpec, SchemaSpec, SchemaSpecData, SiPkg};
 
 #[test]
-async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) {
+async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) -> Result<()> {
     // Let's create a new asset
     let asset_name = "imanasset".to_string();
     let description = None;
@@ -21,27 +27,18 @@ async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) {
         category.clone(),
         color.clone(),
     )
-    .await
-    .expect("Unable to create new asset");
+    .await?;
 
-    let schema = variant
-        .schema(ctx)
-        .await
-        .expect("Unable to get the schema for the variant");
+    let schema = variant.schema(ctx).await?;
 
-    let default_schema_variant = schema
-        .get_default_schema_variant_id(ctx)
-        .await
-        .expect("unable to get the default schema variant id");
+    let default_schema_variant = schema.get_default_schema_variant_id(ctx).await?;
 
     assert!(default_schema_variant.is_some());
     assert_eq!(default_schema_variant, Some(variant.id()));
 
     // now lets create a pkg from the asset and import it
     let (variant_spec, variant_funcs) =
-        PkgExporter::export_variant_standalone(ctx, &variant, schema.name(), None)
-            .await
-            .expect("should go to spec");
+        PkgExporter::export_variant_standalone(ctx, &variant, schema.name(), None).await?;
 
     let schema_spec = SchemaSpec::builder()
         .name(schema.name())
@@ -52,11 +49,9 @@ async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) {
                 .name(schema.name())
                 .category(category.clone())
                 .default_schema_variant(variant.id())
-                .build()
-                .expect("should build data"),
+                .build()?,
         )
-        .build()
-        .expect("should build spec");
+        .build()?;
 
     let func_spec = FuncSpec::builder()
         .name(asset_name.clone())
@@ -68,11 +63,9 @@ async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) {
                 .response_type(FuncBackendResponseType::SchemaVariantDefinition)
                 .handler("main")
                 .code_plaintext("I am code")
-                .build()
-                .expect("should build data"),
+                .build()?,
         )
-        .build()
-        .expect("should make new func spec");
+        .build()?;
 
     let pkg_spec = PkgSpec::builder()
         .name(asset_name)
@@ -81,8 +74,7 @@ async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) {
         .func(func_spec)
         .schemas([schema_spec].to_vec())
         .version("0")
-        .build()
-        .expect("should build");
+        .build()?;
 
     let pkg = SiPkg::load_from_spec(pkg_spec).expect("should load from spec");
 
@@ -95,14 +87,10 @@ async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) {
             ..Default::default()
         }),
     )
-    .await
-    .expect("should import");
+    .await?;
     assert_eq!(variants.len(), 1);
 
-    let default_schema_variant = schema
-        .get_default_schema_variant_id(ctx)
-        .await
-        .expect("unable to get the default schema variant id");
+    let default_schema_variant = schema.get_default_schema_variant_id(ctx).await?;
 
     // the new default variant should be the one we just added
     assert!(default_schema_variant.is_some());
@@ -110,4 +98,163 @@ async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) {
         default_schema_variant,
         Some(variants.pop().expect("should pop"))
     );
+
+    Ok(())
+}
+
+#[test]
+async fn prop_order_preserved(ctx: &mut DalContext) -> Result<()> {
+    // Create a variant with a particular prop order
+    let variant_id = ExpectSchemaVariant::create_named(
+        ctx,
+        "testme",
+        r#"function main() {
+            return new AssetBuilder()
+                .addProp(new PropBuilder().setName("foo").setKind("string").build())
+                .addProp(new PropBuilder().setName("bar").setKind("string").build())
+                .addProp(new PropBuilder().setName("baz").setKind("string").build())
+                .build();
+           // return {
+           //     props: [
+           //         { name: "foo", kind: "string" },
+           //         { name: "bar", kind: "string" },
+           //         { name: "baz", kind: "string" },
+           //     ]
+           // };
+        }"#,
+    )
+    .await
+    .id();
+    let schema_id = SchemaVariant::schema_id_for_schema_variant_id(ctx, variant_id).await?;
+    assert_eq!(
+        variant_prop_names(ctx, variant_id).await?,
+        vec!["foo", "bar", "baz"]
+    );
+
+    // Create a component and check that order is preserved
+    let component_id = create_component_for_schema_variant_on_default_view(ctx, variant_id)
+        .await?
+        .id();
+    assert_eq!(
+        component_prop_names(ctx, component_id).await?,
+        vec!["foo", "bar", "baz"]
+    );
+
+    // Export variant -> PkgSpec
+    let exported_spec =
+        PkgExporter::new_for_module_contribution("testme", "test_version", "me@me.com", schema_id)
+            .export_as_spec(ctx)
+            .await?;
+    assert_eq!(spec_prop_names(&exported_spec), vec!["foo", "bar", "baz"]);
+
+    // PkgSpec -> SiPkg
+    let exported_pkg = SiPkg::load_from_spec(exported_spec)?;
+    assert_eq!(
+        // check that order is preserved by converting back to spec
+        spec_prop_names(&exported_pkg.to_spec().await?),
+        vec!["foo", "bar", "baz"]
+    );
+
+    // Round trip SiPkg -> bytes -> SiPkg
+    let exported_bytes = exported_pkg.write_to_bytes()?;
+    let pkg = SiPkg::load_from_bytes(&exported_bytes)?;
+    // check that order is preserved
+    assert_eq!(
+        spec_prop_names(&pkg.to_spec().await?),
+        vec!["foo", "bar", "baz"]
+    );
+
+    // Check that the SiPkg -> variant has the same prop order
+    let pkg_variant_id = {
+        let (_, pkg_variant_ids, _) = import_pkg_from_pkg(
+            ctx,
+            &pkg,
+            Some(ImportOptions {
+                schema_id: Some(schema_id.into()),
+                ..Default::default()
+            }),
+        )
+        .await?;
+        assert!(pkg_variant_ids.len() == 1);
+        pkg_variant_ids[0]
+    };
+    assert_eq!(
+        variant_prop_names(ctx, pkg_variant_id).await?,
+        vec!["foo", "bar", "baz"]
+    );
+
+    // Create a component and check that order is preserved
+    let pkg_component_id = ExpectSchemaVariant(pkg_variant_id)
+        .create_component_on_default_view(ctx)
+        .await
+        .id();
+    assert_eq!(
+        component_prop_names(ctx, pkg_component_id).await?,
+        vec!["foo", "bar", "baz"]
+    );
+
+    // Check that the SiPkg -> variant -> component has the same prop order
+    Ok(())
+}
+
+async fn variant_prop_names(
+    ctx: &mut DalContext,
+    variant_id: SchemaVariantId,
+) -> Result<Vec<String>> {
+    let domain_path = PropPath::new(["root", "domain"]);
+    let domain_id = Prop::find_prop_id_by_path(ctx, variant_id, &domain_path).await?;
+    child_prop_names(ctx, domain_id, None).await
+}
+
+async fn child_prop_names(
+    ctx: &mut DalContext,
+    prop_id: PropId,
+    prefix: Option<&str>,
+) -> Result<Vec<String>> {
+    let mut result = vec![];
+    for Prop { name, id, .. } in Prop::direct_child_props_ordered(ctx, prop_id).await? {
+        let name = match prefix {
+            Some(prefix) => format!("{}.{}", prefix, name),
+            None => name,
+        };
+        result.push(name.clone());
+        result.extend(Box::pin(child_prop_names(ctx, id, Some(&name))).await?);
+    }
+    Ok(result)
+}
+
+async fn component_prop_names(
+    ctx: &mut DalContext,
+    component_id: ComponentId,
+) -> Result<Vec<String>> {
+    let component = Component::get_by_id(ctx, component_id).await?;
+    let domain_av_id = component.domain_prop_attribute_value(ctx).await?;
+    child_av_names(ctx, domain_av_id, None).await
+}
+
+async fn child_av_names(
+    ctx: &mut DalContext,
+    av_id: AttributeValueId,
+    prefix: Option<&str>,
+) -> Result<Vec<String>> {
+    let mut result = vec![];
+    for child_av_id in AttributeValue::get_child_av_ids_in_order(ctx, av_id).await? {
+        let name = AttributeValue::prop(ctx, child_av_id).await?.name;
+        let name = match prefix {
+            Some(prefix) => format!("{}.{}", prefix, name),
+            None => name,
+        };
+        result.push(name.clone());
+        result.extend(Box::pin(child_av_names(ctx, child_av_id, Some(&name))).await?);
+    }
+    Ok(result)
+}
+
+fn spec_prop_names(spec: &PkgSpec) -> Vec<String> {
+    spec.schemas[0].variants[0]
+        .domain
+        .direct_children()
+        .into_iter()
+        .map(|p| p.name().to_owned())
+        .collect()
 }

--- a/lib/si-pkg/BUCK
+++ b/lib/si-pkg/BUCK
@@ -7,6 +7,7 @@ rust_library(
         "//third-party/rust:base64",
         "//third-party/rust:chrono",
         "//third-party/rust:derive_builder",
+        "//third-party/rust:itertools",
         "//third-party/rust:indexmap",
         "//third-party/rust:petgraph",
         "//third-party/rust:remain",

--- a/lib/si-pkg/Cargo.toml
+++ b/lib/si-pkg/Cargo.toml
@@ -15,6 +15,7 @@ base64 = { workspace = true }
 chrono = { workspace = true }
 derive_builder = { workspace = true }
 indexmap = { workspace = true }
+itertools = { workspace = true }
 petgraph = { workspace = true }
 remain = { workspace = true }
 serde = { workspace = true }

--- a/lib/si-pkg/src/node/mod.rs
+++ b/lib/si-pkg/src/node/mod.rs
@@ -223,6 +223,13 @@ impl PkgNode {
             Self::AuthFunc(_) => NODE_KIND_AUTH_FUNC,
         }
     }
+
+    pub fn child_order(&self) -> Option<&Vec<String>> {
+        match self {
+            Self::Prop(prop) => prop.child_order(),
+            _ => None,
+        }
+    }
 }
 
 impl NameStr for PkgNode {

--- a/lib/si-pkg/src/pkg/prop.rs
+++ b/lib/si-pkg/src/pkg/prop.rs
@@ -73,6 +73,7 @@ pub enum SiPkgProp<'a> {
         unique_id: Option<String>,
         hash: Hash,
         source: Source<'a>,
+        child_order: Option<Vec<String>>,
     },
     String {
         name: String,
@@ -180,6 +181,7 @@ impl<'a> SiPkgProp<'a> {
                 name,
                 data,
                 unique_id,
+                ..
             }
             | PropNode::String {
                 name,
@@ -271,13 +273,14 @@ impl<'a> SiPkgProp<'a> {
                 hash,
                 source,
             },
-            PropNode::Object { .. } => Self::Object {
+            PropNode::Object { child_order, .. } => Self::Object {
                 name,
                 data,
                 unique_id,
 
                 hash,
                 source,
+                child_order,
             },
         })
     }
@@ -344,6 +347,13 @@ impl<'a> SiPkgProp<'a> {
             | Self::Map { source, .. }
             | Self::Array { source, .. }
             | Self::Object { source, .. } => source,
+        }
+    }
+
+    pub fn child_order(&self) -> Option<&Vec<String>> {
+        match self {
+            Self::Object { child_order, .. } => child_order.as_ref(),
+            _ => None,
         }
     }
 }

--- a/lib/si-pkg/src/spec/prop.rs
+++ b/lib/si-pkg/src/spec/prop.rs
@@ -507,7 +507,7 @@ pub struct PropSpecBuilder {
     inputs: Vec<AttrFuncInputSpec>,
     kind: Option<PropSpecKind>,
     map_key_funcs: Vec<MapKeyFuncSpec>,
-    name: Option<String>,
+    pub name: Option<String>,
     type_prop: Option<PropSpec>,
     validation_format: Option<String>,
     widget_kind: Option<PropSpecWidgetKind>,


### PR DESCRIPTION
Right now, packages contributed or uploaded to the module index have their props re-sorted alphabetically. This PR modifies SiPkg and SiPkgNodeit so that going from PkgSpec -> SiPkg -> bytes -> SiPkg -> PackageNode -> dal preserves ordering.

## Testing

* Tested that round-tripping from PkgSpec -> SiPkg -> bytes -> SiPkg -> PksSpec preserves order (it didn't before)
* Added integration test with round tripping that checks the underlying dal functions for:
  - Regenerate (asset func -> dal variant/component)
  - Install Module (bytes -> SiPkg -> dal variant/component)
  - Contribute (dal -> SiPkg -> bytes)
  - Hoist Upload (PkgSpec -> SiPkg)
  - SiPkg -> PkgSpec (prop order not used anywhere except tests at the moment)
* Manual tests:
  * Test that existing uploaded modules still load and are gracefully loaded alphabetically
  * Test that Clover assets uploaded to the module index via hoist preserve prop order after this change.
  * Test that Contribute flow preserves prop order.