### PR TITLE
Only build MVs where the MV ID is immediate

### DIFF
--- a/app/web/src/components/ComponentDetails.vue
+++ b/app/web/src/components/ComponentDetails.vue
@@ -167,10 +167,7 @@
                 viewStore.selectedComponentId
               "
             >
-              <BifrostAssetActionsDetails
-                :componentId="component.def.id"
-                :component="component"
-              />
+              <BifrostAssetActionsDetails :component="component" />
             </template>
             <template v-else>
               <AssetActionsDetails :component="props.component" />

--- a/app/web/src/mead-hall/ActionWidget.vue
+++ b/app/web/src/mead-hall/ActionWidget.vue
@@ -9,10 +9,10 @@
     "
     @click="clickHandler"
   >
-    <Toggle :selected="!!actionPrototypeView.actionId" class="flex-none" />
+    <Toggle :selected="!!props.actionId" class="flex-none" />
     <StatusIndicatorIcon
       type="action"
-      :status="FuncKind.Action"
+      :status="actionPrototypeView.kind"
       tone="inherit"
       class="flex-none"
     />
@@ -56,12 +56,13 @@ import {
   DiagramGroupData,
   DiagramNodeData,
 } from "@/components/ModelingDiagram/diagram_types";
-import { FuncKind } from "@/api/sdf/dal/func";
+import { ActionId } from "@/api/sdf/dal/action";
 import { ActionPrototypeView } from "./AssetActionsDetails.vue";
 
 const props = defineProps<{
   component: DiagramGroupData | DiagramNodeData;
   actionPrototypeView: ActionPrototypeView;
+  actionId?: ActionId;
 }>();
 
 const viewStore = useViewsStore();
