### PR TITLE
Add NATS event callback metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6707,6 +6707,7 @@ dependencies = [
  "serde",
  "serde_json",
  "telemetry",
+ "telemetry-utils",
  "thiserror 2.0.11",
  "tokio",
  "tracing-subscriber",

--- a/lib/naxum/src/middleware/ack/on_failure.rs
+++ b/lib/naxum/src/middleware/ack/on_failure.rs
@@ -25,7 +25,7 @@ impl OnFailure for DefaultOnFailure {
             trace!("nacking message");
             if let Err(err) = acker.ack_with(jetstream::AckKind::Nak(None)).await {
                 warn!(
-                    error = ?err,
+                    si.error.message = ?err,
                     subject = head.subject.as_str(),
                     "failed to nack the message",
                 );

--- a/lib/naxum/src/middleware/ack/on_success.rs
+++ b/lib/naxum/src/middleware/ack/on_success.rs
@@ -25,7 +25,7 @@ impl OnSuccess for DefaultOnSuccess {
             trace!("double acking message");
             if let Err(err) = acker.double_ack().await {
                 warn!(
-                    error = ?err,
+                    si.error.message = ?err,
                     subject = head.subject.as_str(),
                     "failed to double ack the message",
                 );

--- a/lib/naxum/src/serve.rs
+++ b/lib/naxum/src/serve.rs
@@ -271,7 +271,7 @@ where
         Err(err) => {
             if failed_count > MAX_FAILED_MESSAGES {
                 warn!(
-                    error = ?err,
+                    si.error.message = ?err,
                     "failed to read message in after {} consecutive failures; closing stream",
                     failed_count,
                 );

--- a/lib/si-data-nats/BUCK
+++ b/lib/si-data-nats/BUCK
@@ -4,6 +4,7 @@ rust_library(
     name = "si-data-nats",
     deps = [
         "//lib/telemetry-rs:telemetry",
+        "//lib/telemetry-utils-rs:telemetry-utils",
         "//third-party/rust:async-nats",
         "//third-party/rust:bytes",
         "//third-party/rust:futures",

--- a/lib/si-data-nats/Cargo.toml
+++ b/lib/si-data-nats/Cargo.toml
@@ -10,6 +10,7 @@ publish.workspace = true
 
 [dependencies]
 telemetry = { path = "../../lib/telemetry-rs" }
+telemetry-utils = { path = "../../lib/telemetry-utils-rs" }
 
 async-nats = { workspace = true }
 bytes = { workspace = true }

--- a/lib/veritech-server/src/handlers.rs
+++ b/lib/veritech-server/src/handlers.rs
@@ -309,7 +309,7 @@ where
             };
             request.dec_run_metric();
             if let Err(err) = publisher.publish_result(&func_result_error).await {
-                error!(error = ?err, "failed to publish errored result");
+                error!(si.error.message = ?err, "failed to publish errored result");
             }
         }
     }

--- a/lib/veritech-server/src/server.rs
+++ b/lib/veritech-server/src/server.rs
@@ -165,7 +165,7 @@ impl Server {
     #[inline]
     pub async fn run(self) {
         if let Err(err) = self.try_run().await {
-            error!(error = ?err, "error while running veritech main loop");
+            error!(si.error.message = ?err, "error while running veritech main loop");
         }
     }
 


### PR DESCRIPTION
## Description

This PR adds NATS event callback metrics and other logging during events callback. This allows us to detect issues upon reconnection, sending messages after "publishing" them (i.e. sent in an internal channel to be sent to the server later), etc.

As part of these changes, we also fix some "si.error.message" locations.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMnJ2Ym1pY2JjdGM1c2h6Y2k1Y2czMXQ0d215aGl6b2JocWtmM3p6eiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/7rfwKxzvH22cg/giphy.gif"/>