### PR TITLE
fix: add presharedkey prop validation for vpntunneloptionsspecs

### DIFF
--- a/bin/clover/doc-link-cache.json
+++ b/bin/clover/doc-link-cache.json
@@ -9582,5 +9582,10 @@
   "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wisdom-knowledgebase-managedsourceconfiguration.html": 200,
   "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wisdom-knowledgebase-webcrawlerconfiguration.html": 200,
   "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wisdom-knowledgebase-seedurl.html": 200,
-  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wisdom-knowledgebase-appintegrationsconfiguration.html": 200
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wisdom-knowledgebase-appintegrationsconfiguration.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-bedrock-dataautomationproject-videooverrideconfiguration.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-bedrock-dataautomationproject-modalityprocessingconfiguration.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-bedrock-dataautomationproject-modalityroutingconfiguration.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-bedrock-dataautomationproject-imageoverrideconfiguration.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-bedrock-dataautomationproject-audiooverrideconfiguration.html": 200
 }

--- a/bin/clover/src/cloud-control-funcs/overrides/VPNConnection VpnTunnelOptionsSpecifications/qualifications/presharedKeyValidations.ts
+++ b/bin/clover/src/cloud-control-funcs/overrides/VPNConnection VpnTunnelOptionsSpecifications/qualifications/presharedKeyValidations.ts
@@ -1,0 +1,42 @@
+async function main(component: Input): Promise < Output > {
+    const props = component.domain || {};
+    const preSharedKey = props.PreSharedKey;
+
+    // If PreSharedKey is not provided, it's valid as it's optional
+    if (preSharedKey === undefined || preSharedKey === null || preSharedKey === '') {
+        return {
+            result: 'success',
+            message: 'Component qualified'
+        };
+    }
+
+    // Check length constraints (8 to 64 characters)
+    if (preSharedKey.length < 8 || preSharedKey.length > 64) {
+        return {
+            result: 'failure',
+            message: 'PreSharedKey must be between 8 and 64 characters in length'
+        };
+    }
+
+    // Check if it starts with zero
+    if (preSharedKey.startsWith('0')) {
+        return {
+            result: 'failure',
+            message: 'PreSharedKey cannot start with zero (0)'
+        };
+    }
+
+    // Check allowed characters (alphanumeric, periods, and underscores)
+    const allowedPattern = /^[a-zA-Z0-9._]+$/;
+    if (!allowedPattern.test(preSharedKey)) {
+        return {
+            result: 'failure',
+            message: 'PreSharedKey can only contain alphanumeric characters, periods (.), and underscores (_)'
+        };
+    }
+
+    return {
+        result: 'success',
+        message: 'Component qualified'
+    };
+}

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -863,6 +863,19 @@ const overrides = new Map<string, OverrideFn>([
   }],
   ["VPNConnection VpnTunnelOptionsSpecifications", (spec: ExpandedPkgSpec) => {
     const variant = spec.schemas[0].variants[0];
+    const domainId = variant.domain.uniqueId;
+
+    if (!domainId) return;
+
+    const { func, leafFuncSpec } = attachQualificationFunction(
+      "./src/cloud-control-funcs/overrides/VPNConnection VpnTunnelOptionsSpecifications/qualifications/presharedKeyValidations.ts",
+      "Validate PresharedKey",
+      "4e1243bd22c67dd61b0a4c86e9f3c89c84baf7b37a45f93ee4e5ed8a9d7f1c2f",
+      domainId
+    );
+
+    spec.funcs.push(func);
+    variant.leafFunctions.push(leafFuncSpec);
 
     // Remove unnecessary input sockets
     const removedCount = removeInputSockets(variant, [


### PR DESCRIPTION
1. Cannot start with 0
<img width="1102" alt="Screenshot 2025-05-01 at 16 19 56" src="https://github.com/user-attachments/assets/e338c02e-4ae8-49fb-a2fa-fd4ada8bfc57" />
<img width="440" alt="Screenshot 2025-05-01 at 16 20 01" src="https://github.com/user-attachments/assets/5dcd5612-8b47-4ca1-9024-181ebd75c004" />


2. Alphanumeric, periods, underscores only
<img width="1088" alt="Screenshot 2025-05-01 at 16 21 27" src="https://github.com/user-attachments/assets/76c86aaf-ae67-4680-92ff-0ef69bd6a78c" />
<img width="447" alt="Screenshot 2025-05-01 at 16 21 32" src="https://github.com/user-attachments/assets/e837130d-d77d-4a72-a049-396c6c1f0cd6" />


3. Between 8 and 64 chars
<img width="1158" alt="Screenshot 2025-05-01 at 16 20 34" src="https://github.com/user-attachments/assets/d42b4464-6943-4e5f-848d-c461e0dae3b7" />
<img width="446" alt="Screenshot 2025-05-01 at 16 20 39" src="https://github.com/user-attachments/assets/ff9e42e3-b0ca-4a82-b64d-589f86dc7697" />
