### PR TITLE
Move actions list to norse stack

### DIFF
--- a/app/web/src/components/ApplyChangeSetButton.vue
+++ b/app/web/src/components/ApplyChangeSetButton.vue
@@ -33,7 +33,20 @@
       />
     </template>
 
-    <ApprovalFlowModal ref="approvalFlowModalRef" votingKind="merge" />
+    <template
+      v-if="
+        featureFlagsStore.FRONTEND_ARCH_VIEWS &&
+        featureFlagsStore.BIFROST_ACTIONS
+      "
+    >
+      <BifrostApprovalFlowModal
+        ref="bifrostApprovalFlowModalRef"
+        votingKind="merge"
+      />
+    </template>
+    <template v-else>
+      <ApprovalFlowModal ref="approvalFlowModalRef" votingKind="merge" />
+    </template>
   </VButton>
 </template>
 
@@ -50,11 +63,14 @@ import clsx from "clsx";
 import { useChangeSetsStore } from "@/store/change_sets.store";
 import { useStatusStore } from "@/store/status.store";
 import { useActionsStore } from "@/store/actions.store";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import { ChangeSetStatus } from "@/api/sdf/dal/change_set";
+import BifrostApprovalFlowModal from "@/mead-hall/ApprovalFlowModal.vue";
 import ApprovalFlowModal from "./ApprovalFlowModal.vue";
 
 const actionsStore = useActionsStore();
 const changeSetsStore = useChangeSetsStore();
+const featureFlagsStore = useFeatureFlagsStore();
 const statusStore = useStatusStore();
 
 const displayCount = computed(() => actionsStore.proposedActions.length);
@@ -65,9 +81,19 @@ const applyChangeSetReqStatus =
 const approvalFlowModalRef = ref<InstanceType<typeof ApprovalFlowModal> | null>(
   null,
 );
+const bifrostApprovalFlowModalRef = ref<InstanceType<
+  typeof BifrostApprovalFlowModal
+> | null>(null);
 
 const openApprovalFlowModal = () => {
-  approvalFlowModalRef.value?.open();
+  if (
+    featureFlagsStore.FRONTEND_ARCH_VIEWS &&
+    featureFlagsStore.BIFROST_ACTIONS
+  ) {
+    bifrostApprovalFlowModalRef.value?.open();
+  } else {
+    approvalFlowModalRef.value?.open();
+  }
 };
 
 const disableApplyButton = computed(

--- a/app/web/src/components/ComponentDetails.vue
+++ b/app/web/src/components/ComponentDetails.vue
@@ -160,7 +160,22 @@
                 />
               </Inline>
             </template>
-            <AssetActionsDetails :component="props.component" />
+            <template
+              v-if="
+                ffStore.FRONTEND_ARCH_VIEWS &&
+                ffStore.BIFROST_ACTIONS &&
+                viewStore.selectedComponentId
+              "
+            >
+              <BifrostAssetActionsDetails
+                :componentId="component.def.id"
+                :component="component"
+              />
+            </template>
+            <template v-else
+              >.selectedComponentId
+              <AssetActionsDetails :component="props.component" />
+            </template>
           </TabGroupItem>
           <TabGroupItem
             v-if="funcStore.managementFunctionsForSelectedComponent.length > 0"
@@ -197,6 +212,8 @@ import { useQualificationsStore } from "@/store/qualifications.store";
 import { ComponentType } from "@/api/sdf/dal/schema";
 import { useFuncStore } from "@/store/func/funcs.store";
 import { useViewsStore } from "@/store/views.store";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
+import BifrostAssetActionsDetails from "@/mead-hall/AssetActionsDetails.vue";
 import ComponentCard from "./ComponentCard.vue";
 import DetailsPanelTimestamps from "./DetailsPanelTimestamps.vue";
 import ComponentDetailsManagement from "./ComponentDetailsManagement.vue";
@@ -230,6 +247,7 @@ const viewStore = useViewsStore();
 const qualificationsStore = useQualificationsStore();
 const changeSetsStore = useChangeSetsStore();
 const funcStore = useFuncStore();
+const ffStore = useFeatureFlagsStore();
 
 const modelingEventBus = componentsStore.eventBus;
 

--- a/app/web/src/components/NoSelectionDetailsPanel.vue
+++ b/app/web/src/components/NoSelectionDetailsPanel.vue
@@ -59,7 +59,14 @@
         trackingSlug="no-selection-details-panel"
       >
         <TabGroupItem label="Changes" slug="changes">
-          <ChangesPanelProposed />
+          <template
+            v-if="ffStore.FRONTEND_ARCH_VIEWS && ffStore.BIFROST_ACTIONS"
+          >
+            <BifrostChangesPanelProposed />
+          </template>
+          <template v-else>
+            <ChangesPanelProposed />
+          </template>
         </TabGroupItem>
         <TabGroupItem label="History" slug="history">
           <ChangesPanelHistory />
@@ -88,6 +95,8 @@ import clsx from "clsx";
 import { ref } from "vue";
 import ApplyChangeSetButton from "@/components/ApplyChangeSetButton.vue";
 import { useChangeSetsStore } from "@/store/change_sets.store";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
+import BifrostChangesPanelProposed from "@/mead-hall/ChangesPanelProposed.vue";
 import SidebarSubpanelTitle from "./SidebarSubpanelTitle.vue";
 import SecretsPanel from "./SecretsPanel.vue";
 import ChangesPanelProposed from "./ChangesPanelProposed.vue";
@@ -95,6 +104,7 @@ import ChangesPanelHistory from "./ChangesPanelHistory.vue";
 import DetailsPanelMenuIcon from "./DetailsPanelMenuIcon.vue";
 
 const changeSetsStore = useChangeSetsStore();
+const ffStore = useFeatureFlagsStore();
 
 const dropdownMenuRef = ref<InstanceType<typeof DropdownMenu>>();
 const renameModalRef = ref<InstanceType<typeof Modal>>();

--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -45,11 +45,25 @@
       )
     "
   >
-    <InsetApprovalModal
-      v-if="changeSetsStore.selectedChangeSet && approvalData"
-      :approvalData="approvalData"
-      :changeSet="changeSetsStore.selectedChangeSet"
-    />
+    <template
+      v-if="
+        featureFlagsStore.FRONTEND_ARCH_VIEWS &&
+        featureFlagsStore.BIFROST_ACTIONS
+      "
+    >
+      <BifrostInsetApprovalModal
+        v-if="changeSetsStore.selectedChangeSet && approvalData"
+        :approvalData="approvalData"
+        :changeSet="changeSetsStore.selectedChangeSet"
+      />
+    </template>
+    <template v-else>
+      <InsetApprovalModal
+        v-if="changeSetsStore.selectedChangeSet && approvalData"
+        :approvalData="approvalData"
+        :changeSet="changeSetsStore.selectedChangeSet"
+      />
+    </template>
   </div>
   <ModelingDiagram
     v-else
@@ -146,6 +160,7 @@ import { useFuncStore } from "@/store/func/funcs.store";
 import { useAuthStore } from "@/store/auth.store";
 import FloatingConnectionMenu from "@/components/ModelingView/FloatingConnectionMenu.vue";
 import * as heimdall from "@/store/realtime/heimdall";
+import BifrostInsetApprovalModal from "@/mead-hall/InsetApprovalModal.vue";
 import LeftPanelDrawer from "../LeftPanelDrawer.vue";
 import ModelingDiagram from "../ModelingDiagram/ModelingDiagram.vue";
 import AutoconnectMenu from "../ModelingView/AutoconnectMenu.vue";

--- a/app/web/src/mead-hall/ActionCard.vue
+++ b/app/web/src/mead-hall/ActionCard.vue
@@ -1,0 +1,253 @@
+<template>
+  <ActionCardLayout
+    :noInteraction="noInteraction"
+    :selected="selected"
+    :actionFailed="actionFailed"
+    :abbr="actionKindToAbbreviation(props.action.kind)"
+    :description="action.kind === ActionKind.Manual ? action.description : ''"
+    :componentSchemaName="action.componentSchemaName"
+    :componentName="action.componentName"
+    :componentId="action.componentId"
+    :actor="action.actor"
+  >
+    <template #icons>
+      <Icon
+        v-if="actionQueued"
+        :class="
+          clsx(
+            themeClasses('text-neutral-600', 'text-neutral-300'),
+            'translate-y-[-2px]',
+          )
+        "
+        name="nested-arrow-right"
+        size="sm"
+      />
+      <Icon
+        v-else-if="actionRunning"
+        :class="clsx(themeClasses('text-action-300', 'text-action-300'))"
+        name="loader"
+        size="sm"
+      />
+      <Icon
+        v-else-if="actionOnHold"
+        :class="
+          clsx(
+            props.action.holdStatusInfluencedBy.length > 0
+              ? [
+                  'opacity-30',
+                  themeClasses('text-warning-500', 'text-warning-300'),
+                ]
+              : themeClasses('text-warning-400', 'text-warning-300'),
+          )
+        "
+        name="circle-stop"
+        size="sm"
+      />
+      <template v-else-if="actionFailed">
+        <Icon
+          :class="clsx(themeClasses('text-action-700', 'text-action-300'))"
+          name="play"
+          size="sm"
+          @click.stop="retry"
+        />
+        <Icon
+          :class="
+            clsx(themeClasses('text-destructive-500', 'text-destructive-600'))
+          "
+          name="x-hex-outline"
+          size="sm"
+        />
+      </template>
+      <Icon
+        :class="actionIconClass(props.action.kind)"
+        :name="actionIcon(props.action.kind)"
+        size="sm"
+      />
+    </template>
+    <template #interaction>
+      <ConfirmHoldModal
+        v-if="!props.noInteraction"
+        ref="confirmRef"
+        :ok="finishHold"
+      />
+      <DropdownMenu
+        v-if="!props.noInteraction"
+        ref="contextMenuRef"
+        :forceAbove="false"
+        forceAlignRight
+      >
+        <h5 class="text-neutral-400 pl-2xs">ACTIONS:</h5>
+        <DropdownMenuItem
+          v-if="props.action.state === ActionState.Queued"
+          :onSelect="hold"
+          icon="circle-stop"
+          iconClass="text-warning-400"
+          label="Put on hold"
+        />
+        <DropdownMenuItem
+          v-if="props.action.state === ActionState.OnHold"
+          :onSelect="retry"
+          icon="nested-arrow-right"
+          iconClass="text-action-400"
+          label="Put in Queue"
+        />
+        <DropdownMenuItem
+          :onSelect="remove"
+          icon="x"
+          iconClass="text-destructive-500 dark:text-destructive-600"
+          label="Remove from list"
+        />
+        <hr class="border-neutral-600 my-xs" />
+        <h5 class="text-neutral-400 pl-2xs">APPLY BEFORE:</h5>
+        <ol v-if="props.action.myDependentActions.length > 0">
+          <li
+            v-for="a in props.action.myDependentActions"
+            :key="a.id"
+            class="flex flex-row items-center px-2xs gap-xs"
+          >
+            <Icon
+              :class="actionIconClass(a.kind)"
+              :name="actionIcon(a.kind)"
+              size="sm"
+            />
+            <span class="align-baseline leading-[30px]"
+              ><strong>{{ actionKindToAbbreviation(a.kind) }}:</strong>
+              {{ a.componentSchemaName ?? "unknown" }}
+              {{ a.componentName ?? "unknown" }}
+            </span>
+          </li>
+        </ol>
+        <p v-else class="ml-xs">None</p>
+        <h5 class="text-neutral-400 pl-2xs">WAITING ON:</h5>
+        <ol v-if="props.action.dependentOnActions.length > 0">
+          <li
+            v-for="a in props.action.dependentOnActions"
+            :key="a.id"
+            class="flex flex-row items-center px-2xs gap-xs"
+          >
+            <Icon
+              :class="actionIconClass(a.kind)"
+              :name="actionIcon(a.kind)"
+              size="sm"
+            />
+            <span class="align-baseline leading-[30px]"
+              ><strong>{{ actionKindToAbbreviation(a.kind) }}:</strong>
+              {{ a.componentSchemaName ?? "unknown" }}
+              {{ a.componentName ?? "unknown" }}
+            </span>
+          </li>
+        </ol>
+        <p v-else class="ml-xs">None</p>
+      </DropdownMenu>
+      <DetailsPanelMenuIcon
+        v-if="!props.noInteraction"
+        @click="
+          (e) => {
+            contextMenuRef?.open(e, false);
+          }
+        "
+      />
+    </template>
+  </ActionCardLayout>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from "vue";
+
+import {
+  Icon,
+  themeClasses,
+  DropdownMenu,
+  DropdownMenuItem,
+} from "@si/vue-lib/design-system";
+import clsx from "clsx";
+import { ActionKind, ActionState, ActionId } from "@/api/sdf/dal/action";
+import {
+  useActionsStore,
+  actionKindToAbbreviation,
+  actionIconClass,
+  actionIcon,
+} from "@/store/actions.store";
+import ConfirmHoldModal from "@/components/Actions/ConfirmHoldModal.vue";
+
+import DetailsPanelMenuIcon from "@/components/DetailsPanelMenuIcon.vue";
+import ActionCardLayout from "./ActionCardLayout.vue";
+import { ActionProposedViewWithHydratedChildren } from "./ChangesPanelProposed.vue";
+
+const actionStore = useActionsStore();
+
+const props = defineProps<{
+  action: ActionProposedViewWithHydratedChildren;
+  slim?: boolean;
+  selected?: boolean;
+  noInteraction?: boolean;
+}>();
+
+const confirmRef = ref<InstanceType<typeof ConfirmHoldModal> | null>(null);
+
+const hold = () => {
+  const l = props.action.myDependencies?.length;
+  if (l && l > 0) confirmRef.value?.open();
+  else finishHold();
+};
+
+const finishHold = () => {
+  actionStore.PUT_ACTION_ON_HOLD([props.action.id]);
+  confirmRef.value?.close();
+};
+
+const remove = () => {
+  actionStore.CANCEL([props.action.id]);
+};
+
+const retry = () => {
+  actionStore.RETRY([props.action.id]);
+};
+
+const contextMenuRef = ref<InstanceType<typeof DropdownMenu>>();
+
+const actionOnHold = computed(() => {
+  if (props.action && "state" in props.action)
+    return (
+      props.action.state === ActionState.OnHold ||
+      props.action.holdStatusInfluencedBy?.length > 0
+    );
+  else return false;
+});
+const actionFailed = computed(() => {
+  if (props.action) return props.action.state === ActionState.Failed;
+  else return false;
+});
+const actionRunning = computed(() => {
+  if (props.action) return props.action.state === ActionState.Running;
+  else return false;
+});
+const actionQueued = computed(() => {
+  if (props.action) return props.action.state === ActionState.Queued;
+  else return false;
+});
+
+const emit = defineEmits<{
+  (e: "add"): void;
+  (e: "remove"): void;
+  (e: "openMenu", mouse: MouseEvent): void;
+  (e: "history", id: ActionId, tabSlug: string): void;
+}>();
+</script>
+
+<style lang="less">
+@keyframes flashRed {
+  from {
+    background-color: transparent;
+  }
+  50% {
+    background-color: #dc2626; //bg-destructive-600
+  }
+  to {
+    background-color: transparent;
+  }
+}
+.action-failed {
+  animation: 0.75s ease-in flashRed;
+}
+</style>

