### PR TITLE
chore(dal): User/Workspace::get_by_pk_or_error -> get_by_pk

### DIFF
--- a/lib/dal/src/actor_view.rs
+++ b/lib/dal/src/actor_view.rs
@@ -48,9 +48,7 @@ impl ActorView {
     ) -> Result<Self, StandardModelError> {
         match history_actor {
             HistoryActor::User(user_pk) => {
-                let user = User::get_by_pk(ctx, user_pk)
-                    .await?
-                    .ok_or(StandardModelError::UserNotFound(user_pk))?;
+                let user = User::get_by_pk(ctx, user_pk).await?;
                 Ok(Self::User {
                     pk: user.pk(),
                     label: user.name().to_string(),

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -380,9 +380,7 @@ impl DalContext {
             .tenancy()
             .workspace_pk_opt()
             .unwrap_or(WorkspacePk::NONE);
-        let workspace = Workspace::get_by_pk(self, &workspace_pk)
-            .await?
-            .ok_or(TransactionsError::WorkspaceNotFound(workspace_pk))?;
+        let workspace = Workspace::get_by_pk(self, workspace_pk).await?;
         Ok(workspace.default_change_set_id())
     }
 
@@ -391,17 +389,13 @@ impl DalContext {
             .tenancy()
             .workspace_pk_opt()
             .unwrap_or(WorkspacePk::NONE);
-        let workspace = Workspace::get_by_pk(self, &workspace_pk)
-            .await?
-            .ok_or(TransactionsError::WorkspaceNotFound(workspace_pk))?;
+        let workspace = Workspace::get_by_pk(self, workspace_pk).await?;
         Ok(workspace.token())
     }
 
     pub async fn get_workspace(&self) -> Result<Workspace, TransactionsError> {
         let workspace_pk = self.tenancy().workspace_pk().unwrap_or(WorkspacePk::NONE);
-        let workspace = Workspace::get_by_pk(self, &workspace_pk)
-            .await?
-            .ok_or(TransactionsError::WorkspaceNotFound(workspace_pk))?;
+        let workspace = Workspace::get_by_pk(self, workspace_pk).await?;
 
         Ok(workspace)
     }
@@ -770,7 +764,7 @@ impl DalContext {
     }
 
     async fn workspace(&self) -> TransactionsResult<Workspace> {
-        Ok(Workspace::get_by_pk_or_error(self, self.tenancy.workspace_pk()?).await?)
+        Ok(Workspace::get_by_pk(self, self.tenancy.workspace_pk()?).await?)
     }
 
     pub async fn parent_is_head(&self) -> TransactionsResult<bool> {
@@ -1419,8 +1413,6 @@ pub enum TransactionsError {
     TxnStart(&'static str),
     #[error("workspace error: {0}")]
     Workspace(#[from] Box<WorkspaceError>),
-    #[error("workspace not found by pk: {0}")]
-    WorkspaceNotFound(WorkspacePk),
     #[error("workspace not set on DalContext")]
     WorkspaceNotSet,
     #[error("workspace snapshot error: {0}")]

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -449,7 +449,7 @@ impl Diagram {
             return Ok((ctx.workspace_snapshot()?.clone(), false));
         };
 
-        let workspace = Workspace::get_by_pk_or_error(
+        let workspace = Workspace::get_by_pk(
             ctx,
             ctx.tenancy()
                 .workspace_pk_opt()

--- a/lib/dal/src/history_event.rs
+++ b/lib/dal/src/history_event.rs
@@ -50,7 +50,7 @@ impl HistoryActor {
     pub async fn email(&self, ctx: &DalContext) -> HistoryEventResult<String> {
         Ok(match self {
             HistoryActor::SystemInit => "sally@systeminit.com".to_string(),
-            HistoryActor::User(user_pk) => User::get_by_pk_or_error(ctx, *user_pk)
+            HistoryActor::User(user_pk) => User::get_by_pk(ctx, *user_pk)
                 .await
                 .map_err(|e| HistoryEventError::User(e.to_string()))?
                 .email()

--- a/lib/dal/src/key_pair.rs
+++ b/lib/dal/src/key_pair.rs
@@ -133,7 +133,7 @@ impl KeyPair {
     standard_model_accessor_ro!(created_lamport_clock, u64);
 
     pub async fn workspace(&self, ctx: &DalContext) -> KeyPairResult<Workspace> {
-        Workspace::get_by_pk(ctx, &self.workspace_pk)
+        Workspace::get_by_pk_opt(ctx, self.workspace_pk)
             .await
             .map_err(Box::new)?
             .ok_or(KeyPairError::InvalidWorkspace(self.workspace_pk))

--- a/lib/dal/src/module.rs
+++ b/lib/dal/src/module.rs
@@ -546,7 +546,7 @@ impl Module {
         String,
     )> {
         let user = match ctx.history_actor() {
-            HistoryActor::User(user_pk) => User::get_by_pk(ctx, *user_pk).await?,
+            HistoryActor::User(user_pk) => User::get_by_pk_opt(ctx, *user_pk).await?,
             _ => None,
         };
         let (created_by_name, created_by_email) = user

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -124,8 +124,6 @@ pub enum PkgError {
     Workspace(#[from] WorkspaceError),
     #[error("workspace export not supported")]
     WorkspaceExportNotSupported(),
-    #[error("Workspace not found: {0}")]
-    WorkspaceNotFound(WorkspacePk),
     #[error("workspace pk not found on context")]
     WorkspacePkNone,
     #[error("workspace snapshot error: {0}")]

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -1093,9 +1093,7 @@ impl PkgExporter {
 
         if let Some(workspace_pk) = ctx.tenancy().workspace_pk_opt() {
             pkg_spec_builder.workspace_pk(workspace_pk.to_string());
-            let workspace = Workspace::get_by_pk(ctx, &workspace_pk)
-                .await?
-                .ok_or(PkgError::WorkspaceNotFound(workspace_pk))?;
+            let workspace = Workspace::get_by_pk(ctx, workspace_pk).await?;
             pkg_spec_builder.workspace_name(workspace.name());
         }
 

--- a/lib/dal/src/standard_model.rs
+++ b/lib/dal/src/standard_model.rs
@@ -1,4 +1,4 @@
-use crate::{Tenancy, TransactionsError, UserError, UserPk};
+use crate::{Tenancy, TransactionsError, UserError};
 use chrono::{DateTime, Utc};
 use postgres_types::ToSql;
 use serde::{de::DeserializeOwned, Serialize};
@@ -28,8 +28,6 @@ pub enum StandardModelError {
     Transactions(#[from] TransactionsError),
     #[error(transparent)]
     User(#[from] UserError),
-    #[error("user not found: {0}")]
-    UserNotFound(UserPk),
 }
 
 pub type StandardModelResult<T> = Result<T, StandardModelError>;

--- a/lib/dal/src/user.rs
+++ b/lib/dal/src/user.rs
@@ -101,7 +101,7 @@ impl User {
         Ok(object)
     }
 
-    pub async fn get_by_pk(ctx: &DalContext, pk: UserPk) -> UserResult<Option<Self>> {
+    pub async fn get_by_pk_opt(ctx: &DalContext, pk: UserPk) -> UserResult<Option<Self>> {
         let row = ctx
             .txns()
             .await?
@@ -115,8 +115,8 @@ impl User {
             Ok(None)
         }
     }
-    pub async fn get_by_pk_or_error(ctx: &DalContext, pk: UserPk) -> UserResult<Self> {
-        Self::get_by_pk(ctx, pk)
+    pub async fn get_by_pk(ctx: &DalContext, pk: UserPk) -> UserResult<Self> {
+        Self::get_by_pk_opt(ctx, pk)
             .await?
             .ok_or_else(|| UserError::NotFoundInTenancy(pk, *ctx.tenancy()))
     }

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -1433,7 +1433,7 @@ impl WorkspaceSnapshot {
         // Even though the default change set for a workspace can have a base change set, we don't
         // want to consider anything as new/modified/removed when looking at the default change
         // set.
-        let workspace = Workspace::get_by_pk_or_error(ctx, ctx.tenancy().workspace_pk()?)
+        let workspace = Workspace::get_by_pk(ctx, ctx.tenancy().workspace_pk()?)
             .await
             .map_err(Box::new)?;
         if workspace.default_change_set_id() == ctx.change_set_id() {

--- a/lib/dal/tests/integration_test/resource_metadata.rs
+++ b/lib/dal/tests/integration_test/resource_metadata.rs
@@ -103,18 +103,12 @@ async fn list(ctx: &mut DalContext, nw: &WorkspaceSignup) {
         .expect("could not commit and update snapshot to visibility");
 
     // Set the workspace token to mimic how it works with the auth-api.
-    Workspace::get_by_pk(
-        ctx,
-        &ctx.tenancy()
-            .workspace_pk_opt()
-            .expect("could not get workspace pk"),
-    )
-    .await
-    .expect("could not get workspace")
-    .expect("workspace is not some")
-    .set_token(ctx, "token".to_string())
-    .await
-    .expect("could not set token");
+    Workspace::get_by_pk(ctx, ctx.tenancy().workspace_pk().expect("workspace"))
+        .await
+        .expect("could not get workspace")
+        .set_token(ctx, "token".to_string())
+        .await
+        .expect("could not set token");
 
     // Ensure that the parent is head so that the "create" action will execute by default.
     // Technically, this primarily validates the test setup rather than the system itself, but it

--- a/lib/dal/tests/integration_test/secret/with_actions.rs
+++ b/lib/dal/tests/integration_test/secret/with_actions.rs
@@ -139,18 +139,12 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
     );
 
     // set workspace token as it is currently set by interacting with the auth-api
-    Workspace::get_by_pk(
-        ctx,
-        &ctx.tenancy()
-            .workspace_pk_opt()
-            .expect("could not get workspace pk"),
-    )
-    .await
-    .expect("could not get workspace")
-    .expect("workspace is not some")
-    .set_token(ctx, "token".to_string())
-    .await
-    .expect("could not set token");
+    Workspace::get_by_pk(ctx, ctx.tenancy().workspace_pk().expect("workspace"))
+        .await
+        .expect("could not get workspace")
+        .set_token(ctx, "token".to_string())
+        .await
+        .expect("could not set token");
 
     // Ensure that the parent is head so that the "create" action will execute by default.
     // Technically, this primarily validates the test setup rather than the system itself, but it

--- a/lib/dal/tests/integration_test/workspace.rs
+++ b/lib/dal/tests/integration_test/workspace.rs
@@ -31,10 +31,9 @@ async fn export_import_loop(ctx: &mut DalContext) {
         .expect("commit and update snapshot to visibility");
 
     let workspace_pk = ctx.tenancy().workspace_pk_opt().expect("find workspace pk");
-    let mut workspace = Workspace::get_by_pk(ctx, &workspace_pk)
+    let mut workspace = Workspace::get_by_pk(ctx, workspace_pk)
         .await
-        .expect("execute find workspace")
-        .expect("find workspace");
+        .expect("execute find workspace");
 
     // Export changeset
     let workspace_export = workspace

--- a/lib/rebaser-server/src/change_set_processor_task.rs
+++ b/lib/rebaser-server/src/change_set_processor_task.rs
@@ -384,7 +384,7 @@ mod handlers {
                 run_notify.notify_one();
             }
 
-            if let Some(workspace) = Workspace::get_by_pk(&ctx, &workspace_id).await? {
+            if let Some(workspace) = Workspace::get_by_pk_opt(&ctx, workspace_id).await? {
                 if workspace.default_change_set_id() == ctx.visibility().change_set_id {
                     let mut change_set =
                         ChangeSet::get_by_id(&ctx, ctx.visibility().change_set_id).await?;

--- a/lib/rebaser-server/src/rebase.rs
+++ b/lib/rebaser-server/src/rebase.rs
@@ -37,8 +37,6 @@ pub(crate) enum RebaseError {
     Transactions(#[from] TransactionsError),
     #[error("workspace error: {0}")]
     Workspace(#[from] WorkspaceError),
-    #[error("workspace {0} missing")]
-    WorkspaceMissing(WorkspacePk),
     #[error("workspace pk expected but was none")]
     WorkspacePkExpected,
     #[error("workspace snapshot error: {0}")]
@@ -271,7 +269,5 @@ async fn get_workspace(ctx: &DalContext) -> RebaseResult<Workspace> {
         .workspace_pk_opt()
         .ok_or(RebaseError::WorkspacePkExpected)?;
 
-    Workspace::get_by_pk(ctx, &workspace_pk)
-        .await?
-        .ok_or(RebaseError::WorkspaceMissing(workspace_pk))
+    Ok(Workspace::get_by_pk(ctx, workspace_pk).await?)
 }

--- a/lib/sdf-server/src/service/module.rs
+++ b/lib/sdf-server/src/service/module.rs
@@ -10,7 +10,7 @@ use convert_case::{Case, Casing};
 use dal::{
     pkg::PkgError as DalPkgError, ChangeSetError, DalContextBuilder, FuncError, SchemaError,
     SchemaId, SchemaVariantError, SchemaVariantId, StandardModelError, TenancyError,
-    TransactionsError, UserError, UserPk, WorkspaceError, WorkspacePk, WorkspaceSnapshotError,
+    TransactionsError, UserError, WorkspaceError, WorkspacePk, WorkspaceSnapshotError,
     WsEventError,
 };
 use serde::{Deserialize, Serialize};
@@ -53,8 +53,6 @@ pub enum ModuleError {
     Hyper(#[from] hyper::http::Error),
     #[error("Invalid package file name: {0}")]
     InvalidPackageFileName(String),
-    #[error("invalid user: {0}")]
-    InvalidUser(UserPk),
     #[error("invalid user system init")]
     InvalidUserSystemInit,
     #[error("IO Error: {0}")]

--- a/lib/sdf-server/src/service/module/approval_process.rs
+++ b/lib/sdf-server/src/service/module/approval_process.rs
@@ -42,9 +42,7 @@ pub async fn begin_approval_process(
     let metadata = pkg_data.into_latest().metadata;
 
     let user = match ctx.history_actor() {
-        HistoryActor::User(user_pk) => User::get_by_pk(&ctx, *user_pk)
-            .await?
-            .ok_or(ModuleError::InvalidUser(*user_pk))?,
+        HistoryActor::User(user_pk) => User::get_by_pk(&ctx, *user_pk).await?,
 
         HistoryActor::SystemInit => {
             return Err(ModuleError::InvalidUserSystemInit);
@@ -101,9 +99,7 @@ pub async fn cancel_approval_process(
 
     let user_pk = match ctx.history_actor() {
         HistoryActor::User(user_pk) => {
-            let user = User::get_by_pk(&ctx, *user_pk)
-                .await?
-                .ok_or(ModuleError::InvalidUser(*user_pk))?;
+            let user = User::get_by_pk(&ctx, *user_pk).await?;
 
             Some(user.pk())
         }

--- a/lib/sdf-server/src/service/module/import_workspace_vote.rs
+++ b/lib/sdf-server/src/service/module/import_workspace_vote.rs
@@ -28,9 +28,7 @@ pub async fn import_workspace_vote(
     let ctx = builder.build_head(request_ctx).await?;
 
     let user = match ctx.history_actor() {
-        HistoryActor::User(user_pk) => User::get_by_pk(&ctx, *user_pk)
-            .await?
-            .ok_or(ModuleError::InvalidUser(*user_pk))?,
+        HistoryActor::User(user_pk) => User::get_by_pk(&ctx, *user_pk).await?,
 
         HistoryActor::SystemInit => {
             return Err(ModuleError::InvalidUserSystemInit);

--- a/lib/sdf-server/src/service/session/auth_connect.rs
+++ b/lib/sdf-server/src/service/session/auth_connect.rs
@@ -102,7 +102,7 @@ async fn find_or_create_user_and_workspace(
     spicedb_client: Option<&mut SpiceDbClient>,
 ) -> SessionResult<(User, Workspace)> {
     // lookup user or create if we've never seen it before
-    let maybe_user = User::get_by_pk(&ctx, auth_api_user.id).await?;
+    let maybe_user = User::get_by_pk_opt(&ctx, auth_api_user.id).await?;
     let user = match maybe_user {
         Some(user) => user,
         None => {
@@ -119,7 +119,7 @@ async fn find_or_create_user_and_workspace(
     ctx.update_history_actor(HistoryActor::User(user.pk()));
 
     // lookup workspace or create if we've never seen it before
-    let maybe_workspace = Workspace::get_by_pk(&ctx, &auth_api_workspace.id).await?;
+    let maybe_workspace = Workspace::get_by_pk_opt(&ctx, auth_api_workspace.id).await?;
     let workspace = match maybe_workspace {
         Some(mut workspace) => {
             ctx.update_tenancy(Tenancy::new(*workspace.pk()));

--- a/lib/sdf-server/src/service/session/restore_authentication.rs
+++ b/lib/sdf-server/src/service/session/restore_authentication.rs
@@ -2,7 +2,7 @@ use axum::Json;
 use dal::{User, Workspace};
 use serde::{Deserialize, Serialize};
 
-use super::{SessionError, SessionResult};
+use super::SessionResult;
 use crate::extract::{v1::AccessBuilder, workspace::WorkspaceAuthorization, HandlerContext};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -21,9 +21,7 @@ pub async fn restore_authentication(
 ) -> SessionResult<Json<RestoreAuthenticationResponse>> {
     let ctx = builder.build_head(access_builder).await?;
 
-    let workspace = Workspace::get_by_pk(&ctx, &workspace_id)
-        .await?
-        .ok_or(SessionError::InvalidWorkspace(workspace_id))?;
+    let workspace = Workspace::get_by_pk(&ctx, workspace_id).await?;
     let reply = RestoreAuthenticationResponse { user, workspace };
 
     Ok(Json(reply))

--- a/lib/sdf-server/src/service/v2/admin/set_concurrency_limit.rs
+++ b/lib/sdf-server/src/service/v2/admin/set_concurrency_limit.rs
@@ -2,7 +2,7 @@ use axum::{
     extract::{Host, OriginalUri, Path},
     response::Json,
 };
-use dal::{Tenancy, Workspace, WorkspaceError, WorkspacePk};
+use dal::{Tenancy, Workspace, WorkspacePk};
 use serde::{Deserialize, Serialize};
 use telemetry::prelude::*;
 
@@ -53,9 +53,7 @@ pub async fn set_concurrency_limit(
             .unwrap_or("default".to_string()),
     );
 
-    let mut workspace = Workspace::get_by_pk(&ctx, &workspace_id)
-        .await?
-        .ok_or(WorkspaceError::WorkspaceNotFound(workspace_id))?;
+    let mut workspace = Workspace::get_by_pk(&ctx, workspace_id).await?;
 
     workspace
         .set_component_concurrency_limit(&ctx, request.concurrency_limit)

--- a/lib/sdf-server/src/service/v2/audit_log.rs
+++ b/lib/sdf-server/src/service/v2/audit_log.rs
@@ -3,7 +3,6 @@ use axum::{
     routing::get,
     Router,
 };
-use si_events::UserPk;
 use thiserror::Error;
 
 use crate::{service::ApiError, AppState};
@@ -21,8 +20,6 @@ pub enum AuditLogError {
     DalTransactions(#[from] dal::TransactionsError),
     #[error("dal user error: {0}")]
     DalUser(#[from] dal::UserError),
-    #[error("user not found for id: {0}")]
-    UserNotFound(UserPk),
 }
 
 pub type AuditLogResult<T> = Result<T, AuditLogError>;

--- a/lib/sdf-server/src/service/v2/audit_log/list_audit_logs.rs
+++ b/lib/sdf-server/src/service/v2/audit_log/list_audit_logs.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use si_events::{ChangeSetId, UserPk};
 use si_frontend_types as frontend_types;
 
-use super::{AuditLogError, AuditLogResult};
+use super::AuditLogResult;
 use crate::{extract::HandlerContext, service::v2::AccessBuilder, AppState};
 
 #[derive(Deserialize, Debug)]
@@ -142,9 +142,7 @@ impl Assembler {
                         Some(user.name().to_owned()),
                     ))
                 } else {
-                    let user = User::get_by_pk(ctx, user_id)
-                        .await?
-                        .ok_or(AuditLogError::UserNotFound(user_id))?;
+                    let user = User::get_by_pk(ctx, user_id).await?;
                     let found_data = (
                         Some(user_id),
                         Some(user.email().to_owned()),

--- a/lib/sdf-server/src/service/v2/module/builtins.rs
+++ b/lib/sdf-server/src/service/v2/module/builtins.rs
@@ -39,7 +39,7 @@ pub async fn promote(
     };
 
     let user = match ctx.history_actor() {
-        HistoryActor::User(user_pk) => User::get_by_pk(&ctx, *user_pk).await?,
+        HistoryActor::User(user_pk) => User::get_by_pk_opt(&ctx, *user_pk).await?,
         _ => None,
     };
 
@@ -99,7 +99,7 @@ pub async fn reject(
     };
 
     let user = match ctx.history_actor() {
-        HistoryActor::User(user_pk) => User::get_by_pk(&ctx, *user_pk).await?,
+        HistoryActor::User(user_pk) => User::get_by_pk_opt(&ctx, *user_pk).await?,
         _ => None,
     };
 

--- a/lib/sdf-server/src/service/v2/workspace/install_workspace.rs
+++ b/lib/sdf-server/src/service/v2/workspace/install_workspace.rs
@@ -42,9 +42,7 @@ pub async fn install_workspace(
             .tenancy()
             .workspace_pk_opt()
             .ok_or(WorkspaceAPIError::RootTenancyInstallAttempt)?;
-        Workspace::get_by_pk(&ctx, &workspace_pk)
-            .await?
-            .ok_or(WorkspaceAPIError::WorkspaceNotFound(workspace_pk))?
+        Workspace::get_by_pk(&ctx, workspace_pk).await?
     };
 
     let id = Ulid::new();


### PR DESCRIPTION
This does the same thing as get_by_id, for the two things with _pk. I did not rename to _id because I didn't want to take on the work of renaming the type (WorkspacePk -> WorkspaceId) here.

This removes a few unnecessary Workspace/UserNotFound error types and relies on WorkspaceError::WorkspaceNotFound/UserError::UsernotFound instead, but there are no real logic changes, just rename / use underlying error.

## Tests

* Integration tests
* Dragged out a component in the diagram