### PR TITLE
fix: add transitgatewayattachmentid prop and output socket to vpnconnection asset

### DIFF
--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -935,6 +935,32 @@ const overrides = new Map<string, OverrideFn>([
     setAnnotationOnSocket(idSocket, { tokens: ["TransitGatewayId"] });
     setAnnotationOnSocket(idSocket, { tokens: ["Transit Gateway Id"] });
   }],
+  ["AWS::EC2::VPNConnection", (spec: ExpandedPkgSpec) => {
+    const variant = spec.schemas[0].variants[0];
+    const resource_value = variant.resourceValue;
+
+    const transitGatewayAttachmentIdProp = createScalarProp(
+      "TransitGatewayAttachmentId",
+      "string",
+      ["root", "resource_value"],
+      false,
+    );
+    transitGatewayAttachmentIdProp.data.widgetKind = "Text";
+    resource_value.entries.push(transitGatewayAttachmentIdProp);
+
+    const tgwaIdOutputSocket = createOutputSocketFromProp(
+      transitGatewayAttachmentIdProp, 
+      "Transit Gateway Attachment Id"
+    );
+    variant.sockets.push(tgwaIdOutputSocket);
+
+    const tgwaIdSocket = variant.sockets.find(
+      (s: ExpandedSocketSpec) => s.name === "TransitGatewayAttachmentId" && s.data.kind === "output",
+    );
+    if (!tgwaIdSocket) return;
+    setAnnotationOnSocket(tgwaIdSocket, { tokens: ["TransitGatewayAttachmentId"] });
+    setAnnotationOnSocket(tgwaIdSocket, { tokens: ["Transit Gateway Attachment Id"] });
+  }],
 ]);
 
 function attachExtraActionFunction(


### PR DESCRIPTION
Props:
<img width="358" alt="Screenshot 2025-04-26 at 00 07 37" src="https://github.com/user-attachments/assets/884a6efd-ade6-4c74-90eb-e571751f40d5" />

Connected:
<img width="871" alt="Screenshot 2025-04-25 at 21 17 11" src="https://github.com/user-attachments/assets/efa7f080-9390-4e9c-bdac-f7dec2ca1525" />

Output Socket:
<img width="685" alt="Screenshot 2025-04-25 at 21 24 22" src="https://github.com/user-attachments/assets/12835db4-4f9b-4de8-9218-6f7e1517cab4" />