--- a/app/web/src/mead-hall/ActionCardLayout.vue
+++ b/app/web/src/mead-hall/ActionCardLayout.vue
@@ -1,0 +1,64 @@
+<template>
+  <div
+    :class="
+      clsx(
+        'flex flex-row items-center text-sm relative p-2xs min-w-0 w-full border border-transparent',
+        !noInteraction
+          ? 'cursor-pointer hover:border-action-500 dark:hover:border-action-300 group/actioncard'
+          : '',
+        selected
+          ? 'dark:bg-action-900 bg-action-100 border-action-500 dark:border-action-300'
+          : 'dark:border-neutral-800',
+        actionFailed ? 'action-failed' : '',
+      )
+    "
+  >
+    <slot name="icons"> </slot>
+
+    <div class="flex flex-col flex-grow min-w-0">
+      <TruncateWithTooltip class="w-full">
+        <span class="font-bold"> {{ abbr }}: </span>
+        <span
+          :class="
+            clsx(
+              themeClasses('text-neutral-700', 'text-neutral-200'),
+              !noInteraction &&
+                themeClasses(
+                  'group-hover/actioncard:text-action-500',
+                  'group-hover/actioncard:text-action-300',
+                ),
+            )
+          "
+        >
+          <template v-if="componentId">
+            {{ componentSchemaName }}
+            {{ componentName ?? "unknown" }}
+            {{ description }}
+          </template>
+        </span>
+      </TruncateWithTooltip>
+      <div v-if="actor" class="text-neutral-500 dark:text-neutral-400 truncate">
+        <span class="font-bold">By:</span> {{ actor }}
+      </div>
+    </div>
+
+    <slot name="interaction"> </slot>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import clsx from "clsx";
+import { themeClasses, TruncateWithTooltip } from "@si/vue-lib/design-system";
+
+defineProps<{
+  noInteraction?: boolean;
+  selected?: boolean;
+  actionFailed: boolean;
+  componentId: string | null | undefined;
+  componentSchemaName?: string;
+  componentName?: string;
+  description?: string;
+  actor?: string;
+  abbr: string;
+}>();
+</script>

--- a/app/web/src/mead-hall/ActionHistoryCard.vue
+++ b/app/web/src/mead-hall/ActionHistoryCard.vue
@@ -1,0 +1,74 @@
+<template>
+  <ActionCardLayout
+    :noInteraction="noInteraction"
+    :selected="selected"
+    :actionFailed="false"
+    :abbr="actionKindToAbbreviation(props.action.kind)"
+    :description="action.kind === ActionKind.Manual ? action.description : ''"
+    :componentSchemaName="component?.def.schemaName"
+    :componentName="component?.def.displayName"
+    :componentId="component?.def.id"
+    :actor="action.actor"
+  >
+    <template #icons>
+      <Icon
+        :class="resultIconClass(props.action.result)"
+        :name="resultIcon(props.action.result)"
+        size="sm"
+      />
+      <Icon
+        :class="actionIconClass(props.action.kind)"
+        :name="actionIcon(props.action.kind)"
+        size="sm"
+      />
+    </template>
+    <template #interaction>
+      <FuncRunTabDropdown
+        v-if="!props.noInteraction"
+        :funcRunId="props.action.funcRunId"
+        @menuClick="(id, slug) => emit('history', id, slug)"
+      />
+    </template>
+  </ActionCardLayout>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+
+import { Icon } from "@si/vue-lib/design-system";
+import { useComponentsStore } from "@/store/components.store";
+import { ActionKind, ActionId } from "@/api/sdf/dal/action";
+import {
+  ActionHistoryView,
+  actionKindToAbbreviation,
+  actionIconClass,
+  actionIcon,
+  resultIconClass,
+  resultIcon,
+} from "@/store/actions.store";
+import FuncRunTabDropdown from "@/components/FuncRunTabDropdown.vue";
+import ActionCardLayout from "./ActionCardLayout.vue";
+
+const componentsStore = useComponentsStore();
+
+const props = defineProps<{
+  action: ActionHistoryView;
+  slim?: boolean;
+  selected?: boolean;
+  noInteraction?: boolean;
+}>();
+
+// DOUBLE CHECK, this might come over the wire
+// if it doesn't delete componentName from the type
+const component = computed(() => {
+  if (!props.action.componentId) return undefined;
+  return componentsStore.allComponentsById[props.action.componentId];
+});
+
+const emit = defineEmits<{
+  (e: "add"): void;
+  (e: "remove"): void;
+  (e: "openMenu", mouse: MouseEvent): void;
+  (e: "history", id: ActionId, tabSlug: string): void;
+}>();
+</script>

--- a/app/web/src/mead-hall/ActionWidget.vue
+++ b/app/web/src/mead-hall/ActionWidget.vue
@@ -1,0 +1,104 @@
+<template>
+  <div
+    class="cursor-pointer"
+    :class="
+      clsx(
+        'flex flex-row items-center gap-xs p-2xs border-x border-b',
+        themeClasses('border-neutral-200', 'border-neutral-600'),
+      )
+    "
+    @click="clickHandler"
+  >
+    <Toggle :selected="!!actionPrototypeView.actionId" class="flex-none" />
+    <StatusIndicatorIcon
+      type="action"
+      :status="FuncKind.Action"
+      tone="inherit"
+      class="flex-none"
+    />
+    <div class="font-bold leading-normal">
+      {{ actionPrototypeView.displayName || actionPrototypeView.name }}
+    </div>
+
+    <Icon
+      v-if="addRequestStatus.isPending || removeRequestStatus.isPending"
+      name="loader"
+      class="ml-auto"
+      size="sm"
+    />
+    <div
+      v-else
+      :class="
+        clsx(
+          'ml-auto mr-2xs hover:underline font-bold select-none',
+          themeClasses('text-action-500', 'text-action-300'),
+        )
+      "
+      @click.stop="onClickView"
+    >
+      view
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import * as _ from "lodash-es";
+import clsx from "clsx";
+import { computed } from "vue";
+import { Icon, themeClasses, Toggle } from "@si/vue-lib/design-system";
+import { useRouter } from "vue-router";
+import { storeToRefs } from "pinia";
+import { useActionsStore } from "@/store/actions.store";
+import { useViewsStore } from "@/store/views.store";
+import { ComponentType } from "@/api/sdf/dal/schema";
+import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
+import {
+  DiagramGroupData,
+  DiagramNodeData,
+} from "@/components/ModelingDiagram/diagram_types";
+import { FuncKind } from "@/api/sdf/dal/func";
+import { ActionPrototypeView } from "./AssetActionsDetails.vue";
+
+const props = defineProps<{
+  component: DiagramGroupData | DiagramNodeData;
+  actionPrototypeView: ActionPrototypeView;
+}>();
+
+const viewStore = useViewsStore();
+const { selectedComponent } = storeToRefs(viewStore);
+const actionsStore = useActionsStore();
+const router = useRouter();
+
+function clickHandler() {
+  if (props.actionPrototypeView.actionId) {
+    actionsStore.CANCEL([props.actionPrototypeView.actionId]);
+  } else {
+    actionsStore.ADD_ACTION(
+      props.component.def.id,
+      props.actionPrototypeView.id,
+    );
+  }
+}
+
+function onClickView() {
+  if (selectedComponent.value?.def.componentType !== ComponentType.View) {
+    router.push({
+      name: "workspace-lab-assets",
+      query: {
+        s: `a_${selectedComponent.value?.def.schemaVariantId}|f_${props.actionPrototypeView.funcId}`,
+      },
+    });
+  }
+}
+
+const addRequestStatus = actionsStore.getRequestStatus(
+  "ADD_ACTION",
+  props.component.def.id,
+  props.actionPrototypeView.id,
+);
+const removeRequestStatus = actionsStore.getRequestStatus(
+  "CANCEL",
+  computed(() => props.actionPrototypeView.actionId),
+  // ^ this won't accept [] which doesnt bode well
+);
+</script>

