### PR TITLE
All edges should behave like mgmt edges (only show when components/props are selected)

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramEdge.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramEdge.vue
@@ -171,11 +171,7 @@ const showEdge = computed(() => {
     return false;
   }
 
-  if (props.edge.def.isManagement) {
-    return isFromOrToSelected.value || props.isSelected;
-  }
-
-  return true;
+  return isFromOrToSelected.value || props.isSelected;
 });
 
 const mainLineOpacity = computed(() => {


### PR DESCRIPTION
<img src="https://media0.giphy.com/media/YGbF41mvOpGyVleuV6/giphy.gif?cid=bd3ea57epo2x2s2xx6uwk2zyyraic112vy3yfp78b7rnfu25&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>