### PR TITLE
feat(dal,web): Enable users to select which connections they want to create if Autoconnect detects too many options

### DIFF
--- a/app/web/src/api/sdf/dal/component.ts
+++ b/app/web/src/api/sdf/dal/component.ts
@@ -7,6 +7,7 @@ import { ComponentType } from "@/api/sdf/dal/schema";
 import { ViewDescription, ViewId } from "@/api/sdf/dal/views";
 import {
   DiagramSocketDef,
+  DiagramSocketDirection,
   Size2D,
 } from "@/components/ModelingDiagram/diagram_types";
 
@@ -88,3 +89,18 @@ export type Edge = RawEdge & {
   isInferred: boolean;
   isManagement?: boolean;
 };
+
+export interface PotentialConnection {
+  socketId: SocketId;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any | null;
+  attributeValueId: string;
+  direction: DiagramSocketDirection;
+  matches: PotentialMatch[];
+}
+export interface PotentialMatch {
+  socketId: SocketId;
+  componentId: ComponentId;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any | null;
+}

--- a/app/web/src/components/ModelingDiagram/diagram_types.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_types.ts
@@ -393,6 +393,8 @@ export type DiagramNodeDef = {
   resourceId: string;
 };
 
+export type DiagramSocketDirection = "input" | "output" | "bidirectional";
+
 export type DiagramSocketDef = {
   /** unique id of the socket - should be unique across all sockets */
   id: DiagramElementId;
@@ -401,7 +403,7 @@ export type DiagramSocketDef = {
   /** socket can only connect with sockets with compatible annotations */
   connectionAnnotations: ConnectionAnnotation[];
   /** direction of data flow from this socket */
-  direction: "input" | "output" | "bidirectional";
+  direction: DiagramSocketDirection;
   /** arity / max number of connections - null = no limit (most will likely be either 1 or null) */
   maxConnections: number | null;
   /** is a connection required to be valid - will affect display */

--- a/app/web/src/components/ModelingView/AutoconnectMenu.vue
+++ b/app/web/src/components/ModelingView/AutoconnectMenu.vue
@@ -1,0 +1,583 @@
+<template>
+  <Modal
+    ref="modalRef"
+    title="Refactor Component Connections"
+    size="2xl"
+    noAutoFocus
+    class="max-w-[75vw] overflow-hidden"
+  >
+    <div
+      v-if="autoconnectData"
+      class="mx-auto my-4 w-full max-w-3xl flex flex-col"
+      style="max-height: 70vh"
+    >
+      <!-- HEADER -->
+      <div class="mb-sm flex-col flex">
+        <div v-if="createdConnections > 0" class="px-xs py-2xs">
+          Created {{ createdConnections }} connections for
+          {{ autoconnectData.componentName }}
+        </div>
+        <div v-else class="px-xs py-2xs">
+          Couldn't automatically create any connections for
+          {{ autoconnectData.componentName }}.
+        </div>
+        <div
+          v-if="(autoconnectData?.potentialConnections?.length ?? 0) > 0"
+          class="px-xs py-2xs"
+        >
+          Here are the potential connections found that match. For each manually
+          set value you wish to replace, choose the correct connection.
+        </div>
+      </div>
+
+      <div class="flex-1 overflow-y-auto space-y-4">
+        <div
+          v-for="connection in autoconnectData?.potentialConnections ?? []"
+          :key="connection.socketId"
+          class="border dark:border-neutral-700 border-neutral-200 my-xs"
+        >
+          <div v-if="connection && connection.processingConnections.length > 0">
+            <!-- Header for each socket with potential connections -->
+            <div
+              :class="
+                clsx(
+                  'px-3 py-2 cursor-pointer flex items-center justify-between',
+                  {
+                    'bg-warning-600':
+                      selectedConnections[connection.socketId]?.state ===
+                      'hasSelections',
+                    'bg-neutral-100 dark:bg-neutral-800':
+                      selectedConnections[connection.socketId]?.state ===
+                      'empty',
+                    'bg-success-600':
+                      selectedConnections[connection.socketId]?.state ===
+                      'satisfied',
+                  },
+                )
+              "
+              @click="toggleCollapse(connection.socketId)"
+            >
+              Input Socket: {{ connection.socketName }}
+              <Icon
+                :name="
+                  expandedConnections.includes(connection.socketId)
+                    ? 'chevron--down'
+                    : 'chevron--right'
+                "
+                size="sm"
+              />
+            </div>
+            <transition name="expand">
+              <div
+                v-show="expandedConnections.includes(connection.socketId)"
+                class="p-3 space-y-4"
+              >
+                <!-- SINGLE-ARITY SOCKET-->
+
+                <div v-if="connection.socketArity === 'one'">
+                  <p class="text-sm text-gray-500 mb-1">
+                    Click a row below to select exactly one match:
+                  </p>
+                  <div
+                    class="grid grid-cols-3 gap-2 font-semibold border-b py-2"
+                  >
+                    <div>Component Name</div>
+                    <div>Asset Name</div>
+                    <div>Socket Name</div>
+                  </div>
+                  <div
+                    v-for="match in connection.processingConnections"
+                    :key="match.key"
+                    :class="clsx(
+                    'grid grid-cols-3 p-2 border-b last:border-b-0 cursor-pointer',
+                    (selectedConnections[connection.socketId] as SingleConnectionState).socketId === match.key ? ['bg-action-100 dark:bg-action-700',] :
+                      ['dark:hover:text-action-300 hover:text-action-500',
+                        'bg-neutral-100 dark:bg-neutral-700 group'
+                      ]
+                  )"
+                    @click="
+                      selectSingleConnection(connection.socketId, match.key)
+                    "
+                  >
+                    <div>{{ match.componentName }}</div>
+                    <div>{{ match.schemaVariantName }}</div>
+                    <div>
+                      <TruncateWithTooltip>
+                        {{ match.socketName }}
+                      </TruncateWithTooltip>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- MANY-ARITY SOCKET -->
+                <div v-else>
+                  <!-- Toggle for 'bulk' vs 'individual' if both are available -->
+                  <div
+                    v-if="
+                      bulkMatches(connection).length > 0 &&
+                      canDoIndividual(connection)
+                    "
+                    class="flex space-x-4 mb-2"
+                  >
+                    <label class="inline-flex items-center">
+                      <input
+                        v-model="(selectedConnections[connection.socketId] as ManyConnectionState).mode"
+                        type="radio"
+                        value="bulk"
+                        class="mr-1"
+                      />
+                      Bulk (one connection for entire array)
+                    </label>
+                    <label class="inline-flex items-center">
+                      <input
+                        v-model="(selectedConnections[connection.socketId] as ManyConnectionState).mode"
+                        type="radio"
+                        value="individual"
+                        class="mr-1"
+                      />
+                      Individual (create connection per entry)
+                    </label>
+                  </div>
+
+                  <!-- Bulk mode: pick exactly one option to use for the entire array -->
+                  <div
+                    v-if="(selectedConnections[connection.socketId] as ManyConnectionState).mode === 'bulk'"
+                  >
+                    <p class="text-sm text-gray-500 mb-1">
+                      Click a row below to select one match for the entire
+                      array.
+                    </p>
+                    <div
+                      class="grid grid-cols-3 gap-2 font-semibold border-b py-2"
+                    >
+                      <div>Component Name</div>
+                      <div>Asset Name</div>
+                      <div>Socket Name</div>
+                    </div>
+                    <div
+                      v-for="match in bulkMatches(connection)"
+                      :key="match.key"
+                      :class="
+                        clsx(
+                          'grid grid-cols-3 p-2 border-b last:border-b-0 cursor-pointer',
+                          selectedConnections[connection.socketId]?.socketId ===
+                            match.key
+                            ? ['bg-action-100 dark:bg-action-700']
+                            : [
+                                'dark:hover:text-action-300 hover:text-action-500',
+                                'bg-neutral-100 dark:bg-neutral-700 group',
+                              ],
+                        )
+                      "
+                      @click="
+                        selectSingleConnection(connection.socketId, match.key)
+                      "
+                    >
+                      <div>{{ match.componentName }}</div>
+                      <div>{{ match.schemaVariantName }}</div>
+                      <div>
+                        <TruncateWithTooltip>
+                          {{ match.socketName }}
+                        </TruncateWithTooltip>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Individual mode: pick a row for each entry in the array -->
+                  <div v-else class="space-y-2">
+                    <p class="text-sm text-gray-500 mb-1">
+                      For each value, choose which connection should be made:
+                    </p>
+
+                    <div
+                      v-for="(item, idx) in (connection.value as [])"
+                      :key="idx"
+                      class="p-2 bg-neutral-100 dark:bg-neutral-800"
+                    >
+                      <div class="mb-1 text-md font-semibold p-xs">
+                        <TruncateWithTooltip>
+                          "{{ item }}"
+                        </TruncateWithTooltip>
+                      </div>
+                      <div
+                        class="grid grid-cols-3 gap-2 font-semibold border-b py-2"
+                      >
+                        <div>Component Name</div>
+                        <div>Asset Name</div>
+                        <div>Socket Name</div>
+                      </div>
+                      <div
+                        v-for="match in filteredMatches(connection, item)"
+                        :key="match.key"
+                        :class="clsx(
+                        'grid grid-cols-3 p-2 border-b last:border-b-0 cursor-pointer',
+                        (selectedConnections[connection.socketId] as ManyConnectionState).outputsPerIndex[idx] === match.key ? ['bg-action-100 dark:bg-action-700',] :
+                          ['dark:hover:text-action-300 hover:text-action-500',
+                            'bg-neutral-100 dark:bg-neutral-700 group'
+                          ]
+                      )"
+                        @click="
+                          selectIndividualOfMany(
+                            connection.socketId,
+                            idx,
+                            match.key,
+                          )
+                        "
+                      >
+                        <div>{{ match.componentName }}</div>
+                        <div>{{ match.schemaVariantName }}</div>
+                        <div>
+                          <TruncateWithTooltip>
+                            {{ match.socketName }}
+                          </TruncateWithTooltip>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </transition>
+          </div>
+        </div>
+      </div>
+      <!-- Footer button section -->
+      <div class="flex justify-end mt-sm">
+        <div class="flex flex-row gap-sm pt-sm">
+          <VButton
+            icon="x"
+            label="Cancel"
+            tone="shade"
+            variant="ghost"
+            @click="close"
+          />
+          <VButton
+            class="flex-grow"
+            icon="plus"
+            label="Create Connection(s)"
+            tone="action"
+            :disabled="!canCreateAllConnections"
+            @click="makeConnections"
+          />
+        </div>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import * as _ from "lodash-es";
+import {
+  Modal,
+  useModal,
+  VButton,
+  TruncateWithTooltip,
+  Icon,
+} from "@si/vue-lib/design-system";
+import clsx from "clsx";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { storeToRefs } from "pinia";
+import {
+  PotentialConnectionData,
+  PotentialConnectionMatchData,
+  useComponentsStore,
+} from "@/store/components.store";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
+
+const componentsStore = useComponentsStore();
+const featureFlagsStore = useFeatureFlagsStore();
+
+const { autoconnectData } = storeToRefs(componentsStore);
+
+const modalRef = ref<InstanceType<typeof Modal>>();
+const { open: openModal, close: closeModal } = useModal(modalRef);
+
+const errorMessages = ref<string[]>([]);
+
+// Count how many were created
+const createdConnections = computed(
+  () => autoconnectData.value?.createdConnections ?? 0,
+);
+
+// For collapsible panels: track which socket IDs are expanded
+const expandedConnections = ref<string[]>([]);
+function toggleCollapse(key: string) {
+  if (expandedConnections.value.includes(key)) {
+    expandedConnections.value = expandedConnections.value.filter(
+      (id) => id !== key,
+    );
+  } else {
+    expandedConnections.value.push(key);
+  }
+}
+
+// Storing state for user selections
+type SingleConnectionState = {
+  type: "single";
+  socketId: string | null;
+  state: "empty" | "hasSelections" | "satisfied";
+};
+
+type ManyConnectionState = {
+  type: "many";
+  mode: "bulk" | "individual";
+  socketId: string | null;
+  outputsPerIndex: (string | null)[];
+  state: "empty" | "hasSelections" | "satisfied";
+};
+
+type ConnectionState = SingleConnectionState | ManyConnectionState;
+
+const selectedConnections = ref<Record<string, ConnectionState>>({});
+
+// Single-arity OR Many-arity + "bulk mode": user clicks a single row => store that selection
+function selectSingleConnection(socketId: string, key: string) {
+  const st = selectedConnections.value[socketId];
+  if (st) {
+    st.socketId = key;
+    st.state = "satisfied";
+  }
+}
+
+// Many-arity / "individual": user clicks a row for a given index
+function selectIndividualOfMany(socketId: string, index: number, key: string) {
+  const st = selectedConnections.value[socketId];
+  if (st && st.type === "many") {
+    st.outputsPerIndex[index] = key;
+    if (st.outputsPerIndex.every((id) => id != null)) {
+      st.state = "satisfied";
+    } else if (st.outputsPerIndex.filter((id) => id != null).length > 0) {
+      st.state = "hasSelections";
+    }
+  }
+}
+// Many-arity + "bulk mode": return only the matches that can handle the entire array's value.
+// Ex: if "connection.value = [1,2,3]"
+// then we only return matches whose "match.value" is also [1,2,3] (or [2,1,3] for that matter)
+function bulkMatches(connection: PotentialConnectionData) {
+  if (!Array.isArray(connection.value)) return [];
+  return connection.processingConnections.filter((m) => {
+    // Compare m.value to connection.value however you define "matches the entire array."
+    // Simple example: arrays must be identical
+    return arraysAreEqual(m.value, connection.value);
+  });
+}
+
+// For "individual": "item" is the array entry - Return only matches whose value that match the item in question
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function filteredMatches(connection: PotentialConnectionData, item: any) {
+  return connection.processingConnections.filter((m) => {
+    return m.value === item;
+  });
+}
+
+// For "individual": check if each item in the array has at least one match
+function canDoIndividual(connection: PotentialConnectionData) {
+  if (!Array.isArray(connection.value) || !connection.value.length)
+    return false;
+  for (const item of connection.value) {
+    // If no matches for this `item`, individual fails
+    if (filteredMatches(connection, item).length === 0) return false;
+  }
+  return true;
+}
+
+// whether we're ready to hit the button or not!
+const canCreateAllConnections = computed(() => {
+  if (!autoconnectData.value) return false;
+
+  const hasAnySelections = autoconnectData.value.potentialConnections.some(
+    (connection) =>
+      selectedConnections.value[connection.socketId]?.state === "hasSelections",
+  );
+
+  const hasAnySatisfied = autoconnectData.value.potentialConnections.some(
+    (connection) =>
+      selectedConnections.value[connection.socketId]?.state === "satisfied",
+  );
+
+  return !hasAnySelections && hasAnySatisfied;
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function arraysAreEqual(a: any[], b: any[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((val) =>
+    b.some((bVal) => JSON.stringify(val) === JSON.stringify(bVal)),
+  );
+}
+
+// Loop through all selections and create those connections!
+// TODO(brit): rethink how we make connections and expose potential errors. This isn't used yet.
+const makeConnections = async () => {
+  errorMessages.value = [];
+  if (!autoconnectData.value) return;
+
+  for (const connection of autoconnectData.value.potentialConnections) {
+    if (selectedConnections.value[connection.socketId]?.state === "empty") {
+      continue;
+    }
+    try {
+      await connectThisSocket(connection);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      errorMessages.value.push(
+        `Error on socket ${connection.socketName}: ${err.message || err}`,
+      );
+    }
+  }
+
+  // If no errors, we can close the modal
+  // TODO(brit): BUT WHAT IF THERE ARE ERRORS? A tomorrow problem for now
+  if (!errorMessages.value.length) {
+    close();
+  }
+};
+
+// handles grabbing the selections to make connections for
+async function connectThisSocket(connection: PotentialConnectionData) {
+  const mainComponentId = autoconnectData.value?.componentId;
+  if (!mainComponentId) return;
+  const st = selectedConnections.value[connection.socketId];
+  if (!st) return;
+  if (connection.socketArity === "one") {
+    // Single: find the chosen match
+    const chosenKey = (st as SingleConnectionState).socketId;
+    if (!chosenKey) return; // no selection?
+    const chosenMatch = connection.processingConnections.find(
+      (m) => m.key === chosenKey,
+    );
+    if (!chosenMatch)
+      throw new Error(`Cannot find match for key: ${chosenKey}`);
+    // Actually create the connection
+    await doCreateConnection(connection, chosenMatch, mainComponentId);
+  } else {
+    // Many
+    const manySt = st as ManyConnectionState;
+    if (manySt.mode === "bulk") {
+      const chosenKey = manySt.socketId;
+      if (!chosenKey) return;
+      const chosenMatch = connection.processingConnections.find(
+        (m) => m.key === chosenKey,
+      );
+      if (!chosenMatch)
+        throw new Error(`Cannot find bulk match for key: ${chosenKey}`);
+      await doCreateConnection(connection, chosenMatch, mainComponentId);
+    } else {
+      // individual
+      for (let i = 0; i < manySt.outputsPerIndex.length; i++) {
+        const mk = manySt.outputsPerIndex[i];
+        if (!mk) continue; // skip unselected
+        const chosenMatch = connection.processingConnections.find(
+          (m) => m.key === mk,
+        );
+        if (!chosenMatch)
+          throw new Error(`Cannot find match for key: ${mk}, index ${i}`);
+        await doCreateConnection(connection, chosenMatch, mainComponentId);
+      }
+    }
+  }
+}
+
+// handles actually creating the connection based on direction
+async function doCreateConnection(
+  connection: PotentialConnectionData,
+  potentialConnection: PotentialConnectionMatchData,
+  mainComponentId: string,
+) {
+  // If direction is "input", "from" is potentialConnection; "to" is main component
+  const to =
+    connection.direction === "input"
+      ? { componentId: mainComponentId, socketId: connection.socketId }
+      : {
+          componentId: potentialConnection.componentId,
+          socketId: potentialConnection.socketId,
+        };
+
+  const from =
+    connection.direction === "input"
+      ? {
+          componentId: potentialConnection.componentId,
+          socketId: potentialConnection.socketId,
+        }
+      : { componentId: mainComponentId, socketId: connection.socketId };
+
+  // Actually create the connection in the store
+  const resp = await componentsStore.OVERRIDE_WITH_CONNECTION(
+    from,
+    to,
+    connection.attributeValueId,
+  );
+  return resp;
+}
+
+function initializeSelections() {
+  const map: Record<string, ConnectionState> = {};
+
+  if (!autoconnectData.value) return;
+
+  for (const pc of autoconnectData.value.potentialConnections) {
+    if (pc.socketArity === "one") {
+      // Single arity
+      map[pc.socketId] = { type: "single", socketId: null, state: "empty" };
+    } else {
+      // Many arity
+      const arrayLength = Array.isArray(pc.value) ? pc.value.length : 0;
+      const isBulkCapable = bulkMatches(pc).length > 0;
+      const isIndividualCapable = canDoIndividual(pc);
+
+      let initialMode: "bulk" | "individual";
+      if (isBulkCapable && isIndividualCapable) {
+        // Both are possible => let's pick "bulk" by default
+        initialMode = "bulk";
+      } else if (isBulkCapable) {
+        initialMode = "bulk";
+      } else {
+        // default to individual if bulk not possible
+        initialMode = "individual";
+      }
+
+      map[pc.socketId] = {
+        type: "many",
+        mode: initialMode,
+        socketId: null,
+        outputsPerIndex: Array(arrayLength).fill(null),
+        state: "empty",
+      };
+    }
+  }
+
+  selectedConnections.value = map;
+}
+
+const open = () => {
+  // If feature flag is off or no potential connections, do nothing
+  if (!featureFlagsStore.AUTOCONNECT) return;
+  if (
+    !autoconnectData.value ||
+    autoconnectData.value.potentialConnections.length === 0
+  )
+    return;
+
+  openModal();
+  initializeSelections();
+};
+
+const close = () => {
+  // clear state on close
+  autoconnectData.value = null;
+  selectedConnections.value = {};
+  expandedConnections.value = [];
+  closeModal();
+};
+
+// Event bus wiring for opening
+const modelingEventBus = componentsStore.eventBus;
+onMounted(() => {
+  modelingEventBus.on("autoconnectComponent", open);
+});
+onBeforeUnmount(() => {
+  modelingEventBus.off("autoconnectComponent", close);
+});
+
+defineExpose({ open, close });
+</script>

--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -114,6 +114,7 @@
   <RestoreSelectionModal />
   <EraseSelectionModal />
   <TemplateSelectionModal />
+  <AutoconnectMenu v-if="featureFlagsStore.AUTOCONNECT" />
   <CommandModal />
 </template>
 
@@ -141,6 +142,7 @@ import { useFuncStore } from "@/store/func/funcs.store";
 import { useAuthStore } from "@/store/auth.store";
 import LeftPanelDrawer from "../LeftPanelDrawer.vue";
 import ModelingDiagram from "../ModelingDiagram/ModelingDiagram.vue";
+import AutoconnectMenu from "../ModelingView/AutoconnectMenu.vue";
 import AssetPalette from "../AssetPalette.vue";
 import {
   DiagramElementData,

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -9,13 +9,13 @@ use dal::{Component, DalContext, Schema, SchemaVariant};
 use dal_test::expected::{self, ExpectComponent};
 use dal_test::helpers::{
     create_component_for_default_schema_name_in_default_view,
-    create_component_for_schema_variant_on_default_view, update_attribute_value_for_component,
-    ChangeSetTestHelpers,
+    create_component_for_schema_variant_on_default_view, ChangeSetTestHelpers,
 };
 use dal_test::{test, Result};
 use pretty_assertions_sorted::assert_eq;
 use serde_json::json;
 
+mod autoconnect;
 mod debug;
 mod delete;
 mod get_code;
@@ -625,44 +625,6 @@ async fn set_the_universe(ctx: &mut DalContext) -> Result<()> {
         .expect("has a view");
 
     assert_eq!(universe_json, view);
-
-    Ok(())
-}
-
-#[test]
-async fn autoconnect(ctx: &mut DalContext) -> Result<()> {
-    let even =
-        create_component_for_default_schema_name_in_default_view(ctx, "small even lego", "even")
-            .await?;
-    let odd =
-        create_component_for_default_schema_name_in_default_view(ctx, "small odd lego", "odd")
-            .await?;
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
-
-    // update both sides attribute values
-    update_attribute_value_for_component(
-        ctx,
-        even.id(),
-        &["root", "domain", "one"],
-        serde_json::json!["1"],
-    )
-    .await?;
-    update_attribute_value_for_component(
-        ctx,
-        odd.id(),
-        &["root", "domain", "one"],
-        serde_json::json!["1"],
-    )
-    .await?;
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
-
-    // now let's autoconnect!
-    Component::autoconnect(ctx, odd.id()).await?;
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
-
-    let incoming = Component::incoming_connections_for_id(ctx, odd.id()).await?;
-    assert!(!incoming.is_empty());
-    assert!(incoming.len() == 1);
 
     Ok(())
 }

--- a/lib/dal/tests/integration_test/component/autoconnect.rs
+++ b/lib/dal/tests/integration_test/component/autoconnect.rs
@@ -1,0 +1,452 @@
+use dal::func::argument::FuncArgument;
+use dal::func::binding::attribute::AttributeBinding;
+use dal::func::binding::{
+    AttributeArgumentBinding, AttributeFuncArgumentSource, AttributeFuncDestination, EventualParent,
+};
+use dal::prop::{Prop, PropPath};
+use dal::schema::variant::authoring::VariantAuthoringClient;
+use dal::{AttributeValue, Func, InputSocket};
+use dal::{Component, DalContext, Schema};
+use dal_test::helpers::{
+    create_component_for_default_schema_name_in_default_view,
+    create_component_for_schema_variant_on_default_view, update_attribute_value_for_component,
+    ChangeSetTestHelpers,
+};
+use dal_test::{test, Result};
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn autoconnect_basic(ctx: &mut DalContext) -> Result<()> {
+    let even =
+        create_component_for_default_schema_name_in_default_view(ctx, "small even lego", "even")
+            .await?;
+    let odd =
+        create_component_for_default_schema_name_in_default_view(ctx, "small odd lego", "odd")
+            .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // update both sides attribute values
+    update_attribute_value_for_component(
+        ctx,
+        even.id(),
+        &["root", "domain", "one"],
+        serde_json::json!["1"],
+    )
+    .await?;
+    update_attribute_value_for_component(
+        ctx,
+        odd.id(),
+        &["root", "domain", "one"],
+        serde_json::json!["1"],
+    )
+    .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // now let's autoconnect!
+    Component::autoconnect(ctx, odd.id()).await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    let incoming = Component::incoming_connections_for_id(ctx, odd.id()).await?;
+    assert!(!incoming.is_empty());
+    assert!(incoming.len() == 1);
+
+    Ok(())
+}
+
+#[test]
+async fn autoconnect_multiple_options(ctx: &mut DalContext) -> Result<()> {
+    let even =
+        create_component_for_default_schema_name_in_default_view(ctx, "small even lego", "even")
+            .await?;
+    let even_2 =
+        create_component_for_default_schema_name_in_default_view(ctx, "small even lego", "even 2")
+            .await?;
+    let odd =
+        create_component_for_default_schema_name_in_default_view(ctx, "small odd lego", "odd")
+            .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // update both sides attribute values for all components
+    update_attribute_value_for_component(
+        ctx,
+        even.id(),
+        &["root", "domain", "one"],
+        serde_json::json!["1"],
+    )
+    .await?;
+
+    update_attribute_value_for_component(
+        ctx,
+        even_2.id(),
+        &["root", "domain", "one"],
+        serde_json::json!["1"],
+    )
+    .await?;
+    update_attribute_value_for_component(
+        ctx,
+        odd.id(),
+        &["root", "domain", "one"],
+        serde_json::json!["1"],
+    )
+    .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // now let's autoconnect!
+    let (created_connections, potential_connections) =
+        Component::autoconnect(ctx, odd.id()).await?;
+
+    assert!(created_connections.is_empty());
+    assert!(potential_connections.len() == 1);
+
+    // Get first key and first value
+    let first_key = potential_connections.keys().next().unwrap();
+
+    // there should be two potential connections
+    let (mut potential_connections, _) = potential_connections
+        .get(first_key)
+        .expect("no potential connections found")
+        .clone();
+    assert_eq!(potential_connections.len(), 2);
+
+    // create one arbitrarily
+    let (component_id, output_socket_id, _value) = potential_connections
+        .pop()
+        .expect("failed to pop potential connection");
+    // Reset default prototype and create connection
+    AttributeValue::use_default_prototype(ctx, first_key.attribute_value_id)
+        .await
+        .expect("failed to reset default prototype");
+    Component::connect(
+        ctx,
+        component_id,
+        output_socket_id,
+        first_key.component_id,
+        first_key.input_socket_id,
+    )
+    .await
+    .expect("failed to create connection");
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // now run autconnect again, shouldn't return any potential connections now!
+    let (created_connections, potential_connections) =
+        Component::autoconnect(ctx, odd.id()).await?;
+    assert!(created_connections.is_empty());
+    assert!(potential_connections.is_empty());
+
+    let incoming = Component::incoming_connections_for_id(ctx, odd.id()).await?;
+    assert!(!incoming.is_empty());
+    assert!(incoming.len() == 1);
+
+    Ok(())
+}
+
+#[test]
+async fn autoconnect_multiple_incoming_connections(ctx: &mut DalContext) -> Result<()> {
+    let small_even =
+        create_component_for_default_schema_name_in_default_view(ctx, "small even lego", "even")
+            .await?;
+    let small_even_2 =
+        create_component_for_default_schema_name_in_default_view(ctx, "small even lego", "even 2")
+            .await?;
+    let medium_even =
+        create_component_for_default_schema_name_in_default_view(ctx, "medium even lego", "even")
+            .await?;
+    let medium_even_2 =
+        create_component_for_default_schema_name_in_default_view(ctx, "medium even lego", "even 2")
+            .await?;
+
+    let odd =
+        create_component_for_default_schema_name_in_default_view(ctx, "medium odd lego", "odd")
+            .await?;
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // update both sides attribute values for all components
+
+    // small even matches one
+    update_attribute_value_for_component(
+        ctx,
+        small_even.id(),
+        &["root", "domain", "one"],
+        serde_json::json!["1"],
+    )
+    .await?;
+
+    update_attribute_value_for_component(
+        ctx,
+        small_even_2.id(),
+        &["root", "domain", "one"],
+        serde_json::json!["1"],
+    )
+    .await?;
+    update_attribute_value_for_component(
+        ctx,
+        odd.id(),
+        &["root", "domain", "one"],
+        serde_json::json!["1"],
+    )
+    .await?;
+
+    // medium even matches three
+    update_attribute_value_for_component(
+        ctx,
+        medium_even.id(),
+        &["root", "domain", "three"],
+        serde_json::json!["3"],
+    )
+    .await?;
+
+    update_attribute_value_for_component(
+        ctx,
+        medium_even_2.id(),
+        &["root", "domain", "three"],
+        serde_json::json!["3"],
+    )
+    .await?;
+
+    update_attribute_value_for_component(
+        ctx,
+        odd.id(),
+        &["root", "domain", "three"],
+        serde_json::json!["3"],
+    )
+    .await?;
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // now let's autoconnect!
+    let (created_connections, mut potential_connections) =
+        Component::autoconnect(ctx, odd.id()).await?;
+
+    // no connections should be created
+    assert!(created_connections.is_empty());
+
+    // but we should see two input sockets with potential connections
+    assert!(potential_connections.len() == 2);
+
+    // create one arbitrarily for each input socket
+    for (key, (potential_connections, _)) in potential_connections.iter_mut() {
+        let (component_id, output_socket_id, _value) = potential_connections
+            .pop()
+            .expect("failed to pop potential connection");
+
+        // Reset default prototype and create connection
+        AttributeValue::use_default_prototype(ctx, key.attribute_value_id)
+            .await
+            .expect("failed to reset default prototype");
+        Component::connect(
+            ctx,
+            component_id,
+            output_socket_id,
+            key.component_id,
+            key.input_socket_id,
+        )
+        .await
+        .expect("failed to create connection");
+    }
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // now run autconnect again, shouldn't return any potential connections now!
+    let (created_connections, potential_connections) =
+        Component::autoconnect(ctx, odd.id()).await?;
+    assert!(created_connections.is_empty());
+    assert!(potential_connections.is_empty());
+
+    let incoming = Component::incoming_connections_for_id(ctx, odd.id()).await?;
+    assert!(!incoming.is_empty());
+    assert!(incoming.len() == 2);
+
+    Ok(())
+}
+
+#[test]
+async fn autoconnect_multi_arity(ctx: &mut DalContext) -> Result<()> {
+    // create a new schema with a multi-arity input socket  // Let's create a new asset
+    let variant_zero = VariantAuthoringClient::create_schema_and_variant(
+        ctx,
+        "paulsTestAsset",
+        None,
+        None,
+        "Integration Tests",
+        "#00b0b0",
+    )
+    .await?;
+
+    let my_asset_schema = variant_zero.schema(ctx).await?;
+
+    let default_schema_variant = Schema::default_variant_id(ctx, my_asset_schema.id()).await?;
+    assert_eq!(default_schema_variant, variant_zero.id());
+
+    // Now let's update the variant
+    let first_code_update = "function main() {\n
+        
+         const arrayProp = new PropBuilder().setName(\"arrayProp\").setKind(\"array\").setEntry(\n
+            new PropBuilder().setName(\"arrayElem\").setKind(\"string\").build()\n
+        ).build();\n
+        const inputSocket = new SocketDefinitionBuilder().setName(\"one\").setArity(\"many\").build();\n
+         return new AssetBuilder().addProp(arrayProp).addInputSocket(inputSocket).build()\n}"
+        .to_string();
+
+    VariantAuthoringClient::save_variant_content(
+        ctx,
+        variant_zero.id(),
+        my_asset_schema.name.clone(),
+        variant_zero.display_name(),
+        variant_zero.category(),
+        variant_zero.description(),
+        variant_zero.link(),
+        variant_zero.get_color(ctx).await?,
+        variant_zero.component_type(),
+        Some(first_code_update),
+    )
+    .await?;
+
+    let updated_variant_id =
+        VariantAuthoringClient::regenerate_variant(ctx, variant_zero.id()).await?;
+
+    // We should still see that the schema variant we updated is the same as we have no components on the graph
+    assert_eq!(variant_zero.id(), updated_variant_id);
+
+    // now ensure the array prop takes it's value from the input socket
+    let array_prop = Prop::find_prop_id_by_path(
+        ctx,
+        updated_variant_id,
+        &PropPath::new(["root", "domain", "arrayProp"]),
+    )
+    .await?;
+
+    let input_socket = InputSocket::find_with_name_or_error(ctx, "one", updated_variant_id).await?;
+
+    let output_location = AttributeFuncDestination::Prop(array_prop);
+    let input_location = AttributeFuncArgumentSource::InputSocket(input_socket.id());
+    let normalize_to_array_func = Func::find_id_by_name(ctx, "si:normalizeToArray")
+        .await?
+        .expect("normalizeToArray func not found");
+
+    let mut normalize_to_array_arg =
+        FuncArgument::list_for_func(ctx, normalize_to_array_func).await?;
+
+    // should only be one!
+    assert_eq!(normalize_to_array_arg.len(), 1);
+
+    let normalize_to_array_arg = normalize_to_array_arg
+        .pop()
+        .expect("unable to pop func argument");
+
+    let arguments: Vec<AttributeArgumentBinding> = vec![
+        (AttributeArgumentBinding {
+            func_argument_id: normalize_to_array_arg.id,
+            attribute_func_input_location: input_location,
+            attribute_prototype_argument_id: None,
+        }),
+    ];
+
+    AttributeBinding::upsert_attribute_binding(
+        ctx,
+        normalize_to_array_func,
+        Some(EventualParent::SchemaVariant(updated_variant_id)),
+        output_location,
+        arguments,
+    )
+    .await?;
+
+    // now that's all set up, let's create a component that uses this asset
+    let component =
+        create_component_for_schema_variant_on_default_view(ctx, updated_variant_id).await?;
+
+    // now let's create a bunch of other components that can feed this one with individual values
+    let small_even =
+        create_component_for_default_schema_name_in_default_view(ctx, "small even lego", "even")
+            .await?;
+    let small_even_2 =
+        create_component_for_default_schema_name_in_default_view(ctx, "small even lego", "even 2")
+            .await?;
+
+    // set each one to a different value
+    update_attribute_value_for_component(
+        ctx,
+        small_even.id(),
+        &["root", "domain", "one"],
+        serde_json::json!["1"],
+    )
+    .await?;
+
+    update_attribute_value_for_component(
+        ctx,
+        small_even_2.id(),
+        &["root", "domain", "one"],
+        serde_json::json!["2"],
+    )
+    .await?;
+
+    // set the component's value to an array of the small even values
+    update_attribute_value_for_component(
+        ctx,
+        component.id(),
+        &["root", "domain", "arrayProp"],
+        serde_json::json!(["1", "2"]),
+    )
+    .await?;
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // now let's autoconnect!
+    let (created_connections, potential_connections) =
+        Component::autoconnect(ctx, component.id()).await?;
+    assert!(created_connections.len() == 2);
+    assert!(potential_connections.is_empty());
+    let incoming = Component::incoming_connections_for_id(ctx, component.id()).await?;
+    assert!(!incoming.is_empty());
+    assert!(incoming.len() == 2);
+
+    // now let's create another component, and a duplicate potential connection
+    let small_even_3 =
+        create_component_for_default_schema_name_in_default_view(ctx, "small even lego", "even 3")
+            .await?;
+
+    // set it to a duplicate value
+    update_attribute_value_for_component(
+        ctx,
+        small_even_3.id(),
+        &["root", "domain", "one"],
+        serde_json::json!["2"],
+    )
+    .await?;
+
+    let new_component =
+        create_component_for_schema_variant_on_default_view(ctx, updated_variant_id).await?;
+
+    // set it to a duplicate value
+    update_attribute_value_for_component(
+        ctx,
+        new_component.id(),
+        &["root", "domain", "arrayProp"],
+        serde_json::json!(["1", "2"]),
+    )
+    .await?;
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // now let's autoconnect!
+    let (created_connections, mut available_connections) =
+        Component::autoconnect(ctx, new_component.id()).await?;
+    // no created connections because we don't know which to choose
+    assert!(created_connections.is_empty());
+    assert!(available_connections.len() == 1);
+
+    // make sure we see the expected components here
+    for (_key, (potential_connections, _)) in available_connections.iter_mut() {
+        assert!(potential_connections.len() == 3);
+        let components_to_connect_to = potential_connections
+            .iter()
+            .map(|(component_id, _, _)| component_id)
+            .collect::<Vec<_>>();
+        assert!(components_to_connect_to.contains(&&small_even.id()));
+        assert!(components_to_connect_to.contains(&&small_even_2.id()));
+        assert!(components_to_connect_to.contains(&&small_even_3.id()));
+    }
+
+    Ok(())
+}

--- a/lib/sdf-server/src/service/component.rs
+++ b/lib/sdf-server/src/service/component.rs
@@ -42,6 +42,7 @@ pub mod insert_property_editor_value;
 pub mod json;
 pub mod list_qualifications;
 mod manage;
+mod override_with_connection;
 pub mod refresh;
 pub mod restore_default_function;
 pub mod set_name;
@@ -68,6 +69,8 @@ pub enum ComponentError {
     ComponentDebugView(#[from] ComponentDebugViewError),
     #[error("dal component error: {0}")]
     DalComponent(#[from] DalComponentError),
+    #[error("diagram error: {0}")]
+    Diagram(#[from] crate::service::diagram::DiagramError),
     #[error("diagram error: {0}")]
     DiagramError(#[from] dal::diagram::DiagramError),
     #[error("func error: {0}")]
@@ -203,6 +206,10 @@ pub fn routes() -> Router<AppState> {
         .route("/refresh", post(refresh::refresh))
         .route("/debug", get(debug::debug_component))
         .route("/autoconnect", post(autoconnect::autoconnect))
+        .route(
+            "/override_with_connection",
+            post(override_with_connection::override_with_connection),
+        )
         .route("/json", get(json::json))
         .route("/upgrade_component", post(upgrade::upgrade))
         .route("/conflicts", get(conflicts_for_component))

--- a/lib/sdf-server/src/service/component/override_with_connection.rs
+++ b/lib/sdf-server/src/service/component/override_with_connection.rs
@@ -1,0 +1,89 @@
+use axum::{
+    extract::{Host, OriginalUri},
+    Json,
+};
+use dal::{
+    AttributeValue, AttributeValueId, ChangeSet, ComponentId, InputSocketId, OutputSocketId,
+    Visibility,
+};
+use serde::{Deserialize, Serialize};
+
+use super::{ComponentError, ComponentResult};
+use crate::{
+    extract::{v1::AccessBuilder, HandlerContext, PosthogClient},
+    service::{
+        diagram::create_connection::create_connection_inner,
+        force_change_set_response::ForceChangeSetResponse,
+    },
+    track,
+};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct OverrideWithConnectionRequest {
+    pub from_component_id: ComponentId,
+    pub from_socket_id: OutputSocketId,
+    pub to_component_id: ComponentId,
+    pub to_socket_id: InputSocketId,
+    pub attribute_value_id_to_override: AttributeValueId,
+    #[serde(flatten)]
+    pub visibility: Visibility,
+}
+
+pub async fn override_with_connection(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(request_ctx): AccessBuilder,
+    OriginalUri(original_uri): OriginalUri,
+    Host(host_name): Host,
+    PosthogClient(posthog_client): PosthogClient,
+    Json(OverrideWithConnectionRequest {
+        from_component_id,
+        from_socket_id,
+        to_component_id,
+        to_socket_id,
+        attribute_value_id_to_override,
+        visibility,
+    }): Json<OverrideWithConnectionRequest>,
+) -> ComponentResult<ForceChangeSetResponse<()>> {
+    let mut ctx = builder.build(request_ctx.build(visibility)).await?;
+    let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
+
+    // first reset the attribute value prototype being overridden
+    if AttributeValue::component_prototype_id(&ctx, attribute_value_id_to_override)
+        .await?
+        .is_some()
+    {
+        AttributeValue::use_default_prototype(&ctx, attribute_value_id_to_override).await?;
+    }
+    // then make the connection
+    create_connection_inner(
+        &ctx,
+        from_component_id,
+        from_socket_id,
+        to_component_id,
+        to_socket_id,
+    )
+    .await
+    .map_err(ComponentError::Diagram)?;
+    // just look at all this paperwork!
+    track(
+        &posthog_client,
+        &ctx,
+        &original_uri,
+        &host_name,
+        "override_with_connection",
+        serde_json::json!({
+            "from_component_id": from_component_id,
+            "from_socket_id": from_socket_id,
+            "to_component_id": to_component_id,
+            "to_socket_id": to_socket_id,
+            "attribute_value_id_to_override": attribute_value_id_to_override,
+            "change_set_id": ctx.change_set_id(),
+        }),
+    );
+
+    ctx.commit().await?;
+
+    // let the front end know if nothing was created so we can tell the user
+    Ok(ForceChangeSetResponse::empty(force_change_set_id))
+}

--- a/lib/sdf-server/src/service/component/restore_default_function.rs
+++ b/lib/sdf-server/src/service/component/restore_default_function.rs
@@ -31,8 +31,12 @@ pub async fn restore_default_function(
     let mut ctx = builder.build(request_ctx.build(request.visibility)).await?;
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
-
-    AttributeValue::use_default_prototype(&ctx, request.attribute_value_id).await?;
+    if AttributeValue::component_prototype_id(&ctx, request.attribute_value_id)
+        .await?
+        .is_some()
+    {
+        AttributeValue::use_default_prototype(&ctx, request.attribute_value_id).await?;
+    }
 
     track(
         &posthog_client,

--- a/lib/si-frontend-types-rs/src/component.rs
+++ b/lib/si-frontend-types-rs/src/component.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use si_events::{ComponentId, SchemaId, SchemaVariantId, ViewId};
 use std::num::ParseIntError;
 use strum::{AsRefStr, Display, EnumIter, EnumString};
@@ -163,4 +164,21 @@ pub struct DiagramComponentView {
     pub can_be_upgraded: bool,
     pub from_base_change_set: bool,
     pub view_data: Option<GeometryAndView>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PotentialConnection {
+    pub socket_id: String,
+    pub attribute_value_id: String,
+    pub value: Option<Value>,
+    pub direction: DiagramSocketDirection, // whether it's input or output
+    pub matches: Vec<PotentialMatch>,
+}
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PotentialMatch {
+    pub socket_id: String,
+    pub component_id: String,
+    pub value: Option<Value>,
 }

--- a/lib/si-frontend-types-rs/src/lib.rs
+++ b/lib/si-frontend-types-rs/src/lib.rs
@@ -18,8 +18,8 @@ pub use crate::{
     },
     component::{
         ChangeStatus, ConnectionAnnotation, DiagramComponentView, DiagramSocket,
-        DiagramSocketDirection, DiagramSocketNodeSide, GeometryAndView, GridPoint, RawGeometry,
-        Size2D, StringGeometry,
+        DiagramSocketDirection, DiagramSocketNodeSide, GeometryAndView, GridPoint,
+        PotentialConnection, PotentialMatch, RawGeometry, Size2D, StringGeometry,
     },
     conflict::ConflictWithHead,
     func::{


### PR DESCRIPTION
This PR modifies the 'Autoconnect' logic and adds a user experience to accomodate.  Currently, when a user triggers autoconnect, if we find that there are multiple components/output sockets that could replace a manually set value, we do nothing and say 'No connections found'.  With this PR, we will accumulate the possible connections that *could* be made, and display those options so that the user can decide for themselves without having to manually go figure out where the options are in their workspace.

The UI also helps ensure the user doesn't accidentally do the wrong thing. For example, if the input socket in question is multi-arity, there are two 'flavors' of connections that can work: 
1. There could be an output socket somewhere that has that whole array (called "bulk" mode). There could be multiple output sockets like this. 
2. There could be many output sockets, that each drive a single entry in the array (called "individual" mode). There could be many options for a single entry as well. 

In any case, we want the user to know what's allowed, but we don't want them to accidentally create connections for the individual entries and leave one off, so we only let connections be created if all individual entries have corresponding connections. 

Similarly for "bulk" mode, or single array sockets, we only let them choose a single connection to create. 

All of this functionality is behind the same autoconnect feature flag!

<div><img src="https://media4.giphy.com/media/lzL6avFZQ8PJEjdFgS/200.gif?cid=5a38a5a2fglax5chx55n0sj7v1ssbsgdkgzxs28bkx8vot06&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:168px;width:300px"/><br/>via <a href="https://giphy.com/littlemix/">Little Mix</a> on <a href="https://giphy.com/gifs/littlemix-little-mix-black-magic-lzL6avFZQ8PJEjdFgS">GIPHY</a></div>

TESTING
I added more integration tests here around this logic, so if the feature picks up speed, we're less likely to regress! 

Manually tested by creating various permutations of optionality for both multi and single array sockets + matches, and seeing the connections get created correctly.

SCREENSHOTS
(Note: After getting feedback, annotations have been removed from this UI, I just did not update screenshots)

One connection selected for a single-array socket:
<img width="669" alt="image" src="https://github.com/user-attachments/assets/b47532e7-a9ca-473a-a053-33eb6b4bb967" />


Only one selected connection for a multi-array socket, can't create a connection:
<img width="669" alt="image" src="https://github.com/user-attachments/assets/99c4f3b5-1511-44e8-b6d3-cc5aada2e386" />

All entries satisfied for a multi-array socket:
<img width="669" alt="image" src="https://github.com/user-attachments/assets/78127980-9b97-42d6-9944-ce98c3a4f383" />

One entry selected for a multi-array socket:
<img width="668" alt="image" src="https://github.com/user-attachments/assets/fdb4bf8b-bd9a-489b-9287-2672e83d9816" />

