### PR TITLE
feat(billing): Upload Posthog billing data

### DIFF
--- a/component/lambda/functions/si_posthog_api.py
+++ b/component/lambda/functions/si_posthog_api.py
@@ -1,0 +1,88 @@
+from collections.abc import Iterable
+from itertools import islice
+import logging
+import sys
+import urllib.parse
+from pip._vendor import requests
+from pip._vendor.requests.exceptions import HTTPError
+from pip._vendor.requests.models import Response
+from typing import Any, Literal, NotRequired, Optional, Type, TypeVar, TypedDict, Union, cast, overload
+
+from si_types import IsoTimestamp
+
+class PosthogApi:
+    def __init__(self, posthog_api_url: str, posthog_project_api_key: str):
+        self.posthog_api_url = posthog_api_url
+        self.posthog_project_api_key = posthog_project_api_key
+
+    def request(self, method: str, path: str, **kwargs):
+        logging.debug(f"Posthog API request: {method} {path}")
+        response = requests.api.request(
+            method,
+            urllib.parse.urljoin(self.posthog_api_url, path),
+            **kwargs,
+        )
+        
+        try:
+            response.raise_for_status()
+        except HTTPError as e:
+            message = f"{e.response.status_code} for {method} {path}: {e.response.text}"
+            try:
+                json = cast(PosthogApi.HTTPError.ResponseJson, e.response.json())
+            except:
+                logging.warning("Failed to parse JSON from Posthog API response.", exc_info=sys.exc_info())
+                json = None
+            raise PosthogApi.HTTPError(message, response=e.response, json=json) from e
+        return response
+
+    @overload
+    def post(self, path: Literal["/i/v0/e"], json: "EventRequest"): ...
+    @overload
+    def post(self, path: Literal["/batch"], json: "BatchRequest"): ...
+    def post(self, path: str, json):
+        return self.request("POST", path, json = {
+            "api_key": self.posthog_project_api_key,
+            **json
+        })
+
+    class EventRequest(TypedDict):
+        event: str
+        distinct_id: str
+        properties: dict[str, Any]
+        timestamp: NotRequired[IsoTimestamp]
+
+    class BatchRequest(TypedDict):
+        batch: list["PosthogApi.BatchEvent"]
+        historical_migration: NotRequired[bool]
+    class BatchEvent(TypedDict):
+        event: str
+        properties: dict[str, Any]
+        timestamp: NotRequired[IsoTimestamp]
+
+    class HTTPError(HTTPError):
+        class GenericResponseJson(TypedDict):
+            type: str
+            code: str
+            detail: str
+        
+        class MalformedResponseJson(GenericResponseJson):
+            type: Literal["validation_error"]
+            attr: str
+
+        ResponseJson = Union[GenericResponseJson, MalformedResponseJson]
+
+        def __init__(self, *args, json: Optional[ResponseJson], **kwargs):
+            super().__init__(*args, **kwargs)
+            self.json = json
+
+T = TypeVar("T")
+
+def batch(iterable: Iterable[T], n):
+    "Batch data into lists of length n. The last batch may be shorter."
+    # batched('ABCDEFG', 3) --> ABC DEF G
+    it = iter(iterable)
+    while True:
+        batch = list(islice(it, n))
+        if not batch:
+            return
+        yield batch

--- a/component/lambda/functions/si_types.py
+++ b/component/lambda/functions/si_types.py
@@ -1,7 +1,53 @@
-from typing import NewType
+from typing import NewType, Optional, overload
+from datetime import datetime
 
 Ulid = NewType("Ulid", str)
 OwnerPk = NewType("OwnerPk", Ulid)
 WorkspaceId = NewType("WorkspaceId", Ulid)
+# SQL datetime, i.e. 2024-04-03 12:00:00
+SqlDatetime = NewType("SqlDatetime", str)
+# SQL timestamp, i.e. 2024-04-03 12:00:00[.000000].
 SqlTimestamp = NewType("SqlTimestamp", str)
+# ISO 8601 timestamp, i.e. 2024-04-03T12:00:00[.000000]Z
 IsoTimestamp = NewType("IsoTimestamp", str)
