### PR TITLE
feat(innit): init

### DIFF
--- a/.ci/docker-compose.test-integration.yml
+++ b/.ci/docker-compose.test-integration.yml
@@ -11,6 +11,7 @@ services:
       - "SI_TEST_PG_PORT=5432"
       - "SI_TEST_NATS_URL=nats"
       - "SI_TEST_SPICEDB_URL=http://spicedb:50051"
+      - "SI_TEST_LOCALSTACK_URL=http://localstack:4566"
       - "OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317"
     ulimits:
       nofile:
@@ -22,6 +23,7 @@ services:
       - spicedb
       - jaeger
       - otelcol
+      - localstack
 
   # This is the same as the pgbouncer test setup in our dev environment
   postgres-test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-ssm"
+version = "1.71.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07c58e00d2059c0080d11c40ffabb7a4802f7ddf35e04d181f0f090eaf20cab"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.0",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-sso"
 version = "1.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -3998,6 +4021,54 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "innit"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "innit-server",
+ "si-service",
+]
+
+[[package]]
+name = "innit-core"
+version = "0.1.0"
+dependencies = [
+ "aws-sdk-ssm",
+ "chrono",
+ "serde",
+ "serde_json",
+ "ulid",
+]
+
+[[package]]
+name = "innit-server"
+version = "0.1.0"
+dependencies = [
+ "aws-config",
+ "aws-sdk-ssm",
+ "axum 0.6.20",
+ "derive_builder",
+ "futures",
+ "hyper 0.14.32",
+ "innit-core",
+ "remain",
+ "serde",
+ "serde_json",
+ "si-settings",
+ "si-std",
+ "telemetry",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower 0.4.13",
+ "tower-http",
+ "tracing-tunnel",
+ "ulid",
+ "url",
 ]
 
 [[package]]
