### PR TITLE
feat(web) - simpler sockets UI with just one input and one output socket

### DIFF
--- a/app/web/src/components/ModelingDiagram/DiagramGroup.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramGroup.vue
@@ -203,7 +203,13 @@
             :key="socket.uniqueKey"
             :socket="socket"
             :position="socket.position"
-            :connectedEdges="connectedEdgesBySocketKey[socket.uniqueKey]"
+            :connectedEdges="
+              connectedEdgesBySocketKey[
+                featureFlagsStore.SIMPLE_SOCKET_UI && !socket.def.isManagement
+                  ? `${group.def.id}-inputsocket`
+                  : socket.uniqueKey
+              ]
+            "
             :nodeWidth="nodeWidth"
             :isDeleted="isDeleted"
             @hover:start="onSocketHoverStart(socket)"
@@ -222,7 +228,13 @@
             :key="socket.uniqueKey"
             :socket="socket"
             :position="socket.position"
-            :connectedEdges="connectedEdgesBySocketKey[socket.uniqueKey]"
+            :connectedEdges="
+              connectedEdgesBySocketKey[
+                featureFlagsStore.SIMPLE_SOCKET_UI && !socket.def.isManagement
+                  ? `${group.def.id}-outputsocket`
+                  : socket.uniqueKey
+              ]
+            "
             :nodeWidth="nodeWidth"
             :isDeleted="isDeleted"
             @hover:start="onSocketHoverStart(socket)"
