### PR TITLE
fix(sdf): Don't truncate logs

### DIFF
--- a/lib/si-data-nats/src/subscriber.rs
+++ b/lib/si-data-nats/src/subscriber.rs
@@ -50,6 +50,11 @@ impl Subscriber {
         }
     }
 
+    /// Get the subject of this subscription.
+    pub fn subject(&self) -> &str {
+        &self.metadata.messaging_destination_name
+    }
+
     /// Unsubscribes from subscription, draining all remaining messages.
     ///
     /// # Examples


### PR DESCRIPTION
When there are a lot of logs for a function, we don't upload or report them.

This PR fixes this by leaving the output processor running until all logs have been processed.

Fixes BUG-811.

## Testing

- [x] Test management function that prints 10000 log messages, make sure all log messages show up and output task is shut down
- [x] Test multiple DVUs and management functions running in paralllel, make sure all logs show up
- [x] Kill Veritech after 10000 log message function exits but before logs are processed, make sure all logs show up and output task is shut down
- [x] Kill Veritech while 5-minute "print log every second" function is running, make sure job recovers, new log messages show up, and output task is shut down