### PR TITLE
fix(auth-api): More elegant solution for removing a user from a workspace

### DIFF
--- a/bin/auth-api/src/services/workspaces.service.ts
+++ b/bin/auth-api/src/services/workspaces.service.ts
@@ -6,7 +6,6 @@ import { ulid } from "ulidx";
 import { tracker } from "../lib/tracker";
 import {
   createInvitedUser,
-  getUserByEmail,
   getUserById,
   getUsersByEmail,
   UserId,
@@ -234,15 +233,10 @@ export async function inviteMember(
   });
 }
 
-export async function removeUser(email: string, workspaceId: WorkspaceId) {
-  const user = await getUserByEmail(email);
-  if (!user) {
-    return;
-  }
-
+export async function removeUser(userId: string, workspaceId: WorkspaceId) {
   const memberShip = await prisma.workspaceMembers.findFirst({
     where: {
-      userId: user.id,
+      userId,
       workspaceId,
     },
   });


### PR DESCRIPTION
In the old way, we would look up a user by email - we already have the users for the workspace so we can use that workspace membership and find the correct userPk to remove based on that membership list + then safely remove that user

We no longer generate transactional emails when a request to remove happens but the user doesn't get removed - lets say for something like multiple emails in the database for the same person