### PR TITLE
feat(web): Pop up connections menu from attribute tree

### DIFF
--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -117,6 +117,7 @@ import MaterialSymbolsBackspaceOutline from "~icons/material-symbols/backspace-o
 import IconoirMouseScrollWheel from "~icons/iconoir/mouse-scroll-wheel";
 import MdiCursorDefaultClickOutline from "~icons/mdi/cursor-default-click-outline";
 import MaterialSymbolsShiftLockOutline from "~icons/material-symbols/shift-lock-outline";
+import MaterialSymbolsAddLink from "~icons/material-symbols/add-link";
 
 import TdesignLinkUnlink from "~icons/tdesign/link-unlink";
 import PhTestTubeFill from "~icons/ph/test-tube-fill";
@@ -210,6 +211,7 @@ import Mjolnir from "./custom-icons/mjolnir.svg?raw";
 // restricting the type here (Record<string, FunctionalComponent>) kills our IconName type below
 /* eslint sort-keys: "error" */
 export const ICONS = Object.freeze({
+  "add-connection": MaterialSymbolsAddLink,
   "alert-circle": AlertCircle,
   "alert-square": AlertSquare,
   "alert-triangle": AlertTriangle,


### PR DESCRIPTION
- Add links on the attribute editor to allow opening the connections menu
- Allow selecting direction on the connections menu when dealing with sockets

<img width="527" alt="image" src="https://github.com/user-attachments/assets/8c9cbb55-209f-4b3d-8e08-8194e733dd6f" />
<img width="1961" alt="image" src="https://github.com/user-attachments/assets/3680717e-41ea-4ca8-8ce8-1e1bbf85e111" />
