### PR TITLE
Upgrade modules from cached modules

### DIFF
--- a/app/web/src/components/AssetCard.vue
+++ b/app/web/src/components/AssetCard.vue
@@ -41,7 +41,7 @@
 
           <IconButton
             v-if="canUpdate"
-            :loading="installStatus.isPending"
+            :loading="upgradeStatus.isPending"
             icon="code-deployed"
             loadingIcon="loader"
             tooltip="Update"
@@ -149,9 +149,9 @@ const assetStore = useAssetStore();
 const moduleStore = useModuleStore();
 const { theme } = useTheme();
 
-const installStatus = moduleStore.getRequestStatus(
-  "INSTALL_REMOTE_MODULE",
-  moduleStore.upgradeableModules[props.assetId]?.id,
+const upgradeStatus = moduleStore.getRequestStatus(
+  "UPGRADE_MODULES",
+  moduleStore.upgradeableModules[props.assetId]?.schemaId,
 );
 
 const contributeAssetModalRef =
@@ -212,7 +212,7 @@ const updateAsset = () => {
     throw new Error("cannot update asset: no upgradeable module for asset");
   }
 
-  moduleStore.INSTALL_REMOTE_MODULE([module.id]);
+  moduleStore.UPGRADE_MODULES([module.schemaId]);
   assetStore.clearSchemaVariantSelection();
 
   return;

--- a/app/web/src/components/AssetListPanel.vue
+++ b/app/web/src/components/AssetListPanel.vue
@@ -152,9 +152,7 @@ const loadAssetsReqStatus = assetStore.getRequestStatus(
   "LOAD_SCHEMA_VARIANT_LIST",
 );
 const syncModulesReqStatus = moduleStore.getRequestStatus("SYNC");
-const updateModulesReqStatus = moduleStore.getRequestStatus(
-  "INSTALL_REMOTE_MODULE",
-);
+const updateModulesReqStatus = moduleStore.getRequestStatus("UPGRADE_MODULES");
 
 const contributeAssetSuccessModalRef = ref<InstanceType<typeof Modal>>();
 const newAssetModalRef = ref<InstanceType<typeof AssetNameModal>>();
@@ -241,10 +239,10 @@ const newAsset = async (newAssetName: string) => {
 };
 
 const updateAllAssets = () => {
-  const moduleIds = Object.values(moduleStore.upgradeableModules).map(
-    (m) => m.id,
+  const schemaIds = Object.values(moduleStore.upgradeableModules).map(
+    (m) => m.schemaId,
   );
-  moduleStore.INSTALL_REMOTE_MODULE(moduleIds);
+  moduleStore.UPGRADE_MODULES(schemaIds);
   assetStore.clearSchemaVariantSelection();
 };
 

--- a/lib/sdf-server/src/service/module.rs
+++ b/lib/sdf-server/src/service/module.rs
@@ -32,6 +32,7 @@ const MAX_NAME_SEARCH_ATTEMPTS: usize = 100;
 pub mod approval_process;
 pub mod import_workspace_vote;
 pub mod install_module;
+pub mod upgrade_modules;
 
 #[remain::sorted]
 #[derive(Error, Debug)]
@@ -40,6 +41,8 @@ pub enum ModuleError {
     Canonicalize(#[from] CanonicalFileError),
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
+    #[error("dal cached module error: {0}")]
+    DalCachedModule(#[from] dal::cached_module::CachedModuleError),
     #[error("dal pkg error: {0}")]
     DalPkg(#[from] DalPkgError),
     #[error("Trying to export from/import into root tenancy")]
@@ -234,6 +237,7 @@ pub async fn pkg_open(builder: &DalContextBuilder, file_name: &str) -> ModuleRes
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/install_module", post(install_module::install_module))
+        .route("/upgrade_modules", post(upgrade_modules::upgrade_modules))
         .route(
             "/begin_approval_process",
             post(approval_process::begin_approval_process),

--- a/lib/sdf-server/src/service/module/upgrade_modules.rs
+++ b/lib/sdf-server/src/service/module/upgrade_modules.rs
@@ -1,0 +1,116 @@
+use axum::{
+    extract::{Host, OriginalUri},
+    Json,
+};
+use dal::{
+    cached_module::CachedModule,
+    pkg::{import_pkg_from_pkg, ImportOptions},
+    ChangeSet, Func, Schema, SchemaId, SchemaVariant, Visibility, WsEvent,
+};
+use serde::{Deserialize, Serialize};
+use si_frontend_types::SchemaVariant as FrontendVariant;
+
+use crate::{
+    extract::{v1::AccessBuilder, HandlerContext, PosthogClient},
+    service::{force_change_set_response::ForceChangeSetResponse, module::ModuleError},
+    track,
+};
+
+use telemetry::prelude::*;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct UpgradeModulesRequest {
+    pub schema_ids: Vec<SchemaId>,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+pub async fn upgrade_modules(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    PosthogClient(posthog_client): PosthogClient,
+    OriginalUri(original_uri): OriginalUri,
+    Host(host_name): Host,
+    Json(request): Json<UpgradeModulesRequest>,
+) -> Result<ForceChangeSetResponse<Vec<FrontendVariant>>, ModuleError> {
+    let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
+
+    let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
+
+    let mut variants = Vec::new();
+
+    for schema_id in request.schema_ids {
+        let schema_exists_locally = Schema::exists_locally(&ctx, schema_id).await?;
+        let at_least_one_unlocked_variant = SchemaVariant::get_unlocked_for_schema(&ctx, schema_id)
+            .await?
+            .is_some();
+        if schema_exists_locally && at_least_one_unlocked_variant {
+            warn!(%schema_id, %schema_exists_locally, %at_least_one_unlocked_variant, "cannot upgrade module for schema since it exists locally and has at least one unlocked variant");
+            continue;
+        }
+
+        let Some(mut cached_module) =
+            CachedModule::find_latest_for_schema_id(&ctx, schema_id).await?
+        else {
+            warn!(%schema_id, "no cached module found for schema");
+            continue;
+        };
+
+        let si_pkg = cached_module.si_pkg(&ctx).await?;
+
+        let metadata = si_pkg.metadata()?;
+        let (_, schema_variant_ids, _) = match import_pkg_from_pkg(
+            &ctx,
+            &si_pkg,
+            Some(ImportOptions {
+                schema_id: Some(schema_id.into()),
+                ..Default::default()
+            }),
+        )
+        .await
+        {
+            Ok(details) => details,
+            Err(err) => {
+                error!(si.error.message = ?err, %schema_id, cached_module_id = %cached_module.id, "cannot install pkg");
+                continue;
+            }
+        };
+
+        track(
+            &posthog_client,
+            &ctx,
+            &original_uri,
+            &host_name,
+            "upgrade_modules",
+            serde_json::json!({
+                "pkg_name": metadata.name().to_owned(),
+            }),
+        );
+
+        if let Some(schema_variant_id) = schema_variant_ids.first() {
+            let variant = SchemaVariant::get_by_id_or_error(&ctx, *schema_variant_id).await?;
+            let schema_id = variant.schema(&ctx).await?.id();
+            let front_end_variant = variant.into_frontend_type(&ctx, schema_id).await?;
+            WsEvent::module_imported(&ctx, vec![front_end_variant.clone()])
+                .await?
+                .publish_on_commit(&ctx)
+                .await?;
+            for func_id in front_end_variant.func_ids.iter() {
+                let func = Func::get_by_id_or_error(&ctx, *func_id).await?;
+                let front_end_func = func.into_frontend_type(&ctx).await?;
+                WsEvent::func_updated(&ctx, front_end_func, None)
+                    .await?
+                    .publish_on_commit(&ctx)
+                    .await?;
+            }
+            variants.push(front_end_variant);
+        } else {
+            return Err(ModuleError::SchemaNotFoundFromInstall(schema_id.into()));
+        };
+    }
+
+    ctx.commit().await?;
+
+    Ok(ForceChangeSetResponse::new(force_change_set_id, variants))
+}

--- a/lib/sdf-server/src/service/v2/module/sync.rs
+++ b/lib/sdf-server/src/service/v2/module/sync.rs
@@ -24,6 +24,12 @@ pub async fn sync(
         .build(access_builder.build(change_set_id.into()))
         .await?;
 
+    // TODO(nick): the concept of the inner types returned here are from the module index days and
+    // are bullshit. We should provide the minimal set of information, which is moreso just telling
+    // the frontend which _schemas_ are ready to be upgraded or contributed. Yes, schema variants
+    // are the important granular bits, but in the case of upgradeables, you find the cached module
+    // that is "latest" and in the case of contributeables, you can only contribute the default
+    // variant.
     let synced_modules = Module::sync(&ctx).await?;
 
     track(


### PR DESCRIPTION
This PR adds the ability to upgrade modules from the cached modules table. This fixes an error when the "install remote module" logic was used from synced modules using the local cache (introduced by #5524).