### PR TITLE
feat: add buildevents to ci-base

### DIFF
--- a/component/ci-base/Dockerfile
+++ b/component/ci-base/Dockerfile
@@ -35,6 +35,18 @@ RUN set -eux; \
     ; \
     rm -rf /var/lib/apt/lists/*
 
+ARG BUILDEVENTS_VERSION=v0.17.0
+RUN set -eux; \
+    ARCH="$(dpkg --print-architecture)"; \
+    case "${ARCH}" in \
+        amd64) BUILDEVENTS_ARCH="linux-amd64" ;; \
+        arm64) BUILDEVENTS_ARCH="linux-arm64" ;; \
+        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac && \
+    curl -L -o /usr/local/bin/buildevents \
+        "https://github.com/honeycombio/buildevents/releases/download/${BUILDEVENTS_VERSION}/buildevents-${BUILDEVENTS_ARCH}" && \
+    chmod +x /usr/local/bin/buildevents
+
 # Install Cypress Dependencies
 RUN apt-get update; \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
```
 docker run -it  --entrypoint sh systeminit/ci-base:20250411.204011.0-sha.720d2a8d1-amd64
$ buildevents

The buildevents executable creates Honeycomb events and tracing information
about your Continuous Integration builds.

Usage:
  buildevents [command]

Available Commands:
  build       Sends the root span for the entire build
  cmd         Invoke an individual command that is part of the build.
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  step        Joins a collection of individual commands
  watch       Polls the CircleCI API and waits until all jobs have finished.

Flags:
  -a, --apihost string        [env.BUILDEVENT_APIHOST] the hostname for the Honeycomb API server to which to send this event (default "https://api.honeycomb.io")
  -k, --apikey string         [env.BUILDEVENT_APIKEY] the Honeycomb authentication token
  -d, --dataset string        [env.BUILDEVENT_DATASET] the name of the Honeycomb dataset to which to send these events
  -f, --filename string       [env.BUILDEVENT_FILE] the path of a text file holding arbitrary key=val pairs (multi-line-capable, logfmt style) to be added to the Honeycomb event
  -h, --help                  help for buildevents
  -p, --provider string       [env.BUILDEVENT_CIPROVIDER] if unset, will inspect the environment to try to detect common CI providers.
  -n, --service_name string   [env.BUILDEVENT_SERVICE_NAME] the name of the service to which to send these events; overrides dataset
  -v, --version               version for buildevents

Use "buildevents [command] --help" for more information about a command.
```