### PR TITLE
feat(web) - simple socket UI connecting edges on the diagram

### DIFF
--- a/app/web/src/components/Connection.vue
+++ b/app/web/src/components/Connection.vue
@@ -11,30 +11,7 @@
       outputSocket
       :changeStatus="connection.changeStatus"
     />
-    <div
-      :class="
-        clsx(
-          '_connection-label',
-          'border-l-2',
-          connection.changeStatus
-            ? {
-                added: 'border-success-400',
-                deleted: 'border-destructive-500',
-                modified: 'border-warning-400',
-                unmodified: 'border-shade-0',
-              }[connection.changeStatus]
-            : 'border-shade-0',
-          connection.changeStatus
-            ? {
-                added: 'before:bg-success-400 after:bg-success-400',
-                deleted: 'before:bg-destructive-500 after:bg-destructive-500',
-                modified: 'before:bg-warning-400 after:bg-warning-400',
-                unmodified: 'before:bg-shade-0 after:bg-shade-0',
-              }[connection.changeStatus]
-            : 'before:bg-shade-0 after:bg-shade-0',
-        )
-      "
-    >
+    <div :class="clsx('_connection-label border-l-2', statusColors)">
       <div class="flex flex-row items-center">
         <DetailsPanelTimestamps
           noMargin
@@ -62,7 +39,9 @@ import clsx from "clsx";
 import {
   DropdownMenu,
   DropdownMenuItemObjectDef,
+  themeClasses,
 } from "@si/vue-lib/design-system";
+import { tw } from "@si/vue-lib";
 import { isDevMode } from "@/utils/debug";
 import { ChangeStatus } from "@/api/sdf/dal/change_set";
 import { ActorAndTimestamp } from "@/api/sdf/dal/component";
@@ -135,6 +114,24 @@ const triggerDelete = () => {
   viewsStore.setSelectedEdgeId(props.connection.id, viewsStore.selectedEdgeId);
   modelingEventBus.emit("deleteSelection");
 };
+
+const statusColors = computed(() => {
+  const unmodified = themeClasses(
+    tw`border-shade-100 before:bg-shade-100 after:bg-shade-100`,
+    tw`border-shade-0 before:bg-shade-0 after:bg-shade-0`,
+  );
+  if (!props.connection.changeStatus) return unmodified;
+  const colors = {
+    added: themeClasses(
+      tw`border-success-500 before:bg-success-500 after:bg-success-500`,
+      tw`border-success-400 before:bg-success-400 after:bg-success-400`,
+    ),
+    deleted: tw`border-destructive-500 before:bg-destructive-500 after:bg-destructive-500`,
+    modified: tw`border-warning-400 before:bg-warning-400 after:bg-warning-400`,
+    unmodified,
+  };
+  return colors[props.connection.changeStatus];
+});
 </script>
 
 <style lang="less">

--- a/app/web/src/components/DetailsPanelTimestamps.vue
+++ b/app/web/src/components/DetailsPanelTimestamps.vue
@@ -2,7 +2,8 @@
   <div
     :class="
       clsx(
-        'text-xs italic text-neutral-300 grow flex flex-col justify-between',
+        'text-xs italic grow flex flex-col justify-between',
+        themeClasses('text-neutral-500 ', 'text-neutral-300'),
         !noMargin && 'm-xs mt-0',
       )
     "
@@ -10,7 +11,8 @@
     <div
       :class="
         clsx(
-          changeStatus === 'added' && 'text-success-500',
+          changeStatus === 'added' &&
+            themeClasses('text-success-500', 'text-success-400'),
           'flex flex-row gap-2xs items-center',
         )
       "
@@ -80,6 +82,7 @@
 import { PropType } from "vue";
 import clsx from "clsx";
 import { formatters } from "@si/vue-lib";
+import { themeClasses } from "@si/vue-lib/design-system";
 import { ChangeStatus } from "@/api/sdf/dal/change_set";
 import { ActorAndTimestamp } from "@/api/sdf/dal/component";
 import StatusIndicatorIcon from "./StatusIndicatorIcon.vue";

--- a/app/web/src/components/EdgeDetailsPanel.vue
+++ b/app/web/src/components/EdgeDetailsPanel.vue
@@ -12,6 +12,19 @@
           "
         />
       </SidebarSubpanelTitle>
