### PR TITLE
feat: ship logs to honeycomb

### DIFF
--- a/component/init/configs/vector.yaml
+++ b/component/init/configs/vector.yaml
@@ -11,6 +11,21 @@ sources:
       SYSLOG_IDENTIFIER: ["sdf-migration"]
     journal_directory: "/var/log/journal"
 
+transforms:
+  honeycomb_format:
+    type: remap
+    inputs: ["$SI_SERVICE-journal", "sdf-migration"]
+    source: |-
+      if exists(.message) {
+        level_match, err = parse_regex(.message, r'^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+Z\\s+([A-Z]+)\\s')
+
+        if err == null && exists(level_match[1]) {
+            .level = level_match[1]
+          } else {
+            .level = "INFO"
+          }
+        }
+
 sinks:
   cloudwatch:
     type: "aws_cloudwatch_logs"
@@ -21,3 +36,8 @@ sinks:
     region: "us-east-1"
     group_name: "/ec2/$SI_HOSTENV-$SI_SERVICE"
     stream_name: "{{ host }}"
+  honeycomb:
+    type: "honeycomb"
+    inputs: ["honeycomb_format"]
+    api_key: "$SI_HONEYCOMB_API_KEY"
+    dataset: "$SI_SERVICE"


### PR DESCRIPTION
Some remapping to get the level out for handy categorization later. You can see this in action [here](https://ui.honeycomb.io/system-initiative/environments/validating-telemetry-volume/datasets/veritech3/home?tab=logs)

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZmNraXpnYmc4ampkdHhrM3ZmMjcwcTRzY3c0aGQwZ3V4bDI2Y3hzbiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3oEjHZtfFExSy0BS2k/giphy.gif"/>