### PR TITLE
fix(dal): Calculate Action Dependencies using DFS to capture transitive dependencies between components

### DIFF
--- a/lib/dal/src/action/dependency_graph.rs
+++ b/lib/dal/src/action/dependency_graph.rs
@@ -1,5 +1,8 @@
 use itertools::Itertools;
-use petgraph::prelude::*;
+use petgraph::{
+    prelude::*,
+    visit::{Control, DfsEvent},
+};
 use std::collections::{HashMap, HashSet, VecDeque};
 use telemetry::prelude::*;
 
@@ -81,10 +84,15 @@ impl ActionDependencyGraph {
         // Get all inferred connections up front so we don't build this tree each time
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let mut component_tree = workspace_snapshot.inferred_connection_graph(ctx).await?;
+        let mut components_to_process =
+            VecDeque::from(actions_by_component_id.keys().copied().collect_vec());
+        // track which components we've already processed
+        let mut seen_list: HashSet<ComponentId> =
+            HashSet::from_iter(components_to_process.iter().copied());
         // Action dependencies are primarily based on the data flow between Components. Things that
         // feed data into other things must have their actions run before the actions for the
         // things they are feeding data into.
-        for component_id in actions_by_component_id.keys().copied() {
+        while let Some(component_id) = components_to_process.pop_front() {
             let component = Component::get_by_id(ctx, component_id).await?;
             let component_index = component_dependencies_index_by_id
                 .entry(component_id)
@@ -104,6 +112,9 @@ impl ActionDependencyGraph {
                     // components.
                     component_dependencies.update_edge(source_component_index, component_index, ());
                 }
+                if seen_list.insert(incoming_connection.from_component_id) {
+                    components_to_process.push_back(incoming_connection.from_component_id);
+                }
             }
             for inferred_connection in component_tree
                 .inferred_incoming_connections_for_component(ctx, component_id)
@@ -122,11 +133,15 @@ impl ActionDependencyGraph {
                     // components.
                     component_dependencies.update_edge(source_component_index, component_index, ());
                 }
+                if seen_list.insert(inferred_connection.source_component_id) {
+                    components_to_process.push_back(inferred_connection.source_component_id);
+                }
             }
         }
 
-        // Each Component's Actions need to be marked as depending on the Actions that the
-        // Component itself has been determined to be depending on.
+        // For each Component's Actions, mark them as depending on the Actions for the first dependency
+        // found along each branch in the dependency graph as each Component's Actions need to be marked as
+        // depending on the Actions that the Component itself has been determined to be depending on.
         for (component_id, action_ids) in &actions_by_component_id {
             if let Some(&component_index) = component_dependencies_index_by_id.get(component_id) {
                 for &component_action_id in action_ids {
@@ -151,25 +166,44 @@ impl ActionDependencyGraph {
                         ActionKind::Destroy => Outgoing,
                     };
 
-                    for dependency_edgeref in
-                        component_dependencies.edges_directed(component_index, dependency_direction)
-                    {
-                        let dependency_node_index = match dependency_direction {
-                            Outgoing => dependency_edgeref.target(),
-                            Incoming => dependency_edgeref.source(),
-                        };
-                        if let Some(dependency_component_id) =
-                            component_dependencies.node_weight(dependency_node_index)
-                        {
-                            for dependency_action_id in actions_by_component_id
-                                .get(dependency_component_id)
-                                .cloned()
-                                .unwrap_or_default()
-                            {
-                                action_dependency_graph
-                                    .action_depends_on(component_action_id, dependency_action_id);
-                            }
-                        };
+                    // Instead of iterating over immediate neighbors, perform a DFS to find the
+                    // first dependency (along each branch) that has an action.
+                    // Depending on the direction above, we reverse the component dependencies graph to traverse accordingly
+                    match dependency_direction {
+                        Outgoing => {
+                            petgraph::visit::depth_first_search(
+                                &component_dependencies,
+                                Some(component_index),
+                                |event| {
+                                    Self::calculate_dependencies_dfs_event(
+                                        event,
+                                        &mut action_dependency_graph,
+                                        &component_dependencies,
+                                        &actions_by_component_id,
+                                        component_index,
+                                        component_action_id,
+                                    )
+                                },
+                            );
+                        }
+                        Incoming => {
+                            // For Incoming, reverse the view so that the DFS still follows outgoing edges.
+                            let reversed = petgraph::visit::Reversed(&component_dependencies);
+                            petgraph::visit::depth_first_search(
+                                &reversed,
+                                Some(component_index),
+                                |event| {
+                                    Self::calculate_dependencies_dfs_event(
+                                        event,
+                                        &mut action_dependency_graph,
+                                        &component_dependencies,
+                                        &actions_by_component_id,
+                                        component_index,
+                                        component_action_id,
+                                    )
+                                },
+                            );
+                        }
                     }
                 }
             }
@@ -225,5 +259,42 @@ impl ActionDependencyGraph {
             }
         }
         all_dependencies.into_iter().collect_vec()
+    }
+
+    /// For each event, if we find a component with an action, add the dependency and prune (as we don't need to keep traversing)
+    fn calculate_dependencies_dfs_event(
+        event: DfsEvent<NodeIndex>,
+        action_dependency_graph: &mut ActionDependencyGraph,
+        component_dependencies: &StableDiGraph<ComponentId, ()>,
+        actions_by_component_id: &HashMap<ComponentId, HashSet<ActionId>>,
+        component_index: NodeIndex,
+        component_action_id: ActionId,
+    ) -> Control<()> {
+        match event {
+            petgraph::visit::DfsEvent::Discover(node, _) => {
+                // Skip the starting node.
+                if node == component_index {
+                    return petgraph::visit::Control::Continue;
+                }
+                // Look up the component ID from the original graph.
+                else if let Some(dependency_component_id) =
+                    component_dependencies.node_weight(node)
+                {
+                    if let Some(dependency_action_ids) =
+                        actions_by_component_id.get(dependency_component_id)
+                    {
+                        // Found the first dependency on this branch with an action.
+                        for &dependency_action_id in dependency_action_ids {
+                            action_dependency_graph
+                                .action_depends_on(component_action_id, dependency_action_id);
+                        }
+                        // Prune this branch; don't traverse any deeper.
+                        return petgraph::visit::Control::Prune;
+                    }
+                }
+                petgraph::visit::Control::Continue
+            }
+            _ => petgraph::visit::Control::Continue,
+        }
     }
 }


### PR DESCRIPTION
Before this change, we were calculating the order for actions based only on the components with actions enqueued and their direct dependencies. This meant if you had Component A (with action) ---edge to --> Component B (no action) -- edge to --> Component C (with action), we would not detect that Action C should depend on Action A.  

With this change we now build a more full tree of component dependencies, and use petgraph's depth_first_search to find the closest dependency for a given component's action, which allows us to capture these transitive dependencies. 

TESTING
I added an integration test covering both forwards and backwards transitive dependencies (forwards applies to create/update/manual actions, backwards applies to destroy actions)

<div><img src="https://media4.giphy.com/media/xUNd9WbEMv0CGDEK3u/giphy.gif?cid=5a38a5a2c0e47tv522ca6ijtri0zk6rk9su50d9p4znlkcsh&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:225px;width:300px"/><br/>via <a href="https://giphy.com/heyarnold/">Hey Arnold</a> on <a href="https://giphy.com/gifs/heyarnold-nickelodeon-hey-arnold-xUNd9WbEMv0CGDEK3u">GIPHY</a></div>