+      <div
+        v-if="featureFlagsStore.SIMPLE_SOCKET_UI"
+        class="p-xs border-b dark:border-neutral-600 flex flex-row"
+      >
+        <VButton
+          class="grow"
+          size="sm"
+          label="Add Connection"
+          icon="plus"
+          variant="ghost"
+          @click="addConnection"
+        />
+      </div>
     </template>
 
     <div
@@ -56,7 +69,10 @@ import {
   ErrorMessage,
   ScrollArea,
 } from "@si/vue-lib/design-system";
-import { useComponentsStore } from "@/store/components.store";
+import {
+  ConnectionDirection,
+  useComponentsStore,
+} from "@/store/components.store";
 import { useViewsStore } from "@/store/views.store";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import SidebarSubpanelTitle from "./SidebarSubpanelTitle.vue";
@@ -134,6 +150,20 @@ const connections = computed(() => {
     return [connection];
   }
 });
+
+const addConnection = () => {
+  if (!selectedEdge.value || !featureFlagsStore.SIMPLE_SOCKET_UI) return;
+
+  const fromId = selectedEdge.value.fromComponentId;
+  const toId = selectedEdge.value.toComponentId;
+
+  const menuData = {
+    aDirection: "output" as ConnectionDirection,
+    A: { componentId: fromId },
+    B: { componentId: toId },
+  };
+  modelingEventBus.emit("openConnectionsMenu", menuData);
+};
 
 const emit = defineEmits<{
   (e: "openMenu", mouse: MouseEvent): void;

--- a/app/web/src/components/ModelingDiagram/DiagramEdge.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramEdge.vue
@@ -58,6 +58,7 @@
           fontSize: connectionCount < 10 ? 12 : 10,
           fontStyle: 'bold',
           fontFamily: DIAGRAM_FONT_FAMILY,
+          fill: connectionCountColor === '#000000' ? '#FFFFFF' : '#000000',
         }"
       />
     </v-group>
@@ -139,18 +140,23 @@ const props = defineProps({
   isSelected: Boolean,
 });
 