--- a/app/web/src/mead-hall/ActionsList.vue
+++ b/app/web/src/mead-hall/ActionsList.vue
@@ -1,0 +1,204 @@
+<template>
+  <TreeNode :enableGroupToggle="populated > 0" styleAsGutter>
+    <template #label>
+      <div
+        :class="
+          clsx(
+            'flex flex-row gap-2xs justify-between place-items-center bg-neutral-100 dark:bg-neutral-700 text-sm',
+            changeSet ? 'py-2xs px-xs' : 'py-xs',
+          )
+        "
+      >
+        <template v-if="changeSet">
+          <div class="flex flex-col flex-grow min-w-0">
+            <Timestamp
+              :date="changeSet.appliedAt"
+              :timeClasses="
+                themeClasses('text-neutral-500', 'text-neutral-400')
+              "
+              class="text-sm"
+              dateClasses="font-bold"
+              showTimeIfToday
+              size="long"
+            />
+            <div
+              :class="
+                clsx(
+                  'text-xs truncate',
+                  themeClasses('text-neutral-500', 'text-neutral-400'),
+                )
+              "
+            >
+              <span class="font-bold">Change Set:</span> {{ changeSet.name }}
+            </div>
+          </div>
+          <div class="flex-none font-bold">{{ populated }} Action(s)</div>
+          <!-- TODO(Wendy) - maybe a PillCounter makes more sense here? -->
+          <!-- <PillCounter
+            v-tooltip="{ content: 'Actions', placement: 'left' }"
+            :count="displayActions.length"
+            class="flex-none font-bold cursor-pointer"
+            size="lg"
+          /> -->
+        </template>
+        <template v-else>
+          <div class="grow-0 mx-[.66em]">
+            <Icon
+              class="attributes-panel-item__type-icon"
+              name="bullet-list"
+              size="sm"
+            />
+          </div>
+          <div class="grow">{{ populated }} Action(s)</div>
+          <div class="grow-0 flex flex-row mr-xs">
+            <div
+              v-for="(cnt, actionKind) in actionsByKind"
+              :key="actionKind"
+              class="flex flex-row mx-2xs p-2xs rounded dark:bg-neutral-900 bg-neutral-200"
+            >
+              <div class="mx-2xs">{{ cnt }}</div>
+              <StatusIndicatorIcon
+                :status="actionKind.toString()"
+                size="sm"
+                type="action"
+              />
+            </div>
+          </div>
+        </template>
+      </div>
+    </template>
+    <template v-if="proposedActions">
+      <div
+        v-for="action in proposedActions"
+        :key="action.id"
+        :class="
+          clsx(
+            'border-b',
+            themeClasses('border-neutral-100', 'border-neutral-700'),
+          )
+        "
+      >
+        <ActionCard
+          :action="action"
+          :noInteraction="props.noInteraction"
+          :selected="isSelected(action)"
+          :slim="props.slim"
+          @click="props.clickAction && props.clickAction(action, $event)"
+          @history="openHistory"
+          @remove="actionsStore.CANCEL([action.id])"
+        />
+      </div>
+    </template>
+    <template v-if="historyActions">
+      <div
+        v-for="action in historyActions"
+        :key="action.id"
+        :class="
+          clsx(
+            'border-b',
+            themeClasses('border-neutral-100', 'border-neutral-700'),
+          )
+        "
+      >
+        <ActionHistoryCard
+          :action="action"
+          :noInteraction="props.noInteraction"
+          :selected="isSelected(action)"
+          :slim="props.slim"
+          @history="openHistory"
+          @remove="actionsStore.CANCEL([action.id])"
+        />
+      </div>
+    </template>
+  </TreeNode>
+</template>
+
+<script lang="ts" setup>
+import clsx from "clsx";
+import {
+  Icon,
+  Timestamp,
+  TreeNode,
+  themeClasses,
+} from "@si/vue-lib/design-system";
+import { PropType, computed } from "vue";
+import {
+  useActionsStore,
+  ActionView,
+  ActionHistoryView,
+  FuncRunId,
+} from "@/store/actions.store";
+import { DefaultMap } from "@/utils/defaultmap";
+import { ChangeSet } from "@/api/sdf/dal/change_set";
+import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
+import ActionCard from "./ActionCard.vue";
+import ActionHistoryCard from "./ActionHistoryCard.vue";
+import { ActionProposedViewWithHydratedChildren } from "./ChangesPanelProposed.vue";
+
+export type ActionsListKind = "proposed" | "history";
+
+const actionsStore = useActionsStore();
+
+type clickFn = (
+  action: ActionProposedViewWithHydratedChildren,
+  e: MouseEvent,
+) => void;
+
+const props = defineProps({
+  proposedActions: {
+    type: Array<ActionProposedViewWithHydratedChildren>,
+    required: false,
+  },
+  historyActions: { type: Array<ActionHistoryView>, required: false },
+  noInteraction: { type: Boolean },
+  selectedActionIds: { type: Array<string> },
+  selectedFuncRunIds: { type: Array<string> },
+  slim: { type: Boolean },
+  clickAction: {
+    type: Function as PropType<clickFn>,
+    default: undefined,
+  },
+  changeSet: { type: Object as PropType<ChangeSet> },
+});
+
+const populated = computed(
+  () =>
+    (props.proposedActions?.length ?? 0) || (props.historyActions?.length ?? 0),
+);
+
+const selectedIds = computed<string[]>(() => {
+  if (props.proposedActions) {
+    return props.selectedActionIds || [];
+  }
+  return props.selectedFuncRunIds || [];
+});
+
+const isSelected = (action: ActionView) => {
+  let id: string | undefined;
+  if (props.historyActions) {
+    id = action.funcRunId;
+  } else {
+    id = action.id;
+  }
+  if (id) return selectedIds.value.includes(id);
+  return false;
+};
+
+const actionsByKind = computed(() => {
+  const actions = props.proposedActions ?? props.historyActions;
+  if (!actions) return {};
+  const counts = new DefaultMap<string, number>(() => 0);
+  for (const action of actions) {
+    counts.set(action.kind, counts.get(action.kind) + 1);
+  }
+  return Object.fromEntries(counts);
+});
+
+const emit = defineEmits<{
+  (e: "history", id: FuncRunId, tabSlug: string): void;
+}>();
+
+function openHistory(id: FuncRunId, slug: string) {
+  emit("history", id, slug);
+}
+</script>

--- a/app/web/src/mead-hall/ApprovalFlowModal.vue
+++ b/app/web/src/mead-hall/ApprovalFlowModal.vue
@@ -1,0 +1,155 @@
+<template>
+  <div>
+    <!-- this modal is for the voting process -->
+    <Modal ref="modalRef" title="Changes To Be Applied">
+      <div class="max-h-[70vh] overflow-hidden flex flex-col">
+        <div class="text-md mb-xs">
+          Applying this change set may create, modify, or destroy real resources
+          in the cloud.
+        </div>
+        <div class="text-sm mb-sm">
+          These actions will be applied to the real world:
+        </div>
+        <div
+          class="flex-grow overflow-y-auto mb-sm border border-neutral-100 dark:border-neutral-700"
+        >
+          <ActionsList
+            slim
+            kind="proposed"
+            noInteraction
+            :proposedActions="allActionViews"
+          />
+        </div>
+        <div
+          class="flex flex-row w-full items-center justify-center gap-sm mt-xs"
+        >
+          <VButton
+            label="Cancel"
+            icon="x"
+            variant="ghost"
+            tone="warning"
+            @click="closeModalHandler"
+          />
+          <VButton
+            icon="tools"
+            :tone="workspaceHasOneUser ? 'success' : undefined"
+            :label="
+              workspaceHasOneUser ? 'Apply Change Set' : 'Request Approval'
+            "
+            class="grow"
+            @click="applyButtonHandler"
+          />
+        </div>
+      </div>
+    </Modal>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import * as _ from "lodash-es";
+import { VButton, Modal } from "@si/vue-lib/design-system";
+import { computed, ref, watch } from "vue";
+import { useToast } from "vue-toastification";
+import { useQuery } from "@tanstack/vue-query";
+import { ChangeSetStatus } from "@/api/sdf/dal/change_set";
+import { useAuthStore } from "@/store/auth.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
+import ApprovalFlowCancelled from "@/components/toasts/ApprovalFlowCancelled.vue";
+import { usePresenceStore } from "@/store/presence.store";
+import { bifrost, makeArgs, makeKey } from "@/store/realtime/heimdall";
+import { ActionProposedView } from "@/store/actions.store";
+import ActionsList from "./ActionsList.vue";
+import {
+  ActionViewList,
+  ActionProposedViewWithHydratedChildren,
+} from "./ChangesPanelProposed.vue";
+
+const presenceStore = usePresenceStore();
+const changeSetsStore = useChangeSetsStore();
+const authStore = useAuthStore();
+const toast = useToast();
+
+const modalRef = ref<InstanceType<typeof Modal> | null>(null);
+const changeSet = computed(() => changeSetsStore.selectedChangeSet);
+const workspaceHasOneUser = computed(() => authStore.workspaceHasOneUser);
+
+async function openModalHandler() {
+  if (changeSet?.value?.name === "HEAD") return;
+
+  modalRef.value?.open();
+}
+
+function closeModalHandler() {
+  modalRef.value?.close();
+}
+
+function applyButtonHandler() {
+  if (workspaceHasOneUser.value && authStore.user) {
+    changeSetsStore.APPLY_CHANGE_SET(authStore.user.name);
+  } else {
+    changeSetsStore.REQUEST_CHANGE_SET_APPROVAL();
+
+    // TODO(nick): we should remove this in favor of only the WsEvent fetching. It appears that
+    // requesting the approval itself is insufficient for getting the latest approval status at
+    // the time of writing and the reason appears to be that the change set is "open" by the
+    // time the inset modal opens. Fortunately, this will work since we are the requester.
+    if (changeSet.value) {
+      changeSetsStore.FETCH_APPROVAL_STATUS(changeSet.value.id);
+    }
+
+    presenceStore.leftDrawerOpen = false; // close the left draw for the InsetModal
+  }
+
+  closeModalHandler();
+}
+
+const queryKey = makeKey("ActionViewList");
+const actionViewList = useQuery<ActionViewList | null>({
+  queryKey,
+  queryFn: async () =>
+    await bifrost<ActionViewList>(makeArgs("ActionViewList")),
+});
+const allActionViews = computed(() => {
+  if (!actionViewList.data.value) return [];
+  if (actionViewList.data.value.actions.length < 1) return [];
+  const proposed = actionViewList.data.value.actions;
+  const proposedById = proposed.reduce((obj, p) => {
+    obj[p.id] = p;
+    return obj;
+  }, {} as Record<string, ActionProposedView>);
+  return proposed.map((_p) => {
+    const p = { ..._p } as ActionProposedViewWithHydratedChildren;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    p.dependentOnActions = p.dependentOn.map((d) => proposedById[d]!);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    p.myDependentActions = p.myDependencies.map((d) => proposedById[d]!);
+    p.holdStatusInfluencedByActions = p.holdStatusInfluencedBy.map(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (d) => proposedById[d]!,
+    );
+    return p;
+  });
+});
+
+watch(
+  () => changeSetsStore.selectedChangeSet?.status,
+  (newVal, oldVal) => {
+    if (
+      newVal === ChangeSetStatus.Open &&
+      (oldVal === ChangeSetStatus.NeedsApproval ||
+        oldVal === ChangeSetStatus.Approved ||
+        oldVal === ChangeSetStatus.Rejected)
+    ) {
+      if (!changeSetsStore.headSelected) {
+        toast({
+          component: ApprovalFlowCancelled,
+          props: {
+            action: "applying",
+          },
+        });
+      }
+    }
+  },
+);
+defineExpose({ open: openModalHandler });
+</script>

