### PR TITLE
Properly configure cgroups for Veritech & Firecracker

### DIFF
--- a/lib/si-firecracker/src/firecracker.rs
+++ b/lib/si-firecracker/src/firecracker.rs
@@ -42,10 +42,12 @@ impl FirecrackerJail {
         let mut cmd = Command::new("/usr/bin/jailer");
         cmd.arg("--cgroup-version")
             .arg("2")
+            .arg("--parent-cgroup")
+            .arg("veritech/firecracker")
             .arg("--cgroup")
             .arg("cpuset.cpus=16-63")
             .arg("--cgroup")
-            .arg("cpu.max=750000,1000000")
+            .arg("cpu.max=1000000,1000000")
             .arg("--id")
             .arg(id.to_string())
             .arg("--exec-file")


### PR DESCRIPTION
I've tested this on a duplicate Veritech node in terms of resolving the configuration and it all looks good/runs through successfully, see output below:

```
[root@ip-12-0-10-131 ~]# cat $VERITECH_CGROUP/cpuset.cpus.partition
root
[root@ip-12-0-10-131 ~]# cat $VERITECH_CGROUP/cpuset.cpus
0-15
[root@ip-12-0-10-131 ~]# cat $VERITECH_CGROUP/cpuset.mems
0
[root@ip-12-0-10-131 ~]# cat /sys/fs/cgroup/veritech/cgroup.subtree_control
cpuset
[root@ip-12-0-10-131 ~]# cat "$FIRECRACKER_CGROUP/cpuset.cpus.partition"
member
[root@ip-12-0-10-131 ~]# cat  "$FIRECRACKER_CGROUP/cpuset.cpus"
16-63
[root@ip-12-0-10-131 ~]# cat "$FIRECRACKER_CGROUP/cpuset.mems"
0
``` 

These are extremely difficult to test without merging, I believe I have done best effort here.