### PR TITLE
Do not send empty PatchBatch

### DIFF
--- a/lib/edda-server/src/data_cache.rs
+++ b/lib/edda-server/src/data_cache.rs
@@ -19,6 +19,10 @@ pub(crate) struct DataCache;
 impl DataCache {
     #[instrument(name = "data_cache.publish_patch_batch", level = "info", skip_all)]
     pub async fn publish_patch_batch(ctx: &DalContext, patch_batch: PatchBatch) -> Result<()> {
+        if patch_batch.patches.is_empty() {
+            return Ok(());
+        }
+
         ctx.txns()
             .await?
             .nats()


### PR DESCRIPTION
We already suppress individual empty patches to prevent needless messaging, but if the entire PatchBatch has no patches, we were still sending it. We now make sure that there are patches in the PatchBatch before sending the batch out to listening clients.