### PR TITLE
bug: improve removeEmtpy in clover assets

### DIFF
--- a/bin/clover/src/cloud-control-funcs/code-gen/awsCloudControlCodeGenCreate.ts
+++ b/bin/clover/src/cloud-control-funcs/code-gen/awsCloudControlCodeGenCreate.ts
@@ -72,38 +72,77 @@ async function main(component: Input): Promise<Output> {
 }
 
 function removeEmpty(obj: any): any {
-  if (Array.isArray(obj)) {
-    return obj
-      .filter((item) => {
-        if (item === null || item === undefined || item === "") return false;
-        if (Array.isArray(item) && item.length === 0) return false;
-        if (typeof item === "object" && Object.keys(item).length === 0) {
-          return false;
+  // Stack to keep track of objects to process
+  const stack: any = [{
+    parent: null,
+    key: null,
+    value: obj,
+  }];
+
+  while (stack.length) {
+    const {
+      parent,
+      key,
+      value,
+    } = stack.pop();
+
+    if (_.isObject(value)) {
+      // Iterate over the keys of the current object
+      _.forOwn(value, (childValue, childKey) => {
+        stack.push({
+          parent: value,
+          key: childKey,
+          value: childValue,
+        });
+      });
+
+      // After processing children, check if the current object is empty
+      if (_.isEmpty(value) && parent) {
+        if (_.isArray(parent)) {
+          parent.splice(key, 1);
+        } else {
+          delete parent[key];
         }
-        return true;
-      })
-      .map((item) =>
-        typeof item === "object" && item !== null ? removeEmpty(item) : item
-      );
+      }
+    } else if (_.isArray(value)) {
+      // Iterate over the array elements
+      for (let i = value.length - 1; i >= 0; i--) {
+        stack.push({
+          parent: value,
+          key: i,
+          value: value[i],
+        });
+      }
+
+      // After processing elements, check if the current array is empty
+      if (_.isEmpty(value) && parent) {
+        parent.splice(key, 1);
+      }
+    } else {
+      // Handle primitive values: remove if null, undefined, or empty string
+      if (value === null || value === undefined || value === "") {
+        if (_.isArray(parent)) {
+          parent.splice(key, 1);
+        } else {
+          delete parent[key];
+        }
+      }
+    }
   }
 
-  return Object.fromEntries(
-    Object.entries(obj)
-      .filter(([_, value]) => {
-        if (value === null || value === undefined || value === "") return false;
-        if (Array.isArray(value) && value.length === 0) return false;
-        if (typeof value === "object" && Object.keys(value).length === 0) {
-          return false;
-        }
-        return true;
-      })
-      .map(([key, value]) => [
-        key,
-        typeof value === "object" && value !== null
-          ? removeEmpty(value)
-          : value,
-      ]),
-  );
+  // Final pass to remove any remaining empty objects or arrays at the root level
+  _.forOwn(obj, (value, key) => {
+    if (
+      (_.isObject(value) && _.isEmpty(value)) ||
+      value === null ||
+      value === undefined ||
+      value === ""
+    ) {
+      delete obj[key];
+    }
+  });
+
+  return obj;
 }
 
 // If you change this, you should change the same func on awsCloudControlCodeGenUpdate.ts in this same directory

--- a/bin/clover/src/cloud-control-funcs/code-gen/awsCloudFormationLint.ts
+++ b/bin/clover/src/cloud-control-funcs/code-gen/awsCloudFormationLint.ts
@@ -70,36 +70,75 @@ async function main(component: Input): Promise<Output> {
 }
 
 function removeEmpty(obj: any): any {
-  if (Array.isArray(obj)) {
-    return obj
-      .filter((item) => {
-        if (item === null || item === undefined || item === "") return false;
-        if (Array.isArray(item) && item.length === 0) return false;
-        if (typeof item === "object" && Object.keys(item).length === 0) {
-          return false;
+  // Stack to keep track of objects to process
+  const stack: any = [{
+    parent: null,
+    key: null,
+    value: obj,
+  }];
+
+  while (stack.length) {
+    const {
+      parent,
+      key,
+      value,
+    } = stack.pop();
+
+    if (_.isObject(value)) {
+      // Iterate over the keys of the current object
+      _.forOwn(value, (childValue, childKey) => {
+        stack.push({
+          parent: value,
+          key: childKey,
+          value: childValue,
+        });
+      });
+
+      // After processing children, check if the current object is empty
+      if (_.isEmpty(value) && parent) {
+        if (_.isArray(parent)) {
+          parent.splice(key, 1);
+        } else {
+          delete parent[key];
         }
-        return true;
-      })
-      .map((item) =>
-        typeof item === "object" && item !== null ? removeEmpty(item) : item
-      );
+      }
+    } else if (_.isArray(value)) {
+      // Iterate over the array elements
+      for (let i = value.length - 1; i >= 0; i--) {
+        stack.push({
+          parent: value,
+          key: i,
+          value: value[i],
+        });
+      }
+
+      // After processing elements, check if the current array is empty
+      if (_.isEmpty(value) && parent) {
+        parent.splice(key, 1);
+      }
+    } else {
+      // Handle primitive values: remove if null, undefined, or empty string
+      if (value === null || value === undefined || value === "") {
+        if (_.isArray(parent)) {
+          parent.splice(key, 1);
+        } else {
+          delete parent[key];
+        }
+      }
+    }
   }
 
-  return Object.fromEntries(
-    Object.entries(obj)
-      .filter(([_, value]) => {
-        if (value === null || value === undefined || value === "") return false;
-        if (Array.isArray(value) && value.length === 0) return false;
-        if (typeof value === "object" && Object.keys(value).length === 0) {
-          return false;
-        }
-        return true;
-      })
-      .map(([key, value]) => [
-        key,
-        typeof value === "object" && value !== null
-          ? removeEmpty(value)
-          : value,
-      ]),
-  );
+  // Final pass to remove any remaining empty objects or arrays at the root level
+  _.forOwn(obj, (value, key) => {
+    if (
+      (_.isObject(value) && _.isEmpty(value)) ||
+      value === null ||
+      value === undefined ||
+      value === ""
+    ) {
+      delete obj[key];
+    }
+  });
+
+  return obj;
 }


### PR DESCRIPTION
We've added sockets that are more deeply nested in some schemas than we have before. The side effect is that we can fail to remove some empty objects or arrays from the tree, resulting in invalid CloudFormation.

This PR fixes it by rewriting that function to handle deeply nested cases, and to remove its use of recursion (so we don't blow the stack on huge objects).