### PR TITLE
Update: main.js should always have a hash on it

### DIFF
--- a/app/web/vite.config.ts
+++ b/app/web/vite.config.ts
@@ -123,7 +123,7 @@ export default (opts: { mode: string }) => {
             if (chunk.name === "worker") {
               return "assets/webworker.js"; // Specify output path for web worker
             }
-            return "assets/[name].js";
+            return "assets/[name]-[hash].js";
           },
           sourcemap: "inline",
           format: "es",


### PR DESCRIPTION
Test: `pnpm build` the dist/index.html file uses a main.js file with a hash on it