### PR TITLE
fix: duplicate key in cloudwatch config

### DIFF
--- a/component/init/configs/vector.yaml
+++ b/component/init/configs/vector.yaml
@@ -42,7 +42,7 @@ sinks:
     region: "us-east-1"
     group_name: "/ec2/$SI_HOSTENV-$SI_SERVICE"
     stream_name: "{{ host }}"
-  cloudwatch:
+  cloudwatch-docker:
     type: "aws_cloudwatch_logs"
     inputs: ["docker"]
     compression: "gzip"


### PR DESCRIPTION
Log shipping is broken until this is merged.