### PR TITLE
feat: add library for validating CPU/memory configurations for fargate

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -99,6 +99,7 @@ deno_workspace(
         "//bin/lang-js:deno.json",
         "//lib/ts-lib-deno:deno.json",
         "//lib/jsr-systeminit/remove-empty:deno.json",
+        "//lib/jsr-systeminit/ecs-template-qualification:deno.json",
     ],
     visibility = ["PUBLIC"],
 )
@@ -118,4 +119,3 @@ export_file(
 workspace_node_modules(
     name = "node_modules",
 )
-

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,8 @@
     "./bin/lang-js",
     "./lib/ts-lib-deno",
     "./bin/clover",
-    "./lib/jsr-systeminit/remove-empty"
+    "./lib/jsr-systeminit/remove-empty",
+    "./lib/jsr-systeminit/ecs-template-qualification"
   ],
   "imports": {
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.7",

--- a/deno.lock
+++ b/deno.lock
@@ -1857,6 +1857,11 @@
           "npm:web-streams-polyfill@3.3.3"
         ]
       },
+      "lib/jsr-systeminit/ecs-template-qualification": {
+        "dependencies": [
+          "jsr:@std/assert@1"
+        ]
+      },
       "lib/jsr-systeminit/remove-empty": {
         "dependencies": [
           "jsr:@std/assert@1",

--- a/lib/jsr-systeminit/ecs-template-qualification/BUCK
+++ b/lib/jsr-systeminit/ecs-template-qualification/BUCK
@@ -13,7 +13,7 @@ export_file(
 )
 
 filegroup(
-    name = "ecs-template-qualification",
+    name = "remove-empty",
     srcs = glob([
         "**/*",
     ]),

--- a/lib/jsr-systeminit/ecs-template-qualification/DEV.md
+++ b/lib/jsr-systeminit/ecs-template-qualification/DEV.md
@@ -1,0 +1,8 @@
+This package is published to jsr under the @systeminit scope.
+
+To publish a new version:
+
+1. Update the version number; move the major version if you break back-compat!
+2. `deno publish`
+
+You will need your github username added to the appropriate scope in JSR.

--- a/lib/jsr-systeminit/ecs-template-qualification/deno.json
+++ b/lib/jsr-systeminit/ecs-template-qualification/deno.json
@@ -1,0 +1,9 @@
+{
+  "name": "@systeminit/ecs-template-qualification",
+  "version": "0.1.1",
+  "license": "Apache-2.0",
+  "exports": "./mod.ts",
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1"
+  }
+}

--- a/lib/jsr-systeminit/ecs-template-qualification/mod.ts
+++ b/lib/jsr-systeminit/ecs-template-qualification/mod.ts
@@ -1,0 +1,65 @@
+/**
+ * Code to help validate ECS clusters
+ *
+ * Usage:
+ *
+ * ```
+ * import { isValidFargateCpuMemoryCombination } from
+ * "jsr:@systeminit/ecs-template-qualification";
+ *
+ * isValidFargateCpuMemoryCombination(256, 512); # true
+ * isValidFargateCpuMemoryCombination(256, 8192); # false
+ * ```
+ * @module
+ */
+
+/*
+ * CPU/Memory combination pairs
+ */
+export type CpuMemoryPair = {
+  cpu: number;
+  memory: number[];
+};
+
+/*
+ * The valid combinations of CPU and Memory
+ */
+export const validCpuMemoryCombinations: CpuMemoryPair[] = [
+  { cpu: 256, memory: [512, 1024, 2048] }, // 0.25 vCPU
+  { cpu: 512, memory: [1024, 2048, 3072, 4096] }, // 0.5 vCPU
+  { cpu: 1024, memory: [2048, 3072, 4096, 5120, 6144, 7168, 8192] }, // 1 vCPU
+  { cpu: 2048, memory: Array.from({ length: 13 }, (_, i) => 4096 + i * 1024) }, // 2 vCPU: 4GB to 16GB in 1GB increments
+  { cpu: 4096, memory: Array.from({ length: 23 }, (_, i) => 8192 + i * 1024) }, // 4 vCPU: 8GB to 30GB in 1GB increments
+  { cpu: 8192, memory: Array.from({ length: 12 }, (_, i) => 32768 + i * 8192) }, // 8 vCPU: 32GB to 120GB in 8GB increments
+  {
+    cpu: 16384,
+    memory: Array.from({ length: 12 }, (_, i) => 65536 + i * 8192),
+  }, // 16 vCPU: 64GB to 192GB in 8GB increments
+];
+
+/*
+ * Takes a number of CPU and a number of memory, and validates that they are
+ * both correct. Memory must be specified in MiB.
+ */
+export function isValidFargateCpuMemoryCombination(
+  cpu: number,
+  memory: number,
+): boolean {
+  const combination = validCpuMemoryCombinations.find((c) => c.cpu === cpu);
+  return combination ? combination.memory.includes(memory) : false;
+}
+
+/*
+ * Print the valid combinations of CPU and Memory
+ */
+export function printValidCombos() {
+  for (const { cpu, memory } of validCpuMemoryCombinations) {
+    console.log("-----------");
+    console.log(`CPU: ${cpu}`);
+    console.log("-----------");
+    for (const mem of memory) {
+      console.log(`Memory: ${mem}`);
+    }
+    console.log("");
+  }
+}

--- a/lib/jsr-systeminit/ecs-template-qualification/mod_test.ts
+++ b/lib/jsr-systeminit/ecs-template-qualification/mod_test.ts
@@ -1,0 +1,30 @@
+import { assertEquals } from "@std/assert";
+import {
+  isValidFargateCpuMemoryCombination,
+  validCpuMemoryCombinations,
+} from "./mod.ts";
+
+Deno.test(function validCombinations() {
+  for (const { cpu, memory: memoryValues } of validCpuMemoryCombinations) {
+    for (const memory of memoryValues) {
+      assertEquals(
+        isValidFargateCpuMemoryCombination(cpu, memory),
+        true,
+        `cpu: ${cpu}, memory: ${memory}`,
+      );
+    }
+  }
+  assertEquals(
+    isValidFargateCpuMemoryCombination(16384, 122880),
+    true,
+    `cpu: 16384, memory: 122880`,
+  );
+});
+
+Deno.test(function inValidCombinations() {
+  for (const { cpu, memory: memoryValues } of validCpuMemoryCombinations) {
+    for (const memory of memoryValues) {
+      assertEquals(isValidFargateCpuMemoryCombination(cpu, memory + 1), false);
+    }
+  }
+});


### PR DESCRIPTION
Adds a JSR library to help manages ECS task validation when Fargate is in use. Has every valid combination of CPU and Memory!

Hooray for test coverage.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdleW5jbG16b3ltNG5oMTJvaHRxcDc3cnVlcWR1dDN5aGJvNTN6cDJkayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/TIcnbw606Yl0UXiILS/giphy-downsized-medium.gif"/>