### PR TITLE
feat: create wrapper client for aws config for customizable defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1480,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2260,10 +2260,10 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 name = "data-warehouse-stream-client"
 version = "0.1.0"
 dependencies = [
- "aws-config",
  "aws-sdk-firehose",
  "base64 0.22.1",
  "remain",
+ "si-aws-config",
  "telemetry",
  "thiserror 2.0.12",
 ]
@@ -4451,12 +4451,12 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -7773,6 +7773,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "si-aws-config"
+version = "0.1.0"
+dependencies = [
+ "aws-config",
+ "aws-sdk-sts",
+ "remain",
+ "si-tls",
+ "telemetry",
+ "thiserror 2.0.12",
+ "tokio",
+]
+
+[[package]]
 name = "si-crypto"
 version = "0.1.0"
 dependencies = [
@@ -7793,10 +7806,10 @@ dependencies = [
 name = "si-data-acmpca"
 version = "0.1.0"
 dependencies = [
- "aws-config",
  "aws-sdk-acmpca",
  "rcgen",
  "remain",
+ "si-aws-config",
  "si-tls",
  "telemetry",
  "thiserror 2.0.12",
@@ -7870,9 +7883,9 @@ dependencies = [
 name = "si-data-ssm"
 version = "0.1.0"
 dependencies = [
- "aws-config",
  "aws-sdk-ssm",
  "remain",
+ "si-aws-config",
  "telemetry",
  "thiserror 2.0.12",
  "tokio",
@@ -8840,9 +8853,9 @@ version = "0.1.0"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
@@ -9508,9 +9521,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae08be68c056db96f0e6c6dd820727cca756ced9e1f4cc7fdd20e2a55e23898"
+checksum = "1c9bf9513a2f4aeef5fdac8677d7d349c79fdbcc03b9c86da6e9d254f1e43be2"
 dependencies = [
  "dissimilar",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ members = [
     "lib/sdf-v1-routes-variant",
     "lib/shuttle-core",
     "lib/shuttle-server",
+    "lib/si-aws-config",
     "lib/si-crypto",
     "lib/si-db",
     "lib/si-data-acmpca",
@@ -135,6 +136,7 @@ aws-config = { version = "=1.5.18", features = [
 aws-sdk-acmpca = { version = "1.70.0", default-features = false, features = ["rt-tokio"] }
 aws-sdk-firehose = "=1.68.0" # pinned because very next version (1.69.0) starts pulling in `aws-lc-rs`/`aws-lc-sys` which include native C code
 aws-sdk-ssm = { version = "1.71.0", default-features = false, features = ["rt-tokio"] }
+aws-sdk-sts = { version = "1.68.0", default-features = false, features = ["rt-tokio"] }
 # setting smithy like so to avoid pulling in aws-lc-rs for aws-sdk-ssm
 aws-smithy-http-client = { version = "1.0.0", features = ["rustls-ring"] }
 aws-smithy-runtime = { version = "1.8.1", features = ["client", "tls-rustls"] }

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -216,6 +216,7 @@ si_buck2_resource(
 # Locally build and run `innit`
 si_buck2_resource(
     "//bin/innit:innit",
+    auto_init = False,
     resource_deps = [
         "rust-initial-build",
         "otelcol",

--- a/lib/innit-client/src/lib.rs
+++ b/lib/innit-client/src/lib.rs
@@ -208,7 +208,7 @@ impl InnitClient {
 }
 
 async fn generate_cert_from_acmpca(ca_arn: String, for_app: String) -> Result<CertificateSource> {
-    let acmpca_client = PrivateCertManagerClient::new().await;
+    let acmpca_client = PrivateCertManagerClient::new().await?;
     info!("Generating cert for ARN: {ca_arn}");
     let (cert, _) = acmpca_client
         .get_new_cert_from_ca(ca_arn, for_app, "innit".to_string())

--- a/lib/si-aws-config/BUCK
+++ b/lib/si-aws-config/BUCK
@@ -1,14 +1,16 @@
 load("@prelude-si//:macros.bzl", "rust_library")
 
 rust_library(
-    name = "data-warehouse-stream-client",
+    name = "si-aws-config",
     deps = [
-        "//lib/si-aws-config:si-aws-config",
+        "//lib/si-tls:si-tls",
         "//lib/telemetry-rs:telemetry",
-        "//third-party/rust:aws-sdk-firehose",
-        "//third-party/rust:base64",
+
+        "//third-party/rust:aws-config",
+        "//third-party/rust:aws-sdk-sts",
         "//third-party/rust:remain",
         "//third-party/rust:thiserror",
+        "//third-party/rust:tokio",
     ],
     srcs = glob([
         "src/**/*.rs",

--- a/lib/si-aws-config/Cargo.toml
+++ b/lib/si-aws-config/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "data-warehouse-stream-client"
+name = "si-aws-config"
 version.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -9,10 +9,11 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
-si-aws-config = { path = "../../lib/si-aws-config" }
+si-tls = { path = "../../lib/si-tls" }
 telemetry = { path = "../../lib/telemetry-rs" }
 
-aws-sdk-firehose= { workspace = true }
-base64 = { workspace = true }
+aws-config = { workspace = true }
+aws-sdk-sts = { workspace = true }
 remain = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }

--- a/lib/si-aws-config/src/lib.rs
+++ b/lib/si-aws-config/src/lib.rs
@@ -1,0 +1,94 @@
+//! This crate provides a wrapper for aws config
+
+#![warn(
+    bad_style,
+    clippy::missing_panics_doc,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result,
+    clippy::unwrap_used,
+    dead_code,
+    improper_ctypes,
+    missing_debug_implementations,
+    missing_docs,
+    no_mangle_generic_items,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    unconditional_recursion,
+    unreachable_pub,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
+
+use std::{
+    fmt::Debug,
+    result,
+};
+
+use aws_config::{
+    SdkConfig,
+    meta::region::RegionProviderChain,
+    retry::RetryConfig,
+};
+use aws_sdk_sts::error::SdkError;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+const DEFAULT_MAX_ATTEMPTS: u32 = 10;
+const DEFAULT_FALLBACK_REGION: &str = "us-east-1";
+
+#[allow(missing_docs)]
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum AwsConfigError {
+    #[error("AWS STS error: {0}")]
+    Sts(String),
+}
+
+impl AwsConfigError {
+    fn from_sdk_error<T: Debug>(error: SdkError<T>) -> Self {
+        AwsConfigError::Sts(format!("{:?}", error))
+    }
+}
+
+type Result<T> = result::Result<T, AwsConfigError>;
+
+/// Wrapper for aws config
+#[derive(Debug, Clone)]
+pub struct AwsConfig {}
+
+impl AwsConfig {
+    /// Get an aws config from the environment with built-in retry and sane defaults. It will
+    /// attempt to verify the credentials by getting the established caller identity.
+    pub async fn from_env() -> Result<SdkConfig> {
+        let retry_config = RetryConfig::adaptive().with_max_attempts(DEFAULT_MAX_ATTEMPTS);
+
+        let config = aws_config::from_env()
+            .retry_config(retry_config)
+            .region(RegionProviderChain::default_provider().or_else(DEFAULT_FALLBACK_REGION))
+            .load()
+            .await;
+
+        let sts = aws_sdk_sts::Client::new(&config);
+        let ident = sts
+            .get_caller_identity()
+            .send()
+            .await
+            .map_err(AwsConfigError::from_sdk_error)?;
+
+        let Some(account) = ident.account() else {
+            return Err(AwsConfigError::Sts(
+                "Unable to get account from credentials".to_string(),
+            ));
+        };
+
+        info!("Successfully validated AWS Credentials for account: {account}");
+
+        Ok(config)
+    }
+}

--- a/lib/si-data-acmpca/BUCK
+++ b/lib/si-data-acmpca/BUCK
@@ -3,10 +3,10 @@ load("@prelude-si//:macros.bzl", "rust_library")
 rust_library(
     name = "si-data-acmpca",
     deps = [
+        "//lib/si-aws-config:si-aws-config",
         "//lib/si-tls:si-tls",
         "//lib/telemetry-rs:telemetry",
 
-        "//third-party/rust:aws-config",
         "//third-party/rust:aws-sdk-acmpca",
         "//third-party/rust:remain",
         "//third-party/rust:rcgen",

--- a/lib/si-data-acmpca/Cargo.toml
+++ b/lib/si-data-acmpca/Cargo.toml
@@ -9,10 +9,10 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
+si-aws-config = { path = "../../lib/si-aws-config" }
 si-tls = { path = "../../lib/si-tls" }
 telemetry = { path = "../../lib/telemetry-rs" }
 
-aws-config = { workspace = true }
 aws-sdk-acmpca = { workspace = true }
 remain = { workspace = true }
 rcgen = { workspace = true }

--- a/lib/si-data-ssm/BUCK
+++ b/lib/si-data-ssm/BUCK
@@ -3,8 +3,8 @@ load("@prelude-si//:macros.bzl", "rust_library")
 rust_library(
     name = "si-data-ssm",
     deps = [
+        "//lib/si-aws-config:si-aws-config",
         "//lib/telemetry-rs:telemetry",
-        "//third-party/rust:aws-config",
         "//third-party/rust:aws-sdk-ssm",
         "//third-party/rust:remain",
         "//third-party/rust:thiserror",

--- a/lib/si-data-ssm/Cargo.toml
+++ b/lib/si-data-ssm/Cargo.toml
@@ -9,9 +9,9 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
+si-aws-config = { path = "../../lib/si-aws-config" }
 telemetry = { path = "../../lib/telemetry-rs" }
 
-aws-config = { workspace = true }
 aws-sdk-ssm = { workspace = true }
 remain = { workspace = true }
 thiserror = { workspace = true }

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -1449,6 +1449,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "aws-sdk-sts",
+    actual = ":aws-sdk-sts-1.68.0",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "aws-sdk-sts-1.68.0.crate",
     sha256 = "4939f6f449a37308a78c5a910fd91265479bd2bb11d186f0b8fc114d89ec828d",
@@ -1474,6 +1480,7 @@ cargo.rust_library(
         "CARGO_PKG_VERSION_MINOR": "68",
         "CARGO_PKG_VERSION_PATCH": "0",
     },
+    features = ["rt-tokio"],
     visibility = [],
     deps = [
         ":aws-credential-types-1.2.3",
@@ -3348,7 +3355,7 @@ cargo.rust_library(
     deps = [
         ":glob-0.3.2",
         ":libc-0.2.172",
-        ":libloading-0.8.6",
+        ":libloading-0.8.7",
     ],
 )
 
@@ -3406,23 +3413,23 @@ buildscript_run(
 
 alias(
     name = "clap",
-    actual = ":clap-4.5.37",
+    actual = ":clap-4.5.38",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "clap-4.5.37.crate",
-    sha256 = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071",
-    strip_prefix = "clap-4.5.37",
-    urls = ["https://static.crates.io/crates/clap/4.5.37/download"],
+    name = "clap-4.5.38.crate",
+    sha256 = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000",
+    strip_prefix = "clap-4.5.38",
+    urls = ["https://static.crates.io/crates/clap/4.5.38/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap-4.5.37",
-    srcs = [":clap-4.5.37.crate"],
+    name = "clap-4.5.38",
+    srcs = [":clap-4.5.38.crate"],
     crate = "clap",
-    crate_root = "clap-4.5.37.crate/src/lib.rs",
+    crate_root = "clap-4.5.38.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -3438,24 +3445,24 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [
-        ":clap_builder-4.5.37",
+        ":clap_builder-4.5.38",
         ":clap_derive-4.5.32",
     ],
 )
 
 http_archive(
-    name = "clap_builder-4.5.37.crate",
-    sha256 = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2",
-    strip_prefix = "clap_builder-4.5.37",
-    urls = ["https://static.crates.io/crates/clap_builder/4.5.37/download"],
+    name = "clap_builder-4.5.38.crate",
+    sha256 = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120",
+    strip_prefix = "clap_builder-4.5.38",
+    urls = ["https://static.crates.io/crates/clap_builder/4.5.38/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "clap_builder-4.5.37",
-    srcs = [":clap_builder-4.5.37.crate"],
+    name = "clap_builder-4.5.38",
+    srcs = [":clap_builder-4.5.38.crate"],
     crate = "clap_builder",
-    crate_root = "clap_builder-4.5.37.crate/src/lib.rs",
+    crate_root = "clap_builder-4.5.38.crate/src/lib.rs",
     edition = "2021",
     features = [
         "color",
@@ -6636,7 +6643,7 @@ cargo.rust_library(
         ":auto_enums-0.8.7",
         ":bincode-1.3.3",
         ":bytes-1.10.1",
-        ":clap-4.5.37",
+        ":clap-4.5.38",
         ":equivalent-1.0.2",
         ":fastrace-0.7.9",
         ":flume-0.11.1",
@@ -9527,18 +9534,18 @@ buildscript_run(
 )
 
 http_archive(
-    name = "libloading-0.8.6.crate",
-    sha256 = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34",
-    strip_prefix = "libloading-0.8.6",
-    urls = ["https://static.crates.io/crates/libloading/0.8.6/download"],
+    name = "libloading-0.8.7.crate",
+    sha256 = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c",
+    strip_prefix = "libloading-0.8.7",
+    urls = ["https://static.crates.io/crates/libloading/0.8.7/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "libloading-0.8.6",
-    srcs = [":libloading-0.8.6.crate"],
+    name = "libloading-0.8.7",
+    srcs = [":libloading-0.8.7.crate"],
     crate = "libloading",
-    crate_root = "libloading-0.8.6.crate/src/lib.rs",
+    crate_root = "libloading-0.8.7.crate/src/lib.rs",
     edition = "2015",
     platform = {
         "linux-arm64": dict(
@@ -9554,10 +9561,10 @@ cargo.rust_library(
             deps = [":cfg-if-1.0.0"],
         ),
         "windows-gnu": dict(
-            deps = [":windows-targets-0.52.6"],
+            deps = [":windows-targets-0.53.0"],
         ),
         "windows-msvc": dict(
-            deps = [":windows-targets-0.52.6"],
+            deps = [":windows-targets-0.53.0"],
         ),
     },
     visibility = [],
@@ -18395,23 +18402,23 @@ cargo.rust_library(
 
 alias(
     name = "tempfile",
-    actual = ":tempfile-3.19.1",
+    actual = ":tempfile-3.20.0",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "tempfile-3.19.1.crate",
-    sha256 = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf",
-    strip_prefix = "tempfile-3.19.1",
-    urls = ["https://static.crates.io/crates/tempfile/3.19.1/download"],
+    name = "tempfile-3.20.0.crate",
+    sha256 = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1",
+    strip_prefix = "tempfile-3.20.0",
+    urls = ["https://static.crates.io/crates/tempfile/3.20.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "tempfile-3.19.1",
-    srcs = [":tempfile-3.19.1.crate"],
+    name = "tempfile-3.20.0",
+    srcs = [":tempfile-3.20.0.crate"],
     crate = "tempfile",
-    crate_root = "tempfile-3.19.1.crate/src/lib.rs",
+    crate_root = "tempfile-3.20.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "default",
@@ -18592,6 +18599,7 @@ cargo.rust_binary(
         ":aws-sdk-acmpca-1.72.0",
         ":aws-sdk-firehose-1.68.0",
         ":aws-sdk-ssm-1.75.0",
+        ":aws-sdk-sts-1.68.0",
         ":aws-smithy-http-client-1.0.2",
         ":aws-smithy-runtime-1.8.3",
         ":axum-0.6.20",
@@ -18602,7 +18610,7 @@ cargo.rust_binary(
         ":bytes-1.10.1",
         ":chrono-0.4.41",
         ":ciborium-0.2.2",
-        ":clap-4.5.37",
+        ":clap-4.5.38",
         ":color-eyre-0.6.4",
         ":config-0.14.1",
         ":console-subscriber-0.4.1",
@@ -18697,7 +18705,7 @@ cargo.rust_binary(
         ":syn-2.0.101",
         ":sysinfo-0.33.1",
         ":tar-0.4.44",
-        ":tempfile-3.19.1",
+        ":tempfile-3.20.0",
         ":test-log-0.2.17",
         ":thiserror-2.0.12",
         ":thread-priority-1.2.0",
@@ -18719,7 +18727,7 @@ cargo.rust_binary(
         ":tracing-opentelemetry-0.27.0",
         ":tracing-subscriber-0.3.19",
         ":tracing-tunnel-0.1.0",
-        ":trybuild-1.0.104",
+        ":trybuild-1.0.105",
         ":tryhard-0.5.1",
         ":ulid-1.2.1",
         ":url-2.5.4",
@@ -20334,23 +20342,23 @@ cargo.rust_library(
 
 alias(
     name = "trybuild",
-    actual = ":trybuild-1.0.104",
+    actual = ":trybuild-1.0.105",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "trybuild-1.0.104.crate",
-    sha256 = "6ae08be68c056db96f0e6c6dd820727cca756ced9e1f4cc7fdd20e2a55e23898",
-    strip_prefix = "trybuild-1.0.104",
-    urls = ["https://static.crates.io/crates/trybuild/1.0.104/download"],
+    name = "trybuild-1.0.105.crate",
+    sha256 = "1c9bf9513a2f4aeef5fdac8677d7d349c79fdbcc03b9c86da6e9d254f1e43be2",
+    strip_prefix = "trybuild-1.0.105",
+    urls = ["https://static.crates.io/crates/trybuild/1.0.105/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "trybuild-1.0.104",
-    srcs = [":trybuild-1.0.104.crate"],
+    name = "trybuild-1.0.105",
+    srcs = [":trybuild-1.0.105.crate"],
     crate = "trybuild",
-    crate_root = "trybuild-1.0.104.crate/src/lib.rs",
+    crate_root = "trybuild-1.0.105.crate/src/lib.rs",
     edition = "2021",
     features = ["diff"],
     visibility = [],

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -1394,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1404,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3776,12 +3776,12 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -6700,9 +6700,9 @@ checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
@@ -6763,6 +6763,7 @@ dependencies = [
  "aws-sdk-acmpca",
  "aws-sdk-firehose",
  "aws-sdk-ssm",
+ "aws-sdk-sts",
  "aws-smithy-http-client",
  "aws-smithy-runtime",
  "axum 0.6.20",
@@ -7497,9 +7498,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae08be68c056db96f0e6c6dd820727cca756ced9e1f4cc7fdd20e2a55e23898"
+checksum = "1c9bf9513a2f4aeef5fdac8677d7d349c79fdbcc03b9c86da6e9d254f1e43be2"
 dependencies = [
  "dissimilar",
  "glob",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -38,6 +38,7 @@ aws-config = { version = "=1.5.18", features = [
 aws-sdk-acmpca = { version = "1.70.0", default-features = false, features = ["rt-tokio"] }
 aws-sdk-firehose = "=1.68.0" # pinned because very next version (1.69.0) starts pulling in `aws-lc-rs`/`aws-lc-sys` which include native C code
 aws-sdk-ssm = { version = "1.71.0", default-features = false, features = ["rt-tokio"] }
+aws-sdk-sts = { version = "1.68.0", default-features = false, features = ["rt-tokio"] }
 # setting smithy like so to avoid pulling in aws-lc-rs for aws-sdk-ssm
 aws-smithy-http-client = { version = "1.0.0", features = ["rustls-ring"] }
 aws-smithy-runtime = { version = "1.8.1", features = ["client", "tls-rustls"] }


### PR DESCRIPTION
Adds a wrapper for the aws_config crate so we can supply different defaults (adaptive retry, more attempts, fallback region) and so we can validate the credentials are good as soon as we create them (rather than waiting until they are first used).