### PR TITLE
fix(web): Ensuring that we can deal with JSON.Objects in propSpecs

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -13,6 +13,7 @@ export enum PropertyEditorPropKind {
   Object = "object",
   String = "string",
   Map = "map",
+  Json = "json",
 }
 
 export interface PropertyEditorPropWidgetKindCodeEditor {

--- a/app/web/src/assets/static/editor_typescript.txt
+++ b/app/web/src/assets/static/editor_typescript.txt
@@ -396,6 +396,7 @@ type PropDefinitionKind =
   | "boolean"
   | "float"
   | "integer"
+  | "json"
   | "map"
   | "object"
   | "string";
@@ -582,7 +583,7 @@ declare class PropBuilder implements IPropBuilder {
   /**
    * The type of the prop
    *
-   * @param {string} kind [array | boolean | float | integer | map | object | string]
+   * @param {string} kind [array | boolean | float | integer | json | map | object | string]
    *
    * @returns this
    *

--- a/app/web/src/components/AttributesPanel/TreeFormItem.vue
+++ b/app/web/src/components/AttributesPanel/TreeFormItem.vue
@@ -1427,7 +1427,13 @@ const sourceTooltipText = computed(() => {
 
 function resetNewValueToCurrentValue() {
   newValueBoolean.value = !!currentValue.value;
-  newValueString.value = currentValue.value?.toString() || "";
+  if (currentValue.value instanceof Object) {
+    newValueString.value = JSON.stringify(currentValue.value, null, 2);
+  } else if (currentValue.value) {
+    newValueString.value = "";
+  } else {
+    newValueString.value = currentValue.value?.toString() || "";
+  }
   const valAsNumber = parseFloat(currentValue.value?.toString() || "");
   newValueNumber.value = Number.isNaN(valAsNumber) ? undefined : valAsNumber;
   showValidationDetails.value = false;

--- a/app/web/src/store/component_attributes.store.ts
+++ b/app/web/src/store/component_attributes.store.ts
@@ -285,6 +285,19 @@ export const useComponentAttributesStore = (componentId: ComponentId) => {
 
             const isInsert = "insert" in updatePayload;
 
+            if (!isInsert) {
+              const propId = updatePayload.update.propId;
+              const prop = this.schema?.props[propId];
+              if (
+                prop?.kind === "json" &&
+                typeof updatePayload.update.value === "string"
+              ) {
+                updatePayload.update.value = JSON.parse(
+                  updatePayload.update.value,
+                );
+              }
+            }
+
             // If the valueid for this update does not exist in the values tree,
             // we shouldn't perform the update!
             if (

--- a/bin/lang-js/src/asset_builder.ts
+++ b/bin/lang-js/src/asset_builder.ts
@@ -520,6 +520,7 @@ export type PropDefinitionKind =
   | "boolean"
   | "float"
   | "integer"
+  | "json"
   | "map"
   | "object"
   | "string";
@@ -757,7 +758,7 @@ export class PropBuilder implements IPropBuilder {
   /**
    * The type of the prop
    *
-   * @param kind {PropDefinitionKind} [array | boolean | float | integer | map | object | string]
+   * @param kind {PropDefinitionKind} [array | boolean | float | integer | json | map | object | string]
    *
    * @returns this
    *


### PR DESCRIPTION
Testing carried out:

Interacted with current VPC How-to guide and no changes to any of the existing attributes panel items
Added a schema variant with a json / codeeditor prop and was able to get the new behaviour
Even when a prop had json type and an empty string, we still handled that correctly
Update scope is correct to just JSON types