### PR TITLE
fix(innit): handle list types correctly

### DIFF
--- a/lib/innit-server/src/routes/create_parameter.rs
+++ b/lib/innit-server/src/routes/create_parameter.rs
@@ -38,6 +38,9 @@ pub async fn create_parameter_route(
         .set_parameter(Parameter {
             name: name.clone(),
             value: Some(value.clone()),
+            // TODO(scott): this whole route should handle types somehow, but since this is currently just used
+            // in tests this is fine for now
+            r#type: None,
         })
         .await;
 

--- a/lib/innit-server/src/routes/get_parameter.rs
+++ b/lib/innit-server/src/routes/get_parameter.rs
@@ -45,6 +45,7 @@ pub async fn get_parameter_route(
         .set_parameter(Parameter {
             name: parameter.name.clone(),
             value: parameter.value.clone(),
+            r#type: parameter.r#type.clone(),
         })
         .await;
 


### PR DESCRIPTION
We need to handle `StringList` types correctly so ensure we can parse lists into `Vec<String>`.

Also ensures we get all parameters from parameter store as it only returns 10 by default.