### PR TITLE
dal: API to get attribute path to an AV

### DIFF
--- a/lib/dal-materialized-views/src/component/attribute_tree.rs
+++ b/lib/dal-materialized-views/src/component/attribute_tree.rs
@@ -59,7 +59,7 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
     let mut work_queue = VecDeque::from([root_av_id]);
 
     while let Some(av_id) = work_queue.pop_front() {
-        let maybe_parent_av_id = AttributeValue::parent_attribute_value_id(ctx, av_id).await?;
+        let maybe_parent_av_id = AttributeValue::parent_id(ctx, av_id).await?;
         let child_av_ids: Vec<AttributeValueId> =
             AttributeValue::get_child_avs_in_order(ctx, av_id)
                 .await?

--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -421,11 +421,8 @@ impl DependentValueGraph {
             // prop, we have to be sure we add that output socket to the graph if a child of root
             // changes, because if a child of root has changed, then the view of root to the leaves
             // will also change)
-            if let Some(parent_attribute_value_id) = AttributeValue::parent_attribute_value_id(
-                ctx,
-                current_attribute_value_controlling_value_id,
-            )
-            .await?
+            if let Some(parent_attribute_value_id) =
+                AttributeValue::parent_id(ctx, current_attribute_value_controlling_value_id).await?
             {
                 // If this is one of child values we added speculatively we
                 // should only walk the parent tree if we have actually found a

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1010,7 +1010,7 @@ impl Component {
             for old_child_av_id in AttributeValue::get_child_av_ids_in_order(ctx, old_av_id).await?
             {
                 let old_key_or_index =
-                    AttributeValue::get_index_or_key_of_child_entry(ctx, old_child_av_id).await?;
+                    AttributeValue::get_key_or_index_of_child_entry(ctx, old_child_av_id).await?;
                 value_q.push_back((old_child_av_id, old_key_or_index, Some(new_av_id)));
             }
         }

--- a/lib/dal/tests/integration_test/component/debug.rs
+++ b/lib/dal/tests/integration_test/component/debug.rs
@@ -86,6 +86,7 @@ async fn get_debug_view(ctx: &mut DalContext) {
     let attribute_path = AttributeValue::get_path_for_id(ctx, rigid_designator_value_id)
         .await
         .expect("can't get the path");
+    println!("attribute_path: {:?}", attribute_path);
     assert_eq!(
         attribute_path,
         Some(rigid_prop_path.with_replaced_sep("/").to_string())

--- a/lib/sdf-server/src/service/v2/component/attributes.rs
+++ b/lib/sdf-server/src/service/v2/component/attributes.rs
@@ -267,7 +267,7 @@ async fn update_attributes(
 }
 
 async fn parent_prop_is_map_or_array(ctx: &DalContext, av_id: AttributeValueId) -> Result<bool> {
-    let Some(parent_av_id) = AttributeValue::parent_attribute_value_id(ctx, av_id).await? else {
+    let Some(parent_av_id) = AttributeValue::parent_id(ctx, av_id).await? else {
         return Ok(false);
     };
     let parent_prop = AttributeValue::prop(ctx, parent_av_id).await?;


### PR DESCRIPTION
This adds a dal API to get the JSON pointer to the given AttributeValue, relative to its root (e.g. `/domain/IpAddresses/0`). There are several upcoming APIs that need this, and since it's shared infrastructure I split it into its own thing so people could use it sooner.

<IMG SRC="https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExb2JyNDM4eWtuN3Fmc2ZlbzhkeDl4OGxzZjJ2ODY5MmFvc3R0czkweCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/RR8nZxUvng5a12X322/giphy.gif">

## Factor Budget

* Renamed AttributeValue::parent_attribute_value_id() to AttributeValue::parent_id()
* Removed get_key_of_child_entry() in favor of parent_and_map_key()
* Renamed get_index_or_key_of_child_entry() to get_key_or_index_of_child_entry() to match the type name (KeyOrIndex)

## Out of Scope

get_path_by_id() can likely be replaced with path_from_root() at this point (or something more like it), but all callers will have to be checked first.

## Testing

- [x] Integration tests pass
- [x] New tests for AttributeValue::path_from_root()