### PR TITLE
feat(clover): call module-index directly instead of using hoist

### DIFF
--- a/bin/clover/src/specUpdates.ts
+++ b/bin/clover/src/specUpdates.ts
@@ -5,70 +5,61 @@ import _ from "npm:lodash";
 const logger = _logger.ns("packageGen").seal();
 export const EXISTING_PACKAGES = "existing-packages/spec.json";
 
+async function getModuleMap(baseUrl: string): Promise<Record<string, string>> {
+  try {
+    const url = new URL("builtins", baseUrl).toString();
+    logger.debug(`Fetching from URL: ${url}`);
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      logger.warn(
+        `Issue getting modules from module index: ${response.status} ${response.statusText}`,
+      );
+      return {};
+    }
+
+    const data = await response.json();
+    if (!data?.modules) {
+      logger.warn("No modules in response");
+      return {};
+    }
+
+    const moduleMap: Record<string, string> = {};
+    for (const module of data.modules) {
+      if (
+        module?.name && module?.schemaId && module.ownerDisplayName === "Clover"
+      ) {
+        moduleMap[module.name] = module.schemaId;
+      }
+    }
+
+    return moduleMap;
+  } catch (error) {
+    logger.error(
+      `Error fetching modules: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return {};
+  }
+}
+
 export async function getExistingSpecs(
   options: {
     moduleIndexUrl: string;
     forceUpdateExistingPackages?: boolean;
   },
 ): Promise<Record<string, string>> {
-  logger.debug("Getting existing specs...");
+  logger.info("Getting existing specs...");
+
   if (!existsSync(EXISTING_PACKAGES) || options.forceUpdateExistingPackages) {
-    const args = [
-      "run",
-      "//bin/hoist:hoist",
-      "--",
-      "--endpoint",
-      options.moduleIndexUrl,
-      "write-existing-modules-spec",
-      "--out",
+    logger.info(`Fetching builtin modules from ${options.moduleIndexUrl}`);
+    const moduleMap = await getModuleMap(options.moduleIndexUrl);
+
+    await Deno.writeTextFile(
       EXISTING_PACKAGES,
-    ];
-    logger.info(`Running: buck2 ${args.join(" ")}`);
-    const child = new Deno.Command(
-      "buck2",
-      {
-        args,
-        stdout: "piped",
-        stderr: "piped",
-      },
-    ).spawn();
-
-    // Stream stdout
-    const td = new TextDecoder();
-    const stdout = (async () => {
-      const reader = child.stdout.getReader();
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          logger.debug(td.decode(value));
-        }
-      } finally {
-        reader.releaseLock();
-      }
-    })();
-
-    // Stream stderr
-    const stderr = (async () => {
-      const reader = child.stderr.getReader();
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          logger.debug(td.decode(value));
-        }
-      } finally {
-        reader.releaseLock();
-      }
-    })();
-
-    const status = await child.status;
-
-    if (!status.success) {
-      await stdout;
-      await stderr;
-      throw new Error(`Command failed with status: ${status.code}`);
-    }
+      JSON.stringify(moduleMap, null, 2),
+    );
   }
 
   const fullPath = await Deno.realPath(EXISTING_PACKAGES);


### PR DESCRIPTION
Calling buck2 in clover was always meant to be a stopgap. This removes the dependency on hoist and just calls the module index directly.

<img src="https://media0.giphy.com/media/lq4YPb8YTKekY65qCy/giphy-downsized-medium.gif?cid=bd3ea57equt2gt1ooz13752xm196hc6x2i8iepp9wgwk4v5d&ep=v1_gifs_search&rid=giphy-downsized-medium.gif&ct=g"/>