### PR TITLE
feat(dal,web): Expose socket values for Components

### DIFF
--- a/app/web/src/components/ModelingDiagram/diagram_types.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_types.ts
@@ -414,7 +414,9 @@ export type DiagramSocketDef = {
   managedSchemas?: string[];
   /** schema id, for management socket compatibility */
   schemaId?: string;
-
+  /** if there's a value propagated */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value?: any;
   // color
   // shape
 };

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -268,6 +268,7 @@ const getAncestorIds = (
 export type SocketWithParent = DiagramSocketDef & {
   componentName: string;
   componentId: ComponentId;
+  schemaName: string;
 };
 
 export type SocketWithParentAndEdge = SocketWithParent & {
@@ -378,6 +379,7 @@ export function getPossibleAndExistingPeerSockets(
             ...s,
             componentName: c.def.displayName,
             componentId: c.def.id,
+            schemaName: c.def.schemaName,
           })) ?? [],
     );
 

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -15,6 +15,7 @@ const FLAG_MAPPING = {
   AUTOCONNECT: "autoconnect-component-input-sockets",
   PRIVATE_SCOPED_MODULES: "private-scoped-modules",
   DIAGRAM_DRAG_LAYER: "diagram-drag-layer",
+  SOCKET_VALUE: "socket-value",
 };
 
 const WORKSPACE_FLAG_MAPPING = {

--- a/lib/dal/src/component/socket.rs
+++ b/lib/dal/src/component/socket.rs
@@ -180,6 +180,20 @@ impl ComponentOutputSocket {
             .map(|component_output_socket| component_output_socket.attribute_value_id)
             .collect_vec())
     }
+
+    pub async fn value_for_output_socket_id_for_component_id_opt(
+        ctx: &DalContext,
+        component_id: ComponentId,
+        output_socket_id: OutputSocketId,
+    ) -> ComponentResult<Option<serde_json::Value>> {
+        let attribute_value_id = Self::get_by_ids_or_error(ctx, component_id, output_socket_id)
+            .await?
+            .attribute_value_id;
+
+        let av = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
+        let view = av.view(ctx).await?;
+        Ok(view)
+    }
 }
 
 impl ComponentInputSocket {
@@ -409,6 +423,19 @@ impl ComponentInputSocket {
             (None, Some(inferred_source)) => Ok(Some(inferred_source)),
             (None, None) => Ok(None),
         }
+    }
+
+    pub async fn value_for_input_socket_id_for_component_id_opt(
+        ctx: &DalContext,
+        component_id: ComponentId,
+        input_socket_id: InputSocketId,
+    ) -> ComponentResult<Option<serde_json::Value>> {
+        let attribute_value_id = Self::get_by_ids_or_error(ctx, component_id, input_socket_id)
+            .await?
+            .attribute_value_id;
+        let av = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
+        let view = av.view(ctx).await?;
+        Ok(view)
     }
 
     /// Return true if the input socket already has an explicit connection (a user drew an edge)

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -1682,6 +1682,7 @@ impl SchemaVariant {
             node_side: DiagramSocketNodeSide::Left,
             is_management: Some(true),
             managed_schemas: None,
+            value: None,
         };
 
         // You only have an "output" if you have management prototypes
@@ -1695,6 +1696,7 @@ impl SchemaVariant {
             node_side: DiagramSocketNodeSide::Right,
             is_management: Some(true),
             managed_schemas: Some(managed_schemas.into_iter().map(Into::into).collect()),
+            value: None,
         });
 
         Ok((management_input_socket, management_output_socket))

--- a/lib/si-frontend-types-rs/src/component.rs
+++ b/lib/si-frontend-types-rs/src/component.rs
@@ -134,6 +134,7 @@ pub struct DiagramSocket {
     pub node_side: DiagramSocketNodeSide,
     pub is_management: Option<bool>,
     pub managed_schemas: Option<Vec<SchemaId>>,
+    pub value: Option<serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
This PR includes the Value for a given Component's Sockets when fetching Component Data.  The Front end change is behind a feature flag (`socket-value`), which when enabled, exposes this information (and a bit more) in the Connections Panel. We might never want to enable this for users, but shipping this so we can use the data in other places! 

Notably awful about this PR is I'm not handling secrets, so the value that is displayed for a secret socket is the secret ID. Not very helpful. 


Before:
<img width="427" alt="image" src="https://github.com/user-attachments/assets/80d0a476-7d82-4dde-87bf-7e5bca4b5fe4" />

After: 
<img width="428" alt="image" src="https://github.com/user-attachments/assets/ba7a228d-e42a-4224-8bfd-8ace8fa30e21" />

<div><img src="https://media1.giphy.com/media/qE9AFvF4QCPeiP4bh8/200w.gif?cid=5a38a5a2g2gu08rnw6qey5w05teqbzbqt3p1qyvtmnu7me4t&amp;ep=v1_gifs_search&amp;rid=200w.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/outlander/">Outlander</a> on <a href="https://giphy.com/gifs/outlander-season-7-starz-704-qE9AFvF4QCPeiP4bh8">GIPHY</a></div>

Tested with and without the flag on, all works as expected!