### PR TITLE
Restructure AttributeTree MV to be keyed on ComponentId

### DIFF
--- a/lib/dal-materialized-views/src/component.rs
+++ b/lib/dal-materialized-views/src/component.rs
@@ -15,6 +15,8 @@ use si_frontend_types::newhotness::component::{
 };
 use telemetry::prelude::*;
 
+pub mod attribute_tree;
+
 #[instrument(name = "dal_materialized_views.component", level = "debug", skip_all)]
 pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Result<ComponentMv> {
     let ctx = &ctx;

--- a/lib/dal-materialized-views/src/component/attribute_tree.rs
+++ b/lib/dal-materialized-views/src/component/attribute_tree.rs
@@ -1,0 +1,281 @@
+use std::collections::{
+    HashMap,
+    HashSet,
+    VecDeque,
+};
+
+use dal::{
+    AttributePrototype,
+    AttributeValue,
+    Component,
+    DalContext,
+    Func,
+    Prop,
+    SchemaVariant,
+    Secret,
+    component::ControllingFuncData,
+    prop::PropPath,
+    property_editor::schema::WidgetKind,
+    validation::ValidationOutputNode,
+};
+use si_frontend_types::newhotness::component::attribute_tree::{
+    self,
+    AttributeTree,
+    AttributeValue as AttributeValueMv,
+    AvTreeInfo,
+    Prop as PropMv,
+    PropWidgetKind,
+    ValidationOutput,
+    WidgetOption,
+    WidgetOptions,
+};
+use si_id::{
+    AttributeValueId,
+    ComponentId,
+    InputSocketId,
+};
+use telemetry::prelude::*;
+
+/// Generates an [`AttributeTree`] MV.
+pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Result<AttributeTree> {
+    let ctx = &ctx;
+
+    let root_av_id = Component::root_attribute_value_id(ctx, component_id).await?;
+    let schema_variant_id = Component::schema_variant_id(ctx, component_id).await?;
+    let sockets_on_component: HashSet<InputSocketId> =
+        Component::incoming_connections_for_id(ctx, component_id)
+            .await?
+            .iter()
+            .map(|c| c.to_input_socket_id)
+            .collect();
+    let secrets_category_av_id =
+        Component::attribute_value_for_prop(ctx, component_id, &["root", "secrets"]).await?;
+    let secret_ids_by_key = Secret::list_ids_by_key(ctx).await?;
+
+    let mut attribute_values = HashMap::new();
+    let mut props = HashMap::new();
+    let mut tree_info = HashMap::new();
+
+    let mut work_queue = VecDeque::from([root_av_id]);
+
+    while let Some(av_id) = work_queue.pop_front() {
+        let maybe_parent_av_id = AttributeValue::parent_attribute_value_id(ctx, av_id).await?;
+        let child_av_ids: Vec<AttributeValueId> =
+            AttributeValue::get_child_avs_in_order(ctx, av_id)
+                .await?
+                .iter()
+                .map(|av| av.id())
+                .collect();
+        work_queue.extend(&child_av_ids);
+        tree_info.insert(
+            av_id,
+            AvTreeInfo {
+                parent: maybe_parent_av_id,
+                children: child_av_ids,
+            },
+        );
+
+        let maybe_prop = AttributeValue::prop_opt(ctx, av_id).await?;
+
+        // Build si_frontend_types::newhotness::AttributeValue & add to attribute_values HashMap.
+        let key = AttributeValue::key_for_id(ctx, av_id).await?;
+        let value = {
+            let mut value = match AttributeValue::get_by_id(ctx, av_id)
+                .await?
+                .value(ctx)
+                .await?
+            {
+                Some(value) => value,
+                None => match &maybe_prop {
+                    Some(prop) => Prop::default_value(ctx, prop.id)
+                        .await?
+                        .unwrap_or(serde_json::Value::Null),
+                    None => serde_json::Value::Null,
+                },
+            };
+
+            if maybe_parent_av_id == Some(secrets_category_av_id) {
+                let secret_key = Secret::key_from_value_in_attribute_value(value)?;
+                value = match secret_ids_by_key.get(&secret_key) {
+                    Some(secret_id) => serde_json::to_value(secret_id)?,
+
+                    None => {
+                        // NOTE(nick): I ported this comment.
+                        //
+                        // If none of the secrets in the workspace have this key, we assume
+                        // that dependent values haven't updated yet and will be fixed
+                        // shortly. Thus we treat the property as missing for now and
+                        // return null.
+                        //
+                        // This is an expected issue, so we don't warn--but it could trigger
+                        // if something more serious is going on that is making the lookup
+                        // fail more persistently, so we may want to measure how often it
+                        // happens and figure out how to alert in that case.
+                        warn!(
+                            name: "Secret key does not match",
+                            av_id = %av_id,
+                            "Secret key in dependent value does not match any secret key; assuming that dependent values are not up to date and treating the property temporarily as missing",
+                        );
+
+                        serde_json::Value::Null
+                    }
+                }
+            }
+
+            value
+        };
+        let sockets_for_av = AttributeValue::list_input_socket_sources_for_id(ctx, av_id).await?;
+        let can_be_set_by_socket = !sockets_for_av.is_empty();
+        let is_from_external_source = sockets_for_av
+            .iter()
+            .any(|s| sockets_on_component.contains(s));
+        let prototype_id = AttributeValue::prototype_id(ctx, av_id).await?;
+        let func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
+        let func = Func::get_by_id(ctx, func_id).await?;
+
+        // FIXME(nick): this is likely incorrect.
+        let controlling_func = ControllingFuncData {
+            func_id,
+            av_id,
+            is_dynamic_func: func.is_dynamic(),
+        };
+
+        // NOTE(nick): I ported Victor's comment.
+        //
+        // Note (victor): An attribute value is overridden if there is an attribute
+        // prototype for this specific AV, which means it's set for the component,
+        // not the schema variant. If the av is controlled, this check should be
+        // made for its controlling AV.
+        // This could be standalone func for AV, but we'd have to implement a
+        // controlling_ancestors_for_av_id for av, instead of for the whole component.
+        // Not a complicated task, but the PR that adds this has enough code as it is.
+        let overridden = AttributeValue::component_prototype_id(ctx, controlling_func.av_id)
+            .await?
+            .is_some();
+        let validation = ValidationOutputNode::find_for_attribute_value_id(ctx, av_id)
+            .await?
+            .map(|node| ValidationOutput {
+                status: match node.validation.status {
+                    dal::validation::ValidationStatus::Pending => {
+                        attribute_tree::ValidationStatus::Pending
+                    }
+                    dal::validation::ValidationStatus::Error => {
+                        attribute_tree::ValidationStatus::Error
+                    }
+                    dal::validation::ValidationStatus::Failure => {
+                        attribute_tree::ValidationStatus::Failure
+                    }
+                    dal::validation::ValidationStatus::Success => {
+                        attribute_tree::ValidationStatus::Success
+                    }
+                },
+                message: node.validation.message,
+            });
+
+        let av_mv = AttributeValueMv {
+            id: av_id,
+            prop_id: maybe_prop.as_ref().map(|p| p.id),
+            key,
+            path: AttributeValue::get_path_for_id(ctx, av_id).await?,
+            value,
+            can_be_set_by_socket,
+            is_from_external_source,
+            is_controlled_by_ancestor: controlling_func.av_id != av_id,
+            is_controlled_by_dynamic_func: controlling_func.is_dynamic_func,
+            overridden,
+            validation,
+        };
+        attribute_values.insert(av_id, av_mv);
+
+        if let Some(prop) = maybe_prop {
+            // If si_frontend_types::newhotness::Prop is not already in props HashMap, build & add.
+            if let std::collections::hash_map::Entry::Vacant(e) = props.entry(prop.id) {
+                let mut is_create_only = false;
+                let filtered_widget_options = prop.widget_options.clone().map(|options| {
+                    options
+                        .into_iter()
+                        .filter(|option| {
+                            if option.label() == "si_create_only_prop" {
+                                is_create_only = true;
+                                false
+                            } else {
+                                true
+                            }
+                        })
+                        .map(|option| WidgetOption {
+                            label: option.label,
+                            value: option.value,
+                        })
+                        .collect::<WidgetOptions>()
+                });
+                let default_can_be_set_by_socket =
+                    !prop.input_socket_sources(ctx).await?.is_empty();
+                let origin_secret_prop_id =
+                    if SchemaVariant::is_secret_defining(ctx, schema_variant_id).await? {
+                        let output_socket =
+                            SchemaVariant::find_output_socket_for_secret_defining_id(
+                                ctx,
+                                schema_variant_id,
+                            )
+                            .await?;
+                        Some(
+                            Prop::find_prop_id_by_path(
+                                ctx,
+                                schema_variant_id,
+                                &PropPath::new(["root", "secrets", output_socket.name()]),
+                            )
+                            .await?,
+                        )
+                    } else {
+                        None
+                    };
+                let maybe_resource = Component::resource_by_id(ctx, component_id).await?;
+                let has_resource = maybe_resource.is_some();
+
+                let prop_mv = PropMv {
+                    id: prop.id,
+                    path: prop.path(ctx).await?.as_str().to_string(),
+                    name: prop.name,
+                    kind: prop.kind.into(),
+                    widget_kind: match prop.widget_kind {
+                        WidgetKind::Array => PropWidgetKind::Array,
+                        WidgetKind::Checkbox => PropWidgetKind::Checkbox,
+                        WidgetKind::CodeEditor => PropWidgetKind::CodeEditor,
+                        WidgetKind::Header => PropWidgetKind::Header,
+                        WidgetKind::Map => PropWidgetKind::Map,
+                        WidgetKind::Password => PropWidgetKind::Password,
+                        WidgetKind::Select => PropWidgetKind::Select {
+                            options: filtered_widget_options,
+                        },
+                        WidgetKind::Color => PropWidgetKind::Color,
+                        WidgetKind::Secret => PropWidgetKind::Secret {
+                            options: filtered_widget_options,
+                        },
+                        WidgetKind::Text => PropWidgetKind::Text,
+                        WidgetKind::TextArea => PropWidgetKind::TextArea,
+                        WidgetKind::ComboBox => PropWidgetKind::ComboBox {
+                            options: filtered_widget_options,
+                        },
+                    },
+                    doc_link: prop.doc_link,
+                    documentation: prop.documentation,
+                    validation_format: prop.validation_format,
+                    default_can_be_set_by_socket,
+                    is_origin_secret: match origin_secret_prop_id {
+                        Some(prop_id) => prop_id == prop.id,
+                        None => false,
+                    },
+                    create_only: is_create_only && has_resource,
+                };
+                e.insert(prop_mv);
+            }
+        }
+    }
+
+    Ok(AttributeTree {
+        id: component_id,
+        attribute_values,
+        props,
+        tree_info,
+    })
+}

--- a/lib/si-frontend-types-rs/src/newhotness/component.rs
+++ b/lib/si-frontend-types-rs/src/newhotness/component.rs
@@ -18,6 +18,8 @@ use crate::reference::{
     ReferenceKind,
 };
 
+pub mod attribute_tree;
+
 #[derive(
     Debug, Serialize, Deserialize, PartialEq, Eq, Clone, si_frontend_types_macros::FrontendChecksum,
 )]

