### PR TITLE
Feat/tune veritech nodes

### DIFF
--- a/lib/si-firecracker/src/firecracker.rs
+++ b/lib/si-firecracker/src/firecracker.rs
@@ -40,6 +40,8 @@ impl FirecrackerJail {
         let mut cmd = Command::new("/usr/bin/jailer");
         cmd.arg("--cgroup-version")
             .arg("2")
+            .arg("--cgroup")
+            .arg("/sys/fs/cgroup/firecracker")
             .arg("--id")
             .arg(id.to_string())
             .arg("--exec-file")

--- a/lib/si-firecracker/src/scripts/prepare_jailer.sh
+++ b/lib/si-firecracker/src/scripts/prepare_jailer.sh
@@ -192,7 +192,7 @@ fi
 cat << EOF
   ],
   "machine-config": {
-    "vcpu_count": 4,
+    "vcpu_count": 2,
     "mem_size_mib": 512
   },
   "network-interfaces": [{


### PR DESCRIPTION
1. Add Veritech and Firecracker jails into their own cgroups to prevent excessive context switching impacting Veritech's ability to work. Cgroups are configured as follows:
    a) Veritech gets 1/4 of the CPU to supervise (0-15), firecracker gets the remainder (16-63)
    b) Allow the respective cgroup to burn 100% of the allocated cpus
3. Tune a bunch of kernel settings to levels which are a bit more appropriate to our use case/usage of the node, i.e.
    a) Optimize TCP keepalive settings / Detect stale connections faster / Recycle quicker
    b) Reduce stale socket overhead / Timeout dead sockets faster
    c) Configure TCP memory and write buffer limits (to tested sizes)
    d) Reuse closed connections faster (if possible)
5. Reduces the core allocation on each firecracker jail from 4(!!!!) to 2. **_Authors note:_** I think 1 is probably fine here but I haven't tested it

<div><img src="https://media1.giphy.com/media/bHG5gzKfPESAGr4Dxg/giphy.gif?cid=5a38a5a2o4jfog1it2r2uxxameyfi99nigpwzv2d1ib23jzn&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:225px;width:300px"/></div>