### PR TITLE
fix(sdf): Ensure that only workspace approvers can change Slack Webhook URL

### DIFF
--- a/app/web/src/components/WorkspaceIntegrationsModal.vue
+++ b/app/web/src/components/WorkspaceIntegrationsModal.vue
@@ -5,6 +5,7 @@
     size="sm"
     saveLabel="Save"
     title="Save Integrations"
+    :disableSave="!changeSetsStore.currentUserIsDefaultApprover"
     @save="updateIntegrations"
   >
     <VormInput ref="labelRef" v-model="webhookUrl" label="Slack Webhook Url" />
@@ -15,8 +16,10 @@
 import { Modal, VormInput } from "@si/vue-lib/design-system";
 import { ref, computed } from "vue";
 import { useWorkspacesStore } from "@/store/workspaces.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 
 const workspacesStore = useWorkspacesStore();
+const changeSetsStore = useChangeSetsStore();
 
 const modalRef = ref<InstanceType<typeof Modal>>();
 

--- a/app/web/src/store/workspaces.store.ts
+++ b/app/web/src/store/workspaces.store.ts
@@ -117,15 +117,6 @@ export const useWorkspacesStore = () => {
             },
           });
         },
-        async INVITE_USER(email: string) {
-          return new AuthApiRequest<void>({
-            method: "post",
-            url: "workspace/invite",
-            params: {
-              email,
-            },
-          });
-        },
         async BEGIN_WORKSPACE_IMPORT(moduleId: ModuleId) {
           this.workspaceApprovals = {};
           this.importId = null;

--- a/lib/sdf-server/src/service/v2/integrations.rs
+++ b/lib/sdf-server/src/service/v2/integrations.rs
@@ -3,6 +3,7 @@ use axum::{
     routing::{get, post},
     Router,
 };
+use dal::UserPk;
 use hyper::StatusCode;
 use thiserror::Error;
 
@@ -16,8 +17,16 @@ pub mod update_integration;
 pub enum IntegrationsError {
     #[error("integration with id {0} not found")]
     IntegrationNotFound(dal::workspace_integrations::WorkspaceIntegrationId),
+    #[error("invalid user found")]
+    InvalidUser,
+    #[error("permissions error: {0}")]
+    Permissions(#[from] permissions::Error),
+    #[error("SpiceDb client not found")]
+    SpiceDbClientNotFound,
     #[error("transactions error: {0}")]
     Transactions(#[from] dal::TransactionsError),
+    #[error("user unable to approve integration: {0}")]
+    UserUnableToApproveIntegration(UserPk),
     #[error("workspace integration error: {0}")]
     WorkspaceIntegrations(#[from] dal::workspace_integrations::WorkspaceIntegrationsError),
 }

--- a/lib/si-events-rs/src/audit_log/v1.rs
+++ b/lib/si-events-rs/src/audit_log/v1.rs
@@ -417,6 +417,10 @@ pub enum AuditLogKindV1 {
     WithdrawRequestForChangeSetApply {
         from_status: ChangeSetStatus,
     },
+    WorkspaceIntegration {
+        old_slack_webhook_url: String,
+        new_slack_webhook_url: String,
+    },
 }
 
 /// This is an identical copy of latest [`AuditLogKind`], but uses "serde untagged" wrapper. This is used for inserting
@@ -850,6 +854,11 @@ pub enum AuditLogMetadataV1 {
     },
     #[serde(rename_all = "camelCase")]
     WithdrawRequestForChangeSetApply { from_status: ChangeSetStatus },
+    #[serde(rename_all = "camelCase")]
+    WorkspaceIntegration {
+        old_slack_webhook_url: String,
+        new_slack_webhook_url: String,
+    },
 }
 
 impl AuditLogMetadataV1 {
@@ -938,6 +947,7 @@ impl AuditLogMetadataV1 {
             MetadataDiscrim::WithdrawRequestForChangeSetApply => {
                 ("Withdrew Request to Apply", Some("Change Set"))
             }
+            MetadataDiscrim::WorkspaceIntegration => ("Workspace Integration Updated", None),
         }
     }
 }
@@ -1592,6 +1602,13 @@ impl From<Kind> for Metadata {
             Kind::WithdrawRequestForChangeSetApply { from_status } => {
                 Self::WithdrawRequestForChangeSetApply { from_status }
             }
+            Kind::WorkspaceIntegration {
+                old_slack_webhook_url,
+                new_slack_webhook_url,
+            } => Self::WorkspaceIntegration {
+                old_slack_webhook_url,
+                new_slack_webhook_url,
+            },
         }
     }
 }


### PR DESCRIPTION
Also includes an audit trail event for the change of webhook url