### PR TITLE
chore(build): Cargo lockfile update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7194,7 +7194,7 @@ dependencies = [
  "si-events",
  "si-id",
  "strum",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]


### PR DESCRIPTION
When I open the site in my local dev environment, cargo makes this lockfile update - this feels like it was missing from an older PR