### PR TITLE
fix(dal): don't allow billing publish errors to block pointer update

### DIFF
--- a/lib/dal/src/billing_publish.rs
+++ b/lib/dal/src/billing_publish.rs
@@ -62,7 +62,8 @@ type BillingPublishResult<T> = Result<T, BillingPublishError>;
     level = "debug",
     skip(ctx, change_set)
 )]
-pub(crate) async fn for_head_change_set_pointer_update(
+/// Publishes a billing event with resource count if the change set that was updated is HEAD
+pub async fn for_head_change_set_pointer_update(
     ctx: &DalContext,
     change_set: &ChangeSet,
 ) -> BillingPublishResult<()> {

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -335,10 +335,6 @@ impl ChangeSet {
 
         self.workspace_snapshot_address = workspace_snapshot_address;
 
-        billing_publish::for_head_change_set_pointer_update(ctx, self)
-            .await
-            .map_err(Box::new)?;
-
         Ok(())
     }
 


### PR DESCRIPTION
This broke updating the head snapshot in the Admin panel. In general we shouldn't fail to update a pointer row if the billing publish fails.

This moves the billing_publish calls to the points where the rebaser
updates the pointer, which are the only two instances where the update
is relevant for billing.