### PR TITLE
feat(innit): allow setting multiple CAs for validation

### DIFF
--- a/bin/innit/Dockerfile
+++ b/bin/innit/Dockerfile
@@ -35,6 +35,4 @@ COPY --from=builder /tmp/local-bin/* /usr/local/bin/
 
 EXPOSE 5166/tcp
 
-ENTRYPOINT [ \
-  "/sbin/runuser", "-u", "app", "--", "/usr/local/bin/innit", \
-]
+ENTRYPOINT [ "/sbin/runuser", "-u", "app", "--", "/usr/local/bin/innit" ]

--- a/bin/innit/src/args.rs
+++ b/bin/innit/src/args.rs
@@ -61,8 +61,9 @@ pub(crate) struct Args {
     pub(crate) log_json: bool,
 
     /// ARN for a Private Cert Authority in AWS
-    #[arg(long, env)]
-    pub(crate) client_ca_arn: Option<String>,
+    /// Can be specified multiple times for multiple CAs
+    #[arg(long, env, action = ArgAction::Append)]
+    pub(crate) client_ca_arn: Vec<String>,
 
     /// The address and port to bind the HTTP server to [example: 0.0.0.0:80]
     #[arg(long, env)]
@@ -74,8 +75,8 @@ impl TryFrom<Args> for Config {
 
     fn try_from(args: Args) -> Result<Self, Self::Error> {
         ConfigFile::layered_load(NAME, |config_map| {
-            if let Some(ca_arn) = args.client_ca_arn {
-                config_map.set("client_ca_arn", ca_arn);
+            if !args.client_ca_arn.is_empty() {
+                config_map.set("client_ca_arns", args.client_ca_arn);
             }
             if let Some(socket_addr) = args.socket_addr {
                 config_map.set("socket_addr", socket_addr);

--- a/lib/innit-client/tests/integration_test/mod.rs
+++ b/lib/innit-client/tests/integration_test/mod.rs
@@ -75,7 +75,7 @@ mod integration_tests {
 
         let config = innit_server::Config::builder()
             .socket_addr(addr)
-            .client_ca_cert(Some(CertificateSource::Base64(ca_cert)))
+            .client_ca_certs(Some(vec![CertificateSource::Base64(ca_cert)]))
             .test_endpoint(Some(endpoint))
             .build()
             .expect("should build config");

--- a/lib/si-tls/src/lib.rs
+++ b/lib/si-tls/src/lib.rs
@@ -256,9 +256,12 @@ pub struct ClientCertificateVerifier {
 }
 
 impl ClientCertificateVerifier {
-    pub async fn new(ca_cert: CertificateSource) -> Result<Self> {
+    pub async fn new(ca_certs: &[CertificateSource]) -> Result<Self> {
         let mut cert_store = RootCertStore::empty();
-        ca_cert.add_to_cert_store(&mut cert_store).await?;
+
+        for ca_cert in ca_certs {
+            ca_cert.add_to_cert_store(&mut cert_store).await?;
+        }
 
         let verifier = WebPkiClientVerifier::builder(Arc::new(cert_store)).build()?;
 


### PR DESCRIPTION
Allow validation against multiple CAs so we can host a single instance of innit and have both tools and prod validate against it