### PR TITLE
feat(dal): Support chaining before funcs when using attribute value subscriptions

### DIFF
--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -51,6 +51,8 @@ pub mod change_set;
 pub mod component;
 /// Test helpers for schemas
 pub mod schema;
+/// Test helpers for secrets
+pub mod secret;
 
 pub use change_set::ChangeSetTestHelpers;
 use dal::diagram::view::ViewId;

--- a/lib/dal-test/src/helpers/secret.rs
+++ b/lib/dal-test/src/helpers/secret.rs
@@ -1,0 +1,123 @@
+use dal::{
+    BuiltinsResult,
+    prop::{
+        PropPath,
+        SECRET_KIND_WIDGET_OPTION_LABEL,
+    },
+};
+use si_pkg::{
+    AttrFuncInputSpec,
+    AttrFuncInputSpecKind,
+    FuncSpec,
+    PropSpec,
+    PropSpecKind,
+    PropSpecWidgetKind,
+    SocketSpec,
+    SocketSpecArity,
+    SocketSpecData,
+    SocketSpecKind,
+};
+
+/// Mimics functionality from "asset_builder.ts".
+pub fn assemble_dummy_secret_socket_and_prop(
+    identity_func_spec: &FuncSpec,
+    secret_definition_name: &str,
+) -> BuiltinsResult<(SocketSpec, PropSpec)> {
+    // Create the input socket for the secret.
+    let secret_input_socket = SocketSpec::builder()
+        .name(secret_definition_name)
+        .data(
+            SocketSpecData::builder()
+                .name(secret_definition_name)
+                .connection_annotations(serde_json::to_string(&vec![
+                    secret_definition_name.to_lowercase(),
+                ])?)
+                .kind(SocketSpecKind::Input)
+                .arity(SocketSpecArity::One)
+                .func_unique_id(&identity_func_spec.unique_id)
+                .build()?,
+        )
+        .build()?;
+
+    // Create the secret prop for the secret.
+    let secret_prop = PropSpec::builder()
+        .name(secret_definition_name)
+        .kind(PropSpecKind::String)
+        .widget_kind(PropSpecWidgetKind::Secret)
+        .func_unique_id(&identity_func_spec.unique_id)
+        .widget_options(serde_json::json![
+            [
+                {
+                    "label": SECRET_KIND_WIDGET_OPTION_LABEL,
+                    "value": secret_definition_name
+                }
+            ]
+        ])
+        .input(
+            AttrFuncInputSpec::builder()
+                .name("identity")
+                .kind(AttrFuncInputSpecKind::InputSocket)
+                .socket_name(secret_definition_name)
+                .build()?,
+        )
+        .build()?;
+
+    Ok((secret_input_socket, secret_prop))
+}
+
+/// Mimics the "defineSecret" function in "asset_builder.ts".
+pub fn assemble_secret_definition_dummy(
+    identity_func_spec: &FuncSpec,
+    secret_definition_name: &str,
+) -> BuiltinsResult<(PropSpec, PropSpec, SocketSpec)> {
+    // First, create the child of "/root/secret_definition" that defines our secret.
+    let new_secret_definition_prop = PropSpec::builder()
+        .name("value")
+        .kind(PropSpecKind::String)
+        .widget_kind(PropSpecWidgetKind::Password)
+        .build()?;
+
+    // Second, add it as a new prop underneath "/root/secrets" object. Make sure the "secretKind" is available.
+    let new_secret_prop = PropSpec::builder()
+        .name(secret_definition_name)
+        .kind(PropSpecKind::String)
+        .widget_kind(PropSpecWidgetKind::Secret)
+        .widget_options(serde_json::json![
+            [
+                {
+                    "label": SECRET_KIND_WIDGET_OPTION_LABEL,
+                    "value": secret_definition_name
+                }
+            ]
+        ])
+        .build()?;
+
+    // Third, add an output socket for other components to use the secret.
+    let new_secret_output_socket = SocketSpec::builder()
+        .name(secret_definition_name)
+        .data(
+            SocketSpecData::builder()
+                .name(secret_definition_name)
+                .connection_annotations(serde_json::to_string(&vec![
+                    secret_definition_name.to_lowercase(),
+                ])?)
+                .kind(SocketSpecKind::Output)
+                .arity(SocketSpecArity::One)
+                .func_unique_id(&identity_func_spec.unique_id)
+                .build()?,
+        )
+        .input(
+            AttrFuncInputSpec::builder()
+                .name("identity")
+                .kind(AttrFuncInputSpecKind::Prop)
+                .prop_path(PropPath::new(["root", "secrets", secret_definition_name]))
+                .build()?,
+        )
+        .build()?;
+
+    Ok((
+        new_secret_definition_prop,
+        new_secret_prop,
+        new_secret_output_socket,
+    ))
+}

