### PR TITLE
feat(web): Add fuzzy search to floating connections menu

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -63,6 +63,7 @@
     "date-fns": "^2.29.2",
     "floating-vue": "^2.0.0-beta.20",
     "fontfaceobserver": "^2.3.0",
+    "fzf": "^0.5.2",
     "graphology": "^0.25.4",
     "graphology-layout-forceatlas2": "^0.10.1",
     "graphology-layout-noverlap": "^0.4.2",

--- a/app/web/src/components/ModelingView/ConnectionMenuSocketList.vue
+++ b/app/web/src/components/ModelingView/ConnectionMenuSocketList.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="flex flex-col basis-1/2 h-full">
+  <div
+    :class="clsx('flex flex-col basis-1/2 h-full', active && 'bg-neutral-800')"
+  >
     <div
       v-if="listItems.length"
       :class="
@@ -45,11 +47,12 @@
 
         <span>
           <template
-            v-for="(part, partIndex) in item.label.split('/')"
+            v-for="(part, partIndex) in item.label.split('')"
             :key="partIndex"
           >
-            <span v-if="partIndex !== 0" class="text-neutral-400"> / </span>
-            <span>{{ part }}</span>
+            <span v-if="part === '/'" class="text-neutral-400"> / </span>
+            <b v-else-if="item.labelHighlights?.has(partIndex)">{{ part }}</b>
+            <span v-else>{{ part }}</span>
           </template>
         </span>
       </div>
@@ -92,6 +95,7 @@ export type SocketListEntry = {
   component: DiagramNodeData | DiagramGroupData;
   socket: DiagramSocketData;
   label: string;
+  labelHighlights?: Set<number>;
 };
 
 const props = defineProps({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
       fontfaceobserver:
         specifier: ^2.3.0
         version: 2.3.0
+      fzf:
+        specifier: ^0.5.2
+        version: 0.5.2
       graphology:
         specifier: ^0.25.4
         version: 0.25.4(graphology-types@0.24.7)
@@ -5879,6 +5882,9 @@ packages:
   fuzzy@0.1.3:
     resolution: {integrity: sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==}
     engines: {node: '>= 0.6.0'}
+
+  fzf@0.5.2:
+    resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
 
   gauge@3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
@@ -16963,6 +16969,8 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   fuzzy@0.1.3: {}
+
+  fzf@0.5.2: {}
 
   gauge@3.0.2:
     dependencies:


### PR DESCRIPTION
- Options are now filtered via fuzzy search
- tab now selects the highlighted socket (enter key does the same thing, shift+tab undoes selection)
- the active side of the connections menu is highlighted too
- Fixes a bug on the peer socket calculations that would count unary connected sockets as possible connection candidate

<img width="1978" alt="image" src="https://github.com/user-attachments/assets/c0409db2-4c2e-4b4c-ad01-2cb81bbbe3e2" />
