### PR TITLE
fix: set innitctl directory permissions to ensure tempating works

### DIFF
--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -1,6 +1,14 @@
 ---
 services:
 
+  files-init:
+    image: alpine
+    restart: "no"
+    entrypoint: |
+          sh -c "chown -R 1000:1000 /output && chmod -R 775 /output"
+    volumes:
+        - config:/output
+
   innitctl:
     container_name: innitctl
     image: systeminit/innitctl:stable
@@ -9,6 +17,8 @@ services:
       - "/configs"
       - "--output"
       - "/output"
+    depends_on:
+      - files-init
     environment:
       - SI_INNITCTL__HOST_ENVIRONMENT=${SI_HOSTENV}
       - SI_INNITCTL__SERVICE_NAME=${SI_SERVICE}


### PR DESCRIPTION
Since we use `runuser` we need to ensure the mounted volume has the appropriate permissions so we can write to it.