### PR TITLE
feat(auth-stack): Ensure all members of a workspace can create a token

### DIFF
--- a/app/auth-portal/src/pages/WorkspaceAuthTokensPage.vue
+++ b/app/auth-portal/src/pages/WorkspaceAuthTokensPage.vue
@@ -26,7 +26,6 @@
         <Stack>
           <ErrorMessage :asyncState="createAuthToken" />
           <form
-            v-if="workspace.role === 'OWNER'"
             class="flex flex-row flex-wrap items-center justify-center gap-md"
           >
             <VormInput

--- a/bin/auth-api/src/routes/auth_token.routes.ts
+++ b/bin/auth-api/src/routes/auth_token.routes.ts
@@ -38,7 +38,7 @@ router.post("/workspaces/:workspaceId/authTokens", async (ctx) => {
     authUser,
     userId,
     workspace,
-  } = await authorizeWorkspaceRoute(ctx, [RoleType.OWNER]);
+  } = await authorizeWorkspaceRoute(ctx, [RoleType.OWNER, RoleType.APPROVER, RoleType.EDITOR]);
 
   // TODO - this should also get an expiration instead of just defaulting to 1d!
   // Get params from body


### PR DESCRIPTION
A workspace token is more like a PAT so we are going to allow all users of a workspace to be able to create a token. This means that individual users of a workspace can create a workspace token and use it with the public API for that workspace