### PR TITLE
Add rebuild change set index route

### DIFF
--- a/lib/sdf-server/src/service/v2/index.rs
+++ b/lib/sdf-server/src/service/v2/index.rs
@@ -1,27 +1,26 @@
 use futures_lite::StreamExt;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use axum::{
-    extract::{Path, Query},
     response::{IntoResponse, Response},
-    routing::get,
-    Json, Router,
+    routing::{get, post},
+    Router,
 };
-use dal::{ChangeSet, ChangeSetId, WorkspacePk, WorkspaceSnapshotAddress};
+use dal::{ChangeSetId, WorkspacePk, WorkspaceSnapshotAddress};
 use hyper::StatusCode;
-use si_frontend_types::{index::MvIndex, object::FrontendObject, reference::ReferenceKind};
+use si_frontend_types::object::FrontendObject;
 use telemetry::prelude::*;
 use thiserror::Error;
 
-use crate::{
-    extract::{EddaClient, FriggStore, HandlerContext},
-    service::ApiError,
-    AppState,
-};
+use crate::{service::ApiError, AppState};
 
 use super::AccessBuilder;
+
+mod get_change_set_index;
+mod get_front_end_object;
+mod get_workspace_index;
+mod rebuild_change_set_index;
 
 const WATCH_INDEX_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -59,21 +58,18 @@ impl IntoResponse for IndexError {
     }
 }
 
