### PR TITLE
fix(sdf): Catch Node Not Found error on action cancel

### DIFF
--- a/lib/sdf-server/src/service/action.rs
+++ b/lib/sdf-server/src/service/action.rs
@@ -68,6 +68,11 @@ impl IntoResponse for ActionError {
     fn into_response(self) -> Response {
         let (status_code, error_message) = match self {
             ActionError::InvalidOnHoldTransition(_) => (StatusCode::NOT_MODIFIED, self.to_string()),
+            ActionError::Action(dal::action::ActionError::WorkspaceSnapshot(err))
+                if err.is_node_with_id_not_found() =>
+            {
+                (StatusCode::GONE, err.to_string())
+            }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 


### PR DESCRIPTION
If you hit cancel multiple times fast, there's a chance the second request could have thrown a 500 as the node is now gone from the snapshot

We now throw a 410 when that's the case on cancel

Before:
![Screenshot 2025-03-20 at 21 46 38](https://github.com/user-attachments/assets/4b33d7dd-5a7e-4364-8eff-7a400354c013)

After:
![Screenshot 2025-03-20 at 21 47 45](https://github.com/user-attachments/assets/bf7e5b37-baa6-4f6c-a70a-7735e615ee7c)


