### PR TITLE
build(deps): pin `aws-config`/`aws-sdk-firehose` to prevent native code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+checksum = "4471bef4c22a06d2c7a1b6492493d3fdf24a805323109d6874f9c94d5906ac14"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -537,14 +537,14 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76dd04d39cc12844c0994f2c9c5a6f5184c22e9188ec1ff723de41910a21dcad"
+checksum = "0aff45ffe35196e593ea3b9dd65b320e51e2dda95aff4390bc459e461d09c6ad"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-http 0.60.12",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -584,14 +584,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.61.0"
+version = "1.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e65ff295979977039a25f5a0bf067a64bc5e6aa38f3cef4037cf42516265553c"
+checksum = "1d5330ad4e8a1ff49e9f26b738611caa72b105c41d41733801d1a36e8f9de936"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.61.1",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -606,14 +606,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.62.0"
+version = "1.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91430a60f754f235688387b75ee798ef00cfd09709a582be2b7525ebb5306d4f"
+checksum = "7956b1a85d49082347a7d17daa2e32df191f3e23c03d47294b99f95413026a78"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.61.1",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -628,14 +628,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.62.0"
+version = "1.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9276e139d39fff5a0b0c984fc2d30f970f9a202da67234f948fda02e5bea1dbe"
+checksum = "065c533fbe6f84962af33fcf02b0350b7c1f79285baab5924615d2be3b232855"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.61.1",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -651,12 +651,12 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.9"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bfe75fad52793ce6dec0dc3d4b1f388f038b5eb866c8d4d7f3a8e21b5ea5051"
+checksum = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http 0.60.12",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -664,7 +664,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "once_cell",
  "percent-encoding",
  "sha2",
@@ -681,26 +681,6 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.60.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
 ]
 
 [[package]]
@@ -735,7 +715,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 0.4.6",
  "once_cell",
  "percent-encoding",
@@ -797,7 +777,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "once_cell",
@@ -817,7 +797,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -835,7 +815,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -861,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbd0a668309ec1f66c0f6bda4840dd6d4796ae26d699ebc266d7cc95c6d040f"
+checksum = "3873f8deed8927ce8d04487630dc9ff73193bab64742a61d050e57a68dec4125"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -920,7 +900,7 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -963,7 +943,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -1045,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d"
 
 [[package]]
 name = "bigdecimal"
@@ -1185,7 +1165,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-named-pipe",
@@ -1432,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1442,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1455,9 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3163,7 +3143,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http 1.3.1",
  "indexmap 2.8.0",
  "slab",
  "tokio",
@@ -3394,9 +3374,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -3421,18 +3401,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -3495,7 +3475,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2 0.4.8",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -3544,7 +3524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.23",
@@ -3578,7 +3558,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
  "pin-project-lite",
