### PR TITLE
Disable tokio watchdog in si-service apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7171,7 +7171,6 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
- "tokio-watchdog",
 ]
 
 [[package]]

--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -36,7 +36,6 @@ async fn main() -> Result<()> {
 
         telemetry_application::init(config, &task_tracker, shutdown_token.clone())?
     };
-    tokio_watchdog::spawn(BIN_NAME, shutdown_token.clone())?;
 
     startup::startup(BIN_NAME).await?;
 

--- a/bin/forklift/src/main.rs
+++ b/bin/forklift/src/main.rs
@@ -41,7 +41,6 @@ async fn async_main() -> Result<()> {
 
         telemetry_application::init(config, &telemetry_tracker, telemetry_token.clone())?
     };
-    tokio_watchdog::spawn(BIN_NAME, main_token.clone())?;
 
     startup::startup(BIN_NAME).await?;
 

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -51,7 +51,6 @@ async fn async_main() -> Result<()> {
 
         telemetry_application::init(config, &telemetry_tracker, telemetry_token.clone())?
     };
-    tokio_watchdog::spawn(BIN_NAME, main_token.clone())?;
 
     startup::startup(BIN_NAME).await?;
 

--- a/bin/rebaser/src/main.rs
+++ b/bin/rebaser/src/main.rs
@@ -51,7 +51,6 @@ async fn async_main() -> Result<()> {
 
         telemetry_application::init(config, &telemetry_tracker, telemetry_token.clone())?
     };
-    tokio_watchdog::spawn(BIN_NAME, main_token.clone())?;
 
     startup::startup(BIN_NAME).await?;
 

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -57,7 +57,6 @@ async fn async_main() -> Result<()> {
 
         telemetry_application::init(config, &telemetry_tracker, telemetry_token.clone())?
     };
-    tokio_watchdog::spawn(BIN_NAME, main_token.clone())?;
 
     startup::startup(BIN_NAME).await?;
 

--- a/bin/veritech/src/main.rs
+++ b/bin/veritech/src/main.rs
@@ -41,7 +41,6 @@ async fn async_main() -> Result<()> {
 
         telemetry_application::init(config, &telemetry_tracker, telemetry_token.clone())?
     };
-    tokio_watchdog::spawn(BIN_NAME, main_token.clone())?;
 
     startup::startup(BIN_NAME).await?;
 

--- a/lib/si-service/BUCK
+++ b/lib/si-service/BUCK
@@ -7,7 +7,6 @@ rust_library(
         "//lib/si-std:si-std",
         "//lib/telemetry-application-rs:telemetry-application",
         "//lib/telemetry-rs:telemetry",
-        "//lib/tokio-watchdog:tokio-watchdog",
         "//third-party/rust:color-eyre",
         "//third-party/rust:glob",
         "//third-party/rust:thiserror",

--- a/lib/si-service/Cargo.toml
+++ b/lib/si-service/Cargo.toml
@@ -12,7 +12,6 @@ publish.workspace = true
 si-runtime = { path = "../../lib/si-runtime-rs" }
 si-std = { path = "../../lib/si-std" }
 telemetry = { path = "../../lib/telemetry-rs" }
-tokio-watchdog = { path = "../../lib/tokio-watchdog" }
 telemetry-application = { path = "../../lib/telemetry-application-rs" }
 
 color-eyre = { workspace = true }

--- a/lib/si-service/src/lib.rs
+++ b/lib/si-service/src/lib.rs
@@ -32,5 +32,8 @@ pub mod prelude {
     pub use si_std::SensitiveString;
     pub use telemetry_application::prelude::*;
     pub use tokio_util::{sync::CancellationToken, task::TaskTracker};
-    pub use tokio_watchdog;
+
+    // NOTE(nick): if we decide to restore/reuse tokio watchdog, we should provide it through the
+    // service prelude again.
+    // pub use tokio_watchdog;
 }


### PR DESCRIPTION
## Description

This PR disables our tokio watchdog in si-service apps. This was useful in earlier verideath investigation sessions, but we no longer need it. Not only that, but the data returned was not entirely helpful nor could we verify its accuracy. Given that this is spawned with every backend service and sends INFO level logs to Honeycomb, we have decided to remove it from "si-service". This will also slightly speed up compile times for all services due to its removal from the "si-service" crate.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNXI1MHBobnNlbXc2am9xN3Y4eDB5cTJkejFyNmQybDNraGQ5Y3R2YSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/1kkxWqT5nvLXupUTwK/giphy.gif"/>