### PR TITLE
feat(si-api-test): Add a new benchmarking test to trigger a stampede of func executions bypassing DVU

### DIFF
--- a/bin/si-api-test/benchmark/func_stampede.ts
+++ b/bin/si-api-test/benchmark/func_stampede.ts
@@ -1,0 +1,135 @@
+// deno-lint-ignore-file no-explicit-any
+import { SdfApiClient } from "../sdf_api_client.ts";
+import {
+    runWithTemporaryChangeset,
+    sleepBetween,
+    createComponent,
+    extractSchemaVariant,
+    getSchemaVariants,
+    createQualification,
+    testExecuteFunc,
+    getFuncRun,
+    installModule,
+} from "../test_helpers.ts";
+
+export default async function func_stampede(sdfApiClient: SdfApiClient) {
+    await sleepBetween(0, 750);
+    return runWithTemporaryChangeset(sdfApiClient, func_stampede_inner);
+}
+
+
+/// This test creates N chains of pairs, such that setting the attribute value on the first component
+/// in the chain should propagate through the entire chain, adding 1 at each step.
+async function func_stampede_inner(sdf: SdfApiClient,
+    changeSetId: string,
+) {
+    // install requisite modules if necessary
+    const one_upper_module_with_quals = '01JKW4VKKJ0DCVHRH0HQ4D6ZG4'; // one upper with leaf funcs and validations
+    await installModule(sdf, changeSetId, one_upper_module_with_quals);
+
+    // Edit this number for different amount of stress on the system
+    const num_funcs = 50;
+    const { schemaVariants, newCreateComponentApi } = await getSchemaVariants(
+        sdf,
+        changeSetId,
+    );
+
+    const plusOneVariant = await extractSchemaVariant(
+        schemaVariants,
+        "OneUpper",
+        "KEEB",
+    );
+
+    const qualificationCode = `function main(component: Input) {
+    const fakeObject = {
+        inputNumber: component.domain?.input,
+        text: 'Lorem ipsum odor amet, consectetuer adipiscing elit.'
+    };
+
+    // Logging thousands of messages
+    for (let i = 0; i < 10000; i++) {
+        const val = i;
+        console.log('Current fakeObject is {}', fakeObject);
+    }
+
+    return {
+        result: 'success',
+        message: 'Qualified',
+    }; 
+    }`;
+
+    const plusOneVariantId = plusOneVariant.schemaVariantId;
+
+    // unlock schema variant
+    const plusOneVariantUnlocked = await sdf.call({
+        route: "create_unlocked_copy", routeVars: {
+            workspaceId: sdf.workspaceId,
+            changeSetId,
+            schemaVariantId: plusOneVariantId,
+        },
+    });
+    const plusOneVariantIdUnlocked = plusOneVariantUnlocked.schemaVariantId;
+
+    // create a new qualification func with lots of log lines
+    const qualificationId = await createQualification(
+        sdf,
+        changeSetId, "loggyQualification",
+        plusOneVariantIdUnlocked,
+        qualificationCode
+    );
+
+    // create a component (needed to test execute the new qualification)
+    const one_upper = await createComponent(sdf, changeSetId, plusOneVariantIdUnlocked, 0, 0, undefined, newCreateComponentApi);
+    let funcRunsToCheck: string[] = [];
+
+    // Create an array of promises for all test executions
+    const testExecutePromises = Array.from({ length: num_funcs }, async (_, j) => {
+        const args = {
+            domain: {
+                computed: "2",
+                input: "1",
+            }
+        };
+        const resp = await testExecuteFunc(sdf, changeSetId, qualificationId, one_upper, qualificationCode, args);
+        console.log(`Dispatched Func Number ${j} with id ${resp.funcRunId}`);
+        return resp.funcRunId;
+    });
+
+    // Wait for all promises to resolve and collect the funcRunIds
+    funcRunsToCheck = await Promise.all(testExecutePromises);
+
+    // wait for functions to complete!
+    await waitForFuncRuns(sdf, changeSetId, funcRunsToCheck, 1000000);
+}
+
+
+export enum FuncRunState {
+    Created = "Created",
+    Dispatched = "Dispatched",
+    Running = "Running",
+    PostProcessing = "Postprocessing",
+    Failure = "Failure",
+    Success = "Success",
+}
+async function waitForFuncRuns(sdf: SdfApiClient, changeSetId: string, funcRunIds: string[], timeoutMs: number) {
+    const start = Date.now();
+    var numWaiting = funcRunIds.length;
+    const pendingRuns = new Set(funcRunIds);
+    while (pendingRuns.size > 0) {
+        if (Date.now() - start > timeoutMs) {
+            throw new Error('Timeout waiting for func runs to complete');
+        }
+        for (const funcRunId of [...pendingRuns]) {
+
+            const result = await getFuncRun(sdf, changeSetId, funcRunId);
+            console.log(`Func Run ${funcRunId} has state: ${result.funcRun?.state}`);
+            if (result.funcRun?.state === FuncRunState.Success) {
+                numWaiting--;
+                console.log(`Func Run ${funcRunId} Succeeded. Waiting for ${numWaiting} more...`)
+                pendingRuns.delete(funcRunId);
+            }
+        }
+        await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+    console.log("All funcs ran to completion! Woot!");
+}

--- a/bin/si-api-test/run.py
+++ b/bin/si-api-test/run.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+import requests
+import subprocess
+import json
+import time
+import os
+import random
+
+
+### This script makes it easy to execute and run api tests with various levels
+### of parallelism. 
+
+## Steps to use: 
+# 1. Add your Workspace ID to ws_ids
+# 2. Update the SDF_API_URL and AUTH_API_URL (if running locally)
+# 3. Set up credentials, you've got 2 options: 
+#    1. Use the Tech Ops User (get the password out of 1pass and plug into PASSWORD below). 
+#       You'll need to add the Tech Ops user to your workspace if they're not already an authorized user
+#    2. Swipe your bearer token from the front end, and plug into USER_TOKEN below
+#    If the token is set, we'll prefer that over the username/password
+# 4. Configure which test to run. If running an E2E Cron test, set TEST = test_name (example below). 
+#    If running a benchmark test, set TEST = "benchmark/{test_name}" (example below)
+# 5. Configure concurrency - set BATCH = # of concurrent tests you want to kick off 
+#    Beware concurrent tests impacting each other if they're applying to head!   
+# 6. Configure Honeycomb Key: If running tests against a live environment, get the Honeycomb key out of 1pass
+#    This lets us create Honeycomb markers for the start and end of tests to make gathering telemtry easier   
+# 7. Have fun! :)  
+
+
+ws_ids = [
+  #"01JKRT3BB747W4Z74RVZ1XFX4K", # tools.systeminit.com Load Testing 2k25 workspace
+]
+
+SDF_API_URL = "https://tools.systeminit.com/api"
+#SDF_API_URL = "http://localhost:8080/api" # local
+AUTH_API_URL = "https://auth-api.systeminit.com"
+USER_ID = "technical-operations+synthetics@systeminit.com"
+USER_TOKEN = ""
+
+PASSWORD = ""
+HONEYCOMB_KEY = ""
+#TEST = "7-emulate_authoring" ## E2E Cron Test Run
+TEST = "benchmark/func_stampede" ## Benchmark Test Run
+BATCH = "30" ## how many concurrent test runs
+
+
+
+PROFILE = json.dumps({"maxDuration": 150, "rate": 2500, "useJitter": True})
+
+def get_token():
+    if USER_TOKEN == "":
+        response = requests.post(
+            f"{AUTH_API_URL}/auth/login",
+            headers={"Content-Type": "application/json"},
+            json={"email": USER_ID, "password": PASSWORD, "workspaceId": ws_ids[0]}
+        )
+        return response.json().get("token")
+    return USER_TOKEN
+
+    
+
+def post_to_honeycomb(message, event_type):
+    if HONEYCOMB_KEY != "":
+        data = {"message": message, "type": event_type}
+        requests.post(
+            "https://api.honeycomb.io/1/markers/sdf",
+            headers={"X-Honeycomb-Team": HONEYCOMB_KEY},
+            json=data
+    )
+
+def run_task(id, token):
+    env_vars = os.environ.copy()
+    env_vars["SDF_API_URL"] = SDF_API_URL
+    env_vars["AUTH_API_URL"] = AUTH_API_URL
+    cmd = [
+        "deno", "task", "run",
+        "--workspaceId", id,
+        "--tests", TEST,
+        "--token", token,
+        "--reportFile", f"reports/{id}.json",
+        "-b", BATCH,
+    ]
+    return subprocess.Popen(cmd, env=env_vars)
+
+def clear_reports():
+    if os.path.exists('./reports'):
+        for file in os.listdir('./reports'):
+            os.remove(os.path.join('./reports', file))
+
+def process_reports():
+    reports = []
+    for file in os.listdir('./reports'):
+        with open(f'./reports/{file}', 'r') as f:
+            reports.append(json.load(f))
+
+    flattened_reports = [item for sublist in reports for item in sublist]
+    total_success = len([r for r in flattened_reports if r.get("test_result") == "success"])
+    total_failure = len([r for r in flattened_reports if r.get("test_result") == "failure"])
+    average_duration = sum(
+        [int(r.get("test_duration").replace("ms", "")) for r in flattened_reports]
+    ) / len(flattened_reports) if flattened_reports else 0
+
+    failures = [r.get("message") for r in flattened_reports if r.get("test_result") == "failure"]
+
+    with open('./failures', 'w') as f:
+        for failure in failures:
+            f.write(failure + '\n')
+
+    return total_success, total_failure, average_duration
+
+def main():
+    clear_reports()
+    start = time.time()
+    token = get_token()
+    processes = []
+    post_to_honeycomb(f"running load test - {TEST}", "")
+    for id in ws_ids:
+        process = run_task(id, token)
+        processes.append(process)
+        time.sleep(random.randint(1, 4))
+
+    for process in processes:
+        process.wait()
+
+    end = time.time()
+    runtime = end - start
+
+    total_success, total_failure, average_duration = process_reports()
+    post_to_honeycomb(f"finished running load test - {TEST}", "")
+    print(f"With batch size: {BATCH}")
+    print(f"Total Success: {total_success}")
+    print(f"Total Failure: {total_failure}")
+    print(f"Average Duration: {average_duration} ms")
+    print(f"Ran for {runtime} seconds")
+
+if __name__ == "__main__":
+    main()

--- a/bin/si-api-test/sdf_api_client.ts
+++ b/bin/si-api-test/sdf_api_client.ts
@@ -141,6 +141,11 @@ export const ROUTES = {
       `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/schema-variants/${vars.schemaVariantId}`,
     method: "GET",
   },
+  create_unlocked_copy: {
+    path: (vars: ROUTE_VARS) =>
+      `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/schema-variants/${vars.schemaVariantId}`,
+    method: "POST",
+  },
 
   // Action Management -----------------------------------------------------------
   action_list: {
@@ -181,6 +186,16 @@ export const ROUTES = {
     path: (vars: ROUTE_VARS) =>
       `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/funcs/${vars.funcId}/code`,
     method: "PUT",
+  },
+  test_execute: {
+    path: (vars: ROUTE_VARS) =>
+      `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/funcs/${vars.funcId}/test_execute`,
+    method: "POST",
+  },
+  get_func_run: {
+    path: (vars: ROUTE_VARS) =>
+      `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/funcs/runs/${vars.funcRunId}`,
+    method: "GET",
   },
 
   // Modules --------------------------------------

--- a/bin/si-api-test/tests/7-emulate_authoring.ts
+++ b/bin/si-api-test/tests/7-emulate_authoring.ts
@@ -3,7 +3,6 @@ import assert from "node:assert";
 import { SdfApiClient } from "../sdf_api_client.ts";
 import {
     runWithTemporaryChangeset,
-    sleep,
     sleepBetween,
     createComponent,
     createAsset,
@@ -13,8 +12,8 @@ import {
     getPropertyEditor,
     attributeValueIdForPropPath,
     setAttributeValue,
+    createQualification,
 } from "../test_helpers.ts";
-import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
 
 export default async function emulate_authoring(sdfApiClient: SdfApiClient) {
     await sleepBetween(0, 750);
@@ -269,59 +268,6 @@ const doublerQualificationCode = `async function main(component: Input): Promise
 }`;
 
 // REQUEST HELPERS WITH VALIDATIONS
-
-async function createQualification(sdf: SdfApiClient, changeSetId: string, name: string, schemaVariantId: string, code: string) {
-    const createFuncPayload = {
-        name,
-        displayName: name,
-        description: "",
-        binding: {
-            funcId: nilId,
-            schemaVariantId,
-            bindingKind: "qualification",
-            inputs: [],
-        },
-        kind: "Qualification",
-        requestUlid: changeSetId,
-    };
-    const createFuncResp = await sdf.call({
-        route: "create_func",
-        routeVars: {
-            workspaceId: sdf.workspaceId,
-            changeSetId,
-        },
-        body: createFuncPayload,
-    });
-    // now list funcs and let's make sure we see it
-    const funcs = await sdf.call({
-        route: "func_list",
-        routeVars: {
-            workspaceId: sdf.workspaceId,
-            changeSetId,
-        },
-    });
-
-    const createdFunc = funcs.find((f) => f.name === name);
-    assert(createdFunc, "Expected to find newly created func");
-    const funcId = createdFunc.funcId;
-    const codePayload = {
-        code,
-        requestUlid: changeSetId,
-    };
-
-    // save the code
-    const updateFuncResp = await sdf.call({
-        route: "update_func_code",
-        routeVars: {
-            workspaceId: sdf.workspaceId,
-            changeSetId,
-            funcId,
-        },
-        body: codePayload,
-    });
-    return funcId;
-
-}
 
 async function createAttributeFunction(sdf: SdfApiClient, changeSetId: string, name: string, schemaVariantId: string, code: string, outputLocationId: string, funcArguments: any[]) {
     const createFuncPayload = {


### PR DESCRIPTION
To aid in testing/measuring the performance of function execution, this new test takes advantage of the ability to test function executions, where SDF dispatches functions directly to veritech without a Pinga Job.  

I've also included a helpful python script we've been using to execute these tests and some instructions on how to use it!

<div><img src="https://media3.giphy.com/media/3oEjI1erPMTMBFmNHi/200.gif?cid=5a38a5a22pcxzyj1eo4i82sosoey5mrevvpxnv2egzu5t355&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:171px;width:300px"/><br/>via <a href="https://giphy.com/gameofthrones/">Game of Thrones</a> on <a href="https://giphy.com/gifs/game-of-thrones-3oEjI1erPMTMBFmNHi">GIPHY</a></div>