### PR TITLE
Sanitize attribute func test options

### DIFF
--- a/app/web/src/components/FuncEditor/FuncTest.vue
+++ b/app/web/src/components/FuncEditor/FuncTest.vue
@@ -257,7 +257,7 @@ const enableTestTabGroup = computed((): boolean => {
   if (funcStore.selectedFuncSummary?.kind === FuncKind.Attribute) {
     if (
       funcTestSelectorRef.value?.selectedComponentId &&
-      funcTestSelectorRef.value?.selectedPrototypeId
+      funcTestSelectorRef.value?.selectedOutputLocationId
     ) {
       return true;
     }
@@ -366,20 +366,19 @@ const prepareTest = async () => {
   resetTestData();
 
   if (funcStore.selectedFuncSummary?.kind === FuncKind.Attribute) {
-    if (!funcTestSelectorRef.value.selectedPrototypeId) {
+    if (!funcTestSelectorRef.value.selectedOutputLocationId) {
       throw new Error(
-        "cannot prepare test for attribute func without a selected prototype",
+        "cannot prepare test for attribute func without a selected output location",
       );
     }
 
-    const propId = funcTestSelectorRef.value.selectedPrototypeId.startsWith(
-      "p_",
-    )
-      ? funcTestSelectorRef.value.selectedPrototypeId.replace("p_", "")
-      : undefined;
+    const propId =
+      funcTestSelectorRef.value.selectedOutputLocationId.startsWith("p_")
+        ? funcTestSelectorRef.value.selectedOutputLocationId.replace("p_", "")
+        : undefined;
     const outputSocketId =
-      funcTestSelectorRef.value.selectedPrototypeId.startsWith("s_")
-        ? funcTestSelectorRef.value.selectedPrototypeId.replace("s_", "")
+      funcTestSelectorRef.value.selectedOutputLocationId.startsWith("s_")
+        ? funcTestSelectorRef.value.selectedOutputLocationId.replace("s_", "")
         : undefined;
 
     const res = await funcStore.FETCH_PROTOTYPE_ARGUMENTS(


### PR DESCRIPTION
## Description

This PR sanitizes attribute func test options for output locations. Specifically, it makes sure all options are available _and_ selectable. It intentionally leaves the func test experience alone.

## Input Screenshot

<img width="843" alt="Screenshot 2025-03-21 at 4 54 28 PM" src="https://github.com/user-attachments/assets/61cc9867-fe80-4c6a-8bf3-df047c9c249f" />

## Output Screenshot

<img width="844" alt="Screenshot 2025-03-21 at 4 54 31 PM" src="https://github.com/user-attachments/assets/90e28c1c-f235-40f5-90e6-4a2c97b15666" />
