### PR TITLE
build(deps): upgrade to Tokio 1.44.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "serde",
@@ -1741,9 +1741,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1958,7 +1958,7 @@ dependencies = [
  "futures",
  "hex",
  "iftree",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itertools 0.13.0",
  "joi-validator",
  "jwt-simple",
@@ -2252,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -2847,7 +2847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.7",
+ "miniz_oxide 0.8.8",
 ]
 
 [[package]]
@@ -3298,7 +3298,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3317,7 +3317,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3326,9 +3326,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -3991,9 +3991,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -4104,9 +4104,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c102670231191d07d37a35af3eb77f1f0dbf7a71be51a962dcd57ea607be7260"
+checksum = "1f33145a5cbea837164362c7bd596106eb7c5198f97d1ba6f6ebb3223952e488"
 dependencies = [
  "jiff-static",
  "log",
@@ -4117,9 +4117,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdde31a9d349f1b1f51a0b3714a5940ac022976f4b49485fc04be052b183b4c"
+checksum = "43ce13c40ec6956157a3635d97a1ee2df323b263f09ea14165131289cb0f5c19"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4317,9 +4317,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -4530,9 +4530,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -5289,7 +5289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
 ]
@@ -5982,9 +5982,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -6375,7 +6375,7 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -6852,7 +6852,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "memchr",
  "ryu",
@@ -6920,7 +6920,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6946,7 +6946,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "ryu",
  "serde",
@@ -7235,7 +7235,7 @@ dependencies = [
  "foyer",
  "fs4",
  "futures",
- "miniz_oxide 0.8.7",
+ "miniz_oxide 0.8.8",
  "mixtrics",
  "postcard",
  "rand 0.8.5",
@@ -7268,7 +7268,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "derive_builder",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itertools 0.13.0",
  "object-tree",
  "petgraph",
@@ -7294,7 +7294,7 @@ dependencies = [
  "cyclone-core",
  "derive_builder",
  "futures",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "nix 0.29.0",
  "opentelemetry",
  "rand 0.8.5",
@@ -7485,9 +7485,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 dependencies = [
  "serde",
 ]
@@ -7589,7 +7589,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.2",
  "hashlink 0.10.0",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "log",
  "memchr",
  "once_cell",
@@ -8191,9 +8191,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8418,7 +8418,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -9510,9 +9510,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -578,7 +578,7 @@ cargo.rust_library(
         ":futures-core-0.3.31",
         ":memchr-2.7.4",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
     ],
 )
 
@@ -662,7 +662,7 @@ cargo.rust_library(
         ":serde_repr-0.1.20",
         ":thiserror-1.0.69",
         ":time-0.3.41",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-rustls-0.26.2",
         ":tokio-util-0.7.14",
         ":tokio-websockets-0.10.1",
@@ -712,7 +712,7 @@ cargo.rust_library(
         ":serde-1.0.219",
         ":serde_json-1.0.140",
         ":thiserror-1.0.69",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-stream-0.1.17",
         ":tokio-util-0.7.14",
         ":tracing-0.1.41",
@@ -1034,7 +1034,7 @@ cargo.rust_library(
         ":http-0.2.12",
         ":ring-0.17.5",
         ":time-0.3.41",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tracing-0.1.41",
         ":url-2.5.4",
         ":zeroize-1.8.1",
@@ -1390,7 +1390,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.31",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
     ],
 )
 
@@ -1493,7 +1493,7 @@ cargo.rust_library(
         ":aws-smithy-types-1.3.0",
         ":h2-0.4.8",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tracing-0.1.41",
     ],
 )
@@ -1597,7 +1597,7 @@ cargo.rust_library(
         ":once_cell-1.21.3",
         ":pin-project-lite-0.2.16",
         ":pin-utils-0.1.0",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tracing-0.1.41",
     ],
 )
@@ -1634,7 +1634,7 @@ cargo.rust_library(
         ":aws-smithy-types-1.3.0",
         ":bytes-1.10.1",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tracing-0.1.41",
         ":zeroize-1.8.1",
     ],
@@ -1680,7 +1680,7 @@ cargo.rust_library(
         ":pin-utils-0.1.0",
         ":ryu-1.0.20",
         ":time-0.3.41",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-util-0.7.14",
     ],
 )
