### PR TITLE
fix(web): Don't save code when switching between functions

### DIFF
--- a/app/web/src/components/FuncEditor/FuncEditor.vue
+++ b/app/web/src/components/FuncEditor/FuncEditor.vue
@@ -118,7 +118,7 @@ const updateFuncCode = (funcId: string, code: string, debounce: boolean) => {
   if (updatedHead.value) return;
   if (!funcId) return; // protecting empty string, should never happen
   if (selectedFuncSummary.value?.isLocked) return;
-
+  if (selectedFuncSummary.value?.funcId !== funcId) return;
   updatedHead.value =
     changeSetsStore.selectedChangeSetId === changeSetsStore.headChangeSetId;
   funcStore.updateFuncCode(funcId, code, debounce);


### PR DESCRIPTION
When changing Funcs, we were saving an old copy of the as we switched, overwriting any changes that were made. This ensures we only save the code when the funcId matches the currently selected FuncId