### PR TITLE
fix(web): move manifest to the root of the dist

### DIFF
--- a/app/web/vite.config.ts
+++ b/app/web/vite.config.ts
@@ -112,7 +112,7 @@ export default (opts: { mode: string }) => {
       ],
     },
     build: {
-      manifest: true,
+      manifest: "manifest.json",
       rollupOptions: {
         input: {
           main: path.resolve(__dirname, "index.html"),


### PR DESCRIPTION
Moves the `manifest.json` to the root of the dist when building via vite. This ensure we don't need to do any redirect hopping prone to cors and content blocking issues.

![image](https://github.com/user-attachments/assets/d079190a-002e-440b-8a81-e8ba811f15ba)