--- a/lib/si-frontend-types-rs/src/newhotness/component/attribute_tree.rs
+++ b/lib/si-frontend-types-rs/src/newhotness/component/attribute_tree.rs
@@ -1,0 +1,131 @@
+use std::collections::HashMap;
+
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::workspace_snapshot::EntityKind;
+use si_id::{
+    AttributeValueId,
+    ComponentId,
+    PropId,
+};
+use strum::Display;
+
+use crate::{
+    PropKind,
+    reference::ReferenceKind,
+};
+
+// This type goes into the content store so cannot be re-ordered, only extended
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Display)]
+pub enum ValidationStatus {
+    Pending,
+    Error,
+    Failure,
+    Success,
+}
+
+#[derive(
+    Clone, Debug, Deserialize, Eq, PartialEq, Serialize, si_frontend_types_macros::FrontendChecksum,
+)]
+pub struct WidgetOption {
+    pub label: String,
+    pub value: String,
+}
+
+pub type WidgetOptions = Vec<WidgetOption>;
+
+#[remain::sorted]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Display)]
+#[serde(rename_all = "camelCase")]
+pub enum PropWidgetKind {
+    Array,
+    Checkbox,
+    CodeEditor,
+    Color,
+    ComboBox { options: Option<WidgetOptions> },
+    Header,
+    Map,
+    Password,
+    Secret { options: Option<WidgetOptions> },
+    Select { options: Option<WidgetOptions> },
+    Text,
+    TextArea,
+}
+
+#[derive(
+    Clone, Debug, Serialize, Deserialize, PartialEq, Eq, si_frontend_types_macros::FrontendChecksum,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct Prop {
+    pub id: PropId,
+    pub path: String,
+    pub name: String,
+    pub kind: PropKind,
+    pub widget_kind: PropWidgetKind,
+    pub doc_link: Option<String>,
+    pub documentation: Option<String>,
+    pub validation_format: Option<String>,
+    pub default_can_be_set_by_socket: bool,
+    pub is_origin_secret: bool,
+    pub create_only: bool,
+}
+
+#[derive(
+    Deserialize, Serialize, Debug, Clone, PartialEq, Eq, si_frontend_types_macros::FrontendChecksum,
+)]
+pub struct ValidationOutput {
+    pub status: ValidationStatus,
+    pub message: Option<String>,
+}
+
+#[derive(
+    Clone, Debug, Serialize, Deserialize, PartialEq, Eq, si_frontend_types_macros::FrontendChecksum,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributeValue {
+    pub id: AttributeValueId,
+    pub key: Option<String>,
+    pub path: Option<String>,
+    pub prop_id: Option<PropId>,
+    pub value: serde_json::Value,
+    pub can_be_set_by_socket: bool, // true if this prop value is currently driven by a socket, even if the socket isn't in use
+    pub is_from_external_source: bool, // true if this prop has a value provided by a socket
+    pub is_controlled_by_ancestor: bool, // if ancestor of prop is set by dynamic func, ID of ancestor that sets it
+    pub is_controlled_by_dynamic_func: bool, // props driven by non-dynamic funcs have a statically set value
+    pub overridden: bool, // true if this prop has a different controlling func id than the default for this asset
+    pub validation: Option<ValidationOutput>,
+}
+
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Clone,
+    si_frontend_types_macros::FrontendChecksum,
+    si_frontend_types_macros::FrontendObject,
+    si_frontend_types_macros::Refer,
+    si_frontend_types_macros::MV,
+)]
+#[serde(rename_all = "camelCase")]
+#[mv(
+    trigger_entity = EntityKind::Component,
+    reference_kind = ReferenceKind::AttributeTree,
+)]
+pub struct AttributeTree {
+    pub id: ComponentId,
+    pub attribute_values: HashMap<AttributeValueId, AttributeValue>,
+    pub props: HashMap<PropId, Prop>,
+    pub tree_info: HashMap<AttributeValueId, AvTreeInfo>,
+}
+
+#[derive(
+    Debug, Serialize, Deserialize, PartialEq, Eq, Clone, si_frontend_types_macros::FrontendChecksum,
+)]
+pub struct AvTreeInfo {
+    pub parent: Option<AttributeValueId>,
+    pub children: Vec<AttributeValueId>,
+}

--- a/lib/si-frontend-types-rs/src/reference.rs
+++ b/lib/si-frontend-types-rs/src/reference.rs
@@ -35,6 +35,7 @@ use crate::{
 pub enum ReferenceKind {
     ActionPrototypeViewList,
     ActionViewList,
+    AttributeTree,
     ChangeSetList,
     ChangeSetRecord,
     Component,


### PR DESCRIPTION
The prior version of this created a MV per `AttributeValue` across the entire change set. This could be... a very large number of MV instances.

Rather than creating hundreds of thousands of MVs for moderately sized workspaces & change sets, we now collate the `AttributeValue` information into a single MV per Component. While this does mean that we will rebuild the MV to see if it has changed when there have been unrelated changes to the Component, it also means that we will always do this once per Component at most, and are able to cache more information used in the MV across all `AttributeValue`s in the Component.

Co-authored-by: Nick Gerace <nick@systeminit.com>