### PR TITLE
feat: si-split-graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7184,6 +7184,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "si-split-graph"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "blake3",
+ "petgraph",
+ "serde",
+ "si-events",
+ "si-id",
+ "strum",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "si-std"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ members = [
     "lib/si-runtime-rs",
     "lib/si-service",
     "lib/si-settings",
+    "lib/si-split-graph",
     "lib/si-std",
     "lib/si-test-macros",
     "lib/telemetry-application-rs",

--- a/lib/dal/src/approval_requirement.rs
+++ b/lib/dal/src/approval_requirement.rs
@@ -30,17 +30,15 @@
 use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
-use si_events::merkle_tree_hash::MerkleTreeHash;
+use si_events::{merkle_tree_hash::MerkleTreeHash, workspace_snapshot::Change};
 use si_id::{ulid::Ulid, ApprovalRequirementDefinitionId, EntityId, UserPk};
 use telemetry::prelude::*;
 use thiserror::Error;
 
 use crate::{
     layer_db_types::ApprovalRequirementDefinitionContentV1,
-    workspace_snapshot::{
-        graph::detector::Change, traits::approval_requirement::ApprovalRequirementExt,
-    },
-    DalContext, WorkspaceSnapshotError, WsEvent, WsEventResult, WsPayload,
+    workspace_snapshot::traits::approval_requirement::ApprovalRequirementExt, DalContext,
+    WorkspaceSnapshotError, WsEvent, WsEventResult, WsPayload,
 };
 
 pub use crate::workspace_snapshot::traits::approval_requirement::{

--- a/lib/dal/src/entity_kind.rs
+++ b/lib/dal/src/entity_kind.rs
@@ -76,6 +76,8 @@ impl EntityKind {
             | EntityKindEvents::Secret
             | EntityKindEvents::StaticArgumentValue
             | EntityKindEvents::ValidationOutput
+            | EntityKindEvents::SubGraphRoot
+            | EntityKindEvents::ExternalTarget
             | EntityKindEvents::ValidationPrototype => None,
             EntityKindEvents::SchemaVariant => {
                 let variant_name = SchemaVariant::get_by_id(ctx, id.into_inner().into())

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -8,14 +8,14 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use graph::correct_transforms::correct_transforms;
-use graph::detector::{Change, Update};
+use graph::detector::Update;
 use graph::{RebaseBatch, WorkspaceSnapshotGraph};
 use node_weight::traits::CorrectTransformsError;
 use petgraph::prelude::*;
 use serde::{Deserialize, Serialize};
 use si_data_pg::PgError;
 use si_events::merkle_tree_hash::MerkleTreeHash;
-use si_events::workspace_snapshot::Checksum;
+use si_events::workspace_snapshot::{Change, Checksum};
 use si_events::{ulid::Ulid, ContentHash, WorkspaceSnapshotAddress};
 use si_id::{ApprovalRequirementDefinitionId, EntityId};
 use si_layer_cache::LayerDbError;

--- a/lib/dal/src/workspace_snapshot/graph/detector.rs
+++ b/lib/dal/src/workspace_snapshot/graph/detector.rs
@@ -5,8 +5,7 @@ use petgraph::{
     visit::{Control, DfsEvent},
 };
 use serde::{Deserialize, Serialize};
-use si_events::{merkle_tree_hash::MerkleTreeHash, ulid::Ulid, workspace_snapshot::EntityKind};
-use si_id::EntityId;
+use si_events::{ulid::Ulid, workspace_snapshot::Change};
 use strum::EnumDiscriminants;
 
 use crate::{
@@ -38,13 +37,6 @@ pub enum Update {
     NewNode {
         node_weight: NodeWeight,
     },
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct Change {
-    pub entity_id: EntityId,
-    pub entity_kind: EntityKind,
-    pub merkle_tree_hash: MerkleTreeHash,
 }
 
 #[derive(Clone, Debug)]

--- a/lib/dal/src/workspace_snapshot/graph/traits/approval_requirement.rs
+++ b/lib/dal/src/workspace_snapshot/graph/traits/approval_requirement.rs
@@ -1,10 +1,13 @@
 use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
-use si_events::{merkle_tree_hash::MerkleTreeHash, workspace_snapshot::EntityKind};
+use si_events::{
+    merkle_tree_hash::MerkleTreeHash,
+    workspace_snapshot::{Change, EntityKind},
+};
 use si_id::{ApprovalRequirementDefinitionId, EntityId, UserPk, WorkspacePk};
 
-use crate::workspace_snapshot::graph::{detector::Change, WorkspaceSnapshotGraphResult};
+use crate::workspace_snapshot::graph::WorkspaceSnapshotGraphResult;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ApprovalRequirementPermissionLookup {

--- a/lib/dal/src/workspace_snapshot/graph/v4.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v4.rs
@@ -12,7 +12,7 @@ use petgraph::{
     visit::DfsEvent,
 };
 use serde::{Deserialize, Serialize};
-use si_events::{ulid::Ulid, ContentHash};
+use si_events::{ulid::Ulid, workspace_snapshot::Change, ContentHash};
 use si_layer_cache::db::serialize;
 use strum::IntoEnumIterator;
 use telemetry::prelude::*;
@@ -32,8 +32,6 @@ use crate::{
     DalContext, EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants, NodeWeightDiscriminants,
     Timestamp,
 };
-
-use super::detector::Change;
 
 pub mod approval_requirement;
 pub mod component;

--- a/lib/dal/src/workspace_snapshot/graph/v4/approval_requirement.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v4/approval_requirement.rs
@@ -1,13 +1,15 @@
 use std::collections::{HashMap, HashSet};
 
 use petgraph::{prelude::*, Direction};
-use si_events::{merkle_tree_hash::MerkleTreeHash, workspace_snapshot::EntityKind};
+use si_events::{
+    merkle_tree_hash::MerkleTreeHash,
+    workspace_snapshot::{Change, EntityKind},
+};
 use si_id::{ApprovalRequirementDefinitionId, EntityId, WorkspacePk};
 
 use crate::{
     workspace_snapshot::{
         graph::{
-            detector::Change,
             traits::approval_requirement::{
                 ApprovalRequirementApprover, ApprovalRequirementExt,
                 ApprovalRequirementPermissionLookup, ApprovalRequirementRule,

--- a/lib/dal/src/workspace_snapshot/traits/approval_requirement.rs
+++ b/lib/dal/src/workspace_snapshot/traits/approval_requirement.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use si_events::{merkle_tree_hash::MerkleTreeHash, ContentHash};
+use si_events::{merkle_tree_hash::MerkleTreeHash, workspace_snapshot::Change, ContentHash};
 use si_id::{ulid::Ulid, ApprovalRequirementDefinitionId, EntityId, UserPk};
 
 use crate::{
@@ -15,10 +15,7 @@ use crate::{
         ApprovalRequirementDefinitionContent, ApprovalRequirementDefinitionContentV1,
     },
     workspace_snapshot::{
-        graph::{
-            detector::Change,
-            traits::approval_requirement::ApprovalRequirementExt as ApprovalRequirementExtGraph,
-        },
+        graph::traits::approval_requirement::ApprovalRequirementExt as ApprovalRequirementExtGraph,
         node_weight::{traits::SiNodeWeight, NodeWeight},
         WorkspaceSnapshotResult,
     },

--- a/lib/si-events-rs/src/workspace_snapshot.rs
+++ b/lib/si-events-rs/src/workspace_snapshot.rs
@@ -1,10 +1,19 @@
 use serde::Deserialize;
 use serde::Serialize;
+use si_id::EntityId;
 use strum::Display;
 
 use crate::create_xxhash_type;
+use crate::merkle_tree_hash::MerkleTreeHash;
 
 create_xxhash_type!(Checksum);
+
+#[derive(Debug, Clone, Copy)]
+pub struct Change {
+    pub entity_id: EntityId,
+    pub entity_kind: EntityKind,
+    pub merkle_tree_hash: MerkleTreeHash,
+}
 
 #[remain::sorted]
 #[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq, Eq, Display)]
@@ -28,6 +37,7 @@ pub enum EntityKind {
     Component,
     DependentValueRoot,
     DiagramObject,
+    ExternalTarget,
     FinishedDependentValueRoot,
     Func,
     FuncArgument,
@@ -44,6 +54,7 @@ pub enum EntityKind {
     SchemaVariant,
     Secret,
     StaticArgumentValue,
+    SubGraphRoot,
     ValidationOutput,
     ValidationPrototype,
     View,

--- a/lib/si-split-graph/BUCK
+++ b/lib/si-split-graph/BUCK
@@ -1,0 +1,19 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "si-split-graph",
+    deps = [
+        "//lib/si-events-rs:si-events",
+        "//lib/si-id:si-id",
+
+        "//third-party/rust:async-trait",
+        "//third-party/rust:blake3",
+        "//third-party/rust:petgraph",
+        "//third-party/rust:serde",
+        "//third-party/rust:strum",
+        "//third-party/rust:thiserror",
+    ],
+    srcs = glob([
+        "src/**/*.rs",
+    ]),
+)

--- a/lib/si-split-graph/Cargo.toml
+++ b/lib/si-split-graph/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "si-split-graph"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+si-id = { path = "../../lib/si-id" }
+si-events = { path = "../../lib/si-events-rs" }
+
+async-trait = { workspace = true }
+blake3 = { workspace = true }
+petgraph = { workspace = true }
+serde = { workspace = true }
+strum = { workspace = true }
+thiserror = { workspace = true }

--- a/lib/si-split-graph/src/lib.rs
+++ b/lib/si-split-graph/src/lib.rs
@@ -179,12 +179,11 @@ where
 
     pub fn node_hash(&self) -> ContentHash {
         let mut hasher = ContentHash::hasher();
-        if let SplitGraphNodeWeight::Custom(n) = self {
-            return n.node_hash();
-        }
 
         match self {
-            SplitGraphNodeWeight::Custom(_) => {}
+            SplitGraphNodeWeight::Custom(c) => {
+                return c.node_hash();
+            }
             SplitGraphNodeWeight::ExternalTarget {
                 id,
                 subgraph,

--- a/lib/si-split-graph/src/lib.rs
+++ b/lib/si-split-graph/src/lib.rs
@@ -1,0 +1,1177 @@
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use opt_zip::OptZip;
+use petgraph::{prelude::*, stable_graph};
+use serde::{Deserialize, Serialize};
+use si_events::{merkle_tree_hash::MerkleTreeHash, ContentHash};
+use si_id::ulid::Ulid;
+use thiserror::Error;
+
+mod opt_zip;
+pub mod subgraph;
+pub mod subgraph_address;
+pub mod updates;
+
+use subgraph::{SubGraph, SubGraphEdgeIndex, SubGraphNodeIndex};
+pub use subgraph_address::SubGraphAddress;
+use updates::Update;
+
+pub const MAX_NODES: usize = ((u16::MAX / 2) - 1) as usize;
+
+#[derive(Error, Debug)]
+pub enum SplitGraphError {
+    #[error("Node id {0} not found")]
+    NodeNotFound(SplitGraphNodeId),
+    #[error("Node at index not found, this is a bug")]
+    NodeNotFoundAtIndex,
+    #[error("The splitgraph root is missing")]
+    RootNodeNotFound,
+    #[error("reorder must contain all the same ids as the original")]
+    OrderContentMismatch,
+    #[error("reorder must be of the same length as original")]
+    OrderLengthMismatch,
+    #[error("No subgraph at index: {0}")]
+    SubGraphMissing(usize),
+    #[error("error reading subgraph with address {0:?}: {1}")]
+    SubGraphRead(SubGraphAddress, String),
+    #[error("error writing subgraph: {0}")]
+    SubGraphWrite(String),
+}
+
+pub type SplitGraphResult<T> = Result<T, SplitGraphError>;
+
+pub type SplitGraphNodeId = Ulid;
+pub type SubGraphIndex = u16;
+
+#[async_trait]
+pub trait SubGraphReader<N, E, K>: Clone + std::fmt::Debug
+where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    type Error: std::error::Error;
+
+    async fn read_subgraph(
+        &self,
+        address: SubGraphAddress,
+    ) -> Result<SubGraph<N, E, K>, Self::Error>;
+}
+
+#[async_trait]
+pub trait SubGraphWriter<Node, Edge, K>: Clone + std::fmt::Debug
+where
+    Node: CustomNodeWeight,
+    Edge: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    type Error: std::error::Error;
+
+    async fn write_subgraph(
+        &mut self,
+        graph: &SubGraph<Node, Edge, K>,
+    ) -> Result<SubGraphAddress, Self::Error>;
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+pub enum SplitGraphNodeWeight<N>
+where
+    N: CustomNodeWeight,
+{
+    /// The node weight kind provided by users of this crate
+    Custom(N),
+    /// A placeholder for an edge that points to a node in another subgraph
+    ExternalTarget {
+        id: SplitGraphNodeId,
+        subgraph: SubGraphIndex,
+        target: SplitGraphNodeId,
+        merkle_tree_hash: MerkleTreeHash,
+    },
+    /// The ordering node for an ordered container
+    Ordering {
+        id: SplitGraphNodeId,
+        order: Vec<SplitGraphNodeId>,
+        merkle_tree_hash: MerkleTreeHash,
+    },
+    /// The root node for the entire graph
+    GraphRoot {
+        id: SplitGraphNodeId,
+        merkle_tree_hash: MerkleTreeHash,
+    },
+    /// The root node for a subgraph (besides the first subgraph, which has the GraphRoot root)
+    SubGraphRoot {
+        id: SplitGraphNodeId,
+        merkle_tree_hash: MerkleTreeHash,
+    },
+}
+
+impl<N> SplitGraphNodeWeight<N>
+where
+    N: CustomNodeWeight,
+{
+    pub fn id(&self) -> SplitGraphNodeId {
+        match self {
+            SplitGraphNodeWeight::Custom(n) => n.id(),
+            SplitGraphNodeWeight::ExternalTarget { id, .. }
+            | SplitGraphNodeWeight::Ordering { id, .. }
+            | SplitGraphNodeWeight::GraphRoot { id, .. }
+            | SplitGraphNodeWeight::SubGraphRoot { id, .. } => *id,
+        }
+    }
+
+    pub fn lineage_id(&self) -> SplitGraphNodeId {
+        match self {
+            SplitGraphNodeWeight::Custom(n) => n.lineage_id(),
+            other => other.id(),
+        }
+    }
+
+    pub fn set_merkle_tree_hash(&mut self, hash: MerkleTreeHash) {
+        match self {
+            SplitGraphNodeWeight::Custom(n) => n.set_merkle_tree_hash(hash),
+            SplitGraphNodeWeight::ExternalTarget {
+                merkle_tree_hash, ..
+            }
+            | SplitGraphNodeWeight::Ordering {
+                merkle_tree_hash, ..
+            }
+            | SplitGraphNodeWeight::GraphRoot {
+                merkle_tree_hash, ..
+            }
+            | SplitGraphNodeWeight::SubGraphRoot {
+                merkle_tree_hash, ..
+            } => *merkle_tree_hash = hash,
+        }
+    }
+
+    pub fn merkle_tree_hash(&self) -> MerkleTreeHash {
+        match self {
+            SplitGraphNodeWeight::Custom(n) => n.merkle_tree_hash(),
+            SplitGraphNodeWeight::ExternalTarget {
+                merkle_tree_hash, ..
+            }
+            | SplitGraphNodeWeight::Ordering {
+                merkle_tree_hash, ..
+            }
+            | SplitGraphNodeWeight::GraphRoot {
+                merkle_tree_hash, ..
+            }
+            | SplitGraphNodeWeight::SubGraphRoot {
+                merkle_tree_hash, ..
+            } => *merkle_tree_hash,
+        }
+    }
+
+    pub fn node_hash(&self) -> ContentHash {
+        let mut hasher = ContentHash::hasher();
+        if let SplitGraphNodeWeight::Custom(n) = self {
+            return n.node_hash();
+        }
+
+        match self {
+            SplitGraphNodeWeight::Custom(_) => {}
+            SplitGraphNodeWeight::ExternalTarget {
+                id,
+                subgraph,
+                target,
+                ..
+            } => {
+                hasher.update(&id.inner().to_bytes());
+                hasher.update(&subgraph.to_le_bytes());
+                hasher.update(&target.inner().to_bytes());
+            }
+            SplitGraphNodeWeight::Ordering { id, order, .. } => {
+                hasher.update(&id.inner().to_bytes());
+                for id in order {
+                    hasher.update(&id.inner().to_bytes());
+                }
+            }
+            SplitGraphNodeWeight::GraphRoot { id, .. } => {
+                hasher.update(&id.inner().to_bytes());
+            }
+            SplitGraphNodeWeight::SubGraphRoot { id, .. } => {
+                hasher.update(&id.inner().to_bytes());
+            }
+        };
+
+        hasher.finalize()
+    }
+
+    pub fn custom_mut(&mut self) -> Option<&mut N> {
+        match self {
+            SplitGraphNodeWeight::Custom(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    pub fn custom(&self) -> Option<&N> {
+        match self {
+            SplitGraphNodeWeight::Custom(inner) => Some(inner),
+            _ => None,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+pub enum SplitGraphEdgeWeight<E, K>
+where
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    Custom(E),
+    ExternalSource {
+        source_id: SplitGraphNodeId,
+        subgraph: SubGraphIndex,
+        is_default: bool,
+        edge_kind: K,
+    },
+    Ordering,
+    Ordinal,
+}
+
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Serialize, Deserialize, Hash)]
+pub enum SplitGraphEdgeWeightKind<K>
+where
+    K: EdgeKind,
+{
+    Custom(K),
+    ExternalSource,
+    Ordering,
+    Ordinal,
+}
+
+impl<E, K> From<SplitGraphEdgeWeight<E, K>> for SplitGraphEdgeWeightKind<K>
+where
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    fn from(value: SplitGraphEdgeWeight<E, K>) -> Self {
+        match value {
+            SplitGraphEdgeWeight::Custom(c) => SplitGraphEdgeWeightKind::Custom(c.kind()),
+            SplitGraphEdgeWeight::ExternalSource { .. } => SplitGraphEdgeWeightKind::ExternalSource,
+            SplitGraphEdgeWeight::Ordering => SplitGraphEdgeWeightKind::Ordering,
+            SplitGraphEdgeWeight::Ordinal => SplitGraphEdgeWeightKind::Ordinal,
+        }
+    }
+}
+
+impl<E, K> From<&SplitGraphEdgeWeight<E, K>> for SplitGraphEdgeWeightKind<K>
+where
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    fn from(value: &SplitGraphEdgeWeight<E, K>) -> Self {
+        match value {
+            SplitGraphEdgeWeight::Custom(c) => SplitGraphEdgeWeightKind::Custom(c.kind()),
+            SplitGraphEdgeWeight::ExternalSource { .. } => SplitGraphEdgeWeightKind::ExternalSource,
+            SplitGraphEdgeWeight::Ordering => SplitGraphEdgeWeightKind::Ordering,
+            SplitGraphEdgeWeight::Ordinal => SplitGraphEdgeWeightKind::Ordinal,
+        }
+    }
+}
+
+impl<E, K> SplitGraphEdgeWeight<E, K>
+where
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    pub fn custom(&self) -> Option<&E> {
+        match self {
+            SplitGraphEdgeWeight::Custom(weight) => Some(weight),
+            _ => None,
+        }
+    }
+
+    pub fn is_default(&self) -> bool {
+        match self {
+            SplitGraphEdgeWeight::Custom(c) => c.is_default(),
+            SplitGraphEdgeWeight::ExternalSource { is_default, .. } => *is_default,
+            SplitGraphEdgeWeight::Ordering => false,
+            SplitGraphEdgeWeight::Ordinal => false,
+        }
+    }
+
+    pub fn clone_as_non_default(&self) -> Self {
+        match self {
+            SplitGraphEdgeWeight::Custom(c) => {
+                SplitGraphEdgeWeight::Custom(c.clone_as_non_default())
+            }
+            SplitGraphEdgeWeight::ExternalSource {
+                source_id,
+                subgraph,
+                edge_kind,
+                ..
+            } => SplitGraphEdgeWeight::ExternalSource {
+                source_id: *source_id,
+                subgraph: *subgraph,
+                is_default: false,
+                edge_kind: *edge_kind,
+            },
+            SplitGraphEdgeWeight::Ordering => SplitGraphEdgeWeight::Ordering,
+            SplitGraphEdgeWeight::Ordinal => SplitGraphEdgeWeight::Ordinal,
+        }
+    }
+
+    pub fn edge_hash(&self) -> Option<ContentHash> {
+        match self {
+            SplitGraphEdgeWeight::Custom(c) => c.edge_hash(),
+            SplitGraphEdgeWeight::ExternalSource {
+                source_id,
+                subgraph,
+                ..
+            } => {
+                let mut hasher = ContentHash::hasher();
+                hasher.update(&source_id.inner().to_bytes());
+                hasher.update(&subgraph.to_le_bytes());
+                Some(hasher.finalize())
+            }
+            SplitGraphEdgeWeight::Ordering | SplitGraphEdgeWeight::Ordinal => None,
+        }
+    }
+}
+
+pub trait EdgeKind: std::hash::Hash + PartialEq + Eq + Copy + Clone + std::fmt::Debug {}
+
+pub trait CustomNodeWeight: PartialEq + Eq + Clone + std::fmt::Debug {
+    fn id(&self) -> SplitGraphNodeId;
+    fn lineage_id(&self) -> SplitGraphNodeId;
+
+    fn set_merkle_tree_hash(&mut self, hash: MerkleTreeHash);
+    fn merkle_tree_hash(&self) -> MerkleTreeHash;
+    fn node_hash(&self) -> ContentHash;
+    fn ordered(&self) -> bool;
+}
+
+pub trait CustomEdgeWeight<K>: std::hash::Hash + PartialEq + Eq + Clone + std::fmt::Debug
+where
+    K: EdgeKind,
+{
+    fn kind(&self) -> K;
+    fn edge_hash(&self) -> Option<ContentHash>;
+    // Default edges have a rule that there can be only *one* default edge of a certain kind
+    // outgoing from a node. This rule will be enforced when updates are performed.
+    fn is_default(&self) -> bool;
+    fn clone_as_non_default(&self) -> Self;
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct SplitGraphNodeIndex {
+    subgraph: SubGraphIndex,
+    index: SubGraphNodeIndex,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct SplitGraphEdgeIndex {
+    subgraph: SubGraphIndex,
+    index: SubGraphEdgeIndex,
+}
+
+impl SplitGraphNodeIndex {
+    pub fn new(subgraph: SubGraphIndex, index: SubGraphNodeIndex) -> Self {
+        Self { subgraph, index }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SuperGraph {
+    addresses: Vec<SubGraphAddress>,
+    root_index: SplitGraphNodeIndex,
+    split_max: u16,
+}
+
+#[derive(Clone, Debug)]
+pub struct SplitGraph<'a, 'b, N, E, K, R, W>
+where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+    R: SubGraphReader<N, E, K>,
+    W: SubGraphWriter<N, E, K>,
+{
+    supergraph: SuperGraph,
+    subgraphs: Vec<SubGraph<N, E, K>>,
+    reader: &'a R,
+    #[allow(unused)]
+    writer: &'b W,
+}
+
+impl<'a, 'b, N, E, K, R, W> SplitGraph<'a, 'b, N, E, K, R, W>
+where
+    N: CustomNodeWeight,
+    K: EdgeKind,
+    E: CustomEdgeWeight<K>,
+    R: SubGraphReader<N, E, K>,
+    W: SubGraphWriter<N, E, K>,
+{
+    pub fn new(reader: &'a R, writer: &'b W, split_max: u16) -> Self {
+        let mut first_subgraph = SubGraph::new();
+        let root_id = Ulid::new();
+        let root_index = first_subgraph
+            .graph
+            .add_node(SplitGraphNodeWeight::GraphRoot {
+                id: root_id,
+                merkle_tree_hash: MerkleTreeHash::nil(),
+            });
+        first_subgraph.node_index_by_id.insert(root_id, root_index);
+        first_subgraph.root_index = root_index;
+
+        Self {
+            supergraph: SuperGraph {
+                addresses: vec![],
+                root_index: SplitGraphNodeIndex {
+                    index: root_index,
+                    subgraph: 0,
+                },
+                split_max,
+            },
+            subgraphs: vec![first_subgraph],
+            reader,
+            writer,
+        }
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.subgraphs.iter().fold(0, |count, subgraph| {
+            count.saturating_add(subgraph.node_index_by_id.len())
+        })
+    }
+
+    pub fn root_id(&self) -> SplitGraphResult<SplitGraphNodeId> {
+        self.node_weight_by_index(self.supergraph.root_index)
+            .map(|node| node.id())
+            .ok_or(SplitGraphError::RootNodeNotFound)
+    }
+
+    pub fn subgraph_count(&self) -> usize {
+        self.subgraphs.len()
+    }
+
+    pub async fn new_with_addresses(
+        reader: &'a R,
+        writer: &'b W,
+        addresses: &[SubGraphAddress],
+        split_max: u16,
+    ) -> SplitGraphResult<Self> {
+        // We need to do this without creating a root node
+        let mut split_graph = Self::new(reader, writer, split_max);
+        split_graph.add_subgraphs(addresses).await?;
+
+        Ok(split_graph)
+    }
+
+    pub async fn add_subgraphs(
+        &mut self,
+        subgraph_addresses: &[SubGraphAddress],
+    ) -> SplitGraphResult<()> {
+        self.supergraph.addresses.extend(subgraph_addresses.iter());
+
+        for (idx, address) in self.supergraph.addresses.iter().enumerate() {
+            if self.subgraphs.get(idx).is_none() {
+                let subgraph = self
+                    .reader
+                    .read_subgraph(*address)
+                    .await
+                    .map_err(|err| SplitGraphError::SubGraphRead(*address, err.to_string()))?;
+
+                self.subgraphs.push(subgraph);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn recalculate_merkle_tree_hashes_based_on_touched_nodes(&mut self) {
+        self.subgraphs
+            .iter_mut()
+            .for_each(|subgraph| subgraph.recalculate_merkle_tree_hash_based_on_touched_nodes());
+    }
+
+    pub fn recalculate_entire_merkle_tree_hashes(&mut self) {
+        self.subgraphs
+            .iter_mut()
+            .for_each(|subgraph| subgraph.recalculate_entire_merkle_tree_hash());
+    }
+
+    pub fn make_node_id(&mut self) -> SplitGraphNodeId {
+        Ulid::new()
+    }
+
+    fn new_subgraph(&mut self) -> u16 {
+        self.supergraph.addresses.push(SubGraphAddress::nil());
+
+        let subgraph = SubGraph::new_with_root();
+        let subgraph_index = self.subgraphs.len() as u16;
+        self.subgraphs.push(subgraph);
+
+        subgraph_index
+    }
+
+    fn new_empty_subgraph(&mut self) -> u16 {
+        self.supergraph.addresses.push(SubGraphAddress::nil());
+
+        let subgraph = SubGraph::new();
+        let subgraph_index = self.subgraphs.len() as u16;
+        self.subgraphs.push(subgraph);
+
+        subgraph_index
+    }
+
+    fn get_subgraph(&self, subgraph_index: usize) -> SplitGraphResult<&SubGraph<N, E, K>> {
+        self.subgraphs
+            .get(subgraph_index)
+            .ok_or(SplitGraphError::SubGraphMissing(subgraph_index))
+    }
+
+    fn get_subgraph_mut(
+        &mut self,
+        subgraph_index: usize,
+    ) -> SplitGraphResult<&mut SubGraph<N, E, K>> {
+        self.subgraphs
+            .get_mut(subgraph_index)
+            .ok_or(SplitGraphError::SubGraphMissing(subgraph_index))
+    }
+
+    fn add_node_to_subgraph(
+        &mut self,
+        subgraph_index: SubGraphIndex,
+        node: SplitGraphNodeWeight<N>,
+    ) -> SplitGraphResult<SplitGraphNodeIndex> {
+        let subgraph = self.get_subgraph_mut(subgraph_index as usize)?;
+        let node_index = subgraph.add_node(node);
+
+        Ok(SplitGraphNodeIndex::new(subgraph_index, node_index))
+    }
+
+    pub fn add_or_replace_node(&mut self, node: N) -> SplitGraphResult<SplitGraphNodeIndex> {
+        let node_id = node.id();
+        if let Some(split_graph_index) = self.node_id_to_index(node_id) {
+            let subgraph = self.get_subgraph_mut(split_graph_index.subgraph as usize)?;
+            subgraph.replace_node(split_graph_index.index, SplitGraphNodeWeight::Custom(node));
+
+            return Ok(split_graph_index);
+        }
+
+        let subgraph_index = if let Some((index, _)) =
+            self.subgraphs.iter().enumerate().find(|(_, sub)| {
+                // We add one to the max so that the root node is not part of the count
+                sub.node_index_by_id.len() < ((self.supergraph.split_max + 1) as usize)
+            }) {
+            index as u16
+        } else {
+            self.new_subgraph()
+        };
+
+        self.add_node_to_subgraph(subgraph_index, SplitGraphNodeWeight::Custom(node))
+    }
+
+    fn node_weight_by_index(&self, index: SplitGraphNodeIndex) -> Option<&SplitGraphNodeWeight<N>> {
+        self.subgraphs
+            .get(index.subgraph as usize)
+            .and_then(|sub| sub.graph.node_weight(index.index))
+    }
+
+    pub fn subgraph_for_node(&self, node_id: SplitGraphNodeId) -> Option<usize> {
+        for (index, sub) in self.subgraphs.iter().enumerate() {
+            if sub.node_index_by_id.contains_key(&node_id) {
+                return Some(index);
+            }
+        }
+
+        None
+    }
+
+    pub fn subgraph_root_id(&self, subgraph_index: usize) -> Option<SplitGraphNodeId> {
+        self.subgraphs
+            .get(subgraph_index)
+            .and_then(|sub| sub.graph.node_weight(sub.root_index))
+            .map(|n| n.id())
+    }
+
+    pub fn raw_node_weight(&self, node_id: SplitGraphNodeId) -> Option<&SplitGraphNodeWeight<N>> {
+        for sub in &self.subgraphs {
+            if let Some(index) = sub.node_index_by_id.get(&node_id) {
+                return sub.graph.node_weight(*index);
+            }
+        }
+
+        None
+    }
+
+    pub fn node_weight(&self, node_id: SplitGraphNodeId) -> Option<&N> {
+        self.raw_node_weight(node_id)
+            .and_then(|weight| weight.custom())
+    }
+
+    pub fn raw_node_weight_mut(
+        &mut self,
+        node_id: SplitGraphNodeId,
+    ) -> Option<&mut SplitGraphNodeWeight<N>> {
+        for sub in self.subgraphs.iter_mut() {
+            if let Some(index) = sub.node_index_by_id.get(&node_id) {
+                return sub.graph.node_weight_mut(*index);
+            }
+        }
+
+        None
+    }
+
+    pub fn node_weight_mut(&mut self, node_id: SplitGraphNodeId) -> Option<&mut N> {
+        self.raw_node_weight_mut(node_id)
+            .and_then(|weight| weight.custom_mut())
+    }
+
+    pub fn touch_node(&mut self, node_id: SplitGraphNodeId) {
+        for subgraph in self.subgraphs.iter_mut() {
+            if let Some(node_index) = subgraph.node_id_to_index(node_id) {
+                subgraph.touch_node(node_index);
+                break;
+            }
+        }
+    }
+
+    pub fn node_id_to_index(&self, id: SplitGraphNodeId) -> Option<SplitGraphNodeIndex> {
+        self.subgraphs
+            .iter()
+            .enumerate()
+            .find(|(_, sub)| sub.node_index_by_id.contains_key(&id))
+            .and_then(|(idx, sub)| {
+                sub.node_index_by_id
+                    .get(&id)
+                    .map(|subgraph_index| SplitGraphNodeIndex::new(idx as u16, *subgraph_index))
+            })
+    }
+
+    pub fn remove_edge(
+        &mut self,
+        from_id: SplitGraphNodeId,
+        edge_kind: K,
+        to_id: SplitGraphNodeId,
+    ) -> SplitGraphResult<()> {
+        let from_index = self
+            .node_id_to_index(from_id)
+            .ok_or(SplitGraphError::NodeNotFound(from_id))?;
+        let to_index = self
+            .node_id_to_index(to_id)
+            .ok_or(SplitGraphError::NodeNotFound(to_id))?;
+
+        let from_subgraph_idx = from_index.subgraph;
+        let to_subgraph_idx = to_index.subgraph;
+
+        if from_subgraph_idx == to_subgraph_idx {
+            let from_subgraph = self.get_subgraph_mut(from_subgraph_idx as usize)?;
+            if let Some(edge_idx) = from_subgraph
+                .graph
+                .edges_directed(from_index.index, Outgoing)
+                .find(|edge_ref| {
+                    edge_ref
+                        .weight()
+                        .custom()
+                        .map(|edge| edge.kind() == edge_kind)
+                        .unwrap_or(false)
+                        && from_subgraph
+                            .graph
+                            .node_weight(edge_ref.target())
+                            .map(|node| node.id() == to_id)
+                            .unwrap_or(false)
+                })
+                .map(|edge_ref| edge_ref.id())
+            {
+                from_subgraph.remove_edge_by_index(edge_idx);
+            }
+        } else {
+            let from_subgraph = self.get_subgraph_mut(from_subgraph_idx as usize)?;
+            if let Some(edge_idx) = from_subgraph
+                .graph
+                .edges_directed(from_index.index, Outgoing)
+                .find(|edge_ref| {
+                    edge_ref
+                        .weight()
+                        .custom()
+                        .map(|edge| edge.kind() == edge_kind)
+                        .unwrap_or(false)
+                        && from_subgraph
+                            .graph
+                            .node_weight(edge_ref.target())
+                            .map(|node| match node {
+                                SplitGraphNodeWeight::ExternalTarget { target, .. } => {
+                                    *target == to_id
+                                }
+                                _ => false,
+                            })
+                            .unwrap_or(false)
+                })
+                .map(|edge_ref| edge_ref.id())
+            {
+                from_subgraph.remove_edge_by_index(edge_idx);
+                let to_subgraph = self.get_subgraph_mut(to_subgraph_idx as usize)?;
+                let root_index = to_subgraph.root_index;
+                if let Some(edge_idx) = to_subgraph
+                    .graph
+                    .edges_directed(root_index, Outgoing)
+                    .find(|edge_ref| match edge_ref.weight() {
+                        SplitGraphEdgeWeight::ExternalSource {
+                            source_id,
+                            edge_kind: ek,
+                            ..
+                        } => {
+                            *source_id == from_id
+                                && *ek == edge_kind
+                                && to_subgraph
+                                    .graph
+                                    .node_weight(edge_ref.target())
+                                    .map(|node| node.id() == to_id)
+                                    .unwrap_or(false)
+                        }
+                        _ => false,
+                    })
+                    .map(|edge_ref| edge_ref.id())
+                {
+                    to_subgraph.remove_edge_by_index(edge_idx);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn add_edge(
+        &mut self,
+        from_id: SplitGraphNodeId,
+        edge: E,
+        to_id: SplitGraphNodeId,
+    ) -> SplitGraphResult<()> {
+        let from_index = self
+            .node_id_to_index(from_id)
+            .ok_or(SplitGraphError::NodeNotFound(from_id))?;
+        let to_index = self
+            .node_id_to_index(to_id)
+            .ok_or(SplitGraphError::NodeNotFound(to_id))?;
+
+        let from_subgraph_idx = from_index.subgraph;
+        let to_subgraph_idx = to_index.subgraph;
+        if from_subgraph_idx == to_subgraph_idx {
+            let from_subgraph = self.get_subgraph_mut(from_subgraph_idx as usize)?;
+            from_subgraph.add_edge(
+                from_index.index,
+                SplitGraphEdgeWeight::Custom(edge),
+                to_index.index,
+            )?;
+        } else {
+            let ext_target_id = SplitGraphNodeId::new();
+            let ext_target_idx = self.add_node_to_subgraph(
+                from_subgraph_idx,
+                SplitGraphNodeWeight::ExternalTarget {
+                    id: ext_target_id,
+                    subgraph: to_subgraph_idx,
+                    target: to_id,
+                    merkle_tree_hash: MerkleTreeHash::nil(),
+                },
+            )?;
+            let from_subgraph = self.get_subgraph_mut(from_subgraph_idx as usize)?;
+            from_subgraph.add_edge(
+                from_index.index,
+                SplitGraphEdgeWeight::Custom(edge.clone()),
+                ext_target_idx.index,
+            )?;
+            let to_subgraph = self.get_subgraph_mut(to_subgraph_idx as usize)?;
+            to_subgraph.add_edge(
+                to_subgraph.root_index,
+                SplitGraphEdgeWeight::ExternalSource {
+                    source_id: from_id,
+                    subgraph: from_subgraph_idx,
+                    is_default: edge.is_default(),
+                    edge_kind: edge.kind(),
+                },
+                to_index.index,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    pub fn reorder_node<L>(&mut self, node_id: SplitGraphNodeId, lambda: L) -> SplitGraphResult<()>
+    where
+        L: FnOnce(&[SplitGraphNodeId]) -> Vec<SplitGraphNodeId>,
+    {
+        let split_graph_index = self
+            .node_id_to_index(node_id)
+            .ok_or(SplitGraphError::NodeNotFound(node_id))?;
+        let subgraph = self.get_subgraph_mut(split_graph_index.subgraph as usize)?;
+
+        subgraph.reorder_node(split_graph_index.index, lambda)
+    }
+
+    pub fn ordered_children(&self, node_id: SplitGraphNodeId) -> Option<Vec<SplitGraphNodeId>> {
+        let split_graph_index = self.node_id_to_index(node_id)?;
+        let subgraph = self.subgraphs.get(split_graph_index.subgraph as usize)?;
+
+        subgraph
+            .ordered_children_for_node(split_graph_index.index)
+            .map(|node_indexes| {
+                node_indexes
+                    .into_iter()
+                    .filter_map(|idx| {
+                        subgraph.graph.node_weight(idx).map(|n| match n {
+                            SplitGraphNodeWeight::ExternalTarget { target, .. } => *target,
+                            other => other.id(),
+                        })
+                    })
+                    .collect()
+            })
+    }
+
+    pub fn edges_directed(
+        &self,
+        from_id: SplitGraphNodeId,
+        direction: Direction,
+    ) -> SplitGraphResult<SplitGraphEdges<N, E, K>> {
+        let split_graph_index = self
+            .node_id_to_index(from_id)
+            .ok_or(SplitGraphError::NodeNotFound(from_id))?;
+
+        let subgraph = self.get_subgraph(split_graph_index.subgraph as usize)?;
+
+        let edges = subgraph
+            .graph
+            .edges_directed(split_graph_index.index, direction);
+
+        Ok(SplitGraphEdges {
+            subgraph,
+            edges,
+            from_id,
+            direction,
+        })
+    }
+
+    pub fn cleanup(&mut self) {
+        for subgraph in self.subgraphs.iter_mut() {
+            subgraph.cleanup();
+        }
+    }
+
+    pub fn cleanup_and_merkle_tree_hash(&mut self) {
+        self.cleanup();
+        self.recalculate_merkle_tree_hashes_based_on_touched_nodes();
+    }
+
+    /// Calculate the updates that this graph has relative to `base_graph`
+    pub fn detect_updates(&self, base_graph: &SplitGraph<N, E, K, R, W>) -> Vec<Update<N, E, K>> {
+        let mut updates = vec![];
+        for (updated_subgraph, maybe_base_subgraph) in OptZip::new(
+            self.subgraphs.iter().enumerate(),
+            base_graph.subgraphs.iter(),
+        ) {
+            let Some((updated_subgraph_index, updated_subgraph)) = updated_subgraph else {
+                continue;
+            };
+
+            match maybe_base_subgraph {
+                Some(base_subgraph) => updates.extend(
+                    updates::Detector::new(
+                        base_subgraph,
+                        updated_subgraph,
+                        updated_subgraph_index as u16,
+                    )
+                    .detect_updates()
+                    .into_iter(),
+                ),
+                None => {
+                    updates.push(Update::NewSubGraph);
+                    updates.extend(
+                        updates::subgraph_as_updates(
+                            updated_subgraph,
+                            updated_subgraph_index as u16,
+                        )
+                        .into_iter(),
+                    )
+                }
+            }
+        }
+
+        updates
+    }
+
+    pub fn perform_updates(&mut self, updates: &[Update<N, E, K>]) {
+        for update in updates {
+            match update {
+                Update::NewEdge {
+                    subgraph_index,
+                    source,
+                    destination,
+                    edge_weight,
+                } => {
+                    let Some(subgraph) = self.subgraphs.get_mut(*subgraph_index as usize) else {
+                        continue;
+                    };
+                    let Some((from_index, to_index)) = subgraph
+                        .node_id_to_index(*source)
+                        .zip(subgraph.node_id_to_index(*destination))
+                    else {
+                        continue;
+                    };
+
+                    if edge_weight.is_default() {
+                        ensure_only_one_default_edge(
+                            subgraph,
+                            from_index,
+                            to_index,
+                            edge_weight.clone(),
+                        );
+                    }
+
+                    subgraph.add_edge_raw(from_index, edge_weight.clone(), to_index);
+                }
+                Update::RemoveEdge {
+                    subgraph_index,
+                    source,
+                    destination,
+                    edge_kind,
+                } => {
+                    let Some(subgraph) = self.subgraphs.get_mut(*subgraph_index as usize) else {
+                        continue;
+                    };
+                    let Some((from_index, to_index)) = subgraph
+                        .node_id_to_index(*source)
+                        .zip(subgraph.node_id_to_index(*destination))
+                    else {
+                        continue;
+                    };
+
+                    // if matches!(edge_kind, SplitGraphEdgeWeightKind::Ordinal) {
+                    //     subgraph.remove_from_order(from_index, *destination);
+                    // }
+
+                    subgraph.remove_edge_raw(from_index, *edge_kind, to_index);
+                }
+                Update::RemoveNode { subgraph_index, id } => {
+                    let Some(subgraph) = self.subgraphs.get_mut(*subgraph_index as usize) else {
+                        continue;
+                    };
+                    let Some(node_index) = subgraph.node_id_to_index(*id) else {
+                        continue;
+                    };
+
+                    subgraph.remove_node(node_index);
+                }
+                Update::ReplaceNode {
+                    subgraph_index,
+                    node_weight,
+                } => {
+                    let Some(subgraph) = self.subgraphs.get_mut(*subgraph_index as usize) else {
+                        continue;
+                    };
+                    let Some(node_index) = subgraph.node_id_to_index(node_weight.id()) else {
+                        continue;
+                    };
+                    subgraph.replace_node(node_index, node_weight.clone());
+                }
+                Update::NewNode {
+                    subgraph_index,
+                    node_weight,
+                } => {
+                    let Some(subgraph) = self.subgraphs.get_mut(*subgraph_index as usize) else {
+                        continue;
+                    };
+                    match subgraph.node_id_to_index(node_weight.id()) {
+                        Some(existing_index) => {
+                            subgraph.replace_node(existing_index, node_weight.clone())
+                        }
+                        None => {
+                            subgraph.add_node(node_weight.clone());
+                        }
+                    }
+                }
+                Update::NewSubGraph => {
+                    self.new_empty_subgraph();
+                }
+            }
+        }
+    }
+
+    pub fn tiny_dot_to_file(&self, prefix: &str) {
+        for (idx, subgraph) in self.subgraphs.iter().enumerate() {
+            subgraph.tiny_dot_to_file(&format!("{prefix}-subgraph-{}", idx + 1));
+        }
+    }
+}
+
+fn ensure_only_one_default_edge<N, E, K>(
+    graph: &mut SubGraph<N, E, K>,
+    source_idx: SubGraphNodeIndex,
+    destination_idx: SubGraphNodeIndex,
+    edge_weight: SplitGraphEdgeWeight<E, K>,
+) where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    let edge_weight_kind: SplitGraphEdgeWeightKind<K> = edge_weight.into();
+    let existing_default_targets: Vec<(_, _)> = graph
+        .graph
+        .edges_directed(source_idx, Outgoing)
+        .filter(|edge_ref| {
+            edge_weight_kind == edge_ref.weight().into()
+                && edge_ref.weight().is_default()
+                && edge_ref.target() != destination_idx
+        })
+        .map(|edge_ref| (edge_ref.weight().clone(), edge_ref.target()))
+        .collect();
+
+    for (edge_weight, target_idx) in existing_default_targets {
+        graph.remove_edge_raw(source_idx, edge_weight_kind, target_idx);
+        graph.add_edge_raw(source_idx, edge_weight.clone_as_non_default(), target_idx);
+    }
+}
+
+pub struct SplitGraphEdgeReference<'a, E, K>
+where
+    E: 'a + CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    source_id: SplitGraphNodeId,
+    target_id: SplitGraphNodeId,
+    weight: &'a SplitGraphEdgeWeight<E, K>,
+}
+
+impl<E, K> SplitGraphEdgeReference<'_, E, K>
+where
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    pub fn source(&self) -> SplitGraphNodeId {
+        self.source_id
+    }
+
+    pub fn target(&self) -> SplitGraphNodeId {
+        self.target_id
+    }
+
+    pub fn weight(&self) -> &SplitGraphEdgeWeight<E, K> {
+        self.weight
+    }
+}
+
+// pub struct SplitGraphNeighbors<'a, N, E, K>
+// where
+//     N: CustomNodeWeight,
+//     E: CustomEdgeWeight<K>,
+//     K: EdgeKind,
+// {
+//     subgraphs: &'a [SubGraph<N, E, K>],
+//     edges: stable_graph::Edges<'a, SplitGraphEdgeWeight<E, K>, Directed, SubGraphIndex>,
+//     start:
+// }
+
+pub struct SplitGraphEdges<'a, N, E, K>
+where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    subgraph: &'a SubGraph<N, E, K>,
+    edges: stable_graph::Edges<'a, SplitGraphEdgeWeight<E, K>, Directed, SubGraphIndex>,
+    from_id: SplitGraphNodeId,
+    direction: Direction,
+}
+
+impl<'a, N, E, K> Iterator for SplitGraphEdges<'a, N, E, K>
+where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    type Item = SplitGraphEdgeReference<'a, E, K>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.edges.next().and_then(|edge_ref| match self.direction {
+            Outgoing => {
+                if matches!(edge_ref.weight(), SplitGraphEdgeWeight::Ordering) {
+                    // Ordering nodes are hidden
+                    self.next()
+                } else {
+                    self.subgraph
+                        .graph
+                        .node_weight(edge_ref.target())
+                        .map(|n| match n {
+                            SplitGraphNodeWeight::ExternalTarget { target, .. } => *target,
+                            internal_target => internal_target.id(),
+                        })
+                        .map(|target_id| SplitGraphEdgeReference {
+                            source_id: self.from_id,
+                            target_id,
+                            weight: edge_ref.weight(),
+                        })
+                }
+            }
+            Incoming => {
+                let weight = edge_ref.weight();
+                match weight {
+                    SplitGraphEdgeWeight::Ordinal => {
+                        return self.next();
+                    }
+                    SplitGraphEdgeWeight::Custom(_) | SplitGraphEdgeWeight::Ordering => self
+                        .subgraph
+                        .graph
+                        .node_weight(edge_ref.source())
+                        .map(|source_node| source_node.id()),
+                    SplitGraphEdgeWeight::ExternalSource { source_id, .. } => Some(*source_id),
+                }
+                .map(|source_id| SplitGraphEdgeReference {
+                    source_id,
+                    target_id: self.from_id,
+                    weight,
+                })
+            }
+        })
+    }
+}
+
+impl<N, E, K, R, W> petgraph::visit::GraphBase for SplitGraph<'_, '_, N, E, K, R, W>
+where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+    R: SubGraphReader<N, E, K>,
+    W: SubGraphWriter<N, E, K>,
+{
+    type EdgeId = SplitGraphEdgeIndex;
+    type NodeId = Ulid;
+}
+
+impl<N, E, K, R, W> petgraph::visit::Visitable for SplitGraph<'_, '_, N, E, K, R, W>
+where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+    R: SubGraphReader<N, E, K>,
+    W: SubGraphWriter<N, E, K>,
+{
+    type Map = HashSet<Ulid>;
+
+    fn visit_map(&self) -> Self::Map {
+        HashSet::with_capacity(self.node_count())
+    }
+
+    fn reset_map(&self, map: &mut Self::Map) {
+        map.clear();
+    }
+}
+
+// impl<'a, N, E, K, R, W> petgraph::visit::IntoNeighbors for &'a SplitGraph<'_, '_, N, E, K, R, W>
+// where
+//     N: CustomNodeWeight,
+//     E: CustomEdgeWeight<K>,
+//     K: EdgeKind,
+//     R: SubGraphReader<N, E, K>,
+//     W: SubGraphWriter<N, E, K>,
+// {
+//     type Neighbors = ;
+
+//     fn neighbors(self, a: Self::NodeId) -> Self::Neighbors {
+//         todo!()
+//     }
+// }
+
+#[cfg(test)]
+mod tests;

--- a/lib/si-split-graph/src/opt_zip.rs
+++ b/lib/si-split-graph/src/opt_zip.rs
@@ -1,0 +1,135 @@
+/// Akin to `zip` but does not halt the iterator if A or B return None. Only ends when both return None.
+pub struct OptZip<A, B>
+where
+    A: Iterator,
+    B: Iterator,
+{
+    a: A,
+    a_none: bool,
+    b: B,
+    b_none: bool,
+}
+
+impl<A, B> OptZip<A, B>
+where
+    A: Iterator,
+    B: Iterator,
+{
+    pub fn new(a: A, b: B) -> Self {
+        Self {
+            a,
+            a_none: false,
+            b,
+            b_none: false,
+        }
+    }
+}
+
+impl<A, B> Iterator for OptZip<A, B>
+where
+    A: Iterator,
+    B: Iterator,
+{
+    type Item = (Option<A::Item>, Option<B::Item>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.a_none, self.b_none) {
+            (true, true) => None,
+            (true, false) => {
+                let b = self.b.next();
+                self.b_none = b.is_none();
+                if self.b_none {
+                    None
+                } else {
+                    Some((None, b))
+                }
+            }
+            (false, true) => {
+                let a = self.a.next();
+                self.a_none = a.is_none();
+                if self.a_none {
+                    None
+                } else {
+                    Some((a, None))
+                }
+            }
+            (false, false) => {
+                let a = self.a.next();
+                let b = self.b.next();
+                self.a_none = a.is_none();
+                self.b_none = b.is_none();
+
+                if self.a_none && self.b_none {
+                    None
+                } else {
+                    Some((a, b))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OptZip;
+
+    #[test]
+    fn b_longer_than_a() {
+        let a = [1, 2, 3];
+        let b = [1, 2, 3, 4, 5, 6, 7];
+
+        let opt_zip = OptZip::new(a.into_iter(), b.into_iter());
+
+        let expected = vec![
+            (Some(1), Some(1)),
+            (Some(2), Some(2)),
+            (Some(3), Some(3)),
+            (None, Some(4)),
+            (None, Some(5)),
+            (None, Some(6)),
+            (None, Some(7)),
+        ];
+
+        let collected: Vec<(_, _)> = opt_zip.into_iter().collect();
+
+        assert_eq!(expected, collected);
+    }
+
+    #[test]
+    fn a_longer_than_b() {
+        let a = [1, 2, 3, 4];
+        let b = [1, 2, 3];
+
+        let opt_zip = OptZip::new(a.into_iter(), b.into_iter());
+
+        let expected = vec![
+            (Some(1), Some(1)),
+            (Some(2), Some(2)),
+            (Some(3), Some(3)),
+            (Some(4), None),
+        ];
+
+        let collected: Vec<(_, _)> = opt_zip.into_iter().collect();
+
+        assert_eq!(expected, collected);
+    }
+
+    #[test]
+    fn same_size() {
+        let a = [1, 2, 3, 4];
+        let b = [1, 2, 3, 4];
+
+        let opt_zip = OptZip::new(a.into_iter(), b.into_iter());
+
+        let expected = vec![
+            (Some(1), Some(1)),
+            (Some(2), Some(2)),
+            (Some(3), Some(3)),
+            (Some(4), Some(4)),
+        ];
+
+        let collected: Vec<(_, _)> = opt_zip.into_iter().collect();
+
+        assert_eq!(expected, collected);
+    }
+}

--- a/lib/si-split-graph/src/subgraph.rs
+++ b/lib/si-split-graph/src/subgraph.rs
@@ -1,0 +1,578 @@
+use petgraph::prelude::*;
+use serde::{Deserialize, Serialize};
+use si_events::merkle_tree_hash::MerkleTreeHash;
+use std::collections::{HashMap, HashSet};
+use std::io::Write;
+
+use crate::{
+    CustomEdgeWeight, CustomNodeWeight, EdgeKind, SplitGraphEdgeWeight, SplitGraphEdgeWeightKind,
+    SplitGraphError, SplitGraphNodeId, SplitGraphNodeWeight, SplitGraphResult, MAX_NODES,
+};
+
+pub type SubGraphNodeIndex = NodeIndex<u16>;
+pub type SubGraphEdgeIndex = EdgeIndex<u16>;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SubGraph<N, E, K>
+where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    pub(crate) graph: StableDiGraph<SplitGraphNodeWeight<N>, SplitGraphEdgeWeight<E, K>, u16>,
+    pub(crate) node_index_by_id: HashMap<SplitGraphNodeId, SubGraphNodeIndex>,
+    pub(crate) node_indexes_by_lineage_id: HashMap<SplitGraphNodeId, HashSet<SubGraphNodeIndex>>,
+    pub(crate) root_index: SubGraphNodeIndex,
+
+    #[serde(skip)]
+    pub(crate) touched_nodes: HashSet<SubGraphNodeIndex>,
+}
+
+impl<N, E, K> Default for SubGraph<N, E, K>
+where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<N, E, K> SubGraph<N, E, K>
+where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    pub(crate) fn new() -> Self {
+        Self {
+            graph: StableDiGraph::with_capacity(MAX_NODES, MAX_NODES * 2),
+            node_index_by_id: HashMap::new(),
+            node_indexes_by_lineage_id: HashMap::new(),
+            root_index: NodeIndex::new(0),
+
+            touched_nodes: HashSet::new(),
+        }
+    }
+
+    pub(crate) fn new_with_root() -> Self {
+        let mut subgraph = Self {
+            graph: StableDiGraph::with_capacity(MAX_NODES, MAX_NODES * 2),
+            node_index_by_id: HashMap::new(),
+            node_indexes_by_lineage_id: HashMap::new(),
+            root_index: NodeIndex::new(0),
+
+            touched_nodes: HashSet::new(),
+        };
+
+        let root_id = SplitGraphNodeId::new();
+        let root_index = subgraph.graph.add_node(SplitGraphNodeWeight::SubGraphRoot {
+            id: root_id,
+            merkle_tree_hash: MerkleTreeHash::nil(),
+        });
+        subgraph.node_index_by_id.insert(root_id, root_index);
+        subgraph.root_index = root_index;
+
+        subgraph
+    }
+
+    pub(crate) fn cleanup(&mut self) {
+        loop {
+            let orphaned_node_indexes: Vec<SubGraphNodeIndex> = self
+                .graph
+                .externals(Incoming)
+                .filter(|idx| *idx != self.root_index)
+                .collect();
+
+            if orphaned_node_indexes.is_empty() {
+                break;
+            }
+
+            for node_index in orphaned_node_indexes {
+                self.graph.remove_node(node_index);
+            }
+        }
+
+        self.node_index_by_id
+            .retain(|_id, index| self.graph.node_weight(*index).is_some());
+        self.node_indexes_by_lineage_id
+            .iter_mut()
+            .for_each(|(_, node_indexes)| {
+                node_indexes.retain(|index| self.graph.node_weight(*index).is_some());
+            });
+        self.node_indexes_by_lineage_id
+            .retain(|_, indexes| !indexes.is_empty());
+    }
+
+    pub(crate) fn add_node(&mut self, node: SplitGraphNodeWeight<N>) -> SubGraphNodeIndex {
+        let node_id = node.id();
+        let node_index = self.graph.add_node(node);
+        self.node_index_by_id.insert(node_id, node_index);
+        self.node_indexes_by_lineage_id
+            .entry(node_id)
+            .and_modify(|set| {
+                set.insert(node_index);
+            })
+            .or_insert(HashSet::from([node_index]));
+        self.touched_nodes.insert(node_index);
+
+        node_index
+    }
+
+    pub(crate) fn replace_node(&mut self, index: SubGraphNodeIndex, node: SplitGraphNodeWeight<N>) {
+        if let Some(node_ref) = self.graph.node_weight_mut(index) {
+            *node_ref = node;
+        }
+        self.touched_nodes.insert(index);
+    }
+
+    fn edge_exists(
+        &self,
+        from_index: SubGraphNodeIndex,
+        edge_weight: &SplitGraphEdgeWeight<E, K>,
+        to_index: SubGraphNodeIndex,
+    ) -> bool {
+        self.graph
+            .edges_connecting(from_index, to_index)
+            .any(|edge_ref| match edge_ref.weight() {
+                SplitGraphEdgeWeight::Custom(custom_edge) => {
+                    Some(custom_edge.kind()) == edge_weight.custom().map(|e| e.kind())
+                }
+                SplitGraphEdgeWeight::ExternalSource {
+                    source_id,
+                    edge_kind,
+                    ..
+                } => match &edge_weight {
+                    SplitGraphEdgeWeight::ExternalSource {
+                        source_id: new_source_id,
+                        edge_kind: new_edge_kind,
+                        ..
+                    } => source_id == new_source_id && edge_kind == new_edge_kind,
+                    _ => false,
+                },
+                SplitGraphEdgeWeight::Ordering => {
+                    matches!(edge_weight, SplitGraphEdgeWeight::Ordering)
+                }
+                SplitGraphEdgeWeight::Ordinal => {
+                    matches!(edge_weight, SplitGraphEdgeWeight::Ordinal)
+                }
+            })
+    }
+
+    pub(crate) fn ordering_node_for_node_index(
+        &self,
+        node_index: SubGraphNodeIndex,
+    ) -> Option<SubGraphNodeIndex> {
+        let Some(true) = self
+            .graph
+            .node_weight(node_index)
+            .and_then(|weight| weight.custom().map(|c| c.ordered()))
+        else {
+            return None;
+        };
+
+        let ordering_node_index = self
+            .graph
+            .edges_directed(node_index, Outgoing)
+            .find(|edge_ref| matches!(edge_ref.weight(), SplitGraphEdgeWeight::Ordering))
+            .map(|edge_ref| edge_ref.target())?;
+
+        if let SplitGraphNodeWeight::Ordering { .. } =
+            self.graph.node_weight(ordering_node_index)?
+        {
+            Some(ordering_node_index)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn reorder_node<L>(
+        &mut self,
+        node_index: SubGraphNodeIndex,
+        lambda: L,
+    ) -> SplitGraphResult<()>
+    where
+        L: FnOnce(&[SplitGraphNodeId]) -> Vec<SplitGraphNodeId>,
+    {
+        let Some(ordering_node_index) = self.ordering_node_for_node_index(node_index) else {
+            return Ok(());
+        };
+
+        let Some(SplitGraphNodeWeight::Ordering { order, .. }) =
+            self.graph.node_weight_mut(ordering_node_index)
+        else {
+            return Ok(());
+        };
+
+        let new_order = lambda(order.as_slice());
+
+        // Validate the return here to prevent a panic in copy from slice, and to prevent removal of ordered children
+        if new_order.len() != order.len() {
+            return Err(SplitGraphError::OrderLengthMismatch);
+        }
+        for id in order.iter() {
+            if !new_order.contains(id) {
+                return Err(SplitGraphError::OrderContentMismatch);
+            }
+        }
+
+        order.copy_from_slice(new_order.as_slice());
+
+        self.touch_node(ordering_node_index);
+
+        Ok(())
+    }
+
+    pub(crate) fn ordered_children_for_node(
+        &self,
+        node_index: SubGraphNodeIndex,
+    ) -> Option<Vec<SubGraphNodeIndex>> {
+        let ordering_node_index = self.ordering_node_for_node_index(node_index)?;
+
+        let SplitGraphNodeWeight::Ordering { order, .. } =
+            self.graph.node_weight(ordering_node_index)?
+        else {
+            return None;
+        };
+
+        Some(
+            order
+                .iter()
+                .filter_map(|id| self.node_index_by_id.get(id).copied())
+                .collect(),
+        )
+    }
+
+    #[allow(unused)]
+    pub(crate) fn root_node_merkle_tree_hash(&self) -> MerkleTreeHash {
+        self.graph
+            .node_weight(self.root_index)
+            .map(|node| node.merkle_tree_hash())
+            .unwrap_or(MerkleTreeHash::nil())
+    }
+
+    pub(crate) fn recalculate_entire_merkle_tree_hash(&mut self) {
+        let mut dfs = petgraph::visit::DfsPostOrder::new(&self.graph, self.root_index);
+
+        while let Some(node_index) = dfs.next(&self.graph) {
+            if let Some(hash) = self.calculate_merkle_hash_for_node(node_index) {
+                if let Some(node_weight_mut) = self.graph.node_weight_mut(node_index) {
+                    node_weight_mut.set_merkle_tree_hash(hash);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn recalculate_merkle_tree_hash_based_on_touched_nodes(&mut self) {
+        let mut dfs = petgraph::visit::DfsPostOrder::new(&self.graph, self.root_index);
+
+        let mut discovered_nodes = HashSet::new();
+
+        while let Some(node_index) = dfs.next(&self.graph) {
+            if self.touched_nodes.contains(&node_index) || discovered_nodes.contains(&node_index) {
+                if let Some(hash) = self.calculate_merkle_hash_for_node(node_index) {
+                    if let Some(node_weight_mut) = self.graph.node_weight_mut(node_index) {
+                        node_weight_mut.set_merkle_tree_hash(hash);
+                    }
+                }
+                self.graph
+                    .neighbors_directed(node_index, Incoming)
+                    .for_each(|node_idx| {
+                        discovered_nodes.insert(node_idx);
+                    });
+            }
+        }
+
+        self.touched_nodes.clear();
+    }
+
+    pub(crate) fn all_outgoing_stably_ordered(
+        &self,
+        node_index: SubGraphNodeIndex,
+    ) -> Vec<SubGraphNodeIndex> {
+        let ordered_children = self
+            .ordered_children_for_node(node_index)
+            .unwrap_or_default();
+        let mut unordered_children: Vec<(_, _)> = self
+            .graph
+            .neighbors_directed(node_index, Outgoing)
+            .filter(|child_idx| !ordered_children.contains(child_idx))
+            .filter_map(|child_idx| {
+                self.graph
+                    .node_weight(child_idx)
+                    .map(|weight| (weight.id(), child_idx))
+            })
+            .collect();
+
+        // We want to keep the "unordered" children stably sorted as well, so that we get the same hash every time if there are no changes
+        unordered_children.sort_by_cached_key(|(id, _)| *id);
+        let mut all_children =
+            Vec::with_capacity(ordered_children.len() + unordered_children.len());
+        all_children.extend(ordered_children);
+        all_children.extend(unordered_children.into_iter().map(|(_, index)| index));
+
+        all_children
+    }
+
+    fn calculate_merkle_hash_for_node(
+        &self,
+        node_index: SubGraphNodeIndex,
+    ) -> Option<MerkleTreeHash> {
+        let mut hasher = MerkleTreeHash::hasher();
+        hasher.update(self.graph.node_weight(node_index)?.node_hash().as_bytes());
+
+        for child_idx in self.all_outgoing_stably_ordered(node_index) {
+            hasher.update(
+                self.graph
+                    .node_weight(child_idx)?
+                    .merkle_tree_hash()
+                    .as_bytes(),
+            );
+
+            for edge_ref in self.graph.edges_connecting(node_index, child_idx) {
+                if let Some(edge_hash) = edge_ref.weight().edge_hash() {
+                    hasher.update(edge_hash.as_bytes());
+                }
+            }
+        }
+
+        Some(hasher.finalize())
+    }
+
+    pub(crate) fn node_id_to_index(&self, id: SplitGraphNodeId) -> Option<SubGraphNodeIndex> {
+        self.node_index_by_id.get(&id).copied()
+    }
+
+    /// Adds a SplitGraphEdgeWeight if one of the exact same kind does not exist between `from_index`
+    /// and `to_index` and touches `from_index` so that the merkle tree hash will be recalculated.
+    pub(crate) fn add_edge_raw(
+        &mut self,
+        from_index: SubGraphNodeIndex,
+        edge_weight: SplitGraphEdgeWeight<E, K>,
+        to_index: SubGraphNodeIndex,
+    ) {
+        if !self.edge_exists(from_index, &edge_weight, to_index) {
+            self.graph.add_edge(from_index, to_index, edge_weight);
+            self.touch_node(from_index);
+        }
+    }
+
+    pub(crate) fn remove_node(&mut self, node_index: SubGraphNodeIndex) {
+        let parents: Vec<_> = self
+            .graph
+            .neighbors_directed(node_index, Incoming)
+            .collect();
+
+        self.graph.remove_node(node_index);
+        parents
+            .into_iter()
+            .for_each(|parent_idx| self.touch_node(parent_idx));
+    }
+
+    /// Add an edge between `from_index` and `to_index` if the edge does not exist.
+    /// Handles the creation of ordering nodes and the ordering edges if the node at
+    /// `from_index` is an ordered container.
+    pub(crate) fn add_edge(
+        &mut self,
+        from_index: SubGraphNodeIndex,
+        edge_weight: SplitGraphEdgeWeight<E, K>,
+        to_index: SubGraphNodeIndex,
+    ) -> SplitGraphResult<()> {
+        let is_ordered_container = self
+            .graph
+            .node_weight(from_index)
+            .and_then(|weight| weight.custom().map(|c| c.ordered()))
+            .is_some_and(|ordered| ordered);
+
+        if is_ordered_container {
+            let target_id = self
+                .graph
+                .node_weight(to_index)
+                .map(|n| n.id())
+                .ok_or(SplitGraphError::NodeNotFoundAtIndex)?;
+
+            let ordering_node_index = match self
+                .graph
+                .edges_directed(from_index, Outgoing)
+                .find(|edge_ref| matches!(edge_ref.weight(), SplitGraphEdgeWeight::Ordering))
+                .map(|edge_ref| edge_ref.target())
+            {
+                Some(target) => target,
+                None => {
+                    let new_ordering_node_id = SplitGraphNodeId::new();
+                    let ordering_node_index = self.graph.add_node(SplitGraphNodeWeight::Ordering {
+                        id: new_ordering_node_id,
+                        order: vec![],
+                        merkle_tree_hash: MerkleTreeHash::nil(),
+                    });
+
+                    self.node_index_by_id
+                        .insert(new_ordering_node_id, ordering_node_index);
+
+                    self.add_edge_raw(
+                        from_index,
+                        SplitGraphEdgeWeight::Ordering,
+                        ordering_node_index,
+                    );
+
+                    ordering_node_index
+                }
+            };
+
+            if let Some(SplitGraphNodeWeight::Ordering { order, .. }) =
+                self.graph.node_weight_mut(ordering_node_index)
+            {
+                if !order.contains(&target_id) {
+                    order.push(target_id);
+                }
+                self.add_edge_raw(ordering_node_index, SplitGraphEdgeWeight::Ordinal, to_index);
+            }
+        }
+
+        self.add_edge_raw(from_index, edge_weight, to_index);
+
+        Ok(())
+    }
+
+    pub(crate) fn touch_node(&mut self, node_index: SubGraphNodeIndex) {
+        self.touched_nodes.insert(node_index);
+    }
+
+    /// Removes all edges between `from_index` and `to_index` that match the passed in kind.
+    /// Also handles removing any correspond
+    pub(crate) fn remove_edge_raw(
+        &mut self,
+        from_index: SubGraphNodeIndex,
+        kind: SplitGraphEdgeWeightKind<K>,
+        to_index: SubGraphNodeIndex,
+    ) {
+        let edge_indexes: Vec<_> = self
+            .graph
+            .edges_directed(from_index, Outgoing)
+            .filter(|edge_ref| kind == edge_ref.weight().into() && edge_ref.target() == to_index)
+            .map(|edge_ref| edge_ref.id())
+            .collect();
+        for edge_index in edge_indexes {
+            self.graph.remove_edge(edge_index);
+        }
+    }
+
+    pub(crate) fn remove_from_order(
+        &mut self,
+        ordering_node_index: SubGraphNodeIndex,
+        item_id: SplitGraphNodeId,
+    ) {
+        if let Some(SplitGraphNodeWeight::Ordering { order, .. }) =
+            self.graph.node_weight_mut(ordering_node_index)
+        {
+            order.retain(|id| *id != item_id);
+        }
+    }
+
+    /// Removes the edge specified by `edge_index`. Also handles edges to and
+    /// from the ordering node, if one exists for `from_index`, and removes
+    /// the target from the order.
+    pub(crate) fn remove_edge_by_index(&mut self, edge_index: EdgeIndex<u16>) {
+        if let Some((from_index, to_index)) = self.graph.edge_endpoints(edge_index) {
+            self.touch_node(from_index);
+
+            let is_ordered_container = self
+                .graph
+                .node_weight(from_index)
+                .and_then(|weight| weight.custom().map(|c| c.ordered()))
+                .is_some_and(|ordered| ordered);
+
+            if is_ordered_container {
+                let target_id = self.graph.node_weight(to_index).map(|n| n.id()).unwrap();
+                if let Some(ordering_node_index) = self
+                    .graph
+                    .edges_directed(from_index, Outgoing)
+                    .find(|edge_ref| matches!(edge_ref.weight(), SplitGraphEdgeWeight::Ordering))
+                    .map(|edge_ref| edge_ref.target())
+                {
+                    self.touch_node(ordering_node_index);
+                    if let Some(ordinal_edge_index) = self
+                        .graph
+                        .edges_directed(ordering_node_index, Outgoing)
+                        .find(|edge_ref| {
+                            matches!(edge_ref.weight(), SplitGraphEdgeWeight::Ordinal)
+                                && self.graph.node_weight(edge_ref.target()).map(|n| n.id())
+                                    == Some(target_id)
+                        })
+                        .map(|edge_ref| edge_ref.id())
+                    {
+                        self.graph.remove_edge(ordinal_edge_index);
+                        self.remove_from_order(ordering_node_index, target_id);
+                    }
+                }
+            }
+
+            self.graph.remove_edge(edge_index);
+        }
+    }
+
+    pub(crate) fn tiny_dot_to_file(&self, name: &str) {
+        let dot = petgraph::dot::Dot::with_attr_getters(
+            &self.graph,
+            &[
+                petgraph::dot::Config::NodeNoLabel,
+                petgraph::dot::Config::EdgeNoLabel,
+            ],
+            &|_, edge_ref| {
+                let (label, color) = match edge_ref.weight() {
+                    SplitGraphEdgeWeight::Custom(_) => ("".into(), "black"),
+                    SplitGraphEdgeWeight::ExternalSource {
+                        source_id,
+                        subgraph,
+                        ..
+                    } => (
+                        format!("external source: {source_id}\nsubgraph: {}", subgraph + 1),
+                        "red",
+                    ),
+                    SplitGraphEdgeWeight::Ordering => ("ordering".into(), "green"),
+                    SplitGraphEdgeWeight::Ordinal => ("ordinal".into(), "green"),
+                };
+
+                format!("label = \"{label}\"\ncolor = {color}")
+            },
+            &|_, (_, node_weight)| {
+                let (label, color) = match node_weight {
+                    SplitGraphNodeWeight::Custom(n) => {
+                        let node_dbg = format!("{n:?}")
+                            .replace("\"", "'")
+                            .replace("{", "{\n")
+                            .replace("}", "\n}");
+                        (format!("node: {}\n{node_dbg}", n.id()), "black")
+                    }
+                    SplitGraphNodeWeight::ExternalTarget {
+                        target, subgraph, ..
+                    } => (
+                        format!("external target: {target}\nsubgraph: {}", subgraph + 1),
+                        "red",
+                    ),
+                    SplitGraphNodeWeight::GraphRoot { id, .. } => {
+                        (format!("graph root: {id}"), "blue")
+                    }
+                    SplitGraphNodeWeight::SubGraphRoot { id, .. } => {
+                        (format!("subgraph root: {id}"), "blue")
+                    }
+                    SplitGraphNodeWeight::Ordering { id, .. } => {
+                        (format!("ordering: {id}"), "green")
+                    }
+                };
+
+                format!("label = \"{label}\"\ncolor = {color}")
+            },
+        );
+
+        #[allow(clippy::disallowed_methods)]
+        let home_str = std::env::var("HOME").expect("could not find home directory via env");
+        let home = std::path::Path::new(&home_str);
+
+        let mut file =
+            std::fs::File::create(home.join(format!("{name}.txt"))).expect("could not create file");
+        file.write_all(format!("{dot:?}").as_bytes())
+            .expect("could not write file");
+    }
+}

--- a/lib/si-split-graph/src/subgraph.rs
+++ b/lib/si-split-graph/src/subgraph.rs
@@ -224,7 +224,7 @@ where
         Ok(())
     }
 
-    pub(crate) fn ordered_children_for_node(
+    pub(crate) fn ordered_children(
         &self,
         node_index: SubGraphNodeIndex,
     ) -> Option<Vec<SubGraphNodeIndex>> {
@@ -291,9 +291,7 @@ where
         &self,
         node_index: SubGraphNodeIndex,
     ) -> Vec<SubGraphNodeIndex> {
-        let ordered_children = self
-            .ordered_children_for_node(node_index)
-            .unwrap_or_default();
+        let ordered_children = self.ordered_children(node_index).unwrap_or_default();
         let mut unordered_children: Vec<(_, _)> = self
             .graph
             .neighbors_directed(node_index, Outgoing)

--- a/lib/si-split-graph/src/subgraph_address.rs
+++ b/lib/si-split-graph/src/subgraph_address.rs
@@ -1,0 +1,73 @@
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Serialize,
+};
+use std::{fmt, str::FromStr};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("failed to parse hash hex string")]
+pub struct SubGraphAddressParseError(#[from] blake3::HexError);
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct SubGraphAddress(blake3::Hash);
+
+impl SubGraphAddress {
+    #[must_use]
+    pub fn new(input: &[u8]) -> Self {
+        Self(blake3::hash(input))
+    }
+
+    pub fn nil() -> Self {
+        Self(blake3::Hash::from_bytes([0; 32]))
+    }
+}
+
+impl FromStr for SubGraphAddress {
+    type Err = SubGraphAddressParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(blake3::Hash::from_str(s)?))
+    }
+}
+
+impl std::fmt::Display for SubGraphAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Serialize for SubGraphAddress {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+struct SubGraphAddressVisitor;
+
+impl Visitor<'_> for SubGraphAddressVisitor {
+    type Value = SubGraphAddress;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a blake3 hash string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        SubGraphAddress::from_str(v).map_err(|e| E::custom(e.to_string()))
+    }
+}
+
+impl<'de> Deserialize<'de> for SubGraphAddress {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(SubGraphAddressVisitor)
+    }
+}

--- a/lib/si-split-graph/src/tests/mod.rs
+++ b/lib/si-split-graph/src/tests/mod.rs
@@ -1,0 +1,899 @@
+use std::collections::{HashMap, HashSet};
+use strum::EnumDiscriminants;
+
+use updates::subgraph_as_updates;
+
+use super::*;
+
+#[derive(Clone, PartialEq, Eq)]
+struct TestNodeWeight {
+    id: SplitGraphNodeId,
+    name: String,
+    ordered: bool,
+    merkle_tree_hash: MerkleTreeHash,
+}
+
+impl TestNodeWeight {
+    fn set_name(&mut self, name: String) {
+        self.name = name;
+    }
+}
+
+impl std::fmt::Debug for TestNodeWeight {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "name = {}", self.name)
+    }
+}
+
+impl CustomNodeWeight for TestNodeWeight {
+    fn id(&self) -> SplitGraphNodeId {
+        self.id
+    }
+
+    fn lineage_id(&self) -> SplitGraphNodeId {
+        self.id
+    }
+
+    fn set_merkle_tree_hash(&mut self, hash: MerkleTreeHash) {
+        self.merkle_tree_hash = hash;
+    }
+
+    fn merkle_tree_hash(&self) -> MerkleTreeHash {
+        self.merkle_tree_hash
+    }
+
+    fn node_hash(&self) -> ContentHash {
+        let mut hasher = ContentHash::hasher();
+        hasher.update(&self.id.inner().to_bytes());
+        hasher.update(self.name.as_bytes());
+        hasher.update(&[self.ordered as u8]);
+        hasher.finalize()
+    }
+
+    fn ordered(&self) -> bool {
+        self.ordered
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TestReadWriter {
+    graphs: HashMap<
+        SubGraphAddress,
+        SubGraph<TestNodeWeight, TestEdgeWeight, TestEdgeWeightDiscriminants>,
+    >,
+}
+
+fn add_nodes_to_graph<'a, 'b, E, K>(
+    graph: &'a mut SubGraph<TestNodeWeight, E, K>,
+    nodes: &'a [&'b str],
+    ordered: bool,
+) -> HashMap<&'b str, Ulid>
+where
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    let mut node_id_map = HashMap::new();
+    for node in nodes {
+        // "props" here are just nodes that are easy to create and render the name on the dot
+        // output. there is no domain modeling in this test.
+        let id = SplitGraphNodeId::new();
+        let node_weight = TestNodeWeight {
+            id,
+            name: node.to_string(),
+            ordered,
+            merkle_tree_hash: MerkleTreeHash::nil(),
+        };
+        graph.add_node(SplitGraphNodeWeight::Custom(node_weight));
+
+        node_id_map.insert(*node, id);
+    }
+    node_id_map
+}
+
+#[async_trait]
+impl SubGraphReader<TestNodeWeight, TestEdgeWeight, TestEdgeWeightDiscriminants>
+    for TestReadWriter
+{
+    type Error = SplitGraphError;
+
+    async fn read_subgraph(
+        &self,
+        address: SubGraphAddress,
+    ) -> Result<
+        SubGraph<TestNodeWeight, TestEdgeWeight, TestEdgeWeightDiscriminants>,
+        SplitGraphError,
+    > {
+        self.graphs
+            .get(&address)
+            .cloned()
+            .ok_or(SplitGraphError::SubGraphRead(address, "not found".into()))
+    }
+}
+
+#[async_trait]
+impl SubGraphWriter<TestNodeWeight, TestEdgeWeight, TestEdgeWeightDiscriminants>
+    for TestReadWriter
+{
+    type Error = SplitGraphError;
+
+    async fn write_subgraph(
+        &mut self,
+        _subgraph: &SubGraph<TestNodeWeight, TestEdgeWeight, TestEdgeWeightDiscriminants>,
+    ) -> Result<SubGraphAddress, SplitGraphError> {
+        todo!()
+    }
+}
+
+#[derive(EnumDiscriminants, Clone, Debug, PartialEq, Eq, Hash)]
+#[strum_discriminants(derive(Hash))]
+pub enum TestEdgeWeight {
+    EdgeA,
+    EdgeB { is_default: bool },
+}
+
+impl EdgeKind for TestEdgeWeightDiscriminants {}
+
+impl CustomEdgeWeight<TestEdgeWeightDiscriminants> for TestEdgeWeight {
+    fn kind(&self) -> TestEdgeWeightDiscriminants {
+        self.into()
+    }
+
+    fn edge_hash(&self) -> Option<ContentHash> {
+        let mut hasher = ContentHash::hasher();
+        match self {
+            TestEdgeWeight::EdgeA => hasher.update(&(1u8.to_le_bytes())),
+            TestEdgeWeight::EdgeB { is_default } => {
+                hasher.update(&(2u8.to_le_bytes()));
+                hasher.update(&[*is_default as u8]);
+            }
+        }
+
+        Some(hasher.finalize())
+    }
+
+    fn clone_as_non_default(&self) -> Self {
+        match self {
+            TestEdgeWeight::EdgeA => TestEdgeWeight::EdgeA,
+            TestEdgeWeight::EdgeB { .. } => TestEdgeWeight::EdgeB { is_default: false },
+        }
+    }
+
+    fn is_default(&self) -> bool {
+        false
+    }
+}
+
+#[test]
+fn ordered_container() -> SplitGraphResult<()> {
+    let reader_writer = TestReadWriter {
+        graphs: HashMap::new(),
+    };
+    let mut splitgraph = SplitGraph::new(&reader_writer, &reader_writer, 10000);
+
+    let mut node_name_to_id_map = HashMap::new();
+    let container_nodes: Vec<TestNodeWeight> = ["a"]
+        .into_iter()
+        .map(|name| TestNodeWeight {
+            id: Ulid::new(),
+            name: name.to_string(),
+            merkle_tree_hash: MerkleTreeHash::nil(),
+            ordered: true,
+        })
+        .collect();
+
+    let mut nodes_per_container = HashMap::new();
+
+    for container_node in container_nodes {
+        let container_name = container_node.name.to_owned();
+        let container_node_id = container_node.id();
+
+        splitgraph.add_or_replace_node(container_node)?;
+        splitgraph.add_edge(
+            splitgraph.root_id()?,
+            TestEdgeWeight::EdgeA,
+            container_node_id,
+        )?;
+
+        node_name_to_id_map.insert(container_name.to_owned(), container_node_id);
+        let mut nodes = vec![];
+        for i in 0..5 {
+            let node_name = format!("{container_name}-{i}");
+            let node_id = Ulid::new();
+            node_name_to_id_map.insert(node_name.to_owned(), node_id);
+            splitgraph.add_or_replace_node(TestNodeWeight {
+                id: node_id,
+                name: node_name,
+                ordered: false,
+                merkle_tree_hash: MerkleTreeHash::nil(),
+            })?;
+            nodes.push(node_id);
+            splitgraph.add_edge(container_node_id, TestEdgeWeight::EdgeA, node_id)?;
+        }
+        nodes_per_container.insert(container_node_id, nodes);
+    }
+
+    for (container_id, expected_nodes) in nodes_per_container {
+        let ordered_children = splitgraph
+            .ordered_children(container_id)
+            .expect("should have ordered children");
+        assert_eq!(expected_nodes, ordered_children);
+
+        let reversed_nodes: Vec<_> = expected_nodes.into_iter().rev().collect();
+        splitgraph.reorder_node(container_id, |current_order| {
+            current_order
+                .iter()
+                .rev()
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })?;
+
+        let ordered_children = splitgraph
+            .ordered_children(container_id)
+            .expect("should have ordered children");
+
+        assert_eq!(reversed_nodes, ordered_children);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn replace_node() -> SplitGraphResult<()> {
+    let reader_writer = TestReadWriter {
+        graphs: HashMap::new(),
+    };
+    let mut splitgraph = SplitGraph::new(&reader_writer, &reader_writer, 2);
+
+    let mut nodes: Vec<TestNodeWeight> = ["1", "2", "3", "4", "5", "6"]
+        .into_iter()
+        .map(|name| TestNodeWeight {
+            id: Ulid::new(),
+            name: name.to_string(),
+            merkle_tree_hash: MerkleTreeHash::nil(),
+            ordered: false,
+        })
+        .collect();
+
+    for node in &nodes {
+        splitgraph.add_or_replace_node(node.clone())?;
+    }
+
+    for node in nodes.iter_mut() {
+        node.name = format!("{}-{}", node.name, node.id);
+        splitgraph.add_or_replace_node(node.clone())?;
+    }
+
+    for node in &nodes {
+        assert_eq!(
+            Some(node),
+            splitgraph
+                .raw_node_weight(node.id())
+                .and_then(|n| n.custom())
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn cross_graph_edges() -> SplitGraphResult<()> {
+    for ordered in [false, true] {
+        let reader_writer = TestReadWriter {
+            graphs: HashMap::new(),
+        };
+
+        let mut splitgraph = SplitGraph::new(&reader_writer, &reader_writer, 9);
+        let mut unsplitgraph = SplitGraph::new(&reader_writer, &reader_writer, MAX_NODES as u16);
+
+        let nodes = [
+            "graph-1-a",
+            "graph-1-b",
+            "graph-1-c",
+            "graph-1-d",
+            "graph-1-e",
+            "graph-1-f",
+            "graph-1-g",
+            "graph-1-h",
+            "graph-1-i",
+            "graph-2-j",
+            "graph-2-k",
+            "graph-2-l",
+            "graph-2-m",
+            "graph-2-n",
+            "graph-2-o",
+            "graph-2-p",
+            "graph-2-q",
+            "graph-2-r",
+            "graph-3-s",
+            "graph-3-t",
+            "graph-3-u",
+            "graph-3-v",
+            "graph-3-w",
+            "graph-3-x",
+            "graph-3-y",
+            "graph-3-z",
+        ];
+
+        let edges = [
+            ("", "graph-1-a"),
+            ("graph-1-a", "graph-1-b"),
+            ("graph-1-a", "graph-1-c"),
+            ("graph-1-c", "graph-1-d"),
+            ("graph-1-d", "graph-1-e"),
+            ("graph-1-e", "graph-1-f"),
+            ("graph-1-f", "graph-1-g"),
+            ("graph-1-g", "graph-1-h"),
+            ("graph-1-h", "graph-1-i"),
+            ("graph-1-a", "graph-2-j"),
+            ("graph-1-a", "graph-2-k"),
+            ("graph-1-b", "graph-2-k"),
+            ("graph-1-c", "graph-2-k"),
+            ("", "graph-2-l"),
+            ("graph-2-l", "graph-1-b"),
+            ("graph-2-l", "graph-1-c"),
+            ("graph-2-l", "graph-1-d"),
+            ("graph-2-l", "graph-2-m"),
+            ("graph-2-l", "graph-2-n"),
+            ("graph-2-l", "graph-2-o"),
+            ("graph-2-l", "graph-2-p"),
+            ("graph-2-p", "graph-2-q"),
+            ("graph-2-q", "graph-2-r"),
+            ("graph-2-q", "graph-3-s"),
+            ("graph-2-q", "graph-3-t"),
+            ("graph-3-t", "graph-1-b"),
+            ("graph-3-t", "graph-3-u"),
+            ("graph-3-t", "graph-3-v"),
+            ("graph-3-t", "graph-3-w"),
+            ("graph-3-t", "graph-3-x"),
+            ("graph-3-t", "graph-3-y"),
+            ("graph-3-t", "graph-3-z"),
+        ];
+
+        let mut name_to_id_map = HashMap::new();
+        for name in &nodes {
+            let id = Ulid::new();
+            splitgraph.add_or_replace_node(TestNodeWeight {
+                id,
+                name: name.to_string(),
+                merkle_tree_hash: MerkleTreeHash::nil(),
+                ordered,
+            })?;
+            unsplitgraph.add_or_replace_node(TestNodeWeight {
+                id,
+                name: name.to_string(),
+                merkle_tree_hash: MerkleTreeHash::nil(),
+                ordered,
+            })?;
+            println!(
+                "added node {name}:{id}, subgraphs: {}",
+                splitgraph.subgraph_count()
+            );
+            name_to_id_map.insert(name, id);
+        }
+
+        let mut expected_outgoing_targets: HashMap<SplitGraphNodeId, HashSet<SplitGraphNodeId>> =
+            HashMap::new();
+        let mut split_expected_incoming_sources: HashMap<
+            SplitGraphNodeId,
+            HashSet<SplitGraphNodeId>,
+        > = HashMap::new();
+        let mut unsplit_expected_incoming_sources: HashMap<
+            SplitGraphNodeId,
+            HashSet<SplitGraphNodeId>,
+        > = HashMap::new();
+
+        for (from_name, to_name) in edges {
+            let (split_from_id, unsplit_from_id) = if from_name.is_empty() {
+                (splitgraph.root_id()?, unsplitgraph.root_id()?)
+            } else {
+                (
+                    name_to_id_map
+                        .get(&from_name)
+                        .copied()
+                        .expect("from name should exist"),
+                    name_to_id_map
+                        .get(&from_name)
+                        .copied()
+                        .expect("from name should exist"),
+                )
+            };
+
+            let to_id = name_to_id_map.get(&to_name).copied().unwrap();
+
+            splitgraph.add_edge(split_from_id, TestEdgeWeight::EdgeA, to_id)?;
+            unsplitgraph.add_edge(unsplit_from_id, TestEdgeWeight::EdgeA, to_id)?;
+
+            expected_outgoing_targets
+                .entry(split_from_id)
+                .and_modify(|outgoing| {
+                    outgoing.insert(to_id);
+                })
+                .or_insert(HashSet::from([to_id]));
+            expected_outgoing_targets
+                .entry(unsplit_from_id)
+                .and_modify(|outgoing| {
+                    outgoing.insert(to_id);
+                })
+                .or_insert(HashSet::from([to_id]));
+
+            split_expected_incoming_sources
+                .entry(to_id)
+                .and_modify(|incoming| {
+                    incoming.insert(split_from_id);
+                })
+                .or_insert(HashSet::from([split_from_id]));
+            unsplit_expected_incoming_sources
+                .entry(to_id)
+                .and_modify(|incoming| {
+                    incoming.insert(unsplit_from_id);
+                })
+                .or_insert(HashSet::from([unsplit_from_id]));
+        }
+
+        for from_name in &nodes {
+            let (split_from_id, unsplit_from_id) = if from_name.is_empty() {
+                (splitgraph.root_id()?, unsplitgraph.root_id()?)
+            } else {
+                let id = name_to_id_map
+                    .get(&from_name)
+                    .copied()
+                    .expect("should exist");
+                (id, id)
+            };
+
+            let outgoing_targets: HashSet<SplitGraphNodeId> = splitgraph
+                .edges_directed(split_from_id, Outgoing)?
+                .map(|edge_ref| edge_ref.target())
+                .collect();
+            let unsplit_outgoing_targets: HashSet<SplitGraphNodeId> = unsplitgraph
+                .edges_directed(unsplit_from_id, Outgoing)?
+                .map(|edge_ref| edge_ref.target())
+                .collect();
+
+            let incoming_sources: HashSet<SplitGraphNodeId> = splitgraph
+                .edges_directed(split_from_id, Incoming)?
+                .map(|edge_ref| edge_ref.source())
+                .collect();
+            let unsplit_incoming_sources: HashSet<SplitGraphNodeId> = unsplitgraph
+                .edges_directed(unsplit_from_id, Incoming)?
+                .map(|edge_ref| edge_ref.source())
+                .collect();
+
+            if outgoing_targets.is_empty() {
+                assert!(expected_outgoing_targets.contains_key(&split_from_id));
+                assert!(expected_outgoing_targets.contains_key(&unsplit_from_id));
+            } else {
+                assert_eq!(
+                    expected_outgoing_targets
+                        .get(&split_from_id)
+                        .cloned()
+                        .unwrap(),
+                    outgoing_targets
+                );
+                assert_eq!(
+                    expected_outgoing_targets
+                        .get(&unsplit_from_id)
+                        .cloned()
+                        .unwrap(),
+                    unsplit_outgoing_targets
+                );
+
+                for target_id in outgoing_targets {
+                    if let Some(node) = splitgraph
+                        .raw_node_weight(target_id)
+                        .and_then(|n| n.custom())
+                    {
+                        assert_eq!(
+                            Some(target_id),
+                            name_to_id_map.get(&node.name.as_str()).copied()
+                        );
+                    }
+                }
+            }
+
+            if incoming_sources.is_empty() {
+                assert!(split_expected_incoming_sources.contains_key(&split_from_id));
+                assert!(unsplit_expected_incoming_sources.contains_key(&unsplit_from_id));
+            } else {
+                assert_eq!(
+                    split_expected_incoming_sources
+                        .get(&split_from_id)
+                        .cloned()
+                        .unwrap(),
+                    incoming_sources
+                );
+                assert_eq!(
+                    unsplit_expected_incoming_sources
+                        .get(&unsplit_from_id)
+                        .cloned()
+                        .unwrap(),
+                    unsplit_incoming_sources
+                );
+            }
+        }
+
+        // splitgraph.tiny_dot_to_file("before-removal");
+        // unsplitgraph.tiny_dot_to_file("unsplitgraph");
+
+        let graph_2_q = "graph-2-q";
+        let graph_3_t = "graph-3-t";
+        let graph_3_s = "graph-3-s";
+        let graph_2_q_id = name_to_id_map.get(&graph_2_q).copied().unwrap();
+        let graph_3_t_id = name_to_id_map.get(&graph_3_t).copied().unwrap();
+        let graph_3_s_id = name_to_id_map.get(&graph_3_s).copied().unwrap();
+        splitgraph.remove_edge(
+            graph_2_q_id,
+            TestEdgeWeightDiscriminants::EdgeA,
+            graph_3_t_id,
+        )?;
+        unsplitgraph.remove_edge(
+            graph_2_q_id,
+            TestEdgeWeightDiscriminants::EdgeA,
+            graph_3_t_id,
+        )?;
+        splitgraph.cleanup();
+        splitgraph.recalculate_merkle_tree_hashes_based_on_touched_nodes();
+        unsplitgraph.cleanup();
+        unsplitgraph.recalculate_merkle_tree_hashes_based_on_touched_nodes();
+
+        // splitgraph.tiny_dot_to_file("after-removal");
+
+        assert!(splitgraph.raw_node_weight(graph_2_q_id).is_some());
+        assert!(unsplitgraph.raw_node_weight(graph_2_q_id).is_some());
+        assert!(splitgraph.raw_node_weight(graph_3_s_id).is_some());
+        assert!(unsplitgraph.raw_node_weight(graph_3_s_id).is_some());
+
+        for graph_3_name in [
+            "graph-3-t",
+            "graph-3-u",
+            "graph-3-v",
+            "graph-3-w",
+            "graph-3-x",
+            "graph-3-y",
+            "graph-3-z",
+        ] {
+            let id = name_to_id_map.get(&graph_3_name).copied().unwrap();
+            assert!(splitgraph.raw_node_weight(id).is_none());
+            assert!(unsplitgraph.raw_node_weight(id).is_none());
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn detect_and_perform_updates_ordered_containers() -> SplitGraphResult<()> {
+    let reader_writer = TestReadWriter {
+        graphs: HashMap::new(),
+    };
+
+    for split_max in [1, 2, 1000] {
+        let mut base_graph = SplitGraph::new(&reader_writer, &reader_writer, split_max);
+        base_graph.cleanup_and_merkle_tree_hash();
+        let mut updated_graph = base_graph.clone();
+        updated_graph.cleanup_and_merkle_tree_hash();
+
+        let damaya = TestNodeWeight {
+            name: "damaya".to_string(),
+            id: Ulid::new(),
+            ordered: true,
+            merkle_tree_hash: MerkleTreeHash::nil(),
+        };
+
+        let evil_earth = TestNodeWeight {
+            name: "evil_earth".to_string(),
+            id: Ulid::new(),
+            ordered: false,
+            merkle_tree_hash: MerkleTreeHash::nil(),
+        };
+
+        updated_graph.add_or_replace_node(damaya.clone())?;
+        updated_graph.add_edge(updated_graph.root_id()?, TestEdgeWeight::EdgeA, damaya.id())?;
+        updated_graph.add_or_replace_node(evil_earth.clone())?;
+        updated_graph.add_edge(
+            updated_graph.root_id()?,
+            TestEdgeWeight::EdgeA,
+            evil_earth.id(),
+        )?;
+
+        let mut name_to_id_map = HashMap::new();
+        let children = ["corundum", "uche", "nassun"];
+        let mut ordered_child_ids = vec![];
+        for name in &children {
+            let new_node = TestNodeWeight {
+                name: name.to_string(),
+                id: Ulid::new(),
+                ordered: true,
+                merkle_tree_hash: MerkleTreeHash::nil(),
+            };
+            ordered_child_ids.push(new_node.id());
+            updated_graph.add_or_replace_node(new_node.clone())?;
+            name_to_id_map.insert(name.to_string(), new_node.id());
+            updated_graph.add_edge(
+                damaya.id(),
+                TestEdgeWeight::EdgeB { is_default: false },
+                new_node.id(),
+            )?;
+            updated_graph.add_edge(evil_earth.id(), TestEdgeWeight::EdgeA, new_node.id())?;
+        }
+
+        updated_graph.cleanup_and_merkle_tree_hash();
+        let updates = updated_graph.detect_updates(&base_graph);
+
+        assert!(!updates.is_empty());
+
+        base_graph.perform_updates(&updates);
+        base_graph.cleanup_and_merkle_tree_hash();
+
+        let updates = updated_graph.detect_updates(&base_graph);
+        assert!(updates.is_empty());
+
+        assert_eq!(
+            Some(&ordered_child_ids),
+            updated_graph.ordered_children(damaya.id()).as_ref()
+        );
+
+        assert_eq!(
+            Some(&ordered_child_ids),
+            base_graph.ordered_children(damaya.id()).as_ref()
+        );
+
+        let evil_earth_outgoing_updated: HashSet<_> = updated_graph
+            .edges_directed(evil_earth.id(), Outgoing)?
+            .map(|edge_ref| edge_ref.target())
+            .collect();
+
+        let evil_earth_outgoing_base: HashSet<_> = base_graph
+            .edges_directed(evil_earth.id(), Outgoing)?
+            .map(|edge_ref| edge_ref.target())
+            .collect();
+
+        assert!(evil_earth_outgoing_base
+            .difference(&evil_earth_outgoing_updated)
+            .next()
+            .is_none());
+
+        updated_graph.reorder_node(damaya.id(), |order| order.iter().copied().rev().collect())?;
+
+        let subgraph_for_damaya = updated_graph.subgraph_for_node(damaya.id()).unwrap();
+        let updated_root_merkle_before_calculation = updated_graph
+            .raw_node_weight(updated_graph.subgraph_root_id(subgraph_for_damaya).unwrap())
+            .unwrap()
+            .merkle_tree_hash();
+        updated_graph.cleanup_and_merkle_tree_hash();
+        let updated_root_merkle_after_calculation = updated_graph
+            .raw_node_weight(updated_graph.subgraph_root_id(subgraph_for_damaya).unwrap())
+            .unwrap()
+            .merkle_tree_hash();
+
+        assert_ne!(
+            updated_root_merkle_before_calculation,
+            updated_root_merkle_after_calculation
+        );
+
+        let reversed_ids: Vec<_> = ordered_child_ids.iter().copied().rev().collect();
+        assert_eq!(
+            Some(&reversed_ids),
+            updated_graph.ordered_children(damaya.id()).as_ref()
+        );
+
+        let updates_after_reorder = updated_graph.detect_updates(&base_graph);
+        assert_eq!(1, updates_after_reorder.len());
+        assert!(matches!(
+            updates_after_reorder.first().unwrap(),
+            Update::ReplaceNode {
+                node_weight: SplitGraphNodeWeight::Ordering { .. },
+                ..
+            }
+        ));
+
+        base_graph.perform_updates(&updates_after_reorder);
+        base_graph.cleanup_and_merkle_tree_hash();
+        assert_eq!(
+            Some(&reversed_ids),
+            base_graph.ordered_children(damaya.id()).as_ref()
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn detect_updates_simple() -> SplitGraphResult<()> {
+    let reader_writer = TestReadWriter {
+        graphs: HashMap::new(),
+    };
+
+    let mut base_graph = SplitGraph::new(&reader_writer, &reader_writer, 3200);
+    base_graph.cleanup_and_merkle_tree_hash();
+    let mut updated_graph = base_graph.clone();
+    updated_graph.cleanup_and_merkle_tree_hash();
+
+    assert!(updated_graph.detect_updates(&base_graph).is_empty());
+
+    let new_node = TestNodeWeight {
+        name: "damaya".to_string(),
+        id: Ulid::new(),
+        ordered: false,
+        merkle_tree_hash: MerkleTreeHash::nil(),
+    };
+
+    updated_graph.add_or_replace_node(new_node.clone())?;
+    updated_graph.add_edge(
+        updated_graph.root_id()?,
+        TestEdgeWeight::EdgeA,
+        new_node.id(),
+    )?;
+    updated_graph.cleanup_and_merkle_tree_hash();
+
+    let updates = updated_graph.detect_updates(&base_graph);
+
+    assert_eq!(2, updates.len());
+
+    let update_1 = updates.first().unwrap();
+    let update_2 = updates.get(1).unwrap();
+
+    assert!(matches!(
+        update_1,
+        Update::NewNode {
+            subgraph_index: 0,
+            node_weight: SplitGraphNodeWeight::Custom(TestNodeWeight { .. })
+        }
+    ));
+
+    let Update::NewNode {
+        subgraph_index: 0,
+        node_weight: SplitGraphNodeWeight::Custom(custom_node),
+    } = update_1
+    else {
+        unreachable!("we already asserted this!")
+    };
+
+    assert_eq!(new_node.node_hash(), custom_node.node_hash());
+
+    assert!(matches!(
+        update_2,
+        Update::NewEdge {
+            subgraph_index: 0,
+            edge_weight: SplitGraphEdgeWeight::Custom(TestEdgeWeight::EdgeA),
+            ..
+        }
+    ));
+
+    let Update::NewEdge {
+        source,
+        destination,
+        ..
+    } = update_2
+    else {
+        unreachable!("bridge over the river kwai");
+    };
+
+    assert_eq!(updated_graph.root_id()?, *source);
+    assert_eq!(new_node.id(), *destination);
+
+    let inverse_updates = base_graph.detect_updates(&updated_graph);
+    assert_eq!(2, inverse_updates.len());
+
+    assert!(matches!(
+        inverse_updates.first().unwrap(),
+        Update::RemoveEdge { .. }
+    ));
+    assert!(matches!(
+        inverse_updates.get(1).unwrap(),
+        Update::RemoveNode { .. }
+    ));
+
+    let mut second_updated_graph = updated_graph.clone();
+    let mut updated_node = new_node.clone();
+    updated_node.set_name("syenite".into());
+    second_updated_graph.add_or_replace_node(updated_node)?;
+    second_updated_graph.cleanup_and_merkle_tree_hash();
+    let replace_node_update = second_updated_graph.detect_updates(&updated_graph);
+    assert!(matches!(
+        replace_node_update.first().unwrap(),
+        Update::ReplaceNode {
+            subgraph_index: 0,
+            node_weight: SplitGraphNodeWeight::Custom(TestNodeWeight { .. }),
+        }
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn single_subgraph_as_updates() -> SplitGraphResult<()> {
+    let nodes = ["r", "t", "u", "v", "a", "b", "c", "d", "e"];
+    let edges = [
+        (None, "r"),
+        (None, "t"),
+        (Some("t"), "u"),
+        (Some("u"), "v"),
+        (Some("r"), "a"),
+        (Some("r"), "b"),
+        (Some("r"), "e"),
+        (Some("a"), "c"),
+        (Some("b"), "c"),
+        (Some("c"), "d"),
+        (Some("b"), "d"),
+        (Some("d"), "e"),
+        (Some("c"), "e"),
+        (Some("e"), "u"),
+        (Some("c"), "u"),
+        (Some("a"), "u"),
+        (Some("a"), "b"),
+    ];
+
+    let mut subgraph = SubGraph::new_with_root();
+    let node_id_map = add_nodes_to_graph(&mut subgraph, &nodes, false);
+
+    for (source, target) in edges {
+        let from_index = match source {
+            Some(name) => subgraph
+                .node_id_to_index(node_id_map.get(&name).copied().unwrap())
+                .unwrap(),
+            None => subgraph.root_index,
+        };
+        let to_index = subgraph
+            .node_id_to_index(node_id_map.get(&target).copied().unwrap())
+            .unwrap();
+
+        subgraph.add_edge(
+            from_index,
+            SplitGraphEdgeWeight::Custom(TestEdgeWeight::EdgeA),
+            to_index,
+        )?;
+    }
+
+    subgraph.cleanup();
+
+    let root_id = subgraph
+        .graph
+        .node_weight(subgraph.root_index)
+        .unwrap()
+        .id();
+
+    let expected_edges: Vec<Update<TestNodeWeight, TestEdgeWeight, TestEdgeWeightDiscriminants>> =
+        edges
+            .into_iter()
+            .map(|(source, target)| {
+                let source = source
+                    .map(|source| node_id_map.get(&source).copied().unwrap())
+                    .unwrap_or(root_id);
+                let destination = node_id_map.get(&target).copied().unwrap();
+
+                Update::NewEdge {
+                    source,
+                    destination,
+                    edge_weight: SplitGraphEdgeWeight::Custom(TestEdgeWeight::EdgeA),
+                    subgraph_index: 0,
+                }
+            })
+            .collect();
+
+    let updates = subgraph_as_updates(&subgraph, 0);
+    assert!(!updates.is_empty());
+    let mut new_edge_count = 0;
+    let mut new_node_count = 0;
+    for update in updates {
+        match &update {
+            new_edge @ Update::NewEdge { .. } => {
+                new_edge_count += 1;
+                assert!(expected_edges.contains(new_edge));
+            }
+            Update::NewNode {
+                node_weight: SplitGraphNodeWeight::Custom(TestNodeWeight { id, name, .. }),
+                ..
+            } => {
+                new_node_count += 1;
+                assert_eq!(node_id_map.get(&name.as_str()), Some(id))
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(expected_edges.len(), new_edge_count);
+    assert_eq!(nodes.len(), new_node_count);
+
+    Ok(())
+}

--- a/lib/si-split-graph/src/updates.rs
+++ b/lib/si-split-graph/src/updates.rs
@@ -1,0 +1,439 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use petgraph::{
+    prelude::*,
+    visit::{Control, DfsEvent},
+};
+use serde::{Deserialize, Serialize};
+use strum::EnumDiscriminants;
+
+use crate::{
+    subgraph::{SubGraph, SubGraphNodeIndex},
+    CustomEdgeWeight, CustomNodeWeight, EdgeKind, SplitGraphEdgeWeight, SplitGraphEdgeWeightKind,
+    SplitGraphNodeId, SplitGraphNodeWeight,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, EnumDiscriminants)]
+pub enum Update<N, E, K>
+where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    NewEdge {
+        subgraph_index: u16,
+        source: SplitGraphNodeId,
+        destination: SplitGraphNodeId,
+        edge_weight: SplitGraphEdgeWeight<E, K>,
+    },
+    RemoveEdge {
+        subgraph_index: u16,
+        source: SplitGraphNodeId,
+        destination: SplitGraphNodeId,
+        edge_kind: SplitGraphEdgeWeightKind<K>,
+    },
+    RemoveNode {
+        subgraph_index: u16,
+        id: SplitGraphNodeId,
+    },
+    ReplaceNode {
+        subgraph_index: u16,
+        node_weight: SplitGraphNodeWeight<N>,
+    },
+    NewNode {
+        subgraph_index: u16,
+        node_weight: SplitGraphNodeWeight<N>,
+    },
+    NewSubGraph,
+}
+
+#[derive(Clone, Debug)]
+enum NodeDifference {
+    NewNode,
+    MerkleTreeHash(Vec<SubGraphNodeIndex>),
+}
+
+pub struct Detector<'a, 'b, N, E, K>
+where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    updated_graph_index: u16,
+    base_graph: &'a SubGraph<N, E, K>,
+    updated_graph: &'b SubGraph<N, E, K>,
+}
+
+impl<'a, 'b, N, E, K> Detector<'a, 'b, N, E, K>
+where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    pub fn new(
+        base_graph: &'a SubGraph<N, E, K>,
+        updated_graph: &'b SubGraph<N, E, K>,
+        updated_graph_index: u16,
+    ) -> Self {
+        Self {
+            updated_graph_index,
+            base_graph,
+            updated_graph,
+        }
+    }
+
+    /// Performs a post order walk of the updated graph, finding the updates
+    /// made to it when compared to the base graph, using the Merkle tree hash
+    /// to detect changes and ignore unchanged branches.
+    ///
+    /// This assumes that all graphs involved to not have any "garbage" laying around. If in doubt,
+    /// run [`cleanup`][WorkspaceSnapshotGraph::cleanup] on all involved graphs, before handing
+    /// them over to the [`Detector`].
+    pub fn detect_updates(&self) -> Vec<Update<N, E, K>> {
+        let mut updates = vec![];
+        let mut difference_cache = HashMap::new();
+
+        petgraph::visit::depth_first_search(
+            &self.updated_graph.graph,
+            Some(self.updated_graph.root_index),
+            |event| self.calculate_updates_dfs_event(event, &mut updates, &mut difference_cache),
+        );
+
+        // If a node is in base graph but not in updated_graph, it has been removed
+        updates.extend(
+            self.base_graph
+                .node_index_by_id
+                .keys()
+                .filter(|id| !self.updated_graph.node_index_by_id.contains_key(id))
+                .map(|id| Update::RemoveNode {
+                    subgraph_index: self.updated_graph_index,
+                    id: *id,
+                }),
+        );
+
+        updates
+    }
+
+    fn node_diff_from_base_graph(
+        &self,
+        updated_graph_node_index: SubGraphNodeIndex,
+    ) -> Option<NodeDifference> {
+        self.updated_graph
+            .graph
+            .node_weight(updated_graph_node_index)
+            .and_then(|updated_graph_node_weight| {
+                let mut base_graph_node_indexes = HashSet::new();
+                if updated_graph_node_index == self.updated_graph.root_index {
+                    // There can only be one (valid/current) `ContentAddress::Root` at any
+                    // given moment, and the `lineage_id` isn't really relevant as it's not
+                    // globally stable (even though it is locally stable). This matters as we
+                    // may be dealing with a `WorkspaceSnapshotGraph` that is coming to us
+                    // externally from a module that we're attempting to import. The external
+                    // `WorkspaceSnapshotGraph` will be `self`, and the "local" one will be
+                    // `onto`.
+                    base_graph_node_indexes.insert(self.base_graph.root_index);
+                } else if let Some(new_base_graph_node_indexes) = self
+                    .base_graph
+                    .node_indexes_by_lineage_id
+                    .get(&updated_graph_node_weight.lineage_id())
+                {
+                    base_graph_node_indexes.extend(new_base_graph_node_indexes);
+                }
+
+                base_graph_node_indexes
+                    .is_empty()
+                    .then_some(NodeDifference::NewNode)
+                    .or_else(|| {
+                        // If everything with the same `lineage_id` is identical, then
+                        // we can prune the graph traversal, and avoid unnecessary
+                        // lookups/comparisons.
+                        let nodes_with_difference: Vec<SubGraphNodeIndex> = base_graph_node_indexes
+                            .iter()
+                            .filter_map(|&base_graph_index| {
+                                self.base_graph
+                                    .graph
+                                    .node_weight(base_graph_index)
+                                    .and_then(|base_graph_node_weight| {
+                                        (base_graph_node_weight.merkle_tree_hash()
+                                            != updated_graph_node_weight.merkle_tree_hash())
+                                        .then_some(base_graph_index)
+                                    })
+                            })
+                            .collect();
+
+                        (!nodes_with_difference.is_empty())
+                            .then_some(NodeDifference::MerkleTreeHash(nodes_with_difference))
+                    })
+            })
+    }
+
+    fn calculate_updates_dfs_event(
+        &self,
+        event: DfsEvent<SubGraphNodeIndex>,
+        updates: &mut Vec<Update<N, E, K>>,
+        difference_cache: &mut HashMap<SubGraphNodeIndex, Option<NodeDifference>>,
+    ) -> Control<()> {
+        match event {
+            DfsEvent::Discover(updated_graph_index, _) => {
+                let node_diff = self.node_diff_from_base_graph(updated_graph_index);
+                let control = match &node_diff {
+                    Some(NodeDifference::NewNode) => {
+                        if let Some(node_weight) =
+                            self.updated_graph.graph.node_weight(updated_graph_index)
+                        {
+                            // NewNode updates are produced here, so that they
+                            // are in the update array *before* the new edge
+                            // updates which refer to them
+                            updates.push(Update::NewNode {
+                                subgraph_index: self.updated_graph_index,
+                                node_weight: node_weight.to_owned(),
+                            });
+                        }
+
+                        Control::Continue
+                    }
+                    Some(NodeDifference::MerkleTreeHash(_)) => Control::Continue,
+                    // Node is neither different, nor new, prune this branch of
+                    // the graph
+                    None => Control::Prune,
+                };
+
+                difference_cache.insert(updated_graph_index, node_diff);
+
+                control
+            }
+            DfsEvent::Finish(updated_graph_index, _) => {
+                match difference_cache.get(&updated_graph_index) {
+                    // None should be unreachable here....
+                    None | Some(None) => Control::Continue,
+                    Some(Some(diff)) => {
+                        match diff {
+                            NodeDifference::NewNode => {
+                                // A new node! Just gather up all the outgoing edges as NewEdge updates
+                                updates.extend(
+                                    self.updated_graph
+                                        .graph
+                                        .edges_directed(updated_graph_index, Outgoing)
+                                        .map(|edge_ref| {
+                                            (edge_ref.target(), edge_ref.weight().to_owned())
+                                        })
+                                        .filter_map(move |(target_index, edge_weight)| {
+                                            if let Some((source_node, destination_node)) = self
+                                                .updated_graph
+                                                .graph
+                                                .node_weight(updated_graph_index)
+                                                .zip(
+                                                    self.updated_graph
+                                                        .graph
+                                                        .node_weight(target_index),
+                                                )
+                                            {
+                                                Some(Update::NewEdge {
+                                                    subgraph_index: self.updated_graph_index,
+                                                    source: source_node.id(),
+                                                    destination: destination_node.id(),
+                                                    edge_weight,
+                                                })
+                                            } else {
+                                                None
+                                            }
+                                        }),
+                                );
+                            }
+                            NodeDifference::MerkleTreeHash(base_graph_indexes) => {
+                                updates.extend(self.detect_updates_for_node_index(
+                                    updated_graph_index,
+                                    base_graph_indexes,
+                                ));
+                            }
+                        }
+
+                        Control::Continue
+                    }
+                }
+            }
+            _ => Control::Continue,
+        }
+    }
+
+    /// Produces ReplaceNode, NewEdge and RemoveEdge updates. The assumption we
+    /// make here is that updated_graph has seen everything in base_graph. So if
+    /// a node has a different hash from the matching one in base_graph, it has
+    /// been changed and should be replaced. And if an edge is in base_graph but
+    /// not in updated_graph, that means it's been removed. Finally, if an edge
+    /// is in new_graph, but not in base_graph, that means it has been added.
+    fn detect_updates_for_node_index(
+        &self,
+        updated_graph_node_index: SubGraphNodeIndex,
+        base_graph_indexes: &[SubGraphNodeIndex],
+    ) -> Vec<Update<N, E, K>> {
+        #[derive(Debug, Clone)]
+        struct EdgeInfo<E, K>
+        where
+            E: CustomEdgeWeight<K>,
+            K: EdgeKind,
+        {
+            pub source_node: SplitGraphNodeId,
+            pub target_node: SplitGraphNodeId,
+            pub edge_weight: SplitGraphEdgeWeight<E, K>,
+        }
+
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        struct UniqueEdgeInfo<K>
+        where
+            K: EdgeKind,
+        {
+            pub kind: SplitGraphEdgeWeightKind<K>,
+            pub target_lineage: SplitGraphNodeId,
+        }
+
+        let mut updates = vec![];
+
+        let Some(updated_graph_node_weight) = self
+            .updated_graph
+            .graph
+            .node_weight(updated_graph_node_index)
+        else {
+            return updates;
+        };
+        for base_graph_index in base_graph_indexes {
+            let base_graph_index = *base_graph_index;
+
+            if let Some(base_graph_node_weight) =
+                self.base_graph.graph.node_weight(base_graph_index)
+            {
+                // if the node hash is different, then the node has been updated and
+                // needs to be replaced in base_graph (node hash is a hash of the
+                // content, which is not the same as the merkle tree hash, which
+                // also gathers up the hashes of the outgoing neighbors)
+                if updated_graph_node_weight.node_hash() != base_graph_node_weight.node_hash() {
+                    updates.push(Update::ReplaceNode {
+                        subgraph_index: self.updated_graph_index,
+                        node_weight: updated_graph_node_weight.to_owned(),
+                    });
+                }
+
+                let base_graph_edges: HashMap<UniqueEdgeInfo<K>, EdgeInfo<E, K>> = self
+                    .base_graph
+                    .graph
+                    .edges_directed(base_graph_index, Outgoing)
+                    .filter_map(|edge_ref| {
+                        self.base_graph.graph.node_weight(edge_ref.target()).map(
+                            |target_node_weight| {
+                                (
+                                    UniqueEdgeInfo {
+                                        kind: edge_ref.weight().into(),
+                                        target_lineage: target_node_weight.lineage_id(),
+                                    },
+                                    EdgeInfo {
+                                        source_node: base_graph_node_weight.id(),
+                                        target_node: target_node_weight.id(),
+                                        edge_weight: edge_ref.weight().to_owned(),
+                                    },
+                                )
+                            },
+                        )
+                    })
+                    .collect();
+
+                let update_graph_edges: HashMap<UniqueEdgeInfo<K>, EdgeInfo<E, K>> = self
+                    .updated_graph
+                    .graph
+                    .edges_directed(updated_graph_node_index, Outgoing)
+                    .filter_map(|edge_ref| {
+                        self.updated_graph.graph.node_weight(edge_ref.target()).map(
+                            |target_node_weight| {
+                                (
+                                    UniqueEdgeInfo {
+                                        kind: edge_ref.weight().into(),
+                                        target_lineage: target_node_weight.lineage_id(),
+                                    },
+                                    EdgeInfo {
+                                        source_node: updated_graph_node_weight.id(),
+                                        target_node: target_node_weight.id(),
+                                        edge_weight: edge_ref.weight().to_owned(),
+                                    },
+                                )
+                            },
+                        )
+                    })
+                    .collect();
+
+                updates.extend(
+                    base_graph_edges
+                        .iter()
+                        .filter(|(edge_key, _)| !update_graph_edges.contains_key(edge_key))
+                        .map(|(_, edge_info)| Update::RemoveEdge {
+                            subgraph_index: self.updated_graph_index,
+                            source: edge_info.source_node,
+                            destination: edge_info.target_node,
+                            edge_kind: (&edge_info.edge_weight).into(),
+                        }),
+                );
+
+                updates.extend(
+                    update_graph_edges
+                        .into_iter()
+                        .filter(|(edge_key, _)| !base_graph_edges.contains_key(edge_key))
+                        .map(|(_, edge_info)| Update::NewEdge {
+                            subgraph_index: self.updated_graph_index,
+                            source: edge_info.source_node,
+                            destination: edge_info.target_node,
+                            edge_weight: edge_info.edge_weight,
+                        }),
+                );
+            }
+        }
+
+        updates
+    }
+}
+
+/// Transforms a subgraph into NewNode and NewEdge updates
+pub fn subgraph_as_updates<N, E, K>(
+    subgraph: &SubGraph<N, E, K>,
+    subgraph_index: u16,
+) -> Vec<Update<N, E, K>>
+where
+    N: CustomNodeWeight,
+    E: CustomEdgeWeight<K>,
+    K: EdgeKind,
+{
+    let mut updates = vec![];
+    let mut node_index_to_id = BTreeMap::new();
+
+    petgraph::visit::depth_first_search(&subgraph.graph, Some(subgraph.root_index), |event| {
+        match event {
+            DfsEvent::Discover(node_index, _) => {
+                if let Some(node_weight) = subgraph.graph.node_weight(node_index).cloned() {
+                    node_index_to_id.insert(node_index, node_weight.id());
+                    updates.push(Update::NewNode {
+                        subgraph_index,
+                        node_weight,
+                    })
+                }
+            }
+            DfsEvent::Finish(node_index, _) => {
+                updates.extend(
+                    subgraph
+                        .graph
+                        .edges_directed(node_index, Outgoing)
+                        .filter_map(|edge_ref| {
+                            node_index_to_id
+                                .get(&edge_ref.source())
+                                .zip(node_index_to_id.get(&edge_ref.target()))
+                                .map(|(&source, &destination)| Update::NewEdge {
+                                    subgraph_index,
+                                    source,
+                                    destination,
+                                    edge_weight: edge_ref.weight().to_owned(),
+                                })
+                        }),
+                );
+            }
+            _ => {}
+        }
+    });
+
+    updates
+}


### PR DESCRIPTION
A new crate, lib/si-split-graph, containing an initial, generic implementation of a merkle tree hashed graph which can be split into multiple "subgraphs" but allows edges between nodes in different subgraphs. Calculates updates, performs them, and handles the "ordering" concept internally.

This is not yet integrated with the si "dal", and will likely require more changes before that is possible.