### PR TITLE
feat(web, sdf): Add ability to convert a frame to a view

### DIFF
--- a/app/web/src/components/ModelingDiagram/utils/childrenByBoundingBox.ts
+++ b/app/web/src/components/ModelingDiagram/utils/childrenByBoundingBox.ts
@@ -1,0 +1,69 @@
+import { IRect } from "konva/lib/types";
+import { useViewsStore } from "@/store/views.store";
+import { useComponentsStore } from "@/store/components.store";
+import { ComponentId } from "@/api/sdf/dal/component";
+import {
+  DiagramGroupData,
+  DiagramNodeData,
+  DiagramViewData,
+} from "../diagram_types";
+import { rectContainsAnother } from "./math";
+
+export const FindChildrenByBoundingBox = (
+  el: DiagramNodeData | DiagramGroupData,
+  allowDeletedChildrenToBeFilteredOut: boolean,
+): (DiagramNodeData | DiagramGroupData | DiagramViewData)[] => {
+  const componentsStore = useComponentsStore();
+  const viewsStore = useViewsStore();
+
+  const cRect = el.def.isGroup
+    ? viewsStore.groups[el.def.id]
+    : viewsStore.components[el.def.id];
+  if (!cRect) return [];
+
+  const rect = { ...cRect };
+  rect.x -= rect.width / 2;
+
+  const nodes: (DiagramGroupData | DiagramNodeData | DiagramViewData)[] = [];
+  const process = ([id, elRect]: [ComponentId, IRect]) => {
+    // i do not fit inside myself
+    if (el.def.id === id) return;
+    const _r = { ...elRect };
+    _r.x -= _r.width / 2;
+    if (rectContainsAnother(rect, _r)) {
+      const component = componentsStore.allComponentsById[id];
+      if (component) {
+        if (allowDeletedChildrenToBeFilteredOut) {
+          if (
+            "changeStatus" in component.def &&
+            component.def.changeStatus === "deleted"
+          )
+            return;
+          if (
+            "fromBaseChangeSet" in component.def &&
+            component.def.fromBaseChangeSet
+          )
+            return;
+        }
+        nodes.push(component);
+      }
+    }
+  };
+
+  Object.entries(viewsStore.groups).forEach(process);
+  Object.entries(viewsStore.components).forEach(process);
+  Object.values(viewsStore.viewNodes).forEach((viewNode) => {
+    const _r = {
+      x: viewNode.def.x,
+      y: viewNode.def.y,
+      width: viewNode.def.width,
+      height: viewNode.def.height,
+    };
+    _r.x -= _r.width / 2;
+    _r.y -= _r.height / 2;
+    if (rectContainsAnother(rect, _r)) {
+      nodes.push(viewNode);
+    }
+  });
+  return nodes;
+};

--- a/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
+++ b/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
@@ -41,7 +41,6 @@ import {
 } from "@si/vue-lib/design-system";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
-// import plur from "plur";
 import { RouteLocationRaw } from "vue-router";
 import { IRect } from "konva/lib/types";
 import { ComponentType } from "@/api/sdf/dal/schema";
@@ -64,6 +63,7 @@ import {
   DiagramNodeDef,
   DiagramViewData,
 } from "../ModelingDiagram/diagram_types";
+import { FindChildrenByBoundingBox } from "../ModelingDiagram/utils/childrenByBoundingBox";
 
 const contextMenuRef = ref<InstanceType<typeof DropdownMenu>>();
 
@@ -211,6 +211,23 @@ const newView = () => {
   modalRef.value?.open();
 };
 
