### PR TITLE
Fix dynamic imports for action funcs

### DIFF
--- a/bin/lang-js/src/function_kinds/action_run.ts
+++ b/bin/lang-js/src/function_kinds/action_run.ts
@@ -36,7 +36,7 @@ async function execute(
   try {
     const actionRunResult = await runCode(
       code,
-      "main",
+      "siMain",
       FunctionKind.ActionRun,
       executionId,
       timeout,
@@ -118,12 +118,14 @@ async function execute(
   }
 }
 
+// TODO(nick,scott,paul): does this even need a wrapper at all? Only actions have a wrapper like
+// this at the time of writing.
 const wrapCode = (code: string, handler: string) => `
-async function main(arg) {
+${code}
+async function siMain(arg) {
   let payload = null;
   let resourceId = null;
   try {
-    ${code}
     resourceId = arg?.properties?.si?.resourceId;
     payload = arg?.properties?.resource?.payload ?? null;
 
@@ -138,7 +140,7 @@ async function main(arg) {
            }
   }
 }
-export { main };
+export { siMain };
 `;
 
 export default {


### PR DESCRIPTION
This PR fixes dynamic imports for action funcs by ensuring that the code is declared outside of the func that calls and awaits it.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbXlzOWx5eHhpdjU0N2RhMHVzdGN0YzA2enM3M3Awem8zNXYwNGswMSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/YUO7Tc2GC7V2TZ3VSe/giphy.gif"/>