### PR TITLE
Add MVs for incoming socket-to-socket connections

### DIFF
--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -13,7 +13,12 @@ import { WorkspacePk } from "@/store/workspaces.store";
 import { Categories } from "@/store/components.store";
 import { ActionProposedView } from "@/store/actions.store";
 import { ComponentId } from "@/api/sdf/dal/component";
-import { SchemaId, SchemaVariantId } from "@/api/sdf/dal/schema";
+import {
+  InputSocketId,
+  OutputSocketId,
+  SchemaId,
+  SchemaVariantId,
+} from "@/api/sdf/dal/schema";
 import { ActionKind, ActionPrototypeId } from "@/api/sdf/dal/action";
 import { FuncId } from "@/api/sdf/dal/func";
 import { AttributeValueId } from "@/store/status.store";
@@ -339,3 +344,47 @@ export interface BifrostAttributeTree {
   attributeValue: AttributeValue;
   validation?: ValidationOutput;
 }
+
+export interface RawComponentConnectionsListBeta {
+  id: ChangeSetId;
+  componentConnections: Reference[];
+}
+
+export interface BifrostComponentConnectionsListBeta {
+  id: ChangeSetId;
+  componentConnections: BifrostComponentConnectionsBeta[];
+}
+
+export interface BifrostComponentConnectionsBeta {
+  id: ComponentId;
+  incoming: Connection[];
+  outgoing: Connection[];
+}
+
+type Connection =
+  | {
+      kind: "prop";
+      fromComponentId: ComponentId;
+      fromAttributeValueId: AttributeValueId;
+      fromAttributeValuePath: string;
+      fromPropId: PropId;
+      fromPropPath: string;
+      toComponentId: ComponentId;
+      toPropId: PropId;
+      toPropPath: string;
+      toAttributeValueId: AttributeValueId;
+      toAttributeValuePath: string;
+    }
+  | {
+      kind: "socket";
+      fromComponentId: ComponentId;
+      fromAttributeValueId: AttributeValueId;
+      fromAttributeValuePath: string;
+      fromSocketId: OutputSocketId;
+      fromSocketName: string;
+      toComponentId: ComponentId;
+      toSocketId: InputSocketId;
+      toSocketName: string;
+      toAttributeValueId: AttributeValueId;
+      toAttributeValuePath: string;
+    };

--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -52,6 +52,9 @@ import {
   BifrostComponentList,
   RawAttributeTree,
   BifrostAttributeTree,
+  RawComponentConnectionsListBeta,
+  BifrostComponentConnectionsBeta,
+  BifrostComponentConnectionsListBeta,
 } from "./types/dbinterface";
 
 let otelEndpoint = import.meta.env.VITE_OTEL_EXPORTER_OTLP_ENDPOINT;
@@ -959,6 +962,22 @@ const get = async (
       children,
     };
     return attrTree;
+  } else if (kind === "ComponentConnectionsListBeta") {
+    const rawList = atomDoc as RawComponentConnectionsListBeta;
+    const maybeComponentConnections = await Promise.all(
+      rawList.componentConnections.map(async (c) => {
+        return await get(workspaceId, changeSetId, c.kind, c.id);
+      }),
+    );
+    const componentConnections = maybeComponentConnections.filter(
+      (c): c is BifrostComponentConnectionsBeta =>
+        c !== -1 && Object.keys(c).length > 0,
+    );
+    const list: BifrostComponentConnectionsListBeta = {
+      id: rawList.id,
+      componentConnections,
+    };
+    return list;
   } else return atomDoc;
 };
 

