### PR TITLE
chore(firecracker): re-enable vsock telemetry forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6975,11 +6975,11 @@ dependencies = [
  "krata-loopdev",
  "nix 0.29.0",
  "remain",
+ "telemetry",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tokio-vsock",
- "tracing",
 ]
 
 [[package]]

--- a/lib/si-firecracker/BUCK
+++ b/lib/si-firecracker/BUCK
@@ -4,13 +4,13 @@ rust_library(
     name = "si-firecracker",
     deps = [
         "//lib/cyclone-core:cyclone-core",
+        "//lib/telemetry-rs:telemetry",
         "//third-party/rust:futures",
-        "//third-party/rust:remain",
         "//third-party/rust:nix",
+        "//third-party/rust:remain",
         "//third-party/rust:thiserror",
         "//third-party/rust:tokio",
         "//third-party/rust:tokio-util",
-        "//third-party/rust:tracing",
     ] + select({
         "DEFAULT": [],
         "config//os:linux": [

--- a/lib/si-firecracker/Cargo.toml
+++ b/lib/si-firecracker/Cargo.toml
@@ -13,10 +13,10 @@ cyclone-core = { path = "../cyclone-core" }
 futures = { workspace = true }
 nix = { workspace = true }
 remain = { workspace = true }
+telemetry = { path = "../../lib/telemetry-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 

--- a/lib/si-firecracker/src/disk.rs
+++ b/lib/si-firecracker/src/disk.rs
@@ -1,14 +1,16 @@
+use std::{
+    ffi::OsString,
+    fs::{self, remove_dir_all},
+    path::{Path, PathBuf},
+    result,
+};
+
+use devicemapper::{DevId, DmName, DmOptions, DM};
+use krataloopdev::LoopDevice;
 use nix::{errno::Errno, mount::umount};
+use telemetry::prelude::*;
 
 use crate::errors::FirecrackerJailError;
-use devicemapper::{DevId, DmName, DmOptions, DM};
-
-use krataloopdev::LoopDevice;
-use std::ffi::OsString;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::{fs::remove_dir_all, result};
-use tracing::trace;
 
 type Result<T> = result::Result<T, FirecrackerJailError>;
 

--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -93,7 +93,7 @@ cyclone_args=(
   --watch-timeout 30
   --enable-ping
   --enable-watch
-  --disable-forwarder
+  --enable-forwarder
   --enable-process-gatherer
   -vvvv
 )


### PR DESCRIPTION
This change re-enables the stream forwarder in Cyclone and the listener in Veritech, both of which help are used to forward OpenTelemetry data out of a Firecracker VM.

Prior to disabling these tasks, it was unclear whether the spawned tokio tasks would naturally terminate on their own, or whether they would continue to run even as more Firecracker instances were spawing in Pool Noodle's pool. This change attempts to tie the lifetime of these forwarding tasks to the lifetime of the Firecracker instance (that is the termination of the VM should also trigger the shutdown of the forwarding task).

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZXZtZXc0OHF2cm15cHBuajc1YzM1Nzg2ZDltNG1nY2dtdDkxdzk0ciZlcD12MV9naWZzX3NlYXJjaCZjdD1n/eLvnKgH3eDNm49Cotp/giphy.gif"/>