### PR TITLE
fix: remove unnecessary input sockets from vpn tunnel specs to simplify

### DIFF
--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -6,6 +6,7 @@ import {
   createSocketFromPropInner,
   ExpandedSocketSpec,
   propPathToString,
+  removeInputSockets,
   setAnnotationOnSocket,
 } from "../spec/sockets.ts";
 import { ExpandedPkgSpec } from "../spec/pkgs.ts";
@@ -848,6 +849,47 @@ const overrides = new Map<string, OverrideFn>([
     );
     if (!subnetIdSocket) return;
     setAnnotationOnSocket(subnetIdSocket, { tokens: ["subnet id"] });
+  }],
+  ["VPNConnection VpnTunnelOptionsSpecifications", (spec: ExpandedPkgSpec) => {
+    const variant = spec.schemas[0].variants[0];
+
+    // Remove unnecessary input sockets
+    const removedCount = removeInputSockets(variant, [
+      "IKE Versions",
+      "Phase1DHGroup Numbers",
+      "Phase1Encryption Algorithms",
+      "Phase1Integrity Algorithms",
+      "Phase2DHGroup Numbers",
+      "Phase2Encryption Algorithms",
+      "Phase2Integrity Algorithms"
+    ]);
+    logger.debug(`Removed ${removedCount} input sockets from VpnTunnelOptionsSpecifications`);
+
+    const propsToFix = [
+      "IKEVersions",
+      "Phase1DHGroupNumbers",
+      "Phase1EncryptionAlgorithms",
+      "Phase1IntegrityAlgorithms",
+      "Phase2DHGroupNumbers",
+      "Phase2EncryptionAlgorithms",
+      "Phase2IntegrityAlgorithms"  
+    ];
+
+    for (const propName of propsToFix) {
+      const arrayProp = propForOverride(variant.domain, propName);
+      if (!arrayProp || arrayProp.kind !== "array") continue;
+
+      arrayProp.data.widgetKind = "Array";
+      arrayProp.data.inputs = [];
+      arrayProp.data.funcUniqueId = null;
+
+      if (arrayProp.typeProp.kind === "object") {
+        const valueProp = arrayProp.typeProp.entries.find(p => p.name === "Value");
+        if (valueProp) {
+          valueProp.data.widgetKind = "ComboBox";
+        }
+      }  
+    }
   }],
 ]);
 

--- a/bin/clover/src/spec/sockets.ts
+++ b/bin/clover/src/spec/sockets.ts
@@ -287,3 +287,33 @@ export function propHasSocket(prop: ExpandedPropSpec): boolean {
     i.kind === "inputSocket"
   ) !== undefined;
 }
+
+export function removeInputSockets(
+  variant: ExpandedSchemaVariantSpec,
+  socketNamesToRemove: string[],
+): number {
+  if (!variant.sockets || !socketNamesToRemove.length) return 0;
+
+  const initialCount = variant.sockets.length;
+  const normalizedNames = socketNamesToRemove.map(name => name.toLowerCase());
+  
+  // Find and remove the sockets that match the criteria
+  const socketsToRemove: number[] = [];
+  
+  // First identify which sockets to remove (by index)
+  variant.sockets.forEach((socket, index) => {
+    if (socket.data.kind === "input") {
+      const socketNameLower = socket.name.toLowerCase();
+      if (normalizedNames.some(name => socketNameLower.includes(name))) {
+        socketsToRemove.push(index);
+      }
+    }
+  });
+  
+  // Remove the sockets in reverse order to avoid index shifting issues
+  for (let i = socketsToRemove.length - 1; i >= 0; i--) {
+    variant.sockets.splice(socketsToRemove[i], 1);
+  }
+
+  return initialCount - variant.sockets.length;
+}


### PR DESCRIPTION
- fix: remove unnecessary input sockets from VPNConnection VpnTunnelOptionsSpecifications to simplify the component for use with AWS::EC2::VPNConnection
- amend phase1/2 input props so they no longer expect input socket values

Comparison:
<img width="1408" alt="Screenshot 2025-04-23 at 23 26 54" src="https://github.com/user-attachments/assets/87129d89-dcd8-41b0-92e4-a20601b6b478" />

Connected to AWS::EC2::VPNConnection
<img width="1466" alt="Screenshot 2025-04-23 at 23 28 17" src="https://github.com/user-attachments/assets/49d87fe7-46ae-4d20-8f5f-8ea75724b15f" />
