### PR TITLE
fix: strip default values from templates

### DIFF
--- a/lib/dal/src/management/generator.rs
+++ b/lib/dal/src/management/generator.rs
@@ -269,6 +269,13 @@ async fn calculate_paths_to_remove(
             continue;
         }
 
+        // remove the value if it matches the default. This ensures default value changes from prop
+        // updates are propagated
+        if Prop::default_value(ctx, prop_id).await? == Some(current_val.clone()) {
+            result.push(path_as_refs.iter().map(|&s| s.to_string()).collect());
+            continue;
+        }
+
         let prop = Prop::get_by_id(ctx, prop_id).await?;
 
         match prop.kind {

--- a/lib/dal/src/management/generator.rs
+++ b/lib/dal/src/management/generator.rs
@@ -271,7 +271,7 @@ async fn calculate_paths_to_remove(
 
         // remove the value if it matches the default. This ensures default value changes from prop
         // updates are propagated
-        if Prop::default_value(ctx, prop_id).await? == Some(current_val.clone()) {
+        if Prop::default_value(ctx, prop_id).await?.as_ref() == Some(current_val) {
             result.push(path_as_refs.iter().map(|&s| s.to_string()).collect());
             continue;
         }


### PR DESCRIPTION
This ensures that props that contain their default value are not set in mgmt func templates, otherwise updates to the default value will not propagate as the prop will have a set value already.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdldjl3dW1uNHk5M3ZiZ2gzMnNvenRqaG9ubHhndWd2M3A3bWRhYjdkYiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3oEdv3yyWiMAtYlopq/giphy.gif"/>