### PR TITLE
chore: Ulid -> SchemaId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4434,6 +4434,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "si-id",
  "si-pkg",
  "thiserror 2.0.12",
  "tokio",
@@ -4488,6 +4489,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "si-id",
  "ulid",
 ]
 

--- a/bin/hoist/src/main.rs
+++ b/bin/hoist/src/main.rs
@@ -10,7 +10,6 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use ulid::Ulid;
 
 use crate::diff::patch_list_to_summary;
 use clap::Parser;
@@ -125,7 +124,7 @@ async fn detailed_diff_with_module_index(
         }
     };
 
-    let remote_ulid = Ulid::from_string(&remote_module_id)?;
+    let remote_ulid = remote_module_id.parse()?;
 
     let module_bytes = client.download_module(remote_ulid).await?;
 
@@ -300,7 +299,7 @@ async fn diff_summaries_with_module_index(
                     }
                 };
 
-                let remote_ulid = Ulid::from_string(&remote_module_id).unwrap();
+                let remote_ulid = remote_module_id.parse().unwrap();
 
                 let module_bytes = client.download_module(remote_ulid).await.unwrap();
                 let current_pkg = SiPkg::load_from_bytes(&module_bytes)
@@ -353,11 +352,7 @@ async fn diff_summaries_with_module_index(
 }
 
 async fn write_spec(client: ModuleIndexClient, module_id: String, out: PathBuf) -> Result<()> {
-    let pkg = SiPkg::load_from_bytes(
-        &client
-            .download_module(Ulid::from_string(&module_id)?)
-            .await?,
-    )?;
+    let pkg = SiPkg::load_from_bytes(&client.download_module(module_id.parse()?).await?)?;
     let spec = pkg.to_spec().await?;
     let spec_name = format!("{}.json", spec.name);
     fs::create_dir_all(&out)?;

--- a/lib/dal-test/src/test_exclusive_schemas/category_pirate.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/category_pirate.rs
@@ -134,7 +134,7 @@ pub(crate) async fn migrate_test_exclusive_schema_pirate(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )
@@ -231,7 +231,7 @@ pub(crate) async fn migrate_test_exclusive_schema_pet_shop(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )

--- a/lib/dal-test/src/test_exclusive_schemas/category_validated.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/category_validated.rs
@@ -86,7 +86,7 @@ pub(crate) async fn migrate_test_exclusive_schema_bad_validations(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )
@@ -177,7 +177,7 @@ pub(crate) async fn migrate_test_exclusive_schema_validated_output(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )
@@ -275,7 +275,7 @@ pub(crate) async fn migrate_test_exclusive_schema_validated_input(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )

--- a/lib/dal-test/src/test_exclusive_schemas/dummy_secret.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/dummy_secret.rs
@@ -27,7 +27,7 @@ pub(crate) async fn migrate_test_exclusive_schema_dummy_secret(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )

--- a/lib/dal-test/src/test_exclusive_schemas/fake_butane.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/fake_butane.rs
@@ -229,7 +229,7 @@ pub(crate) async fn migrate_test_exclusive_schema_fake_butane(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )

--- a/lib/dal-test/src/test_exclusive_schemas/fake_docker_image.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/fake_docker_image.rs
@@ -119,7 +119,7 @@ pub(crate) async fn migrate_test_exclusive_schema_fake_docker_image(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )

--- a/lib/dal-test/src/test_exclusive_schemas/fallout.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/fallout.rs
@@ -177,7 +177,7 @@ pub(crate) async fn migrate_test_exclusive_schema_fallout(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )

--- a/lib/dal-test/src/test_exclusive_schemas/katy_perry.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/katy_perry.rs
@@ -117,7 +117,7 @@ pub(crate) async fn migrate_test_exclusive_schema_katy_perry(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )

--- a/lib/dal-test/src/test_exclusive_schemas/legos/large.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/legos/large.rs
@@ -141,7 +141,7 @@ pub(crate) async fn migrate_test_exclusive_schema_large_odd_lego(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )
@@ -278,7 +278,7 @@ pub(crate) async fn migrate_test_exclusive_schema_large_even_lego(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )

--- a/lib/dal-test/src/test_exclusive_schemas/legos/medium.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/legos/medium.rs
@@ -137,7 +137,7 @@ pub(crate) async fn migrate_test_exclusive_schema_medium_odd_lego(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )
@@ -269,7 +269,7 @@ pub(crate) async fn migrate_test_exclusive_schema_medium_even_lego(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )

--- a/lib/dal-test/src/test_exclusive_schemas/legos/small.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/legos/small.rs
@@ -792,7 +792,7 @@ pub(crate) async fn migrate_test_exclusive_schema_small_odd_lego(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )
@@ -921,7 +921,7 @@ pub(crate) async fn migrate_test_exclusive_schema_small_even_lego(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )

--- a/lib/dal-test/src/test_exclusive_schemas/mod.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/mod.rs
@@ -24,7 +24,6 @@ use starfield::migrate_test_exclusive_schema_etoiles;
 use starfield::migrate_test_exclusive_schema_morningstar;
 use starfield::migrate_test_exclusive_schema_private_language;
 use starfield::migrate_test_exclusive_schema_starfield;
-use std::str::FromStr;
 use swifty::migrate_test_exclusive_schema_swifty;
 
 mod category_pirate;
@@ -87,153 +86,31 @@ pub const SCHEMA_ID_FAKE_BUTANE: &str = "01JARH2BTA5DK4J9Q4Q0XH46SR";
 // allow expect here for the Ulid conversion. These will never panic.
 #[allow(clippy::expect_used)]
 pub(crate) async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
-    migrate_test_exclusive_schema_starfield(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_STARFIELD)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_private_language(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_PRIVATE_LANGUAGE)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_etoiles(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_ETOILES)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_morningstar(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_MORNINGSTAR)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_fallout(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_FALLOUT)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_dummy_secret(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_DUMMY_SECRET)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_swifty(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_SWIFTY)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_katy_perry(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_KATY_PERRY)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_pirate(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_PIRATE)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_pet_shop(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_PET_SHOP)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_validated_input(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_VALIDATED_INPUT)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_validated_output(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_VALIDATED_OUTPUT)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_bad_validations(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_BAD_VALIDATIONS)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_large_odd_lego(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_LARGE_ODD_LEGO)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_large_even_lego(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_LARGE_EVEN_LEGO)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_medium_even_lego(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_MEDIUM_EVEN_LEGO)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_medium_odd_lego(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_MEDIUM_ODD_LEGO)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_small_odd_lego(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_SMALL_ODD_LEGO)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_small_even_lego(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_SMALL_EVEN_LEGO)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_fake_docker_image(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_FAKE_DOCKER_IMAGE)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
-    migrate_test_exclusive_schema_fake_butane(
-        ctx,
-        ulid::Ulid::from_str(SCHEMA_ID_FAKE_BUTANE)
-            .expect("should convert")
-            .into(),
-    )
-    .await?;
+    migrate_test_exclusive_schema_starfield(ctx, SCHEMA_ID_STARFIELD.parse()?).await?;
+    migrate_test_exclusive_schema_private_language(ctx, SCHEMA_ID_PRIVATE_LANGUAGE.parse()?)
+        .await?;
+    migrate_test_exclusive_schema_etoiles(ctx, SCHEMA_ID_ETOILES.parse()?).await?;
+    migrate_test_exclusive_schema_morningstar(ctx, SCHEMA_ID_MORNINGSTAR.parse()?).await?;
+    migrate_test_exclusive_schema_fallout(ctx, SCHEMA_ID_FALLOUT.parse()?).await?;
+    migrate_test_exclusive_schema_dummy_secret(ctx, SCHEMA_ID_DUMMY_SECRET.parse()?).await?;
+    migrate_test_exclusive_schema_swifty(ctx, SCHEMA_ID_SWIFTY.parse()?).await?;
+    migrate_test_exclusive_schema_katy_perry(ctx, SCHEMA_ID_KATY_PERRY.parse()?).await?;
+    migrate_test_exclusive_schema_pirate(ctx, SCHEMA_ID_PIRATE.parse()?).await?;
+    migrate_test_exclusive_schema_pet_shop(ctx, SCHEMA_ID_PET_SHOP.parse()?).await?;
+    migrate_test_exclusive_schema_validated_input(ctx, SCHEMA_ID_VALIDATED_INPUT.parse()?).await?;
+    migrate_test_exclusive_schema_validated_output(ctx, SCHEMA_ID_VALIDATED_OUTPUT.parse()?)
+        .await?;
+    migrate_test_exclusive_schema_bad_validations(ctx, SCHEMA_ID_BAD_VALIDATIONS.parse()?).await?;
+    migrate_test_exclusive_schema_large_odd_lego(ctx, SCHEMA_ID_LARGE_ODD_LEGO.parse()?).await?;
+    migrate_test_exclusive_schema_large_even_lego(ctx, SCHEMA_ID_LARGE_EVEN_LEGO.parse()?).await?;
+    migrate_test_exclusive_schema_medium_even_lego(ctx, SCHEMA_ID_MEDIUM_EVEN_LEGO.parse()?)
+        .await?;
+    migrate_test_exclusive_schema_medium_odd_lego(ctx, SCHEMA_ID_MEDIUM_ODD_LEGO.parse()?).await?;
+    migrate_test_exclusive_schema_small_odd_lego(ctx, SCHEMA_ID_SMALL_ODD_LEGO.parse()?).await?;
+    migrate_test_exclusive_schema_small_even_lego(ctx, SCHEMA_ID_SMALL_EVEN_LEGO.parse()?).await?;
+    migrate_test_exclusive_schema_fake_docker_image(ctx, SCHEMA_ID_FAKE_DOCKER_IMAGE.parse()?)
+        .await?;
+    migrate_test_exclusive_schema_fake_butane(ctx, SCHEMA_ID_FAKE_BUTANE.parse()?).await?;
     Ok(())
 }
 

