### PR TITLE
feat(dal,si-split-graph): view removal corrections

### DIFF
--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -323,6 +323,7 @@ impl From<String> for PropPath {
     Eq,
     PartialEq,
     Serialize,
+    Hash,
 )]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]

--- a/lib/dal/src/socket.rs
+++ b/lib/dal/src/socket.rs
@@ -51,6 +51,7 @@ pub enum SocketKind {
     Eq,
     PartialEq,
     Serialize,
+    Hash,
 )]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -148,7 +148,7 @@ pub type NodeWeightResult<T> = Result<T, NodeWeightError>;
 
 /// **WARNING**: the order of this enum is important! Do not re-order elements.
 /// New variants must go at the end, even if it's not in lexical order!
-#[derive(Debug, Serialize, Deserialize, Clone, EnumDiscriminants, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, EnumDiscriminants, PartialEq, Eq, Hash)]
 #[strum_discriminants(derive(strum::Display, Hash, Serialize, Deserialize, EnumIter))]
 pub enum NodeWeight {
     Action(ActionNodeWeight),
@@ -1229,7 +1229,15 @@ impl CorrectExclusiveOutgoingEdge for NodeWeight {
     }
 }
 
+impl si_split_graph::NodeKind for NodeWeightDiscriminants {}
+
 impl si_split_graph::CustomNodeWeight for NodeWeight {
+    type Kind = NodeWeightDiscriminants;
+
+    fn kind(&self) -> Self::Kind {
+        self.into()
+    }
+
     fn id(&self) -> si_split_graph::SplitGraphNodeId {
         self.id()
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
@@ -32,7 +32,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ActionNodeWeight {
     pub id: Ulid,
     state: ActionState,

--- a/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
@@ -17,7 +17,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ActionPrototypeNodeWeight {
     pub id: Ulid,
     kind: ActionKind,

--- a/lib/dal/src/workspace_snapshot/node_weight/approval_requirement_definition_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/approval_requirement_definition_node_weight.rs
@@ -14,7 +14,7 @@ pub mod v1;
 pub use v1::ApprovalRequirementDefinitionNodeWeightV1;
 
 #[derive(
-    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiVersionedNodeWeight,
+    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiVersionedNodeWeight, Hash,
 )]
 pub enum ApprovalRequirementDefinitionNodeWeight {
     #[si_versioned_node_weight(current)]

--- a/lib/dal/src/workspace_snapshot/node_weight/approval_requirement_definition_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/approval_requirement_definition_node_weight/v1.rs
@@ -22,7 +22,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiNodeWeight)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiNodeWeight, Hash)]
 #[si_node_weight(discriminant = NodeWeightDiscriminants::ApprovalRequirementDefinition)]
 pub struct ApprovalRequirementDefinitionNodeWeightV1 {
     pub id: Ulid,

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
@@ -20,13 +20,13 @@ use crate::{
 
 /// When this `AttributePrototypeArgument` represents a connection between two
 /// components, we need to know which components are being connected.
-#[derive(Copy, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
 pub struct ArgumentTargets {
     pub source_component_id: ComponentId,
     pub destination_component_id: ComponentId,
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct AttributePrototypeArgumentNodeWeight {
     pub id: Ulid,
     pub lineage_id: LineageId,

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -30,7 +30,7 @@ use crate::{
     },
 };
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct AttributeValueNodeWeight {
     pub id: Ulid,
     pub lineage_id: LineageId,

--- a/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
@@ -26,7 +26,7 @@ use crate::{
 /// the given context). Note that a race to create the category will result in a broken graph(since
 /// having two of the same category would leave the graph in an inconsistent state), so you should
 /// implement the ability to merge your category nodes together.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Display, EnumIter)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Display, EnumIter, Hash)]
 pub enum CategoryNodeKind {
     Action,
     Component,
@@ -40,7 +40,7 @@ pub enum CategoryNodeKind {
     DiagramObject,
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct CategoryNodeWeight {
     pub id: Ulid,
     pub lineage_id: LineageId,

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -63,7 +63,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ComponentNodeWeight {
     pub id: Ulid,
     pub lineage_id: LineageId,

--- a/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
@@ -41,7 +41,7 @@ use crate::{
     },
 };
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ContentNodeWeight {
     /// The stable local ID of the object in question. Mainly used by external things like
     /// the UI to be able to say "do X to _this_ thing" since the `NodeIndex` is an

--- a/lib/dal/src/workspace_snapshot/node_weight/dependent_value_root_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/dependent_value_root_node_weight.rs
@@ -13,7 +13,7 @@ use crate::{
     workspace_snapshot::node_weight::traits::CorrectTransforms,
 };
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct DependentValueRootNodeWeight {
     pub id: Ulid,
     pub lineage_id: Ulid,

--- a/lib/dal/src/workspace_snapshot/node_weight/diagram_object_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/diagram_object_node_weight.rs
@@ -14,7 +14,7 @@ use crate::{
 pub mod v1;
 use v1::DiagramObjectNodeWeightV1;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SiVersionedNodeWeight)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SiVersionedNodeWeight, Hash)]
 pub enum DiagramObjectNodeWeight {
     #[si_versioned_node_weight(current)]
     V1(DiagramObjectNodeWeightV1),

--- a/lib/dal/src/workspace_snapshot/node_weight/diagram_object_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/diagram_object_node_weight/v1.rs
@@ -30,7 +30,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SiNodeWeight)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SiNodeWeight, Hash)]
 #[si_node_weight(discriminant = NodeWeightDiscriminants::Geometry)]
 pub struct DiagramObjectNodeWeightV1 {
     pub id: Ulid,

--- a/lib/dal/src/workspace_snapshot/node_weight/finished_dependent_value_root_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/finished_dependent_value_root_node_weight.rs
@@ -13,7 +13,7 @@ use crate::{
     workspace_snapshot::node_weight::traits::CorrectTransforms,
 };
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct FinishedDependentValueRootNodeWeight {
     pub id: Ulid,
     pub lineage_id: Ulid,

--- a/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_argument_node_weight.rs
@@ -24,7 +24,7 @@ use crate::{
     },
 };
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct FuncArgumentNodeWeight {
     pub id: Ulid,
     pub lineage_id: LineageId,

--- a/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
@@ -25,7 +25,7 @@ use crate::{
     },
 };
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct FuncNodeWeight {
     pub id: Ulid,
     pub lineage_id: LineageId,

--- a/lib/dal/src/workspace_snapshot/node_weight/geometry_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/geometry_node_weight.rs
@@ -16,7 +16,7 @@ use crate::workspace_snapshot::node_weight::{
 };
 
 #[derive(
-    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiVersionedNodeWeight,
+    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiVersionedNodeWeight, Hash,
 )]
 pub enum GeometryNodeWeight {
     #[si_versioned_node_weight(current)]

--- a/lib/dal/src/workspace_snapshot/node_weight/input_socket_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/input_socket_node_weight.rs
@@ -41,7 +41,7 @@ pub enum InputSocketNodeWeightError {
 pub type InputSocketNodeWeightResult<T> = Result<T, InputSocketNodeWeightError>;
 
 #[derive(
-    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiVersionedNodeWeight,
+    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiVersionedNodeWeight, Hash,
 )]
 pub enum InputSocketNodeWeight {
     #[si_versioned_node_weight(current)]

--- a/lib/dal/src/workspace_snapshot/node_weight/input_socket_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/input_socket_node_weight/v1.rs
@@ -26,7 +26,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiNodeWeight)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiNodeWeight, Hash)]
 #[si_node_weight(discriminant = NodeWeightDiscriminants::InputSocket)]
 pub struct InputSocketNodeWeightV1 {
     pub id: Ulid,

--- a/lib/dal/src/workspace_snapshot/node_weight/management_prototype_node_weight/mod.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/management_prototype_node_weight/mod.rs
@@ -39,7 +39,7 @@ pub enum ManagementPrototypeNodeWeightError {
 
 pub type ManagementPrototypeNodeWeightResult<T> = Result<T, ManagementPrototypeNodeWeightError>;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum ManagementPrototypeNodeWeight {
     V1(ManagementPrototypeNodeWeightV1),
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/management_prototype_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/management_prototype_node_weight/v1.rs
@@ -22,7 +22,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ManagementPrototypeNodeWeightV1 {
     pub id: Ulid,
     pub lineage_id: LineageId,

--- a/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/ordering_node_weight.rs
@@ -30,7 +30,7 @@ use crate::{
     },
 };
 
-#[derive(Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct OrderingNodeWeight {
     pub id: Ulid,
     pub lineage_id: Ulid,

--- a/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/prop_node_weight.rs
@@ -25,7 +25,7 @@ use crate::{
     },
 };
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct PropNodeWeight {
     pub id: Ulid,
     pub lineage_id: LineageId,

--- a/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight.rs
@@ -44,7 +44,7 @@ pub enum SchemaVariantNodeWeightError {
 pub type SchemaVariantNodeWeightResult<T> = Result<T, SchemaVariantNodeWeightError>;
 
 #[derive(
-    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiVersionedNodeWeight,
+    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiVersionedNodeWeight, Hash,
 )]
 pub enum SchemaVariantNodeWeight {
     #[si_versioned_node_weight(current)]

--- a/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
@@ -59,7 +59,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiNodeWeight)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiNodeWeight, Hash)]
 #[si_node_weight(discriminant = NodeWeightDiscriminants::SchemaVariant)]
 pub struct SchemaVariantNodeWeightV1 {
     pub id: Ulid,

--- a/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
@@ -38,7 +38,7 @@ use crate::{
     },
 };
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct SecretNodeWeight {
     pub id: Ulid,
     pub lineage_id: LineageId,

--- a/lib/dal/src/workspace_snapshot/node_weight/view_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/view_node_weight.rs
@@ -15,7 +15,7 @@ use crate::workspace_snapshot::node_weight::{
 };
 
 #[derive(
-    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiVersionedNodeWeight,
+    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiVersionedNodeWeight, Hash,
 )]
 pub enum ViewNodeWeight {
     #[si_versioned_node_weight(current)]

--- a/lib/dal/src/workspace_snapshot/node_weight/view_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/view_node_weight/v1.rs
@@ -1,4 +1,6 @@
 use std::collections::{
+    BTreeMap,
+    BTreeSet,
     HashMap,
     HashSet,
 };
@@ -16,27 +18,32 @@ use si_events::{
     ulid::Ulid,
 };
 use si_id::ViewId;
+use si_split_graph::SplitGraphNodeId;
 
-use crate::workspace_snapshot::{
-    EdgeWeightKindDiscriminants,
-    content_address::ContentAddress,
-    graph::{
-        LineageId,
-        WorkspaceSnapshotGraphError,
-        detector::Update,
-    },
-    node_weight::{
-        NodeWeight,
-        NodeWeightDiscriminants,
-        traits::{
-            CorrectExclusiveOutgoingEdge,
-            CorrectTransforms,
-            SiNodeWeight,
+use crate::{
+    EdgeWeight,
+    workspace_snapshot::{
+        EdgeWeightKindDiscriminants,
+        content_address::ContentAddress,
+        graph::{
+            LineageId,
+            WorkspaceSnapshotGraphError,
+            detector::Update,
         },
+        node_weight::{
+            NodeWeight,
+            NodeWeightDiscriminants,
+            traits::{
+                CorrectExclusiveOutgoingEdge,
+                CorrectTransforms,
+                SiNodeWeight,
+            },
+        },
+        split_snapshot,
     },
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SiNodeWeight)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SiNodeWeight, Hash)]
 #[si_node_weight(discriminant = NodeWeightDiscriminants::View)]
 pub struct ViewNodeWeightV1 {
     pub id: Ulid,
@@ -77,6 +84,16 @@ impl CorrectTransforms for ViewNodeWeightV1 {
         let mut removed_components = HashSet::new();
         let mut components_with_new_geometry: HashMap<Ulid, HashSet<Ulid>> = HashMap::new();
         let mut new_geometry_for_other_views: HashSet<Ulid> = HashSet::new();
+
+        // If this view is not in the existing graph, it's net new.
+        // If it's net new, it can't be being removed. Therefore,
+        // we have no corrections to perform on it here
+        if workspace_snapshot_graph
+            .get_node_index_by_id_opt(self.id)
+            .is_none()
+        {
+            return Ok(updates);
+        }
 
         for (update_idx, update) in updates.iter().enumerate() {
             match update {
@@ -228,4 +245,203 @@ impl CorrectExclusiveOutgoingEdge for ViewNodeWeightV1 {
     fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
         &[]
     }
+}
+
+impl
+    split_snapshot::corrections::CorrectTransforms<
+        NodeWeight,
+        EdgeWeight,
+        EdgeWeightKindDiscriminants,
+    > for ViewNodeWeightV1
+{
+    fn correct_transforms(
+        &self,
+        graph: &si_split_graph::SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+        mut updates: Vec<
+            si_split_graph::Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+        >,
+        _from_different_change_set: bool,
+    ) -> split_snapshot::corrections::CorrectTransformsResult<
+        Vec<si_split_graph::Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>,
+    > {
+        // If this view is not in the graph yet, it's new, and we don't have to do anything
+        if graph.node_weight(self.id).is_none() {
+            return Ok(updates);
+        }
+
+        // This correction prevents the removal of a view node if the change set the updates are
+        // being applied to has components that belong to/are contained in that view, but are
+        // not being deleted in this set of updates, and those components do not belong to
+        // any other view (which would cause these components to be view-less). The basic
+        // race condition here is adding a component to the view in one change set, but
+        // deleting it in another (then applying the view deletion to head so that it is
+        // replayed on the change set with the net-new component). But this could also race
+        // in multiplayer.
+
+        let mut view_removal_idxs = vec![];
+        let mut view_removal_ids = BTreeSet::new();
+        let mut removed_geometries = BTreeSet::new();
+        let mut removed_components = BTreeSet::new();
+        let mut components_with_new_geometry: BTreeMap<_, BTreeSet<_>> = BTreeMap::new();
+        let mut new_geometry_for_other_views = BTreeSet::new();
+
+        for (update_idx, update) in updates.iter().enumerate() {
+            match update {
+                si_split_graph::Update::RemoveEdge { destination, .. }
+                    if update.destination_has_id(self.id)
+                        && update.is_of_custom_edge_kind(EdgeWeightKindDiscriminants::Use)
+                        && update
+                            .source_is_of_custom_node_kind(NodeWeightDiscriminants::Category) =>
+                {
+                    view_removal_ids.insert(destination.id);
+                    view_removal_idxs.push(update_idx);
+                }
+                si_split_graph::Update::RemoveEdge { .. }
+                    if update.source_has_id(self.id)
+                        && update.is_of_custom_edge_kind(EdgeWeightKindDiscriminants::Use)
+                        && update.destination_is_of_custom_node_kind(
+                            NodeWeightDiscriminants::Geometry,
+                        ) =>
+                {
+                    if let Some(destination_id) = update.destination_id() {
+                        removed_geometries.insert(destination_id);
+                    }
+                }
+                si_split_graph::Update::RemoveEdge { .. }
+                    if update.is_edge_of_sort(
+                        NodeWeightDiscriminants::Category,
+                        EdgeWeightKindDiscriminants::Use,
+                        NodeWeightDiscriminants::Component,
+                    ) =>
+                {
+                    if let Some(destination_id) = update.destination_id() {
+                        removed_components.insert(destination_id);
+                    }
+                }
+                si_split_graph::Update::NewEdge { .. }
+                    if update.source_is_of_custom_node_kind(NodeWeightDiscriminants::Geometry)
+                        && update
+                            .is_of_custom_edge_kind(EdgeWeightKindDiscriminants::Represents) =>
+                {
+                    let Some((source_id, destination_id)) = update.edge_endpoints() else {
+                        continue;
+                    };
+
+                    components_with_new_geometry
+                        .entry(destination_id)
+                        .and_modify(|entry| {
+                            entry.insert(source_id);
+                        })
+                        .or_insert_with(|| BTreeSet::from([source_id]));
+                }
+                si_split_graph::Update::NewEdge { .. }
+                    if update.is_edge_of_sort(
+                        NodeWeightDiscriminants::View,
+                        EdgeWeightKindDiscriminants::Use,
+                        NodeWeightDiscriminants::Geometry,
+                    ) && !update.source_has_id(self.id) =>
+                {
+                    if let Some(destination_id) = update.destination_id() {
+                        new_geometry_for_other_views.insert(destination_id);
+                    }
+                }
+                si_split_graph::Update::RemoveNode { id, .. } => {
+                    if view_removal_ids.contains(id) {
+                        view_removal_idxs.push(update_idx);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if view_removal_idxs.is_empty() {
+            return Ok(updates);
+        }
+
+        for edge_ref in graph.edges_directed_for_edge_weight_kind(
+            self.id,
+            Outgoing,
+            EdgeWeightKindDiscriminants::Use,
+        )? {
+            let existing_geometry_id = edge_ref.target();
+
+            if removed_geometries.contains(&existing_geometry_id) {
+                continue;
+            }
+
+            let Some(represented_thing_id) = graph
+                .edges_directed_for_edge_weight_kind(
+                    existing_geometry_id,
+                    Outgoing,
+                    EdgeWeightKindDiscriminants::Represents,
+                )?
+                .next()
+                .map(|edge_ref| edge_ref.target())
+            else {
+                continue;
+            };
+
+            if removed_components.contains(&represented_thing_id) {
+                continue;
+            };
+
+            let Some(NodeWeight::Component(_)) = graph.node_weight(represented_thing_id) else {
+                continue;
+            };
+
+            // The component isn't being removed, but we're removing the view that contains it.
+            // We can only do this safely if the component exists in at least one other view
+            if component_is_contained_in_other_views(represented_thing_id, self.id, graph)? {
+                continue;
+            }
+
+            if let Some(component_new_geometry_ids) =
+                components_with_new_geometry.get(&represented_thing_id)
+            {
+                if component_new_geometry_ids
+                    .iter()
+                    .any(|new_geo_id| new_geometry_for_other_views.contains(new_geo_id))
+                {
+                    continue;
+                }
+            }
+
+            // There is no need to sort the indexes since they will be added in order of iteration,
+            // but we reverse them so that removals don't affect the index of earlier entries
+            view_removal_idxs.reverse();
+            for idx in view_removal_idxs {
+                updates.remove(idx);
+            }
+
+            return Ok(updates);
+        }
+
+        Ok(updates)
+    }
+}
+
+#[inline(always)]
+fn component_is_contained_in_other_views(
+    component_id: SplitGraphNodeId,
+    other_than_view_id: SplitGraphNodeId,
+    graph: &si_split_graph::SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+) -> split_snapshot::corrections::CorrectTransformsResult<bool> {
+    for incoming_represents_edge_ref in graph.edges_directed_for_edge_weight_kind(
+        component_id,
+        Incoming,
+        EdgeWeightKindDiscriminants::Represents,
+    )? {
+        let geometry_id = incoming_represents_edge_ref.source();
+        for incoming_use_edge_ref in graph.edges_directed_for_edge_weight_kind(
+            geometry_id,
+            Incoming,
+            EdgeWeightKindDiscriminants::Use,
+        )? {
+            if incoming_use_edge_ref.source() != other_than_view_id {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
 }

--- a/lib/si-events-rs/src/action.rs
+++ b/lib/si-events-rs/src/action.rs
@@ -29,7 +29,9 @@ pub enum ActionKind {
     Update,
 }
 
-#[derive(Debug, Copy, Clone, Deserialize, Serialize, EnumDiscriminants, PartialEq, Eq, Display)]
+#[derive(
+    Debug, Copy, Clone, Deserialize, Serialize, EnumDiscriminants, PartialEq, Eq, Display, Hash,
+)]
 #[strum_discriminants(derive(strum::Display, Serialize, Deserialize))]
 pub enum ActionState {
     /// Action has been determined to be eligible to run, and has had its job sent to the job

--- a/lib/si-events-rs/src/timestamp.rs
+++ b/lib/si-events-rs/src/timestamp.rs
@@ -7,7 +7,7 @@ use serde::{
     Serialize,
 };
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, PartialOrd, Ord, Serialize, Hash)]
 pub struct Timestamp {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/lib/si-split-graph/src/petgraph_traits.rs
+++ b/lib/si-split-graph/src/petgraph_traits.rs
@@ -73,7 +73,8 @@ where
 {
     pub(super) this_subgraph: &'a SubGraph<N, E, K>,
     pub(super) subgraphs: &'a [SubGraph<N, E, K>],
-    pub(super) edges: stable_graph::Edges<'a, SplitGraphEdgeWeight<E, K>, Directed, SubGraphIndex>,
+    pub(super) edges:
+        stable_graph::Edges<'a, SplitGraphEdgeWeight<E, K, N>, Directed, SubGraphIndex>,
     pub(super) from_id: SplitGraphNodeId,
     pub(super) direction: Direction,
     pub(super) debug: bool,
@@ -86,26 +87,29 @@ where
     K: EdgeKind,
 {
     pub(super) this_subgraph: &'a SubGraph<N, E, K>,
-    pub(super) edges: stable_graph::Edges<'a, SplitGraphEdgeWeight<E, K>, Directed, SubGraphIndex>,
+    pub(super) edges:
+        stable_graph::Edges<'a, SplitGraphEdgeWeight<E, K, N>, Directed, SubGraphIndex>,
 }
 
 #[derive(Debug)]
-pub struct RawSplitGraphEdgeReference<'a, E, K>
+pub struct RawSplitGraphEdgeReference<'a, E, K, N>
 where
     E: 'a + CustomEdgeWeight<K>,
+    N: CustomNodeWeight,
     K: EdgeKind,
 {
     source_id: SplitGraphNodeId,
     target_id: SplitGraphNodeId,
-    weight: &'a SplitGraphEdgeWeight<E, K>,
+    weight: &'a SplitGraphEdgeWeight<E, K, N>,
 }
 
-impl<'a, E, K> RawSplitGraphEdgeReference<'a, E, K>
+impl<'a, E, K, N> RawSplitGraphEdgeReference<'a, E, K, N>
 where
     E: 'a + CustomEdgeWeight<K>,
+    N: CustomNodeWeight,
     K: EdgeKind,
 {
-    pub fn weight(&self) -> &'a SplitGraphEdgeWeight<E, K> {
+    pub fn weight(&self) -> &'a SplitGraphEdgeWeight<E, K, N> {
         self.weight
     }
 
@@ -127,9 +131,9 @@ where
     pub(super) subgraph: Option<&'a SubGraph<N, E, K>>,
     pub(super) direction: Direction,
     pub(super) incoming_edges:
-        Option<stable_graph::Edges<'a, SplitGraphEdgeWeight<E, K>, Directed, SubGraphIndex>>,
+        Option<stable_graph::Edges<'a, SplitGraphEdgeWeight<E, K, N>, Directed, SubGraphIndex>>,
     pub(super) outgoing_neighbors:
-        Option<stable_graph::Neighbors<'a, SplitGraphEdgeWeight<E, K>, usize>>,
+        Option<stable_graph::Neighbors<'a, SplitGraphEdgeWeight<E, K, N>, usize>>,
 }
 
 impl<N, E, K> Iterator for SplitGraphNeighbors<'_, N, E, K>
@@ -289,7 +293,7 @@ where
     E: CustomEdgeWeight<K>,
     K: EdgeKind,
 {
-    type Item = RawSplitGraphEdgeReference<'a, E, K>;
+    type Item = RawSplitGraphEdgeReference<'a, E, K, N>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.edges.next().and_then(|edge_ref| {
@@ -445,5 +449,5 @@ where
     K: EdgeKind,
 {
     type NodeWeight = SplitGraphNodeWeight<N>;
-    type EdgeWeight = SplitGraphEdgeWeight<E, K>;
+    type EdgeWeight = SplitGraphEdgeWeight<E, K, N>;
 }


### PR DESCRIPTION
Implements the correction that prevents view deletion if deletion would leave a component on another change set without a view.

Adds data about the kind of node represented by an external source edge and external target and adds that data to the updates to make porting corrections more straightforward.

Adds some quality of life methods to make writing corrections easier.

Also moves away from using subgraph indexes in the updates, using the root id of the subgraph instead, so that interleaved new subgraph updates between change sets will not cause us to add edges to the wrong subgraph.