### PR TITLE
chore: make pg recycle method configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "jobserver",
  "libc",
@@ -2198,6 +2198,7 @@ checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
 dependencies = [
  "deadpool-runtime",
  "num_cpus",
+ "serde",
  "tokio",
 ]
 
@@ -2210,6 +2211,7 @@ dependencies = [
  "async-trait",
  "deadpool",
  "getrandom 0.2.15",
+ "serde",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -2688,9 +2690,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -2834,9 +2836,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flagset"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -2845,7 +2847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.5",
+ "miniz_oxide 0.8.7",
 ]
 
 [[package]]
@@ -4528,9 +4530,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -7233,7 +7235,7 @@ dependencies = [
  "foyer",
  "fs4",
  "futures",
- "miniz_oxide 0.8.5",
+ "miniz_oxide 0.8.7",
  "mixtrics",
  "postcard",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ crossbeam-queue = { version = "0.3.11" }
 darling = "0.20.10"
 dashmap = "6.1.0"
 deadpool = { version = "0.12.1", features = ["rt_tokio_1"] }
-deadpool-postgres = "0.14.0"
+deadpool-postgres = { version = "0.14.0", features = ["serde"] }
 derive_builder = "0.20.2"
 derive_more = "0.99.17"
 devicemapper = { version = "=0.34.1" }

--- a/bin/pinga/src/args.rs
+++ b/bin/pinga/src/args.rs
@@ -102,6 +102,10 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) pg_cert_base64: Option<SensitiveString>,
 
+    /// PostgreSQL connection recycling method [default: Fast]
+    #[arg(long)]
+    pub(crate) pg_recycling_method: Option<String>,
+
     /// NATS connection URL [example: demo.nats.io]
     #[arg(long)]
     pub(crate) nats_url: Option<String>,
@@ -195,6 +199,13 @@ impl TryFrom<Args> for Config {
                 config_map.set(
                     "layer_db_config.pg_pool_config.certificate_base64",
                     cert.to_string(),
+                );
+            }
+            if let Some(recycling_method) = args.pg_recycling_method {
+                config_map.set("pg.recycling_method", recycling_method.clone());
+                config_map.set(
+                    "layer_db_config.pg_pool_config.recycling_method",
+                    recycling_method,
                 );
             }
             if let Some(url) = args.nats_url {

--- a/bin/rebaser/src/args.rs
+++ b/bin/rebaser/src/args.rs
@@ -98,6 +98,10 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) pg_cert_base64: Option<SensitiveString>,
 
+    /// PostgreSQL connection recycling method [default: Fast]
+    #[arg(long)]
+    pub(crate) pg_recycling_method: Option<String>,
+
     /// NATS connection URL [example: demo.nats.io]
     #[arg(long)]
     pub(crate) nats_url: Option<String>,
@@ -191,6 +195,13 @@ impl TryFrom<Args> for Config {
                 config_map.set(
                     "layer_db_config.pg_pool_config.certificate_base64",
                     cert.to_string(),
+                );
+            }
+            if let Some(recycling_method) = args.pg_recycling_method {
+                config_map.set("pg.recycling_method", recycling_method.clone());
+                config_map.set(
+                    "layer_db_config.pg_pool_config.recycling_method",
+                    recycling_method,
                 );
             }
             if let Some(url) = args.nats_url {

--- a/bin/sdf/src/args.rs
+++ b/bin/sdf/src/args.rs
@@ -106,6 +106,10 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) pg_cert_base64: Option<SensitiveString>,
 
+    /// PostgreSQL connection recycling method [default: Fast]
+    #[arg(long)]
+    pub(crate) pg_recycling_method: Option<String>,
+
     /// NATS connection URL [example: demo.nats.io]
     #[arg(long)]
     pub(crate) nats_url: Option<String>,
