### PR TITLE
Perf: fix first paint to only wait on what it needs

### DIFF
--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -241,16 +241,14 @@ const approvalData = computed(
 );
 
 onBeforeMount(async () => {
-  // get to first paint ASAP
-  await Promise.all([
-    viewsStore.LIST_VIEWS(),
-    assetStore.LOAD_SCHEMA_VARIANT_LIST(),
-  ]);
   let viewId;
   if (routeStore.currentRoute?.params?.viewId)
     viewId = routeStore.currentRoute.params.viewId as string;
 
+  // get to first paint ASAP
   await Promise.all([
+    viewsStore.LIST_VIEWS(),
+    assetStore.LOAD_SCHEMA_VARIANT_LIST(),
     viewsStore.FETCH_VIEW(viewId), // draws the minimal diagram, later gets all geometry and component
     funcStore.FETCH_FUNC_LIST(), // required for actions of a selected component to work
   ]);
@@ -266,21 +264,20 @@ onBeforeMount(async () => {
   }
 
   // filling out the rest of the needed data
-  await Promise.all([
-    actionsStore.LOAD_ACTIONS(),
-    actionsStore.LOAD_ACTION_HISTORY(),
-    statusStore.FETCH_DVU_ROOTS(),
-  ]);
+  // we're not waiting on any of this data
+  // however, tests show that even if we did, we can get a first paint
+  viewsStore.FETCH_COMPLETE_DATA();
+  actionsStore.LOAD_ACTIONS();
+  actionsStore.LOAD_ACTION_HISTORY();
+  statusStore.FETCH_DVU_ROOTS();
 
   if (featureFlagsStore.WORKSPACE_FINE_GRAINED_ACCESS_CONTROL) {
-    await Promise.all([
-      changeSetsStore.FETCH_APPROVAL_STATUS(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        changeSetsStore.selectedChangeSetId!,
-      ),
+    changeSetsStore.FETCH_APPROVAL_STATUS(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      authStore.LIST_WORKSPACE_USERS(changeSetsStore.selectedWorkspacePk!),
-    ]);
+      changeSetsStore.selectedChangeSetId!,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    authStore.LIST_WORKSPACE_USERS(changeSetsStore.selectedWorkspacePk!);
   }
 });
 


### PR DESCRIPTION
Here is how we tested the changes in `WorkspaceModelAndView`.

First, I put the rest of the endpoint calls into a setTimeout, in order to know the diagram would load without those being called. And it does load.

Second, I removed the setTimeout and instead awaited a sleep to prevent those from calling. I wanted to know if `await` inside `onBeforeMount` would prevent the diagram from drawing. It does not.

Third; watching the network tab, `get_diagram` is the only endpoint waiting to return, and once it returns we get a diagram painted, as other calls fire.

The main culprit was the other calls inside the success handler for LIST_VIEWS, due to the nature of the ApiRequest object awaiting on the success handler. This is why nothing would load until `get_all_components_and_edges` would finish (the opposite of what we want)

<img src="https://media1.giphy.com/media/3o6vXJRr7PQsBmta48/giphy.gif?cid=bd3ea57eqsfpww59l2yvbkz1tkkf90fsr0xwx1ncqxf9e7oq&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>