### PR TITLE
fix(edda): delete (and log) the request when it fails

### DIFF
--- a/lib/naxum/src/middleware/post_process/on_failure.rs
+++ b/lib/naxum/src/middleware/post_process/on_failure.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
-use tracing::trace;
+use tracing::error;
 
 use crate::Head;
 
@@ -21,9 +21,13 @@ impl DefaultOnFailure {
 }
 
 impl OnFailure for DefaultOnFailure {
-    fn call(&mut self, _head: Arc<Head>, _info: Arc<Info>) -> BoxFuture<'static, ()> {
+    fn call(&mut self, head: Arc<Head>, info: Arc<Info>) -> BoxFuture<'static, ()> {
         Box::pin(async move {
-            trace!("message on failure");
+            error!(
+                subject = head.subject.as_str(),
+                stream_sequence = info.stream_sequence,
+                "message on failure",
+            );
         })
     }
 }


### PR DESCRIPTION
This change alters the middleware stack for the change set processor task in Edda. Prior to this change, when a message is processed that results in an error, it is left in place in the stream and *not* deleted, but rather skipped over. If at a later point in time a new task is spun up to process more messages for that change set, the change set processor task will re-visit this failed request message and potentially result in the exact same behavior (i.e. result in a failure and not delete that message).

This change will log an `error` making it clear that the request failed in some way and will delete the message so that future change set NATS consumers will not re-process this message. A future change may consider re-publishing this message to a "failed requests" stream for later analysis.