### PR TITLE
Add all weak references for incoming connections

### DIFF
--- a/lib/dal-materialized-views/src/incoming_connections.rs
+++ b/lib/dal-materialized-views/src/incoming_connections.rs
@@ -13,12 +13,9 @@ use dal::{
         value_source::ValueSource,
     },
 };
-use si_frontend_mv_types::{
-    incoming_connections::{
-        Connection,
-        IncomingConnections as IncomingConnectionsMv,
-    },
-    reference::WeakReference,
+use si_frontend_mv_types::incoming_connections::{
+    Connection,
+    IncomingConnections as IncomingConnectionsMv,
 };
 use si_id::ComponentId;
 use telemetry::prelude::*;
@@ -105,12 +102,12 @@ async fn socket_to_socket(ctx: &DalContext, component_id: ComponentId) -> Result
                         ))?;
 
                 connections.push(Connection::Socket {
-                    from_component_id: WeakReference::new(component_id),
+                    from_component_id: targets.source_component_id.into(),
                     from_attribute_value_id: output_socket_attribute_value_id,
                     from_attribute_value_path: output_socket_attribute_value_path,
                     from_socket_id: output_socket_id,
                     from_socket_name: output_socket.name().to_string(),
-                    to_component_id: component_id,
+                    to_component_id: component_id.into(),
                     to_socket_id: input_socket_id,
                     to_socket_name: input_socket.name().to_string(),
                     to_attribute_value_id: input_socket_attribute_value_id,
@@ -186,12 +183,12 @@ async fn prop_to_prop(ctx: &DalContext, component_id: ComponentId) -> Result<Vec
             ) in in_progress
             {
                 connections.push(Connection::Prop {
-                    from_component_id,
+                    from_component_id: from_component_id.into(),
                     from_attribute_value_id,
                     from_attribute_value_path,
                     from_prop_id,
                     from_prop_path,
-                    to_component_id: component_id,
+                    to_component_id: component_id.into(),
                     to_prop_id: prop_id,
                     to_prop_path: prop_path.clone(),
                     to_attribute_value_id: attribute_value_id,

--- a/lib/si-frontend-mv-types-rs/src/incoming_connections.rs
+++ b/lib/si-frontend-mv-types-rs/src/incoming_connections.rs
@@ -33,12 +33,12 @@ use crate::reference::{
 pub enum Connection {
     #[serde(rename_all = "camelCase")]
     Prop {
-        from_component_id: ComponentId,
+        from_component_id: WeakReference<ComponentId, weak::markers::Component>,
         from_attribute_value_id: AttributeValueId,
         from_attribute_value_path: String,
         from_prop_id: PropId,
         from_prop_path: String,
-        to_component_id: ComponentId,
+        to_component_id: WeakReference<ComponentId, weak::markers::Component>,
         to_prop_id: PropId,
         to_prop_path: String,
         to_attribute_value_id: AttributeValueId,
@@ -51,7 +51,7 @@ pub enum Connection {
         from_attribute_value_path: String,
         from_socket_id: OutputSocketId,
         from_socket_name: String,
-        to_component_id: ComponentId,
+        to_component_id: WeakReference<ComponentId, weak::markers::Component>,
         to_socket_id: InputSocketId,
         to_socket_name: String,
         to_attribute_value_id: AttributeValueId,

--- a/lib/si-frontend-mv-types-rs/src/reference/weak.rs
+++ b/lib/si-frontend-mv-types-rs/src/reference/weak.rs
@@ -58,6 +58,16 @@ where
     }
 }
 
+impl<T, R> From<T> for WeakReference<T, R>
+where
+    T: Eq + PartialEq + Clone + std::fmt::Debug + Serialize + std::fmt::Display,
+    R: ReferenceKindMarker,
+{
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
 impl<T, R> FrontendChecksum for WeakReference<T, R>
 where
     T: Eq + PartialEq + Clone + std::fmt::Debug + Serialize + std::fmt::Display,


### PR DESCRIPTION
Before this change, the only weak reference for incoming connections was on the "from" side of a "socket-to-socket" connection. Now, the components for both sides of both connection kinds are weak references.

This change also fixes the "from" side of the "socket-to-socket" connection to ensure that the component is correct.

All weak references are now created using a "From" impl too for ease of use.