### PR TITLE
feat(dal): Allow arrays to subscribe to multiple values

### DIFF
--- a/lib/dal-materialized-views/src/component.rs
+++ b/lib/dal-materialized-views/src/component.rs
@@ -37,7 +37,7 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
             InputSocket::component_attribute_value_id(ctx, input_socket_id, component_id).await?;
         let attribute_prototype_id = AttributeValue::prototype_id(ctx, attribute_value_id).await?;
         let attribute_prototype_argument_ids =
-            AttributePrototype::list_arguments_for_id(ctx, attribute_prototype_id).await?;
+            AttributePrototype::list_arguments(ctx, attribute_prototype_id).await?;
         for attribute_prototype_argument_id in attribute_prototype_argument_ids {
             let attribute_prototype_argument =
                 AttributePrototypeArgument::get_by_id(ctx, attribute_prototype_argument_id).await?;

--- a/lib/dal-materialized-views/src/incoming_connections.rs
+++ b/lib/dal-materialized-views/src/incoming_connections.rs
@@ -56,7 +56,7 @@ async fn socket_to_socket(ctx: &DalContext, component_id: ComponentId) -> Result
         let attribute_prototype_id =
             AttributeValue::prototype_id(ctx, input_socket_attribute_value_id).await?;
         let attribute_prototype_argument_ids =
-            AttributePrototype::list_arguments_for_id(ctx, attribute_prototype_id).await?;
+            AttributePrototype::list_arguments(ctx, attribute_prototype_id).await?;
 
         // Don't bother gathering information to cache if there are no prototype arguments.
         if attribute_prototype_argument_ids.is_empty() {
@@ -131,7 +131,7 @@ async fn prop_to_prop(ctx: &DalContext, component_id: ComponentId) -> Result<Vec
         // connections are found.
         let mut in_progress = Vec::new();
         for attribute_prototype_argument_id in
-            AttributePrototype::list_arguments_for_id(ctx, attribute_prototype_id).await?
+            AttributePrototype::list_arguments(ctx, attribute_prototype_id).await?
         {
             if let Some(ValueSource::ValueSubscription(subscription)) =
                 AttributePrototypeArgument::value_source_opt(ctx, attribute_prototype_argument_id)

--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -24,10 +24,6 @@ use dal::{
     SchemaVariantId,
     User,
     UserPk,
-    attribute::{
-        path::AttributePath,
-        value::subscription::ValueSubscription,
-    },
     audit_logging,
     component::socket::{
         ComponentInputSocket,
@@ -45,9 +41,12 @@ use names::{
 use si_data_nats::async_nats::jetstream::stream::Stream;
 use tokio::time::Instant;
 
-mod change_set;
 mod property_editor_test_view;
 
+/// Test helpers for attribute values and prototypes
+pub mod attribute;
+/// Test helpers for change sets
+pub mod change_set;
 /// Test helpers for components
 pub mod component;
 /// Test helpers for schemas
@@ -493,16 +492,4 @@ pub async fn list_audit_logs_until_expected_number_of_rows(
     Err(eyre!(
         "hit timeout before audit logs query returns expected number of rows (expected: {expected_number_of_rows}, actual: {actual_number_of_rows})"
     ))
-}
-
-/// Make a [`ValueSubscription`] for a given [`Component`] and path.
-pub async fn make_subscription(
-    ctx: &DalContext,
-    component_id: dal::ComponentId,
-    json_pointer: impl Into<String>,
-) -> Result<ValueSubscription> {
-    Ok(ValueSubscription {
-        attribute_value_id: Component::root_attribute_value_id(ctx, component_id).await?,
-        path: AttributePath::JsonPointer(json_pointer.into()),
-    })
 }

--- a/lib/dal-test/src/helpers/attribute.rs
+++ b/lib/dal-test/src/helpers/attribute.rs
@@ -1,0 +1,2 @@
+/// Helpers for attribute values
+pub mod value;

--- a/lib/dal-test/src/helpers/attribute/value.rs
+++ b/lib/dal-test/src/helpers/attribute/value.rs
@@ -1,0 +1,190 @@
+use color_eyre::eyre::eyre;
+use dal::{
+    AttributeValue,
+    Component,
+    DalContext,
+    attribute::{
+        path::AttributePath,
+        value::subscription::ValueSubscription,
+    },
+};
+use si_id::{
+    AttributeValueId,
+    ComponentId,
+};
+
+use crate::{
+    Result,
+    helpers::component::ComponentKey,
+};
+
+///
+/// Things that you can pass as attribute values (id, or (component, path))
+///
+#[allow(async_fn_in_trait)]
+pub trait AttributeValueKey {
+    ///
+    /// Get the AttributeValueId for this key
+    ///
+    async fn lookup_attribute_value(self, ctx: &DalContext) -> Result<AttributeValueId>;
+    ///
+    /// Get the AttributeValueId for this key, or None if it doesn't exist
+    ///
+    async fn resolve_attribute_value(self, ctx: &DalContext) -> Result<Option<AttributeValueId>>;
+    ///
+    /// Get the AttributeValueId for this key, *or create it* if it doesn't exist
+    ///
+    async fn vivify_attribute_value(self, ctx: &DalContext) -> Result<AttributeValueId>;
+    ///
+    /// Turn this into a subscription (resolves component but not av)
+    ///
+    async fn to_subscription(self, ctx: &DalContext) -> Result<ValueSubscription>;
+}
+impl AttributeValueKey for AttributeValueId {
+    async fn lookup_attribute_value(self, _: &DalContext) -> Result<AttributeValueId> {
+        Ok(self)
+    }
+    async fn resolve_attribute_value(self, _: &DalContext) -> Result<Option<AttributeValueId>> {
+        Ok(Some(self))
+    }
+    async fn vivify_attribute_value(self, _: &DalContext) -> Result<AttributeValueId> {
+        Ok(self)
+    }
+    async fn to_subscription(self, ctx: &DalContext) -> Result<ValueSubscription> {
+        let (root, path) = AttributeValue::path_from_root(ctx, self).await?;
+        let path: &str = &path;
+        (root, path).to_subscription(ctx).await
+    }
+}
+impl AttributeValueKey for ValueSubscription {
+    async fn lookup_attribute_value(self, ctx: &DalContext) -> Result<AttributeValueId> {
+        self.resolve(ctx)
+            .await?
+            .ok_or(eyre!("Attribute value not found"))
+    }
+    async fn resolve_attribute_value(self, ctx: &DalContext) -> Result<Option<AttributeValueId>> {
+        Ok(self.resolve(ctx).await?)
+    }
+    async fn vivify_attribute_value(self, ctx: &DalContext) -> Result<AttributeValueId> {
+        Ok(self.path.vivify(ctx, self.attribute_value_id).await?)
+    }
+    async fn to_subscription(self, _: &DalContext) -> Result<ValueSubscription> {
+        Ok(self)
+    }
+}
+impl AttributeValueKey for (AttributeValueId, &str) {
+    async fn lookup_attribute_value(self, ctx: &DalContext) -> Result<AttributeValueId> {
+        self.to_subscription(ctx)
+            .await?
+            .lookup_attribute_value(ctx)
+            .await
+    }
+    async fn resolve_attribute_value(self, ctx: &DalContext) -> Result<Option<AttributeValueId>> {
+        self.to_subscription(ctx)
+            .await?
+            .resolve_attribute_value(ctx)
+            .await
+    }
+    async fn vivify_attribute_value(self, ctx: &DalContext) -> Result<AttributeValueId> {
+        self.to_subscription(ctx)
+            .await?
+            .vivify_attribute_value(ctx)
+            .await
+    }
+    async fn to_subscription(self, _: &DalContext) -> Result<ValueSubscription> {
+        Ok(ValueSubscription {
+            attribute_value_id: self.0,
+            path: AttributePath::from_json_pointer(self.1),
+        })
+    }
+}
+impl AttributeValueKey for (ComponentId, &str) {
+    async fn lookup_attribute_value(self, ctx: &DalContext) -> Result<AttributeValueId> {
+        self.to_subscription(ctx)
+            .await?
+            .lookup_attribute_value(ctx)
+            .await
+    }
+    async fn resolve_attribute_value(self, ctx: &DalContext) -> Result<Option<AttributeValueId>> {
+        self.to_subscription(ctx)
+            .await?
+            .resolve_attribute_value(ctx)
+            .await
+    }
+    async fn vivify_attribute_value(self, ctx: &DalContext) -> Result<AttributeValueId> {
+        self.to_subscription(ctx)
+            .await?
+            .vivify_attribute_value(ctx)
+            .await
+    }
+    async fn to_subscription(self, ctx: &DalContext) -> Result<ValueSubscription> {
+        let root_id = Component::root_attribute_value_id(ctx, self.0).await?;
+        (root_id, self.1).to_subscription(ctx).await
+    }
+}
+impl AttributeValueKey for (&str, &str) {
+    async fn lookup_attribute_value(self, ctx: &DalContext) -> Result<AttributeValueId> {
+        self.to_subscription(ctx)
+            .await?
+            .lookup_attribute_value(ctx)
+            .await
+    }
+    async fn resolve_attribute_value(self, ctx: &DalContext) -> Result<Option<AttributeValueId>> {
+        self.to_subscription(ctx)
+            .await?
+            .resolve_attribute_value(ctx)
+            .await
+    }
+    async fn vivify_attribute_value(self, ctx: &DalContext) -> Result<AttributeValueId> {
+        self.to_subscription(ctx)
+            .await?
+            .vivify_attribute_value(ctx)
+            .await
+    }
+    async fn to_subscription(self, ctx: &DalContext) -> Result<ValueSubscription> {
+        let component_id = self.0.lookup_component(ctx).await?;
+        (component_id, self.1).to_subscription(ctx).await
+    }
+}
+
+/// Set the subscriptions on a value
+pub async fn subscribe<S: AttributeValueKey>(
+    ctx: &DalContext,
+    subscriber: impl AttributeValueKey,
+    subscriptions: impl IntoIterator<Item = S>,
+) -> Result<()> {
+    let subscriber = subscriber.vivify_attribute_value(ctx).await?;
+    let mut converted_subscriptions = vec![];
+    for subscription in subscriptions {
+        converted_subscriptions.push(subscription.to_subscription(ctx).await?);
+    }
+    AttributeValue::set_to_subscriptions(ctx, subscriber, converted_subscriptions).await?;
+    Ok(())
+}
+
+/// Get the value
+pub async fn get(ctx: &DalContext, av: impl AttributeValueKey) -> Result<serde_json::Value> {
+    let av_id = av.lookup_attribute_value(ctx).await?;
+    AttributeValue::view_by_id(ctx, av_id)
+        .await?
+        .ok_or(eyre!("Attribute value not found"))
+}
+
+/// Check whether the value exists and is set
+pub async fn has_value(ctx: &DalContext, av: impl AttributeValueKey) -> Result<bool> {
+    match av.resolve_attribute_value(ctx).await? {
+        Some(av_id) => Ok(AttributeValue::view_by_id(ctx, av_id).await?.is_some()),
+        None => Ok(false),
+    }
+}
+
+/// Set a value (creates it if it doesn't exist)
+pub async fn set(
+    ctx: &DalContext,
+    av: impl AttributeValueKey,
+    value: impl Into<serde_json::Value>,
+) -> Result<()> {
+    let av_id = av.vivify_attribute_value(ctx).await?;
+    AttributeValue::update(ctx, av_id, Some(value.into())).await?;
+    Ok(())
+}

--- a/lib/dal-test/src/helpers/change_set.rs
+++ b/lib/dal-test/src/helpers/change_set.rs
@@ -25,6 +25,12 @@ use dal::{
 
 use crate::helpers::generate_fake_name;
 
+/// First, this function performs a blocking commit which will return an error if
+/// there are conflicts.  Then, it updates the snapshot to the current visibility.
+pub async fn commit(ctx: &mut DalContext) -> Result<()> {
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await
+}
+
 /// This unit struct providers helper functions for working with [`ChangeSets`](ChangeSet). It is
 /// designed to centralize logic for test authors wishing to commit changes, fork, apply, abandon,
 /// etc.

--- a/lib/dal-test/src/helpers/schema.rs
+++ b/lib/dal-test/src/helpers/schema.rs
@@ -1,5 +1,3 @@
-#![allow(async_fn_in_trait)]
-
 use dal::{
     DalContext,
     Schema,
@@ -17,6 +15,7 @@ pub mod variant;
 ///
 /// Things that you can pass as schema ids
 ///
+#[allow(async_fn_in_trait)]
 pub trait SchemaKey {
     ///
     /// Turn this into a real SchemaId

--- a/lib/dal-test/src/helpers/schema/variant.rs
+++ b/lib/dal-test/src/helpers/schema/variant.rs
@@ -16,8 +16,9 @@ use crate::{
 // NOTE Most of these should just be in VariantAuthoringClient
 
 ///
-/// Things that you can pass as schema variant ids
+/// Things that you can pass as schema variants (schema name or variant id)
 ///
+#[allow(async_fn_in_trait)]
 pub trait SchemaVariantKey {
     ///
     /// Turn this into a real SchemaVariantId

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -710,7 +710,7 @@ impl AttributePrototype {
         Ok(sources)
     }
 
-    pub async fn list_arguments_for_id(
+    pub async fn list_arguments(
         ctx: &DalContext,
         ap_id: AttributePrototypeId,
     ) -> AttributePrototypeResult<Vec<AttributePrototypeArgumentId>> {
@@ -744,7 +744,7 @@ impl AttributePrototype {
             }
             return Err(AttributePrototypeError::NonIdentityFunc(func.id));
         }
-        let args = AttributePrototype::list_arguments_for_id(ctx, ap_id).await?;
+        let args = AttributePrototype::list_arguments(ctx, ap_id).await?;
         let arg_id = args
             .first()
             .ok_or(AttributePrototypeError::NoArgumentsToIdentityFunction(

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -369,7 +369,7 @@ impl AttributePrototypeArgument {
     ) -> AttributePrototypeArgumentResult<Option<AttributePrototypeArgumentId>> {
         // AP --> APA --> Func Arg
 
-        for apa_id in AttributePrototype::list_arguments_for_id(ctx, ap_id).await? {
+        for apa_id in AttributePrototype::list_arguments(ctx, ap_id).await? {
             let this_func_arg_id = Self::func_argument_id_by_id(ctx, apa_id).await?;
 
             if this_func_arg_id == func_argument_id {

--- a/lib/dal/src/attribute/value/subscription.rs
+++ b/lib/dal/src/attribute/value/subscription.rs
@@ -1,6 +1,10 @@
-use super::AttributeValueResult;
+use si_id::AttributeValueId;
+
+use super::{
+    AttributeValue,
+    AttributeValueResult,
+};
 use crate::{
-    AttributeValueId,
     DalContext,
     attribute::path::AttributePath,
 };
@@ -22,5 +26,11 @@ impl ValueSubscription {
         ctx: &DalContext,
     ) -> AttributeValueResult<Option<AttributeValueId>> {
         self.path.resolve(ctx, self.attribute_value_id).await
+    }
+
+    /// Validate the subscription path matches the schema of the attribute value
+    pub async fn validate(&self, ctx: &DalContext) -> AttributeValueResult<()> {
+        let prop_id = AttributeValue::prop_id(ctx, self.attribute_value_id).await?;
+        self.path.validate(ctx, prop_id).await
     }
 }

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -285,6 +285,8 @@ pub enum ComponentError {
     NodeWeight(#[from] NodeWeightError),
     #[error("component not found: {0}")]
     NotFound(ComponentId),
+    #[error("component not found by name: {0}")]
+    NotFoundByName(String),
     #[error("object prop {0} has no ordering node")]
     ObjectPropHasNoOrderingNode(PropId),
     #[error("output socket error: {0}")]
@@ -1591,6 +1593,12 @@ impl Component {
         }
 
         Ok(None)
+    }
+
+    pub async fn get_by_name(ctx: &DalContext, name: &str) -> ComponentResult<ComponentId> {
+        Self::find_by_name(ctx, name)
+            .await?
+            .ok_or(ComponentError::NotFoundByName(name.into()))
     }
 
     pub async fn find_by_name(

--- a/lib/dal/src/property_editor/values.rs
+++ b/lib/dal/src/property_editor/values.rs
@@ -145,8 +145,7 @@ impl PropertyEditorValues {
                 // Check if the component value is explicitly connected to another component.
                 if let Some(controlling_prototype_id) = controlling_prototype_id {
                     for apa_id in
-                        AttributePrototype::list_arguments_for_id(ctx, controlling_prototype_id)
-                            .await?
+                        AttributePrototype::list_arguments(ctx, controlling_prototype_id).await?
                     {
                         for (edge, _, target) in ctx
                             .workspace_snapshot()?

--- a/lib/dal/tests/integration_test/action.rs
+++ b/lib/dal/tests/integration_test/action.rs
@@ -17,6 +17,7 @@ use dal_test::{
     Result,
     helpers::{
         ChangeSetTestHelpers,
+        attribute::value,
         component,
         connect_components_with_socket_names,
         create_component_for_default_schema_name_in_default_view,
@@ -576,9 +577,9 @@ async fn create_action_ordering_subscriptions(ctx: &mut DalContext) -> Result<()
     );
 
     // Now check that the actions are ordered correctly
-    component::subscribe(ctx, b, "/domain/two", a, "/domain/two").await?;
+    value::subscribe(ctx, (b, "/domain/two"), [(a, "/domain/two")]).await?;
     assert_eq!(vec!["Create a", "Create c"], next_actions(ctx).await?);
-    component::subscribe(ctx, c, "/domain/one", b, "/domain/one").await?;
+    value::subscribe(ctx, (c, "/domain/one"), [(b, "/domain/one")]).await?;
     assert_eq!(vec!["Create a"], next_actions(ctx).await?);
 
     Ok(())
@@ -618,7 +619,7 @@ async fn create_action_ordering_mixed(ctx: &mut DalContext) -> Result<()> {
     // Now check that the actions are ordered correctly
     connect_components_with_socket_names(ctx, a, "two", b, "two").await?;
     assert_eq!(vec!["Create a", "Create c"], next_actions(ctx).await?);
-    component::subscribe(ctx, c, "/domain/one", b, "/domain/one").await?;
+    value::subscribe(ctx, (c, "/domain/one"), [(b, "/domain/one")]).await?;
     assert_eq!(vec!["Create a"], next_actions(ctx).await?);
 
     Ok(())
@@ -636,7 +637,7 @@ async fn create_action_ordering_mixed_2(ctx: &mut DalContext) -> Result<()> {
     );
 
     // Now check that the actions are ordered correctly
-    component::subscribe(ctx, b, "/domain/two", a, "/domain/two").await?;
+    value::subscribe(ctx, (b, "/domain/two"), [(a, "/domain/two")]).await?;
     assert_eq!(vec!["Create a", "Create c"], next_actions(ctx).await?);
     connect_components_with_socket_names(ctx, b, "one", c, "one").await?;
     assert_eq!(vec!["Create a"], next_actions(ctx).await?);
@@ -662,9 +663,9 @@ async fn delete_action_ordering_subscriptions(ctx: &mut DalContext) -> Result<()
     );
 
     // Now check that the actions are ordered correctly
-    component::subscribe(ctx, b, "/domain/two", a, "/domain/two").await?;
+    value::subscribe(ctx, (b, "/domain/two"), [(a, "/domain/two")]).await?;
     assert_eq!(vec!["Destroy b", "Destroy c"], next_actions(ctx).await?);
-    component::subscribe(ctx, c, "/domain/one", b, "/domain/one").await?;
+    value::subscribe(ctx, (c, "/domain/one"), [(b, "/domain/one")]).await?;
     assert_eq!(vec!["Destroy c"], next_actions(ctx).await?);
 
     Ok(())
@@ -716,7 +717,7 @@ async fn delete_action_ordering_mixed(ctx: &mut DalContext) -> Result<()> {
     // Now check that the actions are ordered correctly
     connect_components_with_socket_names(ctx, a, "two", b, "two").await?;
     assert_eq!(vec!["Destroy b", "Destroy c"], next_actions(ctx).await?);
-    component::subscribe(ctx, c, "/domain/one", b, "/domain/one").await?;
+    value::subscribe(ctx, (c, "/domain/one"), [(b, "/domain/one")]).await?;
     assert_eq!(vec!["Destroy c"], next_actions(ctx).await?);
 
     Ok(())
@@ -740,7 +741,7 @@ async fn delete_action_ordering_mixed_2(ctx: &mut DalContext) -> Result<()> {
     );
 
     // Now check that the actions are ordered correctly
-    component::subscribe(ctx, b, "/domain/two", a, "/domain/two").await?;
+    value::subscribe(ctx, (b, "/domain/two"), [(a, "/domain/two")]).await?;
     assert_eq!(vec!["Destroy b", "Destroy c"], next_actions(ctx).await?);
     connect_components_with_socket_names(ctx, b, "one", c, "one").await?;
     assert_eq!(vec!["Destroy c"], next_actions(ctx).await?);

--- a/lib/dal/tests/integration_test/materialized_views.rs
+++ b/lib/dal/tests/integration_test/materialized_views.rs
@@ -18,9 +18,9 @@ use dal::{
 use dal_test::{
     Result,
     helpers::{
+        attribute::value,
         connect_components_with_socket_names,
         create_component_for_default_schema_name_in_default_view,
-        make_subscription,
     },
     prelude::{
         ChangeSetTestHelpers,
@@ -310,21 +310,16 @@ async fn incoming_connections(ctx: &mut DalContext) -> Result<()> {
     {
         connect_components_with_socket_names(ctx, alpha.id(), "two", beta.id(), "two").await?;
         connect_components_with_socket_names(ctx, beta.id(), "one", charlie.id(), "one").await?;
-        AttributeValue::subscribe(
+        value::subscribe(
             ctx,
             charlie_si_name_attribute_value_id,
-            make_subscription(ctx, alpha.id(), alpha_si_name_attribute_value_path.as_str()).await?,
+            [(alpha.id(), alpha_si_name_attribute_value_path.as_str())],
         )
         .await?;
-        AttributeValue::subscribe(
+        value::subscribe(
             ctx,
             charlie_domain_name_attribute_value_id,
-            make_subscription(
-                ctx,
-                beta.id(),
-                beta_domain_name_attribute_value_path.as_str(),
-            )
-            .await?,
+            [(beta.id(), beta_domain_name_attribute_value_path.as_str())],
         )
         .await?;
         ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;


### PR DESCRIPTION
This PR allows you to subscribe to multiple values from a single array, and will put them together into a single array. It has two specific changes:

1. Allows multiple subscriptions to array values
   - Changes `AttributeValue::subscribe()` to `AttributeValue::set_to_subscriptions()`, setting multiple subscriptions at once
   - Adds `keepExistingSubscriptions` option to `PUT /component/:componentId/attributes` to make it easier for the "add subscription" button to be built for arrays
2. Uses `si:normalizeToArray` instead of `si:identity` when the subscriber is an array, to uplevel single values

It will return an error if you attempt to assign multiple subscriptions to a non-array value.

## Factor Budget

* Made the tests super ergonomic with some attribute::value::set/subscribe/get helpers, letting you pass component names and attribute paths to reference things
* AttributeValue::list_arguments_for_id -> list_arguments (there is no other variant)

## Testing

- [X] Test that subscribing from an array to an array flows the values through
- [X] Test that subscribing to a single value from an array uplevels it to an array
- [X] Test that subscribing to multiple scalars flows the values through as an array
- [x] Manually test that subscriptions still work for current values

<IMG SRC="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHQ5cDJkczF3d3A4OWp3eWhzOG84NTJmMmo5dXFhMXZoYm9xZW01YSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/gmETs8k6lI3uIVYcQy/giphy.gif">