### PR TITLE
fix: anonymize socket data

### DIFF
--- a/.github/workflows/asset-push.yml
+++ b/.github/workflows/asset-push.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Push Specs
         run: |
           cd bin/hoist
-          cargo run -- upload-all-specs -y --max-concurrent 25 -t ../clover/si-specs
+          cargo run -- upload-all-specs -y --non-interactive --max-concurrent 25 -t ../clover/si-specs

--- a/bin/hoist/src/commands.rs
+++ b/bin/hoist/src/commands.rs
@@ -79,6 +79,14 @@ pub struct UploadAllSpecsArgs {
         action = clap::ArgAction::SetTrue
     )]
     pub skip_confirmation: bool,
+
+    #[arg(
+        long = "non-interactive",
+        short = 'v',
+        help = "Write to console instead of progress bar",
+        action = clap::ArgAction::SetTrue
+    )]
+    pub non_interactive: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -106,6 +114,14 @@ pub struct UploadSpecArgs {
         action = clap::ArgAction::SetTrue
     )]
     pub skip_confirmation: bool,
+
+    #[arg(
+        long = "non-interactive",
+        short = 'v',
+        help = "Write to console instead of progress bar",
+        action = clap::ArgAction::SetTrue
+    )]
+    pub non_interactive: bool,
 }
 
 #[derive(clap::Args, Debug)]

--- a/lib/si-pkg/src/spec/socket.rs
+++ b/lib/si-pkg/src/spec/socket.rs
@@ -107,6 +107,9 @@ impl SocketSpec {
     }
     pub fn anonymize(&mut self) {
         self.unique_id = None;
-        self.inputs.iter_mut().for_each(|f| f.anonymize())
+        self.inputs.iter_mut().for_each(|f| f.anonymize());
+        if let Some(ref mut data) = self.data {
+            data.anonymize();
+        }
     }
 }


### PR DESCRIPTION
This will cause an upload of all assets.

We added socket data to to_specm but were not calling anonymize on it so the structural hash that was just upload is incorrect.

This also adds logging when using hoist non-interactively

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbzkzcDkybG1ncHByeGp3bzV5ZmV3ZjV2aDcxbjBtYmVreWlmbGw5eCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3osxYc2axjCJNsCXyE/giphy.gif"/>