### PR TITLE
fix(clover): Allow Clover to read RDS DBCluster passwords from SI Secrets

### DIFF
--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -304,6 +304,10 @@ const overrides = new Map<string, OverrideFn>([
     "AWS::SecretsManager::Secret",
     addSecretProp("Secret String", "secretString", ["SecretString"]),
   ],
+  [
+    "AWS::RDS::DBCluster",
+    addSecretProp("Secret String", "secretString", ["MasterUserPassword"]),
+  ],
   ["AWS::EC2::NetworkInterface", (spec: ExpandedPkgSpec) => {
     const variant = spec.schemas[0].variants[0];
 


### PR DESCRIPTION
![Screenshot 2025-04-18 at 18 35 07](https://github.com/user-attachments/assets/13d8f3c8-075b-4e47-bb99-7f94ff209d0a)

Raw strings for RDS DBCluster goes bye bye. This is what we do for SecretsManager::Secrets