### PR TITLE
Connections panel, outgoing connections, weak_references & naming scheme

### DIFF
--- a/app/web/src/mead-hall/ActionWidget.vue
+++ b/app/web/src/mead-hall/ActionWidget.vue
@@ -57,13 +57,10 @@ import {
   DiagramNodeData,
 } from "@/components/ModelingDiagram/diagram_types";
 import { ActionId } from "@/api/sdf/dal/action";
-import {
-  ActionPrototypeView,
-  BifrostComponent,
-} from "@/workers/types/dbinterface";
+import { ActionPrototypeView, Component } from "@/workers/types/dbinterface";
 
 const props = defineProps<{
-  component: DiagramGroupData | DiagramNodeData | BifrostComponent;
+  component: DiagramGroupData | DiagramNodeData | Component;
   actionPrototypeView: ActionPrototypeView;
   actionId?: ActionId;
 }>();

--- a/app/web/src/mead-hall/AssetActionsDetails.vue
+++ b/app/web/src/mead-hall/AssetActionsDetails.vue
@@ -53,7 +53,7 @@ import { bifrost, makeArgs, makeKey } from "@/store/realtime/heimdall";
 import EmptyStateIcon from "@/components/EmptyStateIcon.vue";
 import { ActionPrototypeId, ActionId } from "@/api/sdf/dal/action";
 import {
-  BifrostActionPrototypeViewList,
+  ActionPrototypeViewList,
   BifrostActionViewList,
 } from "@/workers/types/dbinterface";
 import ActionWidget from "./ActionWidget.vue";
@@ -75,18 +75,13 @@ const queryKeyForActionPrototypeViews = makeKey(
   "ActionPrototypeViewList",
   props.component.def.schemaVariantId,
 );
-const actionPrototypeViewsRaw = useQuery<BifrostActionPrototypeViewList | null>(
-  {
-    queryKey: queryKeyForActionPrototypeViews,
-    queryFn: async () =>
-      await bifrost<BifrostActionPrototypeViewList>(
-        makeArgs(
-          "ActionPrototypeViewList",
-          props.component.def.schemaVariantId,
-        ),
-      ),
-  },
-);
+const actionPrototypeViewsRaw = useQuery<ActionPrototypeViewList | null>({
+  queryKey: queryKeyForActionPrototypeViews,
+  queryFn: async () =>
+    await bifrost<ActionPrototypeViewList>(
+      makeArgs("ActionPrototypeViewList", props.component.def.schemaVariantId),
+    ),
+});
 const actionPrototypeViews = computed(
   () => actionPrototypeViewsRaw.data.value?.actionPrototypes ?? [],
 );

--- a/app/web/src/newhotness/ActionsPanel.vue
+++ b/app/web/src/newhotness/ActionsPanel.vue
@@ -26,16 +26,16 @@ import { useQuery } from "@tanstack/vue-query";
 import { computed } from "vue";
 import { bifrost, makeArgs, makeKey } from "@/store/realtime/heimdall";
 import {
-  BifrostActionPrototypeViewList,
+  ActionPrototypeViewList,
   BifrostActionViewList,
-  BifrostComponent,
+  Component,
 } from "@/workers/types/dbinterface";
 import EmptyStateCard from "@/components/EmptyStateCard.vue";
 import { ActionId, ActionPrototypeId } from "@/api/sdf/dal/action";
 import ActionWidget from "@/mead-hall/ActionWidget.vue";
 
 const props = defineProps<{
-  component: BifrostComponent;
+  component: Component;
 }>();
 
 // The code below is the same as in AssetActionsDetails in the mead hall
@@ -46,15 +46,13 @@ const queryKeyForActionPrototypeViews = makeKey(
   "ActionPrototypeViewList",
   props.component.schemaVariantId,
 );
-const actionPrototypeViewsRaw = useQuery<BifrostActionPrototypeViewList | null>(
-  {
-    queryKey: queryKeyForActionPrototypeViews,
-    queryFn: async () =>
-      await bifrost<BifrostActionPrototypeViewList>(
-        makeArgs("ActionPrototypeViewList", props.component.schemaVariantId),
-      ),
-  },
-);
+const actionPrototypeViewsRaw = useQuery<ActionPrototypeViewList | null>({
+  queryKey: queryKeyForActionPrototypeViews,
+  queryFn: async () =>
+    await bifrost<ActionPrototypeViewList>(
+      makeArgs("ActionPrototypeViewList", props.component.schemaVariantId),
+    ),
+});
 const actionPrototypeViews = computed(
   () => actionPrototypeViewsRaw.data.value?.actionPrototypes ?? [],
 );