+
+SQL_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
+ISO_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+# Convert ISO 8601 timestamp to the required format
+@overload
+def sql_to_iso_timestamp(sql_str: SqlTimestamp) -> IsoTimestamp: ...
+@overload
+def sql_to_iso_timestamp(sql_str: None) -> None: ...
+@overload
+def sql_to_iso_timestamp(sql_str: Optional[SqlTimestamp]) -> Optional[IsoTimestamp]: ...
+def sql_to_iso_timestamp(sql_str: Optional[SqlTimestamp]):
+    if sql_str is None:
+        return None
+    if '.' in sql_str:
+        return datetime.strptime(sql_str, "%Y-%m-%d %H:%M:%S.%f").isoformat() + "Z"
+    else:
+        return datetime.strptime(sql_str, "%Y-%m-%d %H:%M:%S").isoformat() + "Z"
+
+# Convert ISO 8601 timestamp to the required format
+@overload
+def iso_to_sql_datetime(iso_str: IsoTimestamp) -> SqlDatetime: ...
+@overload
+def iso_to_sql_datetime(iso_str: None) -> None: ...
+@overload
+def iso_to_sql_datetime(iso_str: Optional[IsoTimestamp]) -> Optional[SqlDatetime]: ...
+def iso_to_sql_datetime(iso_str: Optional[IsoTimestamp]):
+    if iso_str is None:
+        return None
+    return datetime.strptime(iso_str, "%Y-%m-%dT%H:%M:%SZ").strftime("%Y-%m-%d %H:%M:%S")
+
+@overload
+def iso_to_sql_days(iso_str: IsoTimestamp) -> str: ...
+@overload
+def iso_to_sql_days(iso_str: None) -> None: ...
+@overload
+def iso_to_sql_days(iso_str: Optional[IsoTimestamp]) -> Optional[str]: ...
+def iso_to_sql_days(iso_str: Optional[IsoTimestamp]):
+    if iso_str is None:
+        return None
+    return datetime.strptime(iso_str, "%Y-%m-%dT%H:%M:%SZ").strftime('%Y-%m-%d')

--- a/component/lambda/functions/upload-billing-hours.py
+++ b/component/lambda/functions/upload-billing-hours.py
@@ -5,7 +5,7 @@ import logging
 
 from si_lambda import SiLambda, SiLambdaEnv
 from si_lago_api import ExternalSubscriptionId, LagoEvent
-from si_types import SqlTimestamp
+from si_types import SqlDatetime
 
 billable_metric_code = "resource-hours"
 cost_per_resource_hour = 0.007
@@ -30,7 +30,7 @@ class UploadBillingHours(SiLambda):
             next_uninvoiced_month = (next_uninvoiced_month - timedelta(days=1)).replace(day=1)
         return next_uninvoiced_month
 
