### PR TITLE
fix: Update MVs to meet UX Needs

### DIFF
--- a/app/web/src/components/AssetPalette.vue
+++ b/app/web/src/components/AssetPalette.vue
@@ -135,7 +135,6 @@ import {
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { windowListenerManager } from "@si/vue-lib";
-import { useQuery } from "@tanstack/vue-query";
 import {
   useComponentsStore,
   getAssetIcon,
@@ -148,9 +147,6 @@ import NodeSkeleton from "@/components/NodeSkeleton.vue";
 import SidebarSubpanelTitle from "@/components/SidebarSubpanelTitle.vue";
 import EditingPill from "@/components/EditingPill.vue";
 import { useViewsStore } from "@/store/views.store";
-import { bifrost, makeArgs, makeKey } from "@/store/realtime/heimdall";
-import { useFeatureFlagsStore } from "@/store/feature_flags.store";
-import { BifrostSchemaVariantCategories } from "@/workers/types/dbinterface";
 
 const searchRef = ref<InstanceType<typeof SiSearch>>();
 
@@ -165,12 +161,7 @@ const schemasReqStatus = assetStore.getRequestStatus(
 const collapsibleRefs = ref<InstanceType<typeof TreeNode>[]>([]);
 
 const useCorrectId = (schemaVariant: CategoryVariant) => {
-  if (!ffStore.FRONTEND_ARCH_VIEWS) return schemaVariant.id;
-  else {
-    if (schemaVariant.type === "uninstalled")
-      return `${schemaVariant.type}-${schemaVariant.variant.schemaId}`;
-    return `${schemaVariant.type}-${schemaVariant.id}`;
-  }
+  return schemaVariant.id;
 };
 
 const searchString = ref("");
@@ -188,22 +179,8 @@ function onSearchUpdated(newFilterString: string) {
   });
 }
 
-const ffStore = useFeatureFlagsStore();
-
-const queryKey = makeKey("SchemaVariantCategories");
-const schemaVariantCategoriesOverBifrost =
-  useQuery<BifrostSchemaVariantCategories | null>({
-    queryKey,
-    queryFn: async () =>
-      await bifrost<BifrostSchemaVariantCategories>(
-        makeArgs("SchemaVariantCategories"),
-      ),
-  });
-
 const categories = computed(() => {
-  if (ffStore.FRONTEND_ARCH_VIEWS) {
-    return schemaVariantCategoriesOverBifrost.data.value?.categories ?? [];
-  } else return componentsStore.categories;
+  return componentsStore.categories;
 });
 
 const filteredCategoriesBySearchString = (

--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -27,7 +27,7 @@ import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import {
   AttributeTree,
   BifrostComponent,
-  PropOnComponent,
+  Prop,
   AttributeValue,
 } from "@/workers/types/dbinterface";
 import {
@@ -59,7 +59,7 @@ export interface AttrTree {
   id: string;
   children: AttrTree[];
   parent?: string;
-  prop?: PropOnComponent;
+  prop?: Prop;
   attributeValue: AttributeValue;
 }
 

--- a/app/web/src/newhotness/Component.vue
+++ b/app/web/src/newhotness/Component.vue
@@ -91,7 +91,7 @@
             class="rounded border border-neutral-600 p-xs h-12 flex flex-row items-center"
           >
             <IconButton disabled size="md" icon="play" iconTone="action" />
-            {{ func.prototypeName }}
+            {{ func.prototypeName }} {{ func }}
           </li>
         </ul>
       </CollapsingFlexItem>

--- a/app/web/src/newhotness/QualificationPanel.vue
+++ b/app/web/src/newhotness/QualificationPanel.vue
@@ -16,7 +16,7 @@ import {
   AttributeValue,
   AttributeTree,
   BifrostComponent,
-  PropOnComponent,
+  Prop,
 } from "@/workers/types/dbinterface";
 import QualificationView from "@/newhotness/QualificationView.vue";
 import { AttributeValueId } from "@/store/status.store";
@@ -80,7 +80,7 @@ const qualItems = computed<QualItem[]>(() => {
 
 const validations = computed(() => {
   const avsWithValidation: {
-    prop?: PropOnComponent;
+    prop?: Prop;
     attributeValue: AttributeValue;
   }[] = [];
   if (!root.value) return avsWithValidation;

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -10,7 +10,6 @@ import { Operation } from "fast-json-patch";
 import { Span } from "@opentelemetry/api";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import { WorkspacePk } from "@/store/workspaces.store";
-import { Categories } from "@/store/components.store";
 import { ActionProposedView } from "@/store/actions.store";
 import { ComponentId } from "@/api/sdf/dal/component";
 import {
@@ -315,6 +314,37 @@ export interface EddaComponent {
   };
 }
 
+export interface UninstalledVariant {
+  schemaId: string;
+  schemaName: string;
+  displayName: string | null;
+  category: string;
+  color: string;
+  link: string | null;
+  description: string | null;
+}
+
+export interface CategoryInstalledVariant {
+  type: "installed";
+  id: string;
+  variant: SchemaVariant;
+}
+
+export interface CategoryUninstalledVariant {
+  type: "uninstalled";
+  id: string;
+  variant: UninstalledVariant;
+}
+
+export type CategoryVariant =
+  | CategoryInstalledVariant
+  | CategoryUninstalledVariant;
+
+export type Categories = {
+  displayName: string;
+  schemaVariants: CategoryVariant[];
+}[];
+
 export interface SchemaVariant {
   id: string;
   schemaVariantId: string;
@@ -336,7 +366,10 @@ export interface SchemaVariant {
 
   inputSockets: InputSocket[];
   outputSockets: OutputSocket[];
-  props: PropOnComponent[];
+  propTree: {
+    props: Record<PropId, Prop>;
+    tree_info: Record<PropId, { parent?: PropId; children: PropId[] }>;
+  };
   canCreateNewComponents: boolean;
 
   canContribute: boolean;
@@ -346,6 +379,7 @@ export interface SchemaVariant {
     description?: string;
     prototypeName: string;
     name: string;
+    kind: string;
   }[];
 }
 
@@ -405,8 +439,7 @@ export interface ActionPrototypeViewList {
   actionPrototypes: ActionPrototypeView[];
 }
 
-// this matches what comes over the wire from Jacob's attribute tree MV
-export interface PropOnComponent {
+export interface Prop {
   id: PropId;
   path: string;
   name: string;
@@ -418,15 +451,6 @@ export interface PropOnComponent {
   defaultCanBeSetBySocket: boolean;
   isOriginSecret: boolean;
   createOnly: boolean;
-}
-
-// this matches what comes over the wire from both SDF
-// and `SchemaVariantCategories` MV
-export interface PropOnVariant {
-  id: PropId;
-  path: string;
-  name: string;
-  kind: PropKind;
   // this is for output sources
   eligibleToReceiveData: boolean;
   // this is for input sources
@@ -456,7 +480,7 @@ export interface AVTree {
 export interface AttributeTree {
   id: ComponentId;
   attributeValues: Record<AttributeValueId, AttributeValue>;
-  props: Record<PropId, PropOnComponent>;
+  props: Record<PropId, Prop>;
   treeInfo: Record<AttributeValueId, AVTree>;
 }
 

--- a/lib/dal-materialized-views/src/component.rs
+++ b/lib/dal-materialized-views/src/component.rs
@@ -54,16 +54,6 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
     let diff_count = Component::get_diff_count(ctx, component_id).await?;
     let color = Component::color_by_id(ctx, component_id).await?;
 
-    let root_attribute_value_id = Component::root_attribute_value_id(ctx, component_id).await?;
-    let domain_attribute_value_id =
-        Component::attribute_value_for_prop(ctx, component_id, &["root", "domain"]).await?;
-    let secrets_attribute_value_id =
-        Component::attribute_value_for_prop(ctx, component_id, &["root", "secrets"]).await?;
-    let si_attribute_value_id =
-        Component::attribute_value_for_prop(ctx, component_id, &["root", "si"]).await?;
-    let resource_value_attribute_value_id =
-        Component::attribute_value_for_prop(ctx, component_id, &["root", "resource_value"]).await?;
-
     let dal_component_diff = Component::get_diff(ctx, component_id).await?;
     let diff = match dal_component_diff.diff {
         Some(code_view) => code_view.code,
@@ -75,6 +65,8 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
     };
 
     let sv = schema_variant::assemble(ctx.to_owned(), schema_variant.id).await?;
+
+    let attribute_tree = attribute_tree::assemble(ctx.to_owned(), component_id).await?;
 
     Ok(ComponentMv {
         id: component_id,
@@ -91,11 +83,7 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
         qualification_totals: stats,
         input_count,
         diff_count,
-        root_attribute_value_id,
-        domain_attribute_value_id,
-        secrets_attribute_value_id,
-        si_attribute_value_id,
-        resource_value_attribute_value_id,
+        attribute_tree,
         resource_diff,
     })
 }

--- a/lib/dal-materialized-views/src/component/attribute_tree.rs
+++ b/lib/dal-materialized-views/src/component/attribute_tree.rs
@@ -11,26 +11,16 @@ use dal::{
     DalContext,
     Func,
     Prop,
-    SchemaVariant,
     Secret,
     component::ControllingFuncData,
-    prop::PropPath,
-    property_editor::schema::WidgetKind,
     validation::ValidationOutputNode,
 };
-use si_frontend_mv_types::{
-    PropKind,
-    component::attribute_tree::{
-        self,
-        AttributeTree,
-        AttributeValue as AttributeValueMv,
-        AvTreeInfo,
-        Prop as PropMv,
-        PropWidgetKind,
-        ValidationOutput,
-        WidgetOption,
-        WidgetOptions,
-    },
+use si_frontend_mv_types::component::attribute_tree::{
+    self,
+    AttributeTree,
+    AttributeValue as AttributeValueMv,
+    AvTreeInfo,
+    ValidationOutput,
 };
 use si_id::{
     AttributeValueId,
@@ -38,6 +28,8 @@ use si_id::{
     InputSocketId,
 };
 use telemetry::prelude::*;
+
+use crate::schema_variant::prop_tree;
 
 /// Generates an [`AttributeTree`] MV.
 pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Result<AttributeTree> {
@@ -194,99 +186,14 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
         if let Some(prop) = maybe_prop {
             // If si_frontend_mv_types::Prop is not already in props HashMap, build & add.
             if let std::collections::hash_map::Entry::Vacant(e) = props.entry(prop.id) {
-                let mut is_create_only = false;
-                let filtered_widget_options = prop.widget_options.clone().map(|options| {
-                    options
-                        .into_iter()
-                        .filter(|option| {
-                            if option.label() == "si_create_only_prop" {
-                                is_create_only = true;
-                                false
-                            } else {
-                                true
-                            }
-                        })
-                        .map(|option| WidgetOption {
-                            label: option.label,
-                            value: option.value,
-                        })
-                        .collect::<WidgetOptions>()
-                });
-                let default_can_be_set_by_socket =
-                    !prop.input_socket_sources(ctx).await?.is_empty();
-                let origin_secret_prop_id =
-                    if SchemaVariant::is_secret_defining(ctx, schema_variant_id).await? {
-                        let output_socket =
-                            SchemaVariant::find_output_socket_for_secret_defining_id(
-                                ctx,
-                                schema_variant_id,
-                            )
-                            .await?;
-                        Some(
-                            Prop::find_prop_id_by_path(
-                                ctx,
-                                schema_variant_id,
-                                &PropPath::new(["root", "secrets", output_socket.name()]),
-                            )
-                            .await?,
-                        )
-                    } else {
-                        None
-                    };
-                let maybe_resource = Component::resource_by_id(ctx, component_id).await?;
-                let has_resource = maybe_resource.is_some();
-
-                let prop_mv = PropMv {
-                    id: prop.id,
-                    path: prop.path(ctx).await?.as_str().to_string(),
-                    name: prop.name,
-                    kind: match prop.kind {
-                        dal::PropKind::Array => PropKind::Array,
-                        dal::PropKind::Boolean => PropKind::Boolean,
-                        dal::PropKind::Integer => PropKind::Integer,
-                        dal::PropKind::Json => PropKind::Json,
-                        dal::PropKind::Map => PropKind::Map,
-                        dal::PropKind::Object => PropKind::Object,
-                        dal::PropKind::String => PropKind::String,
-                        dal::PropKind::Float => PropKind::Float,
-                    },
-                    widget_kind: match prop.widget_kind {
-                        WidgetKind::Array => PropWidgetKind::Array,
-                        WidgetKind::Checkbox => PropWidgetKind::Checkbox,
-                        WidgetKind::CodeEditor => PropWidgetKind::CodeEditor,
-                        WidgetKind::Header => PropWidgetKind::Header,
-                        WidgetKind::Map => PropWidgetKind::Map,
-                        WidgetKind::Password => PropWidgetKind::Password,
-                        WidgetKind::Select => PropWidgetKind::Select {
-                            options: filtered_widget_options,
-                        },
-                        WidgetKind::Color => PropWidgetKind::Color,
-                        WidgetKind::Secret => PropWidgetKind::Secret {
-                            options: filtered_widget_options,
-                        },
-                        WidgetKind::Text => PropWidgetKind::Text,
-                        WidgetKind::TextArea => PropWidgetKind::TextArea,
-                        WidgetKind::ComboBox => PropWidgetKind::ComboBox {
-                            options: filtered_widget_options,
-                        },
-                    },
-                    doc_link: prop.doc_link,
-                    documentation: prop.documentation,
-                    validation_format: prop.validation_format,
-                    default_can_be_set_by_socket,
-                    is_origin_secret: match origin_secret_prop_id {
-                        Some(prop_id) => prop_id == prop.id,
-                        None => false,
-                    },
-                    create_only: is_create_only && has_resource,
-                };
+                let prop_mv =
+                    prop_tree::assemble_prop(ctx.clone(), prop.id(), schema_variant_id).await?;
                 e.insert(prop_mv);
             }
         }
     }
 
     Ok(AttributeTree {
-        id: component_id,
         attribute_values,
         props,
         tree_info,

--- a/lib/dal-materialized-views/src/incoming_connections.rs
+++ b/lib/dal-materialized-views/src/incoming_connections.rs
@@ -63,8 +63,10 @@ async fn socket_to_socket(ctx: &DalContext, component_id: ComponentId) -> Result
             continue;
         }
 
-        let (_, input_socket_attribute_value_path) =
-            AttributeValue::path_from_root(ctx, input_socket_attribute_value_id).await?;
+        let input_socket_attribute_value_path =
+            AttributeValue::get_path_for_id(ctx, input_socket_attribute_value_id)
+                .await?
+                .unwrap_or_default();
 
         for attribute_prototype_argument_id in attribute_prototype_argument_ids {
             let attribute_prototype_argument =
@@ -93,8 +95,10 @@ async fn socket_to_socket(ctx: &DalContext, component_id: ComponentId) -> Result
                 source_component_id,
             )
             .await?;
-            let (_, output_socket_attribute_value_path) =
-                AttributeValue::path_from_root(ctx, output_socket_attribute_value_id).await?;
+            let output_socket_attribute_value_path =
+                AttributeValue::get_path_for_id(ctx, output_socket_attribute_value_id)
+                    .await?
+                    .unwrap_or_default();
 
             connections.push(Connection::Socket {
                 from_component_id: source_component_id.into(),

--- a/lib/dal-materialized-views/src/schema_variant.rs
+++ b/lib/dal-materialized-views/src/schema_variant.rs
@@ -8,7 +8,6 @@ use dal::{
 use si_frontend_mv_types::{
     InputSocket as InputSocketMv,
     OutputSocket as OutputSocketMv,
-    Prop,
     schema_variant::{
         ConnectionAnnotation,
         SchemaVariant as SchemaVariantMv,
@@ -17,6 +16,7 @@ use si_frontend_mv_types::{
 use telemetry::prelude::*;
 
 use crate::mgmt_prototype_view_list;
+pub mod prop_tree;
 
 #[instrument(
     name = "dal_materialized_views.schema_variant",
@@ -68,9 +68,8 @@ pub async fn assemble(ctx: DalContext, id: SchemaVariantId) -> super::Result<Sch
     }
     output_sockets.sort_by_key(|s| s.id);
 
-    let mut props: Vec<Prop> = sv.props.into_iter().map(Into::into).collect();
-    props.sort_by_key(|p| p.id);
     let mgmt_functions = mgmt_prototype_view_list::assemble(&ctx, id).await?;
+    let prop_tree = prop_tree::assemble(ctx, id).await?;
     Ok(SchemaVariantMv {
         id: sv.schema_variant_id,
         schema_variant_id: sv.schema_variant_id,
@@ -84,11 +83,11 @@ pub async fn assemble(ctx: DalContext, id: SchemaVariantId) -> super::Result<Sch
         color: sv.color,
         input_sockets,
         output_sockets,
-        props,
         is_locked: sv.is_locked,
         timestamp: sv.timestamp,
         can_create_new_components: sv.can_create_new_components,
         can_contribute: sv.can_contribute,
         mgmt_functions,
+        prop_tree,
     })
 }

--- a/lib/dal-materialized-views/src/schema_variant/prop_tree.rs
+++ b/lib/dal-materialized-views/src/schema_variant/prop_tree.rs
@@ -1,0 +1,173 @@
+use std::collections::{
+    HashMap,
+    VecDeque,
+};
+
+use dal::{
+    DalContext,
+    Prop,
+    PropId,
+    SchemaVariant,
+    SchemaVariantId,
+    prop::PropPath,
+    property_editor::schema::WidgetKind,
+};
+use si_frontend_mv_types::schema_variant::prop_tree::{
+    Prop as PropMv,
+    PropKind,
+    PropTree,
+    PropTreeInfo,
+    PropWidgetKind,
+    WidgetOption,
+    WidgetOptions,
+};
+use telemetry::prelude::*;
+
+/// Generates a [`PropTree`] MV.
+#[instrument(
+    name = "dal_materialized_views.assemble_prop_tree"
+    level = "debug",
+    skip_all
+)]
+pub async fn assemble(
+    ctx: DalContext,
+    schema_variant_id: SchemaVariantId,
+) -> crate::Result<PropTree> {
+    let ctx = &ctx;
+
+    let root_prop_id = SchemaVariant::get_root_prop_id(ctx, schema_variant_id).await?;
+
+    let mut props = HashMap::new();
+    let mut tree_info = HashMap::new();
+
+    let mut work_queue = VecDeque::from([root_prop_id]);
+
+    while let Some(prop_id) = work_queue.pop_front() {
+        let maybe_parent_prop_id = Prop::parent_prop_id_by_id(ctx, prop_id).await?;
+        let child_prop_ids: Vec<PropId> = Prop::direct_child_prop_ids_ordered(ctx, prop_id).await?;
+
+        work_queue.extend(&child_prop_ids);
+        tree_info.insert(
+            prop_id,
+            PropTreeInfo {
+                parent: maybe_parent_prop_id,
+                children: child_prop_ids,
+            },
+        );
+
+        let prop_mv = assemble_prop(ctx.clone(), prop_id, schema_variant_id).await?;
+
+        props.insert(prop_id, prop_mv);
+    }
+
+    Ok(PropTree { props, tree_info })
+}
+
+#[instrument(
+    name = "dal_materialized_views.assemble_prop"
+    level = "debug",
+    skip_all
+)]
+pub async fn assemble_prop(
+    ctx: DalContext,
+    prop_id: PropId,
+    schema_variant_id: SchemaVariantId,
+) -> crate::Result<PropMv> {
+    let ctx = &ctx;
+
+    let prop = Prop::get_by_id(ctx, prop_id).await?;
+
+    let mut is_create_only = false;
+    let filtered_widget_options = prop.widget_options.clone().map(|options| {
+        options
+            .into_iter()
+            .filter(|option| {
+                if option.label() == "si_create_only_prop" {
+                    is_create_only = true;
+                    false
+                } else {
+                    true
+                }
+            })
+            .map(|option| WidgetOption {
+                label: option.label,
+                value: option.value,
+            })
+            .collect::<WidgetOptions>()
+    });
+    let default_can_be_set_by_socket = !prop.input_socket_sources(ctx).await?.is_empty();
+    let origin_secret_prop_id = if SchemaVariant::is_secret_defining(ctx, schema_variant_id).await?
+    {
+        let output_socket =
+            SchemaVariant::find_output_socket_for_secret_defining_id(ctx, schema_variant_id)
+                .await?;
+        Some(
+            Prop::find_prop_id_by_path(
+                ctx,
+                schema_variant_id,
+                &PropPath::new(["root", "secrets", output_socket.name()]),
+            )
+            .await?,
+        )
+    } else {
+        None
+    };
+
+    let path = prop.path(ctx).await?.to_string();
+    let prop_mv = PropMv {
+        id: prop_id,
+        path: path.to_owned(),
+        name: prop.name,
+        kind: match prop.kind {
+            dal::PropKind::Array => PropKind::Array,
+            dal::PropKind::Boolean => PropKind::Boolean,
+            dal::PropKind::Integer => PropKind::Integer,
+            dal::PropKind::Json => PropKind::Json,
+            dal::PropKind::Map => PropKind::Map,
+            dal::PropKind::Object => PropKind::Object,
+            dal::PropKind::String => PropKind::String,
+            dal::PropKind::Float => PropKind::Float,
+        },
+        widget_kind: match prop.widget_kind {
+            WidgetKind::Array => PropWidgetKind::Array,
+            WidgetKind::Checkbox => PropWidgetKind::Checkbox,
+            WidgetKind::CodeEditor => PropWidgetKind::CodeEditor,
+            WidgetKind::Header => PropWidgetKind::Header,
+            WidgetKind::Map => PropWidgetKind::Map,
+            WidgetKind::Password => PropWidgetKind::Password,
+            WidgetKind::Select => PropWidgetKind::Select {
+                options: filtered_widget_options,
+            },
+            WidgetKind::Color => PropWidgetKind::Color,
+            WidgetKind::Secret => PropWidgetKind::Secret {
+                options: filtered_widget_options,
+            },
+            WidgetKind::Text => PropWidgetKind::Text,
+            WidgetKind::TextArea => PropWidgetKind::TextArea,
+            WidgetKind::ComboBox => PropWidgetKind::ComboBox {
+                options: filtered_widget_options,
+            },
+        },
+        doc_link: prop.doc_link,
+        documentation: prop.documentation,
+        validation_format: prop.validation_format,
+        default_can_be_set_by_socket,
+        is_origin_secret: match origin_secret_prop_id {
+            Some(prop_id) => prop_id == prop.id,
+            None => false,
+        },
+        create_only: is_create_only,
+        hidden: prop.hidden,
+        eligible_to_receive_data: {
+            // props can receive data if they're on a certain part of the prop tree
+            // or if they're not a child of an array/map (for now?)
+            let eligible_by_path = path == "/root/resource_value"
+                || path == "/root/si/color"
+                || path.starts_with("/root/domain/")
+                || path.starts_with("/root/resource_value/");
+            eligible_by_path && prop.can_be_used_as_prototype_arg
+        },
+        eligible_to_send_data: prop.can_be_used_as_prototype_arg,
+    };
+    Ok(prop_mv)
+}

--- a/lib/dal-materialized-views/src/schema_variant_categories.rs
+++ b/lib/dal-materialized-views/src/schema_variant_categories.rs
@@ -38,8 +38,11 @@ pub async fn assemble(ctx: DalContext) -> super::Result<SchemaVariantCategoriesM
         let variants = variant_by_category
             .entry(category.to_owned())
             .or_insert(vec![]);
+        let variant =
+            crate::schema_variant::assemble(ctx.clone(), installed_variant.schema_variant_id)
+                .await?;
         variants.push(DisambiguateVariant {
-            variant: Variant::SchemaVariant(installed_variant.to_owned().into()),
+            variant: Variant::SchemaVariant(variant),
             variant_type: VariantType::Installed,
             id: installed_variant.schema_variant_id.to_string(),
         });

--- a/lib/edda-server/src/change_set_processor_task/materialized_view.rs
+++ b/lib/edda-server/src/change_set_processor_task/materialized_view.rs
@@ -40,7 +40,6 @@ use si_frontend_mv_types::{
     component::{
         Component as ComponentMv,
         ComponentList as ComponentListMv,
-        attribute_tree::AttributeTree as AttributeTreeMv,
     },
     incoming_connections::{
         IncomingConnections as IncomingConnectionsMv,
@@ -693,32 +692,6 @@ async fn spawn_build_mv_task_for_change_and_mv_kind(
                     change_set_mv_id,
                     ActionViewListMv,
                     dal_materialized_views::action_view_list::assemble(ctx.clone()),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
-        }
-        ReferenceKind::AttributeTree => {
-            let entity_mv_id = change.entity_id.to_string();
-
-            let trigger_entity = <AttributeTreeMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < PARALLEL_BUILD_LIMIT {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    mv_task_ids,
-                    ctx,
-                    frigg,
-                    change,
-                    entity_mv_id,
-                    AttributeTreeMv,
-                    dal_materialized_views::component::attribute_tree::assemble(
-                        ctx.clone(),
-                        si_events::ulid::Ulid::from(change.entity_id).into(),
-                    ),
                 );
             } else {
                 return Ok(Some(QueuedBuildMvTask { change, mv_kind }));

--- a/lib/si-frontend-mv-types-rs/src/checksum.rs
+++ b/lib/si-frontend-mv-types-rs/src/checksum.rs
@@ -35,13 +35,15 @@ use si_id::{
 use crate::{
     InputSocket,
     OutputSocket,
-    Prop,
-    PropKind,
-    component::attribute_tree::{
-        PropWidgetKind,
-        ValidationStatus,
+    component::attribute_tree::ValidationStatus,
+    schema_variant::{
+        SchemaVariantsByCategory,
+        prop_tree::{
+            Prop,
+            PropKind,
+            PropWidgetKind,
+        },
     },
-    schema_variant::SchemaVariantsByCategory,
 };
 
 pub trait FrontendChecksum {
@@ -134,6 +136,12 @@ impl FrontendChecksum for Prop {
         hasher.update(FrontendChecksum::checksum(&self.hidden).as_bytes());
         hasher.update(FrontendChecksum::checksum(&self.eligible_to_receive_data).as_bytes());
         hasher.update(FrontendChecksum::checksum(&self.eligible_to_send_data).as_bytes());
+        hasher.update(FrontendChecksum::checksum(&self.create_only).as_bytes());
+        hasher.update(FrontendChecksum::checksum(&self.doc_link).as_bytes());
+        hasher.update(FrontendChecksum::checksum(&self.documentation).as_bytes());
+        hasher.update(FrontendChecksum::checksum(&self.default_can_be_set_by_socket).as_bytes());
+        hasher.update(FrontendChecksum::checksum(&self.is_origin_secret).as_bytes());
+        hasher.update(FrontendChecksum::checksum(&self.widget_kind).as_bytes());
         hasher.finalize()
     }
 }

--- a/lib/si-frontend-mv-types-rs/src/component.rs
+++ b/lib/si-frontend-mv-types-rs/src/component.rs
@@ -1,16 +1,14 @@
+use attribute_tree::AttributeTree;
 use serde::{
     Deserialize,
     Serialize,
 };
 use si_events::{
+    ChangeSetId,
     ComponentId,
     SchemaId,
     SchemaVariantId,
     workspace_snapshot::EntityKind,
-};
-use si_id::{
-    AttributeValueId,
-    ChangeSetId,
 };
 
 use crate::reference::{
@@ -86,11 +84,7 @@ pub struct Component {
     pub qualification_totals: ComponentQualificationStats,
     pub input_count: usize,
     pub diff_count: usize,
-    pub root_attribute_value_id: AttributeValueId,
-    pub domain_attribute_value_id: AttributeValueId,
-    pub secrets_attribute_value_id: AttributeValueId,
-    pub si_attribute_value_id: AttributeValueId,
-    pub resource_value_attribute_value_id: AttributeValueId,
+    pub attribute_tree: AttributeTree,
     pub resource_diff: ComponentDiff,
 }
 

--- a/lib/si-frontend-mv-types-rs/src/component/attribute_tree.rs
+++ b/lib/si-frontend-mv-types-rs/src/component/attribute_tree.rs
@@ -4,18 +4,13 @@ use serde::{
     Deserialize,
     Serialize,
 };
-use si_events::workspace_snapshot::EntityKind;
 use si_id::{
     AttributeValueId,
-    ComponentId,
     PropId,
 };
 use strum::Display;
 
-use crate::{
-    PropKind,
-    reference::ReferenceKind,
-};
+use crate::schema_variant::prop_tree::Prop;
 
 // This type goes into the content store so cannot be re-ordered, only extended
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Display)]
@@ -24,64 +19,6 @@ pub enum ValidationStatus {
     Error,
     Failure,
     Success,
-}
-
-#[derive(
-    Clone,
-    Debug,
-    Deserialize,
-    Eq,
-    PartialEq,
-    Serialize,
-    si_frontend_mv_types_macros::FrontendChecksum,
-)]
-pub struct WidgetOption {
-    pub label: String,
-    pub value: String,
-}
-
-pub type WidgetOptions = Vec<WidgetOption>;
-
-#[remain::sorted]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Display)]
-#[serde(rename_all = "camelCase")]
-pub enum PropWidgetKind {
-    Array,
-    Checkbox,
-    CodeEditor,
-    Color,
-    ComboBox { options: Option<WidgetOptions> },
-    Header,
-    Map,
-    Password,
-    Secret { options: Option<WidgetOptions> },
-    Select { options: Option<WidgetOptions> },
-    Text,
-    TextArea,
-}
-
-#[derive(
-    Clone,
-    Debug,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Eq,
-    si_frontend_mv_types_macros::FrontendChecksum,
-)]
-#[serde(rename_all = "camelCase")]
-pub struct Prop {
-    pub id: PropId,
-    pub path: String,
-    pub name: String,
-    pub kind: PropKind,
-    pub widget_kind: PropWidgetKind,
-    pub doc_link: Option<String>,
-    pub documentation: Option<String>,
-    pub validation_format: Option<String>,
-    pub default_can_be_set_by_socket: bool,
-    pub is_origin_secret: bool,
-    pub create_only: bool,
 }
 
 #[derive(
@@ -130,17 +67,9 @@ pub struct AttributeValue {
     Eq,
     Clone,
     si_frontend_mv_types_macros::FrontendChecksum,
-    si_frontend_mv_types_macros::FrontendObject,
-    si_frontend_mv_types_macros::Refer,
-    si_frontend_mv_types_macros::MV,
 )]
 #[serde(rename_all = "camelCase")]
-#[mv(
-    trigger_entity = EntityKind::Component,
-    reference_kind = ReferenceKind::AttributeTree,
-)]
 pub struct AttributeTree {
-    pub id: ComponentId,
     pub attribute_values: HashMap<AttributeValueId, AttributeValue>,
     pub props: HashMap<PropId, Prop>,
     pub tree_info: HashMap<AttributeValueId, AvTreeInfo>,

--- a/lib/si-frontend-mv-types-rs/src/lib.rs
+++ b/lib/si-frontend-mv-types-rs/src/lib.rs
@@ -42,8 +42,6 @@ pub use crate::{
         ComponentType,
         InputSocket,
         OutputSocket,
-        Prop,
-        PropKind,
         SchemaVariant,
         UninstalledVariant,
     },

--- a/lib/si-frontend-mv-types-rs/src/management.rs
+++ b/lib/si-frontend-mv-types-rs/src/management.rs
@@ -6,6 +6,7 @@ use si_id::{
     FuncId,
     ManagementPrototypeId,
 };
+use strum::Display;
 
 #[derive(
     Debug,
@@ -23,4 +24,23 @@ pub struct MgmtPrototypeView {
     pub description: Option<String>,
     pub prototype_name: String,
     pub name: String,
+    pub kind: ManagementFuncKind,
+}
+
+#[remain::sorted]
+#[derive(
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Display,
+    si_frontend_mv_types_macros::FrontendChecksum,
+)]
+#[serde(rename_all = "camelCase")]
+pub enum ManagementFuncKind {
+    Discover,
+    Import,
+    Other,
 }

--- a/lib/si-frontend-mv-types-rs/src/reference.rs
+++ b/lib/si-frontend-mv-types-rs/src/reference.rs
@@ -39,7 +39,6 @@ pub use weak::WeakReference;
 pub enum ReferenceKind {
     ActionPrototypeViewList,
     ActionViewList,
-    AttributeTree,
     ChangeSetList,
     ChangeSetRecord,
     Component,

--- a/lib/si-frontend-mv-types-rs/src/schema_variant.rs
+++ b/lib/si-frontend-mv-types-rs/src/schema_variant.rs
@@ -1,3 +1,4 @@
+use prop_tree::PropTree;
 use serde::{
     Deserialize,
     Serialize,
@@ -5,7 +6,6 @@ use serde::{
 use si_events::{
     InputSocketId,
     OutputSocketId,
-    PropId,
     SchemaId,
     SchemaVariantId,
     Timestamp,
@@ -23,6 +23,8 @@ use crate::{
     management::MgmtPrototypeView,
     reference::ReferenceKind,
 };
+
+pub mod prop_tree;
 
 #[derive(
     Clone,
@@ -54,13 +56,13 @@ pub struct SchemaVariant {
     pub color: String,
     pub input_sockets: Vec<InputSocket>,
     pub output_sockets: Vec<OutputSocket>,
-    pub props: Vec<Prop>,
     pub is_locked: bool, // if unlocked, show in both places
     #[serde(flatten)]
     pub timestamp: Timestamp,
     pub can_create_new_components: bool, // if yes, show in modeling screen, if not, only show in customize
     pub can_contribute: bool,
     pub mgmt_functions: Vec<MgmtPrototypeView>,
+    pub prop_tree: PropTree,
 }
 
 #[derive(
@@ -135,33 +137,6 @@ pub struct OutputSocket {
     pub arity: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct Prop {
-    pub id: PropId,
-    pub kind: PropKind,
-    pub name: String,
-    pub path: String,
-    pub hidden: bool,
-    pub eligible_to_receive_data: bool,
-    pub eligible_to_send_data: bool,
-}
-
-#[remain::sorted]
-#[derive(Clone, Debug, Deserialize, Display, Eq, Serialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub enum PropKind {
-    Any,
-    Array,
-    Boolean,
-    Float,
-    Integer,
-    Json,
-    Map,
-    Object,
-    String,
-}
-
 #[derive(
     Clone,
     Debug,
@@ -173,6 +148,7 @@ pub enum PropKind {
     si_frontend_mv_types_macros::FrontendChecksum,
 )]
 #[serde(untagged, rename_all = "camelCase")]
+#[allow(clippy::large_enum_variant)]
 pub enum Variant {
     SchemaVariant(SchemaVariant),
     UninstalledVariant(UninstalledVariant),

--- a/lib/si-frontend-mv-types-rs/src/schema_variant/prop_tree.rs
+++ b/lib/si-frontend-mv-types-rs/src/schema_variant/prop_tree.rs
@@ -1,0 +1,104 @@
+use std::collections::HashMap;
+
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_id::PropId;
+use strum::Display;
+
+#[derive(
+    Clone,
+    Debug,
+    Deserialize,
+    Eq,
+    PartialEq,
+    Serialize,
+    si_frontend_mv_types_macros::FrontendChecksum,
+)]
+pub struct WidgetOption {
+    pub label: String,
+    pub value: String,
+}
+
+pub type WidgetOptions = Vec<WidgetOption>;
+
+#[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Prop {
+    pub id: PropId,
+    pub kind: PropKind,
+    pub widget_kind: PropWidgetKind,
+    pub name: String,
+    pub path: String,
+    pub hidden: bool,
+    pub eligible_to_receive_data: bool,
+    pub eligible_to_send_data: bool,
+    pub create_only: bool,
+    pub doc_link: Option<String>,
+    pub documentation: Option<String>,
+    pub validation_format: Option<String>,
+    pub default_can_be_set_by_socket: bool,
+    pub is_origin_secret: bool,
+}
+
+#[remain::sorted]
+#[derive(Clone, Debug, Deserialize, Display, Eq, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum PropKind {
+    Any,
+    Array,
+    Boolean,
+    Float,
+    Integer,
+    Json,
+    Map,
+    Object,
+    String,
+}
+#[remain::sorted]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Display)]
+#[serde(rename_all = "camelCase")]
+pub enum PropWidgetKind {
+    Array,
+    Checkbox,
+    CodeEditor,
+    Color,
+    ComboBox { options: Option<WidgetOptions> },
+    Header,
+    Map,
+    Password,
+    Secret { options: Option<WidgetOptions> },
+    Select { options: Option<WidgetOptions> },
+    Text,
+    TextArea,
+}
+
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Clone,
+    si_frontend_mv_types_macros::FrontendChecksum,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct PropTree {
+    pub props: HashMap<PropId, Prop>,
+    pub tree_info: HashMap<PropId, PropTreeInfo>,
+}
+
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Clone,
+    si_frontend_mv_types_macros::FrontendChecksum,
+)]
+pub struct PropTreeInfo {
+    pub parent: Option<PropId>,
+    pub children: Vec<PropId>,
+}

--- a/lib/si-frontend-mv-types-rs/src/temporary_conversion_impls.rs
+++ b/lib/si-frontend-mv-types-rs/src/temporary_conversion_impls.rs
@@ -9,19 +9,15 @@ use si_frontend_types::{
     ComponentType as DeprecatedComponentType,
     InputSocket as DeprecatedInputSocket,
     OutputSocket as DeprecatedOutputSocket,
-    Prop as DeprecatedProp,
     PropKind as DeprecatedPropKind,
-    SchemaVariant as DeprecatedSchemaVariant,
 };
 
 use crate::{
     ComponentType,
     InputSocket,
     OutputSocket,
-    Prop,
-    PropKind,
-    SchemaVariant,
     component::ComponentQualificationStats,
+    schema_variant::prop_tree::PropKind,
 };
 
 impl From<DeprecatedComponentQualificationStats> for ComponentQualificationStats {
@@ -32,31 +28,6 @@ impl From<DeprecatedComponentQualificationStats> for ComponentQualificationStats
             succeeded: value.succeeded,
             failed: value.failed,
             running: value.running,
-        }
-    }
-}
-
-impl From<DeprecatedSchemaVariant> for SchemaVariant {
-    fn from(value: DeprecatedSchemaVariant) -> Self {
-        Self {
-            id: value.schema_variant_id,
-            schema_id: value.schema_id,
-            schema_name: value.schema_name,
-            schema_variant_id: value.schema_variant_id,
-            version: value.version,
-            display_name: value.display_name,
-            category: value.category,
-            description: value.description,
-            link: value.link,
-            color: value.color,
-            input_sockets: value.input_sockets.into_iter().map(Into::into).collect(),
-            output_sockets: value.output_sockets.into_iter().map(Into::into).collect(),
-            props: value.props.into_iter().map(Into::into).collect(),
-            is_locked: value.is_locked,
-            timestamp: value.timestamp,
-            can_create_new_components: value.can_create_new_components,
-            can_contribute: value.can_contribute,
-            mgmt_functions: [].to_vec(),
         }
     }
 }
@@ -95,20 +66,6 @@ impl From<DeprecatedOutputSocket> for OutputSocket {
             eligible_to_receive_data: value.eligible_to_receive_data,
             annotations: Vec::new(),
             arity: String::new(),
-        }
-    }
-}
-
-impl From<DeprecatedProp> for Prop {
-    fn from(value: DeprecatedProp) -> Self {
-        Self {
-            id: value.id,
-            kind: value.kind.into(),
-            name: value.name,
-            path: value.path,
-            hidden: value.hidden,
-            eligible_to_receive_data: value.eligible_to_receive_data,
-            eligible_to_send_data: value.eligible_to_send_data,
         }
     }
 }


### PR DESCRIPTION
This PR includes the following updates: 
- AttributeTree is no longer a separate MV and is now included in the Component MV
- Removed the pointers to the Root AV's children as we can use the path to get what we need
- Created PropTree structure, similar to the AttributeTree, which is included with the SchemaVariant MV
- Added ManagementFuncKind as a stop gap until we support actual kinds. Note: this is hardcoded to match our Clover Discover/Import Mgmt Functions
- Return the Socket Name for the attribute path 
- Aligned the Prop structure returned in Components and Schema Variants, combining what each was using
- Return the same Schema Variant object when listing by category as with the reference to Component

