### PR TITLE
feat(web) - diagram drag layer

### DIFF
--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -14,6 +14,7 @@ const FLAG_MAPPING = {
   DIAGRAM_OPTIMIZATION_2: "diagram-optimization-2",
   AUTOCONNECT: "autoconnect-component-input-sockets",
   PRIVATE_SCOPED_MODULES: "private-scoped-modules",
+  DIAGRAM_DRAG_LAYER: "diagram-drag-layer",
 };
 
 const WORKSPACE_FLAG_MAPPING = {


### PR DESCRIPTION
<img src="https://media2.giphy.com/media/QgryIwRN08U7AxcALh/giphy.gif?cid=bd3ea57e06748mw75vhlcsh8cvr3zd30h2i9z8jyfxqyo8c7&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>

Diagram components (nodes, groups, and views) are now rendered in two separate groups - static components on one layer, and components that are being dragged around by the user on another layer.