### PR TITLE
feat(sdf): Add subscription edges to get_diagram API

### DIFF
--- a/app/web/src/api/sdf/dal/component.ts
+++ b/app/web/src/api/sdf/dal/component.ts
@@ -71,24 +71,30 @@ export interface RawComponent {
 export type EdgeId = string;
 export type SocketId = string;
 
-export type RawEdge = {
+// This encompasses all edges, from socket connections to management edges to subscriptions
+// (which don't have sockets)
+export interface ComponentEdge {
   fromComponentId: ComponentId;
-  fromSocketId: SocketId;
   toComponentId: ComponentId;
-  toSocketId: SocketId;
   toDelete: boolean;
   /** change status of edge in relation to head */
   changeStatus?: ChangeStatus;
+}
+
+export interface RawEdge extends ComponentEdge {
+  fromSocketId: SocketId;
+  toSocketId: SocketId;
+  // TODO this does not exist for management edges or subscriptions
   createdInfo: ActorAndTimestamp;
   // updatedInfo?: ActorAndTimestamp; // currently we dont ever update an edge...
   deletedInfo?: ActorAndTimestamp;
-};
+}
 
-export type Edge = RawEdge & {
+export interface Edge extends RawEdge {
   id: EdgeId;
   isInferred: boolean;
   isManagement?: boolean;
-};
+}
 
 export interface PotentialConnection {
   socketId: SocketId;

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -29,6 +29,7 @@ import {
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import {
   ComponentDiff,
+  ComponentEdge,
   ComponentId,
   Edge,
   EdgeId,
@@ -488,8 +489,8 @@ export function getPossibleAndExistingPeerSockets(
 
   const edgeCountForInputKey = {} as Record<string, number>;
   nonDeletedEdges.forEach((e) => {
-    edgeCountForInputKey[e.toSocketKey] ??= 0;
-    edgeCountForInputKey[e.toSocketKey] += 1;
+    edgeCountForInputKey[e.toSocketKey] =
+      (edgeCountForInputKey[e.toSocketKey] ?? 0) + 1;
   });
 
   const existingEdges = nonDeletedEdges
@@ -1008,6 +1009,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               edges: RawEdge[];
               inferredEdges: RawEdge[];
               managementEdges: RawEdge[];
+              attributeSubscriptionEdges: ComponentEdge[];
             }>({
               method: "get",
               url: "diagram/get_all_components_and_edges",

--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -26,6 +26,7 @@ import {
   Size2D,
 } from "@/components/ModelingDiagram/diagram_types";
 import {
+  ComponentEdge,
   ComponentId,
   Edge,
   EdgeId,
@@ -873,6 +874,7 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
               edges: RawEdge[];
               inferredEdges: RawEdge[];
               managementEdges: RawEdge[];
+              attributeSubscriptionEdges: ComponentEdge[];
               views: ViewNodeGeometry[];
             };
           }>({

--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -303,7 +303,7 @@ impl ExpectSchemaVariant {
     }
 
     pub async fn schema(self, ctx: &DalContext) -> ExpectSchema {
-        SchemaVariant::schema_id_for_schema_variant_id(ctx, self.0)
+        SchemaVariant::schema_id(ctx, self.0)
             .await
             .expect("get schema by id")
             .into()

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -511,7 +511,7 @@ impl AttributePrototypeArgument {
         Ok(())
     }
 
-    pub async fn prototype_id_for_argument_id(
+    pub async fn prototype_id(
         ctx: &DalContext,
         attribute_prototype_argument_id: AttributePrototypeArgumentId,
     ) -> AttributePrototypeArgumentResult<AttributePrototypeId> {
@@ -541,13 +541,6 @@ impl AttributePrototypeArgument {
         let prototype_node_weight = workspace_snapshot.get_node_weight(prototype_idx).await?;
 
         Ok(prototype_node_weight.id().into())
-    }
-
-    pub async fn prototype_id(
-        &self,
-        ctx: &DalContext,
-    ) -> AttributePrototypeArgumentResult<AttributePrototypeId> {
-        Self::prototype_id_for_argument_id(ctx, self.id).await
     }
 
     pub async fn set_value_from_input_socket_id(
@@ -734,7 +727,7 @@ impl AttributePrototypeArgument {
     /// A _private_ method that consumes self and removes the corresponding
     /// [`AttributePrototypeArgument`].
     async fn remove_inner(self, ctx: &DalContext) -> AttributePrototypeArgumentResult<()> {
-        let prototype_id = self.prototype_id(ctx).await?;
+        let prototype_id = Self::prototype_id(ctx, self.id).await?;
         // Find all of the "destination" attribute values.
         let mut avs_to_update = AttributePrototype::attribute_value_ids(ctx, prototype_id).await?;
         // If the argument has targets, then we only care about AVs that are for the same

--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -374,8 +374,7 @@ impl DependentValueGraph {
             // on the value of the current value
             for apa in relevant_apas {
                 let prototype_id =
-                    AttributePrototypeArgument::prototype_id_for_argument_id(ctx, apa.id().into())
-                        .await?;
+                    AttributePrototypeArgument::prototype_id(ctx, apa.id().into()).await?;
 
                 let attribute_value_ids =
                     AttributePrototype::attribute_value_ids(ctx, prototype_id).await?;

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1216,7 +1216,8 @@ impl Component {
                     destination_component_id,
                 }) = apa.targets()
                 {
-                    let prototype_id = apa.prototype_id(ctx).await?;
+                    let prototype_id =
+                        AttributePrototypeArgument::prototype_id(ctx, apa_id).await?;
                     let input_sources =
                         AttributePrototype::input_sources(ctx, prototype_id).await?;
                     if input_sources.len() > 1 {
@@ -3224,7 +3225,9 @@ impl Component {
                     AttributePrototypeArgument::get_by_id(ctx, argument_using_id).await?;
                 if let Some(targets) = argument_using.targets() {
                     if targets.source_component_id == self.id() {
-                        let prototype_id = argument_using.prototype_id(ctx).await?;
+                        let prototype_id =
+                            AttributePrototypeArgument::prototype_id(ctx, argument_using_id)
+                                .await?;
                         for maybe_downstream_av_id in
                             AttributePrototype::attribute_value_ids(ctx, prototype_id).await?
                         {

--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -459,7 +459,7 @@ impl FuncAuthoringClient {
     ) -> FuncAuthoringResult<Func> {
         let old_func = Func::get_by_id(ctx, func_id).await?;
 
-        let schema = SchemaVariant::schema_id_for_schema_variant_id(ctx, schema_variant_id).await?;
+        let schema = SchemaVariant::schema_id(ctx, schema_variant_id).await?;
         // is the current schema varaint already unlocked? if so, proceed
         let current_schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
         let new_func = if !current_schema_variant.is_locked() {

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -473,8 +473,7 @@ impl FuncBinding {
         for binding in bindings {
             if let Some(schema_variant_id) = binding.get_schema_variant() {
                 // check the schema for this variant
-                let schema_id =
-                    SchemaVariant::schema_id_for_schema_variant_id(ctx, schema_variant_id).await?;
+                let schema_id = SchemaVariant::schema_id(ctx, schema_variant_id).await?;
                 let maybe_variant = schema_variant_map.get(&schema_id);
                 match maybe_variant {
                     Some(_) => {
@@ -511,8 +510,7 @@ impl FuncBinding {
         for binding in bindings {
             if let Some(schema_variant_id) = binding.get_schema_variant() {
                 // check the schema for this variant
-                let schema =
-                    SchemaVariant::schema_id_for_schema_variant_id(ctx, schema_variant_id).await?;
+                let schema = SchemaVariant::schema_id(ctx, schema_variant_id).await?;
                 // check the map
                 let maybe_default_for_variant = schema_default_map.get_key_value(&schema);
                 match maybe_default_for_variant {

--- a/lib/dal/src/management/prototype.rs
+++ b/lib/dal/src/management/prototype.rs
@@ -331,9 +331,7 @@ impl ManagementPrototype {
 
         let sv_id = snapshot.get_node_weight(sv_source_idx).await?.id();
 
-        Ok(Some(
-            SchemaVariant::schema_id_for_schema_variant_id(ctx, sv_id.into()).await?,
-        ))
+        Ok(Some(SchemaVariant::schema_id(ctx, sv_id.into()).await?))
     }
 
     pub async fn new(

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -1183,7 +1183,7 @@ impl SchemaVariant {
         ctx: &DalContext,
         id: SchemaVariantId,
     ) -> SchemaVariantResult<bool> {
-        let schema_id = Self::schema_id_for_schema_variant_id(ctx, id).await?;
+        let schema_id = Self::schema_id(ctx, id).await?;
 
         Ok(Self::default_id_for_schema(ctx, schema_id).await? == id)
     }
@@ -1753,8 +1753,7 @@ impl SchemaVariant {
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
     ) -> SchemaVariantResult<(DiagramSocket, Option<DiagramSocket>)> {
-        let schema_id =
-            SchemaVariant::schema_id_for_schema_variant_id(ctx, schema_variant_id).await?;
+        let schema_id = SchemaVariant::schema_id(ctx, schema_variant_id).await?;
         let has_mgmt_protos =
             ManagementPrototype::variant_has_management_prototype(ctx, schema_variant_id)
                 .await
@@ -1941,20 +1940,16 @@ impl SchemaVariant {
         Self::schema_for_schema_variant_id(ctx, self.id).await
     }
 
-    pub async fn schema_id(&self, ctx: &DalContext) -> SchemaVariantResult<SchemaId> {
-        Self::schema_id_for_schema_variant_id(ctx, self.id).await
-    }
-
     pub async fn schema_for_schema_variant_id(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
     ) -> SchemaVariantResult<Schema> {
-        let schema_id = Self::schema_id_for_schema_variant_id(ctx, schema_variant_id).await?;
+        let schema_id = Self::schema_id(ctx, schema_variant_id).await?;
 
         Ok(Schema::get_by_id(ctx, schema_id).await?)
     }
 
-    pub async fn schema_id_for_schema_variant_id(
+    pub async fn schema_id(
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
     ) -> SchemaVariantResult<SchemaId> {

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -542,7 +542,7 @@ impl Secret {
                 .get_node_weight(attribute_prototype_argument_index)
                 .await?
                 .get_attribute_prototype_argument_node_weight()?;
-            let attribute_prototype_id = AttributePrototypeArgument::prototype_id_for_argument_id(
+            let attribute_prototype_id = AttributePrototypeArgument::prototype_id(
                 ctx,
                 attribute_prototype_argument_node_weight.id().into(),
             )

--- a/lib/dal/tests/integration_test/func/argument.rs
+++ b/lib/dal/tests/integration_test/func/argument.rs
@@ -68,12 +68,10 @@ async fn list_attribute_prototype_argument_ids(ctx: &DalContext) {
         .pop()
         .expect("empty attribute prototype argument ids");
     assert!(attribute_prototype_argument_ids.is_empty());
-    let attribute_prototype_id = AttributePrototypeArgument::prototype_id_for_argument_id(
-        ctx,
-        attribute_prototype_argument_id,
-    )
-    .await
-    .expect("could not get attribute prototype id");
+    let attribute_prototype_id =
+        AttributePrototypeArgument::prototype_id(ctx, attribute_prototype_argument_id)
+            .await
+            .expect("could not get attribute prototype id");
     let found_func_id = AttributePrototype::func_id(ctx, attribute_prototype_id)
         .await
         .expect("could not get func id");

--- a/lib/dal/tests/integration_test/pkg/mod.rs
+++ b/lib/dal/tests/integration_test/pkg/mod.rs
@@ -165,7 +165,7 @@ async fn prop_order_preserved(ctx: &mut DalContext) -> Result<()> {
             component_prop_names(ctx, component_id).await?,
             expected_props,
         );
-        SchemaVariant::schema_id_for_schema_variant_id(ctx, variant_id).await?
+        SchemaVariant::schema_id(ctx, variant_id).await?
     };
 
     // Export variant -> PkgSpec

--- a/lib/luminork-server/src/api_types/component/v1.rs
+++ b/lib/luminork-server/src/api_types/component/v1.rs
@@ -311,7 +311,7 @@ impl ComponentViewV1 {
 
         let result = ComponentViewV1 {
             id: component_id,
-            schema_id: schema_variant.schema_id(ctx).await?,
+            schema_id: SchemaVariant::schema_id(ctx, schema_variant.id()).await?,
             schema_variant_id: schema_variant.id(),
             sockets,
             domain_props,

--- a/lib/sdf-server/src/service/v2/fs/bindings.rs
+++ b/lib/sdf-server/src/service/v2/fs/bindings.rs
@@ -920,8 +920,7 @@ async fn create_func_binding(ctx: &DalContext, binding: FuncBinding) -> FsResult
     };
 
     if let Some(schema_variant_id) = maybe_schema_variant_id {
-        let schema_id =
-            SchemaVariant::schema_id_for_schema_variant_id(ctx, schema_variant_id).await?;
+        let schema_id = SchemaVariant::schema_id(ctx, schema_variant_id).await?;
 
         let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
         WsEvent::schema_variant_updated(ctx, schema_id, schema_variant)
@@ -975,8 +974,7 @@ async fn delete_binding(
     if did_delete {
         let func = Func::get_by_id(ctx, func_id).await?;
         let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
-        let schema_id =
-            SchemaVariant::schema_id_for_schema_variant_id(ctx, schema_variant_id).await?;
+        let schema_id = SchemaVariant::schema_id(ctx, schema_variant_id).await?;
 
         ctx.write_audit_log(
             AuditLogKind::DetachFunc {

--- a/lib/sdf-server/src/service/v2/func/binding/attribute/reset_attribute_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/attribute/reset_attribute_binding.rs
@@ -77,8 +77,7 @@ pub async fn reset_attribute_binding(
 
         match eventual_parent {
             EventualParent::SchemaVariant(schema_variant_id) => {
-                let schema =
-                    SchemaVariant::schema_id_for_schema_variant_id(&ctx, schema_variant_id).await?;
+                let schema = SchemaVariant::schema_id(&ctx, schema_variant_id).await?;
                 let schema_variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
                 ctx.write_audit_log(
                     AuditLogKind::DetachFunc {

--- a/lib/sdf-server/src/service/v2/func/binding/create_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/create_binding.rs
@@ -180,10 +180,7 @@ pub async fn create_binding(
                             .await?;
 
                             if let Some(variant_id) = schema_variant_id {
-                                let schema = SchemaVariant::schema_id_for_schema_variant_id(
-                                    &ctx, variant_id,
-                                )
-                                .await?;
+                                let schema = SchemaVariant::schema_id(&ctx, variant_id).await?;
                                 let schema_variant =
                                     SchemaVariant::get_by_id(&ctx, variant_id).await?;
                                 WsEvent::schema_variant_updated(&ctx, schema, schema_variant)
@@ -210,11 +207,7 @@ pub async fn create_binding(
                         Some(func_id) => {
                             AuthBinding::create_auth_binding(&ctx, func_id, schema_variant_id)
                                 .await?;
-                            let schema = SchemaVariant::schema_id_for_schema_variant_id(
-                                &ctx,
-                                schema_variant_id,
-                            )
-                            .await?;
+                            let schema = SchemaVariant::schema_id(&ctx, schema_variant_id).await?;
                             let schema_variant =
                                 SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
                             let func = Func::get_by_id(&ctx, func_id).await?;
@@ -255,11 +248,7 @@ pub async fn create_binding(
                                 schema_variant_id,
                             )
                             .await?;
-                            let schema = SchemaVariant::schema_id_for_schema_variant_id(
-                                &ctx,
-                                schema_variant_id,
-                            )
-                            .await?;
+                            let schema = SchemaVariant::schema_id(&ctx, schema_variant_id).await?;
                             let schema_variant =
                                 SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
                             let func = Func::get_by_id(&ctx, func_id).await?;
@@ -309,11 +298,7 @@ pub async fn create_binding(
                                 &inputs,
                             )
                             .await?;
-                            let schema = SchemaVariant::schema_id_for_schema_variant_id(
-                                &ctx,
-                                schema_variant_id,
-                            )
-                            .await?;
+                            let schema = SchemaVariant::schema_id(&ctx, schema_variant_id).await?;
                             let schema_variant =
                                 SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
                             let func = Func::get_by_id(&ctx, func_id).await?;
@@ -356,11 +341,7 @@ pub async fn create_binding(
                                 &inputs,
                             )
                             .await?;
-                            let schema = SchemaVariant::schema_id_for_schema_variant_id(
-                                &ctx,
-                                schema_variant_id,
-                            )
-                            .await?;
+                            let schema = SchemaVariant::schema_id(&ctx, schema_variant_id).await?;
                             let schema_variant =
                                 SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
                             let func = Func::get_by_id(&ctx, func_id).await?;
@@ -405,11 +386,7 @@ pub async fn create_binding(
                                 schema_variant_id,
                             )
                             .await?;
-                            let schema = SchemaVariant::schema_id_for_schema_variant_id(
-                                &ctx,
-                                schema_variant_id,
-                            )
-                            .await?;
+                            let schema = SchemaVariant::schema_id(&ctx, schema_variant_id).await?;
                             let schema_variant =
                                 SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
                             let func = Func::get_by_id(&ctx, func_id).await?;

--- a/lib/sdf-server/src/service/v2/func/binding/delete_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/delete_binding.rs
@@ -175,8 +175,7 @@ pub async fn delete_binding(
     }
 
     for schema_variant_id in modified_sv_ids {
-        let schema =
-            SchemaVariant::schema_id_for_schema_variant_id(&ctx, schema_variant_id).await?;
+        let schema = SchemaVariant::schema_id(&ctx, schema_variant_id).await?;
         let schema_variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
 
         WsEvent::schema_variant_updated(&ctx, schema, schema_variant)

--- a/lib/sdf-server/src/service/v2/func/create_func.rs
+++ b/lib/sdf-server/src/service/v2/func/create_func.rs
@@ -453,8 +453,7 @@ pub async fn create_func(
             schema_variant_id: Some(schema_variant_id),
             ..
         } => {
-            let schema_id =
-                SchemaVariant::schema_id_for_schema_variant_id(&ctx, schema_variant_id).await?;
+            let schema_id = SchemaVariant::schema_id(&ctx, schema_variant_id).await?;
             let schema_variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
             WsEvent::schema_variant_updated(&ctx, schema_id, schema_variant)
                 .await?

--- a/lib/sdf-server/src/service/v2/func/list_funcs.rs
+++ b/lib/sdf-server/src/service/v2/func/list_funcs.rs
@@ -86,8 +86,7 @@ async fn treat_single_function(
                 should_hide = false;
             }
 
-            let schema =
-                SchemaVariant::schema_id_for_schema_variant_id(ctx, schema_variant_id).await?;
+            let schema = SchemaVariant::schema_id(ctx, schema_variant_id).await?;
 
             if let Some(default_sv_id) = schema_default_map.get(&schema) {
                 if schema_variant_id == *default_sv_id {

--- a/lib/sdf-server/src/service/v2/management/generate_template.rs
+++ b/lib/sdf-server/src/service/v2/management/generate_template.rs
@@ -15,6 +15,7 @@ use dal::{
     ChangeSetId,
     ComponentId,
     FuncId,
+    SchemaVariant,
     SchemaVariantId,
     WorkspacePk,
     WsEvent,
@@ -113,7 +114,7 @@ pub async fn generate_template(
     )
     .await?;
 
-    let schema_id = new_variant.schema_id(&ctx).await?;
+    let schema_id = SchemaVariant::schema_id(&ctx, new_variant.id()).await?;
 
     let func = FuncAuthoringClient::create_new_management_func(
         &ctx,

--- a/lib/sdf-server/src/service/v2/variant/get_variant.rs
+++ b/lib/sdf-server/src/service/v2/variant/get_variant.rs
@@ -43,7 +43,7 @@ pub async fn get_variant(
         .await?;
 
     let schema_variant = SchemaVariant::get_by_id(&ctx, schema_variant_id).await?;
-    let schema_id = SchemaVariant::schema_id_for_schema_variant_id(&ctx, schema_variant_id).await?;
+    let schema_id = SchemaVariant::schema_id(&ctx, schema_variant_id).await?;
     let schema_variant = schema_variant.into_frontend_type(&ctx, schema_id).await?;
 
     track(

--- a/lib/sdf-v1-routes-variant/src/regenerate_variant.rs
+++ b/lib/sdf-v1-routes-variant/src/regenerate_variant.rs
@@ -97,8 +97,7 @@ pub async fn regenerate_variant(
         variant.display_name,
     )
     .await?;
-    let schema =
-        SchemaVariant::schema_id_for_schema_variant_id(&ctx, updated_schema_variant_id).await?;
+    let schema = SchemaVariant::schema_id(&ctx, updated_schema_variant_id).await?;
     let updated_schema_variant = SchemaVariant::get_by_id(&ctx, updated_schema_variant_id).await?;
 
     if schema_variant_id == updated_schema_variant_id {


### PR DESCRIPTION
This adds subscription edges to the get_diagram API. Critically, it just adds a new property to the two diagram endpoints; it does not change the existing 

## Factor Budget

I removed the `self` variant of two methods (SchemaVariant.schema_id() and AttributePrototypeArgument.prototype_id()) since they just call the ID version (do not need content of the AV or APA, just ID). This is part of a continuing effort to have fewer variants of the same method and stop assembling DAL content objects when we're just walking the graph.

## Out of Scope

This does not:

* Show the new edges in the UI. It only reports the edges via the API.
* Report attribute subscription edges to/from deleted components. That code is stubbed.

## Testing

- [x] Integration tests pass
- [x] Manual: diagram still shows edges and connections correctly
- [x] Manual: subscriptions show up in API calls with the right IDs