### PR TITLE
Instrument the lifecycle of an edda request

### DIFF
--- a/lib/edda-client/src/lib.rs
+++ b/lib/edda-client/src/lib.rs
@@ -19,6 +19,7 @@ use si_data_nats::{
 use si_events::{
     change_batch::ChangeBatchAddress, ChangeSetId, WorkspacePk, WorkspaceSnapshotAddress,
 };
+use telemetry::prelude::*;
 use telemetry_nats::propagation;
 use thiserror::Error;
 
@@ -77,6 +78,18 @@ impl Client {
 
     /// Asynchronously request an index update from a workspace past snapshot to the current
     /// snapshot & return a [`RequestId`].
+    #[instrument(
+        name = "edda.client.update_from_workspace_snapshot"
+        level = "info",
+        skip_all,
+        fields (
+            si.workspace.id = %workspace_id,
+            si.change_set.id = %change_set_id,
+            edda.client.request.update.from_snapshot_address = ?from_snapshot_address,
+            edda.client.request.update.to_snapshot_address = ?to_snapshot_address,
+            edda.client.request.update.change_batch_address = ?change_batch_address
+        )
+    )]
     pub async fn update_from_workspace_snapshot(
         &self,
         workspace_id: WorkspacePk,
@@ -104,6 +117,15 @@ impl Client {
         .await
     }
 
+    #[instrument(
+        name = "edda.client.rebuild_for_change_set"
+        level = "info",
+        skip_all,
+        fields (
+            si.workspace.id = %workspace_id,
+            si.change_set.id = %change_set_id,
+        )
+    )]
     pub async fn rebuild_for_change_set(
         &self,
         workspace_id: WorkspacePk,

--- a/lib/edda-server/src/change_set_processor_task.rs
+++ b/lib/edda-server/src/change_set_processor_task.rs
@@ -355,6 +355,7 @@ mod handlers {
                     && ctx.workspace_snapshot()?.id().await
                         == update_request.to_snapshot_address =>
             {
+                span.record("si.edda_request.id", update_request.id.to_string());
                 let change_batch = ctx
                     .layer_db()
                     .change_batch()
@@ -381,6 +382,7 @@ mod handlers {
             EddaRequestKind::Update(update_request)
                 if ctx.workspace_snapshot()?.id().await != update_request.to_snapshot_address =>
             {
+                span.record("si.edda_request.id", update_request.id.to_string());
                 materialized_view::build_all_mv_for_change_set(&ctx, &frigg)
                     .instrument(tracing::info_span!(
                         "edda.change_set_processor_task.build_all_mv_for_change_set.snapshot_moved"
@@ -388,7 +390,8 @@ mod handlers {
                     .await
                     .map_err(Into::into)
             }
-            EddaRequestKind::Update(_) => {
+            EddaRequestKind::Update(update_request) => {
+                span.record("si.edda_request.id", update_request.id.to_string());
                 materialized_view::build_all_mv_for_change_set(&ctx, &frigg)
                     .instrument(tracing::info_span!(
                         "edda.change_set_processor_task.build_all_mv_for_change_set.initial_build"
@@ -396,7 +399,8 @@ mod handlers {
                     .await
                     .map_err(Into::into)
             }
-            EddaRequestKind::Rebuild(_) => {
+            EddaRequestKind::Rebuild(rebuild_request) => {
+                span.record("si.edda_request.id", rebuild_request.id.to_string());
                 materialized_view::build_all_mv_for_change_set(&ctx, &frigg)
                     .instrument(tracing::info_span!(
                 "edda.change_set_processor_task.build_all_mv_for_change_set.explicit_rebuild"

--- a/lib/rebaser-server/src/rebase.rs
+++ b/lib/rebaser-server/src/rebase.rs
@@ -69,7 +69,7 @@ type RebaseResult<T> = Result<T, RebaseError>;
         si.updates.count = Empty,
         si.corrected_updates.count = Empty,
         si.workspace.id = %request.workspace_id,
-        si.edda.update_request.id = Empty
+        si.edda_request.id = Empty
     ))]
 pub async fn perform_rebase(
     ctx: &mut DalContext,
@@ -164,7 +164,7 @@ pub async fn perform_rebase(
         let changes = original_workspace_snapshot
             .detect_changes(&to_rebase_workspace_snapshot)
             .instrument(tracing::info_span!(
-                "Detect changes for materialized view rebuild"
+                "rebaser.perform_rebase.detect_changes_for_edda_request"
             ))
             .await?;
         let change_batch_address = ctx.write_change_batch(changes).await?;
@@ -177,10 +177,7 @@ pub async fn perform_rebase(
                 change_batch_address,
             )
             .await?;
-        span.record(
-            "si.edda.update_request.id",
-            edda_update_request_id.to_string(),
-        );
+        span.record("si.edda_request.id", edda_update_request_id.to_string());
     }
 
     // Before replying to the requester, we must commit.


### PR DESCRIPTION
## Description

This PR instruments the lifecycle of an edda request. Specifically, it ensures that we can start from a span of another service and use either child spans or an edda request ID to discern what happened during the life of an edda request.

## Grafana + Jaegar Example

<img width="1304" alt="Screenshot 2025-04-04 at 5 37 41 PM" src="https://github.com/user-attachments/assets/0d784d15-1b50-4bee-bc14-dfdb5896743f" />
