### PR TITLE
Prevent: one million toasts for maintenance or downtime mode

### DIFF
--- a/app/web/src/store/apis.web.ts
+++ b/app/web/src/store/apis.web.ts
@@ -107,6 +107,7 @@ async function handleOutageModes(error: AxiosError) {
     const toast = useToast();
     toast(
       {
+        id: "MAINTENANCE",
         component: MaintenanceMode,
       },
       {
@@ -121,6 +122,7 @@ async function handleOutageModes(error: AxiosError) {
     const toast = useToast();
     toast(
       {
+        id: "DOWNTIMETOAST",
         component: UnscheduledDowntime,
       },
       {


### PR DESCRIPTION
Using an ID with a toast means a new toast should replace an old toast. Which will appear as a "toast that never goes away"... but not one million toasts that take up the entire screen.
<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYzJkajgxNjg4NG84YXlwYnFmNXppMDFiaWdjeXU1b3Z2aHNudnZxZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/26BRwW3ckGjcZmsxO/giphy.gif"/>