--- a/lib/dal-test/src/test_exclusive_schemas/starfield.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/starfield.rs
@@ -391,7 +391,7 @@ pub(crate) async fn migrate_test_exclusive_schema_starfield(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )
@@ -526,7 +526,7 @@ pub(crate) async fn migrate_test_exclusive_schema_morningstar(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )
@@ -788,7 +788,7 @@ pub(crate) async fn migrate_test_exclusive_schema_etoiles(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )
@@ -912,7 +912,7 @@ pub(crate) async fn migrate_test_exclusive_schema_private_language(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )

--- a/lib/dal-test/src/test_exclusive_schemas/swifty.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/swifty.rs
@@ -190,7 +190,7 @@ pub(crate) async fn migrate_test_exclusive_schema_swifty(
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema_id.into()),
+            schema_id: Some(schema_id),
             ..Default::default()
         }),
     )

--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -69,6 +69,8 @@ pub enum BuiltinsError {
     StandardModel(#[from] StandardModelError),
     #[error("error creating new transactions")]
     Transactions(#[from] TransactionsError),
+    #[error("ulid decode error")]
+    UlidDecode(#[from] ulid::DecodeError),
 }
 
 pub type BuiltinsResult<T> = Result<T, BuiltinsError>;

--- a/lib/dal/src/layer_db_types/content_types.rs
+++ b/lib/dal/src/layer_db_types/content_types.rs
@@ -2,8 +2,8 @@ use std::collections::HashSet;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use si_events::ulid::Ulid;
 use si_events::{CasValue, ContentHash};
+use si_id::SchemaId;
 use strum::EnumDiscriminants;
 use thiserror::Error;
 
@@ -435,7 +435,7 @@ pub struct ModuleContentV2 {
     pub description: String,
     pub created_by_email: String,
     pub created_at: DateTime<Utc>,
-    pub schema_id: Option<Ulid>,
+    pub schema_id: Option<SchemaId>,
 }
 
 impl From<ModuleContentV1> for ModuleContentV2 {

--- a/lib/dal/src/module.rs
+++ b/lib/dal/src/module.rs
@@ -81,7 +81,7 @@ pub struct Module {
     description: String,
     created_by_email: String,
     created_at: DateTime<Utc>,
-    schema_id: Option<Ulid>,
+    schema_id: Option<SchemaId>,
 }
 
 impl Module {
@@ -128,7 +128,7 @@ impl Module {
     /// time installing the asset, the schema will get this, but this is not
     /// guaranteed to be the id of the schema in workspaces that have assets
     /// installed before this feature was added!
-    pub fn schema_id(&self) -> Option<Ulid> {
+    pub fn schema_id(&self) -> Option<SchemaId> {
         self.schema_id
     }
 
@@ -141,7 +141,7 @@ impl Module {
         description: impl Into<String>,
         created_by_email: impl Into<String>,
         created_at: impl Into<DateTime<Utc>>,
-        schema_id: Option<Ulid>,
+        schema_id: Option<SchemaId>,
     ) -> ModuleResult<Self> {
         let content = ModuleContentV2 {
             timestamp: Timestamp::now(),
@@ -246,7 +246,7 @@ impl Module {
 
     pub async fn find_for_module_schema_id(
         ctx: &DalContext,
-        module_schema_id: Ulid,
+        module_schema_id: SchemaId,
     ) -> ModuleResult<Option<Self>> {
         Self::find(ctx, |module| module.schema_id() == Some(module_schema_id)).await
     }
@@ -440,9 +440,7 @@ impl Module {
             {
                 latest_cached_module_by_schema_id.insert(schema_id, cached_module);
             }
-            if let Some(installed_module) =
-                Self::find_for_module_schema_id(ctx, schema_id.into()).await?
-            {
+            if let Some(installed_module) = Self::find_for_module_schema_id(ctx, schema_id).await? {
                 installed_module_by_schema_id.insert(schema_id, installed_module);
             }
         }
@@ -584,10 +582,7 @@ impl Module {
         // Check if local information exists for contribution metadata.
         let (local_module_based_on_hash, local_module_schema_id) =
             match Module::find_for_member_id(ctx, associated_schema.id()).await? {
-                Some(module) => (
-                    Some(module.root_hash().to_string()),
-                    module.schema_id().map(|id| id.into()),
-                ),
+                Some(module) => (Some(module.root_hash().to_string()), module.schema_id()),
                 None => (None, None),
             };
 

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -1,5 +1,5 @@
 use chrono::NaiveDateTime;
-use si_events::ulid::Ulid;
+use si_id::SchemaId;
 use si_pkg::{
     SchemaVariantSpecPropRoot, SiPkg, SiPkgActionFunc, SiPkgAttrFuncInputView, SiPkgAuthFunc,
     SiPkgComponent, SiPkgEdge, SiPkgError, SiPkgFunc, SiPkgFuncArgument, SiPkgFuncData, SiPkgKind,
@@ -69,7 +69,7 @@ pub struct ImportOptions {
     /// editable components.
     pub create_unlocked: bool,
     /// The "schema id" for this asset, provided by the module index API
-    pub schema_id: Option<Ulid>,
+    pub schema_id: Option<SchemaId>,
     /// A list of "past hashes" for this module, used to find the existing
     /// schema if a schema_id is not provided
     pub past_module_hashes: Option<Vec<String>>,
@@ -452,11 +452,11 @@ async fn import_func_arguments(
 
 async fn create_schema(
     ctx: &DalContext,
-    maybe_existing_schema_id: Option<Ulid>,
+    maybe_existing_schema_id: Option<SchemaId>,
     schema_spec_data: &SiPkgSchemaData,
 ) -> PkgResult<Schema> {
     let schema = match maybe_existing_schema_id {
-        Some(id) => Schema::new_with_id(ctx, id.into(), schema_spec_data.name()).await?,
+        Some(id) => Schema::new_with_id(ctx, id, schema_spec_data.name()).await?,
         None => Schema::new(ctx, schema_spec_data.name()).await?,
     }
     .modify(ctx, |schema| {

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -571,7 +571,7 @@ impl Schema {
             ctx,
             &si_pkg,
             Some(ImportOptions {
-                schema_id: Some(module.schema_id.into()),
+                schema_id: Some(module.schema_id),
                 ..Default::default()
             }),
         )

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -10,7 +10,6 @@ use serde_json::error::Category;
 use thiserror::Error;
 
 use pkg::import::import_schema_variant;
-use si_events::ulid::Ulid;
 use si_events::FuncRunId;
 use si_layer_cache::LayerDbError;
 use si_pkg::{
@@ -187,7 +186,7 @@ impl VariantAuthoringClient {
                     asset_func.clone(),
                 )])),
                 create_unlocked: true,
-                schema_id: Some(Ulid::new()),
+                schema_id: Some(SchemaId::new()),
                 ..Default::default()
             }),
         )
@@ -278,7 +277,7 @@ impl VariantAuthoringClient {
                         cloned_func.clone(),
                     )])),
                     create_unlocked: true,
-                    schema_id: Some(Ulid::new()),
+                    schema_id: Some(SchemaId::new()),
                     ..Default::default()
                 }),
             )

--- a/lib/dal/tests/integration_test/management.rs
+++ b/lib/dal/tests/integration_test/management.rs
@@ -7,7 +7,7 @@ use dal::{
         prototype::{ManagementPrototype, ManagementPrototypeError, ManagementPrototypeExecution},
         ManagementFuncReturn, ManagementGeometry, ManagementOperator,
     },
-    AttributeValue, Component, ComponentId, DalContext, SchemaId,
+    AttributeValue, Component, ComponentId, DalContext,
 };
 use dal_test::{
     expected::{ExpectComponent, ExpectComponentInputSocket, ExpectSchemaVariant, ExpectView},
@@ -319,13 +319,10 @@ async fn create_and_connect_to_self_as_children(ctx: &mut DalContext) -> Result<
     let managed: HashSet<_> = small_odd_lego.get_managed(ctx).await?.into_iter().collect();
     assert_eq!(children, managed);
 
-    let small_even_lego_schema_id: SchemaId =
-        ulid::Ulid::from_string(SCHEMA_ID_SMALL_EVEN_LEGO)?.into();
-
     for &child_id in &children {
         let c = Component::get_by_id(ctx, child_id).await?;
         let schema_id = c.schema(ctx).await?.id();
-        assert_eq!(small_even_lego_schema_id, schema_id);
+        assert_eq!(schema_id, SCHEMA_ID_SMALL_EVEN_LEGO.parse()?);
     }
 
     // Ensure parallel edges make it through the rebase
@@ -397,8 +394,6 @@ async fn create_and_connect_to_self(ctx: &DalContext) -> Result<()> {
 
     let connections = small_odd_lego.incoming_connections(ctx).await?;
     assert_eq!(3, connections.len());
-    let small_even_lego_schema_id: SchemaId =
-        ulid::Ulid::from_string(SCHEMA_ID_SMALL_EVEN_LEGO)?.into();
     let manager_geometry = small_odd_lego.geometry(ctx, view_id).await?.into_raw();
     for connection in connections {
         let c = Component::get_by_id(ctx, connection.from_component_id).await?;
@@ -410,7 +405,7 @@ async fn create_and_connect_to_self(ctx: &DalContext) -> Result<()> {
         assert_eq!(manager_geometry.y + 10, c_geo.y);
 
         let schema_id = c.schema(ctx).await?.id();
-        assert_eq!(small_even_lego_schema_id, schema_id);
+        assert_eq!(schema_id, SCHEMA_ID_SMALL_EVEN_LEGO.parse()?);
     }
 
     Ok(())
@@ -459,12 +454,10 @@ async fn create_and_connect_from_self(ctx: &DalContext) -> Result<()> {
 
     let connections = small_odd_lego.outgoing_connections(ctx).await?;
     assert_eq!(3, connections.len());
-    let small_even_lego_schema_id: SchemaId =
-        ulid::Ulid::from_string(SCHEMA_ID_SMALL_EVEN_LEGO)?.into();
     for connection in connections {
         let c = Component::get_by_id(ctx, connection.to_component_id).await?;
         let schema_id = c.schema(ctx).await?.id();
-        assert_eq!(small_even_lego_schema_id, schema_id);
+        assert_eq!(schema_id, SCHEMA_ID_SMALL_EVEN_LEGO.parse()?);
     }
 
     Ok(())

--- a/lib/dal/tests/integration_test/pkg/mod.rs
+++ b/lib/dal/tests/integration_test/pkg/mod.rs
@@ -82,7 +82,7 @@ async fn import_pkg_from_pkg_set_latest_default(ctx: &mut DalContext) -> Result<
         ctx,
         &pkg,
         Some(ImportOptions {
-            schema_id: Some(schema.id().into()),
+            schema_id: Some(schema.id()),
             ..Default::default()
         }),
     )
@@ -172,7 +172,7 @@ async fn prop_order_preserved(ctx: &mut DalContext) -> Result<()> {
                 ctx,
                 &pkg,
                 Some(ImportOptions {
-                    schema_id: Some(schema_id.into()),
+                    schema_id: Some(schema_id),
                     ..Default::default()
                 }),
             )

--- a/lib/module-index-client/BUCK
+++ b/lib/module-index-client/BUCK
@@ -4,6 +4,7 @@ rust_library(
     name = "module-index-client",
     deps = [
         "//lib/module-index-types:module-index-types",
+        "//lib/si-id:si-id",
         "//lib/si-pkg:si-pkg",
         "//third-party/rust:chrono",
         "//third-party/rust:remain",

--- a/lib/module-index-client/Cargo.toml
+++ b/lib/module-index-client/Cargo.toml
@@ -10,6 +10,7 @@ publish.workspace = true
 
 [dependencies]
 module-index-types = { path = "../../lib/module-index-types" }
+si-id = { path = "../../lib/si-id" }
 si-pkg = { path = "../../lib/si-pkg" }
 
 chrono = { workspace = true }

--- a/lib/module-index-client/src/lib.rs
+++ b/lib/module-index-client/src/lib.rs
@@ -1,4 +1,5 @@
 use reqwest::StatusCode;
+use si_id::ModuleId;
 use si_pkg::WorkspaceExport;
 use thiserror::Error;
 use ulid::Ulid;
@@ -232,11 +233,11 @@ impl ModuleIndexClient {
         Ok(upsert_response.json::<bool>().await?)
     }
 
-    pub async fn download_module(&self, module_id: Ulid) -> ModuleIndexClientResult<Vec<u8>> {
+    pub async fn download_module(&self, module_id: ModuleId) -> ModuleIndexClientResult<Vec<u8>> {
         let download_url = self
             .base_url
             .join("modules/")?
-            .join(&format!("{}/", module_id.to_string()))?
+            .join(&format!("{}/", module_id))?
             .join("download")?;
         let response = reqwest::Client::new()
             .get(download_url)
@@ -288,7 +289,7 @@ impl ModuleIndexClient {
 
     pub async fn module_details(
         &self,
-        module_id: Ulid,
+        module_id: ModuleId,
     ) -> ModuleIndexClientResult<ModuleDetailsResponse> {
         let details_url = self
             .base_url
@@ -313,11 +314,11 @@ impl ModuleIndexClient {
         Ok(response)
     }
 
-    pub async fn get_builtin(&self, module_id: Ulid) -> ModuleIndexClientResult<Vec<u8>> {
+    pub async fn get_builtin(&self, module_id: ModuleId) -> ModuleIndexClientResult<Vec<u8>> {
         let download_url = self
             .base_url
             .join("modules/")?
-            .join(&format!("{}/", module_id.to_string()))?
+            .join(&format!("{}/", module_id))?
             .join("download_builtin")?;
 
         let mut response = reqwest::Client::new().get(download_url).send().await?;
@@ -328,7 +329,7 @@ impl ModuleIndexClient {
             // We want to fall back to the production module index to pull builtins from there instead
             let url = Url::parse("https://module-index.systeminit.com")?
                 .join("modules/")?
-                .join(&format!("{}/", module_id.to_string()))?
+                .join(&format!("{}/", module_id))?
                 .join("download_builtin")?;
 
             response = reqwest::Client::new().get(url).send().await?;

--- a/lib/module-index-types/BUCK
+++ b/lib/module-index-types/BUCK
@@ -3,6 +3,7 @@ load("@prelude-si//:macros.bzl", "rust_library")
 rust_library(
     name = "module-index-types",
     deps = [
+        "//lib/si-id:si-id",
         "//third-party/rust:chrono",
         "//third-party/rust:serde",
         "//third-party/rust:serde_json",

--- a/lib/module-index-types/Cargo.toml
+++ b/lib/module-index-types/Cargo.toml
@@ -9,6 +9,8 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
+si-id = { path = "../../lib/si-id" }
+
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/lib/module-index-types/src/lib.rs
+++ b/lib/module-index-types/src/lib.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use si_id::SchemaId;
 use ulid::Ulid;
 
 pub const MODULE_BUNDLE_FIELD_NAME: &str = "module_bundle";
@@ -49,10 +50,10 @@ pub struct ModuleDetailsResponse {
 }
 
 impl ModuleDetailsResponse {
-    pub fn schema_id(&self) -> Option<Ulid> {
+    pub fn schema_id(&self) -> Option<SchemaId> {
         self.schema_id
             .as_deref()
-            .and_then(|schema_id| Ulid::from_string(schema_id).ok())
+            .and_then(|schema_id| schema_id.parse().ok())
     }
 }
 
@@ -99,6 +100,6 @@ impl LatestModuleResponse {
     pub fn schema_id(&self) -> Option<Ulid> {
         self.schema_id
             .as_deref()
-            .and_then(|schema_id| Ulid::from_string(schema_id).ok())
+            .and_then(|schema_id| schema_id.parse().ok())
     }
 }

--- a/lib/sdf-server/src/service/module.rs
+++ b/lib/sdf-server/src/service/module.rs
@@ -14,6 +14,7 @@ use dal::{
     WsEventError,
 };
 use serde::{Deserialize, Serialize};
+use si_id::ModuleId;
 use si_layer_cache::LayerDbError;
 use si_pkg::{SiPkg, SiPkgError};
 use si_std::canonical_file::safe_canonically_join;
@@ -21,7 +22,6 @@ use si_std::CanonicalFileError;
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::fs::read_dir;
-use ulid::Ulid;
 
 use super::ApiError;
 use crate::AppState;
@@ -69,6 +69,8 @@ pub enum ModuleError {
     ModuleIndexNotConfigured,
     #[error("No packages path provided")]
     NoPackagesPath,
+    #[error("no schema variants found in module: {0}")]
+    NoSchemaVariantsInModule(ModuleId),
     #[error("Package with that name already installed: {0}")]
     PackageAlreadyInstalled(String),
     #[error("That package already exists: {0}")]
@@ -92,7 +94,7 @@ pub enum ModuleError {
     #[error("schema not found for variant {0}")]
     SchemaNotFoundForVariant(SchemaVariantId),
     #[error("schema install pkg result empty: {0}")]
-    SchemaNotFoundFromInstall(Ulid),
+    SchemaNotFoundFromInstall(SchemaId),
     #[error("schema variant error: {0}")]
     SchemaVariant(#[from] SchemaVariantError),
     #[error("schema variant not found {0}")]

--- a/lib/sdf-server/src/service/module/install_module.rs
+++ b/lib/sdf-server/src/service/module/install_module.rs
@@ -9,8 +9,8 @@ use dal::{
 use module_index_client::ModuleIndexClient;
 use serde::{Deserialize, Serialize};
 use si_frontend_types::SchemaVariant as FrontendVariant;
+use si_id::ModuleId;
 use si_pkg::SiPkg;
-use ulid::Ulid;
 
 use crate::{
     extract::{request::RawAccessToken, v1::AccessBuilder, HandlerContext, PosthogClient},
@@ -23,7 +23,7 @@ use telemetry::prelude::*;
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct InstallModuleRequest {
-    pub ids: Vec<Ulid>,
+    pub ids: Vec<ModuleId>,
     #[serde(flatten)]
     pub visibility: Visibility,
 }
@@ -57,15 +57,15 @@ pub async fn install_module(
         let module_details = module_index_client.module_details(id).await?;
 
         if let Some(schema_id) = module_details.schema_id() {
-            if Schema::exists_locally(&ctx, schema_id.into()).await?
-                && SchemaVariant::get_unlocked_for_schema(&ctx, schema_id.into())
+            if Schema::exists_locally(&ctx, schema_id).await?
+                && SchemaVariant::get_unlocked_for_schema(&ctx, schema_id)
                     .await?
                     .is_some()
             {
                 // TODO(nick): do not use the 500 toast for this.
                 return Err(ModuleError::UnlockedSchemaVariantForModuleToInstall(
                     module_details.id,
-                    schema_id.into(),
+                    schema_id,
                 ));
             }
         } else {
@@ -94,10 +94,7 @@ pub async fn install_module(
         let (schema_id, past_module_hashes) = if pkg.schemas()?.len() > 1 {
             (None, None)
         } else {
-            (
-                module_details.schema_id().map(Into::into),
-                module_details.past_hashes,
-            )
+            (module_details.schema_id(), module_details.past_hashes)
         };
         let metadata = pkg.metadata()?;
         let (_, svs, _) = match import_pkg_from_pkg(
@@ -147,7 +144,7 @@ pub async fn install_module(
             }
             variants.push(front_end_variant);
         } else {
-            return Err(ModuleError::SchemaNotFoundFromInstall(id));
+            return Err(ModuleError::NoSchemaVariantsInModule(id));
         };
     }
 

--- a/lib/sdf-server/src/service/module/upgrade_modules.rs
+++ b/lib/sdf-server/src/service/module/upgrade_modules.rs
@@ -64,7 +64,7 @@ pub async fn upgrade_modules(
             &ctx,
             &si_pkg,
             Some(ImportOptions {
-                schema_id: Some(schema_id.into()),
+                schema_id: Some(schema_id),
                 ..Default::default()
             }),
         )
@@ -106,7 +106,7 @@ pub async fn upgrade_modules(
             }
             variants.push(front_end_variant);
         } else {
-            return Err(ModuleError::SchemaNotFoundFromInstall(schema_id.into()));
+            return Err(ModuleError::SchemaNotFoundFromInstall(schema_id));
         };
     }
 

--- a/lib/sdf-server/src/service/v2/module/module_by_id.rs
+++ b/lib/sdf-server/src/service/v2/module/module_by_id.rs
@@ -5,8 +5,8 @@ use axum::{
 use dal::{ChangeSetId, WorkspacePk};
 use module_index_client::ModuleIndexClient;
 use serde::{Deserialize, Serialize};
+use si_id::ModuleId;
 use si_pkg::SiPkg;
-use ulid::Ulid;
 
 use crate::{
     extract::{request::RawAccessToken, HandlerContext, PosthogClient},
@@ -19,7 +19,7 @@ use super::{ModuleAPIResult, ModulesAPIError};
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct GetRemoteModuleDetailsRequest {
-    pub id: Ulid,
+    pub id: ModuleId,
 }
 
 pub type RemoteModuleDetailsResponse = si_pkg::PkgSpec;


### PR DESCRIPTION
Modified Ulid -> SchemaId / ModuleId in a few places and then fixed the knock-on effects on types (lots fewer into()s). Also used `.parse()` instead of ::from_string() for type system happiness. Separating this out for reviewer joy!

### Testing

Relying on the integration tests in this PR to catch any issues; changes are rote.