### PR TITLE
fix: pkill all the firecrackers, not yourself veritech

### DIFF
--- a/lib/si-firecracker/src/scripts/firecracker-setup.sh
+++ b/lib/si-firecracker/src/scripts/firecracker-setup.sh
@@ -116,7 +116,7 @@ execute_configuration_management() {
         # Clear up any jails that may well be lingering, sometimes it happens
         # when jails are left behind and it causes grief with device usage 
         # on startup after upgrade in place or similar.
-        pkill firecracker || true
+        pkill -e -f '^/firecracker --id' || true
 
         # Update Process Limits
         if grep -Fxq "jailer-shared" /etc/security/limits.conf; then


### PR DESCRIPTION
It's unclear to me why pkill is also killing the `/firecracker-data/firecracker-setup.sh` invocation that is setting up the jails from within veritech, it doesn't match the pkill invocation as far as I can tell. 

Nevertheless, this more explicit match should definitely only match firecracker jails. I can't really test this properly as:
- The veritech nodes don't come up with the previous change/or come up in a bad state
- I don't have a populated veritech node that isn't actual production to verify the change against

What should be for certain, the pkill command no longer kills veritech itself when starting, which is the current problem. I have tested as far as I can within the context of what I have available and it seems to be ok.

When this is merged I may need to do a follow up, depending on whether the jails are actually caught by the modified pkill or not.