### PR TITLE
New Arch, New ChangeSet

### DIFF
--- a/app/web/src/newhotness/AddComponentModal.vue
+++ b/app/web/src/newhotness/AddComponentModal.vue
@@ -246,7 +246,7 @@ keyEmitter.on("Enter", async () => {
   else
     params = {
       schemaType,
-      schemaVariantId: selectedAsset.value.variant.schemaId,
+      schemaId: selectedAsset.value.variant.schemaId,
     };
 
   // TODO "force changeset"
@@ -254,11 +254,14 @@ keyEmitter.on("Enter", async () => {
   const call = api.endpoint<{ componentId: string }>(routes.CreateComponent, {
     viewId: viewId.value,
   });
-  const resp = await call.post<CreateComponentPayload>(payload);
-  if (api.ok(resp)) {
+  const { req, newChangeSetId } = await call.post<CreateComponentPayload>(
+    payload,
+  );
+  if (api.ok(req)) {
     const params = {
-      ...route.params,
-      componentId: resp.data.componentId,
+      workspacePk: route.params.workspacePk,
+      changeSetId: newChangeSetId || route.params.changeSetId,
+      componentId: req.data.componentId,
     };
     router.push({
       name: "new-hotness-component",

--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -24,6 +24,7 @@
 <script lang="ts" setup>
 import { computed, reactive, ref, watch } from "vue";
 import { Fzf } from "fzf";
+import { useRoute, useRouter } from "vue-router";
 import {
   AttributeTree,
   BifrostComponent,
@@ -205,6 +206,8 @@ const save = async (path: string, _id: string, value: string) => {
   await call.put<UpdateComponentAttributesArgs>(payload);
 };
 
+const router = useRouter();
+const route = useRoute();
 const remove = async (path: string, _id: string) => {
   const call = api.endpoint<{ success: boolean }>(
     routes.UpdateComponentAttributes,
@@ -213,7 +216,19 @@ const remove = async (path: string, _id: string) => {
   const payload: UpdateComponentAttributesArgs = {};
   path = path.replace("root", ""); // endpoint doesn't want it
   payload[path] = { $source: null };
-  await call.put<UpdateComponentAttributesArgs>(payload);
+  const { req, newChangeSetId } = await call.put<UpdateComponentAttributesArgs>(
+    payload,
+  );
+  if (newChangeSetId && api.ok(req)) {
+    router.push({
+      name: "new-hotness-component",
+      params: {
+        workspacePk: route.params.workspacePk,
+        changeSetId: newChangeSetId,
+        componentId: props.component.id,
+      },
+    });
+  }
 };
 
 // attributeValue is not "value" for maps.. look at children! i suspect the same for arrays, etc

--- a/app/web/src/newhotness/Component.vue
+++ b/app/web/src/newhotness/Component.vue
@@ -190,7 +190,7 @@ import {
   IconButton,
 } from "@si/vue-lib/design-system";
 import { computed, ref, nextTick } from "vue";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import {
   BifrostComponent,
@@ -291,6 +291,8 @@ const nameFormData = computed<NameFormData>(() => {
 
 const wForm = useWatchedForm<NameFormData>();
 
+const route = useRoute();
+
 const nameForm = wForm.newForm(nameFormData, async ({ value }) => {
   const name = value.name;
   // i wish the validator narrowed this type to always be a string
@@ -298,7 +300,19 @@ const nameForm = wForm.newForm(nameFormData, async ({ value }) => {
     const id = component.value?.id;
     if (!id) throw new Error("Missing id");
     const call = api.endpoint(routes.UpdateComponentName, { id });
-    await call.put<UpdateComponentNameArgs>({ name });
+    const { req, newChangeSetId } = await call.put<UpdateComponentNameArgs>({
+      name,
+    });
+    if (newChangeSetId && api.ok(req)) {
+      router.push({
+        name: "new-hotness-component",
+        params: {
+          workspacePk: route.params.workspacePk,
+          changeSetId: newChangeSetId,
+          componentId: props.componentId,
+        },
+      });
+    }
   }
 });
 

--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -1,4 +1,4 @@
-import { unref, inject } from "vue";
+import { unref, inject, ref, Ref } from "vue";
 import { AxiosResponse } from "axios";
 import { sdfApiInstance as sdf } from "@/store/apis.web";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
@@ -204,6 +204,12 @@ export enum routes {
   CreateComponent = "CreateComponent",
 }
 
+/**
+ * Once we implement the action API calls in here
+ * Those routes would also exist in here
+ */
+const CAN_MUTATE_ON_HEAD: readonly routes[] = [] as const;
+
 const _routes: Record<routes, string> = {
   GetFuncRunsPaginated: "/funcs/runs/paginated",
   FuncRun: "/funcs/runs/<id>",
@@ -219,51 +225,91 @@ export class APICall<Response> {
   workspaceId: string;
   changeSetId: string;
   path: string;
-  url: string;
   ctx: Context;
+  canMutateHead: boolean;
+  description: string;
+  inFlight: Ref<boolean>;
 
-  constructor(ctx: Context, path: string) {
+  constructor(
+    ctx: Context,
+    path: string,
+    canMutateHead: boolean,
+    description: string,
+    inFlight: Ref<boolean>,
+  ) {
     this.ctx = ctx;
     const workspaceId = unref(ctx.workspacePk);
     const changeSetId = unref(ctx.changeSetId);
-    const API_PREFIX = `v2/workspaces/${workspaceId}/change-sets/${changeSetId}`;
     this.workspaceId = workspaceId;
     this.changeSetId = changeSetId;
     this.path = path;
-    this.url = `${API_PREFIX}${this.path}`;
+    this.canMutateHead = canMutateHead;
+    this.description = description;
+    this.inFlight = inFlight;
+  }
+
+  url(): string {
+    const API_PREFIX = `v2/workspaces/${this.workspaceId}/change-sets/${this.changeSetId}`;
+    return `${API_PREFIX}${this.path}`;
   }
 
   async get(params?: URLSearchParams) {
+    this.inFlight.value = true;
     const req = await sdf<Response>({
       method: "GET",
-      url: this.url,
+      url: this.url(),
       params,
     });
+    this.inFlight.value = false;
     return req;
+  }
+
+  async makeChangeSet() {
+    const req = await sdf<{ id: string }>({
+      method: "POST",
+      url: `v2/workspaces/${this.workspaceId}/change-sets/create_change_set`,
+      data: { name: this.description },
+    });
+    if (req.status === 200) {
+      const newChangeSetId = req.data.id;
+      // following API calls will use the new changeSetId
+      this.changeSetId = newChangeSetId;
+      return newChangeSetId;
+    } else throw new Error("Unable to make change set");
   }
 
   async put<D = Record<string, unknown>>(data: D, params?: URLSearchParams) {
-    if (this.ctx.onHead.value) throw new Error("Can't make changes on head");
+    this.inFlight.value = true;
+    let newChangeSetId;
+    if (!this.canMutateHead && this.ctx.onHead.value) {
+      newChangeSetId = await this.makeChangeSet();
+    }
 
     const req = await sdf<Response>({
       method: "PUT",
-      url: this.url,
+      url: this.url(),
       params,
       data,
     });
-    return req;
+    this.inFlight.value = false;
+    return { req, newChangeSetId };
   }
 
   async post<D = Record<string, unknown>>(data: D, params?: URLSearchParams) {
-    if (this.ctx.onHead.value) throw new Error("Can't make changes on head");
+    this.inFlight.value = true;
+    let newChangeSetId;
+    if (!this.canMutateHead && this.ctx.onHead.value) {
+      newChangeSetId = await this.makeChangeSet();
+    }
 
     const req = await sdf<Response>({
       method: "POST",
-      url: this.url,
+      url: this.url(),
       params,
       data,
     });
-    return req;
+    this.inFlight.value = false;
+    return { req, newChangeSetId };
   }
 
   // very odd, i tried having a private `innerPostPut` to pass `method = "POST" | "PUT"`
@@ -285,14 +331,19 @@ export const useApi = () => {
     }
   };
 
+  const inFlight = ref(false);
   const endpoint = <Response>(key: routes, args?: Record<string, string>) => {
     let path = _routes[key];
     if (args)
       Object.entries(args).forEach(([k, v]) => {
         path = path.replace(`<${k}>`, v);
       });
-    return new APICall<Response>(ctx, path);
+    const canMutateHead = CAN_MUTATE_ON_HEAD.includes(key);
+    const desc = `${key} ${
+      args ? [...Object.entries(args)].flatMap((m) => m).join(": ") : ""
+    } by ${ctx.user?.name} on ${new Date().toLocaleDateString()}`;
+    return new APICall<Response>(ctx, path, canMutateHead, desc, inFlight);
   };
 
-  return { ok, endpoint };
+  return { ok, endpoint, inFlight };
 };

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -79,6 +79,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { VButton, IconButton, Icon } from "@si/vue-lib/design-system";
+import { useRoute, useRouter } from "vue-router";
 import { BifrostComponent } from "@/workers/types/dbinterface";
 import AttributeChildLayout from "./AttributeChildLayout.vue";
 import AttributeInput from "./AttributeInput.vue";
@@ -157,6 +158,8 @@ const add = async () => {
   );
 };
 
+const router = useRouter();
+const route = useRoute();
 const showKey = ref(false);
 const wForm = useWatchedForm<{ key: string }>();
 const keyData = ref({ key: "" });
@@ -171,7 +174,19 @@ const keyForm = wForm.newForm(keyData, async ({ value }) => {
       .replace("root", "")
       .replaceAll("\u000b", "/") ?? ""; // endpoint doesn't want it
   payload[`${path}/${value.key}`] = "";
-  await call.put<UpdateComponentAttributesArgs>(payload);
+  const { req, newChangeSetId } = await call.put<UpdateComponentAttributesArgs>(
+    payload,
+  );
+  if (newChangeSetId && api.ok(req)) {
+    router.push({
+      name: "new-hotness-component",
+      params: {
+        workspacePk: route.params.workspacePk,
+        changeSetId: newChangeSetId,
+        componentId: props.component.id,
+      },
+    });
+  }
 });
 
 const saveKey = async () => {

--- a/app/web/src/newhotness/types.ts
+++ b/app/web/src/newhotness/types.ts
@@ -6,6 +6,7 @@ export interface Context {
   changeSetId: ComputedRef<string>;
   user: User | null;
   onHead: ComputedRef<boolean>;
+  headChangeSetId: ComputedRef<string>;
 }
 
 export function assertIsDefined<T>(value: T | undefined): asserts value is T {

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -125,6 +125,21 @@ export const getPossibleConnections = async (args: {
   );
 };
 
+export const linkNewChangeset = async (
+  workspaceId: string,
+  changeSetId: string,
+  workspaceSnapshotAddress: string,
+) => {
+  const changeSetsStore = useChangeSetsStore();
+  if (!changeSetsStore.headChangeSetId) throw new Error("Don't have HEAD");
+  await db.linkNewChangeset(
+    workspaceId,
+    changeSetsStore.headChangeSetId,
+    changeSetId,
+    workspaceSnapshotAddress,
+  );
+};
+
 export const getOutgoingConnections = async (args: {
   workspaceId: string;
   changeSetId: ChangeSetId;

--- a/app/web/src/store/realtime/realtime.store.ts
+++ b/app/web/src/store/realtime/realtime.store.ts
@@ -336,7 +336,7 @@ export const useRealtimeStore = defineStore("realtime", () => {
         eventMetadata.actor !== "System" &&
         eventMetadata.actor.User === authStore.userPk
       ) {
-        bufferWatchList.push(eventData);
+        bufferWatchList.push(eventData.changeSetId);
       }
     }
     if (eventKind === "ChangeSetApplied") {

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -90,7 +90,10 @@ export type WsEventPayloadMap = {
     changeSetId: string | null;
     viewId: string | null;
   };
-  ChangeSetCreated: string;
+  ChangeSetCreated: {
+    changeSetId: string;
+    workspaceSnapshotAddress: string;
+  };
   ChangeSetWritten: string;
   ChangeSetCancelled: string;
   Conflict: string;

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -71,6 +71,12 @@ export interface DBInterface {
   initBifrost(): void;
   bifrostClose(): void;
   bifrostReconnect(): void;
+  linkNewChangeset(
+    workspaceId: string,
+    headChangeSetId: string,
+    changeSetId: string,
+    workspaceSnapshotAddress: string,
+  ): Promise<void>;
   getConnectionByAnnotation(
     workspaceId: string,
     changeSetId: string,

--- a/lib/dal/src/change_set/event.rs
+++ b/lib/dal/src/change_set/event.rs
@@ -2,6 +2,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use si_events::WorkspaceSnapshotAddress;
 
 use crate::{
     ChangeSetId,
@@ -24,8 +25,16 @@ impl WsEvent {
     pub async fn change_set_created(
         ctx: &DalContext,
         change_set_id: ChangeSetId,
+        workspace_snapshot_address: WorkspaceSnapshotAddress,
     ) -> WsEventResult<Self> {
-        WsEvent::new(ctx, WsPayload::ChangeSetCreated(change_set_id)).await
+        WsEvent::new(
+            ctx,
+            WsPayload::ChangeSetCreated(ChangeSetCreatedPayload {
+                change_set_id,
+                workspace_snapshot_address,
+            }),
+        )
+        .await
     }
 
     pub async fn change_set_approval_status_changed(
@@ -190,4 +199,11 @@ pub struct ChangeSetMergeVotePayload {
 pub struct ChangeSetRenamePayload {
     change_set_id: ChangeSetId,
     new_name: String,
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeSetCreatedPayload {
+    change_set_id: ChangeSetId,
+    workspace_snapshot_address: WorkspaceSnapshotAddress,
 }

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -30,6 +30,7 @@ use crate::{
     change_set::event::{
         ChangeSetActorPayload,
         ChangeSetAppliedPayload,
+        ChangeSetCreatedPayload,
         ChangeSetMergeVotePayload,
         ChangeSetRenamePayload,
         ChangeSetStateChangePayload,
@@ -134,7 +135,7 @@ pub enum WsPayload {
     ChangeSetCancelAbandonProcess(ChangeSetActorPayload),
     ChangeSetCancelApprovalProcess(ChangeSetActorPayload),
     ChangeSetCanceled(ChangeSetId),
-    ChangeSetCreated(ChangeSetId),
+    ChangeSetCreated(ChangeSetCreatedPayload),
     ChangeSetMergeVote(ChangeSetMergeVotePayload),
     ChangeSetRename(ChangeSetRenamePayload),
     ChangeSetStatusChanged(ChangeSetStateChangePayload),

--- a/lib/luminork-server/src/service/v1/change_sets/create.rs
+++ b/lib/luminork-server/src/service/v1/change_sets/create.rs
@@ -58,7 +58,7 @@ pub async fn create_change_set(
     ctx.write_audit_log(AuditLogKind::CreateChangeSet, payload.change_set_name)
         .await?;
 
-    WsEvent::change_set_created(ctx, change_set.id)
+    WsEvent::change_set_created(ctx, change_set.id, change_set.workspace_snapshot_address)
         .await?
         .publish_on_commit(ctx)
         .await?;

--- a/lib/sdf-server/src/service/public/change_sets.rs
+++ b/lib/sdf-server/src/service/public/change_sets.rs
@@ -89,7 +89,7 @@ async fn create_change_set(
     ctx.write_audit_log(AuditLogKind::CreateChangeSet, payload.change_set_name)
         .await?;
 
-    WsEvent::change_set_created(ctx, change_set.id)
+    WsEvent::change_set_created(ctx, change_set.id, change_set.workspace_snapshot_address)
         .await?
         .publish_on_commit(ctx)
         .await?;

--- a/lib/sdf-server/src/service/v2/change_set.rs
+++ b/lib/sdf-server/src/service/v2/change_set.rs
@@ -34,6 +34,7 @@ mod apply;
 mod approval_status;
 mod approve;
 mod cancel_approval_request;
+mod create;
 mod force_apply;
 mod list;
 mod rename;
@@ -151,7 +152,9 @@ pub async fn post_to_webhook(
 }
 
 pub fn change_sets_routes() -> Router<AppState> {
-    Router::new().route("/", get(list::list_actionable))
+    Router::new()
+        .route("/", get(list::list_actionable))
+        .route("/create_change_set", post(create::create_change_set))
 }
 
 pub fn change_set_routes(state: AppState) -> Router<AppState> {

--- a/lib/sdf-server/src/service/v2/fs.rs
+++ b/lib/sdf-server/src/service/v2/fs.rs
@@ -228,7 +228,7 @@ pub async fn create_change_set(
     ctx.write_audit_log(AuditLogKind::CreateChangeSet, change_set.name.clone())
         .await?;
 
-    WsEvent::change_set_created(ctx, change_set.id)
+    WsEvent::change_set_created(ctx, change_set.id, change_set.workspace_snapshot_address)
         .await?
         .publish_on_commit(ctx)
         .await?;


### PR DESCRIPTION
# Calling
1. Before we make API calls, detect when we are on HEAD and create a new change set
2. Once that is complete, send the API POST/PUT/DELETE against the new change set
3. Tell the caller about the new change set
4. router.push appropriately

# Bifrosting
1. Listen for new change sets on the OG web socket.
2. Get the HEAD snapshot in sqlite
3. Insert the snapshot record
4. create MTM links based on the HEAD snapshot
5. insert the change set record
6. ping the `/index` endpoint to create the index MV in frigg

## Behavior Change Needed
The current behavior leaves a lot to be desired:
- I have two open tabs, both sitting on HEAD.
- Tab 1, I make the new change set
- Tab 2, is pristine, it receives the WsEvent, creates the MTM behind the scenes ✅ no errors
- Tab 1, creates a race condition because...
- it redirects you to the new change set, before the index is created, before the MTM is done
- niflheim does happen, waits for index to build
- all the query keys bust b/c change set changed
- all queries miss, and throw mjolnir
- all mjolnirs 404, because the index isn't rebuilt yet
- index finally rebuilds and cold start finishes
- all cache keys bust
- data shows up

**Problem**: I can't actually put up a spinner for "all the queries that completed, and missed, because in the future they will re-fire". So, users will see lots of _blank_ no spinner, wondering "wait.. did it work?!"... *snap* the data shows up.

**Proposal**: if we block the `commit` of `/create_changeset` endpoint until the new change set's index is created, then we get no ugliness.. no 404s, no "can't spinner" problem—because I can absolutely show a spinner for "I did an HTTP POST to `/create_changeset` and it hasn't returned yet". This doesn't "lengthen" the wait time for users—in the current behavior where they get redirected immediately, they can't see anything anyway.