### PR TITLE
Feat/add zed cli to toolbox

### DIFF
--- a/component/toolbox/Dockerfile
+++ b/component/toolbox/Dockerfile
@@ -18,17 +18,36 @@ RUN curl -sL https://github.com/nats-io/natscli/releases/download/v0.2.1/nats-0.
     mkdir -p /nats-bin && \
     mv /tmp/nats-0.2.1-linux-amd64/nats /nats-bin/
 
+FROM alpine:latest AS zed-builder
+
+ENV ZED_VERSION=0.30.2
+RUN apk add --no-cache curl tar
+
+# Determine architecture and download correct zed binary
+RUN ARCH=$(uname -m) && \
+    case "$ARCH" in \
+        x86_64) ARCH_ID=amd64 ;; \
+        aarch64) ARCH_ID=arm64 ;; \
+        *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    echo "Detected arch: $ARCH -> $ARCH_ID" && \
+    ZED_URL="https://github.com/authzed/zed/releases/download/v${ZED_VERSION}/zed_${ZED_VERSION}_linux_${ARCH_ID}_musl.tar.gz" && \
+    curl -sL "$ZED_URL" -o /tmp/zed.tar.gz && \
+    tar -xzf /tmp/zed.tar.gz -C /usr/local/bin zed && \
+    chmod +x /usr/local/bin/zed && \
+    zed version
+
 FROM alpine
 
 RUN set -eux; \
-    apk add --no-cache jq aws-cli bash \
-    rm -rf /var/cache/apk/*
+    apk add --no-cache jq aws-cli bash
 
 COPY ./scripts/ /usr/local/bin/si/
 RUN chmod +x /usr/local/bin/si/*
 
 COPY --from=ssm-builder /go/src/github.com/session-manager-plugin/bin/linux_amd64_plugin/session-manager-plugin /usr/local/bin/
 COPY --from=nats-builder /nats-bin/nats /usr/local/bin/nats
+COPY --from=zed-builder /usr/local/bin/zed /usr/local/bin/zed
 
 ENV PATH="/usr/local/bin/si:${PATH}"
 

--- a/component/toolbox/scripts/nats-cli
+++ b/component/toolbox/scripts/nats-cli
@@ -57,7 +57,7 @@ done
 
 profile=$(get_param_or_env "$profile" "AWS_PROFILE" "Enter the AWS profile to use")
 region=$(get_param_or_env "$region" "AWS_REGION" "Enter the AWS region (e.g., us-west-2)")
-nats=$(get_param_or_env "$nats" "NATS_CLUSTER" "Enter the nats cluster to connect to (tools-prod, prod, perf)")
+nats=$(get_param_or_env "$nats" "NATS_CLUSTER" "Enter the nats cluster to connect to (tools-prod, production, perf)")
 
 export AWS_PROFILE="$profile"
 export AWS_REGION="$region"
@@ -66,7 +66,7 @@ case "$nats" in
   tools-prod|perf)
     url="nats://global.tools-internal.nats-si.com:4222"
     ;;
-  prod)
+  production)
     url="nats://global.prod-internal.nats-si.com:4222"
     ;;
   *)

--- a/component/toolbox/scripts/zed-cli
+++ b/component/toolbox/scripts/zed-cli
@@ -1,0 +1,107 @@
+#!/bin/bash
+# ---------------------------------------------------------------------------------------------------
+# Connect to a SpiceDB cluster using AWS credentials and the zed CLI
+# ---------------------------------------------------------------------------------------------------
+
+set -eo pipefail
+
+IMPORT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+for script in ${IMPORT_DIR}/supporting-funcs/*.sh; do
+    if [[ -f "$script" ]]; then
+        source "$script"
+    fi
+done
+
+usage() {
+    echo
+    echo "zed-cli"
+    echo "----------------------------------"
+    echo "This script uses AWS creds to retrieve a preshared key"
+    echo "for a SpiceDB cluster and open a zed session to it."
+    echo "----------------------------------"
+    echo "Usage: spicedb [-p profile] [-r region] [-s spicedb]"
+    echo "  -p profile    AWS profile to use"
+    echo "  -r region     AWS region to use"
+    echo "  -s spicedb    SpiceDB cluster (tools, production, perf)"
+    echo
+    exit 1
+}
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    usage
+fi
+
+while getopts ":p:r:s:" opt; do
+    case ${opt} in
+        p)
+            profile=$OPTARG
+            ;;
+        r)
+            region=$OPTARG
+            ;;
+        s)
+            spicedb=$OPTARG
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            usage
+            ;;
+    esac
+done
+
+profile=$(get_param_or_env "$profile" "AWS_PROFILE" "Enter the AWS profile to use")
+region=$(get_param_or_env "$region" "AWS_REGION" "Enter the AWS region")
+spicedb=$(get_param_or_env "$spicedb" "SPICEDB_CLUSTER" "Enter the SpiceDB cluster (tools, production, perf)")
+
+export AWS_PROFILE="$profile"
+export AWS_REGION="$region"
+
+# Map environment to endpoint
+case "$spicedb" in
+  tools)
+    endpoint="tools-prod-generous-mallard-148888.us-east-1.ahdi0ule.aws.authzed.net:443"
+    ;;
+  production)
+    endpoint="production-neat-mink-us-east-1-cluster.us-east-1.ahdi0ule.aws.authzed.net:443"
+    ;;
+  perf)
+    endpoint="performance-suitable-raccoon-816401.us-east-1.ahdi0ule.aws.authzed.net:443"
+    ;;
+  *)
+    echo "Invalid value for spicedb: $spicedb. Must be one of (tools, production, perf)"
+    exit 1
+    ;;
+esac
+
+# Get preshared key from Secrets Manager
+secret_name="${spicedb}-spicedb-preshared-key"
+preshared_key=$(aws secretsmanager get-secret-value \
+    --secret-id "$secret_name" \
+    --query "SecretString" \
+    --output text)
+
+# Configure zed context
+export ZED_KEYRING_PASSWORD="toolbox-default-pass"
+zed context set "$spicedb" "$endpoint" "$preshared_key"
+zed context use "$spicedb"
+
+export PS1="\e[1;32m[ZED:$spicedb]\e[0m \w \$ "
+
+cat << EOF
+🚀 Welcome to SpiceDB (zed) CLI Interactive Shell 🚀
+---------------------------------------------------
+Connected to:  $endpoint
+Context:       $spicedb
+AWS Profile:   $profile
+AWS Region:    $region
+
+Use 'zed schema read' or another command to begin
+---------------------------------------------------
+EOF
+
+exec bash --norc


### PR DESCRIPTION
Adds ability to speak to the spicedb clusters for each environment, tested locally via tailscale

```
🚀 Welcome to SpiceDB (zed) CLI Interactive Shell 🚀
---------------------------------------------------
Connected to:  abc:443
Context:       perf
AWS Profile:   si-tools-prod
AWS Region:    us-east-1

Use 'zed schema read' or another command to begin
---------------------------------------------------
[ZED:perf] / $ zed schema read
definition user {}

definition workspace {
        relation approver: user
        ...
}
```