--- a/lib/dal-materialized-views/src/component_connections.rs
+++ b/lib/dal-materialized-views/src/component_connections.rs
@@ -1,0 +1,152 @@
+use dal::{
+    AttributePrototype,
+    AttributeValue,
+    Component,
+    DalContext,
+    InputSocket,
+    OutputSocket,
+    attribute::prototype::argument::{
+        AttributePrototypeArgument,
+        value_source::ValueSource,
+    },
+};
+use si_frontend_types::newhotness::component_connections::{
+    ComponentConnectionsBeta as ComponentConnectionsMv,
+    Connection,
+};
+use si_id::ComponentId;
+use telemetry::prelude::*;
+
+use crate::{
+    Error,
+    Result,
+};
+
+#[instrument(
+    name = "dal_materialized_views.component_connections",
+    level = "debug",
+    skip_all
+)]
+pub async fn assemble(
+    ctx: DalContext,
+    component_id: ComponentId,
+) -> Result<ComponentConnectionsMv> {
+    let ctx = &ctx;
+
+    let mut incoming = Vec::new();
+    incoming.extend(incoming_socket_connections(ctx, component_id).await?);
+    incoming.extend(incoming_prop_connections(ctx, component_id).await?);
+    incoming.sort();
+
+    let mut outgoing = Vec::new();
+    outgoing.extend(outgoing_socket_connections(ctx, component_id).await?);
+    outgoing.extend(outgoing_prop_connections(ctx, component_id).await?);
+    outgoing.sort();
+
+    Ok(ComponentConnectionsMv {
+        id: component_id,
+        incoming,
+        outgoing,
+    })
+}
+
+async fn incoming_socket_connections(
+    ctx: &DalContext,
+    component_id: ComponentId,
+) -> Result<Vec<Connection>> {
+    let schema_variant = Component::schema_variant_for_component_id(ctx, component_id).await?;
+    let input_socket_ids =
+        InputSocket::list_ids_for_schema_variant(ctx, schema_variant.id()).await?;
+
+    let mut connections = Vec::new();
+    for input_socket_id in input_socket_ids {
+        let input_socket = InputSocket::get_by_id(ctx, input_socket_id).await?;
+        let input_socket_attribute_value_id =
+            InputSocket::component_attribute_value_for_input_socket_id(
+                ctx,
+                input_socket_id,
+                component_id,
+            )
+            .await?;
+        let input_socket_attribute_value_path =
+            AttributeValue::get_path_for_id(ctx, input_socket_attribute_value_id)
+                .await?
+                .ok_or(Error::EmptyPathForAttributeValue(
+                    input_socket_attribute_value_id,
+                ))?;
+        let attribute_prototype_id =
+            AttributeValue::prototype_id(ctx, input_socket_attribute_value_id).await?;
+        let attribute_prototype_argument_ids =
+            AttributePrototype::list_arguments_for_id(ctx, attribute_prototype_id).await?;
+
+        for attribute_prototype_argument_id in attribute_prototype_argument_ids {
+            let attribute_prototype_argument =
+                AttributePrototypeArgument::get_by_id(ctx, attribute_prototype_argument_id).await?;
+            let value_source =
+                AttributePrototypeArgument::value_source(ctx, attribute_prototype_argument_id)
+                    .await?;
+            let ValueSource::OutputSocket(output_socket_id) = value_source else {
+                return Err(Error::InvalidValueSource(value_source));
+            };
+            let output_socket = OutputSocket::get_by_id(ctx, output_socket_id).await?;
+
+            if let Some(targets) = attribute_prototype_argument.targets() {
+                let output_socket_attribute_value_id =
+                    OutputSocket::component_attribute_value_for_output_socket_id(
+                        ctx,
+                        output_socket_id,
+                        targets.source_component_id,
+                    )
+                    .await?;
+                let output_socket_attribute_value_path =
+                    AttributeValue::get_path_for_id(ctx, output_socket_attribute_value_id)
+                        .await?
+                        .ok_or(Error::EmptyPathForAttributeValue(
+                            output_socket_attribute_value_id,
+                        ))?;
+
+                connections.push(Connection::Socket {
+                    from_component_id: targets.source_component_id,
+                    from_attribute_value_id: output_socket_attribute_value_id,
+                    from_attribute_value_path: output_socket_attribute_value_path,
+                    from_socket_id: output_socket_id,
+                    from_socket_name: output_socket.name().to_string(),
+                    to_component_id: component_id,
+                    to_socket_id: input_socket_id,
+                    to_socket_name: input_socket.name().to_string(),
+                    to_attribute_value_id: input_socket_attribute_value_id,
+                    to_attribute_value_path: input_socket_attribute_value_path.clone(),
+                });
+            }
+        }
+    }
+
+    Ok(connections)
+}
+
+async fn incoming_prop_connections(
+    _ctx: &DalContext,
+    _component_id: ComponentId,
+) -> Result<Vec<Connection>> {
+    let connections = Vec::new();
+
+    Ok(connections)
+}
+
+async fn outgoing_socket_connections(
+    _ctx: &DalContext,
+    _component_id: ComponentId,
+) -> Result<Vec<Connection>> {
+    let connections = Vec::new();
+
+    Ok(connections)
+}
+
+async fn outgoing_prop_connections(
+    _ctx: &DalContext,
+    _component_id: ComponentId,
+) -> Result<Vec<Connection>> {
+    let connections = Vec::new();
+
+    Ok(connections)
+}

