### PR TITLE
feat(hoist, clover): Make props more similar to the shapes the take when created by rust

### DIFF
--- a/bin/clover/src/spec/props.ts
+++ b/bin/clover/src/spec/props.ts
@@ -158,7 +158,9 @@ export function createDefaultPropFromCf(
   }
 
   // Top level prop doesn't actually get the generated doc; we add that to the schema instead
-  rootProp.data.hidden = null;
+  rootProp.data.inputs = null;
+  rootProp.data.widgetOptions = null;
+  rootProp.data.hidden = false;
   rootProp.data.documentation = null;
 
   return rootProp;
@@ -553,7 +555,7 @@ export function createObjectProp(
     inputs: [],
     widgetKind: "Header",
     widgetOptions: [],
-    hidden: null,
+    hidden: false,
     docLink: null,
     documentation: null,
   };
@@ -603,7 +605,7 @@ export function createScalarProp(
     inputs: [],
     widgetKind,
     widgetOptions: null,
-    hidden: null,
+    hidden: false,
     docLink: null,
     documentation: null,
   };

--- a/bin/clover/src/specPipeline.ts
+++ b/bin/clover/src/specPipeline.ts
@@ -52,7 +52,7 @@ export function pkgSpecFromCf(cfSchema: CfSchema): ExpandedPkgSpec {
       version,
       link: createDocLink(cfSchema, undefined),
       color: "#FF9900",
-      displayName: name,
+      displayName: null, // siPkg does not store this
       componentType: "component",
       funcUniqueId: assetFuncUniqueKey,
       description: cfSchema.description,


### PR DESCRIPTION
- Correct the way in which hoist is hashing modules locally
- Prop inputs and widgetOptions for root props now start as null instead of empty arrays
- Added a new diffing strategies to take schema changes
