### PR TITLE
chore: remove unused init profiles

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -4,7 +4,6 @@ services:
   init:
     container_name: init
     image: systeminit/init:${INIT_VERSION:-stable}
-    profiles: [edda, forklift, rebaser, pinga, sdf, veritech]
     environment:
       - SI_HOSTENV=${SI_HOSTENV}
       - SI_SERVICE=${SI_SERVICE}
@@ -15,7 +14,6 @@ services:
   otelcol:
     container_name: otelcol
     image: systeminit/otelcol:${INIT_VERSION:-stable}
-    profiles: [edda, forklift, rebaser, pinga, sdf, veritech]
     ports:
       - 4317:4317
       - 55679:55679
@@ -29,7 +27,6 @@ services:
   node-exporter:
     container_name: node_exporter
     image: prom/node-exporter:v1.7.0
-    profiles: [edda, forklift, rebaser, pinga, sdf, veritech]
     command:
       - --collector.systemd
       - --collector.systemd.unit-include=${SI_SERVICE}.service
@@ -48,7 +45,6 @@ services:
   vector:
     container_name: vector
     image: timberio/vector:0.45.X-debian
-    profiles: [edda, forklift, rebaser, pinga, sdf, veritech]
     ports:
       - 8686:8686
     volumes:
@@ -62,7 +58,6 @@ services:
   prometheus:
     container_name: prometheus
     image: prom/prometheus
-    profiles: [edda, forklift, rebaser, pinga, sdf, veritech]
     ports:
       - "9100:9090"
     volumes:


### PR DESCRIPTION
These were used to toggle pgbouncer, but are no longer needed.