### PR TITLE
feat: set the deploy mode when building web

### DIFF
--- a/.github/workflows/upgrade-web.yml
+++ b/.github/workflows/upgrade-web.yml
@@ -54,7 +54,13 @@ jobs:
         working-directory: app/web
         env:
           VITE_OTEL_EXPORTER_OTLP_ENDPOINT: ${{ vars.VITE_SI_WORKSPACE_URL }}
-        run: pnpm run build
+        run: |
+          if [[ "${{ inputs.environment }}" == "production" ]]; then
+            export MODE=production
+          else
+            export MODE=staging
+          fi
+          pnpm run build --mode $MODE
 
       - name: Deploy
         uses: islishude/spa-deploy-action@v1


### PR DESCRIPTION
This ensures we read from the correct `.env` file as part of the build