### PR TITLE
Fix duplicate incoming connections and wrong prop

### DIFF
--- a/lib/dal-materialized-views/src/component.rs
+++ b/lib/dal-materialized-views/src/component.rs
@@ -33,12 +33,8 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
         InputSocket::list_ids_for_schema_variant(ctx, schema_variant.id()).await?;
     let mut input_count = 0;
     for input_socket_id in input_socket_ids {
-        let attribute_value_id = InputSocket::component_attribute_value_for_input_socket_id(
-            ctx,
-            input_socket_id,
-            component_id,
-        )
-        .await?;
+        let attribute_value_id =
+            InputSocket::component_attribute_value_id(ctx, input_socket_id, component_id).await?;
         let attribute_prototype_id = AttributeValue::prototype_id(ctx, attribute_value_id).await?;
         let attribute_prototype_argument_ids =
             AttributePrototype::list_arguments_for_id(ctx, attribute_prototype_id).await?;

--- a/lib/dal-materialized-views/src/lib.rs
+++ b/lib/dal-materialized-views/src/lib.rs
@@ -82,8 +82,6 @@ pub enum Error {
     Component(#[from] dal::ComponentError),
     #[error("diagram error: {0}")]
     Diagram(#[from] dal::diagram::DiagramError),
-    #[error("empty path for attribute value id {0}")]
-    EmptyPathForAttributeValue(dal::AttributeValueId),
     #[error("func error: {0}")]
     Func(#[from] dal::FuncError),
     #[error("input socket error: {0}")]

--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -669,7 +669,7 @@ impl ExpectComponentInputSocket {
     }
 
     pub async fn attribute_value(self, ctx: &DalContext) -> ExpectAttributeValue {
-        InputSocket::component_attribute_value_for_input_socket_id(ctx, self.1, self.0)
+        InputSocket::component_attribute_value_id(ctx, self.1, self.0)
             .await
             .expect("get attribute value for input socket")
             .into()
@@ -736,7 +736,7 @@ impl ExpectComponentOutputSocket {
     }
 
     pub async fn attribute_value(self, ctx: &DalContext) -> ExpectAttributeValue {
-        OutputSocket::component_attribute_value_for_output_socket_id(ctx, self.1, self.0)
+        OutputSocket::component_attribute_value_id(ctx, self.1, self.0)
             .await
             .expect("get attribute value for output socket")
             .into()

--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -24,6 +24,10 @@ use dal::{
     SchemaVariantId,
     User,
     UserPk,
+    attribute::{
+        path::AttributePath,
+        value::subscription::ValueSubscription,
+    },
     audit_logging,
     component::socket::{
         ComponentInputSocket,
@@ -489,4 +493,16 @@ pub async fn list_audit_logs_until_expected_number_of_rows(
     Err(eyre!(
         "hit timeout before audit logs query returns expected number of rows (expected: {expected_number_of_rows}, actual: {actual_number_of_rows})"
     ))
+}
+
+/// Make a [`ValueSubscription`] for a given [`Component`] and path.
+pub async fn make_subscription(
+    ctx: &DalContext,
+    component_id: dal::ComponentId,
+    json_pointer: impl Into<String>,
+) -> Result<ValueSubscription> {
+    Ok(ValueSubscription {
+        attribute_value_id: Component::root_attribute_value_id(ctx, component_id).await?,
+        path: AttributePath::JsonPointer(json_pointer.into()),
+    })
 }

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -888,7 +888,7 @@ impl AttributeValue {
             // XXX: the two to just be "null" when passing these to a function.
             let output_av = AttributeValue::get_by_id(
                 ctx,
-                OutputSocket::component_attribute_value_for_output_socket_id(
+                OutputSocket::component_attribute_value_id(
                     ctx,
                     inferred_connection.output_socket_id,
                     inferred_connection.source_component_id,

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -2167,13 +2167,12 @@ impl Component {
         }
 
         // filter the value ids by destination_component_id
-        let destination_attribute_value_id =
-            InputSocket::component_attribute_value_for_input_socket_id(
-                ctx,
-                destination_input_socket_id,
-                destination_component_id,
-            )
-            .await?;
+        let destination_attribute_value_id = InputSocket::component_attribute_value_id(
+            ctx,
+            destination_input_socket_id,
+            destination_component_id,
+        )
+        .await?;
 
         let destination_prototype_id =
             AttributeValue::prototype_id(ctx, destination_attribute_value_id).await?;
@@ -3562,7 +3561,7 @@ impl Component {
                                 .await?;
 
                                 let destination_attribute_value_id =
-                                    InputSocket::component_attribute_value_for_input_socket_id(
+                                    InputSocket::component_attribute_value_id(
                                         ctx,
                                         destination_input_socket_id,
                                         destination_component_id,

--- a/lib/dal/src/component/frame.rs
+++ b/lib/dal/src/component/frame.rs
@@ -493,7 +493,7 @@ impl Frame {
             let component_input_socket = ComponentInputSocket {
                 component_id: incoming_connection.destination_component_id,
                 input_socket_id: incoming_connection.input_socket_id,
-                attribute_value_id: InputSocket::component_attribute_value_for_input_socket_id(
+                attribute_value_id: InputSocket::component_attribute_value_id(
                     ctx,
                     incoming_connection.input_socket_id,
                     incoming_connection.destination_component_id,
@@ -503,7 +503,7 @@ impl Frame {
             let component_output_socket = ComponentOutputSocket {
                 component_id: incoming_connection.source_component_id,
                 output_socket_id: incoming_connection.output_socket_id,
-                attribute_value_id: OutputSocket::component_attribute_value_for_output_socket_id(
+                attribute_value_id: OutputSocket::component_attribute_value_id(
                     ctx,
                     incoming_connection.output_socket_id,
                     incoming_connection.source_component_id,

--- a/lib/dal/src/component/socket.rs
+++ b/lib/dal/src/component/socket.rs
@@ -239,7 +239,7 @@ impl ComponentInputSocket {
             .inferred_connections_for_input_socket(ctx, self.component_id, self.input_socket_id)
             .await?
         {
-            let attribute_value_id = OutputSocket::component_attribute_value_for_output_socket_id(
+            let attribute_value_id = OutputSocket::component_attribute_value_id(
                 ctx,
                 inferred_connection.output_socket_id,
                 inferred_connection.source_component_id,

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -461,13 +461,12 @@ impl AttributeBinding {
                         .await?;
                     }
                     EventualParent::Component(component_id) => {
-                        let attribute_value_id =
-                            OutputSocket::component_attribute_value_for_output_socket_id(
-                                ctx,
-                                output_socket_id,
-                                component_id,
-                            )
-                            .await?;
+                        let attribute_value_id = OutputSocket::component_attribute_value_id(
+                            ctx,
+                            output_socket_id,
+                            component_id,
+                        )
+                        .await?;
                         // if we're setting this to unset, need to also clear any existing attribute values
                         if func.backend_kind == FuncBackendKind::Unset {
                             attribute_values_to_update.push(attribute_value_id);

--- a/lib/dal/src/management/prototype.rs
+++ b/lib/dal/src/management/prototype.rs
@@ -256,12 +256,8 @@ async fn build_connection(
         .await?
         .name()
         .to_owned();
-    let av_id = OutputSocket::component_attribute_value_for_output_socket_id(
-        ctx,
-        from_socket_id,
-        from_component_id,
-    )
-    .await?;
+    let av_id =
+        OutputSocket::component_attribute_value_id(ctx, from_socket_id, from_component_id).await?;
     let value = AttributeValue::get_by_id(ctx, av_id)
         .await?
         .view(ctx)

--- a/lib/dal/src/socket/input.rs
+++ b/lib/dal/src/socket/input.rs
@@ -309,7 +309,7 @@ impl InputSocket {
             .map_err(Into::into)
     }
 
-    pub async fn component_attribute_value_for_input_socket_id(
+    pub async fn component_attribute_value_id(
         ctx: &DalContext,
         input_socket_id: InputSocketId,
         component_id: ComponentId,

--- a/lib/dal/src/socket/output.rs
+++ b/lib/dal/src/socket/output.rs
@@ -314,7 +314,7 @@ impl OutputSocket {
         Ok(result)
     }
 
-    pub async fn component_attribute_value_for_output_socket_id(
+    pub async fn component_attribute_value_id(
         ctx: &DalContext,
         output_socket_id: OutputSocketId,
         component_id: ComponentId,

--- a/lib/dal/tests/integration_test/attribute_value/subscription.rs
+++ b/lib/dal/tests/integration_test/attribute_value/subscription.rs
@@ -2,16 +2,13 @@ use dal::{
     AttributeValue,
     Component,
     DalContext,
-    attribute::{
-        path::AttributePath,
-        value::subscription::ValueSubscription,
-    },
 };
 use dal_test::{
     Result,
     helpers::{
         ChangeSetTestHelpers,
         component,
+        make_subscription,
         schema::variant,
     },
     test,
@@ -412,15 +409,4 @@ async fn setup(ctx: &DalContext) -> Result<()> {
     .await?;
 
     Ok(())
-}
-
-async fn make_subscription(
-    ctx: &DalContext,
-    component_id: dal::ComponentId,
-    json_pointer: impl Into<String>,
-) -> Result<ValueSubscription> {
-    Ok(ValueSubscription {
-        attribute_value_id: Component::root_attribute_value_id(ctx, component_id).await?,
-        path: AttributePath::JsonPointer(json_pointer.into()),
-    })
 }


### PR DESCRIPTION
## Description

This change fixes two bugs with incoming connections:

1) Fix duplicate incoming connections by ensuring we do not accidentally process outgoing connections during MV generation.
2) Fix incorrect prop IDs for prop-to-prop connections on the "from" side by using the correct ID.

This change was tested with an included integration test and includes the following misc changes:

- Rename the attribute value ID for socket functions to be shorthand
- Move the "make_subscription" helper to the helpers module

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdld3VqNjZqaGZsMnJ4N2xocWN1bHNtczQ1dDkyZzJydm5pYjR1N2VmbiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/mc7uduXz800wtqU7WV/giphy.gif"/>