### PR TITLE
perf(sdf): Make funcs endpoint faster

### DIFF
--- a/lib/dal/src/func/binding/action.rs
+++ b/lib/dal/src/func/binding/action.rs
@@ -152,7 +152,7 @@ impl ActionBinding {
                 .map_err(|_| {
                     SchemaVariantError::PropNotFoundAtPath(variant_id, path.to_string())
                 })?;
-            ts_types.push(prop.ts_type(ctx).await?)
+            ts_types.push(Prop::ts_type(ctx, prop.id()).await?)
         }
         Ok(format!(
             "type Input {{

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -745,8 +745,7 @@ impl AttributeBinding {
                     if let AttributeFuncArgumentSource::Prop(prop_id) =
                         arg.attribute_func_input_location
                     {
-                        let prop = Prop::get_by_id(ctx, prop_id).await?;
-                        let ts_type = prop.ts_type(ctx).await?;
+                        let ts_type = Prop::ts_type(ctx, prop_id).await?;
 
                         if let std::collections::hash_map::Entry::Vacant(e) =
                             argument_types.entry(arg.func_argument_id)
@@ -763,10 +762,7 @@ impl AttributeBinding {
                     let output_type = if let AttributeFuncDestination::Prop(output_prop_id) =
                         attribute.output_location
                     {
-                        Prop::get_by_id(ctx, output_prop_id)
-                            .await?
-                            .ts_type(ctx)
-                            .await?
+                        Prop::ts_type(ctx, output_prop_id).await?
                     } else {
                         "any".to_string()
                     };

--- a/lib/dal/src/func/binding/leaf.rs
+++ b/lib/dal/src/func/binding/leaf.rs
@@ -293,8 +293,8 @@ impl LeafBinding {
         let mut per_variant_types = vec![];
 
         for variant_id in variant_ids {
-            let prop = Prop::find_prop_by_path(ctx, *variant_id, path).await?;
-            let ts_type = prop.ts_type(ctx).await?;
+            let prop_id = Prop::find_prop_id_by_path(ctx, *variant_id, path).await?;
+            let ts_type = Prop::ts_type(ctx, prop_id).await?;
 
             if !per_variant_types.contains(&ts_type) {
                 per_variant_types.push(ts_type);

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -687,14 +687,18 @@ impl NodeWeight {
         }
     }
 
-    pub fn get_prop_node_weight(&self) -> NodeWeightResult<PropNodeWeight> {
+    pub fn as_prop_node_weight(&self) -> NodeWeightResult<&PropNodeWeight> {
         match self {
-            NodeWeight::Prop(inner) => Ok(inner.to_owned()),
+            NodeWeight::Prop(inner) => Ok(inner),
             other => Err(NodeWeightError::UnexpectedNodeWeightVariant(
                 NodeWeightDiscriminants::Prop,
                 other.into(),
             )),
         }
+    }
+
+    pub fn get_prop_node_weight(&self) -> NodeWeightResult<PropNodeWeight> {
+        Ok(self.as_prop_node_weight()?.to_owned())
     }
 
     pub fn get_func_node_weight(&self) -> NodeWeightResult<FuncNodeWeight> {

--- a/lib/dal/src/workspace_snapshot/traits.rs
+++ b/lib/dal/src/workspace_snapshot/traits.rs
@@ -5,5 +5,6 @@
 pub mod approval_requirement;
 pub mod diagram;
 pub mod entity_kind;
+pub mod prop;
 pub mod schema;
 pub mod socket;

--- a/lib/dal/src/workspace_snapshot/traits/prop.rs
+++ b/lib/dal/src/workspace_snapshot/traits/prop.rs
@@ -1,0 +1,115 @@
+use async_trait::async_trait;
+use petgraph::prelude::*;
+use si_id::PropId;
+
+use crate::{
+    prop::PropResult, workspace_snapshot::node_weight::PropNodeWeight, EdgeWeightKindDiscriminants,
+    PropKind, WorkspaceSnapshot, WorkspaceSnapshotGraphVCurrent,
+};
+
+#[async_trait]
+pub trait PropExt {
+    /// Generate a TypeScript type for a prop tree.
+    async fn ts_type(&self, prop_id: PropId) -> PropResult<String>;
+}
+
+#[async_trait]
+impl PropExt for WorkspaceSnapshot {
+    async fn ts_type(&self, prop_id: PropId) -> PropResult<String> {
+        let graph = self.working_copy().await;
+        let index = graph.get_node_index_by_id(prop_id)?;
+        let node = graph.get_node_weight(index)?.as_prop_node_weight()?;
+        let mut result = String::new();
+        append_ts_type(&graph, node, index, &mut result)?;
+        Ok(result)
+    }
+}
+
+fn append_ts_type(
+    graph: &WorkspaceSnapshotGraphVCurrent,
+    node: &PropNodeWeight,
+    index: NodeIndex,
+    buf: &mut String,
+) -> PropResult<()> {
+    /// Check if the parent of the given node has the specified path.
+    fn parent_has_path(
+        graph: &WorkspaceSnapshotGraphVCurrent,
+        index: NodeIndex,
+        path: &[&str],
+    ) -> PropResult<bool> {
+        // Get the parent
+        let parent_index = graph.get_edge_weight_kind_target_idx_opt(
+            index,
+            Incoming,
+            EdgeWeightKindDiscriminants::Use,
+        )?;
+
+        // If the path is empty, we match iff there is no parent
+        let Some((&name, parent_path)) = path.split_last() else {
+            return Ok(parent_index.is_none());
+        };
+
+        // If the path is non-empty, but we have a parent, we don't match
+        let Some(parent_index) = parent_index else {
+            return Ok(false);
+        };
+
+        let node = graph.get_node_weight(parent_index)?.as_prop_node_weight()?;
+        Ok(name == node.name() && parent_has_path(graph, parent_index, parent_path)?)
+    }
+
+    // Special cases
+    if node.name() == "status" && parent_has_path(graph, index, &["root", "resource"])? {
+        buf.push_str("'ok' | 'warning' | 'error' | undefined | null");
+        return Ok(());
+    }
+    if node.name() == "payload" && parent_has_path(graph, index, &["root", "resource"])? {
+        buf.push_str("any");
+        return Ok(());
+    }
+
+    match node.kind() {
+        PropKind::Array => {
+            append_ts_element_type(graph, index, buf)?;
+            buf.push_str("[]");
+        }
+        PropKind::Boolean => buf.push_str("boolean"),
+        PropKind::Float | PropKind::Integer => buf.push_str("number"),
+        PropKind::Json => buf.push_str("any"),
+        PropKind::Map => {
+            buf.push_str("Record<string, ");
+            append_ts_element_type(graph, index, buf)?;
+            buf.push('>');
+        }
+        PropKind::Object => {
+            buf.push_str("{\n");
+            for child_index in graph.ordered_children_for_node(index)?.unwrap_or(vec![]) {
+                let child_node = graph.get_node_weight(child_index)?.as_prop_node_weight()?;
+                buf.push_str(&serde_json::to_string(child_node.name())?);
+                buf.push_str("?: ");
+                append_ts_type(graph, child_node, child_index, buf)?;
+                buf.push_str(" | null;\n");
+            }
+            buf.push('}');
+        }
+        PropKind::String => buf.push_str("string"),
+    };
+    Ok(())
+}
+
+/// Generate a TypeScript type for the element type of an array or map.
+fn append_ts_element_type(
+    graph: &WorkspaceSnapshotGraphVCurrent,
+    parent_index: NodeIndex,
+    buf: &mut String,
+) -> PropResult<()> {
+    let element_prop_index = graph.get_edge_weight_kind_target_idx(
+        parent_index,
+        Outgoing,
+        EdgeWeightKindDiscriminants::Use,
+    )?;
+    let element_prop_node = graph
+        .get_node_weight(element_prop_index)?
+        .as_prop_node_weight()?;
+    append_ts_type(graph, element_prop_node, element_prop_index, buf)
+}

--- a/lib/dal/tests/integration_test/func.rs
+++ b/lib/dal/tests/integration_test/func.rs
@@ -84,10 +84,8 @@ async fn get_ts_type_from_root(ctx: &mut DalContext) {
     let root_prop_id = SchemaVariant::get_root_prop_id(ctx, schema_variant_id)
         .await
         .expect("could not get root prop id");
-    let root_prop = Prop::get_by_id(ctx, root_prop_id)
-        .await
-        .expect("could not get prop by id");
-
     // TODO(nick): check that the ts type is right!
-    let _ts_type = root_prop.ts_type(ctx).await.expect("could not get ts type");
+    let _ts_type = Prop::ts_type(ctx, root_prop_id)
+        .await
+        .expect("could not get ts type");
 }


### PR DESCRIPTION
This PR speeds up the /funcs endpoint by 4x on my 33-asset workspace locally (from 2.4s -> 0.6s warm, and 5.6s -> 2.9s cold). It does this by speeding up `prop.ts_type()`, which is frequently called. The changes, and their rough impact percentage-wise (the above numbers are for main, and the 17s numbers below relate to my other PR, which had slowed things down by calling ts_type() even more):

* 17s -> 4.7s: Eliminating CAS loads by traversing the graph using `PropId` instead of loading a full `Prop` for each prop in the tree brought a 3-4x improvement.
* 4.7s -> 2.7s: Eliminating #[async_recursion] and await boundaries in the prop tree by holding a lock (SnapshotReadGuard) and traversing the prop tree synchronously bought us another 1.5-2x improvement.
* 2.7s -> 2.6s: Decreasing allocation by building up the type in a String buffer (as opposed to building and concatenating lots of little Strings) bought us a consistent 4-5% or so.
* 2.6s: Moving from ulid/PropId to NodeIndex has negligible performance impact; this PR does it simply because our synchronous graph interface runs largely in terms of NodeIndexes.

One minor change is, it also turns `prop.ts_type()` -> `Prop::ts_type(PropId)`, as it turns out callers only load the root prop in order to call ts_type().

## Testing

* [X] Existing tests: this is a perf-only change, designed to yield the same results as before
* [X] Manual tests: make sure TS types show correctly in editor. Pay particular attention to resource.status and resource.payload, since they are special cases.