### PR TITLE
fix(dal): make secrets list fast

### DIFF
--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -970,6 +970,22 @@ impl SchemaVariant {
         Self::default_id_for_schema(ctx, schema_id).await
     }
 
+    /// Returns a list of all schema variants that are on the graph (not uninstalled variants!)
+    pub async fn list_all_ids(ctx: &DalContext) -> SchemaVariantResult<Vec<SchemaVariantId>> {
+        let mut result = vec![];
+
+        for schema_id in Schema::list_ids(ctx).await? {
+            result.extend(
+                Self::list_for_schema(ctx, schema_id)
+                    .await?
+                    .into_iter()
+                    .map(|sv| sv.id()),
+            );
+        }
+
+        Ok(result)
+    }
+
     pub async fn list_for_schema(
         ctx: &DalContext,
         schema_id: SchemaId,

--- a/lib/dal/src/secret/definition_view.rs
+++ b/lib/dal/src/secret/definition_view.rs
@@ -38,6 +38,7 @@ struct SecretFormDataView {
 impl SecretDefinitionView {
     /// Assembles [`views`](SecretDefinitionView) for all secret definitions in the
     /// [`snapshot`](crate::WorkspaceSnapshot).
+    #[instrument(level = "debug", name = "list_secret_definition_views", skip_all)]
     pub async fn list(ctx: &DalContext) -> SecretDefinitionViewResult<Vec<Self>> {
         let schema_variant_ids = SchemaVariant::list_default_ids(ctx).await?;
 

--- a/lib/sdf-server/src/service/secret.rs
+++ b/lib/sdf-server/src/service/secret.rs
@@ -35,6 +35,8 @@ pub enum SecretError {
     Nats(#[from] si_data_nats::NatsError),
     #[error("pg error: {0}")]
     Pg(#[from] si_data_pg::PgError),
+    #[error("schema variant error: {0}")]
+    SchemaVariant(#[from] dal::SchemaVariantError),
     #[error("secret definition view error: {0}")]
     SecretDefinitionView(#[from] dal::SecretDefinitionViewError),
     #[error("secret view error: {0}")]

--- a/lib/sdf-server/src/service/secret/create_secret.rs
+++ b/lib/sdf-server/src/service/secret/create_secret.rs
@@ -63,7 +63,7 @@ pub async fn create_secret(
 
     ctx.commit().await?;
 
-    let secret = SecretView::from_secret(&ctx, secret).await?;
+    let secret = SecretView::from_secret(&ctx, secret, None).await?;
 
     Ok(ForceChangeSetResponse::new(force_change_set_id, secret))
 }

--- a/lib/sdf-server/src/service/secret/delete_secret.rs
+++ b/lib/sdf-server/src/service/secret/delete_secret.rs
@@ -28,7 +28,7 @@ pub async fn delete_secret(
     // Delete Secret
     let secret = Secret::get_by_id(&ctx, request.id).await?;
 
-    let connected_components = secret.clone().find_connected_components(&ctx).await?;
+    let connected_components = secret.clone().find_connected_components(&ctx, None).await?;
     if !connected_components.is_empty() {
         return Err(SecretError::CantDeleteSecret(request.id));
     }

--- a/lib/sdf-server/src/service/secret/list_secrets.rs
+++ b/lib/sdf-server/src/service/secret/list_secrets.rs
@@ -49,12 +49,16 @@ pub async fn list_secrets(
         })
         .collect::<HashMap<_, _>>();
 
+    let prefetched_secret_props = Secret::list_all_secret_prop_ids(&ctx).await?;
     for secret in Secret::list(&ctx).await? {
         hash_map
             .get_mut(secret.definition())
             .ok_or(SecretError::SecretWithInvalidDefinition(secret.id()))?
             .secrets
-            .push(SecretView::from_secret(&ctx, secret).await?);
+            .push(
+                SecretView::from_secret(&ctx, secret, Some(prefetched_secret_props.as_slice()))
+                    .await?,
+            );
     }
 
     Ok(Json(hash_map))

--- a/lib/sdf-server/src/service/secret/update_secret.rs
+++ b/lib/sdf-server/src/service/secret/update_secret.rs
@@ -78,6 +78,6 @@ pub async fn update_secret(
 
     Ok(ForceChangeSetResponse::new(
         force_change_set_id,
-        SecretView::from_secret(&ctx, secret).await?,
+        SecretView::from_secret(&ctx, secret, None).await?,
     ))
 }


### PR DESCRIPTION
Two big changes here:

1. Don't use `list_user_facing` which does a ton of extra work when all we want is the active variants.
2. Prefetch all the secret prop ids in one query, instead of doing it for every secret