### PR TITLE
feat: add custom discovery for EC2::LaunchTemplate

### DIFF
--- a/bin/clover/src/cloud-control-funcs/overrides/AWS::EC2::LaunchTemplate/discover.ts
+++ b/bin/clover/src/cloud-control-funcs/overrides/AWS::EC2::LaunchTemplate/discover.ts
@@ -1,0 +1,230 @@
+const getImportExceptions = (resourceId: string, region: string) => ({
+    "AWS::EC2::LaunchTemplate": {
+        "altCommand": [
+            "ec2",
+            "describe-launch-template-versions",
+            "--launch-template-id",
+            resourceId,
+            "--versions",
+            "$Latest",
+            "--region",
+            region,
+        ],
+        "resourceExtractor": "LaunchTemplateVersions.0",
+        "fieldMappings": [{
+            sourceField: "LaunchTemplateData",
+            mappedField: "LaunchTemplateData",
+        }, {
+            sourceField: "LaunchTemplateName",
+            mappedField: "LaunchTemplateName",
+        }]
+    }
+})
+
+async function main({
+    thisComponent,
+}: Input): Promise < Output > {
+    const component = thisComponent.properties;
+    const region = _.get(component, ["domain", "extra", "Region"], "");
+    const awsResourceType = _.get(component, [
+        "domain",
+        "extra",
+        "AwsResourceType",
+    ], "");
+
+    let resourceList = [];
+    let finished = false;
+    let nextToken = "";
+    const create = {};
+    const actions = {};
+
+    const refinement = _.cloneDeep(thisComponent.properties.domain);
+    // Remove the 'extra' tree, as it obviously isn't 1:1
+    delete refinement["extra"];
+    // Remove any empty values, as they are never refinements
+    for (const [key, value] of Object.entries(refinement)) {
+        if (_.isEmpty(value) && !_.isNumber(value) && !_.isBoolean(value)) {
+            delete refinement[key];
+        } else if (_.isPlainObject(value)) {
+            refinement[key] = _.pickBy(value, (v) => !_.isEmpty(v) || _.isNumber(v) || _.isBoolean(v));
+            if (_.isEmpty(refinement[key])) {
+                delete refinement[key];
+            }
+        }
+    }
+
+    while (!finished) {
+        const listArgs = [
+            "cloudcontrol",
+            "list-resources",
+            "--region",
+            region,
+            "--type-name",
+            awsResourceType,
+        ];
+        if (!_.isEmpty(refinement)) {
+            listArgs.push("--resource-model");
+            listArgs.push(JSON.stringify(refinement));
+        }
+        if (nextToken) {
+            listArgs.push(nextToken);
+        }
+
+        const listChild = await siExec.waitUntilEnd("aws", listArgs);
+
+        if (listChild.exitCode !== 0) {
+            console.log("Failed to list cloud control resources");
+            console.log(listChild.stdout);
+            console.error(listChild.stderr);
+            return {
+                status: "error",
+                message: `Resource list error; exit code ${listChild.exitCode}.\n\nSTDOUT:\n\n${listChild.stdout}\n\nSTDERR:\n\n${listChild.stderr}`,
+            };
+        }
+        const listResponse = JSON.parse(listChild.stdout);
+        if (listResponse["NextToken"]) {
+            nextToken = listResponse["NextToken"];
+        } else {
+            finished = true;
+        }
+        resourceList = _.union(resourceList, listResponse["ResourceDescriptions"]);
+    }
+
+    let x = 100;
+    let importCount = 0;
+    for (const resource of resourceList) {
+        let resourceId = resource["Identifier"];
+        console.log(`Importing ${resourceId}`);
+
+        let resourceProperties: Record < string, any > = {};
+
+        if (awsResourceType in getImportExceptions(resourceId, region)) {
+            console.log(`${awsResourceType} exists in importExceptions`);
+            const importException = getImportExceptions(resourceId, region)[awsResourceType];
+
+            const fieldMappings = importException.fieldMappings;
+            const altCommand = importException.altCommand;
+            const resourceExtractor = importException.resourceExtractor;
+
+            const child = await siExec.waitUntilEnd("aws", altCommand);
+
+            if (child.exitCode !== 0) {
+                console.log(`Failed to import ${awsResourceType}; continuing.`);
+                console.log(child.stdout);
+                console.log(child.stderr);
+                continue;
+            }
+
+            const response = JSON.parse(child.stdout);
+
+            const extractedProperties = _.get(response, resourceExtractor);
+
+            // Explicitly extract mapped fields back into domain
+            fieldMappings.forEach(({
+                sourceField,
+                mappedField
+            }) => {
+                console.log(`Importing ${sourceField} as ${mappedField} from response`)
+                const value = sourceField
+                    .split(".")
+                    .reduce((acc, key) => (acc && acc[key] ? acc[key] : undefined), extractedProperties);
+
+                console.log(`Value for ${sourceField} found to be ${value}`)
+                if (value !== undefined) {
+                    resourceProperties[mappedField] = value;
+                } else {
+                    console.log(`Value ${value} found to be undefined, ignoring import for this value`)
+                }
+            });
+
+        } else {
+            const child = await siExec.waitUntilEnd("aws", [
+                "cloudcontrol",
+                "get-resource",
+                "--region",
+                region,
+                "--type-name",
+                awsResourceType,
+                "--identifier",
+                resourceId,
+            ]);
+
+            if (child.exitCode !== 0) {
+                console.log(
+                    "Failed to import cloud control resource; continuing, as this is often an AWS bug.",
+                );
+                console.log(child.stdout);
+                console.log(child.stderr);
+                continue;
+            }
+
+            const resourceResponse = JSON.parse(child.stdout);
+            resourceProperties = JSON.parse(
+                resourceResponse["ResourceDescription"]["Properties"],
+            );
+            continue
+        }
+
+        const properties = {
+            si: {
+                resourceId,
+            },
+            domain: {
+                ...resourceProperties,
+            },
+        };
+
+        if (_.isEmpty(refinement) || _.isMatch(properties.domain, refinement)) {
+            const connect = [];
+            for (const key of Object.keys(thisComponent.incomingConnections)) {
+                if (
+                    !_.isNull(thisComponent.incomingConnections[key]) &&
+                    !_.isEmpty(thisComponent.incomingConnections[key])
+                ) {
+                    if (_.isArray(thisComponent.incomingConnections[key])) {
+                        for (const i of thisComponent.incomingConnections[key]) {
+                            connect.push({
+                                from: i,
+                                to: key,
+                            });
+                        }
+                    } else {
+                        connect.push({
+                            from: thisComponent.incomingConnections[key],
+                            to: key,
+                        });
+                    }
+                }
+            }
+            create[resourceId] = {
+                properties,
+                geometry: {
+                    x,
+                    y: 500.0,
+                },
+            };
+            if (!_.isEmpty(connect)) {
+                create[resourceId]["connect"] = connect;
+            }
+            actions[resourceId] = {
+                add: ["refresh"],
+                remove: ["create"],
+            };
+            x = x + 250.0;
+            importCount += 1;
+        } else {
+            console.log(
+                `Skipping import of ${resourceId}; it did not match refinement ${JSON.stringify(refinement, null, 2)}`,
+            );
+        }
+    }
+
+    return {
+        status: "ok",
+        message: `Discovered ${importCount} Components`,
+        ops: {
+            create,
+            actions,
+        },
+    };
+}

