### PR TITLE
Allow firecracker creation skip and fix config mismatch in veritech

### DIFF
--- a/bin/veritech/src/args.rs
+++ b/bin/veritech/src/args.rs
@@ -98,6 +98,10 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) cyclone_pool_size: Option<u32>,
 
+    /// Cyclone create firecracker setup scripts
+    #[arg(long)]
+    pub(crate) cyclone_create_firecracker_setup_scripts: Option<bool>,
+
     /// Veritech decryption key file location [example: /run/veritech/veritech.key]
     #[arg(long)]
     pub(crate) decryption_key: Option<PathBuf>,
@@ -106,9 +110,9 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) cyclone_client_execution_timeout_secs: Option<u64>,
 
-    /// The number of concurrent functions that can be executed [default: 1000]
+    /// The number of concurrent requests that will be processed
     #[arg(long)]
-    pub(crate) concurrency: Option<u32>,
+    pub(crate) veritech_requests_concurrency_limit: Option<u32>,
 
     /// Instance ID [example: 01GWEAANW5BVFK5KDRVS6DEY0F"]
     ///
@@ -156,6 +160,7 @@ impl TryFrom<Args> for Config {
             if let Some(creds_file) = args.nats_creds_path {
                 config_map.set("nats.creds_file", creds_file.display().to_string());
             }
+
             if args.cyclone_local_firecracker {
                 config_map.set("cyclone.runtime_strategy", "LocalFirecracker");
             }
@@ -171,6 +176,15 @@ impl TryFrom<Args> for Config {
             if let Some(size) = args.cyclone_pool_size {
                 config_map.set("cyclone.pool_size", size);
             }
+            if let Some(cyclone_create_firecracker_setup_scripts) =
+                args.cyclone_create_firecracker_setup_scripts
+            {
+                config_map.set(
+                    "cyclone.create_firecracker_setup_scripts",
+                    cyclone_create_firecracker_setup_scripts,
+                );
+            }
+
             if let Some(decryption_key_path) = args.decryption_key {
                 config_map.set(
                     "decryption_key_path",
@@ -181,8 +195,13 @@ impl TryFrom<Args> for Config {
             if let Some(timeout) = args.cyclone_client_execution_timeout_secs {
                 config_map.set("cyclone_client_execution_timeout_secs", timeout);
             }
-            if let Some(concurrency) = args.concurrency {
-                config_map.set("concurrency_limit", i64::from(concurrency));
+            if let Some(veritech_requests_concurrency_limit) =
+                args.veritech_requests_concurrency_limit
+            {
+                config_map.set(
+                    "veritech_requests_concurrency_limit",
+                    i64::from(veritech_requests_concurrency_limit),
+                );
             }
             if let Some(instance_id) = args.instance_id {
                 config_map.set("instance_id", instance_id);

--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -6,6 +6,7 @@ create_workspace_allowlist = [ "$SI_WORKSPACE_ALLOW_LIST" ]
 concurrency_limit = $SI_PINGA_CONCURRENCY_LIMIT
 data_warehouse_stream_name = "$SI_FORKLIFT_DATA_WAREHOUSE_STREAM_NAME"
 enable_audit_logs_app = $SI_FORKLIFT_ENABLE_AUDIT_LOGS_APP
+veritech_requests_concurrency_limit = $SI_VERITECH_REQUESTS_CONCURRENCY_LIMIT
 
 [crypto]
 encryption_key_base64 = "$SI_ENCRYPTION_KEY_BASE64"

--- a/lib/si-firecracker/src/errors.rs
+++ b/lib/si-firecracker/src/errors.rs
@@ -26,6 +26,9 @@ pub enum FirecrackerJailError {
     // Failed to setup firecracker
     #[error("Failed to setup firecracker: {0}")]
     Setup(#[from] tokio::io::Error),
+    // The setup script(s) do not exist
+    #[error("Setup script(s) do not exist: {0:?}")]
+    SetupScriptsDoNotExist(Vec<String>),
     // Failed to spawn firecracker
     #[error("Failed to spawn firecracker: {0}")]
     Spawn(#[source] tokio::io::Error),

--- a/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
+++ b/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
@@ -282,6 +282,10 @@ pub struct LocalUdsInstanceSpec {
     /// Sets the timeout for connecting to firecracker
     #[builder(setter(into), default = "10")]
     connect_timeout: u64,
+
+    /// Sets whether or not the firecracker setup scripts will be created.
+    #[builder(default = "true")]
+    create_firecracker_setup_scripts: bool,
 }
 
 #[async_trait]
@@ -749,7 +753,7 @@ impl LocalFirecrackerRuntime {
     }
 
     async fn setup_firecracker(spec: &LocalUdsInstanceSpec) -> Result<()> {
-        Ok(FirecrackerJail::setup(spec.pool_size).await?)
+        Ok(FirecrackerJail::setup(spec.pool_size, spec.create_firecracker_setup_scripts).await?)
     }
 }
 

--- a/lib/veritech-server/src/server.rs
+++ b/lib/veritech-server/src/server.rs
@@ -149,7 +149,7 @@ impl Server {
 
                 let inner_future = Self::build_app(
                     metadata.clone(),
-                    config.concurrency_limit(),
+                    config.veritech_requests_concurrency_limit(),
                     cyclone_pool,
                     Arc::new(decryption_key),
                     config.cyclone_client_execution_timeout(),


### PR DESCRIPTION
This PR allows firecracker setup script creation to be skipped. This is useful for a variety of reasons: getting a new rootfs, changing the script itself, and more.

This PR also fixes a config mismatch in veritech where pinga's concurrency limit will be derived for all global merged configurations. Until we fix the "pool exhausted == NACK counting towards max failed message count" problem, we cannot afford the concurrency limit to be higher than the pool size. Now, we will be able to individual customize.

Why not pursue a dynamic solution where the concurrency limit is equal to the pool size by default? A bit of magic lies in there as well as a potential side effect to the other runtime strategies (local process and docker). We are really only trying to target the use of concurrency limit in production settings using firecracker, so renaming the variable will suffice.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZ3cxcjI2Z2lzdnhpNmppZWptbmkybHI3azQzYmp1dG1hMjVldXQ5OSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/AiSJLkTXSckitMa4yt/giphy.gif"/>