### PR TITLE
chore(dal): remaining get_by_id_or_error -> get_by_id

### DIFF
--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -384,7 +384,7 @@ impl ExpectSchemaVariant {
     }
 
     pub async fn schema_variant(self, ctx: &DalContext) -> SchemaVariant {
-        SchemaVariant::get_by_id_or_error(ctx, self.0)
+        SchemaVariant::get_by_id(ctx, self.0)
             .await
             .expect("find schema variant by id")
     }

--- a/lib/dal/src/approval_requirement.rs
+++ b/lib/dal/src/approval_requirement.rs
@@ -187,12 +187,9 @@ impl ApprovalRequirementDefinition {
             approvers: content.approvers,
         }
     }
-    pub async fn get_by_id_or_error(
-        ctx: &DalContext,
-        id: ApprovalRequirementDefinitionId,
-    ) -> Result<Self> {
+    pub async fn get_by_id(ctx: &DalContext, id: ApprovalRequirementDefinitionId) -> Result<Self> {
         ctx.workspace_snapshot()?
-            .get_by_id_or_error(ctx, id)
+            .get_approval_requirement_definition_by_id(ctx, id)
             .await
             .map_err(Into::into)
     }

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -186,7 +186,7 @@ impl AttributePrototype {
         ctx: &DalContext,
         prototype_id: AttributePrototypeId,
     ) -> AttributePrototypeResult<Func> {
-        Ok(Func::get_by_id_or_error(ctx, Self::func_id(ctx, prototype_id).await?).await?)
+        Ok(Func::get_by_id(ctx, Self::func_id(ctx, prototype_id).await?).await?)
     }
 
     pub async fn find_for_prop(

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -295,7 +295,7 @@ impl AttributePrototypeArgument {
         ctx: &DalContext,
     ) -> AttributePrototypeArgumentResult<FuncArgument> {
         let func_arg_id = Self::func_argument_id_by_id(ctx, self.id).await?;
-        Ok(FuncArgument::get_by_id_or_error(ctx, func_arg_id).await?)
+        Ok(FuncArgument::get_by_id(ctx, func_arg_id).await?)
     }
 
     pub async fn func_argument_id_by_id(

--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -311,7 +311,7 @@ impl AttributePrototypeDebugView {
         let attribute_values = AttributePrototype::attribute_value_ids(ctx, prototype_id).await?;
         let func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
 
-        let func_name = Func::get_by_id_or_error(ctx, func_id).await?.name;
+        let func_name = Func::get_by_id(ctx, func_id).await?.name;
         let view = AttributePrototypeDebugView {
             func_args: func_binding_args,
             func_id,

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -616,7 +616,7 @@ impl AttributeValue {
             None => None,
         };
 
-        let func = Func::get_by_id_or_error(ctx, prototype_func_id).await?;
+        let func = Func::get_by_id(ctx, prototype_func_id).await?;
         if !func.is_intrinsic() {
             ctx.layer_db()
                 .func_run()
@@ -845,7 +845,7 @@ impl AttributeValue {
     ) -> AttributeValueResult<Func> {
         let prototype_id = Self::prototype_id(ctx, attribute_value_id).await?;
         let prototype_func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
-        Ok(Func::get_by_id_or_error(ctx, prototype_func_id).await?)
+        Ok(Func::get_by_id(ctx, prototype_func_id).await?)
     }
 
     pub async fn is_set_by_dependent_function(
@@ -1901,7 +1901,7 @@ impl AttributeValue {
             }
         };
         let func_id = Func::find_intrinsic(ctx, intrinsic_func).await?;
-        let func = Func::get_by_id_or_error(ctx, func_id).await?;
+        let func = Func::get_by_id(ctx, func_id).await?;
         let prototype = AttributePrototype::new(ctx, func_id).await?;
 
         Self::set_component_prototype_id(ctx, attribute_value_id, prototype.id(), None).await?;

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -587,7 +587,7 @@ impl Component {
         component.set_name(ctx, &name).await?;
 
         //set a component specific prototype for the root/si/type as we don't want it to ever change other than manually
-        let sv_type = SchemaVariant::get_by_id_or_error(ctx, schema_variant_id)
+        let sv_type = SchemaVariant::get_by_id(ctx, schema_variant_id)
             .await?
             .get_type(ctx)
             .await?;
@@ -810,7 +810,7 @@ impl Component {
                         continue;
                     };
 
-                    let prototype_func = Func::get_by_id_or_error(
+                    let prototype_func = Func::get_by_id(
                         ctx,
                         AttributePrototype::func_id(ctx, old_component_prototype_id).await?,
                     )
@@ -1419,7 +1419,7 @@ impl Component {
         component_id: ComponentId,
     ) -> ComponentResult<SchemaVariant> {
         let schema_variant_id = Self::schema_variant_id(ctx, component_id).await?;
-        Ok(SchemaVariant::get_by_id_or_error(ctx, schema_variant_id).await?)
+        Ok(SchemaVariant::get_by_id(ctx, schema_variant_id).await?)
     }
 
     pub async fn schema_variant(&self, ctx: &DalContext) -> ComponentResult<SchemaVariant> {
@@ -2306,7 +2306,7 @@ impl Component {
         while let Some((av_id, maybe_parent_av_id)) = av_queue.pop_front() {
             let prototype_id = AttributeValue::prototype_id(ctx, av_id).await?;
             let func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
-            let func = Func::get_by_id_or_error(ctx, func_id).await?;
+            let func = Func::get_by_id(ctx, func_id).await?;
 
             let this_tuple = ControllingFuncData {
                 func_id,
@@ -3704,13 +3704,12 @@ impl Component {
             match action.state() {
                 ActionState::Failed | ActionState::OnHold | ActionState::Queued => {
                     let func_id = ActionPrototype::func_id(ctx, action_prototype_id).await?;
-                    let queued_func = Func::get_by_id_or_error(ctx, func_id).await?;
+                    let queued_func = Func::get_by_id(ctx, func_id).await?;
 
                     for available_action_prototype in available_for_new_component.clone() {
                         let available_func_id =
                             ActionPrototype::func_id(ctx, available_action_prototype.id()).await?;
-                        let available_func =
-                            Func::get_by_id_or_error(ctx, available_func_id).await?;
+                        let available_func = Func::get_by_id(ctx, available_func_id).await?;
 
                         if available_func.name == queued_func.name
                             && available_func.kind == queued_func.kind

--- a/lib/dal/src/entity_kind.rs
+++ b/lib/dal/src/entity_kind.rs
@@ -78,7 +78,7 @@ impl EntityKind {
             | EntityKindEvents::ValidationOutput
             | EntityKindEvents::ValidationPrototype => None,
             EntityKindEvents::SchemaVariant => {
-                let variant_name = SchemaVariant::get_by_id_or_error(ctx, id.into_inner().into())
+                let variant_name = SchemaVariant::get_by_id(ctx, id.into_inner().into())
                     .await?
                     .display_name()
                     .to_owned();

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -292,7 +292,7 @@ impl Func {
         }
     }
 
-    pub async fn get_by_id(ctx: &DalContext, id: FuncId) -> FuncResult<Option<Self>> {
+    pub async fn get_by_id_opt(ctx: &DalContext, id: FuncId) -> FuncResult<Option<Self>> {
         let (func_node_weight, hash) = if let Some((func_node_weight, hash)) =
             Self::get_node_weight_and_content_hash(ctx, id).await?
         {
@@ -305,7 +305,7 @@ impl Func {
         Ok(Some(func))
     }
 
-    pub async fn get_by_id_or_error(ctx: &DalContext, id: FuncId) -> FuncResult<Self> {
+    pub async fn get_by_id(ctx: &DalContext, id: FuncId) -> FuncResult<Self> {
         let (func_node_weight, hash) =
             Self::get_node_weight_and_content_hash_or_error(ctx, id).await?;
         Self::get_by_id_inner(ctx, &hash, &func_node_weight).await
@@ -316,7 +316,7 @@ impl Func {
         ctx: &DalContext,
         id: FuncId,
     ) -> FuncResult<IntrinsicFunc> {
-        let func = Self::get_by_id_or_error(ctx, id).await?;
+        let func = Self::get_by_id(ctx, id).await?;
 
         Self::get_intrinsic_kind_by_id(ctx, id)
             .await?
@@ -327,7 +327,7 @@ impl Func {
         ctx: &DalContext,
         id: FuncId,
     ) -> FuncResult<Option<IntrinsicFunc>> {
-        let func = Self::get_by_id_or_error(ctx, id).await?;
+        let func = Self::get_by_id(ctx, id).await?;
         Ok(IntrinsicFunc::maybe_from_str(func.name.clone()))
     }
 
@@ -451,7 +451,7 @@ impl Func {
     where
         L: FnOnce(&mut Func) -> FuncResult<()>,
     {
-        let func = Func::get_by_id_or_error(ctx, id).await?;
+        let func = Func::get_by_id(ctx, id).await?;
         let modified_func = func.modify(ctx, lambda).await?;
         Ok(modified_func)
     }
@@ -566,7 +566,7 @@ impl Func {
 
     /// Deletes the [`Func`] and returns the name.
     pub async fn delete_by_id(ctx: &DalContext, id: FuncId) -> FuncResult<String> {
-        let func = Self::get_by_id_or_error(ctx, id).await?;
+        let func = Self::get_by_id(ctx, id).await?;
         // Check that we can remove the func.
         if !FuncBinding::for_func_id(ctx, id)
             .await

--- a/lib/dal/src/func/argument.rs
+++ b/lib/dal/src/func/argument.rs
@@ -263,7 +263,7 @@ impl FuncArgument {
         Ok(FuncArgument::assemble(&func_argument_node_weight, &content))
     }
 
-    pub async fn get_by_id(
+    pub async fn get_by_id_opt(
         ctx: &DalContext,
         id: FuncArgumentId,
     ) -> FuncArgumentResult<Option<Self>> {
@@ -279,10 +279,7 @@ impl FuncArgument {
         Ok(Some(func_argument))
     }
 
-    pub async fn get_by_id_or_error(
-        ctx: &DalContext,
-        id: FuncArgumentId,
-    ) -> FuncArgumentResult<Self> {
+    pub async fn get_by_id(ctx: &DalContext, id: FuncArgumentId) -> FuncArgumentResult<Self> {
         let (node_weight, hash) = Self::get_node_weight_and_content_hash_or_error(ctx, id).await?;
         Self::get_by_id_inner(ctx, &hash, &node_weight).await
     }
@@ -426,7 +423,7 @@ impl FuncArgument {
     where
         L: FnOnce(&mut FuncArgument) -> FuncArgumentResult<()>,
     {
-        let func_argument = Self::get_by_id_or_error(ctx, id).await?;
+        let func_argument = Self::get_by_id(ctx, id).await?;
         let modified_func_argument = func_argument.modify(ctx, lambda).await?;
         Ok(modified_func_argument)
     }

--- a/lib/dal/src/func/associations.rs
+++ b/lib/dal/src/func/associations.rs
@@ -392,7 +392,7 @@ impl FuncAssociations {
             }
         }
         for (arg_id, ts_types) in argument_types.iter() {
-            let func_arg = FuncArgument::get_by_id_or_error(ctx, *arg_id).await?;
+            let func_arg = FuncArgument::get_by_id(ctx, *arg_id).await?;
             let arg_name = func_arg.name;
             input_ts_types
                 .push_str(format!("{}?: {} | null;\n", arg_name, ts_types.join(" | ")).as_str());

--- a/lib/dal/src/func/authoring/save.rs
+++ b/lib/dal/src/func/authoring/save.rs
@@ -394,7 +394,7 @@ pub(crate) async fn save_attr_func_proto_arguments(
     for arg in &arguments {
         // Ensure the func argument exists before continuing. By continuing, we will not add the
         // attribute prototype to the id set and will be deleted.
-        if let Err(err) = FuncArgument::get_by_id_or_error(ctx, arg.func_argument_id).await {
+        if let Err(err) = FuncArgument::get_by_id(ctx, arg.func_argument_id).await {
             match err {
                 FuncArgumentError::WorkspaceSnapshot(
                     WorkspaceSnapshotError::WorkspaceSnapshotGraph(

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -397,7 +397,7 @@ impl FuncBinding {
         ctx: &DalContext,
         func_id: FuncId,
     ) -> FuncBindingResult<Vec<FuncBinding>> {
-        let func = Func::get_by_id_or_error(ctx, func_id).await?;
+        let func = Func::get_by_id(ctx, func_id).await?;
         let bindings = match func.kind {
             FuncKind::Action => ActionBinding::assemble_action_bindings(ctx, func_id).await?,
             FuncKind::Attribute => {
@@ -447,7 +447,7 @@ impl FuncBinding {
                     }
                     None => {
                         if !SchemaVariant::is_locked_by_id(ctx, schema_variant_id).await?
-                            || SchemaVariant::get_by_id_or_error(ctx, schema_variant_id)
+                            || SchemaVariant::get_by_id(ctx, schema_variant_id)
                                 .await?
                                 .is_default(ctx)
                                 .await?
@@ -548,7 +548,7 @@ impl FuncBinding {
         let func_bindings = FuncBinding::for_func_id(ctx, func_id).await?;
         for binding in func_bindings {
             if let Some(sv_id) = binding.get_schema_variant() {
-                let sv = SchemaVariant::get_by_id_or_error(ctx, sv_id).await?;
+                let sv = SchemaVariant::get_by_id(ctx, sv_id).await?;
 
                 // If the variant is locked, not default and was created on this changeset, it needs to be garbage collected
                 if sv.is_locked()
@@ -595,7 +595,7 @@ impl FuncBinding {
 
     /// Compile all the types for all of the bindings to return to the front end for type checking
     pub async fn compile_types(ctx: &DalContext, func_id: FuncId) -> FuncBindingResult<String> {
-        let func = Func::get_by_id_or_error(ctx, func_id).await?;
+        let func = Func::get_by_id(ctx, func_id).await?;
         let types: String = match func.kind {
             FuncKind::Action => ActionBinding::compile_action_types(ctx, func_id).await?,
             FuncKind::CodeGeneration | FuncKind::Qualification => {

--- a/lib/dal/src/func/binding/action.rs
+++ b/lib/dal/src/func/binding/action.rs
@@ -56,7 +56,7 @@ impl ActionBinding {
         let schema_variant_id =
             ActionPrototype::schema_variant_id(ctx, action_prototype_id).await?;
         let func_id = ActionPrototype::func_id(ctx, action_prototype_id).await?;
-        let func = Func::get_by_id_or_error(ctx, func_id).await?; // delete and recreate the prototype
+        let func = Func::get_by_id(ctx, func_id).await?; // delete and recreate the prototype
 
         ActionPrototype::remove(ctx, action_prototype_id).await?;
         ActionPrototype::new(
@@ -103,7 +103,7 @@ impl ActionBinding {
             }
         }
 
-        let func = Func::get_by_id_or_error(ctx, func_id).await?;
+        let func = Func::get_by_id(ctx, func_id).await?;
         ActionPrototype::new(
             ctx,
             action_kind,

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -310,7 +310,7 @@ impl AttributeBinding {
         output_location: AttributeFuncDestination,
         prototype_arguments: Vec<AttributeArgumentBinding>,
     ) -> FuncBindingResult<(AttributePrototype, Option<FuncId>)> {
-        let func = Func::get_by_id_or_error(ctx, func_id).await?;
+        let func = Func::get_by_id(ctx, func_id).await?;
 
         let needs_validate_intrinsic_input = match func.kind {
             FuncKind::Attribute => false,
@@ -471,7 +471,7 @@ impl AttributeBinding {
 
         for arg in &prototype_arguments {
             // Ensure a func argument exists for each input location, before creating new Attribute Prototype Arguments
-            if let Err(err) = FuncArgument::get_by_id_or_error(ctx, arg.func_argument_id).await {
+            if let Err(err) = FuncArgument::get_by_id(ctx, arg.func_argument_id).await {
                 match err {
                     FuncArgumentError::WorkspaceSnapshot(
                         WorkspaceSnapshotError::WorkspaceSnapshotGraph(
@@ -573,7 +573,7 @@ impl AttributeBinding {
         for arg in &prototype_arguments {
             // Ensure the func argument exists before continuing. By continuing, we will not add the
             // attribute prototype to the id set and will be deleted.
-            if let Err(err) = FuncArgument::get_by_id_or_error(ctx, arg.func_argument_id).await {
+            if let Err(err) = FuncArgument::get_by_id(ctx, arg.func_argument_id).await {
                 match err {
                     FuncArgumentError::WorkspaceSnapshot(
                         WorkspaceSnapshotError::WorkspaceSnapshotGraph(
@@ -778,7 +778,7 @@ impl AttributeBinding {
         }
 
         for (arg_id, ts_types) in argument_types.iter() {
-            let func_arg = FuncArgument::get_by_id_or_error(ctx, *arg_id).await?;
+            let func_arg = FuncArgument::get_by_id(ctx, *arg_id).await?;
             let arg_name = func_arg.name;
             input_ts_types
                 .push_str(format!("{}?: {} | null;\n", arg_name, ts_types.join(" | ")).as_str());

--- a/lib/dal/src/func/binding/leaf.rs
+++ b/lib/dal/src/func/binding/leaf.rs
@@ -94,7 +94,7 @@ impl LeafBinding {
         // don't create binding if parent is locked
         eventual_parent.error_if_locked(ctx).await?;
 
-        let func = Func::get_by_id_or_error(ctx, func_id).await?;
+        let func = Func::get_by_id(ctx, func_id).await?;
         match eventual_parent {
             EventualParent::SchemaVariant(schema_variant_id) => {
                 let inputs = match inputs.is_empty() {

--- a/lib/dal/src/func/binding/management.rs
+++ b/lib/dal/src/func/binding/management.rs
@@ -39,7 +39,7 @@ impl ManagementBinding {
         // don't add binding if parent is locked
         SchemaVariant::error_if_locked(ctx, schema_variant_id).await?;
 
-        let func = Func::get_by_id_or_error(ctx, func_id).await?;
+        let func = Func::get_by_id(ctx, func_id).await?;
         ManagementPrototype::new(
             ctx,
             func.name.to_owned(),

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -97,8 +97,6 @@ pub enum FuncRunnerError {
     Func(#[from] FuncError),
     #[error("function backend error: {0}")]
     FuncBackend(#[from] FuncBackendError),
-    #[error("validation function intrinsic func is missing -- bug!")]
-    FuncIntrinsicValidationMissing,
     #[error("func run builder error: {0}")]
     FuncRunBuilder(#[from] FuncRunBuilderError),
     #[error("history event error: {0}")]
@@ -487,9 +485,7 @@ impl FuncRunner {
         ) -> FuncRunnerResult<FuncRunner> {
             let func_id =
                 Func::find_intrinsic(ctx, super::intrinsics::IntrinsicFunc::Validation).await?;
-            let func = Func::get_by_id(ctx, func_id)
-                .await?
-                .ok_or(FuncRunnerError::FuncIntrinsicValidationMissing)?;
+            let func = Func::get_by_id(ctx, func_id).await?;
 
             let args = serde_json::json!({
                 "value": value,
@@ -653,7 +649,7 @@ impl FuncRunner {
             args: serde_json::Value,
             parent_span: &Span,
         ) -> FuncRunnerResult<FuncRunner> {
-            let func = Func::get_by_id_or_error(ctx, func_id).await?;
+            let func = Func::get_by_id(ctx, func_id).await?;
 
             let function_args: CasValue = args.clone().into();
 
@@ -822,7 +818,7 @@ impl FuncRunner {
             args: serde_json::Value,
             span: &Span,
         ) -> FuncRunnerResult<FuncRunner> {
-            let func = Func::get_by_id_or_error(ctx, management_func_id).await?;
+            let func = Func::get_by_id(ctx, management_func_id).await?;
 
             let function_args: CasValue = args.clone().into();
             let (function_args_cas_address, _) = ctx.layer_db().cas().write(
@@ -1002,7 +998,7 @@ impl FuncRunner {
             args: serde_json::Value,
             span: &Span,
         ) -> FuncRunnerResult<FuncRunner> {
-            let func = Func::get_by_id_or_error(ctx, func_id).await?;
+            let func = Func::get_by_id(ctx, func_id).await?;
             let prototype = ActionPrototype::get_by_id(ctx, action_prototype_id)
                 .await
                 .map_err(Box::new)?;
@@ -1478,7 +1474,7 @@ impl FuncRunner {
                     SchemaVariant::list_auth_func_ids_for_id(ctx, secret_defining_schema_variant_id)
                         .await?
                 {
-                    auth_funcs.push(Func::get_by_id_or_error(ctx, auth_func_id).await?)
+                    auth_funcs.push(Func::get_by_id(ctx, auth_func_id).await?)
                 }
                 return Ok(auth_funcs);
             }

--- a/lib/dal/src/job/definition/action.rs
+++ b/lib/dal/src/job/definition/action.rs
@@ -214,7 +214,7 @@ async fn process_execution(
     let prototype_id = Action::prototype_id(ctx, action_id).await?;
     let prototype = ActionPrototype::get_by_id(ctx, prototype_id).await?;
     let func_id = ActionPrototype::func_id(ctx, prototype_id).await?;
-    let func = Func::get_by_id_or_error(ctx, func_id).await?;
+    let func = Func::get_by_id(ctx, func_id).await?;
 
     let component_id = Action::component_id(ctx, action_id)
         .await?

--- a/lib/dal/src/management/mod.rs
+++ b/lib/dal/src/management/mod.rs
@@ -1584,7 +1584,7 @@ async fn remove_action(
             for action_id in actions {
                 let prototype_id = Action::prototype_id(ctx, action_id).await?;
                 let func_id = ActionPrototype::func_id(ctx, prototype_id).await?;
-                let func = Func::get_by_id_or_error(ctx, func_id).await?;
+                let func = Func::get_by_id(ctx, func_id).await?;
                 if Some(func.name) == action.manual_func_name {
                     Action::remove_by_id(ctx, action_id).await?;
                 }
@@ -1635,11 +1635,9 @@ async fn add_action(
                 .iter()
                 .filter(|proto| proto.kind == ActionKind::Manual)
             {
-                let func = Func::get_by_id_or_error(
-                    ctx,
-                    ActionPrototype::func_id(ctx, manual_proto.id()).await?,
-                )
-                .await?;
+                let func =
+                    Func::get_by_id(ctx, ActionPrototype::func_id(ctx, manual_proto.id()).await?)
+                        .await?;
                 if func.name == manual_func_name {
                     proto_id = Some(manual_proto.id());
                     break;

--- a/lib/dal/src/module.rs
+++ b/lib/dal/src/module.rs
@@ -182,7 +182,7 @@ impl Module {
         Ok(Self::assemble(id.into(), content))
     }
 
-    pub async fn get_by_id_or_error(ctx: &DalContext, id: ModuleId) -> ModuleResult<Self> {
+    pub async fn get_by_id(ctx: &DalContext, id: ModuleId) -> ModuleResult<Self> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let node_index = workspace_snapshot.get_node_index_by_id(id).await?;
@@ -229,8 +229,7 @@ impl Module {
                 .await?
                 .get_content_node_weight_of_kind(ContentAddressDiscriminants::Module)?;
 
-            let module: Module =
-                Self::get_by_id_or_error(ctx, module_node_weight.id().into()).await?;
+            let module: Module = Self::get_by_id(ctx, module_node_weight.id().into()).await?;
             if predicate(&module) {
                 return Ok(Some(module));
             }
@@ -270,8 +269,7 @@ impl Module {
                 if ContentAddressDiscriminants::Module
                     == content_node_weight.content_address().into()
                 {
-                    let module =
-                        Self::get_by_id_or_error(ctx, content_node_weight.id().into()).await?;
+                    let module = Self::get_by_id(ctx, content_node_weight.id().into()).await?;
                     return Ok(Some(module));
                 }
             }
@@ -301,7 +299,7 @@ impl Module {
         let node_weights = workspace_snapshot.all_outgoing_targets(self.id).await?;
         for node_weight in node_weights {
             if let NodeWeight::Func(inner) = &node_weight {
-                let func = Func::get_by_id_or_error(ctx, inner.id().into()).await?;
+                let func = Func::get_by_id(ctx, inner.id().into()).await?;
                 all_funcs.push(func);
             }
         }
@@ -353,15 +351,14 @@ impl Module {
         let node_weights = workspace_snapshot.all_outgoing_targets(self.id).await?;
         for node_weight in node_weights {
             if let NodeWeight::SchemaVariant(variant_weight) = &node_weight {
-                let variant =
-                    SchemaVariant::get_by_id_or_error(ctx, variant_weight.id().into()).await?;
+                let variant = SchemaVariant::get_by_id(ctx, variant_weight.id().into()).await?;
                 all_schema_variants.push(variant);
             } else if let NodeWeight::Content(inner) = &node_weight {
                 let inner_addr_discrim: ContentAddressDiscriminants =
                     inner.content_address().into();
 
                 if inner_addr_discrim == ContentAddressDiscriminants::SchemaVariant {
-                    let variant = SchemaVariant::get_by_id_or_error(ctx, inner.id().into()).await?;
+                    let variant = SchemaVariant::get_by_id(ctx, inner.id().into()).await?;
                     all_schema_variants.push(variant);
                 }
             }
@@ -573,7 +570,7 @@ impl Module {
         // The frontend will send us the schema variant as this is what we care about from
         // there. We can then use that schema variant to be able to understand the associated
         // schema for it.
-        let variant = SchemaVariant::get_by_id_or_error(ctx, schema_variant_id).await?;
+        let variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
         let associated_schema = variant.schema(ctx).await?;
 
         // Create module payload.

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -107,7 +107,7 @@ async fn import_change_set(
             };
 
             if let Some(func_id) = maybe_func_id {
-                let func = Func::get_by_id_or_error(ctx, func_id).await?;
+                let func = Func::get_by_id(ctx, func_id).await?;
 
                 thing_map.insert(
                     func_spec.unique_id().to_owned(),
@@ -1070,7 +1070,7 @@ pub async fn import_only_new_funcs(
                     Func::find_id_by_name_and_kind(ctx, func_spec.name(), FuncKind::Intrinsic)
                         .await?
                 {
-                    let func = Func::get_by_id_or_error(ctx, func_id).await?;
+                    let func = Func::get_by_id(ctx, func_id).await?;
                     thing_map.insert(func_spec.unique_id().into(), Thing::Func(func));
                 } else {
                     let mut override_intrinsic_func_specs =
@@ -1108,13 +1108,13 @@ pub async fn import_only_new_funcs(
                     .await?
                     .ok_or(PkgError::MissingIntrinsicFunc(func_spec.name().to_owned()))?;
 
-                let func = Func::get_by_id_or_error(ctx, func_id).await?;
+                let func = Func::get_by_id(ctx, func_id).await?;
                 thing_map.insert(func_spec.unique_id().into(), Thing::Func(func));
             }
         } else {
             // Find or create the func for the provided spec.
             let func = if let Some(func) =
-                Func::get_by_id(ctx, FuncId::from_str(func_spec.unique_id())?).await?
+                Func::get_by_id_opt(ctx, FuncId::from_str(func_spec.unique_id())?).await?
             {
                 func
             } else {

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -947,7 +947,7 @@ impl Prop {
         let prototype_id = Self::prototype_id(ctx, prop_id).await?;
         let prototype_func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
 
-        Ok(Func::get_by_id(ctx, prototype_func_id)
+        Ok(Func::get_by_id_opt(ctx, prototype_func_id)
             .await?
             .map(|f| f.is_dynamic())
             .unwrap_or(false))
@@ -959,8 +959,7 @@ impl Prop {
     ) -> PropResult<Option<serde_json::Value>> {
         let prototype_id = Self::prototype_id(ctx, prop_id).await?;
         let prototype_func =
-            Func::get_by_id_or_error(ctx, AttributePrototype::func_id(ctx, prototype_id).await?)
-                .await?;
+            Func::get_by_id(ctx, AttributePrototype::func_id(ctx, prototype_id).await?).await?;
         if prototype_func.is_dynamic() {
             return Ok(None);
         }

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -198,7 +198,7 @@ impl VariantAuthoringClient {
             .copied()
             .ok_or(VariantAuthoringError::NoAssetCreated)?;
 
-        Ok(SchemaVariant::get_by_id_or_error(ctx, schema_variant_id).await?)
+        Ok(SchemaVariant::get_by_id(ctx, schema_variant_id).await?)
     }
 
     pub async fn create_schema_and_variant(
@@ -235,11 +235,11 @@ impl VariantAuthoringClient {
             return Err(VariantAuthoringError::DuplicatedSchemaName(schema_name));
         };
 
-        let variant = SchemaVariant::get_by_id_or_error(ctx, schema_variant_id).await?;
+        let variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
         let schema = variant.schema(ctx).await?;
 
         if let Some(asset_func_id) = variant.asset_func_id() {
-            let old_func = Func::get_by_id_or_error(ctx, asset_func_id).await?;
+            let old_func = Func::get_by_id(ctx, asset_func_id).await?;
 
             let cloned_func = old_func
                 .clone_func_with_new_name(ctx, schema_name.clone())
@@ -290,7 +290,7 @@ impl VariantAuthoringClient {
                 .ok_or(VariantAuthoringError::NoAssetCreated)?;
 
             Ok((
-                SchemaVariant::get_by_id_or_error(ctx, new_schema_variant_id).await?,
+                SchemaVariant::get_by_id(ctx, new_schema_variant_id).await?,
                 schema,
             ))
         } else {
@@ -309,7 +309,7 @@ impl VariantAuthoringClient {
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
     ) -> VariantAuthoringResult<SchemaVariantId> {
-        let schema_variant = SchemaVariant::get_by_id_or_error(ctx, schema_variant_id).await?;
+        let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
 
         if schema_variant.is_locked {
             return Err(VariantAuthoringError::LockedVariant(schema_variant_id));
@@ -389,7 +389,7 @@ impl VariantAuthoringClient {
     ) -> VariantAuthoringResult<()> {
         // Ok we need to delete the first level of outgoing children for the schema variant
         let current_schema_variant =
-            SchemaVariant::get_by_id_or_error(ctx, current_schema_variant_id).await?;
+            SchemaVariant::get_by_id(ctx, current_schema_variant_id).await?;
 
         // then we can build the package and reimport ALL but the schema variant itself
         let asset_func = current_schema_variant.get_asset_func(ctx).await?;
@@ -447,7 +447,7 @@ impl VariantAuthoringClient {
             .first()
             .ok_or(VariantAuthoringError::PkgMissingSchemaVariant)?;
 
-        let schema = SchemaVariant::get_by_id_or_error(ctx, current_schema_variant_id)
+        let schema = SchemaVariant::get_by_id(ctx, current_schema_variant_id)
             .await?
             .schema(ctx)
             .await?;
@@ -523,7 +523,7 @@ impl VariantAuthoringClient {
     ) -> VariantAuthoringResult<SchemaVariant> {
         let schema_name = schema_name.into();
 
-        let old_sv = SchemaVariant::get_by_id_or_error(ctx, current_sv_id).await?;
+        let old_sv = SchemaVariant::get_by_id(ctx, current_sv_id).await?;
         let old_asset_func = old_sv.get_asset_func(ctx).await?;
 
         let new_asset_func = old_asset_func
@@ -581,7 +581,7 @@ impl VariantAuthoringClient {
             .first()
             .ok_or(VariantAuthoringError::PkgMissingSchemaVariant)?;
 
-        let schema = SchemaVariant::get_by_id_or_error(ctx, current_sv_id)
+        let schema = SchemaVariant::get_by_id(ctx, current_sv_id)
             .await?
             .schema(ctx)
             .await?;
@@ -620,7 +620,7 @@ impl VariantAuthoringClient {
         ctx: &DalContext,
         locked_variant_id: SchemaVariantId,
     ) -> VariantAuthoringResult<SchemaVariant> {
-        let locked_variant = SchemaVariant::get_by_id_or_error(ctx, locked_variant_id).await?;
+        let locked_variant = SchemaVariant::get_by_id(ctx, locked_variant_id).await?;
         let schema = locked_variant.schema(ctx).await?;
 
         if let Some(variant) = SchemaVariant::get_unlocked_for_schema(ctx, schema.id).await? {
@@ -719,7 +719,7 @@ impl VariantAuthoringClient {
         component_type: ComponentType,
         code: Option<impl Into<String>>,
     ) -> VariantAuthoringResult<()> {
-        let schema_variant = SchemaVariant::get_by_id_or_error(ctx, schema_variant_id).await?;
+        let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
 
         if schema_variant.is_locked {
             return Err(VariantAuthoringError::LockedVariant(schema_variant_id));
@@ -771,7 +771,7 @@ impl VariantAuthoringClient {
         }
 
         let code_base64 = code.map(|c| general_purpose::STANDARD_NO_PAD.encode(c.into()));
-        let current_func = Func::get_by_id_or_error(ctx, asset_func_id).await?;
+        let current_func = Func::get_by_id(ctx, asset_func_id).await?;
         current_func
             .modify(ctx, |func| {
                 func.name = generate_scaffold_func_name(schema_name);
@@ -856,7 +856,7 @@ async fn build_variant_spec_based_on_existing_variant(
 ) -> VariantAuthoringResult<(SchemaVariantSpec, Vec<MergeSkip>, Vec<FuncSpec>)> {
     let identity_func_spec = IntrinsicFunc::Identity.to_spec()?;
 
-    let existing_variant = SchemaVariant::get_by_id_or_error(ctx, existing_variant_id).await?;
+    let existing_variant = SchemaVariant::get_by_id(ctx, existing_variant_id).await?;
     let schema = existing_variant.schema(ctx).await?;
     let variant_spec = definition.to_spec(
         metadata.clone(),

--- a/lib/dal/src/schema/variant/leaves.rs
+++ b/lib/dal/src/schema/variant/leaves.rs
@@ -226,7 +226,7 @@ impl SchemaVariant {
         leaf_kind: LeafKind,
         inputs: Vec<LeafInput>,
     ) -> SchemaVariantResult<(PropId, AttributePrototypeId)> {
-        let func = Func::get_by_id_or_error(ctx, func_id).await?;
+        let func = Func::get_by_id(ctx, func_id).await?;
 
         // Ensure the func matches what we need.
         if func.backend_kind != FuncBackendKind::JsAttribute {

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -402,7 +402,7 @@ impl Secret {
     /// [`error`](SecretError).
     ///
     /// _Note:_ this does not contain the encrypted or sensitive bits and is safe for external use.
-    pub async fn get_by_id_or_error(ctx: &DalContext, id: SecretId) -> SecretResult<Self> {
+    pub async fn get_by_id(ctx: &DalContext, id: SecretId) -> SecretResult<Self> {
         let (secret_node_weight, hash) =
             Self::get_node_weight_and_content_hash_or_error(ctx, id).await?;
 
@@ -441,7 +441,7 @@ impl Secret {
         ctx: &DalContext,
         secret_id: SecretId,
     ) -> SecretResult<Value> {
-        let secret = Self::get_by_id_or_error(ctx, secret_id).await?;
+        let secret = Self::get_by_id(ctx, secret_id).await?;
         Ok(serde_json::to_value(
             secret.encrypted_secret_key.to_string(),
         )?)

--- a/lib/dal/src/workspace_snapshot/traits/approval_requirement.rs
+++ b/lib/dal/src/workspace_snapshot/traits/approval_requirement.rs
@@ -75,7 +75,7 @@ pub trait ApprovalRequirementExt {
         id: ApprovalRequirementDefinitionId,
     ) -> WorkspaceSnapshotResult<EntityId>;
 
-    async fn get_by_id_or_error(
+    async fn get_approval_requirement_definition_by_id(
         &self,
         ctx: &DalContext,
         id: ApprovalRequirementDefinitionId,
@@ -84,7 +84,7 @@ pub trait ApprovalRequirementExt {
 
 #[async_trait]
 impl ApprovalRequirementExt for WorkspaceSnapshot {
-    async fn get_by_id_or_error(
+    async fn get_approval_requirement_definition_by_id(
         &self,
         ctx: &DalContext,
         id: ApprovalRequirementDefinitionId,

--- a/lib/dal/tests/integration_test/asset.rs
+++ b/lib/dal/tests/integration_test/asset.rs
@@ -96,7 +96,7 @@ async fn save_and_regenerate(
     schema_name: impl AsRef<str>,
     schema_variant_id: SchemaVariantId,
 ) -> Result<SchemaVariantId, Box<dyn std::error::Error>> {
-    let schema_variant = SchemaVariant::get_by_id_or_error(ctx, schema_variant_id).await?;
+    let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
     let schema_name = schema_name.as_ref();
 
     VariantAuthoringClient::save_variant_content(

--- a/lib/dal/tests/integration_test/audit_logging.rs
+++ b/lib/dal/tests/integration_test/audit_logging.rs
@@ -30,7 +30,7 @@ async fn round_trip(ctx: &mut DalContext, audit_database_context: AuditDatabaseC
     let schema_variant_id = Schema::default_variant_id(ctx, schema.id())
         .await
         .expect("could not get default schema variant id");
-    let schema_variant = SchemaVariant::get_by_id_or_error(ctx, schema_variant_id)
+    let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id)
         .await
         .expect("could not get schema variant");
 

--- a/lib/dal/tests/integration_test/component/upgrade.rs
+++ b/lib/dal/tests/integration_test/component/upgrade.rs
@@ -37,10 +37,9 @@ async fn auto_upgrade_component(ctx: &mut DalContext) {
         .await
         .expect("Unable to get the schema for the variant");
 
-    let default_schema_variant =
-        Schema::default_variant_id(ctx, my_asset_schema.id())
-            .await
-            .expect("unable to get the default schema variant id");
+    let default_schema_variant = Schema::default_variant_id(ctx, my_asset_schema.id())
+        .await
+        .expect("unable to get the default schema variant id");
     assert_eq!(default_schema_variant, variant_zero.id());
 
     // Build Create Action Func
@@ -897,7 +896,7 @@ async fn update_schema_variant_component_type(
     .await
     .expect("save variant contents");
 
-    SchemaVariant::get_by_id_or_error(ctx, variant.id)
+    SchemaVariant::get_by_id(ctx, variant.id)
         .await
         .expect("could not get updated variant")
         .into()
@@ -923,7 +922,7 @@ async fn update_schema_variant_description(
     )
     .await
     .expect("save variant contents");
-    SchemaVariant::get_by_id_or_error(ctx, variant.id)
+    SchemaVariant::get_by_id(ctx, variant.id)
         .await
         .expect("could not get updated variant")
         .into()

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -48,7 +48,7 @@ async fn duplicate(ctx: &mut DalContext) {
             .await
             .expect("unable to create func");
 
-    let func = Func::get_by_id_or_error(ctx, authoring_func.id)
+    let func = Func::get_by_id(ctx, authoring_func.id)
         .await
         .expect("Unable to get the authored func");
 

--- a/lib/dal/tests/integration_test/func/authoring.rs
+++ b/lib/dal/tests/integration_test/func/authoring.rs
@@ -141,7 +141,7 @@ async fn create_unlocked_copy_attribute_func(ctx: &mut DalContext) {
     );
 
     // argument name is "entries"
-    let func_arg_name = FuncArgument::get_by_id_or_error(ctx, arg_binding.func_argument_id)
+    let func_arg_name = FuncArgument::get_by_id(ctx, arg_binding.func_argument_id)
         .await
         .expect("found func arg");
 
@@ -155,9 +155,7 @@ async fn create_unlocked_copy_attribute_func(ctx: &mut DalContext) {
         panic!("expect parent to be for schema variant");
     };
 
-    let sv = SchemaVariant::get_by_id_or_error(ctx, sv_id)
-        .await
-        .expect("has sv");
+    let sv = SchemaVariant::get_by_id(ctx, sv_id).await.expect("has sv");
     assert!(sv.is_locked());
 
     // let's try to edit the func, this will fail because it's currently locked
@@ -237,7 +235,7 @@ async fn create_unlocked_copy_attribute_func(ctx: &mut DalContext) {
         input_socket.name()  // actual
     );
     // func arg name is "entries"
-    let func_arg_name = FuncArgument::get_by_id_or_error(ctx, arg_binding.func_argument_id)
+    let func_arg_name = FuncArgument::get_by_id(ctx, arg_binding.func_argument_id)
         .await
         .expect("found func arg");
 
@@ -326,7 +324,7 @@ async fn create_unlocked_func_and_check_locked_on_apply(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let func = Func::get_by_id_or_error(ctx, func_id)
+    let func = Func::get_by_id(ctx, func_id)
         .await
         .expect("can't find the new func");
 

--- a/lib/dal/tests/integration_test/func/authoring/binding.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding.rs
@@ -55,7 +55,7 @@ async fn get_bindings_for_latest_schema_variants(ctx: &mut DalContext) {
     let old_schema_variant_id = binding.get_schema_variant().expect("has a schema variant");
 
     // this schema variant is locked
-    let old_schema_variant = SchemaVariant::get_by_id_or_error(ctx, old_schema_variant_id)
+    let old_schema_variant = SchemaVariant::get_by_id(ctx, old_schema_variant_id)
         .await
         .expect("has a schema variant");
 
@@ -84,10 +84,9 @@ async fn get_bindings_for_latest_schema_variants(ctx: &mut DalContext) {
     );
 
     for binding in new_bindings {
-        let _sv =
-            SchemaVariant::get_by_id_or_error(ctx, binding.get_schema_variant().expect("has sv"))
-                .await
-                .expect("has sv");
+        let _sv = SchemaVariant::get_by_id(ctx, binding.get_schema_variant().expect("has sv"))
+            .await
+            .expect("has sv");
     }
 
     // now we should have 1 unlocked func binding

--- a/lib/dal/tests/integration_test/func/authoring/binding/action.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding/action.rs
@@ -169,8 +169,7 @@ async fn detach_attach_then_delete_action_func_while_enqueued(ctx: &mut DalConte
         .expect("no func found");
     let _func = Func::get_by_id(ctx, func_id)
         .await
-        .expect("unable to get func")
-        .expect("func is some");
+        .expect("unable to get func");
 
     let bindings = FuncBinding::for_func_id(ctx, func_id)
         .await

--- a/lib/dal/tests/integration_test/func/authoring/binding/attribute.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding/attribute.rs
@@ -113,7 +113,7 @@ async fn create_attribute_prototype_with_attribute_prototype_argument(ctx: &mut 
         .expect("could not commit and update snapshot to visibility");
 
     // Ensure that everything looks as we expect with the new prototype and prototype argument.
-    let func = Func::get_by_id_or_error(ctx, func_id)
+    let func = Func::get_by_id(ctx, func_id)
         .await
         .expect("could not get func by id");
     let func_summary = func

--- a/lib/dal/tests/integration_test/func/authoring/binding/authentication.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding/authentication.rs
@@ -166,7 +166,7 @@ async fn edit_auth_func(ctx: &mut DalContext) {
         .await
         .expect("could not save code");
 
-    let unlocked_func = Func::get_by_id_or_error(ctx, unlocked_func_id.id)
+    let unlocked_func = Func::get_by_id(ctx, unlocked_func_id.id)
         .await
         .expect("could not get func");
     // ensure it saved
@@ -183,7 +183,7 @@ async fn edit_auth_func(ctx: &mut DalContext) {
         .expect("could not apply to base");
 
     // ensure new func is locked
-    let new_locked_func = Func::get_by_id_or_error(ctx, unlocked_func.id)
+    let new_locked_func = Func::get_by_id(ctx, unlocked_func.id)
         .await
         .expect("could not get func");
 
@@ -200,9 +200,8 @@ async fn edit_auth_func(ctx: &mut DalContext) {
     let maybe_locked_schema_variant_id = SchemaVariant::default_id_for_schema(ctx, schema.id())
         .await
         .expect("unable to get default schema variant");
-    let maybe_locked_schema_variant =
-        SchemaVariant::get_by_id_or_error(ctx, maybe_locked_schema_variant_id)
-            .await
-            .expect("could not get schema variant");
+    let maybe_locked_schema_variant = SchemaVariant::get_by_id(ctx, maybe_locked_schema_variant_id)
+        .await
+        .expect("could not get schema variant");
     assert!(maybe_locked_schema_variant.is_locked());
 }

--- a/lib/dal/tests/integration_test/func/authoring/create_func.rs
+++ b/lib/dal/tests/integration_test/func/authoring/create_func.rs
@@ -429,10 +429,9 @@ async fn create_qualification_and_code_gen_with_existing_component(ctx: &mut Dal
         .await
         .expect("Unable to get the schema for the variant");
 
-    let default_schema_variant =
-        Schema::default_variant_id(ctx, my_asset_schema.id())
-            .await
-            .expect("unable to get the default schema variant id");
+    let default_schema_variant = Schema::default_variant_id(ctx, my_asset_schema.id())
+        .await
+        .expect("unable to get the default schema variant id");
     assert_eq!(default_schema_variant, variant_zero.id());
 
     // Now let's update the variant

--- a/lib/dal/tests/integration_test/func/authoring/func_argument.rs
+++ b/lib/dal/tests/integration_test/func/authoring/func_argument.rs
@@ -53,7 +53,7 @@ async fn create_and_delete_attribute_func_with_arguments(ctx: &mut DalContext) {
     // Fetch the view and prepare for adding two func arguments. Then, add the two func arguments
     // and commit.
     {
-        let func = Func::get_by_id_or_error(ctx, func_id)
+        let func = Func::get_by_id(ctx, func_id)
             .await
             .expect("could not get func");
 
@@ -96,7 +96,7 @@ async fn create_and_delete_attribute_func_with_arguments(ctx: &mut DalContext) {
 
     // Fetch the view and check that we added two func arguments successfully.
     let (cached_string_func_argument_id, cached_array_func_argument_id) = {
-        let func = Func::get_by_id_or_error(ctx, func_id)
+        let func = Func::get_by_id(ctx, func_id)
             .await
             .expect("could not get func");
 
@@ -143,7 +143,7 @@ async fn create_and_delete_attribute_func_with_arguments(ctx: &mut DalContext) {
 
     // Fetch the view. Then, delete the two arguments and commit.
     {
-        let func = Func::get_by_id_or_error(ctx, func_id)
+        let func = Func::get_by_id(ctx, func_id)
             .await
             .expect("could not get func");
 
@@ -202,18 +202,19 @@ async fn create_and_delete_attribute_func_with_arguments(ctx: &mut DalContext) {
             .expect("could not commit and update snapshot to visibility");
 
         // Check that the func and its arguments do not exist.
-        let maybe_func = Func::get_by_id(ctx, func_id)
+        let maybe_func = Func::get_by_id_opt(ctx, func_id)
             .await
             .expect("could not perform find by name");
         assert!(maybe_func.is_none());
         let maybe_string_func_argument =
-            FuncArgument::get_by_id(ctx, cached_string_func_argument_id)
+            FuncArgument::get_by_id_opt(ctx, cached_string_func_argument_id)
                 .await
                 .expect("could not perform find by name for func");
         assert!(maybe_string_func_argument.is_none());
-        let maybe_array_func_argument = FuncArgument::get_by_id(ctx, cached_array_func_argument_id)
-            .await
-            .expect("could not perform find by name for func");
+        let maybe_array_func_argument =
+            FuncArgument::get_by_id_opt(ctx, cached_array_func_argument_id)
+                .await
+                .expect("could not perform find by name for func");
         assert!(maybe_array_func_argument.is_none());
     }
 }

--- a/lib/dal/tests/integration_test/func/authoring/save_and_exec.rs
+++ b/lib/dal/tests/integration_test/func/authoring/save_and_exec.rs
@@ -10,7 +10,7 @@ async fn save_and_exec_action_func(ctx: &mut DalContext) {
         .await
         .expect("could not perform find func by name")
         .expect("no func found");
-    Func::get_by_id_or_error(ctx, func_id)
+    Func::get_by_id(ctx, func_id)
         .await
         .expect("could not get func by id");
 
@@ -37,7 +37,7 @@ async fn save_and_exec_attribute_func(ctx: &mut DalContext) {
         .await
         .expect("could not perform find func by name")
         .expect("no func found");
-    let func = Func::get_by_id_or_error(ctx, func_id)
+    let func = Func::get_by_id(ctx, func_id)
         .await
         .expect("could not get func by id");
     func.into_frontend_type(ctx)

--- a/lib/dal/tests/integration_test/func/authoring/save_func.rs
+++ b/lib/dal/tests/integration_test/func/authoring/save_func.rs
@@ -44,7 +44,7 @@ pub async fn save_func_setup(
         .await
         .expect("could not create unlocked copy")
         .id;
-    let func = Func::get_by_id_or_error(ctx, func_id)
+    let func = Func::get_by_id(ctx, func_id)
         .await
         .expect("could not get func by id");
     let before = func
@@ -61,7 +61,7 @@ pub async fn save_func_setup(
         .expect("could not commit and update snapshot to visibility");
 
     // Perform base assertions before getting started.
-    let func = Func::get_by_id_or_error(ctx, func_id)
+    let func = Func::get_by_id(ctx, func_id)
         .await
         .expect("could not get func by id");
     let after = func

--- a/lib/dal/tests/integration_test/func/authoring/test_execute.rs
+++ b/lib/dal/tests/integration_test/func/authoring/test_execute.rs
@@ -27,7 +27,7 @@ async fn test_execute_action_func(ctx: &mut DalContext) {
         .await
         .expect("could not perform find func by name")
         .expect("no func found");
-    let func = Func::get_by_id_or_error(ctx, func_id)
+    let func = Func::get_by_id(ctx, func_id)
         .await
         .expect("could not get func by id");
 
@@ -67,7 +67,7 @@ async fn test_execute_attribute_func(ctx: &mut DalContext) {
         .await
         .expect("could not perform find func by name")
         .expect("no func found");
-    let func = Func::get_by_id_or_error(ctx, func_id)
+    let func = Func::get_by_id(ctx, func_id)
         .await
         .expect("could not get func by id");
 
@@ -107,7 +107,7 @@ async fn test_execute_code_generation_func(ctx: &mut DalContext) {
         .await
         .expect("could not perform find func by name")
         .expect("no func found");
-    let func = Func::get_by_id_or_error(ctx, func_id)
+    let func = Func::get_by_id(ctx, func_id)
         .await
         .expect("could not get func by id");
 
@@ -147,7 +147,7 @@ async fn test_execute_qualification_func(ctx: &mut DalContext) {
         .await
         .expect("could not perform find func by name")
         .expect("no func found");
-    let func = Func::get_by_id_or_error(ctx, func_id)
+    let func = Func::get_by_id(ctx, func_id)
         .await
         .expect("could not get func by id");
 
@@ -191,7 +191,7 @@ async fn test_execute_with_modified_code(ctx: &mut DalContext) {
         .await
         .expect("could create new func")
         .id;
-    let func = Func::get_by_id_or_error(ctx, func_id)
+    let func = Func::get_by_id(ctx, func_id)
         .await
         .expect("could not get func by id");
 

--- a/lib/dal/tests/integration_test/node_weight/schema_variant.rs
+++ b/lib/dal/tests/integration_test/node_weight/schema_variant.rs
@@ -155,7 +155,7 @@ async fn only_one_default_schema_variant(ctx: &mut DalContext) {
             .expect("unable to create variant copy")
             .id();
 
-    let sv_cs_1 = SchemaVariant::get_by_id_or_error(ctx, updated_sv_id_cs_1)
+    let sv_cs_1 = SchemaVariant::get_by_id(ctx, updated_sv_id_cs_1)
         .await
         .expect("unable to get the updated sv");
     sv_cs_1
@@ -185,7 +185,7 @@ async fn only_one_default_schema_variant(ctx: &mut DalContext) {
             .expect("unable to create variant copy")
             .id();
 
-    let sv_cs_2 = SchemaVariant::get_by_id_or_error(ctx, updated_sv_id_cs_2)
+    let sv_cs_2 = SchemaVariant::get_by_id(ctx, updated_sv_id_cs_2)
         .await
         .expect("unable to get the updated sv");
     sv_cs_2

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -47,7 +47,7 @@ async fn verify_prop_used_as_input_flag(ctx: &DalContext) {
         .await
         .expect("should be able to get default");
 
-    let _pirate = SchemaVariant::get_by_id_or_error(ctx, pirate_default_variant_id)
+    let _pirate = SchemaVariant::get_by_id(ctx, pirate_default_variant_id)
         .await
         .expect("should be able to get pirate sv");
 

--- a/lib/dal/tests/integration_test/rebaser.rs
+++ b/lib/dal/tests/integration_test/rebaser.rs
@@ -31,7 +31,7 @@ async fn modify_func_node(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    Func::get_by_id_or_error(ctx, func.id)
+    Func::get_by_id(ctx, func.id)
         .await
         .expect("able to get func by id");
 
@@ -52,7 +52,7 @@ async fn modify_func_node(ctx: &mut DalContext) {
         .await
         .expect("could not commit");
 
-    let refetched_func = Func::get_by_id_or_error(ctx, func.id)
+    let refetched_func = Func::get_by_id(ctx, func.id)
         .await
         .expect("able to fetch func");
 
@@ -71,7 +71,7 @@ async fn modify_func_node(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let modified_func = Func::get_by_id_or_error(ctx, func.id)
+    let modified_func = Func::get_by_id(ctx, func.id)
         .await
         .expect("able to get func by id again");
 
@@ -111,7 +111,7 @@ async fn func_node_with_arguments(ctx: &mut DalContext) {
     .await
     .expect("able to make a func");
 
-    Func::get_by_id_or_error(ctx, func.id)
+    Func::get_by_id(ctx, func.id)
         .await
         .expect("able to get func by id before commit");
 
@@ -119,7 +119,7 @@ async fn func_node_with_arguments(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    Func::get_by_id_or_error(ctx, func.id)
+    Func::get_by_id(ctx, func.id)
         .await
         .expect("able to get func by id after rebase");
 
@@ -148,7 +148,7 @@ async fn func_node_with_arguments(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let modified_func = Func::get_by_id_or_error(ctx, func.id)
+    let modified_func = Func::get_by_id(ctx, func.id)
         .await
         .expect("able to get func by id again");
 
@@ -173,7 +173,7 @@ async fn func_node_with_arguments(ctx: &mut DalContext) {
     .await
     .expect("able to modify func");
 
-    let func_arg_refetch = FuncArgument::get_by_id_or_error(ctx, arg_1.id)
+    let func_arg_refetch = FuncArgument::get_by_id(ctx, arg_1.id)
         .await
         .expect("get func arg");
 
@@ -230,7 +230,7 @@ async fn delete_func_node(ctx: &mut DalContext) {
 
     let snapshot_id_before_deletion = ctx.workspace_snapshot().expect("get snap").id().await;
 
-    Func::get_by_id_or_error(ctx, func.id)
+    Func::get_by_id(ctx, func.id)
         .await
         .expect("able to get func by id");
 
@@ -238,7 +238,7 @@ async fn delete_func_node(ctx: &mut DalContext) {
         .await
         .expect("able to remove func");
 
-    assert!(Func::get_by_id_or_error(ctx, func.id).await.is_err());
+    assert!(Func::get_by_id(ctx, func.id).await.is_err());
 
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
@@ -249,7 +249,7 @@ async fn delete_func_node(ctx: &mut DalContext) {
     // A sanity check
     assert_ne!(snapshot_id_before_deletion, snapshot_id_after_deletion);
 
-    let result = Func::get_by_id_or_error(ctx, func.id).await;
+    let result = Func::get_by_id(ctx, func.id).await;
     assert!(result.is_err());
 }
 

--- a/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/clone_variant.rs
@@ -18,7 +18,7 @@ async fn clone_variant(ctx: &mut DalContext) {
     let default_schema_variant = Schema::default_variant_id(ctx, schema.id())
         .await
         .expect("Unable to find the default schema variant id");
-    let existing_variant = SchemaVariant::get_by_id_or_error(ctx, default_schema_variant)
+    let existing_variant = SchemaVariant::get_by_id(ctx, default_schema_variant)
         .await
         .expect("unable to lookup the default schema variant");
 

--- a/lib/dal/tests/integration_test/schema/variant/authoring/create_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/create_variant.rs
@@ -44,7 +44,7 @@ async fn create_variant(ctx: &mut DalContext) {
     );
     assert!(variant.asset_func_id().is_some());
 
-    let maybe_func = Func::get_by_id(
+    let func = Func::get_by_id(
         ctx,
         variant
             .asset_func_id()
@@ -52,10 +52,6 @@ async fn create_variant(ctx: &mut DalContext) {
     )
     .await
     .expect("unable to get asset authoring func");
-
-    assert!(maybe_func.is_some());
-
-    let func = maybe_func.unwrap();
 
     let scaffold_func_name = format!("{}Scaffold_", asset_name);
     assert!(func.name.contains(&scaffold_func_name));

--- a/lib/dal/tests/integration_test/schema/variant/authoring/delete_unlocked_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/delete_unlocked_variant.rs
@@ -27,7 +27,7 @@ async fn delete_unlocked_variant(ctx: &mut DalContext) {
         .await
         .expect("unable to commit");
 
-    let asset_func = Func::get_by_id_or_error(
+    let asset_func = Func::get_by_id(
         ctx,
         variant
             .asset_func_id()

--- a/lib/dal/tests/integration_test/schema/variant/authoring/save_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/save_variant.rs
@@ -47,7 +47,7 @@ async fn save_variant(ctx: &mut DalContext) {
     );
     assert!(variant.asset_func_id().is_some());
 
-    let maybe_func = Func::get_by_id(
+    let func = Func::get_by_id(
         ctx,
         variant
             .asset_func_id()
@@ -55,10 +55,6 @@ async fn save_variant(ctx: &mut DalContext) {
     )
     .await
     .expect("unable to get asset authoring func");
-
-    assert!(maybe_func.is_some());
-
-    let func = maybe_func.unwrap();
 
     let scaffold_func_name = format!("{}Scaffold_", asset_name);
     assert!(func.name.contains(&scaffold_func_name));
@@ -96,7 +92,7 @@ async fn save_variant(ctx: &mut DalContext) {
     .await
     .expect("Unable to save the func");
 
-    let maybe_func = Func::get_by_id(
+    let func = Func::get_by_id(
         ctx,
         variant
             .asset_func_id()
@@ -104,8 +100,6 @@ async fn save_variant(ctx: &mut DalContext) {
     )
     .await
     .expect("unable to get asset authoring func");
-    assert!(maybe_func.is_some());
-    let func = maybe_func.unwrap();
 
     assert_eq!(func.kind, FuncKind::SchemaVariantDefinition);
     assert_eq!(
@@ -135,7 +129,7 @@ async fn unlock_and_save_variant(ctx: &mut DalContext) {
     let default_schema_variant = Schema::default_variant_id(ctx, schema.id())
         .await
         .expect("Unable to find the default schema variant id");
-    let existing_variant = SchemaVariant::get_by_id_or_error(ctx, default_schema_variant)
+    let existing_variant = SchemaVariant::get_by_id(ctx, default_schema_variant)
         .await
         .expect("unable to lookup the default schema variant");
 
@@ -230,7 +224,7 @@ async fn unlock_and_save_variant(ctx: &mut DalContext) {
     let default_schema_variant = Schema::default_variant_id(ctx, schema.id())
         .await
         .expect("Unable to find the default schema variant id");
-    let new_merged_variant = SchemaVariant::get_by_id_or_error(ctx, default_schema_variant)
+    let new_merged_variant = SchemaVariant::get_by_id(ctx, default_schema_variant)
         .await
         .expect("unable to lookup the default schema variant");
 

--- a/lib/dal/tests/integration_test/schema/variant/authoring/unlock_and_edit_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/unlock_and_edit_variant.rs
@@ -30,7 +30,7 @@ async fn create_variant_merge_unlock_and_edit(ctx: &mut DalContext) {
         .await
         .expect("Unable to get the schema for the variant");
 
-    let asset_func = Func::get_by_id_or_error(
+    let asset_func = Func::get_by_id(
         ctx,
         variant
             .asset_func_id()
@@ -70,7 +70,7 @@ async fn create_variant_merge_unlock_and_edit(ctx: &mut DalContext) {
         .await
         .expect("unable to update asset");
 
-    let sv = SchemaVariant::get_by_id_or_error(ctx, updated_sv_id)
+    let sv = SchemaVariant::get_by_id(ctx, updated_sv_id)
         .await
         .expect("unable to get the updated sv");
     sv.lock(ctx)
@@ -93,13 +93,13 @@ async fn create_variant_merge_unlock_and_edit(ctx: &mut DalContext) {
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let sv = SchemaVariant::get_by_id_or_error(ctx, updated_sv_id)
+    let sv = SchemaVariant::get_by_id(ctx, updated_sv_id)
         .await
         .expect("unable to get the new schema variant");
 
     assert!(sv.is_locked());
 
-    let asset_func = Func::get_by_id_or_error(
+    let asset_func = Func::get_by_id(
         ctx,
         variant
             .asset_func_id()
@@ -122,7 +122,7 @@ async fn create_variant_merge_unlock_and_edit(ctx: &mut DalContext) {
         .await
         .expect("unable to commit");
 
-    let unlocked_asset_func = Func::get_by_id_or_error(
+    let unlocked_asset_func = Func::get_by_id(
         ctx,
         unlocked_schema_variant
             .asset_func_id()

--- a/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
@@ -181,7 +181,7 @@ async fn update_variant_with_new_metadata(ctx: &mut DalContext) {
         .await
         .expect("could not commit");
 
-    let asset_func = Func::get_by_id_or_error(
+    let asset_func = Func::get_by_id(
         ctx,
         first_variant
             .asset_func_id()
@@ -206,7 +206,7 @@ async fn update_variant_with_new_metadata(ctx: &mut DalContext) {
 
     assert_eq!(default_schema_variant, first_variant.id());
 
-    let first_variant = SchemaVariant::get_by_id_or_error(ctx, first_sv_id)
+    let first_variant = SchemaVariant::get_by_id(ctx, first_sv_id)
         .await
         .expect("could not get schema variant");
 
@@ -248,7 +248,7 @@ async fn update_variant_with_new_metadata(ctx: &mut DalContext) {
         .expect("could not commit");
 
     // ensure metadata is correct for the schema variant
-    let second_variant = SchemaVariant::get_by_id_or_error(ctx, first_sv_id)
+    let second_variant = SchemaVariant::get_by_id(ctx, first_sv_id)
         .await
         .expect("could not get schema variant");
     let schema = second_variant
@@ -304,10 +304,9 @@ async fn update_variant_with_new_metadata(ctx: &mut DalContext) {
         .expect("could not commit");
 
     // get updated schema variant after regenerating
-    let updated_variant_after_regen =
-        SchemaVariant::get_by_id_or_error(ctx, updated_sv_id_after_regen)
-            .await
-            .expect("could not get schema variant");
+    let updated_variant_after_regen = SchemaVariant::get_by_id(ctx, updated_sv_id_after_regen)
+        .await
+        .expect("could not get schema variant");
 
     // let's ensure schema variant is as it was before
     assert_ne!(updated_variant_after_regen.id(), first_sv_id);
@@ -370,10 +369,9 @@ async fn update_variant_with_new_metadata(ctx: &mut DalContext) {
         .expect("could not commit");
 
     // make sure everything saved as expected
-    let updated_sv_after_metadata_change =
-        SchemaVariant::get_by_id_or_error(ctx, updated_sv_id_after_regen)
-            .await
-            .expect("could not get schema variant");
+    let updated_sv_after_metadata_change = SchemaVariant::get_by_id(ctx, updated_sv_id_after_regen)
+        .await
+        .expect("could not get schema variant");
     assert_eq!(
         updated_sv_after_metadata_change.id(),
         updated_sv_id_after_regen
@@ -423,10 +421,9 @@ async fn update_variant_with_new_metadata(ctx: &mut DalContext) {
         .await
         .expect("could not commit");
     assert_ne!(updated_sv_id_after_regen, first_sv_id);
-    let updated_variant_after_regen =
-        SchemaVariant::get_by_id_or_error(ctx, updated_sv_id_after_regen)
-            .await
-            .expect("could not get schema variant");
+    let updated_variant_after_regen = SchemaVariant::get_by_id(ctx, updated_sv_id_after_regen)
+        .await
+        .expect("could not get schema variant");
 
     // make sure the metadata matches
     assert_eq!(updated_variant_after_regen.category(), third_category);
@@ -877,7 +874,7 @@ async fn update_variant_with_leaf_func(ctx: &mut DalContext) {
                 .build();
             return new AssetBuilder().addProp(input1).addProp(input2).addProp(calculate).build()
         }";
-    let schema_variant = SchemaVariant::get_by_id_or_error(ctx, first_update_variant_id)
+    let schema_variant = SchemaVariant::get_by_id(ctx, first_update_variant_id)
         .await
         .expect("could not get schema variant");
 
@@ -939,7 +936,7 @@ async fn update_variant_with_leaf_func(ctx: &mut DalContext) {
                 message: 'Component qualified'
             };
         }";
-    // let func = Func::get_by_id_or_error(ctx, created_func_two.id)
+    // let func = Func::get_by_id(ctx, created_func_two.id)
     //     .await
     //     .expect("could not get func");
     FuncAuthoringClient::save_code(ctx, created_func_two.id, code.to_string())

--- a/lib/dal/tests/integration_test/secret.rs
+++ b/lib/dal/tests/integration_test/secret.rs
@@ -48,7 +48,7 @@ async fn new(ctx: &DalContext, nw: &WorkspaceSignup) {
     assert_eq!(nw.key_pair.pk(), key_pair.pk());
 
     // Fetch the secret by id too.
-    let found_secret = Secret::get_by_id_or_error(ctx, secret.id())
+    let found_secret = Secret::get_by_id(ctx, secret.id())
         .await
         .expect("could not perform get by id or secret not found");
     assert_eq!(secret, found_secret);
@@ -81,7 +81,7 @@ async fn encrypt_decrypt_round_trip(ctx: &DalContext, nw: &WorkspaceSignup) {
     .expect("failed to create encrypted secret");
 
     // Ensure that the fetched secret looks as we expected.
-    let found_secret = Secret::get_by_id_or_error(ctx, secret.id())
+    let found_secret = Secret::get_by_id(ctx, secret.id())
         .await
         .expect("could not perform get by id or secret not found");
     assert_eq!(secret.name(), found_secret.name());
@@ -134,7 +134,7 @@ async fn update_metadata_and_encrypted_contents(ctx: &DalContext, nw: &Workspace
     .expect("failed to create encrypted secret");
 
     // Ensure that the fetched secret looks as we expect.
-    let found_secret = Secret::get_by_id_or_error(ctx, secret.id())
+    let found_secret = Secret::get_by_id(ctx, secret.id())
         .await
         .expect("could not perform get by id or secret not found");
     assert_eq!(secret.name(), found_secret.name());
@@ -174,7 +174,7 @@ async fn update_metadata_and_encrypted_contents(ctx: &DalContext, nw: &Workspace
         )
         .await
         .expect("could not update encrypted contents");
-    let found_updated_secret = Secret::get_by_id_or_error(ctx, updated_secret.id())
+    let found_updated_secret = Secret::get_by_id(ctx, updated_secret.id())
         .await
         .expect("could not perform get by id or secret not found");
 
@@ -208,7 +208,7 @@ async fn update_metadata_and_encrypted_contents(ctx: &DalContext, nw: &Workspace
 
     // Now, update the metadata.
     let double_updated_secret = updated_secret.update_metadata(ctx, name, Some("alright, so now we are in the air and I am writing this test offline, which is awesome!".to_string())).await.expect("could not update metadata");
-    let found_double_updated_secret = Secret::get_by_id_or_error(ctx, double_updated_secret.id())
+    let found_double_updated_secret = Secret::get_by_id(ctx, double_updated_secret.id())
         .await
         .expect("could not perform get by id or secret not found");
 
@@ -392,7 +392,7 @@ async fn consumed_secrets_work_when_dvu_not_up_to_date(ctx: &mut DalContext, nw:
         .expect("could not attach secret");
     expected::commit_and_update_snapshot_to_visibility(ctx).await;
 
-    let found_secret = Secret::get_by_id_or_error(ctx, secret.id())
+    let found_secret = Secret::get_by_id(ctx, secret.id())
         .await
         .expect("could not perform get by id or secret not found");
     assert_eq!(secret_message, found_secret.encrypted_secret_key());
@@ -420,7 +420,7 @@ async fn consumed_secrets_work_when_dvu_not_up_to_date(ctx: &mut DalContext, nw:
     )
     .await
     .expect("could not encrypt message");
-    let updated_secret = Secret::get_by_id_or_error(ctx, secret.id())
+    let updated_secret = Secret::get_by_id(ctx, secret.id())
         .await
         .expect("no secret")
         .update_encrypted_contents(
@@ -435,7 +435,7 @@ async fn consumed_secrets_work_when_dvu_not_up_to_date(ctx: &mut DalContext, nw:
     let updated_secret_message = updated_secret.encrypted_secret_key();
 
     // Validate that the secret has the new value.
-    let found_secret = Secret::get_by_id_or_error(ctx, secret.id())
+    let found_secret = Secret::get_by_id(ctx, secret.id())
         .await
         .expect("could not perform get by id or secret not found");
     assert_eq!(updated_secret_message, found_secret.encrypted_secret_key());

--- a/lib/sdf-server/src/service/action/cancel.rs
+++ b/lib/sdf-server/src/service/action/cancel.rs
@@ -27,7 +27,7 @@ pub async fn cancel(
         let prototype_id = Action::prototype_id(&ctx, action_id).await?;
         let prototype = ActionPrototype::get_by_id(&ctx, prototype_id).await?;
         let func_id = ActionPrototype::func_id(&ctx, prototype_id).await?;
-        let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+        let func = Func::get_by_id(&ctx, func_id).await?;
         ctx.write_audit_log(
             AuditLogKind::CancelAction {
                 prototype_id,

--- a/lib/sdf-server/src/service/action/list_actions.rs
+++ b/lib/sdf-server/src/service/action/list_actions.rs
@@ -63,7 +63,7 @@ pub async fn list_actions(
 
         let prototype_id = Action::prototype_id(&ctx, action_id).await?;
         let func_id = ActionPrototype::func_id(&ctx, prototype_id).await?;
-        let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+        let func = Func::get_by_id(&ctx, func_id).await?;
         let prototype = ActionPrototype::get_by_id(&ctx, prototype_id).await?;
         let func_run_id = ctx
             .layer_db()

--- a/lib/sdf-server/src/service/action/put_on_hold.rs
+++ b/lib/sdf-server/src/service/action/put_on_hold.rs
@@ -41,7 +41,7 @@ pub async fn put_on_hold(
         let prototype_id = Action::prototype_id(&ctx, action.id()).await?;
         let prototype = ActionPrototype::get_by_id(&ctx, prototype_id).await?;
         let func_id = ActionPrototype::func_id(&ctx, prototype_id).await?;
-        let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+        let func = Func::get_by_id(&ctx, func_id).await?;
 
         ctx.write_audit_log(
             AuditLogKind::PutActionOnHold {

--- a/lib/sdf-server/src/service/action/retry.rs
+++ b/lib/sdf-server/src/service/action/retry.rs
@@ -32,7 +32,7 @@ pub async fn retry(
         let prototype_id = Action::prototype_id(&ctx, action_id).await?;
         let prototype = ActionPrototype::get_by_id(&ctx, prototype_id).await?;
         let func_id = ActionPrototype::func_id(&ctx, prototype_id).await?;
-        let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+        let func = Func::get_by_id(&ctx, func_id).await?;
         ctx.write_audit_log(
             AuditLogKind::RetryAction {
                 prototype_id,

--- a/lib/sdf-server/src/service/change_set/add_action.rs
+++ b/lib/sdf-server/src/service/change_set/add_action.rs
@@ -55,7 +55,7 @@ pub async fn add_action(
     let component = Component::get_by_id(&ctx, request.component_id).await?;
     let action = Action::new(&ctx, request.prototype_id, Some(request.component_id)).await?;
     let func_id = ActionPrototype::func_id(&ctx, prototype.id).await?;
-    let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+    let func = Func::get_by_id(&ctx, func_id).await?;
     track(
         &posthog_client,
         &ctx,

--- a/lib/sdf-server/src/service/component/get_actions.rs
+++ b/lib/sdf-server/src/service/component/get_actions.rs
@@ -27,9 +27,7 @@ impl ActionPrototypeView {
         ctx: &DalContext,
         prototype: ActionPrototype,
     ) -> ComponentResult<ActionPrototypeView> {
-        let func =
-            Func::get_by_id_or_error(ctx, ActionPrototype::func_id(ctx, prototype.id).await?)
-                .await?;
+        let func = Func::get_by_id(ctx, ActionPrototype::func_id(ctx, prototype.id).await?).await?;
         let display_name = func.display_name.map(|dname| dname.to_string());
         Ok(Self {
             id: prototype.id,

--- a/lib/sdf-server/src/service/component/update_property_editor_value.rs
+++ b/lib/sdf-server/src/service/component/update_property_editor_value.rs
@@ -94,10 +94,7 @@ pub async fn update_property_editor_value(
             let (before_secret_id, before_secret_name) = if let Some(inner) = before_value {
                 let secret_key = Secret::key_from_value_in_attribute_value(inner.to_owned())?;
                 let secret_id = Secret::get_id_by_key_or_error(&ctx, secret_key).await?;
-                let secret_name = Secret::get_by_id_or_error(&ctx, secret_id)
-                    .await?
-                    .name()
-                    .to_string();
+                let secret_name = Secret::get_by_id(&ctx, secret_id).await?.name().to_string();
                 (Some(secret_id), Some(secret_name))
             } else {
                 (None, None)
@@ -106,10 +103,7 @@ pub async fn update_property_editor_value(
             let (after_secret_id, after_secret_name) = if let Some(inner) = request.value {
                 let secret_id: SecretId = serde_json::from_value(inner)
                     .map_err(ComponentError::SecretIdDeserialization)?;
-                let secret_name = Secret::get_by_id_or_error(&ctx, secret_id)
-                    .await?
-                    .name()
-                    .to_string();
+                let secret_name = Secret::get_by_id(&ctx, secret_id).await?.name().to_string();
                 (Some(secret_id), Some(secret_name))
             } else {
                 (None, None)

--- a/lib/sdf-server/src/service/diagram/create_component.rs
+++ b/lib/sdf-server/src/service/diagram/create_component.rs
@@ -81,7 +81,7 @@ pub async fn create_component(
             ))?;
 
             let variant_id = Schema::get_or_install_default_variant(&ctx, schema_id).await?;
-            let variant = SchemaVariant::get_by_id_or_error(&ctx, variant_id).await?;
+            let variant = SchemaVariant::get_by_id(&ctx, variant_id).await?;
             let managed_schema_ids = SchemaVariant::all_managed_schemas(&ctx, variant_id).await?;
 
             // Also install any schemas managed by the variant
@@ -95,7 +95,7 @@ pub async fn create_component(
                 .publish_on_commit(&ctx)
                 .await?;
             for func_id in front_end_variant.func_ids.iter() {
-                let func = Func::get_by_id_or_error(&ctx, *func_id).await?;
+                let func = Func::get_by_id(&ctx, *func_id).await?;
                 let front_end_func = func.into_frontend_type(&ctx).await?;
                 WsEvent::func_updated(&ctx, front_end_func, None)
                     .await?
@@ -107,7 +107,7 @@ pub async fn create_component(
         }
     };
 
-    let variant = SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
+    let variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
     let view_id = View::get_id_for_default(&ctx).await?;
     let mut component = Component::new(&ctx, &name, variant.id(), view_id).await?;
     let initial_geometry = component.geometry(&ctx, view_id).await?;

--- a/lib/sdf-server/src/service/graphviz.rs
+++ b/lib/sdf-server/src/service/graphviz.rs
@@ -107,7 +107,7 @@ pub async fn schema_variant(
     let mut added_edges = HashSet::new();
     let mut root_node_id: Option<Ulid> = None;
 
-    let sv = SchemaVariant::get_by_id_or_error(&ctx, request.schema_variant_id).await?;
+    let sv = SchemaVariant::get_by_id(&ctx, request.schema_variant_id).await?;
     let workspace_snapshot = ctx.workspace_snapshot()?;
 
     let sv_node: GraphVizNode = {

--- a/lib/sdf-server/src/service/module/install_module.rs
+++ b/lib/sdf-server/src/service/module/install_module.rs
@@ -130,7 +130,7 @@ pub async fn install_module(
         );
 
         if let Some(schema_variant_id) = svs.first() {
-            let variant = SchemaVariant::get_by_id_or_error(&ctx, *schema_variant_id).await?;
+            let variant = SchemaVariant::get_by_id(&ctx, *schema_variant_id).await?;
             let schema_id = variant.schema(&ctx).await?.id();
             let front_end_variant = variant.into_frontend_type(&ctx, schema_id).await?;
             WsEvent::module_imported(&ctx, vec![front_end_variant.clone()])
@@ -138,7 +138,7 @@ pub async fn install_module(
                 .publish_on_commit(&ctx)
                 .await?;
             for func_id in front_end_variant.func_ids.iter() {
-                let func = Func::get_by_id_or_error(&ctx, *func_id).await?;
+                let func = Func::get_by_id(&ctx, *func_id).await?;
                 let front_end_func = func.into_frontend_type(&ctx).await?;
                 WsEvent::func_updated(&ctx, front_end_func, None)
                     .await?

--- a/lib/sdf-server/src/service/module/upgrade_modules.rs
+++ b/lib/sdf-server/src/service/module/upgrade_modules.rs
@@ -89,7 +89,7 @@ pub async fn upgrade_modules(
         );
 
         if let Some(schema_variant_id) = schema_variant_ids.first() {
-            let variant = SchemaVariant::get_by_id_or_error(&ctx, *schema_variant_id).await?;
+            let variant = SchemaVariant::get_by_id(&ctx, *schema_variant_id).await?;
             let schema_id = variant.schema(&ctx).await?.id();
             let front_end_variant = variant.into_frontend_type(&ctx, schema_id).await?;
             WsEvent::module_imported(&ctx, vec![front_end_variant.clone()])
@@ -97,7 +97,7 @@ pub async fn upgrade_modules(
                 .publish_on_commit(&ctx)
                 .await?;
             for func_id in front_end_variant.func_ids.iter() {
-                let func = Func::get_by_id_or_error(&ctx, *func_id).await?;
+                let func = Func::get_by_id(&ctx, *func_id).await?;
                 let front_end_func = func.into_frontend_type(&ctx).await?;
                 WsEvent::func_updated(&ctx, front_end_func, None)
                     .await?

--- a/lib/sdf-server/src/service/public/management.rs
+++ b/lib/sdf-server/src/service/public/management.rs
@@ -83,7 +83,7 @@ async fn run_prototype(
         }
 
         let func_id = ManagementPrototype::func_id(ctx, prototype_id).await?;
-        let func = Func::get_by_id_or_error(ctx, func_id).await?;
+        let func = Func::get_by_id(ctx, func_id).await?;
 
         WsEvent::management_operations_complete(
             ctx,

--- a/lib/sdf-server/src/service/secret/delete_secret.rs
+++ b/lib/sdf-server/src/service/secret/delete_secret.rs
@@ -26,7 +26,7 @@ pub async fn delete_secret(
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
     // Delete Secret
-    let secret = Secret::get_by_id_or_error(&ctx, request.id).await?;
+    let secret = Secret::get_by_id(&ctx, request.id).await?;
 
     let connected_components = secret.clone().find_connected_components(&ctx).await?;
     if !connected_components.is_empty() {

--- a/lib/sdf-server/src/service/secret/update_secret.rs
+++ b/lib/sdf-server/src/service/secret/update_secret.rs
@@ -42,7 +42,7 @@ pub async fn update_secret(
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
     // Update secret metadata.
-    let mut secret = Secret::get_by_id_or_error(&ctx, request.id).await?;
+    let mut secret = Secret::get_by_id(&ctx, request.id).await?;
     secret = secret
         .update_metadata(&ctx, request.name, request.description)
         .await?;

--- a/lib/sdf-server/src/service/v2/approval_requirement_definition/remove.rs
+++ b/lib/sdf-server/src/service/v2/approval_requirement_definition/remove.rs
@@ -48,8 +48,7 @@ pub async fn remove(
     );
 
     let current_approval_definition =
-        ApprovalRequirementDefinition::get_by_id_or_error(&ctx, approval_requirement_definition_id)
-            .await?;
+        ApprovalRequirementDefinition::get_by_id(&ctx, approval_requirement_definition_id).await?;
     let individual_approvers: Vec<UserPk> = current_approval_definition
         .approvers
         .iter()

--- a/lib/sdf-server/src/service/v2/fs.rs
+++ b/lib/sdf-server/src/service/v2/fs.rs
@@ -700,7 +700,7 @@ async fn get_func_code(
         serde_json::json!({ "func_id": func_id }),
     );
 
-    let func = dal::Func::get_by_id(&ctx, func_id)
+    let func = dal::Func::get_by_id_opt(&ctx, func_id)
         .await?
         .ok_or(FsError::ResourceNotFound)?;
 
@@ -740,7 +740,7 @@ async fn set_func_code(
 }
 
 async fn func_types_size(ctx: &DalContext, func_id: FuncId) -> FsResult<u64> {
-    let func = dal::Func::get_by_id_or_error(ctx, func_id).await?;
+    let func = dal::Func::get_by_id(ctx, func_id).await?;
     Ok(func.get_types(ctx).await?.len() as u64)
 }
 
@@ -762,7 +762,7 @@ async fn get_func_types(
         serde_json::json!({"func_id": func_id}),
     );
 
-    let func = dal::Func::get_by_id(&ctx, func_id)
+    let func = dal::Func::get_by_id_opt(&ctx, func_id)
         .await?
         .ok_or(FsError::ResourceNotFound)?;
 
@@ -1057,7 +1057,7 @@ async fn set_asset_func_code(
         )
         .await?;
 
-    let updated_variant = SchemaVariant::get_by_id_or_error(&ctx_clone, updated_variant_id).await?;
+    let updated_variant = SchemaVariant::get_by_id(&ctx_clone, updated_variant_id).await?;
 
     if schema_variant_id == updated_variant_id {
         WsEvent::schema_variant_updated(&ctx_clone, schema_id, updated_variant)
@@ -1090,7 +1090,7 @@ async fn install_schema(
 
     if !Schema::exists_locally(&ctx, schema_id).await? {
         let default_variant_id = Schema::get_or_install_default_variant(&ctx, schema_id).await?;
-        let variant = SchemaVariant::get_by_id_or_error(&ctx, default_variant_id).await?;
+        let variant = SchemaVariant::get_by_id(&ctx, default_variant_id).await?;
 
         let front_end_variant = variant.clone().into_frontend_type(&ctx, schema_id).await?;
         WsEvent::module_imported(&ctx, vec![front_end_variant.clone()])
@@ -1394,7 +1394,7 @@ async fn unlock_func(
 
     check_change_set_and_not_head(&ctx).await?;
 
-    let existing_func = dal::Func::get_by_id(&ctx, func_id)
+    let existing_func = dal::Func::get_by_id_opt(&ctx, func_id)
         .await?
         .ok_or(FsError::ResourceNotFound)?;
     if !existing_func.is_locked {

--- a/lib/sdf-server/src/service/v2/func.rs
+++ b/lib/sdf-server/src/service/v2/func.rs
@@ -236,7 +236,7 @@ pub fn v2_routes() -> Router<AppState> {
 
 // helper to assemble the front end struct to return the code and types so SDF can decide when these events need to fire
 pub async fn get_code_response(ctx: &DalContext, func_id: FuncId) -> FuncAPIResult<FuncCode> {
-    let func = Func::get_by_id(ctx, func_id)
+    let func = Func::get_by_id_opt(ctx, func_id)
         .await?
         .ok_or(FuncAPIError::FuncNotFound(func_id))?;
     let code = func.code_plaintext()?.unwrap_or("".to_string());

--- a/lib/sdf-server/src/service/v2/func/argument/create_argument.rs
+++ b/lib/sdf-server/src/service/v2/func/argument/create_argument.rs
@@ -40,7 +40,7 @@ pub async fn create_func_argument(
     )
     .await?;
 
-    let func_summary = Func::get_by_id_or_error(&ctx, func_id)
+    let func_summary = Func::get_by_id(&ctx, func_id)
         .await?
         .into_frontend_type(&ctx)
         .await?;

--- a/lib/sdf-server/src/service/v2/func/argument/delete_argument.rs
+++ b/lib/sdf-server/src/service/v2/func/argument/delete_argument.rs
@@ -33,10 +33,10 @@ pub async fn delete_func_argument(
         .build(access_builder.build(change_set_id.into()))
         .await?;
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
-    let func_arg = FuncArgument::get_by_id_or_error(&ctx, func_argument_id).await?;
+    let func_arg = FuncArgument::get_by_id(&ctx, func_argument_id).await?;
     FuncAuthoringClient::delete_func_argument(&ctx, func_argument_id).await?;
 
-    let func_summary = Func::get_by_id_or_error(&ctx, func_id)
+    let func_summary = Func::get_by_id(&ctx, func_id)
         .await?
         .into_frontend_type(&ctx)
         .await?;

--- a/lib/sdf-server/src/service/v2/func/argument/update_argument.rs
+++ b/lib/sdf-server/src/service/v2/func/argument/update_argument.rs
@@ -43,7 +43,7 @@ pub async fn update_func_argument(
     })
     .await?;
 
-    let func_summary = Func::get_by_id_or_error(&ctx, func_id)
+    let func_summary = Func::get_by_id(&ctx, func_id)
         .await?
         .into_frontend_type(&ctx)
         .await?;

--- a/lib/sdf-server/src/service/v2/func/binding/attribute/reset_attribute_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/attribute/reset_attribute_binding.rs
@@ -32,7 +32,7 @@ pub async fn reset_attribute_binding(
         .build(access_builder.build(change_set_id.into()))
         .await?;
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
-    let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+    let func = Func::get_by_id(&ctx, func_id).await?;
 
     if func.kind != dal::func::FuncKind::Attribute {
         return Err(FuncAPIError::WrongFunctionKindForBinding);
@@ -57,8 +57,7 @@ pub async fn reset_attribute_binding(
             EventualParent::SchemaVariant(schema_variant_id) => {
                 let schema =
                     SchemaVariant::schema_id_for_schema_variant_id(&ctx, schema_variant_id).await?;
-                let schema_variant =
-                    SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
+                let schema_variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
                 ctx.write_audit_log(
                     AuditLogKind::DetachFunc {
                         func_id,
@@ -105,12 +104,12 @@ pub async fn reset_attribute_binding(
             "func_kind": func.kind.clone(),
         }),
     );
-    let binding = Func::get_by_id_or_error(&ctx, func_id)
+    let binding = Func::get_by_id(&ctx, func_id)
         .await?
         .into_frontend_type(&ctx)
         .await?
         .bindings;
-    let func_summary = Func::get_by_id_or_error(&ctx, func_id)
+    let func_summary = Func::get_by_id(&ctx, func_id)
         .await?
         .into_frontend_type(&ctx)
         .await?;

--- a/lib/sdf-server/src/service/v2/func/binding/create_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/create_binding.rs
@@ -36,7 +36,7 @@ pub async fn create_binding(
         .build(access_builder.build(change_set_id.into()))
         .await?;
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
-    let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+    let func = Func::get_by_id(&ctx, func_id).await?;
 
     // add cycle check so we don't end up with a cycle as a result of creating this binding
     let cycle_check_guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
@@ -97,11 +97,10 @@ pub async fn create_binding(
                             // Fire WS Event if the func has changed
                             if let Some(old_func_id) = old_func {
                                 if old_func_id != func_id {
-                                    let old_func_summary =
-                                        Func::get_by_id_or_error(&ctx, old_func_id)
-                                            .await?
-                                            .into_frontend_type(&ctx)
-                                            .await?;
+                                    let old_func_summary = Func::get_by_id(&ctx, old_func_id)
+                                        .await?
+                                        .into_frontend_type(&ctx)
+                                        .await?;
 
                                     WsEvent::func_updated(&ctx, old_func_summary, None)
                                         .await?
@@ -117,7 +116,7 @@ pub async fn create_binding(
                             ) = match eventual_parent {
                                 Some(eventual_parent) => match eventual_parent {
                                     EventualParent::SchemaVariant(schema_variant_id) => (
-                                        SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id)
+                                        SchemaVariant::get_by_id(&ctx, schema_variant_id)
                                             .await?
                                             .display_name()
                                             .to_string(),
@@ -159,7 +158,7 @@ pub async fn create_binding(
                                 )
                                 .await?;
                                 let schema_variant =
-                                    SchemaVariant::get_by_id_or_error(&ctx, variant_id).await?;
+                                    SchemaVariant::get_by_id(&ctx, variant_id).await?;
                                 WsEvent::schema_variant_updated(&ctx, schema, schema_variant)
                                     .await?
                                     .publish_on_commit(&ctx)
@@ -190,8 +189,8 @@ pub async fn create_binding(
                             )
                             .await?;
                             let schema_variant =
-                                SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
-                            let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+                                SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
+                            let func = Func::get_by_id(&ctx, func_id).await?;
                             ctx.write_audit_log(
                                 AuditLogKind::AttachAuthFunc {
                                     func_id: func.id,
@@ -235,8 +234,8 @@ pub async fn create_binding(
                             )
                             .await?;
                             let schema_variant =
-                                SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
-                            let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+                                SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
+                            let func = Func::get_by_id(&ctx, func_id).await?;
                             ctx.write_audit_log(
                                 AuditLogKind::AttachActionFunc {
                                     func_id: func.id,
@@ -289,8 +288,8 @@ pub async fn create_binding(
                             )
                             .await?;
                             let schema_variant =
-                                SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
-                            let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+                                SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
+                            let func = Func::get_by_id(&ctx, func_id).await?;
                             ctx.write_audit_log(
                                 AuditLogKind::AttachCodeGenFunc {
                                     func_id: func.id,
@@ -336,8 +335,8 @@ pub async fn create_binding(
                             )
                             .await?;
                             let schema_variant =
-                                SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
-                            let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+                                SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
+                            let func = Func::get_by_id(&ctx, func_id).await?;
                             ctx.write_audit_log(
                                 AuditLogKind::AttachQualificationFunc {
                                     func_id: func.id,
@@ -386,8 +385,8 @@ pub async fn create_binding(
                             )
                             .await?;
                             let schema_variant =
-                                SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
-                            let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+                                SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
+                            let func = Func::get_by_id(&ctx, func_id).await?;
                             ctx.write_audit_log(
                                 AuditLogKind::AttachManagementFunc {
                                     func_id: func.id,
@@ -432,7 +431,7 @@ pub async fn create_binding(
         }),
     );
 
-    let func_summary = Func::get_by_id_or_error(&ctx, func_id)
+    let func_summary = Func::get_by_id(&ctx, func_id)
         .await?
         .into_frontend_type(&ctx)
         .await?;

--- a/lib/sdf-server/src/service/v2/func/binding/delete_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/delete_binding.rs
@@ -38,7 +38,7 @@ pub async fn delete_binding(
         .build(access_builder.build(change_set_id.into()))
         .await?;
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
-    let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+    let func = Func::get_by_id(&ctx, func_id).await?;
 
     let mut modified_sv_ids = HashSet::new();
 
@@ -119,8 +119,7 @@ pub async fn delete_binding(
         };
         match eventual_parent {
             EventualParent::SchemaVariant(schema_variant_id) => {
-                let schema_variant =
-                    SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
+                let schema_variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
                 ctx.write_audit_log(
                     AuditLogKind::DetachFunc {
                         func_id,
@@ -154,7 +153,7 @@ pub async fn delete_binding(
     for schema_variant_id in modified_sv_ids {
         let schema =
             SchemaVariant::schema_id_for_schema_variant_id(&ctx, schema_variant_id).await?;
-        let schema_variant = SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
+        let schema_variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
 
         WsEvent::schema_variant_updated(&ctx, schema, schema_variant)
             .await?
@@ -175,12 +174,12 @@ pub async fn delete_binding(
             "func_kind": func.kind.clone(),
         }),
     );
-    let binding = Func::get_by_id_or_error(&ctx, func_id)
+    let binding = Func::get_by_id(&ctx, func_id)
         .await?
         .into_frontend_type(&ctx)
         .await?
         .bindings;
-    let func_summary = Func::get_by_id_or_error(&ctx, func_id)
+    let func_summary = Func::get_by_id(&ctx, func_id)
         .await?
         .into_frontend_type(&ctx)
         .await?;

--- a/lib/sdf-server/src/service/v2/func/binding/update_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/update_binding.rs
@@ -174,7 +174,7 @@ pub async fn update_binding(
         .build(access_builder.build(change_set_id.into()))
         .await?;
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
-    let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+    let func = Func::get_by_id(&ctx, func_id).await?;
     // add cycle check so we don't end up with a cycle as a result of updating this binding
     let cycle_check_guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
 
@@ -209,12 +209,12 @@ pub async fn update_binding(
             "func_kind": func.kind.clone(),
         }),
     );
-    let binding = Func::get_by_id_or_error(&ctx, func_id)
+    let binding = Func::get_by_id(&ctx, func_id)
         .await?
         .into_frontend_type(&ctx)
         .await?
         .bindings;
-    let func_summary = Func::get_by_id_or_error(&ctx, func_id)
+    let func_summary = Func::get_by_id(&ctx, func_id)
         .await?
         .into_frontend_type(&ctx)
         .await?;

--- a/lib/sdf-server/src/service/v2/func/create_func.rs
+++ b/lib/sdf-server/src/service/v2/func/create_func.rs
@@ -173,7 +173,7 @@ pub async fn create_func(
                     None => {
                         let schema_variant_id = output_location.find_schema_variant(&ctx).await?;
                         (
-                            SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id)
+                            SchemaVariant::get_by_id(&ctx, schema_variant_id)
                                 .await?
                                 .display_name()
                                 .to_string(),
@@ -264,11 +264,10 @@ pub async fn create_func(
                     func.name.clone(),
                 )
                 .await?;
-                let schema_variant_name =
-                    SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id)
-                        .await?
-                        .display_name()
-                        .to_string();
+                let schema_variant_name = SchemaVariant::get_by_id(&ctx, schema_variant_id)
+                    .await?
+                    .display_name()
+                    .to_string();
                 ctx.write_audit_log(
                     AuditLogKind::AttachCodeGenFunc {
                         func_id: func.id,
@@ -314,11 +313,10 @@ pub async fn create_func(
                     func.name.clone(),
                 )
                 .await?;
-                let schema_variant_name =
-                    SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id)
-                        .await?
-                        .display_name()
-                        .to_string();
+                let schema_variant_name = SchemaVariant::get_by_id(&ctx, schema_variant_id)
+                    .await?
+                    .display_name()
+                    .to_string();
                 ctx.write_audit_log(
                     AuditLogKind::AttachQualificationFunc {
                         func_id: func.id,
@@ -355,11 +353,10 @@ pub async fn create_func(
                     func.name.clone(),
                 )
                 .await?;
-                let schema_variant_name =
-                    SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id)
-                        .await?
-                        .display_name()
-                        .to_string();
+                let schema_variant_name = SchemaVariant::get_by_id(&ctx, schema_variant_id)
+                    .await?
+                    .display_name()
+                    .to_string();
                 ctx.write_audit_log(
                     AuditLogKind::AttachManagementFunc {
                         func_id: func.id,
@@ -427,7 +424,7 @@ pub async fn create_func(
         } => {
             let schema_id =
                 SchemaVariant::schema_id_for_schema_variant_id(&ctx, schema_variant_id).await?;
-            let schema_variant = SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
+            let schema_variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
             WsEvent::schema_variant_updated(&ctx, schema_id, schema_variant)
                 .await?
                 .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/service/v2/func/create_unlocked_copy.rs
+++ b/lib/sdf-server/src/service/v2/func/create_unlocked_copy.rs
@@ -45,7 +45,7 @@ pub async fn create_unlocked_copy(
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
-    let existing_func = Func::get_by_id_or_error(&ctx, func_id).await?;
+    let existing_func = Func::get_by_id(&ctx, func_id).await?;
     if !existing_func.is_locked {
         return Err(FuncAPIError::FuncAlreadyUnlocked(func_id));
     }
@@ -57,7 +57,7 @@ pub async fn create_unlocked_copy(
     let summary = new_func.into_frontend_type(&ctx).await?;
 
     let variant = if let Some(schema_variant_id) = request.schema_variant_id {
-        SchemaVariant::get_by_id(&ctx, schema_variant_id).await?
+        SchemaVariant::get_by_id_opt(&ctx, schema_variant_id).await?
     } else {
         None
     };

--- a/lib/sdf-server/src/service/v2/func/delete_func.rs
+++ b/lib/sdf-server/src/service/v2/func/delete_func.rs
@@ -29,7 +29,7 @@ pub async fn delete_func(
     let mut ctx = builder
         .build(access_builder.build(change_set_id.into()))
         .await?;
-    let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+    let func = Func::get_by_id(&ctx, func_id).await?;
     if func.is_locked {
         return Err(FuncAPIError::CannotDeleteLockedFunc(func_id));
     }

--- a/lib/sdf-server/src/service/v2/func/execute_func.rs
+++ b/lib/sdf-server/src/service/v2/func/execute_func.rs
@@ -26,7 +26,7 @@ pub async fn execute_func(
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
     FuncAuthoringClient::execute_func(&ctx, func_id).await?;
-    let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+    let func = Func::get_by_id(&ctx, func_id).await?;
 
     ctx.write_audit_log(
         AuditLogKind::ExecuteFunc {

--- a/lib/sdf-server/src/service/v2/func/list_funcs.rs
+++ b/lib/sdf-server/src/service/v2/func/list_funcs.rs
@@ -91,7 +91,7 @@ async fn treat_single_function(
                     should_hide = false;
                 }
             } else {
-                let variant = SchemaVariant::get_by_id_or_error(ctx, schema_variant_id).await?;
+                let variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
                 if !variant.is_locked() {
                     should_hide = false;
                 }

--- a/lib/sdf-server/src/service/v2/func/save_code.rs
+++ b/lib/sdf-server/src/service/v2/func/save_code.rs
@@ -38,7 +38,7 @@ pub async fn save_code(
 
     FuncAuthoringClient::save_code(&ctx, func_id, request.code).await?;
     let func_code = get_code_response(&ctx, func_id).await?;
-    let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+    let func = Func::get_by_id(&ctx, func_id).await?;
     WsEvent::func_code_saved(&ctx, func_code, false)
         .await?
         .publish_on_commit(&ctx)

--- a/lib/sdf-server/src/service/v2/func/test_execute.rs
+++ b/lib/sdf-server/src/service/v2/func/test_execute.rs
@@ -42,7 +42,7 @@ pub async fn test_execute(
         .build(access_builder.build(change_set_id.into()))
         .await?;
 
-    let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+    let func = Func::get_by_id(&ctx, func_id).await?;
     let func_run_id = FuncAuthoringClient::test_execute_func(
         &ctx,
         func_id,

--- a/lib/sdf-server/src/service/v2/func/update_func.rs
+++ b/lib/sdf-server/src/service/v2/func/update_func.rs
@@ -39,7 +39,7 @@ pub async fn update_func(
         .build(access_builder.build(change_set_id.into()))
         .await?;
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
-    let old_func = Func::get_by_id_or_error(&ctx, func_id).await?;
+    let old_func = Func::get_by_id(&ctx, func_id).await?;
     let updated_func =
         FuncAuthoringClient::update_func(&ctx, func_id, request.display_name, request.description)
             .await?

--- a/lib/sdf-server/src/service/v2/management.rs
+++ b/lib/sdf-server/src/service/v2/management.rs
@@ -158,7 +158,7 @@ pub async fn run_prototype(
         }
 
         let func_id = ManagementPrototype::func_id(&ctx, prototype_id).await?;
-        let func = Func::get_by_id_or_error(&ctx, func_id).await?;
+        let func = Func::get_by_id(&ctx, func_id).await?;
 
         WsEvent::management_operations_complete(
             &ctx,

--- a/lib/sdf-server/src/service/v2/module/install_from_file.rs
+++ b/lib/sdf-server/src/service/v2/module/install_from_file.rs
@@ -54,7 +54,7 @@ pub async fn install_module_from_file(
     .await?;
 
     if let Some(schema_variant_id) = variant_ids.first() {
-        let variant = SchemaVariant::get_by_id_or_error(ctx, *schema_variant_id).await?;
+        let variant = SchemaVariant::get_by_id(ctx, *schema_variant_id).await?;
         let schema_id = variant.schema(ctx).await?.id();
         let front_end_variant = variant.into_frontend_type(ctx, schema_id).await?;
         WsEvent::module_imported(ctx, vec![front_end_variant.clone()])
@@ -62,7 +62,7 @@ pub async fn install_module_from_file(
             .publish_on_commit(ctx)
             .await?;
         for func_id in front_end_variant.func_ids.iter() {
-            let func = Func::get_by_id_or_error(ctx, *func_id).await?;
+            let func = Func::get_by_id(ctx, *func_id).await?;
             let front_end_func = func.into_frontend_type(ctx).await?;
             WsEvent::func_updated(ctx, front_end_func, None)
                 .await?

--- a/lib/sdf-server/src/service/v2/variant/create_unlocked_copy.rs
+++ b/lib/sdf-server/src/service/v2/variant/create_unlocked_copy.rs
@@ -36,7 +36,7 @@ pub async fn create_unlocked_copy(
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
-    let original_variant = SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
+    let original_variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
 
     let schema = original_variant.schema(&ctx).await?;
 

--- a/lib/sdf-server/src/service/v2/variant/delete_unlocked_variant.rs
+++ b/lib/sdf-server/src/service/v2/variant/delete_unlocked_variant.rs
@@ -26,7 +26,7 @@ pub async fn delete_unlocked_variant(
         .build(access_builder.build(change_set_id.into()))
         .await?;
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
-    let schema_variant = SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
+    let schema_variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
     let schema = schema_variant.schema(&ctx).await?;
 
     let connected_components = SchemaVariant::list_component_ids(&ctx, schema_variant_id).await?;

--- a/lib/sdf-server/src/service/v2/variant/get_variant.rs
+++ b/lib/sdf-server/src/service/v2/variant/get_variant.rs
@@ -28,7 +28,7 @@ pub async fn get_variant(
         .build(access_builder.build(change_set_id.into()))
         .await?;
 
-    let schema_variant = SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
+    let schema_variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
     let schema_id = SchemaVariant::schema_id_for_schema_variant_id(&ctx, schema_variant_id).await?;
     let schema_variant = schema_variant.into_frontend_type(&ctx, schema_id).await?;
 

--- a/lib/sdf-server/src/service/v2/view/create_component.rs
+++ b/lib/sdf-server/src/service/v2/view/create_component.rs
@@ -87,7 +87,7 @@ pub async fn create_component(
             // since this module might have just been installed, or
             // installed by another user
             let variant_id = Schema::get_or_install_default_variant(&ctx, schema_id).await?;
-            let variant = SchemaVariant::get_by_id_or_error(&ctx, variant_id).await?;
+            let variant = SchemaVariant::get_by_id(&ctx, variant_id).await?;
 
             let front_end_variant = variant.into_frontend_type(&ctx, schema_id).await?;
             WsEvent::module_imported(&ctx, vec![front_end_variant.clone()])
@@ -95,7 +95,7 @@ pub async fn create_component(
                 .publish_on_commit(&ctx)
                 .await?;
             for func_id in front_end_variant.func_ids.iter() {
-                let func = Func::get_by_id_or_error(&ctx, *func_id).await?;
+                let func = Func::get_by_id(&ctx, *func_id).await?;
                 let front_end_func = func.into_frontend_type(&ctx).await?;
                 WsEvent::func_updated(&ctx, front_end_func, None)
                     .await?
@@ -107,7 +107,7 @@ pub async fn create_component(
         }
     };
 
-    let variant = SchemaVariant::get_by_id_or_error(&ctx, schema_variant_id).await?;
+    let variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
     let mut component = Component::new(&ctx, &name, variant.id(), view_id).await?;
     let initial_geometry = component.geometry(&ctx, view_id).await?;
     ctx.write_audit_log(

--- a/lib/sdf-server/src/service/variant/regenerate_variant.rs
+++ b/lib/sdf-server/src/service/variant/regenerate_variant.rs
@@ -84,8 +84,7 @@ pub async fn regenerate_variant(
     .await?;
     let schema =
         SchemaVariant::schema_id_for_schema_variant_id(&ctx, updated_schema_variant_id).await?;
-    let updated_schema_variant =
-        SchemaVariant::get_by_id_or_error(&ctx, updated_schema_variant_id).await?;
+    let updated_schema_variant = SchemaVariant::get_by_id(&ctx, updated_schema_variant_id).await?;
 
     if schema_variant_id == updated_schema_variant_id {
         // if old == new -> send updated for it


### PR DESCRIPTION
Turns out there's only a few get_by_id_or_errors left in the codebase. Took a few minutes to just finish that off.

These were fixable entirely by rote rename. The only places unnecessarily using the _opt version were in tests (I fixed those).

## Testing

* Integration tests
* Made sure I could create a component in the UI (that it wasn't completely broken)