### PR TITLE
Use JSON Pointer as the AttributeValue path in AttributeTree MV

### DIFF
--- a/lib/dal-materialized-views/src/component/attribute_tree.rs
+++ b/lib/dal-materialized-views/src/component/attribute_tree.rs
@@ -172,11 +172,12 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
                 message: node.validation.message,
             });
 
+        let (_, av_path) = AttributeValue::path_from_root(ctx, av_id).await?;
         let av_mv = AttributeValueMv {
             id: av_id,
             prop_id: maybe_prop.as_ref().map(|p| p.id),
             key,
-            path: AttributeValue::get_path_for_id(ctx, av_id).await?,
+            path: Some(av_path),
             value,
             can_be_set_by_socket,
             is_from_external_source,

--- a/lib/dal/tests/integration_test/materialized_views.rs
+++ b/lib/dal/tests/integration_test/materialized_views.rs
@@ -1,19 +1,33 @@
 use std::collections::HashSet;
 
 use dal::{
-    Component, DalContext, Func,
-    action::{Action, prototype::ActionPrototype},
+    Component,
+    DalContext,
+    Func,
+    action::{
+        Action,
+        prototype::ActionPrototype,
+    },
     qualification::QualificationSummary,
 };
 use dal_test::{
-    Result, helpers::create_component_for_default_schema_name_in_default_view, prelude::OptionExt,
+    Result,
+    helpers::create_component_for_default_schema_name_in_default_view,
+    prelude::OptionExt,
     test,
 };
 use pretty_assertions_sorted::assert_eq;
-use si_events::{ActionKind, ActionState};
+use si_events::{
+    ActionKind,
+    ActionState,
+};
 use si_frontend_types::{
     action::ActionView,
-    newhotness::component::{Component as ComponentMv, ComponentDiff, ComponentList},
+    newhotness::component::{
+        Component as ComponentMv,
+        ComponentDiff,
+        ComponentList,
+    },
     reference::ReferenceKind,
 };
 
@@ -91,6 +105,19 @@ async fn actions(ctx: &DalContext) -> Result<()> {
         ]), // expected
         kinds // actual
     );
+
+    Ok(())
+}
+
+#[test]
+async fn attribute_tree(ctx: &DalContext) -> Result<()> {
+    let component =
+        create_component_for_default_schema_name_in_default_view(ctx, "swifty", "swifty").await?;
+
+    // NOTE(nick): right now, this test basically just makes sure this does not regress and
+    // provides a psuedo-benchmark for generating MVs for a new component.
+    dal_materialized_views::component::attribute_tree::assemble(ctx.clone(), component.id())
+        .await?;
 
     Ok(())
 }


### PR DESCRIPTION
This matches the path expected by the socketless connections API,
which is the reason the path is included in this MV.