### PR TITLE
fix(web): Set the dropdown search to be active by default

### DIFF
--- a/lib/vue-lib/src/design-system/general/SiSearch.vue
+++ b/lib/vue-lib/src/design-system/general/SiSearch.vue
@@ -222,5 +222,11 @@ function onKeyDown(e: KeyboardEvent) {
   }
 }
 
-defineExpose({ filteringActive, activeFilters, clearSearch });
+const focusSearch = () => {
+  if (searchInputRef.value) {
+    searchInputRef.value.focus();
+  }
+};
+
+defineExpose({ filteringActive, activeFilters, clearSearch, focusSearch });
 </script>

--- a/lib/vue-lib/src/design-system/menus/DropdownMenu.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenu.vue
@@ -270,6 +270,10 @@ function open(e?: MouseEvent, anchorToMouse?: boolean) {
 function finishOpening() {
   readjustMenuPosition();
   startListening();
+  if (props.search && siSearchRef.value) {
+    siSearchRef.value.focusSearch();
+    selectSearch();
+  }
 }
 function close(shouldNotClose = false, closeRecursively = true) {
   if (shouldNotClose) return;


### PR DESCRIPTION
When a search was enabled by default on a large dropdown list, it needed a user to click to enable the search, this makes it enabled by default

So when a user clicks a dropdown list, they can immediately type