@@ -1826,7 +1826,7 @@ cargo.rust_library(
         ":serde_urlencoded-0.7.1",
         ":sha1-0.10.6",
         ":sync_wrapper-0.1.2",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-tungstenite-0.20.1",
         ":tower-0.4.13",
         ":tower-layer-0.3.3",
@@ -1978,7 +1978,7 @@ cargo.rust_library(
         "tokio_1",
     ],
     named_deps = {
-        "tokio_1": ":tokio-1.44.1",
+        "tokio_1": ":tokio-1.44.2",
     },
     visibility = [],
     deps = [
@@ -2716,7 +2716,7 @@ cargo.rust_library(
         ":serde_repr-0.1.20",
         ":serde_urlencoded-0.7.1",
         ":thiserror-2.0.12",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-util-0.7.14",
         ":url-2.5.4",
     ],
@@ -2797,18 +2797,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "bstr-1.11.3.crate",
-    sha256 = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0",
-    strip_prefix = "bstr-1.11.3",
-    urls = ["https://static.crates.io/crates/bstr/1.11.3/download"],
+    name = "bstr-1.12.0.crate",
+    sha256 = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4",
+    strip_prefix = "bstr-1.12.0",
+    urls = ["https://static.crates.io/crates/bstr/1.12.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "bstr-1.11.3",
-    srcs = [":bstr-1.11.3.crate"],
+    name = "bstr-1.12.0",
+    srcs = [":bstr-1.12.0.crate"],
     crate = "bstr",
-    crate_root = "bstr-1.11.3.crate/src/lib.rs",
+    crate_root = "bstr-1.12.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -3117,7 +3117,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":ciborium-io-0.2.2",
-        ":half-2.5.0",
+        ":half-2.6.0",
     ],
 )
 
@@ -3623,7 +3623,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":console-api-0.8.1",
-        ":crossbeam-channel-0.5.14",
+        ":crossbeam-channel-0.5.15",
         ":crossbeam-utils-0.8.21",
         ":futures-task-0.3.31",
         ":hdrhistogram-7.5.4",
@@ -3634,7 +3634,7 @@ cargo.rust_library(
         ":serde-1.0.219",
         ":serde_json-1.0.140",
         ":thread_local-1.1.8",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-stream-0.1.17",
         ":tonic-0.12.3",
         ":tracing-0.1.41",
@@ -3961,18 +3961,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "crossbeam-channel-0.5.14.crate",
-    sha256 = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471",
-    strip_prefix = "crossbeam-channel-0.5.14",
-    urls = ["https://static.crates.io/crates/crossbeam-channel/0.5.14/download"],
+    name = "crossbeam-channel-0.5.15.crate",
+    sha256 = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2",
+    strip_prefix = "crossbeam-channel-0.5.15",
+    urls = ["https://static.crates.io/crates/crossbeam-channel/0.5.15/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "crossbeam-channel-0.5.14",
-    srcs = [":crossbeam-channel-0.5.14.crate"],
+    name = "crossbeam-channel-0.5.15",
+    srcs = [":crossbeam-channel-0.5.15.crate"],
     crate = "crossbeam_channel",
-    crate_root = "crossbeam-channel-0.5.14.crate/src/lib.rs",
+    crate_root = "crossbeam-channel-0.5.15.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -4503,7 +4503,7 @@ cargo.rust_library(
         ":deadpool-runtime-0.1.4",
         ":num_cpus-1.16.0",
         ":serde-1.0.219",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
     ],
 )
 
@@ -4557,7 +4557,7 @@ cargo.rust_library(
         ":async-trait-0.1.88",
         ":deadpool-0.12.2",
         ":serde-1.0.219",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tracing-0.1.41",
     ],
 )
@@ -4578,7 +4578,7 @@ cargo.rust_library(
     edition = "2021",
     features = ["tokio_1"],
     named_deps = {
-        "tokio_1": ":tokio-1.44.1",
+        "tokio_1": ":tokio-1.44.2",
     },
     visibility = [],
 )
@@ -4640,18 +4640,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "deranged-0.4.1.crate",
-    sha256 = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058",
-    strip_prefix = "deranged-0.4.1",
-    urls = ["https://static.crates.io/crates/deranged/0.4.1/download"],
+    name = "deranged-0.4.0.crate",
+    sha256 = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e",
+    strip_prefix = "deranged-0.4.0",
+    urls = ["https://static.crates.io/crates/deranged/0.4.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "deranged-0.4.1",
-    srcs = [":deranged-0.4.1.crate"],
+    name = "deranged-0.4.0",
+    srcs = [":deranged-0.4.0.crate"],
     crate = "deranged",
-    crate_root = "deranged-0.4.1.crate/src/lib.rs",
+    crate_root = "deranged-0.4.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -5629,7 +5629,7 @@ cargo.rust_library(
         ":anstream-0.6.18",
         ":anstyle-1.0.10",
         ":env_filter-0.1.3",
-        ":jiff-0.2.5",
+        ":jiff-0.2.6",
         ":log-0.4.27",
     ],
 )
