### PR TITLE
basic caching for sockets and views

### DIFF
--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -14,6 +14,7 @@ const FLAG_MAPPING = {
   TEMPLATE_MGMT_FUNC_GENERATION: "template-mgmt-func-generation",
   CLOVER_ASSETS: "clover-assets",
   DIAGRAM_OPTIMIZATION: "diagram-optimization",
+  DIAGRAM_OPTIMIZATION_2: "diagram-optimization-2",
   AUTOCONNECT: "autoconnect-component-input-sockets",
 };
 


### PR DESCRIPTION
Basic caching to improve performance - for now, `DiagramNode` and `DiagramGroup` only cache their sockets, while `DiagramView` caches everything except the hover outline.