### PR TITLE
Caching possible connections for the fuzzy filter search

### DIFF
--- a/app/web/src/api/sdf/dal/schema.ts
+++ b/app/web/src/api/sdf/dal/schema.ts
@@ -27,20 +27,23 @@ export enum ComponentType {
   ConfigurationFrameUp = "configurationFrameUp",
   AggregationFrame = "aggregationFrame",
 }
+interface Socket {
+  name: string;
+  annotations: Array<{ tokens: [] }>;
+  arity: "many" | "one";
+}
 
 export type OutputSocketId = string;
 
-export interface OutputSocket {
+export interface OutputSocket extends Socket {
   id: OutputSocketId;
-  name: string;
   eligibleToReceiveData: boolean;
 }
 
 export type InputSocketId = string;
 
-export interface InputSocket {
+export interface InputSocket extends Socket {
   id: InputSocketId;
-  name: string;
   eligibleToSendData: boolean;
 }
 

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -66,6 +66,7 @@
         :attributeValueId="props.attributeTree.attributeValue.id"
         :path="props.attributeTree.attributeValue.path ?? ''"
         :kind="props.attributeTree.prop?.widgetKind"
+        :prop="props.attributeTree.prop"
         :value="props.attributeTree.attributeValue.value?.toString() ?? ''"
         :canDelete="props.attributeTree.isBuildable"
         @save="(path, id, value) => emit('save', path, id, value)"

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -108,6 +108,23 @@ export const bifrost = async <T>(args: {
   return reactive(maybeAtomDoc);
 };
 
+export const getPossibleConnections = async (args: {
+  workspaceId: string;
+  changeSetId: ChangeSetId;
+  annotation: string;
+  _direction?: "output" | "input";
+}) => {
+  // If we end up looking for sockets... we need direction
+  // But sockets are gonna die... so... ???
+  return reactive(
+    await db.getConnectionByAnnotation(
+      args.workspaceId,
+      args.changeSetId,
+      args.annotation,
+    ),
+  );
+};
+
 export const getOutgoingConnections = async (args: {
   workspaceId: string;
   changeSetId: ChangeSetId;

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -71,6 +71,15 @@ export interface DBInterface {
   initBifrost(): void;
   bifrostClose(): void;
   bifrostReconnect(): void;
+  getConnectionByAnnotation(
+    workspaceId: string,
+    changeSetId: string,
+    annotation: string,
+  ): {
+    exactMatches: Array<PossibleConnection>;
+    typeMatches: Array<PossibleConnection>;
+    nonMatches: Array<PossibleConnection>;
+  };
   getOutgoingConnectionsByComponentId(
     workspaceId: string,
     changeSetId: ChangeSetId,
@@ -254,6 +263,17 @@ interface WeakReference {
  *    (e.g. perform the full translation from Edda to Bifrost)
  * 7. `getReferences` SHALL set default/warning data that `getComputed` will write over
  */
+export type PossibleConnection = {
+  attributeValueId: string;
+  name: string;
+  path: string;
+  value: string;
+  componentName: string;
+  schemaName: string;
+  componentId: string;
+  annotation: string;
+};
+
 export interface View {
   id: string;
   name: string;


### PR DESCRIPTION
<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYTQyOHdwZGs5ODB6Y3E5am04ZzBvaHBjNDZ2NHF4OHBzejFkN2l6ZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/1oEttHTW7Dh6WFabZd/giphy-downsized-medium.gif"/>

# Possible Connections State Of the Union
- Right now, this only goes over the props within component attributeValue trees.
- It does not include components sockets
- Sockets are going the way of the dodo
- The new prop <-> prop connection API doesn't support sockets at all
- This work does not give us parity with "edges" on the old system
- The docker / butane relationship basically doesn't work in this world
- Right now, we don't yet have secrets, which means you cannot connect an AWS cred to any component that needs it

## How to Call
On attribute input focus use the key `PossibleConnections` and make the call for `getPossibleConnections` for the annotation type you have on your prop, and the direction (when looking to fill a prop, you're looking for output sockets and other props)

## Return Data
There are three pieces of the return:
- `exactMatches`: this is for "non-generic" types (e.g. string)... for example, if your prop takes `VPC ID` this will contain other `VPC ID`... if you're searching for a generic type, this will be empty.
  - right now all the prop types are generic—maybe this goes away if we don't want "stricter" types
- `typeMatches`: these are all the generic type matches (e.g. string = string)
- `nonMatches`: all the generic types that don't match (e.g. if you're looking for a string, you'll find object, map, boolean here)

You have the AV path, component name, prop name, and the value at that path. Entirely up to the UI as to how you want to display these options! And when you want to make prop <-> prop connections  you have the componentId and path for the API call