### PR TITLE
fix(auth-portal): Ensure we validate Remote URLs correctly

### DIFF
--- a/app/auth-portal/src/lib/validations.ts
+++ b/app/auth-portal/src/lib/validations.ts
@@ -1,1 +1,4 @@
 export const ALLOWED_INPUT_REGEX = /^[a-zA-Z0-9-.,_@/+ ]*$/;
+
+export const ALLOWED_URL_REGEX =
+  "^https?://([\\da-z.-]+)(:\\d+)?(/[\\w .-]*)*/?$";

--- a/app/auth-portal/src/pages/WorkspaceDetailsPage.vue
+++ b/app/auth-portal/src/pages/WorkspaceDetailsPage.vue
@@ -100,6 +100,7 @@
           autocomplete="url"
           label="URL"
           placeholder="The instance url for this workspace"
+          :regex="ALLOWED_URL_REGEX"
           required
         />
 
@@ -269,7 +270,7 @@ import { tracker } from "@/lib/posthog";
 import { API_HTTP_URL } from "@/store/api";
 import MemberListItem from "@/components/MemberListItem.vue";
 import WorkspacePageHeader from "@/components/WorkspacePageHeader.vue";
-import { ALLOWED_INPUT_REGEX } from "@/lib/validations";
+import { ALLOWED_INPUT_REGEX, ALLOWED_URL_REGEX } from "@/lib/validations";
 
 const workspacesStore = useWorkspacesStore();
 const router = useRouter();

--- a/bin/auth-api/src/lib/validation-helpers.ts
+++ b/bin/auth-api/src/lib/validation-helpers.ts
@@ -15,3 +15,5 @@ export function validate<Z extends Zod.Schema>(obj: any, schema: Z) {
 }
 
 export const ALLOWED_INPUT_REGEX = /^[a-zA-Z0-9-.,_@/+ ]*$/;
+
+export const ALLOWED_URL_REGEX = "^https?://([\\da-z.-]+)(:\\d+)?(/[\\w .-]*)*/?$";

--- a/bin/auth-api/src/routes/workspace.routes.ts
+++ b/bin/auth-api/src/routes/workspace.routes.ts
@@ -24,7 +24,11 @@ import {
   setUpdatedDefaultWorkspace,
   WorkspaceId,
 } from "../services/workspaces.service";
-import { validate, ALLOWED_INPUT_REGEX } from "../lib/validation-helpers";
+import {
+  validate,
+  ALLOWED_INPUT_REGEX,
+  ALLOWED_URL_REGEX,
+} from "../lib/validation-helpers";
 
 import { CustomRouteContext } from "../custom-state";
 import {
@@ -116,7 +120,7 @@ router.post("/workspaces/new", async (ctx) => {
   const reqBody = validate(
     ctx.request.body,
     z.object({
-      instanceUrl: z.string().url(),
+      instanceUrl: z.string().url().regex(new RegExp(ALLOWED_URL_REGEX)),
       displayName: z.string().regex(ALLOWED_INPUT_REGEX),
       isDefault: z.boolean(),
       description: z.string().regex(ALLOWED_INPUT_REGEX),


### PR DESCRIPTION
I also protect this in AuthAPI

```
{"kind":"ValidationError","message":"Invalid `instanceUrl` - Invalid"}
```

When sending this request:

```
{"instanceUrl":"javascript:alert(document.cookie)/","displayName":"test13","isDefault":false,"description":"","isFavourite":false,"isHidden":false,"requestUlid":"01JNHA959NB99A17RP8YR9P7G6"}
```