@@ -633,10 +645,21 @@ const rightSockets = computed(() =>
 const connectedEdgesBySocketKey = computed(() => {
   const lookup: Record<DiagramElementUniqueKey, DiagramEdgeData[]> = {};
   _.each(props.connectedEdges, (edge) => {
-    lookup[edge.fromSocketKey] ||= [];
-    lookup[edge.fromSocketKey]!.push(edge); // eslint-disable-line @typescript-eslint/no-non-null-assertion
-    lookup[edge.toSocketKey] ||= [];
-    lookup[edge.toSocketKey]!.push(edge); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    if (featureFlagsStore.SIMPLE_SOCKET_UI && !edge.def.isManagement) {
+      if (edge.toNodeKey === props.group.uniqueKey) {
+        lookup[`${props.group.def.id}-inputsocket`] ||= [];
+        lookup[`${props.group.def.id}-inputsocket`]!.push(edge); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      }
+      if (edge.fromNodeKey === props.group.uniqueKey) {
+        lookup[`${props.group.def.id}-outputsocket`] ||= [];
+        lookup[`${props.group.def.id}-outputsocket`]!.push(edge); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      }
+    } else {
+      lookup[edge.fromSocketKey] ||= [];
+      lookup[edge.fromSocketKey]!.push(edge); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      lookup[edge.toSocketKey] ||= [];
+      lookup[edge.toSocketKey]!.push(edge); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    }
   });
   return lookup;
 });

--- a/app/web/src/components/ModelingDiagram/DiagramNode.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramNode.vue
@@ -243,7 +243,13 @@
           <DiagramNodeSocket
             v-for="socket in leftSockets.sockets"
             :key="socket.uniqueKey"
-            :connectedEdges="connectedEdgesBySocketKey[socket.uniqueKey]"
+            :connectedEdges="
+              connectedEdgesBySocketKey[
+                featureFlagsStore.SIMPLE_SOCKET_UI && !socket.def.isManagement
+                  ? `${node.def.id}-inputsocket`
+                  : socket.uniqueKey
+              ]
+            "
             :nodeWidth="nodeWidth"
             :socket="socket"
             :position="socket.position"
@@ -262,7 +268,13 @@
           <DiagramNodeSocket
             v-for="socket in rightSockets.sockets"
             :key="socket.uniqueKey"
-            :connectedEdges="connectedEdgesBySocketKey[socket.uniqueKey]"
+            :connectedEdges="
+              connectedEdgesBySocketKey[
+                featureFlagsStore.SIMPLE_SOCKET_UI && !socket.def.isManagement
+                  ? `${node.def.id}-outputsocket`
+                  : socket.uniqueKey
+              ]
+            "
             :nodeWidth="nodeWidth"
             :socket="socket"
             :position="socket.position"
@@ -422,10 +434,21 @@ const rightSockets = computed(() =>
 const connectedEdgesBySocketKey = computed(() => {
   const lookup: Record<DiagramElementUniqueKey, DiagramEdgeData[]> = {};
   _.each(props.connectedEdges, (edge) => {
-    lookup[edge.fromSocketKey] ||= [];
-    lookup[edge.fromSocketKey]!.push(edge); // eslint-disable-line @typescript-eslint/no-non-null-assertion
-    lookup[edge.toSocketKey] ||= [];
-    lookup[edge.toSocketKey]!.push(edge); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    if (featureFlagsStore.SIMPLE_SOCKET_UI && !edge.def.isManagement) {
+      if (edge.toNodeKey === props.node.uniqueKey) {
+        lookup[`${props.node.def.id}-inputsocket`] ||= [];
+        lookup[`${props.node.def.id}-inputsocket`]!.push(edge); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      }
+      if (edge.fromNodeKey === props.node.uniqueKey) {
+        lookup[`${props.node.def.id}-outputsocket`] ||= [];
+        lookup[`${props.node.def.id}-outputsocket`]!.push(edge); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      }
+    } else {
+      lookup[edge.fromSocketKey] ||= [];
+      lookup[edge.fromSocketKey]!.push(edge); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      lookup[edge.toSocketKey] ||= [];
+      lookup[edge.toSocketKey]!.push(edge); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    }
   });
   return lookup;
 });

--- a/app/web/src/components/ModelingDiagram/diagram_constants.ts
+++ b/app/web/src/components/ModelingDiagram/diagram_constants.ts
@@ -66,5 +66,9 @@ export const NODE_PADDING_BOTTOM = 10; //
 // width/height of sockets
 export const SOCKET_SIZE = 15;
 
+// hide diagram details zoom levels
+export const ONLY_SHOW_DIAGRAM_TITLES_BELOW_THIS_ZOOM = 0.51;
+export const HIDE_ALL_DIAGRAM_DETAILS_BELOW_THIS_ZOOM = 0.31;
+
 export const detailsModeArray = ["show", "titles", "hide"] as const;
 export type DetailsMode = (typeof detailsModeArray)[number];

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -532,10 +532,14 @@ const processRawEdge = (
   edge: Edge,
   allComponentsById: Record<ComponentId, DiagramGroupData | DiagramNodeData>,
 ): DiagramEdgeData | null => {
+  const featureFlagsStore = useFeatureFlagsStore();
   const toComponent = allComponentsById[edge.toComponentId];
   if (!allComponentsById[edge.fromComponentId]) return null;
   if (!toComponent) return null;
-  else if (!toComponent.def.sockets?.find((s) => s.id === edge.toSocketId)) {
+  else if (
+    !featureFlagsStore.SIMPLE_SOCKET_UI &&
+    !toComponent.def.sockets?.find((s) => s.id === edge.toSocketId)
+  ) {
     return null;
   }
   return new DiagramEdgeData(edge);

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -18,6 +18,7 @@ const FLAG_MAPPING = {
   SOCKET_VALUE: "socket-value",
   FLOATING_CONNECTION_MENU: "floating-connection-menu",
   CONVERT_TO_VIEW: "convert-to-view",
+  SIMPLE_SOCKET_UI: "simple-socket-ui",
 };
 
 const WORKSPACE_FLAG_MAPPING = {


### PR DESCRIPTION
https://github.com/user-attachments/assets/442eb3cc-dc2c-4583-a61b-32f3504ad06b

This turn does not allow for edges to be properly edited on the diagram or viewed in the EdgeDetailsPanel yet. That will be added in the next turn, so for now the feature flag should be kept off unless working on this feature.

Huge thank you to @jobelenus for his help on this beast of a PR 😅 