### PR TITLE
chore(sdf): Give Schema::get_by_id/default_variant_id the good name

### DIFF
--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -230,18 +230,15 @@ impl ExpectSchema {
     }
 
     pub async fn schema(self, ctx: &DalContext) -> Schema {
-        Schema::get_by_id_or_error(ctx, self.0)
+        Schema::get_by_id(ctx, self.0)
             .await
             .expect("get schema by id")
     }
 
     pub async fn default_variant(self, ctx: &DalContext) -> ExpectSchemaVariant {
-        let schema = self.schema(ctx).await;
-        let schema_variant_id = schema
-            .get_default_schema_variant_id(ctx)
+        let schema_variant_id = Schema::default_variant_id(ctx, self.0)
             .await
-            .expect("get default variant id")
-            .expect("default variant exists");
+            .expect("get default variant id");
         ExpectSchemaVariant(schema_variant_id)
     }
 

--- a/lib/dal-test/src/helpers/change_set.rs
+++ b/lib/dal-test/src/helpers/change_set.rs
@@ -147,7 +147,7 @@ impl ChangeSetTestHelpers {
     pub async fn apply_change_set_to_base(ctx: &mut DalContext) -> Result<()> {
         // Lock all unlocked variants
         for schema_id in Schema::list_ids(ctx).await? {
-            let schema = Schema::get_by_id_or_error(ctx, schema_id).await?;
+            let schema = Schema::get_by_id(ctx, schema_id).await?;
             let Some(variant) = SchemaVariant::get_unlocked_for_schema(ctx, schema_id).await?
             else {
                 continue;
@@ -156,7 +156,7 @@ impl ChangeSetTestHelpers {
             let variant_id = variant.id();
 
             variant.lock(ctx).await?;
-            schema.set_default_schema_variant(ctx, variant_id).await?;
+            schema.set_default_variant_id(ctx, variant_id).await?;
         }
         // Lock all unlocked functions too
         for func in Func::list_for_default_and_editing(ctx).await? {

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -464,9 +464,7 @@ impl ChangeSet {
 
         // Lock all unlocked variants
         for schema_id in Schema::list_ids(ctx).await.map_err(Box::new)? {
-            let schema = Schema::get_by_id_or_error(ctx, schema_id)
-                .await
-                .map_err(Box::new)?;
+            let schema = Schema::get_by_id(ctx, schema_id).await.map_err(Box::new)?;
             let Some(variant) = SchemaVariant::get_unlocked_for_schema(ctx, schema_id)
                 .await
                 .map_err(Box::new)?
@@ -478,7 +476,7 @@ impl ChangeSet {
 
             variant.lock(ctx).await.map_err(Box::new)?;
             schema
-                .set_default_schema_variant(ctx, variant_id)
+                .set_default_variant_id(ctx, variant_id)
                 .await
                 .map_err(Box::new)?;
         }

--- a/lib/dal/src/management/prototype.rs
+++ b/lib/dal/src/management/prototype.rs
@@ -309,7 +309,7 @@ impl ManagementPrototype {
         }
 
         for schema_id in managed_schemas {
-            let schema_name = match Schema::get_by_id(ctx, schema_id).await? {
+            let schema_name = match Schema::get_by_id_opt(ctx, schema_id).await? {
                 Some(schema) => schema.name().to_owned(),
                 None => {
                     let Some(cached_module) =
@@ -531,7 +531,7 @@ impl ManagementPrototype {
         let mut variant_socket_map = HashMap::new();
         let schemas = Schema::list(ctx).await?;
         for schema in schemas {
-            let variant_id = schema.get_default_schema_variant_id(ctx).await?;
+            let variant_id = Schema::default_variant_id_opt(ctx, schema.id()).await?;
             if let Some(variant_id) = variant_id {
                 let (output_sockets, input_sockets) =
                     SchemaVariant::list_all_socket_ids(ctx, variant_id).await?;

--- a/lib/dal/src/module.rs
+++ b/lib/dal/src/module.rs
@@ -320,7 +320,7 @@ impl Module {
                     inner.content_address().into();
 
                 if inner_addr_discrim == ContentAddressDiscriminants::Schema {
-                    let schema = Schema::get_by_id_or_error(ctx, inner.id().into()).await?;
+                    let schema = Schema::get_by_id(ctx, inner.id().into()).await?;
                     all_schemas.push(schema);
                 }
             }

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -599,7 +599,7 @@ async fn import_schema_variants_for_imported_schema(
                 can_lock = false;
                 variant.unlock_asset_func_without_copy(ctx).await?;
             } else {
-                schema.set_default_schema_variant(ctx, variant_id).await?;
+                schema.set_default_variant_id(ctx, variant_id).await?;
             }
         }
 

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -357,9 +357,7 @@ impl VariantAuthoringClient {
             }
 
             if original_is_default {
-                schema
-                    .set_default_schema_variant(ctx, new_variant.id)
-                    .await?;
+                schema.set_default_variant_id(ctx, new_variant.id).await?;
             }
 
             // When we get here, "schema_variant_id" points to an unlocked variant with no components

--- a/lib/dal/tests/integration_test/attribute/prototype.rs
+++ b/lib/dal/tests/integration_test/attribute/prototype.rs
@@ -8,11 +8,9 @@ async fn find_for_prop(ctx: &mut DalContext) {
     let schema = Schema::get_by_name(ctx, "swifty")
         .await
         .expect("schema not found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("unable to get schema variant")
-        .expect("schema variant not found");
+        .expect("unable to get schema variant");
     let func_name = "test:generateCode";
 
     // Find the sole attribute prototype via its func. Ensure that we find one and only one.

--- a/lib/dal/tests/integration_test/audit_logging.rs
+++ b/lib/dal/tests/integration_test/audit_logging.rs
@@ -27,11 +27,9 @@ async fn round_trip(ctx: &mut DalContext, audit_database_context: AuditDatabaseC
     let schema = Schema::get_by_name(ctx, "swifty")
         .await
         .expect("schema not found by name");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("could not get default schema variant id")
-        .expect("no default schema variant id found");
+        .expect("could not get default schema variant id");
     let schema_variant = SchemaVariant::get_by_id_or_error(ctx, schema_variant_id)
         .await
         .expect("could not get schema variant");

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -153,7 +153,7 @@ async fn create_and_determine_lineage(ctx: &DalContext) -> Result<()> {
     let schema = schemas.pop().expect("schemas are empty");
 
     // Ensure we can get it by id.
-    let found_schema = Schema::get_by_id_or_error(ctx, schema.id()).await?;
+    let found_schema = Schema::get_by_id(ctx, schema.id()).await?;
     assert_eq!(
         schema.id(),       // expected
         found_schema.id()  // actual

--- a/lib/dal/tests/integration_test/component/upgrade.rs
+++ b/lib/dal/tests/integration_test/component/upgrade.rs
@@ -4,7 +4,7 @@ use dal::diagram::Diagram;
 use dal::func::authoring::FuncAuthoringClient;
 use dal::prop::PropPath;
 use dal::schema::variant::authoring::VariantAuthoringClient;
-use dal::{AttributeValue, Component, ComponentType, DalContext, Prop, SchemaVariant};
+use dal::{AttributeValue, Component, ComponentType, DalContext, Prop, Schema, SchemaVariant};
 use dal_test::expected::{ExpectComponent, ExpectSchema, ExpectSchemaVariant};
 use dal_test::helpers::{
     create_component_for_default_schema_name_in_default_view, ChangeSetTestHelpers,
@@ -37,12 +37,11 @@ async fn auto_upgrade_component(ctx: &mut DalContext) {
         .await
         .expect("Unable to get the schema for the variant");
 
-    let default_schema_variant = my_asset_schema
-        .get_default_schema_variant_id(ctx)
-        .await
-        .expect("unable to get the default schema variant id");
-    assert!(default_schema_variant.is_some());
-    assert_eq!(default_schema_variant, Some(variant_zero.id()));
+    let default_schema_variant =
+        Schema::default_variant_id(ctx, my_asset_schema.id())
+            .await
+            .expect("unable to get the default schema variant id");
+    assert_eq!(default_schema_variant, variant_zero.id());
 
     // Build Create Action Func
     let create_action_code = "async function main() {

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -77,11 +77,9 @@ async fn get_ts_type_from_root(ctx: &mut DalContext) {
     let schema = Schema::get_by_name(ctx, "starfield")
         .await
         .expect("schema not found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("could not perform get default schema variant")
-        .expect("schema variant not found");
+        .expect("could not perform get default schema variant");
 
     let root_prop_id = SchemaVariant::get_root_prop_id(ctx, schema_variant_id)
         .await

--- a/lib/dal/tests/integration_test/func/authoring/binding.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding.rs
@@ -147,11 +147,9 @@ async fn for_action(ctx: &mut DalContext) {
     let schema = Schema::get_by_name(ctx, "swifty")
         .await
         .expect("no schema found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("could not perform get default schema variant")
-        .expect("default schema variant not found");
+        .expect("could not perform get default schema variant");
 
     let func_id = Func::find_id_by_name(ctx, "test:createActionSwifty")
         .await
@@ -179,11 +177,9 @@ async fn for_qualification(ctx: &mut DalContext) {
     let schema = Schema::get_by_name(ctx, "dummy-secret")
         .await
         .expect("no schema found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("could not perform get default schema variant")
-        .expect("default schema variant not found");
+        .expect("could not perform get default schema variant");
 
     let func_id = Func::find_id_by_name(ctx, "test:qualificationDummySecretStringIsTodd")
         .await
@@ -213,11 +209,9 @@ async fn for_code_generation(ctx: &mut DalContext) {
     let schema = Schema::get_by_name(ctx, "katy perry")
         .await
         .expect("no schema found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("could not perform get default schema variant")
-        .expect("default schema variant not found");
+        .expect("could not perform get default schema variant");
 
     let func_id = Func::find_id_by_name(ctx, "test:generateStringCode")
         .await
@@ -245,11 +239,9 @@ async fn for_authentication(ctx: &mut DalContext) {
     let schema = Schema::get_by_name(ctx, "dummy-secret")
         .await
         .expect("no schema found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("could not perform get default schema variant")
-        .expect("default schema variant not found");
+        .expect("could not perform get default schema variant");
 
     let func_id = Func::find_id_by_name(ctx, "test:setDummySecretString")
         .await
@@ -285,11 +277,9 @@ async fn for_attribute_with_prop_input(ctx: &mut DalContext) {
     let schema = Schema::get_by_name(ctx, "starfield")
         .await
         .expect("no schema found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("could not perform get default schema variant")
-        .expect("default schema variant not found");
+        .expect("could not perform get default schema variant");
 
     // Find the sole func argument id. Ensure there is only one.
     let mut func_argument_ids = FuncArgument::list_ids_for_func(ctx, func_id)
@@ -393,11 +383,9 @@ async fn for_attribute_with_input_socket_input(ctx: &mut DalContext) {
     let schema = Schema::get_by_name(ctx, "starfield")
         .await
         .expect("no schema found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("could not perform get default schema variant")
-        .expect("default schema variant not found");
+        .expect("could not perform get default schema variant");
 
     // Find the sole func argument id. Ensure there is only one.
     let mut func_argument_ids = FuncArgument::list_ids_for_func(ctx, func_id)
@@ -477,11 +465,9 @@ async fn for_intrinsics(ctx: &mut DalContext) {
     let schema = Schema::get_by_name(ctx, "starfield")
         .await
         .expect("schema not found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("unable to get schema variant")
-        .expect("schema variant not found");
+        .expect("unable to get schema variant");
     let all_funcs = SchemaVariant::all_funcs(ctx, schema_variant_id)
         .await
         .expect("unable to get all funcs");

--- a/lib/dal/tests/integration_test/func/authoring/binding/attribute.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding/attribute.rs
@@ -255,12 +255,10 @@ async fn create_intrinsic_binding_then_unset(ctx: &mut DalContext) {
         .await
         .expect("Unable to get the schema for the variant");
 
-    let default_schema_variant = schema
-        .get_default_schema_variant_id(ctx)
+    let default_schema_variant = Schema::default_variant_id(ctx, schema.id())
         .await
         .expect("unable to get the default schema variant id");
-    assert!(default_schema_variant.is_some());
-    assert_eq!(default_schema_variant, Some(first_variant.id()));
+    assert_eq!(default_schema_variant, first_variant.id());
 
     // Now let's update the asset and create two props, an input socket, and an output socket
     let new_code = "function main() {\n const myProp = new PropBuilder().setName(\"testProp\").setKind(\"string\").build();\n const inputSocket = new SocketDefinitionBuilder()
@@ -572,12 +570,10 @@ async fn invalid_identity_bindings(ctx: &mut DalContext) {
         .await
         .expect("Unable to get the schema for the variant");
 
-    let default_schema_variant = schema
-        .get_default_schema_variant_id(ctx)
+    let default_schema_variant = Schema::default_variant_id(ctx, schema.id())
         .await
         .expect("unable to get the default schema variant id");
-    assert!(default_schema_variant.is_some());
-    assert_eq!(default_schema_variant, Some(first_variant.id()));
+    assert_eq!(default_schema_variant, first_variant.id());
 
     // Now let's update the asset and create two props, an input socket, and an output socket
     let new_code = "function main() {\n const myProp = new PropBuilder().setName(\"testProp\").setKind(\"string\").build();\n const inputSocket = new SocketDefinitionBuilder()

--- a/lib/dal/tests/integration_test/func/authoring/create_func.rs
+++ b/lib/dal/tests/integration_test/func/authoring/create_func.rs
@@ -19,12 +19,9 @@ async fn create_qualification_with_schema_variant(ctx: &mut DalContext) {
         .await
         .expect("unable to get schema");
 
-    let maybe_sv_id = swifty_schema
-        .get_default_schema_variant_id(ctx)
+    let sv_id = Schema::default_variant_id(ctx, swifty_schema.id())
         .await
         .expect("unable to get schema variant");
-    assert!(maybe_sv_id.is_some());
-    let sv_id = maybe_sv_id.unwrap();
 
     let func_name = "Paul's Test Func 2".to_string();
     assert!(FuncAuthoringClient::create_new_leaf_func(
@@ -92,12 +89,9 @@ async fn create_codegen_with_schema_variant(ctx: &mut DalContext) {
         .await
         .expect("unable to get schema");
 
-    let maybe_sv_id = swifty_schema
-        .get_default_schema_variant_id(ctx)
+    let sv_id = Schema::default_variant_id(ctx, swifty_schema.id())
         .await
         .expect("unable to get schema variant");
-    assert!(maybe_sv_id.is_some());
-    let sv_id = maybe_sv_id.unwrap();
 
     // create unlocked copy
     let sv_id = VariantAuthoringClient::create_unlocked_variant_copy(ctx, sv_id)
@@ -152,11 +146,9 @@ async fn create_attribute_override_dynamic_func_for_prop(ctx: &mut DalContext) {
     let schema = Schema::get_by_name(ctx, "swifty")
         .await
         .expect("schema not found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("unable to get default schema variant id")
-        .expect("default schema variant id not found");
+        .expect("unable to get default schema variant id");
     // create unlocked copy
     let schema_variant_id =
         VariantAuthoringClient::create_unlocked_variant_copy(ctx, schema_variant_id)
@@ -228,11 +220,9 @@ async fn create_attribute_override_dynamic_func_for_output_socket(ctx: &mut DalC
     let schema = Schema::get_by_name(ctx, "swifty")
         .await
         .expect("schema not found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("unable to get default schema variant id")
-        .expect("default schema variant id not found");
+        .expect("unable to get default schema variant id");
     // create unlocked copy
     let schema_variant_id =
         VariantAuthoringClient::create_unlocked_variant_copy(ctx, schema_variant_id)
@@ -302,12 +292,9 @@ async fn create_action_with_schema_variant(ctx: &mut DalContext) {
         .await
         .expect("unable to get schema");
 
-    let maybe_sv_id = swifty_schema
-        .get_default_schema_variant_id(ctx)
+    let sv_id = Schema::default_variant_id(ctx, swifty_schema.id())
         .await
         .expect("unable to get schema variant");
-    assert!(maybe_sv_id.is_some());
-    let sv_id = maybe_sv_id.unwrap();
     // create unlocked copy
     let sv_id = VariantAuthoringClient::create_unlocked_variant_copy(ctx, sv_id)
         .await
@@ -442,12 +429,11 @@ async fn create_qualification_and_code_gen_with_existing_component(ctx: &mut Dal
         .await
         .expect("Unable to get the schema for the variant");
 
-    let default_schema_variant = my_asset_schema
-        .get_default_schema_variant_id(ctx)
-        .await
-        .expect("unable to get the default schema variant id");
-    assert!(default_schema_variant.is_some());
-    assert_eq!(default_schema_variant, Some(variant_zero.id()));
+    let default_schema_variant =
+        Schema::default_variant_id(ctx, my_asset_schema.id())
+            .await
+            .expect("unable to get the default schema variant id");
+    assert_eq!(default_schema_variant, variant_zero.id());
 
     // Now let's update the variant
     let first_code_update = "function main() {\n

--- a/lib/dal/tests/integration_test/module.rs
+++ b/lib/dal/tests/integration_test/module.rs
@@ -79,12 +79,9 @@ async fn module_export_simple(ctx: &mut DalContext) {
         .await
         .expect("schema not found");
 
-    let default_schema_variant = schema
-        .get_default_schema_variant_id(ctx)
+    Schema::default_variant_id(ctx, schema.id())
         .await
         .expect("Unable to find the default schema variant id");
-
-    assert!(default_schema_variant.is_some());
 
     let name = "Paul's Test Pkg".to_string();
     let version = "2019-06-03".to_string();
@@ -174,11 +171,9 @@ async fn prepare_contribution_works(ctx: &DalContext) {
     let name = "Paul's Test Pkg With Extra Spaces At The End    ";
     let version = "    Version With Spaces At The Beginning 2019-06-03";
 
-    let default_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let default_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("unable to get a default variant")
-        .expect("error getting the default variant id");
+        .expect("unable to get a default variant");
 
     let (actual_name, actual_version, _, _, _, _, _, _) =
         Module::prepare_contribution(ctx, name, version, default_variant_id)

--- a/lib/dal/tests/integration_test/node_weight/schema_variant.rs
+++ b/lib/dal/tests/integration_test/node_weight/schema_variant.rs
@@ -163,7 +163,7 @@ async fn only_one_default_schema_variant(ctx: &mut DalContext) {
         .await
         .expect("unable to lock the schema variant");
     schema
-        .set_default_schema_variant(ctx, updated_sv_id_cs_1)
+        .set_default_variant_id(ctx, updated_sv_id_cs_1)
         .await
         .expect("unable to update the default schema variant id");
 
@@ -193,7 +193,7 @@ async fn only_one_default_schema_variant(ctx: &mut DalContext) {
         .await
         .expect("unable to lock the schema variant");
     schema
-        .set_default_schema_variant(ctx, updated_sv_id_cs_2)
+        .set_default_variant_id(ctx, updated_sv_id_cs_2)
         .await
         .expect("unable to update the default schema variant id");
     assert!(SchemaVariant::is_default_by_id(ctx, updated_sv_id_cs_2)

--- a/lib/dal/tests/integration_test/pkg/mod.rs
+++ b/lib/dal/tests/integration_test/pkg/mod.rs
@@ -4,7 +4,7 @@ use dal::prop::PropPath;
 use dal::schema::variant::authoring::VariantAuthoringClient;
 use dal::{
     AttributeValue, AttributeValueId, Component, ComponentId, DalContext, FuncBackendKind,
-    FuncBackendResponseType, Prop, PropId, SchemaVariant, SchemaVariantId,
+    FuncBackendResponseType, Prop, PropId, Schema, SchemaVariant, SchemaVariantId,
 };
 use dal_test::expected::ExpectSchemaVariant;
 use dal_test::helpers::create_component_for_schema_variant_on_default_view;
@@ -31,10 +31,9 @@ async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) -> Result<
 
     let schema = variant.schema(ctx).await?;
 
-    let default_schema_variant = schema.get_default_schema_variant_id(ctx).await?;
+    let default_schema_variant = Schema::default_variant_id(ctx, schema.id()).await?;
 
-    assert!(default_schema_variant.is_some());
-    assert_eq!(default_schema_variant, Some(variant.id()));
+    assert_eq!(default_schema_variant, variant.id());
 
     // now lets create a pkg from the asset and import it
     let (variant_spec, variant_funcs) =
@@ -90,14 +89,10 @@ async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) -> Result<
     .await?;
     assert_eq!(variants.len(), 1);
 
-    let default_schema_variant = schema.get_default_schema_variant_id(ctx).await?;
+    let default_schema_variant = Schema::default_variant_id(ctx, schema.id()).await?;
 
     // the new default variant should be the one we just added
-    assert!(default_schema_variant.is_some());
-    assert_eq!(
-        default_schema_variant,
-        Some(variants.pop().expect("should pop"))
-    );
+    assert_eq!(default_schema_variant, variants.pop().expect("should pop"));
 
     Ok(())
 }

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -43,11 +43,9 @@ async fn verify_prop_used_as_input_flag(ctx: &DalContext) {
         .expect("pirate does not exist")
         .to_owned();
 
-    let pirate_default_variant_id = pirate_schema
-        .get_default_schema_variant_id(ctx)
+    let pirate_default_variant_id = Schema::default_variant_id(ctx, pirate_schema.id())
         .await
-        .expect("should be able to get default")
-        .expect("should have a default schema variant");
+        .expect("should be able to get default");
 
     let _pirate = SchemaVariant::get_by_id_or_error(ctx, pirate_default_variant_id)
         .await
@@ -112,11 +110,9 @@ async fn ordered_child_props(ctx: &DalContext) {
     let schema = Schema::get_by_name(ctx, "starfield")
         .await
         .expect("schema not found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("could not perform get default schema variant")
-        .expect("schema variant not found");
+        .expect("could not perform get default schema variant");
 
     let root_prop_id = SchemaVariant::get_root_prop_id(ctx, schema_variant_id)
         .await

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -109,11 +109,9 @@ async fn all_prop_ids(ctx: &DalContext) {
     let schema = Schema::get_by_name(ctx, "starfield")
         .await
         .expect("schema not found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("unable to get schema variant")
-        .expect("schema variant not found");
+        .expect("unable to get schema variant");
 
     let all_prop_ids = SchemaVariant::all_prop_ids(ctx, schema_variant_id)
         .await
@@ -189,11 +187,9 @@ async fn all_funcs(ctx: &DalContext) {
     let schema = Schema::get_by_name(ctx, "swifty")
         .await
         .expect("schema not found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("unable to get schema variant")
-        .expect("schema variant not found");
+        .expect("unable to get schema variant");
     let all_funcs = SchemaVariant::all_funcs(ctx, schema_variant_id)
         .await
         .expect("unable to get all funcs");
@@ -217,11 +213,9 @@ async fn all_funcs(ctx: &DalContext) {
     let schema = Schema::get_by_name(ctx, "starfield")
         .await
         .expect("schema not found");
-    let schema_variant_id = schema
-        .get_default_schema_variant_id(ctx)
+    let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
-        .expect("unable to get schema variant")
-        .expect("schema variant not found");
+        .expect("unable to get schema variant");
     let all_funcs = SchemaVariant::all_funcs(ctx, schema_variant_id)
         .await
         .expect("unable to get all funcs");

--- a/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
@@ -15,23 +15,17 @@ async fn clone_variant(ctx: &mut DalContext) {
         .await
         .expect("schema not found");
 
-    let default_schema_variant = schema
-        .get_default_schema_variant_id(ctx)
+    let default_schema_variant = Schema::default_variant_id(ctx, schema.id())
         .await
         .expect("Unable to find the default schema variant id");
-    let existing_variant = SchemaVariant::get_by_id_or_error(
-        ctx,
-        default_schema_variant.expect("unable to unwrap schema variant id"),
-    )
-    .await
-    .expect("unable to lookup the default schema variant");
-
-    assert!(default_schema_variant.is_some());
+    let existing_variant = SchemaVariant::get_by_id_or_error(ctx, default_schema_variant)
+        .await
+        .expect("unable to lookup the default schema variant");
 
     let clone_name = format!("{}-Clone", schema.name());
     let (new_schema_variant, _) = VariantAuthoringClient::new_schema_with_cloned_variant(
         ctx,
-        default_schema_variant.expect("unable to get the schema variant id from the option"),
+        default_schema_variant,
         clone_name,
     )
     .await
@@ -54,8 +48,5 @@ async fn clone_variant(ctx: &mut DalContext) {
     );
     assert!(new_schema_variant.asset_func_id().is_some());
 
-    assert_ne!(
-        new_schema_variant.id(),
-        default_schema_variant.expect("unable to unwrap default schema variant id")
-    );
+    assert_ne!(new_schema_variant.id(), default_schema_variant);
 }

--- a/lib/dal/tests/integration_test/schema/variant/authoring/save_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/save_variant.rs
@@ -132,18 +132,12 @@ async fn unlock_and_save_variant(ctx: &mut DalContext) {
     let schema = Schema::get_by_name(ctx, "dummy-secret")
         .await
         .expect("schema not found");
-    let default_schema_variant = schema
-        .get_default_schema_variant_id(ctx)
+    let default_schema_variant = Schema::default_variant_id(ctx, schema.id())
         .await
         .expect("Unable to find the default schema variant id");
-    let existing_variant = SchemaVariant::get_by_id_or_error(
-        ctx,
-        default_schema_variant.expect("unable to unwrap schema variant id"),
-    )
-    .await
-    .expect("unable to lookup the default schema variant");
-
-    assert!(default_schema_variant.is_some());
+    let existing_variant = SchemaVariant::get_by_id_or_error(ctx, default_schema_variant)
+        .await
+        .expect("unable to lookup the default schema variant");
 
     let unlocked_schema_variant =
         VariantAuthoringClient::create_unlocked_variant_copy(ctx, existing_variant.id())
@@ -233,18 +227,13 @@ async fn unlock_and_save_variant(ctx: &mut DalContext) {
     let schema = Schema::get_by_name(ctx, "dummy-secret")
         .await
         .expect("schema not found");
-    let default_schema_variant = schema
-        .get_default_schema_variant_id(ctx)
+    let default_schema_variant = Schema::default_variant_id(ctx, schema.id())
         .await
         .expect("Unable to find the default schema variant id");
-    let new_merged_variant = SchemaVariant::get_by_id_or_error(
-        ctx,
-        default_schema_variant.expect("unable to unwrap schema variant id"),
-    )
-    .await
-    .expect("unable to lookup the default schema variant");
+    let new_merged_variant = SchemaVariant::get_by_id_or_error(ctx, default_schema_variant)
+        .await
+        .expect("unable to lookup the default schema variant");
 
-    assert!(default_schema_variant.is_some());
     // schema variant ids should match
     assert_eq!(new_merged_variant.id(), unlocked_schema_variant.id());
     // new variant is now locked

--- a/lib/dal/tests/integration_test/schema/variant/authoring/unlock_and_edit_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/unlock_and_edit_variant.rs
@@ -77,7 +77,7 @@ async fn create_variant_merge_unlock_and_edit(ctx: &mut DalContext) {
         .await
         .expect("unable to lock the schema variant");
     schema
-        .set_default_schema_variant(ctx, updated_sv_id)
+        .set_default_variant_id(ctx, updated_sv_id)
         .await
         .expect("unable to update the default schema variant id");
     asset_func

--- a/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
@@ -10,7 +10,7 @@ use dal::schema::variant::authoring::VariantAuthoringClient;
 use dal::schema::variant::leaves::{LeafInputLocation, LeafKind};
 use dal::{
     AttributePrototype, AttributePrototypeId, Component, ComponentType, DalContext, Func, Prop,
-    SchemaVariant, SchemaVariantId,
+    Schema, SchemaVariant, SchemaVariantId,
 };
 use dal_test::expected::commit_and_update_snapshot_to_visibility;
 use dal_test::helpers::{
@@ -42,12 +42,10 @@ async fn update_variant(ctx: &mut DalContext) {
         .await
         .expect("Unable to get the schema for the variant");
 
-    let default_schema_variant = schema
-        .get_default_schema_variant_id(ctx)
+    let default_schema_variant = Schema::default_variant_id(ctx, schema.id())
         .await
         .expect("unable to get the default schema variant id");
-    assert!(default_schema_variant.is_some());
-    assert_eq!(default_schema_variant, Some(first_variant.id()));
+    assert_eq!(default_schema_variant, first_variant.id());
 
     // Now let's update the variant
     let new_code = "function main() {\n const myProp = new PropBuilder().setName(\"testProp\").setKind(\"string\").build()\n  return new AssetBuilder().addProp(myProp).build()\n}".to_string();
@@ -151,12 +149,10 @@ async fn update_variant(ctx: &mut DalContext) {
     .expect("able to find anotherProp prop");
 
     // Let's check that the default schema variant has been updated
-    let updated_default_schema_variant = schema
-        .get_default_schema_variant_id(ctx)
+    let updated_default_schema_variant = Schema::default_variant_id(ctx, schema.id())
         .await
         .expect("unable to get the default schema variant id");
-    assert!(updated_default_schema_variant.is_some());
-    assert_eq!(updated_default_schema_variant, Some(second_updated_sv_id));
+    assert_eq!(updated_default_schema_variant, second_updated_sv_id);
 }
 
 #[test]
@@ -204,13 +200,11 @@ async fn update_variant_with_new_metadata(ctx: &mut DalContext) {
         .await
         .expect("Unable to get the schema for the variant");
 
-    let default_schema_variant = schema
-        .get_default_schema_variant_id(ctx)
+    let default_schema_variant = Schema::default_variant_id(ctx, schema.id())
         .await
         .expect("unable to get the default schema variant id");
 
-    assert!(default_schema_variant.is_some());
-    assert_eq!(default_schema_variant, Some(first_variant.id()));
+    assert_eq!(default_schema_variant, first_variant.id());
 
     let first_variant = SchemaVariant::get_by_id_or_error(ctx, first_sv_id)
         .await

--- a/lib/dal/tests/integration_test/schema/variant/view.rs
+++ b/lib/dal/tests/integration_test/schema/variant/view.rs
@@ -28,14 +28,10 @@ async fn get_schema_variant(ctx: &DalContext) {
         .await
         .expect("unable to get schema");
 
-    let maybe_sv_id = swifty_schema
-        .get_default_schema_variant_id(ctx)
+    let sv_id = Schema::default_variant_id(ctx, swifty_schema.id())
         .await
         .expect("unable to get schema variant");
 
-    assert!(maybe_sv_id.is_some());
-
-    let sv_id = maybe_sv_id.unwrap();
     let sv_funcs = SchemaVariant::all_funcs(ctx, sv_id)
         .await
         .expect("Unable to get all schema variant funcs");

--- a/lib/sdf-server/src/service/v2/fs.rs
+++ b/lib/sdf-server/src/service/v2/fs.rs
@@ -1088,7 +1088,7 @@ async fn install_schema(
 
     check_change_set_and_not_head(&ctx).await?;
 
-    if Schema::get_by_id(&ctx, schema_id).await?.is_none() {
+    if !Schema::exists_locally(&ctx, schema_id).await? {
         let default_variant_id = Schema::get_or_install_default_variant(&ctx, schema_id).await?;
         let variant = SchemaVariant::get_by_id_or_error(&ctx, default_variant_id).await?;
 

--- a/lib/sdf-server/src/service/v2/fs/bindings.rs
+++ b/lib/sdf-server/src/service/v2/fs/bindings.rs
@@ -178,11 +178,7 @@ async fn management_binding_to_fs_management_binding(
             let schema_name =
                 match CachedModule::find_latest_for_schema_id(ctx, managed_schema_id).await? {
                     Some(cached_module) => cached_module.schema_name,
-                    None => {
-                        Schema::get_by_id_or_error(ctx, managed_schema_id)
-                            .await?
-                            .name
-                    }
+                    None => Schema::get_by_id(ctx, managed_schema_id).await?.name,
                 };
             managed_names.push(schema_name);
         }

--- a/lib/sdf-server/src/service/v2/variant/create_unlocked_copy.rs
+++ b/lib/sdf-server/src/service/v2/variant/create_unlocked_copy.rs
@@ -40,9 +40,7 @@ pub async fn create_unlocked_copy(
 
     let schema = original_variant.schema(&ctx).await?;
 
-    if Schema::get_default_schema_variant_by_id(&ctx, schema.id()).await?
-        != Some(original_variant.id())
-    {
+    if Schema::default_variant_id_opt(&ctx, schema.id()).await? != Some(original_variant.id()) {
         return Err(SchemaVariantError::CreatingUnlockedCopyForNonDefault(
             original_variant.id(),
         ));

--- a/lib/sdf-server/src/service/v2/view.rs
+++ b/lib/sdf-server/src/service/v2/view.rs
@@ -13,8 +13,8 @@ use dal::{
     pkg::PkgError,
     slow_rt::SlowRuntimeError,
     workspace_snapshot::graph::WorkspaceSnapshotGraphError,
-    ChangeSetError, ComponentError, FuncError, SchemaError, SchemaId, SchemaVariantError,
-    TransactionsError, WorkspaceSnapshotError, WsEventError,
+    ChangeSetError, ComponentError, FuncError, SchemaError, SchemaVariantError, TransactionsError,
+    WorkspaceSnapshotError, WsEventError,
 };
 use si_id::ViewId;
 use thiserror::Error;
@@ -67,8 +67,6 @@ pub enum ViewError {
     Pkg(#[from] PkgError),
     #[error("schema error: {0}")]
     Schema(#[from] SchemaError),
-    #[error("No schema installed after successful package import for {0}")]
-    SchemaNotInstalledAfterImport(SchemaId),
     #[error("schema variant error: {0}")]
     SchemaVariant(#[from] SchemaVariantError),
     #[error("serrde error: {0}")]
@@ -77,8 +75,6 @@ pub enum ViewError {
     SlowRuntime(#[from] SlowRuntimeError),
     #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),
-    #[error("No installable module found for schema id {0}")]
-    UninstalledSchemaNotFound(SchemaId),
     #[error("workspace snapshot error: {0}")]
     WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
     #[error("WsEvent error: {0}")]


### PR DESCRIPTION
This splits a small bit of refactoring so it doesn't pollute a different upcoming PR.

In the continuing quest to make get_by_id more consistent across node types, push errors like NoDefaultSchemaVariantFound down into a single place, and encourage not grabbing entire objects when the ID is all you need, this PR:

* Renames Schema::get_default_schema_variant_by_id[_or_error] -> default_variant_id[_opt]
* Removes Schema::get_default_schema_variant_id[_or_error](&self) since all they did was call _by_id 
* Renames Schema::get_by_id[_or_error] -> get_by_id[_opt]
* Adjusts callers to the new names
* Moves [_opt] callers who immediately error, to get the non-opt version instead
* Calls Schema::exists_locally() instead of Schema::get_by_id_opt().is_some() in a few places
* Moves the "install_component" endpoint to use Schema::get_or_install_default_variant instead of installing the module itself (the code was identical except the error enum being emitted)

## Testing

* Ran integration tests
* Dragged uninstalled component onto the canvas, let it install