### PR TITLE
During app/web `pnpm build` force a comlink chunk

### DIFF
--- a/app/web/vite.config.ts
+++ b/app/web/vite.config.ts
@@ -132,8 +132,10 @@ export default (opts: { mode: string }) => {
             "react-dom": "ReactDOM",
           },
           manualChunks(id) {
-            if (/dynamicEnvVars.ts/.test(id)) {
-              return "projectEnvVariables";
+            // we need to make sure that the comlink lib has its own chunk
+            // so that we can put COOP/COEP headers on it (in addition to webworker.js)
+            if (/comlink/.test(id)) {
+              return "comlink";
             }
           },
         },


### PR DESCRIPTION
Currently `build` already produces a `comlink` chunk. But that may not always happen in the future. So I added it to `manualChunks`

I tested this by running build with "myspecialcomlink" (rather than "comlink") to ensure that the built file would match mine. 

I don't see `projectEnvVariables` as an output, or `dynamicEnvVars.ts` as an input during the build process.. so I removed that.. happy to add that back if it was incorrect.

And the header changes for this file are in this SI changeset on tools: 
![image](https://github.com/user-attachments/assets/bcb15dc9-8786-44e0-9f1f-8614ed761c7e)
