### PR TITLE
Adding the SchemaVariant as a Reference on Component

### DIFF
--- a/app/web/src/api/sdf/dal/schema.ts
+++ b/app/web/src/api/sdf/dal/schema.ts
@@ -56,6 +56,7 @@ export interface UninstalledVariant {
 }
 
 export interface SchemaVariant {
+  id: string;
   schemaVariantId: string;
   schemaName: string;
   schemaDocLinks?: string;

--- a/app/web/src/mead-hall/ActionWidget.vue
+++ b/app/web/src/mead-hall/ActionWidget.vue
@@ -57,10 +57,13 @@ import {
   DiagramNodeData,
 } from "@/components/ModelingDiagram/diagram_types";
 import { ActionId } from "@/api/sdf/dal/action";
-import { ActionPrototypeView, Component } from "@/workers/types/dbinterface";
+import {
+  ActionPrototypeView,
+  BifrostComponent,
+} from "@/workers/types/dbinterface";
 
 const props = defineProps<{
-  component: DiagramGroupData | DiagramNodeData | Component;
+  component: DiagramGroupData | DiagramNodeData | BifrostComponent;
   actionPrototypeView: ActionPrototypeView;
   actionId?: ActionId;
 }>();

--- a/app/web/src/newhotness/ActionsPanel.vue
+++ b/app/web/src/newhotness/ActionsPanel.vue
@@ -28,14 +28,14 @@ import { bifrost, makeArgs, makeKey } from "@/store/realtime/heimdall";
 import {
   ActionPrototypeViewList,
   BifrostActionViewList,
-  Component,
+  BifrostComponent,
 } from "@/workers/types/dbinterface";
 import EmptyStateCard from "@/components/EmptyStateCard.vue";
 import { ActionId, ActionPrototypeId } from "@/api/sdf/dal/action";
 import ActionWidget from "@/mead-hall/ActionWidget.vue";
 
 const props = defineProps<{
-  component: Component;
+  component: BifrostComponent;
 }>();
 
 // The code below is the same as in AssetActionsDetails in the mead hall
@@ -44,13 +44,13 @@ const props = defineProps<{
 // are available for the given component.
 const queryKeyForActionPrototypeViews = makeKey(
   "ActionPrototypeViewList",
-  props.component.schemaVariantId,
+  props.component.schemaVariant.id,
 );
 const actionPrototypeViewsRaw = useQuery<ActionPrototypeViewList | null>({
   queryKey: queryKeyForActionPrototypeViews,
   queryFn: async () =>
     await bifrost<ActionPrototypeViewList>(
-      makeArgs("ActionPrototypeViewList", props.component.schemaVariantId),
+      makeArgs("ActionPrototypeViewList", props.component.schemaVariant.id),
     ),
 });
 const actionPrototypeViews = computed(

--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -26,7 +26,7 @@ import { Fzf } from "fzf";
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import {
   AttributeTree,
-  Component,
+  BifrostComponent,
   Prop,
   AttributeValue,
 } from "@/workers/types/dbinterface";
@@ -40,7 +40,7 @@ import ComponentAttribute from "./layout_components/ComponentAttribute.vue";
 const q = ref("");
 
 const props = defineProps<{
-  component: Component;
+  component: BifrostComponent;
 }>();
 
 const componentId = computed(() => props.component.id);

--- a/app/web/src/newhotness/Component.vue
+++ b/app/web/src/newhotness/Component.vue
@@ -178,7 +178,7 @@ import { computed, ref, nextTick } from "vue";
 import { useRouter } from "vue-router";
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import {
-  Component,
+  BifrostComponent,
   BifrostComponentConnections,
 } from "@/workers/types/dbinterface";
 import AttributePanel from "./AttributePanel.vue";
@@ -204,10 +204,10 @@ const componentId = computed(() => props.componentId);
 const key = useMakeKey();
 const args = useMakeArgs();
 
-const componentQuery = useQuery<Component | null>({
+const componentQuery = useQuery<BifrostComponent | null>({
   queryKey: key("Component", componentId),
   queryFn: async () => {
-    const component = await bifrost<Component>(
+    const component = await bifrost<BifrostComponent>(
       args("Component", componentId.value),
     );
     return component;

--- a/app/web/src/newhotness/ComponentGridTile.vue
+++ b/app/web/src/newhotness/ComponentGridTile.vue
@@ -97,12 +97,12 @@ import {
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { computed } from "vue";
-import { Component } from "@/workers/types/dbinterface";
+import { BifrostComponent } from "@/workers/types/dbinterface";
 import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
 import { getAssetIcon } from "./util";
 
 const props = defineProps<{
-  component: Component;
+  component: BifrostComponent;
   hideConnections?: boolean;
 }>();
 

--- a/app/web/src/newhotness/ConnectionsPanel.vue
+++ b/app/web/src/newhotness/ConnectionsPanel.vue
@@ -16,7 +16,7 @@
 import { computed, Reactive } from "vue";
 import { useQuery } from "@tanstack/vue-query";
 import {
-  Component,
+  BifrostComponent,
   BifrostComponentConnections,
   BifrostConnection,
   OutgoingConnections,
@@ -32,7 +32,7 @@ import ConnectionLayout, {
 } from "./layout_components/ConnectionLayout.vue";
 
 const props = defineProps<{
-  component: Component;
+  component: BifrostComponent;
   connections?: BifrostComponentConnections;
 }>();
 

--- a/app/web/src/newhotness/DiffPanel.vue
+++ b/app/web/src/newhotness/DiffPanel.vue
@@ -14,10 +14,10 @@
 import { computed } from "vue";
 import CodeViewer from "@/components/CodeViewer.vue";
 import EmptyStateCard from "@/components/EmptyStateCard.vue";
-import { Component } from "@/workers/types/dbinterface";
+import { BifrostComponent } from "@/workers/types/dbinterface";
 
 const component = defineProps<{
-  component: Component;
+  component: BifrostComponent;
 }>();
 
 const diff = computed(() => {

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -149,7 +149,7 @@ import { Fzf } from "fzf";
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import {
   BifrostActionViewList,
-  Component,
+  BifrostComponent,
   BifrostComponentList,
   BifrostViewList,
   ViewComponentList,
@@ -251,7 +251,7 @@ const componentList = computed(
 
 const scrollRef = ref<HTMLDivElement>();
 
-const filteredComponents = reactive<Component[]>([]);
+const filteredComponents = reactive<BifrostComponent[]>([]);
 
 const searchString = ref("");
 const computedSearchString = computed(() => searchString.value);

--- a/app/web/src/newhotness/Map.vue
+++ b/app/web/src/newhotness/Map.vue
@@ -108,7 +108,7 @@ import * as _ from "lodash-es";
 import { Fzf } from "fzf";
 import { ComponentId } from "@/api/sdf/dal/component";
 import {
-  Component,
+  BifrostComponent,
   BifrostComponentConnections,
   BifrostIncomingConnectionsList,
 } from "@/workers/types/dbinterface";
@@ -122,7 +122,7 @@ import { getAssetIcon } from "./util";
 
 const props = defineProps<{ active: boolean }>();
 
-const selectedComponent = ref<Component | null>(null);
+const selectedComponent = ref<BifrostComponent | null>(null);
 
 const ctx = inject<Context>("CONTEXT");
 assertIsDefined(ctx);
@@ -330,14 +330,14 @@ const connections = useQuery<BifrostIncomingConnectionsList>({
 const mapData = computed(() => {
   const nodes = new Set<string>();
   const edges = new Set<string>();
-  const components: Record<string, Component> = {};
+  const components: Record<string, BifrostComponent> = {};
   if (!connections.data.value) {
     return { nodes, edges, components };
   }
 
   const matchingIds: string[] = [];
   if (searchString?.value && searchString.value.trim().length > 0) {
-    const componentsMap: Record<string, Component> = {};
+    const componentsMap: Record<string, BifrostComponent> = {};
     connections.data.value.componentConnections.forEach((c) => {
       componentsMap[c.id] = c.component;
     });
@@ -386,7 +386,7 @@ type node = {
   id: string;
   width: number;
   height: number;
-  component: Component;
+  component: BifrostComponent;
   icons: [string | null];
 };
 

--- a/app/web/src/newhotness/QualificationPanel.vue
+++ b/app/web/src/newhotness/QualificationPanel.vue
@@ -15,7 +15,7 @@ import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import {
   AttributeValue,
   AttributeTree,
-  Component,
+  BifrostComponent,
   Prop,
 } from "@/workers/types/dbinterface";
 import QualificationView from "@/newhotness/QualificationView.vue";
@@ -31,7 +31,7 @@ export interface QualItem {
 }
 
 const props = defineProps<{
-  component: Component;
+  component: BifrostComponent;
 }>();
 
 const componentId = computed(() => props.component.id);

--- a/app/web/src/newhotness/layout_components/ConnectionLayout.vue
+++ b/app/web/src/newhotness/layout_components/ConnectionLayout.vue
@@ -23,12 +23,12 @@
 
 <script setup lang="ts">
 import { useRoute, useRouter } from "vue-router";
-import { Component } from "@/workers/types/dbinterface";
+import { BifrostComponent } from "@/workers/types/dbinterface";
 
 export interface SimpleConnection {
   key: string;
   componentId: string;
-  component: Component;
+  component: BifrostComponent;
   self: string;
   other: string;
 }

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -14,7 +14,9 @@ import { Categories } from "@/store/components.store";
 import { ActionProposedView } from "@/store/actions.store";
 import { ComponentId } from "@/api/sdf/dal/component";
 import {
+  InputSocket,
   InputSocketId,
+  OutputSocket,
   OutputSocketId,
   SchemaId,
   SchemaVariantId,
@@ -285,13 +287,75 @@ export interface ComponentQualificationTotals {
   running: number;
 }
 
-export interface Component {
+export interface EddaComponent {
   id: ComponentId;
   name: string;
   color?: string;
   schemaName: string;
   schemaId: SchemaId;
-  schemaVariantId: SchemaVariantId;
+  schemaVariantId: Reference;
+  schemaVariantName: string;
+  schemaVariantDescription?: string;
+  schemaVariantDocLink?: string;
+  schemaCategory: string;
+  hasResource: boolean;
+  qualificationTotals: ComponentQualificationTotals;
+  inputCount: number;
+  // this will only be filled in when it is computed
+  outputCount: number;
+  diffCount: number;
+  rootAttributeValueId: AttributeValueId;
+  domainAttributeValueId: AttributeValueId;
+  secretsAttributeValueId: AttributeValueId;
+  siAttributeValueId: AttributeValueId;
+  resourceValueAttributeValueId: AttributeValueId;
+  resourceDiff: {
+    current?: string;
+    diff?: string;
+  };
+}
+
+export interface SchemaVariant {
+  id: string;
+  schemaVariantId: string;
+  schemaName: string;
+  schemaDocLinks?: string;
+  displayName: string | null;
+  category: string;
+  color: string;
+  link: string | null;
+  description: string | null;
+
+  created_at: IsoDateString;
+  updated_at: IsoDateString;
+
+  version: string;
+  isLocked: boolean;
+
+  schemaId: SchemaId;
+
+  inputSockets: InputSocket[];
+  outputSockets: OutputSocket[];
+  props: Prop[];
+  canCreateNewComponents: boolean;
+
+  canContribute: boolean;
+  mgmtFunctions: {
+    id: string;
+    funcId: FuncId;
+    description?: string;
+    prototypeName: string;
+    name: string;
+  }[];
+}
+
+export interface BifrostComponent {
+  id: ComponentId;
+  name: string;
+  color?: string;
+  schemaName: string;
+  schemaId: SchemaId;
+  schemaVariant: SchemaVariant;
   schemaVariantName: string;
   schemaVariantDescription?: string;
   schemaVariantDocLink?: string;
@@ -315,12 +379,12 @@ export interface Component {
 
 export interface BifrostComponentList {
   id: ChangeSetId;
-  components: Component[];
+  components: BifrostComponent[];
 }
 
 export interface ViewComponentList {
   id: ViewId;
-  components: Component[];
+  components: BifrostComponent[];
 }
 
 export interface EddaComponentList {
@@ -398,7 +462,7 @@ export interface EddaIncomingConnections {
 
 export interface BifrostComponentConnections {
   id: ComponentId;
-  component: Component;
+  component: BifrostComponent;
   incoming: BifrostConnection[];
   // note: outgoing connections cannot be computed right now
 }
@@ -434,12 +498,12 @@ export type EddaConnection =
 export type BifrostConnection =
   | {
       kind: "prop";
-      fromComponent: Component;
+      fromComponent: BifrostComponent;
       fromAttributeValueId: AttributeValueId;
       fromAttributeValuePath: string;
       fromPropId: PropId;
       fromPropPath: string;
-      toComponent: Component;
+      toComponent: BifrostComponent;
       toPropId: PropId;
       toPropPath: string;
       toAttributeValueId: AttributeValueId;
@@ -447,12 +511,12 @@ export type BifrostConnection =
     }
   | {
       kind: "socket";
-      fromComponent: Component;
+      fromComponent: BifrostComponent;
       fromAttributeValueId: AttributeValueId;
       fromAttributeValuePath: string;
       fromSocketId: OutputSocketId;
       fromSocketName: string;
-      toComponent: Component;
+      toComponent: BifrostComponent;
       toSocketId: InputSocketId;
       toSocketName: string;
       toAttributeValueId: AttributeValueId;

--- a/lib/dal-materialized-views/src/component.rs
+++ b/lib/dal-materialized-views/src/component.rs
@@ -14,6 +14,8 @@ use si_frontend_mv_types::component::{
 };
 use telemetry::prelude::*;
 
+use crate::schema_variant;
+
 pub mod attribute_tree;
 
 #[instrument(name = "dal_materialized_views.component", level = "debug", skip_all)]
@@ -72,13 +74,15 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
         diff,
     };
 
+    let sv = schema_variant::assemble(ctx.to_owned(), schema_variant.id).await?;
+
     Ok(ComponentMv {
         id: component_id,
         name: Component::name_by_id(ctx, component_id).await?,
         color,
         schema_name: schema.name.to_owned(),
         schema_id: schema.id(),
-        schema_variant_id: schema_variant.id(),
+        schema_variant_id: (&sv).into(),
         schema_variant_name: schema_variant.display_name().to_owned(),
         schema_category: schema_variant.category().to_owned(),
         schema_variant_description: schema_variant.description().to_owned(),

--- a/lib/dal-materialized-views/src/lib.rs
+++ b/lib/dal-materialized-views/src/lib.rs
@@ -56,6 +56,8 @@ pub mod component;
 pub mod component_list;
 pub mod incoming_connections;
 pub mod incoming_connections_list;
+pub mod mgmt_prototype_view_list;
+pub mod schema_variant;
 pub mod schema_variant_categories;
 pub mod view;
 pub mod view_component_list;
@@ -88,6 +90,8 @@ pub enum Error {
     InputSocket(#[from] dal::socket::input::InputSocketError),
     #[error("invalid value source: {0:?}")]
     InvalidValueSource(dal::attribute::prototype::argument::value_source::ValueSource),
+    #[error("mgmt prototype error: {0}")]
+    ManagementPrototype(#[from] dal::management::prototype::ManagementPrototypeError),
     #[error("output socket error: {0}")]
     OutputSocket(#[from] dal::socket::output::OutputSocketError),
     #[error("prop error: {0}")]

--- a/lib/dal-materialized-views/src/mgmt_prototype_view_list.rs
+++ b/lib/dal-materialized-views/src/mgmt_prototype_view_list.rs
@@ -1,0 +1,37 @@
+use dal::{
+    DalContext,
+    Func,
+    SchemaVariantId,
+    management::prototype::ManagementPrototype,
+};
+use si_frontend_mv_types::management::MgmtPrototypeView;
+use telemetry::prelude::*;
+
+#[instrument(
+  name = "dal_materialized_views.mgmt_prototype_view_list"
+  level = "debug",
+  skip_all
+)]
+pub async fn assemble(
+    ctx: &DalContext,
+    schema_variant_id: SchemaVariantId,
+) -> super::Result<Vec<MgmtPrototypeView>> {
+    let ctx = &ctx;
+    let mut views = Vec::new();
+
+    for p in ManagementPrototype::list_for_variant_id(ctx, schema_variant_id).await? {
+        let func_id = ManagementPrototype::func_id(ctx, p.id).await?;
+        let func = Func::get_by_id(ctx, func_id).await?;
+
+        views.push(MgmtPrototypeView {
+            id: p.id,
+            func_id,
+            description: p.description,
+            prototype_name: p.name,
+            name: func.name,
+        });
+    }
+
+    views.sort_by_key(|v| v.id);
+    Ok(views)
+}

--- a/lib/dal-materialized-views/src/schema_variant.rs
+++ b/lib/dal-materialized-views/src/schema_variant.rs
@@ -1,0 +1,94 @@
+use dal::{
+    DalContext,
+    InputSocket,
+    OutputSocket,
+    SchemaVariant,
+    SchemaVariantId,
+};
+use si_frontend_mv_types::{
+    InputSocket as InputSocketMv,
+    OutputSocket as OutputSocketMv,
+    Prop,
+    schema_variant::{
+        ConnectionAnnotation,
+        SchemaVariant as SchemaVariantMv,
+    },
+};
+use telemetry::prelude::*;
+
+use crate::mgmt_prototype_view_list;
+
+#[instrument(
+    name = "dal_materialized_views.schema_variant",
+    level = "debug",
+    skip_all
+)]
+pub async fn assemble(ctx: DalContext, id: SchemaVariantId) -> super::Result<SchemaVariantMv> {
+    let schema_variant = SchemaVariant::get_by_id(&ctx, id).await?;
+    let schema_id = schema_variant.schema(&ctx).await?.id();
+    let sv = schema_variant.into_frontend_type(&ctx, schema_id).await?;
+
+    let mut input_sockets = Vec::with_capacity(sv.input_sockets.len());
+    for socket_data in sv.input_sockets {
+        let dal_socket = InputSocket::get_by_id(&ctx, socket_data.id).await?;
+        let mut annotations = Vec::new();
+        for annotation in dal_socket.connection_annotations() {
+            annotations.push(ConnectionAnnotation {
+                tokens: annotation.tokens,
+            });
+        }
+        let socket = InputSocketMv {
+            id: socket_data.id,
+            name: socket_data.name,
+            eligible_to_send_data: socket_data.eligible_to_send_data,
+            annotations,
+            arity: dal_socket.arity().to_string(),
+        };
+        input_sockets.push(socket);
+    }
+    input_sockets.sort_by_key(|s| s.id);
+
+    let mut output_sockets = Vec::with_capacity(sv.output_sockets.len());
+    for socket_data in sv.output_sockets {
+        let dal_socket = OutputSocket::get_by_id(&ctx, socket_data.id).await?;
+        let mut annotations = Vec::new();
+        for annotation in dal_socket.connection_annotations() {
+            annotations.push(ConnectionAnnotation {
+                tokens: annotation.tokens,
+            });
+        }
+        let socket = OutputSocketMv {
+            id: socket_data.id,
+            name: socket_data.name,
+            eligible_to_receive_data: socket_data.eligible_to_receive_data,
+            annotations,
+            arity: dal_socket.arity().to_string(),
+        };
+        output_sockets.push(socket);
+    }
+    output_sockets.sort_by_key(|s| s.id);
+
+    let mut props: Vec<Prop> = sv.props.into_iter().map(Into::into).collect();
+    props.sort_by_key(|p| p.id);
+    let mgmt_functions = mgmt_prototype_view_list::assemble(&ctx, id).await?;
+    Ok(SchemaVariantMv {
+        id: sv.schema_variant_id,
+        schema_variant_id: sv.schema_variant_id,
+        schema_id,
+        schema_name: sv.schema_name,
+        version: sv.version,
+        display_name: sv.display_name,
+        category: sv.category,
+        description: sv.description,
+        link: sv.link,
+        color: sv.color,
+        input_sockets,
+        output_sockets,
+        props,
+        is_locked: sv.is_locked,
+        timestamp: sv.timestamp,
+        can_create_new_components: sv.can_create_new_components,
+        can_contribute: sv.can_contribute,
+        mgmt_functions,
+    })
+}

--- a/lib/dal/src/socket/connection_annotation.rs
+++ b/lib/dal/src/socket/connection_annotation.rs
@@ -26,7 +26,7 @@ pub enum ConnectionAnnotationError {
 
 #[derive(Clone, Eq, Debug, PartialEq, Deserialize, Serialize)]
 pub struct ConnectionAnnotation {
-    tokens: Vec<String>,
+    pub tokens: Vec<String>,
 }
 
 impl From<ConnectionAnnotation> for FeConnectionAnnotation {

--- a/lib/dal/tests/integration_test/materialized_views.rs
+++ b/lib/dal/tests/integration_test/materialized_views.rs
@@ -200,6 +200,10 @@ async fn component(ctx: &DalContext) -> Result<()> {
         )),
     };
 
+    let sv_id = created_component.schema_variant(ctx).await?.id();
+    let schema_variant_mv =
+        dal_materialized_views::schema_variant::assemble(ctx.clone(), sv_id).await?;
+
     assert_eq!(
         ComponentMv {
             id: created_component.id(),
@@ -207,7 +211,7 @@ async fn component(ctx: &DalContext) -> Result<()> {
             color: created_component.color(ctx).await?.to_owned(),
             schema_name: schema_name.to_owned(),
             schema_id: schema.id(),
-            schema_variant_id: schema_variant.id(),
+            schema_variant_id: (&schema_variant_mv).into(),
             schema_variant_name: schema_variant.display_name().to_owned(),
             schema_category: schema_variant.category().to_owned(),
             schema_variant_description: schema_variant.description().to_owned(),

--- a/lib/si-frontend-mv-types-rs/src/checksum.rs
+++ b/lib/si-frontend-mv-types-rs/src/checksum.rs
@@ -23,6 +23,7 @@ use si_id::{
     FuncId,
     FuncRunId,
     InputSocketId,
+    ManagementPrototypeId,
     OutputSocketId,
     PropId,
     SchemaId,
@@ -82,6 +83,12 @@ impl FrontendChecksum for ViewId {
 }
 
 impl FrontendChecksum for SchemaId {
+    fn checksum(&self) -> Checksum {
+        FrontendChecksum::checksum(&self.to_string())
+    }
+}
+
+impl FrontendChecksum for ManagementPrototypeId {
     fn checksum(&self) -> Checksum {
         FrontendChecksum::checksum(&self.to_string())
     }

--- a/lib/si-frontend-mv-types-rs/src/component.rs
+++ b/lib/si-frontend-mv-types-rs/src/component.rs
@@ -76,7 +76,8 @@ pub struct Component {
     pub color: Option<String>,
     pub schema_name: String,
     pub schema_id: SchemaId,
-    pub schema_variant_id: SchemaVariantId,
+    #[mv(reference_kind = ReferenceKind::SchemaVariant)]
+    pub schema_variant_id: Reference<SchemaVariantId>,
     pub schema_variant_name: String,
     pub schema_variant_description: Option<String>,
     pub schema_variant_doc_link: Option<String>,

--- a/lib/si-frontend-mv-types-rs/src/lib.rs
+++ b/lib/si-frontend-mv-types-rs/src/lib.rs
@@ -28,6 +28,7 @@ pub mod checksum;
 pub mod component;
 pub mod incoming_connections;
 pub mod index;
+pub mod management;
 pub mod materialized_view;
 pub mod object;
 pub mod reference;

--- a/lib/si-frontend-mv-types-rs/src/management.rs
+++ b/lib/si-frontend-mv-types-rs/src/management.rs
@@ -1,0 +1,26 @@
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_id::{
+    FuncId,
+    ManagementPrototypeId,
+};
+
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Clone,
+    si_frontend_mv_types_macros::FrontendChecksum,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct MgmtPrototypeView {
+    pub id: ManagementPrototypeId,
+    pub func_id: FuncId,
+    pub description: Option<String>,
+    pub prototype_name: String,
+    pub name: String,
+}

--- a/lib/si-frontend-mv-types-rs/src/reference.rs
+++ b/lib/si-frontend-mv-types-rs/src/reference.rs
@@ -47,6 +47,7 @@ pub enum ReferenceKind {
     IncomingConnections,
     IncomingConnectionsList,
     MvIndex,
+    SchemaVariant,
     SchemaVariantCategories,
     View,
     ViewComponentList,

--- a/lib/si-frontend-mv-types-rs/src/schema_variant.rs
+++ b/lib/si-frontend-mv-types-rs/src/schema_variant.rs
@@ -3,7 +3,6 @@ use serde::{
     Serialize,
 };
 use si_events::{
-    FuncId,
     InputSocketId,
     OutputSocketId,
     PropId,
@@ -20,7 +19,10 @@ use strum::{
     EnumString,
 };
 
-use crate::reference::ReferenceKind;
+use crate::{
+    management::MgmtPrototypeView,
+    reference::ReferenceKind,
+};
 
 #[derive(
     Clone,
@@ -30,9 +32,17 @@ use crate::reference::ReferenceKind;
     Serialize,
     PartialEq,
     si_frontend_mv_types_macros::FrontendChecksum,
+    si_frontend_mv_types_macros::FrontendObject,
+    si_frontend_mv_types_macros::Refer,
+    si_frontend_mv_types_macros::MV,
 )]
 #[serde(rename_all = "camelCase")]
+#[mv(
+    trigger_entity = EntityKind::SchemaVariant,
+    reference_kind = ReferenceKind::SchemaVariant,
+)]
 pub struct SchemaVariant {
+    pub id: SchemaVariantId,
     pub schema_id: SchemaId,
     pub schema_name: String,
     pub schema_variant_id: SchemaVariantId,
@@ -42,9 +52,6 @@ pub struct SchemaVariant {
     pub description: Option<String>,
     pub link: Option<String>,
     pub color: String,
-    pub asset_func_id: FuncId,
-    pub func_ids: Vec<FuncId>,
-    pub component_type: ComponentType,
     pub input_sockets: Vec<InputSocket>,
     pub output_sockets: Vec<OutputSocket>,
     pub props: Vec<Prop>,
@@ -53,6 +60,7 @@ pub struct SchemaVariant {
     pub timestamp: Timestamp,
     pub can_create_new_components: bool, // if yes, show in modeling screen, if not, only show in customize
     pub can_contribute: bool,
+    pub mgmt_functions: Vec<MgmtPrototypeView>,
 }
 
 #[derive(
@@ -103,10 +111,18 @@ pub enum ComponentType {
 
 #[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+pub struct ConnectionAnnotation {
+    pub tokens: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct InputSocket {
     pub id: InputSocketId,
     pub name: String,
     pub eligible_to_send_data: bool,
+    pub annotations: Vec<ConnectionAnnotation>,
+    pub arity: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
@@ -115,6 +131,8 @@ pub struct OutputSocket {
     pub id: OutputSocketId,
     pub name: String,
     pub eligible_to_receive_data: bool,
+    pub annotations: Vec<ConnectionAnnotation>,
+    pub arity: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]

--- a/lib/si-frontend-mv-types-rs/src/temporary_conversion_impls.rs
+++ b/lib/si-frontend-mv-types-rs/src/temporary_conversion_impls.rs
@@ -39,6 +39,7 @@ impl From<DeprecatedComponentQualificationStats> for ComponentQualificationStats
 impl From<DeprecatedSchemaVariant> for SchemaVariant {
     fn from(value: DeprecatedSchemaVariant) -> Self {
         Self {
+            id: value.schema_variant_id,
             schema_id: value.schema_id,
             schema_name: value.schema_name,
             schema_variant_id: value.schema_variant_id,
@@ -48,9 +49,6 @@ impl From<DeprecatedSchemaVariant> for SchemaVariant {
             description: value.description,
             link: value.link,
             color: value.color,
-            asset_func_id: value.asset_func_id,
-            func_ids: value.func_ids,
-            component_type: value.component_type.into(),
             input_sockets: value.input_sockets.into_iter().map(Into::into).collect(),
             output_sockets: value.output_sockets.into_iter().map(Into::into).collect(),
             props: value.props.into_iter().map(Into::into).collect(),
@@ -58,6 +56,7 @@ impl From<DeprecatedSchemaVariant> for SchemaVariant {
             timestamp: value.timestamp,
             can_create_new_components: value.can_create_new_components,
             can_contribute: value.can_contribute,
+            mgmt_functions: [].to_vec(),
         }
     }
 }
@@ -82,6 +81,8 @@ impl From<DeprecatedInputSocket> for InputSocket {
             id: value.id,
             name: value.name,
             eligible_to_send_data: value.eligible_to_send_data,
+            annotations: Vec::new(),
+            arity: String::new(),
         }
     }
 }
@@ -92,6 +93,8 @@ impl From<DeprecatedOutputSocket> for OutputSocket {
             id: value.id,
             name: value.name,
             eligible_to_receive_data: value.eligible_to_receive_data,
+            annotations: Vec::new(),
+            arity: String::new(),
         }
     }
 }


### PR DESCRIPTION
The `Component` has a `SchemaVariant` reference now! That reference already has the props and sockets. And we added the socket annotations & arity to the sockets. That clears @nickgerace from any work on annotations! :D 

@nickgerace and I talked about some clean up in the `into()` bits, and getting the big `SchemaVariantCategories` MV to have references to installed MVs (obviously not modules that haven't been installed)