--- a/lib/dal-materialized-views/src/component_connections_list.rs
+++ b/lib/dal-materialized-views/src/component_connections_list.rs
@@ -1,0 +1,27 @@
+use dal::{
+    Component,
+    DalContext,
+};
+use si_frontend_types::newhotness::component_connections::ComponentConnectionsListBeta as ComponentConnectionsListMv;
+use telemetry::prelude::*;
+
+#[instrument(
+    name = "dal_materialized_views.component_connections_list",
+    level = "debug",
+    skip_all
+)]
+pub async fn assemble(ctx: DalContext) -> super::Result<ComponentConnectionsListMv> {
+    let ctx = &ctx;
+    let component_ids = Component::list_ids(ctx).await?;
+    let mut component_connections = Vec::with_capacity(component_ids.len());
+
+    for component_id in component_ids {
+        component_connections
+            .push(super::component_connections::assemble(ctx.clone(), component_id).await?);
+    }
+
+    Ok(ComponentConnectionsListMv {
+        id: ctx.change_set_id(),
+        component_connections: component_connections.iter().map(Into::into).collect(),
+    })
+}

--- a/lib/dal-materialized-views/src/lib.rs
+++ b/lib/dal-materialized-views/src/lib.rs
@@ -53,6 +53,8 @@
 pub mod action_prototype_view_list;
 pub mod action_view_list;
 pub mod component;
+pub mod component_connections;
+pub mod component_connections_list;
 pub mod component_list;
 pub mod schema_variant_categories;
 pub mod view;
