### PR TITLE
Namespace sqlite db, and create dev-only tooling to trigger things

### DIFF
--- a/app/web/src/components/LeftPanelDrawer.vue
+++ b/app/web/src/components/LeftPanelDrawer.vue
@@ -41,10 +41,6 @@
         />
       </template>
 
-      <div v-if="ffStore.FRONTEND_ARCH_VIEWS && false">
-        <IconButton icon="circle-stack" size="md" @click="odin()" />
-      </div>
-
       <div>
         <ViewCard
           v-for="view in sortedViews"
@@ -95,7 +91,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import { useViewsStore } from "@/store/views.store";
 import SidebarSubpanelTitle from "@/components/SidebarSubpanelTitle.vue";
-import { bifrost, odin, makeKey, makeArgs } from "@/store/realtime/heimdall";
+import { bifrost, makeKey, makeArgs } from "@/store/realtime/heimdall";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import { ViewDescription } from "@/api/sdf/dal/views";
 import { BifrostView, BifrostViewList } from "@/workers/types/dbinterface";

--- a/app/web/src/components/layout/navbar/NavbarPanelRight.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelRight.vue
@@ -5,6 +5,48 @@
     <Collaborators />
     <Notifications />
 
+    <template v-if="featureFlagsStore.SQLITE_TOOLS">
+      <NavbarButton icon="odin" size="sm">
+        <template #dropdownContent>
+          <DropdownMenuItem
+            v-if="
+              changeSetsStore.selectedWorkspacePk &&
+              changeSetsStore.selectedChangeSetId
+            "
+            icon="niflheim"
+            label="Re-do Cold Start"
+            @click="
+              heimdall.niflheim(
+                changeSetsStore.selectedWorkspacePk,
+                changeSetsStore.selectedChangeSetId,
+                true,
+              )
+            "
+          />
+          <DropdownMenuItem
+            icon="mjolnir"
+            label="Throw Hammer"
+            @click="() => modalRef.open()"
+          />
+          <DropdownMenuItem
+            v-if="changeSetsStore.selectedChangeSetId"
+            icon="odin"
+            label="Log Sqlite"
+            @click="
+              () =>
+                changeSetsStore.selectedChangeSetId &&
+                heimdall.odin(changeSetsStore.selectedChangeSetId)
+            "
+          />
+          <DropdownMenuItem
+            icon="trash"
+            label="Bobby Drop Tables"
+            @click="() => heimdall.bobby()"
+          />
+        </template>
+      </NavbarButton>
+    </template>
+
     <template v-if="!collapse">
       <NavbarButton
         tooltipText="Documentation"
@@ -22,22 +64,66 @@
     </template>
 
     <ProfileButton :showTopLevelMenuItems="collapse" />
+
+    <Modal ref="modalRef" title="Throw">
+      <Stack>
+        <VormInput v-model="entityKind" label="Entity Kind" type="text" />
+        <VormInput v-model="entityId" label="ID" type="text" />
+        <VButton
+          label="Mjolnir!"
+          tone="action"
+          variant="soft"
+          @click="hammer"
+        />
+      </Stack>
+    </Modal>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import {
+  DropdownMenuItem,
+  VormInput,
+  VButton,
+  Modal,
+  Stack,
+} from "@si/vue-lib/design-system";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
+import * as heimdall from "@/store/realtime/heimdall";
+import { useChangeSetsStore } from "@/store/change_sets.store";
 import NavbarButton from "./NavbarButton.vue";
 import Collaborators from "./Collaborators.vue";
 import Notifications from "./Notifications.vue";
 import WorkspaceSettingsMenu from "./WorkspaceSettingsMenu.vue";
 import ProfileButton from "./ProfileButton.vue";
 
