### PR TITLE
fix(dal): Validate default values if present

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -783,7 +783,8 @@ impl Component {
                             // If for whatever reason, there isn't a value set yet for the type, set it to the old
                             // Prop's default value
                             if prop_path == ["root", "si", "type"] {
-                                let old_value = old_av.value_or_default(ctx, old_prop_id).await?;
+                                let old_value =
+                                    old_av.value_or_default_or_null(ctx, old_prop_id).await?;
                                 AttributeValue::set_value(ctx, new_av_id, Some(old_value)).await?;
                             }
 

--- a/lib/dal/src/job/definition/compute_validation.rs
+++ b/lib/dal/src/job/definition/compute_validation.rs
@@ -11,7 +11,7 @@ use crate::{
         JobConsumer, JobConsumerError, JobConsumerMetadata, JobConsumerResult, JobInfo,
     },
     job::producer::{JobProducer, JobProducerResult},
-    AccessBuilder, AttributeValue, AttributeValueId, DalContext, Visibility,
+    AccessBuilder, AttributeValueId, DalContext, Visibility,
 };
 use crate::{ChangeSet, ChangeSetStatus};
 
@@ -107,14 +107,8 @@ impl JobConsumer for ComputeValidation {
                 continue;
             }
 
-            let value = AttributeValue::get_by_id(ctx, av_id)
-                .await?
-                .value(ctx)
-                .await?;
-
             let maybe_validation =
-                ValidationOutput::compute_for_attribute_value_and_value(ctx, av_id, value.clone())
-                    .await?;
+                ValidationOutput::compute_for_attribute_value(ctx, av_id).await?;
 
             ValidationOutputNode::upsert_or_wipe_for_attribute_value(
                 ctx,

--- a/lib/dal/src/property_editor/values.rs
+++ b/lib/dal/src/property_editor/values.rs
@@ -79,7 +79,7 @@ impl PropertyEditorValues {
                 id: root_value_id,
                 prop_id: root_prop_id.into(),
                 key: None,
-                value: root_av.value_or_default(ctx, root_prop_id).await?,
+                value: root_av.value_or_default_or_null(ctx, root_prop_id).await?,
                 validation,
                 is_from_external_source: false,
                 can_be_set_by_socket: false,
@@ -132,7 +132,7 @@ impl PropertyEditorValues {
                 // Get the value
                 let mut value = AttributeValue::get_by_id(ctx, av_id)
                     .await?
-                    .value_or_default(ctx, prop_id)
+                    .value_or_default_or_null(ctx, prop_id)
                     .await?;
 
                 // If this is a secret, the JSON value has the secret key, not the secret id.

--- a/lib/dal/src/validation.rs
+++ b/lib/dal/src/validation.rs
@@ -275,12 +275,16 @@ impl ValidationOutput {
     }
 
     /// If an attribute value is for a [Prop](Prop) that has a `validation_format`, run a validation
-    /// for that format and the value passed in.
-    pub async fn compute_for_attribute_value_and_value(
+    /// for that format.
+    pub async fn compute_for_attribute_value(
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
-        value: Option<serde_json::Value>,
     ) -> ValidationResult<Option<ValidationOutput>> {
+        let value = AttributeValue::get_by_id(ctx, attribute_value_id)
+            .await?
+            .value_or_default(ctx)
+            .await?;
+
         match Self::get_format_for_attribute_value_id(ctx, attribute_value_id).await? {
             None => Ok(None),
             Some(validation_format) => Ok(Some(


### PR DESCRIPTION
This PR makes sure we correctly validate fields with default values and Joi.required(). If the field was unset (meaning it has a default), we were marking it invalid ("field is required") before.

Fixes BUG-808.