### PR TITLE
feat(dal): Respect subscriptions when calculating action dependencies

### DIFF
--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -78,6 +78,12 @@ pub mod prototype;
 pub enum ActionError {
     #[error("action prototype error: {0}")]
     ActionPrototype(#[from] ActionPrototypeError),
+    #[error("attribute prototype error: {0}")]
+    AttributePrototype(#[from] crate::attribute::prototype::AttributePrototypeError),
+    #[error("attribute prototype argument error: {0}")]
+    AttributePrototypeArgument(
+        #[from] crate::attribute::prototype::argument::AttributePrototypeArgumentError,
+    ),
     #[error("AttributeValue error: {0}")]
     AttributeValue(#[from] AttributeValueError),
     #[error("Change Set error: {0}")]

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -96,6 +96,7 @@ use crate::{
         ActorViewError,
     },
     attribute::{
+        path::AttributePath,
         prototype::{
             AttributePrototypeError,
             AttributePrototypeSource,
@@ -1319,6 +1320,16 @@ impl Component {
         }
 
         Ok(input_socket_ids)
+    }
+
+    /// Gets the list of subscriptions pointing at this root AV, returning the subscriber AV
+    /// as well as the path they are subscribed to.
+    pub async fn subscribers(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<impl Iterator<Item = (AttributePath, AttributePrototypeArgumentId)>> {
+        let root_av_id = Self::root_attribute_value_id(ctx, component_id).await?;
+        Ok(AttributeValue::subscribers(ctx, root_av_id).await?)
     }
 
     pub async fn get_children_for_id(


### PR DESCRIPTION
This causes actions to run in the proper order when components depend on each other via subscription.

Fixes ENG-3019.

## Tests

- [X] New integration tests
- [ ] Manual test: create VPC and subnet with socket connections and make sure VPC goes first
- [ ] Manual test: create VPC and subnet with subscriptions and make sure VPC goes first

<IMG SRC="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExenEydHI0aWhlM2xkYW94OHk2N2FnYjlwbXp1cjAxNDJnYmpqcnpzaSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/XxR9qcIwcf5Jq404Sx/giphy.gif" />