+const { theme } = useTheme();
+
 const COUNT_ICON_SIZE = 16;
 const connectionCountColor = computed(() => {
-  return `#${
-    props.edge.def.changeStatus
-      ? {
-          added: "4ADE80",
-          deleted: "EF4444",
-          modified: "F59E0B",
-          unmodified: "FFFFFF",
-        }[props.edge.def.changeStatus]
-      : "FFFFFF"
-  }`;
+  const neutral = theme.value === "dark" ? "FFFFFF" : "000000";
+  if (!props.edge.def.changeStatus) {
+    return neutral;
+  }
+
+  const colors = {
+    added: "4ADE80",
+    deleted: "EF4444",
+    modified: "F59E0B",
+    unmodified: neutral,
+  };
+
+  return `#${colors[props.edge.def.changeStatus]}`;
 });
 const connectionCountText = computed(() => {
   if (!props.connectionCount) return "";
@@ -159,8 +165,6 @@ const connectionCountText = computed(() => {
 });
 
 const emit = defineEmits(["hover:start", "hover:end"]);
-
-const { theme } = useTheme();
 
 const diagramContext = useDiagramContext();
 const { drawEdgeState } = diagramContext;

--- a/app/web/src/components/ModelingDiagram/DiagramHelpModal.vue
+++ b/app/web/src/components/ModelingDiagram/DiagramHelpModal.vue
@@ -59,6 +59,14 @@
       <div class="flex flex-row items-center gap-xs">
         <div class="w-12 flex flex-row items-center justify-center">
           <div class="text-xl font-bold leading-none flex-grow text-center">
+            C
+          </div>
+        </div>
+        <div>Press C to open the connections menu.</div>
+      </div>
+      <div class="flex flex-row items-center gap-xs">
+        <div class="w-12 flex flex-row items-center justify-center">
+          <div class="text-xl font-bold leading-none flex-grow text-center">
             R
           </div>
         </div>

--- a/app/web/src/components/ModelingView/ConnectionMenuSocketList.vue
+++ b/app/web/src/components/ModelingView/ConnectionMenuSocketList.vue
@@ -4,12 +4,17 @@
       clsx(
         'basis-1/2 h-full min-h-0 border-x-2 border-b-2 p-xs ',
         active && themeClasses('bg-neutral-100', 'bg-neutral-800'),
-        socketToShow?.uniqueKey ? 'children:h-1/2' : 'children:h-full',
+        socketToShow?.uniqueKey && doneLoading
+          ? 'children:h-1/2'
+          : 'children:h-full',
       )
     "
   >
+    <div v-if="!doneLoading" class="h-full flex flex-row items-center">
+      <LoadingMessage message="Loading socket data..." />
+    </div>
     <div
-      v-if="listItems.length"
+      v-else-if="listItems.length"
       ref="scrollRef"
       :class="
         clsx(
@@ -136,7 +141,7 @@
     >
       No available sockets
     </div>
-    <div v-if="socketToShow?.uniqueKey" class="w-full min-h-0">
+    <div v-if="socketToShow?.uniqueKey && doneLoading" class="w-full min-h-0">
       <CodeEditor
         v-if="socketToShow.value"
         :id="`func-${socketToShow.uniqueKey}`"
@@ -159,7 +164,7 @@
 <script lang="ts" setup>
 import { computed, PropType, reactive, ref, watch, watchEffect } from "vue";
 import clsx from "clsx";
-import { Icon, themeClasses } from "@si/vue-lib/design-system";
+import { Icon, LoadingMessage, themeClasses } from "@si/vue-lib/design-system";
 import { useVirtualizer } from "@tanstack/vue-virtual";
 import CodeEditor from "@/components/CodeEditor.vue";
 import {
@@ -188,6 +193,7 @@ const props = defineProps({
   highlightedIndex: { type: Number },
   highlightedSocket: { type: Object as PropType<DiagramSocketData> },
   active: { type: Boolean },
+  doneLoading: { type: Boolean },
 });
 const localHighlightedIndex = computed(() =>
   props.active ? props.highlightedIndex : undefined,

--- a/app/web/src/components/SocketCard.vue
+++ b/app/web/src/components/SocketCard.vue
@@ -2,15 +2,9 @@
   <div
     :class="
       clsx(
-        'p-xs border-l-4 border relative bg-shade-100',
-        changeStatus
-          ? {
-              added: 'border-success-400',
-              deleted: 'border-destructive-500',
-              modified: 'border-warning-400',
-              unmodified: 'border-shade-0',
-            }[changeStatus]
-          : 'border-shade-0',
+        'p-xs border-l-4 border relative',
+        themeClasses('bg-shade-0', 'bg-shade-100'),
+        statusColors,
       )
     "
   >
@@ -61,18 +55,36 @@
 
 <script lang="ts" setup>
 import clsx from "clsx";
-import { Icon, Stack, TruncateWithTooltip } from "@si/vue-lib/design-system";
-import { PropType } from "vue";
+import {
+  Icon,
+  Stack,
+  themeClasses,
+  TruncateWithTooltip,
+} from "@si/vue-lib/design-system";
+import { computed, PropType } from "vue";
+import { tw } from "@si/vue-lib";
 import { useViewsStore } from "@/store/views.store";
 import { ChangeStatus } from "@/api/sdf/dal/change_set";
 import { DiagramSocketData } from "./ModelingDiagram/diagram_types";
 import StatusIndicatorIcon from "./StatusIndicatorIcon.vue";
 
-defineProps({
+const props = defineProps({
   socket: { type: Object as PropType<DiagramSocketData>, required: true },
   changeStatus: { type: String as PropType<ChangeStatus> },
   outputSocket: { type: Boolean },
 });
 
 const viewsStore = useViewsStore();
+
+const statusColors = computed(() => {
+  const unmodified = themeClasses(tw`border-shade-100`, tw`border-shade-0`);
+  if (!props.changeStatus) return unmodified;
+  const colors = {
+    added: themeClasses(tw`border-success-500`, tw`border-success-400`),
+    deleted: tw`border-destructive-500`,
+    modified: tw`border-warning-400`,
+    unmodified,
+  };
+  return colors[props.changeStatus];
+});
 </script>


### PR DESCRIPTION
Components can now have their data sockets connected via the diagram. Dragging an edge between components will open up the connections panel to create a connection. A new connection can also be added to two components which are already connected by selecting the edge between them and clicking the button on the `EdgeDetailsPanel`.

Currently the empty states for the connections panel could be improved and the user cannot add multiple connections at once.