### PR TITLE
fix(billing): Work around SQL being unable to parse nanoseconds >= .9999995

### DIFF
--- a/component/lambda/sql/workspace_verifications.sql
+++ b/component/lambda/sql/workspace_verifications.sql
@@ -78,7 +78,7 @@ CREATE OR REPLACE VIEW workspace_verifications.workspace_update_events_before_su
     WITH
         workspace_update_events_summary AS (
             SELECT workspace_id, MIN(event_timestamp) AS first_event, MAX(event_timestamp) AS last_event
-              FROM workspace_update_events.workspace_update_events
+              FROM workspace_operations.workspace_update_events_clean
              GROUP BY workspace_id
         )
     SELECT


### PR DESCRIPTION
PostgreSQL (or maybe Redshift's version of it) throws a parse exception when you try to parse `2025-04-03T22:19:42.999999945Z` as a timestamp.

This is because it rounds the fractional seconds to microseconds, and then throws an exception if it's >= 1 (because fractional seconds can't be 1!). While PostgreSQL should handle this, we need our billing pipeline not to break :)

The fix here is to truncate our timestamps to microseconds before parsing them. The original data in forklift still contains all the precision you could ever want.

## Testing

- [X] Created a jkeiser_workspace_operations schema in Redshift with the views from this .sql file and re-ran the SELECT that is currently failing.
- [X] Checked that the user who just went over 100 resources still has the same billing output.