### PR TITLE
Fix: initialization of the bifrost on the new hotness

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -87,8 +87,9 @@ import { useRoute, useRouter } from "vue-router";
 import clsx from "clsx";
 import {
   computed,
-  onBeforeUnmount,
   onMounted,
+  onBeforeUnmount,
+  onBeforeMount,
   ref,
   provide,
   toRef,
@@ -146,7 +147,7 @@ const router = useRouter();
 
 const queryClient = useQueryClient();
 
-onMounted(async () => {
+onBeforeMount(async () => {
   // NOTE(nick,wendy): if you do not have the flag enabled, you will be re-directed. This will be
   // true for all of the new hotness routes, provided that they are all children of the parent
   // route that uses this component. This is wrapped in a "setTimeout" to ensure that the feature

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -1,8 +1,9 @@
 import * as Comlink from "comlink";
-import { computed, reactive, Reactive } from "vue";
+import { computed, reactive, Reactive, inject } from "vue";
 import { QueryClient } from "@tanstack/vue-query";
 import { DBInterface, Id, BustCacheFn } from "@/workers/types/dbinterface";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
+import { WSCS } from "@/newhotness/types";
 import { useChangeSetsStore } from "../change_sets.store";
 import { useWorkspacesStore } from "../workspaces.store";
 
@@ -117,11 +118,17 @@ export const niflheim = async (
 };
 
 export const changeSetId = computed(() => {
+  const WSCS: WSCS | undefined = inject("WSCS");
+  if (WSCS && WSCS.changeSetId.value) return WSCS.changeSetId.value;
+
   const changeSetsStore = useChangeSetsStore();
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return changeSetsStore.selectedChangeSetId!;
 });
 const workspaceId = computed(() => {
+  const WSCS: WSCS | undefined = inject("WSCS");
+  if (WSCS && WSCS.workspacePk.value) return WSCS.workspacePk.value;
+
   const workspaceStore = useWorkspacesStore();
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return workspaceStore.selectedWorkspacePk!;


### PR DESCRIPTION
1. Heimdall looks for the injection of change set and workspace.
2. Heimdall inits before mount (before children) not onmount