### PR TITLE
feat(dal): Mirror connections between copy/pasted components

### DIFF
--- a/lib/dal/src/attribute/path.rs
+++ b/lib/dal/src/attribute/path.rs
@@ -27,6 +27,14 @@ pub enum AttributePath {
     JsonPointer(String),
 }
 
+impl std::fmt::Display for AttributePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AttributePath::JsonPointer(path) => write!(f, "{}", path),
+        }
+    }
+}
+
 impl AttributePath {
     pub fn from_json_pointer(path: impl Into<String>) -> Self {
         AttributePath::JsonPointer(path.into())

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -1957,8 +1957,7 @@ pub async fn attach_resource_payload_to_value(
                     false
                 }
             } {
-                let apa = AttributePrototypeArgument::get_by_id(ctx, apa_id).await?;
-                apa.set_value_from_prop_id(ctx, source_prop_id).await?;
+                AttributePrototypeArgument::set_value_source(ctx, apa_id, source_prop_id).await?;
             }
         }
         None => {

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -1231,6 +1231,23 @@ impl WorkspaceSnapshot {
         Ok(())
     }
 
+    pub async fn remove_outgoing_edges_of_kind(
+        &self,
+        source_id: impl Into<Ulid>,
+        kind: EdgeWeightKindDiscriminants,
+    ) -> WorkspaceSnapshotResult<()> {
+        let source_id = source_id.into();
+
+        let targets = self
+            .outgoing_targets_for_edge_weight_kind(source_id, kind)
+            .await?;
+        for target_id in targets {
+            self.remove_edge(source_id, target_id, kind).await?;
+        }
+
+        Ok(())
+    }
+
     pub async fn get_edges_between_nodes(
         &self,
         from_node_id: Ulid,

--- a/lib/dal/src/workspace_snapshot/selector.rs
+++ b/lib/dal/src/workspace_snapshot/selector.rs
@@ -477,6 +477,25 @@ impl WorkspaceSnapshotSelector {
         }
     }
 
+    pub async fn remove_outgoing_edges_of_kind(
+        &self,
+        source_id: impl Into<Ulid>,
+        kind: EdgeWeightKindDiscriminants,
+    ) -> WorkspaceSnapshotResult<()> {
+        match self {
+            Self::LegacySnapshot(snapshot) => {
+                snapshot
+                    .remove_outgoing_edges_of_kind(source_id, kind)
+                    .await
+            }
+            Self::SplitSnapshot(snapshot) => {
+                snapshot
+                    .remove_outgoing_edges_of_kind(source_id, kind)
+                    .await
+            }
+        }
+    }
+
     pub async fn get_edges_between_nodes(
         &self,
         from_node_id: Ulid,

--- a/lib/dal/tests/integration_test/component/paste.rs
+++ b/lib/dal/tests/integration_test/component/paste.rs
@@ -7,7 +7,10 @@ use dal::{
 use dal_test::{
     Result,
     expected::ExpectComponent,
-    helpers::ChangeSetTestHelpers,
+    helpers::{
+        ChangeSetTestHelpers,
+        attribute::value,
+    },
     test,
 };
 use pretty_assertions_sorted::assert_eq;
@@ -153,9 +156,6 @@ async fn paste_component_with_dependent_value(ctx: &mut DalContext) -> Result<()
 #[test]
 async fn paste_components_with_connections(ctx: &mut DalContext) -> Result<()> {
     let test = ConnectableTest::setup(ctx).await?;
-
-    // let out_one = OutputSocket::find_with_name_or_error(ctx, "One", connectable.id()).await?;
-    // let one = InputSocket::find_with_name_or_error(ctx, "One", connectable.id()).await?;
 
     // input1
     let input1 = test.create_connectable(ctx, "input1", None, []).await?;
@@ -370,6 +370,364 @@ async fn paste_components_with_connections_opposite_order(ctx: &mut DalContext) 
             [input1, input2, original1, original2],
         )
         .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "output",
+            "One": "original2",
+            "Many": ["input1", "input2", "original1", "original2"],
+        }),
+        output.domain(ctx).await?
+    );
+
+    // Copy/paste original2/1 -> pasted2/1
+    let (pasted2, pasted1) = {
+        let pasted = Component::batch_copy(
+            ctx,
+            View::get_id_for_default(ctx).await?,
+            None,
+            vec![(original2.id, GEOMETRY2), (original1.id, GEOMETRY1)],
+        )
+        .await?;
+        assert_eq!(pasted.len(), 2);
+        (
+            Connectable::new(test, pasted[0]),
+            Connectable::new(test, pasted[1]),
+        )
+    };
+
+    // Set the pasted components' values to make sure those are flowing as expected
+    pasted1.set_value(ctx, "pasted1").await?;
+    pasted2.set_value(ctx, "pasted2").await?;
+
+    // Set the external components' values to new values to ensure they flow through the pasted
+    // connections
+    input1.set_value(ctx, "input1-new").await?;
+    input2.set_value(ctx, "input2-new").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Make sure original1 and original2 didn't change
+    assert_eq!(
+        json!({
+            "Value": "original1",
+            "One": "input1-new",
+            "Many": ["input1-new", "input2-new"],
+        }),
+        original1.domain(ctx).await?
+    );
+    assert_eq!(
+        json!({
+            "Value": "original2",
+            "One": "original1",
+            "Many": ["input1-new", "input2-new", "original1"],
+        }),
+        original2.domain(ctx).await?
+    );
+
+    // Make sure the pasted components got the connected values we expect
+    assert_eq!(
+        json!({
+            "Value": "pasted1",
+            "One": "input1-new",
+            "Many": ["input1-new", "input2-new"],
+        }),
+        pasted1.domain(ctx).await?
+    );
+    assert_eq!(
+        json!({
+            "Value": "pasted2",
+            "One": "pasted1",
+            "Many": ["input1-new", "input2-new", "pasted1"],
+        }),
+        pasted2.domain(ctx).await?
+    );
+
+    // Make sure the pasted components were *not* connected to the output
+    assert_eq!(
+        json!({
+            "Value": "output",
+            "One": "original2",
+            // TODO incorrect
+            "Many": ["input1-new", "input2-new", "original1", "original2"],
+        }),
+        output.domain(ctx).await?
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn paste_components_with_subscriptions(ctx: &mut DalContext) -> Result<()> {
+    let test = ConnectableTest::setup(ctx).await?;
+
+    // input1
+    let input1 = test.create_connectable(ctx, "input1", None, []).await?;
+    assert_eq!(
+        json!({
+            "Value": "input1"
+        }),
+        input1.domain(ctx).await?
+    );
+
+    // input2
+    let input2 = test.create_connectable(ctx, "input2", None, []).await?;
+    assert_eq!(
+        json!({
+            "Value": "input2"
+        }),
+        input2.domain(ctx).await?
+    );
+
+    // input1 -> original1
+    let original1 = test.create_connectable(ctx, "original1", None, []).await?;
+    value::subscribe(
+        ctx,
+        ("original1", "/domain/One"),
+        [("input1", "/domain/Value")],
+    )
+    .await?;
+    value::subscribe(
+        ctx,
+        ("original1", "/domain/Many"),
+        [("input1", "/domain/Value"), ("input2", "/domain/Value")],
+    )
+    .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "original1",
+            "One": "input1",
+            "Many": ["input1", "input2"],
+        }),
+        original1.domain(ctx).await?
+    );
+
+    // original1 -> original2
+    let original2 = test.create_connectable(ctx, "original2", None, []).await?;
+    value::subscribe(
+        ctx,
+        ("original2", "/domain/One"),
+        [("original1", "/domain/Value")],
+    )
+    .await?;
+    value::subscribe(
+        ctx,
+        ("original2", "/domain/Many"),
+        [
+            ("input1", "/domain/Value"),
+            ("input2", "/domain/Value"),
+            ("original1", "/domain/Value"),
+        ],
+    )
+    .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "original2",
+            "One": "original1",
+            "Many": ["input1", "input2", "original1"],
+        }),
+        original2.domain(ctx).await?
+    );
+
+    // original1 -> output
+    let output = test.create_connectable(ctx, "output", None, []).await?;
+    value::subscribe(
+        ctx,
+        ("output", "/domain/One"),
+        [("original2", "/domain/Value")],
+    )
+    .await?;
+    value::subscribe(
+        ctx,
+        ("output", "/domain/Many"),
+        [
+            ("input1", "/domain/Value"),
+            ("input2", "/domain/Value"),
+            ("original1", "/domain/Value"),
+            ("original2", "/domain/Value"),
+        ],
+    )
+    .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "output",
+            "One": "original2",
+            "Many": ["input1", "input2", "original1", "original2"],
+        }),
+        output.domain(ctx).await?
+    );
+
+    // Copy/paste original2/1 -> pasted2/1
+    let (pasted1, pasted2) = {
+        let pasted = Component::batch_copy(
+            ctx,
+            View::get_id_for_default(ctx).await?,
+            None,
+            vec![(original1.id, GEOMETRY2), (original2.id, GEOMETRY1)],
+        )
+        .await?;
+        assert_eq!(pasted.len(), 2);
+        (
+            Connectable::new(test, pasted[0]),
+            Connectable::new(test, pasted[1]),
+        )
+    };
+
+    // Set the pasted components' values to make sure those are flowing as expected
+    pasted1.set_value(ctx, "pasted1").await?;
+    pasted2.set_value(ctx, "pasted2").await?;
+
+    // Set the external components' values to new values to ensure they flow through the pasted
+    // connections
+    input1.set_value(ctx, "input1-new").await?;
+    input2.set_value(ctx, "input2-new").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Make sure original1 and original2 didn't change
+    assert_eq!(
+        json!({
+            "Value": "original1",
+            "One": "input1-new",
+            "Many": ["input1-new", "input2-new"],
+        }),
+        original1.domain(ctx).await?
+    );
+    assert_eq!(
+        json!({
+            "Value": "original2",
+            "One": "original1",
+            "Many": ["input1-new", "input2-new", "original1"],
+        }),
+        original2.domain(ctx).await?
+    );
+
+    // Make sure the pasted components got the connected values we expect
+    assert_eq!(
+        json!({
+            "Value": "pasted1",
+            "One": "input1-new",
+            "Many": ["input1-new", "input2-new"],
+        }),
+        pasted1.domain(ctx).await?
+    );
+    assert_eq!(
+        json!({
+            "Value": "pasted2",
+            "One": "pasted1",
+            "Many": ["input1-new", "input2-new", "pasted1"],
+        }),
+        pasted2.domain(ctx).await?
+    );
+
+    // Make sure the pasted components were *not* connected to the output
+    assert_eq!(
+        json!({
+            "Value": "output",
+            "One": "original2",
+            // TODO incorrect
+            "Many": ["input1-new", "input2-new", "original1", "original2"],
+        }),
+        output.domain(ctx).await?
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn paste_components_with_subscriptions_opposite_order(ctx: &mut DalContext) -> Result<()> {
+    let test = ConnectableTest::setup(ctx).await?;
+
+    // input1
+    let input1 = test.create_connectable(ctx, "input1", None, []).await?;
+    assert_eq!(
+        json!({
+            "Value": "input1"
+        }),
+        input1.domain(ctx).await?
+    );
+
+    // input2
+    let input2 = test.create_connectable(ctx, "input2", None, []).await?;
+    assert_eq!(
+        json!({
+            "Value": "input2"
+        }),
+        input2.domain(ctx).await?
+    );
+
+    // input1 -> original1
+    let original1 = test.create_connectable(ctx, "original1", None, []).await?;
+    value::subscribe(
+        ctx,
+        ("original1", "/domain/One"),
+        [("input1", "/domain/Value")],
+    )
+    .await?;
+    value::subscribe(
+        ctx,
+        ("original1", "/domain/Many"),
+        [("input1", "/domain/Value"), ("input2", "/domain/Value")],
+    )
+    .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "original1",
+            "One": "input1",
+            "Many": ["input1", "input2"],
+        }),
+        original1.domain(ctx).await?
+    );
+
+    // original1 -> original2
+    let original2 = test.create_connectable(ctx, "original2", None, []).await?;
+    value::subscribe(
+        ctx,
+        ("original2", "/domain/One"),
+        [("original1", "/domain/Value")],
+    )
+    .await?;
+    value::subscribe(
+        ctx,
+        ("original2", "/domain/Many"),
+        [
+            ("input1", "/domain/Value"),
+            ("input2", "/domain/Value"),
+            ("original1", "/domain/Value"),
+        ],
+    )
+    .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        json!({
+            "Value": "original2",
+            "One": "original1",
+            "Many": ["input1", "input2", "original1"],
+        }),
+        original2.domain(ctx).await?
+    );
+
+    // original1 -> output
+    let output = test.create_connectable(ctx, "output", None, []).await?;
+    value::subscribe(
+        ctx,
+        ("output", "/domain/One"),
+        [("original2", "/domain/Value")],
+    )
+    .await?;
+    value::subscribe(
+        ctx,
+        ("output", "/domain/Many"),
+        [
+            ("input1", "/domain/Value"),
+            ("input2", "/domain/Value"),
+            ("original1", "/domain/Value"),
+            ("original2", "/domain/Value"),
+        ],
+    )
+    .await?;
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
     assert_eq!(
         json!({


### PR DESCRIPTION
Right now, when you copy/paste two components with subscriptions to one another (e.g. a VPC and a Subnet), the subscription is not mirrored the same way as connections: Subnet' is connected to VPC (the original). Socket connections are "mirrored" so that VPC' and Subnet' are connected; subscriptions should do the same!

Fixes ENG-3026.

## Testing

- [x] Existing tests pass
- [x] Integration tests for copy/paste subscriptions
- [x] Manual: copy/paste sockets still mirrors connections
- [x] Manual: copy/paste subscriptions mirrors subscriptions

## Factor Budget

- Removed AttributePrototypeArgument::set_value_from_xxx() methods, most of which are now unused.
- Reduced usage of AttributePrototypeArgument::set_value_source() as well in places where new() can be used instead.

![giphy](https://github.com/user-attachments/assets/22672018-4505-4953-ab5a-3f5fb5bdbc75)