### PR TITLE
fix(sdf): Only enqueue update functions if the values have changed

### DIFF
--- a/lib/sdf-server/src/service/component/update_property_editor_value.rs
+++ b/lib/sdf-server/src/service/component/update_property_editor_value.rs
@@ -71,6 +71,7 @@ pub async fn update_property_editor_value(
             )
             .await
             .unwrap_or(false)
+            && request.value != before_value
         {
             Component::enqueue_relevant_update_actions(&ctx, request.attribute_value_id).await?;
         }


### PR DESCRIPTION
We enqueue an update action downstream even if the value hasn't changed