### PR TITLE
fix(si-split-graph): cycle detection

### DIFF
--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -114,7 +114,8 @@ pub mod prelude {
     };
 }
 mod signup;
-mod test_exclusive_schemas;
+/// Schema variants the test harness expects to be installed
+pub mod test_exclusive_schemas;
 
 pub use color_eyre::{
     self,

--- a/lib/dal-test/src/signup.rs
+++ b/lib/dal-test/src/signup.rs
@@ -49,7 +49,7 @@ impl WorkspaceSignup {
         ctx.set_workspace_split_snapshot(workspace_snapshot);
 
         migrate_intrinsics_no_commit(ctx).await.map_err(Box::new)?;
-        // crate::test_exclusive_schemas::migrate(ctx).await?;
+        crate::test_exclusive_schemas::migrate(ctx).await?;
 
         let workspace_snapshot_address = ctx
             .workspace_snapshot()?
@@ -106,18 +106,20 @@ impl WorkspaceSignup {
         user_email: impl AsRef<str>,
         token: impl AsRef<str>,
     ) -> color_eyre::Result<Self> {
-        let workspace =
-            Workspace::new_from_builtin(ctx, WorkspacePk::generate(), workspace_name, token)
-                .await?;
+        let use_split = false;
 
-        // let workspace = Self::new_split_graph_workspace(
-        //     ctx,
-        //     WorkspacePk::generate(),
-        //     workspace_name,
-        //     token,
-        //     500,
-        // )
-        // .await?;
+        let workspace = if use_split {
+            Self::new_split_graph_workspace(
+                ctx,
+                WorkspacePk::generate(),
+                workspace_name,
+                token,
+                500,
+            )
+            .await?
+        } else {
+            Workspace::new_from_builtin(ctx, WorkspacePk::generate(), workspace_name, token).await?
+        };
 
         let key_pair = KeyPair::new(ctx, "default").await?;
 

--- a/lib/dal-test/src/test_exclusive_schemas/mod.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/mod.rs
@@ -102,9 +102,10 @@ pub const SCHEMA_ID_FAKE_DOCKER_IMAGE: &str = "01JARFRNN5VV1NMM0H5M63K3QH";
 /// Schema id for the `fake butane` schema variant
 pub const SCHEMA_ID_FAKE_BUTANE: &str = "01JARH2BTA5DK4J9Q4Q0XH46SR";
 
-// allow expect here for the Ulid conversion. These will never panic.
+/// Install the test schemas
+/// allow expect here for the Ulid conversion. These will never panic.
 #[allow(clippy::expect_used)]
-pub(crate) async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
+pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
     migrate_test_exclusive_schema_starfield(
         ctx,
         ulid::Ulid::from_str(SCHEMA_ID_STARFIELD)

--- a/lib/dal/examples/rebase/main.rs
+++ b/lib/dal/examples/rebase/main.rs
@@ -1,25 +1,40 @@
 use std::{
     env,
     fs::File,
-    io::prelude::*,
+    io::{
+        Read as _,
+        Write as _,
+    },
 };
 
 use dal::{
     WorkspaceSnapshotGraph,
-    workspace_snapshot::node_weight::NodeWeight,
+    workspace_snapshot::{
+        node_weight::NodeWeight,
+        split_snapshot::{
+            SplitSnapshotGraphV1,
+            SubGraphV1,
+        },
+    },
 };
-use petgraph::{
-    Direction::Incoming,
-    visit::EdgeRef,
+use petgraph::visit::{
+    Dfs,
+    IntoNeighborsDirected,
+    IntoNodeIdentifiers,
+    Reversed,
+    VisitMap,
+    Visitable,
 };
 use serde::de::DeserializeOwned;
 use si_layer_cache::db::serialize;
+use si_split_graph::SuperGraph;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + 'static>>;
 
 const USAGE: &str = "usage: cargo run --example rebase <TO_REBASE_FILE_PATH> <REBASE_BATCH_PATH>";
 
-fn load_snapshot_graph<T: DeserializeOwned>(path: &str) -> Result<T> {
+fn load_serialized_stuff<T: DeserializeOwned>(path: &str) -> Result<T> {
+    println!("opening file: {}", path);
     let mut file = File::open(path)?;
     let mut bytes = vec![];
     file.read_to_end(&mut bytes)?;
@@ -27,6 +42,7 @@ fn load_snapshot_graph<T: DeserializeOwned>(path: &str) -> Result<T> {
     Ok(serialize::from_bytes(&bytes)?)
 }
 
+#[allow(unused)]
 fn write_snapshot_graph(path: &str, graph: &WorkspaceSnapshotGraph) -> Result<()> {
     let mut file = File::create(path)?;
     let (bytes, _) = serialize::to_vec(graph)?;
@@ -39,39 +55,149 @@ fn main() -> Result<()> {
     let args: Vec<String> = env::args().take(10).collect();
 
     for i in 1..args.len() {
-        let to_rebase_path = args.get(i).expect(USAGE);
+        let snapshot_folder = args.get(i).expect(USAGE);
 
-        let mut to_rebase_graph: WorkspaceSnapshotGraph = load_snapshot_graph(to_rebase_path)?;
+        let mut read_only_graph = read_graph(snapshot_folder, true)?;
+        read_only_graph.cleanup_and_merkle_tree_hash();
+        let mut working_copy = read_graph(snapshot_folder, false)?;
+        working_copy.cleanup_and_merkle_tree_hash();
 
-        let mut orphaned_component_idxs = vec![];
+        assert!(toposort(&read_only_graph).is_ok());
+        assert!(toposort(&working_copy).is_ok());
 
-        for (node_weight, node_idx) in to_rebase_graph.nodes() {
-            if let NodeWeight::Component(_) = node_weight {
-                let mut has_edge_to_category = false;
-                for edge_ref in to_rebase_graph.edges_directed(node_idx, Incoming) {
-                    if let NodeWeight::Category(_) =
-                        to_rebase_graph.get_node_weight(edge_ref.source()).unwrap()
-                    {
-                        has_edge_to_category = true;
-                        break;
-                    }
-                }
+        let updates = read_only_graph.detect_updates(&working_copy);
+        let mut graph_to_update = read_only_graph.clone();
+        graph_to_update.perform_updates(&updates);
 
-                if !has_edge_to_category {
-                    orphaned_component_idxs.push(node_idx);
-                }
-            }
+        if let Err(Cycle(node_id)) = toposort(&graph_to_update) {
+            println!("Cycle detected at node ID: {}", node_id);
+            // dbg!(
+            //     graph_to_update
+            //         .raw_nodes()
+            //         .find(|node| node.id() == node_id)
+            // );
+            // dbg!(graph_to_update.brute_search_external_source_edges(node_id));
+            // dbg!(
+            //     read_only_graph
+            //         .raw_nodes()
+            //         .find(|node| node.id() == node_id)
+            // );
+            // dbg!(working_copy.raw_nodes().find(|node| node.id() == node_id));
+            //     for subgraph in working_copy.subgraphs() {
+            //         let mut subgraph_copy = subgraph.clone();
+            //         if !removed.is_empty() {
+            //             dbg!(removed);
+            //             let externals: Vec<_> = subgraph_copy.graph().externals(Incoming).collect();
+            //             for external in externals {
+            //                 dbg!(subgraph_copy.graph().node_weight(external));
+            //             }
+            //             let externals: Vec<_> = subgraph.graph().externals(Incoming).collect();
+            //             for external in externals {
+            //                 dbg!(subgraph.graph().node_weight(external));
+            //             }
+            //         }
+            //     }
+            //     println!("detecto");
+            //     working_copy
+            //         .edges_directed(node_id, Incoming)?
+            //         .for_each(|edge| {
+            //             dbg!(edge);
+            //         });
+            //     println!("detectNO!");
+
+            //     dbg!(working_copy.brute_search_external_source_edges(node_id));
+            //     dbg!(updates.iter().find(|update| match update {
+            //         si_split_graph::Update::NewNode { node_weight, .. } => node_weight.id() == node_id,
+            //         si_split_graph::Update::NewEdge { edge_weight, .. } => match edge_weight {
+            //             si_split_graph::SplitGraphEdgeWeight::ExternalSource { source_id, .. } =>
+            //                 *source_id == node_id,
+            //             _ => false,
+            //         },
+            //         _ => false,
+            //     }));
         }
-
-        for orphaned_idx in dbg!(orphaned_component_idxs) {
-            to_rebase_graph.remove_node(orphaned_idx);
-        }
-
-        to_rebase_graph.cleanup_and_merkle_tree_hash().unwrap();
-        let filename = format!("{}.fixed.snapshot", to_rebase_path);
-        write_snapshot_graph(&filename, &to_rebase_graph).expect("write");
-        println!("wrote {filename}");
     }
 
     Ok(())
+}
+
+fn read_graph(
+    snapshot_folder: &str,
+    read_only: bool,
+) -> Result<si_split_graph::SplitGraph<NodeWeight, dal::EdgeWeight, dal::EdgeWeightKindDiscriminants>>
+{
+    let prefix = if read_only {
+        "read_only"
+    } else {
+        "working_copy"
+    };
+
+    let supergraph: SuperGraph =
+        load_serialized_stuff(&format!("{snapshot_folder}/{prefix}_supergraph.snapshot"))?;
+    let mut subgraphs = vec![];
+    for i in 0..supergraph.addresses().len() {
+        let subgraph: SubGraphV1 =
+            load_serialized_stuff(&format!("{snapshot_folder}/{prefix}_subgraph_{i}.snapshot"))?;
+        subgraphs.push(subgraph);
+    }
+    let split_graph = SplitSnapshotGraphV1::from_parts(supergraph, subgraphs);
+
+    Ok(split_graph)
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Cycle<N>(N);
+
+pub fn toposort<G>(g: G) -> std::result::Result<Vec<G::NodeId>, Cycle<G::NodeId>>
+where
+    G: IntoNeighborsDirected + IntoNodeIdentifiers + Visitable,
+{
+    // based on kosaraju scc
+    let mut dfs = Dfs::empty(g);
+
+    dfs.reset(g);
+    let mut finished = g.visit_map();
+
+    let mut finish_stack = Vec::new();
+    for i in g.node_identifiers() {
+        if dfs.discovered.is_visited(&i) {
+            continue;
+        }
+        dfs.stack.push(i);
+        while let Some(&nx) = dfs.stack.last() {
+            if dfs.discovered.visit(nx) {
+                // First time visiting `nx`: Push neighbors, don't pop `nx`
+                for succ in g.neighbors(nx) {
+                    if succ == nx {
+                        // self cycle
+                        return Err(Cycle(nx));
+                    }
+                    if !dfs.discovered.is_visited(&succ) {
+                        dfs.stack.push(succ);
+                    }
+                }
+            } else {
+                dfs.stack.pop();
+                if finished.visit(nx) {
+                    // Second time: All reachable nodes must have been finished
+                    finish_stack.push(nx);
+                }
+            }
+        }
+    }
+    finish_stack.reverse();
+
+    dfs.reset(g);
+    for &i in &finish_stack {
+        dfs.move_to(i);
+        let mut cycle = false;
+        while let Some(j) = dfs.next(Reversed(g)) {
+            if cycle {
+                return Err(Cycle(j));
+            }
+            cycle = true;
+        }
+    }
+
+    Ok(finish_stack)
 }

--- a/lib/dal/src/workspace_snapshot/split_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot.rs
@@ -519,6 +519,88 @@ impl SplitSnapshot {
         Err(WorkspaceSnapshotError::WorkspaceSnapshotNotFetched)
     }
 
+    pub async fn has_mutable_working_copy(&self) -> bool {
+        self.working_copy.read().await.is_some()
+    }
+
+    // pub async fn write_to_files(&self, read_only: bool, rebase_batch_bytes: Option<Vec<u8>>) {
+    //     std::fs::create_dir_all("snapshot_dumps").unwrap_or_else(|_| {
+    //         warn!("Directory snapshot_dumps already exists or could not be created");
+    //     });
+
+    //     let working_copy = if read_only {
+    //         self.read_only_graph.as_ref()
+    //     } else {
+    //         self.cleanup_and_merkle_tree_hash().await.unwrap();
+    //         &*self.working_copy_mut().await
+    //     };
+
+    //     let prefix = if read_only {
+    //         "read_only"
+    //     } else {
+    //         "working_copy"
+    //     };
+
+    //     // Write the supergraph
+    //     if let Ok(file) =
+    //         std::fs::File::create(format!("snapshot_dumps/{prefix}_supergraph.snapshot"))
+    //     {
+    //         if let Ok((bytes, _)) =
+    //             si_layer_cache::db::serialize::to_vec(&working_copy.supergraph())
+    //         {
+    //             if let Err(e) =
+    //                 std::io::Write::write_all(&mut std::io::BufWriter::new(file), &bytes)
+    //             {
+    //                 error!("Failed to write supergraph to file: {}", e);
+    //             }
+    //         } else {
+    //             println!("Failed to serialize supergraph");
+    //         }
+    //     }
+
+    //     // Write each subgraph
+    //     for (i, subgraph) in working_copy.subgraphs().iter().enumerate() {
+    //         let filename = format!("snapshot_dumps/{prefix}_subgraph_{i}.snapshot");
+    //         if let Ok(file) = std::fs::File::create(&filename) {
+    //             match si_layer_cache::db::serialize::to_vec(&subgraph) {
+    //                 Ok((bytes, _)) => {
+    //                     match std::io::Write::write_all(&mut std::io::BufWriter::new(file), &bytes)
+    //                     {
+    //                         Ok(_) => {}
+    //                         Err(e) => {
+    //                             println!("Failed to write subgraph {} to file: {}", i, e);
+    //                         }
+    //                     }
+    //                 }
+    //                 Err(e) => {
+    //                     println!("Failed to serialize subgraph {}: {}", i, e);
+    //                 }
+    //             }
+    //         } else {
+    //             println!("Failed to create file {}", filename);
+    //         }
+    //     }
+
+    //     // Write the rebase batch to a file if it exists
+    //     if let Some(bytes) = rebase_batch_bytes {
+    //         let filename = "snapshot_dumps/rebase_batch.rbatch";
+    //         if let Ok(file) = std::fs::File::create(filename) {
+    //             match std::io::Write::write_all(&mut std::io::BufWriter::new(file), &bytes) {
+    //                 Ok(_) => {
+    //                     println!("Wrote rebase batch to {}", filename);
+    //                 }
+    //                 Err(e) => {
+    //                     println!("Failed to write rebase batch to file: {}", e);
+    //                 }
+    //             }
+    //         } else {
+    //             println!("Failed to create file {}", filename);
+    //         }
+    //     }
+
+    //     println!("Wrote working_copy supergraph and subgraphs to snapshot_dumps directory");
+    // }
+
     pub async fn write(
         &self,
         ctx: &DalContext,

--- a/lib/si-split-graph/src/tests/mod.rs
+++ b/lib/si-split-graph/src/tests/mod.rs
@@ -1499,7 +1499,8 @@ fn single_subgraph_as_updates() -> SplitGraphResult<()> {
         );
     }
 
-    subgraph.cleanup();
+    subgraph.remove_externals();
+    subgraph.cleanup_maps();
 
     let root_id = subgraph
         .graph
@@ -1626,7 +1627,6 @@ fn graph_dfs() -> SplitGraphResult<()> {
 }
 
 #[test]
-#[ignore]
 fn graph_cycle_test() -> SplitGraphResult<()> {
     let mut split_graph = SplitGraph::new(3);
 
@@ -1772,9 +1772,8 @@ fn graph_cycle_test() -> SplitGraphResult<()> {
 }
 
 #[test]
-#[ignore]
 fn graph_cycle_test_mimic_component_parentage() -> SplitGraphResult<()> {
-    for split_max in [500] {
+    for split_max in [1, 2, 3, 500] {
         let mut split_graph = SplitGraph::new(split_max);
 
         let node_id_map = add_nodes_to_splitgraph(
@@ -1868,8 +1867,6 @@ fn graph_cycle_test_mimic_component_parentage() -> SplitGraphResult<()> {
                 )
                 .is_err()
         );
-
-        split_graph.tiny_dot_to_file("foo");
     }
 
     Ok(())

--- a/lib/si-split-graph/src/updates.rs
+++ b/lib/si-split-graph/src/updates.rs
@@ -41,6 +41,15 @@ where
     pub kind: K,
 }
 
+impl<K> ExternalSourceData<K>
+where
+    K: EdgeKind,
+{
+    pub fn source_id(&self) -> SplitGraphNodeId {
+        self.source_id
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, EnumDiscriminants)]
 pub enum Update<N, E, K>
 where


### PR DESCRIPTION
Cycle detection was failing because the cleanup of the graph did not
fully remove nodes when they were the children of an external source
which was removed.

Removal of "orphaned" nodes (nodes with no incoming edges) must proceed
in tandem with the removal of external source edges whose "tail" is the
orphaned node. That will orphan new nodes, so the process has to be
repeated until there are no more orphaned nodes left. Previously the
split graph cleanup would only remove the first layer if there were
children of the orphaned node pointed to by an external source edge.
The result would be weird walks of the graph during the cross-graph dfs
searching for cycles, reporting cycles on acyclic graphs.