@@ -3930,9 +3910,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c163c633eb184a4ad2a5e7a5dacf12a58c830d717a7963563d4eceb4ced079f"
+checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
 dependencies = [
  "jiff-static",
  "log",
@@ -3943,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc3e0019b0f5f43038cf46471b1312136f29e36f54436c6042c8f155fec8789"
+checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4075,9 +4055,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libloading"
@@ -4855,7 +4835,7 @@ checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
 dependencies = [
  "async-trait",
  "futures-core",
- "http 1.2.0",
+ "http 1.3.1",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -5589,9 +5569,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -5942,15 +5922,15 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "389a89e494bbc88bebf30e23da98742c843863a16a352647716116aa71fae80a"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
@@ -6021,9 +6001,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -7299,7 +7279,7 @@ version = "0.1.1"
 source = "git+https://github.com/systeminit/spicedb-client.git?branch=si-stable#38f5f8388077a9dcb345ca84c5b188bf62d5370c"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
  "prost",
  "prost-types",
  "spicedb-grpc",
@@ -8157,7 +8137,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http 1.3.1",
  "httparse",
  "rand 0.8.5",
  "ring",
@@ -8214,7 +8194,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2 0.4.8",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
@@ -9002,13 +8982,13 @@ checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.2.0",
+ "windows-result 0.3.1",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -9022,21 +9002,20 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -9090,11 +9069,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -9110,6 +9105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9120,6 +9121,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9134,10 +9141,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9152,6 +9171,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9162,6 +9187,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9176,6 +9207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9186,6 +9223,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,8 @@ async-nats = { version = "0.39.0", features = ["service"] }
 async-openai = "0.26.0"
 async-recursion = "1.1.1"
 async-trait = "0.1.83"
-aws-config = { version = "1.5.10", features = ["behavior-version-latest"] }
-aws-sdk-firehose = "1.56.0"
+aws-config = { version = "=1.5.18", features = ["behavior-version-latest"] } # pinned because very next version (1.6.0) starts pulling in `aws-lc-rs`/`aws-lc-sys` which include native C code
+aws-sdk-firehose = "=1.68.0" # pinned because very next version (1.69.0) starts pulling in `aws-lc-rs`/`aws-lc-sys` which include native C code
 axum = { version = "0.6.20", features = [
     "macros",
     "multipart",

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -706,7 +706,7 @@ cargo.rust_library(
         ":eventsource-stream-0.2.3",
         ":futures-0.3.31",
         ":rand-0.8.5",
-        ":reqwest-0.12.12",
+        ":reqwest-0.12.13",
         ":reqwest-eventsource-0.6.0",
         ":secrecy-0.8.0",
         ":serde-1.0.219",
@@ -743,7 +743,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -788,7 +788,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -817,7 +817,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -952,7 +952,7 @@ cargo.rust_library(
     deps = [
         ":derive_utils-0.15.0",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -1016,18 +1016,18 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":aws-credential-types-1.2.1",
-        ":aws-runtime-1.5.5",
-        ":aws-sdk-sso-1.61.0",
-        ":aws-sdk-ssooidc-1.62.0",
-        ":aws-sdk-sts-1.62.0",
+        ":aws-credential-types-1.2.2",
+        ":aws-runtime-1.5.6",
+        ":aws-sdk-sso-1.62.0",
+        ":aws-sdk-ssooidc-1.63.0",
+        ":aws-sdk-sts-1.63.0",
         ":aws-smithy-async-1.2.5",
         ":aws-smithy-http-0.61.1",
         ":aws-smithy-json-0.61.3",
         ":aws-smithy-runtime-1.8.0",
         ":aws-smithy-runtime-api-1.7.4",
         ":aws-smithy-types-1.3.0",
-        ":aws-types-1.3.5",
+        ":aws-types-1.3.6",
         ":bytes-1.10.1",
         ":fastrand-2.3.0",
         ":hex-0.4.3",
@@ -1042,18 +1042,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "aws-credential-types-1.2.1.crate",
-    sha256 = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da",
-    strip_prefix = "aws-credential-types-1.2.1",
-    urls = ["https://static.crates.io/crates/aws-credential-types/1.2.1/download"],
+    name = "aws-credential-types-1.2.2.crate",
+    sha256 = "4471bef4c22a06d2c7a1b6492493d3fdf24a805323109d6874f9c94d5906ac14",
+    strip_prefix = "aws-credential-types-1.2.2",
+    urls = ["https://static.crates.io/crates/aws-credential-types/1.2.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-credential-types-1.2.1",
-    srcs = [":aws-credential-types-1.2.1.crate"],
+    name = "aws-credential-types-1.2.2",
+    srcs = [":aws-credential-types-1.2.2.crate"],
     crate = "aws_credential_types",
-    crate_root = "aws-credential-types-1.2.1.crate/src/lib.rs",
+    crate_root = "aws-credential-types-1.2.2.crate/src/lib.rs",
     edition = "2021",
     features = ["test-util"],
     visibility = [],
@@ -1101,18 +1101,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "aws-runtime-1.5.5.crate",
-    sha256 = "76dd04d39cc12844c0994f2c9c5a6f5184c22e9188ec1ff723de41910a21dcad",
-    strip_prefix = "aws-runtime-1.5.5",
-    urls = ["https://static.crates.io/crates/aws-runtime/1.5.5/download"],
+    name = "aws-runtime-1.5.6.crate",
+    sha256 = "0aff45ffe35196e593ea3b9dd65b320e51e2dda95aff4390bc459e461d09c6ad",
+    strip_prefix = "aws-runtime-1.5.6",
+    urls = ["https://static.crates.io/crates/aws-runtime/1.5.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-runtime-1.5.5",
-    srcs = [":aws-runtime-1.5.5.crate"],
+    name = "aws-runtime-1.5.6",
+    srcs = [":aws-runtime-1.5.6.crate"],
     crate = "aws_runtime",
-    crate_root = "aws-runtime-1.5.5.crate/src/lib.rs",
+    crate_root = "aws-runtime-1.5.6.crate/src/lib.rs",
     edition = "2021",
     named_deps = {
         "http_02x": ":http-0.2.12",
@@ -1120,14 +1120,14 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":aws-credential-types-1.2.1",
-        ":aws-sigv4-1.2.9",
+        ":aws-credential-types-1.2.2",
+        ":aws-sigv4-1.3.0",
         ":aws-smithy-async-1.2.5",
-        ":aws-smithy-http-0.60.12",
+        ":aws-smithy-http-0.62.0",
         ":aws-smithy-runtime-1.8.0",
         ":aws-smithy-runtime-api-1.7.4",
         ":aws-smithy-types-1.3.0",
-        ":aws-types-1.3.5",
+        ":aws-types-1.3.6",
         ":bytes-1.10.1",
         ":fastrand-2.3.0",
         ":once_cell-1.21.0",
@@ -1176,15 +1176,15 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":aws-credential-types-1.2.1",
-        ":aws-runtime-1.5.5",
+        ":aws-credential-types-1.2.2",
+        ":aws-runtime-1.5.6",
         ":aws-smithy-async-1.2.5",
         ":aws-smithy-http-0.61.1",
         ":aws-smithy-json-0.61.3",
         ":aws-smithy-runtime-1.8.0",
         ":aws-smithy-runtime-api-1.7.4",
         ":aws-smithy-types-1.3.0",
-        ":aws-types-1.3.5",
+        ":aws-types-1.3.6",
         ":bytes-1.10.1",
         ":http-0.2.12",
         ":once_cell-1.21.0",
@@ -1194,41 +1194,41 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "aws-sdk-sso-1.61.0.crate",
-    sha256 = "e65ff295979977039a25f5a0bf067a64bc5e6aa38f3cef4037cf42516265553c",
-    strip_prefix = "aws-sdk-sso-1.61.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-sso/1.61.0/download"],
+    name = "aws-sdk-sso-1.62.0.crate",
+    sha256 = "1d5330ad4e8a1ff49e9f26b738611caa72b105c41d41733801d1a36e8f9de936",
+    strip_prefix = "aws-sdk-sso-1.62.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-sso/1.62.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-sso-1.61.0",
-    srcs = [":aws-sdk-sso-1.61.0.crate"],
+    name = "aws-sdk-sso-1.62.0",
+    srcs = [":aws-sdk-sso-1.62.0.crate"],
     crate = "aws_sdk_sso",
-    crate_root = "aws-sdk-sso-1.61.0.crate/src/lib.rs",
+    crate_root = "aws-sdk-sso-1.62.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-sso-1.61.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-sso-1.62.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS Single Sign-On",
         "CARGO_PKG_NAME": "aws-sdk-sso",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.61.0",
+        "CARGO_PKG_VERSION": "1.62.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "61",
+        "CARGO_PKG_VERSION_MINOR": "62",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     visibility = [],
     deps = [
-        ":aws-credential-types-1.2.1",
-        ":aws-runtime-1.5.5",
+        ":aws-credential-types-1.2.2",
+        ":aws-runtime-1.5.6",
         ":aws-smithy-async-1.2.5",
-        ":aws-smithy-http-0.61.1",
+        ":aws-smithy-http-0.62.0",
         ":aws-smithy-json-0.61.3",
         ":aws-smithy-runtime-1.8.0",
         ":aws-smithy-runtime-api-1.7.4",
         ":aws-smithy-types-1.3.0",
-        ":aws-types-1.3.5",
+        ":aws-types-1.3.6",
         ":bytes-1.10.1",
         ":http-0.2.12",
         ":once_cell-1.21.0",
@@ -1238,41 +1238,41 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "aws-sdk-ssooidc-1.62.0.crate",
-    sha256 = "91430a60f754f235688387b75ee798ef00cfd09709a582be2b7525ebb5306d4f",
-    strip_prefix = "aws-sdk-ssooidc-1.62.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-ssooidc/1.62.0/download"],
+    name = "aws-sdk-ssooidc-1.63.0.crate",
+    sha256 = "7956b1a85d49082347a7d17daa2e32df191f3e23c03d47294b99f95413026a78",
+    strip_prefix = "aws-sdk-ssooidc-1.63.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-ssooidc/1.63.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-ssooidc-1.62.0",
-    srcs = [":aws-sdk-ssooidc-1.62.0.crate"],
+    name = "aws-sdk-ssooidc-1.63.0",
+    srcs = [":aws-sdk-ssooidc-1.63.0.crate"],
     crate = "aws_sdk_ssooidc",
-    crate_root = "aws-sdk-ssooidc-1.62.0.crate/src/lib.rs",
+    crate_root = "aws-sdk-ssooidc-1.63.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-ssooidc-1.62.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-ssooidc-1.63.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS SSO OIDC",
         "CARGO_PKG_NAME": "aws-sdk-ssooidc",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.62.0",
+        "CARGO_PKG_VERSION": "1.63.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "62",
+        "CARGO_PKG_VERSION_MINOR": "63",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     visibility = [],
     deps = [
-        ":aws-credential-types-1.2.1",
-        ":aws-runtime-1.5.5",
+        ":aws-credential-types-1.2.2",
+        ":aws-runtime-1.5.6",
         ":aws-smithy-async-1.2.5",
-        ":aws-smithy-http-0.61.1",
+        ":aws-smithy-http-0.62.0",
         ":aws-smithy-json-0.61.3",
         ":aws-smithy-runtime-1.8.0",
         ":aws-smithy-runtime-api-1.7.4",
         ":aws-smithy-types-1.3.0",
-        ":aws-types-1.3.5",
+        ":aws-types-1.3.6",
         ":bytes-1.10.1",
         ":http-0.2.12",
         ":once_cell-1.21.0",
@@ -1282,43 +1282,43 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "aws-sdk-sts-1.62.0.crate",
-    sha256 = "9276e139d39fff5a0b0c984fc2d30f970f9a202da67234f948fda02e5bea1dbe",
-    strip_prefix = "aws-sdk-sts-1.62.0",
-    urls = ["https://static.crates.io/crates/aws-sdk-sts/1.62.0/download"],
+    name = "aws-sdk-sts-1.63.0.crate",
+    sha256 = "065c533fbe6f84962af33fcf02b0350b7c1f79285baab5924615d2be3b232855",
+    strip_prefix = "aws-sdk-sts-1.63.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-sts/1.63.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sdk-sts-1.62.0",
-    srcs = [":aws-sdk-sts-1.62.0.crate"],
+    name = "aws-sdk-sts-1.63.0",
+    srcs = [":aws-sdk-sts-1.63.0.crate"],
     crate = "aws_sdk_sts",
-    crate_root = "aws-sdk-sts-1.62.0.crate/src/lib.rs",
+    crate_root = "aws-sdk-sts-1.63.0.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-sdk-sts-1.62.0.crate",
+        "CARGO_MANIFEST_DIR": "aws-sdk-sts-1.63.0.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "AWS SDK for AWS Security Token Service",
         "CARGO_PKG_NAME": "aws-sdk-sts",
         "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
-        "CARGO_PKG_VERSION": "1.62.0",
+        "CARGO_PKG_VERSION": "1.63.0",
         "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "62",
+        "CARGO_PKG_VERSION_MINOR": "63",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
     visibility = [],
     deps = [
-        ":aws-credential-types-1.2.1",
-        ":aws-runtime-1.5.5",
+        ":aws-credential-types-1.2.2",
+        ":aws-runtime-1.5.6",
         ":aws-smithy-async-1.2.5",
-        ":aws-smithy-http-0.61.1",
+        ":aws-smithy-http-0.62.0",
         ":aws-smithy-json-0.61.3",
         ":aws-smithy-query-0.60.7",
         ":aws-smithy-runtime-1.8.0",
         ":aws-smithy-runtime-api-1.7.4",
         ":aws-smithy-types-1.3.0",
         ":aws-smithy-xml-0.60.9",
-        ":aws-types-1.3.5",
+        ":aws-types-1.3.6",
         ":http-0.2.12",
         ":once_cell-1.21.0",
         ":regex-lite-0.1.6",
@@ -1327,18 +1327,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "aws-sigv4-1.2.9.crate",
-    sha256 = "9bfe75fad52793ce6dec0dc3d4b1f388f038b5eb866c8d4d7f3a8e21b5ea5051",
-    strip_prefix = "aws-sigv4-1.2.9",
-    urls = ["https://static.crates.io/crates/aws-sigv4/1.2.9/download"],
+    name = "aws-sigv4-1.3.0.crate",
+    sha256 = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db",
+    strip_prefix = "aws-sigv4-1.3.0",
+    urls = ["https://static.crates.io/crates/aws-sigv4/1.3.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-sigv4-1.2.9",
-    srcs = [":aws-sigv4-1.2.9.crate"],
+    name = "aws-sigv4-1.3.0",
+    srcs = [":aws-sigv4-1.3.0.crate"],
     crate = "aws_sigv4",
-    crate_root = "aws-sigv4-1.2.9.crate/src/lib.rs",
+    crate_root = "aws-sigv4-1.3.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -1351,15 +1351,15 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":aws-credential-types-1.2.1",
-        ":aws-smithy-http-0.60.12",
+        ":aws-credential-types-1.2.2",
+        ":aws-smithy-http-0.62.0",
         ":aws-smithy-runtime-api-1.7.4",
         ":aws-smithy-types-1.3.0",
         ":bytes-1.10.1",
         ":form_urlencoded-1.2.1",
         ":hex-0.4.3",
         ":hmac-0.12.1",
-        ":http-1.2.0",
+        ":http-1.3.1",
         ":once_cell-1.21.0",
         ":percent-encoding-2.3.1",
         ":sha2-0.10.8",
@@ -1388,39 +1388,6 @@ cargo.rust_library(
         ":futures-util-0.3.31",
         ":pin-project-lite-0.2.16",
         ":tokio-1.44.0",
-    ],
-)
-
-http_archive(
-    name = "aws-smithy-http-0.60.12.crate",
-    sha256 = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc",
-    strip_prefix = "aws-smithy-http-0.60.12",
-    urls = ["https://static.crates.io/crates/aws-smithy-http/0.60.12/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "aws-smithy-http-0.60.12",
-    srcs = [":aws-smithy-http-0.60.12.crate"],
-    crate = "aws_smithy_http",
-    crate_root = "aws-smithy-http-0.60.12.crate/src/lib.rs",
-    edition = "2021",
-    named_deps = {
-        "http_02x": ":http-0.2.12",
-        "http_body_04x": ":http-body-0.4.6",
-    },
-    visibility = [],
-    deps = [
-        ":aws-smithy-runtime-api-1.7.4",
-        ":aws-smithy-types-1.3.0",
-        ":bytes-1.10.1",
-        ":bytes-utils-0.1.4",
-        ":futures-core-0.3.31",
-        ":once_cell-1.21.0",
-        ":percent-encoding-2.3.1",
-        ":pin-project-lite-0.2.16",
-        ":pin-utils-0.1.0",
-        ":tracing-0.1.41",
     ],
 )
 
@@ -1473,7 +1440,7 @@ cargo.rust_library(
     edition = "2021",
     named_deps = {
         "http_02x": ":http-0.2.12",
-        "http_1x": ":http-1.2.0",
+        "http_1x": ":http-1.3.1",
         "http_body_04x": ":http-body-0.4.6",
     },
     visibility = [],
@@ -1589,7 +1556,7 @@ cargo.rust_library(
     ],
     named_deps = {
         "http_02x": ":http-0.2.12",
-        "http_1x": ":http-1.2.0",
+        "http_1x": ":http-1.3.1",
         "http_body_04x": ":http-body-0.4.6",
         "http_body_1x": ":http-body-1.0.1",
     },
@@ -1634,7 +1601,7 @@ cargo.rust_library(
     ],
     named_deps = {
         "http_02x": ":http-0.2.12",
-        "http_1x": ":http-1.2.0",
+        "http_1x": ":http-1.3.1",
     },
     visibility = [],
     deps = [
@@ -1670,7 +1637,7 @@ cargo.rust_library(
         "test-util",
     ],
     named_deps = {
-        "http_1x": ":http-1.2.0",
+        "http_1x": ":http-1.3.1",
         "http_body_0_4": ":http-body-0.4.6",
         "http_body_1_0": ":http-body-1.0.1",
     },
@@ -1681,7 +1648,7 @@ cargo.rust_library(
         ":bytes-utils-0.1.4",
         ":futures-core-0.3.31",
         ":http-0.2.12",
-        ":http-body-util-0.1.2",
+        ":http-body-util-0.1.3",
         ":itoa-1.0.15",
         ":num-integer-0.1.46",
         ":pin-project-lite-0.2.16",
@@ -1712,34 +1679,34 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "aws-types-1.3.5.crate",
-    sha256 = "dfbd0a668309ec1f66c0f6bda4840dd6d4796ae26d699ebc266d7cc95c6d040f",
-    strip_prefix = "aws-types-1.3.5",
-    urls = ["https://static.crates.io/crates/aws-types/1.3.5/download"],
+    name = "aws-types-1.3.6.crate",
+    sha256 = "3873f8deed8927ce8d04487630dc9ff73193bab64742a61d050e57a68dec4125",
+    strip_prefix = "aws-types-1.3.6",
+    urls = ["https://static.crates.io/crates/aws-types/1.3.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "aws-types-1.3.5",
-    srcs = [":aws-types-1.3.5.crate"],
+    name = "aws-types-1.3.6",
+    srcs = [":aws-types-1.3.6.crate"],
     crate = "aws_types",
-    crate_root = "aws-types-1.3.5.crate/src/lib.rs",
+    crate_root = "aws-types-1.3.6.crate/src/lib.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-types-1.3.5.crate",
+        "CARGO_MANIFEST_DIR": "aws-types-1.3.6.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "Cross-service types for the AWS SDK.",
         "CARGO_PKG_NAME": "aws-types",
         "CARGO_PKG_REPOSITORY": "https://github.com/smithy-lang/smithy-rs",
-        "CARGO_PKG_VERSION": "1.3.5",
+        "CARGO_PKG_VERSION": "1.3.6",
         "CARGO_PKG_VERSION_MAJOR": "1",
         "CARGO_PKG_VERSION_MINOR": "3",
-        "CARGO_PKG_VERSION_PATCH": "5",
-        "OUT_DIR": "$(location :aws-types-1.3.5-build-script-run[out_dir])",
+        "CARGO_PKG_VERSION_PATCH": "6",
+        "OUT_DIR": "$(location :aws-types-1.3.6-build-script-run[out_dir])",
     },
     visibility = [],
     deps = [
-        ":aws-credential-types-1.2.1",
+        ":aws-credential-types-1.2.2",
         ":aws-smithy-async-1.2.5",
         ":aws-smithy-runtime-api-1.7.4",
         ":aws-smithy-types-1.3.0",
@@ -1748,31 +1715,31 @@ cargo.rust_library(
 )
 
 cargo.rust_binary(
-    name = "aws-types-1.3.5-build-script-build",
-    srcs = [":aws-types-1.3.5.crate"],
+    name = "aws-types-1.3.6-build-script-build",
+    srcs = [":aws-types-1.3.6.crate"],
     crate = "build_script_build",
-    crate_root = "aws-types-1.3.5.crate/build.rs",
+    crate_root = "aws-types-1.3.6.crate/build.rs",
     edition = "2021",
     env = {
-        "CARGO_MANIFEST_DIR": "aws-types-1.3.5.crate",
+        "CARGO_MANIFEST_DIR": "aws-types-1.3.6.crate",
         "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
         "CARGO_PKG_DESCRIPTION": "Cross-service types for the AWS SDK.",
         "CARGO_PKG_NAME": "aws-types",
         "CARGO_PKG_REPOSITORY": "https://github.com/smithy-lang/smithy-rs",
-        "CARGO_PKG_VERSION": "1.3.5",
+        "CARGO_PKG_VERSION": "1.3.6",
         "CARGO_PKG_VERSION_MAJOR": "1",
         "CARGO_PKG_VERSION_MINOR": "3",
-        "CARGO_PKG_VERSION_PATCH": "5",
+        "CARGO_PKG_VERSION_PATCH": "6",
     },
     visibility = [],
     deps = [":rustc_version-0.4.1"],
 )
 
 buildscript_run(
-    name = "aws-types-1.3.5-build-script-run",
+    name = "aws-types-1.3.6-build-script-run",
     package_name = "aws-types",
-    buildscript_rule = ":aws-types-1.3.5-build-script-build",
-    version = "1.3.5",
+    buildscript_rule = ":aws-types-1.3.6-build-script-build",
+    version = "1.3.6",
 )
 
 alias(
@@ -1862,9 +1829,9 @@ cargo.rust_library(
         ":axum-core-0.4.5",
         ":bytes-1.10.1",
         ":futures-util-0.3.31",
-        ":http-1.2.0",
+        ":http-1.3.1",
         ":http-body-1.0.1",
-        ":http-body-util-0.1.2",
+        ":http-body-util-0.1.3",
         ":itoa-1.0.15",
         ":matchit-0.7.3",
         ":memchr-2.7.4",
@@ -1926,9 +1893,9 @@ cargo.rust_library(
         ":async-trait-0.1.87",
         ":bytes-1.10.1",
         ":futures-util-0.3.31",
-        ":http-1.2.0",
+        ":http-1.3.1",
         ":http-body-1.0.1",
-        ":http-body-util-0.1.2",
+        ":http-body-util-0.1.3",
         ":mime-0.3.17",
         ":pin-project-lite-0.2.16",
         ":rustversion-1.0.20",
@@ -1958,7 +1925,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -2021,7 +1988,7 @@ cargo.rust_library(
         "linux-arm64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -2029,7 +1996,7 @@ cargo.rust_library(
         "linux-x86_64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -2037,7 +2004,7 @@ cargo.rust_library(
         "macos-arm64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -2045,7 +2012,7 @@ cargo.rust_library(
         "macos-x86_64": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -2053,7 +2020,7 @@ cargo.rust_library(
         "windows-gnu": dict(
             deps = [
                 ":addr2line-0.21.0",
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":miniz_oxide-0.7.4",
                 ":object-0.32.2",
             ],
@@ -2162,18 +2129,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "base64ct-1.6.0.crate",
-    sha256 = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b",
-    strip_prefix = "base64ct-1.6.0",
-    urls = ["https://static.crates.io/crates/base64ct/1.6.0/download"],
+    name = "base64ct-1.7.1.crate",
+    sha256 = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d",
+    strip_prefix = "base64ct-1.7.1",
+    urls = ["https://static.crates.io/crates/base64ct/1.7.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "base64ct-1.6.0",
-    srcs = [":base64ct-1.6.0.crate"],
+    name = "base64ct-1.7.1",
+    srcs = [":base64ct-1.7.1.crate"],
     crate = "base64ct",
-    crate_root = "base64ct-1.6.0.crate/src/lib.rs",
+    crate_root = "base64ct-1.7.1.crate/src/lib.rs",
     edition = "2021",
     features = ["alloc"],
     visibility = [],
@@ -2313,7 +2280,7 @@ cargo.rust_library(
         ":lazycell-1.3.0",
         ":peeking_take_while-0.1.2",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":regex-1.11.1",
         ":rustc-hash-1.1.0",
         ":shlex-1.3.0",
@@ -2706,8 +2673,8 @@ cargo.rust_library(
         ":futures-core-0.3.31",
         ":futures-util-0.3.31",
         ":hex-0.4.3",
-        ":http-1.2.0",
-        ":http-body-util-0.1.2",
+        ":http-1.3.1",
+        ":http-body-util-0.1.3",
         ":hyper-1.6.0",
         ":hyper-util-0.1.10",
         ":log-0.4.26",
@@ -2915,16 +2882,16 @@ cargo.rust_library(
     features = ["parallel"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
     },
     visibility = [],
@@ -3164,7 +3131,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":glob-0.3.2",
-        ":libc-0.2.170",
+        ":libc-0.2.171",
         ":libloading-0.8.6",
     ],
 )
@@ -3223,23 +3190,23 @@ buildscript_run(
 
 alias(
     name = "clap",
-    actual = ":clap-4.5.31",
+    actual = ":clap-4.5.32",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "clap-4.5.31.crate",
-    sha256 = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767",
-    strip_prefix = "clap-4.5.31",
-    urls = ["https://static.crates.io/crates/clap/4.5.31/download"],
+    name = "clap-4.5.32.crate",
+    sha256 = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83",
+    strip_prefix = "clap-4.5.32",
+    urls = ["https://static.crates.io/crates/clap/4.5.32/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap-4.5.31",
-    srcs = [":clap-4.5.31.crate"],
+    name = "clap-4.5.32",
+    srcs = [":clap-4.5.32.crate"],
     crate = "clap",
-    crate_root = "clap-4.5.31.crate/src/lib.rs",
+    crate_root = "clap-4.5.32.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -3255,24 +3222,24 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":clap_builder-4.5.31",
-        ":clap_derive-4.5.28",
+        ":clap_builder-4.5.32",
+        ":clap_derive-4.5.32",
     ],
 )
 
 http_archive(
-    name = "clap_builder-4.5.31.crate",
-    sha256 = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863",
-    strip_prefix = "clap_builder-4.5.31",
-    urls = ["https://static.crates.io/crates/clap_builder/4.5.31/download"],
+    name = "clap_builder-4.5.32.crate",
+    sha256 = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8",
+    strip_prefix = "clap_builder-4.5.32",
+    urls = ["https://static.crates.io/crates/clap_builder/4.5.32/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap_builder-4.5.31",
-    srcs = [":clap_builder-4.5.31.crate"],
+    name = "clap_builder-4.5.32",
+    srcs = [":clap_builder-4.5.32.crate"],
     crate = "clap_builder",
-    crate_root = "clap_builder-4.5.31.crate/src/lib.rs",
+    crate_root = "clap_builder-4.5.32.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -3295,18 +3262,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "clap_derive-4.5.28.crate",
-    sha256 = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed",
-    strip_prefix = "clap_derive-4.5.28",
-    urls = ["https://static.crates.io/crates/clap_derive/4.5.28/download"],
+    name = "clap_derive-4.5.32.crate",
+    sha256 = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7",
+    strip_prefix = "clap_derive-4.5.32",
+    urls = ["https://static.crates.io/crates/clap_derive/4.5.32/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap_derive-4.5.28",
-    srcs = [":clap_derive-4.5.28.crate"],
+    name = "clap_derive-4.5.32",
+    srcs = [":clap_derive-4.5.32.crate"],
     crate = "clap_derive",
-    crate_root = "clap_derive-4.5.28.crate/src/lib.rs",
+    crate_root = "clap_derive-4.5.32.crate/src/lib.rs",
     edition = "2021",
     features = ["default"],
     proc_macro = True,
@@ -3314,7 +3281,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.5.0",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -3370,22 +3337,22 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-msvc": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
     },
     visibility = [],
@@ -3570,7 +3537,7 @@ cargo.rust_library(
     },
     visibility = [],
     deps = [
-        ":libc-0.2.170",
+        ":libc-0.2.171",
         ":once_cell-1.21.0",
         ":unicode-width-0.2.0",
     ],
@@ -3717,7 +3684,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":core-foundation-sys-0.8.7",
-        ":libc-0.2.170",
+        ":libc-0.2.171",
     ],
 )
 
@@ -3742,7 +3709,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":core-foundation-sys-0.8.7",
-        ":libc-0.2.170",
+        ":libc-0.2.171",
     ],
 )
 
@@ -3783,10 +3750,10 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
     },
     visibility = [],
@@ -4174,7 +4141,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -4233,7 +4200,7 @@ cargo.rust_library(
         ":fnv-1.0.7",
         ":ident_case-1.0.1",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":strsim-0.11.1",
         ":syn-2.0.100",
     ],
@@ -4257,7 +4224,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":darling_core-0.20.10",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -4497,7 +4464,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -4576,7 +4543,7 @@ cargo.rust_library(
     deps = [
         ":darling-0.20.10",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -4657,7 +4624,7 @@ cargo.rust_library(
     deps = [
         ":convert_case-0.4.0",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -4679,7 +4646,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -4918,16 +4885,16 @@ cargo.rust_library(
     edition = "2015",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.48.0"],
@@ -4958,7 +4925,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -5212,7 +5179,7 @@ cargo.rust_library(
     deps = [
         ":enum-ordinalize-4.3.0",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -5402,7 +5369,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -5492,7 +5459,7 @@ cargo.rust_library(
         ":anstream-0.6.18",
         ":anstyle-1.0.10",
         ":env_filter-0.1.3",
-        ":jiff-0.2.3",
+        ":jiff-0.2.4",
         ":log-0.4.26",
     ],
 )
@@ -5531,16 +5498,16 @@ cargo.rust_library(
     features = ["std"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.59.0"],
@@ -5795,7 +5762,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro-error2-2.0.1",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -5860,16 +5827,16 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.59.0"],
@@ -6279,7 +6246,7 @@ cargo.rust_library(
         ":auto_enums-0.8.7",
         ":bincode-1.3.3",
         ":bytes-1.10.1",
-        ":clap-4.5.31",
+        ":clap-4.5.32",
         ":equivalent-1.0.2",
         ":fastrace-0.7.6",
         ":flume-0.11.1",
@@ -6289,7 +6256,7 @@ cargo.rust_library(
         ":futures-core-0.3.31",
         ":futures-util-0.3.31",
         ":itertools-0.14.0",
-        ":libc-0.2.170",
+        ":libc-0.2.171",
         ":lz4-1.28.1",
         ":ordered_hash_map-0.4.0",
         ":parking_lot-0.12.3",
@@ -6374,7 +6341,7 @@ cargo.rust_library(
     rustc_flags = ["@$(location :fuser-0.15.1-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
-        ":libc-0.2.170",
+        ":libc-0.2.171",
         ":log-0.4.26",
         ":memchr-2.7.4",
         ":nix-0.29.0",
@@ -6644,7 +6611,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -6823,16 +6790,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
     },
     visibility = [],
@@ -6863,16 +6830,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
     },
     visibility = [],
@@ -6896,16 +6863,16 @@ cargo.rust_library(
     features = ["std"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             deps = [":windows-targets-0.52.6"],
@@ -7064,7 +7031,7 @@ cargo.rust_library(
         ":fnv-1.0.7",
         ":futures-core-0.3.31",
         ":futures-sink-0.3.31",
-        ":http-1.2.0",
+        ":http-1.3.1",
         ":indexmap-2.8.0",
         ":slab-0.4.9",
         ":tokio-1.44.0",
@@ -7529,18 +7496,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "http-1.2.0.crate",
-    sha256 = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea",
-    strip_prefix = "http-1.2.0",
-    urls = ["https://static.crates.io/crates/http/1.2.0/download"],
+    name = "http-1.3.1.crate",
+    sha256 = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565",
+    strip_prefix = "http-1.3.1",
+    urls = ["https://static.crates.io/crates/http/1.3.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "http-1.2.0",
-    srcs = [":http-1.2.0.crate"],
+    name = "http-1.3.1",
+    srcs = [":http-1.3.1.crate"],
     crate = "http",
-    crate_root = "http-1.2.0.crate/src/lib.rs",
+    crate_root = "http-1.3.1.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -7593,29 +7560,30 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bytes-1.10.1",
-        ":http-1.2.0",
+        ":http-1.3.1",
     ],
 )
 
 http_archive(
-    name = "http-body-util-0.1.2.crate",
-    sha256 = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f",
-    strip_prefix = "http-body-util-0.1.2",
-    urls = ["https://static.crates.io/crates/http-body-util/0.1.2/download"],
+    name = "http-body-util-0.1.3.crate",
+    sha256 = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a",
+    strip_prefix = "http-body-util-0.1.3",
+    urls = ["https://static.crates.io/crates/http-body-util/0.1.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "http-body-util-0.1.2",
-    srcs = [":http-body-util-0.1.2.crate"],
+    name = "http-body-util-0.1.3",
+    srcs = [":http-body-util-0.1.3.crate"],
     crate = "http_body_util",
-    crate_root = "http-body-util-0.1.2.crate/src/lib.rs",
+    crate_root = "http-body-util-0.1.3.crate/src/lib.rs",
     edition = "2018",
+    features = ["default"],
     visibility = [],
     deps = [
         ":bytes-1.10.1",
-        ":futures-util-0.3.31",
-        ":http-1.2.0",
+        ":futures-core-0.3.31",
+        ":http-1.3.1",
         ":http-body-1.0.1",
         ":pin-project-lite-0.2.16",
     ],
@@ -7773,7 +7741,7 @@ cargo.rust_library(
         ":futures-channel-0.3.31",
         ":futures-util-0.3.31",
         ":h2-0.4.8",
-        ":http-1.2.0",
+        ":http-1.3.1",
         ":http-body-1.0.1",
         ":httparse-1.10.1",
         ":httpdate-1.0.3",
@@ -7879,7 +7847,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":futures-util-0.3.31",
-        ":http-1.2.0",
+        ":http-1.3.1",
         ":hyper-1.6.0",
         ":hyper-util-0.1.10",
         ":rustls-0.23.23",
@@ -7945,7 +7913,7 @@ cargo.rust_library(
         ":bytes-1.10.1",
         ":futures-channel-0.3.31",
         ":futures-util-0.3.31",
-        ":http-1.2.0",
+        ":http-1.3.1",
         ":http-body-1.0.1",
         ":hyper-1.6.0",
         ":pin-project-lite-0.2.16",
@@ -8004,7 +7972,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":hex-0.4.3",
-        ":http-body-util-0.1.2",
+        ":http-body-util-0.1.3",
         ":hyper-1.6.0",
         ":hyper-util-0.1.10",
         ":pin-project-lite-0.2.16",
@@ -8280,7 +8248,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -8376,7 +8344,7 @@ cargo.rust_library(
     deps = [
         ":ignore-0.4.23",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":serde-1.0.219",
         ":syn-2.0.100",
         ":toml-0.8.20",
@@ -8572,7 +8540,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -8632,16 +8600,16 @@ cargo.rust_library(
     edition = "2018",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.59.0"],
@@ -8741,18 +8709,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "jiff-0.2.3.crate",
-    sha256 = "5c163c633eb184a4ad2a5e7a5dacf12a58c830d717a7963563d4eceb4ced079f",
-    strip_prefix = "jiff-0.2.3",
-    urls = ["https://static.crates.io/crates/jiff/0.2.3/download"],
+    name = "jiff-0.2.4.crate",
+    sha256 = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e",
+    strip_prefix = "jiff-0.2.4",
+    urls = ["https://static.crates.io/crates/jiff/0.2.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "jiff-0.2.3",
-    srcs = [":jiff-0.2.3.crate"],
+    name = "jiff-0.2.4",
+    srcs = [":jiff-0.2.4.crate"],
     crate = "jiff",
-    crate_root = "jiff-0.2.3.crate/src/lib.rs",
+    crate_root = "jiff-0.2.4.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -8781,16 +8749,16 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
     },
     visibility = [],
@@ -9001,7 +8969,7 @@ cargo.rust_library(
     crate_root = "krata-loopdev-0.0.21.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
-    deps = [":libc-0.2.170"],
+    deps = [":libc-0.2.171"],
 )
 
 alias(
@@ -9050,33 +9018,33 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "libc-0.2.170.crate",
-    sha256 = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828",
-    strip_prefix = "libc-0.2.170",
-    urls = ["https://static.crates.io/crates/libc/0.2.170/download"],
+    name = "libc-0.2.171.crate",
+    sha256 = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6",
+    strip_prefix = "libc-0.2.171",
+    urls = ["https://static.crates.io/crates/libc/0.2.171/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "libc-0.2.170",
-    srcs = [":libc-0.2.170.crate"],
+    name = "libc-0.2.171",
+    srcs = [":libc-0.2.171.crate"],
     crate = "libc",
-    crate_root = "libc-0.2.170.crate/src/lib.rs",
+    crate_root = "libc-0.2.171.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
         "extra_traits",
         "std",
     ],
-    rustc_flags = ["@$(location :libc-0.2.170-build-script-run[rustc_flags])"],
+    rustc_flags = ["@$(location :libc-0.2.171-build-script-run[rustc_flags])"],
     visibility = [],
 )
 
 cargo.rust_binary(
-    name = "libc-0.2.170-build-script-build",
-    srcs = [":libc-0.2.170.crate"],
+    name = "libc-0.2.171-build-script-build",
+    srcs = [":libc-0.2.171.crate"],
     crate = "build_script_build",
-    crate_root = "libc-0.2.170.crate/build.rs",
+    crate_root = "libc-0.2.171.crate/build.rs",
     edition = "2021",
     features = [
         "default",
@@ -9087,15 +9055,15 @@ cargo.rust_binary(
 )
 
 buildscript_run(
-    name = "libc-0.2.170-build-script-run",
+    name = "libc-0.2.171-build-script-run",
     package_name = "libc",
-    buildscript_rule = ":libc-0.2.170-build-script-build",
+    buildscript_rule = ":libc-0.2.171-build-script-build",
     features = [
         "default",
         "extra_traits",
         "std",
     ],
-    version = "0.2.170",
+    version = "0.2.171",
 )
 
 http_archive(
@@ -9406,7 +9374,7 @@ cargo.rust_library(
     edition = "2015",
     visibility = [],
     deps = [
-        ":libc-0.2.170",
+        ":libc-0.2.171",
         ":libsodium-sys-0.2.7-libsodium",
     ],
 )
@@ -9841,7 +9809,7 @@ cargo.rust_library(
     edition = "2015",
     visibility = [],
     deps = [
-        ":libc-0.2.170",
+        ":libc-0.2.171",
         ":lz4-sys-1.11.1+lz4-1.10.0-lz4-sys",
     ],
 )
@@ -9905,7 +9873,7 @@ cargo.rust_library(
     deps = [
         ":darling_core-0.20.10",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
     ],
 )
 
@@ -9928,7 +9896,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro-utils-0.10.0",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
     ],
 )
 
@@ -9987,7 +9955,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -10262,16 +10230,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -10362,7 +10330,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -10562,7 +10530,7 @@ cargo.rust_library(
     deps = [
         ":bitflags-1.3.2",
         ":cfg-if-1.0.0",
-        ":libc-0.2.170",
+        ":libc-0.2.171",
     ],
 )
 
@@ -10591,7 +10559,7 @@ cargo.rust_library(
     deps = [
         ":bitflags-2.9.0",
         ":cfg-if-1.0.0",
-        ":libc-0.2.170",
+        ":libc-0.2.171",
     ],
 )
 
@@ -10632,7 +10600,7 @@ cargo.rust_library(
     deps = [
         ":bitflags-2.9.0",
         ":cfg-if-1.0.0",
-        ":libc-0.2.170",
+        ":libc-0.2.171",
     ],
 )
 
@@ -11076,16 +11044,16 @@ cargo.rust_library(
     edition = "2015",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
     },
     visibility = [],
@@ -11280,7 +11248,7 @@ cargo.rust_library(
     deps = [
         ":async-trait-0.1.87",
         ":futures-core-0.3.31",
-        ":http-1.2.0",
+        ":http-1.3.1",
         ":opentelemetry-0.26.0",
         ":opentelemetry-proto-0.26.1",
         ":opentelemetry_sdk-0.26.0",
@@ -11595,7 +11563,7 @@ cargo.rust_library(
         ":heck-0.4.1",
         ":proc-macro2-1.0.94",
         ":proc-macro2-diagnostics-0.10.1",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -11744,16 +11712,16 @@ cargo.rust_library(
     edition = "2015",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             deps = [":winapi-0.3.9"],
@@ -11826,16 +11794,16 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             deps = [":windows-targets-0.52.6"],
@@ -11948,7 +11916,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["alloc"],
     visibility = [],
-    deps = [":base64ct-1.6.0"],
+    deps = [":base64ct-1.7.1"],
 )
 
 http_archive(
@@ -12107,7 +12075,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -12353,7 +12321,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.5.0",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -12558,7 +12526,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
     ],
 )
 
@@ -12584,7 +12552,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro-error-attr2-2.0.0",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -12614,7 +12582,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":smallvec-1.14.0",
     ],
 )
@@ -12694,7 +12662,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
         ":yansi-1.0.1",
     ],
@@ -12838,7 +12806,7 @@ cargo.rust_library(
         ":anyhow-1.0.97",
         ":itertools-0.14.0",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -13006,7 +12974,7 @@ cargo.rust_library(
     rustc_flags = ["@$(location :quinn-udp-0.5.10-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
-        ":libc-0.2.170",
+        ":libc-0.2.171",
         ":tracing-0.1.41",
     ],
 )
@@ -13032,23 +13000,23 @@ buildscript_run(
 
 alias(
     name = "quote",
-    actual = ":quote-1.0.39",
+    actual = ":quote-1.0.40",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "quote-1.0.39.crate",
-    sha256 = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801",
-    strip_prefix = "quote-1.0.39",
-    urls = ["https://static.crates.io/crates/quote/1.0.39/download"],
+    name = "quote-1.0.40.crate",
+    sha256 = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d",
+    strip_prefix = "quote-1.0.40",
+    urls = ["https://static.crates.io/crates/quote/1.0.40/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "quote-1.0.39",
-    srcs = [":quote-1.0.39.crate"],
+    name = "quote-1.0.40",
+    srcs = [":quote-1.0.40.crate"],
     crate = "quote",
-    crate_root = "quote-1.0.39.crate/src/lib.rs",
+    crate_root = "quote-1.0.40.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -13087,25 +13055,25 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":rand_chacha-0.2.2",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":rand_chacha-0.2.2",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":rand_chacha-0.2.2",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":rand_chacha-0.2.2",
             ],
         ),
@@ -13154,16 +13122,16 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
     },
     visibility = [],
@@ -13515,7 +13483,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.5.0",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":refinery-core-0.8.16",
         ":regex-1.11.1",
         ":syn-2.0.100",
@@ -13744,30 +13712,30 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
 
 alias(
     name = "reqwest",
-    actual = ":reqwest-0.12.12",
+    actual = ":reqwest-0.12.13",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "reqwest-0.12.12.crate",
-    sha256 = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da",
-    strip_prefix = "reqwest-0.12.12",
-    urls = ["https://static.crates.io/crates/reqwest/0.12.12/download"],
+    name = "reqwest-0.12.13.crate",
+    sha256 = "389a89e494bbc88bebf30e23da98742c843863a16a352647716116aa71fae80a",
+    strip_prefix = "reqwest-0.12.13",
+    urls = ["https://static.crates.io/crates/reqwest/0.12.13/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "reqwest-0.12.12",
-    srcs = [":reqwest-0.12.12.crate"],
+    name = "reqwest-0.12.13",
+    srcs = [":reqwest-0.12.13.crate"],
     crate = "reqwest",
-    crate_root = "reqwest-0.12.12.crate/src/lib.rs",
+    crate_root = "reqwest-0.12.13.crate/src/lib.rs",
     edition = "2021",
     features = [
         "__rustls",
@@ -13786,7 +13754,7 @@ cargo.rust_library(
         "linux-arm64": dict(
             deps = [
                 ":http-body-1.0.1",
-                ":http-body-util-0.1.2",
+                ":http-body-util-0.1.3",
                 ":hyper-1.6.0",
                 ":hyper-rustls-0.27.5",
                 ":hyper-util-0.1.10",
@@ -13811,7 +13779,7 @@ cargo.rust_library(
         "linux-x86_64": dict(
             deps = [
                 ":http-body-1.0.1",
-                ":http-body-util-0.1.2",
+                ":http-body-util-0.1.3",
                 ":hyper-1.6.0",
                 ":hyper-rustls-0.27.5",
                 ":hyper-util-0.1.10",
@@ -13836,7 +13804,7 @@ cargo.rust_library(
         "macos-arm64": dict(
             deps = [
                 ":http-body-1.0.1",
-                ":http-body-util-0.1.2",
+                ":http-body-util-0.1.3",
                 ":hyper-1.6.0",
                 ":hyper-rustls-0.27.5",
                 ":hyper-util-0.1.10",
@@ -13861,7 +13829,7 @@ cargo.rust_library(
         "macos-x86_64": dict(
             deps = [
                 ":http-body-1.0.1",
-                ":http-body-util-0.1.2",
+                ":http-body-util-0.1.3",
                 ":hyper-1.6.0",
                 ":hyper-rustls-0.27.5",
                 ":hyper-util-0.1.10",
@@ -13886,7 +13854,7 @@ cargo.rust_library(
         "windows-gnu": dict(
             deps = [
                 ":http-body-1.0.1",
-                ":http-body-util-0.1.2",
+                ":http-body-util-0.1.3",
                 ":hyper-1.6.0",
                 ":hyper-rustls-0.27.5",
                 ":hyper-util-0.1.10",
@@ -13906,13 +13874,13 @@ cargo.rust_library(
                 ":tokio-util-0.7.13",
                 ":tower-0.5.2",
                 ":webpki-roots-0.26.8",
-                ":windows-registry-0.2.0",
+                ":windows-registry-0.4.0",
             ],
         ),
         "windows-msvc": dict(
             deps = [
                 ":http-body-1.0.1",
-                ":http-body-util-0.1.2",
+                ":http-body-util-0.1.3",
                 ":hyper-1.6.0",
                 ":hyper-rustls-0.27.5",
                 ":hyper-util-0.1.10",
@@ -13932,7 +13900,7 @@ cargo.rust_library(
                 ":tokio-util-0.7.13",
                 ":tower-0.5.2",
                 ":webpki-roots-0.26.8",
-                ":windows-registry-0.2.0",
+                ":windows-registry-0.4.0",
             ],
         ),
     },
@@ -13942,7 +13910,7 @@ cargo.rust_library(
         ":bytes-1.10.1",
         ":futures-core-0.3.31",
         ":futures-util-0.3.31",
-        ":http-1.2.0",
+        ":http-1.3.1",
         ":mime_guess-2.0.4",
         ":serde-1.0.219",
         ":serde_json-1.0.140",
@@ -13975,7 +13943,7 @@ cargo.rust_library(
         ":mime-0.3.17",
         ":nom-7.1.3",
         ":pin-project-lite-0.2.16",
-        ":reqwest-0.12.12",
+        ":reqwest-0.12.13",
         ":thiserror-1.0.69",
     ],
 )
@@ -14167,7 +14135,7 @@ cargo.rust_library(
                 "RING_CORE_PREFIX": "ring_core_0_17_5_",
             },
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":ring-0.17.5-ring-c-asm-elf-aarch64",
                 ":ring-0.17.5-ring-c-asm-elf-aarch64",
                 ":spin-0.9.8",
@@ -14178,7 +14146,7 @@ cargo.rust_library(
                 "RING_CORE_PREFIX": "ring_core_0_17_5_",
             },
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":ring-0.17.5-ring-c-asm-elf-x86_84",
                 ":ring-0.17.5-ring-c-asm-elf-x86_84",
                 ":spin-0.9.8",
@@ -15052,7 +15020,7 @@ cargo.rust_library(
                 "libc_errno": ":errno-0.3.10",
             },
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":linux-raw-sys-0.4.15",
             ],
         ),
@@ -15061,7 +15029,7 @@ cargo.rust_library(
                 "libc_errno": ":errno-0.3.10",
             },
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":linux-raw-sys-0.4.15",
             ],
         ),
@@ -15069,13 +15037,13 @@ cargo.rust_library(
             named_deps = {
                 "libc_errno": ":errno-0.3.10",
             },
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
             named_deps = {
                 "libc_errno": ":errno-0.3.10",
             },
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             named_deps = {
@@ -15162,7 +15130,7 @@ cargo.rust_library(
                 "libc_errno": ":errno-0.3.10",
             },
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":linux-raw-sys-0.9.2",
             ],
         ),
@@ -15171,7 +15139,7 @@ cargo.rust_library(
                 "libc_errno": ":errno-0.3.10",
             },
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":linux-raw-sys-0.9.2",
             ],
         ),
@@ -15179,13 +15147,13 @@ cargo.rust_library(
             named_deps = {
                 "libc_errno": ":errno-0.3.10",
             },
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
             named_deps = {
                 "libc_errno": ":errno-0.3.10",
             },
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             named_deps = {
@@ -15713,7 +15681,7 @@ cargo.rust_library(
         ":heck-0.4.1",
         ":proc-macro-error2-2.0.1",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -15816,7 +15784,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.4.1",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
         ":unicode-ident-1.0.18",
     ],
@@ -16002,7 +15970,7 @@ cargo.rust_library(
         ":bitflags-2.9.0",
         ":core-foundation-0.9.4",
         ":core-foundation-sys-0.8.7",
-        ":libc-0.2.170",
+        ":libc-0.2.171",
         ":security-framework-sys-2.14.0",
     ],
 )
@@ -16030,7 +15998,7 @@ cargo.rust_library(
         ":bitflags-2.9.0",
         ":core-foundation-0.10.0",
         ":core-foundation-sys-0.8.7",
-        ":libc-0.2.170",
+        ":libc-0.2.171",
         ":security-framework-sys-2.14.0",
     ],
 )
@@ -16058,7 +16026,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":core-foundation-sys-0.8.7",
-        ":libc-0.2.170",
+        ":libc-0.2.171",
     ],
 )
 
@@ -16235,7 +16203,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -16374,7 +16342,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -16483,7 +16451,7 @@ cargo.rust_library(
     deps = [
         ":darling-0.20.10",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -16663,7 +16631,7 @@ cargo.rust_library(
     crate_root = "signal-hook-registry-1.4.2.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
-    deps = [":libc-0.2.170"],
+    deps = [":libc-0.2.171"],
 )
 
 http_archive(
@@ -16874,16 +16842,16 @@ cargo.rust_library(
     features = ["all"],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             deps = [":windows-sys-0.52.0"],
@@ -16923,7 +16891,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":ed25519-1.5.3",
-        ":libc-0.2.170",
+        ":libc-0.2.171",
         ":libsodium-sys-0.2.7",
         ":serde-1.0.219",
     ],
@@ -16948,7 +16916,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":bytes-1.10.1",
-        ":http-1.2.0",
+        ":http-1.3.1",
         ":prost-0.13.5",
         ":prost-types-0.13.5",
         ":spicedb-grpc-0.1.1",
@@ -17030,7 +16998,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":base64ct-1.6.0",
+        ":base64ct-1.7.1",
         ":der-0.7.9",
     ],
 )
@@ -17341,7 +17309,7 @@ cargo.rust_library(
     deps = [
         ":heck-0.5.0",
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":rustversion-1.0.20",
         ":syn-2.0.100",
     ],
@@ -17434,7 +17402,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":unicode-ident-1.0.18",
     ],
 )
@@ -17499,7 +17467,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -17536,33 +17504,33 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
             deps = [
                 ":core-foundation-sys-0.8.7",
-                ":libc-0.2.170",
+                ":libc-0.2.171",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
                 ":core-foundation-sys-0.8.7",
-                ":libc-0.2.170",
+                ":libc-0.2.171",
             ],
         ),
         "windows-gnu": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":ntapi-0.4.1",
                 ":windows-0.57.0",
             ],
         ),
         "windows-msvc": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":ntapi-0.4.1",
                 ":windows-0.57.0",
             ],
@@ -17602,25 +17570,25 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":xattr-1.5.0",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":xattr-1.5.0",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":xattr-1.5.0",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":xattr-1.5.0",
             ],
         ),
@@ -17825,7 +17793,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -17851,7 +17819,7 @@ cargo.rust_binary(
         ":bytes-1.10.1",
         ":chrono-0.4.40",
         ":ciborium-0.2.2",
-        ":clap-4.5.31",
+        ":clap-4.5.32",
         ":color-eyre-0.6.3",
         ":config-0.14.1",
         ":convert_case-0.6.0",
@@ -17915,12 +17883,12 @@ cargo.rust_binary(
         ":pretty_assertions_sorted-1.2.3",
         ":proc-macro2-1.0.94",
         ":procfs-0.17.0",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":rand-0.8.5",
         ":refinery-0.8.16",
         ":regex-1.11.1",
         ":remain-0.2.15",
-        ":reqwest-0.12.12",
+        ":reqwest-0.12.13",
         ":ring-0.17.5",
         ":rust-s3-0.34.0-rc4",
         ":rustls-0.23.23",
@@ -18037,7 +18005,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -18060,7 +18028,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -18087,26 +18055,26 @@ cargo.rust_library(
     edition = "2021",
     platform = {
         "linux-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "linux-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-arm64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
-            deps = [":libc-0.2.170"],
+            deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":winapi-0.3.9",
             ],
         ),
         "windows-msvc": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":winapi-0.3.9",
             ],
         ),
@@ -18362,7 +18330,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -18415,28 +18383,28 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.8",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.8",
             ],
         ),
         "macos-arm64": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.8",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
-                ":libc-0.2.170",
+                ":libc-0.2.171",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.8",
             ],
@@ -18487,7 +18455,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -18810,7 +18778,7 @@ cargo.rust_library(
     deps = [
         ":bytes-1.10.1",
         ":futures-0.3.31",
-        ":libc-0.2.170",
+        ":libc-0.2.171",
         ":tokio-1.44.0",
         ":vsock-0.3.0",
     ],
@@ -18842,7 +18810,7 @@ cargo.rust_library(
         ":bytes-1.10.1",
         ":futures-core-0.3.31",
         ":futures-sink-0.3.31",
-        ":http-1.2.0",
+        ":http-1.3.1",
         ":httparse-1.10.1",
         ":rand-0.8.5",
         ":ring-0.17.5",
@@ -18979,9 +18947,9 @@ cargo.rust_library(
         ":base64-0.22.1",
         ":bytes-1.10.1",
         ":h2-0.4.8",
-        ":http-1.2.0",
+        ":http-1.3.1",
         ":http-body-1.0.1",
-        ":http-body-util-0.1.2",
+        ":http-body-util-0.1.3",
         ":hyper-1.6.0",
         ":hyper-timeout-0.5.2",
         ":hyper-util-0.1.10",
@@ -19247,7 +19215,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -20144,7 +20112,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":libc-0.2.170",
+        ":libc-0.2.171",
         ":nix-0.24.3",
     ],
 )
@@ -20582,7 +20550,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -20605,7 +20573,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -20628,24 +20596,28 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "windows-registry-0.2.0.crate",
-    sha256 = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0",
-    strip_prefix = "windows-registry-0.2.0",
-    urls = ["https://static.crates.io/crates/windows-registry/0.2.0/download"],
+    name = "windows-registry-0.4.0.crate",
+    sha256 = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3",
+    strip_prefix = "windows-registry-0.4.0",
+    urls = ["https://static.crates.io/crates/windows-registry/0.4.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "windows-registry-0.2.0",
-    srcs = [":windows-registry-0.2.0.crate"],
+    name = "windows-registry-0.4.0",
+    srcs = [":windows-registry-0.4.0.crate"],
     crate = "windows_registry",
-    crate_root = "windows-registry-0.2.0.crate/src/lib.rs",
+    crate_root = "windows-registry-0.4.0.crate/src/lib.rs",
     edition = "2021",
+    features = [
+        "default",
+        "std",
+    ],
     visibility = [],
     deps = [
-        ":windows-result-0.2.0",
-        ":windows-strings-0.1.0",
-        ":windows-targets-0.52.6",
+        ":windows-result-0.3.1",
+        ":windows-strings-0.3.1",
+        ":windows-targets-0.53.0",
     ],
 )
 
@@ -20672,50 +20644,41 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "windows-result-0.2.0.crate",
-    sha256 = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e",
-    strip_prefix = "windows-result-0.2.0",
-    urls = ["https://static.crates.io/crates/windows-result/0.2.0/download"],
+    name = "windows-result-0.3.1.crate",
+    sha256 = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189",
+    strip_prefix = "windows-result-0.3.1",
+    urls = ["https://static.crates.io/crates/windows-result/0.3.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "windows-result-0.2.0",
-    srcs = [":windows-result-0.2.0.crate"],
+    name = "windows-result-0.3.1",
+    srcs = [":windows-result-0.3.1.crate"],
     crate = "windows_result",
-    crate_root = "windows-result-0.2.0.crate/src/lib.rs",
+    crate_root = "windows-result-0.3.1.crate/src/lib.rs",
     edition = "2021",
-    features = [
-        "default",
-        "std",
-    ],
+    features = ["std"],
     visibility = [],
-    deps = [":windows-targets-0.52.6"],
+    deps = [":windows-link-0.1.0"],
 )
 
 http_archive(
-    name = "windows-strings-0.1.0.crate",
-    sha256 = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10",
-    strip_prefix = "windows-strings-0.1.0",
-    urls = ["https://static.crates.io/crates/windows-strings/0.1.0/download"],
+    name = "windows-strings-0.3.1.crate",
+    sha256 = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319",
+    strip_prefix = "windows-strings-0.3.1",
+    urls = ["https://static.crates.io/crates/windows-strings/0.3.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "windows-strings-0.1.0",
-    srcs = [":windows-strings-0.1.0.crate"],
+    name = "windows-strings-0.3.1",
+    srcs = [":windows-strings-0.3.1.crate"],
     crate = "windows_strings",
-    crate_root = "windows-strings-0.1.0.crate/src/lib.rs",
+    crate_root = "windows-strings-0.3.1.crate/src/lib.rs",
     edition = "2021",
-    features = [
-        "default",
-        "std",
-    ],
+    features = ["std"],
     visibility = [],
-    deps = [
-        ":windows-result-0.2.0",
-        ":windows-targets-0.52.6",
-    ],
+    deps = [":windows-link-0.1.0"],
 )
 
 http_archive(
@@ -20893,6 +20856,34 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "windows-targets-0.53.0.crate",
+    sha256 = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b",
+    strip_prefix = "windows-targets-0.53.0",
+    urls = ["https://static.crates.io/crates/windows-targets/0.53.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-targets-0.53.0",
+    srcs = [":windows-targets-0.53.0.crate"],
+    crate = "windows_targets",
+    crate_root = "windows-targets-0.53.0.crate/src/lib.rs",
+    edition = "2021",
+    platform = {
+        "linux-x86_64": dict(
+            deps = [":windows_x86_64_gnu-0.53.0"],
+        ),
+        "windows-gnu": dict(
+            deps = [":windows_x86_64_gnu-0.53.0"],
+        ),
+        "windows-msvc": dict(
+            deps = [":windows_x86_64_msvc-0.53.0"],
+        ),
+    },
+    visibility = [],
+)
+
+http_archive(
     name = "windows_x86_64_gnu-0.48.5.crate",
     sha256 = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e",
     strip_prefix = "windows_x86_64_gnu-0.48.5",
@@ -20927,6 +20918,23 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "windows_x86_64_gnu-0.53.0.crate",
+    sha256 = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba",
+    strip_prefix = "windows_x86_64_gnu-0.53.0",
+    urls = ["https://static.crates.io/crates/windows_x86_64_gnu/0.53.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows_x86_64_gnu-0.53.0",
+    srcs = [":windows_x86_64_gnu-0.53.0.crate"],
+    crate = "windows_x86_64_gnu",
+    crate_root = "windows_x86_64_gnu-0.53.0.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+)
+
+http_archive(
     name = "windows_x86_64_msvc-0.48.5.crate",
     sha256 = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538",
     strip_prefix = "windows_x86_64_msvc-0.48.5",
@@ -20956,6 +20964,23 @@ cargo.rust_library(
     srcs = [":windows_x86_64_msvc-0.52.6.crate"],
     crate = "windows_x86_64_msvc",
     crate_root = "windows_x86_64_msvc-0.52.6.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+)
+
+http_archive(
+    name = "windows_x86_64_msvc-0.53.0.crate",
+    sha256 = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486",
+    strip_prefix = "windows_x86_64_msvc-0.53.0",
+    urls = ["https://static.crates.io/crates/windows_x86_64_msvc/0.53.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows_x86_64_msvc-0.53.0",
+    srcs = [":windows_x86_64_msvc-0.53.0.crate"],
+    crate = "windows_x86_64_msvc",
+    crate_root = "windows_x86_64_msvc-0.53.0.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
 )
@@ -21224,7 +21249,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
         ":synstructure-0.13.1",
     ],
@@ -21343,7 +21368,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -21388,7 +21413,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
         ":synstructure-0.13.1",
     ],
@@ -21435,7 +21460,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )
@@ -21484,7 +21509,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":proc-macro2-1.0.94",
-        ":quote-1.0.39",
+        ":quote-1.0.40",
         ":syn-2.0.100",
     ],
 )

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+checksum = "4471bef4c22a06d2c7a1b6492493d3fdf24a805323109d6874f9c94d5906ac14"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -459,14 +459,14 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76dd04d39cc12844c0994f2c9c5a6f5184c22e9188ec1ff723de41910a21dcad"
+checksum = "0aff45ffe35196e593ea3b9dd65b320e51e2dda95aff4390bc459e461d09c6ad"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-http 0.60.12",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -506,14 +506,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.61.0"
+version = "1.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e65ff295979977039a25f5a0bf067a64bc5e6aa38f3cef4037cf42516265553c"
+checksum = "1d5330ad4e8a1ff49e9f26b738611caa72b105c41d41733801d1a36e8f9de936"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.61.1",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -528,14 +528,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.62.0"
+version = "1.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91430a60f754f235688387b75ee798ef00cfd09709a582be2b7525ebb5306d4f"
+checksum = "7956b1a85d49082347a7d17daa2e32df191f3e23c03d47294b99f95413026a78"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.61.1",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -550,14 +550,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.62.0"
+version = "1.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9276e139d39fff5a0b0c984fc2d30f970f9a202da67234f948fda02e5bea1dbe"
+checksum = "065c533fbe6f84962af33fcf02b0350b7c1f79285baab5924615d2be3b232855"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.61.1",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -573,12 +573,12 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.9"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bfe75fad52793ce6dec0dc3d4b1f388f038b5eb866c8d4d7f3a8e21b5ea5051"
+checksum = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http 0.60.12",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -586,7 +586,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "once_cell",
  "percent-encoding",
  "sha2",
@@ -603,26 +603,6 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.60.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
 ]
 
 [[package]]
@@ -657,7 +637,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 0.4.6",
  "once_cell",
  "percent-encoding",
@@ -719,7 +699,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "once_cell",
@@ -739,7 +719,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -757,7 +737,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -783,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbd0a668309ec1f66c0f6bda4840dd6d4796ae26d699ebc266d7cc95c6d040f"
+checksum = "3873f8deed8927ce8d04487630dc9ff73193bab64742a61d050e57a68dec4125"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -842,7 +822,7 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -885,7 +865,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -967,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d"
 
 [[package]]
 name = "bigdecimal"
@@ -1092,7 +1072,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-named-pipe",
@@ -1318,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1328,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1341,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2750,7 +2730,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http 1.3.1",
  "indexmap 2.8.0",
  "slab",
  "tokio",
@@ -2948,9 +2928,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -2975,18 +2955,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -3049,7 +3029,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2 0.4.8",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -3098,7 +3078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.23",
@@ -3132,7 +3112,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
  "pin-project-lite",
@@ -3484,9 +3464,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c163c633eb184a4ad2a5e7a5dacf12a58c830d717a7963563d4eceb4ced079f"
+checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
 dependencies = [
  "jiff-static",
  "log",
@@ -3497,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc3e0019b0f5f43038cf46471b1312136f29e36f54436c6042c8f155fec8789"
+checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3613,9 +3593,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libloading"
@@ -4199,7 +4179,7 @@ checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
 dependencies = [
  "async-trait",
  "futures-core",
- "http 1.2.0",
+ "http 1.3.1",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -4866,9 +4846,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -5148,15 +5128,15 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "389a89e494bbc88bebf30e23da98742c843863a16a352647716116aa71fae80a"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
@@ -6030,7 +6010,7 @@ version = "0.1.1"
 source = "git+https://github.com/systeminit/spicedb-client.git?branch=si-stable#38f5f8388077a9dcb345ca84c5b188bf62d5370c"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
  "prost",
  "prost-types",
  "spicedb-grpc",
@@ -6945,7 +6925,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http 1.3.1",
  "httparse",
  "rand 0.8.5",
  "ring",
@@ -7002,7 +6982,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2 0.4.8",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
@@ -7716,13 +7696,13 @@ checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.2.0",
+ "windows-result 0.3.1",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -7736,21 +7716,20 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -7804,11 +7783,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -7824,6 +7819,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7834,6 +7835,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7848,10 +7855,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7866,6 +7885,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7876,6 +7901,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7890,6 +7921,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7900,6 +7937,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -32,8 +32,8 @@ async-nats = { version = "0.39.0", features = ["service"] }
 async-openai = "0.26.0"
 async-recursion = "1.1.1"
 async-trait = "0.1.83"
-aws-config = { version = "1.5.10", features = ["behavior-version-latest"] }
-aws-sdk-firehose = "1.56.0"
+aws-config = { version = "=1.5.18", features = ["behavior-version-latest"] } # pinned because very next version (1.6.0) starts pulling in `aws-lc-rs`/`aws-lc-sys` which include native C code
+aws-sdk-firehose = "=1.68.0" # pinned because very next version (1.69.0) starts pulling in `aws-lc-rs`/`aws-lc-sys` which include native C code
 axum = { version = "0.6.20", features = [
     "macros",
     "multipart",


### PR DESCRIPTION
This change pins the AWS-related crates, only used in the `lib/data-warehouse-stream-client` crate, used by Forklift. The next versions of `aws-config` (i.e. [1.6.0][aws-config-1.6.0]) and `aws-sdk-firehose` (i.e. [1.69.0][aws-sdk-firehose-1.69.0]) pull in HTTP clients that use the [aws-lc-rs] crate which contains native C code which would need to be built via Buck2.

Porting the 900-line [build script] is going to take some effort and won't be a quick solve...

[aws-config-1.6.0]: https://crates.io/crates/aws-config/1.6.0
[aws-sdk-firehose-1.69.0]: https://crates.io/crates/aws-sdk-firehose/1.69.0
[aws-lc-rs]: https://github.com/aws/aws-lc-rs
[build script]: https://github.com/aws/aws-lc-rs/blob/main/aws-lc-sys/builder/main.rs

<img src="https://media1.giphy.com/media/3o9bJX4O9ShW1L32eY/giphy.gif?cid=bd3ea57es93l5abhq8p0r3rbo6h78j7igyzqbmn56ej7fwfe&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>