### PR TITLE
chore(dal): snapshot node viewer for debugging

### DIFF
--- a/lib/dal/examples/snapshot-surfer/main.rs
+++ b/lib/dal/examples/snapshot-surfer/main.rs
@@ -1,0 +1,145 @@
+use std::{
+    env,
+    fs::File,
+    io::{
+        Read as _,
+        Write,
+    },
+};
+
+use dal::{
+    EdgeWeightKind,
+    NodeWeightDiscriminants,
+    Ulid,
+    WorkspaceSnapshotGraph,
+    workspace_snapshot::node_weight::NodeWeight,
+};
+use itertools::Itertools as _;
+use petgraph::prelude::*;
+use si_layer_cache::db::serialize;
+use tokio::time::Instant;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error + 'static>>;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // To fix a snapshot, first download the snapshot from the admin portal
+    // Then run this like so in dal/examples:
+    // cargo run --example snapshot-surfer <PATH> <NODE_ID> ...
+    // ex: cargo run --example snapshot-surfer ~/Downloads/head.snapshot 01JTXGMYKFFPY7H2ZNV7SKFQ9X 01JPT6SHX1X43GTM8XHQ6VJRTM
+    let mut args = env::args();
+    args.next(); // skip program name
+    let snap_path = args
+        .next()
+        .expect("usage: program <SNAPSHOT_FILE_PATH> <NODE_ID> ...");
+
+    let mut snap_file = File::open(snap_path)?;
+
+    let mut snap_bytes = vec![];
+    snap_file.read_to_end(&mut snap_bytes)?;
+
+    println!("snap bytes compressed: {}", snap_bytes.len());
+    let decompressed = serialize::decompress_to_vec(&snap_bytes)?;
+    println!("decompressed: {}", decompressed.len());
+
+    let now = Instant::now();
+    let mut graph: WorkspaceSnapshotGraph = serialize::from_bytes(&snap_bytes)?;
+    println!("deserialization took: {:?}", now.elapsed());
+    // Make your edits:
+    // Example: We were seeing:
+    // attribute value error: attribute value 01JTXGMYKFFPY7H2ZNV7SKFQ9X has no outgoing edge to a prop or socket"
+    // so we needed to remove it
+    // let node_id = "01JTXGMYKFFPY7H2ZNV7SKFQ9X";
+    // remove_node_by_id(&mut graph, node_id)?;
+    for arg in args {
+        let node_id = Ulid::from_string(&arg)?;
+        let node_idx = graph.get_node_index_by_id(node_id)?;
+        let ident = node_ident(&graph, node_idx)?;
+        println!();
+        println!("{}", "=".repeat(ident.len()));
+        println!("{}", ident);
+        println!();
+        println!("  {:?}", graph.get_node_weight(node_idx)?);
+        print_edges(&graph, node_idx)?;
+    }
+    // let output_socket =
+    //     graph.get_node_index_by_id(Ulid::from_string("01JP40FPPQBGR31K6K4WT896P4")?)?;
+    // let component = graph.get_node_index_by_id(Ulid::from_string("01JPT6SHX1X43GTM8XHQ6VJRTM")?)?;
+    // print_edges(&graph, output_socket);
+
+    // Cleanup and update merkle tree
+    graph.cleanup_and_merkle_tree_hash()?;
+
+    // write snapshot
+    write_snapshot_graph("./fixed.snapshot", &graph)?;
+
+    // then head back to the admin portal and replace snapshot with this new fixed snapshot
+    Ok(())
+}
+
+fn print_edges(graph: &WorkspaceSnapshotGraph, index: NodeIndex) -> Result<()> {
+    let incoming: Vec<_> = graph
+        .edges_directed(index, Direction::Incoming)
+        .map(|edge| {
+            node_ident(graph, edge.source())
+                .map(|source| format!(" ← {:?} - {}", edge.weight().kind(), source))
+        })
+        .try_collect()?;
+    println!();
+    for incoming in incoming {
+        println!("  {}", incoming);
+    }
+
+    println!();
+    let outgoing: Vec<_> = graph
+        .edges_directed(index, Direction::Outgoing)
+        .map(|edge| {
+            node_ident(graph, edge.target())
+                .map(|target| format!(" → {:?} - {}", edge.weight().kind(), target))
+        })
+        .try_collect()?;
+    for outgoing in outgoing {
+        println!("  {}", outgoing);
+    }
+    Ok(())
+}
+
+fn node_ident(graph: &WorkspaceSnapshotGraph, index: NodeIndex) -> Result<String> {
+    let node = graph.get_node_weight(index)?;
+    let discrim = match node.content_address_discriminants() {
+        Some(discrim) => discrim.to_string(),
+        None => NodeWeightDiscriminants::from(node).to_string(),
+    };
+    let extra = match node {
+        NodeWeight::AttributeValue(_) => match graph.target_opt(index, EdgeWeightKind::Prop)? {
+            Some(prop_index) => {
+                let prop = graph.get_node_weight(prop_index)?.as_prop_node_weight()?;
+                Some(format!(" (prop {} - {})", prop.id(), prop.name()))
+            }
+            None => None,
+        },
+        _ => None,
+    };
+    Ok(format!(
+        "{} {}{}",
+        discrim,
+        node.id(),
+        extra.unwrap_or("".to_string())
+    ))
+}
+
+fn write_snapshot_graph(path: &str, graph: &WorkspaceSnapshotGraph) -> Result<()> {
+    let mut file = File::create(path)?;
+    let (bytes, _) = serialize::to_vec(graph)?;
+    file.write_all(&bytes)?;
+
+    Ok(())
+}
+
+#[allow(unused)]
+fn remove_node_by_id(graph: &mut WorkspaceSnapshotGraph, id: &str) -> Result<()> {
+    let node_id = si_id::ulid::Ulid::from_string(id)?;
+    let node_idx = graph.get_node_index_by_id(node_id)?;
+    graph.remove_node(node_idx);
+    Ok(())
+}


