### PR TITLE
feat: add optional support for tokio-console in all Rust services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.7.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bigdecimal"
@@ -1564,6 +1564,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,6 +1713,15 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -3233,7 +3281,10 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
+ "base64 0.21.7",
  "byteorder",
+ "flate2",
+ "nom",
  "num-traits",
 ]
 
@@ -3437,9 +3488,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -4803,9 +4854,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.0"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "openssl-probe"
@@ -5922,9 +5973,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.13"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389a89e494bbc88bebf30e23da98742c843863a16a352647716116aa71fae80a"
+checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6044,9 +6095,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
  "const-oid",
  "digest",
@@ -7704,6 +7755,7 @@ name = "telemetry-application"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "console-subscriber",
  "derive_builder",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -7950,9 +8002,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7963,6 +8015,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -8092,9 +8145,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -9233,9 +9286,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ clap = { version = "4.5.23", features = [
 ] }
 color-eyre = "0.6.3"
 config = { version = "0.14.1", default-features = false, features = ["toml"] }
+console-subscriber = { version = "0.4.1", default-features = false }
 convert_case = "0.6.0"
 crossbeam-queue = { version = "0.3.11" }
 darling = "0.20.10"

--- a/bin/cyclone/src/args.rs
+++ b/bin/cyclone/src/args.rs
@@ -59,6 +59,17 @@ pub(crate) struct Args {
     )]
     pub(crate) log_json: bool,
 
+    /// Enables support for emitting async runtime data to `tokio-console`.
+    ///
+    /// For more details, visit: <https://github.com/tokio-rs/console>.
+    #[arg(
+        long = "tokio-console",
+        default_value = "false",
+        env = "SI_TOKIO_CONSOLE",
+        hide_env_values = true
+    )]
+    pub(crate) tokio_console: bool,
+
     /// Binds service to a socket address [example: 0.0.0.0:5157]
     #[arg(long, group = "bind")]
     pub(crate) bind_addr: Option<SocketAddr>,

--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<()> {
                     .then_some(ConsoleLogFormat::Json)
                     .unwrap_or_default(),
             )
+            .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)
             .service_namespace("si")
             .log_env_var_prefix("SI")

--- a/bin/forklift/src/args.rs
+++ b/bin/forklift/src/args.rs
@@ -56,6 +56,17 @@ pub(crate) struct Args {
     )]
     pub(crate) log_json: bool,
 
+    /// Enables support for emitting async runtime data to `tokio-console`.
+    ///
+    /// For more details, visit: <https://github.com/tokio-rs/console>.
+    #[arg(
+        long = "tokio-console",
+        default_value = "false",
+        env = "SI_TOKIO_CONSOLE",
+        hide_env_values = true
+    )]
+    pub(crate) tokio_console: bool,
+
     /// The ID of this forklift instance [example: 01GWEAANW5BVFK5KDRVS6DEY0F"]
     #[arg(long)]
     pub(crate) instance_id: Option<String>,

--- a/bin/forklift/src/main.rs
+++ b/bin/forklift/src/main.rs
@@ -31,6 +31,7 @@ async fn async_main() -> Result<()> {
                     .then_some(ConsoleLogFormat::Json)
                     .unwrap_or_default(),
             )
+            .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)
             .service_namespace("si")
             .log_env_var_prefix("SI")

--- a/bin/module-index/src/args.rs
+++ b/bin/module-index/src/args.rs
@@ -59,6 +59,17 @@ pub(crate) struct Args {
     )]
     pub(crate) log_json: bool,
 
+    /// Enables support for emitting async runtime data to `tokio-console`.
+    ///
+    /// For more details, visit: <https://github.com/tokio-rs/console>.
+    #[arg(
+        long = "tokio-console",
+        default_value = "false",
+        env = "SI_TOKIO_CONSOLE",
+        hide_env_values = true
+    )]
+    pub(crate) tokio_console: bool,
+
     /// Override for the auth api url
     #[arg(long, env = "SI_AUTH_API_URL")]
     pub(crate) auth_api_url: Option<String>,

--- a/bin/module-index/src/main.rs
+++ b/bin/module-index/src/main.rs
@@ -35,6 +35,7 @@ async fn async_main() -> Result<()> {
                     .then_some(ConsoleLogFormat::Json)
                     .unwrap_or_default(),
             )
+            .tokio_console(args.tokio_console)
             .service_name("module-index")
             .service_namespace("si")
             .log_env_var_prefix("SI")

--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -59,6 +59,17 @@ pub(crate) struct Args {
     )]
     pub(crate) log_json: bool,
 
+    /// Enables support for emitting async runtime data to `tokio-console`.
+    ///
+    /// For more details, visit: <https://github.com/tokio-rs/console>.
+    #[arg(
+        long = "tokio-console",
+        default_value = "false",
+        env = "SI_TOKIO_CONSOLE",
+        hide_env_values = true
+    )]
+    pub(crate) tokio_console: bool,
+
     /// PostgreSQL connection pool dbname [example: myapp]
     #[arg(long)]
     pub(crate) pg_dbname: Option<String>,

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -33,6 +33,7 @@ async fn async_main() -> Result<()> {
                     .then_some(ConsoleLogFormat::Json)
                     .unwrap_or_default(),
             )
+            .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)
             .service_namespace("si")
             .log_env_var_prefix("SI")

--- a/bin/rebaser/src/args.rs
+++ b/bin/rebaser/src/args.rs
@@ -55,6 +55,17 @@ pub(crate) struct Args {
     )]
     pub(crate) log_json: bool,
 
+    /// Enables support for emitting async runtime data to `tokio-console`.
+    ///
+    /// For more details, visit: <https://github.com/tokio-rs/console>.
+    #[arg(
+        long = "tokio-console",
+        default_value = "false",
+        env = "SI_TOKIO_CONSOLE",
+        hide_env_values = true
+    )]
+    pub(crate) tokio_console: bool,
+
     /// PostgreSQL connection pool dbname [example: myapp]
     #[arg(long)]
     pub(crate) pg_dbname: Option<String>,

--- a/bin/rebaser/src/main.rs
+++ b/bin/rebaser/src/main.rs
@@ -33,6 +33,7 @@ async fn async_main() -> Result<()> {
                     .then_some(ConsoleLogFormat::Json)
                     .unwrap_or_default(),
             )
+            .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)
             .service_namespace("si")
             .log_env_var_prefix("SI")

