### PR TITLE
feat(web): Expose the audit log link on the new approval modal

### DIFF
--- a/app/web/src/components/InsetApprovalModal.vue
+++ b/app/web/src/components/InsetApprovalModal.vue
@@ -73,6 +73,39 @@
       </ErrorMessage>
     </div>
 
+    <div
+      :class="
+        clsx(
+          'flex flex-row gap-xs flex-1 overflow-hidden',
+          fineGrainedAccessControl ? 'place-content-evenly' : 'justify-center',
+        )
+      "
+    >
+      <div
+        :class="
+          clsx(
+            'flex flex-col gap-xs overflow-hidden text-center',
+            fineGrainedAccessControl && 'basis-1/2',
+          )
+        "
+      >
+        <RouterLink
+          :to="{
+            name: 'workspace-audit',
+            params: { changeSetId: 'auto' },
+          }"
+          target="_blank"
+          class="text-action-500 hover:underline pl-4 pb-2xs text-sm font-bold"
+          >See the breakdown of changes
+          <Icon
+            size="sm"
+            name="logs-pop-square"
+            class="ml-2xs inline-block mb-[-.3em]"
+          />
+        </RouterLink>
+      </div>
+    </div>
+
     <!-- MAIN SECTION -->
     <div
       :class="
@@ -233,6 +266,7 @@ import {
   TruncateWithTooltip,
 } from "@si/vue-lib/design-system";
 import { computed, ref } from "vue";
+import { RouterLink } from "vue-router";
 import clsx from "clsx";
 import {
   ApprovalData,


### PR DESCRIPTION
<img width="746" alt="Screenshot 2025-02-28 at 22 36 54" src="https://github.com/user-attachments/assets/53e5df86-63b3-41bf-939e-1b36f31b9f96" />
