### PR TITLE
feat(sdf): API to create map/array elements that do not exist

### DIFF
--- a/app/web/src/store/component_attributes.store.ts
+++ b/app/web/src/store/component_attributes.store.ts
@@ -136,10 +136,10 @@ export interface ResetPropertyEditorValueArgs {
 //   avoid injection attacks.
 //
 //       {
-//         "/si/name": "Baby's First Subnet",
-//         "/domain/IpAddresses/0": "10.0.0.1",
-//         "/domain/Tags/Environment": "production",
-//         "/domain/DomainConfig/blah.com/TTL": 3600
+//         "/domain/Tags": {
+//           "$source": "value",
+//           "value": { "Environment": "Prod", "$source": "ThisTagIsActuallyNamed_$source" }
+//         }
 //       }
 //
 export type UpdateComponentAttributesArgs = Record<

--- a/lib/dal/src/attribute.rs
+++ b/lib/dal/src/attribute.rs
@@ -1,5 +1,6 @@
 //! This module contains the "attribute" domain concept, which primarily involves
 //! [`AttributeValue`](crate::AttributeValue) and [`AttributePrototype`](crate::AttributePrototype).
 
+pub mod path;
 pub mod prototype;
 pub mod value;

--- a/lib/dal/src/attribute/path.rs
+++ b/lib/dal/src/attribute/path.rs
@@ -1,0 +1,242 @@
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_id::PropId;
+use strum::EnumDiscriminants;
+
+use super::value::{
+    AttributeValueError,
+    AttributeValueResult,
+};
+use crate::{
+    AttributeValue,
+    AttributeValueId,
+    DalContext,
+    Prop,
+    PropKind,
+    prop::PropError,
+};
+
+/// A path to an attribute value, relative to its root value
+/// This type is postcard serialized and new enum variants *MUST* be added to the end *ONLY*.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, EnumDiscriminants)]
+#[strum_discriminants(derive(Hash, Serialize, Deserialize, strum::EnumIter, strum::Display))]
+pub enum AttributePath {
+    /// A JSON pointer (e.g. `/domain/PolicyDocument/Statements/0/Operation`)
+    JsonPointer(String),
+}
+
+impl AttributePath {
+    pub fn from_json_pointer(path: impl Into<String>) -> Self {
+        AttributePath::JsonPointer(path.into())
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            AttributePath::JsonPointer(path) => path.as_bytes(),
+        }
+    }
+
+    pub async fn resolve(
+        &self,
+        ctx: &DalContext,
+        av_id: AttributeValueId,
+    ) -> AttributeValueResult<Option<AttributeValueId>> {
+        match self {
+            AttributePath::JsonPointer(pointer) => {
+                let pointer = jsonptr::Pointer::parse(pointer)?;
+                resolve_json_pointer(ctx, av_id, pointer).await
+            }
+        }
+    }
+
+    pub async fn vivify(
+        &self,
+        ctx: &DalContext,
+        av_id: AttributeValueId,
+    ) -> AttributeValueResult<AttributeValueId> {
+        match self {
+            AttributePath::JsonPointer(pointer) => {
+                let pointer = jsonptr::Pointer::parse(pointer)?;
+                vivify_json_pointer(ctx, av_id, pointer).await
+            }
+        }
+    }
+
+    pub async fn validate(&self, ctx: &DalContext, prop_id: PropId) -> AttributeValueResult<()> {
+        match self {
+            AttributePath::JsonPointer(pointer) => {
+                let pointer = jsonptr::Pointer::parse(pointer)?;
+                validate_json_pointer(ctx, prop_id, pointer).await
+            }
+        }
+    }
+}
+
+// Gets the attribute value at the JSON pointer, or None if it cannot be found.
+// Returns None if the AV points at non-existent props.
+async fn resolve_json_pointer(
+    ctx: &DalContext,
+    mut av_id: AttributeValueId,
+    pointer: &jsonptr::Pointer,
+) -> AttributeValueResult<Option<AttributeValueId>> {
+    // Go through each segment of the JSON pointer (e.g. /foo/bar/0 = foo, bar, 0)
+    // and look for its child
+    for token in pointer {
+        let prop = AttributeValue::prop(ctx, av_id).await?;
+        let child_av_id = match prop.kind {
+            // Look up array index in ordering node
+            PropKind::Array => match token.to_index() {
+                Ok(jsonptr::index::Index::Num(index)) => {
+                    AttributeValue::get_child_av_ids_in_order(ctx, av_id)
+                        .await?
+                        .get(index)
+                        .copied()
+                }
+                Ok(jsonptr::index::Index::Next) | Err(_) => None,
+            },
+
+            // Look at child Contains edges to find the one with the right name
+            PropKind::Map => {
+                AttributeValue::map_child_opt(ctx, av_id, token.decoded().as_ref()).await?
+            }
+
+            // The object's children AVs will already have been vivified. Just grab the right one.
+            PropKind::Object => {
+                AttributeValue::object_child_opt(ctx, av_id, token.decoded().as_ref()).await?
+            }
+
+            // These cannot have children
+            PropKind::Boolean
+            | PropKind::Integer
+            | PropKind::Json
+            | PropKind::Float
+            | PropKind::String => {
+                return Err(AttributeValueError::NoChildWithName(
+                    av_id,
+                    token.decoded().into_owned(),
+                ))?;
+            }
+        };
+        let Some(child_av_id) = child_av_id else {
+            return Ok(None);
+        };
+        av_id = child_av_id;
+    }
+    Ok(Some(av_id))
+}
+
+// Gets the attribute value at the JSON pointer, or creates it if it doesn't exist.
+// Returns an error if an AV cannot be created.
+async fn vivify_json_pointer(
+    ctx: &DalContext,
+    mut av_id: AttributeValueId,
+    pointer: &jsonptr::Pointer,
+) -> AttributeValueResult<AttributeValueId> {
+    // Go through each segment of the JSON pointer (e.g. /foo/bar/0 = foo, bar, 0)
+    // and look for its child. If it doesn't exist, create it.
+    for token in pointer {
+        let prop = AttributeValue::prop(ctx, av_id).await?;
+        av_id =
+            match prop.kind {
+                PropKind::Array => {
+                    // Make sure the user asked to append (can't insert at an index that doesn't exist)
+                    let elements = AttributeValue::get_child_av_ids_in_order(ctx, av_id).await?;
+                    match token.to_index()? {
+                        // If it's - or the next index (len+1), we can append!
+                        jsonptr::index::Index::Next => {
+                            AttributeValue::insert(ctx, av_id, None, None).await?
+                        }
+                        jsonptr::index::Index::Num(index) if index == elements.len() => {
+                            AttributeValue::insert(ctx, av_id, None, None).await?
+                        }
+
+                        // If it's not the last index + 1, we retrieve the existing one
+                        jsonptr::index::Index::Num(index) => elements.get(index).copied().ok_or(
+                            AttributeValueError::IndexOutOfRange(index, av_id, elements.len()),
+                        )?,
+                    }
+                }
+
+                // Create empty map entry with given name
+                PropKind::Map => {
+                    let name = token.decoded();
+                    match AttributeValue::map_child_opt(ctx, av_id, name.as_ref()).await? {
+                        Some(child_av_id) => child_av_id,
+                        None => {
+                            AttributeValue::insert(ctx, av_id, None, Some(name.into_owned()))
+                                .await?
+                        }
+                    }
+                }
+
+                // Get the matching child AV (all possible child AVs must already exist)
+                PropKind::Object => {
+                    let name = token.decoded();
+                    AttributeValue::object_child(ctx, av_id, name.as_ref()).await?
+                }
+
+                // These cannot have children
+                PropKind::Boolean
+                | PropKind::Integer
+                | PropKind::Json
+                | PropKind::Float
+                | PropKind::String => {
+                    return Err(AttributeValueError::NoChildWithName(
+                        av_id,
+                        token.decoded().into_owned(),
+                    ))?;
+                }
+            }
+    }
+    Ok(av_id)
+}
+
+// Validate that a JSON pointer *could* be used to access a child of the given AV (that it
+// has valid prop names and indices).
+async fn validate_json_pointer(
+    ctx: &DalContext,
+    mut prop_id: PropId,
+    pointer: &jsonptr::Pointer,
+) -> AttributeValueResult<()> {
+    // Go through each segment of the JSON pointer (e.g. /foo/bar/0 = foo, bar, 0)
+    // and validate that the child prop exists or that it is a valid index and not -
+    for token in pointer {
+        let prop = Prop::get_by_id(ctx, prop_id).await?;
+        prop_id = match prop.kind {
+            // Look up array index in ordering node
+            PropKind::Array => match token.to_index()? {
+                jsonptr::index::Index::Num(_) => Prop::element_prop_id(ctx, prop_id).await?,
+
+                jsonptr::index::Index::Next => {
+                    return Err(PropError::CannotSubscribeToNextElement(
+                        prop_id,
+                        pointer.to_string(),
+                    ))?;
+                }
+            },
+
+            // All strings are valid map keys
+            PropKind::Map => Prop::element_prop_id(ctx, prop_id).await?,
+
+            // The key must be a valid child prop name
+            PropKind::Object => {
+                Prop::child_prop_id(ctx, prop_id.into(), token.decoded().as_ref()).await?
+            }
+
+            // These cannot have children
+            PropKind::Boolean
+            | PropKind::Integer
+            | PropKind::Json
+            | PropKind::Float
+            | PropKind::String => {
+                return Err(PropError::ChildPropNotFoundByName(
+                    prop_id.into(),
+                    token.decoded().into_owned(),
+                ))?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/lib/dal/src/attribute/value/subscription.rs
+++ b/lib/dal/src/attribute/value/subscription.rs
@@ -1,17 +1,8 @@
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use strum::EnumDiscriminants;
-
-use super::{
-    AttributeValue,
-    AttributeValueResult,
-};
+use super::AttributeValueResult;
 use crate::{
     AttributeValueId,
     DalContext,
-    PropKind,
+    attribute::path::AttributePath,
 };
 
 /// A subscription to an attribute value: the root value and path relative to that value
@@ -20,16 +11,7 @@ pub struct ValueSubscription {
     // The root attribute value
     pub attribute_value_id: AttributeValueId,
     // The path to the actual attribute value, relative to the root
-    pub path: ValueSubscriptionPath,
-}
-
-/// A path to an attribute value, relative to its root value
-/// This type is postcard serialized and new enum variants *MUST* be added to the end *ONLY*.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, EnumDiscriminants)]
-#[strum_discriminants(derive(Hash, Serialize, Deserialize, strum::EnumIter, strum::Display))]
-pub enum ValueSubscriptionPath {
-    /// A JSON pointer (e.g. `/domain/PolicyDocument/Statements/0/Operation`)
-    JsonPointer(String),
+    pub path: AttributePath,
 }
 
 impl ValueSubscription {
@@ -39,80 +21,6 @@ impl ValueSubscription {
         &self,
         ctx: &DalContext,
     ) -> AttributeValueResult<Option<AttributeValueId>> {
-        match self.path {
-            ValueSubscriptionPath::JsonPointer(ref json_pointer) => {
-                Self::resolve_json_pointer(ctx, self.attribute_value_id, json_pointer).await
-            }
-        }
-    }
-
-    pub async fn resolve_json_pointer(
-        ctx: &DalContext,
-        mut av_id: AttributeValueId,
-        json_pointer: &str,
-    ) -> AttributeValueResult<Option<AttributeValueId>> {
-        // Go through each segment of the JSON pointer (e.g. /foo/bar/0 = foo, bar, 0)
-        // and look for its child
-        let ptr = jsonptr::Pointer::parse(json_pointer)?;
-        for token in ptr {
-            let Some(child_av_id) = resolve_child(ctx, av_id, token).await? else {
-                // If we can't find the child for this segment, we can't resolve the full
-                // path, so return None.
-                return Ok(None);
-            };
-            av_id = child_av_id;
-        }
-
-        Ok(Some(av_id))
-    }
-}
-
-async fn resolve_child(
-    ctx: &DalContext,
-    av_id: AttributeValueId,
-    token: jsonptr::Token<'_>,
-) -> AttributeValueResult<Option<AttributeValueId>> {
-    let prop = AttributeValue::prop(ctx, av_id).await?;
-    Ok(match prop.kind {
-        // Look up array index in ordering node
-        PropKind::Array => match token.to_index() {
-            Ok(jsonptr::index::Index::Num(index)) => {
-                AttributeValue::get_child_av_ids_in_order(ctx, av_id)
-                    .await?
-                    .get(index)
-                    .copied()
-            }
-            Ok(jsonptr::index::Index::Next) | Err(_) => None,
-        },
-
-        // Look at child Contains edges to find the one with the right name
-        PropKind::Map => AttributeValue::map_children(ctx, av_id)
-            .await?
-            .get(token.decoded().as_ref())
-            .copied(),
-
-        // Look at all child AVs and find the one that matches the index
-        PropKind::Object => AttributeValue::object_children(ctx, av_id)
-            .await?
-            .get(token.decoded().as_ref())
-            .copied(),
-
-        // These cannot have children
-        PropKind::Boolean
-        | PropKind::Integer
-        | PropKind::Json
-        | PropKind::Float
-        | PropKind::String => None,
-    })
-}
-
-impl ValueSubscriptionPath {
-    pub fn from_json_pointer(path: impl Into<String>) -> Self {
-        ValueSubscriptionPath::JsonPointer(path.into())
-    }
-    pub fn as_bytes(&self) -> &[u8] {
-        match self {
-            ValueSubscriptionPath::JsonPointer(path) => path.as_bytes(),
-        }
+        self.path.resolve(ctx, self.attribute_value_id).await
     }
 }

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -8,7 +8,7 @@ use serde::{
 };
 use strum::EnumDiscriminants;
 
-use crate::attribute::value::subscription::ValueSubscriptionPath;
+use crate::attribute::path::AttributePath;
 
 /// This type is postcard serialized and new enum variants *MUST* be added to the end *ONLY*.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, EnumDiscriminants)]
@@ -78,9 +78,9 @@ pub enum EdgeWeightKind {
     /// An edge from an
     /// [`AttributePrototypeArgument`][crate::AttributePrototypeArgument] representing a value
     /// from a component, where the edge target points at the component/root av id, and the
-    /// [`ValueSubscriptionPath`] is a path to a nested child AV (e.g.
+    /// [`AttributePath`] is a path to a nested child AV (e.g.
     /// `/domain/PolicyDocument/Statements/0/Operation`).
-    ValueSubscription(ValueSubscriptionPath),
+    ValueSubscription(AttributePath),
 }
 
 impl EdgeWeightKind {

--- a/lib/dal/tests/integration_test/attribute_value/subscription.rs
+++ b/lib/dal/tests/integration_test/attribute_value/subscription.rs
@@ -2,9 +2,9 @@ use dal::{
     AttributeValue,
     Component,
     DalContext,
-    attribute::value::subscription::{
-        ValueSubscription,
-        ValueSubscriptionPath,
+    attribute::{
+        path::AttributePath,
+        value::subscription::ValueSubscription,
     },
 };
 use dal_test::{
@@ -338,6 +338,6 @@ async fn make_subscription(
 ) -> Result<ValueSubscription> {
     Ok(ValueSubscription {
         attribute_value_id: Component::root_attribute_value_id(ctx, component_id).await?,
-        path: ValueSubscriptionPath::JsonPointer(json_pointer.into()),
+        path: AttributePath::JsonPointer(json_pointer.into()),
     })
 }

--- a/lib/dal/tests/integration_test/deserialize/mod.rs
+++ b/lib/dal/tests/integration_test/deserialize/mod.rs
@@ -27,7 +27,7 @@ use dal::{
         prototype::ActionKind,
     },
     approval_requirement::ApprovalRequirementApprover,
-    attribute::value::subscription::ValueSubscriptionPath,
+    attribute::path::AttributePath,
     func::{
         FuncKind,
         argument::FuncArgumentKind,
@@ -274,9 +274,9 @@ fn make_me_one_with_everything(graph: &mut WorkspaceSnapshotGraphVCurrent) {
             EdgeWeightKindDiscriminants::ApprovalRequirementDefinition => {
                 EdgeWeightKind::ApprovalRequirementDefinition
             }
-            EdgeWeightKindDiscriminants::ValueSubscription => EdgeWeightKind::ValueSubscription(
-                ValueSubscriptionPath::from_json_pointer("/json_pointer"),
-            ),
+            EdgeWeightKindDiscriminants::ValueSubscription => {
+                EdgeWeightKind::ValueSubscription(AttributePath::from_json_pointer("/json_pointer"))
+            }
         };
 
         if last_node + 1 == node_indexes.len() {

--- a/lib/sdf-server/src/service/v2/component.rs
+++ b/lib/sdf-server/src/service/v2/component.rs
@@ -23,6 +23,8 @@ pub enum Error {
     ChangeSet(#[from] dal::ChangeSetError),
     #[error("component error: {0}")]
     Component(#[from] dal::ComponentError),
+    #[error("json pointer parse error: {0}")]
+    JsonptrParseError(#[from] jsonptr::ParseError),
     #[error("no value to set at path {0}")]
     NoValueToSet(String),
     #[error("source component not found: {0}")]


### PR DESCRIPTION
This modifies the `PUT /attributes` API to support creation of arrays/maps that do not exist, removal of array and map items when desired, and validation of subscription paths.

1. Creates map/array elements that do not exist when setting a value at a path.
    - `{ "/domain/Tags/Environment": "prod" }` will create the map element Environment if it does not exist.
    - `{ "/domain/IpAddresses/0": "10.0.0.1", "/domain/IpAddresses/1": "10.0.0.2" }` will create elements 0 and 1 if they do not exist.
2. Append: supports JSON pointer array index `-`, which means "append"
   -  `{ "/domain/IpAddresses/-": "127.0.0.1" }` will append that value to the end of the array
3. Recursive: a map in a map in an array will auto-vivify all the things
   - `{ "/domain/TLDs/blah.com/Subdomains/foo/TTL": 100 }` will create TLD blah.com, then Subdomain foo, then set its TTL to 100.
4. Removal: unsetting an array or map element will now remove it.
   - `{ "/domain/IpAddresses/1": { "$source": "value" }` will remove the second ip address from the array if it exists
   - `{ "/domain/Tags/Environment": { "$source": "value" }` will remove the Environment key from the map if it exists
4. Validates Subscriptions: we now validate subscription paths as well, to ensure props aren't misspelled and that you specify numbers for array elements.
   - `{ "/domain/SubnetId": { "$source": "subscription", "component": "My Subnet", "path": "/resource/SlumnetIDD" }` will yield a 400 error instead of creating the subscription, since the property SlumnetIDD does not exist.
   - `{ "/domain/SubnetId": { "$source": "subscription", "component": "My Subnet", "path": "" }` will yield a 400 error now because the JSON pointer cannot be parsed.
   - `{ "/domain/IpAddress": { "$source": "subscription", "component": "Elastic Batch", "path": "/domain/IpAddresses/Zero" } }` will yield a 400 error instead of creating the subscription, because Zero is not a number.
   - `{ "/domain/IpAddress": { "$source": "subscription", "component": "Elastic Batch, "path": "/domain/IpAddresses/-" } }` will yield a 400 error even though it is a valid JSON pointer, because "-" refers to the "next value after end of the array" for append purposes, and will never yield a value.

## Out of Scope

Because this API is not yet public, and John needs it for UI work today, I'm going to fast-follow with more integration tests (which may involve moving more of the code from the route into the dal so it can be effectively tested).

## Testing

- [x] Existing tests pass
- [x] Manual API tests for removing array and map elements, and that setting values creates and then sets the value

![exist](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZno0bW5ha2o2MHNoNmRncWtmdzY0bmIwd2JxY3J1amVuczVuazlndCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/73bFnzgVf3XLnodKdR/giphy.gif)