--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -63,6 +63,17 @@ pub(crate) struct Args {
     )]
     pub(crate) log_json: bool,
 
+    /// Enables support for emitting async runtime data to `tokio-console`.
+    ///
+    /// For more details, visit: <https://github.com/tokio-rs/console>.
+    #[arg(
+        long = "tokio-console",
+        default_value = "false",
+        env = "SI_TOKIO_CONSOLE",
+        hide_env_values = true
+    )]
+    pub(crate) tokio_console: bool,
+
     /// PostgreSQL connection pool dbname [example: myapp]
     #[arg(long)]
     pub(crate) pg_dbname: Option<String>,

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -40,6 +40,7 @@ async fn async_main() -> Result<()> {
                     .then_some(ConsoleLogFormat::Json)
                     .unwrap_or_default(),
             )
+            .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)
             .service_namespace("si")
             .log_env_var_prefix("SI")

--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -55,6 +55,17 @@ pub(crate) struct Args {
     )]
     pub(crate) log_json: bool,
 
+    /// Enables support for emitting async runtime data to `tokio-console`.
+    ///
+    /// For more details, visit: <https://github.com/tokio-rs/console>.
+    #[arg(
+        long = "tokio-console",
+        default_value = "false",
+        env = "SI_TOKIO_CONSOLE",
+        hide_env_values = true
+    )]
+    pub(crate) tokio_console: bool,
+
     /// NATS connection URL [example: 0.0.0.0:4222]
     #[arg(long, short = 'u')]
     pub(crate) nats_url: Option<String>,

--- a/bin/veritech/src/main.rs
+++ b/bin/veritech/src/main.rs
@@ -31,6 +31,7 @@ async fn async_main() -> Result<()> {
                     .then_some(ConsoleLogFormat::Json)
                     .unwrap_or_default(),
             )
+            .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)
             .service_namespace("si")
             .log_env_var_prefix("SI")

--- a/flake.nix
+++ b/flake.nix
@@ -396,6 +396,7 @@
               shfmt
               spicedb-zed
               tilt
+              tokio-console
               typos
               yapf
             ]

--- a/lib/telemetry-application-rs/BUCK
+++ b/lib/telemetry-application-rs/BUCK
@@ -5,6 +5,7 @@ rust_library(
     deps = [
         "//lib/telemetry-rs:telemetry",
         "//third-party/rust:chrono",
+        "//third-party/rust:console-subscriber",
         "//third-party/rust:derive_builder",
         "//third-party/rust:opentelemetry-otlp",
         "//third-party/rust:opentelemetry-semantic-conventions",

--- a/lib/telemetry-application-rs/Cargo.toml
+++ b/lib/telemetry-application-rs/Cargo.toml
@@ -10,6 +10,7 @@ publish.workspace = true
 
 [dependencies]
 chrono = { workspace = true }
+console-subscriber = { workspace = true }
 derive_builder = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -108,37 +108,37 @@ cargo.rust_library(
         "linux-arm64": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
             ],
         ),
         "linux-x86_64": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
             ],
         ),
         "macos-arm64": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
             ],
         ),
         "macos-x86_64": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
             ],
         ),
         "windows-gnu": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
             ],
         ),
         "windows-msvc": dict(
             deps = [
                 ":getrandom-0.2.15",
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
             ],
         ),
     },
@@ -167,22 +167,22 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":once_cell-1.21.0"],
+            deps = [":once_cell-1.21.1"],
         ),
         "linux-x86_64": dict(
-            deps = [":once_cell-1.21.0"],
+            deps = [":once_cell-1.21.1"],
         ),
         "macos-arm64": dict(
-            deps = [":once_cell-1.21.0"],
+            deps = [":once_cell-1.21.1"],
         ),
         "macos-x86_64": dict(
-            deps = [":once_cell-1.21.0"],
+            deps = [":once_cell-1.21.1"],
         ),
         "windows-gnu": dict(
-            deps = [":once_cell-1.21.0"],
+            deps = [":once_cell-1.21.1"],
         ),
         "windows-msvc": dict(
-            deps = [":once_cell-1.21.0"],
+            deps = [":once_cell-1.21.1"],
         ),
     },
     visibility = [],
