### PR TITLE
fix(sdf): Report errors from management functions correctly

### DIFF
--- a/app/web/src/api/sdf/dal/action.ts
+++ b/app/web/src/api/sdf/dal/action.ts
@@ -23,8 +23,4 @@ export interface ActionPrototype {
   displayName: string;
 }
 
-export enum ActionResultState {
-  Success = "Success",
-  Failure = "Failure",
-  Unknown = "Unknown",
-}
+export type ActionResultState = "Success" | "Failure" | "Unknown";

--- a/app/web/src/components/ChangesPanelHistory.vue
+++ b/app/web/src/components/ChangesPanelHistory.vue
@@ -155,11 +155,11 @@ const deselectActionOrMgmtRun = () => {
 const clickActionOrMgmtRun = async (
   run: ActionHistoryView | ActionProposedView | ManagementHistoryItem,
 ): Promise<void> => {
-  if (selectedFuncRunId.value === run.funcRunId) {
+  if (selectedFuncRunId.value === run.id) {
     deselectActionOrMgmtRun();
   } else {
-    selectedFuncRunId.value = run.funcRunId;
-    await getFuncRun(run.funcRunId);
+    selectedFuncRunId.value = run.id;
+    await getFuncRun(run.id);
   }
 };
 

--- a/app/web/src/components/ComponentDetailsManagement.vue
+++ b/app/web/src/components/ComponentDetailsManagement.vue
@@ -42,7 +42,7 @@
     <template v-for="item in componentManagementHistory" :key="item.funcRunId">
       <ManagementHistoryCard
         :item="item"
-        :selected="item.funcRunId === selectedFuncRunId"
+        :selected="item.id === selectedFuncRunId"
         @clickItem="clickItem"
       />
     </template>
@@ -104,7 +104,7 @@ const showLatestRunTab = async (id: FuncRunId, slug: string) => {
 
 const clickItem = async (item: ManagementHistoryItem, _e: MouseEvent) => {
   openFuncRunTab.value = true;
-  selectedFuncRunId.value = item.funcRunId;
+  selectedFuncRunId.value = item.id;
 };
 
 const hideFuncRun = () => {

--- a/app/web/src/components/Management/ManagementHistoryCard.vue
+++ b/app/web/src/components/Management/ManagementHistoryCard.vue
@@ -24,7 +24,9 @@
     >
       <StatusIndicatorIcon type="management" :status="status" />
 
-      <TruncateWithTooltip class="grow">{{ item.name }}</TruncateWithTooltip>
+      <TruncateWithTooltip class="grow">{{
+        item.functionDisplayName ?? item.functionName
+      }}</TruncateWithTooltip>
 
       <Timestamp
         :date="item.updatedAt"
@@ -36,7 +38,7 @@
       />
 
       <FuncRunTabDropdown
-        :funcRunId="item.funcRunId"
+        :funcRunId="item.id"
         @menuClick="(id, slug) => emit('history', id, slug)"
       />
     </div>
@@ -51,6 +53,7 @@ import {
   TruncateWithTooltip,
   Timestamp,
 } from "@si/vue-lib/design-system";
+import { funcRunStatus } from "@/store/func_runs.store";
 import { ManagementHistoryItem } from "@/store/management_runs.store";
 import StatusIndicatorIcon from "../StatusIndicatorIcon.vue";
 import FuncRunTabDropdown from "../FuncRunTabDropdown.vue";
@@ -61,16 +64,7 @@ const props = defineProps<{
 }>();
 
 // We're hijacking the action status here since that's what we store in the FuncRun
-const status = computed(() => {
-  switch (props.item.status) {
-    case "Success":
-      return "ok";
-    case "Failure":
-      return "error";
-    default:
-      return "unknown";
-  }
-});
+const status = computed(() => funcRunStatus(props.item));
 
 const emit = defineEmits<{
   (e: "history", id: string, tabSlug: string): void;

--- a/app/web/src/components/Management/ManagementHistoryList.vue
+++ b/app/web/src/components/Management/ManagementHistoryList.vue
@@ -3,7 +3,7 @@
     <template v-for="item in managementHistory" :key="item.funcRunId">
       <ManagementHistoryCard
         :item="item"
-        :selected="item.funcRunId === funcRunId"
+        :selected="item.id === funcRunId"
         @clickItem="clickItem"
         @history="openHistory"
       />

--- a/app/web/src/components/ManagementRunPrototype.vue
+++ b/app/web/src/components/ManagementRunPrototype.vue
@@ -60,7 +60,7 @@ import { useFuncStore, MgmtPrototype } from "@/store/func/funcs.store";
 import {
   FuncRun,
   FuncRunId,
-  FuncRunState,
+  funcRunStatus,
   useFuncRunsStore,
 } from "@/store/func_runs.store";
 import { useManagementRunsStore } from "@/store/management_runs.store";
@@ -142,17 +142,7 @@ const lastExecution = computed<FuncRun | null>(() => {
   }
 });
 
-const lastExecutionState = computed<"ok" | "error" | null>(() => {
-  switch (lastExecution.value?.state) {
-    case FuncRunState.Success:
-      return "ok";
-    case FuncRunState.Failure:
-      return "error";
-    default:
-      return null;
-  }
-});
-
+const lastExecutionState = computed(() => funcRunStatus(lastExecution.value));
 const runPrototype = async (viewId: ViewId) => {
   funcStore.RUN_MGMT_PROTOTYPE(
     props.prototype.managementPrototypeId,

--- a/app/web/src/components/StatusIndicatorIcon.vue
+++ b/app/web/src/components/StatusIndicatorIcon.vue
@@ -65,8 +65,13 @@ const CONFIG = {
     _default: { iconName: "question-circle", tone: "warning" },
   },
   management: {
-    ok: { iconName: "check-circle", tone: "success" },
-    error: { iconName: "x-circle", tone: "destructive" },
+    Created: { iconName: "loader", tone: "neutral" },
+    Dispatched: { iconName: "loader", tone: "neutral" },
+    Running: { iconName: "loader", tone: "action" },
+    Postprocessing: { iconName: "loader", tone: "action" },
+    Failure: { iconName: "x-circle", tone: "destructive" },
+    ActionFailure: { iconName: "x-circle", tone: "destructive" },
+    Success: { iconName: "check-circle", tone: "success" },
   },
 };
 

--- a/app/web/src/store/func_runs.store.ts
+++ b/app/web/src/store/func_runs.store.ts
@@ -18,23 +18,21 @@ export type FuncRunId = string;
 export type FuncRunLogId = string;
 export type ContentHash = string;
 
-export enum FuncRunState {
-  Created = "Created",
-  Dispatched = "Dispatched",
-  Running = "Running",
-  PostProcessing = "Postprocessing",
-  Failure = "Failure",
-  Success = "Success",
-}
+export type FuncRunState =
+  | "Created"
+  | "Dispatched"
+  | "Running"
+  | "Postprocessing"
+  | "Failure"
+  | "Success";
 
-export enum FuncKind {
-  Action = "action",
-  Attribute = "attribute",
-  Authentication = "authentication",
-  CodeGeneration = "codeGeneration",
-  Intrinsic = "intrinsic",
-  Management = "management",
-}
+export type FuncKind =
+  | "action"
+  | "attribute"
+  | "authentication"
+  | "codeGeneration"
+  | "intrinsic"
+  | "management";
 
 export enum FuncBackendKind {
   Array,
@@ -91,6 +89,16 @@ export interface FuncRunLog {
   funcRunID: FuncRunId;
   logs: OutputLine[];
   finalized: boolean;
+}
+
+// Get the Status (for StatusIndicatorIcon) from the FuncRunState
+export function funcRunStatus(
+  funcRun?: Pick<FuncRun, "state" | "actionResultState"> | null,
+): FuncRunState | "ActionFailure" | undefined | null {
+  if (!funcRun) return funcRun;
+  // If actionResultState is Failure, it's an error even though state == Success
+  if (funcRun.actionResultState === "Failure") return "ActionFailure";
+  return funcRun.state;
 }
 
 export interface FuncRun {

--- a/app/web/src/store/management_runs.store.ts
+++ b/app/web/src/store/management_runs.store.ts
@@ -6,22 +6,24 @@ import { useWorkspacesStore } from "./workspaces.store";
 import { useChangeSetsStore } from "./change_sets.store";
 import handleStoreError from "./errors";
 import { useRealtimeStore } from "./realtime/realtime.store";
-import { FuncRun, FuncRunId, useFuncRunsStore } from "./func_runs.store";
+import {
+  FuncRun,
+  FuncRunId,
+  FuncRunState,
+  useFuncRunsStore,
+} from "./func_runs.store";
 
 export interface ManagementHistoryItem {
-  funcRunId: FuncRunId;
-  name: string;
-  funcId: string;
-  originatingChangeSetName: string;
-  updatedAt: string;
-  resourceResult?: string;
-  codeExecuted?: string;
-  logs?: string;
-  arguments?: string;
+  id: FuncRunId;
+  state: FuncRunState;
+  functionName: string;
+  functionDisplayName?: string;
   componentId: string;
   componentName: string;
   schemaName: string;
-  status: ActionResultState;
+  originatingChangeSetName: string;
+  updatedAt: string;
+  actionResultState?: ActionResultState;
 }
 
 export const useManagementRunsStore = () => {


### PR DESCRIPTION
When management functions have errors, we report their status differently depending on whether it's in History or is the latest management function run. This PR makes them uniform and shows the correct success / error icon depending on what is reported.

![image](https://github.com/user-attachments/assets/0b4e1242-cc1c-4084-883b-04461264584d)

* Makes manage/history and manage/latest APIs return the same shape, including both execution state and actionResultState.
* Calculates the status icon using a common funcRunStatus() function, treating these cases as errors:
  * Function throws exception
  * Function returns `{ status: "error", message: "message" }`
  * Function returns `{ schtatus: "ok" }`
* Uses appropriate icons (similar to other status indicators). In particular, "running" states now show a spinner, just like other running status indicators.

Fixes BUG-792.

**Factor Budget:** I changed a couple of our enums to string unions, which works a tiny bit better with typescript type checking and is the recommendation of the TS community for string enums, as far as I could find one.

### Out of Scope

These cases either report the wrong status or don't update run status at all, and fall outside the scope of this UI-only fix:

* When `ops` contains invalid data or otherwise cannot be deserialized, we still treat status as Success instead of Failure
* Function timeouts and early terminations don't get updated run status and show perennially as Running
* There are other failure cases in the runner where we still don't update func run status, but these are harder to trigger

Additionally, there are reactivity issues showing long-running management functions n history due to the lack of a FuncRunStarted WsEvent. Finally, when the function fails, management function interface returns 400 and the "last run" does not immediately show failure because the store is listening for success, though it does show up in history. All of these are fixed by clicking away from history and coming back in.

## Testing

- [x] Test that exceptions, bad return payloads, and successful "return error" JS runs all report correct errors
- [x] Test that successful and long-running functions report status as expected
- [x] Integration tests still succeed