### PR TITLE
feat(web): Stream management function logs while they are running

### DIFF
--- a/app/web/src/components/ComponentDetailsManagement.vue
+++ b/app/web/src/components/ComponentDetailsManagement.vue
@@ -32,7 +32,6 @@
           :prototype="prototype"
           :component="props.component"
           @showLatestRunTab="showLatestRunTab"
-          @runUpdated="updateFuncRunTab"
           @click="hideFuncRun"
         />
       </template>
@@ -65,7 +64,7 @@ import {
   ManagementHistoryItem,
   useManagementRunsStore,
 } from "@/store/management_runs.store";
-import { FuncRun, FuncRunId, useFuncRunsStore } from "@/store/func_runs.store";
+import { FuncRunId, useFuncRunsStore } from "@/store/func_runs.store";
 import { useViewsStore } from "@/store/views.store";
 import ManagementRunPrototype from "./ManagementRunPrototype.vue";
 import ManagementHistoryCard from "./Management/ManagementHistoryCard.vue";
@@ -85,33 +84,24 @@ const resourceId = ref("");
 
 const selectedFuncRunId = ref<FuncRunId | undefined>();
 const selectedTab = ref<string | undefined>();
-const funcRun = ref<FuncRun | undefined>();
+const funcRun = computed(() => {
+  if (!selectedFuncRunId.value) return undefined;
+  // If it doesn't exist, start a fetch to get it
+  if (!funcRunStore.funcRuns[selectedFuncRunId.value])
+    funcRunStore.GET_FUNC_RUN(selectedFuncRunId.value);
+  return funcRunStore.funcRuns[selectedFuncRunId.value];
+});
 const openFuncRunTab = ref(false);
-
-const getFuncRun = async (id: FuncRunId) => {
-  if (funcRunStore.funcRuns[id]) {
-    funcRun.value = funcRunStore.funcRuns[id];
-  } else {
-    await funcRunStore.GET_FUNC_RUN(id);
-    funcRun.value = funcRunStore.funcRuns[id];
-  }
-};
 
 const showLatestRunTab = async (id: FuncRunId, slug: string) => {
   openFuncRunTab.value = true;
   selectedFuncRunId.value = id;
-  await getFuncRun(id);
   selectedTab.value = slug;
-};
-
-const updateFuncRunTab = async (id: FuncRunId) => {
-  await getFuncRun(id);
 };
 
 const clickItem = async (item: ManagementHistoryItem, _e: MouseEvent) => {
   openFuncRunTab.value = true;
   selectedFuncRunId.value = item.funcRunId;
-  await getFuncRun(item.funcRunId);
 };
 
 const hideFuncRun = () => {

--- a/app/web/src/components/ManagementRunPrototype.vue
+++ b/app/web/src/components/ManagementRunPrototype.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, onMounted, watch } from "vue";
+import { ref, computed, onMounted } from "vue";
 import clsx from "clsx";
 import {
   DropdownMenu,
@@ -82,7 +82,6 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: "showLatestRunTab", id: FuncRunId, slug: string): void;
-  (e: "runUpdated", id: FuncRunId): void;
 }>();
 
 const request = funcStore.getRequestStatus(
@@ -118,12 +117,6 @@ const componentViews = computed(() =>
       !!viewsStore.viewsById[viewId]?.groups[props.component.def.id],
   ),
 );
-
-watch(latestRunId, (latest) => {
-  if (latest) {
-    emit("runUpdated", latest);
-  }
-});
 
 const lastExecution = computed<FuncRun | null>(() => {
   if (latestRunId.value) {

--- a/app/web/src/store/func_runs.store.ts
+++ b/app/web/src/store/func_runs.store.ts
@@ -176,6 +176,9 @@ export const useFuncRunsStore = () => {
           {
             eventType: "FuncRunLogUpdated",
             callback: (payload) => {
+              // If the func run already exists, update it
+              if (this.funcRuns[payload.funcRunId])
+                this.GET_FUNC_RUN(payload.funcRunId);
               if (payload.actionId)
                 this.lastRuns[payload.actionId] = new Date();
             },


### PR DESCRIPTION
If you look at the logs for a running function, they stay static forever until you reload. This PR makes it so that we stream new logs whenever they become available, by calling GET_FUNC_RUN when we see FuncRunLogUpdated. We only do this if the func run is cached, to prevent unnecessary network usage.

### Tests

- [x] Run a management function that logs and sleeps repeatedly for 10 seconds; click out of mgmt fns view and back in to get the run to show up; click the run, click logs, and watch logs stream to the browser