### PR TITLE
Add "diff" content to the component mv. Also, fix the feature flag sponge we keep messing up

### DIFF
--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -100,6 +100,10 @@ export function useFeatureFlagsStore() {
         // events (e.g. change set abandoned). For now, let's play it safe and make sure that
         // everything in the new frontend arch comes in together. Both of these flags should
         // eventually die though.
+
+        // turning this on for local development
+        if (import.meta.env.VITE_SI_ENV === "local") this.NEW_HOTNESS = true;
+
         if (this.NEW_HOTNESS) {
           // eslint-disable-next-line no-console
           console.log(

--- a/lib/dal/tests/integration_test/materialized_views.rs
+++ b/lib/dal/tests/integration_test/materialized_views.rs
@@ -1,32 +1,19 @@
 use std::collections::HashSet;
 
 use dal::{
-    Component,
-    DalContext,
-    Func,
-    action::{
-        Action,
-        prototype::ActionPrototype,
-    },
+    Component, DalContext, Func,
+    action::{Action, prototype::ActionPrototype},
     qualification::QualificationSummary,
 };
 use dal_test::{
-    Result,
-    helpers::create_component_for_default_schema_name_in_default_view,
-    prelude::OptionExt,
+    Result, helpers::create_component_for_default_schema_name_in_default_view, prelude::OptionExt,
     test,
 };
 use pretty_assertions_sorted::assert_eq;
-use si_events::{
-    ActionKind,
-    ActionState,
-};
+use si_events::{ActionKind, ActionState};
 use si_frontend_types::{
     action::ActionView,
-    newhotness::component::{
-        Component as ComponentMv,
-        ComponentList,
-    },
+    newhotness::component::{Component as ComponentMv, ComponentDiff, ComponentList},
     reference::ReferenceKind,
 };
 
@@ -162,6 +149,15 @@ async fn component(ctx: &DalContext) -> Result<()> {
     )
     .await?;
 
+    let resource_diff = ComponentDiff {
+        current: Some(String::from(
+            "{\n  \"si\": {\n    \"name\": \"starfield\",\n    \"type\": \"component\",\n    \"color\": \"#ffffff\"\n  }\n}",
+        )),
+        diff: Some(String::from(
+            "+{\n+  \"si\": {\n+    \"name\": \"starfield\",\n+    \"type\": \"component\",\n+    \"color\": \"#ffffff\"\n+  }\n+}",
+        )),
+    };
+
     assert_eq!(
         ComponentMv {
             id: created_component.id(),
@@ -183,6 +179,7 @@ async fn component(ctx: &DalContext) -> Result<()> {
             secrets_attribute_value_id,
             si_attribute_value_id,
             resource_value_attribute_value_id,
+            resource_diff,
         }, // expected
         component // actual
     );

--- a/lib/si-frontend-types-rs/src/newhotness/component.rs
+++ b/lib/si-frontend-types-rs/src/newhotness/component.rs
@@ -42,6 +42,15 @@ pub struct ComponentQualificationStats {
 }
 
 #[derive(
+    Debug, Serialize, Deserialize, PartialEq, Eq, Clone, si_frontend_types_macros::FrontendChecksum,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentDiff {
+    pub current: Option<String>,
+    pub diff: Option<String>,
+}
+
+#[derive(
     Debug,
     Serialize,
     Deserialize,
@@ -78,6 +87,7 @@ pub struct Component {
     pub secrets_attribute_value_id: AttributeValueId,
     pub si_attribute_value_id: AttributeValueId,
     pub resource_value_attribute_value_id: AttributeValueId,
+    pub resource_diff: ComponentDiff,
 }
 
 #[derive(


### PR DESCRIPTION
I'm not making a separate Mv to keep a lid on total number of mvs, given everything that is going on. Maybe in the future we have a better place for this to live. But for now, it functions and stays up to date.

Also—please give me the more correct rust way to do the if-let-some nonsense I did hear 😇 ... it works, but obviously its not pretty.