### PR TITLE
perf(veritech): Run simple Joi validations in Rust instead of JS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,6 +1852,7 @@ dependencies = [
  "iftree",
  "indexmap 2.7.1",
  "itertools 0.13.0",
+ "joi-validator",
  "jwt-simple",
  "lazy_static",
  "module-index-client",
@@ -3880,6 +3881,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "joi-validator"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "color-eyre",
+ "derive_more",
+ "remain",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "si-std",
+ "telemetry",
+ "thiserror 2.0.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "lib/dal-test",
     "lib/data-warehouse-stream-client",
     "lib/forklift-server",
+    "lib/joi-validator",
     "lib/module-index-client",
     "lib/module-index-server",
     "lib/nats-dead-letter-queue",

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -11,6 +11,7 @@ rust_library(
         "//lib/audit-logs-stream:audit-logs-stream",
         "//lib/billing-events:billing-events",
         "//lib/dal-macros:dal-macros",
+        "//lib/joi-validator:joi-validator",
         "//lib/module-index-client:module-index-client",
         "//lib/object-tree:object-tree",
         "//lib/pending-events:pending-events",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -13,6 +13,7 @@ audit-database = { path = "../../lib/audit-database" }
 audit-logs-stream = { path = "../../lib/audit-logs-stream" }
 billing-events = { path = "../../lib/billing-events" }
 dal-macros = { path = "../../lib/dal-macros" }
+joi-validator = { path = "../../lib/joi-validator" }
 module-index-client = { path = "../../lib/module-index-client" }
 object-tree = { path = "../../lib/object-tree" }
 pending-events = { path = "../../lib/pending-events" }

--- a/lib/joi-validator/BUCK
+++ b/lib/joi-validator/BUCK
@@ -1,0 +1,22 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "joi-validator",
+    deps = [
+        "//lib/si-std:si-std",
+        "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:chrono",
+        "//third-party/rust:derive_more",
+        "//third-party/rust:remain",
+        "//third-party/rust:serde",
+        "//third-party/rust:serde_json",
+        "//third-party/rust:serde_with",
+        "//third-party/rust:thiserror",
+    ],
+    srcs = glob([
+        "src/**/*.rs",
+    ]),
+    test_unit_deps = [
+        "//third-party/rust:color-eyre",
+    ],
+)

--- a/lib/joi-validator/Cargo.toml
+++ b/lib/joi-validator/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "joi-validator"
+edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+si-std = { path = "../../lib/si-std" }
+telemetry = { path = "../../lib/telemetry-rs" }
+
+chrono = { workspace = true }
+derive_more = { workspace = true }
+remain = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+color-eyre = { workspace = true }

--- a/lib/joi-validator/src/alternatives.rs
+++ b/lib/joi-validator/src/alternatives.rs
@@ -1,0 +1,8 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct Validator {
+    pub matches: Vec<crate::Validator>,
+}

--- a/lib/joi-validator/src/boolean.rs
+++ b/lib/joi-validator/src/boolean.rs
@@ -1,0 +1,73 @@
+use serde::Deserialize;
+
+use crate::{generic, rule_err};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct Validator {
+    #[serde(default)]
+    rules: Vec<Rule>,
+    // #[serde(default)]
+    // falsy: Vec<String>,
+    // #[serde(default)]
+    // truthy: Vec<String>,
+    #[serde(flatten)]
+    pub base: generic::Validator<bool, Flags>,
+}
+
+impl Validator {
+    pub fn validate(self, value: &Option<serde_json::Value>) -> Result<(), (String, String)> {
+        self.base.validate_presence(value)?;
+        if let Some(value) = value {
+            let value = match value {
+                serde_json::Value::Bool(boolean) => Some(*boolean),
+                serde_json::Value::String(string) => {
+                    if string.eq_ignore_ascii_case("true") {
+                        Some(true)
+                    } else if string.eq_ignore_ascii_case("false") {
+                        Some(false)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+            .ok_or(rule_err("boolean.base", "must be a boolean"))?;
+
+            // Now that we have the boolean, validate it
+            self.base.validate_value(&value)?;
+            for rule in self.rules {
+                rule.validate(&value)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn rule_names(&self) -> Vec<&'static str> {
+        let mut rule_names = self.base.rule_names();
+        rule_names.push("boolean.base");
+        rule_names
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+#[serde(tag = "name")]
+enum Rule {}
+
+impl Rule {
+    fn validate(&self, _value: &bool) -> Result<(), (String, String)> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct Flags {
+    // // Set true to not check if the number is in the safe range
+    // #[serde(default)]
+    // sensitive: bool,
+}

--- a/lib/joi-validator/src/date.rs
+++ b/lib/joi-validator/src/date.rs
@@ -1,0 +1,31 @@
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::{generic, Args, Limit};
+
+pub type Validator = generic::Validator<DateTime<Utc>, Rule, Flags>;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+#[serde(tag = "name")]
+pub enum Rule {
+    Greater(Args<Limit<DateTime<Utc>>>),
+    Less(Args<Limit<DateTime<Utc>>>),
+    Max(Args<Limit<DateTime<Utc>>>),
+    Min(Args<Limit<DateTime<Utc>>>),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct Flags {
+    pub format: Option<Format>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Format {
+    Iso,        // Joi.date().iso()
+    Javascript, // Joi.date().timestamp()
+}

--- a/lib/joi-validator/src/generic.rs
+++ b/lib/joi-validator/src/generic.rs
@@ -1,0 +1,116 @@
+use std::fmt::Debug;
+
+use serde::{Deserialize, Serialize};
+
+use crate::require;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct Validator<T, ExtraFlags> {
+    // Flags that affect rules (such as "only" and "presence")
+    #[serde(default)]
+    pub flags: Flags<ExtraFlags>,
+    // Allowed values (only checked if flags.only is set)
+    pub allow: Option<Vec<T>>,
+    // Disallowed values
+    pub invalid: Option<Vec<T>>,
+
+    // Preferences like whether to convert values
+    // pub preferences: Option<Preferences>,
+
+    // Descriptive stuff that's OK to pass through
+    pub examples: Option<Vec<T>>,
+    pub metas: Option<Vec<serde_json::Value>>,
+    pub notes: Option<Vec<String>>,
+    pub tags: Option<Vec<String>>,
+}
+
+impl<T: PartialEq + Serialize + Debug, ExtraFlags> Validator<T, ExtraFlags> {
+    pub fn validate_value(&self, value: &T) -> Result<(), (String, String)> {
+        self.validate_valid_values(value)
+    }
+
+    pub fn validate_presence<V>(&self, value: &Option<V>) -> Result<(), (String, String)> {
+        match self.flags.presence {
+            Some(Presence::Required) => require(value.is_some(), "any.required", "is required"),
+            Some(Presence::Forbidden) => require(value.is_none(), "any.unknown", "is not allowed"),
+            Some(Presence::Optional) | None => Ok(()),
+        }
+    }
+
+    fn validate_valid_values(&self, value: &T) -> Result<(), (String, String)> {
+        // Check if it's one of the allowed values
+        if self.flags.only {
+            if let Some(allow) = &self.allow {
+                require(
+                    allow.contains(value),
+                    "any.only",
+                    format!("must be one of {:?}", self.allow),
+                )?;
+            }
+        }
+        // Check for invalid values
+        if let Some(invalid) = &self.invalid {
+            require(
+                !invalid.contains(value),
+                "any.invalid",
+                "contains an invalid value",
+            )?;
+        }
+        Ok(())
+    }
+
+    pub fn rule_names(&self) -> Vec<&'static str> {
+        let mut rule_names = vec![];
+        match self.flags.presence {
+            Some(Presence::Required) => rule_names.push("any.required"),
+            Some(Presence::Forbidden) => rule_names.push("any.unknown"),
+            Some(Presence::Optional) | None => (),
+        }
+        if self.flags.only {
+            if let Some(_allow) = &self.allow {
+                rule_names.push("any.only");
+            }
+        }
+        if let Some(_invalid) = &self.invalid {
+            rule_names.push("any.invalid");
+        }
+        rule_names
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct Flags<ExtraFlags> {
+    #[serde(default)]
+    pub only: bool, // Defaults to false
+    pub presence: Option<Presence>,
+    // pub unit: Option<String>,
+
+    // Label to use in error messages
+    pub label: Option<String>,
+
+    // Purely descriptive
+    pub description: Option<String>,
+
+    #[serde(flatten)]
+    pub extra_flags: ExtraFlags,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub enum Presence {
+    Forbidden,
+    Optional,
+    Required,
+}
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// pub struct Preferences {
+//     pub convert: Option<bool>,
+// }

--- a/lib/joi-validator/src/lib.rs
+++ b/lib/joi-validator/src/lib.rs
@@ -1,0 +1,197 @@
+//! This create provides centralized support for using AI to generate assets.
+
+#![warn(
+    bad_style,
+    clippy::missing_panics_doc,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result,
+    clippy::unwrap_used,
+    dead_code,
+    improper_ctypes,
+    missing_debug_implementations,
+    // missing_docs,
+    no_mangle_generic_items,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    unconditional_recursion,
+    unreachable_pub,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_with::serde_as;
+
+// These are commented out until we decide to support them in any way.
+// pub mod alternatives;
+// pub mod date;
+mod boolean;
+pub mod generic;
+mod number;
+mod string;
+#[cfg(test)]
+mod test;
+
+#[remain::sorted]
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Unreachable")]
+    Unreachable,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+#[serde(tag = "type")]
+pub enum Validator {
+    // Alternatives(alternatives::Validator),
+    Boolean(boolean::Validator),
+    // Date(date::Validator),
+    Number(number::Validator),
+    String(string::Validator),
+}
+
+impl Validator {
+    // Takes in an optional value, validates it according to the rules, and returns a response
+    // in Joi format.
+    pub fn validate(
+        mut self,
+        value: &Option<serde_json::Value>,
+    ) -> ValidateResponse<Option<serde_json::Value>> {
+        let label = self.take_label().unwrap_or("value".into());
+        let result = match self {
+            Validator::Boolean(validator) => validator.validate(value),
+            Validator::Number(validator) => validator.validate(value),
+            Validator::String(validator) => validator.validate(value),
+        };
+        ValidateResponse {
+            value: value.clone(),
+            error: match result {
+                Ok(()) => None,
+                Err((r#type, message)) => Some(ValidateError {
+                    _original: value.clone(),
+                    details: vec![ValidateErrorDetails {
+                        message: format!("{} {}", Self::to_json_string(&label), message),
+                        r#type,
+                        path: vec![],
+                        context: ValidateContext {
+                            label,
+                            value: value.clone(),
+                            extra: None,
+                        },
+                    }],
+                }),
+            },
+            warning: None,
+            artifacts: None,
+        }
+    }
+
+    // Outputs a JSON string, with quotes and escapes
+    fn to_json_string(string: &str) -> String {
+        serde_json::Value::from(string).to_string()
+    }
+
+    fn take_label(&mut self) -> Option<String> {
+        match self {
+            Validator::Boolean(validator) => validator.base.flags.label.take(),
+            Validator::Number(validator) => validator.base.flags.label.take(),
+            Validator::String(validator) => validator.base.flags.label.take(),
+        }
+    }
+
+    pub fn rule_names(&self) -> Vec<&'static str> {
+        match self {
+            Validator::Boolean(validator) => validator.rule_names(),
+            Validator::Number(validator) => validator.rule_names(),
+            Validator::String(validator) => validator.rule_names(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct ValidateResponse<T> {
+    pub value: T,
+    pub error: Option<ValidateError<T>>,
+    pub warning: Option<ValidateError<T>>,
+    pub artifacts: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct ValidateError<T> {
+    pub _original: T,
+    pub details: Vec<ValidateErrorDetails<T>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct ValidateErrorDetails<T> {
+    pub message: String,
+    pub path: Vec<StringOrNumber>,
+    pub r#type: String,
+    pub context: ValidateContext<T>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct ValidateContext<T> {
+    pub label: String,
+    pub value: T,
+    #[serde(flatten)]
+    pub extra: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(untagged)]
+pub enum StringOrNumber {
+    String(String),
+    Number(usize),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct Args<T> {
+    pub args: T,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct Options<T> {
+    pub options: T,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct OneOrMany<T: DeserializeOwned>(#[serde_as(as = "serde_with::OneOrMany<_>")] pub Vec<T>);
+
+fn rule_err(r#type: impl Into<String>, message: impl Into<String>) -> (String, String) {
+    (r#type.into(), message.into())
+}
+
+fn require(
+    condition: bool,
+    r#type: impl Into<String>,
+    message: impl Into<String>,
+) -> Result<(), (String, String)> {
+    if condition {
+        Ok(())
+    } else {
+        Err(rule_err(r#type, message))
+    }
+}

--- a/lib/joi-validator/src/number.rs
+++ b/lib/joi-validator/src/number.rs
@@ -1,0 +1,164 @@
+use std::f64;
+
+use serde::Deserialize;
+
+use crate::{generic, require, rule_err, Args};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct Validator {
+    #[serde(default)]
+    rules: Vec<Rule>,
+    #[serde(flatten)]
+    pub base: generic::Validator<f64, Flags>,
+}
+
+impl Validator {
+    fn validate_safe(&self, value: f64) -> Result<(), (String, String)> {
+        if !self.base.flags.extra_flags.r#unsafe {
+            require(
+                (JS_MIN_SAFE_INTEGER..=JS_MAX_SAFE_INTEGER).contains(&value),
+                "number.unsafe",
+                "unsafe number",
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl Validator {
+    pub fn validate(self, value: &Option<serde_json::Value>) -> Result<(), (String, String)> {
+        self.base.validate_presence(value)?;
+        if let Some(value) = value {
+            let value = match value {
+                serde_json::Value::Number(number) => number.as_f64(),
+                serde_json::Value::String(string) => string.trim().parse().ok(),
+                _ => None,
+            }
+            .ok_or_else(|| rule_err("number.base", "must be a number"))?;
+
+            // Now that we have the float, validate it
+            self.validate_safe(value)?;
+            self.base.validate_value(&value)?;
+            for rule in self.rules {
+                rule.validate(&value)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn rule_names(&self) -> Vec<&'static str> {
+        let mut rule_names = self.base.rule_names();
+        rule_names.push("number.base");
+        if !self.base.flags.extra_flags.r#unsafe {
+            rule_names.push("number.unsafe");
+        }
+        rule_names.extend(self.rules.iter().map(Rule::rule_name));
+        rule_names
+    }
+}
+
+const JS_MIN_SAFE_INTEGER: f64 = -9007199254740991.0;
+const JS_MAX_SAFE_INTEGER: f64 = 9007199254740991.0;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+#[serde(tag = "name")]
+enum Rule {
+    Greater(Args<Limit>),
+    Integer,
+    Less(Args<Limit>),
+    Max(Args<Limit>),
+    Min(Args<Limit>),
+    // Multiple(Args<Multiple>),
+    // Port,
+    // Precision(Precision),
+    // Sign(Args<SignArgs>),
+}
+
+impl Rule {
+    fn validate(&self, value: &f64) -> Result<(), (String, String)> {
+        match self {
+            Rule::Integer => require(value.fract() == 0.0, "number.integer", "must be an integer"),
+            Rule::Greater(rule) => require(
+                value > &rule.args.limit,
+                "number.greater",
+                format!("must be greater than {}", rule.args.limit),
+            ),
+            Rule::Less(rule) => require(
+                value < &rule.args.limit,
+                "number.less",
+                format!("must be less than {}", rule.args.limit),
+            ),
+            Rule::Max(rule) => require(
+                value <= &rule.args.limit,
+                "number.max",
+                format!("must be less than or equal to {}", rule.args.limit),
+            ),
+            Rule::Min(rule) => require(
+                value >= &rule.args.limit,
+                "number.min",
+                format!("must be greater than or equal to {}", rule.args.limit),
+            ),
+        }
+    }
+
+    fn rule_name(&self) -> &'static str {
+        match self {
+            Rule::Greater(_) => "number.greater",
+            Rule::Integer => "number.integer",
+            Rule::Less(_) => "number.less",
+            Rule::Max(_) => "number.max",
+            Rule::Min(_) => "number.min",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+struct Limit {
+    limit: f64,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct Flags {
+    // Set true to not check if the number is in the safe range
+    #[serde(default)]
+    r#unsafe: bool,
+}
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// struct Precision {
+//     limit: u64,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// struct Multiple {
+//     base: f64,
+//     base_decimal_place: u64,
+//     pfactor: f64,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// struct SignArgs {
+//     sign: Sign,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// enum Sign {
+//     Negative,
+//     Positive,
+// }

--- a/lib/joi-validator/src/string.rs
+++ b/lib/joi-validator/src/string.rs
@@ -1,0 +1,392 @@
+use crate::{generic, require, rule_err, Args};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct Validator {
+    #[serde(default)]
+    rules: Vec<Rule>,
+    #[serde(flatten)]
+    pub base: generic::Validator<String, Flags>,
+}
+
+impl Validator {
+    pub fn validate(self, value: &Option<serde_json::Value>) -> Result<(), (String, String)> {
+        self.base.validate_presence(value)?;
+        match value {
+            Some(serde_json::Value::String(value)) => {
+                // Now that we have the string, validate it
+                self.base.validate_value(value)?;
+                for rule in self.rules {
+                    rule.validate(value)?;
+                }
+                Ok(())
+            }
+            Some(_) => Err(rule_err("string.base", "must be a string")),
+            None => Ok(()),
+        }
+    }
+
+    pub fn rule_names(&self) -> Vec<&'static str> {
+        let mut rule_names = self.base.rule_names();
+        rule_names.push("string.base");
+        rule_names.extend(self.rules.iter().map(Rule::rule_name));
+        rule_names
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+#[serde(tag = "name")]
+enum Rule {
+    // Alphanum,
+    // Base64(Args<Options<Base64Options>>),
+    // Case(Args<Options<CaseOptions>>),
+    // CreditCard,
+    // DataUri(Args<Options<DataUriOptions>>),
+    // Domain(Args<Options<DomainOptions>>),
+    // Email(Args<Options<EmailOptions>>),
+    // Guid(Args<Options<GuidOptions>>),
+    // Hex(Args<Options<HexOptions>>),
+    // Hostname,
+    // Ip(Args<Options<IpOptions>>),
+    // IsoDate,
+    // IsoDuration,
+    Length(Args<LengthLimit>),
+    Min(Args<LengthLimit>),
+    Max(Args<LengthLimit>),
+    // Normalize(Args<Normalize>),
+    // Pattern(Args<Pattern>),
+    // Replace(Args<Replace>),
+    // Token,
+    // Trim(Args<Enabled>),
+    // Truncate(Args<Enabled>),
+    // Uri(Args<Options<UriOptions>>),
+}
+
+impl Rule {
+    fn validate(self, value: &str) -> Result<(), (String, String)> {
+        match self {
+            Self::Length(rule) => require(
+                value.len() == rule.args.limit,
+                "string.length",
+                format!("length must be {} characters long", rule.args.limit),
+            ),
+            Self::Min(rule) => require(
+                value.len() >= rule.args.limit,
+                "string.min",
+                format!(
+                    "length must be at least {} characters long",
+                    rule.args.limit
+                ),
+            ),
+            Self::Max(rule) => require(
+                value.len() <= rule.args.limit,
+                "string.max",
+                format!(
+                    "length must be less than or equal to {} characters long",
+                    rule.args.limit
+                ),
+            ),
+        }
+    }
+
+    fn rule_name(&self) -> &'static str {
+        match self {
+            Self::Length(_) => "string.length",
+            Self::Min(_) => "string.min",
+            Self::Max(_) => "string.max",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+struct LengthLimit {
+    limit: usize,
+    // encoding: Option<Encoding>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct Flags {
+    // insensitive: Option<bool>,
+}
+
+// #[derive(Debug, Clone, Deserialize, Default)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// pub struct Base64Options {
+//     pub padding_required: Option<bool>,
+//     pub url_safe: Option<bool>,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// pub struct CaseOptions {
+//     pub direction: CaseDirection,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// pub enum CaseDirection {
+//     Lower,
+//     Upper,
+// }
+
+// #[derive(Debug, Clone, Deserialize, Default)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// pub struct DataUriOptions {
+//     pub padding_required: Option<bool>,
+// }
+
+// // allowFullyQualified - if true, domains ending with a . character are permitted. Defaults to false.
+// // allowUnicode - if true, Unicode characters are permitted. Defaults to true.
+// // minDomainSegments - number of segments required for the domain. Defaults to 2.
+// // maxDomainSegments - maximum number of allowed domain segments. Default to no limit.
+// // tlds - options for TLD (top level domain) validation. By default, the TLD must be a valid name listed on the IANA registry. To disable validation, set tlds to false. To customize how TLDs are validated, set one of these:
+// // allow - one of:
+// // true to use the IANA list of registered TLDs. This is the default value.
+// // false to allow any TLD not listed in the deny list, if present.
+// // a Set or array of the allowed TLDs. Cannot be used together with deny.
+// // deny - one of:
+// // a Set or array of the forbidden TLDs. Cannot be used together with a custom allow list.
+// #[derive(Debug, Clone, Deserialize, Default)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// pub struct DomainOptions {
+//     pub allow_fully_qualified: Option<bool>,
+//     pub allow_unicode: Option<bool>,
+//     pub min_domain_segments: Option<u64>,
+//     pub max_domain_segments: Option<u64>,
+//     pub tlds: Option<DomainTldsOptions>,
+// }
+
+// #[derive(Debug, Clone, Deserialize, Default)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// pub struct DomainTldsOptions {
+//     pub allow: DomainTldsAllow,
+//     pub deny: Option<Vec<String>>,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// #[serde(untagged)]
+// pub enum DomainTldsAllow {
+//     All(bool),
+//     Some(Vec<String>),
+// }
+
+// impl Default for DomainTldsAllow {
+//     fn default() -> Self {
+//         DomainTldsAllow::All(true)
+//     }
+// }
+
+// // options - optional settings:
+// // allowFullyQualified - if true, domains ending with a . character are permitted. Defaults to false.
+// // allowUnicode - if true, Unicode characters are permitted. Defaults to true.
+// // ignoreLength - if true, ignore invalid email length errors. Defaults to false.
+// // minDomainSegments - number of segments required for the domain. The default setting excludes single segment domains such as example@io which is a valid email but very uncommon. Defaults to 2.
+// // maxDomainSegments - maximum number of allowed domain segments. Default to no limit.
+// // multiple - if true, allows multiple email addresses in a single string, separated by , or the separator characters. Defaults to false.
+// // separator - when multiple is true, overrides the default , separator. String can be a single character or multiple separator characters. Defaults to ','.
+// // tlds - options for TLD (top level domain) validation. By default, the TLD must be a valid name listed on the IANA registry. To disable validation, set tlds to false. To customize how TLDs are validated, set one of these:
+// // allow - one of:
+// // true to use the IANA list of registered TLDs. This is the default value.
+// // false to allow any TLD not listed in the deny list, if present.
+// // a Set or array of the allowed TLDs. Cannot be used together with deny.
+// // deny - one of:
+// // a Set or array of the forbidden TLDs. Cannot be used together with a custom allow list.
+// #[derive(Debug, Clone, Deserialize, Default)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// pub struct EmailOptions {
+//     pub allow_fully_qualified: Option<bool>,
+//     pub allow_unicode: Option<bool>,
+//     pub ignore_length: Option<bool>,
+//     pub min_domain_segments: Option<u64>,
+//     pub max_domain_segments: Option<u64>,
+//     pub multiple: Option<bool>,
+//     pub separator: Option<String>,
+//     pub tlds: Option<DomainTldsOptions>,
+// }
+
+// // Requires the string value to be a valid GUID.
+
+// // options - optional settings:
+// // version - specifies one or more acceptable versions. Can be an Array or String with the following values: uuidv1, uuidv2, uuidv3, uuidv4, uuidv5, uuidv6, uuidv7 or uuidv8. If no version is specified then it is assumed to be a generic guid which will not validate the version or variant of the guid and just check for general structure format.
+// // separator - defines the allowed or required GUID separator where:
+// // true - a separator is required, can be either : or -.
+// // false - separator is not allowed.
+// // '-' - a dash separator is required.
+// // ':' - a colon separator is required.
+// // defaults to optional : or - separator.
+// #[derive(Debug, Clone, Deserialize, Default)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// struct GuidOptions {
+//     version: Option<OneOrMany<GuidVersion>>,
+//     separator: Option<GuidSeparator>,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// enum GuidSeparator {
+//     #[serde(rename = "-")]
+//     Dash,
+//     #[serde(rename = ":")]
+//     Colon,
+//     Any(Option<bool>),
+// }
+
+// impl Default for GuidSeparator {
+//     fn default() -> Self {
+//         GuidSeparator::Any(None)
+//     }
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// enum GuidVersion {
+//     Uuidv1,
+//     Uuidv2,
+//     Uuidv3,
+//     Uuidv4,
+//     Uuidv5,
+//     Uuidv6,
+//     Uuidv7,
+//     Uuidv8,
+// }
+
+// // Requires the string value to be a valid hexadecimal string.
+
+// // options - optional settings:
+// // byteAligned - Boolean specifying whether you want to check that the hexadecimal string is byte aligned. If convert is true, a 0 will be added in front of the string in case it needs to be aligned. Defaults to false.
+// // prefix - Boolean or optional. When true, the string will be considered valid if prefixed with 0x or 0X. When false, the prefix is forbidden. When optional, the string will be considered valid if prefixed or not prefixed at all. Defaults to false.
+// #[derive(Debug, Clone, Deserialize, Default)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// struct HexOptions {
+//     byte_aligned: Option<bool>,
+//     prefix: Option<HexPrefix>,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// enum HexPrefix {
+//     Required(bool),
+//     #[serde(rename = "optional")]
+//     Optional,
+// }
+
+// impl Default for HexPrefix {
+//     fn default() -> Self {
+//         HexPrefix::Required(false)
+//     }
+// }
+
+// // options - optional settings:
+// // version - One or more IP address versions to validate against. Valid values: ipv4, ipv6, ipvfuture
+// // cidr - Used to determine if a CIDR is allowed or not. Valid values: optional, required, forbidden
+// #[derive(Debug, Clone, Deserialize, Default)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// struct IpOptions {
+//     version: Option<OneOrMany<IpVersion>>,
+//     cidr: Option<IpCidr>,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// enum IpVersion {
+//     Ipv4,
+//     Ipv6,
+//     Ipvfuture,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// enum IpCidr {
+//     Optional,
+//     Required,
+//     Forbidden,
+// }
+
+// #[derive(Debug, Clone, Deserialize, Default)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// struct Normalize {
+//     form: NormalizedForm,
+// }
+
+// #[derive(Debug, Clone, Deserialize, Default)]
+// // We deliberately do not rename_all
+// enum NormalizedForm {
+//     #[default]
+//     NFC,
+//     NFD,
+//     NFKC,
+//     NFKD,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// struct Replace {
+//     pattern: Pattern,
+//     replacement: String,
+// }
+
+// // options - optional settings:
+// // scheme - Specifies one or more acceptable Schemes, should only include the scheme name. Can be an Array or String (strings are automatically escaped for use in a Regular Expression).
+// // allowRelative - Allow relative URIs. Defaults to false.
+// // relativeOnly - Restrict only relative URIs. Defaults to false.
+// // allowQuerySquareBrackets - Allows unencoded square brackets inside the query string. This is NOT RFC 3986 compliant but query strings like abc[]=123&abc[]=456 are very common these days. Defaults to false.
+// // domain - Validate the domain component using the options specified in string.domain().
+// // encodeUri - When convert is true, if the validation fails, attempts to encode the URI using encodeURI before validating it again. This allows to provide, for example, unicode URIs, and have it encoded for you. Defaults to false.
+// #[derive(Debug, Clone, Deserialize, Default)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// struct UriOptions {
+//     scheme: Option<OneOrMany<String>>,
+//     allow_relative: Option<bool>,
+//     relative_only: Option<bool>,
+//     allow_query_square_brackets: Option<bool>,
+//     domain: Option<DomainOptions>,
+//     encode_uri: Option<bool>,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// struct Enabled {
+//     enabled: bool,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// enum Encoding {
+//     Utf8,
+//     // ???
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// #[serde(deny_unknown_fields)]
+// struct Pattern {
+//     regex: String,
+//     name: Option<String>,
+//     invert: Option<bool>,
+// }

--- a/lib/joi-validator/src/test.rs
+++ b/lib/joi-validator/src/test.rs
@@ -1,0 +1,863 @@
+use crate::{ValidateResponse, Validator};
+pub(crate) use color_eyre::{eyre::eyre, Result};
+pub(crate) use serde_json::json;
+
+pub(crate) fn valid_opt(json: &str, value: Option<serde_json::Value>) -> Result<()> {
+    let validator: Validator = serde_json::from_str(json)?;
+    let response = validator.validate(&value);
+    if let ValidateResponse {
+        error: Some(error), ..
+    } = response
+    {
+        return Err(eyre!("validation error: {:?}", error));
+    }
+    Ok(())
+}
+
+pub(crate) fn valid(json: &str, value: impl Into<serde_json::Value>) -> Result<()> {
+    valid_opt(json, Some(value.into()))
+}
+
+pub(crate) fn invalid_opt(json: &str, value: Option<serde_json::Value>) -> Result<()> {
+    match valid_opt(json, value.clone()) {
+        Ok(_) => Err(eyre!("expected validation error on {:?}", value)),
+        Err(_) => Ok(()),
+    }
+}
+
+pub(crate) fn invalid(json: &str, value: impl Into<serde_json::Value>) -> Result<()> {
+    invalid_opt(json, Some(value.into()))
+}
+
+pub(crate) fn unsupported(json: &str) -> Result<()> {
+    match serde_json::from_str::<Validator>(json) {
+        Ok(_) => Err(eyre!("expected schema to be unsupported: {:?}", json)),
+        Err(_) => Ok(()),
+    }
+}
+
+mod any {
+    use super::*;
+
+    #[test]
+    fn unsupported_basics() -> Result<()> {
+        unsupported(r#"{ }"#)?;
+        unsupported(r#""string"#)?;
+        unsupported(r#"10""#)?;
+        unsupported(r#"null"#)?;
+        unsupported(r#"[]"#)?;
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_types() -> Result<()> {
+        unsupported(r#"{ "type": "any" }"#)?;
+        unsupported(r#"{ "type": "alternatives" }"#)?;
+        unsupported(r#"{ "type": "date" }"#)?;
+        Ok(())
+    }
+}
+
+mod boolean {
+    use super::*;
+
+    #[test]
+    fn type_boolean() -> Result<()> {
+        let joi = r#"{ "type": "boolean" }"#;
+        valid_opt(joi, None)?;
+        valid(joi, true)?;
+        valid(joi, "true")?;
+        valid(joi, false)?;
+        valid(joi, "false")?;
+        Ok(())
+    }
+
+    #[test]
+    fn allow_values() -> Result<()> {
+        let joi = r#"{ "type": "boolean" }"#;
+        valid(joi, true)?;
+        valid(joi, "true")?;
+        valid(joi, false)?;
+        valid(joi, "false")?;
+
+        let joi = r#"{ "type": "boolean", "allow": [false] }"#;
+        valid(joi, true)?;
+        valid(joi, "true")?;
+        valid(joi, false)?;
+        valid(joi, "false")?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn valid_values() -> Result<()> {
+        let joi = r#"{ "type": "boolean", "flags": { "only": true } }"#;
+        valid(joi, true)?;
+        valid(joi, "true")?;
+        valid(joi, false)?;
+        valid(joi, "false")?;
+
+        let joi = r#"{ "type": "boolean", "flags": { "only": true }, "allow": [] }"#;
+        invalid(joi, true)?;
+        invalid(joi, "true")?;
+        invalid(joi, false)?;
+        invalid(joi, "false")?;
+
+        let joi = r#"{ "type": "boolean", "flags": { "only": true }, "allow": [true] }"#;
+        valid(joi, true)?;
+        valid(joi, "true")?;
+        invalid(joi, false)?;
+        invalid(joi, "false")?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_values() -> Result<()> {
+        let joi = r#"{ "type": "boolean", "invalid": [] }"#;
+        valid(joi, true)?;
+        valid(joi, "true")?;
+        valid(joi, false)?;
+        valid(joi, "false")?;
+
+        let joi = r#"{ "type": "boolean", "invalid": [false] }"#;
+        valid(joi, true)?;
+        valid(joi, "true")?;
+        invalid(joi, false)?;
+        invalid(joi, "false")?;
+
+        let joi = r#"{ "type": "boolean", "allow": [true], "invalid": [false] }"#;
+        valid(joi, true)?;
+        valid(joi, "true")?;
+        invalid(joi, false)?;
+        invalid(joi, "false")?;
+
+        let joi = r#"{ "type": "boolean", "flags": { "only": true }, "invalid": [false] }"#;
+        valid(joi, true)?;
+        valid(joi, "true")?;
+        invalid(joi, false)?;
+        invalid(joi, "false")?;
+
+        let joi = r#"{ "type": "boolean", "flags": { "only": true }, "allow": [true], "invalid": [false] }"#;
+        valid(joi, true)?;
+        valid(joi, "true")?;
+        invalid(joi, false)?;
+        invalid(joi, "false")?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn required() -> Result<()> {
+        let joi = r#"{ "type": "boolean", "flags": { "presence": "required" } }"#;
+        valid(joi, true)?;
+        valid(joi, "true")?;
+        valid(joi, false)?;
+        valid(joi, "false")?;
+        invalid(joi, json!(null))?;
+        invalid_opt(joi, None)?;
+        Ok(())
+    }
+
+    #[test]
+    fn forbidden() -> Result<()> {
+        let joi = r#"{ "type": "boolean", "flags": { "presence": "forbidden" } }"#;
+        invalid(joi, true)?;
+        invalid(joi, "true")?;
+        invalid(joi, false)?;
+        invalid(joi, "false")?;
+        invalid(joi, json!(null))?;
+        valid_opt(joi, None)?;
+        Ok(())
+    }
+
+    #[test]
+    fn optional() -> Result<()> {
+        let joi = r#"{ "type": "boolean", "flags": { "presence": "optional" } }"#;
+        valid(joi, true)?;
+        valid(joi, "true")?;
+        valid(joi, false)?;
+        valid(joi, "false")?;
+        invalid(joi, json!(null))?;
+        valid_opt(joi, None)?;
+        Ok(())
+    }
+
+    #[test]
+    fn passthrough() -> Result<()> {
+        valid(
+            r#"{ "type": "boolean", "flags": { "description": "a" } }"#,
+            true,
+        )?;
+        valid(r#"{ "type": "boolean", "examples": [ true ] }"#, true)?;
+        valid(
+            r#"{ "type": "boolean", "metas": [ { "foo": "bar" } ] }"#,
+            true,
+        )?;
+        valid(r#"{ "type": "boolean", "notes": [ "a", "b" ] }"#, true)?;
+        valid(r#"{ "type": "boolean", "tags": [ "a", "b" ] }"#, true)?;
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_rules() -> Result<()> {
+        unsupported(r#"{ "type": "boolean", "rules": [ { "name": "extra" } ] }"#)?;
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_flags() -> Result<()> {
+        unsupported(r#"{ "type": "boolean", "flags": { "sensitive": false } }"#)?;
+        unsupported(r#"{ "type": "boolean", "flags": { "sensitive": true } }"#)?;
+        unsupported(r#"{ "type": "boolean", "flags": { "extra": true } }"#)?;
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_basics() -> Result<()> {
+        unsupported(r#"{ "type": "boolean", "truthy": ["Y"] }"#)?;
+        unsupported(r#"{ "type": "boolean", "falsy": ["Y"] }"#)?;
+        unsupported(r#"{ "type": "boolean", "extra": true }"#)?;
+        unsupported(r#"{ "type": "boolean", "preferences": {} }"#)?;
+        Ok(())
+    }
+}
+
+mod number {
+    use super::{invalid_opt, json, unsupported, valid_opt, Result};
+    use std::f64::consts::PI;
+
+    // tests both the float and string version of the value
+    fn valid(joi: &str, value: impl Into<f64>) -> Result<()> {
+        let value = value.into();
+        super::valid(joi, value)?;
+        super::valid(joi, value.to_string())?;
+        Ok(())
+    }
+
+    // tests both the float and string version of the value
+    fn invalid(joi: &str, value: impl Into<f64>) -> Result<()> {
+        let value = value.into();
+        super::invalid(joi, value)?;
+        super::invalid(joi, value.to_string())?;
+        Ok(())
+    }
+
+    #[test]
+    fn type_number() -> Result<()> {
+        let joi = r#"{ "type": "number" }"#;
+        valid_opt(joi, None)?;
+        valid(joi, 0)?;
+        valid(joi, 10)?;
+        valid(joi, PI)?;
+        valid(joi, -PI)?;
+        super::invalid(joi, "")?;
+        super::invalid(joi, "a")?;
+        super::invalid(joi, json!([]))?;
+        super::invalid(joi, json!(["a"]))?;
+        super::invalid(joi, json!({}))?;
+        super::invalid(joi, json!({ "a": "b" }))?;
+        super::invalid(joi, json!(null))?;
+        Ok(())
+    }
+
+    #[test]
+    fn unsafe_numbers() -> Result<()> {
+        // Safe range
+        let joi = r#"{ "type": "number" }"#;
+        super::valid(joi, 9007199254740991i64)?;
+        super::valid(joi, -9007199254740991i64)?;
+        valid(joi, 9007199254740991.0f64)?;
+        valid(joi, -9007199254740991.0f64)?;
+        super::invalid(joi, 9007199254740992i64)?;
+        super::invalid(joi, -9007199254740992i64)?;
+        invalid(joi, 9007199254740992.0f64)?;
+        invalid(joi, -9007199254740992.0f64)?;
+
+        let joi = r#"{ "type": "number", "flags": { "unsafe": false } }"#;
+        super::valid(joi, 9007199254740991i64)?;
+        super::valid(joi, -9007199254740991i64)?;
+        valid(joi, 9007199254740991.0f64)?;
+        valid(joi, -9007199254740991.0f64)?;
+        super::invalid(joi, 9007199254740992i64)?;
+        super::invalid(joi, -9007199254740992i64)?;
+        invalid(joi, 9007199254740992.0f64)?;
+        invalid(joi, -9007199254740992.0f64)?;
+
+        let joi = r#"{ "type": "number", "flags": { "unsafe": true } }"#;
+        super::valid(joi, 9007199254740991i64)?;
+        super::valid(joi, -9007199254740991i64)?;
+        valid(joi, 9007199254740991.0f64)?;
+        valid(joi, -9007199254740991.0f64)?;
+        super::valid(joi, 9007199254740992i64)?;
+        super::valid(joi, -9007199254740992i64)?;
+        valid(joi, 9007199254740992.0f64)?;
+        valid(joi, -9007199254740992.0f64)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn integer() -> Result<()> {
+        let joi = r#"{ "type": "number", "rules": [
+            { "name": "integer" }
+        ] }"#;
+        valid(joi, -100)?;
+        valid(joi, 0)?;
+        valid(joi, 100)?;
+        valid(joi, 0.0f64)?;
+        invalid(joi, -0.1)?;
+        invalid(joi, -100.5)?;
+        invalid(joi, 0.1)?;
+        invalid(joi, 100.5)?;
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "min", "args": { } } ] }"#)?;
+        Ok(())
+    }
+
+    #[test]
+    fn min() -> Result<()> {
+        let joi = r#"{ "type": "number", "rules": [
+            { "name": "min", "args": { "limit": 2 } }
+        ] }"#;
+        invalid(joi, -5)?;
+        invalid(joi, 0)?;
+        invalid(joi, 1)?;
+        valid(joi, 2)?;
+        valid(joi, 2.5)?;
+        valid(joi, 3)?;
+        valid(joi, 4)?;
+        valid(joi, 5)?;
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "min" } ] }"#)?;
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "min", "args": { } } ] }"#)?;
+        unsupported(
+            r#"{ "type": "number", "rules": [ { "name": "min", "args": { "limit": 2, "extra": true } } ] }"#,
+        )?;
+        unsupported(
+            r#"{ "type": "number", "rules": [ { "name": "min", "args": { "limit": "2" } } ] }"#,
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn greater() -> Result<()> {
+        let joi = r#"{ "type": "number", "rules": [
+            { "name": "greater", "args": { "limit": 2 } }
+        ] }"#;
+        invalid(joi, -5)?;
+        invalid(joi, 0)?;
+        invalid(joi, 1)?;
+        invalid(joi, 2)?;
+        valid(joi, 2.5)?;
+        valid(joi, 3)?;
+        valid(joi, 4)?;
+        valid(joi, 5)?;
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "greater" } ] }"#)?;
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "greater", "args": { } } ] }"#)?;
+        unsupported(
+            r#"{ "type": "number", "rules": [ { "name": "greater", "args": { "limit": 2, "extra": true } } ] }"#,
+        )?;
+        unsupported(
+            r#"{ "type": "number", "rules": [ { "name": "greater", "args": { "limit": "2" } } ] }"#,
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn max() -> Result<()> {
+        let joi = r#"{ "type": "number", "rules": [
+            { "name": "max", "args": { "limit": 3 } }
+        ] }"#;
+        valid(joi, -5)?;
+        valid(joi, 0)?;
+        valid(joi, 1)?;
+        valid(joi, 2)?;
+        valid(joi, 2.5)?;
+        valid(joi, 3)?;
+        invalid(joi, 4)?;
+        invalid(joi, 5)?;
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "max" } ] }"#)?;
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "max", "args": { } } ] }"#)?;
+        unsupported(
+            r#"{ "type": "number", "rules": [ { "name": "max", "args": { "limit": 2, "extra": true } } ] }"#,
+        )?;
+        unsupported(
+            r#"{ "type": "number", "rules": [ { "name": "max", "args": { "limit": "2" } } ] }"#,
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn less() -> Result<()> {
+        let joi = r#"{ "type": "number", "rules": [
+            { "name": "less", "args": { "limit": 3 } }
+        ] }"#;
+        valid(joi, -5)?;
+        valid(joi, 0)?;
+        valid(joi, 1)?;
+        valid(joi, 2)?;
+        valid(joi, 2.5)?;
+        invalid(joi, 3)?;
+        invalid(joi, 4)?;
+        invalid(joi, 5)?;
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "less" } ] }"#)?;
+        unsupported(
+            r#"{ "type": "number", "rules": [ { "name": "less", "args": { "limit": 2 }, "extra": true } ] }"#,
+        )?;
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "less", "args": { } } ] }"#)?;
+        unsupported(
+            r#"{ "type": "number", "rules": [ { "name": "less", "args": { "limit": 2, "extra": true } } ] }"#,
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn allow_values() -> Result<()> {
+        let joi = r#"{ "type": "number" }"#;
+        valid(joi, 1)?;
+        valid(joi, 2)?;
+        valid(joi, 3)?;
+        valid(joi, 4)?;
+        valid(joi, 5)?;
+        valid(joi, 6)?;
+
+        let joi = r#"{ "type": "number", "allow": [1, 2] }"#;
+        valid(joi, 1)?;
+        valid(joi, 2)?;
+        valid(joi, 3)?;
+        valid(joi, 4)?;
+        valid(joi, 5)?;
+        valid(joi, 6)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn valid_values() -> Result<()> {
+        let joi = r#"{ "type": "number", "flags": { "only": true } }"#;
+        valid(joi, 1)?;
+        valid(joi, 2)?;
+        valid(joi, 3)?;
+        valid(joi, 4)?;
+        valid(joi, 5)?;
+        valid(joi, 6)?;
+
+        let joi = r#"{ "type": "number", "flags": { "only": true }, "allow": [] }"#;
+        invalid(joi, 1)?;
+        invalid(joi, 2)?;
+        invalid(joi, 3)?;
+        invalid(joi, 4)?;
+        invalid(joi, 5)?;
+        invalid(joi, 6)?;
+
+        let joi = r#"{ "type": "number", "flags": { "only": true }, "allow": [1, 2] }"#;
+        valid(joi, 1)?;
+        valid(joi, 2)?;
+        invalid(joi, 3)?;
+        invalid(joi, 4)?;
+        invalid(joi, 5)?;
+        invalid(joi, 6)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_values() -> Result<()> {
+        let joi = r#"{ "type": "number", "invalid": [] }"#;
+        valid(joi, 1)?;
+        valid(joi, 2)?;
+        valid(joi, 3)?;
+        valid(joi, 4)?;
+        valid(joi, 5)?;
+        valid(joi, 6)?;
+
+        let joi = r#"{ "type": "number", "invalid": [3, 4] }"#;
+        valid(joi, 1)?;
+        valid(joi, 2)?;
+        invalid(joi, 3)?;
+        invalid(joi, 4)?;
+        valid(joi, 5)?;
+        valid(joi, 6)?;
+
+        let joi = r#"{ "type": "number", "allow": [1, 2], "invalid": [3, 4] }"#;
+        valid(joi, 1)?;
+        valid(joi, 2)?;
+        invalid(joi, 3)?;
+        invalid(joi, 4)?;
+        valid(joi, 5)?;
+        valid(joi, 6)?;
+
+        let joi = r#"{ "type": "number", "flags": { "only": true }, "invalid": [3, 4] }"#;
+        valid(joi, 1)?;
+        valid(joi, 2)?;
+        invalid(joi, 3)?;
+        invalid(joi, 4)?;
+        valid(joi, 5)?;
+        valid(joi, 6)?;
+
+        let joi = r#"{ "type": "number", "flags": { "only": true }, "allow": [1, 2], "invalid": [3, 4] }"#;
+        valid(joi, 1)?;
+        valid(joi, 2)?;
+        invalid(joi, 3)?;
+        invalid(joi, 4)?;
+        invalid(joi, 5)?;
+        invalid(joi, 6)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn required() -> Result<()> {
+        let joi = r#"{ "type": "number", "flags": { "presence": "required" } }"#;
+        valid(joi, 0)?;
+        valid(joi, 1)?;
+        super::invalid(joi, json!(null))?;
+        invalid_opt(joi, None)?;
+        Ok(())
+    }
+
+    #[test]
+    fn forbidden() -> Result<()> {
+        let joi = r#"{ "type": "number", "flags": { "presence": "forbidden" } }"#;
+        invalid(joi, 0)?;
+        invalid(joi, 1)?;
+        super::invalid(joi, json!(null))?;
+        valid_opt(joi, None)?;
+        Ok(())
+    }
+
+    #[test]
+    fn optional() -> Result<()> {
+        let joi = r#"{ "type": "number", "flags": { "presence": "optional" } }"#;
+        valid(joi, 0)?;
+        valid(joi, 1)?;
+        super::invalid(joi, json!(null))?;
+        valid_opt(joi, None)?;
+        Ok(())
+    }
+
+    #[test]
+    fn passthrough() -> Result<()> {
+        valid(
+            r#"{ "type": "number", "flags": { "description": "a" } }"#,
+            1,
+        )?;
+        valid(r#"{ "type": "number", "examples": [ 1, 2 ] }"#, 1)?;
+        valid(r#"{ "type": "number", "metas": [ { "foo": "bar" } ] }"#, 1)?;
+        valid(r#"{ "type": "number", "notes": [ "a", "b" ] }"#, 1)?;
+        valid(r#"{ "type": "number", "tags": [ "a", "b" ] }"#, 1)?;
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_rules() -> Result<()> {
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "multiple" } ] }"#)?;
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "port" } ] }"#)?;
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "precision" } ] }"#)?;
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "sign" } ] }"#)?;
+        unsupported(r#"{ "type": "number", "rules": [ { "name": "extra" } ] }"#)?;
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_flags() -> Result<()> {
+        unsupported(r#"{ "type": "number", "flags": { "extra": true } }"#)?;
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_basics() -> Result<()> {
+        unsupported(r#"{ "type": "number", "extra": true }"#)?;
+        unsupported(r#"{ "type": "number", "preferences": {} }"#)?;
+        Ok(())
+    }
+}
+
+mod string {
+    use super::*;
+    use std::f64::consts::PI;
+
+    #[test]
+    fn type_string() -> Result<()> {
+        let joi = r#"{ "type": "string" }"#;
+        valid_opt(joi, None)?;
+        invalid(joi, 0)?;
+        invalid(joi, 10)?;
+        invalid(joi, PI)?;
+        invalid(joi, -PI)?;
+        valid(joi, "")?;
+        valid(joi, "a")?;
+        invalid(joi, json!([]))?;
+        invalid(joi, json!(["a"]))?;
+        invalid(joi, json!({}))?;
+        invalid(joi, json!({ "a": "b" }))?;
+        invalid(joi, json!(null))?;
+        Ok(())
+    }
+
+    #[test]
+    fn min() -> Result<()> {
+        let joi = r#"{ "type": "string", "rules": [
+            { "name": "min", "args": { "limit": 2 } }
+        ] }"#;
+        invalid(joi, "")?;
+        invalid(joi, "a")?;
+        valid(joi, "ab")?;
+        valid(joi, "abc")?;
+        valid(joi, "abcd")?;
+        valid(joi, "abcde")?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "min" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "min", "args": { } } ] }"#)?;
+        unsupported(
+            r#"{ "type": "string", "rules": [ { "name": "min", "args": { "limit": 2, "extra": true } } ] }"#,
+        )?;
+        unsupported(
+            r#"{ "type": "string", "rules": [ { "name": "min", "args": { "limit": "2" } } ] }"#,
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn max() -> Result<()> {
+        let joi = r#"{ "type": "string", "rules": [
+            { "name": "max", "args": { "limit": 3 } }
+        ] }"#;
+        valid(joi, "")?;
+        valid(joi, "a")?;
+        valid(joi, "ab")?;
+        valid(joi, "abc")?;
+        invalid(joi, "abcd")?;
+        invalid(joi, "abcde")?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "max" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "max", "args": { } } ] }"#)?;
+        unsupported(
+            r#"{ "type": "string", "rules": [ { "name": "max", "args": { "limit": 2, "extra": true } } ] }"#,
+        )?;
+        unsupported(
+            r#"{ "type": "string", "rules": [ { "name": "max", "args": { "limit": "2" } } ] }"#,
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn length() -> Result<()> {
+        let joi = r#"{ "type": "string", "rules": [
+            { "name": "length", "args": { "limit": 2 } }
+        ] }"#;
+        invalid(joi, "")?;
+        invalid(joi, "a")?;
+        valid(joi, "ab")?;
+        invalid(joi, "abc")?;
+        invalid(joi, "abcd")?;
+        invalid(joi, "abcde")?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "length" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "length", "args": { } } ] }"#)?;
+        unsupported(
+            r#"{ "type": "string", "rules": [ { "name": "length", "args": { "limit": 2, "extra": true } } ] }"#,
+        )?;
+        unsupported(
+            r#"{ "type": "string", "rules": [ { "name": "length", "args": { "limit": "2" } } ] }"#,
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn multi() -> Result<()> {
+        let joi = r#"{ "type": "string", "flags": { "presence": "required", "only": true }, "rules": [
+            { "name": "min", "args": { "limit": 2 } },
+            { "name": "max", "args": { "limit": 3 } }
+        ] }"#;
+        invalid(joi, "")?;
+        invalid(joi, "a")?;
+        valid(joi, "ab")?;
+        valid(joi, "abc")?;
+        invalid(joi, "abcd")?;
+        invalid(joi, "abcde")?;
+        invalid(joi, 10)?;
+        invalid(joi, json!(null))?;
+        invalid_opt(joi, None)?;
+        Ok(())
+    }
+
+    #[test]
+    fn allow_values() -> Result<()> {
+        let joi = r#"{ "type": "string" }"#;
+        valid(joi, "a")?;
+        valid(joi, "b")?;
+        valid(joi, "c")?;
+        valid(joi, "d")?;
+        valid(joi, "e")?;
+        valid(joi, "f")?;
+
+        let joi = r#"{ "type": "string", "allow": ["a", "b"] }"#;
+        valid(joi, "a")?;
+        valid(joi, "b")?;
+        valid(joi, "c")?;
+        valid(joi, "d")?;
+        valid(joi, "e")?;
+        valid(joi, "f")?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn valid_values() -> Result<()> {
+        let joi = r#"{ "type": "string", "flags": { "only": true } }"#;
+        valid(joi, "a")?;
+        valid(joi, "b")?;
+        valid(joi, "c")?;
+        valid(joi, "d")?;
+        valid(joi, "e")?;
+        valid(joi, "f")?;
+
+        let joi = r#"{ "type": "string", "flags": { "only": true }, "allow": [] }"#;
+        invalid(joi, "a")?;
+        invalid(joi, "b")?;
+        invalid(joi, "c")?;
+        invalid(joi, "d")?;
+        invalid(joi, "e")?;
+        invalid(joi, "f")?;
+
+        let joi = r#"{ "type": "string", "flags": { "only": true }, "allow": ["a", "b"] }"#;
+        valid(joi, "a")?;
+        valid(joi, "b")?;
+        invalid(joi, "c")?;
+        invalid(joi, "d")?;
+        invalid(joi, "e")?;
+        invalid(joi, "f")?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_values() -> Result<()> {
+        let joi = r#"{ "type": "string", "invalid": [] }"#;
+        valid(joi, "a")?;
+        valid(joi, "b")?;
+        valid(joi, "c")?;
+        valid(joi, "d")?;
+        valid(joi, "e")?;
+        valid(joi, "f")?;
+
+        let joi = r#"{ "type": "string", "invalid": ["c", "d"] }"#;
+        valid(joi, "a")?;
+        valid(joi, "b")?;
+        invalid(joi, "c")?;
+        invalid(joi, "d")?;
+        valid(joi, "e")?;
+        valid(joi, "f")?;
+
+        let joi = r#"{ "type": "string", "allow": ["a", "b"], "invalid": ["c", "d"] }"#;
+        valid(joi, "a")?;
+        valid(joi, "b")?;
+        invalid(joi, "c")?;
+        invalid(joi, "d")?;
+        valid(joi, "e")?;
+        valid(joi, "f")?;
+
+        let joi = r#"{ "type": "string", "flags": { "only": true }, "invalid": ["c", "d"] }"#;
+        valid(joi, "a")?;
+        valid(joi, "b")?;
+        invalid(joi, "c")?;
+        invalid(joi, "d")?;
+        valid(joi, "e")?;
+        valid(joi, "f")?;
+
+        let joi = r#"{ "type": "string", "flags": { "only": true }, "allow": ["a", "b"], "invalid": ["c", "d"] }"#;
+        valid(joi, "a")?;
+        valid(joi, "b")?;
+        invalid(joi, "c")?;
+        invalid(joi, "d")?;
+        invalid(joi, "e")?;
+        invalid(joi, "f")?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn required() -> Result<()> {
+        let joi = r#"{ "type": "string", "flags": { "presence": "required" } }"#;
+        valid(joi, "")?;
+        valid(joi, "a")?;
+        invalid(joi, json!(null))?;
+        invalid_opt(joi, None)?;
+        Ok(())
+    }
+
+    #[test]
+    fn forbidden() -> Result<()> {
+        let joi = r#"{ "type": "string", "flags": { "presence": "forbidden" } }"#;
+        invalid(joi, "")?;
+        invalid(joi, "a")?;
+        invalid(joi, json!(null))?;
+        valid_opt(joi, None)?;
+        Ok(())
+    }
+
+    #[test]
+    fn optional() -> Result<()> {
+        let joi = r#"{ "type": "string", "flags": { "presence": "optional" } }"#;
+        valid(joi, "")?;
+        valid(joi, "a")?;
+        invalid(joi, json!(null))?;
+        valid_opt(joi, None)?;
+        Ok(())
+    }
+
+    #[test]
+    fn passthrough() -> Result<()> {
+        valid(
+            r#"{ "type": "string", "flags": { "description": "a" } }"#,
+            "",
+        )?;
+        valid(r#"{ "type": "string", "examples": [ "a", "b" ] }"#, "")?;
+        valid(r#"{ "type": "string", "metas": [ { "foo": "bar" } ] }"#, "")?;
+        valid(r#"{ "type": "string", "notes": [ "a", "b" ] }"#, "")?;
+        valid(r#"{ "type": "string", "tags": [ "a", "b" ] }"#, "")?;
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_rules() -> Result<()> {
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "alphanum" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "base64" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "case" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "creditCard" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "dataUri" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "domain" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "email" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "guid" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "hex" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "hostname" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "ip" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "isoDate" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "isoDuration" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "normalize" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "pattern" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "replace" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "token" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "trim" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "truncate" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "uri" } ] }"#)?;
+        unsupported(r#"{ "type": "string", "rules": [ { "name": "extra" } ] }"#)?;
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_flags() -> Result<()> {
+        unsupported(r#"{ "type": "string", "flags": { "extra": true } }"#)?;
+        unsupported(r#"{ "type": "string", "flags": { "insensitive": true } }"#)?;
+        unsupported(r#"{ "type": "string", "flags": { "insensitive": false } }"#)?;
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_basics() -> Result<()> {
+        unsupported(r#"{ "type": "string", "extra": true }"#)?;
+        unsupported(r#"{ "type": "string", "preferences": {} }"#)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR intercepts the simplest Joi validations and runs them in Rust instead of dispatching to Veritech:

- [boolean/string/number].required/valid(a,b,c)/invalid(a,b,c)
- number.integer/min/max/less/greater/unsafe
- string.min/max/length

Any validation not supported on that list, or with any unexpected options, is dispatched to Veritech instead and runs and returns exactly as before.

We produce the same results, as well as the same error message, for all of these, so user experience should be identical.

### Why

Once Clover added automated validations to lots of fields on many assets, Veritech is under heavy load because every time you drag out a new asset, many Joi validations are run. All of the Clover validations are very straightforward, however, and encompass a very small subset of what is possible with Joi.

### How

When a user does `.setValidationFormat(Joi.string().min(2).max(3).required()` in an asset function, we internally call `describe()` on that Joi schema, which produces JSON that looks like this:

```json
{
  "type": "string",
  "flags": { "presence": "required" },
  "rules": [
       { "name": "min", "args": { "limit": 2 } },
       { "name": "max", "args": { "limit": 3 } }
  ]
}
```

Because there is no longer any JS involved, we can read this format in any language we like and interpret it.

## Testing

- New tests: tons and tons of tests of the new validation library, including both valid and invalid values for all supported rules and flags.
- Dragged out an EC2::Subnet
  - watched validations run locally instead of remotely
  - Validated that simple fields still go red when they don't match, and green when you fix them
- Dragged out S3::AccessPoint, with BucketAccountId (a pattern field requiring twelve digits)
  - Watched validation dispatch to Veritech
  - Ensured that BucketAccountId goes red when you enter bad data
  - Watched BucketAccountId go green when entering 12 digits

## Risk Mitigation

- This is a drop-in replacement for parts of the library and does not increase or shrink product surface area, limiting the number of new interactions that can happen
- The library uses strict serde features like `deny_unknown_fields` to ensure we only deserialize exactly things we support, and tests those few things heavily

## Later

Arguably the goal is to run all Clover validations in Rust instead of JS. However, `pattern()` isn't supported as part of this turn. There is a Rust library we may pick up, but regexes are a large surface area to test, and we want to evaluate whether this has a discernible impact before we reach out for that.