### PR TITLE
feat(luminork): Ability to get a component by Id, find by name, and list all Component Ids for a workspace

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -302,7 +302,7 @@ si_buck2_resource(
         ),
     ),
     links = [
-        link("http://127.0.0.1:5380"),
+        link("http://127.0.0.1:5380/swagger-ui", "swagger-ui"),
     ],
     **RUST_RESOURCE_ARGS
 )

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -2006,6 +2006,13 @@ impl Component {
         self.attribute_value_for_prop(ctx, &["root", "domain"])
             .await
     }
+    pub async fn resource_value_prop_attribute_value(
+        &self,
+        ctx: &DalContext,
+    ) -> ComponentResult<AttributeValueId> {
+        self.attribute_value_for_prop(ctx, &["root", "resource_value"])
+            .await
+    }
 
     pub async fn attribute_values_for_all_sockets(
         ctx: &DalContext,

--- a/lib/luminork-server/src/api_types.rs
+++ b/lib/luminork-server/src/api_types.rs
@@ -1,0 +1,1 @@
+pub mod component;

--- a/lib/luminork-server/src/api_types/component.rs
+++ b/lib/luminork-server/src/api_types/component.rs
@@ -1,0 +1,1 @@
+pub mod v1;

--- a/lib/luminork-server/src/api_types/component/v1.rs
+++ b/lib/luminork-server/src/api_types/component/v1.rs
@@ -1,0 +1,307 @@
+use std::collections::VecDeque;
+
+use dal::{
+    AttributeValue,
+    Component,
+    ComponentId,
+    DalContext,
+    SchemaId,
+    SchemaVariant,
+    SchemaVariantId,
+    SocketArity,
+    component::socket::{
+        ComponentInputSocket,
+        ComponentOutputSocket,
+    },
+    diagram::{
+        geometry::Geometry,
+        view::View,
+    },
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use serde_json::Value;
+use si_id::{
+    AttributeValueId,
+    PropId,
+    ViewId,
+};
+use strum::{
+    AsRefStr,
+    Display,
+    EnumIter,
+    EnumString,
+};
+use utoipa::ToSchema;
+
+use crate::service::v1::ComponentsResult;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct ComponentViewV1 {
+    #[schema(value_type = String)]
+    pub id: ComponentId,
+    #[schema(value_type = String)]
+    pub schema_id: SchemaId,
+    #[schema(value_type = String)]
+    pub schema_variant_id: SchemaVariantId,
+    pub sockets: Vec<SocketViewV1>,
+    // this is everything below root/domain - the whole tree! (not including root/domain itself)
+    pub domain_props: Vec<ComponentPropViewV1>,
+    // from root/resource_value NOT root/resource/payload
+    pub resource_props: Vec<ComponentPropViewV1>,
+    // maps to root/si/name
+    pub name: String,
+    // maps to root/si/resource_id
+    pub resource_id: String,
+    pub to_delete: bool,
+    pub can_be_upgraded: bool,
+    // current connections to/from this component (should these be separated?)
+    pub connections: Vec<ConnectionViewV1>,
+    // what views this component is in
+    pub views: Vec<ViewV1>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentPropViewV1 {
+    #[schema(value_type = String)]
+    pub id: AttributeValueId, // I know prop view with an id for an AV...
+    #[schema(value_type = String)]
+    pub prop_id: PropId,
+    #[schema(value_type = Object)]
+    pub value: Option<Value>,
+    #[schema(value_type = String, example = "path/to/prop")]
+    pub path: String,
+    // todo: Validation
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ViewV1 {
+    #[schema(value_type = String)]
+    pub id: ViewId,
+    pub name: String,
+    pub is_default: bool,
+}
+
+#[derive(AsRefStr, Clone, Debug, Deserialize, Display, Eq, PartialEq, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum ConnectionViewV1 {
+    Incoming(IncomingConnectionViewV1),
+    Outgoing(OutgoingConnectionViewV1),
+    Managing(ManagingConnectionViewV1),
+    ManagedBy(ManagedByConnectionViewV1),
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct IncomingConnectionViewV1 {
+    #[schema(value_type = String)]
+    pub from_component_id: ComponentId,
+    pub from_component_name: String,
+    pub from: String, // from socket or prop
+    pub to: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OutgoingConnectionViewV1 {
+    #[schema(value_type = String)]
+    pub to_component_id: ComponentId,
+    pub to_component_name: String,
+    pub from: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagingConnectionViewV1 {
+    #[schema(value_type = String)]
+    pub component_id: ComponentId,
+    pub component_name: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagedByConnectionViewV1 {
+    #[schema(value_type = String)]
+    pub component_id: ComponentId,
+    pub component_name: String,
+}
+
+#[remain::sorted]
+#[derive(
+    AsRefStr,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Display,
+    EnumIter,
+    EnumString,
+    Eq,
+    PartialEq,
+    Serialize,
+    ToSchema,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum SocketDirection {
+    Input,
+    Output,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SocketViewV1 {
+    pub id: String,
+    pub name: String,
+    pub direction: SocketDirection,
+    #[schema(value_type = String, example = "one", example = "many")]
+    pub arity: SocketArity,
+    #[schema(value_type = Object)]
+    pub value: Option<serde_json::Value>,
+}
+
+impl ComponentViewV1 {
+    pub async fn assemble(ctx: &DalContext, component_id: ComponentId) -> ComponentsResult<Self> {
+        let component = Component::get_by_id(ctx, component_id).await?;
+        let schema_variant = component.schema_variant(ctx).await?;
+        // lets get all sockets
+        let mut sockets = Vec::new();
+        let (output_sockets, input_sockets) =
+            SchemaVariant::list_all_sockets(ctx, schema_variant.id()).await?;
+        for output in output_sockets {
+            sockets.push(SocketViewV1 {
+                id: output.id().to_string(),
+                name: output.name().to_owned(),
+                direction: SocketDirection::Output,
+                arity: output.arity(),
+                value: ComponentOutputSocket::value_for_output_socket_id_for_component_id_opt(
+                    ctx,
+                    component_id,
+                    output.id(),
+                )
+                .await?,
+            });
+        }
+
+        for input in input_sockets {
+            // TODO(brit): figure out connection annotations
+            sockets.push(SocketViewV1 {
+                id: input.id().to_string(),
+                name: input.name().to_owned(),
+                direction: SocketDirection::Input,
+                arity: input.arity(),
+                value: ComponentInputSocket::value_for_input_socket_id_for_component_id_opt(
+                    ctx,
+                    component_id,
+                    input.id(),
+                )
+                .await?,
+            });
+        }
+        // Connections
+        // TODO(brit): Management connections!!
+        let mut connections = Vec::new();
+        let incoming = component.incoming_connections(ctx).await?;
+        for input in incoming {
+            connections.push(ConnectionViewV1::Incoming(IncomingConnectionViewV1 {
+                from_component_id: input.from_component_id,
+                from_component_name: Component::name_by_id(ctx, input.from_component_id).await?,
+                from: input.from_output_socket_id.to_string(),
+                to: input.to_input_socket_id.to_string(),
+            }));
+        }
+        let outgoing = component.outgoing_connections(ctx).await?;
+        for output in outgoing {
+            connections.push(ConnectionViewV1::Outgoing(OutgoingConnectionViewV1 {
+                to_component_id: output.to_component_id,
+                to_component_name: Component::name_by_id(ctx, output.to_component_id).await?,
+                from: output.from_output_socket_id.to_string(),
+            }));
+        }
+
+        // Domain Props
+        // todo(brit): filter out domain/root AND hidden props
+        let mut domain_props = Vec::new();
+        let domain_root_av = component.domain_prop_attribute_value(ctx).await?;
+        let mut work_queue = VecDeque::new();
+        work_queue.push_back(domain_root_av);
+        while let Some(av) = work_queue.pop_front() {
+            let attribute_value = AttributeValue::get_by_id(ctx, av).await?;
+
+            let view = ComponentPropViewV1 {
+                id: av,
+                prop_id: AttributeValue::prop_id(ctx, av).await?,
+                value: attribute_value.view(ctx).await?,
+                path: AttributeValue::get_path_for_id(ctx, av)
+                    .await?
+                    .unwrap_or_else(String::new),
+            };
+            domain_props.push(view);
+            let children = AttributeValue::get_child_av_ids_in_order(ctx, av).await?;
+
+            work_queue.extend(children);
+        }
+        // sort alphabetically by path
+        domain_props.sort_by_key(|view| view.path.to_lowercase());
+
+        // Resource Props
+        let mut resource_props = Vec::new();
+        let resource_value_root_av = component.resource_value_prop_attribute_value(ctx).await?;
+        let mut work_queue = VecDeque::new();
+        let resource_value_values =
+            AttributeValue::get_child_av_ids_in_order(ctx, resource_value_root_av).await?;
+        work_queue.extend(resource_value_values);
+        while let Some(av) = work_queue.pop_front() {
+            let attribute_value = AttributeValue::get_by_id(ctx, av).await?;
+
+            let view = ComponentPropViewV1 {
+                id: av,
+                prop_id: AttributeValue::prop_id(ctx, av).await?,
+                value: attribute_value.view(ctx).await?,
+                path: AttributeValue::get_path_for_id(ctx, av)
+                    .await?
+                    .unwrap_or_else(String::new),
+            };
+            resource_props.push(view);
+            let children = AttributeValue::get_child_av_ids_in_order(ctx, av).await?;
+
+            work_queue.extend(children);
+        }
+
+        // sort alphabetically by path
+        resource_props.sort_by_key(|view| view.path.to_lowercase());
+
+        // get views
+        let mut views = Vec::new();
+        let geos = Geometry::by_view_for_component_id(ctx, component_id).await?;
+        for view_id in geos.keys() {
+            let view = View::get_by_id(ctx, *view_id).await?;
+            views.push(ViewV1 {
+                id: *view_id,
+                name: view.name().to_string(),
+                is_default: view.is_default(ctx).await?,
+            });
+        }
+
+        let result = ComponentViewV1 {
+            id: component_id,
+            schema_id: schema_variant.schema_id(ctx).await?,
+            schema_variant_id: schema_variant.id(),
+            sockets,
+            domain_props,
+            resource_props,
+            name: component.name(ctx).await?,
+            resource_id: component.resource_id(ctx).await?,
+            to_delete: component.to_delete(),
+            can_be_upgraded: component.can_be_upgraded(ctx).await?,
+            connections,
+            views,
+        };
+        Ok(result)
+    }
+}

--- a/lib/luminork-server/src/lib.rs
+++ b/lib/luminork-server/src/lib.rs
@@ -19,6 +19,7 @@ use frigg::FriggError;
 use si_data_spicedb::SpiceDbError;
 use thiserror::Error;
 
+mod api_types;
 mod app;
 mod app_state;
 mod config;

--- a/lib/luminork-server/src/service/v1.rs
+++ b/lib/luminork-server/src/service/v1.rs
@@ -28,6 +28,7 @@ pub use change_sets::{
 pub use components::{
     ComponentV1RequestPath,
     ComponentsError,
+    ComponentsResult,
     connections::{
         ComponentReference,
         Connection,
@@ -38,11 +39,12 @@ pub use components::{
         CreateComponentV1Response,
     },
     delete_component::DeleteComponentV1Response,
+    find_component::FindComponentV1Request,
     get_component::{
-        GeometryAndViewAndName,
         GetComponentV1Response,
         GetComponentV1ResponseManagementFunction,
     },
+    list_components::ListComponentsV1Response,
     update_component::{
         ComponentPropKey,
         DomainPropPath,
@@ -63,6 +65,12 @@ pub use schema::{
     list_schema::ListSchemaV1Response,
 };
 pub use workspaces::WorkspaceError;
+
+pub use crate::api_types::component::v1::{
+    ComponentPropViewV1,
+    ComponentViewV1,
+    ConnectionViewV1,
+};
 
 /// OpenAPI documentation for v1 API
 #[derive(OpenApi)]
@@ -85,6 +93,8 @@ pub use workspaces::WorkspaceError;
         change_sets::request_approval::request_approval,
         components::get_component::get_component,
         components::create_component::create_component,
+        components::list_components::list_components,
+        components::find_component::find_component,
         components::update_component::update_component,
         components::delete_component::delete_component,
         management::run_prototype::run_prototype,
@@ -108,7 +118,6 @@ pub use workspaces::WorkspaceError;
             CreateComponentV1Request,
             CreateComponentV1Response,
             Connection,
-            GeometryAndViewAndName,
             ListSchemaV1Response,
             UpdateComponentV1Request,
             UpdateComponentV1Response,
@@ -119,7 +128,12 @@ pub use workspaces::WorkspaceError;
             ComponentPropKey,
             DomainPropPath,
             ConnectionPoint,
-            ComponentReference
+            ComponentReference,
+            ComponentViewV1,
+            ComponentPropViewV1,
+            ConnectionViewV1,
+            ListComponentsV1Response,
+            FindComponentV1Request,
         )
     ),
     tags(

--- a/lib/luminork-server/src/service/v1/components/connections.rs
+++ b/lib/luminork-server/src/service/v1/components/connections.rs
@@ -54,15 +54,15 @@ pub enum Connection {
 /// Returns the component ID if found, or appropriate error if not found or if duplicate names exist
 pub async fn find_component_id_by_name(
     ctx: &dal::DalContext,
-    component_list: &[Component],
+    component_list: &[ComponentId],
     component_name: &str,
 ) -> Result<ComponentId, ComponentsError> {
     let mut matching_components = Vec::new();
 
-    for c in component_list {
-        let name = c.name(ctx).await?;
+    for component_id in component_list {
+        let name = Component::name_by_id(ctx, *component_id).await?;
         if name == component_name {
-            matching_components.push(c.id());
+            matching_components.push(*component_id);
         }
     }
 
@@ -81,7 +81,7 @@ pub async fn find_component_id_by_name(
 pub async fn resolve_component_reference(
     ctx: &dal::DalContext,
     component_ref: &ComponentReference,
-    component_list: &[Component],
+    component_list: &[ComponentId],
 ) -> Result<ComponentId, ComponentsError> {
     match component_ref {
         ComponentReference::ById { component_id } => Ok(*component_id),
@@ -144,7 +144,7 @@ pub async fn handle_connection(
     connection: &Connection,
     component_id: ComponentId,
     variant_id: SchemaVariantId,
-    component_list: &[Component],
+    component_list: &[ComponentId],
     is_add: bool,
 ) -> Result<(), ComponentsError> {
     match connection {

--- a/lib/luminork-server/src/service/v1/components/list_components.rs
+++ b/lib/luminork-server/src/service/v1/components/list_components.rs
@@ -1,0 +1,44 @@
+use axum::response::Json;
+use dal::{
+    Component,
+    ComponentId,
+};
+use sdf_extract::change_set::ChangeSetDalContext;
+use serde::Serialize;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use super::ComponentsError;
+
+#[derive(Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListComponentsV1Response {
+    #[schema(value_type = String)]
+    pub components: Vec<ComponentId>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/components",
+    params(
+        ("workspace_id", description = "Workspace identifier"),
+        ("change_set_id", description = "Change set identifier"),
+    ),
+    tag = "components",
+    responses(
+        (status = 200, description = "Components retrieved successfully"),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn list_components(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+) -> Result<Json<ListComponentsV1Response>, ComponentsError> {
+    let component_ids = Component::list_ids(ctx).await?;
+
+    Ok(Json(ListComponentsV1Response {
+        components: component_ids,
+    }))
+}

--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -20,7 +20,9 @@ use crate::AppState;
 pub mod connections;
 pub mod create_component;
 pub mod delete_component;
+pub mod find_component;
 pub mod get_component;
+pub mod list_components;
 pub mod update_component;
 
 #[remain::sorted]
@@ -57,6 +59,8 @@ pub enum ComponentsError {
     #[error("ws event error: {0}")]
     WsEvent(#[from] dal::WsEventError),
 }
+
+pub type ComponentsResult<T> = Result<T, ComponentsError>;
 
 #[derive(Deserialize, ToSchema)]
 pub struct ComponentV1RequestPath {
@@ -107,6 +111,8 @@ impl crate::service::v1::common::ErrorIntoResponse for ComponentsError {
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/", post(create_component::create_component))
+        .route("/", get(list_components::list_components))
+        .route("/find", post(find_component::find_component))
         .nest(
             "/:component_id",
             Router::new()


### PR DESCRIPTION

This adds some initial functionality for listing component Ids, getting a component by Id, and finding a component by name. 

I also added Workpace Id and ChangeSet Id to the params for the swagger UI, mimicing what we had for the jwt, because I was sick of having to copy them in each time across each route.  Claude helped here, we needed to inject these as global parameters so that we have access to them, doing this in the interceptor didn't work as the OpenAI spec validates the request before it gets there and the validation was failing when workspace Id and change set Id were empty. 

I'm also experimenting with versioned API types in luminork itself, we can rip this into a separate crate once we get further and see the shapes of these things - we'll have to see how this feels.

Expect these shapes to change as we build out the API, but the scaffold is there to build on. 

Tested by executing the routes and seeing them work using the swagger-ui!

<div><img src="https://media0.giphy.com/media/13GIgrGdslD9oQ/giphy.gif?cid=5a38a5a24b64grnuosbrd0t3mioe0liyows7nle5zeqam5x4&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:180px;width:300px"/><br/>via <a href="https://giphy.com/gifs/reaction-typing-unpopular-opinion-13GIgrGdslD9oQ">GIPHY</a></div>