+const convertToView = async () => {
+  if (!viewsStore.selectedViewId) return;
+  if (!viewsStore.selectedComponent) return;
+  const children = FindChildrenByBoundingBox(
+    viewsStore.selectedComponent as DiagramNodeData | DiagramGroupData,
+    true,
+  );
+  const child_ids = children.map((c) => c.def.id);
+  if (viewsStore.selectedComponentId) {
+    await viewsStore.CONVERT_TO_VIEW(
+      viewsStore.selectedViewId,
+      viewsStore.selectedComponentId,
+      child_ids,
+    );
+  }
+};
+
 const create = async () => {
   if (!viewsStore.selectedViewId) return;
   if (!viewName.value) {
@@ -275,6 +292,13 @@ const rightClickMenuItems = computed(() => {
         submenuItems: copyToSubmenuItems,
       });
     }
+  }
+  if (featureFlagsStore.CONVERT_TO_VIEW) {
+    items.push({
+      label: "Convert to View",
+      icon: "create",
+      onSelect: convertToView,
+    });
   }
   items.push({
     label: "Remove",

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -17,6 +17,7 @@ const FLAG_MAPPING = {
   DIAGRAM_DRAG_LAYER: "diagram-drag-layer",
   SOCKET_VALUE: "socket-value",
   FLOATING_CONNECTION_MENU: "floating-connection-menu",
+  CONVERT_TO_VIEW: "convert-to-view",
 };
 
 const WORKSPACE_FLAG_MAPPING = {

--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -1624,6 +1624,42 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
             },
           });
         },