-    def format_event(self, event: tuple[ExternalSubscriptionId, SqlTimestamp, int]) -> LagoEvent:
+    def format_event(self, event: tuple[ExternalSubscriptionId, SqlDatetime, int]) -> LagoEvent:
         [external_subscription_id, hour_start, resource_count] = event
 
         event_time = datetime.strptime(hour_start, "%Y-%m-%d %H:%M:%S").replace(
@@ -64,7 +64,7 @@ class UploadBillingHours(SiLambda):
             # Upload events by hour
             #
             all_events = cast(
-                Iterable[tuple[ExternalSubscriptionId, SqlTimestamp, int]],
+                Iterable[tuple[ExternalSubscriptionId, SqlDatetime, int]],
                 self.redshift.query_raw(
                     f"""
                     SELECT external_subscription_id, hour_start, resource_count

--- a/component/lambda/functions/upload-posthog-billing-data.py
+++ b/component/lambda/functions/upload-posthog-billing-data.py
@@ -1,0 +1,129 @@
+from typing import Iterable, NotRequired, cast
+from datetime import date, datetime, timedelta, timezone
+import itertools
+import logging
+
+from si_posthog_api import PosthogApi
+from si_lago_api import ExternalSubscriptionId
+from si_lambda import SiLambda, SiLambdaEnv
+from si_types import OwnerPk, SqlTimestamp, WorkspaceId, sql_to_iso_timestamp
+
+POSTHOG_EVENT_NAME = "test-billing-workspace_resource_hours"
+
+class UploadPosthogBillingDataEnv(SiLambdaEnv):
+    batch_hours: NotRequired[int]
+
+class UploadPosthogBillingData(SiLambda):
+    def __init__(self, event: UploadPosthogBillingDataEnv):
+        super().__init__(event)
+        self.batch_hours = int(event.get("batch_hours", 24*10))
+        assert self.batch_hours > 0
+
+    def run(self):
+        while self.upload_batch():
+            pass
+
+    def upload_batch(self):
+        #
+        # Upload events
+        #
+        upload_start, upload_end = self.get_upload_range()
+        if upload_start >= upload_end:
+            logging.info(f"No more events to upload! upload_range {upload_start} to {upload_end} is empty.")
+            return False
+
+        print("Uploading events from {upload_start} to {upload_end}")
+        all_events = [
+            cast(tuple[WorkspaceId, SqlTimestamp, int, OwnerPk, SqlTimestamp, str], row)
+            for row in self.redshift.query_raw(
+                f"""
+                    SELECT workspace_id, hour_start, resource_count, owner_pk, event_timestamp, owner_si_hours_with_subscriptions.plan_code
+                      FROM workspace_operations.workspace_resource_hours
+                      LEFT OUTER JOIN workspace_operations.owner_si_hours_with_subscriptions USING (owner_pk, hour_start)
+                     CROSS JOIN workspace_operations.workspace_update_events_summary
+                     WHERE resource_count > 0
+                       AND :upload_start <= hour_start
+                       AND hour_start < :upload_end
+                     ORDER BY hour_start DESC
+                """,
+                upload_start=upload_start,
+                upload_end=upload_end,
+            )
+        ]
+        self.posthog.post("/batch", {
+            "historical_migration": True,
+            "batch": [
+                {
+                    "event": "test-billing-workspace_resource_hours",
+                    "properties": {
+                        "distinct_id": str(owner_pk),
+                        "workspace_id": str(workspace_id),
+                        "resource_count": resource_count,
+                        "event_timestamp": sql_to_iso_timestamp(event_timestamp),
+                        "plan_code": plan_code,
+                    },
+                    "timestamp": sql_to_iso_timestamp(hour_start),
+                }
+                for [workspace_id, hour_start, resource_count, owner_pk, event_timestamp, plan_code] in all_events
+            ]
+        })
+        self.update_progress(upload_end)
+        logging.info(f"Uploaded {len(all_events)} events to Posthog from {upload_start} to {upload_end}")
+        return True
+
+    def get_upload_range(self):
+        first_hour_start, last_complete_hour_end = [
+            cast(tuple[SqlTimestamp, SqlTimestamp], row)
+            for row in self.redshift.query_raw(
+                f"""
+                    SELECT DATE_TRUNC('hour', first_event) AS first_hour_start, last_complete_hour_end
+                    FROM workspace_operations.workspace_update_events_summary
+                """)
+        ][0]
+        # Start the upload where we last left off, or at the beginning of time
+        uploaded_to = [
+            cast(SqlTimestamp, uploaded_to)
+            for [uploaded_to] in self.redshift.query_raw(f"""
+                SELECT uploaded_to
+                FROM workspace_operations.upload_progress
+                WHERE upload_type = 'posthog-workspace_resource_counts'
+            """)
+        ]
+        batch_start = uploaded_to[0] if len(uploaded_to) > 0 else first_hour_start
+        # End the batch at the last complete hour, or the max batch size, whichever comes first
+        batch_end = [
+            cast(SqlTimestamp, batch_end)
+            for [batch_end] in self.redshift.query_raw(
+                f"""
+                    -- I can't believe this is the simplest way to get the maximum of two values
+                    SELECT MIN(batch_end) AS batch_end FROM (
+                        SELECT DATEADD(HOUR, {self.batch_hours}, :batch_start::timestamp) AS batch_end
+                        UNION
+                        SELECT :last_complete_hour_end::timestamp AS batch_end
+                    )
+                """,
+                batch_start=batch_start,
+                last_complete_hour_end=last_complete_hour_end
+            )
+        ][0]
+        return (batch_start, batch_end)
+
+    def update_progress(self, uploaded_to: SqlTimestamp):
+       self.redshift.execute(
+           f"""
+                -- There doesn't seem to be a nicer way to INSERT OR UPDATE in Redshift
+                MERGE INTO workspace_operations.upload_progress
+                    USING (SELECT
+                        'posthog-workspace_resource_counts' AS upload_type,
+                        :uploaded_to::timestamp AS uploaded_to
+                    ) AS my_source
+                    ON upload_progress.upload_type = my_source.upload_type
+                    WHEN MATCHED THEN UPDATE SET uploaded_to = my_source.uploaded_to
+                    WHEN NOT MATCHED THEN INSERT (upload_type, uploaded_to) VALUES (my_source.upload_type, my_source.uploaded_to)
+            """,
+            uploaded_to=uploaded_to
+        )
+
+lambda_handler = UploadPosthogBillingData.lambda_handler
+
+lambda_handler()


### PR DESCRIPTION
This uploads one event per hour per workspace showing the workspace's resource count. The value is chosen such that SUM(resource_count) for a given owner_pk is the same as the billing resource hours for that user (and thus if it is over 100, the user has crossed to paid tier).

The progress table is particularly nasty to work with, but it seems to be working at this point.

## Testing

- [ ] Test initial upload, progressive upload, and end of upload using a temporary update_progress table
- [ ] Upload events to dev and prod, see how people feel about the data