--- a/app/web/src/mead-hall/AssetActionsDetails.vue
+++ b/app/web/src/mead-hall/AssetActionsDetails.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="h-full relative">
+    <TabGroup
+      variant="secondary"
+      :startSelectedTabSlug="viewStore.detailsTabSlugs[1] || 'resource-actions'"
+      marginTop="2xs"
+      @update:selectedTab="onTabSelected"
+    >
+      <TabGroupItem label="Actions" slug="resource-actions">
+        <div
+          v-if="actionPrototypeViews.length === 0"
+          class="flex flex-col items-center pt-lg h-full w-full text-neutral-400"
+        >
+          <div class="w-64">
+            <EmptyStateIcon name="no-changes" />
+          </div>
+          <span class="text-xl">No Actions available</span>
+        </div>
+        <div v-else class="flex flex-col">
+          <div
+            class="text-sm text-neutral-700 dark:text-neutral-300 p-xs italic border-b dark:border-neutral-600"
+          >
+            The changes below will run when you click "Apply Changes".
+          </div>
+          <ActionWidget
+            v-for="actionPrototypeView in actionPrototypeViews"
+            :key="actionPrototypeView.id"
+            :actionPrototypeView="actionPrototypeView"
+            :component="props.component"
+          />
+        </div>
+      </TabGroupItem>
+      <TabGroupItem slug="resource-resource" label="Resource Data">
+        <ComponentDetailsResource />
+      </TabGroupItem>
+    </TabGroup>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import * as _ from "lodash-es";
+import { TabGroup, TabGroupItem } from "@si/vue-lib/design-system";
+import { useQuery } from "@tanstack/vue-query";
+import { useViewsStore } from "@/store/views.store";
+import ComponentDetailsResource from "@/components/ComponentDetailsResource.vue";
+import {
+  DiagramGroupData,
+  DiagramNodeData,
+} from "@/components/ModelingDiagram/diagram_types";
+import { bifrost, makeArgs, makeKey } from "@/store/realtime/heimdall";
+import EmptyStateIcon from "@/components/EmptyStateIcon.vue";
+import { ActionId, ActionKind, ActionPrototypeId } from "@/api/sdf/dal/action";
+import { FuncId } from "@/api/sdf/dal/func";
+import { SchemaVariantId } from "@/api/sdf/dal/schema";
+import { ComponentId } from "@/api/sdf/dal/component";
+import ActionWidget from "./ActionWidget.vue";
+
+const props = defineProps<{
+  component: DiagramNodeData | DiagramGroupData;
+  componentId: ComponentId;
+}>();
+
+const viewStore = useViewsStore();
+
+const tabsRef = ref<InstanceType<typeof TabGroup>>();
+function onTabSelected(newTabSlug?: string) {
+  viewStore.setComponentDetailsTab(newTabSlug || null);
+}
+
+export interface ActionPrototypeView {
+  id: ActionPrototypeId;
+  funcId: FuncId;
+  schemaVariantId: SchemaVariantId;
+  kind: ActionKind;
+  displayName?: string;
+  name: string;
+  actionId?: ActionId;
+}
+
+interface ActionPrototypeViewsByComponentId {
+  id: ComponentId;
+  actionPrototypes: ActionPrototypeView[];
+}
+
+const queryKey = makeKey(
+  "ActionPrototypeViewsByComponentId",
+  props.componentId,
+);
+const actionPrototypeViewsRaw =
+  useQuery<ActionPrototypeViewsByComponentId | null>({
+    queryKey,
+    queryFn: async () =>
+      await bifrost<ActionPrototypeViewsByComponentId>(
+        makeArgs("ActionPrototypeViewsByComponentId", props.componentId),
+      ),
+  });
+const actionPrototypeViews = computed(
+  () => actionPrototypeViewsRaw.data.value?.actionPrototypes ?? [],
+);
+
+watch(
+  () => viewStore.selectedComponentDetailsTab,
+  (tabSlug) => {
+    if (tabSlug?.startsWith("resource-")) {
+      tabsRef.value?.selectTab(tabSlug);
+    }
+  },
+);
+</script>

--- a/app/web/src/mead-hall/ChangesPanelProposed.vue
+++ b/app/web/src/mead-hall/ChangesPanelProposed.vue
@@ -1,0 +1,282 @@
+<template>
+  <div class="h-full flex flex-col overflow-hidden">
+    <ConfirmHoldModal ref="confirmRef" :ok="finishHold" />
+    <div v-if="proposedActions.length > 0">
+      <!-- TODO(Wendy)- SEARCH BAR SHOULD GO HERE -->
+      <div class="flex flex-row place-content-center">
+        <VButton
+          :disabled="disabledMultiple"
+          class="flex-1 m-xs dark:hover:bg-action-900 hover:bg-action-100 dark:hover:text-action-300 hover:text-action-700 hover:underline"
+          icon="circle-stop"
+          iconClass="text-warning-400"
+          label="Put On Hold"
+          size="xs"
+          tone="empty"
+          variant="solid"
+          @click="holdAll"
+        />
+        <VButton
+          :disabled="disabledMultiple"
+          class="flex-1 m-xs dark:hover:bg-action-900 hover:bg-action-100 dark:hover:text-action-300 hover:text-action-700 hover:underline"
+          icon="x"
+          iconClass="dark:text-destructive-600 text-destructive-500"
+          label="Remove"
+          size="xs"
+          tone="empty"
+          variant="solid"
+          @click="removeAll"
+        />
+      </div>
+    </div>
+    <FuncRunTabGroup
+      :close="deselectAction"
+      :funcRun="funcRun"
+      :open="!!singleSelectedAction"
+      :selectedTab="selectedTab"
+    />
+    <template v-if="changeSetStore.headSelected">
+      <ActionsList
+        v-if="allActionViews.length > 0"
+        :clickAction="clickAction"
+        :selectedActionIds="selectedActionIds"
+        :proposedActions="allActionViews"
+      />
+      <EmptyStateCard
+        v-else
+        iconName="actions"
+        primaryText="All Actions on HEAD have been run"
+        secondaryText="You can see those actions in the history tab."
+      />
+    </template>
+    <template v-else>
+      <TreeNode
+        enableDefaultHoverClasses
+        enableGroupToggle
+        alwaysShowArrow
+        indentationSize="none"
+        leftBorderSize="none"
+        defaultOpen
+        internalScrolling
+        class="min-h-[32px]"
+        primaryIconClasses=""
+        label="Proposed Actions In This Change Set"
+      >
+        <ActionsList
+          v-if="proposedActions.length > 0"
+          class="mt-sm"
+          :clickAction="clickAction"
+          :selectedActionIds="selectedActionIds"
+          :proposedActions="proposedActions"
+        />
+        <EmptyStateCard
+          v-else
+          iconName="actions"
+          primaryText="No Actions Have Been Proposed In This Change Set"
+          secondaryText="Propose some actions to see them here."
+        />
+      </TreeNode>
+      <TreeNode
+        enableDefaultHoverClasses
+        enableGroupToggle
+        alwaysShowArrow
+        indentationSize="none"
+        leftBorderSize="none"
+        defaultOpen
+        internalScrolling
+        class="min-h-[32px]"
+        primaryIconClasses=""
+        label="Actions In Queue on HEAD"
+      >
+        <ActionsList
+          v-if="headActions.length > 0"
+          class="mt-sm"
+          :selectedActionIds="selectedActionIds"
+          :proposedActions="headActions"
+          noInteraction
+        />
+        <EmptyStateCard
+          v-else
+          iconName="actions"
+          primaryText="All Actions on HEAD have run"
+          secondaryText="See past actions in the history tab."
+        />
+      </TreeNode>
+    </template>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import * as _ from "lodash-es";
+import { ref, reactive, computed, watch, WatchStopHandle } from "vue";
+import { VButton, TreeNode } from "@si/vue-lib/design-system";
+import { useQuery } from "@tanstack/vue-query";
+import { ActionId, ActionState } from "@/api/sdf/dal/action";
+import FuncRunTabGroup from "@/components/Actions/FuncRunTabGroup.vue";
+import { FuncRun, useFuncRunsStore } from "@/store/func_runs.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
+import ConfirmHoldModal from "@/components/Actions/ConfirmHoldModal.vue";
+import EmptyStateCard from "@/components/EmptyStateCard.vue";
+import { ChangeSetId } from "@/api/sdf/dal/change_set";
+import { bifrost, makeArgs, makeKey } from "@/store/realtime/heimdall";
+import { ActionProposedView, useActionsStore } from "@/store/actions.store";
+import ActionsList from "./ActionsList.vue";
+
+export interface ActionViewList {
+  id: ChangeSetId;
+  actions: ActionProposedView[];
+}
+
+export interface ActionProposedViewWithHydratedChildren
+  extends ActionProposedView {
+  dependentOnActions: ActionProposedView[];
+  myDependentActions: ActionProposedView[];
+  holdStatusInfluencedByActions: ActionProposedView[];
+}
+
+const actionsStore = useActionsStore();
+const funcRunsStore = useFuncRunsStore();
+const changeSetStore = useChangeSetsStore();
+
+const queryKey = makeKey("ActionViewList");
+const actionViewList = useQuery<ActionViewList | null>({
+  queryKey,
+  queryFn: async () =>
+    await bifrost<ActionViewList>(makeArgs("ActionViewList")),
+});
+
+// Materialized views cannot, yet, build circular references
+// Ideally, this gets moved lower in the stack, with generated code
+const allActionViews = computed(() => {
+  if (!actionViewList.data.value) return [];
+  if (actionViewList.data.value.actions.length < 1) return [];
+  const proposed = actionViewList.data.value.actions;
+  const proposedById = proposed.reduce((obj, p) => {
+    obj[p.id] = p;
+    return obj;
+  }, {} as Record<string, ActionProposedView>);
+  return proposed.map((_p) => {
+    const p = { ..._p } as ActionProposedViewWithHydratedChildren;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    p.dependentOnActions = p.dependentOn.map((d) => proposedById[d]!);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    p.myDependentActions = p.myDependencies.map((d) => proposedById[d]!);
+    p.holdStatusInfluencedByActions = p.holdStatusInfluencedBy.map(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (d) => proposedById[d]!,
+    );
+    return p;
+  });
+});
+const proposedActions = computed(() =>
+  allActionViews.value.filter(
+    // NOTE(nick): this was ported over, but this is really not the right way to check HEAD.
+    (apv) => apv.originatingChangeSetId === changeSetStore.selectedChangeSetId,
+  ),
+);
+const headActions = computed(() =>
+  allActionViews.value.filter(
+    // NOTE(nick): this was ported over, but this is really not the right way to check HEAD.
+    (apv) => apv.originatingChangeSetId !== changeSetStore.selectedChangeSetId,
+  ),
+);
+
+const confirmRef = ref<InstanceType<typeof ConfirmHoldModal> | null>(null);
+
+const selectedActions: Map<ActionId, ActionProposedView> = reactive(new Map());
+
+const singleSelectedAction = computed(() =>
+  selectedActions.size === 1
+    ? selectedActions.values().next().value
+    : undefined,
+);
+
+const selectedActionIds = computed(() =>
+  Object.keys(Object.fromEntries(selectedActions)),
+);
+
+const disabledMultiple = computed(() => selectedActions.size === 0);
+
+const holdAll = () => {
+  const actions = Object.values(Object.fromEntries(selectedActions));
+  if (_.some(actions, (a) => a.myDependencies.length > 0))
+    confirmRef.value?.open();
+  else finishHold();
+};
+
+const finishHold = (): void => {
+  if (selectedActionIds.value.length > 0)
+    actionsStore.PUT_ACTION_ON_HOLD(selectedActionIds.value);
+  confirmRef.value?.close();
+};
+
+const removeAll = () => {
+  if (selectedActionIds.value.length > 0)
+    actionsStore.CANCEL(selectedActionIds.value);
+};
+
+const funcRun = ref<FuncRun | undefined>();
+const selectedTab = ref<string | undefined>();
+
+let funcRunWatcher: WatchStopHandle | undefined;
+
+const clickAction = async (
+  action: ActionProposedViewWithHydratedChildren,
+  e: MouseEvent,
+) => {
+  if (e.shiftKey) {
+    if (!selectedActions.has(action.id)) {
+      selectedActions.set(action.id, action as ActionProposedView);
+    } else selectedActions.delete(action.id);
+  } else {
+    const singleSelectionActionId = singleSelectedAction.value?.id;
+    selectedActions.clear();
+
+    if (singleSelectionActionId === action.id) {
+      funcRun.value = undefined;
+      return;
+    }
+
+    selectedActions.set(action.id, action as ActionProposedView);
+
+    const { funcRunId } = action;
+
+    if (!funcRunId) {
+      funcRun.value = undefined;
+      return;
+    }
+
+    if (funcRunWatcher) {
+      funcRunWatcher();
+    }
+    funcRunWatcher = watch(
+      () => funcRunsStore.lastRuns[action.id],
+      async () => {
+        // we don't want the variable from the closure b/c
+        // the actions list has been updated behind the scenes
+        // and it has a new fun run id, go get it and load that func run
+        if (action && action.funcRunId) {
+          await funcRunsStore.GET_FUNC_RUN(action.funcRunId);
+          funcRun.value = funcRunsStore.funcRuns[action.funcRunId];
+        }
+      },
+    );
+
+    await funcRunsStore.GET_FUNC_RUN(funcRunId);
+    funcRun.value = funcRunsStore.funcRuns[funcRunId];
+
+    if ([ActionState.Queued, ActionState.OnHold].includes(action.state)) {
+      selectedTab.value = "arguments";
+    } else {
+      selectedTab.value = "logs";
+    }
+  }
+};
+
+const deselectAction = () => {
+  selectedActions.clear();
+};
+
+defineProps({
+  old: { type: Boolean },
+});
+</script>

