### PR TITLE
fix(clover): add missing api key for asset update

### DIFF
--- a/.github/workflows/asset-update.yml
+++ b/.github/workflows/asset-update.yml
@@ -11,6 +11,7 @@ jobs:
     env:
       SI_BEARER_TOKEN: ${{ secrets.SI_BEARER_TOKEN }}
       SI_MODULE_INDEX_URL: "https://module-index.systeminit.com"
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2


### PR DESCRIPTION
https://github.com/systeminit/si/actions/runs/14013774191/job/39236797092

```
Task run deno run --allow-all main.ts "infer-ai"
  error: Missing required environment variable "OPENAI_API_KEY".
  ```