### PR TITLE
feat(web): Change tooltip in code editor to be over the word rather than the current letter

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,3 +41,4 @@ We contributors to System Initiative:
 * Mr Lizard (@Mr-Lizard)
 * Aaron Dernley (@aaron-dernley)
 * systeminitbot (@systeminitbot)
+* Jake Ginnivan (@JakeGinnivan)

--- a/app/web/src/utils/typescriptLinter.ts
+++ b/app/web/src/utils/typescriptLinter.ts
@@ -265,7 +265,8 @@ export function GetTooltipFromPos(pos: number): Tooltip | null {
     : "";
 
   return {
-    pos,
+    pos:quickInfo.textSpan.start,
+    end: quickInfo.textSpan.start + quickInfo.textSpan.length,
     create() {
       const dom = document.createElement("div");
       dom.innerHTML = parts + docs + tags;


### PR DESCRIPTION
It is currently quite hard to get the mouse onto the editor tooltip to view type information etc when you need to scroll.

This changes the tooltip to be on the word rather than just the current letter so it's easier to keep the tooltip up

Before

![Kapture 2025-04-29 at 17 55 31](https://github.com/user-attachments/assets/ef4123e6-fa45-4e89-be8f-ba98b01a0ebf)

After

![Kapture 2025-04-29 at 17 57 21](https://github.com/user-attachments/assets/4d431631-aa16-4038-8ee6-7a0fe95af52a)