--- a/bin/clover/src/cloud-control-funcs/overrides/AWS::EC2::LaunchTemplate/import.ts
+++ b/bin/clover/src/cloud-control-funcs/overrides/AWS::EC2::LaunchTemplate/import.ts
@@ -1,1 +1,118 @@
-function main() {}
+const getImportExceptions = (resourceId: string, region: string) => ({
+    "AWS::EC2::LaunchTemplate": {
+        "altCommand": [
+            "ec2",
+            "describe-launch-template-versions",
+            "--launch-template-id",
+            resourceId,
+            "--versions",
+            "$Latest",
+            "--region",
+            region,
+        ],
+        "resourceExtractor": "LaunchTemplateVersions.0",
+        "fieldMappings": [{
+            sourceField: "LaunchTemplateData",
+            mappedField: "LaunchTemplateData",
+        }, {
+            sourceField: "LaunchTemplateName",
+            mappedField: "LaunchTemplateName",
+        }]
+    }
+})
+
+async function main({
+    thisComponent,
+}: Input): Promise < Output > {
+    const component = thisComponent.properties;
+
+    let resourceId = _.get(component, ["si", "resourceId"]);
+
+    if (!resourceId) {
+        return {
+            status: "error",
+            message: "No resourceId set, cannot import resource",
+        };
+    }
+
+    const region = _.get(component, ["domain", "extra", "Region"], "");
+    if (!region) {
+        return {
+            status: "error",
+            message: "No region set, cannot import resource",
+        };
+    }
+
+    const awsResourceType = "AWS::EC2::LaunchTemplate";
+
+    console.log(`Importing ${resourceId} of type ${awsResourceType}`);
+
+    let resourceProperties: Record < string, any > = {};
+
+    const importException = getImportExceptions(resourceId, region)[awsResourceType];
+
+    const fieldMappings = importException.fieldMappings;
+    const altCommand = importException.altCommand;
+    const resourceExtractor = importException.resourceExtractor;
+
+    const child = await siExec.waitUntilEnd("aws", altCommand);
+
+    if (child.exitCode !== 0) {
+        console.log(`Failed to import ${awsResourceType}; continuing.`);
+        console.log(child.stdout);
+        console.log(child.stderr);
+        return {
+            "status": "error",
+            "message": `unable to import: ${child.stderr}`
+        }
+    }
+
+    const response = JSON.parse(child.stdout);
+
+    const extractedProperties = _.get(response, resourceExtractor);
+
+    // Explicitly extract mapped fields back into domain
+    fieldMappings.forEach(({
+        sourceField,
+        mappedField
+    }) => {
+        console.log(`Importing ${sourceField} as ${mappedField} from response`)
+        const value = sourceField
+            .split(".")
+            .reduce((acc, key) => (acc && acc[key] ? acc[key] : undefined), extractedProperties);
+
+        console.log(`Value for ${sourceField} found to be ${value}`)
+        if (value !== undefined) {
+            resourceProperties[mappedField] = value;
+        } else {
+            console.log(`Value ${value} found to be undefined, ignoring import for this value`)
+        }
+    });
+
+    const properties = {
+        si: {
+            resourceId,
+        },
+        domain: {
+            ...resourceProperties,
+        },
+    };
+
+    return {
+        status: "ok",
+        message: "Imported Resource",
+        ops: {
+            update: {
+                self: {
+                    properties,
+                },
+            },
+            actions: {
+                self: {
+                    remove: ["create"],
+                    add: ["refresh"],
+                },
+            },
+        },
+    };
+}

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -54,13 +54,21 @@ const overrides = new Map<string, OverrideFn>([
     prop!.data.widgetKind = "CodeEditor";
   }],
   ["AWS::EC2::LaunchTemplate", (spec: ExpandedPkgSpec) => {
-    const targetId = MANAGEMENT_FUNCS["Import from AWS"].id;
-    const newId =
+    const importTargetId = MANAGEMENT_FUNCS["Import from AWS"].id;
+    const newImportId =
       "0583c411a5b41594706ae8af473ed6d881357a1e692fb53981417f625f99374b";
-    const path =
+    const importPath =
       "./src/cloud-control-funcs/overrides/AWS::EC2::LaunchTemplate/import.ts";
 
-    modifyFunc(spec, targetId, newId, path);
+    modifyFunc(spec, importTargetId, newImportId, importPath);
+
+    const discoverTargetId = MANAGEMENT_FUNCS["Discover on AWS"].id;
+    const newDiscoverId =
+      "cfebba8fc2d7cd88e5fc2b0c47a777b3737b8c2bcb88fbbb143be48018f22836";
+    const discoverPath =
+      "./src/cloud-control-funcs/overrides/AWS::EC2::LaunchTemplate/discover.ts";
+
+    modifyFunc(spec, discoverTargetId, newDiscoverId, discoverPath);
   }],
   ["AWS::EC2::NetworkInterface", (spec: ExpandedPkgSpec) => {
     const variant = spec.schemas[0].variants[0];


### PR DESCRIPTION
Add more in depth discovery/import for EC2::LaunchTemplate to ensure we pull back in as much data as possible for the objects we find.

I've tested both funcs against existing objects in prod.