### PR TITLE
fix: alter vpn connection type override and add cgw override for type

### DIFF
--- a/bin/clover/doc-link-cache.json
+++ b/bin/clover/doc-link-cache.json
@@ -9587,5 +9587,7 @@
   "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-bedrock-dataautomationproject-modalityprocessingconfiguration.html": 200,
   "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-bedrock-dataautomationproject-modalityroutingconfiguration.html": 200,
   "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-bedrock-dataautomationproject-imageoverrideconfiguration.html": 200,
-  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-bedrock-dataautomationproject-audiooverrideconfiguration.html": 200
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-bedrock-dataautomationproject-audiooverrideconfiguration.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-distributionconfiguration-ssmparameterconfiguration.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mediatailor-playbackconfiguration-adconditioningconfiguration.html": 200
 }

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -953,9 +953,19 @@ const overrides = new Map<string, OverrideFn>([
     const resource_value = variant.resourceValue;
     const domain = variant.domain;
 
-    const typeProp = findPropByName(domain, "Type");
-    if (typeProp) {
+    removeInputSockets(variant, [
+      "Type",
+    ]);
+
+    const typeProp = propForOverride(variant.domain, "Type");
+    if (typeProp && typeProp.kind === "string") {
+      typeProp.data.widgetKind = "ComboBox";
       typeProp.data.defaultValue = "ipsec.1";
+      typeProp.data.inputs = [];
+      typeProp.data.funcUniqueId = null;
+      typeProp.data.widgetOptions = [
+        { label: "si_create_only_prop", value: "true" }
+      ];
     }
 
     const transitGatewayAttachmentIdProp = createScalarProp(
@@ -993,7 +1003,26 @@ const overrides = new Map<string, OverrideFn>([
     );
     if (!subnetInputSocket) return;
     setAnnotationOnSocket(subnetInputSocket, { tokens: ["subnets"] });
-  }]
+  }],
+  ['AWS::EC2::CustomerGateway', (spec: ExpandedPkgSpec) => {
+    const variant = spec.schemas[0].variants[0];
+    const domain = variant.domain;
+
+    removeInputSockets(variant, [
+      "Type",
+    ]);
+
+    const typeProp = propForOverride(variant.domain, "Type");
+    if (typeProp && typeProp.kind === "string") {
+      typeProp.data.widgetKind = "ComboBox";
+      typeProp.data.defaultValue = "ipsec.1";
+      typeProp.data.inputs = [];
+      typeProp.data.funcUniqueId = null;
+      typeProp.data.widgetOptions = [
+        { label: "si_create_only_prop", value: "true" }
+      ];
+    }
+  }],
 ]);
 
 function attachExtraActionFunction(


### PR DESCRIPTION
There can be only one Type option - ipsec.1, so make it non-editable. Removed the redundant input sockets for type on both components too.