--- a/app/web/src/mead-hall/InsetApprovalModal.vue
+++ b/app/web/src/mead-hall/InsetApprovalModal.vue
@@ -1,0 +1,478 @@
+<template>
+  <div
+    v-if="mode !== 'error'"
+    :class="
+      clsx(
+        'flex flex-col gap-sm p-sm',
+        'xl:max-w-[50vw] xl:min-w-[680px] max-h-full',
+        'rounded shadow-2xl overflow-hidden',
+        themeClasses('bg-shade-0 border', 'bg-neutral-900'),
+      )
+    "
+  >
+    <!-- HEADER -->
+    <div class="flex flex-row flex-none gap-md mb-sm items-center">
+      <div class="flex flex-col max-w-[66%] min-w-[50%]">
+        <TruncateWithTooltip class="font-bold italic pb-2xs">
+          {{ changeSetName }}
+        </TruncateWithTooltip>
+        <TruncateWithTooltip class="font-bold pb-2xs">{{
+          modalData.title
+        }}</TruncateWithTooltip>
+        <div v-if="modalData.date" class="text-sm italic">
+          <Timestamp :date="modalData.date" showTimeIfToday size="extended" />
+        </div>
+      </div>
+
+      <ErrorMessage
+        :tone="modalData.messageTone"
+        :icon="modalData.messageIcon"
+        variant="block"
+        class="rounded grow"
+      >
+        <template v-if="mode === 'requested'">
+          There are approvals that must be met before the change set can be
+          applied.
+        </template>
+        <template v-else-if="mode === 'approved'">
+          <p>
+            {{ requesterIsYou ? "Your" : "The" }} request to
+            <span class="font-bold">Apply</span> change set
+            <span class="font-bold">{{ changeSetName }}</span> has been
+            approved.
+          </p>
+        </template>
+        <template v-else>
+          ERROR - this message should not ever show. Something has gone wrong!
+        </template>
+      </ErrorMessage>
+    </div>
+
+    <div
+      :class="
+        clsx('flex flex-row gap-xs flex-1 overflow-hidden place-content-evenly')
+      "
+    >
+      <div
+        :class="
+          clsx('flex flex-col gap-xs overflow-hidden text-center basis-1/2')
+        "
+      >
+        <RouterLink
+          :to="{
+            name: 'workspace-audit',
+            params: { changeSetId: 'auto' },
+          }"
+          target="_blank"
+          class="text-action-500 hover:underline pl-4 pb-2xs text-sm font-bold"
+          >See the breakdown of changes
+          <Icon
+            size="sm"
+            name="logs-pop-square"
+            class="ml-2xs inline-block mb-[-.3em]"
+          />
+        </RouterLink>
+      </div>
+    </div>
+
+    <!-- MAIN SECTION -->
+    <div
+      :class="
+        clsx('flex flex-row gap-xs flex-1 overflow-hidden place-content-evenly')
+      "
+    >
+      <div class="flex flex-col basis-1/2 text-sm gap-xs overflow-y-auto">
+        <div
+          v-for="group in requirementGroups"
+          :key="group.key"
+          class="border-neutral-200 dark:border-neutral-700 border"
+        >
+          <div class="bg-neutral-200 dark:bg-neutral-700 p-xs">
+            {{ group.requiredCount }} of the following users for{{
+              group.labels.length > 1
+                ? ` ${group.labels.length} requirements:`
+                : ""
+            }}
+            <span v-if="group.labels.length === 1" class="italic">{{
+              group.labels[0]
+            }}</span>
+            <TruncateWithTooltip
+              v-else
+              expandOnClick
+              :expandableStringArray="group.labels"
+              class="italic break-all"
+            />
+          </div>
+          <ul>
+            <li
+              v-for="vote in group.votes"
+              :key="vote.user.id"
+              :class="
+                clsx(
+                  'flex flex-row items-center gap-xs px-xs py-2xs',
+                  themeClasses('even:bg-neutral-100', 'even:bg-neutral-800'),
+                )
+              "
+            >
+              <TruncateWithTooltip class="flex-grow"
+                >{{ vote.user.name }} ({{
+                  vote.user.email
+                }})</TruncateWithTooltip
+              >
+              <div
+                :class="
+                  clsx(
+                    'flex flex-col items-center flex-none w-[60px]',
+                    vote.status ? 'font-bold' : 'italic',
+                    vote.status === 'Rejected' && 'text-destructive-500',
+                    vote.status === 'Approved' && 'text-success-500',
+                  )
+                "
+              >
+                <div v-if="!vote.status">Waiting...</div>
+                <div v-else>{{ vote.status }}</div>
+              </div>
+              <span class="flex flex-row items-center flex-none">
+                <Icon
+                  size="md"
+                  name="thumbs-up"
+                  tone="success"
+                  :class="clsx(vote.status !== 'Approved' ? 'opacity-20' : '')"
+                />
+                <Icon
+                  size="md"
+                  name="thumbs-down"
+                  tone="error"
+                  :class="clsx(vote.status !== 'Rejected' ? 'opacity-20' : '')"
+                />
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div :class="clsx('flex flex-col gap-xs overflow-hidden basis-1/2')">
+        <div class="text-sm">
+          These actions will be applied to the real world:
+        </div>
+        <div
+          class="flex-grow overflow-y-auto border border-neutral-100 dark:border-neutral-700 min-w-[250px]"
+        >
+          <ActionsList
+            slim
+            kind="proposed"
+            noInteraction
+            :proposedActions="allActionViews"
+          />
+        </div>
+      </div>
+    </div>
+
+    <!-- BUTTONS -->
+    <div class="flex flex-row flex-none gap-sm justify-center mt-sm">
+      <VButton
+        label="Withdraw Request"
+        tone="warning"
+        variant="ghost"
+        icon="x"
+        @click="withdraw"
+      />
+      <template v-if="userIsApprover">
+        <VButton
+          :disabled="iRejected"
+          label="Reject Request"
+          tone="destructive"
+          icon="thumbs-down"
+          @click="rejectHandler"
+        />
+        <VButton
+          :disabled="iApproved"
+          label="Approve Request"
+          tone="success"
+          icon="thumbs-up"
+          @click="approve"
+        />
+      </template>
+      <VButton
+        :disabled="mode !== 'approved'"
+        tone="success"
+        :loading="mode === 'approved' ? applyingChangeSet : false"
+        loadingText="Applying..."
+        @click="apply"
+      >
+        <span class="dark:text-neutral-800">Apply Change Set</span>
+        <template #icon>
+          <Icon name="tools" size="sm" class="dark:text-neutral-800" />
+        </template>
+      </VButton>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import * as _ from "lodash-es";
+import {
+  VButton,
+  Timestamp,
+  Tones,
+  ErrorMessage,
+  Icon,
+  IconNames,
+  themeClasses,
+  TruncateWithTooltip,
+} from "@si/vue-lib/design-system";
+import { computed, ref } from "vue";
+import { RouterLink } from "vue-router";
+import clsx from "clsx";
+import { useQuery } from "@tanstack/vue-query";
+import {
+  ApprovalData,
+  ApprovalStatus,
+  approverForChangeSet,
+  useChangeSetsStore,
+} from "@/store/change_sets.store";
+import { useAuthStore, WorkspaceUser } from "@/store/auth.store";
+import { ChangeSetStatus, ChangeSet } from "@/api/sdf/dal/change_set";
+import { useViewsStore } from "@/store/views.store";
+import { bifrost, makeArgs, makeKey } from "@/store/realtime/heimdall";
+import { ActionProposedView } from "@/store/actions.store";
+import ActionsList from "./ActionsList.vue";
+import {
+  ActionViewList,
+  ActionProposedViewWithHydratedChildren,
+} from "./ChangesPanelProposed.vue";
+
+export type InsetApprovalModalMode =
+  | "requested"
+  | "approved"
+  | "rejected"
+  | "error";
+
+const authStore = useAuthStore();
+const changeSetsStore = useChangeSetsStore();
+const viewStore = useViewsStore();
+
+const applyingChangeSet = ref(false);
+const changeSetName = computed(() => changeSetsStore.selectedChangeSet?.name);
+
+const props = defineProps<{
+  approvalData: ApprovalData | undefined;
+  changeSet: ChangeSet;
+}>();
+
+interface RequirementGroup {
+  key: string;
+  labels: string[];
+  votes: Vote[];
+  satisfied: boolean;
+  requiredCount: number;
+}
+interface Vote {
+  user: WorkspaceUser;
+  status?: ApprovalStatus;
+}
+
+const requirementGroups = computed(() => {
+  const groups: Map<Set<string>, RequirementGroup> = new Map();
+  props.approvalData?.requirements.forEach((r) => {
+    const userIds = Object.values(r.approverGroups)
+      .flat()
+      .concat(r.approverIndividuals);
+    const votes: Vote[] = [];
+    userIds.forEach((id) => {
+      const user = authStore.workspaceUsers[id];
+      if (!user) {
+        return;
+      }
+      const submitted = props.approvalData?.latestApprovals.find(
+        (a) =>
+          a.isValid &&
+          a.userId === id &&
+          r.applicableApprovalIds.includes(a.id),
+      );
+      const vote: Vote = { user };
+      if (submitted) vote.status = submitted.status;
+      votes.push(vote);
+    });
+
+    let label;
+    if (r.entityKind === "ApprovalRequirementDefinition") {
+      label = ["Approval Requirement change"];
+    }
+    // else if (r.entityKind === "Schema") {
+    //   const variantForSchema = assetStore.schemaVariants.find(
+    //     (thing) => thing.schemaId === r.entityId,
+    //   );
+    //   label = variantForSchema?.schemaName
+    //     ? `Asset named ${variantForSchema?.schemaName}`
+    //     : "an Asset";
+    // } else if (r.entityKind === "SchemaVariant") {
+    //   let name = assetStore.variantFromListById[r.entityId]?.displayName;
+    //   if (!name) {
+    //     name = assetStore.variantFromListById[r.entityId]?.schemaName;
+    //   }
+    //   label = name ? `Asset named ${name}` : "Asset (name not found)";
+    // }
+    else if (r.entityKind === "View") {
+      const name = viewStore.viewsById[r.entityId]?.name;
+      label = [name ? `View named ${name}` : "View (name not found)"];
+    } else {
+      label = ["Workspace change"];
+    }
+
+    const group: RequirementGroup = {
+      key: r.entityId,
+      labels: label,
+      votes,
+      satisfied: r.isSatisfied,
+      requiredCount: r.requiredCount,
+    };
+
+    // Check if this RequirementGroup has the same votes and/or label as an existing one and group/filter accordingly
+    const key = new Set(group.votes.map((vote) => vote.user.id));
+    const check = [...groups.entries()].find(
+      ([k, _]) => k.size === key.size && [...k].every((i) => key.has(i)),
+    );
+    if (check) {
+      const [_, set] = check;
+      const label = group.labels[0];
+      if (label && !set.labels.includes(label)) {
+        // different label and same votes - group together
+        set.labels.push(label);
+      }
+      // same label and same votes - don't push in
+    } else {
+      groups.set(key, group);
+    }
+  });
+  return [...groups.values()];
+});
+
+const satisfied = computed(
+  () => !props.approvalData?.requirements.some((r) => r.isSatisfied === false),
+);
+
+const myVote = computed(() =>
+  props.approvalData?.latestApprovals.find(
+    (a) => a.isValid && a.userId === authStore.user?.pk,
+  ),
+);
+
+const iApproved = computed(() => myVote.value?.status === "Approved");
+
+const iRejected = computed(() => myVote.value?.status === "Rejected");
+
+const mode = computed(() => {
+  if (satisfied.value === true) return "approved";
+  switch (props.changeSet.status) {
+    case ChangeSetStatus.NeedsApproval:
+      return "requested";
+    case ChangeSetStatus.Approved:
+      return "approved";
+    case ChangeSetStatus.Rejected:
+      return "rejected";
+    default:
+      return "error";
+  }
+});
+
+const requesterIsYou = computed(
+  () => props.changeSet.mergeRequestedByUserId === authStore.user?.pk,
+);
+const userIsApprover = computed(() => {
+  if (authStore.user && props.approvalData)
+    return approverForChangeSet(authStore.user.pk, props.approvalData);
+  return false;
+});
+
+const approverEmail = computed(() => props.changeSet.reviewedByUser);
+const requesterEmail = computed(() => props.changeSet.mergeRequestedByUser);
+
+const approveDate = computed(() => props.changeSet.reviewedAt as IsoDateString);
+const requestDate = computed(
+  () => props.changeSet.mergeRequestedAt as IsoDateString,
+);
+
+const modalData = computed(() => {
+  if (mode.value === "requested") {
+    return {
+      title: `Approval Requested by ${
+        requesterIsYou.value ? "You" : requesterEmail.value
+      }`,
+      date: requestDate.value,
+      messageTone: "warning" as Tones,
+      messageIcon: "exclamation-circle" as IconNames,
+    };
+    // approved & rejected are deprecating with the new approach
+  } else if (mode.value === "approved") {
+    return {
+      title: approverEmail.value
+        ? `Approval Granted by ${approverEmail.value}`
+        : "Approval Granted",
+      date: approveDate.value,
+      messageTone: "success" as Tones,
+      messageIcon: "check-circle" as IconNames,
+    };
+  } else if (mode.value === "rejected") {
+    return {
+      title: `Approval Rejected by ${approverEmail.value}`,
+      date: approveDate.value,
+      messageTone: "destructive" as Tones,
+      messageIcon: "exclamation-circle" as IconNames,
+    };
+  }
+
+  return {
+    title: "ERROR! Go back to HEAD",
+    date: new Date(),
+    messageTone: "destructive" as Tones,
+  };
+});
+
+const approve = () => {
+  changeSetsStore.APPROVE_CHANGE_SET_FOR_APPLY();
+};
+
+const apply = () => {
+  if (authStore.user) {
+    applyingChangeSet.value = true;
+    changeSetsStore.APPLY_CHANGE_SET(authStore.user.name);
+  }
+};
+
+const withdraw = () => {
+  if (mode.value === "rejected") changeSetsStore.REOPEN_CHANGE_SET();
+  else changeSetsStore.CANCEL_APPROVAL_REQUEST();
+};
+
+const rejectHandler = () => {
+  changeSetsStore.REJECT_CHANGE_SET_APPLY();
+};
+
+const queryKey = makeKey("ActionViewList");
+const actionViewList = useQuery<ActionViewList | null>({
+  queryKey,
+  queryFn: async () =>
+    await bifrost<ActionViewList>(makeArgs("ActionViewList")),
+});
+const allActionViews = computed(() => {
+  if (!actionViewList.data.value) return [];
+  if (actionViewList.data.value.actions.length < 1) return [];
+  const proposed = actionViewList.data.value.actions;
+  const proposedById = proposed.reduce((obj, p) => {
+    obj[p.id] = p;
+    return obj;
+  }, {} as Record<string, ActionProposedView>);
+  return proposed.map((_p) => {
+    const p = { ..._p } as ActionProposedViewWithHydratedChildren;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    p.dependentOnActions = p.dependentOn.map((d) => proposedById[d]!);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    p.myDependentActions = p.myDependencies.map((d) => proposedById[d]!);
+    p.holdStatusInfluencedByActions = p.holdStatusInfluencedBy.map(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (d) => proposedById[d]!,
+    );
+    return p;
+  });
+});
+</script>

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -26,6 +26,7 @@ const WORKSPACE_FLAG_MAPPING = {
   WORKSPACE_FINE_GRAINED_ACCESS_CONTROL:
     "workspace-fine-grained-access-control",
   FRONTEND_ARCH_VIEWS: "workspace-frontend-arch-views",
+  BIFROST_ACTIONS: "workspace-bifrost-actions",
 };
 
 const ALL_FLAG_MAPPING: Record<FeatureFlags, string> = {

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -92,6 +92,7 @@ export interface DBInterface {
       },
   ): SqlValue[][];
   bobby(): Promise<void>;
