### PR TITLE
chore: ensure innitctl can reach cert cache

### DIFF
--- a/bin/innitctl/Dockerfile
+++ b/bin/innitctl/Dockerfile
@@ -37,4 +37,4 @@ COPY --from=builder /tmp/nix-store-closure /nix/store
 COPY --from=builder /tmp/local-bin/* /usr/local/bin/
 COPY --chown=app:app ./configs /configs
 
-ENTRYPOINT ["/sbin/runuser", "-u", "app", "--", "/usr/local/bin/innitctl"]
+ENTRYPOINT ["/usr/local/bin/innitctl"]

--- a/component/deploy/docker-compose.yaml
+++ b/component/deploy/docker-compose.yaml
@@ -1,14 +1,5 @@
 ---
 services:
-
-  files-init:
-    image: alpine
-    restart: "no"
-    entrypoint: |
-          sh -c "chown -R 1000:1000 /output && chmod -R 775 /output"
-    volumes:
-        - config:/output
-
   innitctl:
     container_name: innitctl
     image: systeminit/innitctl:stable
@@ -17,8 +8,6 @@ services:
       - "/configs"
       - "--output"
       - "/output"
-    depends_on:
-      - files-init
     environment:
       - SI_INNITCTL__HOST_ENVIRONMENT=${SI_HOSTENV}
       - SI_INNITCTL__SERVICE_NAME=${SI_SERVICE}
@@ -26,6 +15,7 @@ services:
       - SI_INNIT__CLIENT_CA_ARN=${SI_PRIVATE_CA_ARN}
     volumes:
       - config:/output
+      - /etc/ssl/private:/etc/ssl/private
 
   otelcol:
     container_name: otelcol


### PR DESCRIPTION
Innitctl needs to be able to interact with the host disk to find cached certs