### PR TITLE
feat: add message prop to code gen to show failures

### DIFF
--- a/app/web/src/components/ComponentDetailsCode.vue
+++ b/app/web/src/components/ComponentDetailsCode.vue
@@ -18,7 +18,7 @@
               {{ item.message }}
             </ErrorMessage>
             <div class="relative">
-              <CodeViewer v-if="item.code" :code="item.code" />
+              <CodeViewer v-if="item.code && !item.message" :code="item.code" />
             </div>
           </div>
         </template>

--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -407,6 +407,19 @@ impl RootProp {
         )
         .await?;
 
+        let _child_message_prop = Prop::new(
+            ctx,
+            "message",
+            PropKind::String,
+            true,
+            None,
+            None,
+            None,
+            None,
+            code_map_item_prop_id,
+        )
+        .await?;
+
         Ok(code_map_prop_id)
     }
 


### PR DESCRIPTION
Maybe there's a better way to do this, but since we don't save off the message, it doesn't ever come back when these fail. Adding this to the root prop means we save off the child av when the func runs. However, this requires regenerating the assets, unless we want to do this inline somehow.

![image](https://github.com/user-attachments/assets/147edcba-3dd5-4c0e-a6ba-14a868a38e75)
 