### PR TITLE
Ability to use the keyboard to select components on the Explore page

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -1,6 +1,11 @@
 <template>
   <!-- eslint-disable vue/no-multiple-template-root -->
-  <label ref="anchorRef" class="pl-xs flex flex-row items-center">
+  <label
+    ref="anchorRef"
+    :class="
+      clsx(showOptions && 'bg-neutral-500', 'pl-xs flex flex-row items-center')
+    "
+  >
     <span>{{ displayName }}</span>
     <template v-if="maybeOptions.hasOptions"> </template>
     <valueForm.Field name="value">
@@ -60,6 +65,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from "vue";
+import clsx from "clsx";
 import { Icon } from "@si/vue-lib/design-system";
 import { Fzf } from "fzf";
 import { BifrostAttributeTree } from "@/workers/types/dbinterface";


### PR DESCRIPTION
Also, something we forgot—on the attribute input, when the input is focused, use the same background as the menu below to indicate that the menu controls are related to the input

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYXFkZGkyYjRxczg0M2x3YTZ0cTN4aWtxYjBjajR4OTc2OG55b2d2cyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/cOcZMxxI2H3qxv4iM1/giphy.gif"/>