### PR TITLE
fix(edda,sdf): Flip some events to debug level, and return more accurate errors on mjlonir endpoints

### DIFF
--- a/lib/edda-server/src/change_set_processor_task/materialized_view.rs
+++ b/lib/edda-server/src/change_set_processor_task/materialized_view.rs
@@ -160,7 +160,7 @@ pub async fn build_all_mv_for_change_set(
 
     let mut index_entries: Vec<_> = frontend_objects.into_iter().map(Into::into).collect();
     index_entries.sort();
-    info!("index_entries {:?}", index_entries);
+    debug!("index_entries {:?}", index_entries);
     let mv_index = MvIndex::new(ctx.change_set_id(), index_entries);
     let mv_index_frontend_object = FrontendObject::try_from(mv_index)?;
     frigg
@@ -489,7 +489,7 @@ where
     MaterializedViewError: From<E>,
     MaterializedViewError: From<<T as TryInto<FrontendObject>>::Error>,
 {
-    info!(kind = %mv_kind, id = %mv_id, "Building MV");
+    debug!(kind = %mv_kind, id = %mv_id, "Building MV");
     let result = build_mv_task_inner(
         &ctx,
         &frigg,

--- a/lib/sdf-server/src/service/v2/index.rs
+++ b/lib/sdf-server/src/service/v2/index.rs
@@ -50,6 +50,14 @@ pub enum IndexError {
     Frigg(#[from] frigg::FriggError),
     #[error("index not found; workspace_pk={0}, change_set_id={1}")]
     IndexNotFound(WorkspacePk, ChangeSetId),
+    #[error("index not found after rebuild; workspace_pk={0}, change_set_id={1}")]
+    IndexNotFoundAfterFreshBuild(WorkspacePk, ChangeSetId),
+    #[error("index not found after rebuild; workspace_pk={0}, change_set_id={1}")]
+    IndexNotFoundAfterRebuild(WorkspacePk, ChangeSetId),
+    #[error("item with checksum not found; workspace_pk={0}, change_set_id={1}, kind={2}")]
+    ItemWithChecksumNotFound(WorkspacePk, ChangeSetId, String),
+    #[error("latest item not found; workspace_pk={0}, change_set_id={1}, kind={2}")]
+    LatestItemNotFound(WorkspacePk, ChangeSetId, String),
     #[error("transactions error: {0}")]
     Transactions(#[from] dal::TransactionsError),
     #[error("timed out when watching index with duration: {0:?}")]
@@ -61,7 +69,10 @@ pub type IndexResult<T> = Result<T, IndexError>;
 impl IntoResponse for IndexError {
     fn into_response(self) -> Response {
         let status_code = match &self {
-            IndexError::IndexNotFound(_, _) => StatusCode::NOT_FOUND,
+            IndexError::IndexNotFound(_, _)
+            | IndexError::IndexNotFoundAfterFreshBuild(_, _)
+            | IndexError::IndexNotFoundAfterRebuild(_, _)
+            | IndexError::ItemWithChecksumNotFound(_, _, _) => StatusCode::NOT_FOUND,
             _ => ApiError::DEFAULT_ERROR_STATUS_CODE,
         };
 

--- a/lib/sdf-server/src/service/v2/index/get_change_set_index.rs
+++ b/lib/sdf-server/src/service/v2/index/get_change_set_index.rs
@@ -95,7 +95,10 @@ pub async fn get_change_set_index(
                     .get_index(workspace_pk, change_set_id)
                     .await?
                     .map(|i| i.0)
-                    .ok_or(IndexError::IndexNotFound(workspace_pk, change_set_id))?
+                    .ok_or(IndexError::IndexNotFoundAfterRebuild(
+                        workspace_pk,
+                        change_set_id,
+                    ))?
             }
         }
         None => {
@@ -108,7 +111,10 @@ pub async fn get_change_set_index(
                 .get_index(workspace_pk, change_set_id)
                 .await?
                 .map(|i| i.0)
-                .ok_or(IndexError::IndexNotFound(workspace_pk, change_set_id))?
+                .ok_or(IndexError::IndexNotFoundAfterFreshBuild(
+                    workspace_pk,
+                    change_set_id,
+                ))?
         }
     };
 

--- a/lib/sdf-server/src/service/v2/index/get_front_end_object.rs
+++ b/lib/sdf-server/src/service/v2/index/get_front_end_object.rs
@@ -51,12 +51,20 @@ pub async fn get_front_end_object(
         obj = frigg
             .get_object(workspace_pk, &request.kind, &request.id, &checksum)
             .await?
-            .ok_or(IndexError::IndexNotFound(workspace_pk, change_set_id))?;
+            .ok_or(IndexError::ItemWithChecksumNotFound(
+                workspace_pk,
+                change_set_id,
+                request.kind,
+            ))?;
     } else {
         obj = frigg
             .get_current_object(workspace_pk, change_set_id, &request.kind, &request.id)
             .await?
-            .ok_or(IndexError::IndexNotFound(workspace_pk, change_set_id))?;
+            .ok_or(IndexError::LatestItemNotFound(
+                workspace_pk,
+                change_set_id,
+                request.kind,
+            ))?;
     }
 
     Ok(Json(FrontEndObjectMeta {


### PR DESCRIPTION
<div><img src="https://media2.giphy.com/media/U7isUDZ6VPWJW/200.gif?cid=5a38a5a2nmc2kugwe1tl1stj3fwtrnhqui6j2rn0tnqhsvz4&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:243px;width:300px"/><br/>via <a href="https://giphy.com/gifs/comedy-tim-and-eric-U7isUDZ6VPWJW">GIPHY</a></div>