@@ -70,8 +71,8 @@ const actionsStore = useActionsStore();
 const router = useRouter();
 
 function clickHandler() {
-  if (props.actionPrototypeView.actionId) {
-    actionsStore.CANCEL([props.actionPrototypeView.actionId]);
+  if (props.actionId) {
+    actionsStore.CANCEL([props.actionId]);
   } else {
     actionsStore.ADD_ACTION(
       props.component.def.id,
@@ -98,7 +99,7 @@ const addRequestStatus = actionsStore.getRequestStatus(
 );
 const removeRequestStatus = actionsStore.getRequestStatus(
   "CANCEL",
-  computed(() => props.actionPrototypeView.actionId),
+  computed(() => props.actionId),
   // ^ this won't accept [] which doesnt bode well
 );
 </script>

--- a/app/web/src/mead-hall/AssetActionsDetails.vue
+++ b/app/web/src/mead-hall/AssetActionsDetails.vue
@@ -26,6 +26,7 @@
             v-for="actionPrototypeView in actionPrototypeViews"
             :key="actionPrototypeView.id"
             :actionPrototypeView="actionPrototypeView"
+            :actionId="actionByPrototype[actionPrototypeView.id]"
             :component="props.component"
           />
         </div>
@@ -50,15 +51,14 @@ import {
 } from "@/components/ModelingDiagram/diagram_types";
 import { bifrost, makeArgs, makeKey } from "@/store/realtime/heimdall";
 import EmptyStateIcon from "@/components/EmptyStateIcon.vue";
-import { ActionId, ActionKind, ActionPrototypeId } from "@/api/sdf/dal/action";
+import { ActionKind, ActionPrototypeId, ActionId } from "@/api/sdf/dal/action";
 import { FuncId } from "@/api/sdf/dal/func";
 import { SchemaVariantId } from "@/api/sdf/dal/schema";
-import { ComponentId } from "@/api/sdf/dal/component";
 import ActionWidget from "./ActionWidget.vue";
+import { ActionViewList } from "./ChangesPanelProposed.vue";
 
 const props = defineProps<{
   component: DiagramNodeData | DiagramGroupData;
-  componentId: ComponentId;
 }>();
 
 const viewStore = useViewsStore();
@@ -71,33 +71,58 @@ function onTabSelected(newTabSlug?: string) {
 export interface ActionPrototypeView {
   id: ActionPrototypeId;
   funcId: FuncId;
-  schemaVariantId: SchemaVariantId;
   kind: ActionKind;
   displayName?: string;
   name: string;
-  actionId?: ActionId;
 }
 
-interface ActionPrototypeViewsByComponentId {
-  id: ComponentId;
+interface ActionPrototypeViewList {
+  id: SchemaVariantId;
   actionPrototypes: ActionPrototypeView[];
 }
 
-const queryKey = makeKey(
-  "ActionPrototypeViewsByComponentId",
-  props.componentId,
+// This is the core materialized view for this component. We need it to know what action prototypes
+// are available for the given component.
+const queryKeyForActionPrototypeViews = makeKey(
+  "ActionPrototypeViewList",
+  props.component.def.schemaVariantId,
 );
-const actionPrototypeViewsRaw =
-  useQuery<ActionPrototypeViewsByComponentId | null>({
-    queryKey,
-    queryFn: async () =>
-      await bifrost<ActionPrototypeViewsByComponentId>(
-        makeArgs("ActionPrototypeViewsByComponentId", props.componentId),
-      ),
-  });
+const actionPrototypeViewsRaw = useQuery<ActionPrototypeViewList | null>({
+  queryKey: queryKeyForActionPrototypeViews,
+  queryFn: async () =>
+    await bifrost<ActionPrototypeViewList>(
+      makeArgs("ActionPrototypeViewList", props.component.def.schemaVariantId),
+    ),
+});
 const actionPrototypeViews = computed(
   () => actionPrototypeViewsRaw.data.value?.actionPrototypes ?? [],
 );
+
+// Use the materialized view for actions to know what actions exist for a given prototype and the
+// selected component.
+const queryKeyForActionViewList = makeKey("ActionViewList");
+const actionViewList = useQuery<ActionViewList | null>({
+  queryKey: queryKeyForActionViewList,
+  queryFn: async () =>
+    await bifrost<ActionViewList>(makeArgs("ActionViewList")),
+});
+const actionByPrototype = computed(() => {
+  if (!actionViewList.data.value?.actions) return {};
+  if (actionViewList.data.value.actions.length < 1) return {};
+
+  const result: Record<ActionPrototypeId, ActionId> = {};
+  for (const action of actionViewList.data.value.actions) {
+    if (action.componentId === props.component.def.id) {
+      // NOTE(nick): this assumes that there can be one action for a given prototype and component.
+      // As of the time of writing, this is true, but multiple actions per prototype and component
+      // aren't disallowed from the underlying graph's perspective. Theorhetically, you could
+      // enqueue two refreshes back-to-back. What then? I don't think we'll expose an interface to
+      // do that for awhile, so this should be sufficient.
+      result[action.prototypeId] = action.id;
+    }
+  }
+  return result;
+});
 
 watch(
   () => viewStore.selectedComponentDetailsTab,

--- a/lib/dal/tests/integration_test/materialized_view.rs
+++ b/lib/dal/tests/integration_test/materialized_view.rs
@@ -62,10 +62,10 @@ async fn actions(ctx: &DalContext) -> Result<()> {
     );
 
     // Check the frontend payload for action prototypes.
-    let mv = ActionPrototype::as_frontend_list_type_by_component_id(ctx, component.id()).await?;
+    let mv = ActionPrototype::as_frontend_list_type(ctx, schema_variant_id).await?;
     assert_eq!(
-        component.id(), // expected
-        mv.id           // actual
+        schema_variant_id, // expected
+        mv.id              // actual
     );
     assert_eq!(
         4,                          // expected
@@ -73,21 +73,6 @@ async fn actions(ctx: &DalContext) -> Result<()> {
     );
     let mut kinds = HashSet::new();
     for action_prototype_view in mv.action_prototypes {
-        match action_prototype_view.kind {
-            ActionKind::Create => {
-                assert_eq!(
-                    create_action_prototype.id(), // expected
-                    action_prototype_view.id      // actual
-                );
-                assert_eq!(
-                    Some(create_action_id),          // expected
-                    action_prototype_view.action_id  // actual
-                );
-            }
-            _ => {
-                assert!(action_prototype_view.action_id.is_none());
-            }
-        }
         kinds.insert(action_prototype_view.kind);
     }
     assert_eq!(

--- a/lib/si-frontend-types-rs/src/action.rs
+++ b/lib/si-frontend-types-rs/src/action.rs
@@ -15,7 +15,7 @@ use crate::{
 pub mod prototype;
 
 pub use prototype::ActionPrototypeView;
-pub use prototype::ActionPrototypeViewsByComponentId;
+pub use prototype::ActionPrototypeViewList;
 
 #[derive(
     Debug, Serialize, Deserialize, PartialEq, Eq, Clone, si_frontend_types_macros::FrontendChecksum,

--- a/lib/si-frontend-types-rs/src/action/prototype.rs
+++ b/lib/si-frontend-types-rs/src/action/prototype.rs
@@ -3,7 +3,7 @@ use si_events::{
     workspace_snapshot::{Checksum, ChecksumHasher, EntityKind},
     ActionKind,
 };
-use si_id::{ActionId, ActionPrototypeId, ComponentId, FuncId, SchemaVariantId};
+use si_id::{ActionPrototypeId, FuncId, SchemaVariantId};
 
 use crate::checksum::FrontendChecksum;
 use crate::{
@@ -19,12 +19,9 @@ use crate::{
 pub struct ActionPrototypeView {
     pub id: ActionPrototypeId,
     pub func_id: FuncId,
-    pub schema_variant_id: SchemaVariantId,
     pub kind: ActionKind,
     pub display_name: Option<String>,
     pub name: String,
-    // If this is "None", then there is no running or enqueued action for this prototype
-    pub action_id: Option<ActionId>,
 }
 
 #[derive(
@@ -40,10 +37,10 @@ pub struct ActionPrototypeView {
 )]
 #[serde(rename_all = "camelCase")]
 #[mv(
-    trigger_entity = EntityKind::Root,
-    reference_kind = ReferenceKind::ActionPrototypeViewsByComponentId,
+    trigger_entity = EntityKind::SchemaVariant,
+    reference_kind = ReferenceKind::ActionPrototypeViewList,
 )]
-pub struct ActionPrototypeViewsByComponentId {
-    pub id: ComponentId,
+pub struct ActionPrototypeViewList {
+    pub id: SchemaVariantId,
     pub action_prototypes: Vec<ActionPrototypeView>,
 }

--- a/lib/si-frontend-types-rs/src/reference.rs
+++ b/lib/si-frontend-types-rs/src/reference.rs
@@ -24,7 +24,7 @@ use crate::{checksum::FrontendChecksum, object::FrontendObject};
 )]
 #[serde(rename_all = "PascalCase")]
 pub enum ReferenceKind {
-    ActionPrototypeViewsByComponentId,
+    ActionPrototypeViewList,
     ActionViewList,
     ChangeSetList,
     ChangeSetRecord,


### PR DESCRIPTION
## Description

This PR ensures that we only build MVs where the MV ID is the same as the trigger's change ID or is the change set ID. This ensures that we do not run into situations where deleted nodes cannot be found when "hopping" to the desired MV ID from a change ID.

As a result of these changes, this is the first commit where we have removed an existing MV. It is no longer in use. We are not concerned about backwards compatibility here since it is not deserialized anywhere.

This PR also fixes the issue where the icons for action prototypes were all question marks.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlODJrb2l2aHl6am5mYjBsdHg2ZWRmZnFneGJyMXYyMzJtMG1zcG93bSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xUPGcoHH03ZLh5H7QQ/giphy.gif"/>