### PR TITLE
chore: flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "lastModified": 1747312588,
+        "narHash": "sha256-MmJvj6mlWzeRwKGLcwmZpKaOPZ5nJb/6al5CXqJsgjo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "rev": "b1bebd0fe266bbd1820019612ead889e96a8fa2d",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744857263,
-        "narHash": "sha256-M4X/CnquHozzgwDk+CbFb8Sb4rSGJttfNOKcpRwziis=",
+        "lastModified": 1747190175,
+        "narHash": "sha256-s33mQ2s5L/2nyllhRTywgECNZyCqyF4MJeM3vG/GaRo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9f3d63d569536cd661a4adcf697e32eb08d61e31",
+        "rev": "58160be7abad81f6f8cb53120d5b88c16e01c06d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
     flake-utils.lib.eachDefaultSystem (system: let
       overlays = [
         (self: super: {
-          nodejs = super.nodejs-18_x;
+          nodejs = super.nodejs_20;
         })
         (import rust-overlay)
       ];
@@ -35,7 +35,7 @@
       rustfmt-nightly = pkgs.rust-bin.nightly."2025-04-17".rustfmt;
 
       nodePkgs = pkgs.nodePackages.override {
-        nodejs = pkgs.nodejs_18;
+        nodejs = pkgs.nodejs_20;
       };
 
       buck2NativeBuildInputs = with pkgs;


### PR DESCRIPTION
Specifically to get the latest buck2. Needed to pull in a later nodejs as 18 is deprecated. I will confirm this locally to ensure we have no breakages. 