### PR TITLE
fix: when running via systemd, ensure we clean up lingering jails

### DIFF
--- a/bin/veritech/veritech.service
+++ b/bin/veritech/veritech.service
@@ -1,12 +1,15 @@
 [Unit]
-Description=Veritech Server
+Description=Veritech
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/veritech --cyclone-local-firecracker --cyclone-pool-size 1000
+ExecStartPre=-/usr/bin/pkill -e -f '^/firecracker --id'
+ExecStart=/usr/local/bin/veritech
+ExecStopPost=-/usr/bin/pkill -e -f '^/firecracker --id'
+LimitNOFILE=1048576
+
 Type=exec
 Restart=always
-
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Okay. Last one. I promise.

When we Veritech run via systemd, the pkill doesn't catch the jails when running in the firecracker-setup.sh but it does when running firecracker via buck2 locally. Honestly? I'm not sure why this is the case at all, as when running the pkill on the host directly when veritech is running it `does` clean the pids up correctly. I imagine this might be something to do with cgroup inference/parental tree. Nevertheless, this sticks the cleanup as a pre-req and post-req in the systemd unit file definition for veritech so that:
- Before veritech even starts, there are no jails
- After veritech stops, any jails lingering are terminated

This explicitly ensures we issue a pkill when both starting and stopping  veritech via the systemd service. I'm leaving the original pkill in the firecracker-setup script as when running firecracker via buck2, it cleans up correctly. We don't use systemd in buck2 so it's important we catch both sources.

Oh, and it's noteworthy this particular systemd unit file isn't actually used anywhere, we use a HEREDOC within the userdata to set the unit which I will update after this is merged. This file is just for reference so this change is totally a no-op/informational.

<div><img src="https://media4.giphy.com/media/SwyTq2jJxc9im6BYnN/giphy.gif?cid=5a38a5a27vwmuvlk361b18niakurt5f9b6iznp9qtzs8tdvh&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/></div>