@@ -417,13 +417,13 @@ cargo.rust_library(
     platform = {
         "windows-gnu": dict(
             deps = [
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
                 ":windows-sys-0.59.0",
             ],
         ),
         "windows-msvc": dict(
             deps = [
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
                 ":windows-sys-0.59.0",
             ],
         ),
@@ -578,7 +578,7 @@ cargo.rust_library(
         ":futures-core-0.3.31",
         ":memchr-2.7.4",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
     ],
 )
 
@@ -648,7 +648,7 @@ cargo.rust_library(
         ":memchr-2.7.4",
         ":nkeys-0.4.4",
         ":nuid-0.5.0",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":pin-project-1.1.10",
         ":portable-atomic-1.11.0",
         ":rand-0.8.5",
@@ -662,9 +662,9 @@ cargo.rust_library(
         ":serde_repr-0.1.20",
         ":thiserror-1.0.69",
         ":time-0.3.39",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tokio-rustls-0.26.2",
-        ":tokio-util-0.7.13",
+        ":tokio-util-0.7.14",
         ":tokio-websockets-0.10.1",
         ":tracing-0.1.41",
         ":tryhard-0.5.1",
@@ -706,15 +706,15 @@ cargo.rust_library(
         ":eventsource-stream-0.2.3",
         ":futures-0.3.31",
         ":rand-0.8.5",
-        ":reqwest-0.12.13",
+        ":reqwest-0.12.14",
         ":reqwest-eventsource-0.6.0",
         ":secrecy-0.8.0",
         ":serde-1.0.219",
         ":serde_json-1.0.140",
         ":thiserror-1.0.69",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tokio-stream-0.1.17",
-        ":tokio-util-0.7.13",
+        ":tokio-util-0.7.14",
         ":tracing-0.1.41",
     ],
 )
@@ -1034,7 +1034,7 @@ cargo.rust_library(
         ":http-0.2.12",
         ":ring-0.17.5",
         ":time-0.3.39",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tracing-0.1.41",
         ":url-2.5.4",
         ":zeroize-1.8.1",
@@ -1130,7 +1130,7 @@ cargo.rust_library(
         ":aws-types-1.3.6",
         ":bytes-1.10.1",
         ":fastrand-2.3.0",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.16",
         ":tracing-0.1.41",
@@ -1187,7 +1187,7 @@ cargo.rust_library(
         ":aws-types-1.3.6",
         ":bytes-1.10.1",
         ":http-0.2.12",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":regex-lite-0.1.6",
         ":tracing-0.1.41",
     ],
@@ -1231,7 +1231,7 @@ cargo.rust_library(
         ":aws-types-1.3.6",
         ":bytes-1.10.1",
         ":http-0.2.12",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":regex-lite-0.1.6",
         ":tracing-0.1.41",
     ],
@@ -1275,7 +1275,7 @@ cargo.rust_library(
         ":aws-types-1.3.6",
         ":bytes-1.10.1",
         ":http-0.2.12",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":regex-lite-0.1.6",
         ":tracing-0.1.41",
     ],
@@ -1320,7 +1320,7 @@ cargo.rust_library(
         ":aws-smithy-xml-0.60.9",
         ":aws-types-1.3.6",
         ":http-0.2.12",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":regex-lite-0.1.6",
         ":tracing-0.1.41",
     ],
@@ -1360,7 +1360,7 @@ cargo.rust_library(
         ":hex-0.4.3",
         ":hmac-0.12.1",
         ":http-1.3.1",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":percent-encoding-2.3.1",
         ":sha2-0.10.8",
         ":time-0.3.39",
@@ -1387,7 +1387,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.31",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
     ],
 )
 
@@ -1416,7 +1416,7 @@ cargo.rust_library(
         ":bytes-1.10.1",
         ":bytes-utils-0.1.4",
         ":futures-core-0.3.31",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.16",
         ":pin-utils-0.1.0",
@@ -1450,7 +1450,7 @@ cargo.rust_library(
         ":bytes-1.10.1",
         ":bytes-utils-0.1.4",
         ":futures-core-0.3.31",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.16",
         ":pin-utils-0.1.0",
@@ -1490,7 +1490,7 @@ cargo.rust_library(
         ":aws-smithy-types-1.3.0",
         ":h2-0.4.8",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tracing-0.1.41",
     ],
 )
@@ -1569,10 +1569,10 @@ cargo.rust_library(
         ":aws-smithy-types-1.3.0",
         ":bytes-1.10.1",
         ":fastrand-2.3.0",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":pin-project-lite-0.2.16",
         ":pin-utils-0.1.0",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tracing-0.1.41",
     ],
 )
@@ -1609,7 +1609,7 @@ cargo.rust_library(
         ":aws-smithy-types-1.3.0",
         ":bytes-1.10.1",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tracing-0.1.41",
         ":zeroize-1.8.1",
     ],
@@ -1655,8 +1655,8 @@ cargo.rust_library(
         ":pin-utils-0.1.0",
         ":ryu-1.0.20",
         ":time-0.3.39",
-        ":tokio-1.44.0",
-        ":tokio-util-0.7.13",
+        ":tokio-1.44.1",
+        ":tokio-util-0.7.14",
     ],
 )
 
@@ -1801,7 +1801,7 @@ cargo.rust_library(
         ":serde_urlencoded-0.7.1",
         ":sha1-0.10.6",
         ":sync_wrapper-0.1.2",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tokio-tungstenite-0.20.1",
         ":tower-0.4.13",
         ":tower-layer-0.3.3",
@@ -1953,7 +1953,7 @@ cargo.rust_library(
         "tokio_1",
     ],
     named_deps = {
-        "tokio_1": ":tokio-1.44.0",
+        "tokio_1": ":tokio-1.44.1",
     },
     visibility = [],
     deps = [
@@ -2135,18 +2135,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "base64ct-1.7.1.crate",
-    sha256 = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d",
-    strip_prefix = "base64ct-1.7.1",
-    urls = ["https://static.crates.io/crates/base64ct/1.7.1/download"],
+    name = "base64ct-1.7.3.crate",
+    sha256 = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3",
+    strip_prefix = "base64ct-1.7.3",
+    urls = ["https://static.crates.io/crates/base64ct/1.7.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "base64ct-1.7.1",
-    srcs = [":base64ct-1.7.1.crate"],
+    name = "base64ct-1.7.3",
+    srcs = [":base64ct-1.7.3.crate"],
     crate = "base64ct",
-    crate_root = "base64ct-1.7.1.crate/src/lib.rs",
+    crate_root = "base64ct-1.7.3.crate/src/lib.rs",
     edition = "2021",
     features = ["alloc"],
     visibility = [],
@@ -2691,8 +2691,8 @@ cargo.rust_library(
         ":serde_repr-0.1.20",
         ":serde_urlencoded-0.7.1",
         ":thiserror-2.0.12",
-        ":tokio-1.44.0",
-        ":tokio-util-0.7.13",
+        ":tokio-1.44.1",
+        ":tokio-util-0.7.14",
         ":url-2.5.4",
     ],
 )
@@ -3414,7 +3414,7 @@ cargo.rust_library(
         ":color-spantrace-0.2.1",
         ":eyre-0.6.12",
         ":indenter-0.3.3",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":owo-colors-3.5.0",
         ":tracing-error-0.2.1",
     ],
@@ -3436,7 +3436,7 @@ cargo.rust_library(
     edition = "2018",
     visibility = [],
     deps = [
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":owo-colors-3.5.0",
         ":tracing-core-0.1.33",
         ":tracing-error-0.2.1",
@@ -3544,8 +3544,77 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":libc-0.2.171",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":unicode-width-0.2.0",
+    ],
+)
+
+http_archive(
+    name = "console-api-0.8.1.crate",
+    sha256 = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857",
+    strip_prefix = "console-api-0.8.1",
+    urls = ["https://static.crates.io/crates/console-api/0.8.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "console-api-0.8.1",
+    srcs = [":console-api-0.8.1.crate"],
+    crate = "console_api",
+    crate_root = "console-api-0.8.1.crate/src/lib.rs",
+    edition = "2021",
+    features = ["transport"],
+    visibility = [],
+    deps = [
+        ":futures-core-0.3.31",
+        ":prost-0.13.5",
+        ":prost-types-0.13.5",
+        ":tonic-0.12.3",
+        ":tracing-core-0.1.33",
+    ],
+)
+
+alias(
+    name = "console-subscriber",
+    actual = ":console-subscriber-0.4.1",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "console-subscriber-0.4.1.crate",
+    sha256 = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01",
+    strip_prefix = "console-subscriber-0.4.1",
+    urls = ["https://static.crates.io/crates/console-subscriber/0.4.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "console-subscriber-0.4.1",
+    srcs = [":console-subscriber-0.4.1.crate"],
+    crate = "console_subscriber",
+    crate_root = "console-subscriber-0.4.1.crate/src/lib.rs",
+    edition = "2021",
+    rustc_flags = ["--cfg=tokio_unstable"],
+    visibility = [],
+    deps = [
+        ":console-api-0.8.1",
+        ":crossbeam-channel-0.5.14",
+        ":crossbeam-utils-0.8.21",
+        ":futures-task-0.3.31",
+        ":hdrhistogram-7.5.4",
+        ":humantime-2.2.0",
+        ":hyper-util-0.1.10",
+        ":prost-0.13.5",
+        ":prost-types-0.13.5",
+        ":serde-1.0.219",
+        ":serde_json-1.0.140",
+        ":thread_local-1.1.8",
+        ":tokio-1.44.1",
+        ":tokio-stream-0.1.17",
+        ":tonic-0.12.3",
+        ":tracing-0.1.41",
+        ":tracing-core-0.1.33",
+        ":tracing-subscriber-0.3.19",
     ],
 )
 
@@ -3606,7 +3675,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":getrandom-0.2.15",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":tiny-keccak-2.0.2",
     ],
 )
@@ -3820,6 +3889,28 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [":cfg-if-1.0.0"],
+)
+
+http_archive(
+    name = "crossbeam-channel-0.5.14.crate",
+    sha256 = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471",
+    strip_prefix = "crossbeam-channel-0.5.14",
+    urls = ["https://static.crates.io/crates/crossbeam-channel/0.5.14/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "crossbeam-channel-0.5.14",
+    srcs = [":crossbeam-channel-0.5.14.crate"],
+    crate = "crossbeam_channel",
+    crate_root = "crossbeam-channel-0.5.14.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [":crossbeam-utils-0.8.21"],
 )
 
 http_archive(
@@ -4284,7 +4375,7 @@ cargo.rust_library(
         ":crossbeam-utils-0.8.21",
         ":hashbrown-0.14.5",
         ":lock_api-0.4.12",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":parking_lot_core-0.9.10",
     ],
 )
@@ -4341,7 +4432,7 @@ cargo.rust_library(
     deps = [
         ":deadpool-runtime-0.1.4",
         ":num_cpus-1.16.0",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
     ],
 )
 
@@ -4393,7 +4484,7 @@ cargo.rust_library(
     deps = [
         ":async-trait-0.1.87",
         ":deadpool-0.12.2",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tracing-0.1.41",
     ],
 )
@@ -4414,7 +4505,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["tokio_1"],
     named_deps = {
-        "tokio_1": ":tokio-1.44.0",
+        "tokio_1": ":tokio-1.44.1",
     },
     visibility = [],
 )
@@ -5425,7 +5516,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":humantime-2.1.0",
+        ":humantime-2.2.0",
         ":is-terminal-0.4.16",
         ":log-0.4.26",
         ":regex-1.11.1",
@@ -5670,7 +5761,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":indenter-0.3.3",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
     ],
 )
 
@@ -5741,7 +5832,7 @@ cargo.rust_library(
     deps = [
         ":fastant-0.1.10",
         ":fastrace-macro-0.7.6",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":parking_lot-0.12.3",
         ":pin-project-1.1.10",
         ":rand-0.9.0",
@@ -6043,22 +6134,22 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "linux-x86_64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "macos-arm64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "macos-x86_64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "windows-gnu": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "windows-msvc": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
     },
     visibility = [],
@@ -6092,22 +6183,22 @@ cargo.rust_library(
     features = ["tracing"],
     platform = {
         "linux-arm64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "linux-x86_64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "macos-arm64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "macos-x86_64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "windows-gnu": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "windows-msvc": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
     },
     visibility = [],
@@ -6166,22 +6257,22 @@ cargo.rust_library(
     },
     platform = {
         "linux-arm64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "linux-x86_64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "macos-arm64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "macos-x86_64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "windows-gnu": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "windows-msvc": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
     },
     visibility = [],
@@ -6224,22 +6315,22 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "linux-x86_64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "macos-arm64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "macos-x86_64": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "windows-gnu": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
         "windows-msvc": dict(
-            deps = [":tokio-1.44.0"],
+            deps = [":tokio-1.44.1"],
         ),
     },
     visibility = [],
@@ -7010,8 +7101,8 @@ cargo.rust_library(
         ":http-0.2.12",
         ":indexmap-2.8.0",
         ":slab-0.4.9",
-        ":tokio-1.44.0",
-        ":tokio-util-0.7.13",
+        ":tokio-1.44.1",
+        ":tokio-util-0.7.14",
         ":tracing-0.1.41",
     ],
 )
@@ -7040,8 +7131,8 @@ cargo.rust_library(
         ":http-1.3.1",
         ":indexmap-2.8.0",
         ":slab-0.4.9",
-        ":tokio-1.44.0",
-        ":tokio-util-0.7.13",
+        ":tokio-1.44.1",
+        ":tokio-util-0.7.14",
         ":tracing-0.1.41",
     ],
 )
