### PR TITLE
fix: this must continue on failure if there are no jails

### DIFF
--- a/lib/si-firecracker/src/scripts/firecracker-setup.sh
+++ b/lib/si-firecracker/src/scripts/firecracker-setup.sh
@@ -116,7 +116,7 @@ execute_configuration_management() {
         # Clear up any jails that may well be lingering, sometimes it happens
         # when jails are left behind and it causes grief with device usage 
         # on startup after upgrade in place or similar.
-        pkill firecracker
+        pkill firecracker || true
 
         # Update Process Limits
         if grep -Fxq "jailer-shared" /etc/security/limits.conf; then


### PR DESCRIPTION
We run the script with pipefail. Under the condition there are no jails to cleanup, we must still return 0 otherwise the orchestration will fail.

NB: there are probably 6-7 million better ways of doing this, but this is perfectly acceptable.