### PR TITLE
feat: use innit-client in layered load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,7 @@ dependencies = [
 name = "config-file"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "config",
  "directories",
  "pathdiff",
@@ -4040,7 +4041,10 @@ dependencies = [
 name = "innit-client"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "base64 0.22.1",
+ "buck2-resources",
+ "config-file",
  "derive_builder",
  "hyper 0.14.32",
  "innit-core",
@@ -4068,6 +4072,7 @@ version = "0.1.0"
 dependencies = [
  "aws-sdk-ssm",
  "chrono",
+ "config-file",
  "serde",
  "serde_json",
  "ulid",
@@ -4423,6 +4428,7 @@ name = "luminork"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "innit-client",
  "luminork-server",
  "si-service",
 ]
@@ -7896,6 +7902,7 @@ dependencies = [
 name = "si-settings"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "config-file",
  "remain",
  "serde",

--- a/bin/luminork/BUCK
+++ b/bin/luminork/BUCK
@@ -8,6 +8,7 @@ load(
 rust_binary(
     name = "luminork",
     deps = [
+        "//lib/innit-client:innit-client",
         "//lib/luminork-server:luminork-server",
         "//lib/si-service:si-service",
         "//third-party/rust:clap",

--- a/bin/luminork/Cargo.toml
+++ b/bin/luminork/Cargo.toml
@@ -14,5 +14,6 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true }
+innit-client = { path = "../../lib/innit-client" }
 luminork-server = { path = "../../lib/luminork-server" }
 si-service = { path = "../../lib/si-service" }

--- a/bin/luminork/src/args.rs
+++ b/bin/luminork/src/args.rs
@@ -12,7 +12,9 @@ use luminork_server::{
     Config,
     ConfigError,
     ConfigFile,
+    ConfigMap,
     FeatureFlag,
+    ParameterProvider,
     StandardConfigFile,
     WorkspacePermissions,
     WorkspacePermissionsMode,
@@ -262,147 +264,166 @@ impl Args {
     }
 }
 
+fn build_config_map(args: Args, config_map: &mut ConfigMap) -> &ConfigMap {
+    if let Some(instance_id) = args.instance_id {
+        config_map.set("instance_id", instance_id);
+    }
+
+    if let Some(dbname) = args.pg_dbname {
+        config_map.set("pg.dbname", dbname);
+    }
+
+    if let Some(layer_cache_pg_dbname) = args.layer_db_pg_dbname {
+        config_map.set(
+            "layer_db_config.pg_pool_config.dbname",
+            layer_cache_pg_dbname,
+        );
+    }
+    if let Some(hostname) = args.pg_hostname {
+        config_map.set("pg.hostname", hostname.clone());
+        config_map.set("layer_db_config.pg_pool_config.hostname", hostname);
+    }
+    if let Some(pool_max_size) = args.pg_pool_max_size {
+        config_map.set("pg.pool_max_size", i64::from(pool_max_size));
+        config_map.set(
+            "layer_db_config.pg_pool_config.pool_max_size",
+            i64::from(pool_max_size),
+        );
+    }
+    if let Some(port) = args.pg_port {
+        config_map.set("pg.port", i64::from(port));
+        config_map.set("layer_db_config.pg_pool_config.port", i64::from(port));
+    }
+    if let Some(user) = args.pg_user {
+        config_map.set("pg.user", user.clone());
+        config_map.set("layer_db_config.pg_pool_config.user", user);
+    }
+    if let Some(cert_path) = args.pg_cert_path {
+        config_map.set("pg.certificate_path", cert_path.display().to_string());
+        config_map.set(
+            "layer_db_config.pg_pool_config.certificate_path",
+            cert_path.display().to_string(),
+        );
+    }
+    if let Some(recycling_method) = args.pg_recycling_method {
+        config_map.set("pg.recycling_method", recycling_method.clone());
+        config_map.set(
+            "layer_db_config.pg_pool_config.recycling_method",
+            recycling_method,
+        );
+    }
+    if let Some(cert) = args.pg_cert_base64 {
+        config_map.set("pg.certificate_base64", cert.to_string());
+        config_map.set(
+            "layer_db_config.pg_pool_config.certificate_base64",
+            cert.to_string(),
+        );
+    }
+    if let Some(url) = args.nats_url {
+        config_map.set("nats.url", url.clone());
+        config_map.set("layer_db_config.nats_config.url", url);
+    }
+    if let Some(creds) = args.nats_creds {
+        config_map.set("nats.creds", creds.to_string());
+        config_map.set("layer_db_config.nats_config.creds", creds.to_string());
+    }
+    if let Some(creds_file) = args.nats_creds_path {
+        config_map.set("nats.creds_file", creds_file.display().to_string());
+        config_map.set(
+            "layer_db_config.nats_config.creds_file",
+            creds_file.display().to_string(),
+        );
+    }
+    if let Some(veritech_encryption_key_file) = args.veritech_encryption_key_path {
+        config_map.set(
+            "crypto.encryption_key_file",
+            veritech_encryption_key_file.display().to_string(),
+        );
+    }
+    if let Some(veritech_encryption_key_base64) = args.veritech_encryption_key_base64 {
+        config_map.set(
+            "crypto.encryption_key_base64",
+            veritech_encryption_key_base64.to_string(),
+        );
+    }
+    if let Some(base64) = args.symmetric_crypto_active_key_base64 {
+        config_map.set(
+            "symmetric_crypto_service.active_key_base64",
+            base64.to_string(),
+        );
+    }
+
+    if let Some(jwt) = args.jwt_public_signing_key_base64 {
+        config_map.set("jwt_signing_public_key.key_base64", jwt);
+    }
+    if let Some(algo) = args.jwt_public_signing_key_algo {
+        config_map.set("jwt_signing_public_key.algo", algo);
+    }
+
+    if let Some(jwt) = args.jwt_secondary_public_signing_key_base64 {
+        config_map.set("jwt_secondary_signing_public_key.key_base64", jwt);
+    }
+    if let Some(algo) = args.jwt_secondary_public_signing_key_algo {
+        config_map.set("jwt_secondary_signing_public_key.algo", algo);
+    }
+
+    if let Some(layer_cache_disk_path) = args.layer_db_disk_path {
+        config_map.set("layer_db_config.disk_path", layer_cache_disk_path);
+    }
+    if let Some(pkgs_path) = args.pkgs_path {
+        config_map.set("pkgs_path", pkgs_path);
+    }
+    if let Some(module_index_url) = args.module_index_url {
+        config_map.set("module_index_url", module_index_url);
+    }
+
+    if let Some(auth_api_url) = args.auth_api_url {
+        config_map.set("auth_api_url", auth_api_url);
+    }
+
+    config_map.set("boot_feature_flags", args.features);
+
+    if let Some(create_workspace_permissions) = args.create_workspace_permissions {
+        config_map.set("create_workspace_permissions", create_workspace_permissions);
+    }
+
+    if !args.create_workspace_allowlist.is_empty() {
+        config_map.set(
+            "create_workspace_allowlist",
+            args.create_workspace_allowlist,
+        );
+    }
+
+    config_map.set("nats.connection_name", NAME);
+    config_map.set("pg.application_name", NAME);
+    config_map.set("layer_db_config.pg_pool_config.application_name", NAME);
+    config_map.set("layer_db_config.nats_config.connection_name", NAME);
+    config_map
+}
+
 impl TryFrom<Args> for Config {
     type Error = ConfigError;
 
     fn try_from(args: Args) -> Result<Self, Self::Error> {
         ConfigFile::layered_load(NAME, |config_map| {
-            if let Some(instance_id) = args.instance_id {
-                config_map.set("instance_id", instance_id);
-            }
-
-            if let Some(dbname) = args.pg_dbname {
-                config_map.set("pg.dbname", dbname);
-            }
-
-            if let Some(layer_cache_pg_dbname) = args.layer_db_pg_dbname {
-                config_map.set(
-                    "layer_db_config.pg_pool_config.dbname",
-                    layer_cache_pg_dbname,
-                );
-            }
-            if let Some(hostname) = args.pg_hostname {
-                config_map.set("pg.hostname", hostname.clone());
-                config_map.set("layer_db_config.pg_pool_config.hostname", hostname);
-            }
-            if let Some(pool_max_size) = args.pg_pool_max_size {
-                config_map.set("pg.pool_max_size", i64::from(pool_max_size));
-                config_map.set(
-                    "layer_db_config.pg_pool_config.pool_max_size",
-                    i64::from(pool_max_size),
-                );
-            }
-            if let Some(port) = args.pg_port {
-                config_map.set("pg.port", i64::from(port));
-                config_map.set("layer_db_config.pg_pool_config.port", i64::from(port));
-            }
-            if let Some(user) = args.pg_user {
-                config_map.set("pg.user", user.clone());
-                config_map.set("layer_db_config.pg_pool_config.user", user);
-            }
-            if let Some(cert_path) = args.pg_cert_path {
-                config_map.set("pg.certificate_path", cert_path.display().to_string());
-                config_map.set(
-                    "layer_db_config.pg_pool_config.certificate_path",
-                    cert_path.display().to_string(),
-                );
-            }
-            if let Some(recycling_method) = args.pg_recycling_method {
-                config_map.set("pg.recycling_method", recycling_method.clone());
-                config_map.set(
-                    "layer_db_config.pg_pool_config.recycling_method",
-                    recycling_method,
-                );
-            }
-            if let Some(cert) = args.pg_cert_base64 {
-                config_map.set("pg.certificate_base64", cert.to_string());
-                config_map.set(
-                    "layer_db_config.pg_pool_config.certificate_base64",
-                    cert.to_string(),
-                );
-            }
-            if let Some(url) = args.nats_url {
-                config_map.set("nats.url", url.clone());
-                config_map.set("layer_db_config.nats_config.url", url);
-            }
-            if let Some(creds) = args.nats_creds {
-                config_map.set("nats.creds", creds.to_string());
-                config_map.set("layer_db_config.nats_config.creds", creds.to_string());
-            }
-            if let Some(creds_file) = args.nats_creds_path {
-                config_map.set("nats.creds_file", creds_file.display().to_string());
-                config_map.set(
-                    "layer_db_config.nats_config.creds_file",
-                    creds_file.display().to_string(),
-                );
-            }
-            if let Some(veritech_encryption_key_file) = args.veritech_encryption_key_path {
-                config_map.set(
-                    "crypto.encryption_key_file",
-                    veritech_encryption_key_file.display().to_string(),
-                );
-            }
-            if let Some(veritech_encryption_key_base64) = args.veritech_encryption_key_base64 {
-                config_map.set(
-                    "crypto.encryption_key_base64",
-                    veritech_encryption_key_base64.to_string(),
-                );
-            }
-            if let Some(base64) = args.symmetric_crypto_active_key_base64 {
-                config_map.set(
-                    "symmetric_crypto_service.active_key_base64",
-                    base64.to_string(),
-                );
-            }
-
-            if let Some(jwt) = args.jwt_public_signing_key_base64 {
-                config_map.set("jwt_signing_public_key.key_base64", jwt);
-            }
-            if let Some(algo) = args.jwt_public_signing_key_algo {
-                config_map.set("jwt_signing_public_key.algo", algo);
-            }
-
-            if let Some(jwt) = args.jwt_secondary_public_signing_key_base64 {
-                config_map.set("jwt_secondary_signing_public_key.key_base64", jwt);
-            }
-            if let Some(algo) = args.jwt_secondary_public_signing_key_algo {
-                config_map.set("jwt_secondary_signing_public_key.algo", algo);
-            }
-
-            if let Some(layer_cache_disk_path) = args.layer_db_disk_path {
-                config_map.set("layer_db_config.disk_path", layer_cache_disk_path);
-            }
-            if let Some(pkgs_path) = args.pkgs_path {
-                config_map.set("pkgs_path", pkgs_path);
-            }
-            if let Some(module_index_url) = args.module_index_url {
-                config_map.set("module_index_url", module_index_url);
-            }
-
-            if let Some(auth_api_url) = args.auth_api_url {
-                config_map.set("auth_api_url", auth_api_url);
-            }
-
-            config_map.set("boot_feature_flags", args.features);
-
-            if let Some(create_workspace_permissions) = args.create_workspace_permissions {
-                config_map.set("create_workspace_permissions", create_workspace_permissions);
-            }
-
-            if !args.create_workspace_allowlist.is_empty() {
-                config_map.set(
-                    "create_workspace_allowlist",
-                    args.create_workspace_allowlist,
-                );
-            }
-
-            config_map.set("nats.connection_name", NAME);
-            config_map.set("pg.application_name", NAME);
-            config_map.set("layer_db_config.pg_pool_config.application_name", NAME);
-            config_map.set("layer_db_config.nats_config.connection_name", NAME);
+            build_config_map(args, config_map);
         })?
         .try_into()
     }
+}
+
+pub async fn load_config_with_provider<P>(
+    args: Args,
+    provider: Option<(P, String)>,
+) -> Result<Config, ConfigError>
+where
+    P: ParameterProvider + 'static,
+{
+    ConfigFile::layered_load_with_provider::<_, P>(NAME, provider, move |config_map| {
+        build_config_map(args, config_map);
+    })
+    .await?
+    .try_into()
 }
 
 #[cfg(test)]

--- a/bin/luminork/src/main.rs
+++ b/bin/luminork/src/main.rs
@@ -5,9 +5,16 @@ use std::{
     time::Duration,
 };
 
+use args::load_config_with_provider;
+use innit_client::{
+    InnitClient,
+    config::Config as InnitConfig,
+};
 use luminork_server::{
     Config,
     Server,
+    StandardConfig,
+    get_host_environment,
     key_generation,
 };
 use si_service::{
@@ -101,7 +108,13 @@ async fn async_main() -> Result<()> {
         )
         .await
     } else {
-        let config = Config::try_from(args)?;
+        debug!("creating innit-client...");
+        let provider = Some((
+            InnitClient::new(InnitConfig::builder().build()?).await?,
+            get_host_environment(),
+        ));
+        let config = load_config_with_provider(args, provider).await?;
+
         debug!(?config, "computed configuration");
 
         run_server(

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -17,6 +17,7 @@ groups = {
     ],
     "backend": [
         "auth-api",
+        "innit",
         "edda",
         "forklift",
         "module-index",
@@ -212,6 +213,16 @@ si_buck2_resource(
     **RUST_RESOURCE_ARGS
 )
 
+# Locally build and run `innit`
+si_buck2_resource(
+    "//bin/innit:innit",
+    resource_deps = [
+        "rust-initial-build",
+        "otelcol",
+    ],
+    **RUST_RESOURCE_ARGS
+)
+
 # Locally build and run `forklift`
 si_buck2_resource(
     "//bin/forklift:forklift",
@@ -293,6 +304,7 @@ si_buck2_resource(
         "rebaser",
         "edda",
         "forklift",
+        "innit",
     ],
     readiness_probe = probe(
         period_secs = 5,
@@ -393,6 +405,7 @@ si_buck2_resource(
 
 rust_build_targets = [
     "//bin/edda:edda",
+    "//bin/innit:innit",
     "//bin/forklift:forklift",
     "//bin/pinga:pinga",
     "//bin/rebaser:rebaser",

--- a/lib/config-file/BUCK
+++ b/lib/config-file/BUCK
@@ -11,6 +11,7 @@ rust_library(
         "toml",
     ],
     deps = [
+        "//third-party/rust:async-trait",
         "//third-party/rust:config",
         "//third-party/rust:directories",
         "//third-party/rust:pathdiff",

--- a/lib/config-file/Cargo.toml
+++ b/lib/config-file/Cargo.toml
@@ -33,6 +33,7 @@ layered-toml = ["layered", "toml", "config/toml"]
 layered-yaml = ["layered", "yaml", "config/yaml"]
 
 [dependencies]
+async-trait = { workspace = true }
 config = { workspace = true, optional = true }
 directories = { workspace = true }
 pathdiff = { workspace = true }

--- a/lib/config-file/src/lib.rs
+++ b/lib/config-file/src/lib.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 mod find;
 #[cfg(feature = "layered")]
 mod layered_load;
+pub mod parameter_provider;
 mod simple_load;
 
 pub use config::ValueKind;
@@ -22,6 +23,7 @@ pub use find::find;
 pub use layered_load::{
     ConfigMap,
     layered_load,
+    layered_load_with_provider,
 };
 #[cfg(feature = "load-str")]
 pub use simple_load::load_from_str;

--- a/lib/config-file/src/parameter_provider.rs
+++ b/lib/config-file/src/parameter_provider.rs
@@ -1,0 +1,113 @@
+use std::error::Error;
+
+use async_trait::async_trait;
+use config::{
+    ConfigBuilder,
+    Value,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use tracing::warn;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParameterError {
+    #[error("Failed to fetch parameters: {0}")]
+    Fetch(String),
+    #[error(transparent)]
+    Other(#[from] Box<dyn Error + Send + Sync>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Parameter {
+    pub name: String,
+    pub value: Option<String>,
+}
+
+#[async_trait]
+pub trait ParameterProvider: Send + Sync {
+    async fn get_parameters_by_path(&self, path: String) -> Result<Vec<Parameter>, ParameterError>;
+}
+
+pub struct ParameterSource<P: ParameterProvider> {
+    provider: P,
+    environment: String,
+    service_name: String,
+}
+
+impl<P: ParameterProvider> ParameterSource<P> {
+    pub fn new(provider: P, environment: String, service_name: String) -> Self {
+        Self {
+            provider,
+            environment,
+            service_name,
+        }
+    }
+
+    /// get all global params, then all service-specific params, and merge the service-specific
+    /// params over the globals
+    pub async fn load<St: config::builder::BuilderState>(
+        &self,
+        builder: ConfigBuilder<St>,
+    ) -> Result<ConfigBuilder<St>, config::ConfigError> {
+        let global_path = format!("si/{}/global", self.environment);
+        let global_params = match self
+            .provider
+            .get_parameters_by_path(global_path.clone())
+            .await
+        {
+            Ok(params) => params,
+            Err(e) => {
+                warn!(error = %e, "Failed to load global parameters");
+                return Ok(builder);
+            }
+        };
+
+        let service_path = format!("si/{}/{}", self.environment, self.service_name);
+        let service_params = match self
+            .provider
+            .get_parameters_by_path(service_path.clone())
+            .await
+        {
+            Err(e) => {
+                warn!(error = %e, "Failed to load service parameters");
+                // failures are okay here, we assume we only want to use globals
+                vec![]
+            }
+            Ok(params) => params,
+        };
+
+        let mut builder = builder;
+
+        for param in global_params {
+            let key = extract_config_key(&global_path, &param.name);
+            if !key.is_empty() {
+                builder = builder.set_override(key, Value::from(param.value))?;
+            }
+        }
+
+        for param in service_params {
+            let key = extract_config_key(&service_path, &param.name);
+            if !key.is_empty() {
+                builder = builder.set_override(key, Value::from(param.value))?;
+            }
+        }
+
+        Ok(builder)
+    }
+}
+
+/// Extract the config key from a parameter name
+/// e.g., "/si/tools/global/pg/hostname" -> "pg.hostname"
+fn extract_config_key(prefix: &str, name: &str) -> String {
+    // Normalize both the prefix and name to ensure they have consistent formats
+    let norm_prefix = prefix.trim_start_matches('/');
+    let norm_name = name.trim_start_matches('/');
+
+    if let Some(stripped) = norm_name.strip_prefix(norm_prefix) {
+        stripped.trim_start_matches('/').replace('/', ".")
+    } else {
+        norm_name.replace('/', ".")
+    }
+}

--- a/lib/dal/examples/rebase/main.rs
+++ b/lib/dal/examples/rebase/main.rs
@@ -36,7 +36,7 @@ fn write_snapshot_graph(path: &str, graph: &WorkspaceSnapshotGraph) -> Result<()
 }
 
 fn main() -> Result<()> {
-    let args: Vec<String> = env::args().take(10).map(Into::into).collect();
+    let args: Vec<String> = env::args().take(10).collect();
 
     for i in 1..args.len() {
         let to_rebase_path = args.get(i).expect(USAGE);

--- a/lib/innit-client/BUCK
+++ b/lib/innit-client/BUCK
@@ -3,12 +3,15 @@ load("@prelude-si//:macros.bzl", "rust_library")
 rust_library(
     name = "innit-client",
     deps = [
+        "//lib/config-file:config-file",
+        "//lib/buck2-resources:buck2-resources",
         "//lib/innit-core:innit-core",
         "//lib/si-settings:si-settings",
         "//lib/si-std:si-std",
         "//lib/si-tls:si-tls",
         "//lib/telemetry-rs:telemetry",
 
+        "//third-party/rust:async-trait",
         "//third-party/rust:base64",
         "//third-party/rust:derive_builder",
         "//third-party/rust:remain",

--- a/lib/innit-client/Cargo.toml
+++ b/lib/innit-client/Cargo.toml
@@ -9,12 +9,15 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
+buck2-resources = { path = "../../lib/buck2-resources" }
+config-file = { path = "../../lib/config-file" }
 innit-core = { path = "../../lib/innit-core" }
 si-settings = { path = "../../lib/si-settings" }
 si-std = { path = "../../lib/si-std" }
 si-tls = { path = "../../lib/si-tls" }
 telemetry = { path = "../../lib/telemetry-rs" }
 
+async-trait = { workspace = true }
 base64 = { workspace = true }
 derive_builder = { workspace = true }
 remain = { workspace = true }

--- a/lib/innit-core/BUCK
+++ b/lib/innit-core/BUCK
@@ -3,6 +3,8 @@ load("@prelude-si//:macros.bzl", "rust_library")
 rust_library(
     name = "innit-core",
     deps = [
+        "//lib/config-file:config-file",
+
         "//third-party/rust:aws-sdk-ssm",
         "//third-party/rust:chrono",
         "//third-party/rust:serde",

--- a/lib/innit-core/Cargo.toml
+++ b/lib/innit-core/Cargo.toml
@@ -9,6 +9,8 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
+config-file = { path = "../../lib/config-file" }
+
 aws-sdk-ssm = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }

--- a/lib/innit-core/src/lib.rs
+++ b/lib/innit-core/src/lib.rs
@@ -1,4 +1,5 @@
 use aws_sdk_ssm::types::Parameter as AwsParameter;
+use config_file::parameter_provider::Parameter as ParameterProviderParameter;
 use serde::{
     Deserialize,
     Serialize,
@@ -8,7 +9,6 @@ use serde::{
 pub struct Parameter {
     pub name: String,
     pub value: Option<String>,
-    pub version: Option<i64>,
 }
 
 impl From<AwsParameter> for Parameter {
@@ -16,7 +16,15 @@ impl From<AwsParameter> for Parameter {
         Self {
             name: p.name().unwrap_or_default().to_string(),
             value: p.value().map(|s| s.to_string()),
-            version: Some(p.version()),
+        }
+    }
+}
+
+impl From<Parameter> for ParameterProviderParameter {
+    fn from(p: Parameter) -> Self {
+        Self {
+            name: p.name,
+            value: p.value,
         }
     }
 }

--- a/lib/innit-server/src/routes/get_parameter.rs
+++ b/lib/innit-server/src/routes/get_parameter.rs
@@ -3,6 +3,7 @@ use axum::extract::{
     State,
 };
 use innit_core::GetParameterResponse;
+use telemetry::tracing::info;
 
 use super::AppError;
 use crate::{
@@ -17,7 +18,11 @@ pub async fn get_parameter_route(
         ..
     }): State<AppState>,
 ) -> Result<Json<GetParameterResponse>, AppError> {
-    let parameter = parameter_store_client.get_parameter(name).await?.into();
+    let parameter = parameter_store_client
+        .get_parameter(name.clone())
+        .await?
+        .into();
+    info!("Serving parameter: {name}");
 
     Ok(Json(GetParameterResponse { parameter }))
 }

--- a/lib/luminork-server/src/lib.rs
+++ b/lib/luminork-server/src/lib.rs
@@ -42,6 +42,11 @@ pub use dal::{
         FeatureFlagService,
     },
 };
+pub use si_settings::{
+    ConfigMap,
+    ParameterProvider,
+    get_host_environment,
+};
 
 pub(crate) use self::app_state::AppState;
 pub use self::{

--- a/lib/si-settings/BUCK
+++ b/lib/si-settings/BUCK
@@ -6,6 +6,7 @@ rust_library(
     name = "si-settings",
     deps = [
         "//lib/config-file:config-file",
+        "//third-party/rust:async-trait",
         "//third-party/rust:remain",
         "//third-party/rust:serde",
         "//third-party/rust:thiserror",

--- a/lib/si-settings/Cargo.toml
+++ b/lib/si-settings/Cargo.toml
@@ -11,6 +11,7 @@ publish.workspace = true
 [dependencies]
 config-file = { path = "../../lib/config-file", features = ["layered-toml"] }
 
+async-trait = { workspace = true }
 remain = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOHd5cmlnaDFrN2MyNmF4ZWd0bDhjdzQwb3k1eXluYmY1djJmNHJoZSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/WUlzarOFoH7oaHM6Cm/giphy.gif"/>

* add generic provider for getting parameters into layered_load
* thread that sucker through to si_settings and up to the bins
* do so using divergent (copy paste) implementations to avoid blast radius
* get from global path `/si/${env}/global` and `/si/${env}/${service}` to layer global and service-specific configs
* tell luminork to use the layered_load that gets from parameter store, passing in innit-client

```bash
❯ curl http://localhost:5166/parameters/si/tools/ | jq
{
  "parameters": [
    {
      "name": "/si/tools/global/pg/user",
      "value": "si"
    },
    {
      "name": "/si/tools/global/pg/hostname",
      "value": "abc"
    },
    {
      "name": "/si/tools/global/pg/dbname",
      "value": "butt"
    },
    {
      "name": "/si/tools/sdf/pg/hostname",
      "value": "derpdoop"
    },
    {
      "name": "/si/tools/luminork/pg/hostname",
      "value": "def"
    }
  ]
}
```

For luminork, it will generate the following pg config

```json
{
    "user": "si",
    "password": "",
    "dbname": "butt",
    "application_name": "luminork",
    "hostname": "def"
}
```


