### PR TITLE
perf(veritech): Batch logs before sending to veritech

### DIFF
--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -87,6 +87,10 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) cyclone_pool_size: Option<u32>,
 
+    /// Cyclone create firecracker setup scripts
+    #[arg(long)]
+    pub(crate) cyclone_create_firecracker_setup_scripts: Option<bool>,
+
     /// Veritech decryption key file location [example: /run/veritech/veritech.key]
     #[arg(long)]
     pub(crate) decryption_key: Option<PathBuf>,
@@ -159,6 +163,14 @@ impl TryFrom<Args> for Config {
             }
             if let Some(size) = args.cyclone_pool_size {
                 config_map.set("cyclone.pool_size", size);
+            }
+            if let Some(create_firecracker_setup_scripts) =
+                args.cyclone_create_firecracker_setup_scripts
+            {
+                config_map.set(
+                    "cyclone.create_firecracker_setup_scripts",
+                    create_firecracker_setup_scripts,
+                );
             }
             if let Some(decryption_key_path) = args.decryption_key {
                 config_map.set(

--- a/lib/si-firecracker/src/firecracker.rs
+++ b/lib/si-firecracker/src/firecracker.rs
@@ -12,6 +12,7 @@ use std::result;
 use tokio::fs;
 use tokio::process::Child;
 use tokio::process::Command;
+use tracing::info;
 
 type Result<T> = result::Result<T, FirecrackerJailError>;
 
@@ -91,8 +92,13 @@ impl FirecrackerJail {
         Ok(())
     }
 
-    pub async fn setup(pool_size: u32) -> Result<()> {
-        Self::create_scripts().await?;
+    pub async fn setup(pool_size: u32, create_scripts: bool) -> Result<()> {
+        if create_scripts {
+            info!("creating scripts during firecracker setup...");
+            Self::create_scripts().await?;
+        } else {
+            info!("skipping scripts creation during firecracker setup...");
+        }
 
         // we want to work with a clean slate, but we don't necessarily care about failures here
         for id in 0..pool_size + 1 {

--- a/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
+++ b/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
@@ -282,6 +282,10 @@ pub struct LocalUdsInstanceSpec {
     /// Sets the timeout for connecting to firecracker
     #[builder(setter(into), default = "10")]
     connect_timeout: u64,
+
+    /// Indicates whether or not we will create firecracker setup scripts.
+    #[builder(setter(into), default = "true")]
+    create_firecracker_setup_scripts: bool,
 }
 
 #[async_trait]
@@ -749,7 +753,7 @@ impl LocalFirecrackerRuntime {
     }
 
     async fn setup_firecracker(spec: &LocalUdsInstanceSpec) -> Result<()> {
-        Ok(FirecrackerJail::setup(spec.pool_size).await?)
+        Ok(FirecrackerJail::setup(spec.pool_size, spec.create_firecracker_setup_scripts).await?)
     }
 }
 

--- a/lib/veritech-server/src/config.rs
+++ b/lib/veritech-server/src/config.rs
@@ -375,6 +375,8 @@ pub enum CycloneConfig {
         pool_size: u32,
         #[serde(default)]
         connect_timeout: u64,
+        #[serde(default = "default_create_firecracker_setup_scripts")]
+        create_firecracker_setup_scripts: bool,
     },
 }
 
@@ -407,6 +409,7 @@ impl CycloneConfig {
             action: default_enable_endpoint(),
             pool_size: default_pool_size(),
             connect_timeout: default_connect_timeout(),
+            create_firecracker_setup_scripts: default_create_firecracker_setup_scripts(),
         }
     }
 
@@ -517,6 +520,7 @@ impl TryFrom<CycloneConfig> for CycloneSpec {
                 action,
                 pool_size,
                 connect_timeout,
+                create_firecracker_setup_scripts,
             } => {
                 let mut builder = LocalUdsInstance::spec();
 
@@ -549,6 +553,7 @@ impl TryFrom<CycloneConfig> for CycloneSpec {
                 }
                 builder.pool_size(pool_size);
                 builder.connect_timeout(connect_timeout);
+                builder.create_firecracker_setup_scripts(create_firecracker_setup_scripts);
 
                 Ok(Self::LocalUds(
                     builder.build().map_err(ConfigError::cyclone_spec_build)?,
@@ -615,6 +620,10 @@ fn default_limit_requests() -> Option<u32> {
 }
 
 fn default_enable_endpoint() -> bool {
+    true
+}
+
+fn default_create_firecracker_setup_scripts() -> bool {
     true
 }
 


### PR DESCRIPTION
This PR batches logs and sends them every N milliseconds (but will limit batching to 8MB).

One of our theories is we're bogging the reactors sending a log line every 8 nanoseconds. This should help both reduce the total size (only one message overhead per batch instead of per line) and the number of messages.

![batch](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExcm9mMjl5eHJxOXg1OGZvejh5eXNscGg5dDZ5anJkZGYycDkxZGw5eSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/5R31AXE8lsERwAEpS6/giphy.gif)

### Draft

Flaw: if a log line is emitted, and no more logs are emitted for a long time, it will sit in the buffer until another log line comes in or . This is not ideal--you'd want users to see the last thing that happened sooner rather than later. I've used systems like this and watching logs while not being sure you're seeing all the logs is a problem--particularly, if there was an error or warning just before a program hung, you wouldn't see it until it eventually timed out.

Improvement: currently this will only cache log lines as long as they are the same level/group/etc. This could be better if it held onto all of these the whole time, but it's unclear how often it happens in practice.
