### PR TITLE
chore(dal): simplify APA creation

### DIFF
--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -96,6 +96,8 @@ pub enum AttributePrototypeError {
     ChangeSet(#[from] ChangeSetError),
     #[error("func error: {0}")]
     Func(#[from] FuncError),
+    #[error("func error: {0}")]
+    FuncArgument(#[from] crate::func::argument::FuncArgumentError),
     #[error("helper error: {0}")]
     Helper(#[from] HelperError),
     #[error("layer db error: {0}")]

--- a/lib/dal/src/attribute/prototype/argument/value_source.rs
+++ b/lib/dal/src/attribute/prototype/argument/value_source.rs
@@ -53,7 +53,7 @@ pub enum ValueSourceError {
 pub type ValueSourceResult<T> = Result<T, ValueSourceError>;
 
 #[remain::sorted]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, derive_more::From)]
 pub enum ValueSource {
     InputSocket(InputSocketId),
     OutputSocket(OutputSocketId),
@@ -61,32 +61,6 @@ pub enum ValueSource {
     Secret(SecretId),
     StaticArgumentValue(StaticArgumentValueId),
     ValueSubscription(ValueSubscription),
-}
-
-impl From<InputSocketId> for ValueSource {
-    fn from(id: InputSocketId) -> Self {
-        Self::InputSocket(id)
-    }
-}
-impl From<OutputSocketId> for ValueSource {
-    fn from(id: OutputSocketId) -> Self {
-        Self::OutputSocket(id)
-    }
-}
-impl From<PropId> for ValueSource {
-    fn from(id: PropId) -> Self {
-        Self::Prop(id)
-    }
-}
-impl From<SecretId> for ValueSource {
-    fn from(id: SecretId) -> Self {
-        Self::Secret(id)
-    }
-}
-impl From<StaticArgumentValueId> for ValueSource {
-    fn from(id: StaticArgumentValueId) -> Self {
-        Self::StaticArgumentValue(id)
-    }
 }
 
 impl ValueSource {

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -2030,10 +2030,13 @@ impl AttributeValue {
                         .to_owned()
                 };
 
-                AttributePrototypeArgument::new(ctx, prototype.id(), func_arg_id)
-                    .await?
-                    .set_value_from_static_value(ctx, value.to_owned())
-                    .await?;
+                AttributePrototypeArgument::new_static_value(
+                    ctx,
+                    prototype.id(),
+                    func_arg_id,
+                    value.to_owned(),
+                )
+                .await?;
 
                 serde_json::json!({ func_arg_name: value } )
             }
@@ -2198,11 +2201,13 @@ impl AttributeValue {
                 let from_value_source =
                     AttributePrototypeArgument::value_source(ctx, from_apa_id).await?;
 
-                let dest_apa =
-                    AttributePrototypeArgument::new(ctx, dest_prototype.id(), from_func_arg_id)
-                        .await?;
-                AttributePrototypeArgument::set_value_source(ctx, dest_apa.id(), from_value_source)
-                    .await?;
+                AttributePrototypeArgument::new(
+                    ctx,
+                    dest_prototype.id(),
+                    from_func_arg_id,
+                    from_value_source,
+                )
+                .await?;
             }
 
             AttributeValue::set_component_prototype_id(ctx, dest_av_id, dest_prototype.id, None)
@@ -2294,10 +2299,10 @@ impl AttributeValue {
         // Add the subscriptions as the argument
         let arg_id = FuncArgument::single_arg_for_intrinsic(ctx, func_id).await?;
         for subscription in subscriptions {
-            let apa = AttributePrototypeArgument::new(ctx, prototype_id, arg_id).await?;
-            AttributePrototypeArgument::set_value_source(
+            AttributePrototypeArgument::new(
                 ctx,
-                apa.id(),
+                prototype_id,
+                arg_id,
                 ValueSource::ValueSubscription(subscription),
             )
             .await?;
@@ -2310,8 +2315,8 @@ impl AttributeValue {
         Ok(())
     }
 
-    // Subscriptions from this attribute value to others. If this attribute value is unset or
-    // is not set solely to subscriptions, this returns None.
+    /// Subscriptions from this attribute value to others. If this attribute value is unset or
+    /// is not set solely to subscriptions, this returns None.
     pub async fn subscriptions(
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
@@ -2332,6 +2337,7 @@ impl AttributeValue {
         Ok(Some(subscriptions))
     }
 
+    /// Subscriptions to attributes under this AV.
     pub async fn subscribers(
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1106,9 +1106,8 @@ impl Component {
         // All inputs are valid, create the component specific override
         let new_prototype = AttributePrototype::new(ctx, component_prototype_func.id).await?;
         for (func_arg_id, value_source) in new_value_sources {
-            let new_apa =
-                AttributePrototypeArgument::new(ctx, new_prototype.id, func_arg_id).await?;
-            AttributePrototypeArgument::set_value_source(ctx, new_apa.id(), value_source).await?;
+            AttributePrototypeArgument::new(ctx, new_prototype.id, func_arg_id, value_source)
+                .await?;
         }
 
         AttributeValue::set_component_prototype_id(
@@ -3601,10 +3600,10 @@ impl Component {
     #[instrument(level = "debug", skip(ctx))]
     pub async fn upgrade_to_new_variant(
         ctx: &DalContext,
-        component_id: ComponentId,
+        original_component_id: ComponentId,
         schema_variant_id: SchemaVariantId,
     ) -> ComponentResult<Component> {
-        let original_component = Self::get_by_id(ctx, component_id).await?;
+        let original_component = Self::get_by_id(ctx, original_component_id).await?;
 
         // ================================================================================
         // Cache original component data
@@ -3613,8 +3612,7 @@ impl Component {
 
         let original_component_node_weight = snap.get_node_weight(original_component.id).await?;
 
-        let original_component_name = Self::name_by_id(ctx, component_id).await?;
-        let original_component_id = component_id;
+        let original_component_name = Self::name_by_id(ctx, original_component_id).await?;
         let original_component_lineage_id = original_component_node_weight.lineage_id();
 
         let original_managed = original_component.get_managed(ctx).await?;
@@ -3625,7 +3623,7 @@ impl Component {
         let original_parent = original_component.parent(ctx).await?;
         let original_children = Component::get_children_for_id(ctx, original_component_id).await?;
 
-        let geometry_ids = Geometry::list_ids_by_component(ctx, component_id).await?;
+        let geometry_ids = Geometry::list_ids_by_component(ctx, original_component_id).await?;
 
         // ================================================================================
         // Create new component and run changes that depend on the old one still existing
@@ -3642,7 +3640,7 @@ impl Component {
         for geometry_id in geometry_ids {
             snap.remove_edge(
                 geometry_id,
-                component_id,
+                original_component_id,
                 EdgeWeightKindDiscriminants::Represents,
             )
             .await?;

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -494,7 +494,7 @@ impl AttributeBinding {
             AttributeValue::update_from_prototype_function(ctx, attribute_value).await?;
         }
 
-        for arg in &prototype_arguments {
+        for arg in prototype_arguments {
             // Ensure a func argument exists for each input location, before creating new Attribute Prototype Arguments
             if let Err(err) = FuncArgument::get_by_id(ctx, arg.func_argument_id).await {
                 match err {
@@ -509,50 +509,44 @@ impl AttributeBinding {
                 }
             }
 
-            match &arg.attribute_func_input_location {
+            match arg.attribute_func_input_location {
                 super::AttributeFuncArgumentSource::Prop(prop_id) => {
-                    let attribute_prototype_argument = AttributePrototypeArgument::new(
+                    AttributePrototypeArgument::new(
                         ctx,
                         attribute_prototype_id,
                         arg.func_argument_id,
+                        prop_id,
                     )
                     .await?;
-                    attribute_prototype_argument
-                        .set_value_from_prop_id(ctx, *prop_id)
-                        .await?;
                 }
                 super::AttributeFuncArgumentSource::InputSocket(input_socket_id) => {
-                    let attribute_prototype_argument = AttributePrototypeArgument::new(
+                    AttributePrototypeArgument::new(
                         ctx,
                         attribute_prototype_id,
                         arg.func_argument_id,
+                        input_socket_id,
                     )
                     .await?;
-                    attribute_prototype_argument
-                        .set_value_from_input_socket_id(ctx, *input_socket_id)
-                        .await?;
                 }
                 // note: this isn't in use yet, but is ready for when we enable users to set default values via the UI
                 super::AttributeFuncArgumentSource::StaticArgument(value) => {
-                    let attribute_prototype_argument = AttributePrototypeArgument::new(
+                    AttributePrototypeArgument::new_static_value(
                         ctx,
                         attribute_prototype_id,
                         arg.func_argument_id,
+                        value,
                     )
                     .await?;
-                    attribute_prototype_argument
-                        .set_value_from_static_value(ctx, value.clone())
-                        .await?;
                 }
                 // we do not allow users to manually set these as inputs right now
                 super::AttributeFuncArgumentSource::Secret(secret_id) => {
                     return Err(FuncBindingError::InvalidAttributePrototypeArgumentSource(
-                        AttributeFuncArgumentSource::Secret(*secret_id),
+                        AttributeFuncArgumentSource::Secret(secret_id),
                     ));
                 }
                 super::AttributeFuncArgumentSource::OutputSocket(output_socket_id) => {
                     return Err(FuncBindingError::InvalidAttributePrototypeArgumentSource(
-                        AttributeFuncArgumentSource::OutputSocket(*output_socket_id),
+                        AttributeFuncArgumentSource::OutputSocket(output_socket_id),
                     ));
                 }
             };
@@ -595,7 +589,7 @@ impl AttributeBinding {
         Self::delete_attribute_prototype_args(ctx, attribute_prototype_id).await?;
 
         // recreate them
-        for arg in &prototype_arguments {
+        for arg in prototype_arguments {
             // Ensure the func argument exists before continuing. By continuing, we will not add the
             // attribute prototype to the id set and will be deleted.
             if let Err(err) = FuncArgument::get_by_id(ctx, arg.func_argument_id).await {
@@ -609,50 +603,44 @@ impl AttributeBinding {
                 }
             }
 
-            match &arg.attribute_func_input_location {
+            match arg.attribute_func_input_location {
                 super::AttributeFuncArgumentSource::Prop(prop_id) => {
-                    let attribute_prototype_argument = AttributePrototypeArgument::new(
+                    AttributePrototypeArgument::new(
                         ctx,
                         attribute_prototype_id,
                         arg.func_argument_id,
+                        prop_id,
                     )
                     .await?;
-                    attribute_prototype_argument
-                        .set_value_from_prop_id(ctx, *prop_id)
-                        .await?;
                 }
                 super::AttributeFuncArgumentSource::InputSocket(input_socket_id) => {
-                    let attribute_prototype_argument = AttributePrototypeArgument::new(
+                    AttributePrototypeArgument::new(
                         ctx,
                         attribute_prototype_id,
                         arg.func_argument_id,
+                        input_socket_id,
                     )
                     .await?;
-                    attribute_prototype_argument
-                        .set_value_from_input_socket_id(ctx, *input_socket_id)
-                        .await?;
                 }
                 // note: this isn't in use yet, but is ready for when we enable users to set default values via the UI
                 super::AttributeFuncArgumentSource::StaticArgument(value) => {
-                    let attribute_prototype_argument = AttributePrototypeArgument::new(
+                    AttributePrototypeArgument::new_static_value(
                         ctx,
                         attribute_prototype_id,
                         arg.func_argument_id,
+                        value,
                     )
                     .await?;
-                    attribute_prototype_argument
-                        .set_value_from_static_value(ctx, value.clone())
-                        .await?;
                 }
                 // we do not allow users to manually set these as inputs right now
                 super::AttributeFuncArgumentSource::Secret(secret_id) => {
                     return Err(FuncBindingError::InvalidAttributePrototypeArgumentSource(
-                        AttributeFuncArgumentSource::Secret(*secret_id),
+                        AttributeFuncArgumentSource::Secret(secret_id),
                     ));
                 }
                 super::AttributeFuncArgumentSource::OutputSocket(output_socket_id) => {
                     return Err(FuncBindingError::InvalidAttributePrototypeArgumentSource(
-                        AttributeFuncArgumentSource::OutputSocket(*output_socket_id),
+                        AttributeFuncArgumentSource::OutputSocket(output_socket_id),
                     ));
                 }
             };

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -1656,23 +1656,13 @@ async fn create_attr_proto_arg(
         SiPkgAttrFuncInputView::Prop { prop_path, .. } => {
             let prop_id =
                 Prop::find_prop_id_by_path(ctx, schema_variant_id, &prop_path.into()).await?;
-            let apa = AttributePrototypeArgument::new(ctx, prototype_id, arg.id).await?;
-            let apa_id = apa.id();
-
-            apa.set_value_from_prop_id(ctx, prop_id).await?;
-
-            apa_id
+            AttributePrototypeArgument::new(ctx, prototype_id, arg.id, prop_id).await?
         }
         SiPkgAttrFuncInputView::InputSocket { socket_name, .. } => {
             let input_socket = InputSocket::find_with_name(ctx, socket_name, schema_variant_id)
                 .await?
                 .ok_or(PkgError::MissingInputSocketName(socket_name.to_owned()))?;
-            let apa = AttributePrototypeArgument::new(ctx, prototype_id, arg.id).await?;
-            let apa_id = apa.id();
-
-            apa.set_value_from_input_socket_id(ctx, input_socket.id())
-                .await?;
-            apa_id
+            AttributePrototypeArgument::new(ctx, prototype_id, arg.id, input_socket.id()).await?
         }
         SiPkgAttrFuncInputView::OutputSocket {
             name, socket_name, ..
@@ -1682,7 +1672,8 @@ async fn create_attr_proto_arg(
                 socket_name.to_owned(),
             ));
         }
-    })
+    }
+    .id())
 }
 
 #[derive(Debug, Clone)]
@@ -1971,8 +1962,8 @@ pub async fn attach_resource_payload_to_value(
             }
         }
         None => {
-            let apa = AttributePrototypeArgument::new(ctx, target_id, func_argument_id).await?;
-            apa.set_value_from_prop_id(ctx, source_prop_id).await?;
+            AttributePrototypeArgument::new(ctx, target_id, func_argument_id, source_prop_id)
+                .await?;
         }
     }
 

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -1066,7 +1066,7 @@ impl Prop {
 
         AttributePrototype::update_func_by_id(ctx, prototype_id, intrinsic_id).await?;
 
-        if let Some(existing_apa) =
+        if let Some(apa_id) =
             AttributePrototypeArgument::find_by_func_argument_id_and_attribute_prototype_id(
                 ctx,
                 func_arg_id,
@@ -1074,15 +1074,11 @@ impl Prop {
             )
             .await?
         {
-            let existing_apa = AttributePrototypeArgument::get_by_id(ctx, existing_apa).await?;
-            existing_apa.set_value_from_static_value(ctx, value).await?;
+            AttributePrototypeArgument::set_static_value_source(ctx, apa_id, value).await?;
         } else {
-            AttributePrototypeArgument::new(ctx, prototype_id, func_arg_id)
-                .await?
-                .set_value_from_static_value(ctx, value)
+            AttributePrototypeArgument::new_static_value(ctx, prototype_id, func_arg_id, value)
                 .await?;
-        }
-
+        };
         Ok(())
     }
 

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -1724,13 +1724,13 @@ impl SchemaVariant {
                     %input_prop_id, ?input.location, "adding root child attribute prototype argument",
                 );
 
-                let new_apa = AttributePrototypeArgument::new(
+                AttributePrototypeArgument::new(
                     ctx,
                     attribute_prototype_id,
                     input.func_argument_id,
+                    input_prop_id,
                 )
                 .await?;
-                new_apa.set_value_from_prop_id(ctx, input_prop_id).await?;
             }
         }
 

--- a/lib/dal/src/schema/variant/leaves.rs
+++ b/lib/dal/src/schema/variant/leaves.rs
@@ -312,10 +312,13 @@ impl SchemaVariant {
             )
             .await?;
 
-            AttributePrototypeArgument::new(ctx, attribute_prototype_id, input.func_argument_id)
-                .await?
-                .set_value_from_prop_id(ctx, input_prop_id)
-                .await?;
+            AttributePrototypeArgument::new(
+                ctx,
+                attribute_prototype_id,
+                input.func_argument_id,
+                input_prop_id,
+            )
+            .await?;
         }
 
         Ok((map_prop_id, attribute_prototype_id))

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -457,9 +457,7 @@ impl Secret {
                 func_id,
                 func_argument_name.to_owned(),
             ))?;
-        AttributePrototypeArgument::new(ctx, attribute_prototype.id(), func_argument.id)
-            .await?
-            .set_value_from_secret_id(ctx, secret_id)
+        AttributePrototypeArgument::new(ctx, attribute_prototype.id(), func_argument.id, secret_id)
             .await?;
         ctx.add_dependent_values_and_enqueue(vec![secret_id])
             .await?;

--- a/lib/sdf-server/src/service/v2/fs/bindings.rs
+++ b/lib/sdf-server/src/service/v2/fs/bindings.rs
@@ -417,7 +417,7 @@ async fn inputs_into_attribute_argument_bindings(
 
                 let apa_id = match proto_id {
                     Some(proto_id) => Some(
-                        AttributePrototypeArgument::new(ctx, proto_id, func_arg.id)
+                        AttributePrototypeArgument::new_without_source(ctx, proto_id, func_arg.id)
                             .await?
                             .id(),
                     ),


### PR DESCRIPTION
Breaking out this factoring from a feature PR I'm working on, so it and the original can be reviewed easily and quickly. This PR simplifies the creation of AttributePrototypeArguments in two ways:

1. Adds the ValueSource directly as an argument to new(), since in 10 out of 11 places, we set the ValueSource immediately after .
   - The existing source-less function is now new_without_source(), and is called in two places in si-fs.
2. Makes set_value_source() take impl Into<ValueSource>, and removing the named variants like set_value_source_from_input_socket() (so you can just call `set_value_source(<input socket id>)`)
   - Also uses derive_more::From to derive the ValueSource::from() impls, since the variants are (currently) fully discriminated by type

## Testing

- [x] Integration tests pass
- [x] Inspection of code to ensure we're doing the same thing as before