### PR TITLE
Use DeriveValueType on ModuleKind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6552,9 +6552,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3417812d38049e8ec3d588c03570f8c60de811d2453fb48e424045a1600ffd86"
+checksum = "013d6c9e421b9c44c6eb6ebbee283b2a2c90eab2682088c4a2449706a42d117f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6572,7 +6572,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "time",
  "tracing",
  "url",
@@ -6581,9 +6581,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d705ba84e1c74c8ac27784e4ac6f21584058c1dc0cadb9d39b43e109fcf8139c"
+checksum = "31feeff3ad5e999c64b2b8fd30933b2871911567c4d62dcf70b3effd970c7891"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ rust-s3 = { version = "0.34.0-rc4", default-features = false, features = [
 rustls = { version = "0.23.19", default-features = false } # NOTE(nick,fletcher): rustls switched to "aws-lc-rs" as its default crypto provider, but we want ring (i.e. we disable the default feature for "aws-lc-rs")
 rustls-native-certs = "0.8.1"
 rustls-pemfile = { version = "2.2.0" }
-sea-orm = { version = "1.1.2", features = [
+sea-orm = { version = "1.1.8", features = [
     "sqlx-postgres",
     "runtime-tokio-rustls",
     "macros",


### PR DESCRIPTION
Hi there, thank you for using SeaORM! I've released a new feature in [sea-orm 1.1.8](https://github.com/SeaQL/sea-orm/releases/tag/1.1.8), which could reduce some boilerplate for `si_module`.

I'd suggest upgrading `sea-orm` to the latest version to use this feature.