### PR TITLE
chore: pin vector to 0.45

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
 
   vector:
     container_name: vector
-    image: timberio/vector:0.X-debian
+    image: timberio/vector:0.45.X-debian
     profiles: [edda, forklift, rebaser, pinga, sdf, veritech]
     ports:
       - 8686:8686


### PR DESCRIPTION
Vector's latest release is having issues. We're pinning to a more specific version until the issue is resolved.

https://github.com/vectordotdev/vector/issues/22840#issuecomment-2789929247
