### PR TITLE
feat: pull ci-base from ecr

### DIFF
--- a/.ci/docker-compose.test-integration.yml
+++ b/.ci/docker-compose.test-integration.yml
@@ -1,7 +1,7 @@
 ---
 services:
   app:
-    image: systeminit/ci-base:stable
+    image: 179845983369.dkr.ecr.us-east-2.amazonaws.com/docker-hub/systeminit/ci-base:stable
     environment:
       - "USE_CI_PG_SETUP=true"
       - "SI_TEST_PG_HOSTNAME=postgres-test"
@@ -25,7 +25,7 @@ services:
 
   # This is the same as the pgbouncer test setup in our dev environment
   postgres-test:
-    image: systeminit/pgbouncer:stable
+    image: 179845983369.dkr.ecr.us-east-2.amazonaws.com/docker-hub/systeminit/pgbouncer:stable
     environment:
       - "DB_USER=si_test"
       - "DB_PASSWORD=bugbear"
@@ -45,7 +45,7 @@ services:
   # *no* need for the `postgres` service as we aren't running the full service
   # stack.
   db-test:
-    image: systeminit/postgres:stable
+    image: 179845983369.dkr.ecr.us-east-2.amazonaws.com/docker-hub/systeminit/postgres:stable
     environment:
       - "POSTGRES_PASSWORD=bugbear"
       - "PGPASSWORD=bugbear"
@@ -59,16 +59,16 @@ services:
       - "full_page_writes=off"
 
   nats:
-    image: systeminit/nats:stable
+    image: 179845983369.dkr.ecr.us-east-2.amazonaws.com/docker-hub/systeminit/nats:stable
     command:
       - "--config"
       - "nats-server.conf"
 
   jaeger:
-    image: systeminit/jaeger:stable
+    image: 179845983369.dkr.ecr.us-east-2.amazonaws.com/docker-hub/systeminit/jaeger:stable
 
   otelcol:
-    image: systeminit/otelcol:stable
+    image: 179845983369.dkr.ecr.us-east-2.amazonaws.com/docker-hub/systeminit/otelcol:stable
     depends_on:
       - jaeger
 

--- a/.ci/generate-creds-from-iam-role.sh
+++ b/.ci/generate-creds-from-iam-role.sh
@@ -7,3 +7,4 @@ VALUES=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254
 echo "export AWS_ACCESS_KEY_ID=$(echo $VALUES | jq -r '.AccessKeyId')"
 echo "export AWS_SECRET_ACCESS_KEY=$(echo $VALUES | jq -r '.SecretAccessKey')"
 echo "export AWS_SESSION_TOKEN=$(echo $VALUES | jq -r '.Token')"
+aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 179845983369.dkr.ecr.us-east-2.amazonaws.com


### PR DESCRIPTION
Sets the ci-base to the ecr pull-through target. Here is a working try

https://buildkite.com/system-initiative/si-merge-queue/builds/5158#0195d7f6-7690-42ca-83b1-1fc1c782a8e1

that shows

> :docker: Running command in 179845983369.dkr.ecr.us-east-2.amazonaws.com/docker-hub/systeminit/ci-base:stable