### PR TITLE
feat(web): Initial floating connections menu

### DIFF
--- a/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
+++ b/app/web/src/components/ModelingDiagram/ModelingDiagram.vue
@@ -95,13 +95,13 @@ overflow hidden */
             :connectedEdges="connectedEdgesByElementKey[group.uniqueKey]"
             :debug="enableDebugMode"
             :group="group"
+            :hideDetails="hideDiagramDetails"
             :isHovered="elementIsHovered(group)"
             :isSelected="elementIsSelected(group)"
+            :occlusionRect="occlusionRect"
             :qualificationStatus="
               qualificationStore.qualificationStatusForComponentId(group.def.id)
             "
-            :hideDetails="hideDiagramDetails"
-            :occlusionRect="occlusionRect"
             @rename="
               (f) => {
                 renameOnDiagram(group, f);
@@ -113,15 +113,15 @@ overflow hidden */
             :key="node.uniqueKey"
             :connectedEdges="connectedEdgesByElementKey[node.uniqueKey]"
             :debug="enableDebugMode"
+            :hideDetails="hideDiagramDetails"
             :isHovered="elementIsHovered(node)"
             :isLoading="statusStore.componentIsLoading(node.def.id)"
             :isSelected="elementIsSelected(node)"
             :node="node"
+            :occlusionRect="occlusionRect"
             :qualificationStatus="
               qualificationStore.qualificationStatusForComponentId(node.def.id)
             "
-            :hideDetails="hideDiagramDetails"
-            :occlusionRect="occlusionRect"
             @rename="
               (f) => {
                 renameOnDiagram(node, f);
@@ -132,12 +132,12 @@ overflow hidden */
             v-for="view in staticRenderViews"
             :key="view.def.id"
             ref="diagramViewRefs"
+            :debug="enableDebugMode"
+            :hideDetails="hideDiagramDetails"
             :isHovered="elementIsHovered(view)"
             :isSelected="elementIsSelected(view)"
-            :view="view.def"
-            :hideDetails="hideDiagramDetails"
             :occlusionRect="occlusionRect"
-            :debug="enableDebugMode"
+            :view="view.def"
           />
           <DiagramEdge
             v-for="edge in viewsStore.edges"
@@ -225,13 +225,13 @@ overflow hidden */
             :connectedEdges="connectedEdgesByElementKey[group.uniqueKey]"
             :debug="enableDebugMode"
             :group="group"
+            :hideDetails="hideDiagramDetails"
             :isHovered="elementIsHovered(group)"
             :isSelected="elementIsSelected(group)"
+            :occlusionRect="occlusionRect"
             :qualificationStatus="
               qualificationStore.qualificationStatusForComponentId(group.def.id)
             "
-            :hideDetails="hideDiagramDetails"
-            :occlusionRect="occlusionRect"
             @rename="
               (f) => {
                 renameOnDiagram(group, f);
@@ -243,15 +243,15 @@ overflow hidden */
             :key="node.uniqueKey"
             :connectedEdges="connectedEdgesByElementKey[node.uniqueKey]"
             :debug="enableDebugMode"
+            :hideDetails="hideDiagramDetails"
             :isHovered="elementIsHovered(node)"
             :isLoading="statusStore.componentIsLoading(node.def.id)"
             :isSelected="elementIsSelected(node)"
             :node="node"
+            :occlusionRect="occlusionRect"
             :qualificationStatus="
               qualificationStore.qualificationStatusForComponentId(node.def.id)
             "
-            :hideDetails="hideDiagramDetails"
-            :occlusionRect="occlusionRect"
             @rename="
               (f) => {
                 renameOnDiagram(node, f);
@@ -262,12 +262,12 @@ overflow hidden */
             v-for="view in dragRenderViews"
             :key="view.def.id"
             ref="diagramViewRefs"
+            :debug="enableDebugMode"
+            :hideDetails="hideDiagramDetails"
             :isHovered="elementIsHovered(view)"
             :isSelected="elementIsSelected(view)"
-            :view="view.def"
-            :hideDetails="hideDiagramDetails"
             :occlusionRect="occlusionRect"
-            :debug="enableDebugMode"
+            :view="view.def"
           />
           <DiagramGroupOverlay
             v-for="group in dragRenderGroups"
@@ -998,6 +998,25 @@ async function onKeyDown(e: KeyboardEvent) {
   ) {
     e.preventDefault();
     modelingEventBus.emit("templateFromSelection");
+  }
+  if (
+    featureFlagsStore.FLOATING_CONNECTION_MENU &&
+    !props.readOnly &&
+    !(e.metaKey || e.ctrlKey) &&
+    e.key === "c"
+  ) {
+    e.preventDefault();
+    componentsStore.eventBus.emit("openConnectionsMenu", {
+      aDirection: undefined,
+      A: {
+        componentId: viewsStore.selectedComponentId ?? undefined,
+        socketId: undefined,
+      },
+      B: {
+        componentId: undefined,
+        socketId: undefined,
+      },
+    });
   }
 }
 

--- a/app/web/src/components/ModelingView/ConnectionMenuSocketList.vue
+++ b/app/web/src/components/ModelingView/ConnectionMenuSocketList.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="flex flex-col basis-1/2 h-full">
+    <div
+      :class="
+        clsx(
+          'flex flex-col grow px-2xs gap-2xs py-3xs',
+          !active && 'text-neutral-400',
+        )
+      "
+    >
+      <div
+        v-for="(item, index) in listItems"
+        :key="index"
+        :class="
+          clsx(
+            'flex gap-xs align-middle items-center',
+            active &&
+              index === localHighlightedIndex &&
+              'bg-action-400 text-white',
+            active &&
+              index !== localHighlightedIndex &&
+              'hover:bg-action-300 hover:text-black',
+            index !== localHighlightedIndex &&
+              item.socket.def.id === selectedSocket?.def.id &&
+              'bg-neutral-600 text-white',
+            'rounded cursor-pointer',
+            'py-xs px-2xs my-0.5',
+          )
+        "
+        @click="emit('select', index)"
+      >
+        <Icon
+          :name="
+            item.socket.def.direction === 'output'
+              ? 'output-socket'
+              : 'input-socket'
+          "
+          size="sm"
+        />
+
+        <span>
+          {{ item.socket.def.label }} on component
+          {{ item.component.def.title }} ({{ item.component.def.schemaName }})
+        </span>
+      </div>
+    </div>
+    <div class="w-full border-t-2 p-xs min-h-[64px]">
+      <div v-if="selectedSocket">
+        {{ selectedSocket?.def.id }}
+        {{ selectedSocket?.def.label }}
+      </div>
+      <div v-else>Select the socket you would like to connect.</div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, PropType } from "vue";
+import clsx from "clsx";
+import { Icon } from "@si/vue-lib/design-system";
+import {
+  DiagramGroupData,
+  DiagramNodeData,
+  DiagramSocketData,
+} from "../ModelingDiagram/diagram_types";
+
+export type SocketListEntry = {
+  component: DiagramNodeData | DiagramGroupData;
+  socket: DiagramSocketData;
+};
+
+const props = defineProps({
+  listItems: {
+    type: Array as PropType<SocketListEntry[]>,
+    default: [] as SocketListEntry[],
+  },
+  selectedSocket: { type: DiagramSocketData },
+  highlightedIndex: { type: Number },
+  active: { type: Boolean },
+});
+const localHighlightedIndex = computed(() =>
+  props.active ? props.highlightedIndex : undefined,
+);
+
+const emit = defineEmits<{
+  (e: "select", index: number): void;
+}>();
+</script>

--- a/app/web/src/components/ModelingView/FloatingConnectionMenu.vue
+++ b/app/web/src/components/ModelingView/FloatingConnectionMenu.vue
@@ -1,0 +1,389 @@
+<template>
+  <Modal ref="popoverRef" size="max" title="Create Connection">
+    <div
+      class="flex flex-col border-2 h-[80vh]"
+      @click="focusOnInput"
+      @keydown.up.prevent="highlightPrev"
+      @keydown.down.prevent="highlightNext"
+      @keydown.enter.prevent="processHighlighted"
+      @keydown.tab.prevent="toggleEditTarget"
+    >
+      <VormInput ref="inputRef" v-model="searchString" label="Search" noLabel />
+      <div class="flex flex-row grow border-t-2">
+        <!-- Socket A -->
+        <ConnectionMenuSocketList
+          :active="activeSide === 'a'"
+          :highlightedIndex="highlightedIndex"
+          :listItems="listAItems"
+          :selectedSocket="selectedSocketA"
+          class="border-r-2"
+          @select="selectA"
+        />
+        <!-- Socket B -->
+        <ConnectionMenuSocketList
+          :active="activeSide === 'b'"
+          :highlightedIndex="highlightedIndex"
+          :listItems="listBItems"
+        />
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<script lang="ts" setup>
+import * as _ from "lodash-es";
+import { VormInput, Modal } from "@si/vue-lib/design-system";
+import {
+  computed,
+  nextTick,
+  onMounted,
+  onUnmounted,
+  reactive,
+  ref,
+  watch,
+} from "vue";
+import {
+  ConnectionMenuData,
+  useComponentsStore,
+} from "@/store/components.store";
+import ConnectionMenuSocketList, {
+  SocketListEntry,
+} from "./ConnectionMenuSocketList.vue";
+
+const popoverRef = ref<InstanceType<typeof Modal>>();
+const inputRef = ref<InstanceType<typeof VormInput>>();
+
+onMounted(() => {
+  componentsStore.eventBus.on("openConnectionsMenu", open);
+});
+
+onUnmounted(() => {
+  componentsStore.eventBus.off("openConnectionsMenu", open);
+});
+
+const componentsStore = useComponentsStore();
+
+const searchString = ref("");
+// const socketKind = ref<"input" | "output" | undefined>();
+
+const listAItems = ref<SocketListEntry[]>([]);
+const listBItems = ref<SocketListEntry[]>([]);
+// const filteredListItems = computed(() =>
+//   listItems.value
+//   // listItems.value.filter((s) => s.def.label.toLowerCase().includes(searchString.value.toLowerCase()))
+// )
+
+const focusOnInput = () => {
+  nextTick(() => {
+    inputRef.value?.focus();
+  });
+};
+
+// Selection data
+const connectionData = reactive<ConnectionMenuData>({
+  aDirection: undefined,
+  A: {
+    componentId: undefined,
+    socketId: undefined,
+  },
+  B: {
+    componentId: undefined,
+    socketId: undefined,
+  },
+});
+
+const invertDirection = (direction?: string) => {
+  switch (direction) {
+    case "input":
+      return "output";
+    case "output":
+      return "input";
+    default:
+      return undefined;
+  }
+};
+
+const bDirection = computed(() => invertDirection(connectionData.aDirection));
+
+const selectedSocketA = computed(() => {
+  if (!connectionData.A.componentId || !connectionData.A.socketId) {
+    return;
+  }
+
+  const component =
+    componentsStore.allComponentsById[connectionData.A.componentId];
+
+  if (!component) return;
+
+  return component.sockets.find((s) => s.def.id === connectionData.A.socketId);
+});
+
+const activeSide = ref<"a" | "b">("a");
+const toggleEditTarget = () => {
+  activeSide.value = activeSide.value === "a" ? "b" : "a";
+};
+
+// TODO only show sockets that have matching annotations
+watch(
+  connectionData,
+  (data) => {
+    let AComponents = data.A.componentId
+      ? _.compact([componentsStore.allComponentsById[data.A.componentId]])
+      : _.values(componentsStore.allComponentsById);
+
+    if (data.B.componentId) {
+      AComponents = AComponents.filter((c) => c.def.id !== data.B.componentId);
+    }
+
+    let aSockets = _.flatten(
+      AComponents?.map((c) =>
+        c.sockets
+          .filter((s) => !s.def.isManagement)
+          .map((s) => ({
+            component: c,
+            socket: s,
+          })),
+      ),
+    );
+
+    if (data.aDirection) {
+      aSockets = aSockets.filter(
+        ({ socket }) => socket.def.direction === data.aDirection,
+      );
+    }
+
+    listAItems.value = aSockets;
+
+    let BComponents = data.B.componentId
+      ? _.compact([componentsStore.allComponentsById[data.B.componentId]])
+      : _.values(componentsStore.allComponentsById);
+
+    if (data.A.componentId) {
+      BComponents = BComponents.filter((c) => c.def.id !== data.A.componentId);
+    }
+
+    let bSockets = _.flatten(
+      BComponents?.map((c) =>
+        c.sockets.map((s) => ({
+          component: c,
+          socket: s,
+        })),
+      ),
+    );
+
+    if (bDirection.value) {
+      bSockets = bSockets.filter(
+        ({ socket }) => socket.def.direction === bDirection.value,
+      );
+    }
+
+    listBItems.value = bSockets;
+
+    // const componentA = componentsStore.allComponentsById[data.A.componentId];
+    //
+    // if (!componentA) {
+    //   listAItems.value = [];
+    //   return;
+    // }
+    //
+    // if (!data.B.componentId) {
+    //   if (!data.A.socketId) {
+    //     const sockets = data.A.direction ? componentA.sockets.filter((s) => s.def.direction === data.A.direction) : componentA.sockets;
+    //
+    //     listAItems.value = sockets.map(s => ({
+    //       component: componentA,
+    //       socket: s,
+    //     }));
+    //
+    //   } else {
+    //     // TODO filter component Bs to only have components that could match the selected socket
+    //     listAItems.value = _.values(componentsStore.allComponentsById)
+    //       .filter(c => c.def.id !== data.A.componentId)
+    //       .map(c => ({
+    //       component: c,
+    //       socket: undefined,
+    //     }));
+    //   }
+
+    //   return;
+    // }
+    //
+    //
+    // const componentB = componentsStore.allComponentsById[data.B.componentId];
+    //
+    // if (!componentB) {
+    //   listAItems.value = [];
+    //   return;
+    // }
+    //
+    // if (!data.A.socketId) {
+    //   // TODO list only sockets that would match between components A and B
+    //   const sockets = data.A.direction ? componentA.sockets.filter((s) => s.def.direction === data.A.direction) : componentA.sockets;
+    //
+    //   listAItems.value = sockets.map(s => ({
+    //     component: componentA,
+    //     socket: s,
+    //   }));
+    //
+    //   return;
+    // }
+    //
+    //
+    // if (data.B.socketId) {
+    //   // TODO something when A and B sockets are selected
+    //   listAItems.value = [];
+    //   const [from, to] = data.A.direction === "output" ?
+    //     [
+    //       { componentId: data.A.componentId, socketId: data.A.socketId},
+    //       { componentId: data.B.componentId, socketId: data.B.socketId},
+    //     ] :
+    //     [
+    //       { componentId: data.B.componentId, socketId: data.B.socketId},
+    //       { componentId: data.A.componentId, socketId: data.A.socketId},
+    //     ];
+    //
+    //   componentsStore.CREATE_COMPONENT_CONNECTION(from, to);
+    //   // FIXME select both components when we show edges between the components that are selected
+    //   componentsStore.eventBus.emit("setSelection", [data.A.componentId]);
+    //
+    //   close();
+    //   return;
+    // }
+    //
+    // // TODO list only sockets that would match socket A
+    // listAItems.value = componentB.sockets
+    //   .map(s => ({
+    //     component: componentB,
+    //     socket: s,
+    //   }));
+  },
+  { immediate: true },
+);
+
+const highlightedIndex = ref(0);
+// Try to keep the selected option selected when list changes, else reset selected to 0
+// watch(filteredListItems, (list, oldList) => {
+//   const oldItem = oldList[selectedIndex.value];
+//
+//   const newId = list.findIndex((i) => i.def.id === oldItem?.def.id);
+//
+//   if (oldItem && newId >= 0) {
+//     selectedIndex.value = newId;
+//     return;
+//   }
+//
+//   selectedIndex.value = 0;
+// })
+
+const highlightNext = () => {
+  const upperLimit =
+    (activeSide.value === "a"
+      ? listAItems.value.length
+      : listBItems.value.length) - 1;
+
+  highlightedIndex.value = Math.min(highlightedIndex.value + 1, upperLimit);
+};
+const highlightPrev = () => {
+  highlightedIndex.value = Math.max(highlightedIndex.value - 1, 0);
+};
+
+const selectA = (index: number) => {
+  highlightedIndex.value = index;
+  processHighlighted();
+};
+
+watch(activeSide, () => {
+  highlightedIndex.value = 0;
+});
+
+const processHighlighted = () => {
+  if (activeSide.value === "a") {
+    const selectedItem = listAItems.value[highlightedIndex.value];
+    if (!selectedItem) return;
+    connectionData.A.socketId = selectedItem.socket.def.id;
+    connectionData.aDirection =
+      selectedItem.socket.def.direction === "bidirectional"
+        ? undefined
+        : selectedItem.socket.def.direction;
+    connectionData.A.componentId = selectedItem.component.def.id;
+  } else {
+    const selectedItem = listBItems.value[highlightedIndex.value];
+    if (!selectedItem) return;
+
+    connectionData.B.socketId = selectedItem.socket.def.id;
+    connectionData.aDirection = invertDirection(
+      selectedItem.socket.def.direction === "bidirectional"
+        ? undefined
+        : selectedItem.socket.def.direction,
+    );
+
+    connectionData.B.componentId = selectedItem.component.def.id;
+  }
+
+  if (
+    connectionData.A.componentId &&
+    connectionData.B.componentId &&
+    connectionData.A.socketId &&
+    connectionData.B.socketId
+  ) {
+    const [from, to] =
+      connectionData.aDirection === "output"
+        ? [
+            {
+              componentId: connectionData.A.componentId,
+              socketId: connectionData.A.socketId,
+            },
+            {
+              componentId: connectionData.B.componentId,
+              socketId: connectionData.B.socketId,
+            },
+          ]
+        : [
+            {
+              componentId: connectionData.B.componentId,
+              socketId: connectionData.B.socketId,
+            },
+            {
+              componentId: connectionData.A.componentId,
+              socketId: connectionData.A.socketId,
+            },
+          ];
+
+    componentsStore.CREATE_COMPONENT_CONNECTION(from, to);
+    // FIXME select both components when we show edges between the components that are selected
+    componentsStore.eventBus.emit("setSelection", [
+      connectionData.A.componentId,
+    ]);
+
+    close();
+  } else {
+    toggleEditTarget();
+  }
+
+  highlightedIndex.value = 0;
+  focusOnInput();
+};
+
+// Modal Mgmt
+function open(initialState: ConnectionMenuData) {
+  popoverRef.value?.open();
+
+  activeSide.value = "a";
+  connectionData.aDirection = initialState.aDirection;
+  connectionData.A = initialState.A;
+  connectionData.B = initialState.B;
+
+  // For some reason nextTick does not work but this does and UX feels fine
+  setTimeout(() => {
+    inputRef.value?.focus();
+  }, 100);
+}
+
+function close() {
+  popoverRef.value?.close();
+}
+
+const isOpen = computed(() => popoverRef.value?.isOpen);
+
+defineExpose({ open, close, isOpen });
+</script>

--- a/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
+++ b/app/web/src/components/ModelingView/ModelingRightClickMenu.vue
@@ -14,17 +14,17 @@
     />
     <Modal
       ref="modalRef"
-      type="save"
-      size="sm"
       saveLabel="Create"
+      size="sm"
       title="Create View"
+      type="save"
       @save="create"
     >
       <VormInput
         ref="labelRef"
         v-model="viewName"
-        required
         label="View Name"
+        required
         @enterPressed="create"
       />
     </Modal>
@@ -298,6 +298,14 @@ const rightClickMenuItems = computed(() => {
       icon: "cursor",
       onSelect: renameComponent,
     });
+    if (featureFlagsStore.FLOATING_CONNECTION_MENU) {
+      items.push({
+        label: "Connections",
+        shortcut: "C",
+        icon: "socket",
+        onSelect: openConnectionsMenu,
+      });
+    }
     if (featureFlagsStore.AUTOCONNECT) {
       items.push({
         label: "Auto Connect",
@@ -547,6 +555,20 @@ function renameComponent() {
   if (selectedComponentId.value) {
     componentsStore.eventBus.emit("rename", selectedComponentId.value);
   }
+}
+
+function openConnectionsMenu() {
+  componentsStore.eventBus.emit("openConnectionsMenu", {
+    aDirection: undefined,
+    A: {
+      componentId: selectedComponentId.value ?? undefined,
+      socketId: undefined,
+    },
+    B: {
+      componentId: undefined,
+      socketId: undefined,
+    },
+  });
 }
 
 function autoConnectComponent() {

--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -2,11 +2,11 @@
 <template>
   <!-- Left Panel - views drawer and outline + asset palette -->
   <section
-    class="absolute flex flex-row h-full"
     :style="{
       left: drawerLeftPos + 'px',
       transition: 'left 0.15s ease-out',
     }"
+    class="absolute flex flex-row h-full"
   >
     <LeftPanelDrawer
       :changeSetId="changeSetsStore.selectedChangeSetId"
@@ -24,8 +24,8 @@
       <template #subpanel1>
         <DiagramOutline
           :actionsAreRunning="actionsAreRunning"
-          :toggleDrawer="toggleDrawer"
           :leftDrawerOpen="presenceStore.leftDrawerOpen"
+          :toggleDrawer="toggleDrawer"
           @right-click-item="onOutlineRightClick"
         />
       </template>
@@ -68,9 +68,9 @@
     <component
       :is="ResizablePanel"
       ref="rightResizablePanelRef"
-      class="h-full"
       :defaultSize="320"
       :minSize="320"
+      class="h-full"
       rememberSizeKey="details-panel"
       side="right"
       @sizeSet="rightPanelSize"
@@ -115,6 +115,7 @@
   <EraseSelectionModal />
   <TemplateSelectionModal />
   <CommandModal />
+  <FloatingConnectionMenu v-if="featureFlagsStore.FLOATING_CONNECTION_MENU" />
 </template>
 
 <script lang="ts" setup>
@@ -139,6 +140,7 @@ import { useRouterStore } from "@/store/router.store";
 import { useAssetStore } from "@/store/asset.store";
 import { useFuncStore } from "@/store/func/funcs.store";
 import { useAuthStore } from "@/store/auth.store";
+import FloatingConnectionMenu from "@/components/ModelingView/FloatingConnectionMenu.vue";
 import LeftPanelDrawer from "../LeftPanelDrawer.vue";
 import ModelingDiagram from "../ModelingDiagram/ModelingDiagram.vue";
 import AssetPalette from "../AssetPalette.vue";

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -164,6 +164,19 @@ export type APIComponentGeometry = {
   height?: string;
 };
 
+export type ConnectionMenuStateEntry = {
+  componentId: ComponentId;
+  socketId: SocketId;
+};
+
+export type ConnectionDirection = "output" | "input";
+
+export type ConnectionMenuData = {
+  aDirection: ConnectionDirection | undefined;
+  A: Partial<ConnectionMenuStateEntry>;
+  B: Partial<ConnectionMenuStateEntry>;
+};
+
 type EventBusEvents = {
   deleteSelection: void;
   restoreSelection: void;
@@ -177,6 +190,7 @@ type EventBusEvents = {
   setSelection: ComponentId[];
   rename: ComponentId;
   renameView: ViewId;
+  openConnectionsMenu: ConnectionMenuData;
 };
 
 export const DEFAULT_COLLAPSED_SIZE = { height: 100, width: 300 };

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -16,6 +16,7 @@ const FLAG_MAPPING = {
   PRIVATE_SCOPED_MODULES: "private-scoped-modules",
   DIAGRAM_DRAG_LAYER: "diagram-drag-layer",
   SOCKET_VALUE: "socket-value",
+  FLOATING_CONNECTION_MENU: "floating-connection-menu",
 };
 
 const WORKSPACE_FLAG_MAPPING = {

--- a/lib/vue-lib/src/design-system/modals/Modal.vue
+++ b/lib/vue-lib/src/design-system/modals/Modal.vue
@@ -58,6 +58,8 @@
                     '4xl': 'max-w-4xl',
                     '4wxl': 'w-[56rem]',
                     '6xl': 'max-w-6xl',
+                    '7xl': 'max-w-7xl',
+                    max: 'max-w-[75vw]',
                   }[size],
                 )
               "
@@ -84,21 +86,21 @@
                   class="py-3 flex flex-row justify-between gap-sm"
                 >
                   <VButton
-                    tone="destructive"
                     buttonRank="tertiary"
                     icon="x"
                     label="Cancel"
-                    variant="ghost"
                     size="xs"
+                    tone="destructive"
+                    variant="ghost"
                     @click="close"
                   />
                   <VButton
                     :disabled="disableSave"
-                    tone="success"
-                    icon="check"
                     :label="saveLabel"
-                    size="xs"
                     class="grow"
+                    icon="check"
+                    size="xs"
+                    tone="success"
                     @click="emit('save')"
                   />
                 </div>
@@ -111,13 +113,13 @@
                 "
               >
                 <DialogTitle
-                  as="p"
                   :class="
                     clsx(
                       'font-medium line-clamp-5 pb-[1px]',
                       capitalizeTitle && 'capitalize',
                     )
                   "
+                  as="p"
                 >
                   <slot name="title">{{ title }}</slot>
                 </DialogTitle>
@@ -167,7 +169,7 @@ const props = defineProps({
   beginOpen: { type: Boolean, default: false },
   size: {
     type: String as PropType<
-      "sm" | "md" | "lg" | "xl" | "2xl" | "4xl" | "4wxl" | "6xl"
+      "sm" | "md" | "lg" | "xl" | "2xl" | "4xl" | "4wxl" | "6xl" | "7xl" | "max"
     >,
     default: "md",
   },


### PR DESCRIPTION
- Type `C` when interacting the diagram to open the connections menu
- Choose a pair of sockets and it should connect
- Stills allows for bad connections to be attempted, this will come in a future PR
- Can be opened up via a commandBuffer event
- Unlocks the diagram changes we need to do for the connections work
- Behind `floating-connection-menu` feature flag

<img width="2051" alt="image" src="https://github.com/user-attachments/assets/fa6fd378-8793-4f83-9095-e234ab1ad443" />
