### PR TITLE
Fix: send the right option value, and display the label of the chosen option

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -25,7 +25,12 @@
         <input
           class="block w-72 ml-auto text-white bg-black border-2 border-neutral-300 disabled:bg-neutral-900"
           type="text"
-          :value="field.state.value"
+          :value="
+            maybeOptions.hasOptions
+              ? maybeOptions.options.find((o) => o.value === field.state.value)
+                  ?.label
+              : field.state.value
+          "
           :disabled="wForm.bifrosting.value || bifrostingTrash"
           @input="(e) => field.handleChange((e.target as HTMLInputElement).value)"
           @blur="blur"
@@ -240,7 +245,7 @@ const focus = () => {
 };
 
 const select = (option: LabelEntry<AttrOption>) => {
-  valueForm.fieldInfo.value.instance?.handleChange(option.label);
+  valueForm.fieldInfo.value.instance?.handleChange(option.value);
   valueForm.handleSubmit();
   showOptions.value = false;
 };


### PR DESCRIPTION
Steps to repro:
1. go to an AWS Region component
2. open the `Diff` panel
3. change the region dropdown to a different value by picking from the list
4. see the full label value in the text box
5. see the value of region change in the diff panel (you may need to rebuild the index if patches aren't working)

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlcHpsZG1vN2FrcXN4cmhrNjI5ODVkZ3ZiZnFxODdmNDVjNG1oNm90eiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/s7qmvjy9qQej0KMf2K/giphy.gif"/>