### PR TITLE
BUG-791: remember the last grid origin per view, and load it when you look at that view

### DIFF
--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -442,6 +442,17 @@ const containerViewportY = ref(0);
 // and we're choosing to keep our origin (defaulting to 0,0) at the center of the diagram to keep things (hopefully) simpler
 const gridOrigin = ref<Vector2d>({ x: 0, y: 0 });
 
+watch(
+  gridOrigin,
+  () => {
+    window.localStorage.setItem(
+      `si-diagram-grid-origin-${viewsStore.selectedViewId}`,
+      JSON.stringify(gridOrigin.value),
+    );
+  },
+  { flush: "post" },
+);
+
 // zoom level (1 = 100%)
 // I opted to track this internally rather than use v-model so the parent component isn't _forced_ to care about it
 // but there will often probably be some external controls, which can be done using exposed setZoom and update:zoom event
@@ -614,6 +625,24 @@ onMounted(() => {
     zoomLevel.value = Number(lastZoomValue);
   }
 });
+
+watch(
+  () => viewsStore.selectedViewId,
+  () => {
+    const key = `si-diagram-grid-origin-${viewsStore.selectedViewId}`;
+    const lastGridOriginString = window.localStorage.getItem(key);
+    if (lastGridOriginString) {
+      const lastGridOrigin: Vector2d = JSON.parse(lastGridOriginString);
+      if (lastGridOrigin.x && lastGridOrigin.y) {
+        gridOrigin.value.x = lastGridOrigin.x;
+        gridOrigin.value.y = lastGridOrigin.y;
+      }
+    } else {
+      gridOrigin.value.x = 0;
+      gridOrigin.value.y = 0;
+    }
+  },
+);
 
 const CLIPBOARD_LOCALSTORAGE_KEY = computed(
   () => `clipboard-si-${changeSetsStore.selectedChangeSetId}`,

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -176,7 +176,8 @@ export function useChangeSetsStore() {
           if (!stayOnView && name === "workspace-compose-view") {
             name = "workspace-compose";
             delete params.viewId;
-          } else if (params.viewId) {
+          }
+          if (params.viewId) {
             name = "workspace-compose-view";
           }
           await router.push({

--- a/app/web/src/store/router.store.ts
+++ b/app/web/src/store/router.store.ts
@@ -31,6 +31,8 @@ export const useRouterStore = defineStore("router", {
       location: RouteLocationAsRelativeGeneric,
     ) {
       // if you're not operating on the same change set we are viewing, you can't change the router/URL
+      if (!location.name && this.currentRoute)
+        location.name = this.currentRoute.name;
       if (this.currentRoute?.params?.changeSetId === originChangeSetId) {
         router.replace(location);
         this.currentRoute = location;


### PR DESCRIPTION
Also, it seems we had a URL bug where the viewId was not getting into the URL (we were redirected back to workspace-compose).

I wanted to do this months ago 😉 