### PR TITLE
fix(billing): Remove extraneous semicolons from view definitions

### DIFF
--- a/component/lambda/functions/si_posthog_api.py
+++ b/component/lambda/functions/si_posthog_api.py
@@ -74,15 +74,3 @@ class PosthogApi:
         def __init__(self, *args, json: Optional[ResponseJson], **kwargs):
             super().__init__(*args, **kwargs)
             self.json = json
-
-T = TypeVar("T")
-
-def batch(iterable: Iterable[T], n):
-    "Batch data into lists of length n. The last batch may be shorter."
-    # batched('ABCDEFG', 3) --> ABC DEF G
-    it = iter(iterable)
-    while True:
-        batch = list(islice(it, n))
-        if not batch:
-            return
-        yield batch

--- a/component/lambda/functions/upload-posthog-billing-data.py
+++ b/component/lambda/functions/upload-posthog-billing-data.py
@@ -1,10 +1,6 @@
-from typing import Iterable, NotRequired, cast
-from datetime import date, datetime, timedelta, timezone
-import itertools
+from typing import NotRequired, cast
 import logging
 
-from si_posthog_api import PosthogApi
-from si_lago_api import ExternalSubscriptionId
 from si_lambda import SiLambda, SiLambdaEnv
 from si_types import OwnerPk, SqlTimestamp, WorkspaceId, sql_to_iso_timestamp
 

--- a/component/lambda/sql/workspace_operations.sql
+++ b/component/lambda/sql/workspace_operations.sql
@@ -65,14 +65,14 @@ CREATE OR REPLACE VIEW workspace_operations.workspaces AS
 CREATE OR REPLACE VIEW workspace_operations.workspace_si_hours AS
     SELECT *
       FROM workspace_operations.si_hours
-     CROSS JOIN workspace_operations.workspaces;
+     CROSS JOIN workspace_operations.workspaces
      WHERE first_hour <= hour_start;
 
--- One row per owner per hour from Sep. 2024 until now (excluding hours where an owner had no workspace)
+-- One row per workspace per hour from the workspace start time until now)
 CREATE OR REPLACE VIEW workspace_operations.owner_si_hours AS
     SELECT *
       FROM workspace_operations.si_hours
-     CROSS JOIN workspace_operations.owners;
+     CROSS JOIN workspace_operations.owners
      WHERE first_hour <= hour_start;
 
 -- workspace_update_events, with data cleanup


### PR DESCRIPTION
Typo that was never deployed. I fixed it when I "deployed," this is just a record of what is actually in Redshift.

(This is what happens when your deployment method is "wait until it's merged, then paste the SQL into Redshift." This is also why our database is almost entirely *views*: repairing them is literally just redefining the view to the old version.)

Also removed some unused imports and an unused method from the Python.