### PR TITLE
fix(sdf): Allow hitting the update_module_cache endpoint with an automation token

### DIFF
--- a/lib/sdf-server/src/service/v2/admin/update_module_cache.rs
+++ b/lib/sdf-server/src/service/v2/admin/update_module_cache.rs
@@ -3,10 +3,7 @@ use telemetry::prelude::*;
 
 use super::{AdminAPIResult, AdminUserContext};
 use crate::{
-    extract::{
-        workspace::{TargetWorkspaceIdFromToken, WorkspaceAuthorization},
-        PosthogClient,
-    },
+    extract::{workspace::TargetWorkspaceIdFromToken, PosthogClient},
     service::async_route::handle_error,
     track,
 };
@@ -26,16 +23,15 @@ pub struct UpdateModuleCacheResponse {
 
 #[instrument(name = "admin.update_module_cache", skip_all)]
 pub async fn update_module_cache(
-    _: TargetWorkspaceIdFromToken,
+    workspace_id: TargetWorkspaceIdFromToken,
     AdminUserContext(mut ctx): AdminUserContext,
     PosthogClient(posthog_client): PosthogClient,
     OriginalUri(original_uri): OriginalUri,
     Host(host_name): Host,
-    WorkspaceAuthorization { workspace_id, .. }: WorkspaceAuthorization,
 ) -> AdminAPIResult<Json<UpdateModuleCacheResponse>> {
     let task_id = Ulid::new();
 
-    ctx.update_tenancy(Tenancy::new(workspace_id));
+    ctx.update_tenancy(Tenancy::new(workspace_id.into()));
     tokio::task::spawn(async move {
         if let Err(err) = update_cached_modules_inner(
             &ctx,


### PR DESCRIPTION
Wehave a check that the user POSTing to this API is locked down to system initiative users but welocked it down too far to be a web token only - we now can make this either web or automation which means I can hit this endpoint after an asset update of the AWS generated assets to clear the cache

Testing:

Works from API using an automation token:

```
▶ curl -vX POST "http://localhost:8080/api/v2/admin/update_module_cache" -H "Authorization: Bearer ${SI_BEARER_TOKEN}"
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* connect to ::1 port 8080 from ::1 port 62152 failed: Connection refused
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080
> POST /api/v2/admin/update_module_cache HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
> Authorization: Bearer ****
>
* Request completely sent off
< HTTP/1.1 200 OK
< vary: origin, access-control-request-method, access-control-request-headers
< content-type: application/json
< content-length: 35
< access-control-allow-credentials: true
< date: Fri, 11 Apr 2025 18:00:57 GMT
< connection: keep-alive
<
* Connection #0 to host localhost left intact
{"id":"01JRK0649K0Q1JHRDJVJNMEG28"}%
```

Also works from the browser as well via the Admin panel