### PR TITLE
Fix: force "teleport" input to always have focus

### DIFF
--- a/app/web/src/components/ModelingView/ConnectionMenuSocketList.vue
+++ b/app/web/src/components/ModelingView/ConnectionMenuSocketList.vue
@@ -96,6 +96,7 @@
         v-model="socketToShow.value"
         :recordId="''"
         disabled
+        noVim
         json
       />
       <div

--- a/app/web/src/components/ModelingView/FloatingConnectionMenu.vue
+++ b/app/web/src/components/ModelingView/FloatingConnectionMenu.vue
@@ -1,5 +1,10 @@
 <template>
-  <Modal ref="modalRef" size="max" title="Create Connection">
+  <Modal
+    ref="modalRef"
+    size="max"
+    title="Create Connection"
+    @click="focusOnInput"
+  >
     <div
       class="flex flex-col border-2 h-[80vh] rounded-sm"
       @click="focusOnInput"

--- a/lib/vue-lib/src/design-system/modals/Modal.vue
+++ b/lib/vue-lib/src/design-system/modals/Modal.vue
@@ -63,6 +63,7 @@
                   }[size],
                 )
               "
+              @click="onChromeClick"
             >
               <!-- fake input to prevent initial focus... only way to stop headless UI -->
               <input
@@ -250,10 +251,15 @@ function exitHandler() {
 
 const saveLabel = toRef(props, "saveLabel", "Create");
 
+const onChromeClick = () => {
+  emit("click");
+};
+
 const emit = defineEmits<{
   close: [];
   closeComplete: [];
   save: [];
+  click: [];
 }>();
 
 defineExpose({ open, close, isOpen });


### PR DESCRIPTION
Repro steps:
1. select a component
2. hit `c`
3. see the input has focus ✅ 
4. click the modal title bar
5. hit backspace/del ❌ 

the Modal "chrome" clicks were removing focus
<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOWYzM2J3NTlyYnU4ZW0zOHJlem81aGNrYTViZXQ1a2JidHFqdmdxNSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xTk9ZE94CfWTe2fzMI/giphy.gif"/>

I also got rid of the "read only" code editor in the display