### PR TITLE
fix(luminork): Adding WSEvents for reactivity from luminork.

### DIFF
--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -364,6 +364,7 @@ impl Action {
         unimplemented!("You should never be setting func_execution_pk; bug!");
     }
 
+    /// Enqueues a new action and publishes a WSEvent
     #[instrument(level = "info", skip(ctx))]
     pub async fn new(
         ctx: &DalContext,

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -799,6 +799,7 @@ impl ChangeSet {
     /// Applies the current [`ChangeSet`] in the provided [`DalContext`]. [`Actions`](Action)
     /// are enqueued as needed and only done so if the base [`ChangeSet`] is "HEAD" (i.e.
     /// the default [`ChangeSet`] of the [`Workspace`]).
+    /// Also sends the relevant WSEvent
     #[instrument(level = "info", skip_all)]
     pub async fn apply_to_base_change_set(ctx: &mut DalContext) -> ChangeSetApplyResult<ChangeSet> {
         // Apply to the base change with the current change set (non-editing) and commit.
@@ -876,8 +877,8 @@ impl ChangeSet {
     }
 
     /// Applies the current [`ChangeSet`] in the provided [`DalContext`] to its base
-    /// [`ChangeSet`]. This involves performing a rebase request and updating the status
-    /// of the [`ChangeSet`] accordingly.
+    /// [`ChangeSet`]. This involves performing a rebase request, updating the status
+    /// of the [`ChangeSet`] accordingly, and publishing a WSEvent
     ///
     /// This function neither changes the visibility nor the snapshot after performing the
     /// aforementioned actions.
@@ -1011,6 +1012,7 @@ impl ChangeSet {
         Ok(())
     }
 
+    /// Updates the status for a ChangeSet to be [`ChangeSetStatus::Abandoned`] and fires necessary WSEvent
     pub async fn abandon(&mut self, ctx: &DalContext) -> ChangeSetResult<()> {
         self.update_status(ctx, ChangeSetStatus::Abandoned).await?;
         let user_id = Self::extract_userid_from_context(ctx).await;


### PR DESCRIPTION
With this PR - all Luminork endpoints should have the same coverage in WSEvents as SDF. I added some comments to where the WSEvent is fired from lower in the dal to be clear, but I can't wait to rip all of this out 

<div><img src="https://media1.giphy.com/media/xT8qB7GQDfnldWTFhS/giphy.gif?cid=5a38a5a29u25egrksw062dq102pq5ctj3n0uvkzp8papb656&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/bobs-burgers/">Bob&#x27;s Burgers</a> on <a href="https://giphy.com/gifs/bobs-burgers-fox-bobs-burgers-tv-xT8qB7GQDfnldWTFhS">GIPHY</a></div>