+  ragnarok(workspaceId: string, changeSetId: string): Promise<void>;
   // show me everything
   odin(changeSetId: ChangeSetId): object;
 }

--- a/app/web/src/workers/webworker.test.ts
+++ b/app/web/src/workers/webworker.test.ts
@@ -473,6 +473,14 @@ const fullDiagnosticTest = async (db: Comlink.Remote<DBInterface>) => {
 
   log("~~ MJOLNIR COMPLETED ~~");
 
+  try {
+    await db.ragnarok("W", "empty_list");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (err: any) {
+    assert(!err, err.toString());
+  }
+  log("~~ RAGNAROK COMPLETED ~~");
+
   log("~~ DIAGNOSTIC COMPLETED ~~");
   done();
 };

--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -769,7 +769,7 @@ const niflheim = async (workspaceId: string, changeSetId: ChangeSetId) => {
 const ragnarok = async (workspaceId: string, changeSetId: string) => {
   // get rid of the snapshots we have for this changeset
   await db.exec({
-    sql: `delete from snapshots where address IN (select snapshot_address from changesets where workspace_id = ? and changeset_id = ? );`,
+    sql: `delete from snapshots where address IN (select snapshot_address from changesets where workspace_id = ? and change_set_id = ? );`,
     bind: [workspaceId, changeSetId],
   });
   // remove the atoms we have for this change set
@@ -973,7 +973,7 @@ const dbInterface: DBInterface = {
   oneInOne,
   handleHammer,
   bobby: dropTables,
-
+  ragnarok,
   changeSetExists: async (workspaceId: string, changeSetId: ChangeSetId) => {
     const row = await db.exec({
       sql: "select change_set_id from changesets where workspace_id = ? and change_set_id = ?",

--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -4,8 +4,9 @@ use petgraph::prelude::*;
 use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 use si_events::ulid::Ulid;
+use si_frontend_types::action::{ActionView, ActionViewList};
 use si_layer_cache::LayerDbError;
-use strum::{AsRefStr, Display, EnumDiscriminants, EnumIter, EnumString};
+use strum::{AsRefStr, Display, EnumIter, EnumString};
 use telemetry::prelude::*;
 use thiserror::Error;
 
@@ -23,8 +24,8 @@ use crate::{
         category_node_weight::CategoryNodeKind, ActionNodeWeight, NodeWeight, NodeWeightError,
     },
     AttributeValue, ChangeSetError, ChangeSetId, Component, ComponentError, ComponentId,
-    DalContext, EdgeWeightKind, EdgeWeightKindDiscriminants, HelperError, TransactionsError,
-    WorkspaceSnapshotError, WsEvent, WsEventError, WsEventResult, WsPayload,
+    DalContext, EdgeWeightKind, EdgeWeightKindDiscriminants, Func, FuncError, HelperError,
+    TransactionsError, WorkspaceSnapshotError, WsEvent, WsEventError, WsEventResult, WsPayload,
 };
 
 pub mod dependency_graph;
@@ -43,6 +44,8 @@ pub enum ActionError {
     Component(#[from] ComponentError),
     #[error("component not found for action: {0}")]
     ComponentNotFoundForAction(ActionId),
+    #[error("func error: {0}")]
+    Func(#[from] FuncError),
     #[error("Helper error: {0}")]
     Helper(#[from] HelperError),
     #[error("InferredConnectionGraph error: {0}")]
@@ -65,27 +68,9 @@ pub enum ActionError {
 
 pub type ActionResult<T> = Result<T, ActionError>;
 
+pub use si_events::ActionState;
 pub use si_id::ActionId;
 pub use si_id::ActionPrototypeId;
-
-#[derive(Debug, Copy, Clone, Deserialize, Serialize, EnumDiscriminants, PartialEq, Eq, Display)]
-#[strum_discriminants(derive(strum::Display, Serialize, Deserialize))]
-pub enum ActionState {
-    /// Action has been determined to be eligible to run, and has had its job sent to the job
-    /// queue.
-    Dispatched,
-    /// Action failed during execution. See the job history for details.
-    Failed,
-    /// Action is "queued", but should not be considered as eligible to run, until moved to the
-    /// `Queued` state.
-    OnHold,
-    /// Action is available to be dispatched once all of its prerequisites have succeeded, and been
-    /// removed from the graph.
-    Queued,
-    /// Action has been dispatched, and started execution in the job system. See the job history
-    /// for details.
-    Running,
-}
 
 /// The completion status of a [`ActionRunner`]
 ///
@@ -616,6 +601,70 @@ impl Action {
         ctx.enqueue_action(ActionJob::new(ctx, action_id)).await?;
 
         Ok(())
+    }
+
+    #[instrument(name = "action.as_frontend_list_type", level = "info", skip_all)]
+    pub async fn as_frontend_list_type(ctx: &DalContext) -> ActionResult<ActionViewList> {
+        let action_ids = Self::list_topologically(ctx).await?;
+
+        let mut views = Vec::new();
+
+        let action_graph = ActionDependencyGraph::for_workspace(ctx).await?;
+        if !action_graph.is_acyclic() {
+            warn!("action graph has a cycle");
+        }
+
+        for action_id in action_ids {
+            let action = Self::get_by_id(ctx, action_id).await?;
+
+            let prototype_id = Self::prototype_id(ctx, action_id).await?;
+            let func_id = ActionPrototype::func_id(ctx, prototype_id).await?;
+            let func = Func::get_by_id(ctx, func_id).await?;
+            let prototype = ActionPrototype::get_by_id(ctx, prototype_id).await?;
+            let func_run_id = ctx
+                .layer_db()
+                .func_run()
+                .get_last_run_for_action_id_opt(ctx.events_tenancy().workspace_pk, action.id())
+                .await?
+                .map(|f| f.id());
+
+            let component_id = Self::component_id(ctx, action_id).await?;
+            let (component_schema_name, component_name) = match component_id {
+                Some(component_id) => {
+                    let schema = Component::schema_for_component_id(ctx, component_id).await?;
+                    let component_name = Component::name_by_id(ctx, component_id).await?;
+                    (Some(schema.name().to_owned()), Some(component_name))
+                }
+                None => (None, None),
+            };
+
+            views.push(ActionView {
+                id: action_id,
+                prototype_id: prototype.id(),
+                name: prototype.name().clone(),
+                component_id,
+                component_schema_name,
+                component_name,
+                description: func.display_name,
+                kind: prototype.kind.into(),
+                state: action.state(),
+                func_run_id,
+                originating_change_set_id: action.originating_changeset_id(),
+                my_dependencies: action_graph.get_all_dependencies(action_id),
+                dependent_on: action_graph.direct_dependencies_of(action_id),
+                hold_status_influenced_by: Self::get_hold_status_influenced_by(
+                    ctx,
+                    &action_graph,
+                    action_id,
+                )
+                .await?,
+            })
+        }
+
+        Ok(ActionViewList {
+            id: ctx.change_set_id(),
+            actions: views,
+        })
     }
 }
 

--- a/lib/dal/tests/integration_test/materialized_view.rs
+++ b/lib/dal/tests/integration_test/materialized_view.rs
@@ -1,0 +1,104 @@
+use std::collections::HashSet;
+
+use dal::action::prototype::ActionPrototype;
+use dal::action::Action;
+use dal::Component;
+use dal::DalContext;
+use dal::Func;
+use dal_test::helpers::create_component_for_default_schema_name_in_default_view;
+use dal_test::prelude::OptionExt;
+use dal_test::test;
+use dal_test::Result;
+use pretty_assertions_sorted::assert_eq;
+use si_events::ActionKind;
+use si_events::ActionState;
+use si_frontend_types::action::ActionView;
+
+#[test]
+async fn actions(ctx: &DalContext) -> Result<()> {
+    let schema_name = "swifty";
+    let component_name = "tes vi";
+    let component =
+        create_component_for_default_schema_name_in_default_view(ctx, schema_name, component_name)
+            .await?;
+    let schema_variant_id = Component::schema_variant_id(ctx, component.id()).await?;
+
+    // Gather what we need for the assertions after the component has been created.
+    let create_action_prototype = ActionPrototype::for_variant(ctx, schema_variant_id)
+        .await?
+        .into_iter()
+        .find(|ap| ap.kind == dal::action::prototype::ActionKind::Create)
+        .ok_or_eyre("could not find action prototype")?;
+    let func_id = ActionPrototype::func_id(ctx, create_action_prototype.id()).await?;
+    let func = Func::get_by_id(ctx, func_id).await?;
+    let create_action_id =
+        Action::find_equivalent(ctx, create_action_prototype.id(), Some(component.id()))
+            .await?
+            .ok_or_eyre("action not found")?;
+    let create_action = Action::get_by_id(ctx, create_action_id).await?;
+
+    // Check the frontend payload for actions.
+    let mut mv = Action::as_frontend_list_type(ctx).await?;
+    let action_view = mv.actions.pop().ok_or_eyre("empty actions")?;
+    assert!(mv.actions.is_empty(), "only one action should exist");
+    assert_eq!(
+        ActionView {
+            id: create_action.id(),
+            prototype_id: create_action_prototype.id,
+            component_id: Some(component.id()),
+            component_schema_name: Some(schema_name.to_owned()),
+            component_name: Some(component_name.to_owned()),
+            name: create_action_prototype.name.to_owned(),
+            description: func.display_name,
+            kind: ActionKind::Create,
+            state: ActionState::Queued,
+            originating_change_set_id: create_action.originating_changeset_id(),
+            func_run_id: None,
+            my_dependencies: Vec::new(),
+            dependent_on: Vec::new(),
+            hold_status_influenced_by: Vec::new(),
+        }, // expected
+        action_view // actual
+    );
+
+    // Check the frontend payload for action prototypes.
+    let mv = ActionPrototype::as_frontend_list_type_by_component_id(ctx, component.id()).await?;
+    assert_eq!(
+        component.id(), // expected
+        mv.id           // actual
+    );
+    assert_eq!(
+        4,                          // expected
+        mv.action_prototypes.len()  // actual
+    );
+    let mut kinds = HashSet::new();
+    for action_prototype_view in mv.action_prototypes {
+        match action_prototype_view.kind {
+            ActionKind::Create => {
+                assert_eq!(
+                    create_action_prototype.id(), // expected
+                    action_prototype_view.id      // actual
+                );
+                assert_eq!(
+                    Some(create_action_id),          // expected
+                    action_prototype_view.action_id  // actual
+                );
+            }
+            _ => {
+                assert!(action_prototype_view.action_id.is_none());
+            }
+        }
+        kinds.insert(action_prototype_view.kind);
+    }
+    assert_eq!(
+        HashSet::from_iter([
+            ActionKind::Create,
+            ActionKind::Destroy,
+            ActionKind::Refresh,
+            ActionKind::Update
+        ]), // expected
+        kinds // actual
+    );
+
+    Ok(())
+}

--- a/lib/dal/tests/integration_test/mod.rs
+++ b/lib/dal/tests/integration_test/mod.rs
@@ -13,6 +13,7 @@ mod frame;
 mod func;
 mod input_sources;
 mod management;
+mod materialized_view;
 mod module;
 mod node_weight;
 mod pkg;

--- a/lib/edda-server/src/lib.rs
+++ b/lib/edda-server/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use thiserror::Error;
 
 mod app_state;

--- a/lib/si-events-rs/src/action.rs
+++ b/lib/si-events-rs/src/action.rs
@@ -1,0 +1,48 @@
+use serde::{Deserialize, Serialize};
+use strum::{AsRefStr, Display, EnumDiscriminants};
+
+pub use si_id::ActionId;
+pub use si_id::ActionPrototypeId;
+
+#[remain::sorted]
+#[derive(AsRefStr, Debug, Copy, Clone, Deserialize, Serialize, PartialEq, Eq, Display, Hash)]
+pub enum ActionKind {
+    /// Create the "outside world" version of the modeled object.
+    Create,
+    /// Destroy the "outside world" version of the modeled object referenced in the resource.
+    Destroy,
+    /// This [`Action`][crate::Action] will only ever be manually queued.
+    Manual,
+    /// Refresh the resource to reflect the current state of the modeled object in the "outside
+    /// world".
+    Refresh,
+    /// Update the version of the modeled object in the "outside world" to match the state of the
+    /// model.
+    Update,
+}
+
+#[derive(Debug, Copy, Clone, Deserialize, Serialize, EnumDiscriminants, PartialEq, Eq, Display)]
+#[strum_discriminants(derive(strum::Display, Serialize, Deserialize))]
+pub enum ActionState {
+    /// Action has been determined to be eligible to run, and has had its job sent to the job
+    /// queue.
+    Dispatched,
+    /// Action failed during execution. See the job history for details.
+    Failed,
+    /// Action is "queued", but should not be considered as eligible to run, until moved to the
+    /// `Queued` state.
+    OnHold,
+    /// Action is available to be dispatched once all of its prerequisites have succeeded, and been
+    /// removed from the graph.
+    Queued,
+    /// Action has been dispatched, and started execution in the job system. See the job history
+    /// for details.
+    Running,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Display, Serialize, Deserialize)]
+pub enum ActionResultState {
+    Success,
+    Failure,
+    Unknown,
+}

--- a/lib/si-events-rs/src/func_run.rs
+++ b/lib/si-events-rs/src/func_run.rs
@@ -1,12 +1,12 @@
 use chrono::{DateTime, Utc};
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
+use si_id::{ActionId, ActionPrototypeId};
 use strum::{AsRefStr, Display, EnumIter, EnumString};
 
+use crate::{ActionKind, ActionResultState};
 use crate::{Actor, ChangeSetId, ContentHash, FuncId, Tenancy, WorkspacePk};
 
-pub use si_id::ActionId;
-pub use si_id::ActionPrototypeId;
 pub use si_id::AttributePrototypeArgumentId;
 pub use si_id::AttributePrototypeId;
 pub use si_id::AttributeValueId;
@@ -136,30 +136,6 @@ pub enum FuncBackendResponseType {
     Void,
     Management,
     Float,
-}
-
-#[remain::sorted]
-#[derive(AsRefStr, Debug, Copy, Clone, Deserialize, Serialize, PartialEq, Eq, Display, Hash)]
-pub enum ActionKind {
-    /// Create the "outside world" version of the modeled object.
-    Create,
-    /// Destroy the "outside world" version of the modeled object referenced in the resource.
-    Destroy,
-    /// This [`Action`][crate::Action] will only ever be manually queued.
-    Manual,
-    /// Refresh the resource to reflect the current state of the modeled object in the "outside
-    /// world".
-    Refresh,
-    /// Update the version of the modeled object in the "outside world" to match the state of the
-    /// model.
-    Update,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Display, Serialize, Deserialize)]
-pub enum ActionResultState {
-    Success,
-    Failure,
-    Unknown,
 }
 
 #[derive(Debug, Clone, Builder, Serialize, Deserialize)]

--- a/lib/si-events-rs/src/lib.rs
+++ b/lib/si-events-rs/src/lib.rs
@@ -11,6 +11,7 @@ pub mod xxhash_type;
 
 pub use si_id::ulid;
 
+mod action;
 mod actor;
 mod cas;
 mod change_set_approval;
@@ -31,6 +32,7 @@ mod vector_clock_id;
 mod web_event;
 
 pub use crate::{
+    action::{ActionId, ActionKind, ActionPrototypeId, ActionResultState, ActionState},
     actor::Actor,
     actor::UserPk,
     authentication_method::{AuthenticationMethod, AuthenticationMethodRole},
@@ -43,10 +45,10 @@ pub use crate::{
     func::{FuncArgumentId, FuncId},
     func_execution::*,
     func_run::{
-        ActionId, ActionKind, ActionPrototypeId, ActionResultState, AttributePrototypeArgumentId,
-        AttributePrototypeId, AttributeValueId, ComponentId, FuncArgumentKind, FuncBackendKind,
-        FuncBackendResponseType, FuncKind, FuncRun, FuncRunBuilder, FuncRunBuilderError, FuncRunId,
-        FuncRunState, FuncRunValue, ManagementPrototypeId, ViewId,
+        AttributePrototypeArgumentId, AttributePrototypeId, AttributeValueId, ComponentId,
+        FuncArgumentKind, FuncBackendKind, FuncBackendResponseType, FuncKind, FuncRun,
+        FuncRunBuilder, FuncRunBuilderError, FuncRunId, FuncRunState, FuncRunValue,
+        ManagementPrototypeId, ViewId,
     },
     func_run_log::{FuncRunLog, FuncRunLogId, OutputLine},
     resource_metadata::{ResourceMetadata, ResourceStatus},

--- a/lib/si-frontend-types-macros/src/lib.rs
+++ b/lib/si-frontend-types-macros/src/lib.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use darling::FromAttributes;
 use manyhow::{bail, emit, manyhow};
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{Data, DeriveInput, Path};
 
 #[manyhow]
@@ -359,49 +359,36 @@ pub fn build_mv(input: proc_macro2::TokenStream) -> syn::Result<proc_macro2::Tok
         build_fn,
     } = syn::parse::<BuildMv>(input.into())?;
 
-    let build_mv_ident = format_ident!(
-        "build_mv_{}",
-        mv_name
-            .segments
-            .iter()
-            .map(|segment| segment.ident.to_string())
-            .collect::<Vec<_>>()
-            .join("_")
-    );
-
     let output = quote! {
         {
-            async fn #build_mv_ident(
-                ctx: &DalContext,
-                frigg: &frigg::FriggStore,
-                change: &Change,
-                mv_id: String,
-            ) -> Result<(
-                Option<si_frontend_types::object::patch::ObjectPatch>,
-                Option<si_frontend_types::object::FrontendObject>,
-            ), MaterializedViewError> {
-                if <#mv_name as si_frontend_types::materialized_view::MaterializedView>::trigger_entity() == change.entity_kind {
-                    if !ctx
-                        .workspace_snapshot()?
-                        .node_exists(change.entity_id)
-                        .await
-                    {
-                        // Object was removed
-                        return Ok((
-                            Some(si_frontend_types::object::patch::ObjectPatch {
-                                kind: <#mv_name as si_frontend_types::materialized_view::MaterializedView>::kind().to_string(),
-                                id: mv_id,
-                                // TODO: we need to get the prior version of this
-                                from_checksum: Checksum::default().to_string(),
-                                to_checksum: "0".to_string(),
-                                patch: json_patch::Patch(vec![json_patch::PatchOperation::Remove(
-                                    json_patch::RemoveOperation::default(),
-                                )]),
-                            }),
-                            None,
-                        ));
-                    }
+            let ctx = #ctx;
+            let frigg = #frigg;
+            let change = #change;
+            let mv_id = #mv_id;
 
+            if <#mv_name as si_frontend_types::materialized_view::MaterializedView>::trigger_entity() != change.entity_kind {
+                Ok((None, None))
+            } else {
+                if !ctx
+                    .workspace_snapshot()?
+                    .node_exists(change.entity_id)
+                    .await
+                {
+                    // Object was removed
+                    Ok((
+                        Some(si_frontend_types::object::patch::ObjectPatch {
+                            kind: <#mv_name as si_frontend_types::materialized_view::MaterializedView>::kind().to_string(),
+                            id: mv_id,
+                            // TODO: we need to get the prior version of this
+                            from_checksum: Checksum::default().to_string(),
+                            to_checksum: "0".to_string(),
+                            patch: json_patch::Patch(vec![json_patch::PatchOperation::Remove(
+                                json_patch::RemoveOperation::default(),
+                            )]),
+                        }),
+                        None,
+                    ))
+                } else {
                     let mv = #build_fn?;
                     let mv_json = serde_json::to_value(&mv)?;
                     let to_checksum = si_frontend_types::checksum::FrontendChecksum::checksum(&mv).to_string();
@@ -425,12 +412,8 @@ pub fn build_mv(input: proc_macro2::TokenStream) -> syn::Result<proc_macro2::Tok
                         }),
                         Some(frontend_object),
                     ))
-                } else {
-                    Ok((None, None))
                 }
             }
-
-            #build_mv_ident(#ctx, #frigg, #change, #mv_id)
         }
     };
 

--- a/lib/si-frontend-types-rs/src/action.rs
+++ b/lib/si-frontend-types-rs/src/action.rs
@@ -1,0 +1,64 @@
+use serde::{Deserialize, Serialize};
+use si_events::{
+    workspace_snapshot::{Checksum, ChecksumHasher, EntityKind},
+    ActionKind, ActionState,
+};
+use si_id::{ActionId, ActionPrototypeId, ChangeSetId, ComponentId, FuncRunId};
+
+use crate::checksum::FrontendChecksum;
+use crate::{
+    object::FrontendObject,
+    reference::{Refer, Reference, ReferenceId, ReferenceKind},
+    MaterializedView,
+};
+
+pub mod prototype;
+
+pub use prototype::ActionPrototypeView;
+pub use prototype::ActionPrototypeViewsByComponentId;
+
+#[derive(
+    Debug, Serialize, Deserialize, PartialEq, Eq, Clone, si_frontend_types_macros::FrontendChecksum,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionView {
+    pub id: ActionId,
+    pub prototype_id: ActionPrototypeId,
+    pub component_id: Option<ComponentId>,
+    pub component_schema_name: Option<String>,
+    pub component_name: Option<String>,
+    pub name: String,
+    pub description: Option<String>,
+    pub kind: ActionKind,
+    pub state: ActionState,
+    pub originating_change_set_id: ChangeSetId,
+    pub func_run_id: Option<FuncRunId>,
+    // Actions that will wait until I've successfully completed before running
+    pub my_dependencies: Vec<ActionId>,
+    // Things that need to finish before I can start
+    pub dependent_on: Vec<ActionId>,
+    // includes action ids that impact this status
+    // this occurs when ancestors of this action are on hold or have failed
+    pub hold_status_influenced_by: Vec<ActionId>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    PartialEq,
+    Eq,
+    si_frontend_types_macros::FrontendChecksum,
+    si_frontend_types_macros::FrontendObject,
+    si_frontend_types_macros::Refer,
+    si_frontend_types_macros::MV,
+)]
+#[serde(rename_all = "camelCase")]
+#[mv(
+    trigger_entity = EntityKind::CategoryAction,
+    reference_kind = ReferenceKind::ActionViewList,
+)]
+pub struct ActionViewList {
+    pub id: ChangeSetId,
+    pub actions: Vec<ActionView>,
+}

--- a/lib/si-frontend-types-rs/src/action/prototype.rs
+++ b/lib/si-frontend-types-rs/src/action/prototype.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+use si_events::{
+    workspace_snapshot::{Checksum, ChecksumHasher, EntityKind},
+    ActionKind,
+};
+use si_id::{ActionId, ActionPrototypeId, ComponentId, FuncId, SchemaVariantId};
+
+use crate::checksum::FrontendChecksum;
+use crate::{
+    object::FrontendObject,
+    reference::{Refer, Reference, ReferenceId, ReferenceKind},
+    MaterializedView,
+};
+
+#[derive(
+    Debug, Serialize, Deserialize, PartialEq, Eq, Clone, si_frontend_types_macros::FrontendChecksum,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionPrototypeView {
+    pub id: ActionPrototypeId,
+    pub func_id: FuncId,
+    pub schema_variant_id: SchemaVariantId,
+    pub kind: ActionKind,
+    pub display_name: Option<String>,
+    pub name: String,
+    // If this is "None", then there is no running or enqueued action for this prototype
+    pub action_id: Option<ActionId>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    PartialEq,
+    Eq,
+    si_frontend_types_macros::FrontendChecksum,
+    si_frontend_types_macros::FrontendObject,
+    si_frontend_types_macros::Refer,
+    si_frontend_types_macros::MV,
+)]
+#[serde(rename_all = "camelCase")]
+#[mv(
+    trigger_entity = EntityKind::Root,
+    reference_kind = ReferenceKind::ActionPrototypeViewsByComponentId,
+)]
+pub struct ActionPrototypeViewsByComponentId {
+    pub id: ComponentId,
+    pub action_prototypes: Vec<ActionPrototypeView>,
+}