--- a/app/web/src/newhotness/CodePanel.vue
+++ b/app/web/src/newhotness/CodePanel.vue
@@ -23,7 +23,7 @@
 import { useQuery } from "@tanstack/vue-query";
 import { computed } from "vue";
 import { bifrost, makeArgs, makeKey } from "@/store/realtime/heimdall";
-import { BifrostAttributeTree } from "@/workers/types/dbinterface";
+import { AttributeTree } from "@/workers/types/dbinterface";
 import CodeViewer from "@/components/CodeViewer.vue";
 import EmptyStateCard from "@/components/EmptyStateCard.vue";
 import { findAvsAtPropPath } from "./util";
@@ -34,10 +34,9 @@ const props = defineProps<{
 
 const attributeTreeMakeKey = makeKey("AttributeTree", props.componentId);
 const attributeTreeMakeArgs = makeArgs("AttributeTree", props.componentId);
-const attributeTreeQuery = useQuery<BifrostAttributeTree | null>({
+const attributeTreeQuery = useQuery<AttributeTree | null>({
   queryKey: attributeTreeMakeKey,
-  queryFn: async () =>
-    await bifrost<BifrostAttributeTree>(attributeTreeMakeArgs),
+  queryFn: async () => await bifrost<AttributeTree>(attributeTreeMakeArgs),
 });
 
 const root = computed(() => attributeTreeQuery.data.value);

--- a/app/web/src/newhotness/ComponentGridTile.vue
+++ b/app/web/src/newhotness/ComponentGridTile.vue
@@ -52,17 +52,28 @@
         />
         <div>Resource</div>
       </li>
-      <hr class="border-neutral-500" />
-      <li>
-        <Icon name="output-connection" size="sm" />
-        <div>Inputs</div>
-        <PillCounter :count="component.inputCount" size="sm" class="ml-auto" />
-      </li>
-      <li>
-        <Icon name="input-connection" size="sm" />
-        <div>Outputs</div>
-        <PillCounter :count="0" size="sm" class="ml-auto" />
-      </li>
+      <!-- NOTE: when coming from the Map page we don't have accurate outputCount, hiding this -->
+      <template v-if="!props.hideConnections">
+        <hr class="border-neutral-500" />
+        <li>
+          <Icon name="output-connection" size="sm" />
+          <div>Inputs</div>
+          <PillCounter
+            :count="component.inputCount"
+            size="sm"
+            class="ml-auto"
+          />
+        </li>
+        <li>
+          <Icon name="input-connection" size="sm" />
+          <div>Outputs</div>
+          <PillCounter
+            :count="component.outputCount"
+            size="sm"
+            class="ml-auto"
+          />
+        </li>
+      </template>
     </ol>
     <!-- <footer class="grid grid-cols-2 p-xs">
       <div class="place-self-start">
@@ -86,12 +97,13 @@ import {
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { computed } from "vue";
-import { BifrostComponent } from "@/workers/types/dbinterface";
+import { Component } from "@/workers/types/dbinterface";
 import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
 import { getAssetIcon } from "./util";
 
 const props = defineProps<{
-  component: BifrostComponent;
+  component: Component;
+  hideConnections?: boolean;
 }>();
 
 const qualificationSummary = computed(() => {

--- a/app/web/src/newhotness/ConnectionsPanel.vue
+++ b/app/web/src/newhotness/ConnectionsPanel.vue
@@ -1,0 +1,105 @@
+<template>
+  <div
+    v-if="incoming.length > 0 || outgoing.length > 0"
+    class="border border-neutral-500 rounded bg-neutral-900 pb-sm"
+  >
+    <template v-if="incoming.length">
+      <ConnectionLayout label="Inputs" :connections="incoming" />
+    </template>
+    <template v-if="outgoing.length">
+      <ConnectionLayout label="Outputs" :connections="outgoing" />
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, Reactive } from "vue";
+import { useQuery } from "@tanstack/vue-query";
+import {
+  Component,
+  BifrostComponentConnections,
+  BifrostConnection,
+  OutgoingConnections,
+} from "@/workers/types/dbinterface";
+import {
+  bifrost,
+  getOutgoingConnections,
+  useMakeArgs,
+  useMakeKey,
+} from "@/store/realtime/heimdall";
+import ConnectionLayout, {
+  SimpleConnection,
+} from "./layout_components/ConnectionLayout.vue";
+
+const props = defineProps<{
+  component: Component;
+  connections?: BifrostComponentConnections;
+}>();
+
+const key = useMakeKey();
+const args = useMakeArgs();
+
+const componentId = computed(() => props.component.id);
+const enableLookup = computed(
+  () => !(props.connections && "id" in props.connections),
+);
+
+const componentConnectionsQuery = useQuery<BifrostComponentConnections | null>({
+  enabled: enableLookup,
+  queryKey: key("IncomingConnections", componentId),
+  queryFn: async () => {
+    const componentConnections = await bifrost<BifrostComponentConnections>(
+      args("IncomingConnections", componentId.value),
+    );
+    return componentConnections;
+  },
+});
+
+const outgoingQuery = useQuery<Reactive<OutgoingConnections>>({
+  queryKey: key("OutgoingConnections"),
+  queryFn: async () => {
+    return await getOutgoingConnections(args("OutgoingConnections"));
+  },
+});
+
+const componentConnections = computed(() => {
+  if (enableLookup.value && componentConnectionsQuery.data.value) {
+    const { incoming } = componentConnectionsQuery.data.value;
+    return { incoming };
+  } else if (props.connections) {
+    const { incoming } = props.connections;
+    return { incoming };
+  } else {
+    return {
+      incoming: [] as BifrostConnection[],
+    };
+  }
+});
+
+// these two shouldn't be the same shape?
+const incoming = computed(
+  () =>
+    componentConnections.value.incoming.map((conn) => {
+      return {
+        key: `${conn.toAttributeValueId}-${conn.toComponent.id}-${conn.fromComponent.id}-${conn.fromAttributeValueId}`,
+        component: conn.fromComponent,
+        componentId: conn.fromComponent.id,
+        self: conn.toAttributeValuePath,
+        other: conn.fromAttributeValuePath,
+      };
+    }) ?? ([] as SimpleConnection[]),
+);
+
+const outgoing = computed<SimpleConnection[]>(() => {
+  const outgoing = outgoingQuery.data?.value?.get(componentId.value) ?? [];
+  return outgoing.map((conn) => {
+    return {
+      key: `${conn.toAttributeValueId}-${conn.toComponent.id}-${conn.fromComponent.id}-${conn.fromAttributeValueId}`,
+      component: conn.fromComponent,
+      componentId: conn.fromComponent.id,
+      self: conn.toAttributeValuePath,
+      other: conn.fromAttributeValuePath,
+    };
+  });
+});
+</script>

--- a/app/web/src/newhotness/DiffPanel.vue
+++ b/app/web/src/newhotness/DiffPanel.vue
@@ -14,10 +14,10 @@
 import { computed } from "vue";
 import CodeViewer from "@/components/CodeViewer.vue";
 import EmptyStateCard from "@/components/EmptyStateCard.vue";
-import { BifrostComponent } from "@/workers/types/dbinterface";
+import { Component } from "@/workers/types/dbinterface";
 
 const component = defineProps<{
-  component: BifrostComponent;
+  component: Component;
 }>();
 
 const diff = computed(() => {

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -149,7 +149,7 @@ import { Fzf } from "fzf";
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import {
   BifrostActionViewList,
-  BifrostComponent,
+  Component,
   BifrostComponentList,
   BifrostViewList,
   ViewComponentList,
@@ -251,7 +251,7 @@ const componentList = computed(
 
 const scrollRef = ref<HTMLDivElement>();
 
-const filteredComponents = reactive<BifrostComponent[]>([]);
+const filteredComponents = reactive<Component[]>([]);
 
 const searchString = ref("");
 const computedSearchString = computed(() => searchString.value);

--- a/app/web/src/newhotness/QualificationPanel.vue
+++ b/app/web/src/newhotness/QualificationPanel.vue
@@ -14,8 +14,8 @@ import { computed } from "vue";
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import {
   AttributeValue,
-  BifrostAttributeTree,
-  BifrostComponent,
+  AttributeTree,
+  Component,
   Prop,
 } from "@/workers/types/dbinterface";
 import QualificationView from "@/newhotness/QualificationView.vue";
@@ -31,19 +31,17 @@ export interface QualItem {
 }
 
 const props = defineProps<{
-  component: BifrostComponent;
+  component: Component;
 }>();
 
 const componentId = computed(() => props.component.id);
 
 const key = useMakeKey();
 const args = useMakeArgs();
-const attributeTreeQuery = useQuery<BifrostAttributeTree | null>({
+const attributeTreeQuery = useQuery<AttributeTree | null>({
   queryKey: key("AttributeTree", componentId),
   queryFn: async () =>
-    await bifrost<BifrostAttributeTree>(
-      args("AttributeTree", componentId.value),
-    ),
+    await bifrost<AttributeTree>(args("AttributeTree", componentId.value)),
 });
 
 const root = computed(() => attributeTreeQuery.data.value);

--- a/app/web/src/newhotness/ResourcePanel.vue
+++ b/app/web/src/newhotness/ResourcePanel.vue
@@ -17,7 +17,7 @@
 import { useQuery } from "@tanstack/vue-query";
 import { computed } from "vue";
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
-import { BifrostAttributeTree } from "@/workers/types/dbinterface";
+import { AttributeTree } from "@/workers/types/dbinterface";
 import CodeViewer from "@/components/CodeViewer.vue";
 import EmptyStateCard from "@/components/EmptyStateCard.vue";
 import { findAvsAtPropPath } from "./util";
@@ -30,12 +30,10 @@ const componentId = computed(() => props.componentId ?? "");
 
 const key = useMakeKey();
 const args = useMakeArgs();
-const attributeTreeQuery = useQuery<BifrostAttributeTree | null>({
+const attributeTreeQuery = useQuery<AttributeTree | null>({
   queryKey: key("AttributeTree", componentId),
   queryFn: async () =>
-    await bifrost<BifrostAttributeTree>(
-      args("AttributeTree", componentId.value),
-    ),
+    await bifrost<AttributeTree>(args("AttributeTree", componentId.value)),
 });
 
 const root = computed(() => attributeTreeQuery.data.value);

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -78,10 +78,10 @@ import {
 import { LabelEntry, LabelList } from "@/api/sdf/dal/label_list";
 import { attributeEmitter } from "../logic_composables/emitters";
 import { useWatchedForm } from "../logic_composables/watched_form";
-import { AttributeTree } from "../AttributePanel.vue";
+import { AttrTree } from "../AttributePanel.vue";
 
 const props = defineProps<{
-  attributeTree: AttributeTree;
+  attributeTree: AttrTree;
   displayName: string;
 }>();
 

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -44,10 +44,10 @@ import { VButton } from "@si/vue-lib/design-system";
 import { filterMissingAtom } from "../util";
 import AttributeChildLayout from "./AttributeChildLayout.vue";
 import AttributeInput from "./AttributeInput.vue";
-import { AttributeTree } from "../AttributePanel.vue";
+import { AttrTree } from "../AttributePanel.vue";
 
 const props = defineProps<{
-  attributeTree: AttributeTree;
+  attributeTree: AttrTree;
 }>();
 
 // this handles objects and arrays but not empty arrays

--- a/app/web/src/newhotness/layout_components/ConnectionLayout.vue
+++ b/app/web/src/newhotness/layout_components/ConnectionLayout.vue
@@ -1,0 +1,51 @@
+<!-- eslint-disable vue/no-multiple-template-root -->
+<template>
+  <h3 class="m-xs">{{ props.label }}</h3>
+  <ul class="flex flex-col gap-xs mx-xs">
+    <li
+      v-for="conn in props.connections"
+      :key="`${conn.key}`"
+      class="p-xs border-neutral-600 border"
+    >
+      <p
+        class="text-neutral-400 text-sm cursor-pointer"
+        @click="() => navigate(conn.componentId)"
+      >
+        {{ conn.component.schemaName }}
+        {{ conn.component.name }}
+      </p>
+      <!-- negative margin pulls things together -->
+      <p class="text-white text-lg mb-[-6px] mt-[-4px]">{{ conn.self }}</p>
+      <p class="text-neutral-400 text-sm">{{ conn.other }}</p>
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import { useRoute, useRouter } from "vue-router";
+import { Component } from "@/workers/types/dbinterface";
+
+export interface SimpleConnection {
+  key: string;
+  componentId: string;
+  component: Component;
+  self: string;
+  other: string;
+}
+
+const props = defineProps<{
+  label: string;
+  connections: SimpleConnection[];
+}>();
+
+const router = useRouter();
+const route = useRoute();
+const navigate = (componentId: string) => {
+  const params = { ...route.params };
+  params.componentId = componentId;
+  router.push({
+    name: "new-hotness-component",
+    params,
+  });
+};
+</script>

--- a/app/web/src/newhotness/logic_composables/navigation_stack.ts
+++ b/app/web/src/newhotness/logic_composables/navigation_stack.ts
@@ -1,10 +1,14 @@
+import * as _ from "lodash-es";
 import { reactive } from "vue";
 
 const LIMIT = 5;
 
+export type params = Record<string, string | string[]>;
+export type query = Record<string, string | string[]>;
 export interface Breadcrumb {
   url: string;
-  params: Record<string, string | string[]>;
+  params: params;
+  query: query;
   name: string;
 }
 
@@ -13,9 +17,18 @@ export const breadcrumbs = reactive<Breadcrumb[]>([]);
 export const push = (
   url: string,
   name: string,
-  params: Record<string, string | string[]>,
+  params: params,
+  query: query,
 ) => {
-  breadcrumbs.push({ url, name, params });
+  const prev = prevPage();
+  if (!prev) breadcrumbs.push({ url, name, params, query });
+  else if (
+    prev.name !== name &&
+    prev.url !== url &&
+    !_.isEqual(prev.params, params) &&
+    !_.isEqual(prev.query, query)
+  )
+    breadcrumbs.push({ url, name, params, query });
   if (breadcrumbs.length > LIMIT) breadcrumbs.shift();
 };
 

--- a/app/web/src/newhotness/util.ts
+++ b/app/web/src/newhotness/util.ts
@@ -1,6 +1,6 @@
 import { Ref, unref } from "vue";
 import { IconNames } from "@si/vue-lib/design-system";
-import { BifrostAttributeTree } from "@/workers/types/dbinterface";
+import { AttributeTree } from "@/workers/types/dbinterface";
 import { Toggle } from "./logic_composables/toggle_containers";
 
 export const getAssetIcon = (name: string) => {
@@ -57,10 +57,7 @@ export const filterMissingAtom = (obj: unknown) => {
 };
 
 // Used in the component page vue components
-export const findAvsAtPropPath = (
-  data: BifrostAttributeTree,
-  parts: string[],
-) => {
+export const findAvsAtPropPath = (data: AttributeTree, parts: string[]) => {
   const path = parts.join("\u000b");
   const propId = Object.keys(data.props).find((pId) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -2,7 +2,10 @@ import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
 import * as _ from "lodash-es";
 import { nextTick } from "vue";
 import { posthog } from "@/utils/posthog";
-import { push as pushBreadcrumb } from "@/newhotness/logic_composables/navigation_stack";
+import {
+  push as pushBreadcrumb,
+  query,
+} from "@/newhotness/logic_composables/navigation_stack";
 import { useAuthStore } from "./store/auth.store";
 import { useRouterStore } from "./store/router.store";
 import { isDevMode } from "./utils/debug";
@@ -300,7 +303,7 @@ router.afterEach((to) => {
     console.error("can't find name in matched route", e);
   }
   try {
-    pushBreadcrumb(to.path, name, { ...to.params });
+    pushBreadcrumb(to.path, name, { ...to.params }, { ...to.query } as query);
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error("can't push breadcrumb", e);

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -1,9 +1,15 @@
 import * as Comlink from "comlink";
 import { computed, reactive, Reactive, inject, ComputedRef, unref } from "vue";
 import { QueryClient } from "@tanstack/vue-query";
-import { DBInterface, Id, BustCacheFn } from "@/workers/types/dbinterface";
+import {
+  DBInterface,
+  Id,
+  BustCacheFn,
+  BifrostConnection,
+} from "@/workers/types/dbinterface";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import { Context } from "@/newhotness/types";
+import { DefaultMap } from "@/utils/defaultmap";
 import { useChangeSetsStore } from "../change_sets.store";
 import { useWorkspacesStore } from "../workspaces.store";
 
@@ -102,6 +108,20 @@ export const bifrost = async <T>(args: {
   return reactive(maybeAtomDoc);
 };
 
+export const getOutgoingConnections = async (args: {
+  workspaceId: string;
+  changeSetId: ChangeSetId;
+}) => {
+  if (!initCompleted.value) throw new Error("bifrost not initiated");
+
+  const connectionsById = await db.getOutgoingConnectionsByComponentId(
+    args.workspaceId,
+    args.changeSetId,
+  );
+  if (connectionsById) return reactive(connectionsById);
+  return new DefaultMap<string, BifrostConnection[]>(() => []);
+};
+
 // cold start
 export const niflheim = async (
   workspaceId: string,
@@ -114,6 +134,8 @@ export const niflheim = async (
     // eslint-disable-next-line no-console
     console.log("❄️ NIFLHEIM ❄️");
     await db.niflheim(workspaceId, changeSetId);
+    // eslint-disable-next-line no-console
+    console.log("❄️ DONE ❄️");
   }
 };
 


### PR DESCRIPTION
We now have a codified pattern: `get` -> `getReferences` -> `getComputed`. This is how we string together strong and weak references. However, it comes with a limitation; circular references/infinite loops/cycles, call it what you will, but its bad 😈 .

This implication of this is that, we can do all the things we want—except compute the outgoing connections when looking up input connections. Thats the cycle. (There is probably a clever way around this... but my brain has been bashing on this its starting to turn into mush... so, we can figure that out another day).

What does this mean for you?! When you are looking up connections and want outgoing connections—you need to make a separate call. Thats it, for now. You'll see this example in the `ConnectionsPanel`. When you're asking for a `Component` or `ComponentList` or `ViewComponentList`, you'll get the `outputCount` populated (and it stays reactive thanks to weak references!).

**_Note_**: the outgoing connections cache is a tad slow right now. We can take a deeper dive into speeding it up, potentially. But for now, the way it works is that all the atom build, regardless of if they have a ready cache of connections. Then once the connections are built—that cache busts, and things re-query, re-compute, and the UI updates.

The best way to observe this effect is by going to the Map page, selecting a component, and hitting refresh. The map will refresh, the component tile will show. Connections won't show. Until the list is generated. And then the connections show.

### Outgoing Connections Cache
I've moved around the cache busting bits a little. This achieves a fully up to date list of outgoing connections is ready and waiting for each computed operation that requires it.
1. When patching atoms, note which kinds are being patched
2. Mark the connections dirty based on the kind (`IncomingConnections`, `IncomingConnectionsList`)
3. Patch the changes
4. Hold the atoms that must be busted
5. Recreate the connections
6. Bust the caches, based on the weak references, et al.

### Naming Scheme
This is taken from my code comment in the `dbinterface.ts` file:
```
/**
 * NAMING RULES
 * 1. If the type is not mutated at all
 * (e.g. it does not have an if-block in `getReferences` or `getComputed`)
 * THOU SHALT name it according the entity kind--EXACT MATCH PLEASE
 * 
 * 2. If the type is mutated, you will prefix the EXACT entity kind...
 * THOU SHALT prefix the type that comes over the wire with `Edda`
 * THOU SHALT prefix the type that returns from `bifrost` fn with `Bifrost`
 * 
 * 3. `EddaXXX` types SHALL NOT have `BifrostXXX` types on them
 * 4. `BifrostXXX` types SHALL NOT have `EddaXXX` types on them
 * 5. Vue components SHALL NEVER use `EddaXXX` types
 * 6. `getReferences` SHALL NEVER return an `EddaXXX` type
 *    (e.g. perform the full translation from Edda to Bifrost)
 * 7. `getReferences` SHALL set default/warning data that `getComputed` will write over
 */
```
I was confusing the hell out of myself without a stricter naming scheme, "what type went with what entity kind?! is this before the reference lookup or not?!"... Happy to take other suggestions, just felt the need to put some pattern down to our typing schemes