### PR TITLE
fix(web): Don't add requestUlid for list calls

### DIFF
--- a/lib/vue-lib/src/pinia/pinia_api_tools.ts
+++ b/lib/vue-lib/src/pinia/pinia_api_tools.ts
@@ -292,7 +292,10 @@ export const initPiniaApiToolkitPlugin = (config: { api: AxiosInstance }) => {
       }
 
       if (!requestSpec.params) requestSpec.params = {};
-      if (!requestSpec.passRequestUlidInHeadersOnly) {
+      if (
+        !requestSpec.passRequestUlidInHeadersOnly &&
+        requestSpec.method !== "get"
+      ) {
         requestSpec.params.requestUlid = requestUlid;
       }
 


### PR DESCRIPTION
This change ensures we don't add the request Ulid to get requests, so that we can take advantage of the deduplication logic. By adding the request Ulid, it guarantees each api request is unique, so we never find a match in the state of active/pending requests and we end up spawning many many parallel API requests for the same list calls. 

JAM On Main: https://jam.dev/c/ea2a70aa-3671-414c-b441-9fa845134829 

JAM On this Branch in tools: https://jam.dev/c/596c214e-edd1-4b97-8c3e-6cea3a68d851 

<div><img src="https://media2.giphy.com/media/fQoIDlLW6A6BAhyev8/giphy.gif?cid=5a38a5a2b051qfkk4kcf468m9zdo8ukx2g3473j4yodw9p78&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/cbc/">CBC</a> on <a href="https://giphy.com/gifs/cbc-schittscreek-schitts-creek-fQoIDlLW6A6BAhyev8">GIPHY</a></div>