### PR TITLE
feat(module-index): allow specifying a cloudfront domain

### DIFF
--- a/lib/module-index-server/src/routes/download_module_route.rs
+++ b/lib/module-index-server/src/routes/download_module_route.rs
@@ -43,7 +43,7 @@ impl IntoResponse for DownloadModuleError {
 pub async fn download_module_route(
     Path(module_id): Path<ModuleId>,
     Authorization { .. }: Authorization,
-    ExtractedS3Bucket(s3_bucket): ExtractedS3Bucket,
+    bucket: ExtractedS3Bucket,
     DbConnection(txn): DbConnection,
 ) -> Result<Redirect, DownloadModuleError> {
     let module = match si_module::Entity::find_by_id(module_id).one(&txn).await? {
@@ -51,9 +51,7 @@ pub async fn download_module_route(
         _ => return Err(DownloadModuleError::NotFound(module_id)),
     };
 
-    let download_url = s3_bucket
-        .presign_get(format!("{}.sipkg", module.latest_hash), 60 * 5, None)
-        .await?;
-
-    Ok(Redirect::temporary(&download_url))
+    Ok(Redirect::temporary(
+        &bucket.url_for_module(module.latest_hash).await?,
+    ))
 }

--- a/lib/module-index-server/src/routes/promote_builtin_route.rs
+++ b/lib/module-index-server/src/routes/promote_builtin_route.rs
@@ -15,7 +15,7 @@ use crate::models::si_module::make_module_details_response;
 use crate::routes::upsert_module_route::UpsertModuleError;
 use crate::whoami::{is_systeminit_auth_token, WhoamiError};
 use crate::{
-    extract::{Authorization, DbConnection, ExtractedS3Bucket},
+    extract::{Authorization, DbConnection},
     models::si_module::{self, ModuleId},
 };
 
@@ -54,7 +54,6 @@ pub async fn promote_builtin_route(
         user_claim: _user_claim,
         auth_token,
     }: Authorization,
-    ExtractedS3Bucket(_s3_bucket): ExtractedS3Bucket,
     DbConnection(txn): DbConnection,
     State(state): State<AppState>,
     mut multipart: Multipart,

--- a/lib/module-index-server/src/routes/reject_module_route.rs
+++ b/lib/module-index-server/src/routes/reject_module_route.rs
@@ -17,7 +17,7 @@ use crate::models::si_module::{make_module_details_response, SchemaIdReferenceLi
 use crate::routes::upsert_module_route::UpsertModuleError;
 use crate::whoami::{is_systeminit_auth_token, WhoamiError};
 use crate::{
-    extract::{Authorization, DbConnection, ExtractedS3Bucket},
+    extract::{Authorization, DbConnection},
     models::si_module::{self, ModuleId},
 };
 
@@ -58,7 +58,6 @@ pub async fn reject_module(
         user_claim: _user_claim,
         auth_token,
     }: Authorization,
-    ExtractedS3Bucket(_s3_bucket): ExtractedS3Bucket,
     DbConnection(txn): DbConnection,
     State(state): State<AppState>,
     mut multipart: Multipart,

--- a/lib/module-index-server/src/routes/upsert_builtin_route.rs
+++ b/lib/module-index-server/src/routes/upsert_builtin_route.rs
@@ -58,7 +58,7 @@ pub async fn upsert_builtin_route(
         user_claim,
         auth_token,
     }: Authorization,
-    ExtractedS3Bucket(s3_bucket): ExtractedS3Bucket,
+    ExtractedS3Bucket { s3_bucket, .. }: ExtractedS3Bucket,
     DbConnection(txn): DbConnection,
     State(state): State<AppState>,
     mut multipart: Multipart,

--- a/lib/module-index-server/src/routes/upsert_module_route.rs
+++ b/lib/module-index-server/src/routes/upsert_module_route.rs
@@ -76,7 +76,7 @@ impl IntoResponse for UpsertModuleError {
 // #[debug_handler]
 pub async fn upsert_module_route(
     Authorization { user_claim, .. }: Authorization,
-    ExtractedS3Bucket(s3_bucket): ExtractedS3Bucket,
+    ExtractedS3Bucket { s3_bucket, .. }: ExtractedS3Bucket,
     DbConnection(txn): DbConnection,
     mut multipart: Multipart,
 ) -> Result<Json<ModuleDetailsResponse>, UpsertModuleError> {

--- a/lib/module-index-server/src/routes/upsert_workspace_route.rs
+++ b/lib/module-index-server/src/routes/upsert_workspace_route.rs
@@ -62,7 +62,7 @@ impl IntoResponse for UpsertWorkspaceError {
 
 pub async fn upsert_workspace_route(
     Authorization { user_claim, .. }: Authorization,
-    ExtractedS3Bucket(s3_bucket): ExtractedS3Bucket,
+    ExtractedS3Bucket { s3_bucket, .. }: ExtractedS3Bucket,
     DbConnection(txn): DbConnection,
     mut multipart: Multipart,
 ) -> Result<(), UpsertWorkspaceError> {

--- a/lib/module-index-server/src/s3.rs
+++ b/lib/module-index-server/src/s3.rs
@@ -8,6 +8,7 @@ pub struct S3Config {
     pub region: String,
     pub bucket: String,
     pub path_prefix: String,
+    pub cloudfront_domain: Option<String>,
 }
 
 impl Default for S3Config {
@@ -19,6 +20,7 @@ impl Default for S3Config {
             bucket: String::from("modules-index-sandbox"),
             // TODO? is this right?
             path_prefix: String::from("dev"),
+            cloudfront_domain: None,
         }
     }
 }


### PR DESCRIPTION
Allows the module-index to generate urls for either s3 directly or cloudfront. If the cloudfront config is empty (the default), we behave exactly the same as we do now, so this should not cause any behavioral changes until config changes happen.

If the cloudfront domain is set, gets for modules or exports will go through cloudfront, leveraging the cdn. This should allow for cache rebuilds to be faster and generate less overall traffic it to S3. This will likely make the biggest difference in local development, but only if the cloudfront url is configured. We can configure this by default after the production instance is deployed successfully.