### PR TITLE
Fix: grid tiles shouldn't stretch their height to fit the container

### DIFF
--- a/app/web/src/newhotness/ComponentGridTile.vue
+++ b/app/web/src/newhotness/ComponentGridTile.vue
@@ -15,7 +15,7 @@
       <li>Outputs: {{ component.outputCount }}</li>
     </ol>
     <footer class="grid grid-cols-2">
-      <div class="place-self-start">
+      <div class="justify-self-start self-end">
         <VButton label="📌" size="sm" tone="neutral" variant="ghost" />
         <VButton label="Upgrade" size="sm" tone="action" />
       </div>

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -27,14 +27,16 @@
       <!-- right header -->
       right header
     </div>
-    <div class="scrollable tilegrid">
+    <div class="max-h-fit scrollable">
       <!-- body -->
-      <ComponentGridTile
-        v-for="component in componentViewList"
-        :key="component.id"
-        :component="component"
-        @dblclick="componentNavigate"
-      />
+      <div class="tilegrid">
+        <ComponentGridTile
+          v-for="component in componentViewList"
+          :key="component.id"
+          :component="component"
+          @dblclick="componentNavigate"
+        />
+      </div>
     </div>
     <div class="grid grid-rows-subgrid gap-sm" :style="collapsingStyles">
       <CollapsingGridItem ref="actions">

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -304,7 +304,6 @@ body.light .scrollable {
 
   > * {
     // only direct children
-    // flex-grow: 1;
     padding: 0.5rem;
   }
 


### PR DESCRIPTION
CSS grid items (based on the definition via `repeat`) share the same height between them (e.g. `stretch`). We want stretch, because if it was a defined height there would be gaps between items if their content was meaningfully different sizes.

Initially I had put `grow` on the elements inside each tile—as the container grows, they should take the space available. If they didn't grow, we would have to align the content inside (top, center, bottom) and there would be tons of space that appears as padding between the content and the border lines. Undesirable. But, as they grow (imagine after the blank slate where you've added your first component) a single row of items would take up the entire height. Undesirable.

I wondered if we could manipulate the `main` `grow`, but we cannot. That gives us the ability to put content at the bottom of the browser window (e.g. even if we didn't have footer, we still want `main` to grow to the bottom, so we can place content there.

The solution here is to put the grid inside a container that will only grow to fit the size of its content. In order to do this, we needed to add a new div (with `max-h-fit` and `scrollable`) for the `tilegrid` to go inside. A grid always occupies all the space its container gives it.

Quick overall diagram of the CSS rules for the layout:
```
+--------------------------------+
| app-layout, flex col
|   +------------------------------
|   | nav shrink
|   +-----------------------------
|   | main, grow
|   |
|   |           explore layout, grid
|   |           +------------------------------------
|   |           | search              |   right header
|   |           +---------------------+---------------
|   |           | div max-h-fit          |  actions
|   |           |   +-----------------+  |
|   |           |    | tilegrid       |  +----------------
|   |           |    |                |  | history
|   |           |    +----------------+  |
|   |           +---------------------+----------------
|   |           | footer              |
|   |           +-------------------------------------
|   +-----------------------------
|   | div (footer)
+--------------------------------+

```