@@ -7209,9 +7300,18 @@ cargo.rust_library(
     crate = "hdrhistogram",
     crate_root = "hdrhistogram-7.5.4.crate/src/lib.rs",
     edition = "2018",
+    features = [
+        "base64",
+        "flate2",
+        "nom",
+        "serialization",
+    ],
     visibility = [],
     deps = [
+        ":base64-0.21.7",
         ":byteorder-1.5.0",
+        ":flate2-1.1.0",
+        ":nom-7.1.3",
         ":num-traits-0.2.19",
     ],
 )
@@ -7651,19 +7751,19 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "humantime-2.1.0.crate",
-    sha256 = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
-    strip_prefix = "humantime-2.1.0",
-    urls = ["https://static.crates.io/crates/humantime/2.1.0/download"],
+    name = "humantime-2.2.0.crate",
+    sha256 = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f",
+    strip_prefix = "humantime-2.2.0",
+    urls = ["https://static.crates.io/crates/humantime/2.2.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "humantime-2.1.0",
-    srcs = [":humantime-2.1.0.crate"],
+    name = "humantime-2.2.0",
+    srcs = [":humantime-2.2.0.crate"],
     crate = "humantime",
-    crate_root = "humantime-2.1.0.crate/src/lib.rs",
-    edition = "2018",
+    crate_root = "humantime-2.2.0.crate/src/lib.rs",
+    edition = "2021",
     visibility = [],
 )
 
