### PR TITLE
chore: remove NodeIndex from all public WorkspaceSnapshot methods

### DIFF
--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -287,7 +287,7 @@ impl Action {
     pub async fn get_by_id(ctx: &DalContext, id: ActionId) -> ActionResult<Self> {
         let action: Self = ctx
             .workspace_snapshot()?
-            .get_node_weight_by_id(id)
+            .get_node_weight(id)
             .await?
             .get_action_node_weight()?
             .into();
@@ -296,10 +296,9 @@ impl Action {
 
     #[instrument(level = "info", skip_all, fields(si.action.id = ?id, si.action.state = ?state))]
     pub async fn set_state(ctx: &DalContext, id: ActionId, state: ActionState) -> ActionResult<()> {
-        let idx = ctx.workspace_snapshot()?.get_node_index_by_id(id).await?;
         let node_weight = ctx
             .workspace_snapshot()?
-            .get_node_weight(idx)
+            .get_node_weight(id)
             .await?
             .get_action_node_weight()?;
         let mut new_node_weight = node_weight.clone();
@@ -362,7 +361,7 @@ impl Action {
 
         let new_action: Self = ctx
             .workspace_snapshot()?
-            .get_node_weight_by_id(new_id)
+            .get_node_weight(new_id)
             .await?
             .get_action_node_weight()?
             .into();

--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -185,7 +185,7 @@ impl ActionPrototype {
 
         let new_prototype: Self = ctx
             .workspace_snapshot()?
-            .get_node_weight_by_id(new_id)
+            .get_node_weight(new_id)
             .await?
             .get_action_prototype_node_weight()?
             .into();
@@ -212,7 +212,7 @@ impl ActionPrototype {
     pub async fn get_by_id(ctx: &DalContext, id: ActionPrototypeId) -> ActionPrototypeResult<Self> {
         let prototype: Self = ctx
             .workspace_snapshot()?
-            .get_node_weight_by_id(id)
+            .get_node_weight(id)
             .await?
             .get_action_prototype_node_weight()?
             .into();
@@ -220,15 +220,13 @@ impl ActionPrototype {
     }
 
     pub async fn func_id(ctx: &DalContext, id: ActionPrototypeId) -> ActionPrototypeResult<FuncId> {
-        for (_, _tail_node_idx, head_node_idx) in ctx
+        for (_, _, target_id) in ctx
             .workspace_snapshot()?
             .edges_directed_for_edge_weight_kind(id, Outgoing, EdgeWeightKindDiscriminants::Use)
             .await?
         {
-            if let NodeWeight::Func(node_weight) = ctx
-                .workspace_snapshot()?
-                .get_node_weight(head_node_idx)
-                .await?
+            if let NodeWeight::Func(node_weight) =
+                ctx.workspace_snapshot()?.get_node_weight(target_id).await?
             {
                 return Ok(node_weight.id().into());
             }

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -154,7 +154,7 @@ impl AttributePrototype {
         let lineage_id = workspace_snapshot.generate_ulid().await?;
         let node_weight =
             NodeWeight::new_content(id, lineage_id, ContentAddress::AttributePrototype(hash));
-        let _node_index = workspace_snapshot.add_or_replace_node(node_weight).await?;
+        workspace_snapshot.add_or_replace_node(node_weight).await?;
 
         let prototype = AttributePrototype::assemble(id.into(), &content);
 
@@ -292,7 +292,7 @@ impl AttributePrototype {
     ) -> AttributePrototypeResult<(ContentNodeWeight, AttributePrototypeContentV1)> {
         let content_weight = ctx
             .workspace_snapshot()?
-            .get_node_weight_by_id(prototype_id)
+            .get_node_weight(prototype_id)
             .await?;
         let prototype_node_weight = content_weight
             .get_content_node_weight_of_kind(ContentAddressDiscriminants::AttributePrototype)?;
@@ -319,11 +319,7 @@ impl AttributePrototype {
     ) -> AttributePrototypeResult<()> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        let attribute_prototype_idx = workspace_snapshot
-            .get_node_index_by_id(attribute_prototype_id)
-            .await?;
-
-        let current_func_node_idx = workspace_snapshot
+        let current_func_node_id = workspace_snapshot
             .edges_directed(attribute_prototype_id, Direction::Outgoing)
             .await?
             .iter()
@@ -335,8 +331,8 @@ impl AttributePrototype {
 
         workspace_snapshot
             .remove_edge(
-                attribute_prototype_idx,
-                current_func_node_idx,
+                attribute_prototype_id,
+                current_func_node_id,
                 EdgeWeightKindDiscriminants::Use,
             )
             .await?;

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -181,8 +181,7 @@ impl AttributePrototypeArgument {
     ) -> AttributePrototypeArgumentResult<Self> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        let node_index = workspace_snapshot.get_node_index_by_id(id).await?;
-        let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
+        let node_weight = workspace_snapshot.get_node_weight(id).await?;
 
         Ok(node_weight
             .get_attribute_prototype_argument_node_weight()?
@@ -421,10 +420,9 @@ impl AttributePrototypeArgument {
             )
             .await?
         {
-            let self_node_index = workspace_snapshot.get_node_index_by_id(apa_id).await?;
             workspace_snapshot
                 .remove_edge(
-                    self_node_index,
+                    apa_id,
                     existing_value_source,
                     EdgeWeightKindDiscriminants::PrototypeArgumentValue,
                 )

--- a/lib/dal/src/attribute/prototype/argument/static_value.rs
+++ b/lib/dal/src/attribute/prototype/argument/static_value.rs
@@ -70,8 +70,7 @@ impl StaticArgumentValue {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let ulid: si_events::ulid::Ulid = id.into();
-        let node_index = workspace_snapshot.get_node_index_by_id(ulid).await?;
-        let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
+        let node_weight = workspace_snapshot.get_node_weight(ulid).await?;
         let hash = node_weight.content_hash();
 
         let content: StaticArgumentValueContent = ctx

--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -84,16 +84,12 @@ impl DependentValueGraph {
             // are other modifications to the snapshot before the DVU job starts executing, as the
             // job always operates on the current state of the change set's snapshot, not the state
             // at the time the job was created.
-            if workspace_snapshot
-                .get_node_index_by_id_opt(root_ulid)
-                .await
-                .is_none()
-            {
+            if !workspace_snapshot.node_exists(root_ulid).await {
                 debug!(%root_ulid, "missing node, skipping it in DependentValueGraph");
                 continue;
             }
 
-            let node_weight = workspace_snapshot.get_node_weight_by_id(root_ulid).await?;
+            let node_weight = workspace_snapshot.get_node_weight(root_ulid).await?;
 
             match node_weight.into() {
                 NodeWeightDiscriminants::AttributeValue => {

--- a/lib/dal/src/diagram/geometry.rs
+++ b/lib/dal/src/diagram/geometry.rs
@@ -459,16 +459,13 @@ impl Geometry {
         ctx: &DalContext,
         geometry_id: GeometryId,
     ) -> DiagramResult<Option<(GeometryNodeWeight, GeometryContent)>> {
-        let id: Ulid = geometry_id.into();
-
-        let Some(node_index) = ctx.workspace_snapshot()?.get_node_index_by_id_opt(id).await else {
+        let Some(node_weight) = ctx
+            .workspace_snapshot()?
+            .get_node_weight_opt(geometry_id)
+            .await
+        else {
             return Ok(None);
         };
-
-        let node_weight = ctx
-            .workspace_snapshot()?
-            .get_node_weight(node_index)
-            .await?;
 
         let hash = node_weight.content_hash();
         let component_node_weight = node_weight.get_geometry_node_weight()?;

--- a/lib/dal/src/diagram/view.rs
+++ b/lib/dal/src/diagram/view.rs
@@ -229,15 +229,10 @@ impl View {
     ) -> DiagramResult<Option<(ViewNodeWeight, ViewContent)>> {
         let id: Ulid = view_id.into();
 
-        let Some(node_index) = ctx.workspace_snapshot()?.get_node_index_by_id_opt(id).await else {
-            return Ok(None);
+        let node_weight = match ctx.workspace_snapshot()?.get_node_weight_opt(id).await {
+            Some(node_weight) => node_weight.get_view_node_weight()?,
+            None => return Ok(None),
         };
-
-        let node_weight = ctx
-            .workspace_snapshot()?
-            .get_node_weight(node_index)
-            .await?
-            .get_view_node_weight()?;
 
         let hash = node_weight.content_hash();
 

--- a/lib/dal/src/job/definition/compute_validation.rs
+++ b/lib/dal/src/job/definition/compute_validation.rs
@@ -98,11 +98,7 @@ impl JobConsumer for ComputeValidation {
             // things now. This could happen if there are other modifications to the snapshot before the CV job starts
             // executing, as the job always operates on the current state of the change set's snapshot, not the state at the time
             // the job was created.
-            if workspace_snapshot
-                .get_node_index_by_id_opt(av_id)
-                .await
-                .is_none()
-            {
+            if !workspace_snapshot.node_exists(av_id).await {
                 debug!("Attribute Value {av_id} missing, skipping it in ComputeValidations");
                 continue;
             }

--- a/lib/dal/src/management/prototype.rs
+++ b/lib/dal/src/management/prototype.rs
@@ -435,12 +435,8 @@ impl ManagementPrototype {
     ) -> ManagementPrototypeResult<Option<Self>> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        let Some(idx) = workspace_snapshot.get_node_index_by_id_opt(id).await else {
-            return Ok(None);
-        };
-
-        let NodeWeight::ManagementPrototype(inner) =
-            workspace_snapshot.get_node_weight(idx).await?
+        let Some(NodeWeight::ManagementPrototype(inner)) =
+            workspace_snapshot.get_node_weight_opt(id).await
         else {
             return Ok(None);
         };

--- a/lib/dal/src/module.rs
+++ b/lib/dal/src/module.rs
@@ -185,8 +185,7 @@ impl Module {
     pub async fn get_by_id(ctx: &DalContext, id: ModuleId) -> ModuleResult<Self> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        let node_index = workspace_snapshot.get_node_index_by_id(id).await?;
-        let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
+        let node_weight = workspace_snapshot.get_node_weight(id).await?;
         let hash = node_weight.content_hash();
 
         let content: ModuleContent = ctx

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -3,6 +3,7 @@ use petgraph::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use si_events::ContentHash;
+use si_id::ulid::Ulid;
 use si_pkg::PropSpecKind;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
@@ -45,8 +46,8 @@ pub enum PropError {
     AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
-    #[error("child prop of {0:?} not found by name: {1}")]
-    ChildPropNotFoundByName(NodeIndex, String),
+    #[error("child prop of {0} not found by name: {1}")]
+    ChildPropNotFoundByName(Ulid, String),
     #[error("prop {0} of kind {1} does not have an element prop")]
     ElementPropNotOnKind(PropId, PropKind),
     #[error("func error: {0}")]
@@ -659,7 +660,7 @@ impl Prop {
     pub async fn path_by_id(ctx: &DalContext, prop_id: PropId) -> PropResult<PropPath> {
         let name = ctx
             .workspace_snapshot()?
-            .get_node_weight_by_id(prop_id)
+            .get_node_weight(prop_id)
             .await?
             .get_prop_node_weight()?
             .name()
@@ -671,10 +672,8 @@ impl Prop {
         while let Some(prop_id) = work_queue.pop_front() {
             if let Some(prop_id) = Self::parent_prop_id_by_id(ctx, prop_id).await? {
                 let workspace_snapshot = ctx.workspace_snapshot()?;
-                let node_idx = workspace_snapshot.get_node_index_by_id(prop_id).await?;
 
-                if let NodeWeight::Prop(inner) =
-                    workspace_snapshot.get_node_weight(node_idx).await?
+                if let NodeWeight::Prop(inner) = workspace_snapshot.get_node_weight(prop_id).await?
                 {
                     parts.push_front(inner.name().to_owned());
                     work_queue.push_back(inner.id().into());
@@ -722,10 +721,8 @@ impl Prop {
 
     pub async fn get_by_id(ctx: &DalContext, id: PropId) -> PropResult<Self> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
-        let ulid: ::si_events::ulid::Ulid = id.into();
-        let node_index = workspace_snapshot.get_node_index_by_id(ulid).await?;
         let node_weight = workspace_snapshot
-            .get_node_weight(node_index)
+            .get_node_weight(id)
             .await?
             .get_prop_node_weight()?;
         let hash = node_weight.content_hash();
@@ -735,7 +732,7 @@ impl Prop {
             .cas()
             .try_read_as(&hash)
             .await?
-            .ok_or(WorkspaceSnapshotError::MissingContentFromStore(ulid))?;
+            .ok_or(WorkspaceSnapshotError::MissingContentFromStore(id.into()))?;
 
         // NOTE(nick,jacob,zack): if we had a v2, then there would be migration logic here.
         let PropContent::V1(inner) = content;
@@ -751,31 +748,28 @@ impl Prop {
             .ok_or(PropError::MapOrArrayMissingElementProp(prop_id))
     }
 
-    pub async fn find_child_prop_index_by_name(
+    pub async fn find_child_prop_id_by_name(
         ctx: &DalContext,
-        node_index: NodeIndex,
+        parent_node_id: Ulid,
         child_name: impl AsRef<str>,
-    ) -> PropResult<NodeIndex> {
+    ) -> PropResult<PropId> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        for prop_node_index in workspace_snapshot
-            .outgoing_targets_for_edge_weight_kind_by_index(
-                node_index,
-                EdgeWeightKindDiscriminants::Use,
-            )
+        for prop_node_id in workspace_snapshot
+            .outgoing_targets_for_edge_weight_kind(parent_node_id, EdgeWeightKindDiscriminants::Use)
             .await?
         {
             if let NodeWeight::Prop(prop_inner) =
-                workspace_snapshot.get_node_weight(prop_node_index).await?
+                workspace_snapshot.get_node_weight(prop_node_id).await?
             {
                 if prop_inner.name() == child_name.as_ref() {
-                    return Ok(prop_node_index);
+                    return Ok(prop_node_id.into());
                 }
             }
         }
 
         Err(PropError::ChildPropNotFoundByName(
-            node_index,
+            parent_node_id,
             child_name.as_ref().to_string(),
         ))
     }
@@ -846,20 +840,17 @@ impl Prop {
     ) -> PropResult<PropId> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        let schema_variant_node_index = workspace_snapshot
-            .get_node_index_by_id(schema_variant_id)
-            .await?;
-
         let path_parts = path.as_parts();
 
-        let mut current_node_index = schema_variant_node_index;
+        let mut current_id: Ulid = schema_variant_id.into();
         for part in path_parts {
-            current_node_index =
-                Self::find_child_prop_index_by_name(ctx, current_node_index, part).await?;
+            current_id = Self::find_child_prop_id_by_name(ctx, current_id, part)
+                .await?
+                .into();
         }
 
         Ok(workspace_snapshot
-            .get_node_weight(current_node_index)
+            .get_node_weight(current_id)
             .await?
             .id()
             .into())
@@ -1035,9 +1026,8 @@ impl Prop {
         let mut node_weights = vec![];
         let mut content_hashes = vec![];
         for prop_id in prop_ids {
-            let prop_node_index = workspace_snapshot.get_node_index_by_id(prop_id).await?;
             let node_weight = workspace_snapshot
-                .get_node_weight(prop_node_index)
+                .get_node_weight(prop_id)
                 .await?
                 .get_prop_node_weight()?;
             content_hashes.push(node_weight.content_hash());

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -43,7 +43,6 @@ use crate::socket::output::OutputSocketError;
 use crate::workspace_snapshot::{
     content_address::{ContentAddress, ContentAddressDiscriminants},
     edge_weight::{EdgeWeightKind, EdgeWeightKindDiscriminants},
-    graph::NodeIndex,
     node_weight::{
         input_socket_node_weight::InputSocketNodeWeightError, traits::SiNodeWeight, NodeWeight,
         NodeWeightDiscriminants, NodeWeightError, PropNodeWeight, SchemaVariantNodeWeight,
@@ -581,7 +580,7 @@ impl SchemaVariant {
             if schema_variant.is_locked() != before_modification_variant.is_locked() {
                 let node_weight = ctx
                     .workspace_snapshot()?
-                    .get_node_weight_by_id(before_modification_variant.id())
+                    .get_node_weight(before_modification_variant.id())
                     .await?;
                 let mut schema_variant_node_weight =
                     node_weight.get_schema_variant_node_weight()?;
@@ -674,7 +673,7 @@ impl SchemaVariant {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         while let Some(prop_id) = work_queue.pop_front() {
-            let node_weight = workspace_snapshot.get_node_weight_by_id(prop_id).await?;
+            let node_weight = workspace_snapshot.get_node_weight(prop_id).await?;
 
             // Find and load any child props.
             match node_weight {
@@ -729,20 +728,10 @@ impl SchemaVariant {
     ) -> SchemaVariantResult<Option<Self>> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        let maybe_node_result = workspace_snapshot.get_node_index_by_id(id).await;
-
-        let node_index = match maybe_node_result {
-            Ok(node_index) => node_index,
-            Err(e) => {
-                return if e.is_node_with_id_not_found() {
-                    Ok(None)
-                } else {
-                    Err(SchemaVariantError::from(e))
-                }
-            }
+        let Some(node_weight) = workspace_snapshot.get_node_weight_opt(id).await else {
+            return Ok(None);
         };
 
-        let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
         let schema_variant_node_weight = node_weight.get_schema_variant_node_weight()?;
 
         let content: SchemaVariantContent = ctx
@@ -988,22 +977,18 @@ impl SchemaVariant {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let mut schema_variants = vec![];
-        let parent_index = workspace_snapshot.get_node_index_by_id(schema_id).await?;
 
         // We want to use the EdgeWeightKindDiscriminants rather than EdgeWeightKind
         // this will bring us back all use and default edges!
-        let node_indices = workspace_snapshot
-            .outgoing_targets_for_edge_weight_kind_by_index(
-                parent_index,
-                EdgeWeightKindDiscriminants::Use,
-            )
+        let variant_ids = workspace_snapshot
+            .outgoing_targets_for_edge_weight_kind(schema_id, EdgeWeightKindDiscriminants::Use)
             .await?;
 
         let mut node_weights = vec![];
         let mut content_hashes = vec![];
-        for index in node_indices {
+        for id in variant_ids {
             let node_weight = workspace_snapshot
-                .get_node_weight(index)
+                .get_node_weight(id)
                 .await?
                 .get_schema_variant_node_weight()?;
             content_hashes.push(node_weight.content_hash());
@@ -1136,16 +1121,15 @@ impl SchemaVariant {
         schema_variant_id: SchemaVariantId,
     ) -> SchemaVariantResult<PropNodeWeight> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
-        let edge_targets: Vec<NodeIndex> = workspace_snapshot
+        let edge_targets: Vec<_> = workspace_snapshot
             .edges_directed(schema_variant_id, Direction::Outgoing)
             .await?
             .into_iter()
-            .map(|(_, _, target_idx)| target_idx)
+            .map(|(_, _, target_id)| target_id)
             .collect();
 
-        for index in edge_targets {
-            let node_weight = workspace_snapshot.get_node_weight(index).await?;
-            // TODO(nick): ensure that only one prop can be under a schema variant.
+        for id in edge_targets {
+            let node_weight = workspace_snapshot.get_node_weight(id).await?;
             if let NodeWeight::Prop(inner_weight) = node_weight {
                 if inner_weight.name() == "root" {
                     return Ok(inner_weight.clone());
@@ -1224,20 +1208,17 @@ impl SchemaVariant {
     ) -> SchemaVariantResult<()> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let root_prop_node_weight = Self::get_root_prop_node_weight(ctx, schema_variant_id).await?;
-        let root_prop_idx = workspace_snapshot
-            .get_node_index_by_id(root_prop_node_weight.id())
-            .await?;
 
         let mut work_queue = VecDeque::new();
-        work_queue.push_back(root_prop_idx);
+        work_queue.push_back(root_prop_node_weight.id());
 
-        while let Some(prop_idx) = work_queue.pop_front() {
+        while let Some(prop_id) = work_queue.pop_front() {
             workspace_snapshot
-                .mark_prop_as_able_to_be_used_as_prototype_arg(prop_idx)
+                .mark_prop_as_able_to_be_used_as_prototype_arg(prop_id)
                 .await?;
 
             let node_weight = workspace_snapshot
-                .get_node_weight(prop_idx)
+                .get_node_weight(prop_id)
                 .await?
                 .to_owned();
             if let NodeWeight::Prop(prop) = node_weight {
@@ -1785,13 +1766,7 @@ impl SchemaVariant {
                 WorkspaceSnapshotError::MissingContentFromStore(input_socket_id.into()),
             )?;
 
-            let node_weight = workspace_snapshot
-                .get_node_weight(
-                    workspace_snapshot
-                        .get_node_index_by_id(input_socket_id)
-                        .await?,
-                )
-                .await?;
+            let node_weight = workspace_snapshot.get_node_weight(input_socket_id).await?;
             let input_socket_weight = node_weight.get_input_socket_node_weight()?;
 
             let input_socket_content_inner = match input_socket_content {

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -424,9 +424,7 @@ impl Secret {
         id: SecretId,
     ) -> SecretResult<(SecretNodeWeight, ContentHash)> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
-        let ulid: Ulid = id.into();
-        let node_index = workspace_snapshot.get_node_index_by_id(ulid).await?;
-        let node_weight = workspace_snapshot.get_node_weight(node_index).await?;
+        let node_weight = workspace_snapshot.get_node_weight(id).await?;
 
         let hash = node_weight.content_hash();
         let secret_node_weight = node_weight.get_secret_node_weight()?;

--- a/lib/dal/src/socket/output.rs
+++ b/lib/dal/src/socket/output.rs
@@ -222,7 +222,7 @@ impl OutputSocket {
     ) -> OutputSocketResult<(ContentNodeWeight, OutputSocketContentV1)> {
         let weight = ctx
             .workspace_snapshot()?
-            .get_node_weight_by_id(output_socket_id)
+            .get_node_weight(output_socket_id)
             .await?
             .get_content_node_weight_of_kind(ContentAddressDiscriminants::OutputSocket)?;
         let content: OutputSocketContent = ctx

--- a/lib/dal/src/validation.rs
+++ b/lib/dal/src/validation.rs
@@ -165,10 +165,8 @@ impl ValidationOutputNode {
         {
             let id = existing_node.id;
 
-            let idx = workspace_snapshot.get_node_index_by_id(id).await?;
-
             let node_weight = workspace_snapshot
-                .get_node_weight(idx)
+                .get_node_weight(id)
                 .await?
                 .get_content_node_weight_of_kind(ContentAddressDiscriminants::ValidationOutput)?;
 

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -487,16 +487,16 @@ impl Workspace {
             // From root, get every value from every node, store with hash
             let mut queue = VecDeque::from([snap.root().await?]);
 
-            while let Some(this_node_idx) = queue.pop_front() {
+            while let Some(this_node_id) = queue.pop_front() {
                 // Queue contents
                 content_hashes.extend(
-                    snap.get_node_weight(this_node_idx)
+                    snap.get_node_weight(this_node_id)
                         .await?
                         .content_store_hashes(),
                 );
 
                 let children = snap
-                    .edges_directed_by_index(this_node_idx, Direction::Outgoing)
+                    .edges_directed(this_node_id, Direction::Outgoing)
                     .await?
                     .into_iter()
                     .map(|(_, _, target)| target)

--- a/lib/dal/src/workspace_snapshot/traits/approval_requirement.rs
+++ b/lib/dal/src/workspace_snapshot/traits/approval_requirement.rs
@@ -90,7 +90,7 @@ impl ApprovalRequirementExt for WorkspaceSnapshot {
         id: ApprovalRequirementDefinitionId,
     ) -> WorkspaceSnapshotResult<ApprovalRequirementDefinition> {
         let node_weight = self
-            .get_node_weight_by_id(id)
+            .get_node_weight(id)
             .await?
             .get_approval_requirement_definition_node_weight()?;
         let content: ApprovalRequirementDefinitionContent = ctx
@@ -152,7 +152,7 @@ impl ApprovalRequirementExt for WorkspaceSnapshot {
         id: ApprovalRequirementDefinitionId,
         user_id: UserPk,
     ) -> WorkspaceSnapshotResult<()> {
-        let node_weight = self.get_node_weight_by_id(id).await?;
+        let node_weight = self.get_node_weight(id).await?;
         let content: ApprovalRequirementDefinitionContent = ctx
             .layer_db()
             .cas()
@@ -189,7 +189,7 @@ impl ApprovalRequirementExt for WorkspaceSnapshot {
         id: ApprovalRequirementDefinitionId,
         user_id: UserPk,
     ) -> WorkspaceSnapshotResult<()> {
-        let node_weight = self.get_node_weight_by_id(id).await?;
+        let node_weight = self.get_node_weight(id).await?;
         let content: ApprovalRequirementDefinitionContent = ctx
             .layer_db()
             .cas()

--- a/lib/dal/tests/integration_test/change_set/approval.rs
+++ b/lib/dal/tests/integration_test/change_set/approval.rs
@@ -16,7 +16,7 @@ async fn new_and_list_latest(ctx: &mut DalContext) -> Result<()> {
     let status = ChangeSetApprovalStatus::Approved;
     let component_node_weight = ctx
         .workspace_snapshot()?
-        .get_node_weight_by_id(component.id())
+        .get_node_weight(component.id())
         .await?;
     let approving_ids_with_hashes = vec![(
         component_node_weight.id().into(),

--- a/lib/dal/tests/integration_test/node_weight/component.rs
+++ b/lib/dal/tests/integration_test/node_weight/component.rs
@@ -177,12 +177,12 @@ async fn deleting_a_component_deletes_component_in_other_change_sets(ctx: &mut D
 
     update_visibility_and_snapshot_to_visibility(ctx, cs_1.id).await;
 
-    assert!(ctx
-        .workspace_snapshot()
-        .expect("get snap")
-        .get_node_index_by_id_opt(docker_image_1.id())
-        .await
-        .is_none());
+    assert!(
+        !ctx.workspace_snapshot()
+            .expect("get snap")
+            .node_exists(docker_image_1.id())
+            .await
+    );
 }
 
 #[test]

--- a/lib/sdf-server/src/dal_wrapper/change_set.rs
+++ b/lib/sdf-server/src/dal_wrapper/change_set.rs
@@ -384,7 +384,7 @@ async fn inner_determine_approving_ids_with_hashes(
                     *merkle_tree_hash_for_deleted_node
                 } else {
                     ctx.workspace_snapshot()?
-                        .get_node_weight_by_id(rule.entity_id)
+                        .get_node_weight(rule.entity_id)
                         .await?
                         .merkle_tree_hash()
                 };

--- a/lib/sdf-server/src/service/node_debug.rs
+++ b/lib/sdf-server/src/service/node_debug.rs
@@ -63,7 +63,7 @@ async fn node_debug(
     let mut outgoing_edges = vec![];
 
     let snapshot = ctx.workspace_snapshot()?;
-    let node = snapshot.get_node_weight_by_id(node_id).await?;
+    let node = snapshot.get_node_weight(node_id).await?;
 
     for (edge_weight, source_idx, _) in snapshot
         .edges_directed(node_id, Direction::Incoming)

--- a/lib/sdf-server/src/service/v2/fs.rs
+++ b/lib/sdf-server/src/service/v2/fs.rs
@@ -542,12 +542,7 @@ async fn lookup_variant_for_schema_with_prefetched_modules(
     unlocked: bool,
     cached_modules: &Option<&[CachedModule]>,
 ) -> FsResult<Option<SchemaVariant>> {
-    if ctx
-        .workspace_snapshot()?
-        .get_node_index_by_id_opt(schema_id)
-        .await
-        .is_none()
-    {
+    if !ctx.workspace_snapshot()?.node_exists(schema_id).await {
         if let Some(cached_modules) = cached_modules {
             if cached_modules.iter().any(|m| m.schema_id == schema_id) {
                 return Ok(None);


### PR DESCRIPTION
In order to prepare for the split-graph to integrate with the DAL, we need to remove all of the public methods on WorkspaceSnapshot that make use of the petgraph NodeIndex type, since the SplitGraph will not expose the NodeIndex type externally.  This is also a quality of life refactor, which simplifies some "warty" usage patterns (where we were converting between Ulid and NodeIndex, book-keeping work that the snapshot is capable of doing internally).