### PR TITLE
wip(edda): Various fixes to Edda and MVs

### DIFF
--- a/lib/sdf-server/src/service/v2/index.rs
+++ b/lib/sdf-server/src/service/v2/index.rs
@@ -72,7 +72,8 @@ impl IntoResponse for IndexError {
             IndexError::IndexNotFound(_, _)
             | IndexError::IndexNotFoundAfterFreshBuild(_, _)
             | IndexError::IndexNotFoundAfterRebuild(_, _)
-            | IndexError::ItemWithChecksumNotFound(_, _, _) => StatusCode::NOT_FOUND,
+            | IndexError::ItemWithChecksumNotFound(_, _, _)
+            | IndexError::LatestItemNotFound(_, _, _) => StatusCode::NOT_FOUND,
             _ => ApiError::DEFAULT_ERROR_STATUS_CODE,
         };
 


### PR DESCRIPTION
This includes the following: 
1. Ensure that within an Action MV, the list of cross action dependencies is stably ordered
2. Return 404 on the other custom error kind I added (I just missed this yesterday)
3. (main fix!) After we loop through the ready to process MV kinds, we need to see if any of those kinds actually had build tasks spawned/queued, and if not, remove it from the dep graph. Otherwise, downstream MV Kinds will never become ready because we were only removing the kind from the graph when the build tasks finished, so if one was never spawned we'd wait forever