@@ -316,6 +320,13 @@ impl TryFrom<Args> for Config {
                 config_map.set(
                     "layer_db_config.pg_pool_config.certificate_path",
                     cert_path.display().to_string(),
+                );
+            }
+            if let Some(recycling_method) = args.pg_recycling_method {
+                config_map.set("pg.recycling_method", recycling_method.clone());
+                config_map.set(
+                    "layer_db_config.pg_pool_config.recycling_method",
+                    recycling_method,
                 );
             }
             if let Some(cert) = args.pg_cert_base64 {

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -2897,18 +2897,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "cc-1.2.17.crate",
-    sha256 = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a",
-    strip_prefix = "cc-1.2.17",
-    urls = ["https://static.crates.io/crates/cc/1.2.17/download"],
+    name = "cc-1.2.18.crate",
+    sha256 = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c",
+    strip_prefix = "cc-1.2.18",
+    urls = ["https://static.crates.io/crates/cc/1.2.18/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "cc-1.2.17",
-    srcs = [":cc-1.2.17.crate"],
+    name = "cc-1.2.18",
+    srcs = [":cc-1.2.18.crate"],
     crate = "cc",
-    crate_root = "cc-1.2.17.crate/src/lib.rs",
+    crate_root = "cc-1.2.18.crate/src/lib.rs",
     edition = "2018",
     features = ["parallel"],
     platform = {
@@ -4495,12 +4495,14 @@ cargo.rust_library(
         "default",
         "managed",
         "rt_tokio_1",
+        "serde",
         "unmanaged",
     ],
     visibility = [],
     deps = [
         ":deadpool-runtime-0.1.4",
         ":num_cpus-1.16.0",
+        ":serde-1.0.219",
         ":tokio-1.44.1",
     ],
 )
@@ -4528,6 +4530,7 @@ cargo.rust_library(
     features = [
         "default",
         "rt_tokio_1",
+        "serde",
     ],
     platform = {
         "linux-arm64": dict(
@@ -4553,6 +4556,7 @@ cargo.rust_library(
     deps = [
         ":async-trait-0.1.88",
         ":deadpool-0.12.2",
+        ":serde-1.0.219",
         ":tokio-1.44.1",
         ":tracing-0.1.41",
     ],
@@ -4606,7 +4610,7 @@ cargo.rust_library(
     deps = [
         ":const-oid-0.9.6",
         ":der_derive-0.7.3",
-        ":flagset-0.4.6",
+        ":flagset-0.4.7",
         ":pem-rfc7468-0.7.0",
         ":zeroize-1.8.1",
     ],
@@ -5648,18 +5652,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "errno-0.3.10.crate",
-    sha256 = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d",
-    strip_prefix = "errno-0.3.10",
-    urls = ["https://static.crates.io/crates/errno/0.3.10/download"],
+    name = "errno-0.3.11.crate",
+    sha256 = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e",
+    strip_prefix = "errno-0.3.11",
+    urls = ["https://static.crates.io/crates/errno/0.3.11/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "errno-0.3.10",
-    srcs = [":errno-0.3.10.crate"],
+    name = "errno-0.3.11",
+    srcs = [":errno-0.3.11.crate"],
     crate = "errno",
-    crate_root = "errno-0.3.10.crate/src/lib.rs",
+    crate_root = "errno-0.3.11.crate/src/lib.rs",
     edition = "2018",
     features = ["std"],
     platform = {
@@ -6033,18 +6037,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "flagset-0.4.6.crate",
-    sha256 = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec",
-    strip_prefix = "flagset-0.4.6",
-    urls = ["https://static.crates.io/crates/flagset/0.4.6/download"],
+    name = "flagset-0.4.7.crate",
+    sha256 = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe",
+    strip_prefix = "flagset-0.4.7",
+    urls = ["https://static.crates.io/crates/flagset/0.4.7/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "flagset-0.4.6",
-    srcs = [":flagset-0.4.6.crate"],
+    name = "flagset-0.4.7",
+    srcs = [":flagset-0.4.7.crate"],
     crate = "flagset",
-    crate_root = "flagset-0.4.6.crate/src/lib.rs",
+    crate_root = "flagset-0.4.7.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
 )
@@ -6078,7 +6082,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":crc32fast-1.4.2",
-        ":miniz_oxide-0.8.5",
+        ":miniz_oxide-0.8.7",
     ],
 )
 
@@ -10450,23 +10454,23 @@ cargo.rust_library(
 
 alias(
     name = "miniz_oxide",
-    actual = ":miniz_oxide-0.8.5",
+    actual = ":miniz_oxide-0.8.7",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "miniz_oxide-0.8.5.crate",
-    sha256 = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5",
-    strip_prefix = "miniz_oxide-0.8.5",
-    urls = ["https://static.crates.io/crates/miniz_oxide/0.8.5/download"],
+    name = "miniz_oxide-0.8.7.crate",
+    sha256 = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430",
+    strip_prefix = "miniz_oxide-0.8.7",
+    urls = ["https://static.crates.io/crates/miniz_oxide/0.8.7/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "miniz_oxide-0.8.5",
-    srcs = [":miniz_oxide-0.8.5.crate"],
+    name = "miniz_oxide-0.8.7",
+    srcs = [":miniz_oxide-0.8.7.crate"],
     crate = "miniz_oxide",
-    crate_root = "miniz_oxide-0.8.5.crate/src/lib.rs",
+    crate_root = "miniz_oxide-0.8.7.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -15249,7 +15253,7 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             named_deps = {
-                "libc_errno": ":errno-0.3.10",
+                "libc_errno": ":errno-0.3.11",
             },
             deps = [
                 ":libc-0.2.171",
@@ -15258,7 +15262,7 @@ cargo.rust_library(
         ),
         "linux-x86_64": dict(
             named_deps = {
-                "libc_errno": ":errno-0.3.10",
+                "libc_errno": ":errno-0.3.11",
             },
             deps = [
                 ":libc-0.2.171",
@@ -15267,25 +15271,25 @@ cargo.rust_library(
         ),
         "macos-arm64": dict(
             named_deps = {
-                "libc_errno": ":errno-0.3.10",
+                "libc_errno": ":errno-0.3.11",
             },
             deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
             named_deps = {
-                "libc_errno": ":errno-0.3.10",
+                "libc_errno": ":errno-0.3.11",
             },
             deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             named_deps = {
-                "libc_errno": ":errno-0.3.10",
+                "libc_errno": ":errno-0.3.11",
             },
             deps = [":windows-sys-0.59.0"],
         ),
         "windows-msvc": dict(
             named_deps = {
-                "libc_errno": ":errno-0.3.10",
+                "libc_errno": ":errno-0.3.11",
             },
             deps = [":windows-sys-0.59.0"],
         ),
@@ -15359,7 +15363,7 @@ cargo.rust_library(
     platform = {
         "linux-arm64": dict(
             named_deps = {
-                "libc_errno": ":errno-0.3.10",
+                "libc_errno": ":errno-0.3.11",
             },
             deps = [
                 ":libc-0.2.171",
@@ -15368,7 +15372,7 @@ cargo.rust_library(
         ),
         "linux-x86_64": dict(
             named_deps = {
-                "libc_errno": ":errno-0.3.10",
+                "libc_errno": ":errno-0.3.11",
             },
             deps = [
                 ":libc-0.2.171",
@@ -15377,25 +15381,25 @@ cargo.rust_library(
         ),
         "macos-arm64": dict(
             named_deps = {
-                "libc_errno": ":errno-0.3.10",
+                "libc_errno": ":errno-0.3.11",
             },
             deps = [":libc-0.2.171"],
         ),
         "macos-x86_64": dict(
             named_deps = {
-                "libc_errno": ":errno-0.3.10",
+                "libc_errno": ":errno-0.3.11",
             },
             deps = [":libc-0.2.171"],
         ),
         "windows-gnu": dict(
             named_deps = {
-                "libc_errno": ":errno-0.3.10",
+                "libc_errno": ":errno-0.3.11",
             },
             deps = [":windows-sys-0.59.0"],
         ),
         "windows-msvc": dict(
             named_deps = {
-                "libc_errno": ":errno-0.3.10",
+                "libc_errno": ":errno-0.3.11",
             },
             deps = [":windows-sys-0.59.0"],
         ),
@@ -18137,7 +18141,7 @@ cargo.rust_binary(
         ":log-0.4.27",
         ":manyhow-0.11.4",
         ":mime_guess-2.0.4",
-        ":miniz_oxide-0.8.5",
+        ":miniz_oxide-0.8.7",
         ":mixtrics-0.0.3",
         ":monostate-0.1.14",
         ":names-0.14.0",

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -1227,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "jobserver",
  "libc",
@@ -1819,6 +1819,7 @@ checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
 dependencies = [
  "deadpool-runtime",
  "num_cpus",
+ "serde",
  "tokio",
 ]
 
@@ -1831,6 +1832,7 @@ dependencies = [
  "async-trait",
  "deadpool",
  "getrandom 0.2.15",
+ "serde",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -2232,9 +2234,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -2378,9 +2380,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flagset"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -2389,7 +2391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.5",
+ "miniz_oxide 0.8.7",
 ]
 
 [[package]]
@@ -3970,9 +3972,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -6629,7 +6631,7 @@ dependencies = [
  "log",
  "manyhow",
  "mime_guess",
- "miniz_oxide 0.8.5",
+ "miniz_oxide 0.8.7",
  "mixtrics",
  "monostate",
  "names",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -61,7 +61,7 @@ crossbeam-queue = { version = "0.3.11" }
 darling = "0.20.10"
 dashmap = "6.1.0"
 deadpool = { version = "0.12.1", features = ["rt_tokio_1"] }
-deadpool-postgres = "0.14.0"
+deadpool-postgres = { version = "0.14.0", features = ["serde"] }
 derive_builder = "0.20.2"
 derive_more = "0.99.17"
 devicemapper = { version = "=0.34.1" }


### PR DESCRIPTION
These settings were changed when we added pgbouncer to better handle migrations. Pgbouncer recommends sending a `RECONNECT` after DDL changes to reset the open transactions and `RESET ALL` in order to clear the prepared statement cache. Without doing these, we were seeing open connections serving the incorrect schema.

We have now switched to using RDS Proxy, which, after DDL changes, purports to close the transaction and clear the prepared statement cache. Because of this, I believe it is safe to change back to using Fast recycles here.

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.howitworks.html

Unfortunately, the only way to test this is to create a new database migration and see how it handles.

This PR allows us the configure the recycle method. Setting `Custom` uses the const defined alongside the poolconfig. 

```
  manager: Some(
        ManagerConfig {
            recycling_method: Custom(
                "\n    SET CLIENT_MIN_MESSAGES TO ERROR;\n    ROLLBACK;\n    SET CLIENT_MIN_MESSAGES TO WARNING;\n    CLOSE ALL;\n    SET SESSION AUTHORIZATION DEFAULT;\n    RESET ALL;\n    UNLISTEN *;\n    SELECT pg_advisory_unlock_all();\n    DISCARD TEMP;\n    DISCARD SEQUENCES;\n    DISCARD PLANS;\n",
            ),
        },
    ),
```