### PR TITLE
Add "all-rust-targets" BUCK target and two aliases

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -59,6 +59,16 @@ alias(
     actual = "//app/docs:dev",
 )
 
+alias(
+    name = "sync-cargo-deps",
+    actual = "//support/buck2:sync-cargo-deps",
+)
+
+alias(
+    name = "all-rust-targets",
+    actual = "//support/buck2:all-rust-targets",
+)
+
 export_file(
     name = ".editorconfig",
 )

--- a/support/buck2/BUCK
+++ b/support/buck2/BUCK
@@ -12,6 +12,11 @@ sh_binary(
     main = "buck2-update-prelude.sh",
 )
 
+sh_binary(
+    name = "all-rust-targets",
+    main = "buck2-all-rust-targets.sh",
+)
+
 python_bootstrap_binary(
     name = "sync-cargo-deps",
     main = "buck2-sync-cargo-deps.py",

--- a/support/buck2/buck2-all-rust-targets.sh
+++ b/support/buck2/buck2-all-rust-targets.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+if [ -z "$1" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ] || [ "$1" = "help" ]; then
+  echo "============================================================================"
+  echo "Provide the buck2 command to run for all Rust targets in the repository."
+  echo "You can also provide the mode, flags, and more (e.g. 'build @//mode/debug')."
+  echo "============================================================================"
+  exit 1
+fi
+
+set -euxo pipefail
+buck2 uquery 'kind("rust_(binary|library|test)", set("//bin/..." "//lib/..."))' | xargs buck2 "$@"


### PR DESCRIPTION
## Description

This PR adds the "all-rust-targets" BUCK target to perform "buck2" commands on all targets in the repository from any directory. It also adds an alias in the root BUCK file for the new script as well as adds an alias for the "sync-cargo-deps" target.

## Examples

```bash
buck2 run :sync-cargo-deps
buck2 run :all-rust-targets
buck2 run :all-rust-targets build
buck2 run :all-rust-targets build @//mode/debug
```

## GIF

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZHo2a2U3ZGxiYzR0OG5zangzc3BlYmlodG15dmQyZmE1b2M3emEyMSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/U8gOonVDkaiIMQzLTy/giphy-downsized-medium.gif"/>