### PR TITLE
feat: add incoming connections to mgmt functions components

### DIFF
--- a/bin/lang-js/src/component.ts
+++ b/bin/lang-js/src/component.ts
@@ -1,3 +1,5 @@
+import { SocketName, SocketRefAndValue } from "./function_kinds/management.ts";
+
 export interface Component {
   name: string;
   properties: Record<string, unknown>;
@@ -13,4 +15,7 @@ export interface Geometry {
 export interface ComponentWithGeometry {
   properties: Record<string, unknown>;
   geometry: { [key: string]: Geometry };
+  incomingConnections?: {
+    [key: SocketName]: SocketRefAndValue[] | SocketRefAndValue | undefined;
+  };
 }

--- a/bin/lang-js/src/function_kinds/management.ts
+++ b/bin/lang-js/src/function_kinds/management.ts
@@ -15,19 +15,11 @@ const debug = Debug("langJs:management");
 
 export interface ManagementFunc extends Func {
   currentView: string;
-  thisComponent: ThisComponent;
+  thisComponent: ComponentWithGeometry;
   components: {
     [key: string]: ComponentWithGeometry;
   };
   variantSocketMap: Record<SchemaName, number>;
-}
-
-export interface ThisComponent extends ComponentWithGeometry {
-  incomingConnections: {
-    [key: SocketName]: SocketRefAndValue[] | SocketRefAndValue | undefined;
-  };
-  // TODO outgoingConnections so we can automatically connect *output* from created components
-  // to existing components
 }
 
 export type ManagementFuncResult =

--- a/lib/cyclone-client/src/client.rs
+++ b/lib/cyclone-client/src/client.rs
@@ -450,7 +450,7 @@ mod tests {
     use cyclone_core::{
         ActionRunRequest, ComponentKind, ComponentView, ComponentViewWithGeometry, FunctionResult,
         ManagementRequest, ProgressMessage, ResolverFunctionComponent, ResolverFunctionRequest,
-        SchemaVariantDefinitionRequest, ThisComponent, ValidationRequest,
+        SchemaVariantDefinitionRequest, ValidationRequest,
     };
     use cyclone_server::{Config, ConfigBuilder, Runnable as _, Server};
     use futures::StreamExt;
@@ -1376,12 +1376,10 @@ mod tests {
             execution_id: "1234".to_string(),
             handler: "manage".to_string(),
             current_view: "DEFAULT".to_string(),
-            this_component: ThisComponent {
-                component: ComponentViewWithGeometry {
-                    kind: None,
-                    properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),
-                    geometry: serde_json::json!({"x": "1", "y": "2"}),
-                },
+            this_component: ComponentViewWithGeometry {
+                kind: None,
+                properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),
+                geometry: serde_json::json!({"x": "1", "y": "2"}),
                 incoming_connections: serde_json::json!({}),
             },
             components: HashMap::new(),
@@ -1471,12 +1469,10 @@ mod tests {
             execution_id: "1234".to_string(),
             handler: "manage".to_string(),
             current_view: "DEFAULT".to_string(),
-            this_component: ThisComponent {
-                component: ComponentViewWithGeometry {
-                    kind: None,
-                    properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),
-                    geometry: serde_json::json!({"x": "1", "y": "2"}),
-                },
+            this_component: ComponentViewWithGeometry {
+                kind: None,
+                properties: serde_json::json!({"it": "is", "a": "principle", "of": "music", "to": "repeat the theme"}),
+                geometry: serde_json::json!({"x": "1", "y": "2"}),
                 incoming_connections: serde_json::json!({}),
             },
             components: HashMap::new(),

--- a/lib/cyclone-core/src/component_view.rs
+++ b/lib/cyclone-core/src/component_view.rs
@@ -38,6 +38,7 @@ pub struct ComponentViewWithGeometry {
     pub kind: Option<String>,
     pub properties: Value,
     pub geometry: Value,
+    pub incoming_connections: Value,
 }
 
 impl Default for ComponentViewWithGeometry {
@@ -46,23 +47,6 @@ impl Default for ComponentViewWithGeometry {
             kind: None,
             properties: serde_json::json!({}),
             geometry: serde_json::json!({}),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[serde(deny_unknown_fields)]
-pub struct ThisComponent {
-    #[serde(flatten)]
-    pub component: ComponentViewWithGeometry,
-    pub incoming_connections: Value,
-}
-
-impl Default for ThisComponent {
-    fn default() -> Self {
-        Self {
-            component: Default::default(),
             incoming_connections: serde_json::json!({}),
         }
     }

--- a/lib/cyclone-core/src/lib.rs
+++ b/lib/cyclone-core/src/lib.rs
@@ -32,7 +32,7 @@ pub use si_crypto::SensitiveStrings;
 pub use action_run::{ActionRunRequest, ActionRunResultSuccess, ResourceStatus};
 pub use before::BeforeFunction;
 pub use canonical_command::{CanonicalCommand, CanonicalCommandError};
-pub use component_view::{ComponentKind, ComponentView, ComponentViewWithGeometry, ThisComponent};
+pub use component_view::{ComponentKind, ComponentView, ComponentViewWithGeometry};
 pub use kill_execution::KillExecutionRequest;
 pub use liveness::{LivenessStatus, LivenessStatusParseError};
 pub use management::{ManagementFuncStatus, ManagementRequest, ManagementResultSuccess};

--- a/lib/cyclone-core/src/management.rs
+++ b/lib/cyclone-core/src/management.rs
@@ -4,10 +4,7 @@ use serde::{Deserialize, Serialize};
 use telemetry::prelude::*;
 use telemetry_utils::metric;
 
-use crate::{
-    component_view::{ComponentViewWithGeometry, ThisComponent},
-    BeforeFunction, CycloneRequestable,
-};
+use crate::{component_view::ComponentViewWithGeometry, BeforeFunction, CycloneRequestable};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -16,7 +13,7 @@ pub struct ManagementRequest {
     pub handler: String,
     pub code_base64: String,
     pub current_view: String,
-    pub this_component: ThisComponent,
+    pub this_component: ComponentViewWithGeometry,
     pub components: HashMap<String, ComponentViewWithGeometry>,
     pub variant_socket_map: HashMap<String, usize>,
     pub before: Vec<BeforeFunction>,

--- a/lib/dal/src/func/backend/management.rs
+++ b/lib/dal/src/func/backend/management.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use veritech_client::{
     BeforeFunction, ComponentViewWithGeometry, FunctionResult, ManagementRequest,
-    ManagementResultSuccess, ThisComponent,
+    ManagementResultSuccess,
 };
 
 use crate::func::backend::{FuncBackendResult, FuncDispatch, FuncDispatchContext};
@@ -13,7 +13,7 @@ use super::ExtractPayload;
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct FuncBackendManagementArgs {
-    this_component: ThisComponent,
+    this_component: ComponentViewWithGeometry,
     components: HashMap<String, ComponentViewWithGeometry>,
     current_view: String,
     variant_socket_map: HashMap<String, usize>,

--- a/lib/dal/src/func/binding/management.rs
+++ b/lib/dal/src/func/binding/management.rs
@@ -95,6 +95,7 @@ impl ManagementBinding {
                                 kind: {json_name},
                                 properties?: {sv_type},
                                 geometry?: {{ [key: string]: Geometry }},
+                                incomingConnections?: {{ [socket: string]: {INCOMING_CONNECTION_TYPE} | {INCOMING_CONNECTION_TYPE}[] }},
                                 connect?: {{
                                     from: string,
                                     to: {{

--- a/lib/veritech-client/src/lib.rs
+++ b/lib/veritech-client/src/lib.rs
@@ -20,7 +20,7 @@ pub use cyclone_core::{
     ManagementResultSuccess, OutputStream, ResolverFunctionComponent, ResolverFunctionRequest,
     ResolverFunctionResponseType, ResolverFunctionResultSuccess, ResourceStatus,
     SchemaVariantDefinitionRequest, SchemaVariantDefinitionResultSuccess, SensitiveContainer,
-    ThisComponent, ValidationRequest, ValidationResultSuccess,
+    ValidationRequest, ValidationResultSuccess,
 };
 pub use veritech_core::{encrypt_value_tree, VeritechValueEncryptError};
 

--- a/lib/veritech-client/tests/integration.rs
+++ b/lib/veritech-client/tests/integration.rs
@@ -5,7 +5,7 @@ use cyclone_core::{
     ActionRunRequest, ComponentKind, ComponentView, ComponentViewWithGeometry, FunctionResult,
     FunctionResultFailureErrorKind, ManagementRequest, ResolverFunctionComponent,
     ResolverFunctionRequest, ResolverFunctionResponseType, ResourceStatus,
-    SchemaVariantDefinitionRequest, ThisComponent, ValidationRequest,
+    SchemaVariantDefinitionRequest, ValidationRequest,
 };
 use si_data_nats::{NatsClient, NatsConfig};
 use test_log::test;
@@ -108,12 +108,10 @@ async fn executes_simple_management_function() {
         execution_id: "1234".to_string(),
         handler: "numberOfInputs".to_string(),
         current_view: "DEFAULT".to_string(),
-        this_component: ThisComponent {
-            component: ComponentViewWithGeometry {
-                kind: None,
-                properties: serde_json::json!({ "foo": "bar", "baz": "quux", "bar": "foo" }),
-                geometry: serde_json::json!({"x": "1", "y": "1"}),
-            },
+        this_component: ComponentViewWithGeometry {
+            kind: None,
+            properties: serde_json::json!({ "foo": "bar", "baz": "quux", "bar": "foo" }),
+            geometry: serde_json::json!({"x": "1", "y": "1"}),
             incoming_connections: serde_json::json!({}),
         },
         components: HashMap::new(),


### PR DESCRIPTION
Adding an `incomingConnections` field to every component, rather than just the input component.

<img src="https://media0.giphy.com/media/e53FCyb1UjS0pWHQXX/giphy.gif?cid=bd3ea57eji8gg7zzet1gu21hqhzslnczyikyz78nkzt67g1j&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>