### PR TITLE
Timings on bifrosting and getReferences, Fix `head` router

### DIFF
--- a/app/web/src/newhotness/AddViewModal.vue
+++ b/app/web/src/newhotness/AddViewModal.vue
@@ -57,6 +57,7 @@ const formData = computed<{ name: string }>(() => {
 });
 
 const nameForm = wForm.newForm(
+  "view.add",
   formData,
   async ({ value }) => {
     const call = api.endpoint<{ id: string }>(routes.CreateView);

--- a/app/web/src/newhotness/Component.vue
+++ b/app/web/src/newhotness/Component.vue
@@ -295,28 +295,32 @@ const wForm = useWatchedForm<NameFormData>();
 
 const route = useRoute();
 
-const nameForm = wForm.newForm(nameFormData, async ({ value }) => {
-  const name = value.name;
-  // i wish the validator narrowed this type to always be a string
-  if (name) {
-    const id = component.value?.id;
-    if (!id) throw new Error("Missing id");
-    const call = api.endpoint(routes.UpdateComponentName, { id });
-    const { req, newChangeSetId } = await call.put<UpdateComponentNameArgs>({
-      name,
-    });
-    if (newChangeSetId && api.ok(req)) {
-      router.push({
-        name: "new-hotness-component",
-        params: {
-          workspacePk: route.params.workspacePk,
-          changeSetId: newChangeSetId,
-          componentId: props.componentId,
-        },
+const nameForm = wForm.newForm(
+  "component.name",
+  nameFormData,
+  async ({ value }) => {
+    const name = value.name;
+    // i wish the validator narrowed this type to always be a string
+    if (name) {
+      const id = component.value?.id;
+      if (!id) throw new Error("Missing id");
+      const call = api.endpoint(routes.UpdateComponentName, { id });
+      const { req, newChangeSetId } = await call.put<UpdateComponentNameArgs>({
+        name,
       });
+      if (newChangeSetId && api.ok(req)) {
+        router.push({
+          name: "new-hotness-component",
+          params: {
+            workspacePk: route.params.workspacePk,
+            changeSetId: newChangeSetId,
+            componentId: props.componentId,
+          },
+        });
+      }
     }
-  }
-});
+  },
+);
 
 const required = ({ value }: { value: string | undefined }) => {
   const len = value?.trim().length ?? 0;

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -145,9 +145,13 @@ const attrData = computed<AttrData>(() => {
   return { value: props.value };
 });
 
-const valueForm = wForm.newForm(attrData, async ({ value }) => {
-  emit("save", path.value, props.attributeValueId, value.value);
-});
+const valueForm = wForm.newForm(
+  "component.av.prop",
+  attrData,
+  async ({ value }) => {
+    emit("save", path.value, props.attributeValueId, value.value);
+  },
+);
 
 // i assume more things than comboboxes have a list of options
 type AttrOption = string | number;

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -32,12 +32,13 @@ const routes: RouteRecordRaw[] = [
     beforeEnter: async (loc) => {
       const resp = await sdf<WorkspaceMetadata>({
         method: "GET",
-        url: `/v2/workspaces/${loc.params.workspacePk}/change-sets/`,
+        url: `v2/workspaces/${loc.params.workspacePk}/change-sets`,
       });
       const changeSetId = resp.data.defaultChangeSetId;
-      return `/n/${loc.params.workspacePk}/${changeSetId}/h`;
+      const newloc = `/n/${loc.params.workspacePk}/${changeSetId}/h`;
+      return newloc;
     },
-    redirect: () => "/", // ignored, here just to make the typing happy
+    component: () => import("@/newhotness/Workspace.vue"),
   },
   {
     name: "new-hotness",

--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -1274,6 +1274,14 @@ const getReferences = async (
   )
     return [atomDoc, false];
 
+  const span = tracer.startSpan("getReferences");
+  span.setAttributes({
+    workspaceId,
+    changeSetId,
+    kind,
+    id,
+  });
+
   debug("🔗 reference query", kind, id);
 
   let hasReferenceError = false;
@@ -1310,6 +1318,7 @@ const getReferences = async (
       ...data,
       schemaVariant: sv !== -1 ? sv : ({} as SchemaVariant),
     };
+    span.end();
     return [component, hasReferenceError];
   } else if (kind === "ViewList") {
     const rawList = atomDoc as RawViewList;
@@ -1342,6 +1351,7 @@ const getReferences = async (
       id: rawList.id,
       views,
     };
+    span.end();
     return [list, hasReferenceError];
   } else if (kind === "ComponentList" || kind === "ViewComponentList") {
     const rawList = atomDoc as EddaComponentList;
@@ -1377,6 +1387,7 @@ const getReferences = async (
       id: rawList.id,
       components,
     };
+    span.end();
     return [list, hasReferenceError];
   } else if (kind === "IncomingConnections") {
     const raw = atomDoc as EddaIncomingConnections;
@@ -1452,6 +1463,7 @@ const getReferences = async (
       }),
     );
 
+    span.end();
     return [
       {
         id: raw.id,
@@ -1487,6 +1499,7 @@ const getReferences = async (
       id: rawList.id,
       componentConnections,
     };
+    span.end();
     return [list, hasReferenceError];
   } else return [atomDoc, hasReferenceError];
 };


### PR DESCRIPTION
Adding honeycomb timings that represent the "lived user experience" of how long it takes to submit a form and see your data change out the other end.

Also, fixed the vanity `head` URL to redirect properly.