### PR TITLE
feat(sdf): Keep external connections on paste

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6299,6 +6299,7 @@ dependencies = [
  "futures-lite",
  "hyper 0.14.32",
  "indoc",
+ "itertools 0.13.0",
  "module-index-client",
  "names",
  "nats-multiplexer",

--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -327,6 +327,17 @@ pub async fn get_attribute_value_for_component(
     ctx: &DalContext,
     component_id: ComponentId,
     prop_path: &[&str],
+) -> Result<Value> {
+    get_attribute_value_for_component_opt(ctx, component_id, prop_path)
+        .await?
+        .ok_or(eyre!("unexpected: missing attribute value"))
+}
+
+/// Given a [`ComponentId`] and PropPath, get the value for an attribute value at that path
+pub async fn get_attribute_value_for_component_opt(
+    ctx: &DalContext,
+    component_id: ComponentId,
+    prop_path: &[&str],
 ) -> Result<Option<Value>> {
     let component = Component::get_by_id(ctx, component_id).await?;
     let mut attribute_value_ids = component.attribute_values_for_prop(ctx, prop_path).await?;

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -109,6 +109,7 @@ rust_test(
         "//lib/veritech-client:veritech-client",
         "//third-party/rust:chrono",
         "//third-party/rust:base64",
+        "//third-party/rust:derive_more",
         "//third-party/rust:itertools",
         "//third-party/rust:petgraph",
         "//third-party/rust:pretty_assertions_sorted",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -85,6 +85,7 @@ telemetry = { path = "../../lib/telemetry-rs" }
 telemetry-nats = { path = "../../lib/telemetry-nats-rs" }
 veritech-client = { path = "../../lib/veritech-client" }
 
+derive_more = { workspace = true }
 itertools = { workspace = true }
 pretty_assertions_sorted = { workspace = true }
 tempfile = { workspace = true }

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -85,9 +85,9 @@ pub mod socket;
 #[derive(Debug, Error)]
 pub enum ComponentError {
     #[error("action error: {0}")]
-    Action(Box<ActionError>),
+    Action(#[from] Box<ActionError>),
     #[error("action prototype error: {0}")]
-    ActionPrototype(Box<ActionPrototypeError>),
+    ActionPrototype(#[from] Box<ActionPrototypeError>),
     #[error("attribute prototype error: {0}")]
     AttributePrototype(#[from] AttributePrototypeError),
     #[error("attribute prototype argument error: {0}")]
@@ -125,7 +125,7 @@ pub enum ComponentError {
     #[error("connection destination component {0} has no attribute value for input socket {1}")]
     DestinationComponentMissingAttributeValueForInputSocket(ComponentId, InputSocketId),
     #[error("diagram error: {0}")]
-    Diagram(Box<DiagramError>),
+    Diagram(#[from] Box<DiagramError>),
     #[error("frame error: {0}")]
     Frame(#[from] Box<FrameError>),
     #[error("func error: {0}")]
@@ -234,23 +234,38 @@ pub enum ComponentError {
     WsEvent(#[from] WsEventError),
 }
 
+impl From<ActionError> for ComponentError {
+    fn from(err: ActionError) -> Self {
+        Box::new(err).into()
+    }
+}
+impl From<ActionPrototypeError> for ComponentError {
+    fn from(err: ActionPrototypeError) -> Self {
+        Box::new(err).into()
+    }
+}
+impl From<DiagramError> for ComponentError {
+    fn from(err: DiagramError) -> Self {
+        Box::new(err).into()
+    }
+}
+impl From<FrameError> for ComponentError {
+    fn from(err: FrameError) -> Self {
+        Box::new(err).into()
+    }
+}
+impl From<FuncBindingError> for ComponentError {
+    fn from(err: FuncBindingError) -> Self {
+        Box::new(err).into()
+    }
+}
+
 pub type ComponentResult<T> = Result<T, ComponentError>;
 
 pub use si_id::ComponentId;
 
 #[derive(Clone, Debug)]
-pub struct IncomingConnection {
-    pub attribute_prototype_argument_id: AttributePrototypeArgumentId,
-    pub to_component_id: ComponentId,
-    pub to_input_socket_id: InputSocketId,
-    pub from_component_id: ComponentId,
-    pub from_output_socket_id: OutputSocketId,
-    pub created_info: HistoryEventMetadata,
-    pub deleted_info: Option<HistoryEventMetadata>,
-}
-
-#[derive(Clone, Debug)]
-pub struct OutgoingConnection {
+pub struct Connection {
     pub attribute_prototype_argument_id: AttributePrototypeArgumentId,
     pub to_component_id: ComponentId,
     pub to_input_socket_id: InputSocketId,
@@ -430,9 +445,7 @@ impl Component {
                 .await?;
 
         // Create geometry node
-        Geometry::new_for_component(ctx, component.id, view_id)
-            .await
-            .map_err(|e| ComponentError::Diagram(Box::new(e)))?;
+        Geometry::new_for_component(ctx, component.id, view_id).await?;
 
         Ok(component)
     }
@@ -594,9 +607,7 @@ impl Component {
         )
         .await?
         {
-            Action::new(ctx, prototype_id, Some(component.id))
-                .await
-                .map_err(|err| ComponentError::Action(Box::new(err)))?;
+            Action::new(ctx, prototype_id, Some(component.id)).await?;
         }
 
         Ok(component)
@@ -1050,7 +1061,7 @@ impl Component {
     pub async fn outgoing_connections_for_id(
         ctx: &DalContext,
         component_id: ComponentId,
-    ) -> ComponentResult<Vec<OutgoingConnection>> {
+    ) -> ComponentResult<Vec<Connection>> {
         let mut outgoing_edges = vec![];
 
         for from_output_socket in
@@ -1089,7 +1100,7 @@ impl Component {
                     if let Some(AttributePrototypeSource::InputSocket(input_socket, _)) =
                         input_sources.first()
                     {
-                        outgoing_edges.push(OutgoingConnection {
+                        outgoing_edges.push(Connection {
                             attribute_prototype_argument_id: apa_id,
                             to_component_id: destination_component_id,
                             from_component_id: source_component_id,
@@ -1106,18 +1117,12 @@ impl Component {
         Ok(outgoing_edges)
     }
 
-    pub async fn outgoing_connections(
-        &self,
-        ctx: &DalContext,
-    ) -> ComponentResult<Vec<OutgoingConnection>> {
+    pub async fn outgoing_connections(&self, ctx: &DalContext) -> ComponentResult<Vec<Connection>> {
         Self::outgoing_connections_for_id(ctx, self.id).await
     }
 
     /// Calls [`Self::incoming_connections_by_id`] by passing in the id from [`self`](Component).
-    pub async fn incoming_connections(
-        &self,
-        ctx: &DalContext,
-    ) -> ComponentResult<Vec<IncomingConnection>> {
+    pub async fn incoming_connections(&self, ctx: &DalContext) -> ComponentResult<Vec<Connection>> {
         Self::incoming_connections_for_id(ctx, self.id).await
     }
 
@@ -1131,7 +1136,7 @@ impl Component {
     pub async fn incoming_connections_for_id(
         ctx: &DalContext,
         id: ComponentId,
-    ) -> ComponentResult<Vec<IncomingConnection>> {
+    ) -> ComponentResult<Vec<Connection>> {
         let mut incoming_connections = vec![];
 
         for component_input_socket in ComponentInputSocket::list_for_component_id(ctx, id).await? {
@@ -1146,7 +1151,7 @@ impl Component {
                         timestamp: apa.timestamp().created_at,
                     }
                 };
-                incoming_connections.push(IncomingConnection {
+                incoming_connections.push(Connection {
                     attribute_prototype_argument_id: apa.id(),
                     to_component_id: id,
                     from_component_id,
@@ -1448,9 +1453,7 @@ impl Component {
     }
 
     pub async fn geometry(&self, ctx: &DalContext, view_id: ViewId) -> ComponentResult<Geometry> {
-        Geometry::get_by_component_and_view(ctx, self.id, view_id)
-            .await
-            .map_err(|e| ComponentError::Diagram(Box::new(e)))
+        Ok(Geometry::get_by_component_and_view(ctx, self.id, view_id).await?)
     }
 
     pub async fn set_geometry(
@@ -1480,10 +1483,7 @@ impl Component {
     ) -> ComponentResult<Geometry> {
         let mut geometry_pre = self.geometry(ctx, view_id).await?;
         if geometry_pre.into_raw() != raw_geometry {
-            geometry_pre
-                .update(ctx, raw_geometry)
-                .await
-                .map_err(|e| ComponentError::Diagram(Box::new(e)))?;
+            geometry_pre.update(ctx, raw_geometry).await?;
         }
 
         Ok(geometry_pre)
@@ -1727,8 +1727,7 @@ impl Component {
                 | (ComponentType::ConfigurationFrameUp, ComponentType::Component)
                 | (ComponentType::ConfigurationFrameUp, ComponentType::ConfigurationFrameDown) => {
                     Frame::update_type_from_or_to_frame(ctx, component_id, reference_id, new_type)
-                        .await
-                        .map_err(Box::new)?;
+                        .await?;
                 }
                 (new, old) => return Err(ComponentError::InvalidComponentTypeUpdate(old, new)),
             }
@@ -2481,13 +2480,9 @@ impl Component {
             // if we are removing a component with children, re-parent them if I have a parent
             // if this component doesn't have a parent, it's children will be orphaned anyways
             for child_id in Component::get_children_for_id(ctx, id).await? {
-                Frame::upsert_parent(ctx, child_id, parent_id)
-                    .await
-                    .map_err(Box::new)?;
+                Frame::upsert_parent(ctx, child_id, parent_id).await?;
             }
-            Frame::orphan_child(ctx, id)
-                .await
-                .map_err(|e| ComponentError::Frame(Box::new(e)))?;
+            Frame::orphan_child(ctx, id).await?;
         }
 
         for incoming_connection in component.incoming_connections(ctx).await? {
@@ -2516,14 +2511,10 @@ impl Component {
         }
 
         // Remove all geometries for the component
-        Geometry::remove_all_for_component_id(ctx, id)
-            .await
-            .map_err(|e| ComponentError::Diagram(Box::new(e)))?;
+        Geometry::remove_all_for_component_id(ctx, id).await?;
 
         // Remove all actions for this component from queue
-        Action::remove_all_for_component_id(ctx, id)
-            .await
-            .map_err(|err| ComponentError::Action(Box::new(err)))?;
+        Action::remove_all_for_component_id(ctx, id).await?;
         WsEvent::action_list_updated(ctx)
             .await?
             .publish_on_commit(ctx)
@@ -2659,15 +2650,11 @@ impl Component {
             )
             .await?
             {
-                Action::new(ctx, prototype_id, Some(component_id))
-                    .await
-                    .map_err(|err| ComponentError::Action(Box::new(err)))?;
+                Action::new(ctx, prototype_id, Some(component_id)).await?;
             }
         } else if !to_delete {
             // Remove delete actions for component
-            Action::remove_all_for_component_id(ctx, component_id)
-                .await
-                .map_err(|err| ComponentError::Action(Box::new(err)))?;
+            Action::remove_all_for_component_id(ctx, component_id).await?;
             WsEvent::action_list_updated(ctx)
                 .await?
                 .publish_on_commit(ctx)
@@ -2742,13 +2729,10 @@ impl Component {
             for prototype_id in prototypes_for_variant {
                 // don't enqueue the same action twice!
                 if Action::find_equivalent(ctx, prototype_id, Some(component_id))
-                    .await
-                    .map_err(|err| ComponentError::Action(Box::new(err)))?
+                    .await?
                     .is_none()
                 {
-                    let new_action = Action::new(ctx, prototype_id, Some(component_id))
-                        .await
-                        .map_err(|err| ComponentError::Action(Box::new(err)))?;
+                    let new_action = Action::new(ctx, prototype_id, Some(component_id)).await?;
                     enqueued_actions.push(new_action);
                 }
             }
@@ -3033,7 +3017,7 @@ impl Component {
         Ok(results)
     }
 
-    pub async fn create_copy(
+    pub async fn copy_without_connections(
         &self,
         ctx: &DalContext,
         view_id: ViewId,
@@ -3064,6 +3048,94 @@ impl Component {
         Ok(pasted_comp)
     }
 
+    // Copy a batch of components, and replicate connections between them
+    pub async fn batch_copy(
+        ctx: &mut DalContext,
+        to_view_id: ViewId,
+        to_parent_id: Option<ComponentId>,
+        components: Vec<(ComponentId, RawGeometry)>,
+    ) -> ComponentResult<Vec<ComponentId>> {
+        // Paste all the components and get the mapping from original to pasted
+        let mut pasted_component_ids = vec![];
+        let mut to_pasted_id = HashMap::new();
+        for (component_id, raw_geometry) in components.into_iter() {
+            let component = Component::get_by_id(ctx, component_id).await?;
+            let pasted_component = component
+                .copy_without_connections(ctx, to_view_id, raw_geometry)
+                .await?;
+            pasted_component_ids.push(pasted_component.id());
+            to_pasted_id.insert(component_id, pasted_component.id());
+        }
+
+        let maybe_pasted = |id: ComponentId| to_pasted_id.get(&id).copied().unwrap_or(id);
+
+        // Fix parentage and connections
+        for (&component_id, &pasted_component_id) in &to_pasted_id {
+            // Fix parentage:
+            // 1. If the component's parent was in the batch, use the pasted version.
+            // 2. Otherwise, set it to the place the user is pasting to.
+            let pasted_parent_id = Component::get_parent_by_id(ctx, component_id)
+                .await?
+                .and_then(|parent_id| to_pasted_id.get(&parent_id).copied());
+            if let Some(pasted_parent_id) = pasted_parent_id.or(to_parent_id) {
+                Frame::upsert_parent(ctx, pasted_component_id, pasted_parent_id).await?;
+            }
+
+            // Copy manager connections
+            for manager_id in Component::managers_by_id(ctx, component_id).await? {
+                // If we were managed by a component that was also pasted, we should be managed by
+                // the pasted version--otherwise we're still managed by the original
+                match Component::manage_component(
+                    ctx,
+                    maybe_pasted(manager_id),
+                    maybe_pasted(component_id),
+                )
+                .await
+                {
+                    Ok(_) => {}
+                    Err(ComponentError::ComponentNotManagedSchema(_, _, _)) => {
+                        // This error should not occur, but we also don't want to
+                        // fail the paste just because the managed schemas are out
+                        // of sync
+                        error!("Could not manage pasted component, but continuing paste");
+                    }
+                    Err(err) => {
+                        return Err(err)?;
+                    }
+                };
+            }
+
+            // Copy incoming socket connections
+            for connection in Component::incoming_connections_for_id(ctx, component_id).await? {
+                println!(
+                    "Connecting {}.{} <- {}.{} (was from {}.{})",
+                    Component::name_by_id(ctx, pasted_component_id).await?,
+                    InputSocket::get_by_id(ctx, connection.to_input_socket_id)
+                        .await?
+                        .name(),
+                    Component::name_by_id(ctx, maybe_pasted(connection.from_component_id)).await?,
+                    OutputSocket::get_by_id(ctx, connection.from_output_socket_id)
+                        .await?
+                        .name(),
+                    Component::name_by_id(ctx, connection.from_component_id).await?,
+                    OutputSocket::get_by_id(ctx, connection.from_output_socket_id)
+                        .await?
+                        .name(),
+                );
+                Component::connect(
+                    ctx,
+                    maybe_pasted(connection.from_component_id),
+                    connection.from_output_socket_id,
+                    pasted_component_id,
+                    connection.to_input_socket_id,
+                )
+                .await?;
+            }
+        }
+
+        Ok(pasted_component_ids)
+    }
+
     pub async fn add_to_view(
         ctx: &DalContext,
         component_id: ComponentId,
@@ -3071,8 +3143,7 @@ impl Component {
         raw_geometry: RawGeometry,
     ) -> ComponentResult<()> {
         if Geometry::try_get_by_component_and_view(ctx, component_id, view_id)
-            .await
-            .map_err(|e| ComponentError::Diagram(Box::new(e)))?
+            .await?
             .is_some()
         {
             return Err(ComponentError::ComponentAlreadyInView(
@@ -3081,14 +3152,9 @@ impl Component {
             ));
         }
 
-        let mut geometry = Geometry::new_for_component(ctx, component_id, view_id)
-            .await
-            .map_err(|e| ComponentError::Diagram(Box::new(e)))?;
+        let mut geometry = Geometry::new_for_component(ctx, component_id, view_id).await?;
 
-        geometry
-            .update(ctx, raw_geometry)
-            .await
-            .map_err(|e| ComponentError::Diagram(Box::new(e)))?;
+        geometry.update(ctx, raw_geometry).await?;
 
         Ok(())
     }
@@ -3295,9 +3361,7 @@ impl Component {
         let original_parent = original_component.parent(ctx).await?;
         let original_children = Component::get_children_for_id(ctx, original_component_id).await?;
 
-        let geometry_ids = Geometry::list_ids_by_component(ctx, self.id)
-            .await
-            .map_err(|e| ComponentError::Diagram(Box::new(e)))?;
+        let geometry_ids = Geometry::list_ids_by_component(ctx, self.id).await?;
 
         // ================================================================================
         // Create new component and run changes that depend on the old one still existing
@@ -3416,7 +3480,7 @@ impl Component {
         // Remove all children from the "old" frame before we delete it. We'll add them all to the
         // new frame after we've deleted the old one.
         for &child in &original_children {
-            Frame::orphan_child(ctx, child).await.map_err(Box::new)?;
+            Frame::orphan_child(ctx, child).await?;
         }
 
         // Remove the original resource so that we don't queue a delete action
@@ -3449,16 +3513,12 @@ impl Component {
 
         // Restore parent connection on new component
         if let Some(parent) = original_parent {
-            Frame::upsert_parent(ctx, finalized_new_component.id(), parent)
-                .await
-                .map_err(Box::new)?;
+            Frame::upsert_parent(ctx, finalized_new_component.id(), parent).await?;
         }
 
         // Restore child connections on new component
         for child in original_children {
-            Frame::upsert_parent(ctx, child, finalized_new_component.id())
-                .await
-                .map_err(Box::new)?;
+            Frame::upsert_parent(ctx, child, finalized_new_component.id()).await?;
         }
 
         // Restore connections on new component
@@ -3557,38 +3617,25 @@ impl Component {
     ) -> ComponentResult<()> {
         // Remove any actions created for the new component as a side effect of the upgrade
         // Then loop through the existing queued actions for the old component and re-add them piecemeal.
-        Action::remove_all_for_component_id(ctx, new_component_id)
-            .await
-            .map_err(|err| ComponentError::Action(Box::new(err)))?;
+        Action::remove_all_for_component_id(ctx, new_component_id).await?;
 
-        let queued_for_old_component = Action::find_for_component_id(ctx, old_component_id)
-            .await
-            .map_err(|err| ComponentError::Action(Box::new(err)))?;
-        let available_for_new_component = ActionPrototype::for_variant(ctx, new_schema_variant_id)
-            .await
-            .map_err(|err| ComponentError::ActionPrototype(Box::new(err)))?;
+        let queued_for_old_component = Action::find_for_component_id(ctx, old_component_id).await?;
+        let available_for_new_component =
+            ActionPrototype::for_variant(ctx, new_schema_variant_id).await?;
         for existing_queued in queued_for_old_component {
-            let action = Action::get_by_id(ctx, existing_queued)
-                .await
-                .map_err(|err| ComponentError::Action(Box::new(err)))?;
-            let action_prototype_id = Action::prototype_id(ctx, existing_queued)
-                .await
-                .map_err(|err| ComponentError::Action(Box::new(err)))?;
+            let action = Action::get_by_id(ctx, existing_queued).await?;
+            let action_prototype_id = Action::prototype_id(ctx, existing_queued).await?;
             // what do we do about the various states?
             // maybe you shouldn't upgrade a component if an action
             // is dispatched or running for the current?
             match action.state() {
                 ActionState::Failed | ActionState::OnHold | ActionState::Queued => {
-                    let func_id = ActionPrototype::func_id(ctx, action_prototype_id)
-                        .await
-                        .map_err(|err| ComponentError::ActionPrototype(Box::new(err)))?;
+                    let func_id = ActionPrototype::func_id(ctx, action_prototype_id).await?;
                     let queued_func = Func::get_by_id_or_error(ctx, func_id).await?;
 
                     for available_action_prototype in available_for_new_component.clone() {
                         let available_func_id =
-                            ActionPrototype::func_id(ctx, available_action_prototype.id())
-                                .await
-                                .map_err(|err| ComponentError::ActionPrototype(Box::new(err)))?;
+                            ActionPrototype::func_id(ctx, available_action_prototype.id()).await?;
                         let available_func =
                             Func::get_by_id_or_error(ctx, available_func_id).await?;
 
@@ -3600,8 +3647,7 @@ impl Component {
                                 available_action_prototype.id(),
                                 Some(new_component_id),
                             )
-                            .await
-                            .map_err(|err| ComponentError::Action(Box::new(err)))?;
+                            .await?;
                         }
                     }
                 }
@@ -3652,9 +3698,7 @@ impl Component {
         ctx.add_dependent_values_and_enqueue(component.input_socket_attribute_values(ctx).await?)
             .await?;
 
-        Geometry::restore_all_for_component_id(ctx, component_id)
-            .await
-            .map_err(|e| ComponentError::Diagram(Box::new(e)))?;
+        Geometry::restore_all_for_component_id(ctx, component_id).await?;
 
         Ok(())
     }
@@ -3793,6 +3837,28 @@ impl Component {
         Ok(result)
     }
 
+    /// Return the ids of all the components that manage this component
+    pub async fn managers_by_id(
+        ctx: &DalContext,
+        id: ComponentId,
+    ) -> ComponentResult<Vec<ComponentId>> {
+        let mut result = vec![];
+
+        let snapshot = ctx.workspace_snapshot()?;
+
+        for source_idx in snapshot
+            .incoming_sources_for_edge_weight_kind(id, EdgeWeightKindDiscriminants::Manages)
+            .await?
+        {
+            let node_weight = snapshot.get_node_weight(source_idx).await?;
+            if let NodeWeight::Component(_) = &node_weight {
+                result.push(node_weight.id().into());
+            }
+        }
+
+        Ok(result)
+    }
+
     /// Return the ids of all the components managed by this component
     pub async fn get_managed(&self, ctx: &DalContext) -> ComponentResult<Vec<ComponentId>> {
         let mut result = vec![];
@@ -3908,9 +3974,7 @@ impl Component {
         let maybe_parent = self.parent(ctx).await?;
 
         let geometry = if let Some(geometry) = maybe_geometry {
-            let view_id = Geometry::get_view_id_by_id(ctx, geometry.id())
-                .await
-                .map_err(|e| ComponentError::Diagram(Box::new(e)))?;
+            let view_id = Geometry::get_view_id_by_id(ctx, geometry.id()).await?;
 
             Some(GeometryAndView {
                 view_id,
@@ -3953,9 +4017,7 @@ impl Component {
         change_status: ChangeStatus,
         diagram_sockets: &mut HashMap<SchemaVariantId, Vec<DiagramSocket>>,
     ) -> ComponentResult<DiagramComponentView> {
-        let default_view_id = View::get_id_for_default(ctx)
-            .await
-            .map_err(|e| ComponentError::Diagram(Box::new(e)))?;
+        let default_view_id = View::get_id_for_default(ctx).await?;
         let geometry = self.geometry(ctx, default_view_id).await?;
 
         self.into_frontend_type(ctx, Some(&geometry), change_status, diagram_sockets)

--- a/lib/dal/src/management/mod.rs
+++ b/lib/dal/src/management/mod.rs
@@ -26,7 +26,7 @@ use crate::{
         value::AttributeValueError,
     },
     change_status::ChangeStatus::Added,
-    component::IncomingConnection,
+    component::Connection,
     diagram::{geometry::RawGeometry, SummaryDiagramEdge},
     history_event::HistoryEventMetadata,
     prop::{PropError, PropPath},
@@ -828,7 +828,7 @@ impl<'a> ManagementOperator<'a> {
                     timestamp: apa.timestamp().created_at,
                 }
             };
-            let incoming_connection = IncomingConnection {
+            let incoming_connection = Connection {
                 attribute_prototype_argument_id: connection_apa_id,
                 to_component_id: destination_component_id,
                 to_input_socket_id: destination_input_socket_id,

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -31,7 +31,7 @@ use crate::change_set::{ChangeSetError, ChangeSetId};
 use crate::component::inferred_connection_graph::{
     InferredConnectionGraph, InferredConnectionGraphError,
 };
-use crate::component::{ComponentResult, IncomingConnection};
+use crate::component::{ComponentResult, Connection};
 use crate::slow_rt::{self, SlowRuntimeError};
 use crate::socket::connection_annotation::ConnectionAnnotationError;
 use crate::socket::input::InputSocketError;
@@ -1429,7 +1429,7 @@ impl WorkspaceSnapshot {
     pub async fn socket_edges_removed_relative_to_base(
         &self,
         ctx: &DalContext,
-    ) -> WorkspaceSnapshotResult<Vec<IncomingConnection>> {
+    ) -> WorkspaceSnapshotResult<Vec<Connection>> {
         // Even though the default change set for a workspace can have a base change set, we don't
         // want to consider anything as new/modified/removed when looking at the default change
         // set.

--- a/lib/dal/tests/integration_test/component/paste.rs
+++ b/lib/dal/tests/integration_test/component/paste.rs
@@ -1,0 +1,1063 @@
+use dal::component::frame::Frame;
+use dal::diagram::view::View;
+use dal::{Component, DalContext, FuncId, OutputSocketId, SchemaVariantId};
+use dal::{ComponentId, ComponentType, InputSocket, OutputSocket};
+use dal_test::expected::{ExpectComponent, ExpectFunc, ExpectSchemaVariant};
+use dal_test::helpers::{
+    create_component_for_schema_variant_on_default_view, get_attribute_value_for_component,
+    update_attribute_value_for_component, ChangeSetTestHelpers,
+};
+use dal_test::{test, Result};
+use pretty_assertions_sorted::assert_eq;
+use serde_json::{json, Value};
+use si_frontend_types::RawGeometry;
+
+#[test]
+async fn paste_component_with_value(ctx: &mut DalContext) -> Result<()> {
+    let component = ExpectComponent::create_named(ctx, "pirate", "Long John Silver").await;
+    let parrots = component
+        .prop(ctx, ["root", "domain", "parrot_names"])
+        .await;
+
+    // set value on pet shop component
+    parrots.push(ctx, "Captain Flint").await;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    assert!(parrots.has_value(ctx).await);
+
+    let default_view_id = View::get_id_for_default(ctx).await?;
+
+    // Copy/paste the pirate component
+    let component_copy = ExpectComponent(
+        component
+            .component(ctx)
+            .await
+            .copy_without_connections(
+                ctx,
+                default_view_id,
+                component.geometry_for_default(ctx).await,
+            )
+            .await?
+            .id(),
+    );
+    let parrots_copy = component_copy.prop(ctx, parrots).await;
+
+    assert_ne!(component.id(), component_copy.id());
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Validate that component_copy has the new value
+    assert!(parrots_copy.has_value(ctx).await);
+    assert_eq!(json!(["Captain Flint"]), parrots_copy.get(ctx).await);
+
+    assert!(parrots.has_value(ctx).await);
+
+    Ok(())
+}
+
+#[test]
+async fn paste_component_with_dependent_value(ctx: &mut DalContext) -> Result<()> {
+    let source = ExpectComponent::create_named(ctx, "pet_shop", "Petopia").await;
+    let downstream = ExpectComponent::create_named(ctx, "pirate", "Long John Silver").await;
+    let source_parrots = source.prop(ctx, ["root", "domain", "parrot_names"]).await;
+    let downstream_parrots = downstream
+        .prop(ctx, ["root", "domain", "parrot_names"])
+        .await;
+
+    // set value on source component
+    source_parrots.push(ctx, "Captain Flint").await;
+    source
+        .connect(ctx, "parrot_names", downstream, "parrot_names")
+        .await;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Check that downstream has the parrots value, and that it is not explicitly set
+    assert!(downstream_parrots.has_value(ctx).await);
+    assert_eq!(
+        Some(json!(["Captain Flint"])),
+        downstream_parrots.view(ctx).await
+    );
+
+    let default_view_id = View::get_id_for_default(ctx).await?;
+
+    // Copy/paste the downstream component
+    let downstream_copy = ExpectComponent(
+        downstream
+            .component(ctx)
+            .await
+            .copy_without_connections(
+                ctx,
+                default_view_id,
+                downstream.geometry_for_default(ctx).await,
+            )
+            .await?
+            .id(),
+    );
+    let downstream_copy_parrots = downstream_copy.prop(ctx, downstream_parrots).await;
+
+    assert_ne!(downstream.id(), downstream_copy.id());
+
+    // Check that the copy does *not* have the parrots value, because it is not explicitly set
+    // (because it has no link)
+    assert!(!downstream_copy_parrots.has_value(ctx).await);
+    assert_eq!(None, downstream_copy_parrots.view(ctx).await);
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Check that the copy does *not* have the parrots value, because it is not explicitly set
+    // (because it has no link)
+    assert!(!downstream_copy_parrots.has_value(ctx).await);
+    assert_eq!(None, downstream_copy_parrots.view(ctx).await);
+
+    assert!(downstream_parrots.has_value(ctx).await);
+    assert_eq!(
+        Some(json!(["Captain Flint"])),
+        downstream_parrots.view(ctx).await
+    );
+
+    assert_eq!(
+        Some(json!({
+            "domain": {
+                // Propagated from /si/name, which means the attribute prototype has been copied
+                // from the copied component (since we manually set all values, which removes the
+                // default attribute prototype for the slot
+                "name": "Long John Silver - Copy",
+
+                // The connection is not copied
+                // "parrot_names": [
+                //     "Captain Flint",
+                // ],
+            },
+            "resource_value": {},
+            "resource": {},
+            "si": {
+                "color": "#ff00ff",
+                "name": "Long John Silver - Copy",
+                "type": "component",
+            },
+        })),
+        downstream_copy.view(ctx).await,
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn paste_components_with_connections(ctx: &mut DalContext) -> Result<()> {
+    let test = ConnectableTest::setup(ctx).await;
+
+    // let out_one = OutputSocket::find_with_name_or_error(ctx, "One", connectable.id()).await?;
+    // let one = InputSocket::find_with_name_or_error(ctx, "One", connectable.id()).await?;
+
+    // input1
+    let input1 = test.create_connectable(ctx, "input1", None, []).await?;
+    assert_eq!(
+        json!({
+            "Value": "input1"
+        }),
+        input1.domain(ctx).await?
+    );
+
+    // input2
+    let input2 = test.create_connectable(ctx, "input2", None, []).await?;
+    assert_eq!(
+        json!({
+            "Value": "input2"
+        }),
+        input2.domain(ctx).await?
+    );
+
+    // input1 -> original1
+    let original1 = test
+        .create_connectable(ctx, "original1", Some(input1), [input1, input2])
+        .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "original1",
+            "One": "input1",
+            "Many": ["input1", "input2"],
+        }),
+        original1.domain(ctx).await?
+    );
+
+    // original1 -> original2
+    let original2 = test
+        .create_connectable(
+            ctx,
+            "original2",
+            Some(original1),
+            [input1, input2, original1],
+        )
+        .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "original2",
+            "One": "original1",
+            "Many": ["input1", "input2", "original1"],
+        }),
+        original2.domain(ctx).await?
+    );
+
+    // original1 -> output
+    let output = test
+        .create_connectable(
+            ctx,
+            "output",
+            Some(original2),
+            [input1, input2, original1, original2],
+        )
+        .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "output",
+            "One": "original2",
+            "Many": ["input1", "input2", "original1", "original2"],
+        }),
+        output.domain(ctx).await?
+    );
+
+    // Copy/paste original2/1 -> pasted2/1
+    let (pasted1, pasted2) = {
+        let pasted = Component::batch_copy(
+            ctx,
+            View::get_id_for_default(ctx).await?,
+            None,
+            vec![(original1.id, GEOMETRY2), (original2.id, GEOMETRY1)],
+        )
+        .await?;
+        assert_eq!(pasted.len(), 2);
+        (
+            Connectable::new(test, pasted[0]),
+            Connectable::new(test, pasted[1]),
+        )
+    };
+
+    // Set the pasted components' values to make sure those are flowing as expected
+    pasted1.set_value(ctx, "pasted1").await?;
+    pasted2.set_value(ctx, "pasted2").await?;
+
+    // Set the external components' values to new values to ensure they flow through the pasted
+    // connections
+    input1.set_value(ctx, "input1-new").await?;
+    input2.set_value(ctx, "input2-new").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Make sure original1 and original2 didn't change
+    assert_eq!(
+        json!({
+            "Value": "original1",
+            "One": "input1-new",
+            "Many": ["input1-new", "input2-new"],
+        }),
+        original1.domain(ctx).await?
+    );
+    assert_eq!(
+        json!({
+            "Value": "original2",
+            "One": "original1",
+            "Many": ["input1-new", "input2-new", "original1"],
+        }),
+        original2.domain(ctx).await?
+    );
+
+    // Make sure the pasted components got the connected values we expect
+    assert_eq!(
+        json!({
+            "Value": "pasted1",
+            "One": "input1-new",
+            "Many": ["input1-new", "input2-new"],
+        }),
+        pasted1.domain(ctx).await?
+    );
+    assert_eq!(
+        json!({
+            "Value": "pasted2",
+            "One": "pasted1",
+            "Many": ["input1-new", "input2-new", "pasted1"],
+        }),
+        pasted2.domain(ctx).await?
+    );
+
+    // Make sure the pasted components were *not* connected to the output
+    assert_eq!(
+        json!({
+            "Value": "output",
+            "One": "original2",
+            // TODO incorrect
+            "Many": ["input1-new", "input2-new", "original1", "original2"],
+        }),
+        output.domain(ctx).await?
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn paste_components_with_connections_opposite_order(ctx: &mut DalContext) -> Result<()> {
+    let test = ConnectableTest::setup(ctx).await;
+
+    // let out_one = OutputSocket::find_with_name_or_error(ctx, "One", connectable.id()).await?;
+    // let one = InputSocket::find_with_name_or_error(ctx, "One", connectable.id()).await?;
+
+    // input1
+    let input1 = test.create_connectable(ctx, "input1", None, []).await?;
+    assert_eq!(
+        json!({
+            "Value": "input1"
+        }),
+        input1.domain(ctx).await?
+    );
+
+    // input2
+    let input2 = test.create_connectable(ctx, "input2", None, []).await?;
+    assert_eq!(
+        json!({
+            "Value": "input2"
+        }),
+        input2.domain(ctx).await?
+    );
+
+    // input1 -> original1
+    let original1 = test
+        .create_connectable(ctx, "original1", Some(input1), [input1, input2])
+        .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "original1",
+            "One": "input1",
+            "Many": ["input1", "input2"],
+        }),
+        original1.domain(ctx).await?
+    );
+
+    // original1 -> original2
+    let original2 = test
+        .create_connectable(
+            ctx,
+            "original2",
+            Some(original1),
+            [input1, input2, original1],
+        )
+        .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "original2",
+            "One": "original1",
+            "Many": ["input1", "input2", "original1"],
+        }),
+        original2.domain(ctx).await?
+    );
+
+    // original1 -> output
+    let output = test
+        .create_connectable(
+            ctx,
+            "output",
+            Some(original2),
+            [input1, input2, original1, original2],
+        )
+        .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "output",
+            "One": "original2",
+            "Many": ["input1", "input2", "original1", "original2"],
+        }),
+        output.domain(ctx).await?
+    );
+
+    // Copy/paste original2/1 -> pasted2/1
+    let (pasted2, pasted1) = {
+        let pasted = Component::batch_copy(
+            ctx,
+            View::get_id_for_default(ctx).await?,
+            None,
+            vec![(original2.id, GEOMETRY2), (original1.id, GEOMETRY1)],
+        )
+        .await?;
+        assert_eq!(pasted.len(), 2);
+        (
+            Connectable::new(test, pasted[0]),
+            Connectable::new(test, pasted[1]),
+        )
+    };
+
+    // Set the pasted components' values to make sure those are flowing as expected
+    pasted1.set_value(ctx, "pasted1").await?;
+    pasted2.set_value(ctx, "pasted2").await?;
+
+    // Set the external components' values to new values to ensure they flow through the pasted
+    // connections
+    input1.set_value(ctx, "input1-new").await?;
+    input2.set_value(ctx, "input2-new").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Make sure original1 and original2 didn't change
+    assert_eq!(
+        json!({
+            "Value": "original1",
+            "One": "input1-new",
+            "Many": ["input1-new", "input2-new"],
+        }),
+        original1.domain(ctx).await?
+    );
+    assert_eq!(
+        json!({
+            "Value": "original2",
+            "One": "original1",
+            "Many": ["input1-new", "input2-new", "original1"],
+        }),
+        original2.domain(ctx).await?
+    );
+
+    // Make sure the pasted components got the connected values we expect
+    assert_eq!(
+        json!({
+            "Value": "pasted1",
+            "One": "input1-new",
+            "Many": ["input1-new", "input2-new"],
+        }),
+        pasted1.domain(ctx).await?
+    );
+    assert_eq!(
+        json!({
+            "Value": "pasted2",
+            "One": "pasted1",
+            "Many": ["input1-new", "input2-new", "pasted1"],
+        }),
+        pasted2.domain(ctx).await?
+    );
+
+    // Make sure the pasted components were *not* connected to the output
+    assert_eq!(
+        json!({
+            "Value": "output",
+            "One": "original2",
+            // TODO incorrect
+            "Many": ["input1-new", "input2-new", "original1", "original2"],
+        }),
+        output.domain(ctx).await?
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn paste_child_and_parent(ctx: &mut DalContext) -> Result<()> {
+    let test = ConnectableTest::setup(ctx).await;
+
+    // parent and child
+    let parent = test.create_parent(ctx, "parent").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    let child = test.create_connectable(ctx, "child", None, []).await?;
+    Frame::upsert_parent(ctx, child.id, parent.id).await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "child",
+            "Inferred": "parent",
+        }),
+        child.domain(ctx).await?
+    );
+
+    // Copy/paste parent/child -> pasted_parent/pasted_child
+    let (pasted_parent, pasted_child) = {
+        let pasted = Component::batch_copy(
+            ctx,
+            View::get_id_for_default(ctx).await?,
+            None,
+            vec![(parent.id, GEOMETRY1), (child.id, GEOMETRY2)],
+        )
+        .await?;
+        assert_eq!(pasted.len(), 2);
+        (
+            Connectable::new(test, pasted[0]),
+            Connectable::new(test, pasted[1]),
+        )
+    };
+
+    // Set the pasted components' values to make sure those are flowing as expected
+    pasted_parent.set_value(ctx, "pasted parent").await?;
+    pasted_child.set_value(ctx, "pasted child").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Make sure child infers its value from parent now
+    assert_eq!(
+        json!({
+            "Value": "pasted child",
+            "Inferred": "pasted parent"
+        }),
+        pasted_child.domain(ctx).await?
+    );
+
+    // Make sure original didn't change
+    assert_eq!(
+        json!({
+            "Value": "child",
+            "Inferred": "parent",
+        }),
+        child.domain(ctx).await?
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn paste_child_and_parent_opposite_order(ctx: &mut DalContext) -> Result<()> {
+    let test = ConnectableTest::setup(ctx).await;
+
+    // parent and child
+    let parent = test.create_parent(ctx, "parent").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    let child = test.create_connectable(ctx, "child", None, []).await?;
+    Frame::upsert_parent(ctx, child.id, parent.id).await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "child",
+            "Inferred": "parent",
+        }),
+        child.domain(ctx).await?
+    );
+
+    // Copy/paste child/parent -> pasted_child, pasted_parent
+    let (pasted_child, pasted_parent) = {
+        let pasted = Component::batch_copy(
+            ctx,
+            View::get_id_for_default(ctx).await?,
+            None,
+            vec![(child.id, GEOMETRY1), (parent.id, GEOMETRY2)],
+        )
+        .await?;
+        assert_eq!(pasted.len(), 2);
+        (
+            Connectable::new(test, pasted[0]),
+            Connectable::new(test, pasted[1]),
+        )
+    };
+
+    // Set the pasted components' values to make sure those are flowing as expected
+    pasted_parent.set_value(ctx, "pasted parent").await?;
+    pasted_child.set_value(ctx, "pasted child").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Make sure child infers its value from parent now
+    assert_eq!(
+        json!({
+            "Value": "pasted child",
+            "Inferred": "pasted parent"
+        }),
+        pasted_child.domain(ctx).await?
+    );
+
+    // Make sure original didn't change
+    assert_eq!(
+        json!({
+            "Value": "child",
+            "Inferred": "parent",
+        }),
+        child.domain(ctx).await?
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn paste_child_only(ctx: &mut DalContext) -> Result<()> {
+    let test = ConnectableTest::setup(ctx).await;
+
+    // parent and child
+    let parent = test.create_parent(ctx, "parent").await?;
+    let child = test.create_connectable(ctx, "child", None, []).await?;
+    Frame::upsert_parent(ctx, child.id, parent.id).await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "child",
+            "Inferred": "parent",
+        }),
+        child.domain(ctx).await?
+    );
+
+    // Copy/paste child -> pasted_child
+    let pasted_child = {
+        let pasted = Component::batch_copy(
+            ctx,
+            View::get_id_for_default(ctx).await?,
+            None,
+            vec![(child.id, GEOMETRY1)],
+        )
+        .await?;
+        assert_eq!(pasted.len(), 1);
+        Connectable::new(test, pasted[0])
+    };
+
+    // Set the pasted components' values to make sure those are flowing as expected
+    pasted_child.set_value(ctx, "pasted child").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Make sure child no longer gets a parent value
+    assert_eq!(
+        json!({
+            "Value": "pasted child"
+        }),
+        pasted_child.domain(ctx).await?
+    );
+
+    // Make sure originals didn't change
+    assert_eq!(
+        json!({
+            "Value": "child",
+            "Inferred": "parent",
+        }),
+        child.domain(ctx).await?
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn paste_child_into_new_parent(ctx: &mut DalContext) -> Result<()> {
+    let test = ConnectableTest::setup(ctx).await;
+
+    // parent and child
+    let parent = test.create_parent(ctx, "parent").await?;
+    let parent2 = test.create_parent(ctx, "parent2").await?;
+    let child = test.create_connectable(ctx, "child", None, []).await?;
+    Frame::upsert_parent(ctx, child.id, parent.id).await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "child",
+            "Inferred": "parent",
+        }),
+        child.domain(ctx).await?
+    );
+
+    // Copy/paste child -> pasted_child
+    let pasted_child = {
+        let pasted = Component::batch_copy(
+            ctx,
+            View::get_id_for_default(ctx).await?,
+            Some(parent2.id),
+            vec![(child.id, GEOMETRY1)],
+        )
+        .await?;
+        assert_eq!(pasted.len(), 1);
+        Connectable::new(test, pasted[0])
+    };
+
+    // Set the pasted components' values to make sure those are flowing as expected
+    pasted_child.set_value(ctx, "pasted child").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Make sure child infers its value from parent now
+    assert_eq!(
+        json!({
+            "Value": "pasted child",
+            "Inferred": "parent2"
+        }),
+        pasted_child.domain(ctx).await?
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn paste_manager_and_managed(ctx: &mut DalContext) -> Result<()> {
+    let test = ConnectableTest::setup(ctx).await;
+
+    // manager and original
+    let manager = test.create_manager(ctx, "manager").await?;
+    let original = test.create_connectable(ctx, "original", None, []).await?;
+    Component::manage_component(ctx, manager.id, original.id).await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Copy/paste manager/original -> pasted_manager/pasted
+    let (pasted_manager, pasted) = {
+        let pasted = Component::batch_copy(
+            ctx,
+            View::get_id_for_default(ctx).await?,
+            None,
+            vec![(manager.id, GEOMETRY1), (original.id, GEOMETRY2)],
+        )
+        .await?;
+        assert_eq!(pasted.len(), 2);
+        (
+            Connectable::new(test, pasted[0]),
+            Connectable::new(test, pasted[1]),
+        )
+    };
+
+    // Set the pasted component's value so we can tell the difference
+    pasted.set_value(ctx, "pasted").await?;
+    pasted_manager.set_value(ctx, "pasted manager").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Make sure the originals are unaltered
+    assert_eq!(json!(["original"]), manager.run_management_func(ctx).await?);
+
+    // Make sure the pasted components are managed
+    assert_eq!(
+        json!(["pasted"]),
+        pasted_manager.run_management_func(ctx).await?
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn paste_manager_and_managed_opposite_order(ctx: &mut DalContext) -> Result<()> {
+    let test = ConnectableTest::setup(ctx).await;
+
+    // manager and original
+    let manager = test.create_manager(ctx, "manager").await?;
+    let original = test.create_connectable(ctx, "original", None, []).await?;
+    Component::manage_component(ctx, manager.id, original.id).await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Copy/paste original/manager -> pasted/pasted_manager
+    let (pasted, pasted_manager) = {
+        let pasted = Component::batch_copy(
+            ctx,
+            View::get_id_for_default(ctx).await?,
+            None,
+            vec![(original.id, GEOMETRY1), (manager.id, GEOMETRY2)],
+        )
+        .await?;
+        assert_eq!(pasted.len(), 2);
+        (
+            Connectable::new(test, pasted[0]),
+            Connectable::new(test, pasted[1]),
+        )
+    };
+
+    // Set the pasted component's value so we can tell the difference
+    pasted.set_value(ctx, "pasted").await?;
+    pasted_manager.set_value(ctx, "pasted manager").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Make sure the originals are unaltered
+    assert_eq!(json!(["original"]), manager.run_management_func(ctx).await?);
+
+    // Make sure the pasted components are managed
+    assert_eq!(
+        json!(["pasted"]),
+        pasted_manager.run_management_func(ctx).await?
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn paste_manager(ctx: &mut DalContext) -> Result<()> {
+    let test = ConnectableTest::setup(ctx).await;
+
+    // manager and original
+    let manager = test.create_manager(ctx, "manager").await?;
+    let original = test.create_connectable(ctx, "original", None, []).await?;
+    Component::manage_component(ctx, manager.id, original.id).await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Copy/paste manager -> pasted_manager
+    let pasted_manager = {
+        let pasted = Component::batch_copy(
+            ctx,
+            View::get_id_for_default(ctx).await?,
+            None,
+            vec![(manager.id, GEOMETRY1)],
+        )
+        .await?;
+        assert_eq!(pasted.len(), 1);
+        Connectable::new(test, pasted[0])
+    };
+
+    // Set the pasted component's value so we can tell the difference
+    pasted_manager.set_value(ctx, "pasted manager").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Make sure the originals are unaltered
+    assert_eq!(json!(["original"]), manager.run_management_func(ctx).await?);
+
+    // Make sure the pasted component has no managed components
+    assert_eq!(json!([]), pasted_manager.run_management_func(ctx).await?);
+
+    Ok(())
+}
+
+#[test]
+async fn paste_managed(ctx: &mut DalContext) -> Result<()> {
+    let test = ConnectableTest::setup(ctx).await;
+
+    // manager and original
+    let manager = test.create_manager(ctx, "manager").await?;
+    let original = test.create_connectable(ctx, "original", None, []).await?;
+    Component::manage_component(ctx, manager.id, original.id).await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Copy/paste original -> pasted
+    let pasted = {
+        let pasted = Component::batch_copy(
+            ctx,
+            View::get_id_for_default(ctx).await?,
+            None,
+            vec![(original.id, GEOMETRY1)],
+        )
+        .await?;
+        assert_eq!(pasted.len(), 1);
+        Connectable::new(test, pasted[0])
+    };
+
+    // Set the pasted component's value so we can tell the difference
+    pasted.set_value(ctx, "pasted").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Make sure the original management function is unaltered
+    assert_eq!(
+        json!(["original", "pasted"]),
+        manager.run_management_func(ctx).await?
+    );
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ConnectableTest {
+    connectable_variant_id: SchemaVariantId,
+    parent_variant_id: SchemaVariantId,
+    management_func_id: FuncId,
+}
+
+impl ConnectableTest {
+    async fn setup(ctx: &DalContext) -> Self {
+        let connectable = ExpectSchemaVariant::create_named(
+            ctx,
+            "connectable",
+            r#"
+                function main() {
+                    return {
+                        props: [
+                            { name: "Value", kind: "string" },
+                            { name: "One", kind: "string", valueFrom: { kind: "inputSocket", socket_name: "One" } },
+                            { name: "Many", kind: "array",
+                                entry: { name: "ManyItem", kind: "string" },
+                                valueFrom: { kind: "inputSocket", socket_name: "Many" },
+                            },
+                            { name: "Inferred", kind: "string", valueFrom: { kind: "inputSocket", socket_name: "Inferred" } },
+                            { name: "Missing", kind: "string", valueFrom: { kind: "inputSocket", socket_name: "Missing" } },
+                            { name: "Empty", kind: "array",
+                                entry: { name: "EmptyItem", kind: "string" },
+                                valueFrom: { kind: "inputSocket", socket_name: "Empty" },
+                            },
+                        ],
+                        inputSockets: [
+                            { name: "One", arity: "one", connectionAnnotations: "[\"Value\"]" },
+                            { name: "Many", arity: "many", connectionAnnotations: "[\"Value\"]" },
+                            { name: "Missing", arity: "one", connectionAnnotations: "[\"Value\"]" },
+                            { name: "Empty", arity: "many", connectionAnnotations: "[\"Value\"]" },
+                            { name: "Inferred", arity: "one", connectionAnnotations: "[\"Inferred\"]" },
+                        ],
+                        outputSockets: [
+                            { name: "Value", arity: "one", valueFrom: { kind: "prop", prop_path: [ "root", "domain", "Value" ] }, connectionAnnotations: "[\"Value\"]" },
+                        ],
+                    };
+                }
+            "#,
+        )
+        .await;
+        let manager = ExpectSchemaVariant::create_named(
+            ctx,
+            "connectable manager",
+            r#"
+                function main() {
+                    return {
+                        props: [
+                            { name: "Value", kind: "string" },
+                            { name: "ManagedValues", kind: "array",
+                                entry: { name: "ManagedValuesItem", kind: "string" },
+                            },
+                        ],
+                        outputSockets: [
+                            { name: "Inferred", arity: "one", valueFrom: { kind: "prop", prop_path: [ "root", "domain", "Value" ] }, connectionAnnotations: "[\"Inferred\"]" },
+                        ],
+                    };
+                }
+            "#,
+        )
+        .await;
+        manager
+            .set_type(ctx, ComponentType::ConfigurationFrameDown)
+            .await;
+        let management_func = manager
+            .create_management_func(
+                ctx,
+                &[connectable.schema(ctx).await.id()],
+                r#"
+                    function main(input) {
+                        let managed_values = Object.values(input.components).map(c => c.properties.domain.Value).sort();
+                        return {
+                            status: "ok",
+                            ops: {
+                                update: {
+                                    self: {
+                                        properties: {
+                                            domain: {
+                                                ManagedValues: managed_values
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                "#,
+            )
+            .await;
+        Self {
+            connectable_variant_id: connectable.id(),
+            parent_variant_id: manager.id(),
+            management_func_id: management_func.id(),
+        }
+    }
+
+    async fn create_connectable(
+        self,
+        ctx: &DalContext,
+        name: &str,
+        connect_one: Option<Connectable>,
+        connect_many: impl IntoIterator<Item = Connectable>,
+    ) -> Result<Connectable> {
+        let one =
+            InputSocket::find_with_name_or_error(ctx, "One", self.connectable_variant_id).await?;
+        let many =
+            InputSocket::find_with_name_or_error(ctx, "Many", self.connectable_variant_id).await?;
+
+        let connectable = {
+            let component = create_component_for_schema_variant_on_default_view(
+                ctx,
+                self.connectable_variant_id,
+            )
+            .await?;
+            component.set_name(ctx, name).await?;
+            Component::set_type_by_id(ctx, component.id(), ComponentType::ConfigurationFrameDown)
+                .await?;
+            Connectable::new(self, component.id())
+        };
+
+        connectable.set_value(ctx, name).await?;
+
+        if let Some(from) = connect_one {
+            Component::connect(
+                ctx,
+                from.id,
+                from.value_output_socket_id(ctx).await?,
+                connectable.id,
+                one.id(),
+            )
+            .await?;
+        }
+        for from in connect_many {
+            Component::connect(
+                ctx,
+                from.id,
+                from.value_output_socket_id(ctx).await?,
+                connectable.id,
+                many.id(),
+            )
+            .await?;
+        }
+
+        Ok(connectable)
+    }
+
+    async fn create_parent(self, ctx: &DalContext, name: &str) -> Result<Connectable> {
+        let component =
+            create_component_for_schema_variant_on_default_view(ctx, self.parent_variant_id)
+                .await?;
+        component.set_name(ctx, name).await?;
+        update_attribute_value_for_component(
+            ctx,
+            component.id(),
+            &["root", "domain", "Value"],
+            name.into(),
+        )
+        .await?;
+        Ok(Connectable::new(self, component.id()))
+    }
+
+    async fn create_manager(self, ctx: &DalContext, name: &str) -> Result<Connectable> {
+        self.create_parent(ctx, name).await
+    }
+}
+
+// Component with output socket "Value" and input sockets "One", "Many", "Inferred", "Missing", and
+// "Empty" which can connect to "Value".
+#[derive(Debug, Copy, Clone, derive_more::From, derive_more::Into)]
+struct Connectable {
+    test: ConnectableTest,
+    id: ComponentId,
+}
+
+impl Connectable {
+    fn new(test: ConnectableTest, id: ComponentId) -> Self {
+        Self { test, id }
+    }
+
+    async fn run_management_func(self, ctx: &mut DalContext) -> Result<Value> {
+        ExpectComponent(self.id)
+            .execute_management_func(ctx, ExpectFunc(self.test.management_func_id))
+            .await;
+        ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+        get_attribute_value_for_component(ctx, self.id, &["root", "domain", "ManagedValues"]).await
+    }
+
+    async fn set_value(self, ctx: &DalContext, value: &str) -> Result<()> {
+        update_attribute_value_for_component(
+            ctx,
+            self.id,
+            &["root", "domain", "Value"],
+            value.into(),
+        )
+        .await
+    }
+
+    // Get the domain, with the Many prop sorted
+    async fn domain(self, ctx: &mut DalContext) -> Result<Value> {
+        let mut domain =
+            get_attribute_value_for_component(ctx, self.id, &["root", "domain"]).await?;
+        if let Some(many) = domain.get_mut("Many") {
+            let many = many.as_array_mut().expect("Many is an array");
+            many.sort_by_key(|v| v.as_str().expect("Many is an array of strings").to_string());
+        }
+        Ok(domain)
+    }
+
+    async fn value_output_socket_id(self, ctx: &DalContext) -> Result<OutputSocketId> {
+        let variant_id = Component::schema_variant_id(ctx, self.id).await?;
+        let value_socket = OutputSocket::find_with_name_or_error(ctx, "Value", variant_id).await?;
+        Ok(value_socket.id())
+    }
+}
+
+const GEOMETRY1: RawGeometry = RawGeometry {
+    x: 1,
+    y: 11,
+    width: Some(111),
+    height: Some(1111),
+};
+
+const GEOMETRY2: RawGeometry = RawGeometry {
+    x: 2,
+    y: 22,
+    width: Some(222),
+    height: Some(2222),
+};

--- a/lib/dal/tests/integration_test/component/property_order.rs
+++ b/lib/dal/tests/integration_test/component/property_order.rs
@@ -335,7 +335,7 @@ async fn child_property_value_remains_after_update_and_paste(
         component
             .component(ctx)
             .await
-            .create_copy(
+            .copy_without_connections(
                 ctx,
                 default_view_id,
                 component.geometry_for_default(ctx).await,

--- a/lib/dal/tests/integration_test/func/authoring/binding/attribute.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding/attribute.rs
@@ -16,8 +16,8 @@ use dal::{
 };
 use dal_test::helpers::{
     connect_components_with_socket_names, create_component_for_default_schema_name_in_default_view,
-    get_attribute_value_for_component, get_component_output_socket_value,
-    update_attribute_value_for_component, ChangeSetTestHelpers,
+    get_attribute_value_for_component, get_attribute_value_for_component_opt,
+    get_component_output_socket_value, update_attribute_value_for_component, ChangeSetTestHelpers,
 };
 use dal_test::test;
 use itertools::Itertools;
@@ -478,15 +478,13 @@ async fn create_intrinsic_binding_then_unset(ctx: &mut DalContext) {
     // check test prop to make sure the value propagated
     let value = get_attribute_value_for_component(ctx, component.id(), test_prop_path)
         .await
-        .expect("could not get attribute value")
-        .expect("attribute value is none");
+        .expect("could not get attribute value");
     assert_eq!(serde_json::Value::String("test".to_string()), value);
 
     // check another prop too
     let value = get_attribute_value_for_component(ctx, component.id(), another_test_prop_path)
         .await
-        .expect("could not get attribute value")
-        .expect("attribute value is none");
+        .expect("could not get attribute value");
     assert_eq!(serde_json::Value::String("test".to_string()), value);
 
     // check output socket
@@ -537,7 +535,7 @@ async fn create_intrinsic_binding_then_unset(ctx: &mut DalContext) {
         .any(|binding| binding.output_location == AttributeFuncDestination::Prop(another_prop)));
 
     // let's make sure another_prop was cleared!
-    let value = get_attribute_value_for_component(ctx, component.id(), another_test_prop_path)
+    let value = get_attribute_value_for_component_opt(ctx, component.id(), another_test_prop_path)
         .await
         .expect("could not get attribute value");
 

--- a/lib/dal/tests/integration_test/management.rs
+++ b/lib/dal/tests/integration_test/management.rs
@@ -1432,10 +1432,10 @@ async fn upgrade_manager_variant(ctx: &mut DalContext) {
         ctx,
         "createme",
         r#"
-        function main() {
-            return new AssetBuilder().build();
-        }
-    "#,
+            function main() {
+                return new AssetBuilder().build();
+            }
+        "#,
     )
     .await;
     expected::commit_and_update_snapshot_to_visibility(ctx).await;
@@ -1444,17 +1444,17 @@ async fn upgrade_manager_variant(ctx: &mut DalContext) {
             ctx,
             &[original_variant.schema(ctx).await.id()],
             r#"
-            function main(input) {
-                return {
-                    status: "ok",
-                    ops: {
-                        create: {
-                            created: { kind: "createme" }
+                function main(input) {
+                    return {
+                        status: "ok",
+                        ops: {
+                            create: {
+                                created: { kind: "createme" }
+                            }
                         }
                     }
                 }
-            }
-        "#,
+            "#,
         )
         .await;
     expected::commit_and_update_snapshot_to_visibility(ctx).await;

--- a/lib/dal/tests/integration_test/secret.rs
+++ b/lib/dal/tests/integration_test/secret.rs
@@ -310,7 +310,7 @@ async fn copy_paste_component_with_secrets_being_used(ctx: &mut DalContext, nw: 
             .expect("couldn't get geometry");
 
         component
-            .create_copy(
+            .copy_without_connections(
                 ctx,
                 default_view_id,
                 RawGeometry {
@@ -336,7 +336,7 @@ async fn copy_paste_component_with_secrets_being_used(ctx: &mut DalContext, nw: 
     user_component
         .component(ctx)
         .await
-        .create_copy(
+        .copy_without_connections(
             ctx,
             default_view_id,
             RawGeometry {

--- a/lib/sdf-server/BUCK
+++ b/lib/sdf-server/BUCK
@@ -42,6 +42,7 @@ rust_library(
         "//third-party/rust:futures",
         "//third-party/rust:futures-lite",
         "//third-party/rust:hyper",
+        "//third-party/rust:itertools",
         "//third-party/rust:names",
         "//third-party/rust:nix",
         "//third-party/rust:once_cell",

--- a/lib/sdf-server/Cargo.toml
+++ b/lib/sdf-server/Cargo.toml
@@ -49,6 +49,7 @@ derive_more = { workspace = true }
 futures = { workspace = true }
 futures-lite = { workspace = true }
 hyper = { workspace = true }
+itertools = { workspace = true }
 names = { workspace = true }
 nix = { workspace = true }
 once_cell = { workspace = true }

--- a/lib/sdf-server/src/service/diagram/set_component_position.rs
+++ b/lib/sdf-server/src/service/diagram/set_component_position.rs
@@ -94,7 +94,7 @@ pub async fn set_component_position(
                         };
                         diagram_inferred_edges.push(SummaryDiagramInferredEdge::assemble(
                             inferred_stack_connection,
-                        )?)
+                        ))
                     }
                 }
             }

--- a/lib/sdf-server/src/service/v2/view.rs
+++ b/lib/sdf-server/src/service/v2/view.rs
@@ -16,6 +16,7 @@ use dal::{
     ChangeSetError, ComponentError, FuncError, SchemaError, SchemaId, SchemaVariantError,
     TransactionsError, WorkspaceSnapshotError, WsEventError,
 };
+use si_id::ViewId;
 use thiserror::Error;
 use tokio::task::JoinError;
 
@@ -162,4 +163,9 @@ pub fn v2_routes() -> Router<AppState> {
             "/:view_id/view_object/set_geometry",
             put(set_geometry::set_view_object_geometry),
         )
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ViewParam {
+    view_id: ViewId,
 }


### PR DESCRIPTION
When you paste multiple things, we already restore connections between the components you copied--but we don't copy connections to things *outside* the pasted subgraph. This PR preserves connections to non-copied components when you copy/paste.

### Changes

This PR:

* Copies incoming connections from components not being pasted.
* Copies "managed by" connection from components not being pasted.
* Now sends an event to let the frontend know when the pasted component has a parent--this makes inferred connections show up in the UI.
* Continues to "mirror" incoming and management connections from components being pasted
* Continues to "mirror" parentage for elements where both parent and child are pasted
* Centralizes the copy/paste logic into Component::batch_copy, so it can be tested in the dal; SDF now just sends the WsEvents

### Refactoring Budget

My PRs often try to improve something sort-of-related "while I'm in there." To hopefully move forward while keeping the code review process pleasant, I'm limiting the amount and scope of it. I spent the refactoring budget here on:

* Used Result<()> in component tests, replacing .expect() calls with `?`.
* Added From<Box<E>> for boxed error types in component.rs, and removed `.map_err(Box::new)` everywhere in that file.
* Replaced OutgoingConnections and IncomingConnections with Connections. It is a directionless struct and it clarifies code that wants to handle both outgoing and incoming connections in one place.

## Testing

* Added DAL tests (without WsEvents)
* Manually tested copying with external and internal connections
* Manually tested copying with both external and internal manager connections
* Manually tested copying parent, child, and both