### PR TITLE
feat: expanded socket annotations

### DIFF
--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -22,6 +22,7 @@ import {
   ExpandedSchemaVariantSpec,
 } from "../spec/pkgs.ts";
 import { createPolicyDocumentInputSockets } from "../pipeline-steps/createPolicyDocumentInputSockets.ts";
+import { annotateCommonOutputSockets } from "../pipeline-steps/annotateCommonOutputSockets.ts";
 import { prettifySocketNames } from "../pipeline-steps/prettifySocketNames.ts";
 import { loadInferred } from "../spec/inferred.ts";
 import { addInferredEnums } from "../pipeline-steps/addInferredEnums.ts";
@@ -79,6 +80,7 @@ export async function generateSiSpecs(
   specs = await removeBadDocLinks(specs, options.docLinkCache);
   specs = addInferredEnums(specs, inferred);
   specs = generateOutputSocketsFromProps(specs);
+  specs = annotateCommonOutputSockets(specs);
   specs = addDefaultPropsAndSockets(specs);
   specs = attachDefaultActionFuncs(specs);
   specs = generateDefaultLeafFuncs(specs);

--- a/bin/clover/src/pipeline-steps/annotateCommonOutputSockets.ts
+++ b/bin/clover/src/pipeline-steps/annotateCommonOutputSockets.ts
@@ -1,0 +1,92 @@
+import _ from "lodash";
+import { bfsPropTree } from "../spec/props.ts";
+import {
+  createExtendedAnnotationForProp,
+  setAnnotationOnSocket,
+} from "../spec/sockets.ts";
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+import { socketNameFromProp } from "../spec/sockets.ts";
+import { getSocketOnVariant } from "../spec/sockets.ts";
+
+export function annotateCommonOutputSockets(
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const newSpecs = [] as ExpandedPkgSpec[];
+
+  for (const spec of specs) {
+    const [schema] = spec.schemas;
+    const [variant] = schema.variants;
+    const domain = variant.domain;
+    const resource = variant.resourceValue;
+
+    const category = schema.data.category.split("::")[1];
+    const variantName = variant.data.displayName;
+
+    bfsPropTree([resource, domain], (prop) => {
+      if (prop.name.endsWith("Id")) {
+        const propName = prop.name;
+        const socketName = socketNameFromProp(prop);
+        const socket = getSocketOnVariant(variant, socketName, "output");
+        if (socket) {
+          for (
+            const annotation of [
+              `${variantName}${propName}`,
+              `${category}${variantName}${propName}`,
+              `${category}${propName}`,
+              `${variantName}${propName}entifier`,
+              `${category}${propName}entifier`,
+              `${variantName}${propName}entifier`,
+              `${category}${variantName}${propName}entifer`,
+
+              `${variantName} ${propName}`,
+              `${category} ${variantName} ${propName}`,
+              `${category} ${propName}`,
+              `${variantName} ${propName}entifier`,
+              `${category} ${propName}entifier`,
+              `${variantName} ${propName}entifier`,
+              `${category} ${variantName} ${propName}entifer`,
+            ]
+          ) {
+            setAnnotationOnSocket(
+              socket,
+              {
+                tokens: createExtendedAnnotationForProp([annotation], prop),
+              },
+            );
+          }
+        }
+      }
+
+      if (prop.name.endsWith("Name") || prop.metadata.primaryIdentifier) {
+        const propName = prop.name;
+        const socketName = socketNameFromProp(prop);
+        const socket = getSocketOnVariant(variant, socketName, "output");
+        if (socket) {
+          for (
+            const annotation of [
+              `${variantName}${propName}`,
+              `${category}${variantName}${propName}`,
+              `${category}${propName}`,
+              `${variantName} ${propName}`,
+              `${category} ${propName}`,
+              `${category} ${variantName} ${propName}`,
+            ]
+          ) {
+            setAnnotationOnSocket(
+              socket,
+              {
+                tokens: createExtendedAnnotationForProp([annotation], prop),
+              },
+            );
+          }
+        }
+      }
+    }, {
+      skipTypeProps: true,
+    });
+
+    newSpecs.push(spec);
+  }
+
+  return newSpecs;
+}

--- a/bin/clover/src/pipeline-steps/createInputSocketsAcrossAssets.ts
+++ b/bin/clover/src/pipeline-steps/createInputSocketsAcrossAssets.ts
@@ -28,8 +28,8 @@ export function createInputSocketsBasedOnOutputSockets(
 
     for (const socket of schemaVariant.sockets) {
       if (socket.data?.kind === "output") {
-        foundOutputSockets[socket.name] ??= [];
-        foundOutputSockets[socket.name].push(schemaVariant);
+        foundOutputSockets[socket.name.toLowerCase()] ??= [];
+        foundOutputSockets[socket.name.toLowerCase()].push(schemaVariant);
 
         // add annotations as we may generate relevant output socket annotations
         // that match props
@@ -38,10 +38,6 @@ export function createInputSocketsBasedOnOutputSockets(
         ) as ConnectionAnnotation[];
 
         for (const { tokens } of existingAnnotations) {
-          if (tokens.length !== 1) {
-            continue;
-          }
-
           const annotationToken = tokens[0];
 
           // One of the annotations is always the socket name. We'll skip that one
@@ -49,8 +45,8 @@ export function createInputSocketsBasedOnOutputSockets(
             continue;
           }
 
-          foundOutputSockets[annotationToken] ??= [];
-          foundOutputSockets[annotationToken].push(schemaVariant);
+          foundOutputSockets[annotationToken.toLowerCase()] ??= [];
+          foundOutputSockets[annotationToken.toLowerCase()].push(schemaVariant);
         }
       }
     }
@@ -73,36 +69,13 @@ export function createInputSocketsBasedOnOutputSockets(
   }
 
   for (const spec of specs) {
-    const schema = spec.schemas[0];
-
-    if (!schema) {
-      console.log(
-        `Could not generate input for ${spec.name}: missing schema`,
-      );
-      continue;
-    }
-
-    const schemaVariant = schema.variants[0];
-
-    if (!schemaVariant) {
-      console.log(
-        `Could not generate input for ${spec.name}: missing variant`,
-      );
-      continue;
-    }
-
-    const domain = schema.variants[0].domain;
-
-    if (domain?.kind !== "object") {
-      console.log(
-        `Could not generate input for ${spec.name}: missing domain`,
-      );
-      continue;
-    }
+    const [schema] = spec.schemas;
+    const [schemaVariant] = schema.variants;
+    const domain = schemaVariant.domain;
 
     // Create sockets that props match exactly
     for (const prop of domain.entries) {
-      const fromVariants = foundOutputSockets[prop.name];
+      const fromVariants = foundOutputSockets[prop.name.toLowerCase()];
       if (!fromVariants) continue;
       // We don't create input sockets *just* to link to the same output socket/component.
       // There has to be another reason.

--- a/bin/clover/src/pipeline-steps/generateOutputSocketsFromProps.ts
+++ b/bin/clover/src/pipeline-steps/generateOutputSocketsFromProps.ts
@@ -34,15 +34,13 @@ function createSocketsFromResource(
   if (resource.kind !== "object") throw "Resource prop is not object";
 
   for (const prop of resource.entries) {
-    if (!["array", "object"].includes(prop.kind)) {
-      const socket = getOrCreateOutputSocketFromProp(variant, prop);
-      // if this socket is an arn, we want to make sure that all input sockets
-      // that might also be arns can take this value
-      if (socket.name.toLowerCase().endsWith("arn")) {
-        const token = prop.name.slice(0, -3);
-        if (token !== "") {
-          setAnnotationOnSocket(socket, { tokens: [token] });
-        }
+    const socket = getOrCreateOutputSocketFromProp(variant, prop);
+    // if this socket is an arn, we want to make sure that all input sockets
+    // that might also be arns can take this value
+    if (socket.name.toLowerCase().endsWith("arn")) {
+      const token = prop.name.slice(0, -3);
+      if (token !== "") {
+        setAnnotationOnSocket(socket, { tokens: [token] });
       }
     }
   }

--- a/bin/clover/src/pipeline-steps/prettifySocketNames.ts
+++ b/bin/clover/src/pipeline-steps/prettifySocketNames.ts
@@ -40,6 +40,6 @@ function toSpaceCase(name: string) {
   return name
     // separate any sequence of lowercase letters followed by an uppercase letter
     .replace(/([a-z])([A-Z])/g, "$1 $2")
-    // Separate any sequence of more than 1 of uppercase letters (acronyms) from the next word
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2");
+    // Separate any sequence of more than 3 of uppercase letters (acronyms) from the next word
+    .replace(/([A-Z]{3,})([A-Z][a-z])/g, "$1 $2");
 }


### PR DESCRIPTION
Various fixes for socket annotations ids and names, including splatting id into identifier where appropriate.

```javascript
[
`${variantName}${propName}`,
`${category}${variantName}${propName}`,
`${category}${propName}`,
`${variantName}${propName}entifier`,
`${category}${propName}entifier`,
`${variantName}${propName}entifier`,
`${category}${variantName}${propName}entifer`,

`${variantName} ${propName}`,
`${category} ${variantName} ${propName}`,
`${category} ${propName}`,
`${variantName} ${propName}entifier`,
`${category} ${propName}entifier`,
`${variantName} ${propName}entifier`,
`${category} ${variantName} ${propName}entifer`,
]
```
Results in 

```
KeyId
KeyId<string<scalar>>
KeyKeyId<string<scalar>>
KMSKeyKeyId<string<scalar>>
KMSKeyId<string<scalar>>
KeyKeyIdentifier<string<scalar>>
KMSKeyIdentifier<string<scalar>>
KMSKeyKeyIdentifer<string<scalar>>
Key KeyId<string<scalar>>
KMS Key KeyId<string<scalar>>
KMS KeyId<string<scalar>>
Key KeyIdentifier<string<scalar>>
KMS KeyIdentifier<string<scalar>>
KMS Key KeyIdentifer<string<scalar>>
Key
Key Id
```
  
See the overrides that we removed for an idea of the scenarios this covers.

NOTE: this also fixes a bug where we weren't creating output sockets for resource values of arrays and objects.
       