### PR TITLE
feat(sdf): Add inferred connections to incomingConnections in management funcs

### DIFF
--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -492,7 +492,7 @@ impl ExpectComponent {
             .await
     }
 
-    pub async fn list(ctx: &mut DalContext) -> Vec<ExpectComponent> {
+    pub async fn list(ctx: &DalContext) -> Vec<ExpectComponent> {
         Component::list_ids(ctx)
             .await
             .expect("list components")
@@ -501,7 +501,7 @@ impl ExpectComponent {
             .collect()
     }
 
-    pub async fn find_opt(ctx: &mut DalContext, name: impl AsRef<str>) -> Option<ExpectComponent> {
+    pub async fn find_opt(ctx: &DalContext, name: impl AsRef<str>) -> Option<ExpectComponent> {
         for component in ExpectComponent::list(ctx).await {
             if name.as_ref() == component.name(ctx).await {
                 return Some(component);
@@ -510,7 +510,7 @@ impl ExpectComponent {
         None
     }
 
-    pub async fn find(ctx: &mut DalContext, name: impl AsRef<str>) -> ExpectComponent {
+    pub async fn find(ctx: &DalContext, name: impl AsRef<str>) -> ExpectComponent {
         Self::find_opt(ctx, name)
             .await
             .expect("component not found")
@@ -526,7 +526,7 @@ impl ExpectComponent {
             .expect("get component by id")
     }
 
-    pub async fn name(&self, ctx: &mut DalContext) -> String {
+    pub async fn name(&self, ctx: &DalContext) -> String {
         Component::name_by_id(ctx, self.0)
             .await
             .expect("get component name")
@@ -575,6 +575,10 @@ impl ExpectComponent {
         let schema_variant = self.schema_variant(ctx).await;
         let prop_id = prop.lookup_prop(ctx, schema_variant.id()).await;
         ExpectComponentProp(self.0, prop_id)
+    }
+
+    pub async fn domain(self, ctx: &DalContext) -> Value {
+        self.prop(ctx, ["root", "domain"]).await.get(ctx).await
     }
 
     pub async fn connect(

--- a/lib/dal-test/src/test_exclusive_schemas/legos/small.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/legos/small.rs
@@ -273,7 +273,7 @@ pub(crate) async fn migrate_test_exclusive_schema_small_odd_lego(
     )?;
 
     // This will create a small even lego component and connect its inputs to everything
-    // conneted to the management component's "one" or "arity_one" sockets.
+    // connected to the management component's "one" or "arity_one" sockets.
     let create_and_connect_to_inputs_func = build_management_func(
         r#"
     async function main({ thisComponent, components }: Input): Promise<Output> {

--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -270,9 +270,9 @@ impl AttributePrototypeDebugView {
                     .await?
             {
                 // now get inferred func binding args and values!
-                for output_match in
-                    ComponentInputSocket::find_inferred_connections(ctx, component_input_socket)
-                        .await?
+                for output_match in component_input_socket
+                    .find_inferred_connections(ctx)
+                    .await?
                 {
                     let arg_used = Component::should_data_flow_between_components(
                         ctx,

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -1414,11 +1414,8 @@ impl FuncRunner {
                             input_socket_id,
                         )
                         .await?;
-                        if let Some(source_component_id) =
-                            ComponentInputSocket::find_connection_arity_one(
-                                ctx,
-                                component_input_socket,
-                            )
+                        if let Some(source_component_id) = component_input_socket
+                            .find_connection_arity_one(ctx)
                             .await?
                         {
                             work_queue.push_back(source_component_id);

--- a/lib/dal/src/socket/debug.rs
+++ b/lib/dal/src/socket/debug.rs
@@ -130,12 +130,12 @@ impl SocketDebugView {
         let path =
             (AttributeValue::get_path_for_id(ctx, attribute_value_id).await?).unwrap_or_default();
         let value_view = attribute_value.view(ctx).await?;
-        let inferred_connections =
-            ComponentInputSocket::find_inferred_connections(ctx, component_input_socket)
-                .await?
-                .into_iter()
-                .map(|output_socket| Ulid::from(output_socket.attribute_value_id))
-                .collect();
+        let inferred_connections = component_input_socket
+            .find_inferred_connections(ctx)
+            .await?
+            .into_iter()
+            .map(|output_socket| Ulid::from(output_socket.attribute_value_id))
+            .collect();
         let view = SocketDebugView {
             prototype_id,
             prototype_is_component_specific: prototype_debug_view.is_component_specific,

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -368,10 +368,10 @@ async fn simple_frames(ctx: &mut DalContext) {
                 .expect("couldn't get input sockets")
         {
             if component_input_socket.input_socket_id == swifty_input.id() {
-                let mut possible_match =
-                    ComponentInputSocket::find_inferred_connections(ctx, component_input_socket)
-                        .await
-                        .expect("couldn't find implicit inputs");
+                let mut possible_match = component_input_socket
+                    .find_inferred_connections(ctx)
+                    .await
+                    .expect("couldn't find implicit inputs");
                 assert!(!possible_match.is_empty());
                 let travis_output_match = possible_match.pop().expect("has a value");
                 //maybe_travis_output_socket = Some(travis_output);
@@ -455,10 +455,10 @@ async fn simple_frames(ctx: &mut DalContext) {
                 .expect("couldn't get input sockets")
         {
             if component_input_socket.input_socket_id == swifty_input.id() {
-                let possible_match =
-                    ComponentInputSocket::find_inferred_connections(ctx, component_input_socket)
-                        .await
-                        .expect("couldn't find implicit inputs");
+                let possible_match = component_input_socket
+                    .find_inferred_connections(ctx)
+                    .await
+                    .expect("couldn't find implicit inputs");
                 assert!(possible_match.is_empty());
             }
         }


### PR DESCRIPTION
This adds inferred connections to `thisComponent.incomingConnections` when running a management func. This means that if your management component lives inside an AWS Credential and Region (and has inferred connections to them because of parentage), your component will get those connections and be able to pass them on to components it creates or manages.

Refactor budget: updated paste.rs and management.rs tests to use `Result<>`

## Testing

* Tested manually with components in the UI
* Created management function in Subnet and verified it received AWS Credential and Region inferred connections
* Integration tests