@@ -7096,9 +7167,9 @@ dependencies = [
 
 [[package]]
 name = "sea-query"
-version = "0.32.3"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a24d8b9fcd2674a6c878a3d871f4f1380c6c43cc3718728ac96864d888458e"
+checksum = "d99447c24da0cded00089e2021e1624af90878c65f7534319448d01da3df869d"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1429,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2221,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -4047,8 +4047,6 @@ dependencies = [
 name = "innit-server"
 version = "0.1.0"
 dependencies = [
- "aws-config",
- "aws-sdk-ssm",
  "axum 0.6.20",
  "derive_builder",
  "futures",
@@ -4057,6 +4055,7 @@ dependencies = [
  "remain",
  "serde",
  "serde_json",
+ "si-data-ssm",
  "si-settings",
  "si-std",
  "telemetry",
@@ -7555,6 +7554,18 @@ dependencies = [
  "tokio",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "si-data-ssm"
+version = "0.1.0"
+dependencies = [
+ "aws-config",
+ "aws-sdk-ssm",
+ "remain",
+ "telemetry",
+ "thiserror 2.0.12",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "bin/edda",
     "bin/forklift",
     "bin/hoist",
+    "bin/innit",
     "bin/luminork",
     "bin/module-index",
     "bin/pinga",
@@ -34,6 +35,8 @@ members = [
     "lib/edda-server",
     "lib/forklift-server",
     "lib/frigg",
+    "lib/innit-core",
+    "lib/innit-server",
     "lib/joi-validator",
     "lib/luminork-server",
     "lib/module-index-client",
@@ -119,6 +122,10 @@ aws-config = { version = "=1.5.18", features = [
     "behavior-version-latest",
 ] } # pinned because very next version (1.6.0) starts pulling in `aws-lc-rs`/`aws-lc-sys` which include native C code
 aws-sdk-firehose = "=1.68.0" # pinned because very next version (1.69.0) starts pulling in `aws-lc-rs`/`aws-lc-sys` which include native C code
+aws-sdk-ssm = { version = "1.71.0", default-features = false, features = ["rt-tokio"] }
+# setting smithy like so to avoid pulling in aws-lc-rs for aws-sdk-ssm
+aws-smithy-http-client = { version = "1.0.0", features = ["rustls-ring"] }
+aws-smithy-runtime = { version = "1.8.1", features = ["client", "tls-rustls"] }
 axum = { version = "0.6.20", features = [
     "macros",
     "multipart",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ members = [
     "lib/si-data-nats",
     "lib/si-data-pg",
     "lib/si-data-spicedb",
+    "lib/si-data-ssm",
     "lib/si-events-rs",
     "lib/si-filesystem",
     "lib/si-firecracker",

--- a/bin/innit/BUCK
+++ b/bin/innit/BUCK
@@ -19,7 +19,7 @@ rust_binary(
 docker_image(
     name = "image",
     image_name = "innit",
-    flake_lock = "//:flake.lock",
+    build_deps = ["//bin/innit:innit"],
 )
 
 nix_omnibus_pkg(

--- a/bin/innit/BUCK
+++ b/bin/innit/BUCK
@@ -1,0 +1,29 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "docker_image",
+    "rust_binary",
+    "nix_omnibus_pkg",
+)
+
+rust_binary(
+    name = "innit",
+    deps = [
+        "//lib/innit-server:innit-server",
+        "//lib/si-service:si-service",
+        "//third-party/rust:clap",
+    ],
+    srcs = glob(["src/**/*.rs"]),
+    env = {"CARGO_BIN_NAME": "innit"},
+)
+
+docker_image(
+    name = "image",
+    image_name = "innit",
+    flake_lock = "//:flake.lock",
+)
+
+nix_omnibus_pkg(
+    name = "omnibus",
+    pkg_name = "innit",
+    build_dep = "//bin/innit:innit",
+)

--- a/bin/innit/Cargo.toml
+++ b/bin/innit/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "innit"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+clap = { workspace = true }
+innit-server = { path = "../../lib/innit-server" }
+si-service = { path = "../../lib/si-service" }

--- a/bin/innit/Dockerfile
+++ b/bin/innit/Dockerfile
@@ -33,7 +33,7 @@ WORKDIR /run/$BIN
 COPY --from=builder /tmp/nix-store-closure /nix/store
 COPY --from=builder /tmp/local-bin/* /usr/local/bin/
 
-EXPOSE 5157/tcp
+EXPOSE 5166/tcp
 
 ENTRYPOINT [ \
   "/sbin/runuser", "-u", "app", "--", "/usr/local/bin/innit", \

--- a/bin/innit/Dockerfile
+++ b/bin/innit/Dockerfile
@@ -1,0 +1,40 @@
+# hadolint ignore=DL3007
+FROM nixos/nix:2.21.2 AS builder
+ARG BIN=innit
+
+COPY . /workdir
+WORKDIR /workdir
+
+RUN set -eux; \
+    nix \
+        --extra-experimental-features "nix-command flakes impure-derivations ca-derivations" \
+        --option filter-syscalls false \
+        build \
+        ".#$BIN";
+
+RUN mkdir -p /tmp/nix-store-closure /tmp/local-bin
+# hadolint ignore=SC2046
+RUN cp -R $(nix-store --query --requisites result/) /tmp/nix-store-closure
+# hadolint ignore=SC2046
+RUN ln -snf $(nix-store --query result/)/bin/* /tmp/local-bin/
+
+FROM alpine:3 AS final
+ARG BIN=innit
+
+# hadolint ignore=DL3018
+RUN set -eux; \
+    apk add --no-cache runuser; \
+    adduser -D app; \
+    for dir in /run /etc /usr/local/etc /home/app/.config; do \
+        mkdir -pv "$dir/$BIN"; \
+    done;
+
+WORKDIR /run/$BIN
+COPY --from=builder /tmp/nix-store-closure /nix/store
+COPY --from=builder /tmp/local-bin/* /usr/local/bin/
+
+EXPOSE 5157/tcp
+
+ENTRYPOINT [ \
+  "/sbin/runuser", "-u", "app", "--", "/usr/local/bin/innit", \
+]

--- a/bin/innit/src/args.rs
+++ b/bin/innit/src/args.rs
@@ -1,0 +1,84 @@
+use clap::{ArgAction, Parser};
+use innit_server::StandardConfigFile;
+use innit_server::{Config, ConfigError, ConfigFile};
+
+use si_service::prelude::*;
+
+const NAME: &str = "innit";
+
+pub(crate) fn parse() -> Args {
+    Args::parse()
+}
+
+#[derive(Parser, Debug)]
+#[command(name = NAME, max_term_width = 100)]
+pub(crate) struct Args {
+    /// Sets the verbosity mode.
+    ///
+    /// Multiple -v options increase verbosity. The maximum is 6.
+    #[arg(short = 'v', long = "verbose", action = ArgAction::Count)]
+    pub(crate) verbose: u8,
+
+    /// Disables ANSI coloring in log output, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long = "no-color",
+        default_value = "false",
+        env = "SI_NO_COLOR",
+        hide_env_values = true,
+        conflicts_with = "force_color"
+    )]
+    pub(crate) no_color: bool,
+
+    /// Forces ANSI coloring, even if standard output refers to a terminal/TTY.
+    ///
+    /// For more details, visit: <http://no-color.org/>.
+    #[arg(
+        long = "force-color",
+        default_value = "false",
+        env = "SI_FORCE_COLOR",
+        hide_env_values = true,
+        conflicts_with = "no_color"
+    )]
+    pub(crate) force_color: bool,
+
+    /// Prints telemetry logging as JSON lines.
+    ///
+    /// For more details, visit: <https://jsonlines.org/>.
+    #[arg(
+        long = "log-json",
+        default_value = "false",
+        env = "SI_LOG_JSON",
+        hide_env_values = true
+    )]
+    pub(crate) log_json: bool,
+
+    /// The address and port to bind the HTTP server to [example: 0.0.0.0:80]
+    #[arg(long, env)]
+    pub(crate) socket_addr: Option<String>,
+}
+
+impl TryFrom<Args> for Config {
+    type Error = ConfigError;
+
+    fn try_from(args: Args) -> Result<Self, Self::Error> {
+        ConfigFile::layered_load(NAME, |config_map| {
+            if let Some(socket_addr) = args.socket_addr {
+                config_map.set("socket_addr", socket_addr);
+            }
+        })?
+        .try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_command() {
+        use clap::CommandFactory;
+        Args::command().debug_assert()
+    }
+}

--- a/bin/innit/src/main.rs
+++ b/bin/innit/src/main.rs
@@ -1,0 +1,97 @@
+use std::time::Duration;
+
+use color_eyre::Result;
+use innit_server::{Config, Server};
+use si_service::{
+    color_eyre,
+    prelude::*,
+    rt, startup,
+    telemetry_application::{self, TelemetryShutdownGuard},
+};
+
+mod args;
+
+const BIN_NAME: &str = env!("CARGO_BIN_NAME");
+const LIB_NAME: &str = concat!(env!("CARGO_BIN_NAME"), "_server");
+
+const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60 * 10);
+
+fn main() -> Result<()> {
+    rt::block_on(BIN_NAME, async_main())
+}
+
+async fn async_main() -> Result<()> {
+    let main_tracker = TaskTracker::new();
+    let main_token = CancellationToken::new();
+    let telemetry_tracker = TaskTracker::new();
+    let telemetry_token = CancellationToken::new();
+
+    color_eyre::install()?;
+    let args = args::parse();
+    let (mut telemetry, telemetry_shutdown) = {
+        let config = TelemetryConfig::builder()
+            .force_color(args.force_color.then_some(true))
+            .no_color(args.no_color.then_some(true))
+            .console_log_format(
+                args.log_json
+                    .then_some(ConsoleLogFormat::Json)
+                    .unwrap_or_default(),
+            )
+            .service_name(BIN_NAME)
+            .service_namespace("si")
+            .log_env_var_prefix("SI")
+            .app_modules(vec![BIN_NAME, LIB_NAME])
+            .interesting_modules(vec![])
+            .build()?;
+
+        telemetry_application::init(config, &telemetry_tracker, telemetry_token.clone())?
+    };
+
+    startup::startup(BIN_NAME).await?;
+
+    if args.verbose > 0 {
+        telemetry
+            .set_verbosity_and_wait(args.verbose.into())
+            .await?;
+    }
+    debug!(arguments =?args, "parsed cli arguments");
+
+    let config = Config::try_from(args)?;
+    debug!(?config, "computed configuration");
+    run_server(
+        config,
+        main_tracker,
+        main_token,
+        telemetry_tracker,
+        telemetry_token,
+        telemetry_shutdown,
+    )
+    .await
+}
+
+#[inline]
+#[allow(clippy::too_many_arguments)]
+async fn run_server(
+    config: Config,
+    main_tracker: TaskTracker,
+    main_token: CancellationToken,
+    telemetry_tracker: TaskTracker,
+    telemetry_token: CancellationToken,
+    telemetry_shutdown: TelemetryShutdownGuard,
+) -> Result<()> {
+    let server = Server::http(config, main_token.clone()).await?;
+
+    main_tracker.spawn(async move {
+        info!("ready to receive requests");
+        server.run().await
+    });
+
+    shutdown::graceful()
+        .group(main_tracker, main_token)
+        .group(telemetry_tracker, telemetry_token)
+        .telemetry_guard(telemetry_shutdown.into_future())
+        .timeout(GRACEFUL_SHUTDOWN_TIMEOUT)
+        .wait()
+        .await
+        .map_err(Into::into)
+}

--- a/flake.nix
+++ b/flake.nix
@@ -332,6 +332,8 @@
 
           forklift = binDerivation {pkgName = "forklift";};
 
+          innit = binDerivation {pkgName = "innit";};
+
           module-index = binDerivation {pkgName = "module-index";};
 
           pinga = binDerivation {pkgName = "pinga";};

--- a/lib/innit-core/BUCK
+++ b/lib/innit-core/BUCK
@@ -1,0 +1,15 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "innit-core",
+    deps = [
+        "//third-party/rust:aws-sdk-ssm",
+        "//third-party/rust:chrono",
+        "//third-party/rust:serde",
+        "//third-party/rust:serde_json",
+        "//third-party/rust:ulid"
+    ],
+    srcs = glob([
+        "src/**/*.rs",
+    ]),
+)

--- a/lib/innit-core/Cargo.toml
+++ b/lib/innit-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "innit-core"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+aws-sdk-ssm = { workspace = true }
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+ulid = { workspace = true }

--- a/lib/innit-core/src/lib.rs
+++ b/lib/innit-core/src/lib.rs
@@ -1,0 +1,24 @@
+use aws_sdk_ssm::types::Parameter as AwsParameter;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Parameter {
+    pub name: String,
+    pub value: Option<String>,
+    pub version: Option<i64>,
+}
+
+impl From<AwsParameter> for Parameter {
+    fn from(p: AwsParameter) -> Self {
+        Self {
+            name: p.name().unwrap_or_default().to_string(),
+            value: p.value().map(|s| s.to_string()),
+            version: Some(p.version()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ListParametersResponse {
+    pub parameters: Vec<Parameter>,
+}

--- a/lib/innit-core/src/lib.rs
+++ b/lib/innit-core/src/lib.rs
@@ -19,6 +19,11 @@ impl From<AwsParameter> for Parameter {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct GetParameterResponse {
+    pub parameter: Parameter,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct ListParametersResponse {
     pub parameters: Vec<Parameter>,
 }

--- a/lib/innit-server/BUCK
+++ b/lib/innit-server/BUCK
@@ -4,11 +4,10 @@ rust_library(
     name = "innit-server",
     deps = [
         "//lib/innit-core:innit-core",
+        "//lib/si-data-ssm:si-data-ssm",
         "//lib/si-settings:si-settings",
         "//lib/si-std:si-std",
         "//lib/telemetry-rs:telemetry",
-        "//third-party/rust:aws-config",
-        "//third-party/rust:aws-sdk-ssm",
         "//third-party/rust:axum",
         "//third-party/rust:derive_builder",
         "//third-party/rust:futures",

--- a/lib/innit-server/BUCK
+++ b/lib/innit-server/BUCK
@@ -1,0 +1,32 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "innit-server",
+    deps = [
+        "//lib/innit-core:innit-core",
+        "//lib/si-settings:si-settings",
+        "//lib/si-std:si-std",
+        "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:aws-config",
+        "//third-party/rust:aws-sdk-ssm",
+        "//third-party/rust:axum",
+        "//third-party/rust:derive_builder",
+        "//third-party/rust:futures",
+        "//third-party/rust:hyper",
+        "//third-party/rust:remain",
+        "//third-party/rust:serde",
+        "//third-party/rust:serde_json",
+        "//third-party/rust:thiserror",
+        "//third-party/rust:tokio",
+        "//third-party/rust:tokio-stream",
+        "//third-party/rust:tokio-util",
+        "//third-party/rust:tower",
+        "//third-party/rust:tower-http",
+        "//third-party/rust:tracing-tunnel",
+        "//third-party/rust:ulid",
+        "//third-party/rust:url",
+    ],
+    srcs = glob([
+        "src/**/*.rs",
+    ]),
+)

--- a/lib/innit-server/Cargo.toml
+++ b/lib/innit-server/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "innit-server"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+innit-core = { path = "../../lib/innit-core" }
+si-settings = { path = "../../lib/si-settings" }
+si-std = { path = "../../lib/si-std" }
+telemetry = { path = "../../lib/telemetry-rs" }
+
+aws-config = { workspace = true }
+aws-sdk-ssm = { workspace = true }
+axum = { workspace = true }
+derive_builder = { workspace = true }
+futures = { workspace = true }
+hyper = { workspace = true }
+remain = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
+tracing-tunnel = { workspace = true }
+ulid = { workspace = true }
+url = { workspace = true }

--- a/lib/innit-server/Cargo.toml
+++ b/lib/innit-server/Cargo.toml
@@ -10,12 +10,11 @@ publish.workspace = true
 
 [dependencies]
 innit-core = { path = "../../lib/innit-core" }
+si-data-ssm = { path = "../../lib/si-data-ssm" }
 si-settings = { path = "../../lib/si-settings" }
 si-std = { path = "../../lib/si-std" }
 telemetry = { path = "../../lib/telemetry-rs" }
 
-aws-config = { workspace = true }
-aws-sdk-ssm = { workspace = true }
 axum = { workspace = true }
 derive_builder = { workspace = true }
 futures = { workspace = true }

--- a/lib/innit-server/src/api_error.rs
+++ b/lib/innit-server/src/api_error.rs
@@ -1,0 +1,82 @@
+use std::fmt::Display;
+
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::{Serialize, Serializer};
+use telemetry::prelude::*;
+use tracing_tunnel::TracingLevel;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ApiErrorError {
+    message: String,
+    #[serde(serialize_with = "status_code_to_u16")]
+    status_code: StatusCode,
+}
+
+fn status_code_to_u16<S>(status_code: &StatusCode, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_u16(status_code.as_u16())
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiError {
+    error: ApiErrorError,
+    level: Option<TracingLevel>,
+}
+
+impl ApiError {
+    pub fn new<E: Display>(status_code: StatusCode, err: E) -> Self {
+        Self {
+            error: ApiErrorError {
+                message: err.to_string(),
+                status_code,
+            },
+            level: None,
+        }
+    }
+
+    // keeping this here to allow for future use
+    #[allow(dead_code)]
+    fn with_level(mut self, level: TracingLevel) -> Self {
+        self.level = Some(level);
+        self
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        match self.level {
+            Some(TracingLevel::Info) => {
+                info!(err=?self, ?self.error.status_code, ?self.error.status_code, self.error.message )
+            }
+            Some(TracingLevel::Debug) => {
+                debug!(err=?self, ?self.error.status_code, ?self.error.status_code, self.error.message )
+            }
+            Some(TracingLevel::Error) => {
+                error!(err=?self, ?self.error.status_code, ?self.error.status_code, self.error.message )
+            }
+            Some(TracingLevel::Trace) => {
+                trace!(err=?self, ?self.error.status_code, ?self.error.status_code, self.error.message )
+            }
+            Some(TracingLevel::Warn) => {
+                warn!(err=?self, ?self.error.status_code, ?self.error.status_code, self.error.message )
+            }
+            None => {
+                if self.error.status_code.is_client_error() {
+                    warn!(err=?self, ?self.error.status_code, ?self.error.status_code, self.error.message );
+                } else if self.error.status_code.is_server_error() {
+                    error!(err=?self, ?self.error.status_code, ?self.error.status_code, self.error.message );
+                }
+            }
+        }
+
+        (self.error.status_code, Json(self)).into_response()
+    }
+}

--- a/lib/innit-server/src/app_state.rs
+++ b/lib/innit-server/src/app_state.rs
@@ -1,0 +1,23 @@
+use aws_sdk_ssm::Client;
+use axum::extract::FromRef;
+use tokio_util::sync::CancellationToken;
+
+#[remain::sorted]
+#[derive(Debug, Eq, PartialEq)]
+pub enum ShutdownSource {}
+
+#[derive(Clone, Debug, FromRef)]
+pub struct AppState {
+    pub ssm_client: Client,
+    shutdown_token: CancellationToken,
+}
+
+impl AppState {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(ssm_client: Client, shutdown_token: CancellationToken) -> Self {
+        Self {
+            ssm_client,
+            shutdown_token,
+        }
+    }
+}

--- a/lib/innit-server/src/app_state.rs
+++ b/lib/innit-server/src/app_state.rs
@@ -1,5 +1,5 @@
-use aws_sdk_ssm::Client;
 use axum::extract::FromRef;
+use si_data_ssm::ParameterStoreClient;
 use tokio_util::sync::CancellationToken;
 
 #[remain::sorted]
@@ -8,15 +8,18 @@ pub enum ShutdownSource {}
 
 #[derive(Clone, Debug, FromRef)]
 pub struct AppState {
-    pub ssm_client: Client,
+    pub parameter_store_client: ParameterStoreClient,
     shutdown_token: CancellationToken,
 }
 
 impl AppState {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(ssm_client: Client, shutdown_token: CancellationToken) -> Self {
+    pub fn new(
+        parameter_store_client: ParameterStoreClient,
+        shutdown_token: CancellationToken,
+    ) -> Self {
         Self {
-            ssm_client,
+            parameter_store_client,
             shutdown_token,
         }
     }

--- a/lib/innit-server/src/config.rs
+++ b/lib/innit-server/src/config.rs
@@ -1,0 +1,153 @@
+use std::{env, net::SocketAddr, time::Duration};
+
+// use buck2_resources::Buck2Resources;
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+use si_std::CanonicalFileError;
+use telemetry::prelude::*;
+use thiserror::Error;
+use ulid::Ulid;
+
+pub use si_settings::{StandardConfig, StandardConfigFile};
+
+const DEFAULT_CONCURRENCY_LIMIT: Option<usize> = None;
+
+const DEFAULT_QUIESCENT_PERIOD_SECS: u64 = 60 * 2;
+const DEFAULT_QUIESCENT_PERIOD: Duration = Duration::from_secs(DEFAULT_QUIESCENT_PERIOD_SECS);
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("config builder")]
+    Builder(#[from] ConfigBuilderError),
+    #[error("canonical file error: {0}")]
+    CanonicalFile(#[from] CanonicalFileError),
+    #[error("error configuring for development")]
+    Development(#[source] Box<dyn std::error::Error + 'static + Sync + Send>),
+    #[error("si settings error: {0}")]
+    SiSettings(#[from] si_settings::SettingsError),
+}
+
+type Result<T> = std::result::Result<T, ConfigError>;
+
+/// The config for the forklift server.
+#[derive(Debug, Builder)]
+pub struct Config {
+    #[builder(default = "random_instance_id()")]
+    instance_id: String,
+
+    #[builder(default = "default_concurrency_limit()")]
+    concurrency_limit: Option<usize>,
+
+    #[builder(default = "default_quiescent_period()")]
+    quiescent_period: Duration,
+
+    #[builder(default = "get_default_socket_addr()")]
+    socket_addr: SocketAddr,
+}
+
+impl StandardConfig for Config {
+    type Builder = ConfigBuilder;
+}
+
+impl Config {
+    /// Gets the config's concurrency limit.
+    pub fn concurrency_limit(&self) -> Option<usize> {
+        self.concurrency_limit
+    }
+
+    /// Gets the config's instance ID.
+    pub fn instance_id(&self) -> &str {
+        self.instance_id.as_ref()
+    }
+
+    /// Gets the period of inactivity before a change set consuming stream will shut down
+    pub fn quiescent_period(&self) -> Duration {
+        self.quiescent_period
+    }
+
+    /// Gets the socket address
+    pub fn socket_addr(&self) -> &SocketAddr {
+        &self.socket_addr
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ConfigFile {
+    #[serde(default = "random_instance_id")]
+    instance_id: String,
+    #[serde(default = "default_concurrency_limit")]
+    concurrency_limit: Option<usize>,
+    #[serde(default = "default_quiescent_period_secs")]
+    quiescent_period_secs: u64,
+    #[serde(default = "get_default_socket_addr")]
+    socket_addr: SocketAddr,
+}
+
+impl Default for ConfigFile {
+    fn default() -> Self {
+        Self {
+            instance_id: random_instance_id(),
+            concurrency_limit: default_concurrency_limit(),
+            quiescent_period_secs: default_quiescent_period_secs(),
+            socket_addr: get_default_socket_addr(),
+        }
+    }
+}
+
+impl StandardConfigFile for ConfigFile {
+    type Error = ConfigError;
+}
+
+impl TryFrom<ConfigFile> for Config {
+    type Error = ConfigError;
+
+    fn try_from(mut value: ConfigFile) -> Result<Self> {
+        detect_and_configure_development(&mut value)?;
+
+        let mut config = Config::builder();
+        config.concurrency_limit(value.concurrency_limit);
+        config.instance_id(value.instance_id);
+        config.quiescent_period(Duration::from_secs(value.quiescent_period_secs));
+        config.build().map_err(Into::into)
+    }
+}
+
+fn random_instance_id() -> String {
+    Ulid::new().to_string()
+}
+
+fn default_concurrency_limit() -> Option<usize> {
+    DEFAULT_CONCURRENCY_LIMIT
+}
+
+fn default_quiescent_period() -> Duration {
+    DEFAULT_QUIESCENT_PERIOD
+}
+
+fn default_quiescent_period_secs() -> u64 {
+    DEFAULT_QUIESCENT_PERIOD_SECS
+}
+
+fn get_default_socket_addr() -> SocketAddr {
+    SocketAddr::from(([0, 0, 0, 0], 5166))
+}
+
+#[allow(clippy::disallowed_methods)] // Used to determine if running in development
+pub fn detect_and_configure_development(config: &mut ConfigFile) -> Result<()> {
+    if env::var("BUCK_RUN_BUILD_ID").is_ok() || env::var("BUCK_BUILD_ID").is_ok() {
+        buck2_development(config)
+    } else if let Ok(dir) = env::var("CARGO_MANIFEST_DIR") {
+        cargo_development(dir, config)
+    } else {
+        Ok(())
+    }
+}
+
+fn buck2_development(_config: &mut ConfigFile) -> Result<()> {
+    Ok(())
+}
+
+fn cargo_development(_dir: String, _config: &mut ConfigFile) -> Result<()> {
+    Ok(())
+}

--- a/lib/innit-server/src/lib.rs
+++ b/lib/innit-server/src/lib.rs
@@ -1,0 +1,18 @@
+use thiserror::Error;
+
+mod api_error;
+mod app_state;
+mod config;
+mod routes;
+mod server;
+
+pub use self::{
+    config::{
+        detect_and_configure_development, Config, ConfigError, ConfigFile, StandardConfigFile,
+    },
+    server::Server,
+};
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ServerError {}

--- a/lib/innit-server/src/routes.rs
+++ b/lib/innit-server/src/routes.rs
@@ -6,10 +6,12 @@ use axum::{
 };
 use hyper::StatusCode;
 use serde_json::{json, Value};
+use si_data_ssm::ParameterStoreClientError;
 use thiserror::Error;
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 
+mod get_parameter;
 mod list_parameters;
 
 use crate::api_error::ApiError;
@@ -21,6 +23,7 @@ pub fn routes(state: AppState) -> Router {
     let mut router: Router<AppState> = Router::new();
     router = router
         .route("/", get(system_status_route))
+        .route("/parameter/*path", get(get_parameter::get_parameter_route))
         .route(
             "/parameters/*path",
             get(list_parameters::list_parameters_route),
@@ -39,6 +42,8 @@ async fn system_status_route() -> Json<Value> {
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum AppError {
+    #[error(transparent)]
+    ParameterStoreClient(#[from] ParameterStoreClientError),
     #[error(transparent)]
     Server(#[from] ServerError),
 }

--- a/lib/innit-server/src/routes.rs
+++ b/lib/innit-server/src/routes.rs
@@ -1,0 +1,52 @@
+use axum::{
+    response::Json,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use hyper::StatusCode;
+use serde_json::{json, Value};
+use thiserror::Error;
+use tower_http::compression::CompressionLayer;
+use tower_http::cors::CorsLayer;
+
+mod list_parameters;
+
+use crate::api_error::ApiError;
+
+use super::{app_state::AppState, server::ServerError};
+
+#[allow(clippy::too_many_arguments)]
+pub fn routes(state: AppState) -> Router {
+    let mut router: Router<AppState> = Router::new();
+    router = router
+        .route("/", get(system_status_route))
+        .route(
+            "/parameters/*path",
+            get(list_parameters::list_parameters_route),
+        )
+        .layer(CorsLayer::permissive())
+        .layer(CompressionLayer::new());
+
+    router.with_state(state)
+}
+
+async fn system_status_route() -> Json<Value> {
+    Json(json!({ "ok": true }))
+}
+
+#[allow(clippy::large_enum_variant)]
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error(transparent)]
+    Server(#[from] ServerError),
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let (status_code, error_message) = (StatusCode::INTERNAL_SERVER_ERROR, self.to_string());
+
+        ApiError::new(status_code, error_message).into_response()
+    }
+}

--- a/lib/innit-server/src/routes/get_parameter.rs
+++ b/lib/innit-server/src/routes/get_parameter.rs
@@ -1,0 +1,19 @@
+use crate::routes::Json;
+use axum::extract::{Path, State};
+use innit_core::GetParameterResponse;
+
+use crate::app_state::AppState;
+
+use super::AppError;
+
+pub async fn get_parameter_route(
+    Path(name): Path<String>,
+    State(AppState {
+        parameter_store_client,
+        ..
+    }): State<AppState>,
+) -> Result<Json<GetParameterResponse>, AppError> {
+    let parameter = parameter_store_client.get_parameter(name).await?.into();
+
+    Ok(Json(GetParameterResponse { parameter }))
+}

--- a/lib/innit-server/src/routes/list_parameters.rs
+++ b/lib/innit-server/src/routes/list_parameters.rs
@@ -1,49 +1,21 @@
 use crate::routes::Json;
-use aws_sdk_ssm::error::SdkError;
-use aws_sdk_ssm::operation::get_parameters_by_path::GetParametersByPathError;
-use axum::{
-    extract::{Path, State},
-    response::{IntoResponse, Response},
-};
-use hyper::StatusCode;
+use axum::extract::{Path, State};
 use innit_core::ListParametersResponse;
-use thiserror::Error;
 
-use crate::{api_error::ApiError, app_state::AppState};
+use crate::app_state::AppState;
 
-#[remain::sorted]
-#[derive(Error, Debug)]
-pub enum ListParamsError {
-    #[error("AWS SSM error: {0}")]
-    Aws(#[from] SdkError<GetParametersByPathError>),
-    #[error("Parameter path not found: {0}")]
-    PathNotFound(String),
-}
-
-impl IntoResponse for ListParamsError {
-    fn into_response(self) -> Response {
-        let (status_code, error_message) = (StatusCode::INTERNAL_SERVER_ERROR, self.to_string());
-
-        ApiError::new(status_code, error_message).into_response()
-    }
-}
+use super::AppError;
 
 pub async fn list_parameters_route(
     Path(path): Path<String>,
-    State(AppState { ssm_client, .. }): State<AppState>,
-) -> Result<Json<ListParametersResponse>, ListParamsError> {
-    let result = ssm_client
-        .get_parameters_by_path()
-        .path(format!("/{path}"))
-        .recursive(true)
-        .send()
-        .await?;
-
-    let parameters = result.parameters();
-    if parameters.is_empty() {
-        return Err(ListParamsError::PathNotFound(path));
-    }
-    let parameters = parameters
+    State(AppState {
+        parameter_store_client,
+        ..
+    }): State<AppState>,
+) -> Result<Json<ListParametersResponse>, AppError> {
+    let parameters = parameter_store_client
+        .parameters_by_path(path)
+        .await?
         .iter()
         .cloned()
         .map(innit_core::Parameter::from)

--- a/lib/innit-server/src/routes/list_parameters.rs
+++ b/lib/innit-server/src/routes/list_parameters.rs
@@ -1,0 +1,53 @@
+use crate::routes::Json;
+use aws_sdk_ssm::error::SdkError;
+use aws_sdk_ssm::operation::get_parameters_by_path::GetParametersByPathError;
+use axum::{
+    extract::{Path, State},
+    response::{IntoResponse, Response},
+};
+use hyper::StatusCode;
+use innit_core::ListParametersResponse;
+use thiserror::Error;
+
+use crate::{api_error::ApiError, app_state::AppState};
+
+#[remain::sorted]
+#[derive(Error, Debug)]
+pub enum ListParamsError {
+    #[error("AWS SSM error: {0}")]
+    Aws(#[from] SdkError<GetParametersByPathError>),
+    #[error("Parameter path not found: {0}")]
+    PathNotFound(String),
+}
+
+impl IntoResponse for ListParamsError {
+    fn into_response(self) -> Response {
+        let (status_code, error_message) = (StatusCode::INTERNAL_SERVER_ERROR, self.to_string());
+
+        ApiError::new(status_code, error_message).into_response()
+    }
+}
+
+pub async fn list_parameters_route(
+    Path(path): Path<String>,
+    State(AppState { ssm_client, .. }): State<AppState>,
+) -> Result<Json<ListParametersResponse>, ListParamsError> {
+    let result = ssm_client
+        .get_parameters_by_path()
+        .path(format!("/{path}"))
+        .recursive(true)
+        .send()
+        .await?;
+
+    let parameters = result.parameters();
+    if parameters.is_empty() {
+        return Err(ListParamsError::PathNotFound(path));
+    }
+    let parameters = parameters
+        .iter()
+        .cloned()
+        .map(innit_core::Parameter::from)
+        .collect();
+
+    Ok(Json(ListParametersResponse { parameters }))
+}

--- a/lib/innit-server/src/server.rs
+++ b/lib/innit-server/src/server.rs
@@ -1,0 +1,97 @@
+use aws_sdk_ssm::Client;
+use axum::response::{IntoResponse, Response};
+use std::io;
+use tokio_util::sync::CancellationToken;
+
+use super::routes;
+
+use axum::Router;
+use axum::{error_handling::HandleErrorLayer, routing::IntoMakeService};
+use hyper::{
+    server::{accept::Accept, conn::AddrIncoming},
+    StatusCode,
+};
+use telemetry::prelude::*;
+use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tower::{buffer::BufferLayer, BoxError, ServiceBuilder};
+use tower_http::trace::{DefaultMakeSpan, TraceLayer};
+
+use crate::{app_state::AppState, Config};
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ServerError {
+    #[error("hyper server error")]
+    Hyper(#[from] hyper::Error),
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("failed to setup signal handler")]
+    Signal(#[source] io::Error),
+}
+
+type ServerResult<T> = std::result::Result<T, ServerError>;
+
+pub struct Server<I> {
+    inner: axum::Server<I, IntoMakeService<Router>>,
+    token: CancellationToken,
+}
+
+impl Server<()> {
+    #[allow(clippy::too_many_arguments)]
+    pub async fn http(
+        config: Config,
+        token: CancellationToken,
+    ) -> ServerResult<Server<AddrIncoming>> {
+        let aws_config = aws_config::load_from_env().await;
+        let ssm_client = Client::new(&aws_config);
+
+        let service = build_service(ssm_client, token.clone())?;
+
+        info!(
+            "binding to HTTP socket; socket_addr={}",
+            config.socket_addr()
+        );
+        let inner = axum::Server::bind(config.socket_addr()).serve(service.into_make_service());
+
+        Ok(Server { inner, token })
+    }
+}
+
+impl<I, IO, IE> Server<I>
+where
+    I: Accept<Conn = IO, Error = IE>,
+    IO: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    IE: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    pub async fn run(self) -> ServerResult<()> {
+        self.inner
+            .with_graceful_shutdown(async { self.token.cancelled().await })
+            .await
+            .map_err(Into::into)
+    }
+}
+
+pub fn build_service(client: Client, token: CancellationToken) -> ServerResult<Router> {
+    let state = AppState::new(client, token);
+
+    let routes = routes::routes(state)
+        .layer(
+            ServiceBuilder::new()
+                .layer(HandleErrorLayer::new(|err: BoxError| async move {
+                    tracing::error!(error = %err, "Unexpected error in request processing");
+                    Response::builder()
+                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                        .body(format!("Internal server error: {}", err))
+                        .expect("Unable to build error response body")
+                        .into_response()
+                }))
+                .layer(BufferLayer::new(128)),
+        )
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(DefaultMakeSpan::default().include_headers(true)),
+        );
+
+    Ok(routes)
+}

--- a/lib/si-data-ssm/BUCK
+++ b/lib/si-data-ssm/BUCK
@@ -1,0 +1,32 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "si-data-ssm",
+    deps = [
+        "//lib/telemetry-rs:telemetry",
+        "//third-party/rust:aws-config",
+        "//third-party/rust:aws-sdk-ssm",
+        "//third-party/rust:remain",
+        "//third-party/rust:thiserror",
+    ],
+    srcs = glob([
+        "src/**/*.rs",
+    ]),
+)
+
+rust_test(
+    name = "test-integration",
+    deps = [
+        "//third-party/rust:tokio",
+        ":si-data-ssm",
+    ],
+    srcs = glob([
+        "tests/**/*.rs",
+    ]),
+    crate_root = "tests/integration.rs",
+    env = {
+        "CARGO_PKG_NAME": "integration",
+        "RUSTC_BOOTSTRAP": "1",
+        "CI": "buildkite",
+    },
+)

--- a/lib/si-data-ssm/Cargo.toml
+++ b/lib/si-data-ssm/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "si-data-ssm"
+edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+telemetry = { path = "../../lib/telemetry-rs" }
+
+aws-config = { workspace = true }
+aws-sdk-ssm = { workspace = true }
+remain = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }

--- a/lib/si-data-ssm/src/lib.rs
+++ b/lib/si-data-ssm/src/lib.rs
@@ -1,0 +1,171 @@
+//! This crate provides a client for interacting with AWS SSM, Parameter Store in particular
+
+#![warn(
+    bad_style,
+    clippy::missing_panics_doc,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result,
+    clippy::unwrap_used,
+    dead_code,
+    improper_ctypes,
+    missing_debug_implementations,
+    missing_docs,
+    no_mangle_generic_items,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    unconditional_recursion,
+    unreachable_pub,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
+
+use aws_config::Region;
+use aws_sdk_ssm::config::Credentials;
+use aws_sdk_ssm::error::SdkError;
+use aws_sdk_ssm::types::{Parameter, ParameterType};
+use std::fmt::Debug;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+#[allow(missing_docs)]
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ParameterStoreClientError {
+    #[error("AWS Parameter Store error: {0}")]
+    AwsParameterStore(String),
+    #[error("Parameter path invalid, must start with /: {0}")]
+    InvalidPath(String),
+    #[error("Parameter not found: {0}")]
+    ParameterNotFound(String),
+    #[error("Parameter path not found: {0}")]
+    PathNotFound(String),
+}
+
+impl ParameterStoreClientError {
+    fn from_sdk_error<T: Debug>(error: SdkError<T>) -> Self {
+        ParameterStoreClientError::AwsParameterStore(format!("{:?}", error))
+    }
+}
+
+type ParameterStoreClientResult<T> = Result<T, ParameterStoreClientError>;
+
+/// A client for communicating with ssm.
+#[derive(Debug, Clone)]
+pub struct ParameterStoreClient {
+    inner: Box<aws_sdk_ssm::Client>,
+}
+
+impl ParameterStoreClient {
+    /// Creates a new [client for interacting with SSM Parameter Store](ParameterStoreClient).
+    #[instrument(name = "parameter_store_client.new", level = "info")]
+    pub async fn new() -> Self {
+        let config = aws_config::load_from_env().await;
+        let client = aws_sdk_ssm::Client::new(&config);
+        Self {
+            inner: Box::new(client),
+        }
+    }
+
+    /// Creates a [ParameterStoreClient] configured for testing (e.g., LocalStack).
+    pub fn new_for_test(
+        endpoint: String,
+        region: String,
+        access_key: String,
+        secret_key: String,
+    ) -> Self {
+        let shared_config = aws_sdk_ssm::config::Builder::new()
+            .region(Region::new(region))
+            .endpoint_url(endpoint)
+            .credentials_provider(Credentials::new(
+                access_key, secret_key, None, None, "tests",
+            ))
+            .behavior_version_latest()
+            .build();
+
+        let client = aws_sdk_ssm::Client::from_conf(shared_config);
+
+        Self {
+            inner: Box::new(client),
+        }
+    }
+
+    /// Create a String type parameter
+    pub async fn create_string_parameter(
+        &self,
+        name: String,
+        value: String,
+    ) -> ParameterStoreClientResult<()> {
+        self.create_parameter(name, value, ParameterType::String)
+            .await
+    }
+
+    #[instrument(name = "parameter_store_client.create_parameter", level = "debug")]
+    async fn create_parameter(
+        &self,
+        name: String,
+        value: String,
+        parameter_type: ParameterType,
+    ) -> ParameterStoreClientResult<()> {
+        self.inner
+            .put_parameter()
+            .name(name.clone())
+            .value(value)
+            .r#type(parameter_type)
+            .overwrite(true)
+            .send()
+            .await
+            .map_err(ParameterStoreClientError::from_sdk_error)?;
+
+        Ok(())
+    }
+
+    /// Gets a specific parameter by name
+    #[instrument(name = "parameter_store_client.parameter", level = "debug")]
+    pub async fn get_parameter(&self, name: String) -> ParameterStoreClientResult<Parameter> {
+        let result = self
+            .inner
+            .get_parameter()
+            .name(name.clone())
+            .send()
+            .await
+            .map_err(ParameterStoreClientError::from_sdk_error)?;
+
+        result
+            .parameter()
+            .cloned()
+            .ok_or(ParameterStoreClientError::ParameterNotFound(name))
+    }
+
+    /// Gets all parameters under a path, e.g. /si/global/pg
+    #[instrument(name = "parameter_store_client.parameters", level = "debug")]
+    pub async fn parameters_by_path(
+        &self,
+        path: String,
+    ) -> ParameterStoreClientResult<Vec<Parameter>> {
+        if !path.starts_with("/") {
+            return Err(ParameterStoreClientError::InvalidPath(path));
+        }
+
+        let result = self
+            .inner
+            .get_parameters_by_path()
+            .path(path.clone())
+            .recursive(true)
+            .send()
+            .await
+            .map_err(ParameterStoreClientError::from_sdk_error)?;
+
+        let parameters = result.parameters();
+        if parameters.is_empty() {
+            return Err(ParameterStoreClientError::PathNotFound(path));
+        }
+
+        Ok(parameters.to_vec())
+    }
+}

--- a/lib/si-data-ssm/tests/integration.rs
+++ b/lib/si-data-ssm/tests/integration.rs
@@ -1,0 +1,1 @@
+mod integration_test;

--- a/lib/si-data-ssm/tests/integration_test/mod.rs
+++ b/lib/si-data-ssm/tests/integration_test/mod.rs
@@ -1,0 +1,86 @@
+#[cfg(test)]
+mod integration_tests {
+    use std::env;
+
+    use si_data_ssm::ParameterStoreClient;
+
+    const ENV_VAR_LOCALSTACK_URL: &str = "SI_TEST_LOCALSTACK_URL";
+    #[tokio::test]
+    async fn test_create_get_and_get_by_path() {
+        let mut endpoint = "http://localhost:4566".to_string();
+        #[allow(clippy::disallowed_methods)] // Used only in tests & so prefixed with `SI_TEST_`
+        if let Ok(value) = env::var(ENV_VAR_LOCALSTACK_URL) {
+            endpoint = value;
+        }
+        dbg!("connecting to {}", &endpoint);
+        let client = ParameterStoreClient::new_for_test(
+            endpoint,
+            "us-east-1".to_string(),
+            "test".to_string(),
+            "test".to_string(),
+        );
+
+        let parameter_name = "/test/integration/parameter";
+        let parameter_value = "test_value";
+        let parameter_path = "/test/integration";
+
+        let create_result = client
+            .create_string_parameter(parameter_name.to_string(), parameter_value.to_string())
+            .await;
+
+        assert!(
+            create_result.is_ok(),
+            "Failed to create parameter: {:?}",
+            create_result.err()
+        );
+
+        let get_result = client.get_parameter(parameter_name.to_string()).await;
+        assert!(
+            get_result.is_ok(),
+            "Failed to get parameter: {:?}",
+            get_result.err()
+        );
+
+        let parameter = get_result.expect("should get parameter");
+        assert_eq!(
+            parameter.name().expect("parameter should have a name"),
+            parameter_name,
+            "Unexpected parameter name"
+        );
+        assert_eq!(
+            parameter.value().expect("parameter should have a value"),
+            parameter_value,
+            "Unexpected parameter value"
+        );
+
+        let get_by_path_result = client.parameters_by_path(parameter_path.to_string()).await;
+        assert!(
+            get_by_path_result.is_ok(),
+            "Failed to get parameters by path: {:?}",
+            get_by_path_result.err()
+        );
+
+        let parameters = get_by_path_result.expect("should get parameters by path");
+        assert_eq!(
+            parameters.len(),
+            1,
+            "Unexpected number of parameters under the path"
+        );
+
+        let path_parameter = &parameters[0];
+        assert_eq!(
+            path_parameter
+                .name()
+                .expect("path paramter should have a name"),
+            parameter_name,
+            "Unexpected parameter name in path"
+        );
+        assert_eq!(
+            path_parameter
+                .value()
+                .expect("path parameter should have a value"),
+            parameter_value,
+            "Unexpected parameter value in path"
+        );
+    }
+}

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -1193,6 +1193,58 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "aws-sdk-ssm",
+    actual = ":aws-sdk-ssm-1.71.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "aws-sdk-ssm-1.71.0.crate",
+    sha256 = "d07c58e00d2059c0080d11c40ffabb7a4802f7ddf35e04d181f0f090eaf20cab",
+    strip_prefix = "aws-sdk-ssm-1.71.0",
+    urls = ["https://static.crates.io/crates/aws-sdk-ssm/1.71.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "aws-sdk-ssm-1.71.0",
+    srcs = [":aws-sdk-ssm-1.71.0.crate"],
+    crate = "aws_sdk_ssm",
+    crate_root = "aws-sdk-ssm-1.71.0.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "CARGO_MANIFEST_DIR": "aws-sdk-ssm-1.71.0.crate",
+        "CARGO_PKG_AUTHORS": "AWS Rust SDK Team <aws-sdk-rust@amazon.com>:Russell Cohen <rcoh@amazon.com>",
+        "CARGO_PKG_DESCRIPTION": "AWS SDK for Amazon Simple Systems Manager (SSM)",
+        "CARGO_PKG_NAME": "aws-sdk-ssm",
+        "CARGO_PKG_REPOSITORY": "https://github.com/awslabs/aws-sdk-rust",
+        "CARGO_PKG_VERSION": "1.71.0",
+        "CARGO_PKG_VERSION_MAJOR": "1",
+        "CARGO_PKG_VERSION_MINOR": "71",
+        "CARGO_PKG_VERSION_PATCH": "0",
+    },
+    features = ["rt-tokio"],
+    visibility = [],
+    deps = [
+        ":aws-credential-types-1.2.2",
+        ":aws-runtime-1.5.6",
+        ":aws-smithy-async-1.2.5",
+        ":aws-smithy-http-0.62.0",
+        ":aws-smithy-json-0.61.3",
+        ":aws-smithy-runtime-1.8.1",
+        ":aws-smithy-runtime-api-1.7.4",
+        ":aws-smithy-types-1.3.0",
+        ":aws-types-1.3.6",
+        ":bytes-1.10.1",
+        ":fastrand-2.3.0",
+        ":http-0.2.12",
+        ":once_cell-1.21.3",
+        ":regex-lite-0.1.6",
+        ":tracing-0.1.41",
+    ],
+)
+
 http_archive(
     name = "aws-sdk-sso-1.64.0.crate",
     sha256 = "02d4bdb0e5f80f0689e61c77ab678b2b9304af329616af38aef5b6b967b8e736",
@@ -1461,6 +1513,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "aws-smithy-http-client",
+    actual = ":aws-smithy-http-client-1.0.1",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "aws-smithy-http-client-1.0.1.crate",
     sha256 = "8aff1159006441d02e57204bf57a1b890ba68bedb6904ffd2873c1c4c11c546b",
@@ -1476,11 +1534,14 @@ cargo.rust_library(
     crate_root = "aws-smithy-http-client-1.0.1.crate/src/lib.rs",
     edition = "2021",
     features = [
+        "default-client",
         "hyper-014",
         "legacy-rustls-ring",
+        "rustls-ring",
     ],
     named_deps = {
         "http_02x": ":http-0.2.12",
+        "http_1x": ":http-1.3.1",
         "http_body_04x": ":http-body-0.4.6",
         "hyper_0_14": ":hyper-0.14.32",
         "legacy_hyper_rustls": ":hyper-rustls-0.24.2",
@@ -1492,8 +1553,15 @@ cargo.rust_library(
         ":aws-smithy-runtime-api-1.7.4",
         ":aws-smithy-types-1.3.0",
         ":h2-0.4.9",
+        ":hyper-1.6.0",
+        ":hyper-rustls-0.27.5",
+        ":hyper-util-0.1.11",
         ":pin-project-lite-0.2.16",
+        ":rustls-0.23.26",
+        ":rustls-native-certs-0.8.1",
+        ":rustls-pki-types-1.11.0",
         ":tokio-1.44.2",
+        ":tower-0.5.2",
         ":tracing-0.1.41",
     ],
 )
@@ -1556,6 +1624,12 @@ cargo.rust_library(
         ":aws-smithy-types-1.3.0",
         ":urlencoding-2.1.3",
     ],
+)
+
+alias(
+    name = "aws-smithy-runtime",
+    actual = ":aws-smithy-runtime-1.8.1",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -2767,23 +2841,23 @@ cargo.rust_library(
     deps = [
         ":alloc-no-stdlib-2.0.4",
         ":alloc-stdlib-0.2.2",
-        ":brotli-decompressor-4.0.2",
+        ":brotli-decompressor-4.0.3",
     ],
 )
 
 http_archive(
-    name = "brotli-decompressor-4.0.2.crate",
-    sha256 = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37",
-    strip_prefix = "brotli-decompressor-4.0.2",
-    urls = ["https://static.crates.io/crates/brotli-decompressor/4.0.2/download"],
+    name = "brotli-decompressor-4.0.3.crate",
+    sha256 = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd",
+    strip_prefix = "brotli-decompressor-4.0.3",
+    urls = ["https://static.crates.io/crates/brotli-decompressor/4.0.3/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "brotli-decompressor-4.0.2",
-    srcs = [":brotli-decompressor-4.0.2.crate"],
+    name = "brotli-decompressor-4.0.3",
+    srcs = [":brotli-decompressor-4.0.3.crate"],
     crate = "brotli_decompressor",
-    crate_root = "brotli-decompressor-4.0.2.crate/src/lib.rs",
+    crate_root = "brotli-decompressor-4.0.3.crate/src/lib.rs",
     edition = "2015",
     features = [
         "alloc-stdlib",
@@ -3221,23 +3295,23 @@ buildscript_run(
 
 alias(
     name = "clap",
-    actual = ":clap-4.5.36",
+    actual = ":clap-4.5.37",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "clap-4.5.36.crate",
-    sha256 = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04",
-    strip_prefix = "clap-4.5.36",
-    urls = ["https://static.crates.io/crates/clap/4.5.36/download"],
+    name = "clap-4.5.37.crate",
+    sha256 = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071",
+    strip_prefix = "clap-4.5.37",
+    urls = ["https://static.crates.io/crates/clap/4.5.37/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap-4.5.36",
-    srcs = [":clap-4.5.36.crate"],
+    name = "clap-4.5.37",
+    srcs = [":clap-4.5.37.crate"],
     crate = "clap",
-    crate_root = "clap-4.5.36.crate/src/lib.rs",
+    crate_root = "clap-4.5.37.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -3253,24 +3327,24 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":clap_builder-4.5.36",
+        ":clap_builder-4.5.37",
         ":clap_derive-4.5.32",
     ],
 )
 
 http_archive(
-    name = "clap_builder-4.5.36.crate",
-    sha256 = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5",
-    strip_prefix = "clap_builder-4.5.36",
-    urls = ["https://static.crates.io/crates/clap_builder/4.5.36/download"],
+    name = "clap_builder-4.5.37.crate",
+    sha256 = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2",
+    strip_prefix = "clap_builder-4.5.37",
+    urls = ["https://static.crates.io/crates/clap_builder/4.5.37/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap_builder-4.5.36",
-    srcs = [":clap_builder-4.5.36.crate"],
+    name = "clap_builder-4.5.37",
+    srcs = [":clap_builder-4.5.37.crate"],
     crate = "clap_builder",
-    crate_root = "clap_builder-4.5.36.crate/src/lib.rs",
+    crate_root = "clap_builder-4.5.37.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -4584,18 +4658,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "der-0.7.9.crate",
-    sha256 = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0",
-    strip_prefix = "der-0.7.9",
-    urls = ["https://static.crates.io/crates/der/0.7.9/download"],
+    name = "der-0.7.10.crate",
+    sha256 = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb",
+    strip_prefix = "der-0.7.10",
+    urls = ["https://static.crates.io/crates/der/0.7.10/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "der-0.7.9",
-    srcs = [":der-0.7.9.crate"],
+    name = "der-0.7.10",
+    srcs = [":der-0.7.10.crate"],
     crate = "der",
-    crate_root = "der-0.7.9.crate/src/lib.rs",
+    crate_root = "der-0.7.10.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
@@ -5206,7 +5280,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":der-0.7.9",
+        ":der-0.7.10",
         ":digest-0.10.7",
         ":elliptic-curve-0.13.8",
         ":rfc6979-0.4.0",
@@ -6416,7 +6490,7 @@ cargo.rust_library(
         ":auto_enums-0.8.7",
         ":bincode-1.3.3",
         ":bytes-1.10.1",
-        ":clap-4.5.36",
+        ":clap-4.5.37",
         ":equivalent-1.0.2",
         ":fastrace-0.7.9",
         ":flume-0.11.1",
@@ -8010,6 +8084,7 @@ cargo.rust_library(
     edition = "2021",
     features = [
         "http1",
+        "http2",
         "native-tokio",
         "ring",
         "rustls-native-certs",
@@ -12330,7 +12405,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":der-0.7.9",
+        ":der-0.7.10",
         ":pkcs8-0.10.2",
         ":spki-0.7.3",
     ],
@@ -12357,7 +12432,7 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":der-0.7.9",
+        ":der-0.7.10",
         ":spki-0.7.3",
     ],
 )
@@ -15998,7 +16073,7 @@ cargo.rust_library(
         ":pgvector-0.4.0",
         ":rust_decimal-1.37.1",
         ":sea-orm-macros-1.1.10",
-        ":sea-query-0.32.3",
+        ":sea-query-0.32.4",
         ":sea-query-binder-0.7.0",
         ":serde-1.0.219",
         ":serde_json-1.0.140",
@@ -16047,18 +16122,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "sea-query-0.32.3.crate",
-    sha256 = "f5a24d8b9fcd2674a6c878a3d871f4f1380c6c43cc3718728ac96864d888458e",
-    strip_prefix = "sea-query-0.32.3",
-    urls = ["https://static.crates.io/crates/sea-query/0.32.3/download"],
+    name = "sea-query-0.32.4.crate",
+    sha256 = "d99447c24da0cded00089e2021e1624af90878c65f7534319448d01da3df869d",
+    strip_prefix = "sea-query-0.32.4",
+    urls = ["https://static.crates.io/crates/sea-query/0.32.4/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sea-query-0.32.3",
-    srcs = [":sea-query-0.32.3.crate"],
+    name = "sea-query-0.32.4",
+    srcs = [":sea-query-0.32.4.crate"],
     crate = "sea_query",
-    crate_root = "sea-query-0.32.3.crate/src/lib.rs",
+    crate_root = "sea-query-0.32.4.crate/src/lib.rs",
     edition = "2021",
     features = [
         "backend-mysql",
@@ -16130,7 +16205,7 @@ cargo.rust_library(
         ":bigdecimal-0.4.8",
         ":chrono-0.4.40",
         ":rust_decimal-1.37.1",
-        ":sea-query-0.32.3",
+        ":sea-query-0.32.4",
         ":serde_json-1.0.140",
         ":sqlx-0.8.5",
         ":time-0.3.41",
@@ -16166,7 +16241,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":base16ct-0.2.0",
-        ":der-0.7.9",
+        ":der-0.7.10",
         ":generic-array-0.14.7",
         ":pkcs8-0.10.2",
         ":subtle-2.6.1",
@@ -17277,7 +17352,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":base64ct-1.7.3",
-        ":der-0.7.9",
+        ":der-0.7.10",
     ],
 )
 
@@ -18088,6 +18163,9 @@ cargo.rust_binary(
         ":async-trait-0.1.88",
         ":aws-config-1.5.18",
         ":aws-sdk-firehose-1.68.0",
+        ":aws-sdk-ssm-1.71.0",
+        ":aws-smithy-http-client-1.0.1",
+        ":aws-smithy-runtime-1.8.1",
         ":axum-0.6.20",
         ":backtrace-0.3.71",
         ":base64-0.22.1",
@@ -18096,7 +18174,7 @@ cargo.rust_binary(
         ":bytes-1.10.1",
         ":chrono-0.4.40",
         ":ciborium-0.2.2",
-        ":clap-4.5.36",
+        ":clap-4.5.37",
         ":color-eyre-0.6.3",
         ":config-0.14.1",
         ":console-subscriber-0.4.1",
@@ -21509,7 +21587,7 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":const-oid-0.9.6",
-        ":der-0.7.9",
+        ":der-0.7.10",
         ":spki-0.7.3",
         ":tls_codec-0.4.2",
     ],
@@ -21788,6 +21866,34 @@ cargo.rust_library(
         "CARGO_PKG_VERSION_MAJOR": "0",
         "CARGO_PKG_VERSION_MINOR": "8",
         "CARGO_PKG_VERSION_PATCH": "24",
+        "OUT_DIR": "$(location :zerocopy-0.8.24-build-script-run[out_dir])",
+    },
+    features = [
+        "derive",
+        "simd",
+        "zerocopy-derive",
+    ],
+    rustc_flags = ["@$(location :zerocopy-0.8.24-build-script-run[rustc_flags])"],
+    visibility = [],
+    deps = [":zerocopy-derive-0.8.24"],
+)
+
+cargo.rust_binary(
+    name = "zerocopy-0.8.24-build-script-build",
+    srcs = [":zerocopy-0.8.24.crate"],
+    crate = "build_script_build",
+    crate_root = "zerocopy-0.8.24.crate/build.rs",
+    edition = "2021",
+    env = {
+        "CARGO_MANIFEST_DIR": "zerocopy-0.8.24.crate",
+        "CARGO_PKG_AUTHORS": "Joshua Liebow-Feeser <joshlf@google.com>:Jack Wrenn <jswrenn@amazon.com>",
+        "CARGO_PKG_DESCRIPTION": "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to.",
+        "CARGO_PKG_NAME": "zerocopy",
+        "CARGO_PKG_REPOSITORY": "https://github.com/google/zerocopy",
+        "CARGO_PKG_VERSION": "0.8.24",
+        "CARGO_PKG_VERSION_MAJOR": "0",
+        "CARGO_PKG_VERSION_MINOR": "8",
+        "CARGO_PKG_VERSION_PATCH": "24",
     },
     features = [
         "derive",
@@ -21795,7 +21901,18 @@ cargo.rust_library(
         "zerocopy-derive",
     ],
     visibility = [],
-    deps = [":zerocopy-derive-0.8.24"],
+)
+
+buildscript_run(
+    name = "zerocopy-0.8.24-build-script-run",
+    package_name = "zerocopy",
+    buildscript_rule = ":zerocopy-0.8.24-build-script-build",
+    features = [
+        "derive",
+        "simd",
+        "zerocopy-derive",
+    ],
+    version = "0.8.24",
 )
 
 http_archive(

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -505,6 +505,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-ssm"
+version = "1.71.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07c58e00d2059c0080d11c40ffabb7a4802f7ddf35e04d181f0f090eaf20cab"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.0",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-sso"
 version = "1.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,12 +683,20 @@ dependencies = [
  "aws-smithy-types",
  "h2 0.4.9",
  "http 0.2.12",
+ "http 1.3.1",
  "http-body 0.4.6",
  "hyper 0.14.32",
+ "hyper 1.6.0",
  "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.5",
+ "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
+ "rustls 0.23.26",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
  "tokio",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -1154,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -5699,9 +5730,9 @@ dependencies = [
 
 [[package]]
 name = "sea-query"
-version = "0.32.3"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a24d8b9fcd2674a6c878a3d871f4f1380c6c43cc3718728ac96864d888458e"
+checksum = "d99447c24da0cded00089e2021e1624af90878c65f7534319448d01da3df869d"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -6580,6 +6611,9 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-firehose",
+ "aws-sdk-ssm",
+ "aws-smithy-http-client",
+ "aws-smithy-runtime",
  "axum 0.6.20",
  "backtrace",
  "base64 0.22.1",

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -1343,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1353,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1880,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "der_derive",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -36,6 +36,10 @@ aws-config = { version = "=1.5.18", features = [
     "behavior-version-latest",
 ] } # pinned because very next version (1.6.0) starts pulling in `aws-lc-rs`/`aws-lc-sys` which include native C code
 aws-sdk-firehose = "=1.68.0" # pinned because very next version (1.69.0) starts pulling in `aws-lc-rs`/`aws-lc-sys` which include native C code
+aws-sdk-ssm = { version = "1.71.0", default-features = false, features = ["rt-tokio"] }
+# setting smithy like so to avoid pulling in aws-lc-rs for aws-sdk-ssm
+aws-smithy-http-client = { version = "1.0.0", features = ["rustls-ring"] }
+aws-smithy-runtime = { version = "1.8.1", features = ["client", "tls-rustls"] }
 axum = { version = "0.6.20", features = [
     "macros",
     "multipart",

--- a/third-party/rust/fixups/aws-sdk-ssm/fixups.toml
+++ b/third-party/rust/fixups/aws-sdk-ssm/fixups.toml
@@ -1,0 +1,1 @@
+cargo_env = true

--- a/third-party/rust/fixups/zerocopy/fixups.toml
+++ b/third-party/rust/fixups/zerocopy/fixups.toml
@@ -1,1 +1,6 @@
 cargo_env = true
+
+[[buildscript]]
+[buildscript.gen_srcs]
+[[buildscript]]
+[buildscript.rustc_flags]


### PR DESCRIPTION
<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYmR5a21hazEzcG1tdnlpa2R1ZXNuOHd6NWF6cnJjdGtxOWM3ZmtkaCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/imAw0xPt0HkO71jyH9/giphy.gif"/>

Basic structure for an http server that our services can interact with to discover their configuration. The idea here is to give us a single entrypoint for interacting with configuration that can be backed by external sources. The initial source is just AWS Parameter Store. The only things implemented so far:

* `GET /` returns a `200 OK`
* `GET /parameters/*` where * is the path of the configured parameter, eg. `/parameters/si/tools/global/postgres`. Per the design, this will look something like `/si/[env]/[namespace]/param`. This will allow us to set environment-wide settings with app-specific overrides, where necessary. This also allows us to rely entirely on the parameter name without supplying additional metadata in the description
* `GET /parameter*` where * is the name of the parameter

Much more to come, such as figuring out persistence, rate limiting, a client, etc.

![image](https://github.com/user-attachments/assets/d65e7f7b-1303-4a3e-8d46-829b305faeed)