### PR TITLE
Ensure invalid reference kinds trigger rebuilds

### DIFF
--- a/lib/sdf-server/src/service/v2/index.rs
+++ b/lib/sdf-server/src/service/v2/index.rs
@@ -50,8 +50,6 @@ pub enum IndexError {
     Frigg(#[from] frigg::FriggError),
     #[error("index not found; workspace_pk={0}, change_set_id={1}")]
     IndexNotFound(WorkspacePk, ChangeSetId),
-    #[error("invalid string for reference kind: {0}")]
-    InvalidStringForReferenceKind(#[source] strum::ParseError),
     #[error("transactions error: {0}")]
     Transactions(#[from] dal::TransactionsError),
     #[error("timed out when watching index with duration: {0:?}")]


### PR DESCRIPTION
This PR ensures invalid reference kinds trigger rebuilds. Removed or deprecated reference kinds are a-okay, but we need to make sure sdf rebuilds the index accordingly.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlazRsNmVnOTRvcWtzZ2JuZnBsMnV5ejQ4N2QzOXkxbjYwNjJ5a2tkYSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ZO19BOWoczJ82msvLV/giphy.gif"/>