+const featureFlagsStore = useFeatureFlagsStore();
+const changeSetsStore = useChangeSetsStore();
+const modalRef = ref();
+const entityId = ref("");
+const entityKind = ref("");
+
 const windowWidth = ref(window.innerWidth);
 const collapse = computed(() => windowWidth.value < 1200);
 
 const windowResizeHandler = () => {
   windowWidth.value = window.innerWidth;
+};
+
+const hammer = () => {
+  if (
+    changeSetsStore.selectedWorkspacePk &&
+    changeSetsStore.selectedChangeSetId
+  ) {
+    heimdall.mjolnir(
+      changeSetsStore.selectedWorkspacePk,
+      changeSetsStore.selectedChangeSetId,
+      entityKind.value,
+      entityId.value,
+    );
+    modalRef.value.close();
+  }
 };
 
 onMounted(() => {

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -19,6 +19,7 @@ const FLAG_MAPPING = {
   FLOATING_CONNECTION_MENU: "floating-connection-menu",
   CONVERT_TO_VIEW: "convert-to-view",
   SIMPLE_SOCKET_UI: "simple-socket-ui",
+  SQLITE_TOOLS: "sqlite-tools",
 };
 
 const WORKSPACE_FLAG_MAPPING = {

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -144,15 +144,25 @@ export const makeArgs = (kind: string, id?: string) => {
   };
 };
 
-/*
-const fullDiagnosticTest = async () => {
-  await db.fullDiagnosticTest();
-}; */
-
-export const odin = async () => {
-  const allData = await db.odin();
+export const odin = async (changeSetId: string) => {
+  const allData = await db.odin(changeSetId);
   // eslint-disable-next-line no-console
   console.log("⚡ ODIN ⚡");
   // eslint-disable-next-line no-console
   console.log(allData);
+};
+
+export const bobby = async () => {
+  await db.bobby();
+  // eslint-disable-next-line no-console
+  console.log("🗑️ BOBBY DROP TABLE 🗑️");
+};
+
+export const mjolnir = async (
+  workspaceId: string,
+  changeSetId: string,
+  kind: string,
+  id: string,
+) => {
+  await db.mjolnir(workspaceId, changeSetId, kind, id);
 };

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -91,8 +91,9 @@ export interface DBInterface {
         sql: FlexibleString;
       },
   ): SqlValue[][];
+  bobby(): Promise<void>;
   // show me everything
-  odin(): object;
+  odin(changeSetId: ChangeSetId): object;
 }
 
 export class Ragnarok extends Error {

--- a/lib/vue-lib/src/design-system/icons/custom-icons/mjolnir.svg
+++ b/lib/vue-lib/src/design-system/icons/custom-icons/mjolnir.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <!-- Transparent background is default -->
+  
+  <!-- Hammer handle -->
+  <rect x="11" y="10" width="2" height="11" fill="currentColor"/>
+  
+  <!-- Hammer head  -->
+  <path d="M8 4h8v6h-8z" fill="currentColor"/>
+  
+  <!-- Handle binding/wrap -->
+  <rect x="10.5" y="9.5" width="3" height="1.5" fill="currentColor"/>
+</svg>

--- a/lib/vue-lib/src/design-system/icons/custom-icons/odin.svg
+++ b/lib/vue-lib/src/design-system/icons/custom-icons/odin.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <!-- Main vertical line -->
+  <line x1="8" y1="4" x2="8" y2="20" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  
+  <!-- Upper diagonal line -->
+  <line x1="8" y1="4" x2="16" y2="10" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  
+  <!-- Lower diagonal line -->
+  <line x1="8" y1="12" x2="16" y2="18" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/lib/vue-lib/src/design-system/icons/custom-icons/snowflake.svg
+++ b/lib/vue-lib/src/design-system/icons/custom-icons/snowflake.svg
@@ -1,0 +1,49 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <!-- Main vertical line -->
+  <line x1="12" y1="2" x2="12" y2="22" stroke="black" stroke-width="1.2"/>
+  
+  <!-- Main horizontal line -->
+  <line x1="2" y1="12" x2="22" y2="12" stroke="black" stroke-width="1.2"/>
+  
+  <!-- Diagonal lines (top-left to bottom-right) -->
+  <line x1="5" y1="5" x2="19" y2="19" stroke="black" stroke-width="1.2"/>
+  
+  <!-- Diagonal lines (top-right to bottom-left) -->
+  <line x1="19" y1="5" x2="5" y2="19" stroke="black" stroke-width="1.2"/>
+  
+  <!-- Small decorative branches -->
+  <!-- Top branch -->
+  <line x1="10" y1="4" x2="12" y2="6" stroke="black" stroke-width="0.8"/>
+  <line x1="14" y1="4" x2="12" y2="6" stroke="black" stroke-width="0.8"/>
+  
+  <!-- Right branch -->
+  <line x1="20" y1="10" x2="18" y2="12" stroke="black" stroke-width="0.8"/>
+  <line x1="20" y1="14" x2="18" y2="12" stroke="black" stroke-width="0.8"/>
+  
+  <!-- Bottom branch -->
+  <line x1="10" y1="20" x2="12" y2="18" stroke="black" stroke-width="0.8"/>
+  <line x1="14" y1="20" x2="12" y2="18" stroke="black" stroke-width="0.8"/>
+  
+  <!-- Left branch -->
+  <line x1="4" y1="10" x2="6" y2="12" stroke="black" stroke-width="0.8"/>
+  <line x1="4" y1="14" x2="6" y2="12" stroke="black" stroke-width="0.8"/>
+  
+  <!-- Diagonal branch (top-left) -->
+  <line x1="6" y1="6" x2="8" y2="8" stroke="black" stroke-width="0.8"/>
+  <line x1="8" y1="6" x2="8" y2="8" stroke="black" stroke-width="0.8"/>
+  
+  <!-- Diagonal branch (top-right) -->
+  <line x1="18" y1="6" x2="16" y2="8" stroke="black" stroke-width="0.8"/>
+  <line x1="16" y1="6" x2="16" y2="8" stroke="black" stroke-width="0.8"/>
+  
+  <!-- Diagonal branch (bottom-right) -->
+  <line x1="18" y1="18" x2="16" y2="16" stroke="black" stroke-width="0.8"/>
+  <line x1="16" y1="18" x2="16" y2="16" stroke="black" stroke-width="0.8"/>
+  
+  <!-- Diagonal branch (bottom-left) -->
+  <line x1="6" y1="18" x2="8" y2="16" stroke="black" stroke-width="0.8"/>
+  <line x1="8" y1="18" x2="8" y2="16" stroke="black" stroke-width="0.8"/>
+  
+  <!-- Center circle -->
+  <circle cx="12" cy="12" r="1.5" fill="black"/>
+</svg>

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -203,6 +203,9 @@ import FrameUp from "./custom-icons/frameup.svg?raw";
 import FrameDown from "./custom-icons/framedown.svg?raw";
 import InputConnection from "./custom-icons/input-connection.svg?raw";
 import OutputConnection from "./custom-icons/output-connection.svg?raw";
+import Odin from "./custom-icons/odin.svg?raw";
+import Niflheim from "./custom-icons/snowflake.svg?raw";
+import Mjolnir from "./custom-icons/mjolnir.svg?raw";
 
 // restricting the type here (Record<string, FunctionalComponent>) kills our IconName type below
 /* eslint sort-keys: "error" */
@@ -300,12 +303,15 @@ export const ICONS = Object.freeze({
   "minus-hex": MinusHex,
   "minus-hex-outline": MinusHexOutline,
   "minus-square": MinusSquare,
+  mjolnir: Mjolnir,
   moon: Moon,
   "mouse-and-touchpad": MaterialSymbolsLightTouchpadMouseRounded,
   "mouse-scroll": IconoirMouseScrollWheel,
   multiselect: Boxes,
   "nested-arrow-right": NestedArrowRight,
+  niflheim: Niflheim,
   none: EmptyIcon,
+  odin: Odin,
   option: MaterialSymbolsKeyboardOptionKey,
   "output-connection": OutputConnection,
   "output-socket": OutputSocket,


### PR DESCRIPTION
Scott made sure the the `.env.production` and `.env.staging` are loaded _during_ vite build, which means we can lean on them to know if the file is being built for prod, or its local dev. This allows us to namespace the sqlite DBs, so that, if we were to alter the tables during local dev, it wouldn't break prod execution in our browsers.

Also, opening up some tooling to interacting with SQLite which can make testing & discovery easier. [These are behind a flag for only the SI cohort](https://us.posthog.com/project/20369/feature_flags/126595).

![image](https://github.com/user-attachments/assets/9ea99d35-8426-4395-b2b4-d231a0105c7a)

![image](https://github.com/user-attachments/assets/cab3da5f-549f-4fef-808e-4b963e497b11)