@@ -7713,7 +7813,7 @@ cargo.rust_library(
         ":itoa-1.0.15",
         ":pin-project-lite-0.2.16",
         ":socket2-0.5.8",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tower-service-0.3.3",
         ":tracing-0.1.41",
         ":want-0.3.1",
@@ -7754,7 +7854,7 @@ cargo.rust_library(
         ":itoa-1.0.15",
         ":pin-project-lite-0.2.16",
         ":smallvec-1.14.0",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":want-0.3.1",
     ],
 )
@@ -7779,7 +7879,7 @@ cargo.rust_library(
         ":hyper-1.6.0",
         ":hyper-util-0.1.10",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tower-service-0.3.3",
         ":winapi-0.3.9",
     ],
@@ -7819,7 +7919,7 @@ cargo.rust_library(
         ":log-0.4.26",
         ":rustls-0.21.12",
         ":rustls-native-certs-0.6.3",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tokio-rustls-0.24.1",
     ],
 )
@@ -7858,7 +7958,7 @@ cargo.rust_library(
         ":hyper-util-0.1.10",
         ":rustls-0.23.23",
         ":rustls-native-certs-0.8.1",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tokio-rustls-0.26.2",
         ":tower-service-0.3.3",
         ":webpki-roots-0.26.8",
@@ -7884,7 +7984,7 @@ cargo.rust_library(
         ":hyper-1.6.0",
         ":hyper-util-0.1.10",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tower-service-0.3.3",
     ],
 )
@@ -7924,7 +8024,7 @@ cargo.rust_library(
         ":hyper-1.6.0",
         ":pin-project-lite-0.2.16",
         ":socket2-0.5.8",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tower-service-0.3.3",
         ":tracing-0.1.41",
     ],
@@ -7949,7 +8049,7 @@ cargo.rust_library(
         ":hex-0.4.3",
         ":hyper-0.14.32",
         ":pin-project-1.1.10",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
     ],
 )
 
@@ -7982,7 +8082,7 @@ cargo.rust_library(
         ":hyper-1.6.0",
         ":hyper-util-0.1.10",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tower-service-0.3.3",
     ],
 )