@@ -80,10 +82,14 @@ pub enum Error {
     Component(#[from] dal::ComponentError),
     #[error("diagram error: {0}")]
     Diagram(#[from] dal::diagram::DiagramError),
+    #[error("empty path for attribute value id {0}")]
+    EmptyPathForAttributeValue(dal::AttributeValueId),
     #[error("func error: {0}")]
     Func(#[from] dal::FuncError),
     #[error("input socket error: {0}")]
     InputSocket(#[from] dal::socket::input::InputSocketError),
+    #[error("invalid value source: {0:?}")]
+    InvalidValueSource(dal::attribute::prototype::argument::value_source::ValueSource),
     #[error("output socket error: {0}")]
     OutputSocket(#[from] dal::socket::output::OutputSocketError),
     #[error("prop error: {0}")]

--- a/lib/si-frontend-types-macros/src/lib.rs
+++ b/lib/si-frontend-types-macros/src/lib.rs
@@ -55,7 +55,9 @@ fn derive_frontend_checksum_struct(
             );
             continue;
         };
+        let field_name = field_ident.to_string();
         field_update_parts.push(quote! {
+            hasher.update(#field_name.as_bytes());
             hasher.update(
                 crate::checksum::FrontendChecksum::checksum(&self.#field_ident).as_bytes()
             );
@@ -105,7 +107,9 @@ fn derive_frontend_checksum_enum(
                 );
                 // Checksum each field
                 let checksum_fields = fields_named.iter().map(|field_ident| {
+                    let field_name = field_ident.to_string();
                     quote! {
+                        hasher.update(#field_name.as_bytes());
                         hasher.update(
                             crate::checksum::FrontendChecksum::checksum(#field_ident).as_bytes()
                         );
@@ -113,8 +117,10 @@ fn derive_frontend_checksum_enum(
                 });
                 let checksum_fields_stream = TokenStream::from_iter(checksum_fields);
 
+                let variant_name = variant_ident.to_string();
                 quote! {
                     #ident::#variant_ident { #fields_named } => {
+                        hasher.update(#variant_name.as_bytes());
                         #checksum_fields_stream
                     }
                 }
@@ -131,7 +137,9 @@ fn derive_frontend_checksum_enum(
                     syn::punctuated::Punctuated::<_, syn::Token![,]>::from_iter(fields.iter());
                 // Checksum each field
                 let checksum_fields = fields.iter().map(|field_ident| {
+                    let field_name = field_ident.to_string();
                     quote! {
+                        hasher.update(#field_name.as_bytes());
                         hasher.update(
                             crate::checksum::FrontendChecksum::checksum(#field_ident).as_bytes()
                         );
@@ -139,8 +147,10 @@ fn derive_frontend_checksum_enum(
                 });
                 let checksum_fields_stream = TokenStream::from_iter(checksum_fields);
 
+                let variant_name = variant_ident.to_string();
                 quote! {
                     #ident::#variant_ident(#fields_named) => {
+                        hasher.update(#variant_name.as_bytes());
                         #checksum_fields_stream
                     }
                 }

--- a/lib/si-frontend-types-rs/src/action.rs
+++ b/lib/si-frontend-types-rs/src/action.rs
@@ -5,11 +5,7 @@ use serde::{
 use si_events::{
     ActionKind,
     ActionState,
-    workspace_snapshot::{
-        Checksum,
-        ChecksumHasher,
-        EntityKind,
-    },
+    workspace_snapshot::EntityKind,
 };
 use si_id::{
     ActionId,
@@ -19,17 +15,7 @@ use si_id::{
     FuncRunId,
 };
 
-use crate::{
-    MaterializedView,
-    checksum::FrontendChecksum,
-    object::FrontendObject,
-    reference::{
-        Refer,
-        Reference,
-        ReferenceId,
-        ReferenceKind,
-    },
-};
+use crate::reference::ReferenceKind;
 
 pub mod prototype;
 

--- a/lib/si-frontend-types-rs/src/action/prototype.rs
+++ b/lib/si-frontend-types-rs/src/action/prototype.rs
@@ -4,11 +4,7 @@ use serde::{
 };
 use si_events::{
     ActionKind,
-    workspace_snapshot::{
-        Checksum,
-        ChecksumHasher,
-        EntityKind,
-    },
+    workspace_snapshot::EntityKind,
 };
 use si_id::{
     ActionPrototypeId,
@@ -16,17 +12,7 @@ use si_id::{
     SchemaVariantId,
 };
 
-use crate::{
-    MaterializedView,
-    checksum::FrontendChecksum,
-    object::FrontendObject,
-    reference::{
-        Refer,
-        Reference,
-        ReferenceId,
-        ReferenceKind,
-    },
-};
+use crate::reference::ReferenceKind;
 
 #[derive(
     Debug, Serialize, Deserialize, PartialEq, Eq, Clone, si_frontend_types_macros::FrontendChecksum,

--- a/lib/si-frontend-types-rs/src/change_set.rs
+++ b/lib/si-frontend-types-rs/src/change_set.rs
@@ -13,11 +13,7 @@ use si_events::{
     ChangeSetId,
     ChangeSetStatus,
     UserPk,
-    workspace_snapshot::{
-        Checksum,
-        ChecksumHasher,
-        EntityKind,
-    },
+    workspace_snapshot::EntityKind,
 };
 use si_id::{
     ChangeSetApprovalId,
@@ -26,14 +22,8 @@ use si_id::{
 };
 
 use crate::{
-    checksum::FrontendChecksum,
     object::FrontendObject,
-    reference::{
-        Refer,
-        Reference,
-        ReferenceId,
-        ReferenceKind,
-    },
+    reference::Reference,
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]

--- a/lib/si-frontend-types-rs/src/checksum.rs
+++ b/lib/si-frontend-types-rs/src/checksum.rs
@@ -283,3 +283,19 @@ impl FrontendChecksum for u64 {
         FrontendChecksum::checksum(&self.to_string())
     }
 }
+
+impl FrontendChecksum for Vec<u8> {
+    fn checksum(&self) -> Checksum {
+        let mut hasher = ChecksumHasher::new();
+        hasher.update(self.as_slice());
+        hasher.finalize()
+    }
+}
+
+impl FrontendChecksum for &[u8] {
+    fn checksum(&self) -> Checksum {
+        let mut hasher = ChecksumHasher::new();
+        hasher.update(self);
+        hasher.finalize()
+    }
+}

--- a/lib/si-frontend-types-rs/src/index.rs
+++ b/lib/si-frontend-types-rs/src/index.rs
@@ -2,10 +2,6 @@ use serde::{
     Deserialize,
     Serialize,
 };
-use si_events::workspace_snapshot::{
-    Checksum,
-    ChecksumHasher,
-};
 use si_id::ChangeSetId;
 
 use crate::{

--- a/lib/si-frontend-types-rs/src/lib.rs
+++ b/lib/si-frontend-types-rs/src/lib.rs
@@ -80,3 +80,122 @@ pub use crate::{
     },
     workspace::WorkspaceMetadata,
 };
+
+#[cfg(test)]
+mod tests {
+    use serde::{
+        Deserialize,
+        Serialize,
+    };
+
+    use crate::checksum::FrontendChecksum;
+
+    #[test]
+    fn enum_with_tuple_variant_bytestreams() {
+        #[derive(
+            Clone,
+            Debug,
+            Deserialize,
+            Eq,
+            PartialEq,
+            Ord,
+            PartialOrd,
+            Serialize,
+            si_frontend_types_macros::FrontendChecksum,
+        )]
+        #[remain::sorted]
+        #[serde(rename_all = "camelCase")]
+        enum Todd {
+            Howard(Vec<u8>, Vec<u8>),
+        }
+
+        let item_one = "oblivion remastered";
+        let item_two = "tes vi";
+
+        let todd_one = {
+            let mut first_vec = Vec::new();
+            first_vec.extend(item_one.as_bytes());
+            first_vec.extend(item_two.as_bytes());
+            let second_vec = Vec::new();
+            let todd = Todd::Howard(first_vec, second_vec);
+            FrontendChecksum::checksum(&todd)
+        };
+
+        let todd_two = {
+            let mut first_vec = Vec::new();
+            first_vec.extend(item_one.as_bytes());
+            let mut second_vec = Vec::new();
+            second_vec.extend(item_two.as_bytes());
+            let todd = Todd::Howard(first_vec, second_vec);
+            FrontendChecksum::checksum(&todd)
+        };
+
+        let todd_three = {
+            let first_vec = Vec::new();
+            let mut second_vec = Vec::new();
+            second_vec.extend(item_one.as_bytes());
+            second_vec.extend(item_two.as_bytes());
+            let todd = Todd::Howard(first_vec, second_vec);
+            FrontendChecksum::checksum(&todd)
+        };
+
+        assert_ne!(todd_one, todd_two);
+        assert_ne!(todd_one, todd_three);
+        assert_ne!(todd_two, todd_three);
+    }
+
+    #[test]
+    fn struct_with_bytestream_fields() {
+        #[derive(
+            Clone,
+            Debug,
+            Deserialize,
+            Eq,
+            PartialEq,
+            Ord,
+            PartialOrd,
+            Serialize,
+            si_frontend_types_macros::FrontendChecksum,
+        )]
+        #[remain::sorted]
+        #[serde(rename_all = "camelCase")]
+        struct Example {
+            howard: Vec<u8>,
+            todd: Vec<u8>,
+        }
+
+        let item_one = "oblivion remastered";
+        let item_two = "tes vi";
+
+        let example_one = {
+            let mut howard = Vec::new();
+            howard.extend(item_one.as_bytes());
+            howard.extend(item_two.as_bytes());
+            let todd = Vec::new();
+            let example = Example { howard, todd };
+            FrontendChecksum::checksum(&example)
+        };
+
+        let example_two = {
+            let mut howard = Vec::new();
+            howard.extend(item_one.as_bytes());
+            let mut todd = Vec::new();
+            todd.extend(item_two.as_bytes());
+            let example = Example { howard, todd };
+            FrontendChecksum::checksum(&example)
+        };
+
+        let example_three = {
+            let howard = Vec::new();
+            let mut todd = Vec::new();
+            todd.extend(item_one.as_bytes());
+            todd.extend(item_two.as_bytes());
+            let example = Example { howard, todd };
+            FrontendChecksum::checksum(&example)
+        };
+
+        assert_ne!(example_one, example_two);
+        assert_ne!(example_one, example_three);
+        assert_ne!(example_two, example_three);
+    }
+}

--- a/lib/si-frontend-types-rs/src/newhotness.rs
+++ b/lib/si-frontend-types-rs/src/newhotness.rs
@@ -1,1 +1,2 @@
 pub mod component;
+pub mod component_connections;

--- a/lib/si-frontend-types-rs/src/newhotness/component.rs
+++ b/lib/si-frontend-types-rs/src/newhotness/component.rs
@@ -6,27 +6,16 @@ use si_events::{
     ComponentId,
     SchemaId,
     SchemaVariantId,
-    workspace_snapshot::{
-        Checksum,
-        ChecksumHasher,
-        EntityKind,
-    },
+    workspace_snapshot::EntityKind,
 };
 use si_id::{
     AttributeValueId,
     ChangeSetId,
 };
 
-use crate::{
-    MaterializedView,
-    checksum::FrontendChecksum,
-    object::FrontendObject,
-    reference::{
-        Refer,
-        Reference,
-        ReferenceId,
-        ReferenceKind,
-    },
+use crate::reference::{
+    Reference,
+    ReferenceKind,
 };
 
 #[derive(

--- a/lib/si-frontend-types-rs/src/newhotness/component_connections.rs
+++ b/lib/si-frontend-types-rs/src/newhotness/component_connections.rs
@@ -1,0 +1,84 @@
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::workspace_snapshot::EntityKind;
+use si_frontend_types_macros::{
+    FrontendChecksum,
+    FrontendObject,
+    MV,
+    Refer,
+};
+use si_id::{
+    AttributeValueId,
+    ChangeSetId,
+    ComponentId,
+    InputSocketId,
+    OutputSocketId,
+    PropId,
+};
+
+use crate::reference::{
+    Reference,
+    ReferenceKind,
+};
+
+#[derive(
+    Clone, Debug, Deserialize, Eq, PartialEq, Ord, PartialOrd, Serialize, FrontendChecksum,
+)]
+#[remain::sorted]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum Connection {
+    Prop {
+        from_component_id: ComponentId,
+        from_attribute_value_id: AttributeValueId,
+        from_attribute_value_path: String,
+        from_prop_id: PropId,
+        from_prop_path: String,
+        to_component_id: ComponentId,
+        to_prop_id: PropId,
+        to_prop_path: String,
+        to_attribute_value_id: AttributeValueId,
+        to_attribute_value_path: String,
+    },
+    Socket {
+        from_component_id: ComponentId,
+        from_attribute_value_id: AttributeValueId,
+        from_attribute_value_path: String,
+        from_socket_id: OutputSocketId,
+        from_socket_name: String,
+        to_component_id: ComponentId,
+        to_socket_id: InputSocketId,
+        to_socket_name: String,
+        to_attribute_value_id: AttributeValueId,
+        to_attribute_value_path: String,
+    },
+}
+
+#[derive(
+    Clone, Debug, Deserialize, Eq, PartialEq, Serialize, FrontendChecksum, FrontendObject, Refer, MV,
+)]
+#[serde(rename_all = "camelCase")]
+#[mv(
+    trigger_entity = EntityKind::Component,
+    reference_kind = ReferenceKind::ComponentConnectionsBeta,
+)]
+pub struct ComponentConnectionsBeta {
+    pub id: ComponentId,
+    pub incoming: Vec<Connection>,
+    pub outgoing: Vec<Connection>,
+}
+
+#[derive(
+    Clone, Debug, Deserialize, Eq, PartialEq, Serialize, FrontendChecksum, FrontendObject, Refer, MV,
+)]
+#[serde(rename_all = "camelCase")]
+#[mv(
+  trigger_entity = EntityKind::CategoryComponent,
+  reference_kind = ReferenceKind::ComponentConnectionsListBeta,
+)]
+pub struct ComponentConnectionsListBeta {
+    pub id: ChangeSetId,
+    #[mv(reference_kind = ReferenceKind::ComponentConnectionsBeta)]
+    pub component_connections: Vec<Reference<ComponentId>>,
+}

--- a/lib/si-frontend-types-rs/src/reference.rs
+++ b/lib/si-frontend-types-rs/src/reference.rs
@@ -38,6 +38,8 @@ pub enum ReferenceKind {
     ChangeSetList,
     ChangeSetRecord,
     Component,
+    ComponentConnectionsBeta,
+    ComponentConnectionsListBeta,
     ComponentList,
     MvIndex,
     SchemaVariantCategories,

--- a/lib/si-frontend-types-rs/src/schema_variant.rs
+++ b/lib/si-frontend-types-rs/src/schema_variant.rs
@@ -10,11 +10,7 @@ use si_events::{
     SchemaId,
     SchemaVariantId,
     Timestamp,
-    workspace_snapshot::{
-        Checksum,
-        ChecksumHasher,
-        EntityKind,
-    },
+    workspace_snapshot::EntityKind,
 };
 use si_id::ChangeSetId;
 use strum::{
@@ -24,17 +20,7 @@ use strum::{
     EnumString,
 };
 
-use crate::{
-    MaterializedView,
-    checksum::FrontendChecksum,
-    object::FrontendObject,
-    reference::{
-        Refer,
-        Reference,
-        ReferenceId,
-        ReferenceKind,
-    },
-};
+use crate::reference::ReferenceKind;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/lib/si-frontend-types-rs/src/view.rs
+++ b/lib/si-frontend-types-rs/src/view.rs
@@ -4,11 +4,13 @@ use serde::{
 };
 use si_events::{
     Timestamp,
-    workspace_snapshot::{
-        Checksum,
-        ChecksumHasher,
-        EntityKind,
-    },
+    workspace_snapshot::EntityKind,
+};
+use si_frontend_types_macros::{
+    FrontendChecksum,
+    FrontendObject,
+    MV,
+    Refer,
 };
 use si_id::{
     ChangeSetId,
@@ -16,29 +18,13 @@ use si_id::{
     ViewId,
 };
 
-use crate::{
-    MaterializedView,
-    checksum::FrontendChecksum,
-    object::FrontendObject,
-    reference::{
-        Refer,
-        Reference,
-        ReferenceId,
-        ReferenceKind,
-    },
+use crate::reference::{
+    Reference,
+    ReferenceKind,
 };
 
 #[derive(
-    Clone,
-    Debug,
-    Deserialize,
-    Serialize,
-    Eq,
-    PartialEq,
-    si_frontend_types_macros::FrontendChecksum,
-    si_frontend_types_macros::FrontendObject,
-    si_frontend_types_macros::Refer,
-    si_frontend_types_macros::MV,
+    Clone, Debug, Deserialize, Serialize, Eq, PartialEq, FrontendChecksum, FrontendObject, Refer, MV,
 )]
 #[serde(rename_all = "camelCase")]
 #[mv(
@@ -53,17 +39,7 @@ pub struct View {
     pub timestamp: Timestamp,
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Serialize,
-    PartialEq,
-    Eq,
-    si_frontend_types_macros::FrontendChecksum,
-    si_frontend_types_macros::FrontendObject,
-    si_frontend_types_macros::Refer,
-    si_frontend_types_macros::MV,
-)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, FrontendChecksum, FrontendObject, Refer, MV)]
 #[mv(
     trigger_entity = EntityKind::CategoryView,
     reference_kind = ReferenceKind::ViewList,


### PR DESCRIPTION
## Description

This change adds MVs for incoming socket-to-socket connections. The MVs have a "Beta" suffix for easy invalidations once we test all four kinds of connections needed in the new UI.

As a consequence of these changes, the macro(s) used for MVs have been adjusted to handle enums with struct variants.

For the record, @fnichol architected the vast majority of this. I just wired it up to the frontend and drove it home. Go Fletcher!

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZXQ0a2tteDdydW03N2dwbXJ3bnpsYWtjYWJxZTNnbnFvdjM0NDd4YiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/DoWqmz4TGL3Tk9jwTZ/giphy.gif"/>