### PR TITLE
Fix: unexpected type mismatch or bad data

### DIFF
--- a/app/web/src/components/LeftPanelDrawer.vue
+++ b/app/web/src/components/LeftPanelDrawer.vue
@@ -139,6 +139,9 @@ const viewAddMutation = useMutation({
           views: [],
         };
       }
+      if (!old.views || !Array.isArray(old.views)) {
+        old.views = [];
+      }
       old.views = [
         ...old.views,
         {


### PR DESCRIPTION
### Please come save us type generation

<img src="https://media1.giphy.com/media/tMNuvbHyLLXvq/giphy.gif?cid=bd3ea57egddargpsiw9g0fhl9mrkgfr2jj8idyg8ju5iir71&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>

here is the error from Jacob:
![image](https://github.com/user-attachments/assets/9a8c3f09-54f6-47b5-852c-e3bd7d6c11ba)


here is the built code:
```
return ee.setQueryData(he, Ae => (Ae || (Ae = {
                    id: sl("new list id"),
                    views: []
                }),
                Ae.views = [...Ae.views, {
                    id: sl("new-view-id"),
                    name: oe,
                    isDefault: !1,
                    created_at: new Date().toLocaleString(),
                    updated_at: new Date().toLocaleString()
                }],
```
Here is the code I wrote:
```
if (!old) {
        old = {
          id: _.uniqueId("new list id"),
          views: [],
        };
      }
      old.views = [
        ...old.views,
        {
          id: _.uniqueId("new-view-id"),
          name: newName,
          isDefault: false,
          created_at: new Date().toLocaleString(),
          updated_at: new Date().toLocaleString(),
        },
      ];
```

Which means... that `old` exists as something?! but it doesn't have a views property as an array like we expect. So I'm gonna slam this in here