### PR TITLE
BUG-860: INC ui not loading code editor

### DIFF
--- a/app/web/src/utils/typescriptLinter.ts
+++ b/app/web/src/utils/typescriptLinter.ts
@@ -67,7 +67,6 @@ export const createTypescriptSource = async (
     allowJs: true,
     checkJs: true,
     strict: false,
-    suppressImplicitAnyIndexErrors: true,
   };
 
   if (!fsMap && !vfsSystem) {


### PR DESCRIPTION
The error that occurs (which was being suppressed) is: Error: error TS5101: Option 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.

That is thrown by our mounting of the code editor to give it tool tips:
```
await createTypescriptSource(props.typescript);
```

Fix: remove the deprecated option