### PR TITLE
Add code body to info span for func runner

### DIFF
--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -182,6 +182,7 @@ impl FuncRunner {
             si.func_run.func.id = Empty,
             si.func_run.func.kind = func.kind.as_ref(),
             si.func_run.func.name = func.name.as_str(),
+            si.func_run.func.code_plaintext = Empty,
             si.func_run.id = Empty,
             si.workspace.id = Empty,
         )
@@ -246,6 +247,7 @@ impl FuncRunner {
                 let id = func_run_inner.id().array_to_str(&mut id_buf);
                 span.record("job.id", &id);
                 span.record("si.func_run.id", &id);
+                span.record("si.func_run.func.code_plaintext", &func.code_plaintext()?);
 
                 span.record("si.func_run.func.id", func.id.array_to_str(&mut id_buf));
 
@@ -312,6 +314,7 @@ impl FuncRunner {
             si.func_run.func.id = Empty,
             si.func_run.func.kind = func.kind.as_ref(),
             si.func_run.func.name = func.name.as_str(),
+            si.func_run.func.code_plaintext = Empty,
             si.func_run.id = Empty,
             si.workspace.id = Empty,
         )
@@ -389,6 +392,7 @@ impl FuncRunner {
                 let id = func_run_inner.id().array_to_str(&mut id_buf);
                 span.record("job.id", &id);
                 span.record("si.func_run.id", &id);
+                span.record("si.func_run.func.code_plaintext", &func.code_plaintext()?);
 
                 span.record("si.func_run.func.id", func.id.array_to_str(&mut id_buf));
 
@@ -453,6 +457,7 @@ impl FuncRunner {
             si.func_run.func.id = Empty,
             si.func_run.func.kind = Empty,
             si.func_run.func.name = Empty,
+            si.func_run.func.code_plaintext = Empty,
             si.func_run.id = Empty,
             si.workspace.id = Empty,
         )
@@ -543,6 +548,7 @@ impl FuncRunner {
                 let id = func_run_inner.id().array_to_str(&mut id_buf);
                 span.record("job.id", &id);
                 span.record("si.func_run.id", &id);
+                span.record("si.func_run.func.code_plaintext", &func.code_plaintext()?);
 
                 span.record("job.invoked_name", func.name.as_str());
                 span.record("si.func_run.func.name", func.name.as_str());
@@ -620,6 +626,7 @@ impl FuncRunner {
             si.func_run.func.id = Empty,
             si.func_run.func.kind = Empty,
             si.func_run.func.name = Empty,
+            si.func_run.func.code_plaintext = Empty,
             si.func_run.id = Empty,
         )
     )]
@@ -713,6 +720,7 @@ impl FuncRunner {
                 let id = func_run_inner.id().array_to_str(&mut id_buf);
                 parent_span.record("job.id", &id);
                 parent_span.record("si.func_run.id", &id);
+                parent_span.record("si.func_run.func.code_plaintext", &func.code_plaintext()?);
 
                 parent_span.record("job.invoked_name", func.name.as_str());
                 parent_span.record("si.func_run.func.name", func.name.as_str());
@@ -786,6 +794,7 @@ impl FuncRunner {
             si.func_run.func.id = Empty,
             si.func_run.func.kind = Empty,
             si.func_run.func.name = Empty,
+            si.func_run.func.code_plaintext = Empty,
             si.func_run.id = Empty,
             si.workspace.id = Empty,
         )
@@ -881,6 +890,7 @@ impl FuncRunner {
                 let id = func_run_inner.id().array_to_str(&mut id_buf);
                 span.record("job.id", &id);
                 span.record("si.func_run.id", &id);
+                span.record("si.func_run.func.code_plaintext", &func.code_plaintext()?);
 
                 span.record("job.invoked_name", func.name.as_str());
                 span.record("si.func_run.func.name", func.name.as_str());
@@ -966,6 +976,7 @@ impl FuncRunner {
             si.func_run.func.id = Empty,
             si.func_run.func.kind = Empty,
             si.func_run.func.name = Empty,
+            si.func_run.func.code_plaintext = Empty,
             si.func_run.id = Empty,
             si.workspace.id = Empty,
         )
@@ -1092,6 +1103,7 @@ impl FuncRunner {
                 let id = func_run_inner.id().array_to_str(&mut id_buf);
                 span.record("job.id", &id);
                 span.record("si.func_run.id", &id);
+                span.record("si.func_run.func.code_plaintext", &func.code_plaintext()?);
 
                 span.record("job.invoked_name", func.name.as_str());
                 span.record("si.func_run.func.name", func.name.as_str());


### PR DESCRIPTION
## Description

This PR adds the code in plaintext to existing info spans for funcs executed via the func runner. This does not increase the number of spans. It adds metadata to existing ones.

## No Code (e.g. Intrinsic)

<img width="1557" alt="Screenshot 2025-03-24 at 4 08 12 PM" src="https://github.com/user-attachments/assets/85bdefad-6cff-48d0-8a19-9420dc2b5360" />

## With Code (e.g. Qualification)

<img width="1599" alt="Screenshot 2025-03-24 at 4 10 00 PM" src="https://github.com/user-attachments/assets/2a630044-c373-4349-8ae0-8e05371c08d8" />