### PR TITLE
fix: fix dupe targetgrouparn bug

### DIFF
--- a/bin/clover/src/cloud-control-funcs/overrides/Listener DefaultActions/attribute/setTargetGroupArns.ts
+++ b/bin/clover/src/cloud-control-funcs/overrides/Listener DefaultActions/attribute/setTargetGroupArns.ts
@@ -6,5 +6,5 @@ async function main(input: Input): Promise<Output> {
       { TargetGroupArn: tgArn },
     ];
   }
-  [];
+  return [];
 }

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -609,7 +609,7 @@ const overrides = new Map<string, OverrideFn>([
     ];
 
     const attrFuncId =
-      "213e2a5df4f3585d17774e5617db3bf47b764ca5b83e118eda4f5235acab46bd";
+      "2930eb8752c80c973163b3dec9cc2465b98d6257a49469c823429da4031a1c32";
     const targetGroupArnToListFunc = createFunc(
       "Set Forward Config if Target Group Arn is set",
       "jsAttribute",


### PR DESCRIPTION
When a new TargetGroupArn was created via a AWS::ElasticLoadBalancingV2::TargetGroup the previous entry on Listener DefaultActions wasn't overwritten, instead a new value was added to the array causing an error.

