### PR TITLE
fix(clover): Ensure that MasterPassword is set as a secret in AWS::RDS::DBInstance rather than a string

### DIFF
--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -333,6 +333,10 @@ const overrides = new Map<string, OverrideFn>([
     "AWS::RDS::DBCluster",
     addSecretProp("Secret String", "secretString", ["MasterUserPassword"]),
   ],
+  [
+    "AWS::RDS::DBInstance",
+    addSecretProp("Secret String", "secretString", ["MasterUserPassword"]),
+  ],
   ["AWS::EC2::NetworkInterface", (spec: ExpandedPkgSpec) => {
     const variant = spec.schemas[0].variants[0];
 


### PR DESCRIPTION
This keeps on par with AWS::RDS::DBCluster