### PR TITLE
Add mjolnir smoke test for tools tests

### DIFF
--- a/bin/si-sdf-api-test/README.md
+++ b/bin/si-sdf-api-test/README.md
@@ -8,23 +8,19 @@ Run all tests (with auth api running locally):
 export SDF_API_URL="http://localhost:8080"
 export AUTH_API_URL="http://localhost:9001"
 
-deno task run --workspace-id $WORKSPACE_ID \
-              --userId $EMAIL \
-              --password $PASSWORD \
-              --profile '{"maxDuration": "5", "rate": "1", "useJitter": false}'
-              --tests create_and_use_variant,get_head_changeset
+export BEARER_TOKEN="<your-bearer-token>"
+export WORKSPACE_ID="<your-workspace-id>"
+export CHANGE_SET_ID="<your-change-set-id>"
 
-Usage: deno run main.ts [options]
-
-Options:
-  --workspaceId, -w   Workspace ID (required)
-  --userId, -u        User ID (optional, if token is provided)
-  --password, -p      User password (optional, if token is provided)
-  --token, -t         User token (optional, if userId and password are provided)
-  --tests, -t         Test names to run (comma-separated, optional)
-  --profile, -l       Test profile in JSON format (optional)
-  --help              Show this help message
+deno task run \
+  -w $WORKSPACE_ID \ # required
+  -c $CHANGE_SET_ID \ # optional depending on the test
+  -k $BEARER_TOKEN \ # can replace with user and password
+  -t 8-check_mjolnir # comma separated list (runs all if nothing is provied)
 ```
+
+> [!TIP]
+> Run `deno task run --help` for help options.
 
 Alternately, you can skip the password argument, pass in a userId in place of
 the email and set a jwt private key, such as
@@ -32,9 +28,16 @@ the email and set a jwt private key, such as
 in our config/keys folder, to the JWT_PRIVATE_KEY env variable. This is good for
 local development, but not how we'll do it in GitHub actions.
 
+> [!TIP]
+> You can pass in a profile as well to customize test execution setup.
+>
+> ```shell
+> --profile '{"maxDuration": "5", "rate": "1", "useJitter": false}'
+> ```
+
 ## Adding new tests
 
-Add a new file into ./tests/<something>.ts and then invoke it using the --tests
+Add a new file into `./tests/<something>.ts` and then invoke it using the --tests
 param in the binary execution
 
 ## Benchmarking

--- a/bin/si-sdf-api-test/tests/8-check_mjolnir.ts
+++ b/bin/si-sdf-api-test/tests/8-check_mjolnir.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert";
+import { SdfApiClient } from "../sdf_api_client.ts";
+import { runWithTemporaryChangeset } from "../test_helpers.ts";
+
+// ==========================
+// Tunables for testing here!
+const SCHEMA_NAME = "AWS::EC2::KeyPair"; // the schema name to be used for the test (needs to be installed on HEAD in the target workspace)
+const INDEX_MAX_CALLS = 20; // the max number of times the index route can be called
+const INDEX_SLEEP_MS = 10; // the sleep duration between each index route call
+const MJOLNIR_MAX_CALLS = 20; // the max number of times the mjolnir route can be called
+const MJOLNIR_SLEEP_MS = 10; // the sleep duration between each mjolnir route call
+// ==========================
+
+
+export default async function check_mjolnir(
+  sdfApiClient: SdfApiClient,
+  changeSetId: string,
+) {
+  if (changeSetId) {
+    return await check_mjolnir_inner(sdfApiClient, changeSetId);
+  } else {
+    return runWithTemporaryChangeset(
+      sdfApiClient,
+      check_mjolnir_inner,
+    );
+  }
+}
+
+async function check_mjolnir_inner(
+  sdfApiClient: SdfApiClient,
+  changeSetId: string,
+) {
+  // Get the schema variant
+  let schemaVariants = await sdfApiClient.call({
+    route: "schema_variants",
+    routeVars: { changeSetId },
+  });
+
+  const newCreateComponentApi = Array.isArray(schemaVariants?.installed);
+  if (newCreateComponentApi) {
+    schemaVariants = schemaVariants.installed;
+  }
+
+  assert(
+    Array.isArray(schemaVariants),
+    "List schema variants should return an array",
+  );
+  const schemaName = SCHEMA_NAME;
+  const schemaVariantId = schemaVariants.find((sv) =>
+    sv.schemaName === schemaName
+  )?.schemaVariantId;
+  assert(
+    schemaVariantId,
+    `Expected to find ${schemaName} schema and variant`,
+  );
+
+  // Create the Component
+  const createComponentPayload = {
+    schemaVariantId,
+    x: "0",
+    y: "0",
+    visibility_change_set_pk: changeSetId,
+    workspaceId: sdfApiClient.workspaceId,
+  };
+  if (newCreateComponentApi) {
+    createComponentPayload["schemaType"] = "installed";
+  }
+
+  const createComponentResp = await sdfApiClient.call({
+    route: "create_component",
+    body: createComponentPayload,
+  });
+
+  const newComponentId = createComponentResp?.componentId;
+  assert(newComponentId, "Expected to get a component id after creation");
+  
+  // Check that component exists on diagram
+  const diagram = await sdfApiClient.call({
+    route: "get_diagram",
+    routeVars: { changeSetId },
+  });
+  assert(diagram?.components, "Expected components list on the diagram");
+  assert(
+    diagram.components.length === 1,
+    "Expected a single component on the diagram",
+  );
+  const createdComponent = diagram.components[0];
+  assert(
+    createdComponent?.id === newComponentId,
+    "Expected diagram component id to match create component API return ID",
+  );
+  assert(
+    createdComponent?.schemaVariantId === schemaVariantId,
+    "Expected diagram component schema variant id to match sv id",
+  );
+
+  // Get the checksum for the individual component MV
+  let maybeChecksum = null;
+  for (let count = 1; count < INDEX_MAX_CALLS - 1; count++) {
+    const response = await sdfApiClient.call({
+      route: "index",
+      routeVars: { changeSetId },
+    });
+
+    // If we find the checksum, then we are done
+    for (const mv of response?.frontEndObject?.data?.mvList) {
+      if ((mv?.id === newComponentId) && (mv?.kind === "Component")) {
+        maybeChecksum = mv?.checksum;
+        break;
+      }
+    }
+    if (maybeChecksum) {
+      break;
+    }
+      
+    console.log(`index not yet built or available (sleeping for ${INDEX_SLEEP_MS}ms: attempt ${count} of ${INDEX_MAX_CALLS})`);
+    await new Promise(f => setTimeout(f, INDEX_SLEEP_MS));
+  }
+
+  // Confirm that we have the checksum
+  const checksum = maybeChecksum!;
+
+  // With the checksum in hand, get the component MV
+  let maybeComponentName = null;
+  for (let count = 1; count < MJOLNIR_MAX_CALLS - 1; count++) {
+    const response = await sdfApiClient.call({
+      route: "mjolnir",
+      routeVars: { changeSetId, materializedViewId: newComponentId, referenceKind: "Component", materializedViewChecksum: checksum },
+    }, true);
+
+    // If the call succeeded, try to get the component name
+    if (response?.status === 200) {
+      try {
+        const json = await response.json();
+        maybeComponentName = json?.frontEndObject?.data?.name;
+      } catch (err) {
+        console.error("Error trying to parse response body as JSON", err);
+      }
+      
+      // If we found the component name, then we are done (otherwise, retry!)
+      if (maybeComponentName) {
+        break;
+      }
+    } else if (response?.status === 404) {
+      // Retry on 404
+      console.log(`Received 404 error (retrying): ${await response.text()}`);
+    } else {
+      // Fail on non-200 and non-404 errors
+      throw new Error(`Error ${response.status}: ${await response.text()}`);
+    }
+
+    console.log(`mjolnir not yet available (sleeping for ${MJOLNIR_SLEEP_MS}ms: attempt ${count} of ${MJOLNIR_MAX_CALLS})`);
+    await new Promise(f => setTimeout(f, MJOLNIR_SLEEP_MS));
+  }
+
+  // Make sure the MV data looks as we expect
+  assert(
+    createdComponent?.displayName === maybeComponentName,
+    "Expected diagram component name to match component MV name"
+  );
+
+  // Delete the Component
+  const deleteComponentPayload = {
+    componentIds: [newComponentId],
+    forceErase: false,
+    visibility_change_set_pk: changeSetId,
+    workspaceId: sdfApiClient.workspaceId,
+  };
+  await sdfApiClient.call({
+    route: "delete_components",
+    body: deleteComponentPayload,
+  });
+
+  // Check that component has been removed from diagram
+  const diagramAfterDelete = await sdfApiClient.call({
+    route: "get_diagram",
+    routeVars: { changeSetId },
+  });
+  assert(
+    diagramAfterDelete?.components,
+    "Expected components list on the diagram",
+  );
+  assert(
+    diagramAfterDelete.components.length === 0,
+    "Expected no components on the diagram",
+  );
+}


### PR DESCRIPTION
## Description

This change adds a mjolnir smoke test for tools crons and general testing. This will be in the prod tests too.

Why use diagram calls for the test if it is likely going away in favor of the new map view? The test that was copied (the "2" API test) uses the same routes.

The README for the sdf API tests has been adjusted too for present day usage.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMWRrenBjbmo0aW1sMGM5cWZ0bWpkOWV4cThxZmVzdDlyMmYzamVsbCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/TIM1KsNP19yH8PnjkG/giphy.gif"/>