### PR DESCRIPTION
This is a rudimentary CLI that lets you open a snapshot and print out a node (and/or edges). It could be tons better, but was super useful in our debugging just now!

```
~/si/lib/dal/examples$ cargo run --example snapshot-surfer ~/my.snapshot 01JVQZD3480HFAV52Y7J2X6Q05 01JQ1XD6MM993AQP3W3X248K96`
snap bytes compressed: 5824912
decompressed: 8633340
deserialization took: 362.178364ms

==================================================================================
AttributeValue 01JVQZD3480HFAV52Y7J2X6Q05 (prop 01JQ1XD6MM993AQP3W3X248K96 - code)

  AttributeValue(AttributeValueNodeWeight { id: "01JVQZD3480HFAV52Y7J2X6Q05", lineage_id: "01JVQZD3480HFAV52Y7J2X6Q06", value: Some(JsonValue(ContentHash(9afc404c867338ec6cd499708784b339))), unprocessed_value: Some(JsonValue(ContentHash(9afc404c867338ec6cd499708784b339))), node_hash: ContentHash(d645cfee6d6d089ff5cf7bb37379c929), merkle_tree_hash: MerkleTreeHash(c6de6f7ba527bd5630cfb1d5c335df28) })

   ← Contain(None) - AttributeValue 01JVQZD347WE33VTJ165SYTY5A (prop 01JQ1XD6MJPPG5SPT9N6CHPHRY - root)
   ← Ordinal - Ordering 01JVQZD347WE33VTJ165SYTY5C

   → Contain(Some("awsCloudControlCreate")) - AttributeValue 01JVQZD34D0GXDE0PQYQY5TF2J (prop 01JQ1XD6MM993AQP3W3X248K9A - codeItem)
   → Contain(Some("awsCloudControlUpdate")) - AttributeValue 01JVQZD34D0GXDE0PQYQY5TF2E (prop 01JQ1XD6MM993AQP3W3X248K9A - codeItem)
   → Contain(Some("awsCloudFormationLint")) - AttributeValue 01JVQZD34D0GXDE0PQYQY5TF2A (prop 01JQ1XD6MM993AQP3W3X248K9A - codeItem)
   → Prop - Prop 01JQ1XD6MM993AQP3W3X248K96
   → Ordering - Ordering 01JVQZD3480HFAV52Y7J2X6Q07
   → Prototype(None) - AttributePrototype 01JVQZEZ5MGM0KRJKN5YQJB35Z

===============================
Prop 01JQ1XD6MM993AQP3W3X248K96

  Prop(PropNodeWeight { id: "01JQ1XD6MM993AQP3W3X248K96", lineage_id: "01JQ1XD6MM993AQP3W3X248K97", kind: Map, name: "code", content_hash: ContentHash(cfae44d95bf86b4c1b0ab4a6a09c9b32), merkle_tree_hash: MerkleTreeHash(4685f74546c33ce18b132b6dfd210e54) })

   ← Prop - AttributeValue 01JVQZCYQ8ASC809BDF7M1EFZG (prop 01JQ1XD6MM993AQP3W3X248K96 - code)
   ← Prop - AttributeValue 01JVQZD3480HFAV52Y7J2X6Q05 (prop 01JQ1XD6MM993AQP3W3X248K96 - code)
   ← Prop - AttributeValue 01JVQZCZD1GM5F189FQCXPMM3S (prop 01JQ1XD6MM993AQP3W3X248K96 - code)
   ← Prop - AttributeValue 01JVQZD16KMXMAC44TPA2BEE78 (prop 01JQ1XD6MM993AQP3W3X248K96 - code)
   ← Prop - AttributeValue 01JQ1XT57GQHJAC8CQE9NXA64Q (prop 01JQ1XD6MM993AQP3W3X248K96 - code)
   ← PrototypeArgumentValue - AttributePrototypeArgument 01JQ1XD6WTQA56FFAABQGZMYRV
   ← PrototypeArgumentValue - AttributePrototypeArgument 01JQ1XD6WRNEVCA1JM0HHJ1AA2
   ← Ordinal - Ordering 01JQ1XD6MJPPG5SPT9N6CHPHS0
   ← Use { is_default: false } - Prop 01JQ1XD6MJPPG5SPT9N6CHPHRY
   ← Prop - AttributeValue 01JQ1XT0CG2HY9YWXHKV5XSK1R (prop 01JQ1XD6MM993AQP3W3X248K96 - code)
   ← Prop - AttributeValue 01JQ1XX2S8FYTZ2KR89XVS9SX8 (prop 01JQ1XD6MM993AQP3W3X248K96 - code)

   → Prototype(None) - AttributePrototype 01JQ1XD6MZQQ8XS0HJ139GSGER
   → Use { is_default: false } - Prop 01JQ1XD6MM993AQP3W3X248K9A
   → Ordering - Ordering 01JQ1XD6MM993AQP3W3X248K98
```