-pub async fn get_workspace_index(
-    HandlerContext(builder): HandlerContext,
-    AccessBuilder(access_builder): AccessBuilder,
-    FriggStore(frigg): FriggStore,
-    Path(workspace_pk): Path<WorkspacePk>,
-) -> IndexResult<Json<HashMap<ChangeSetId, Option<FrontendObject>>>> {
-    let ctx = builder.build_head(access_builder).await?;
+pub fn v2_workspace_routes() -> Router<AppState> {
+    Router::new().route("/", get(get_workspace_index::get_workspace_index))
+}
 
-    let mut indexes = HashMap::new();
-    for change_set in ChangeSet::list_active(&ctx).await? {
-        let maybe_index = frigg.get_index(workspace_pk, change_set.id).await?;
-        indexes.insert(change_set.id, maybe_index.map(|i| i.0));
-    }
-
-    Ok(Json(indexes))
+pub fn v2_change_set_routes() -> Router<AppState> {
+    Router::new()
+        .route("/", get(get_change_set_index::get_change_set_index))
+        .route("/mjolnir", get(get_front_end_object::get_front_end_object))
+        .route(
+            "/rebuild",
+            post(rebuild_change_set_index::rebuild_change_set_index),
+        )
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
@@ -83,77 +79,30 @@ pub struct FrontEndObjectMeta {
     front_end_object: FrontendObject,
 }
 
-pub async fn get_change_set_index(
-    HandlerContext(builder): HandlerContext,
-    AccessBuilder(access_builder): AccessBuilder,
-    FriggStore(frigg): FriggStore,
-    EddaClient(edda_client): EddaClient,
-    Path((workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
-) -> IndexResult<Json<FrontEndObjectMeta>> {
-    let ctx = builder
-        .build(access_builder.build(change_set_id.into()))
+#[instrument(
+    level = "info",
+    name = "sdf.index.request_rebuild",
+    skip_all,
+    fields(
+        si.edda_request.id = Empty
+    )
+)]
+async fn request_rebuild(
+    edda_client: &edda_client::EddaClient,
+    workspace_pk: WorkspacePk,
+    change_set_id: ChangeSetId,
+) -> IndexResult<()> {
+    let span = Span::current();
+    let request_id = edda_client
+        .rebuild_for_change_set(workspace_pk, change_set_id)
         .await?;
-    let change_set = ChangeSet::get_by_id(&ctx, change_set_id).await?;
-
-    let index = match frigg.get_index(workspace_pk, change_set_id).await? {
-        Some((index, _kv_revision)) => {
-            let mv_index: MvIndex = serde_json::from_value(index.data.to_owned())
-                .map_err(IndexError::DeserializingMvIndexData)?;
-
-            // NOTE(nick,jacob): this may or may not be better suited for "edda". Let's trace this
-            // to ensure that this stopgap solution does not bog the system down.
-            let span = info_span!("sdf.index.get_change_set_index.implemented_kinds");
-            let implemented_kinds = span.in_scope(|| {
-                let mut implemented_kinds = HashSet::new();
-                for index_ref in mv_index.mv_list {
-                    let kind = ReferenceKind::try_from(index_ref.kind.as_str())
-                        .map_err(IndexError::InvalidStringForReferenceKind)?;
-                    if kind.is_revision_sensitive() {
-                        implemented_kinds.insert(kind);
-                    }
-                }
-                IndexResult::Ok(implemented_kinds)
-            })?;
-
-            if implemented_kinds == ReferenceKind::revision_sensitive() {
-                index
-            } else {
-                info!(
-                    "Index out of date for change_set {}; attempting full build",
-                    change_set_id,
-                );
-                request_rebuild_and_watch(&frigg, &edda_client, workspace_pk, change_set_id)
-                    .await?;
-                frigg
-                    .get_index(workspace_pk, change_set_id)
-                    .await?
-                    .map(|i| i.0)
-                    .ok_or(IndexError::IndexNotFound(workspace_pk, change_set_id))?
-            }
-        }
-        None => {
-            info!(
-                "Index not found for change_set {}; attempting full build",
-                change_set_id,
-            );
-            request_rebuild_and_watch(&frigg, &edda_client, workspace_pk, change_set_id).await?;
-            frigg
-                .get_index(workspace_pk, change_set_id)
-                .await?
-                .map(|i| i.0)
-                .ok_or(IndexError::IndexNotFound(workspace_pk, change_set_id))?
-        }
-    };
-
-    Ok(Json(FrontEndObjectMeta {
-        workspace_snapshot_address: change_set.workspace_snapshot_address,
-        front_end_object: index,
-    }))
+    span.record("si.edda_request.id", request_id.to_string());
+    Ok(())
 }
 
 #[instrument(
     level = "info",
-    name = "sdf.index.get_change_set_index.request_rebuild_and_watch",
+    name = "sdf.index.request_rebuild_and_watch",
     skip_all,
     fields(
         si.edda_request.id = Empty
@@ -177,53 +126,4 @@ async fn request_rebuild_and_watch(
         _ = tokio::time::sleep(timeout) => Err(IndexError::WatchIndexTimeout(timeout)),
         _ = watch.next() => Ok(())
     }
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct FrontendObjectRequest {
-    pub kind: String,
-    pub id: String,
-    pub checksum: Option<String>,
-}
-
-pub async fn get_front_end_object(
-    HandlerContext(builder): HandlerContext,
-    AccessBuilder(access_builder): AccessBuilder,
-    FriggStore(frigg): FriggStore,
-    Path((workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
-    Query(request): Query<FrontendObjectRequest>,
-) -> IndexResult<Json<FrontEndObjectMeta>> {
-    let ctx = builder
-        .build(access_builder.build(change_set_id.into()))
-        .await?;
-    let change_set = ChangeSet::get_by_id(&ctx, change_set_id).await?;
-
-    let obj;
-    if let Some(checksum) = request.checksum {
-        obj = frigg
-            .get_object(workspace_pk, &request.kind, &request.id, &checksum)
-            .await?
-            .ok_or(IndexError::IndexNotFound(workspace_pk, change_set_id))?;
-    } else {
-        obj = frigg
-            .get_current_object(workspace_pk, change_set_id, &request.kind, &request.id)
-            .await?
-            .ok_or(IndexError::IndexNotFound(workspace_pk, change_set_id))?;
-    }
-
-    Ok(Json(FrontEndObjectMeta {
-        workspace_snapshot_address: change_set.workspace_snapshot_address,
-        front_end_object: obj,
-    }))
-}
-
-pub fn v2_workspace_routes() -> Router<AppState> {
-    Router::new().route("/", get(get_workspace_index))
-}
-
-pub fn v2_change_set_routes() -> Router<AppState> {
-    Router::new()
-        .route("/", get(get_change_set_index))
-        .route("/mjolnir", get(get_front_end_object))
 }

--- a/lib/sdf-server/src/service/v2/index/get_change_set_index.rs
+++ b/lib/sdf-server/src/service/v2/index/get_change_set_index.rs
@@ -1,0 +1,80 @@
+use std::collections::HashSet;
+
+use axum::{extract::Path, Json};
+
+use dal::{ChangeSet, ChangeSetId, WorkspacePk};
+use si_frontend_types::{index::MvIndex, reference::ReferenceKind};
+use telemetry::prelude::*;
+
+use crate::extract::{EddaClient, FriggStore, HandlerContext};
+
+use super::request_rebuild_and_watch;
+use super::{AccessBuilder, FrontEndObjectMeta, IndexError, IndexResult};
+
+pub async fn get_change_set_index(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    FriggStore(frigg): FriggStore,
+    EddaClient(edda_client): EddaClient,
+    Path((workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
+) -> IndexResult<Json<FrontEndObjectMeta>> {
+    let ctx = builder
+        .build(access_builder.build(change_set_id.into()))
+        .await?;
+    let change_set = ChangeSet::get_by_id(&ctx, change_set_id).await?;
+
+    let index = match frigg.get_index(workspace_pk, change_set_id).await? {
+        Some((index, _kv_revision)) => {
+            let mv_index: MvIndex = serde_json::from_value(index.data.to_owned())
+                .map_err(IndexError::DeserializingMvIndexData)?;
+
+            // NOTE(nick,jacob): this may or may not be better suited for "edda". Let's trace this
+            // to ensure that this stopgap solution does not bog the system down.
+            let span = info_span!("sdf.index.get_change_set_index.implemented_kinds");
+            let implemented_kinds = span.in_scope(|| {
+                let mut implemented_kinds = HashSet::new();
+                for index_ref in mv_index.mv_list {
+                    let kind = ReferenceKind::try_from(index_ref.kind.as_str())
+                        .map_err(IndexError::InvalidStringForReferenceKind)?;
+                    if kind.is_revision_sensitive() {
+                        implemented_kinds.insert(kind);
+                    }
+                }
+                IndexResult::Ok(implemented_kinds)
+            })?;
+
+            if implemented_kinds == ReferenceKind::revision_sensitive() {
+                index
+            } else {
+                info!(
+                    "Index out of date for change_set {}; attempting full build",
+                    change_set_id,
+                );
+                request_rebuild_and_watch(&frigg, &edda_client, workspace_pk, change_set_id)
+                    .await?;
+                frigg
+                    .get_index(workspace_pk, change_set_id)
+                    .await?
+                    .map(|i| i.0)
+                    .ok_or(IndexError::IndexNotFound(workspace_pk, change_set_id))?
+            }
+        }
+        None => {
+            info!(
+                "Index not found for change_set {}; attempting full build",
+                change_set_id,
+            );
+            request_rebuild_and_watch(&frigg, &edda_client, workspace_pk, change_set_id).await?;
+            frigg
+                .get_index(workspace_pk, change_set_id)
+                .await?
+                .map(|i| i.0)
+                .ok_or(IndexError::IndexNotFound(workspace_pk, change_set_id))?
+        }
+    };
+
+    Ok(Json(FrontEndObjectMeta {
+        workspace_snapshot_address: change_set.workspace_snapshot_address,
+        front_end_object: index,
+    }))
+}

--- a/lib/sdf-server/src/service/v2/index/get_front_end_object.rs
+++ b/lib/sdf-server/src/service/v2/index/get_front_end_object.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+
+use axum::{
+    extract::{Path, Query},
+    Json,
+};
+use dal::{ChangeSet, ChangeSetId, WorkspacePk};
+
+use crate::extract::{FriggStore, HandlerContext};
+
+use super::{AccessBuilder, FrontEndObjectMeta, IndexError, IndexResult};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct FrontendObjectRequest {
+    pub kind: String,
+    pub id: String,
+    pub checksum: Option<String>,
+}
+
+pub async fn get_front_end_object(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    FriggStore(frigg): FriggStore,
+    Path((workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
+    Query(request): Query<FrontendObjectRequest>,
+) -> IndexResult<Json<FrontEndObjectMeta>> {
+    let ctx = builder
+        .build(access_builder.build(change_set_id.into()))
+        .await?;
+    let change_set = ChangeSet::get_by_id(&ctx, change_set_id).await?;
+
+    let obj;
+    if let Some(checksum) = request.checksum {
+        obj = frigg
+            .get_object(workspace_pk, &request.kind, &request.id, &checksum)
+            .await?
+            .ok_or(IndexError::IndexNotFound(workspace_pk, change_set_id))?;
+    } else {
+        obj = frigg
+            .get_current_object(workspace_pk, change_set_id, &request.kind, &request.id)
+            .await?
+            .ok_or(IndexError::IndexNotFound(workspace_pk, change_set_id))?;
+    }
+
+    Ok(Json(FrontEndObjectMeta {
+        workspace_snapshot_address: change_set.workspace_snapshot_address,
+        front_end_object: obj,
+    }))
+}

--- a/lib/sdf-server/src/service/v2/index/get_workspace_index.rs
+++ b/lib/sdf-server/src/service/v2/index/get_workspace_index.rs
@@ -1,0 +1,27 @@
+use std::collections::HashMap;
+
+use axum::{extract::Path, Json};
+
+use dal::{ChangeSet, ChangeSetId, WorkspacePk};
+use si_frontend_types::object::FrontendObject;
+
+use crate::extract::{FriggStore, HandlerContext};
+
+use super::{AccessBuilder, IndexResult};
+
+pub async fn get_workspace_index(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    FriggStore(frigg): FriggStore,
+    Path(workspace_pk): Path<WorkspacePk>,
+) -> IndexResult<Json<HashMap<ChangeSetId, Option<FrontendObject>>>> {
+    let ctx = builder.build_head(access_builder).await?;
+
+    let mut indexes = HashMap::new();
+    for change_set in ChangeSet::list_active(&ctx).await? {
+        let maybe_index = frigg.get_index(workspace_pk, change_set.id).await?;
+        indexes.insert(change_set.id, maybe_index.map(|i| i.0));
+    }
+
+    Ok(Json(indexes))
+}

--- a/lib/sdf-server/src/service/v2/index/rebuild_change_set_index.rs
+++ b/lib/sdf-server/src/service/v2/index/rebuild_change_set_index.rs
@@ -1,0 +1,13 @@
+use axum::extract::Path;
+use dal::{ChangeSetId, WorkspacePk};
+
+use crate::extract::EddaClient;
+
+use super::{request_rebuild, IndexResult};
+
+pub async fn rebuild_change_set_index(
+    EddaClient(edda_client): EddaClient,
+    Path((workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
+) -> IndexResult<()> {
+    request_rebuild(&edda_client, workspace_pk, change_set_id).await
+}


### PR DESCRIPTION
## Description

This PR adds the rebuild change set index route. There is no corresponding button or action that can trigger it in the frontend yet, but it is available.

This PR also standardizes the two rebuild functions' trace naming schemes and moves them to the root index module. In addition to these changes, all routes are now in their own submodules.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlenVzbm11d2pyeGFwajM2bmZ1Z3U1bm02dGNzY2VrbWI3MXF5aXd2ciZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ZO19BOWoczJ82msvLV/giphy.gif"/>