### PR TITLE
fix: don't name NATS Ordered Consumers

### DIFF
--- a/lib/shuttle-server/src/lib.rs
+++ b/lib/shuttle-server/src/lib.rs
@@ -146,7 +146,6 @@ impl Shuttle {
         let incoming = {
             limits_based_source_stream
                 .create_consumer(async_nats::jetstream::consumer::push::OrderedConfig {
-                    name: Some(consumer_name.to_owned()),
                     deliver_subject,
                     filter_subject: source_subject.to_string(),
                     ..Default::default()


### PR DESCRIPTION
This change removes explicit names when creating [Ordered Consumers]. Ordered consumers are ephemeral and the NATS server may re-create these consumers often server-side. If a name is provided in the consumer config, it's likely that the NATS server attempts to re-use the user-provided name which results in a consumer create error.

The fix here is to not explicitly name the consumers and allow the client and server to coordinate when re-creating consumers is appropriate. Note that in the Rust client, that field type for `OrderedConfig.name` is `Option<String>` with the default value being `None`. As a result we can omit setting this field and rely on the defaults to get us what we need.

[Ordered Consumers]: https://docs.nats.io/using-nats/developer/develop_jetstream/consumers#ordered-consumers

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaGU0dnIwdXI2MHJ2MW5sMnE2N2JhMnpkY2tkc3QxZGxwbmRxdWtnaiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/dUkxbC3pQrRZsrTw6O/giphy-downsized-medium.gif"/>