### PR TITLE
fix: handle the case where object children do exist, but they are also empty so are not valid refinements

### DIFF
--- a/bin/clover/src/cloud-control-funcs/management/awsCloudControlDiscover.ts
+++ b/bin/clover/src/cloud-control-funcs/management/awsCloudControlDiscover.ts
@@ -22,6 +22,11 @@ async function main({
   for (const [key, value] of Object.entries(refinement)) {
     if (_.isEmpty(value)) {
       delete refinement[key];
+    } else if (_.isPlainObject(value)) {
+      refinement[key] = _.pickBy(value, (v) => !_.isEmpty(v) || _.isNumber(v) || _.isBoolean(v));
+      if (_.isEmpty(refinement[key])) {
+        delete refinement[key];
+      }
     }
   }
 


### PR DESCRIPTION
For EC2::LaunchTemplate (and some others we've probably not found yet), object children may exist as null and should be skipped during refinement:

```
Skipping import of lt-026952649cf076dbc; it did not match refinement {
  "LaunchTemplateData": {
    "SecurityGroups": []
  }
}
```

Currently, these aren't skipped as a refinement, as we are looking for any nested key or value regardless of value or content. 

This PR now handles the case where an object may have children, but they're also empty.