### PR TITLE
fix(auth-api): Prevent sending multiple transactional emails when removing a user

### DIFF
--- a/bin/auth-api/src/routes/workspace.routes.ts
+++ b/bin/auth-api/src/routes/workspace.routes.ts
@@ -315,15 +315,15 @@ router.delete("/workspace/:workspaceId/members", async (ctx) => {
       role: wm.roleType,
       signupAt: wm.user.signupAt,
     });
+  });
 
-    tracker.trackEvent(authUser, "workspace_user_removed_v2", {
-      workspaceId: workspace.id,
-      workspaceName: workspace.displayName,
-      initiatedBy: authUser.email,
-      memberUserName: reqBody.email,
-      memberChangedAt: new Date(),
-      newPermissionLevel: "No Access",
-    });
+  tracker.trackEvent(authUser, "workspace_user_removed_v2", {
+    workspaceId: workspace.id,
+    workspaceName: workspace.displayName,
+    initiatedBy: authUser.email,
+    memberUserName: reqBody.email,
+    memberChangedAt: new Date(),
+    newPermissionLevel: "No Access",
   });
 
   ctx.body = members;


### PR DESCRIPTION
The tracking event was happening in the for list for the users so removing a user from a workspace with 5 emails - 4 emails to the user being removed