### PR TITLE
chore: create separate config value for layer db host

### DIFF
--- a/component/init/configs/service.toml
+++ b/component/init/configs/service.toml
@@ -58,7 +58,7 @@ user = "si"
 password = "$SI_PG_PASSWORD"
 dbname = "$SI_LAYER_CACHE_DBNAME"
 application_name = "$SI_SERVICE"
-hostname = "$SI_PG_PROXY_HOST"
+hostname = "$SI_PG_LAYER_CACHE_PROXY_HOST"
 port = 5432
 pool_max_size = $SI_PG_POOL_SIZE
 


### PR DESCRIPTION
Added to prod [here](https://systeminit.slack.com/archives/C084J3EJABG/p1743104458788359)

Gives us a separate value so we can configure a separate proxy host for the layer cache