### PR TITLE
feat: ensure we rotate expired certs

### DIFF
--- a/lib/dal-macros/tests/trybuild.rs
+++ b/lib/dal-macros/tests/trybuild.rs
@@ -2,7 +2,7 @@
 // figure out why and re-enable them or just remove this project.
 #[test]
 pub fn trybuild() {
-    let t = trybuild::TestCases::new();
+    let _t = trybuild::TestCases::new();
     // t.pass("tests/ui/*-pass.rs");
     // t.compile_fail("tests/ui/*-fail.rs")
 }

--- a/lib/innit-client/src/config.rs
+++ b/lib/innit-client/src/config.rs
@@ -66,7 +66,7 @@ pub struct Config {
     #[builder(default = "default_env()")]
     environment: String,
 
-    #[builder(default = None)]
+    #[builder(default = "default_cert_cache_location()")]
     generated_cert_location: Option<PathBuf>,
 
     #[builder(default = "default_app_name()")]
@@ -115,7 +115,7 @@ pub struct ConfigFile {
     environment: String,
     #[serde(default = "default_app_name")]
     for_app: String,
-    #[serde(default)]
+    #[serde(default = "default_cert_cache_location")]
     generated_cert_location: Option<PathBuf>,
 }
 
@@ -127,7 +127,7 @@ impl Default for ConfigFile {
             base_url: default_url(),
             environment: default_env(),
             for_app: default_app_name(),
-            generated_cert_location: None,
+            generated_cert_location: default_cert_cache_location(),
         }
     }
 }
@@ -150,6 +150,10 @@ impl TryFrom<ConfigFile> for Config {
         config.generated_cert_location(value.generated_cert_location);
         config.build().map_err(Into::into)
     }
+}
+
+fn default_cert_cache_location() -> Option<PathBuf> {
+    Some("/etc/ssl/private/si-cert".to_string().into())
 }
 
 fn default_app_name() -> String {

--- a/lib/innit-client/src/lib.rs
+++ b/lib/innit-client/src/lib.rs
@@ -227,7 +227,12 @@ async fn get_or_generate_cert(
         if cert_path.exists() {
             let cert = CanonicalFile::try_from(cert_path.as_path())?;
             let cached_source = CertificateSource::Path(cert);
-            if cached_source.load_certificates().await.is_ok() {
+            if cached_source.is_expired().await? {
+                info!(
+                    "Cached cert is expired, generating a new one: {:?}",
+                    cert_path
+                );
+            } else if cached_source.load_certificates().await.is_ok() {
                 info!("Using cached certificate from: {:?}", cert_path);
                 return Ok(cached_source);
             }


### PR DESCRIPTION
Since we are caching the cert and they are short-lived we will eventually find out they are expired. This ensures we regenerate expired certs.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlcHVnemlwN2huN3ZyYW15b29zejBpc2RtMWg5dGZheGU0bzhvaDkyZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/QSYixcaskVY8z7fQ8Q/giphy-downsized-medium.gif"/>