--- a/lib/si-frontend-types-rs/src/checksum.rs
+++ b/lib/si-frontend-types-rs/src/checksum.rs
@@ -1,11 +1,11 @@
 use chrono::{DateTime, Utc};
 use si_events::{
     workspace_snapshot::{Checksum, ChecksumHasher},
-    ChangeSetStatus, Timestamp,
+    ActionKind, ActionState, ChangeSetStatus, Timestamp,
 };
 use si_id::{
-    ChangeSetId, FuncId, InputSocketId, OutputSocketId, PropId, SchemaId, SchemaVariantId, ViewId,
-    WorkspaceId,
+    ActionId, ActionPrototypeId, ChangeSetId, ComponentId, FuncId, FuncRunId, InputSocketId,
+    OutputSocketId, PropId, SchemaId, SchemaVariantId, ViewId, WorkspaceId,
 };
 
 use crate::schema_variant::SchemaVariantsByCategory;
@@ -182,5 +182,41 @@ where
 impl FrontendChecksum for DateTime<Utc> {
     fn checksum(&self) -> Checksum {
         FrontendChecksum::checksum(&self.to_rfc3339())
+    }
+}
+
+impl FrontendChecksum for ActionId {
+    fn checksum(&self) -> Checksum {
+        FrontendChecksum::checksum(&self.to_string())
+    }
+}
+
+impl FrontendChecksum for ActionPrototypeId {
+    fn checksum(&self) -> Checksum {
+        FrontendChecksum::checksum(&self.to_string())
+    }
+}
+
+impl FrontendChecksum for ComponentId {
+    fn checksum(&self) -> Checksum {
+        FrontendChecksum::checksum(&self.to_string())
+    }
+}
+
+impl FrontendChecksum for ActionKind {
+    fn checksum(&self) -> Checksum {
+        FrontendChecksum::checksum(&self.to_string())
+    }
+}
+
+impl FrontendChecksum for ActionState {
+    fn checksum(&self) -> Checksum {
+        FrontendChecksum::checksum(&self.to_string())
+    }
+}
+
+impl FrontendChecksum for FuncRunId {
+    fn checksum(&self) -> Checksum {
+        FrontendChecksum::checksum(&self.to_string())
     }
 }

