### PR TITLE
feat(module-index): Add support for private_scoped_modules

### DIFF
--- a/lib/module-index-server/src/migrations/U0011__modules__is_private.sql
+++ b/lib/module-index-server/src/migrations/U0011__modules__is_private.sql
@@ -1,0 +1,1 @@
+ALTER TABLE modules ADD is_private_scoped boolean NOT NULL DEFAULT FALSE;

--- a/lib/module-index-server/src/models/si_module.rs
+++ b/lib/module-index-server/src/models/si_module.rs
@@ -34,6 +34,7 @@ pub struct Model {
     #[sea_orm(column_type = r##"custom("ident")"##, nullable)]
     pub schema_variant_id: Option<SchemaVariantId>,
     pub schema_variant_version: Option<String>,
+    pub is_private_scoped: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/lib/module-index-server/src/routes/list_modules_route.rs
+++ b/lib/module-index-server/src/routes/list_modules_route.rs
@@ -82,6 +82,9 @@ pub async fn list_module_route(
     // We want to filter out the builtins from the list as they will already be in our system
     let query = query.filter(si_module::Column::IsBuiltinAt.is_null());
 
+    // Ignore the private scoped modules as they are not accessible by default
+    let query = query.filter(si_module::Column::IsPrivateScoped.eq(false));
+
     // ordering
     let query = query
         .order_by_desc(si_module::Column::OwnerUserId)


### PR DESCRIPTION
This is the precursor to be able to.mark a module as a private module and thus not being able to be returned in any public module searches

This doesn't change ANY of the module upload scenarios right now so this will always default to false at this stage when uploading a module thanks to:

```
let new_module = si_module::ActiveModel {
        name: Set(module_metadata.name().to_owned()),
        ........ items here
        schema_variant_id: Set(schema_variant_id),
        schema_variant_version: Set(multi_part_data.schema_variant_version),
        ..Default::default() // all other attributes are `NotSet` <------ this is what allows things to work as normal!
    };
```