### PR TITLE
feat: override update on AWS::ECS::TaskDefinition

### DIFF
--- a/bin/clover/src/cloud-control-funcs/overrides/AWS::ECS::TaskDefinition/actions/update.ts
+++ b/bin/clover/src/cloud-control-funcs/overrides/AWS::ECS::TaskDefinition/actions/update.ts
@@ -1,0 +1,190 @@
+async function main(component: Input): Promise<Output> {
+  const codeString = component.properties.code?.["awsCloudControlCreate"]?.code;
+
+  if (!codeString) {
+    return {
+      status: "error",
+      message: `Could not find awsCloudControlCreate for resource`,
+    };
+  }
+
+  const domain = component.properties?.domain;
+  const code = JSON.parse(codeString);
+
+  const payload = code["DesiredState"];
+  const propUsageMap = JSON.parse(domain.extra.PropUsageMap);
+  addSecretsToPayload(payload, propUsageMap);
+
+  const inputObject = {
+    TypeName: code["TypeName"],
+    DesiredState: JSON.stringify(payload),
+  };
+  const inputJson = JSON.stringify(inputObject);
+
+  const child = await siExec.waitUntilEnd("aws", [
+    "cloudcontrol",
+    "create-resource",
+    "--region",
+    domain?.extra?.Region || "",
+    "--cli-input-json",
+    inputJson || "",
+  ]);
+
+  if (child.exitCode !== 0) {
+    console.error(child.stderr);
+    return {
+      status: "error",
+      message:
+        `Unable to create; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
+    };
+  }
+
+  const progressEvent = JSON.parse(child.stdout);
+  console.log("Progress Event", progressEvent);
+
+  const delay = (time: number) => {
+    return new Promise((res) => {
+      setTimeout(res, time);
+    });
+  };
+
+  let finished = false;
+  let success = false;
+  let wait = 1000;
+  const upperLimit = 10000;
+  let message = "";
+  let identifier = "";
+
+  while (!finished) {
+    const child = await siExec.waitUntilEnd("aws", [
+      "cloudcontrol",
+      "get-resource-request-status",
+      "--region",
+      domain?.extra?.Region || "",
+      "--request-token",
+      _.get(progressEvent, ["ProgressEvent", "RequestToken"]),
+    ]);
+
+    if (child.exitCode !== 0) {
+      console.error(child.stderr);
+      return {
+        status: "error",
+        message:
+          `Unable to create; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
+      };
+    }
+    const currentProgressEvent = JSON.parse(child.stdout);
+    console.log("Current Progress", currentProgressEvent);
+    const operationStatus =
+      currentProgressEvent["ProgressEvent"]["OperationStatus"];
+    if (operationStatus == "SUCCESS") {
+      finished = true;
+      success = true;
+      identifier = currentProgressEvent["ProgressEvent"]["Identifier"];
+    } else if (operationStatus == "FAILED") {
+      finished = true;
+      success = false;
+      message = currentProgressEvent["ProgressEvent"]["StatusMessage"] ||
+        currentProgressEvent["ProgressEvent"]["ErrorCode"];
+    } else if (operationStatus == "CANCEL_COMPLETE") {
+      finished = true;
+      success = false;
+      message = "Operation Canceled by API or AWS.";
+    }
+
+    if (!finished) {
+      console.log("\nWaiting to check status!\n");
+      await delay(wait);
+      if (wait != upperLimit) {
+        wait = wait + 1000;
+      }
+    }
+  }
+  if (success) {
+    const child = await siExec.waitUntilEnd("aws", [
+      "cloudcontrol",
+      "get-resource",
+      "--region",
+      _.get(component, "properties.domain.extra.Region", ""),
+      "--type-name",
+      _.get(component, "properties.domain.extra.AwsResourceType", ""),
+      "--identifier",
+      identifier,
+    ]);
+
+    if (child.exitCode !== 0) {
+      console.log("Failed to refresh cloud control resource");
+      console.log(child.stdout);
+      console.error(child.stderr);
+      return {
+        status: "error",
+        message:
+          `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+      };
+    }
+
+    const resourceResponse = JSON.parse(child.stdout);
+    const payload = JSON.parse(
+      resourceResponse["ResourceDescription"]["Properties"],
+    );
+    return {
+      payload,
+      status: "ok",
+    };
+  } else {
+    return {
+      message,
+      status: "error",
+    };
+  }
+}
+
+// If you change this, you should change the same func on awsCloudControlUpdate.ts in this same directory
+function addSecretsToPayload(
+  payload: Record<string, any>,
+  propUsageMap: {
+    secrets: {
+      secretKey: string;
+      propPath: string[];
+    }[];
+  },
+) {
+  if (
+    !Array.isArray(propUsageMap.secrets)
+  ) {
+    throw Error("malformed propUsageMap on asset");
+  }
+
+  for (
+    const {
+      secretKey,
+      propPath,
+    } of propUsageMap.secrets
+  ) {
+    const secret = requestStorage.getItem(secretKey);
+
+    if (!propPath?.length || propPath.length < 1) {
+      throw Error("malformed secret on propUsageMap: bad propPath");
+    }
+    if (!secret) continue;
+
+    let secretParent = payload;
+    let propKey = propPath[0];
+    for (let i = 1; i < propPath.length; i++) {
+      const thisProp = secretParent[propKey];
+
+      if (!thisProp) {
+        break;
+      }
+
+      secretParent = secretParent[propKey];
+      propKey = propPath[i];
+    }
+
+    // Only add secret to payload if the codegen output has it
+    if (propKey in secretParent) {
+      secretParent[propKey] = secret;
+    }
+  }
+}
+

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -20,6 +20,7 @@ import {
   createActionFuncSpec,
   createFunc,
   MANAGEMENT_FUNCS,
+  ACTION_FUNC_SPECS,
   modifyFunc,
   strippedBase64,
 } from "../spec/funcs.ts";
@@ -712,6 +713,13 @@ const overrides = new Map<string, OverrideFn>([
     defaultValue["createOnly"] = createOnly;
     defaultValue["updatable"] = updatable;
     propUsageMapProp!.data.defaultValue = JSON.stringify(defaultValue);
+
+    const updateTargetId = ACTION_FUNC_SPECS["Update Asset"].id;
+    const newUpdateId =
+      "7eb4e58626f9fd7ee003bb9a1de814ab31cbb8ea2ae87d844864058bc4296c63";
+    const newUpdatePath =
+        "./src/cloud-control-funcs/overrides/AWS::ECS::TaskDefinition/actions/update.ts";
+    modifyFunc(spec, updateTargetId, newUpdateId, newUpdatePath);
   }],
   ["AWS::ECR::RegistryPolicy", (spec: ExpandedPkgSpec) => {
     const variant = spec.schemas[0].variants[0];


### PR DESCRIPTION
This overrides the update function on AWS::ECS::TaskDefinition with a new one, which registers a new task definition via the same process as 'create' instead, and then runs the refresh function inline.

