### PR TITLE
fix(web): Restore showing action details when selecting an Action

### DIFF
--- a/app/web/src/components/ChangesPanelHistory.vue
+++ b/app/web/src/components/ChangesPanelHistory.vue
@@ -23,7 +23,7 @@
             :key="detail.changeSetId"
             :actions="actions"
             :changeSet="getChangeSet(detail)"
-            :clickAction="clickActionOrMgmtRun"
+            :clickAction="clickActionRun"
             :selectedFuncRunIds="selectedFuncRunId ? [selectedFuncRunId] : []"
             noInteraction
             kind="history"
@@ -62,7 +62,7 @@
         <ManagementHistoryList
           v-if="managementHistoryForChangeSet.length > 0"
           :managementHistory="managementHistoryForChangeSet"
-          :clickItem="clickActionOrMgmtRun"
+          :clickItem="clickMgmtRun"
           :funcRunId="selectedFuncRunId"
           @history="openHistory"
         />
@@ -152,14 +152,23 @@ const deselectActionOrMgmtRun = () => {
   selectedFuncRunId.value = undefined;
 };
 
-const clickActionOrMgmtRun = async (
-  run: ActionHistoryView | ActionProposedView | ManagementHistoryItem,
-): Promise<void> => {
+const clickMgmtRun = async (run: ManagementHistoryItem): Promise<void> => {
   if (selectedFuncRunId.value === run.id) {
     deselectActionOrMgmtRun();
   } else {
     selectedFuncRunId.value = run.id;
     await getFuncRun(run.id);
+  }
+};
+
+const clickActionRun = async (
+  run: ActionHistoryView | ActionProposedView,
+): Promise<void> => {
+  if (selectedFuncRunId.value === run.funcRunId) {
+    deselectActionOrMgmtRun();
+  } else {
+    selectedFuncRunId.value = run.funcRunId;
+    await getFuncRun(run.funcRunId);
   }
 };
 


### PR DESCRIPTION
This fixes a regression where users could no longer view the logs/arguments/etc. for actions. This is because we were fetching the func runs details using the `actionId` and not the `funcRunId`.

Tested manually by running actions and seeing their details both when the action is still enqueued, and when it's no longer enqueued. 

<div><img src="https://media4.giphy.com/media/VL5JGMwlSOFsIuc8z0/giphy.gif?cid=5a38a5a2j5umfmj9b5tfn07nzelznxznomwhbvut4b846dhu&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/gerbert/">Gerbert!</a> on <a href="https://giphy.com/gifs/gerbert-puppet-VL5JGMwlSOFsIuc8z0">GIPHY</a></div>