@@ -6082,7 +6082,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":crc32fast-1.4.2",
-        ":miniz_oxide-0.8.7",
+        ":miniz_oxide-0.8.8",
     ],
 )
 
@@ -6207,22 +6207,22 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "linux-x86_64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "macos-arm64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "macos-x86_64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "windows-gnu": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "windows-msvc": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
     },
     visibility = [],
@@ -6256,22 +6256,22 @@ cargo.rust_library(
     features = ["tracing"],
     platform = {
         "linux-arm64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "linux-x86_64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "macos-arm64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "macos-x86_64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "windows-gnu": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "windows-msvc": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
     },
     visibility = [],
@@ -6330,22 +6330,22 @@ cargo.rust_library(
     },
     platform = {
         "linux-arm64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "linux-x86_64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "macos-arm64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "macos-x86_64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "windows-gnu": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "windows-msvc": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
     },
     visibility = [],
@@ -6388,22 +6388,22 @@ cargo.rust_library(
     ],
     platform = {
         "linux-arm64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "linux-x86_64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "macos-arm64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "macos-x86_64": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "windows-gnu": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
         "windows-msvc": dict(
-            deps = [":tokio-1.44.1"],
+            deps = [":tokio-1.44.2"],
         ),
     },
     visibility = [],
@@ -6516,7 +6516,7 @@ cargo.rust_library(
         ":memchr-2.7.4",
         ":nix-0.29.0",
         ":page_size-0.6.0",
-        ":smallvec-1.14.0",
+        ":smallvec-1.15.0",
         ":zerocopy-0.8.24",
     ],
 )
@@ -7117,7 +7117,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":aho-corasick-1.1.3",
-        ":bstr-1.11.3",
+        ":bstr-1.12.0",
         ":log-0.4.27",
         ":regex-automata-0.4.9",
         ":regex-syntax-0.8.5",
@@ -7169,9 +7169,9 @@ cargo.rust_library(
         ":futures-sink-0.3.31",
         ":futures-util-0.3.31",
         ":http-0.2.12",
-        ":indexmap-2.8.0",
+        ":indexmap-2.9.0",
         ":slab-0.4.9",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-util-0.7.14",
         ":tracing-0.1.41",
     ],
@@ -7199,27 +7199,27 @@ cargo.rust_library(
         ":futures-core-0.3.31",
         ":futures-sink-0.3.31",
         ":http-1.3.1",
-        ":indexmap-2.8.0",
+        ":indexmap-2.9.0",
         ":slab-0.4.9",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-util-0.7.14",
         ":tracing-0.1.41",
     ],
 )
 
 http_archive(
-    name = "half-2.5.0.crate",
-    sha256 = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1",
-    strip_prefix = "half-2.5.0",
-    urls = ["https://static.crates.io/crates/half/2.5.0/download"],
+    name = "half-2.6.0.crate",
+    sha256 = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9",
+    strip_prefix = "half-2.6.0",
+    urls = ["https://static.crates.io/crates/half/2.6.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "half-2.5.0",
-    srcs = [":half-2.5.0.crate"],
+    name = "half-2.6.0",
+    srcs = [":half-2.6.0.crate"],
     crate = "half",
-    crate_root = "half-2.5.0.crate/src/lib.rs",
+    crate_root = "half-2.6.0.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
     deps = [":cfg-if-1.0.0"],
@@ -7883,7 +7883,7 @@ cargo.rust_library(
         ":itoa-1.0.15",
         ":pin-project-lite-0.2.16",
         ":socket2-0.5.9",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tower-service-0.3.3",
         ":tracing-0.1.41",
         ":want-0.3.1",
@@ -7923,8 +7923,8 @@ cargo.rust_library(
         ":httpdate-1.0.3",
         ":itoa-1.0.15",
         ":pin-project-lite-0.2.16",
-        ":smallvec-1.14.0",
-        ":tokio-1.44.1",
+        ":smallvec-1.15.0",
+        ":tokio-1.44.2",
         ":want-0.3.1",
     ],
 )
@@ -7949,7 +7949,7 @@ cargo.rust_library(
         ":hyper-1.6.0",
         ":hyper-util-0.1.11",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tower-service-0.3.3",
         ":winapi-0.3.9",
     ],
@@ -7989,7 +7989,7 @@ cargo.rust_library(
         ":log-0.4.27",
         ":rustls-0.21.12",
         ":rustls-native-certs-0.6.3",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-rustls-0.24.1",
     ],
 )
@@ -8028,7 +8028,7 @@ cargo.rust_library(
         ":hyper-util-0.1.11",
         ":rustls-0.23.25",
         ":rustls-native-certs-0.8.1",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-rustls-0.26.2",
         ":tower-service-0.3.3",
         ":webpki-roots-0.26.8",
@@ -8054,7 +8054,7 @@ cargo.rust_library(
         ":hyper-1.6.0",
         ":hyper-util-0.1.11",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tower-service-0.3.3",
     ],
 )
@@ -8095,7 +8095,7 @@ cargo.rust_library(
         ":libc-0.2.171",
         ":pin-project-lite-0.2.16",
         ":socket2-0.5.9",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tower-service-0.3.3",
         ":tracing-0.1.41",
     ],
@@ -8120,7 +8120,7 @@ cargo.rust_library(
         ":hex-0.4.3",
         ":hyper-0.14.32",
         ":pin-project-1.1.10",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
     ],
 )
 
