### PR TITLE
Fix: code editor reloads text when saved unless you were the client that saved it

### DIFF
--- a/app/web/src/components/FuncEditor/FuncEditor.vue
+++ b/app/web/src/components/FuncEditor/FuncEditor.vue
@@ -64,7 +64,8 @@ const funcStore = useFuncStore();
 const selectedFuncSummary = computed(() => funcStore.selectedFuncSummary);
 const selectedFuncCode = computed(() => funcStore.selectedFuncCode);
 
-const editingFunc = ref<string>(selectedFuncCode.value?.code ?? "");
+// note this is a space on purpose, CodeEditor has a fit with a fully empty string
+const editingFunc = ref<string>(selectedFuncCode.value?.code ?? " ");
 
 const selectedAsset = computed(() => assetStore.selectedSchemaVariant);
 

--- a/app/web/src/store/func/funcs.store.ts
+++ b/app/web/src/store/func/funcs.store.ts
@@ -882,19 +882,19 @@ export const useFuncStore = () => {
           },
           {
             eventType: "FuncCodeSaved",
-            callback: ({ generated, funcCode: { funcId } }, metadata) => {
+            callback: ({ funcCode: { funcId } }, metadata) => {
               if (metadata.change_set_id !== selectedChangeSetId) return;
 
-              // TODO we update every time *any* function is generated unless you are in the
-              // function editor. That's because we can't tell from here if the function is
-              // the asset function editor from here (and we can't useAssetStore() because
-              // that would cause a circular dependency). We should fix this, but asset
-              // generation doesn't happen so often it's a giant problem right now.
-              if (
-                (funcId === this.selectedFuncId || !this.selectedFuncId) &&
-                generated
-              ) {
-                this.FETCH_CODE(funcId);
+              // TODO we update every time *any* function is generated unless you are the
+              // one that made the change in the function editor. If we were to remove that check
+              // every time your code editor saved, it would remount with the new code, and you'd lose
+              // your cursor. It would feel like you can't just keep typing, and you'd get angry
+              if (funcId === this.selectedFuncId || !this.selectedFuncId) {
+                const didIFireThisRequest =
+                  !!realtimeStore.inflightRequests.get(metadata.request_ulid);
+                if (metadata.actor === "System" || !didIFireThisRequest) {
+                  this.FETCH_CODE(funcId);
+                }
               }
             },
           },


### PR DESCRIPTION
Testing steps:
1. unlock a function
2. open two tabs
3. make changes in one tab
4. see the other tab reload the editor
5. your tab did not reload the editor and you can keep typing

This will work against `sifs` too, your code will always reload.

PSA: I went down a _loooooong_ rabbit hole before landing on this specific fix. I was trying to have my cake and eat it too—always update the store, but not remount the component. And, this part scares me, _I couldn't do it to save my life_.

I literally took out every piece of the puzzle I could so that none of the props to `<CodeEditor>` changed, which means it shouldn't have re-mounted. But it kept remounting. (My thought process was to not remount it, and instead edit the `yDoc` to have the new code as its contents, but I couldn't pull that off)

Whenever we return and try to implement the CRDT for multiplayer editing we have two choices:
1. Remove the `didIMakeThis` check, and never update the store for the selected func code, with the guarantee that the crdt is keeping everyone in matching state. Note: `sifs` will never have matching state in either direction (see below).
2. Figure out how to get this thing to not remount, even when we update the store.

For both of those scenarios,  we could add a `originating_client` enum to all `WsEvents` whether they came from `BROWSER` or `SIFS`. That way the browser could say "we got an update from `sifs`, reload your code I'm going to break you're keyboard focus. And `sifs` could act on it as well (since it currently doesn't listen to any events).

Clarification; you may be thinking "but if the store doesn't update, how will people see the correct code when they use the UI?!" Every time someone clicks on a function / asset function in the customize screen on the left—we always go fetch the code. If a component needs the func code, and we don't have it—we always go fetch it. Any code save that happens _when you're not staring at the function in the customize editor_ *does* update the store.