@@ -8948,7 +9048,7 @@ cargo.rust_library(
     deps = [
         ":cfg-if-1.0.0",
         ":elliptic-curve-0.13.8",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":sha2-0.10.8",
         ":signature-2.2.0",
     ],
@@ -11116,23 +11216,23 @@ cargo.rust_library(
 
 alias(
     name = "once_cell",
-    actual = ":once_cell-1.21.0",
+    actual = ":once_cell-1.21.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "once_cell-1.21.0.crate",
-    sha256 = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad",
-    strip_prefix = "once_cell-1.21.0",
-    urls = ["https://static.crates.io/crates/once_cell/1.21.0/download"],
+    name = "once_cell-1.21.1.crate",
+    sha256 = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc",
+    strip_prefix = "once_cell-1.21.1",
+    urls = ["https://static.crates.io/crates/once_cell/1.21.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "once_cell-1.21.0",
-    srcs = [":once_cell-1.21.0.crate"],
+    name = "once_cell-1.21.1",
+    srcs = [":once_cell-1.21.1.crate"],
     crate = "once_cell",
-    crate_root = "once_cell-1.21.0.crate/src/lib.rs",
+    crate_root = "once_cell-1.21.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -11202,7 +11302,7 @@ cargo.rust_library(
     deps = [
         ":futures-core-0.3.31",
         ":futures-sink-0.3.31",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":pin-project-lite-0.2.16",
         ":thiserror-1.0.69",
     ],
@@ -11260,7 +11360,7 @@ cargo.rust_library(
         ":opentelemetry_sdk-0.26.0",
         ":prost-0.13.5",
         ":thiserror-1.0.69",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tonic-0.12.3",
     ],
 )
@@ -11372,13 +11472,13 @@ cargo.rust_library(
         ":futures-executor-0.3.31",
         ":futures-util-0.3.31",
         ":glob-0.3.2",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":opentelemetry-0.26.0",
         ":percent-encoding-2.3.1",
         ":rand-0.8.5",
         ":serde_json-1.0.140",
         ":thiserror-1.0.69",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tokio-stream-0.1.17",
     ],
 )
@@ -11922,7 +12022,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["alloc"],
     visibility = [],
-    deps = [":base64ct-1.7.1"],
+    deps = [":base64ct-1.7.3"],
 )
 
 http_archive(
@@ -12897,7 +12997,7 @@ cargo.rust_library(
         ":rustls-0.23.23",
         ":socket2-0.5.8",
         ":thiserror-2.0.12",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tracing-0.1.41",
     ],
 )
@@ -12964,14 +13064,14 @@ cargo.rust_library(
         ),
         "windows-gnu": dict(
             deps = [
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
                 ":socket2-0.5.8",
                 ":windows-sys-0.59.0",
             ],
         ),
         "windows-msvc": dict(
             deps = [
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
                 ":socket2-0.5.8",
                 ":windows-sys-0.59.0",
             ],
@@ -13462,7 +13562,7 @@ cargo.rust_library(
         ":siphasher-1.0.1",
         ":thiserror-1.0.69",
         ":time-0.3.39",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tokio-postgres-0.7.13",
         ":toml-0.8.20",
         ":url-2.5.4",
@@ -13725,23 +13825,23 @@ cargo.rust_library(
 
 alias(
     name = "reqwest",
-    actual = ":reqwest-0.12.13",
+    actual = ":reqwest-0.12.14",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "reqwest-0.12.13.crate",
-    sha256 = "389a89e494bbc88bebf30e23da98742c843863a16a352647716116aa71fae80a",
-    strip_prefix = "reqwest-0.12.13",
-    urls = ["https://static.crates.io/crates/reqwest/0.12.13/download"],
+    name = "reqwest-0.12.14.crate",
+    sha256 = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254",
+    strip_prefix = "reqwest-0.12.14",
+    urls = ["https://static.crates.io/crates/reqwest/0.12.14/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "reqwest-0.12.13",
-    srcs = [":reqwest-0.12.13.crate"],
+    name = "reqwest-0.12.14",
+    srcs = [":reqwest-0.12.14.crate"],
     crate = "reqwest",
-    crate_root = "reqwest-0.12.13.crate/src/lib.rs",
+    crate_root = "reqwest-0.12.14.crate/src/lib.rs",
     edition = "2021",
     features = [
         "__rustls",
@@ -13767,7 +13867,7 @@ cargo.rust_library(
                 ":ipnet-2.11.0",
                 ":log-0.4.26",
                 ":mime-0.3.17",
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.16",
                 ":quinn-0.11.6",
@@ -13775,9 +13875,9 @@ cargo.rust_library(
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.11.0",
-                ":tokio-1.44.0",
+                ":tokio-1.44.1",
                 ":tokio-rustls-0.26.2",
-                ":tokio-util-0.7.13",
+                ":tokio-util-0.7.14",
                 ":tower-0.5.2",
                 ":webpki-roots-0.26.8",
             ],
@@ -13792,7 +13892,7 @@ cargo.rust_library(
                 ":ipnet-2.11.0",
                 ":log-0.4.26",
                 ":mime-0.3.17",
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.16",
                 ":quinn-0.11.6",
@@ -13800,9 +13900,9 @@ cargo.rust_library(
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.11.0",
-                ":tokio-1.44.0",
+                ":tokio-1.44.1",
                 ":tokio-rustls-0.26.2",
-                ":tokio-util-0.7.13",
+                ":tokio-util-0.7.14",
                 ":tower-0.5.2",
                 ":webpki-roots-0.26.8",
             ],
@@ -13817,7 +13917,7 @@ cargo.rust_library(
                 ":ipnet-2.11.0",
                 ":log-0.4.26",
                 ":mime-0.3.17",
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.16",
                 ":quinn-0.11.6",
@@ -13825,9 +13925,9 @@ cargo.rust_library(
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.11.0",
-                ":tokio-1.44.0",
+                ":tokio-1.44.1",
                 ":tokio-rustls-0.26.2",
-                ":tokio-util-0.7.13",
+                ":tokio-util-0.7.14",
                 ":tower-0.5.2",
                 ":webpki-roots-0.26.8",
             ],
@@ -13842,7 +13942,7 @@ cargo.rust_library(
                 ":ipnet-2.11.0",
                 ":log-0.4.26",
                 ":mime-0.3.17",
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.16",
                 ":quinn-0.11.6",
@@ -13850,9 +13950,9 @@ cargo.rust_library(
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.11.0",
-                ":tokio-1.44.0",
+                ":tokio-1.44.1",
                 ":tokio-rustls-0.26.2",
-                ":tokio-util-0.7.13",
+                ":tokio-util-0.7.14",
                 ":tower-0.5.2",
                 ":webpki-roots-0.26.8",
             ],
@@ -13867,7 +13967,7 @@ cargo.rust_library(
                 ":ipnet-2.11.0",
                 ":log-0.4.26",
                 ":mime-0.3.17",
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.16",
                 ":quinn-0.11.6",
@@ -13875,9 +13975,9 @@ cargo.rust_library(
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.11.0",
-                ":tokio-1.44.0",
+                ":tokio-1.44.1",
                 ":tokio-rustls-0.26.2",
-                ":tokio-util-0.7.13",
+                ":tokio-util-0.7.14",
                 ":tower-0.5.2",
                 ":webpki-roots-0.26.8",
                 ":windows-registry-0.4.0",
@@ -13893,7 +13993,7 @@ cargo.rust_library(
                 ":ipnet-2.11.0",
                 ":log-0.4.26",
                 ":mime-0.3.17",
-                ":once_cell-1.21.0",
+                ":once_cell-1.21.1",
                 ":percent-encoding-2.3.1",
                 ":pin-project-lite-0.2.16",
                 ":quinn-0.11.6",
@@ -13901,9 +14001,9 @@ cargo.rust_library(
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.11.0",
-                ":tokio-1.44.0",
+                ":tokio-1.44.1",
                 ":tokio-rustls-0.26.2",
-                ":tokio-util-0.7.13",
+                ":tokio-util-0.7.14",
                 ":tower-0.5.2",
                 ":webpki-roots-0.26.8",
                 ":windows-registry-0.4.0",
@@ -13949,7 +14049,7 @@ cargo.rust_library(
         ":mime-0.3.17",
         ":nom-7.1.3",
         ":pin-project-lite-0.2.16",
-        ":reqwest-0.12.13",
+        ":reqwest-0.12.14",
         ":thiserror-1.0.69",
     ],
 )
@@ -14717,18 +14817,18 @@ cxx_library(
 )
 
 http_archive(
-    name = "rsa-0.9.7.crate",
-    sha256 = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519",
-    strip_prefix = "rsa-0.9.7",
-    urls = ["https://static.crates.io/crates/rsa/0.9.7/download"],
+    name = "rsa-0.9.8.crate",
+    sha256 = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b",
+    strip_prefix = "rsa-0.9.8",
+    urls = ["https://static.crates.io/crates/rsa/0.9.8/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rsa-0.9.7",
-    srcs = [":rsa-0.9.7.crate"],
+    name = "rsa-0.9.8",
+    srcs = [":rsa-0.9.8.crate"],
     crate = "rsa",
-    crate_root = "rsa-0.9.7.crate/src/lib.rs",
+    crate_root = "rsa-0.9.8.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -14854,7 +14954,7 @@ cargo.rust_library(
         ":sha2-0.10.8",
         ":thiserror-1.0.69",
         ":time-0.3.39",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tokio-rustls-0.24.1",
         ":tokio-stream-0.1.17",
         ":url-2.5.4",
@@ -15272,7 +15372,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":log-0.4.26",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":ring-0.17.5",
         ":rustls-webpki-0.102.8",
         ":subtle-2.6.1",
@@ -17004,7 +17104,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":base64ct-1.7.1",
+        ":base64ct-1.7.3",
         ":der-0.7.9",
     ],
 )
@@ -17101,7 +17201,7 @@ cargo.rust_library(
         ":indexmap-2.8.0",
         ":log-0.4.26",
         ":memchr-2.7.4",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":percent-encoding-2.3.1",
         ":rust_decimal-1.36.0",
         ":rustls-0.23.23",
@@ -17112,7 +17212,7 @@ cargo.rust_library(
         ":smallvec-1.14.0",
         ":thiserror-2.0.12",
         ":time-0.3.39",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tokio-stream-0.1.17",
         ":tracing-0.1.41",
         ":url-2.5.4",
@@ -17175,7 +17275,7 @@ cargo.rust_library(
         ":md-5-0.10.6",
         ":memchr-2.7.4",
         ":num-bigint-0.4.6",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":rand-0.8.5",
         ":rust_decimal-1.36.0",
         ":serde-1.0.219",
@@ -17362,7 +17462,7 @@ cargo.rust_library(
         "rrsa",
     ],
     named_deps = {
-        "rrsa": ":rsa-0.9.7",
+        "rrsa": ":rsa-0.9.8",
     },
     visibility = [],
     deps = [
@@ -17686,7 +17786,7 @@ cargo.rust_library(
     deps = [
         ":cfg-if-1.0.0",
         ":fastrand-2.3.0",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
     ],
 )
 
@@ -17829,6 +17929,7 @@ cargo.rust_binary(
         ":clap-4.5.32",
         ":color-eyre-0.6.3",
         ":config-0.14.1",
+        ":console-subscriber-0.4.1",
         ":convert_case-0.6.0",
         ":crossbeam-queue-0.3.12",
         ":darling-0.20.10",
@@ -17873,7 +17974,7 @@ cargo.rust_binary(
         ":nix-0.29.0",
         ":nkeys-0.4.4",
         ":num_cpus-1.16.0",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":opentelemetry-0.26.0",
         ":opentelemetry-otlp-0.26.0",
         ":opentelemetry-semantic-conventions-0.14.0",
@@ -17895,7 +17996,7 @@ cargo.rust_binary(
         ":refinery-0.8.16",
         ":regex-1.11.1",
         ":remain-0.2.15",
-        ":reqwest-0.12.13",
+        ":reqwest-0.12.14",
         ":ring-0.17.5",
         ":rust-s3-0.34.0-rc4",
         ":rustls-0.23.23",
@@ -17920,13 +18021,13 @@ cargo.rust_binary(
         ":thiserror-2.0.12",
         ":thread-priority-1.2.0",
         ":time-0.3.39",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tokio-postgres-0.7.13",
         ":tokio-postgres-rustls-0.13.0",
         ":tokio-serde-0.9.0",
         ":tokio-stream-0.1.17",
         ":tokio-tungstenite-0.20.1",
-        ":tokio-util-0.7.13",
+        ":tokio-util-0.7.14",
         ":tokio-vsock-0.4.0",
         ":toml-0.8.20",
         ":tower-0.4.13",
@@ -18112,7 +18213,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":cfg-if-1.0.0",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
     ],
 )
 
@@ -18344,23 +18445,23 @@ cargo.rust_library(
 
 alias(
     name = "tokio",
-    actual = ":tokio-1.44.0",
+    actual = ":tokio-1.44.1",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tokio-1.44.0.crate",
-    sha256 = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a",
-    strip_prefix = "tokio-1.44.0",
-    urls = ["https://static.crates.io/crates/tokio/1.44.0/download"],
+    name = "tokio-1.44.1.crate",
+    sha256 = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a",
+    strip_prefix = "tokio-1.44.1",
+    urls = ["https://static.crates.io/crates/tokio/1.44.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tokio-1.44.0",
-    srcs = [":tokio-1.44.0.crate"],
+    name = "tokio-1.44.1",
+    srcs = [":tokio-1.44.1.crate"],
     crate = "tokio",
-    crate_root = "tokio-1.44.0.crate/src/lib.rs",
+    crate_root = "tokio-1.44.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "bytes",
@@ -18385,6 +18486,7 @@ cargo.rust_library(
         "time",
         "tokio-macros",
         "tokio_track_caller",
+        "tracing",
         "windows-sys",
     ],
     platform = {
@@ -18558,8 +18660,8 @@ cargo.rust_library(
         ":postgres-protocol-0.6.8",
         ":postgres-types-0.2.9",
         ":rand-0.9.0",
-        ":tokio-1.44.0",
-        ":tokio-util-0.7.13",
+        ":tokio-1.44.1",
+        ":tokio-util-0.7.14",
         ":whoami-1.5.2",
     ],
 )
@@ -18581,7 +18683,7 @@ cargo.rust_library(
         ":const-oid-0.9.6",
         ":ring-0.17.5",
         ":rustls-0.23.23",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tokio-postgres-0.7.13",
         ":tokio-rustls-0.26.2",
         ":x509-cert-0.2.5",
@@ -18610,7 +18712,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rustls-0.21.12",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
     ],
 )
 
@@ -18636,7 +18738,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rustls-0.23.23",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
     ],
 )
 
@@ -18710,8 +18812,8 @@ cargo.rust_library(
     deps = [
         ":futures-core-0.3.31",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.0",
-        ":tokio-util-0.7.13",
+        ":tokio-1.44.1",
+        ":tokio-util-0.7.14",
     ],
 )
 
@@ -18745,30 +18847,30 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.31",
         ":log-0.4.26",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tungstenite-0.20.1",
     ],
 )
 
 alias(
     name = "tokio-util",
-    actual = ":tokio-util-0.7.13",
+    actual = ":tokio-util-0.7.14",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tokio-util-0.7.13.crate",
-    sha256 = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078",
-    strip_prefix = "tokio-util-0.7.13",
-    urls = ["https://static.crates.io/crates/tokio-util/0.7.13/download"],
+    name = "tokio-util-0.7.14.crate",
+    sha256 = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034",
+    strip_prefix = "tokio-util-0.7.14",
+    urls = ["https://static.crates.io/crates/tokio-util/0.7.14/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tokio-util-0.7.13",
-    srcs = [":tokio-util-0.7.13.crate"],
+    name = "tokio-util-0.7.14",
+    srcs = [":tokio-util-0.7.14.crate"],
     crate = "tokio_util",
-    crate_root = "tokio-util-0.7.13.crate/src/lib.rs",
+    crate_root = "tokio-util-0.7.14.crate/src/lib.rs",
     edition = "2021",
     features = [
         "codec",
@@ -18786,7 +18888,7 @@ cargo.rust_library(
         ":futures-sink-0.3.31",
         ":futures-util-0.3.31",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
     ],
 )
 
@@ -18815,7 +18917,7 @@ cargo.rust_library(
         ":bytes-1.10.1",
         ":futures-0.3.31",
         ":libc-0.2.171",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":vsock-0.3.0",
     ],
 )
@@ -18851,9 +18953,9 @@ cargo.rust_library(
         ":rand-0.8.5",
         ":ring-0.17.5",
         ":rustls-pki-types-1.11.0",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tokio-rustls-0.26.2",
-        ":tokio-util-0.7.13",
+        ":tokio-util-0.7.14",
         ":webpki-roots-0.26.8",
     ],
 )
@@ -18936,7 +19038,7 @@ cargo.rust_library(
         ":serde-1.0.219",
         ":serde_spanned-0.6.8",
         ":toml_datetime-0.6.8",
-        ":winnow-0.7.3",
+        ":winnow-0.7.4",
     ],
 )
 
@@ -18968,6 +19070,7 @@ cargo.rust_library(
     features = [
         "channel",
         "codegen",
+        "default",
         "prost",
         "router",
         "server",
@@ -18994,7 +19097,7 @@ cargo.rust_library(
         ":prost-0.13.5",
         ":rustls-pemfile-2.2.0",
         ":socket2-0.5.8",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tokio-rustls-0.26.2",
         ":tokio-stream-0.1.17",
         ":tower-0.4.13",
@@ -19068,8 +19171,8 @@ cargo.rust_library(
         ":pin-project-lite-0.2.16",
         ":rand-0.8.5",
         ":slab-0.4.9",
-        ":tokio-1.44.0",
-        ":tokio-util-0.7.13",
+        ":tokio-1.44.1",
+        ":tokio-util-0.7.14",
         ":tower-layer-0.3.3",
         ":tower-service-0.3.3",
         ":tracing-0.1.41",
@@ -19106,7 +19209,7 @@ cargo.rust_library(
         ":futures-util-0.3.31",
         ":pin-project-lite-0.2.16",
         ":sync_wrapper-1.0.2",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":tower-layer-0.3.3",
         ":tower-service-0.3.3",
     ],
@@ -19155,8 +19258,8 @@ cargo.rust_library(
         ":http-body-0.4.6",
         ":http-range-header-0.3.1",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.0",
-        ":tokio-util-0.7.13",
+        ":tokio-1.44.1",
+        ":tokio-util-0.7.14",
         ":tower-layer-0.3.3",
         ":tower-service-0.3.3",
         ":tracing-0.1.41",
@@ -19276,7 +19379,7 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
-    deps = [":once_cell-1.21.0"],
+    deps = [":once_cell-1.21.1"],
 )
 
 http_archive(
@@ -19325,7 +19428,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":log-0.4.26",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":tracing-core-0.1.33",
     ],
 )
@@ -19369,7 +19472,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":opentelemetry-0.26.0",
         ":opentelemetry_sdk-0.26.0",
         ":smallvec-1.14.0",
@@ -19447,7 +19550,7 @@ cargo.rust_library(
     deps = [
         ":matchers-0.1.0",
         ":nu-ansi-term-0.46.0",
-        ":once_cell-1.21.0",
+        ":once_cell-1.21.1",
         ":regex-1.11.1",
         ":serde-1.0.219",
         ":serde_json-1.0.140",
@@ -19567,7 +19670,7 @@ cargo.rust_library(
     deps = [
         ":futures-0.3.31",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
     ],
 )
 
@@ -21022,18 +21125,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "winnow-0.7.3.crate",
-    sha256 = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1",
-    strip_prefix = "winnow-0.7.3",
-    urls = ["https://static.crates.io/crates/winnow/0.7.3/download"],
+    name = "winnow-0.7.4.crate",
+    sha256 = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36",
+    strip_prefix = "winnow-0.7.4",
+    urls = ["https://static.crates.io/crates/winnow/0.7.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "winnow-0.7.3",
-    srcs = [":winnow-0.7.3.crate"],
+    name = "winnow-0.7.4",
+    srcs = [":winnow-0.7.4.crate"],
     crate = "winnow",
-    crate_root = "winnow-0.7.3.crate/src/lib.rs",
+    crate_root = "winnow-0.7.4.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -21211,7 +21314,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.31",
         ":thiserror-1.0.69",
-        ":tokio-1.44.0",
+        ":tokio-1.44.1",
         ":yrs-0.17.4",
     ],
 )

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.7.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bigdecimal"
@@ -1431,6 +1431,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1580,15 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -2807,7 +2855,10 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
+ "base64 0.21.7",
  "byteorder",
+ "flate2",
+ "nom",
  "num-traits",
 ]
 
@@ -2991,9 +3042,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -4147,9 +4198,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.0"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "openssl-probe"
@@ -5128,9 +5179,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.13"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389a89e494bbc88bebf30e23da98742c843863a16a352647716116aa71fae80a"
+checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5250,9 +5301,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
  "const-oid",
  "digest",
@@ -6492,6 +6543,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "config",
+ "console-subscriber",
  "convert_case 0.6.0",
  "crossbeam-queue",
  "darling 0.20.10",
@@ -6762,9 +6814,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6775,6 +6827,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -6890,9 +6943,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -7947,9 +8000,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -54,6 +54,7 @@ clap = { version = "4.5.23", features = [
 ] }
 color-eyre = "0.6.3"
 config = { version = "0.14.1", default-features = false, features = ["toml"] }
+console-subscriber = { version = "0.4.1", default-features = false }
 convert_case = "0.6.0"
 crossbeam-queue = { version = "0.3.11" }
 darling = "0.20.10"

--- a/third-party/rust/fixups/console-subscriber/fixups.toml
+++ b/third-party/rust/fixups/console-subscriber/fixups.toml
@@ -1,0 +1,1 @@
+cfgs = ["tokio_unstable"]


### PR DESCRIPTION
This change adds a new CLI flag of `--tokio-console` which will enable collection and transmission of Tokio runtime telemetry for use with the [tokio-console] debugging tool.

By default, the responsible subscriber will not be active as there is a potential for performance impact.

To enable this mode in any of the Rust services there are 2 ways to do this:

- Add a `--tokio-console` flag to the CLI when starting
- Export `SI_TOKIO_CONSOLE=true` when running a service

[tokio-console]: https://github.com/tokio-rs/console

<img src="https://media3.giphy.com/media/tVXqVRdInsRIajEqKp/giphy.gif?cid=bd3ea57e8i67v7wz44lw8ebjp6z3kiyi3zgqiw0lfg1d74gm&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>