--- a/lib/si-frontend-types-rs/src/lib.rs
+++ b/lib/si-frontend-types-rs/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod action;
 mod approval_requirement;
 mod audit_log;
 mod change_set;

--- a/lib/si-frontend-types-rs/src/reference.rs
+++ b/lib/si-frontend-types-rs/src/reference.rs
@@ -24,6 +24,8 @@ use crate::{checksum::FrontendChecksum, object::FrontendObject};
 )]
 #[serde(rename_all = "PascalCase")]
 pub enum ReferenceKind {
+    ActionPrototypeViewsByComponentId,
+    ActionViewList,
     ChangeSetList,
     ChangeSetRecord,
     MvIndex,


### PR DESCRIPTION
## Description

This PR moves the "list_actions" functionality to the norse stack. It also brings in action prototype views into the fold from the "AssetActionsDetails" component.

As a result of these changes, the new "mead-hall" directory contains the beginning of flagged, bifrost-powered components that should be guarded by feature flag. As things move over to the new paradigm, we do not want to infect existing components. Rather, we want to feature flag which component is used solely at the template level, if possible.

One of the materialized views from these changes involves a multi-trigger approach where the entity kind is "root", but additional checks need to be performed to know the minimal set of MVs to build. The "build_mv!" macro has been changed to accomodate this.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlamE0ZDVsMXl2eDk1dzRkemljOHRkMXg4YWVlNXQyNzQxdHF5Z3Z1cCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/86xW2hFnhePa0DH11o/giphy-downsized-medium.gif"/>