### PR TITLE
feat: add a `SIGQUIT` listener that writes a Tokio tasks report file

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+[target.'cfg(target_os = "linux")']
+rustflags = [
+    "--cfg", "tokio_taskdump",
+    "--cfg", "tokio_unstable",
+]
+
+[target.'cfg(not(target_os = "linux"))']
+rustflags = [
+    "--cfg", "tokio_unstable",
+]

--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,18 @@
+# Add Tokio unstable `--cfg` options when compiling Rust code.
+#
+# Setting this in an environment variable ensures that all `cargo` and
+# `rust-analyzer` commands gets this value.
+#
+# See: https://doc.rust-lang.org/cargo/reference/environment-variables.html
+case "$(uname -s)" in
+  Linux)
+    export RUSTFLAGS="--cfg tokio_taskdump --cfg tokio_unstable"
+    ;;
+  *)
+    export RUSTFLAGS="--cfg tokio_unstable"
+    ;;
+esac
+
 # Also load things from .env for developer-specific environment variables.
 dotenv_if_exists
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7703,6 +7703,7 @@ dependencies = [
 name = "telemetry-application"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "derive_builder",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ axum = { version = "0.6.20", features = [
     "multipart",
     "ws",
 ] } # todo: upgrade this alongside hyper/http/tokio-tungstenite
+backtrace = "0.3.71"
 base64 = "0.22.1"
 blake3 = "1.5.5"
 bollard = "0.18.1"

--- a/flake.nix
+++ b/flake.nix
@@ -176,7 +176,7 @@
         '',
         extraBuildPhase ? "",
         installPhase,
-        dontStrip ? false,
+        dontStrip ? true,
         dontPatchELF ? false,
         dontAutoPatchELF ? false,
         postFixup ? "",
@@ -256,7 +256,7 @@
         pkgName,
         extraBuildPhase ? "",
         extraInstallPhase ? "",
-        dontStrip ? false,
+        dontStrip ? true,
         dontPatchELF ? false,
         dontAutoPatchELF ? false,
       }: (buck2Derivation {

--- a/lib/telemetry-application-rs/BUCK
+++ b/lib/telemetry-application-rs/BUCK
@@ -4,6 +4,7 @@ rust_library(
     name = "telemetry-application",
     deps = [
         "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:chrono",
         "//third-party/rust:derive_builder",
         "//third-party/rust:opentelemetry-otlp",
         "//third-party/rust:opentelemetry-semantic-conventions",
@@ -20,4 +21,9 @@ rust_library(
         "CARGO_PKG_VERSION": "0.1.0",
     },
     srcs = glob(["src/**/*.rs"]),
+)
+
+alias(
+    name = "telemetry-application-rs",
+    actual = ":telemetry-application",
 )

--- a/lib/telemetry-application-rs/Cargo.toml
+++ b/lib/telemetry-application-rs/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
+chrono = { workspace = true }
 derive_builder = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }

--- a/lib/telemetry-rs/src/lib.rs
+++ b/lib/telemetry-rs/src/lib.rs
@@ -179,6 +179,7 @@ pub trait TelemetryLevel: Send + Sync {
 /// A telemetry client which holds handles to a process' tracing and OpenTelemetry setup.
 #[derive(Clone, Debug)]
 pub struct ApplicationTelemetryClient {
+    service_name: Box<str>,
     app_modules: Arc<Vec<&'static str>>,
     interesting_modules: Arc<Vec<&'static str>>,
     never_modules: Arc<Vec<&'static str>>,
@@ -188,6 +189,7 @@ pub struct ApplicationTelemetryClient {
 
 impl ApplicationTelemetryClient {
     pub fn new(
+        service_name: Box<str>,
         app_modules: Vec<&'static str>,
         interesting_modules: Vec<&'static str>,
         never_modules: Vec<&'static str>,
@@ -195,12 +197,17 @@ impl ApplicationTelemetryClient {
         update_telemetry_tx: mpsc::UnboundedSender<TelemetryCommand>,
     ) -> Self {
         Self {
+            service_name,
             app_modules: Arc::new(app_modules),
             interesting_modules: Arc::new(interesting_modules),
             never_modules: Arc::new(never_modules),
             tracing_level: Arc::new(Mutex::new(tracing_level)),
             update_telemetry_tx,
         }
+    }
+
+    pub fn service_name(&self) -> &str {
+        &self.service_name
     }
 
     pub async fn set_verbosity_and_wait(&mut self, updated: Verbosity) -> Result<(), ClientError> {

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -1965,6 +1965,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "backtrace",
+    actual = ":backtrace-0.3.71",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "backtrace-0.3.71.crate",
     sha256 = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d",
@@ -17813,6 +17819,7 @@ cargo.rust_binary(
         ":aws-config-1.5.18",
         ":aws-sdk-firehose-1.68.0",
         ":axum-0.6.20",
+        ":backtrace-0.3.71",
         ":base64-0.22.1",
         ":blake3-1.6.1",
         ":bollard-0.18.1",
@@ -18382,50 +18389,80 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
+            rustc_flags = [
+                "--cfg=tokio_taskdump",
+                "--cfg=tokio_track_caller",
+                "--cfg=tokio_unstable",
+            ],
             deps = [
+                ":backtrace",
                 ":libc-0.2.171",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.8",
+                ":tracing",
             ],
         ),
         "linux-x86_64": dict(
+            rustc_flags = [
+                "--cfg=tokio_taskdump",
+                "--cfg=tokio_track_caller",
+                "--cfg=tokio_unstable",
+            ],
             deps = [
+                ":backtrace",
                 ":libc-0.2.171",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.8",
+                ":tracing",
             ],
         ),
         "macos-arm64": dict(
+            rustc_flags = [
+                "--cfg=tokio_track_caller",
+                "--cfg=tokio_unstable",
+            ],
             deps = [
                 ":libc-0.2.171",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.8",
+                ":tracing",
             ],
         ),
         "macos-x86_64": dict(
+            rustc_flags = [
+                "--cfg=tokio_track_caller",
+                "--cfg=tokio_unstable",
+            ],
             deps = [
                 ":libc-0.2.171",
                 ":signal-hook-registry-1.4.2",
                 ":socket2-0.5.8",
+                ":tracing",
             ],
         ),
         "windows-gnu": dict(
+            rustc_flags = [
+                "--cfg=tokio_track_caller",
+                "--cfg=tokio_unstable",
+            ],
             deps = [
                 ":socket2-0.5.8",
+                ":tracing",
                 ":windows-sys-0.52.0",
             ],
         ),
         "windows-msvc": dict(
+            rustc_flags = [
+                "--cfg=tokio_track_caller",
+                "--cfg=tokio_unstable",
+            ],
             deps = [
                 ":socket2-0.5.8",
+                ":tracing",
                 ":windows-sys-0.52.0",
             ],
         ),
     },
-    rustc_flags = [
-        "--cfg=tokio_track_caller",
-        "--cfg=tokio_unstable",
-    ],
     visibility = [],
     deps = [
         ":bytes-1.10.1",
@@ -18433,7 +18470,6 @@ cargo.rust_library(
         ":parking_lot-0.12.3",
         ":pin-project-lite-0.2.16",
         ":tokio-macros-2.5.0",
-        ":tracing",
     ],
 )
 

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -6482,6 +6482,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-firehose",
  "axum 0.6.20",
+ "backtrace",
  "base64 0.22.1",
  "blake3",
  "bollard",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -39,6 +39,7 @@ axum = { version = "0.6.20", features = [
     "multipart",
     "ws",
 ] } # todo: upgrade this alongside hyper/http/tokio-tungstenite
+backtrace = "0.3.71"
 base64 = "0.22.1"
 blake3 = "1.5.5"
 bollard = "0.18.1"

--- a/third-party/rust/fixups/tokio/fixups.toml
+++ b/third-party/rust/fixups/tokio/fixups.toml
@@ -4,11 +4,27 @@
 # commit-date: 2022-12-01T03:10:27-0800
 # source: https://github.com/facebook/buck2/blob/9080cce1b8588afc08e5c9d53d22c652f7567ecf/shim/third-party/rust/fixups/tokio/fixups.toml
 
-cfgs = ["tokio_unstable", "tokio_track_caller"]
-
 extra_srcs = ["src/**/*.rs"]
 
 buildscript = []
 features = ["tokio_track_caller"]
 
-extra_deps = [ ":tracing" ]
+[platform_fixup.'cfg(target_os = "linux")']
+cfgs = [
+    "tokio_taskdump",
+    "tokio_track_caller",
+    "tokio_unstable",
+]
+extra_deps = [
+    ":backtrace",
+    ":tracing",
+]
+
+[platform_fixup.'cfg(not(target_os = "linux"))']
+cfgs = [
+    "tokio_track_caller",
+    "tokio_unstable",
+]
+extra_deps = [
+    ":tracing",
+]

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -62,7 +62,10 @@ system_rust_toolchain(
     visibility = ["PUBLIC"],
     rustc_flags = [
         "-Copt-level=3",
-        "-Cdebuginfo=none",
+        # https://doc.rust-lang.org/cargo/reference/profiles.html#debug
+        "-Cdebuginfo=line-tables-only",
+        # https://doc.rust-lang.org/cargo/reference/profiles.html#strip
+        "-Cstrip=none",
         "-Cdebug-assertions=false",
         "-Coverflow-checks=false",
         "-Clto=false",


### PR DESCRIPTION
This change adds a signal listener to all Rust `bin/*` binaries, that upon receiving a `SIGQUIT` signal, will write a "process report" file to the temp file system, named with the service name and second-resolution timestamp. This report currently prints a trace for every currently spawned task on the main Tokio runtime.

The file looks something like this (appologies for the Markdown escapes, it's the only way to render in a Git commit message *and* GitHub PR message without being dropped):

```
\# veritech Report (2025-03-12T16:59:18Z)

\## Tokio Task Traces

\### Task 0 Trace
\```
╼ <core::pin::Pin<P> as core::future::future::Future>::poll at /nix/store/yxdqfnnr48j8m5h00806i4l2vqi4fiyr-rust-default-1.84.1/lib/rustlib/src/rust/library/core/src/future/future.rs:124:9
  └╼ <tower::buffer::worker::Worker<T,Request> as core::future::future::Future>::poll at ./third-party/rust/tower-0.4.13.crate/src/buffer/worker.rs:181:26
     └╼ tower::buffer::worker::Worker<T,Request>::poll_next_msg at ./third-party/rust/tower-0.4.13.crate/src/buffer/worker.rs:122:38
        └╼ tokio::sync::mpsc::unbounded::UnboundedReceiver<T>::poll_recv at ./third-party/rust/tokio-1.44.0.crate/src/sync/mpsc/unbounded.rs:432:9
           └╼ tokio::sync::mpsc::chan::Rx<T,S>::recv at ./third-party/rust/tokio-1.44.0.crate/src/sync/mpsc/chan.rs:292:16
\```

\### Task 1 Trace
\```
╼ <core::pin::Pin<P> as core::future::future::Future>::poll at /nix/store/yxdqfnnr48j8m5h00806i4l2vqi4fiyr-rust-default-1.84.1/lib/rustlib/src/rust/library/core/src/future/future.rs:124:9
  └╼ opentelemetry_sdk::trace::span_processor::BatchSpanProcessor<R>::new::{{closure}} at ./third-party/rust/opentelemetry_sdk-0.26.0.crate/src/trace/span_processor.rs:474:37
     └╼ opentelemetry_sdk::trace::span_processor::BatchSpanProcessorInternal<R>::run::{{closure}} at ./third-party/rust/opentelemetry_sdk-0.26.0.crate/src/trace/span_processor.rs:428:13
        └╼ <futures_util::future::poll_fn::PollFn<F> as core::future::future::Future>::poll at ./third-party/rust/futures-util-0.3.31.crate/src/future/poll_fn.rs:56:9
           └╼ opentelemetry_sdk::trace::span_processor::BatchSpanProcessorInternal<R>::run::{{closure}}::{{closure}} at ./third-party/rust/futures-util-0.3.31.crate/src/async_await/select_mod.rs:323:13
              └╼ core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut at /nix/store/yxdqfnnr48j8m5h00806i4l2vqi4fiyr-rust-default-1.84.1/lib/rustlib/src/rust/library/core/src/ops/function.rs:294:13
 
...snip...
```

The file created is determined by using the `TMPDIR`/`TMP`/`TEMP` environment variables first, falling back to `/tmp` and would be named something like:

````
/tmp/veritech.report.2025-03-12T16:59:18Z.md
````

Note that in our Nix development environment, it's more likely that the file would be something like:

````
/tmp/nix-shell.LnbroP/nix-shell.Exe6tX/veritech.report.2025-03-12T16:59:18Z.md
````

The main process will emit an `info` line to confirm that a report file is being written out and have its filename there so an operator can find which report file was generated at which point in time.

Final note: this report is only supported on Linux systems. On macOS an `info` line is emitted to remind its user that this only works on Linux.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMGRkYXk0cWR3dHNsZ3R5MzJ0Mnoxc3cwdGpnZWQyMTZwczRhdXV4YSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/SEWEmCymjv8XDbsb8I/giphy.gif"/>