### PR TITLE
fix: add curl to langjs extra packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,7 @@
         flyctl
         azure-cli
         govc
+        curl
         (pkgs.python3.withPackages (p:
           with p; [
             cfn-lint


### PR DESCRIPTION
To allow for interaction with not certified endpoints within authored functions.