### PR TITLE
Fix MV ID population for ComponentList

### DIFF
--- a/lib/edda-server/src/change_set_processor_task/materialized_view.rs
+++ b/lib/edda-server/src/change_set_processor_task/materialized_view.rs
@@ -745,7 +745,7 @@ async fn spawn_build_mv_task_for_change_and_mv_kind(
             }
         }
         ReferenceKind::ComponentList => {
-            let entity_mv_id = change.entity_id.to_string();
+            let change_set_mv_id = change_set_id.to_string();
 
             let trigger_entity = <ComponentListMv as MaterializedView>::trigger_entity();
             if change.entity_kind != trigger_entity {
@@ -759,7 +759,7 @@ async fn spawn_build_mv_task_for_change_and_mv_kind(
                     ctx,
                     frigg,
                     change,
-                    entity_mv_id,
+                    change_set_mv_id,
                     ComponentListMv,
                     dal_materialized_views::component_list::assemble(ctx.clone(),),
                 );


### PR DESCRIPTION
The MV ID for the ComponentList was accidentally the entity ID instead of the change set ID. This could cause an incredible number of rebuilds since the MV ID could change based on any affected Component.