### PR TITLE
feat(auth-api): Include userId property in Posthog person profile

### DIFF
--- a/bin/auth-api/src/lib/tracker.ts
+++ b/bin/auth-api/src/lib/tracker.ts
@@ -2,23 +2,25 @@
  * small wrapper for tracking so we can pass in our domain objects
  * and get consistently formatted data
  */
-import _ from 'lodash';
-import { User } from '@prisma/client';
-import { posthog } from './posthog';
+import _ from "lodash";
+import { User } from "@prisma/client";
+import { posthog } from "./posthog";
 
 function identifyUser(user: User) {
   posthog.identify({
     distinctId: user.id,
     properties: {
+      userId: user.id,
       // TODO: convert to snake_case??
       ..._.pick(user, [
-        'auth0Id',
-        'email',
-        'firstName',
-        'lastName',
-        'nickname',
-        'githubUsername',
-        'discordUsername',
+        "auth0Id",
+        "email",
+        "firstName",
+        "lastName",
+        "pictureUrl",
+        "nickname",
+        "githubUsername",
+        "discordUsername",
       ]),
     },
   });

--- a/bin/auth-api/src/services/users.service.ts
+++ b/bin/auth-api/src/services/users.service.ts
@@ -139,7 +139,6 @@ export async function createOrUpdateUserFromAuth0Details(
         auth0Details: auth0UserData as Prisma.JsonObject,
       },
     });
-    tracker.identifyUser(user);
   } else {
     isSignup = true;
     user = await prisma.user.create({
@@ -150,9 +149,9 @@ export async function createOrUpdateUserFromAuth0Details(
         ...setUserDataFromAuth0Details({}, auth0UserData, isSignup),
       },
     });
-
-    tracker.identifyUser(user);
   }
+
+  tracker.identifyUser(user);
 
   if (isSignup) {
     tracker.trackEvent(user, "auth_connected", {


### PR DESCRIPTION
When you log in or restore session, this will add "userId" to your profile. This will allow us to see the userId in their profile in Posthog when there are multiple primary aliases. (It will also add "pictureUrl," just so's we can have that in visualizations if we want.)