### PR TITLE
Switched icons around to make it clearer you can create a new function

### DIFF
--- a/app/web/src/components/AssetFuncAttachDropdown.vue
+++ b/app/web/src/components/AssetFuncAttachDropdown.vue
@@ -1,12 +1,12 @@
 <template>
   <IconButton
     iconTone="action"
-    icon="link"
+    icon="plus"
     size="sm"
     :requestStatus="requestStatus"
     :selected="menuRef?.isOpen"
-    tooltip="Attach Function"
-    loadingTooltip="Attaching new function..."
+    tooltip="Add Function"
+    loadingTooltip="Adding function..."
     @click="onClick"
   >
     <DropdownMenu ref="menuRef" forceAlignRight>
@@ -18,7 +18,7 @@
         New function
       </DropdownMenuItem>
       <DropdownMenuItem
-        icon="func"
+        icon="link"
         :disabled="assetStore.selectedSchemaVariant?.isLocked"
         @select="emit('selectedAttachType', 'existing')"
       >


### PR DESCRIPTION
When first playing around with the asset panel, it took me longer than I'd like to admit to find now to add a new function. 

The chain icon feels unintuitive to click on to create a new function. So I've changed the icon to the +, then new continues to have the + and the chain icon is used to add an existing.

Before:
![image](https://github.com/user-attachments/assets/557ef87d-d8c1-4e47-aee3-09c152d2f1e8)

After:

![image](https://github.com/user-attachments/assets/cdbccb9c-e935-4dc8-a44e-dda6e9d71e38)