+        async CONVERT_TO_VIEW(
+          sourceViewId: ViewId,
+          componentId: ComponentId,
+          containedComponentIds: ComponentId[],
+        ) {
+          const placeViewAt = this.groups[componentId];
+          const viewToHexagonGeo = {
+            x: placeViewAt?.x.toString(),
+            y: placeViewAt?.y.toString(),
+            radius: "250",
+          };
+          const stringGeometries: Record<ComponentId, StringGeometry> = {};
+          containedComponentIds.forEach((c) => {
+            const geo = this.components[c];
+            stringGeometries[c] = {
+              x: Math.round(geo?.x || 0).toString(),
+              y: Math.round(geo?.y || 0).toString(),
+              width: Math.round(geo?.width || 0).toString(),
+              height: Math.round(geo?.height || 0).toString(),
+            };
+          });
+          return new ApiRequest({
+            method: "post",
+            url: API_PREFIX.concat(["convert_to_view"]),
+            params: {
+              componentId,
+              sourceViewId,
+              containedComponentIds: stringGeometries,
+              placeViewAt: viewToHexagonGeo,
+            },
+            optimistic: () => {
+              this.setSelectedComponentId(null);
+              this.syncSelectionIntoUrl();
+            },
+          });
+        },
         async CREATE_VIEW_AND_MOVE(
           name: string,
           sourceViewId: ViewId,

--- a/lib/sdf-server/src/service/v2/view/convert_to_view.rs
+++ b/lib/sdf-server/src/service/v2/view/convert_to_view.rs
@@ -1,0 +1,178 @@
+use crate::extract::{HandlerContext, PosthogClient};
+use axum::extract::{Host, OriginalUri, Path};
+use axum::Json;
+use dal::component::frame::Frame;
+use dal::diagram::geometry::Geometry;
+use serde::{Deserialize, Serialize};
+use si_id::ViewId;
+use std::collections::HashMap;
+
+use dal::diagram::view::{View, ViewComponentsUpdateList, ViewView};
+use dal::{
+    ChangeSet, ChangeSetId, Component, ComponentError, ComponentId, ComponentType, WorkspacePk,
+    WsEvent,
+};
+
+use crate::service::force_change_set_response::ForceChangeSetResponse;
+use crate::service::v2::view::{ViewError, ViewNodeGeometry, ViewResult};
+use crate::service::v2::AccessBuilder;
+use si_frontend_types::{RawGeometry, StringGeometry};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Request {
+    pub component_id: ComponentId,
+    pub contained_component_ids: HashMap<ComponentId, StringGeometry>,
+    pub source_view_id: ViewId,
+    pub place_view_at: ViewNodeGeometry,
+}
+
+pub async fn convert_to_view(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    PosthogClient(_posthog_client): PosthogClient,
+    OriginalUri(_original_uri): OriginalUri,
+    Host(_host_name): Host,
+    Path((_workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
+    Json(Request {
+        component_id,
+        mut contained_component_ids,
+        source_view_id,
+        place_view_at,
+    }): Json<Request>,
+) -> ViewResult<ForceChangeSetResponse<ViewView>> {
+    let mut ctx = builder
+        .build(access_builder.build(change_set_id.into()))
+        .await?;
+
+    let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
+
+    let component = Component::get_by_id(&ctx, component_id).await?;
+    if component.get_type(&ctx).await? == ComponentType::Component {
+        return Err(ViewError::ComponentIsNotAFrame(component_id));
+    }
+
+    let variant = component.schema_variant(&ctx).await?;
+    let component_name = component.name(&ctx).await?;
+
+    if variant.display_name() == "Generic Frame" {
+        let maybe_eventual_parent = component.parent(&ctx).await?;
+        let child_components_ids = Component::get_children_for_id(&ctx, component_id).await?;
+        for child_comp_id in child_components_ids {
+            let child = Component::get_by_id(&ctx, child_comp_id).await?;
+            if let Some(parent_component) = child.parent(&ctx).await? {
+                if parent_component == component.id() {
+                    match maybe_eventual_parent {
+                        Some(eventual_parent) => {
+                            Frame::upsert_parent_no_events(&ctx, child_comp_id, eventual_parent)
+                                .await?;
+                        }
+                        None => {
+                            Frame::orphan_child(&ctx, child_comp_id).await?;
+                        }
+                    }
+                }
+            }
+        }
+
+        component.delete(&ctx).await?;
+        WsEvent::component_deleted(&ctx, component_id)
+            .await?
+            .publish_on_commit(&ctx)
+            .await?;
+    } else {
+        contained_component_ids.insert(
+            component_id,
+            StringGeometry {
+                x: place_view_at.x.clone(),
+                y: place_view_at.y.clone(),
+                height: None,
+                width: None,
+            },
+        );
+    };
+
+    let view = View::new(&ctx, component_name.clone()).await?;
+    let view_id = view.id();
+    let view_view = ViewView::from_view(&ctx, view).await?;
+    WsEvent::view_created(&ctx, view_view.clone())
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    let mut updated_components = ViewComponentsUpdateList::new();
+    let mut successful_erase = false;
+    let mut latest_error = None;
+
+    // Move the components to the new view
+    for (component_id, string_geometry) in contained_component_ids {
+        let geometry: RawGeometry = string_geometry.try_into()?;
+
+        match Component::add_to_view(&ctx, component_id, view_id, geometry.clone()).await {
+            Ok(_) => {}
+            Err(err @ ComponentError::ComponentAlreadyInView(_, _)) => {
+                latest_error = Some(err);
+                continue;
+            }
+            Err(err) => return Err(err)?,
+        };
+
+        successful_erase = true;
+
+        updated_components
+            .entry(view_id)
+            .or_default()
+            .added
+            .insert(component_id, geometry);
+
+        let old_geometry =
+            Geometry::get_by_component_and_view(&ctx, component_id, source_view_id).await?;
+
+        updated_components
+            .entry(source_view_id)
+            .or_default()
+            .removed
+            .insert(component_id);
+
+        Geometry::remove(&ctx, old_geometry.id()).await?
+    }
+
+    if let Some(err) = latest_error {
+        if !successful_erase {
+            return Err(err)?;
+        }
+    }
+
+    WsEvent::view_components_update(&ctx, updated_components)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    let (Ok(x), Ok(y), Ok(radius)) = (
+        place_view_at.x.clone().parse::<isize>(),
+        place_view_at.y.clone().parse::<isize>(),
+        place_view_at.radius.clone().parse::<isize>(),
+    ) else {
+        ctx.rollback().await?;
+        return Err(ViewError::InvalidRequest(
+            "geometry unable to be parsed from create view object request".into(),
+        ));
+    };
+
+    let geometry = RawGeometry {
+        x,
+        y,
+        width: Some(radius),
+        height: Some(radius),
+    };
+    View::add_to_another_view(&ctx, view_id, source_view_id, geometry.clone()).await?;
+
+    WsEvent::view_object_created(&ctx, source_view_id, view_id, geometry)
+        .await?
+        .publish_on_commit(&ctx)
+        .await?;
+
+    ctx.commit().await?;
+
+    Ok(ForceChangeSetResponse::new(force_change_set_id, view_view))
+}


### PR DESCRIPTION
This takes all of the contents of a generic frame, reparents the contents of the frame, if necessary, and creates a new view with a view diagram object in it's place

If the user does this on a up or down frae, it will move the items directly and not delete or reparent

