### PR TITLE
Don't lose track of MVs when rebuilding, and ensure MVs have stable output

### DIFF
--- a/lib/dal-materialized-views/src/component_list.rs
+++ b/lib/dal-materialized-views/src/component_list.rs
@@ -12,7 +12,8 @@ use telemetry::prelude::*;
 )]
 pub async fn assemble(ctx: DalContext) -> super::Result<ComponentListMv> {
     let ctx = &ctx;
-    let component_ids = Component::list_ids(ctx).await?;
+    let mut component_ids = Component::list_ids(ctx).await?;
+    component_ids.sort();
     let mut components = Vec::with_capacity(component_ids.len());
 
     for component_id in component_ids {

--- a/lib/dal-materialized-views/src/schema_variant_categories.rs
+++ b/lib/dal-materialized-views/src/schema_variant_categories.rs
@@ -93,7 +93,7 @@ pub async fn assemble(ctx: DalContext) -> super::Result<SchemaVariantCategoriesM
     let mut categories: Vec<SchemaVariantsByCategory> = vec![];
     for (name, variants) in variant_by_category.iter() {
         let mut variants = variants.to_vec();
-        variants.sort_by_key(|v| match v.variant.to_owned() {
+        variants.sort_by_cached_key(|v| match v.variant.to_owned() {
             Variant::SchemaVariant(schema_variant) => schema_variant.display_name,
             Variant::UninstalledVariant(uninstalled_variant) => uninstalled_variant
                 .display_name
@@ -104,7 +104,7 @@ pub async fn assemble(ctx: DalContext) -> super::Result<SchemaVariantCategoriesM
             schema_variants: variants,
         });
     }
-    categories.sort_by_key(|c| c.display_name.to_owned());
+    categories.sort_by_cached_key(|c| c.display_name.to_owned());
 
     Ok(SchemaVariantCategoriesMv {
         id: ctx.change_set_id(),

--- a/lib/edda-server/src/change_set_processor_task/materialized_view.rs
+++ b/lib/edda-server/src/change_set_processor_task/materialized_view.rs
@@ -604,17 +604,17 @@ fn mv_dependency_graph() -> Result<DependencyGraph<ReferenceKind>, MaterializedV
     // fields... too easy to shoot yourself in the foot.
     //
     // All `MaterializedView` types must be covered here for them to be built.
-    add_reference_dependencies_to_dependency_graph!(dependency_graph, ViewMv);
-    add_reference_dependencies_to_dependency_graph!(dependency_graph, ViewListMv);
-    add_reference_dependencies_to_dependency_graph!(dependency_graph, ViewComponentListMv);
-    add_reference_dependencies_to_dependency_graph!(dependency_graph, SchemaVariantCategoriesMv);
-    add_reference_dependencies_to_dependency_graph!(dependency_graph, SchemaVariantMv);
-    add_reference_dependencies_to_dependency_graph!(dependency_graph, ActionViewListMv);
     add_reference_dependencies_to_dependency_graph!(dependency_graph, ActionPrototypeViewListMv);
+    add_reference_dependencies_to_dependency_graph!(dependency_graph, ActionViewListMv);
     add_reference_dependencies_to_dependency_graph!(dependency_graph, ComponentListMv);
     add_reference_dependencies_to_dependency_graph!(dependency_graph, ComponentMv);
-    add_reference_dependencies_to_dependency_graph!(dependency_graph, IncomingConnectionsMv);
     add_reference_dependencies_to_dependency_graph!(dependency_graph, IncomingConnectionsListMv);
+    add_reference_dependencies_to_dependency_graph!(dependency_graph, IncomingConnectionsMv);
+    add_reference_dependencies_to_dependency_graph!(dependency_graph, SchemaVariantCategoriesMv);
+    add_reference_dependencies_to_dependency_graph!(dependency_graph, SchemaVariantMv);
+    add_reference_dependencies_to_dependency_graph!(dependency_graph, ViewComponentListMv);
+    add_reference_dependencies_to_dependency_graph!(dependency_graph, ViewListMv);
+    add_reference_dependencies_to_dependency_graph!(dependency_graph, ViewMv);
 
     // The MvIndex depends on everything else, but doesn't define any
     // `MaterializedView::reference_dependencies()` directly.

--- a/lib/edda-server/src/change_set_processor_task/materialized_view.rs
+++ b/lib/edda-server/src/change_set_processor_task/materialized_view.rs
@@ -439,7 +439,6 @@ async fn build_mv_inner(
             // If there are no more running tasks for this MV kind, then we can remove it from the dependency
             // graph to free up the next batch of MVs to run.
             if mv_kind_task_ids.get().is_empty() {
-                info!(kind = %kind, "All MV build tasks finished for MV kind.");
                 mv_dependency_graph.remove_id(kind);
             }
 

--- a/lib/edda-server/src/change_set_processor_task/materialized_view.rs
+++ b/lib/edda-server/src/change_set_processor_task/materialized_view.rs
@@ -159,7 +159,8 @@ pub async fn build_all_mv_for_change_set(
     )
     .await?;
 
-    let index_entries = frontend_objects.into_iter().map(Into::into).collect();
+    let mut index_entries: Vec<_> = frontend_objects.into_iter().map(Into::into).collect();
+    index_entries.sort();
     info!("index_entries {:?}", index_entries);
     let mv_index = MvIndex::new(ctx.change_set_id(), index_entries);
     let mv_index_frontend_object = FrontendObject::try_from(mv_index)?;

--- a/lib/edda-server/src/change_set_processor_task/materialized_view.rs
+++ b/lib/edda-server/src/change_set_processor_task/materialized_view.rs
@@ -411,14 +411,14 @@ async fn build_mv_inner(
                     }
                 }
             }
-        }
 
-        // Now that these MV kinds have had their build tasks kicked off, we want to prevent kicking them off again
-        // as MV build tasks finish, and we also don't want to free up the things that depend on them until _all_
-        // of the started tasks for that MV kind have finished. Once the build tasks have finished, we'll remove the
-        // MV kind from the graph, which will let the downstream MVs start.
-        for &running_mv_kind in &ready_to_start_mv_kinds {
-            mv_dependency_graph.cycle_on_self(running_mv_kind);
+            // Now that these MV kinds have had their build tasks kicked off, we want to prevent kicking them off again
+            // as MV build tasks finish, and we also don't want to free up the things that depend on them until _all_
+            // of the started tasks for that MV kind have finished. Once the build tasks have finished, we'll remove the
+            // MV kind from the graph, which will let the downstream MVs start.
+            for &running_mv_kind in &ready_to_start_mv_kinds {
+                mv_dependency_graph.cycle_on_self(running_mv_kind);
+            }
         }
 
         if let Some(join_result) = build_tasks.join_next().await {

--- a/lib/edda-server/src/change_set_processor_task/materialized_view.rs
+++ b/lib/edda-server/src/change_set_processor_task/materialized_view.rs
@@ -568,7 +568,7 @@ where
         };
 
         if from_checksum == to_checksum {
-            Ok((None, None))
+            Ok((None, Some(frontend_object)))
         } else {
             Ok((
                 Some(ObjectPatch {


### PR DESCRIPTION
The driving factor here is that the `MvIndex` was not always including all of the MVs that had been built. The rest are things that were discovered along the journey to find the cause behind the missing MVs.

# Always return the FrontendObject when building MVs

Previously we were skipping returning both the patch from the previous version, and the new version of the FrontendObject if the new & old versions had the same checksum to cut down on the number of "empty" patches we would send to listening clients. However, this resulted in an unstable MvIndex if any of the MVs had been previously built and we were doing a full rebuild for any reason. The full rebuild only includes the FrontendObjects that are returned from building the MVs without includeing anything from the old/current MvIndex, and when individual MVs are built, they always check the old/current MvIndex to see if there is a version that they should generate a patch against, returning neither a patch, nor the FrontendObject if the generated FrontendObjects were the same.

# Sort adding reference dependencies by MV kind in edda

The order the dependencies for each MV kind is added to the dependency graph edda uses is not significant on its own. Because of this, we can sort the order we do this in to make it easier to scan and find if a particular MV kind is being handled.

# Remove info log of all build tasks of a particular MV kind finishing in edda

This log message was happening multiple times within a single build batch, because it was only accounting for currently running tasks for that MV kind, not for any tasks that have been queued to dispatch.

Since edda's logging is pretty noisy at the moment, this is being removed instead of fixed for that to try to get a better signal to noise ratio.

# Only mark MV kinds as "building" if that kind has been dispatched or queued

In the MV kind dependency graph, we mark a kind as "running, but not finished yet" by introducing a cycle on itself to prevent trying to dispatch kinds that depend on it and to prevent trying to dispatch it again while we're waiting for its tasks to run. We should only mark a kind if we have actually dispatched, or queued its tasks.

Previously, we could have marked a kind as running, even though we had not dispatched, or queued its tasks if its dependencies had finished, but there were still queued tasks to dispatch, which would have prevented that kind and all downstream kinds from ever being dispatched.

# Ensure MVs have stable output

All lists of data, at every depth, inside of MVs must have stable output in order to prevent needless churn of telling clients that something has changed when the only reason for the change is non-deterministic output, not because of a meaningful difference in the data.