### PR TITLE
don't cache the icons for DiagramView

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramView.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramView.vue
@@ -43,47 +43,46 @@
             wrap: 'word',
           }"
         />
-
-        <!-- status icons -->
-        <v-group
-          v-if="statusIcons?.length && hideDetails === 'show'"
-          :config="{
-            x: (statusIcons.length * 26) / 2,
-            y: -20,
-          }"
+      </v-group>
+      <!-- status icons -->
+      <v-group
+        v-if="statusIcons?.length && hideDetails === 'show'"
+        :config="{
+          x: (statusIcons.length * 26) / 2,
+          y: -20,
+        }"
+      >
+        <template
+          v-for="(statusIcon, i) in _.reverse(_.slice(statusIcons))"
+          :key="`status-icon-${i}`"
         >
-          <template
-            v-for="(statusIcon, i) in _.reverse(_.slice(statusIcons))"
-            :key="`status-icon-${i}`"
-          >
-            <v-text
-              v-if="hideDetails === 'show'"
-              :config="{
-                x: i * -26 - 25,
-                y: radius - 43,
-                align: 'center',
-                verticalAlign: 'top',
-                width: 25,
-                height: 30,
-                text: statusIcon.count,
-                padding: 2,
-                fill: colors.headerText,
-                fontSize: 11,
-                fontFamily: DIAGRAM_FONT_FAMILY,
-                listening: false,
-                wrap: 'char',
-              }"
-            />
-            <DiagramIcon
-              :icon="statusIcon.icon"
-              :color="getToneColorHex(statusIcon.tone)"
-              :size="24"
-              :x="i * -26"
-              :y="radius - 5"
-              origin="bottom-right"
-            />
-          </template>
-        </v-group>
+          <v-text
+            v-if="hideDetails === 'show'"
+            :config="{
+              x: i * -26 - 25,
+              y: radius - 43,
+              align: 'center',
+              verticalAlign: 'top',
+              width: 25,
+              height: 30,
+              text: statusIcon.count,
+              padding: 2,
+              fill: colors.headerText,
+              fontSize: 11,
+              fontFamily: DIAGRAM_FONT_FAMILY,
+              listening: false,
+              wrap: 'char',
+            }"
+          />
+          <DiagramIcon
+            :icon="statusIcon.icon"
+            :color="getToneColorHex(statusIcon.tone)"
+            :size="24"
+            :x="i * -26"
+            :y="radius - 5"
+            origin="bottom-right"
+          />
+        </template>
       </v-group>
       <v-shape v-if="isHovered" :config="selectionConfig" />
     </v-group>


### PR DESCRIPTION
<img src="https://media3.giphy.com/media/3htQ6tCfZ3qfv4sXk6/giphy-downsized-medium.gif?cid=bd3ea57etawa53m40zjip7ohnqpblzxh5l51yy2uwsdct6k7&ep=v1_gifs_search&rid=giphy-downsized-medium.gif&ct=g"/>

For now, let's just not cache the icons for DiagramView to avoid having to sort out busting the cache.