### PR TITLE
feat(dal): preserve attribute subscriptions on upgrade

### DIFF
--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -56,7 +56,10 @@ use crate::{
         value::AttributeValueError,
     },
     change_set::ChangeSetError,
-    func::intrinsics::IntrinsicFunc,
+    func::{
+        argument::FuncArgument,
+        intrinsics::IntrinsicFunc,
+    },
     implement_add_edge_to,
     layer_db_types::{
         AttributePrototypeContent,
@@ -469,6 +472,21 @@ impl AttributePrototype {
         }
 
         Ok(attribute_value_ids)
+    }
+
+    /// Adds a new APA with the given source, to the single function argument (used for intrinsics)
+    pub async fn add_arg_to_intrinsic(
+        ctx: &DalContext,
+        attribute_prototype_id: AttributePrototypeId,
+        value_source: impl Into<ValueSource>,
+    ) -> AttributePrototypeResult<AttributePrototypeArgumentId> {
+        let func_id = Self::func_id(ctx, attribute_prototype_id).await?;
+        let arg_id = FuncArgument::single_arg_for_intrinsic(ctx, func_id).await?;
+        Ok(
+            AttributePrototypeArgument::new(ctx, attribute_prototype_id, arg_id, value_source)
+                .await?
+                .id(),
+        )
     }
 
     /// If this prototype is defined at the component level, it will have an incoming edge from the

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -2299,13 +2299,7 @@ impl AttributeValue {
         // Add the subscriptions as the argument
         let arg_id = FuncArgument::single_arg_for_intrinsic(ctx, func_id).await?;
         for subscription in subscriptions {
-            AttributePrototypeArgument::new(
-                ctx,
-                prototype_id,
-                arg_id,
-                ValueSource::ValueSubscription(subscription),
-            )
-            .await?;
+            AttributePrototypeArgument::new(ctx, prototype_id, arg_id, subscription).await?;
         }
 
         // DVU all the way!


### PR DESCRIPTION
Right now we drop subscriptions to a component when we upgrade it. This fixes that.

## Testing

- [ ] New integration test

<IMG SRC="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExb2NoNHR6ZTMwOHI4dW51ZjJ3bWZqaHE5bzV0aTF2bHR3bmJ3YnhieCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/7vfhdCIn13zm8/giphy.gif" />