@@ -8153,7 +8153,7 @@ cargo.rust_library(
         ":hyper-1.6.0",
         ":hyper-util-0.1.11",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tower-service-0.3.3",
     ],
 )
@@ -8323,7 +8323,7 @@ cargo.rust_library(
         ":icu_normalizer_data-1.5.1",
         ":icu_properties-1.5.1",
         ":icu_provider-1.5.0",
-        ":smallvec-1.14.0",
+        ":smallvec-1.15.0",
         ":utf16_iter-1.0.5",
         ":utf8_iter-1.0.4",
         ":write16-1.0.0",
@@ -8520,7 +8520,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":idna_adapter-1.2.0",
-        ":smallvec-1.14.0",
+        ":smallvec-1.15.0",
         ":utf8_iter-1.0.4",
     ],
 )
@@ -8661,23 +8661,23 @@ cargo.rust_library(
 
 alias(
     name = "indexmap",
-    actual = ":indexmap-2.8.0",
+    actual = ":indexmap-2.9.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "indexmap-2.8.0.crate",
-    sha256 = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058",
-    strip_prefix = "indexmap-2.8.0",
-    urls = ["https://static.crates.io/crates/indexmap/2.8.0/download"],
+    name = "indexmap-2.9.0.crate",
+    sha256 = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e",
+    strip_prefix = "indexmap-2.9.0",
+    urls = ["https://static.crates.io/crates/indexmap/2.9.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "indexmap-2.8.0",
-    srcs = [":indexmap-2.8.0.crate"],
+    name = "indexmap-2.9.0",
+    srcs = [":indexmap-2.9.0.crate"],
     crate = "indexmap",
-    crate_root = "indexmap-2.8.0.crate/src/lib.rs",
+    crate_root = "indexmap-2.9.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -8980,18 +8980,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "jiff-0.2.5.crate",
-    sha256 = "c102670231191d07d37a35af3eb77f1f0dbf7a71be51a962dcd57ea607be7260",
-    strip_prefix = "jiff-0.2.5",
-    urls = ["https://static.crates.io/crates/jiff/0.2.5/download"],
+    name = "jiff-0.2.6.crate",
+    sha256 = "1f33145a5cbea837164362c7bd596106eb7c5198f97d1ba6f6ebb3223952e488",
+    strip_prefix = "jiff-0.2.6",
+    urls = ["https://static.crates.io/crates/jiff/0.2.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "jiff-0.2.5",
-    srcs = [":jiff-0.2.5.crate"],
+    name = "jiff-0.2.6",
+    srcs = [":jiff-0.2.6.crate"],
     crate = "jiff",
-    crate_root = "jiff-0.2.5.crate/src/lib.rs",
+    crate_root = "jiff-0.2.6.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -9949,18 +9949,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "linux-raw-sys-0.9.3.crate",
-    sha256 = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413",
-    strip_prefix = "linux-raw-sys-0.9.3",
-    urls = ["https://static.crates.io/crates/linux-raw-sys/0.9.3/download"],
+    name = "linux-raw-sys-0.9.4.crate",
+    sha256 = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12",
+    strip_prefix = "linux-raw-sys-0.9.4",
+    urls = ["https://static.crates.io/crates/linux-raw-sys/0.9.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "linux-raw-sys-0.9.3",
-    srcs = [":linux-raw-sys-0.9.3.crate"],
+    name = "linux-raw-sys-0.9.4",
+    srcs = [":linux-raw-sys-0.9.4.crate"],
     crate = "linux_raw_sys",
-    crate_root = "linux-raw-sys-0.9.3.crate/src/lib.rs",
+    crate_root = "linux-raw-sys-0.9.4.crate/src/lib.rs",
     edition = "2021",
     features = [
         "elf",
@@ -10454,23 +10454,23 @@ cargo.rust_library(
 
 alias(
     name = "miniz_oxide",
-    actual = ":miniz_oxide-0.8.7",
+    actual = ":miniz_oxide-0.8.8",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "miniz_oxide-0.8.7.crate",
-    sha256 = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430",
-    strip_prefix = "miniz_oxide-0.8.7",
-    urls = ["https://static.crates.io/crates/miniz_oxide/0.8.7/download"],
+    name = "miniz_oxide-0.8.8.crate",
+    sha256 = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a",
+    strip_prefix = "miniz_oxide-0.8.8",
+    urls = ["https://static.crates.io/crates/miniz_oxide/0.8.8/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "miniz_oxide-0.8.7",
-    srcs = [":miniz_oxide-0.8.7.crate"],
+    name = "miniz_oxide-0.8.8",
+    srcs = [":miniz_oxide-0.8.8.crate"],
     crate = "miniz_oxide",
-    crate_root = "miniz_oxide-0.8.7.crate/src/lib.rs",
+    crate_root = "miniz_oxide-0.8.8.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -11077,7 +11077,7 @@ cargo.rust_library(
         ":num-iter-0.1.45",
         ":num-traits-0.2.19",
         ":rand-0.8.5",
-        ":smallvec-1.14.0",
+        ":smallvec-1.15.0",
         ":zeroize-1.8.1",
     ],
 )
@@ -11459,7 +11459,7 @@ cargo.rust_library(
         ":opentelemetry_sdk-0.26.0",
         ":prost-0.13.5",
         ":thiserror-1.0.69",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tonic-0.12.3",
     ],
 )
@@ -11577,7 +11577,7 @@ cargo.rust_library(
         ":rand-0.8.5",
         ":serde_json-1.0.140",
         ":thiserror-1.0.69",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-stream-0.1.17",
     ],
 )
@@ -12003,7 +12003,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":cfg-if-1.0.0",
-        ":smallvec-1.14.0",
+        ":smallvec-1.15.0",
     ],
 )
 
@@ -12160,7 +12160,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":fixedbitset-0.4.2",
-        ":indexmap-2.8.0",
+        ":indexmap-2.9.0",
         ":serde-1.0.219",
         ":serde_derive-1.0.219",
     ],
@@ -12770,7 +12770,7 @@ cargo.rust_library(
     deps = [
         ":proc-macro2-1.0.94",
         ":quote-1.0.40",
-        ":smallvec-1.14.0",
+        ":smallvec-1.15.0",
     ],
 )
 
@@ -13098,7 +13098,7 @@ cargo.rust_library(
         ":rustc-hash-2.1.1",
         ":rustls-0.23.25",
         ":thiserror-2.0.12",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tracing-0.1.41",
     ],
 )
@@ -13692,7 +13692,7 @@ cargo.rust_library(
         ":siphasher-1.0.1",
         ":thiserror-1.0.69",
         ":time-0.3.41",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-postgres-0.7.13",
         ":toml-0.8.20",
         ":url-2.5.4",
@@ -14005,7 +14005,7 @@ cargo.rust_library(
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.11.0",
-                ":tokio-1.44.1",
+                ":tokio-1.44.2",
                 ":tokio-rustls-0.26.2",
                 ":tokio-util-0.7.14",
                 ":tower-0.5.2",
@@ -14030,7 +14030,7 @@ cargo.rust_library(
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.11.0",
-                ":tokio-1.44.1",
+                ":tokio-1.44.2",
                 ":tokio-rustls-0.26.2",
                 ":tokio-util-0.7.14",
                 ":tower-0.5.2",
@@ -14055,7 +14055,7 @@ cargo.rust_library(
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.11.0",
-                ":tokio-1.44.1",
+                ":tokio-1.44.2",
                 ":tokio-rustls-0.26.2",
                 ":tokio-util-0.7.14",
                 ":tower-0.5.2",
@@ -14080,7 +14080,7 @@ cargo.rust_library(
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.11.0",
-                ":tokio-1.44.1",
+                ":tokio-1.44.2",
                 ":tokio-rustls-0.26.2",
                 ":tokio-util-0.7.14",
                 ":tower-0.5.2",
@@ -14105,7 +14105,7 @@ cargo.rust_library(
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.11.0",
-                ":tokio-1.44.1",
+                ":tokio-1.44.2",
                 ":tokio-rustls-0.26.2",
                 ":tokio-util-0.7.14",
                 ":tower-0.5.2",
@@ -14131,7 +14131,7 @@ cargo.rust_library(
                 ":rustls-native-certs-0.8.1",
                 ":rustls-pemfile-2.2.0",
                 ":rustls-pki-types-1.11.0",
-                ":tokio-1.44.1",
+                ":tokio-1.44.2",
                 ":tokio-rustls-0.26.2",
                 ":tokio-util-0.7.14",
                 ":tower-0.5.2",
@@ -15084,7 +15084,7 @@ cargo.rust_library(
         ":sha2-0.10.8",
         ":thiserror-1.0.69",
         ":time-0.3.41",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-rustls-0.24.1",
         ":tokio-stream-0.1.17",
         ":url-2.5.4",
@@ -15367,7 +15367,7 @@ cargo.rust_library(
             },
             deps = [
                 ":libc-0.2.171",
-                ":linux-raw-sys-0.9.3",
+                ":linux-raw-sys-0.9.4",
             ],
         ),
         "linux-x86_64": dict(
@@ -15376,7 +15376,7 @@ cargo.rust_library(
             },
             deps = [
                 ":libc-0.2.171",
-                ":linux-raw-sys-0.9.3",
+                ":linux-raw-sys-0.9.4",
             ],
         ),
         "macos-arm64": dict(
@@ -16496,7 +16496,7 @@ cargo.rust_library(
     rustc_flags = ["@$(location :serde_json-1.0.140-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
-        ":indexmap-2.8.0",
+        ":indexmap-2.9.0",
         ":itoa-1.0.15",
         ":memchr-2.7.4",
         ":ryu-1.0.20",
@@ -16675,7 +16675,7 @@ cargo.rust_library(
     named_deps = {
         "chrono_0_4": ":chrono-0.4.40",
         "indexmap_1": ":indexmap-1.9.3",
-        "indexmap_2": ":indexmap-2.8.0",
+        "indexmap_2": ":indexmap-2.9.0",
         "time_0_3": ":time-0.3.41",
     },
     visibility = [],
@@ -16735,7 +16735,7 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [
-        ":indexmap-2.8.0",
+        ":indexmap-2.9.0",
         ":itoa-1.0.15",
         ":ryu-1.0.20",
         ":serde-1.0.219",
@@ -17077,22 +17077,22 @@ cargo.rust_library(
     edition = "2018",
     features = ["union"],
     visibility = [],
-    deps = [":smallvec-1.14.0"],
+    deps = [":smallvec-1.15.0"],
 )
 
 http_archive(
-    name = "smallvec-1.14.0.crate",
-    sha256 = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd",
-    strip_prefix = "smallvec-1.14.0",
-    urls = ["https://static.crates.io/crates/smallvec/1.14.0/download"],
+    name = "smallvec-1.15.0.crate",
+    sha256 = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9",
+    strip_prefix = "smallvec-1.15.0",
+    urls = ["https://static.crates.io/crates/smallvec/1.15.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "smallvec-1.14.0",
-    srcs = [":smallvec-1.14.0.crate"],
+    name = "smallvec-1.15.0",
+    srcs = [":smallvec-1.15.0.crate"],
     crate = "smallvec",
-    crate_root = "smallvec-1.14.0.crate/src/lib.rs",
+    crate_root = "smallvec-1.15.0.crate/src/lib.rs",
     edition = "2018",
     features = [
         "const_generics",
@@ -17371,7 +17371,7 @@ cargo.rust_library(
         ":futures-util-0.3.31",
         ":hashbrown-0.15.2",
         ":hashlink-0.10.0",
-        ":indexmap-2.8.0",
+        ":indexmap-2.9.0",
         ":log-0.4.27",
         ":memchr-2.7.4",
         ":once_cell-1.21.3",
@@ -17382,10 +17382,10 @@ cargo.rust_library(
         ":serde-1.0.219",
         ":serde_json-1.0.140",
         ":sha2-0.10.8",
-        ":smallvec-1.14.0",
+        ":smallvec-1.15.0",
         ":thiserror-2.0.12",
         ":time-0.3.41",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-stream-0.1.17",
         ":tracing-0.1.41",
         ":url-2.5.4",
@@ -17454,7 +17454,7 @@ cargo.rust_library(
         ":serde-1.0.219",
         ":serde_json-1.0.140",
         ":sha2-0.10.8",
-        ":smallvec-1.14.0",
+        ":smallvec-1.15.0",
         ":sqlx-core-0.8.3",
         ":stringprep-0.1.5",
         ":thiserror-2.0.12",
@@ -18129,7 +18129,7 @@ cargo.rust_binary(
         ":hyper-0.14.32",
         ":hyperlocal-0.8.0",
         ":iftree-1.0.6",
-        ":indexmap-2.8.0",
+        ":indexmap-2.9.0",
         ":indicatif-0.17.11",
         ":indoc-2.0.6",
         ":insta-1.42.2",
@@ -18141,7 +18141,7 @@ cargo.rust_binary(
         ":log-0.4.27",
         ":manyhow-0.11.4",
         ":mime_guess-2.0.4",
-        ":miniz_oxide-0.8.7",
+        ":miniz_oxide-0.8.8",
         ":mixtrics-0.0.3",
         ":monostate-0.1.14",
         ":names-0.14.0",
@@ -18195,7 +18195,7 @@ cargo.rust_binary(
         ":thiserror-2.0.12",
         ":thread-priority-1.2.0",
         ":time-0.3.41",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-postgres-0.7.13",
         ":tokio-postgres-rustls-0.13.0",
         ":tokio-serde-0.9.0",
@@ -18423,7 +18423,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":deranged-0.4.1",
+        ":deranged-0.4.0",
         ":itoa-1.0.15",
         ":num-conv-0.1.0",
         ":powerfmt-0.2.0",
@@ -18619,23 +18619,23 @@ cargo.rust_library(
 
 alias(
     name = "tokio",
-    actual = ":tokio-1.44.1",
+    actual = ":tokio-1.44.2",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tokio-1.44.1.crate",
-    sha256 = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a",
-    strip_prefix = "tokio-1.44.1",
-    urls = ["https://static.crates.io/crates/tokio/1.44.1/download"],
+    name = "tokio-1.44.2.crate",
+    sha256 = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48",
+    strip_prefix = "tokio-1.44.2",
+    urls = ["https://static.crates.io/crates/tokio/1.44.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tokio-1.44.1",
-    srcs = [":tokio-1.44.1.crate"],
+    name = "tokio-1.44.2",
+    srcs = [":tokio-1.44.2.crate"],
     crate = "tokio",
-    crate_root = "tokio-1.44.1.crate/src/lib.rs",
+    crate_root = "tokio-1.44.2.crate/src/lib.rs",
     edition = "2021",
     features = [
         "bytes",
@@ -18834,7 +18834,7 @@ cargo.rust_library(
         ":postgres-protocol-0.6.8",
         ":postgres-types-0.2.9",
         ":rand-0.9.0",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-util-0.7.14",
         ":whoami-1.6.0",
     ],
@@ -18857,7 +18857,7 @@ cargo.rust_library(
         ":const-oid-0.9.6",
         ":ring-0.17.5",
         ":rustls-0.23.25",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-postgres-0.7.13",
         ":tokio-rustls-0.26.2",
         ":x509-cert-0.2.5",
@@ -18886,7 +18886,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rustls-0.21.12",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
     ],
 )
 
@@ -18912,7 +18912,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":rustls-0.23.25",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
     ],
 )
 
@@ -18986,7 +18986,7 @@ cargo.rust_library(
     deps = [
         ":futures-core-0.3.31",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-util-0.7.14",
     ],
 )
@@ -19021,7 +19021,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.31",
         ":log-0.4.27",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tungstenite-0.20.1",
     ],
 )
@@ -19062,7 +19062,7 @@ cargo.rust_library(
         ":futures-sink-0.3.31",
         ":futures-util-0.3.31",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
     ],
 )
 
@@ -19091,7 +19091,7 @@ cargo.rust_library(
         ":bytes-1.10.1",
         ":futures-0.3.31",
         ":libc-0.2.171",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":vsock-0.5.1",
     ],
 )
@@ -19127,7 +19127,7 @@ cargo.rust_library(
         ":rand-0.8.5",
         ":ring-0.17.5",
         ":rustls-pki-types-1.11.0",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-rustls-0.26.2",
         ":tokio-util-0.7.14",
         ":webpki-roots-0.26.8",
@@ -19208,11 +19208,11 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":indexmap-2.8.0",
+        ":indexmap-2.9.0",
         ":serde-1.0.219",
         ":serde_spanned-0.6.8",
         ":toml_datetime-0.6.8",
-        ":winnow-0.7.4",
+        ":winnow-0.7.6",
     ],
 )
 
@@ -19271,7 +19271,7 @@ cargo.rust_library(
         ":prost-0.13.5",
         ":rustls-pemfile-2.2.0",
         ":socket2-0.5.9",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-rustls-0.26.2",
         ":tokio-stream-0.1.17",
         ":tower-0.4.13",
@@ -19345,7 +19345,7 @@ cargo.rust_library(
         ":pin-project-lite-0.2.16",
         ":rand-0.8.5",
         ":slab-0.4.9",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-util-0.7.14",
         ":tower-layer-0.3.3",
         ":tower-service-0.3.3",
@@ -19383,7 +19383,7 @@ cargo.rust_library(
         ":futures-util-0.3.31",
         ":pin-project-lite-0.2.16",
         ":sync_wrapper-1.0.2",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tower-layer-0.3.3",
         ":tower-service-0.3.3",
     ],
@@ -19432,7 +19432,7 @@ cargo.rust_library(
         ":http-body-0.4.6",
         ":http-range-header-0.3.1",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":tokio-util-0.7.14",
         ":tower-layer-0.3.3",
         ":tower-service-0.3.3",
@@ -19649,7 +19649,7 @@ cargo.rust_library(
         ":once_cell-1.21.3",
         ":opentelemetry-0.26.0",
         ":opentelemetry_sdk-0.26.0",
-        ":smallvec-1.14.0",
+        ":smallvec-1.15.0",
         ":tracing-0.1.41",
         ":tracing-core-0.1.33",
         ":tracing-log-0.2.0",
@@ -19729,7 +19729,7 @@ cargo.rust_library(
         ":serde-1.0.219",
         ":serde_json-1.0.140",
         ":sharded-slab-0.1.7",
-        ":smallvec-1.14.0",
+        ":smallvec-1.15.0",
         ":thread_local-1.1.8",
         ":tracing-0.1.41",
         ":tracing-core-0.1.33",
@@ -19844,7 +19844,7 @@ cargo.rust_library(
     deps = [
         ":futures-0.3.31",
         ":pin-project-lite-0.2.16",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
     ],
 )
 
@@ -21373,18 +21373,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "winnow-0.7.4.crate",
-    sha256 = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36",
-    strip_prefix = "winnow-0.7.4",
-    urls = ["https://static.crates.io/crates/winnow/0.7.4/download"],
+    name = "winnow-0.7.6.crate",
+    sha256 = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10",
+    strip_prefix = "winnow-0.7.6",
+    urls = ["https://static.crates.io/crates/winnow/0.7.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "winnow-0.7.4",
-    srcs = [":winnow-0.7.4.crate"],
+    name = "winnow-0.7.6",
+    srcs = [":winnow-0.7.6.crate"],
     crate = "winnow",
-    crate_root = "winnow-0.7.4.crate/src/lib.rs",
+    crate_root = "winnow-0.7.6.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -21562,7 +21562,7 @@ cargo.rust_library(
     deps = [
         ":futures-util-0.3.31",
         ":thiserror-1.0.69",
-        ":tokio-1.44.1",
+        ":tokio-1.44.2",
         ":yrs-0.17.4",
     ],
 )
@@ -21669,7 +21669,7 @@ cargo.rust_library(
         ":serde-1.0.219",
         ":serde_json-1.0.140",
         ":smallstr-0.3.0",
-        ":smallvec-1.14.0",
+        ":smallvec-1.15.0",
         ":thiserror-1.0.69",
     ],
 )

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -1164,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "serde",
@@ -1608,9 +1608,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1873,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -2391,7 +2391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.7",
+ "miniz_oxide 0.8.8",
 ]
 
 [[package]]
@@ -2789,7 +2789,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2808,7 +2808,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2817,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -3449,9 +3449,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -3562,9 +3562,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c102670231191d07d37a35af3eb77f1f0dbf7a71be51a962dcd57ea607be7260"
+checksum = "1f33145a5cbea837164362c7bd596106eb7c5198f97d1ba6f6ebb3223952e488"
 dependencies = [
  "jiff-static",
  "log",
@@ -3575,9 +3575,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdde31a9d349f1b1f51a0b3714a5940ac022976f4b49485fc04be052b183b4c"
+checksum = "43ce13c40ec6956157a3635d97a1ee2df323b263f09ea14165131289cb0f5c19"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3759,9 +3759,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -3972,9 +3972,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -4509,7 +4509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
 ]
@@ -5077,9 +5077,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -5470,7 +5470,7 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -5850,7 +5850,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "memchr",
  "ryu",
@@ -5918,7 +5918,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5944,7 +5944,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "ryu",
  "serde",
@@ -6075,9 +6075,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 dependencies = [
  "serde",
 ]
@@ -6179,7 +6179,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.2",
  "hashlink",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "log",
  "memchr",
  "once_cell",
@@ -6619,7 +6619,7 @@ dependencies = [
  "hyper 0.14.32",
  "hyperlocal 0.8.0",
  "iftree",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "indicatif",
  "indoc",
  "insta",
@@ -6631,7 +6631,7 @@ dependencies = [
  "log",
  "manyhow",
  "mime_guess",
- "miniz_oxide 0.8.7",
+ "miniz_oxide 0.8.8",
  "mixtrics",
  "monostate",
  "names",
@@ -6864,9 +6864,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7067,7 +7067,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8085,9 +8085,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
This was accomplishes by running:

```sh
buck2 run support/buck2:sync-cargo-deps
```

Remediates: https://github.com/systeminit/si/security/dependabot/397