### PR TITLE
fix(web): Prevent users from triggering management functions for a component currently being updated

### DIFF
--- a/app/web/src/components/ComponentDetailsManagement.vue
+++ b/app/web/src/components/ComponentDetailsManagement.vue
@@ -21,7 +21,8 @@
     <div
       class="text-sm text-neutral-700 dark:text-neutral-300 p-xs italic border-b dark:border-neutral-600"
     >
-      The functions below will run immediately in a change set
+      <div v-if="isLoading">Component update in progress...</div>
+      <div v-else>The functions below will run immediately in a change set</div>
     </div>
     <ul class="text-sm">
       <template
@@ -66,6 +67,7 @@ import {
 } from "@/store/management_runs.store";
 import { FuncRunId, useFuncRunsStore } from "@/store/func_runs.store";
 import { useViewsStore } from "@/store/views.store";
+import { useStatusStore } from "@/store/status.store";
 import ManagementRunPrototype from "./ManagementRunPrototype.vue";
 import ManagementHistoryCard from "./Management/ManagementHistoryCard.vue";
 import {
@@ -79,6 +81,7 @@ const funcRunStore = useFuncRunsStore();
 const componentsStore = useComponentsStore();
 const viewStore = useViewsStore();
 const mgmtStore = useManagementRunsStore();
+const statusStore = useStatusStore();
 
 const resourceId = ref("");
 
@@ -112,6 +115,10 @@ const hideFuncRun = () => {
 const props = defineProps<{
   component: DiagramGroupData | DiagramNodeData;
 }>();
+
+const isLoading = computed(() =>
+  statusStore.componentIsLoading(props.component.def.id),
+);
 
 watch(
   () => props.component.def.resourceId,

--- a/app/web/src/components/ManagementRunPrototype.vue
+++ b/app/web/src/components/ManagementRunPrototype.vue
@@ -17,7 +17,15 @@
       />
     </DropdownMenu>
 
-    <IconButton icon="play" :requestStatus="request" @click="runClick" />
+    <IconButton
+      icon="play"
+      :requestStatus="request"
+      :disabled="isLoading"
+      :tooltip="
+        isLoading ? `Wait for component finish updating` : `Run Function`
+      "
+      @click="runClick"
+    />
 
     <TruncateWithTooltip class="grow">{{
       `Run ${props.prototype.label}`
@@ -56,6 +64,7 @@ import {
   useFuncRunsStore,
 } from "@/store/func_runs.store";
 import { useManagementRunsStore } from "@/store/management_runs.store";
+import { useStatusStore } from "@/store/status.store";
 import { useViewsStore } from "@/store/views.store";
 import { ViewId } from "@/api/sdf/dal/views";
 import { ComponentType } from "@/api/sdf/dal/schema";
@@ -69,6 +78,7 @@ import FuncRunTabDropdown from "./FuncRunTabDropdown.vue";
 const funcStore = useFuncStore();
 const viewStore = useViewsStore();
 const router = useRouter();
+const statusStore = useStatusStore();
 const managementRunsStore = useManagementRunsStore();
 const viewsStore = useViewsStore();
 const funcRunStore = useFuncRunsStore();
@@ -88,6 +98,10 @@ const request = funcStore.getRequestStatus(
   "RUN_MGMT_PROTOTYPE",
   props.prototype.managementPrototypeId,
   props.component.def.id,
+);
+
+const isLoading = computed(() =>
+  statusStore.componentIsLoading(props.component.def.id),
 );
 
 const historicalFuncRun = ref<FuncRun | null>(null);


### PR DESCRIPTION
This PR is a bit of a stop gap, while we don't have coordination between Management Functions and DVU yet, we do have the data on the front end to know if a Component is currently being impacted by DVU.  Use this data to block the ability for users to trigger a management function while a component is being updated to reduce the risk of management functions executing on stale data.

Tested by creating a qualification with a sleep, and seeing that the right click menu and management functions panel are reactive to the Component status changing as DVU starts/stops. 

<div><img src="https://media3.giphy.com/media/htVOLW8TStuLFlUAvG/200.gif?cid=5a38a5a2t3qpxzeada3ccuiww2kag2nsrggc92ie5q089dkn&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:170px;width:300px"/><br/>via <a href="https://giphy.com/BigBrotherAU/">Big Brother Australia</a> on <a href="https://giphy.com/gifs/BigBrotherAU-bbau-bigbrotherau-bbau3-htVOLW8TStuLFlUAvG">GIPHY</a></div>