### PR TITLE
fix(billing): Don't double-count "no free trial subscription"

### DIFF
--- a/component/lambda/sql/workspace_verifications.sql
+++ b/component/lambda/sql/workspace_verifications.sql
@@ -23,7 +23,6 @@ CREATE OR REPLACE VIEW workspace_verifications.subscription_issues AS
             WHEN start_time > end_time THEN 'start_after_end'
             WHEN plan_code = 'launch_trial' AND end_time IS NULL THEN 'unbounded_free_trial'
             WHEN plan_code = 'launch_trial' AND prev_subscription_end_time IS NOT NULL THEN 'free_trial_not_first'
-            WHEN plan_code <> 'launch_trial' AND prev_subscription_end_time IS NULL THEN 'free_trial_not_first'
             WHEN prev_subscription_end_time < start_time THEN 'gap_in_subscriptions'
             WHEN prev_subscription_end_time > start_time THEN 'overlapping_subscriptions'
             WHEN end_time < next_subscription_start_time THEN 'gap_in_subscriptions'


### PR DESCRIPTION
The billing data quality alert double counts "no free trial subscription" by saying `free_trial_not_first` on the non-free-trial subscription. If there is a free trial that is not first, this will still fire. If there is no free trial at all, `no_free_trial` will fire from `subscription_count_issues`.