### PR TITLE
fix(dal,naxum,rebaser): Cleaning up some traces that are not adding value

### DIFF
--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -320,7 +320,7 @@ impl ChangeSet {
         Ok(self.workspace(ctx).await?.default_change_set_id() == self.id)
     }
 
-    #[instrument(name = "change_set.update_pointer", level = "info", skip_all)]
+    #[instrument(name = "change_set.update_pointer", level = "debug", skip_all)]
     pub async fn update_pointer(
         &mut self,
         ctx: &DalContext,

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -465,7 +465,7 @@ impl WorkspaceSnapshot {
     /// those updates to ensure an incorrect graph is not created
     #[instrument(
         name = "workspace_snapshot.correct_transforms",
-        level = "info",
+        level = "debug",
         skip_all
     )]
     pub async fn correct_transforms(
@@ -1282,7 +1282,7 @@ impl WorkspaceSnapshot {
     /// another [`snapshot`](WorkspaceSnapshot) as the "onto" graph.
     #[instrument(
         name = "workspace_snapshot.perform_updates",
-        level = "info",
+        level = "debug",
         skip_all,
         fields()
     )]

--- a/lib/naxum/src/serve.rs
+++ b/lib/naxum/src/serve.rs
@@ -153,7 +153,7 @@ where
         let token = graceful_token.clone();
         tracker.spawn(async move {
             signal.await;
-            info!("received graceful shutdown signal, telling tasks to shutdown");
+            debug!("received graceful shutdown signal, telling tasks to shutdown");
             token.cancel();
         });
 
@@ -170,7 +170,7 @@ where
                     biased;
 
                     _ = graceful_token.cancelled() => {
-                        info!("signal received, not accepting new messages");
+                        debug!("signal received, not accepting new messages");
                         tracker.close();
                         break;
                     }


### PR DESCRIPTION
I also moved some of the timings to fields in the main rebaser loop, as we want to measure this over time but no need to send a full event for each one.

<div><img src="https://media4.giphy.com/media/fQoIDlLW6A6BAhyev8/giphy.gif?cid=5a38a5a24boi5wk428owtrkfsx8weecdkorm3i4gggcgl2se&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/cbc/">CBC</a> on <a href="https://giphy.com/gifs/cbc-schittscreek-schitts-creek-fQoIDlLW6A6BAhyev8">GIPHY</a></div>