--- a/lib/dal-test/src/test_exclusive_schemas/mod.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/mod.rs
@@ -17,6 +17,7 @@ use dal::{
         intrinsics::IntrinsicFunc,
     },
 };
+use dummy_double_secret::migrate_test_exclusive_schema_dummy_double_secret;
 use dummy_secret::migrate_test_exclusive_schema_dummy_secret;
 use fake_butane::migrate_test_exclusive_schema_fake_butane;
 use fake_docker_image::migrate_test_exclusive_schema_fake_docker_image;
@@ -47,6 +48,7 @@ use swifty::migrate_test_exclusive_schema_swifty;
 
 mod category_pirate;
 mod category_validated;
+mod dummy_double_secret;
 mod dummy_secret;
 mod fake_butane;
 mod fake_docker_image;
@@ -59,6 +61,8 @@ mod swifty;
 const PKG_VERSION: &str = "2019-06-03";
 const PKG_CREATED_BY: &str = "System Initiative";
 
+/// Schema id for the `dummy double secret` schema variant
+pub const SCHEMA_ID_DUMMY_DOUBLE_SECRET: &str = "01JARFRNN5VV1NMM0H5M63K3QX";
 /// Schema id for the `starfield` schema variant
 pub const SCHEMA_ID_STARFIELD: &str = "01JARFRNN5VV1NMM0H5M63K3PY";
 /// Schema id for the `private language` schema varitn
@@ -144,6 +148,13 @@ pub async fn migrate(ctx: &DalContext) -> BuiltinsResult<()> {
     migrate_test_exclusive_schema_dummy_secret(
         ctx,
         ulid::Ulid::from_str(SCHEMA_ID_DUMMY_SECRET)
+            .expect("should convert")
+            .into(),
+    )
+    .await?;
+    migrate_test_exclusive_schema_dummy_double_secret(
+        ctx,
+        ulid::Ulid::from_str(SCHEMA_ID_DUMMY_DOUBLE_SECRET)
             .expect("should convert")
             .into(),
     )

--- a/lib/dal/tests/integration_test/module.rs
+++ b/lib/dal/tests/integration_test/module.rs
@@ -26,6 +26,7 @@ async fn list_modules(ctx: &DalContext) {
         "Docker Image".to_string(),
         "ValidatedInput".to_string(),
         "ValidatedOutput".to_string(),
+        "dummy-double-secret".to_string(),
         "dummy-secret".to_string(),
         "etoiles".to_string(),
         "fallout".to_string(),


### PR DESCRIPTION
This PR adapts gathering before functions to work with attribute value subscriptions.  

To test, I added a new test exclusive schema aptly named `double-dummy-secret` which is similar to the `dummy-secret` except that it also accepts an secret itself (from `dummy-secret`) to ensure we chain the before funcs appropriately.  

We didn't have coverage of chaining before funcs already, so this first tests the existing functionality that relies on socket connections, as well as ensures that adding an attribute subscription (prop to prop connection) for secrets works exactly as socket connections do. 

I pulled out some helper functions into a common place for this, so a bit more code churn than I'd like considering the actual change is only a few lines, but so it goes. 

<div><img src="https://media1.giphy.com/media/9kwOxInrc1eSdIFHUJ/giphy.gif?cid=5a38a5a2t1khox76i6zuzfjlbs2rlbdlz8689c5f0bw51mnm&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/freeform/">Freeform</a> on <a href="https://giphy.com/gifs/freeform-halloween-spooky-halloweentown-9kwOxInrc1eSdIFHUJ">GIPHY</a></div>