### PR TITLE
feat(innit): in-memory cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,7 +4083,7 @@ name = "innit-server"
 version = "0.1.0"
 dependencies = [
  "axum 0.6.20",
- "base64 0.22.1",
+ "dashmap",
  "derive_builder",
  "futures",
  "hyper 0.14.32",

--- a/lib/innit-client/tests/integration_test/mod.rs
+++ b/lib/innit-client/tests/integration_test/mod.rs
@@ -2,7 +2,11 @@ mod certs;
 #[cfg(test)]
 mod integration_tests {
 
-    use std::net::SocketAddr;
+    use std::{
+        env,
+        net::SocketAddr,
+        sync::Once,
+    };
 
     use base64::{
         Engine as _,
@@ -31,10 +35,22 @@ mod integration_tests {
         client_key: String,
     }
 
+    const ENV_VAR_LOCALSTACK_URL: &str = "SI_TEST_LOCALSTACK_URL";
+    const DEFAULT_ENDPOINT: &str = "http://localhost:4566";
+    static INIT: Once = Once::new();
+
+    // a crypto provider (only one) is required to generate certs, which happens in these tests
+    fn initialize_crypto() {
+        INIT.call_once(|| {
+            rustls::crypto::ring::default_provider()
+                .install_default()
+                .expect("Failed to install rustls crypto provider");
+        });
+    }
+
     fn create_certs() -> TestCerts {
-        rustls::crypto::ring::default_provider()
-            .install_default()
-            .expect("Failed to install rustls crypto provider");
+        initialize_crypto();
+
         let (ca, ca_key) = new_ca();
         let (client_cert, client_key) = new_end_entity(&ca, &ca_key);
 
@@ -50,9 +66,17 @@ mod integration_tests {
         ca_cert: String,
     ) -> (Server<AddrIncoming>, CancellationToken) {
         let token = CancellationToken::new();
+
+        let mut endpoint = DEFAULT_ENDPOINT.to_string();
+        #[allow(clippy::disallowed_methods)] // Used only in tests & so prefixed with `SI_TEST_`
+        if let Ok(value) = env::var(ENV_VAR_LOCALSTACK_URL) {
+            endpoint = value;
+        }
+
         let config = innit_server::Config::builder()
             .socket_addr(addr)
             .client_ca_cert(Some(CertificateSource::Base64(ca_cert)))
+            .test_endpoint(Some(endpoint))
             .build()
             .expect("should build config");
         let server = Server::http(config, token.clone())
@@ -121,6 +145,179 @@ mod integration_tests {
 
         // should auth and be ok
         assert!(client.check_health().await.expect("should be ok").ok);
+
+        token.cancel();
+        server_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn create_param() {
+        let certs = create_certs();
+        let addr = SocketAddr::from(([0, 0, 0, 0], 0));
+        let (server, token) = setup_test_server(addr, certs.ca_cert).await;
+        let bound_port = server.bound_port();
+        let server_handle =
+            tokio::spawn(async move { server.run().await.expect("should run server") });
+
+        // Create client with proper auth certs
+        let client_config = innit_client::config::Config::builder()
+            .base_url(
+                Url::parse(&format!("http://{}:{}", &addr.ip(), bound_port))
+                    .expect("should parse addr"),
+            )
+            .auth_config(AuthConfig {
+                client_cert: Some(CertificateSource::Base64(certs.client_cert)),
+                client_key: Some(KeySource::Base64(certs.client_key)),
+            })
+            .build()
+            .expect("should make new config");
+
+        let client = InnitClient::new(client_config)
+            .await
+            .expect("should make new client");
+
+        let param_name = "/si/test/test/param1";
+        let initial_value = "initial_value";
+        let updated_value = "updated_value";
+
+        // create a parameter
+        client
+            .create_parameter(param_name.to_string(), initial_value.to_string())
+            .await
+            .expect("should create parameter");
+
+        // get it, should be cached
+        let get_response = client
+            .get_parameter(param_name.to_string())
+            .await
+            .expect("should get parameter");
+
+        assert_eq!(
+            get_response.parameter.value,
+            Some(initial_value.to_string())
+        );
+        assert!(get_response.is_cached);
+
+        // update it
+        client
+            .create_parameter(param_name.to_string(), updated_value.to_string())
+            .await
+            .expect("should update parameter");
+
+        // get it, should be cached
+        let get_response = client
+            .get_parameter(param_name.to_string())
+            .await
+            .expect("should get updated parameter");
+
+        assert_eq!(
+            get_response.parameter.value,
+            Some(updated_value.to_string())
+        );
+        assert!(get_response.is_cached);
+
+        // clear the cache
+        let refresh_response = client
+            .clear_parameter_cache()
+            .await
+            .expect("should refresh cache");
+
+        assert!(refresh_response.success, "Cache refresh should succeed");
+
+        // get again, ensure not cached
+        let get_response = client
+            .get_parameter(param_name.to_string())
+            .await
+            .expect("should get parameter");
+
+        assert_eq!(
+            get_response.parameter.value,
+            Some(updated_value.to_string())
+        );
+        assert!(!get_response.is_cached);
+
+        token.cancel();
+        server_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn create_and_get_by_path() {
+        let certs = create_certs();
+        let addr = SocketAddr::from(([0, 0, 0, 0], 0));
+        let (server, token) = setup_test_server(addr, certs.ca_cert).await;
+        let bound_port = server.bound_port();
+        let server_handle =
+            tokio::spawn(async move { server.run().await.expect("should run server") });
+
+        // Create client with proper auth certs
+        let client_config = innit_client::config::Config::builder()
+            .base_url(
+                Url::parse(&format!("http://{}:{}", &addr.ip(), bound_port))
+                    .expect("should parse addr"),
+            )
+            .auth_config(AuthConfig {
+                client_cert: Some(CertificateSource::Base64(certs.client_cert)),
+                client_key: Some(KeySource::Base64(certs.client_key)),
+            })
+            .build()
+            .expect("should make new config");
+
+        let client = InnitClient::new(client_config)
+            .await
+            .expect("should make new client");
+
+        let path_prefix = "/si/test/test";
+
+        // create two parameters in the same path
+        client
+            .create_parameter(
+                format!("{}/param1", path_prefix),
+                "path_test_value".to_string(),
+            )
+            .await
+            .expect("should create parameter");
+
+        client
+            .create_parameter(
+                format!("{}/param2", path_prefix),
+                "path_test_value".to_string(),
+            )
+            .await
+            .expect("should create second parameter");
+
+        // clear the cache
+        let refresh_response = client
+            .clear_parameter_cache()
+            .await
+            .expect("should refresh cache");
+
+        assert!(refresh_response.success, "Cache refresh should succeed");
+
+        // get parameters by path, no cache
+        let list_response = client
+            .get_parameters_by_path(path_prefix.to_string())
+            .await
+            .expect("should list parameters");
+
+        assert_eq!(
+            list_response.parameters.len(),
+            2,
+            "Should find two parameters"
+        );
+        assert!(!list_response.is_cached);
+
+        // Make a second request which should be served from cache
+        let cached_list_response = client
+            .get_parameters_by_path(path_prefix.to_string())
+            .await
+            .expect("should list parameters from cache");
+
+        assert_eq!(
+            cached_list_response.parameters.len(),
+            2,
+            "Should find two parameters from cache"
+        );
+        assert!(cached_list_response.is_cached);
 
         token.cancel();
         server_handle.abort();

--- a/lib/innit-core/src/lib.rs
+++ b/lib/innit-core/src/lib.rs
@@ -34,12 +34,27 @@ pub struct CheckHealthResponse {
     pub ok: bool,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct CreateParameterRequest {
+    pub value: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateParameterResponse {}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetParameterResponse {
     pub parameter: Parameter,
+    pub is_cached: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListParametersResponse {
     pub parameters: Vec<Parameter>,
+    pub is_cached: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RefreshCacheResponse {
+    pub success: bool,
 }

--- a/lib/innit-server/BUCK
+++ b/lib/innit-server/BUCK
@@ -10,6 +10,7 @@ rust_library(
         "//lib/si-tls:si-tls",
         "//lib/telemetry-rs:telemetry",
         "//third-party/rust:axum",
+        "//third-party/rust:dashmap",
         "//third-party/rust:derive_builder",
         "//third-party/rust:futures",
         "//third-party/rust:hyper",

--- a/lib/innit-server/Cargo.toml
+++ b/lib/innit-server/Cargo.toml
@@ -17,7 +17,7 @@ si-tls = { path = "../../lib/si-tls" }
 telemetry = { path = "../../lib/telemetry-rs" }
 
 axum = { workspace = true }
-base64 = { workspace = true }
+dashmap = { workspace = true }
 derive_builder = { workspace = true }
 futures = { workspace = true }
 hyper = { workspace = true }

--- a/lib/innit-server/src/app_state.rs
+++ b/lib/innit-server/src/app_state.rs
@@ -2,12 +2,15 @@ use axum::extract::FromRef;
 use si_data_ssm::ParameterStoreClient;
 use tokio_util::sync::CancellationToken;
 
+use crate::parameter_cache::ParameterCache;
+
 #[remain::sorted]
 #[derive(Debug, Eq, PartialEq)]
 pub enum ShutdownSource {}
 
 #[derive(Clone, Debug, FromRef)]
 pub struct AppState {
+    pub parameter_cache: ParameterCache,
     pub parameter_store_client: ParameterStoreClient,
     shutdown_token: CancellationToken,
 }
@@ -15,10 +18,12 @@ pub struct AppState {
 impl AppState {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        parameter_cache: ParameterCache,
         parameter_store_client: ParameterStoreClient,
         shutdown_token: CancellationToken,
     ) -> Self {
         Self {
+            parameter_cache,
             parameter_store_client,
             shutdown_token,
         }

--- a/lib/innit-server/src/lib.rs
+++ b/lib/innit-server/src/lib.rs
@@ -2,6 +2,7 @@ mod api_error;
 mod app_state;
 mod config;
 mod middleware;
+mod parameter_cache;
 mod routes;
 mod server;
 

--- a/lib/innit-server/src/parameter_cache.rs
+++ b/lib/innit-server/src/parameter_cache.rs
@@ -1,0 +1,90 @@
+use std::{
+    sync::Arc,
+    time::{
+        Duration,
+        Instant,
+    },
+};
+
+use dashmap::DashMap;
+use innit_core::Parameter;
+use tokio::sync::RwLock;
+
+#[derive(Debug, Clone)]
+pub struct CachedValue<T> {
+    pub value: T,
+    pub cached_at: Instant,
+}
+
+impl<T> CachedValue<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            value,
+            cached_at: Instant::now(),
+        }
+    }
+
+    pub fn is_expired(&self, ttl: Duration) -> bool {
+        self.cached_at.elapsed() > ttl
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ParameterCache {
+    // Cache for single parameters
+    parameter_cache: Arc<DashMap<String, CachedValue<Parameter>>>,
+    // Cache for parameter paths
+    path_cache: Arc<DashMap<String, CachedValue<Vec<Parameter>>>>,
+    // Last refresh timestamp
+    last_refresh: Arc<RwLock<Option<Instant>>>,
+    // TTL for cache entries
+    ttl: Duration,
+}
+
+impl ParameterCache {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            parameter_cache: Arc::new(DashMap::new()),
+            path_cache: Arc::new(DashMap::new()),
+            last_refresh: Arc::new(RwLock::new(None)),
+            ttl,
+        }
+    }
+
+    pub async fn get_parameter(&self, name: &str) -> Option<Parameter> {
+        if let Some(cached) = self.parameter_cache.get(name) {
+            if !cached.is_expired(self.ttl) {
+                return Some(cached.value.clone());
+            }
+        }
+        None
+    }
+
+    pub async fn set_parameter(&self, parameter: Parameter) {
+        self.parameter_cache
+            .insert(parameter.name.clone(), CachedValue::new(parameter));
+    }
+
+    pub async fn get_parameters_by_path(&self, path: &str) -> Option<Vec<Parameter>> {
+        if let Some(cached) = self.path_cache.get(path) {
+            if !cached.is_expired(self.ttl) {
+                return Some(cached.value.clone());
+            }
+        }
+        None
+    }
+
+    pub async fn set_parameters_by_path(&self, path: String, parameters: Vec<Parameter>) {
+        self.path_cache.insert(path, CachedValue::new(parameters));
+    }
+
+    pub async fn clear_cache(&self) {
+        self.parameter_cache.clear();
+        self.path_cache.clear();
+        *self.last_refresh.write().await = Some(Instant::now());
+    }
+
+    pub async fn get_last_refresh(&self) -> Option<Instant> {
+        *self.last_refresh.read().await
+    }
+}

--- a/lib/innit-server/src/routes.rs
+++ b/lib/innit-server/src/routes.rs
@@ -5,7 +5,11 @@ use axum::{
         Json,
         Response,
     },
-    routing::get,
+    routing::{
+        get,
+        post,
+        put,
+    },
 };
 use hyper::StatusCode;
 use serde_json::{
@@ -19,6 +23,8 @@ use tower_http::{
     cors::CorsLayer,
 };
 
+mod clear_cache;
+mod create_parameter;
 mod get_parameter;
 mod list_parameters;
 
@@ -33,7 +39,12 @@ pub fn routes(state: AppState) -> Router {
     let mut router: Router<AppState> = Router::new();
     router = router
         .route("/", get(system_status_route))
+        .route("/cache/clear", post(clear_cache::clear_cache_route))
         .route("/parameter/*path", get(get_parameter::get_parameter_route))
+        .route(
+            "/parameter/*path",
+            put(create_parameter::create_parameter_route),
+        )
         .route(
             "/parameters/*path",
             get(list_parameters::list_parameters_route),

--- a/lib/innit-server/src/routes/clear_cache.rs
+++ b/lib/innit-server/src/routes/clear_cache.rs
@@ -1,0 +1,20 @@
+use axum::{
+    Json,
+    extract::State,
+    http::StatusCode,
+};
+use innit_core::RefreshCacheResponse;
+use telemetry::tracing::info;
+
+use crate::app_state::AppState;
+
+pub async fn clear_cache_route(
+    State(AppState {
+        parameter_cache, ..
+    }): State<AppState>,
+) -> Result<Json<RefreshCacheResponse>, StatusCode> {
+    parameter_cache.clear_cache().await;
+
+    info!("Cleared parameter cache.");
+    Ok(Json(RefreshCacheResponse { success: true }))
+}

--- a/lib/innit-server/src/routes/create_parameter.rs
+++ b/lib/innit-server/src/routes/create_parameter.rs
@@ -1,0 +1,47 @@
+use axum::{
+    Json,
+    extract::{
+        Path,
+        State,
+    },
+};
+use innit_core::{
+    CreateParameterRequest,
+    CreateParameterResponse,
+    Parameter,
+};
+use telemetry::tracing::info;
+
+use super::AppError;
+use crate::app_state::AppState;
+
+pub async fn create_parameter_route(
+    Path(name): Path<String>,
+    State(AppState {
+        parameter_cache,
+        parameter_store_client,
+        ..
+    }): State<AppState>,
+    Json(CreateParameterRequest { value }): Json<CreateParameterRequest>,
+) -> Result<Json<CreateParameterResponse>, AppError> {
+    let name = if !name.starts_with('/') {
+        format!("/{}", name)
+    } else {
+        name.clone()
+    };
+
+    parameter_store_client
+        .create_string_parameter(name.clone(), value.clone())
+        .await?;
+
+    parameter_cache
+        .set_parameter(Parameter {
+            name: name.clone(),
+            value: Some(value.clone()),
+        })
+        .await;
+
+    info!("Created parameter: {name}/{value}");
+
+    Ok(Json(CreateParameterResponse {}))
+}

--- a/lib/si-data-ssm/src/lib.rs
+++ b/lib/si-data-ssm/src/lib.rs
@@ -79,18 +79,11 @@ impl ParameterStoreClient {
     }
 
     /// Creates a [ParameterStoreClient] configured for testing (e.g., LocalStack).
-    pub fn new_for_test(
-        endpoint: String,
-        region: String,
-        access_key: String,
-        secret_key: String,
-    ) -> Self {
+    pub fn new_for_test(endpoint: String) -> Self {
         let shared_config = aws_sdk_ssm::config::Builder::new()
-            .region(Region::new(region))
+            .region(Region::new("us-east-1"))
             .endpoint_url(endpoint)
-            .credentials_provider(Credentials::new(
-                access_key, secret_key, None, None, "tests",
-            ))
+            .credentials_provider(Credentials::new("test", "test", None, None, "test"))
             .behavior_version_latest()
             .build();
 

--- a/lib/si-data-ssm/tests/integration_test/mod.rs
+++ b/lib/si-data-ssm/tests/integration_test/mod.rs
@@ -13,12 +13,7 @@ mod integration_tests {
             endpoint = value;
         }
         dbg!("connecting to {}", &endpoint);
-        let client = ParameterStoreClient::new_for_test(
-            endpoint,
-            "us-east-1".to_string(),
-            "test".to_string(),
-            "test".to_string(),
-        );
+        let client = ParameterStoreClient::new_for_test(endpoint);
 
         let parameter_name = "/test/integration/parameter";
         let parameter_value = "test_value";


### PR DESCRIPTION
Adds an in-memory cache for parameter values to manage backend pressure. There are separate caches for individual params and lists just for simplicity. By default, cache items expire after 24 hours. 

Also adds a create endpoint to facilitate testing.