### PR TITLE
fix(dal): Don't error when finding Attribute Values for components that are being deleted

### DIFF
--- a/lib/dal/tests/integration_test/component/delete.rs
+++ b/lib/dal/tests/integration_test/component/delete.rs
@@ -969,6 +969,379 @@ async fn delete_with_frames_and_resources(ctx: &mut DalContext) {
 }
 
 #[test]
+async fn delete_with_multiple_frames(ctx: &mut DalContext) {
+    ChangeSetTestHelpers::fork_from_head_change_set(ctx)
+        .await
+        .expect("could not fork head");
+    // create a frame
+    let outer_frame = create_component_for_schema_name_with_type_on_default_view(
+        ctx,
+        "large odd lego",
+        "large odd",
+        ComponentType::ConfigurationFrameDown,
+    )
+    .await
+    .expect("could not create component");
+    let outer_frame_id = outer_frame.id();
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+    // cache id to use throughout the test
+
+    // set a value on the outer frame that will pass to the component
+    update_attribute_value_for_component(
+        ctx,
+        outer_frame_id,
+        &["root", "domain", "six"],
+        serde_json::json!["6"],
+    )
+    .await
+    .expect("could not set attribute value");
+
+    let resource_data = ResourceData::new(
+        ResourceStatus::Ok,
+        Some(serde_json::json![{"resource": "something"}]),
+    );
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit and update snapshot to visibility");
+    // create 2 other frames that won't pass data
+    let inner_frame_1 = create_component_for_schema_name_with_type_on_default_view(
+        ctx,
+        "swifty",
+        "swifty",
+        ComponentType::ConfigurationFrameDown,
+    )
+    .await
+    .expect("could not create component");
+
+    let inner_frame_1_id = inner_frame_1.id();
+    let inner_frame_2 = create_component_for_schema_name_with_type_on_default_view(
+        ctx,
+        "swifty",
+        "swifty 2",
+        ComponentType::ConfigurationFrameDown,
+    )
+    .await
+    .expect("could not create component");
+
+    let inner_frame_id_2 = inner_frame_2.id();
+
+    Frame::upsert_parent(ctx, inner_frame_1.id(), outer_frame.id())
+        .await
+        .expect("could not upsert frame");
+    Frame::upsert_parent(ctx, inner_frame_2.id(), outer_frame.id())
+        .await
+        .expect("could not upsert frame");
+
+    // create 2 components that take input from the top most, in each inner frame
+    let component_1 = create_component_for_schema_name_with_type_on_default_view(
+        ctx,
+        "large even lego",
+        "large even",
+        ComponentType::Component,
+    )
+    .await
+    .expect("could not create component");
+    component_1
+        .set_resource(ctx, resource_data.clone())
+        .await
+        .expect("could not set resource");
+    let component_1_id = component_1.id();
+
+    Frame::upsert_parent(ctx, component_1_id, inner_frame_1.id())
+        .await
+        .expect("could not upsert frame");
+
+    let component_2 = create_component_for_schema_name_with_type_on_default_view(
+        ctx,
+        "large even lego",
+        "large even 2",
+        ComponentType::Component,
+    )
+    .await
+    .expect("could not create component");
+    component_2
+        .set_resource(ctx, resource_data)
+        .await
+        .expect("could not set resource");
+    let component_2_id = component_2.id();
+
+    Frame::upsert_parent(ctx, component_2_id, inner_frame_2.id())
+        .await
+        .expect("could not upsert frame");
+
+    // let's remove all create actions and set the resource manually to simulate create + refresh
+    let all_actions = Action::list_topologically(ctx)
+        .await
+        .expect("could not get actions");
+    for action in all_actions {
+        Action::remove_by_id(ctx, action)
+            .await
+            .expect("could not remove action");
+    }
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit");
+
+    // make sure values propagated accordingly
+    let component_1_av_six = get_component_input_socket_value(ctx, component_2_id, "six")
+        .await
+        .expect("could not get socket value")
+        .expect("should have a value");
+    assert_eq!(component_1_av_six, "6");
+    let component_2_av_six = get_component_input_socket_value(ctx, component_2_id, "six")
+        .await
+        .expect("could not get socket value")
+        .expect("should have a value");
+    assert_eq!(component_2_av_six, "6");
+
+    // Apply to the base change set to simulate running actions
+    assert!(ctx
+        .parent_is_head()
+        .await
+        .expect("could not perform parent is head"));
+
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx)
+        .await
+        .expect("could not apply change set");
+
+    // check that the resource is not set for the outer most frame
+    let outer_frame = Component::get_by_id(ctx, outer_frame_id)
+        .await
+        .expect("could not get component");
+    assert!(outer_frame
+        .resource(ctx)
+        .await
+        .expect("could not get resource")
+        .is_none());
+
+    // both inner components have resources
+    let component_1 = Component::get_by_id(ctx, component_2_id)
+        .await
+        .expect("could not get component");
+    let component_1_resource = component_1
+        .resource(ctx)
+        .await
+        .expect("could not get resource");
+    assert!(component_1_resource.is_some());
+    let resource_1 = component_1_resource.expect("is some");
+    assert_eq!(
+        resource_1.payload,
+        Some(serde_json::json![{"resource": "something"}])
+    );
+    assert_eq!(resource_1.status, ResourceStatus::Ok);
+
+    let component_1 = Component::get_by_id(ctx, component_1_id)
+        .await
+        .expect("could not get component");
+    let component_1_resource = component_1
+        .resource(ctx)
+        .await
+        .expect("could not get resource");
+    assert!(component_1_resource.is_some());
+    let resource_1 = component_1_resource.expect("is some");
+    assert_eq!(
+        resource_1.payload,
+        Some(serde_json::json![{"resource": "something"}])
+    );
+    assert_eq!(resource_1.status, ResourceStatus::Ok);
+
+    // check there's no resource for both inner frames
+    let inner_frame_1 = Component::get_by_id(ctx, inner_frame_1_id)
+        .await
+        .expect("coudl not get component");
+    assert!(inner_frame_1
+        .resource(ctx)
+        .await
+        .expect("could not get resource")
+        .is_none());
+    let inner_frame_2 = Component::get_by_id(ctx, inner_frame_id_2)
+        .await
+        .expect("coudl not get component");
+    assert!(inner_frame_2
+        .resource(ctx)
+        .await
+        .expect("could not get resource")
+        .is_none());
+
+    // Fork Head
+    ChangeSetTestHelpers::fork_from_head_change_set(ctx)
+        .await
+        .expect("could not fork head");
+
+    // delete all components (as if you deleted the parent in sdf)
+    // ensure everything is set to delete
+    let outer_frame = Component::get_by_id(ctx, outer_frame_id)
+        .await
+        .expect("could not get component");
+    let deleted_outer = outer_frame
+        .delete(ctx)
+        .await
+        .expect("could not delete component");
+    assert!(deleted_outer.is_some());
+
+    let inner_frame_1 = Component::get_by_id(ctx, inner_frame_1_id)
+        .await
+        .expect("could not get component");
+    let deleted_inner_1 = inner_frame_1
+        .delete(ctx)
+        .await
+        .expect("could not delete component");
+    assert!(deleted_inner_1.is_some());
+
+    let inner_frame_2 = Component::get_by_id(ctx, inner_frame_id_2)
+        .await
+        .expect("could not get component");
+    let deleted_inner_1 = inner_frame_2
+        .delete(ctx)
+        .await
+        .expect("could not delete component");
+    assert!(deleted_inner_1.is_some());
+
+    let component_1 = Component::get_by_id(ctx, component_1_id)
+        .await
+        .expect("could not get component");
+    let deleted_component_1 = component_1
+        .delete(ctx)
+        .await
+        .expect("could not delete component")
+        .expect("is some");
+
+    assert!(&deleted_component_1.to_delete());
+
+    let component_2 = Component::get_by_id(ctx, component_2_id)
+        .await
+        .expect("could not get component");
+    let deleted_component_2 = component_2
+        .delete(ctx)
+        .await
+        .expect("could not delete component")
+        .expect("is some");
+
+    assert!(&deleted_component_2.to_delete());
+
+    let components_to_delete = Component::list_to_be_deleted(ctx)
+        .await
+        .expect("could not list components to be deleted");
+    assert_eq!(components_to_delete.len(), 5);
+
+    // make sure values propagated accordingly
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit");
+    let component_av_six_1 = get_component_input_socket_value(ctx, component_1_id, "six")
+        .await
+        .expect("could not get socket value")
+        .expect("should have a value");
+    assert_eq!(component_av_six_1, "6");
+
+    let component_av_six_2 = get_component_input_socket_value(ctx, component_2_id, "six")
+        .await
+        .expect("could not get socket value")
+        .expect("should have a value");
+    assert_eq!(component_av_six_2, "6");
+
+    // make sure there are 5 components on the diagram
+    let all_components = Component::list(ctx)
+        .await
+        .expect("could not list components");
+    assert_eq!(all_components.len(), 5);
+
+    // now manually remove the resource of all of the frames and dequeue their actions (so only the inner 2 component's delete action has to run)
+    let outer_frame = Component::get_by_id(ctx, outer_frame_id)
+        .await
+        .expect("could not get component");
+    outer_frame
+        .clear_resource(ctx)
+        .await
+        .expect("could not clear the resource");
+    // dequeue the delete actions for this component
+    let actions_for_outer = Action::find_for_component_id(ctx, outer_frame_id)
+        .await
+        .expect("could not list actions for outer frame");
+    assert_eq!(actions_for_outer.len(), 1);
+    Action::remove_all_for_component_id(ctx, outer_frame_id)
+        .await
+        .expect("could not remove actions");
+    let actions_for_inner_1 = Action::find_for_component_id(ctx, inner_frame_1_id)
+        .await
+        .expect("could not find actions for inner frame");
+    assert_eq!(actions_for_inner_1.len(), 1);
+    Action::remove_all_for_component_id(ctx, inner_frame_1_id)
+        .await
+        .expect("could not remove actions for inner");
+    let actions_for_inner_2 = Action::find_for_component_id(ctx, inner_frame_id_2)
+        .await
+        .expect("could not find actions for inner frame");
+    assert_eq!(actions_for_inner_2.len(), 1);
+    Action::remove_all_for_component_id(ctx, inner_frame_id_2)
+        .await
+        .expect("could not remove actions for inner");
+
+    // should only be two actions left for the components
+    let actions_enqueued = Action::list_topologically(ctx)
+        .await
+        .expect("could not list actions");
+    assert_eq!(actions_enqueued.len(), 2);
+    for action_id in actions_enqueued {
+        let action = Action::get_by_id(ctx, action_id)
+            .await
+            .expect("couldn't get action");
+        assert_eq!(action.is_eligible_to_dispatch(), true);
+    }
+
+    // make sure values are still propagated accordingly
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("could not commit");
+    let component_av_six = get_component_input_socket_value(ctx, component_2_id, "six")
+        .await
+        .expect("could not get socket value")
+        .expect("should have a value");
+    assert_eq!(component_av_six, "6");
+
+    let component_av_six = get_component_input_socket_value(ctx, component_1_id, "six")
+        .await
+        .expect("could not get socket value")
+        .expect("should have a value");
+    assert_eq!(component_av_six, "6");
+
+    // apply and let the two delete actions run
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx)
+        .await
+        .expect("could not apply to head");
+    ChangeSetTestHelpers::wait_for_actions_to_run(ctx)
+        .await
+        .expect("could not run actions");
+    // loop until the other components are removed
+    let total_count = 50;
+    let mut count = 0;
+
+    while count < total_count {
+        ctx.update_snapshot_to_visibility()
+            .await
+            .expect("could not update snapshot");
+        let components = Component::list(ctx)
+            .await
+            .expect("could not list components");
+        if components.is_empty() {
+            break;
+        }
+        count += 1;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let components = Component::list(ctx)
+        .await
+        .expect("could not list components");
+    // make sure there are no more components left!
+    assert_eq!(components.len(), 0);
+}
+
+#[test]
 async fn delete_multiple_components(ctx: &mut DalContext) {
     ChangeSetTestHelpers::fork_from_head_change_set(ctx)
         .await


### PR DESCRIPTION
To clean up frames during destroy actions, we check to see if the frame has a resource by finding the attribute value for `root/resource` by prop path. If there are multiple components for the same schema variant, and one has been deleted, but the snapshot hasn't been cleaned up, we'll stumble on the attribute value for that deleted component and returning an error, causing the component we're trying to delete to remain, leaving ghosted frames incorrectly.

I debated cleaning up the snapshot when the component is deleted, but figured there are other sneaky instances where we're looking for a specific attribute value for a component and there could be deleted components in that snapshot of the same kind. 

<div><img src="https://media2.giphy.com/media/uUJdyR6h1zPHvPROSC/giphy.gif?cid=5a38a5a28k8apcpbingbdbm44mnxezsr09r0xspr1bn8rn9r&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/cbc/">CBC</a> on <a href="https://giphy.com/gifs/cbc-schittscreek-schitts-creek-uUJdyR6h1zPHvPROSC">GIPHY</a></div>