### PR TITLE
fix(bifrost): Make components draggable to canvas again

### DIFF
--- a/lib/si-frontend-mv-types-rs/src/schema_variant.rs
+++ b/lib/si-frontend-mv-types-rs/src/schema_variant.rs
@@ -174,7 +174,7 @@ pub enum Variant {
     Serialize,
     si_frontend_mv_types_macros::FrontendChecksum,
 )]
-#[serde(rename_all = "PascalCase")]
+#[serde(rename_all = "camelCase")]
 pub enum VariantType {
     Installed,
     Uninstalled,


### PR DESCRIPTION
This makes it possible to drag components onto the canvas again in environments using bifrost for the old UI (localdev).

## Tests

- [ ] Regression tests pass
- [ ] Drag uninstalled and installed components onto the canvas