### PR TITLE
Prevent flash of `loading` state with a generalized solution

### DIFF
--- a/app/web/src/newhotness/Component.vue
+++ b/app/web/src/newhotness/Component.vue
@@ -1,5 +1,6 @@
 <template>
-  <section v-if="!component">
+  <DelayedLoader v-if="componentQuery.isLoading.value" :size="'full'" />
+  <section v-else-if="!component">
     <h3 class="text-destructive-500">
       This component does not exist on this change set
     </h3>
@@ -198,6 +199,7 @@ import {
 import AttributePanel from "./AttributePanel.vue";
 import { attributeEmitter } from "./logic_composables/emitters";
 import CollapsingFlexItem from "./layout_components/CollapsingFlexItem.vue";
+import DelayedLoader from "./layout_components/DelayedLoader.vue";
 import EditInPlace from "./layout_components/EditInPlace.vue";
 import { useApi, routes, UpdateComponentNameArgs } from "./api_composables";
 import { useWatchedForm } from "./logic_composables/watched_form";

--- a/app/web/src/newhotness/layout_components/DelayedLoader.vue
+++ b/app/web/src/newhotness/layout_components/DelayedLoader.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="h-[50%] w-full">
+    <Icon v-if="show" :size="props.size" name="loader" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { Icon, IconSizes } from "@si/vue-lib/design-system";
+
+const props = defineProps<{
+  size: IconSizes;
+}>();
+
+/**
+ * The idea of this component is that, we only want to show a big loader
+ * when folks are actually waiting a significant amount of time
+ *
+ * We don't want to "flash" a loader at them for a few frames bc the tanstack
+ * query took ~90ms to return...
+ */
+const DELAY = 300; // 300ms
+const show = ref(false);
+onMounted(() => {
+  setTimeout(() => {
+    show.value = true;
+  }, DELAY);
+});
+</script>


### PR DESCRIPTION
The idea of this component is that, we only want to show a big loader when folks are actually waiting a significant amount of time. We don't want to "flash" a loader at them for a few frames bc the tanstack query took ~90ms to return...

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlcDJyZWMzYzlxYTZvcnl0NG9rdXhwNmp1cHowdW5uMGRtZmNkaHVhcCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/dSKv5HBs5XKY3mQ3gJ/giphy.gif"/>