### PR TITLE
feat(clover): Make all AWS output sockets arity=many

### DIFF
--- a/bin/clover/src/spec/sockets.ts
+++ b/bin/clover/src/spec/sockets.ts
@@ -20,7 +20,12 @@ export function createOutputSocketFromProp(
   prop: ExpandedPropSpec,
   overrideName?: string,
 ): ExpandedSocketSpec {
-  const socket = createSocketFromPropInner(prop, "output", overrideName);
+  const socket = createSocketFromPropInner(
+    prop,
+    "output",
+    "many",
+    overrideName,
+  );
   socket.data.funcUniqueId = getSiFuncId("si:identity");
   socket.inputs = [attrFuncInputSpecFromProp(prop)];
 
@@ -36,6 +41,7 @@ export function createInputSocketFromProp(
   const socket = createSocketFromPropInner(
     prop,
     "input",
+    prop.kind === "array" ? "many" : "one",
     undefined,
     extraConnectionAnnotations,
   );
@@ -53,10 +59,10 @@ export function createInputSocketFromProp(
 function createSocketFromPropInner(
   prop: ExpandedPropSpec,
   kind: "input" | "output",
+  arity: SocketSpecArity,
   overrideName?: string,
   extraConnectionAnnotations?: ConnectionAnnotation[],
 ) {
-  const arity = prop.kind === "array" ? "many" : "one";
   const socketName = overrideName ?? socketNameFromProp(prop);
   extraConnectionAnnotations ??= [];
 


### PR DESCRIPTION
When we restricted single-valued input sockets to arity=one, we inadvertently did the same for output sockets, which are often IDs that can and should be reused in multiple places.

This PR sets all output sockets to arity=many, even if they are strings or objects.

### Risk Mitigation

* Diffed the clover assets and verified that output socket arities were the only thing that changed
* The product doesn't presently respect this (you can connect an output socket to as many input sockets as you want), so the risk of the actual change is low.

### Testing

* Loaded up the VPC asset in a local workspace and checked that I could connect its output socket to subnet input sockets.