### PR TITLE
feat(dal,si-split-graph): port all remaining corrections to split graph

### DIFF
--- a/lib/dal-test/src/helpers/change_set.rs
+++ b/lib/dal-test/src/helpers/change_set.rs
@@ -58,7 +58,7 @@ pub async fn wait_for_dvu(ctx: &mut DalContext) -> Result<()> {
     Ok(())
 }
 
-/// This unit struct providers helper functions for working with [`ChangeSets`](ChangeSet). It is
+/// This unit struct provides helper functions for working with [`ChangeSets`](ChangeSet). It is
 /// designed to centralize logic for test authors wishing to commit changes, fork, apply, abandon,
 /// etc.
 #[derive(Debug)]
@@ -150,7 +150,8 @@ impl ChangeSetTestHelpers {
         )
     }
 
-    async fn apply_change_set_to_base_inner(ctx: &mut DalContext) -> Result<bool> {
+    /// Applies the current change set to the base change set, waiting for replays to land on any open change sets.
+    pub async fn apply_change_set_to_base_inner(ctx: &mut DalContext) -> Result<bool> {
         let mut open_change_sets = ChangeSet::list_active(ctx)
             .await?
             .iter()

--- a/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
@@ -1,34 +1,20 @@
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 
 use petgraph::prelude::*;
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use si_events::{
-    ContentHash,
-    merkle_tree_hash::MerkleTreeHash,
-    ulid::Ulid,
-};
+use serde::{Deserialize, Serialize};
+use si_events::{ContentHash, merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
+use si_split_graph::SplitGraphNodeId;
 
 use super::traits::CorrectTransformsResult;
 use crate::{
-    ChangeSetId,
-    EdgeWeightKindDiscriminants,
-    NodeWeightDiscriminants,
+    ChangeSetId, EdgeWeight, EdgeWeightKindDiscriminants, NodeWeightDiscriminants,
     WorkspaceSnapshotGraphVCurrent,
     action::ActionState,
     workspace_snapshot::{
-        NodeId,
-        NodeInformation,
-        graph::{
-            LineageId,
-            detector::Update,
-        },
-        node_weight::{
-            NodeWeight,
-            traits::CorrectTransforms,
-        },
+        NodeId, NodeInformation,
+        graph::{LineageId, detector::Update},
+        node_weight::{NodeWeight, traits::CorrectTransforms},
+        split_snapshot,
     },
 };
 
@@ -127,6 +113,10 @@ impl CorrectTransforms for ActionNodeWeight {
         // than rewriting all the graphs to have distinct edge kinds for action
         // prototypes and/or the components the action is for.
 
+        if graph.get_node_index_by_id_opt(self.id).is_none() {
+            return Ok(updates);
+        }
+
         struct ActionUseTargets {
             component: Option<NodeId>,
             prototype: Option<NodeId>,
@@ -206,6 +196,104 @@ impl CorrectTransforms for ActionNodeWeight {
                         )
                     }),
             )
+        }
+
+        Ok(updates)
+    }
+}
+
+impl
+    split_snapshot::corrections::CorrectTransforms<
+        NodeWeight,
+        EdgeWeight,
+        EdgeWeightKindDiscriminants,
+    > for ActionNodeWeight
+{
+    fn correct_transforms(
+        &self,
+        graph: &si_split_graph::SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+        mut updates: Vec<
+            si_split_graph::Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+        >,
+        _from_different_change_set: bool,
+    ) -> split_snapshot::corrections::CorrectTransformsResult<
+        Vec<si_split_graph::Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>,
+    > {
+        if !graph.node_exists(self.id()) {
+            return Ok(updates);
+        }
+
+        // An action's Use edge should be exclusive for both the component and
+        // the prototype. The generic exclusive edge logic assumes there can be
+        // one and only one edge of the given kind, so we have to do a custom
+        // implementation here for actions, since they should have just one use
+        // edge to a component and one use edge to a prototype. This is simpler
+        // than rewriting all the graphs to have distinct edge kinds for action
+        // prototypes and/or the components the action is for.
+
+        struct ActionUseTargets {
+            component: Option<SplitGraphNodeId>,
+            prototype: Option<SplitGraphNodeId>,
+        }
+
+        let mut new_action_use_targets = ActionUseTargets {
+            component: None,
+            prototype: None,
+        };
+
+        let mut removal_set = BTreeSet::new();
+
+        for update in &updates {
+            match update {
+                si_split_graph::Update::NewEdge { destination, .. }
+                    if update.source_has_id(self.id())
+                        && update.is_of_custom_edge_kind(EdgeWeightKindDiscriminants::Use) =>
+                {
+                    removal_set.remove(&destination.id);
+                    match destination.custom_kind {
+                        Some(NodeWeightDiscriminants::ActionPrototype) => {
+                            new_action_use_targets.prototype = Some(destination.id);
+                        }
+                        Some(NodeWeightDiscriminants::Component) => {
+                            new_action_use_targets.component = Some(destination.id);
+                        }
+                        _ => {}
+                    }
+                }
+                si_split_graph::Update::RemoveEdge { destination, .. }
+                    if update.source_has_id(self.id())
+                        && update.is_of_custom_edge_kind(EdgeWeightKindDiscriminants::Use) =>
+                {
+                    removal_set.insert(&destination.id);
+                }
+                _ => {}
+            }
+        }
+
+        let removals: Vec<_> = graph
+            .outgoing_edges(self.id(), EdgeWeightKindDiscriminants::Use)?
+            .filter_map(|edge_ref| {
+                graph
+                    .node_weight(edge_ref.target())
+                    .and_then(|destination_weight| {
+                        match destination_weight {
+                            NodeWeight::ActionPrototype(_) => new_action_use_targets.prototype,
+                            NodeWeight::Component(_) => new_action_use_targets.component,
+                            _ => None,
+                        }
+                        .is_some_and(|new_destination_id| {
+                            new_destination_id != edge_ref.target()
+                                && !removal_set.contains(&new_destination_id)
+                        })
+                        .then_some(edge_ref.triplet())
+                    })
+            })
+            .collect();
+
+        for (source_id, kind, target_id) in removals {
+            updates.extend(si_split_graph::Update::remove_edge_updates(
+                graph, source_id, kind, target_id,
+            )?);
         }
 
         Ok(updates)

--- a/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_node_weight.rs
@@ -1,19 +1,39 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{
+    BTreeSet,
+    HashSet,
+};
 
 use petgraph::prelude::*;
-use serde::{Deserialize, Serialize};
-use si_events::{ContentHash, merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::{
+    ContentHash,
+    merkle_tree_hash::MerkleTreeHash,
+    ulid::Ulid,
+};
 use si_split_graph::SplitGraphNodeId;
 
 use super::traits::CorrectTransformsResult;
 use crate::{
-    ChangeSetId, EdgeWeight, EdgeWeightKindDiscriminants, NodeWeightDiscriminants,
+    ChangeSetId,
+    EdgeWeight,
+    EdgeWeightKindDiscriminants,
+    NodeWeightDiscriminants,
     WorkspaceSnapshotGraphVCurrent,
     action::ActionState,
     workspace_snapshot::{
-        NodeId, NodeInformation,
-        graph::{LineageId, detector::Update},
-        node_weight::{NodeWeight, traits::CorrectTransforms},
+        NodeId,
+        NodeInformation,
+        graph::{
+            LineageId,
+            detector::Update,
+        },
+        node_weight::{
+            NodeWeight,
+            traits::CorrectTransforms,
+        },
         split_snapshot,
     },
 };

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -1,32 +1,18 @@
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use si_events::{
-    ContentHash,
-    merkle_tree_hash::MerkleTreeHash,
-    ulid::Ulid,
-};
+use serde::{Deserialize, Serialize};
+use si_events::{ContentHash, merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
+use si_split_graph::SplitGraphNodeWeight;
 
-use super::{
-    NodeWeight,
-    category_node_weight::CategoryNodeKind,
-    traits::CorrectTransformsResult,
-};
+use super::{NodeWeight, category_node_weight::CategoryNodeKind, traits::CorrectTransformsResult};
 use crate::{
-    EdgeWeightKindDiscriminants,
-    WorkspaceSnapshotGraphVCurrent,
+    EdgeWeight, EdgeWeightKindDiscriminants, WorkspaceSnapshotGraphVCurrent,
     workspace_snapshot::{
         NodeId,
         content_address::ContentAddress,
-        graph::{
-            LineageId,
-            correct_transforms::add_dependent_value_root_updates,
-            detector::Update,
-        },
+        graph::{LineageId, correct_transforms, detector::Update},
         node_weight::traits::CorrectTransforms,
+        split_snapshot,
     },
 };
 
@@ -198,10 +184,81 @@ impl CorrectTransforms for AttributeValueNodeWeight {
         }
 
         if should_add {
-            updates.extend(add_dependent_value_root_updates(
+            updates.extend(correct_transforms::add_dependent_value_root_updates(
                 graph,
                 &HashSet::from([self.id()]),
             )?);
+        }
+
+        Ok(updates)
+    }
+}
+
+impl
+    split_snapshot::corrections::CorrectTransforms<
+        NodeWeight,
+        EdgeWeight,
+        EdgeWeightKindDiscriminants,
+    > for AttributeValueNodeWeight
+{
+    fn correct_transforms(
+        &self,
+        graph: &si_split_graph::SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+        mut updates: Vec<
+            si_split_graph::Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+        >,
+        from_different_change_set: bool,
+    ) -> split_snapshot::corrections::CorrectTransformsResult<
+        Vec<si_split_graph::Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>,
+    > {
+        if !from_different_change_set {
+            return Ok(updates);
+        }
+
+        let dvu_cat_id = split_snapshot::corrections::get_category_node_id(
+            graph,
+            CategoryNodeKind::DependentValueRoots,
+        )?;
+        let mut should_add = false;
+
+        for update in &updates {
+            match update {
+                si_split_graph::Update::NewEdge { .. }
+                    if update.source_has_id(self.id())
+                        && update
+                            .is_of_custom_edge_kind(EdgeWeightKindDiscriminants::Prototype) =>
+                {
+                    should_add = !graph.node_exists(self.id());
+                }
+                si_split_graph::Update::RemoveEdge { .. } if update.source_id() == dvu_cat_id => {
+                    return Ok(updates);
+                }
+                si_split_graph::Update::NewNode {
+                    node_weight:
+                        SplitGraphNodeWeight::Custom(NodeWeight::DependentValueRoot(dvu_root_inner)),
+                    ..
+                } if dvu_root_inner.value_id() == self.id() => {
+                    return Ok(updates);
+                }
+                si_split_graph::Update::ReplaceNode { node_weight, .. }
+                    if node_weight.id() == self.id() =>
+                {
+                    should_add = graph.node_weight(self.id()).is_some_and(|existing_av| {
+                        existing_av.node_hash() != node_weight.node_hash()
+                    });
+                }
+
+                _ => {}
+            }
+        }
+
+        if should_add {
+            updates.extend(
+                split_snapshot::corrections::add_dependent_value_root_updates(
+                    graph,
+                    &BTreeSet::from([self.id()]),
+                )?,
+            );
         }
 
         Ok(updates)

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -1,16 +1,36 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{
+    BTreeSet,
+    HashSet,
+};
 
-use serde::{Deserialize, Serialize};
-use si_events::{ContentHash, merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::{
+    ContentHash,
+    merkle_tree_hash::MerkleTreeHash,
+    ulid::Ulid,
+};
 use si_split_graph::SplitGraphNodeWeight;
 
-use super::{NodeWeight, category_node_weight::CategoryNodeKind, traits::CorrectTransformsResult};
+use super::{
+    NodeWeight,
+    category_node_weight::CategoryNodeKind,
+    traits::CorrectTransformsResult,
+};
 use crate::{
-    EdgeWeight, EdgeWeightKindDiscriminants, WorkspaceSnapshotGraphVCurrent,
+    EdgeWeight,
+    EdgeWeightKindDiscriminants,
+    WorkspaceSnapshotGraphVCurrent,
     workspace_snapshot::{
         NodeId,
         content_address::ContentAddress,
-        graph::{LineageId, correct_transforms, detector::Update},
+        graph::{
+            LineageId,
+            correct_transforms,
+            detector::Update,
+        },
         node_weight::traits::CorrectTransforms,
         split_snapshot,
     },

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -1,67 +1,35 @@
-use std::{
-    collections::HashSet,
-    sync::Arc,
-};
+use std::{collections::HashSet, sync::Arc};
 
 use itertools::Itertools;
-use petgraph::{
-    Direction::Incoming,
-    prelude::*,
-    stable_graph::EdgeReference,
-};
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use si_events::{
-    ContentHash,
-    Timestamp,
-    merkle_tree_hash::MerkleTreeHash,
-    ulid::Ulid,
-};
-use si_id::{
-    AttributeValueId,
-    ComponentId,
-};
+use petgraph::{Direction::Incoming, prelude::*, stable_graph::EdgeReference};
+use serde::{Deserialize, Serialize};
+use si_events::{ContentHash, Timestamp, merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
+use si_id::{AttributeValueId, ComponentId};
 
 use super::{
-    ArgumentTargets,
-    NodeWeight,
-    NodeWeightDiscriminants,
-    NodeWeightDiscriminants::Component,
-    NodeWeightError,
-    NodeWeightResult,
-    category_node_weight::CategoryNodeKind,
+    ArgumentTargets, NodeWeight, NodeWeightDiscriminants, NodeWeightDiscriminants::Component,
+    NodeWeightError, NodeWeightResult, category_node_weight::CategoryNodeKind,
     traits::CorrectTransformsResult,
 };
 use crate::{
-    DalContext,
-    EdgeWeight,
-    EdgeWeightKind,
-    EdgeWeightKindDiscriminants,
+    DalContext, EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants,
     WorkspaceSnapshotGraphVCurrent,
     layer_db_types::{
-        ComponentContent,
-        ComponentContentDiscriminants,
-        ComponentContentV2,
-        GeometryContent,
+        ComponentContent, ComponentContentDiscriminants, ComponentContentV2, GeometryContent,
         GeometryContentV1,
     },
     workspace_snapshot::{
         NodeInformation,
-        content_address::{
-            ContentAddress,
-            ContentAddressDiscriminants,
-        },
+        content_address::{ContentAddress, ContentAddressDiscriminants},
         graph::{
-            LineageId,
-            WorkspaceSnapshotGraphV4,
-            correct_transforms::add_dependent_value_root_updates,
-            detector::Update,
+            LineageId, WorkspaceSnapshotGraphV4,
+            correct_transforms::add_dependent_value_root_updates, detector::Update,
         },
         node_weight::traits::CorrectTransforms,
     },
 };
+
+mod split_corrections;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ComponentNodeWeight {
@@ -488,9 +456,7 @@ impl CorrectTransforms for ComponentNodeWeight {
                     destination,
                 } if EdgeWeightKindDiscriminants::Use == edge_weight.kind().into()
                     && is_self(source)
-                    && graph
-                        .get_node_weight_by_id_opt(destination.id)
-                        .is_some_and(|n| NodeWeightDiscriminants::SchemaVariant == n.into()) =>
+                    && destination.node_weight_kind == NodeWeightDiscriminants::SchemaVariant =>
                 {
                     // Root props and sockets get all new AttributeValues during upgrade, but
                     // the RemoveEdges for the old ones may be stale; RemoveEdge the real ones

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight.rs
@@ -1,29 +1,63 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::HashSet,
+    sync::Arc,
+};
 
 use itertools::Itertools;
-use petgraph::{Direction::Incoming, prelude::*, stable_graph::EdgeReference};
-use serde::{Deserialize, Serialize};
-use si_events::{ContentHash, Timestamp, merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
-use si_id::{AttributeValueId, ComponentId};
+use petgraph::{
+    Direction::Incoming,
+    prelude::*,
+    stable_graph::EdgeReference,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::{
+    ContentHash,
+    Timestamp,
+    merkle_tree_hash::MerkleTreeHash,
+    ulid::Ulid,
+};
+use si_id::{
+    AttributeValueId,
+    ComponentId,
+};
 
 use super::{
-    ArgumentTargets, NodeWeight, NodeWeightDiscriminants, NodeWeightDiscriminants::Component,
-    NodeWeightError, NodeWeightResult, category_node_weight::CategoryNodeKind,
+    ArgumentTargets,
+    NodeWeight,
+    NodeWeightDiscriminants,
+    NodeWeightDiscriminants::Component,
+    NodeWeightError,
+    NodeWeightResult,
+    category_node_weight::CategoryNodeKind,
     traits::CorrectTransformsResult,
 };
 use crate::{
-    DalContext, EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants,
+    DalContext,
+    EdgeWeight,
+    EdgeWeightKind,
+    EdgeWeightKindDiscriminants,
     WorkspaceSnapshotGraphVCurrent,
     layer_db_types::{
-        ComponentContent, ComponentContentDiscriminants, ComponentContentV2, GeometryContent,
+        ComponentContent,
+        ComponentContentDiscriminants,
+        ComponentContentV2,
+        GeometryContent,
         GeometryContentV1,
     },
     workspace_snapshot::{
         NodeInformation,
-        content_address::{ContentAddress, ContentAddressDiscriminants},
+        content_address::{
+            ContentAddress,
+            ContentAddressDiscriminants,
+        },
         graph::{
-            LineageId, WorkspaceSnapshotGraphV4,
-            correct_transforms::add_dependent_value_root_updates, detector::Update,
+            LineageId,
+            WorkspaceSnapshotGraphV4,
+            correct_transforms::add_dependent_value_root_updates,
+            detector::Update,
         },
         node_weight::traits::CorrectTransforms,
     },

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight/split_corrections.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight/split_corrections.rs
@@ -1,22 +1,43 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{
+    BTreeSet,
+    HashSet,
+};
 
-use petgraph::Direction::{Incoming, Outgoing};
-use si_id::{ComponentId, InputSocketId, OutputSocketId};
-use si_split_graph::{SplitGraph, SplitGraphNodeId, Update};
-
-use crate::{
-    EdgeWeight, EdgeWeightKindDiscriminants, NodeWeightDiscriminants,
-    workspace_snapshot::{
-        content_address::ContentAddressDiscriminants,
-        node_weight::{ArgumentTargets, NodeWeight},
-        split_snapshot::{
-            self,
-            corrections::{CorrectTransformsResult, add_dependent_value_root_updates},
-        },
-    },
+use petgraph::Direction::{
+    Incoming,
+    Outgoing,
+};
+use si_id::{
+    ComponentId,
+    InputSocketId,
+    OutputSocketId,
+};
+use si_split_graph::{
+    SplitGraph,
+    SplitGraphNodeId,
+    Update,
 };
 
 use super::ComponentNodeWeight;
+use crate::{
+    EdgeWeight,
+    EdgeWeightKindDiscriminants,
+    NodeWeightDiscriminants,
+    workspace_snapshot::{
+        content_address::ContentAddressDiscriminants,
+        node_weight::{
+            ArgumentTargets,
+            NodeWeight,
+        },
+        split_snapshot::{
+            self,
+            corrections::{
+                CorrectTransformsResult,
+                add_dependent_value_root_updates,
+            },
+        },
+    },
+};
 
 type Graph = SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>;
 

--- a/lib/dal/src/workspace_snapshot/node_weight/component_node_weight/split_corrections.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/component_node_weight/split_corrections.rs
@@ -1,0 +1,445 @@
+use std::collections::{BTreeSet, HashSet};
+
+use petgraph::Direction::{Incoming, Outgoing};
+use si_id::{ComponentId, InputSocketId, OutputSocketId};
+use si_split_graph::{SplitGraph, SplitGraphNodeId, Update};
+
+use crate::{
+    EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants, NodeWeightDiscriminants,
+    workspace_snapshot::{
+        content_address::ContentAddressDiscriminants,
+        node_weight::{ArgumentTargets, NodeWeight, category_node_weight::CategoryNodeKind},
+        split_snapshot::{self, corrections::CorrectTransformsResult},
+    },
+};
+
+use super::ComponentNodeWeight;
+
+type Graph = SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>;
+
+impl
+    split_snapshot::corrections::CorrectTransforms<
+        NodeWeight,
+        EdgeWeight,
+        EdgeWeightKindDiscriminants,
+    > for ComponentNodeWeight
+{
+    fn correct_transforms(
+        &self,
+        graph: &Graph,
+        mut updates: Vec<Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>,
+        _from_different_change_set: bool,
+    ) -> CorrectTransformsResult<Vec<Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>>
+    {
+        // Net new components do not need any corrections (currently)
+        if !graph.node_exists(self.id) {
+            return Ok(updates);
+        }
+
+        let is_to_self = |update: &Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>| {
+            update.destination_has_id(self.id)
+        };
+
+        let mut remove_edges = HashSet::new();
+        let mut component_will_be_deleted = false;
+
+        for update in &updates {
+            match update {
+                // Single Parent Rule: Component: FrameContains <Self> <- FrameContains: Component
+                // When we're setting the parent for a component, we need to remove any existing
+                // FrameContains edges to other components.
+                Update::NewEdge { .. }
+                    if update
+                        .is_of_custom_edge_kind(EdgeWeightKindDiscriminants::FrameContains)
+                        && is_to_self(update) =>
+                {
+                    remove_edges.extend(
+                        graph
+                            .incoming_edges(self.id(), EdgeWeightKindDiscriminants::FrameContains)?
+                            .map(|edge_ref| edge_ref.triplet()),
+                    );
+                }
+
+                // If the component is being deleted, the RemoveEdges may be stale (from an old
+                // snapshot) and we need to ensure that we truly delete everything. Detected by
+                // noticing an edge was removed from the component category:
+                //
+                //   Category -> Use: <Self>
+                Update::RemoveEdge { .. }
+                    if update.destination_has_id(self.id)
+                        && update
+                            .source_is_of_custom_node_kind(NodeWeightDiscriminants::Category) =>
+                {
+                    component_will_be_deleted = true;
+                }
+                // It's impossible for this to happen in a single rebase batch, however,
+                // theoretically we could combine rebase batches.
+                Update::NewEdge { .. }
+                    if update.destination_has_id(self.id)
+                        && update
+                            .source_is_of_custom_node_kind(NodeWeightDiscriminants::Category) =>
+                {
+                    component_will_be_deleted = false;
+                }
+
+                // If SchemaVariant gets set, we are upgrading a component, which disconnects
+                // and reconnects prop and socket values and connections. The disconnects may
+                // be stale (based on an old snapshot), so when we detect schema upgrade, we
+                // redo the disconnects.
+                Update::NewEdge { .. }
+                    if update.source_has_id(self.id)
+                        && update.destination_is_of_custom_node_kind(
+                            NodeWeightDiscriminants::SchemaVariant,
+                        ) =>
+                {
+                    // All outgoing edges from the component have to be removed since they will all be
+                    // reconstructed by the sv change
+                    remove_edges.extend(
+                        graph
+                            .edges_directed(self.id, Outgoing)?
+                            .map(|edge_ref| edge_ref.triplet()),
+                    );
+
+                    // Be sure to delete the root attribute value completely by removing incoming edges to it (it may have
+                    // a value subscription edge)
+                    if let Some(root_av_id) = graph
+                        .outgoing_targets(self.id, EdgeWeightKindDiscriminants::Root)?
+                        .next()
+                    {
+                        remove_edges.extend(
+                            graph
+                                .edges_directed(root_av_id, Incoming)?
+                                .map(|edge_ref| edge_ref.triplet()),
+                        );
+                    }
+
+                    // Input and output sockets get new prototype arguments during upgrade. So we remove all
+                    // prototype arguments to be sure
+                    let apas = sockets(graph, self.id)?
+                        .filter_map(|socket| {
+                            input_socket_connections(graph, self.id.into(), socket.into())
+                                .ok()
+                                .zip(
+                                    output_socket_connections(graph, self.id.into(), socket.into())
+                                        .ok(),
+                                )
+                        })
+                        .flat_map(|(input_sockets, output_sockets)| {
+                            input_sockets.chain(output_sockets)
+                        });
+
+                    remove_edges.extend(
+                        apas.filter_map(|apa| graph.edges_directed(apa, Incoming).ok())
+                            .flatten()
+                            .map(|edge_ref| edge_ref.triplet()),
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        if component_will_be_deleted {
+            updates.extend(remove_hanging_socket_connections(graph, self.id)?);
+
+            // The root attribute value id must be deleted if the component is being deleted
+            if let Some(root_av_id) = graph
+                .outgoing_targets(self.id, EdgeWeightKindDiscriminants::Root)?
+                .next()
+            {
+                remove_edges.extend(
+                    graph
+                        .edges_directed(root_av_id, Incoming)?
+                        .map(|edge_ref| edge_ref.triplet()),
+                );
+            }
+
+            // Ensure we delete any incoming edges to the deleted component that might have been
+            // added in another change set
+            remove_edges.extend(
+                graph
+                    .edges_directed(self.id, Incoming)?
+                    .map(|edge_ref| edge_ref.triplet()),
+            );
+        }
+
+        for (source_id, kind, target_id) in remove_edges {
+            updates.extend(Update::remove_edge_updates(
+                graph, source_id, kind, target_id,
+            )?);
+        }
+
+        Ok(updates)
+    }
+}
+
+fn remove_hanging_socket_connections(
+    graph: &Graph,
+    component_id: SplitGraphNodeId,
+) -> CorrectTransformsResult<Vec<Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>> {
+    // To find the attribute prototype arguments that need to be removed, we
+    // have to find the OutputSockets for this component. Once we find them, we
+    // need to find the incoming PrototypeArgumentValue edge from the
+    // AttributePrototypeArgument to that socket. Then we have to verify that
+    // the argument has our component as a source. Then we can issue RemoveEdge
+    // updates for all incoming edges to that attribute prototype argument. With
+    // no incoming edges, the APA will be removed from the graph.
+
+    let mut removals = vec![];
+    let mut new_updates = vec![];
+    let mut affected_attribute_values = BTreeSet::new();
+
+    for socket_value_target in
+        graph.outgoing_targets(component_id, EdgeWeightKindDiscriminants::SocketValue)?
+    {
+        for output_socket_id in graph
+            .outgoing_targets(socket_value_target, EdgeWeightKindDiscriminants::Socket)?
+            .filter(|target_id| {
+                graph
+                    .node_weight(*target_id)
+                    .is_some_and(|weight| match weight {
+                        NodeWeight::Content(content_node_weight) => {
+                            content_node_weight.content_address_discriminants()
+                                == ContentAddressDiscriminants::OutputSocket
+                        }
+                        _ => false,
+                    })
+            })
+        {
+            for (apa_id, destination_component_id) in graph
+                .incoming_sources(
+                    output_socket_id,
+                    EdgeWeightKindDiscriminants::PrototypeArgumentValue,
+                )?
+                .filter_map(|source_id| {
+                    graph
+                        .node_weight(source_id)
+                        .and_then(|node_weight| match node_weight {
+                            NodeWeight::AttributePrototypeArgument(inner) => {
+                                inner.targets().and_then(|targets| {
+                                    if targets.source_component_id == component_id.into() {
+                                        Some((source_id, targets.destination_component_id))
+                                    } else {
+                                        None
+                                    }
+                                })
+                            }
+                            _ => None,
+                        })
+                })
+            {
+                // Add remove edge updates for these attribute prototype arguments
+                for edge_ref in graph.edges_directed(apa_id, Incoming)? {
+                    removals.push(edge_ref.triplet());
+
+                    for incoming_edge_ref in graph.edges_directed(edge_ref.source(), Incoming)? {
+                        let maybe_av_id = edge_ref.source();
+                        let Some(NodeWeight::AttributeValue(_)) =
+                            graph.node_weight(incoming_edge_ref.source())
+                        else {
+                            continue;
+                        };
+
+                        if socket_attribute_value_belongs_to_component(
+                            graph,
+                            destination_component_id,
+                            maybe_av_id,
+                        )? {
+                            affected_attribute_values.insert(maybe_av_id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    for (source_id, kind, target_id) in removals {
+        new_updates.extend(Update::remove_edge_updates(
+            graph, source_id, kind, target_id,
+        )?);
+    }
+
+    new_updates.extend(add_dependent_value_root_updates(
+        graph,
+        &affected_attribute_values,
+    )?);
+
+    Ok(new_updates)
+}
+
+fn choose_subgraph_root_for_node(
+    graph: &Graph,
+    node_in_subgraph: Option<SplitGraphNodeId>,
+    category_node_id: SplitGraphNodeId,
+) -> CorrectTransformsResult<SplitGraphNodeId> {
+    Ok(node_in_subgraph
+        .and_then(|node_in_subgraph| graph.subgraph_root_id_for_node(node_in_subgraph))
+        .or_else(|| graph.subgraph_root_id_for_node(category_node_id))
+        .unwrap_or(graph.root_id()?))
+}
+
+/// Produce the NewNode and NewEdge updates required for adding a dependent value root to the graph
+pub fn add_dependent_value_root_updates(
+    graph: &Graph,
+    value_ids: &BTreeSet<SplitGraphNodeId>,
+) -> CorrectTransformsResult<Vec<Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>> {
+    let mut updates = vec![];
+
+    if let Some(category_node_id) =
+        get_category_node_id(graph, CategoryNodeKind::DependentValueRoots)?
+    {
+        let existing_dvu_nodes: BTreeSet<_> = graph
+            .edges_directed(category_node_id, Outgoing)?
+            .filter_map(|edge_ref| {
+                graph
+                    .node_weight(edge_ref.target())
+                    .and_then(|weight| match weight {
+                        NodeWeight::DependentValueRoot(inner) => Some(inner.value_id()),
+                        _ => None,
+                    })
+            })
+            .collect();
+
+        for value_id in value_ids {
+            if existing_dvu_nodes.contains(value_id) {
+                continue;
+            }
+
+            let id = SplitGraphNodeId::new();
+            let lineage_id = SplitGraphNodeId::new();
+            let new_dvu_node = si_split_graph::SplitGraphNodeWeight::Custom(
+                NodeWeight::new_dependent_value_root(id, lineage_id, *value_id),
+            );
+
+            let new_node_subgraph_root_id = choose_subgraph_root_for_node(
+                graph,
+                existing_dvu_nodes.last().copied(),
+                category_node_id,
+            )?;
+
+            updates.push(Update::NewNode {
+                subgraph_root_id: new_node_subgraph_root_id,
+                node_weight: new_dvu_node,
+            });
+
+            updates.extend(Update::new_edge_between_nodes_updates(
+                category_node_id,
+                choose_subgraph_root_for_node(graph, Some(category_node_id), category_node_id)?,
+                NodeWeightDiscriminants::Category,
+                id,
+                new_node_subgraph_root_id,
+                NodeWeightDiscriminants::DependentValueRoot,
+                EdgeWeight::new(EdgeWeightKind::new_use()),
+                graph.root_id()?,
+            ));
+        }
+    }
+
+    Ok(updates)
+}
+
+fn socket_attribute_value_belongs_to_component(
+    graph: &Graph,
+    destination_component_id: ComponentId,
+    starting_attribute_value: SplitGraphNodeId,
+) -> CorrectTransformsResult<bool> {
+    if !graph.node_exists(starting_attribute_value) {
+        return Ok(false);
+    }
+
+    let Some(component_id) = graph
+        .incoming_sources(
+            starting_attribute_value,
+            EdgeWeightKindDiscriminants::SocketValue,
+        )?
+        .next()
+    else {
+        return Ok(false);
+    };
+
+    Ok(component_id == destination_component_id.into())
+}
+
+// Get all Socket nodes for a given component (by going through its SocketValues).
+//
+// <COMPONENT> -> SocketValue -> Socket: <OUTPUT SOCKET> | <INPUT SOCKET>
+fn sockets(
+    graph: &Graph,
+    component: SplitGraphNodeId,
+) -> CorrectTransformsResult<impl Iterator<Item = SplitGraphNodeId> + '_> {
+    Ok(graph
+        .outgoing_targets(component, EdgeWeightKindDiscriminants::SocketValue)?
+        .filter_map(|out_value| {
+            graph
+                .outgoing_targets(out_value, EdgeWeightKindDiscriminants::Socket)
+                .ok()
+        })
+        .flatten())
+}
+
+/// Get all connection nodes (PrototypeArguments) to an input socket on a component.
+fn input_socket_connections(
+    graph: &Graph,
+    component_id: ComponentId,
+    input_socket: InputSocketId,
+) -> CorrectTransformsResult<impl Iterator<Item = SplitGraphNodeId> + '_> {
+    // From the Socket, find all PrototypeArguments representing the connection:
+    // - <INPUT SOCKET> --Prototype-> --PrototypeArgument-> <ARG> --PrototypeArgumentValue-> <OUTPUT SOCKET>
+    Ok(graph
+        .outgoing_targets(input_socket.into(), EdgeWeightKindDiscriminants::Prototype)?
+        .filter_map(|prototype| {
+            graph
+                .outgoing_targets(prototype, EdgeWeightKindDiscriminants::PrototypeArgument)
+                .ok()
+        })
+        .flatten()
+        .filter(move |&argument| {
+            argument_targets(graph, argument)
+                .is_some_and(|t| component_id == t.destination_component_id)
+        }))
+}
+
+/// Get all connection nodes (PrototypeArguments) from an output socket on a component.
+fn output_socket_connections(
+    graph: &Graph,
+    component_id: ComponentId,
+    output_socket: OutputSocketId,
+) -> CorrectTransformsResult<impl Iterator<Item = SplitGraphNodeId> + '_> {
+    // From the output socket, walk back to the PrototypeArguments representing connections
+    // - <INPUT SOCKET> --Prototype-> --PrototypeArgument-> <ARG> --PrototypeArgumentValue-> <OUTPUT SOCKET>
+    Ok(graph
+        .incoming_sources(
+            output_socket.into(),
+            EdgeWeightKindDiscriminants::PrototypeArgumentValue,
+        )?
+        .filter(move |&argument| {
+            argument_targets(graph, argument).is_some_and(|t| component_id == t.source_component_id)
+        }))
+}
+
+fn argument_targets(graph: &Graph, argument: SplitGraphNodeId) -> Option<ArgumentTargets> {
+    match graph.node_weight(argument) {
+        Some(NodeWeight::AttributePrototypeArgument(argument)) => argument.targets(),
+        _ => None,
+    }
+}
+
+fn get_category_node_id(
+    graph: &Graph,
+    kind: CategoryNodeKind,
+) -> CorrectTransformsResult<Option<SplitGraphNodeId>> {
+    let root_id = graph.root_id()?;
+
+    for maybe_category_node_id in
+        graph.outgoing_targets(root_id, EdgeWeightKindDiscriminants::Use)?
+    {
+        let Some(NodeWeight::Category(inner)) = graph.node_weight(maybe_category_node_id) else {
+            continue;
+        };
+
+        if inner.kind() == kind {
+            return Ok(Some(maybe_category_node_id));
+        }
+    }
+
+    Ok(None)
+}

--- a/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
@@ -1,22 +1,51 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{
+    BTreeMap,
+    HashMap,
+};
 
 use petgraph::prelude::*;
-use serde::{Deserialize, Serialize};
-use si_events::{ContentHash, merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
-use si_split_graph::{SplitGraphNodeId, SplitGraphNodeWeight};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::{
+    ContentHash,
+    merkle_tree_hash::MerkleTreeHash,
+    ulid::Ulid,
+};
+use si_split_graph::{
+    SplitGraphNodeId,
+    SplitGraphNodeWeight,
+};
 
 use super::{
     NodeWeight,
-    traits::{CorrectTransformsResult, SiVersionedNodeWeight},
+    traits::{
+        CorrectTransformsResult,
+        SiVersionedNodeWeight,
+    },
 };
 use crate::{
-    ComponentId, EdgeWeight, EdgeWeightKindDiscriminants, SocketArity,
+    ComponentId,
+    EdgeWeight,
+    EdgeWeightKindDiscriminants,
+    SocketArity,
     WorkspaceSnapshotGraphVCurrent,
     workspace_snapshot::{
         NodeInformation,
-        content_address::{ContentAddress, ContentAddressDiscriminants},
-        graph::{LineageId, detector::Update},
-        node_weight::{NodeWeightError, NodeWeightResult, traits::CorrectTransforms},
+        content_address::{
+            ContentAddress,
+            ContentAddressDiscriminants,
+        },
+        graph::{
+            LineageId,
+            detector::Update,
+        },
+        node_weight::{
+            NodeWeightError,
+            NodeWeightResult,
+            traits::CorrectTransforms,
+        },
         split_snapshot,
     },
 };
@@ -424,7 +453,7 @@ fn protect_arity_for_input_socket_split(
                     && update
                         .is_of_custom_edge_kind(EdgeWeightKindDiscriminants::PrototypeArgument) =>
             {
-                if let Some(&new_apa) = new_node_map.get(&destination.id.into()) {
+                if let Some(&new_apa) = new_node_map.get(&destination.id) {
                     let targets = match new_apa.targets() {
                         Some(targets) => targets,
                         None => {

--- a/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/content_node_weight.rs
@@ -1,43 +1,23 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use petgraph::prelude::*;
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use si_events::{
-    ContentHash,
-    merkle_tree_hash::MerkleTreeHash,
-    ulid::Ulid,
-};
+use serde::{Deserialize, Serialize};
+use si_events::{ContentHash, merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
+use si_split_graph::{SplitGraphNodeId, SplitGraphNodeWeight};
 
 use super::{
     NodeWeight,
-    traits::{
-        CorrectTransformsResult,
-        SiVersionedNodeWeight,
-    },
+    traits::{CorrectTransformsResult, SiVersionedNodeWeight},
 };
 use crate::{
-    ComponentId,
-    EdgeWeightKindDiscriminants,
-    SocketArity,
+    ComponentId, EdgeWeight, EdgeWeightKindDiscriminants, SocketArity,
     WorkspaceSnapshotGraphVCurrent,
     workspace_snapshot::{
         NodeInformation,
-        content_address::{
-            ContentAddress,
-            ContentAddressDiscriminants,
-        },
-        graph::{
-            LineageId,
-            detector::Update,
-        },
-        node_weight::{
-            NodeWeightError,
-            NodeWeightResult,
-            traits::CorrectTransforms,
-        },
+        content_address::{ContentAddress, ContentAddressDiscriminants},
+        graph::{LineageId, detector::Update},
+        node_weight::{NodeWeightError, NodeWeightResult, traits::CorrectTransforms},
+        split_snapshot,
     },
 };
 
@@ -333,4 +313,140 @@ impl CorrectTransforms for ContentNodeWeight {
             _ => updates,
         })
     }
+}
+
+impl
+    split_snapshot::corrections::CorrectTransforms<
+        NodeWeight,
+        EdgeWeight,
+        EdgeWeightKindDiscriminants,
+    > for ContentNodeWeight
+{
+    fn correct_transforms(
+        &self,
+        graph: &si_split_graph::SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+        updates: Vec<si_split_graph::Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>,
+        _from_different_change_set: bool,
+    ) -> split_snapshot::corrections::CorrectTransformsResult<
+        Vec<si_split_graph::Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>,
+    > {
+        Ok(match self.content_address_discriminants() {
+            ContentAddressDiscriminants::AttributePrototype => {
+                protect_arity_for_input_socket_split(graph, updates, self)?
+            }
+            _ => updates,
+        })
+    }
+}
+
+fn remove_outgoing_prototype_argument_value_targets_to_dest_split(
+    graph: &si_split_graph::SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+    prototype_id: SplitGraphNodeId,
+    destination_component_id: ComponentId,
+) -> split_snapshot::corrections::CorrectTransformsResult<
+    Vec<si_split_graph::Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>,
+> {
+    let mut remove_updates = vec![];
+
+    let triplets: Vec<_> = graph
+        .edges_directed_for_edge_weight_kind(
+            prototype_id,
+            Outgoing,
+            EdgeWeightKindDiscriminants::PrototypeArgument,
+        )?
+        .filter(|edge_ref| {
+            graph
+                .node_weight(edge_ref.target())
+                .is_some_and(|weight| match weight {
+                    NodeWeight::AttributePrototypeArgument(apa_inner) => {
+                        apa_inner.targets().is_some_and(|targets| {
+                            targets.destination_component_id == destination_component_id
+                        })
+                    }
+                    _ => false,
+                })
+        })
+        .map(|edge_ref| edge_ref.triplet())
+        .collect();
+
+    for (source_id, kind, target_id) in triplets {
+        remove_updates.extend(si_split_graph::Update::remove_edge_updates(
+            graph, source_id, kind, target_id,
+        )?);
+    }
+
+    Ok(remove_updates)
+}
+
+fn protect_arity_for_input_socket_split(
+    graph: &si_split_graph::SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+    mut updates: Vec<si_split_graph::Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>,
+    self_node: &ContentNodeWeight,
+) -> split_snapshot::corrections::CorrectTransformsResult<
+    Vec<si_split_graph::Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>,
+> {
+    let mut new_updates = vec![];
+
+    if !graph.node_exists(self_node.id()) {
+        return Ok(updates);
+    }
+
+    let Some(input_socket_inner) = graph
+        .incoming_sources(self_node.id(), EdgeWeightKindDiscriminants::Prototype)?
+        .filter_map(|source_id| graph.node_weight(source_id))
+        .next()
+        .and_then(|node_weight| match node_weight {
+            NodeWeight::InputSocket(inner) => Some(inner.inner()),
+            _ => None,
+        })
+    else {
+        return Ok(updates);
+    };
+
+    if input_socket_inner.arity() != SocketArity::One {
+        return Ok(updates);
+    }
+
+    let mut new_node_map = BTreeMap::new();
+
+    for update in &updates {
+        match update {
+            si_split_graph::Update::NewNode { node_weight, .. } => {
+                if let SplitGraphNodeWeight::Custom(NodeWeight::AttributePrototypeArgument(
+                    apa_inner,
+                )) = node_weight
+                {
+                    new_node_map.insert(node_weight.id(), apa_inner);
+                }
+            }
+            si_split_graph::Update::NewEdge { destination, .. }
+                if update.source_has_id(self_node.id())
+                    && update
+                        .is_of_custom_edge_kind(EdgeWeightKindDiscriminants::PrototypeArgument) =>
+            {
+                if let Some(&new_apa) = new_node_map.get(&destination.id.into()) {
+                    let targets = match new_apa.targets() {
+                        Some(targets) => targets,
+                        None => {
+                            // No targets, then we don't want you
+                            continue;
+                        }
+                    };
+
+                    new_updates.extend(
+                        remove_outgoing_prototype_argument_value_targets_to_dest_split(
+                            graph,
+                            self_node.id(),
+                            targets.destination_component_id,
+                        )?,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    updates.extend(new_updates);
+
+    Ok(updates)
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/diagram_object_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/diagram_object_node_weight/v1.rs
@@ -1,20 +1,38 @@
 use std::collections::BTreeSet;
 
 use dal_macros::SiNodeWeight;
-use petgraph::Direction::{Incoming, Outgoing};
-use serde::{Deserialize, Serialize};
-use si_events::{ContentHash, merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
+use petgraph::Direction::{
+    Incoming,
+    Outgoing,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::{
+    ContentHash,
+    merkle_tree_hash::MerkleTreeHash,
+    ulid::Ulid,
+};
 
 use crate::{
-    EdgeWeight, EdgeWeightKindDiscriminants,
+    EdgeWeight,
+    EdgeWeightKindDiscriminants,
     workspace_snapshot::{
-        graph::{LineageId, detector::Update},
+        graph::{
+            LineageId,
+            detector::Update,
+        },
         node_weight::{
-            NodeWeight, NodeWeightDiscriminants,
+            NodeWeight,
+            NodeWeightDiscriminants,
             diagram_object_node_weight::DiagramObjectKind,
             traits::{
-                CorrectExclusiveOutgoingEdge, CorrectTransforms, CorrectTransformsError,
-                CorrectTransformsResult, SiNodeWeight,
+                CorrectExclusiveOutgoingEdge,
+                CorrectTransforms,
+                CorrectTransformsError,
+                CorrectTransformsResult,
+                SiNodeWeight,
             },
         },
         split_snapshot,

--- a/lib/dal/src/workspace_snapshot/node_weight/geometry_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/geometry_node_weight/v1.rs
@@ -1,25 +1,51 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{
+        BTreeMap,
+        HashMap,
+    },
     mem,
 };
 
 use dal_macros::SiNodeWeight;
-use jwt_simple::prelude::{Deserialize, Serialize};
-use petgraph::Direction::{self, Incoming, Outgoing};
-use si_events::{ContentHash, Timestamp, merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
+use jwt_simple::prelude::{
+    Deserialize,
+    Serialize,
+};
+use petgraph::Direction::{
+    self,
+    Incoming,
+    Outgoing,
+};
+use si_events::{
+    ContentHash,
+    Timestamp,
+    merkle_tree_hash::MerkleTreeHash,
+    ulid::Ulid,
+};
 
-use super::{GeometryNodeWeight, NodeWeightDiscriminants};
+use super::{
+    GeometryNodeWeight,
+    NodeWeightDiscriminants,
+};
 use crate::{
-    EdgeWeight, EdgeWeightKindDiscriminants, WorkspaceSnapshotGraphVCurrent,
+    EdgeWeight,
+    EdgeWeightKindDiscriminants,
+    WorkspaceSnapshotGraphVCurrent,
     workspace_snapshot::{
         content_address::ContentAddress,
-        graph::{LineageId, detector::Update},
+        graph::{
+            LineageId,
+            detector::Update,
+        },
         node_weight::{
             NodeWeight,
             diagram_object_node_weight::DiagramObjectKind,
             traits::{
-                CorrectExclusiveOutgoingEdge, CorrectTransforms, CorrectTransformsError,
-                CorrectTransformsResult, SiNodeWeight,
+                CorrectExclusiveOutgoingEdge,
+                CorrectTransforms,
+                CorrectTransformsError,
+                CorrectTransformsResult,
+                SiNodeWeight,
             },
         },
         split_snapshot,

--- a/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
@@ -59,6 +59,8 @@ use crate::{
     },
 };
 
+mod split_corrections;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, dal_macros::SiNodeWeight, Hash)]
 #[si_node_weight(discriminant = NodeWeightDiscriminants::SchemaVariant)]
 pub struct SchemaVariantNodeWeightV1 {

--- a/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1/split_corrections.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1/split_corrections.rs
@@ -1,0 +1,306 @@
+use std::collections::{
+    BTreeMap,
+    BTreeSet,
+};
+
+use si_id::{
+    SchemaId,
+    SchemaVariantId,
+};
+use si_split_graph::{
+    SplitGraph,
+    SplitGraphNodeWeight,
+    SplitGraphResult,
+    Update,
+};
+
+use super::SchemaVariantNodeWeightV1;
+use crate::{
+    EdgeWeight,
+    EdgeWeightKindDiscriminants,
+    NodeWeightDiscriminants,
+    workspace_snapshot::{
+        content_address::ContentAddressDiscriminants,
+        node_weight::{
+            NodeWeight,
+            traits::SiVersionedNodeWeight,
+        },
+        split_snapshot::{
+            corrections::{
+                CorrectTransforms,
+                CorrectTransformsResult,
+            },
+            schema_ids_for_schema_variant_id,
+        },
+    },
+};
+
+fn schema_variant_id_lock_status_for_schema_id(
+    graph: &SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+    schema_id: SchemaId,
+) -> SplitGraphResult<BTreeMap<SchemaVariantId, bool>> {
+    Ok(graph
+        .outgoing_targets(schema_id.into(), EdgeWeightKindDiscriminants::Use)?
+        .filter_map(|variant_id| match graph.node_weight(variant_id) {
+            Some(NodeWeight::SchemaVariant(variant)) => {
+                Some((variant_id.into(), variant.inner().is_locked()))
+            }
+            _ => None,
+        })
+        .collect())
+}
+
+/// We need to ensure that there is only one unlocked variant for each schema in a change set. We do this
+/// by figuring out if there are more than one unlocked variants for this variant's schema, and if so, we
+/// produce ReplaceNode updates which will ensure all but one variant become locked
+impl CorrectTransforms<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>
+    for SchemaVariantNodeWeightV1
+{
+    fn correct_transforms(
+        &self,
+        graph: &SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+        mut updates: Vec<Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>,
+        _from_different_change_set: bool,
+    ) -> CorrectTransformsResult<Vec<Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>>
+    {
+        let mut maybe_my_schema_id = if graph.node_exists(self.id) {
+            schema_ids_for_schema_variant_id(graph, self.id.into())?
+                .first()
+                .copied()
+        } else {
+            None
+        };
+
+        let mut new_schemas = BTreeMap::new();
+        let mut schema_variants_in_this_update_set = BTreeMap::new();
+        let mut new_variants_for_schema: BTreeMap<_, BTreeSet<_>> = BTreeMap::new();
+        let mut removed_variants = BTreeSet::new();
+        let mut variant_lock_statuses = BTreeMap::new();
+
+        let mut self_is_locked = self.is_locked();
+
+        #[inline(always)]
+        fn variant_is_locked(node_weight: &SplitGraphNodeWeight<NodeWeight>) -> bool {
+            match node_weight {
+                SplitGraphNodeWeight::Custom(NodeWeight::SchemaVariant(variant)) => {
+                    variant.inner().is_locked()
+                }
+                _ => false,
+            }
+        }
+
+        for update in &updates {
+            match update {
+                Update::NewNode {
+                    subgraph_root_id,
+                    node_weight,
+                } => match node_weight {
+                    SplitGraphNodeWeight::Custom(NodeWeight::Content(content_node_weight))
+                        if content_node_weight.content_address_discriminants()
+                            == ContentAddressDiscriminants::Schema =>
+                    {
+                        new_schemas.insert(node_weight.id(), subgraph_root_id);
+                    }
+                    SplitGraphNodeWeight::Custom(NodeWeight::SchemaVariant(_)) => {
+                        schema_variants_in_this_update_set
+                            .insert(node_weight.id(), (node_weight.clone(), *subgraph_root_id));
+                        let is_locked = variant_is_locked(node_weight);
+                        variant_lock_statuses.insert(node_weight.id(), is_locked);
+                    }
+                    _ => {}
+                },
+                Update::NewEdge { .. }
+                    if update.is_edge_of_sort(
+                        NodeWeightDiscriminants::Content,
+                        EdgeWeightKindDiscriminants::Use,
+                        NodeWeightDiscriminants::SchemaVariant,
+                    ) =>
+                {
+                    let Some((schema_id, variant_id)) =
+                        update.source_id().zip(update.destination_id())
+                    else {
+                        continue;
+                    };
+
+                    new_variants_for_schema
+                        .entry(schema_id)
+                        .and_modify(|entry| {
+                            entry.insert(variant_id);
+                        })
+                        .or_insert_with(|| BTreeSet::from([variant_id]));
+
+                    if variant_id == self.id {
+                        maybe_my_schema_id = Some(schema_id.into());
+                    }
+                }
+                Update::RemoveEdge { .. }
+                    if update.is_edge_of_sort(
+                        NodeWeightDiscriminants::Content,
+                        EdgeWeightKindDiscriminants::Use,
+                        NodeWeightDiscriminants::SchemaVariant,
+                    ) =>
+                {
+                    let Some(variant_id) = update.destination_id() else {
+                        continue;
+                    };
+                    removed_variants.insert(variant_id);
+                }
+                Update::ReplaceNode {
+                    node_weight,
+                    subgraph_root_id,
+                    ..
+                } if node_weight.custom_kind() == Some(NodeWeightDiscriminants::SchemaVariant) => {
+                    let variant_id = node_weight.id();
+                    // If this is false, this means the node has been removed from the graph
+                    // we're applying the update to. So we don't care about it.
+                    if !graph.node_exists(variant_id) {
+                        continue;
+                    }
+
+                    schema_variants_in_this_update_set
+                        .insert(node_weight.id(), (node_weight.clone(), *subgraph_root_id));
+
+                    let is_locked = variant_is_locked(node_weight);
+                    if variant_id == self.id {
+                        self_is_locked = is_locked;
+                    }
+
+                    variant_lock_statuses.insert(variant_id, is_locked);
+                }
+                _ => {}
+            }
+        }
+
+        // If we are locked, then we don't have to make any corrections, since
+        // we don't have to prevent multiple unlocked resulting from this schema
+        // variant being unlocked.
+        if self_is_locked {
+            return Ok(updates);
+        }
+
+        // At this point, we should already have a schema id. Either it was on the graph already,
+        // or there was a NewEdge update for it in the set of updates. If neither of those are true,
+        // then we're a variant without a schema. Which is tragic, but we can't do anything about it
+        // here.
+        let Some(my_schema_id) = maybe_my_schema_id else {
+            return Ok(updates);
+        };
+
+        // Get all variant lock statuses on the graph we are modifying with these updates
+        let mut variant_lock_statuses_for_schema_id = if graph.node_exists(my_schema_id.into()) {
+            schema_variant_id_lock_status_for_schema_id(graph, my_schema_id)?
+        } else {
+            BTreeMap::new()
+        };
+
+        // Now, merge those lock statuses with the changes we have detected in this set of updates,
+
+        // First, all the new variants that were added in this set of updates for this schema
+        if let Some(new_variants_for_my_schema) = new_variants_for_schema.get(&my_schema_id.into())
+        {
+            for variant_id in new_variants_for_my_schema {
+                if let Some(variant_lock_status) = variant_lock_statuses.get(variant_id) {
+                    variant_lock_statuses_for_schema_id
+                        .insert((*variant_id).into(), *variant_lock_status);
+                }
+            }
+        }
+
+        // Now, anything leftover, from the ReplaceNode updates. This will do a tiny bit of double work.
+        for (variant_id, lock_status) in variant_lock_statuses {
+            variant_lock_statuses_for_schema_id
+                .entry(variant_id.into())
+                .and_modify(|entry| *entry = lock_status);
+        }
+
+        // Find out which variants are unlocked after all the updates.
+        let unlocked_variants_for_my_schema: Vec<_> = variant_lock_statuses_for_schema_id
+            .iter()
+            .filter(|(_, lock_status)| !**lock_status)
+            .map(|(variant_id, _)| *variant_id)
+            .collect();
+
+        // We can only have one unlocked variant for a schema. If there are more than one,
+        // we need to produce ReplaceNode updates to lock all but one of the variants.
+        // First, if we don't have more than one unlocked, then we have nothing to do.
+        if unlocked_variants_for_my_schema.len() <= 1 {
+            return Ok(updates);
+        }
+
+        // If we're here, then more than one is unlocked. Find out which one should stay unlocked. We do this
+        // by finding the unlocked variant with the latest timestamp.
+        let mut winning_variant_node_weight: Option<&Self> = None;
+        for variant_id in &unlocked_variants_for_my_schema {
+            let variant_inner = if let Some((
+                SplitGraphNodeWeight::Custom(NodeWeight::SchemaVariant(sv_node_weight)),
+                _,
+            )) = schema_variants_in_this_update_set.get(&(variant_id.into()))
+            {
+                Some(sv_node_weight.inner())
+            } else if let Some(NodeWeight::SchemaVariant(sv_node_weight)) =
+                graph.node_weight(variant_id.into())
+            {
+                Some(sv_node_weight.inner())
+            } else {
+                None
+            };
+
+            if let Some(variant_inner) = variant_inner {
+                if winning_variant_node_weight.is_none()
+                    || winning_variant_node_weight
+                        .is_some_and(|winning| variant_inner.timestamp > winning.timestamp)
+                {
+                    winning_variant_node_weight = Some(variant_inner);
+                }
+            }
+        }
+
+        let Some(winning_variant_node_weight) = winning_variant_node_weight else {
+            // Somehow, we did not find a winnner. This could only happen if there is an unlocked
+            // variant that wasn't in the update set and wasn't on the graph. That seems impossible?
+            // So this should never happen.
+            return Ok(updates);
+        };
+
+        // Finally, produce updates which will lock the variants.
+        // By appending these to the end, they will override any other ReplaceNode updates
+        // that are in the update set.
+        for variant_id in unlocked_variants_for_my_schema {
+            if variant_id == winning_variant_node_weight.id.into() {
+                continue;
+            }
+
+            if let Some((
+                SplitGraphNodeWeight::Custom(NodeWeight::SchemaVariant(sv_node_weight)),
+                subgraph_root_id,
+            )) = schema_variants_in_this_update_set.get(&variant_id.into())
+            {
+                let mut sv_node_weight = sv_node_weight.clone();
+                sv_node_weight.inner_mut().set_is_locked(true);
+                updates.push(Update::ReplaceNode {
+                    subgraph_root_id: *subgraph_root_id,
+                    base_graph_node_id: None,
+                    node_weight: SplitGraphNodeWeight::Custom(NodeWeight::SchemaVariant(
+                        sv_node_weight,
+                    )),
+                });
+            } else if let Some(NodeWeight::SchemaVariant(sv_node_weight)) =
+                graph.node_weight(variant_id.into())
+            {
+                let mut sv_node_weight = sv_node_weight.clone();
+                sv_node_weight.inner_mut().set_is_locked(true);
+                if let Some(subgraph_root_id) = graph.subgraph_root_id_for_node(variant_id.into()) {
+                    updates.push(Update::ReplaceNode {
+                        subgraph_root_id,
+                        base_graph_node_id: None,
+                        node_weight: SplitGraphNodeWeight::Custom(NodeWeight::SchemaVariant(
+                            sv_node_weight,
+                        )),
+                    });
+                }
+            }
+        }
+
+        Ok(updates)
+    }
+}

--- a/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
@@ -1,40 +1,18 @@
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use si_events::{
-    ContentHash,
-    EncryptedSecretKey,
-    merkle_tree_hash::MerkleTreeHash,
-    ulid::Ulid,
-};
+use serde::{Deserialize, Serialize};
+use si_events::{ContentHash, EncryptedSecretKey, merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
+use si_split_graph::{SplitGraph, SplitGraphNodeWeight};
 
-use super::{
-    NodeWeight,
-    category_node_weight::CategoryNodeKind,
-    traits::CorrectTransformsResult,
-};
+use super::{NodeWeight, category_node_weight::CategoryNodeKind, traits::CorrectTransformsResult};
 use crate::{
-    EdgeWeightKindDiscriminants,
-    WorkspaceSnapshotGraphVCurrent,
+    EdgeWeight, EdgeWeightKindDiscriminants, WorkspaceSnapshotGraphVCurrent,
     workspace_snapshot::{
         NodeId,
-        content_address::{
-            ContentAddress,
-            ContentAddressDiscriminants,
-        },
-        graph::{
-            LineageId,
-            correct_transforms::add_dependent_value_root_updates,
-            detector::Update,
-        },
-        node_weight::{
-            NodeWeightError,
-            NodeWeightResult,
-            traits::CorrectTransforms,
-        },
+        content_address::{ContentAddress, ContentAddressDiscriminants},
+        graph::{LineageId, correct_transforms, detector::Update},
+        node_weight::{NodeWeightError, NodeWeightResult, traits::CorrectTransforms},
+        split_snapshot::{self, corrections::get_category_node_id},
     },
 };
 
@@ -203,10 +181,89 @@ impl CorrectTransforms for SecretNodeWeight {
         }
 
         if should_add {
-            updates.extend(add_dependent_value_root_updates(
+            updates.extend(correct_transforms::add_dependent_value_root_updates(
                 graph,
                 &HashSet::from([self.id()]),
             )?);
+        }
+
+        Ok(updates)
+    }
+}
+
+impl
+    split_snapshot::corrections::CorrectTransforms<
+        NodeWeight,
+        EdgeWeight,
+        EdgeWeightKindDiscriminants,
+    > for SecretNodeWeight
+{
+    fn correct_transforms(
+        &self,
+        graph: &SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+        mut updates: Vec<
+            si_split_graph::Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+        >,
+        from_different_change_set: bool,
+    ) -> split_snapshot::corrections::CorrectTransformsResult<
+        Vec<si_split_graph::Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>,
+    > {
+        if !from_different_change_set {
+            return Ok(updates);
+        }
+
+        let dvu_cat_id = get_category_node_id(graph, CategoryNodeKind::DependentValueRoots)?;
+        let mut should_add = false;
+
+        for update in &updates {
+            match update {
+                si_split_graph::Update::RemoveEdge { .. } if update.source_id() == dvu_cat_id => {
+                    return Ok(updates);
+                }
+                si_split_graph::Update::NewNode { node_weight, .. } => {
+                    if let SplitGraphNodeWeight::Custom(NodeWeight::DependentValueRoot(
+                        dvu_root_inner,
+                    )) = node_weight
+                    {
+                        // This is already a DVU root, so nothing to do
+                        if dvu_root_inner.value_id() == self.id() {
+                            return Ok(updates);
+                        }
+                    } else if let SplitGraphNodeWeight::Custom(NodeWeight::Secret(_)) = node_weight
+                    {
+                        should_add = node_weight.id() == self.id();
+                    }
+                }
+                si_split_graph::Update::ReplaceNode { node_weight, .. }
+                    if node_weight.id() == self.id() =>
+                {
+                    if let SplitGraphNodeWeight::Custom(NodeWeight::Secret(updated_secret)) =
+                        node_weight
+                    {
+                        should_add =
+                            graph
+                                .node_weight(self.id())
+                                .is_some_and(|secret| match secret {
+                                    NodeWeight::Secret(inner) => {
+                                        inner.encrypted_secret_key()
+                                            != updated_secret.encrypted_secret_key()
+                                    }
+                                    _ => false,
+                                });
+                    }
+                }
+
+                _ => {}
+            }
+        }
+
+        if should_add {
+            updates.extend(
+                split_snapshot::corrections::add_dependent_value_root_updates(
+                    graph,
+                    &BTreeSet::from([self.id()]),
+                )?,
+            );
         }
 
         Ok(updates)

--- a/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
@@ -1,18 +1,52 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{
+    BTreeSet,
+    HashSet,
+};
 
-use serde::{Deserialize, Serialize};
-use si_events::{ContentHash, EncryptedSecretKey, merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
-use si_split_graph::{SplitGraph, SplitGraphNodeWeight};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::{
+    ContentHash,
+    EncryptedSecretKey,
+    merkle_tree_hash::MerkleTreeHash,
+    ulid::Ulid,
+};
+use si_split_graph::{
+    SplitGraph,
+    SplitGraphNodeWeight,
+};
 
-use super::{NodeWeight, category_node_weight::CategoryNodeKind, traits::CorrectTransformsResult};
+use super::{
+    NodeWeight,
+    category_node_weight::CategoryNodeKind,
+    traits::CorrectTransformsResult,
+};
 use crate::{
-    EdgeWeight, EdgeWeightKindDiscriminants, WorkspaceSnapshotGraphVCurrent,
+    EdgeWeight,
+    EdgeWeightKindDiscriminants,
+    WorkspaceSnapshotGraphVCurrent,
     workspace_snapshot::{
         NodeId,
-        content_address::{ContentAddress, ContentAddressDiscriminants},
-        graph::{LineageId, correct_transforms, detector::Update},
-        node_weight::{NodeWeightError, NodeWeightResult, traits::CorrectTransforms},
-        split_snapshot::{self, corrections::get_category_node_id},
+        content_address::{
+            ContentAddress,
+            ContentAddressDiscriminants,
+        },
+        graph::{
+            LineageId,
+            correct_transforms,
+            detector::Update,
+        },
+        node_weight::{
+            NodeWeightError,
+            NodeWeightResult,
+            traits::CorrectTransforms,
+        },
+        split_snapshot::{
+            self,
+            corrections::get_category_node_id,
+        },
     },
 };
 

--- a/lib/dal/src/workspace_snapshot/node_weight/view_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/view_node_weight/v1.rs
@@ -1,9 +1,22 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{
+    BTreeMap,
+    BTreeSet,
+    HashMap,
+    HashSet,
+};
 
 use dal_macros::SiNodeWeight;
-use jwt_simple::prelude::{Deserialize, Serialize};
+use jwt_simple::prelude::{
+    Deserialize,
+    Serialize,
+};
 use petgraph::prelude::*;
-use si_events::{ContentHash, Timestamp, merkle_tree_hash::MerkleTreeHash, ulid::Ulid};
+use si_events::{
+    ContentHash,
+    Timestamp,
+    merkle_tree_hash::MerkleTreeHash,
+    ulid::Ulid,
+};
 use si_id::ViewId;
 use si_split_graph::SplitGraphNodeId;
 
@@ -12,10 +25,19 @@ use crate::{
     workspace_snapshot::{
         EdgeWeightKindDiscriminants,
         content_address::ContentAddress,
-        graph::{LineageId, WorkspaceSnapshotGraphError, detector::Update},
+        graph::{
+            LineageId,
+            WorkspaceSnapshotGraphError,
+            detector::Update,
+        },
         node_weight::{
-            NodeWeight, NodeWeightDiscriminants,
-            traits::{CorrectExclusiveOutgoingEdge, CorrectTransforms, SiNodeWeight},
+            NodeWeight,
+            NodeWeightDiscriminants,
+            traits::{
+                CorrectExclusiveOutgoingEdge,
+                CorrectTransforms,
+                SiNodeWeight,
+            },
         },
         split_snapshot,
     },

--- a/lib/dal/src/workspace_snapshot/split_snapshot/corrections.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot/corrections.rs
@@ -18,8 +18,10 @@ use si_split_graph::{
 use thiserror::Error;
 
 use crate::{
-    EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants,
-    workspace_snapshot::node_weight::{NodeWeight, traits::SiVersionedNodeWeight},
+    EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants, NodeWeightDiscriminants,
+    workspace_snapshot::node_weight::{
+        NodeWeight, category_node_weight::CategoryNodeKind, traits::SiVersionedNodeWeight,
+    },
 };
 
 #[derive(Debug, Error)]
@@ -92,6 +94,9 @@ impl CorrectTransforms<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants> for 
             }
             NodeWeight::View(view_node_weight) => {
                 view_node_weight.correct_transforms(graph, updates, from_different_change_set)
+            }
+            NodeWeight::Secret(secret_node_weight) => {
+                secret_node_weight.correct_transforms(graph, updates, from_different_change_set)
             }
             _ => Ok(updates),
         }
@@ -398,4 +403,96 @@ fn resolve_ordering(
     final_order.extend(order.iter().filter(|id| added_children.contains(id)));
 
     final_order
+}
+
+pub fn choose_subgraph_root_for_node(
+    graph: &SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+    node_in_subgraph: Option<SplitGraphNodeId>,
+    category_node_id: SplitGraphNodeId,
+) -> CorrectTransformsResult<SplitGraphNodeId> {
+    Ok(node_in_subgraph
+        .and_then(|node_in_subgraph| graph.subgraph_root_id_for_node(node_in_subgraph))
+        .or_else(|| graph.subgraph_root_id_for_node(category_node_id))
+        .unwrap_or(graph.root_id()?))
+}
+
+pub fn get_category_node_id(
+    graph: &SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+    kind: CategoryNodeKind,
+) -> CorrectTransformsResult<Option<SplitGraphNodeId>> {
+    let root_id = graph.root_id()?;
+
+    for maybe_category_node_id in
+        graph.outgoing_targets(root_id, EdgeWeightKindDiscriminants::Use)?
+    {
+        let Some(NodeWeight::Category(inner)) = graph.node_weight(maybe_category_node_id) else {
+            continue;
+        };
+
+        if inner.kind() == kind {
+            return Ok(Some(maybe_category_node_id));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Produce the NewNode and NewEdge updates required for adding a dependent value root to the graph
+pub fn add_dependent_value_root_updates(
+    graph: &SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>,
+    value_ids: &BTreeSet<SplitGraphNodeId>,
+) -> CorrectTransformsResult<Vec<Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>> {
+    let mut updates = vec![];
+
+    if let Some(category_node_id) =
+        get_category_node_id(graph, CategoryNodeKind::DependentValueRoots)?
+    {
+        let existing_dvu_nodes: BTreeSet<_> = graph
+            .edges_directed(category_node_id, Outgoing)?
+            .filter_map(|edge_ref| {
+                graph
+                    .node_weight(edge_ref.target())
+                    .and_then(|weight| match weight {
+                        NodeWeight::DependentValueRoot(inner) => Some(inner.value_id()),
+                        _ => None,
+                    })
+            })
+            .collect();
+
+        for value_id in value_ids {
+            if existing_dvu_nodes.contains(value_id) {
+                continue;
+            }
+
+            let id = SplitGraphNodeId::new();
+            let lineage_id = SplitGraphNodeId::new();
+            let new_dvu_node = si_split_graph::SplitGraphNodeWeight::Custom(
+                NodeWeight::new_dependent_value_root(id, lineage_id, *value_id),
+            );
+
+            let new_node_subgraph_root_id = choose_subgraph_root_for_node(
+                graph,
+                existing_dvu_nodes.last().copied(),
+                category_node_id,
+            )?;
+
+            updates.push(Update::NewNode {
+                subgraph_root_id: new_node_subgraph_root_id,
+                node_weight: new_dvu_node,
+            });
+
+            updates.extend(Update::new_edge_between_nodes_updates(
+                category_node_id,
+                choose_subgraph_root_for_node(graph, Some(category_node_id), category_node_id)?,
+                NodeWeightDiscriminants::Category,
+                id,
+                new_node_subgraph_root_id,
+                NodeWeightDiscriminants::DependentValueRoot,
+                EdgeWeight::new(EdgeWeightKind::new_use()),
+                graph.root_id()?,
+            ));
+        }
+    }
+
+    Ok(updates)
 }

--- a/lib/dal/src/workspace_snapshot/split_snapshot/corrections.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot/corrections.rs
@@ -101,6 +101,8 @@ impl CorrectTransforms<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants> for 
     ) -> CorrectTransformsResult<Vec<Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>>
     {
         match self {
+            NodeWeight::DiagramObject(diagram_object_node_weight) => diagram_object_node_weight
+                .correct_transforms(graph, updates, from_different_change_set),
             NodeWeight::Geometry(geometry_node_weight) => {
                 geometry_node_weight.correct_transforms(graph, updates, from_different_change_set)
             }

--- a/lib/dal/src/workspace_snapshot/split_snapshot/corrections.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot/corrections.rs
@@ -5,23 +5,41 @@
 /// corrections need to know about AttributeValue container objects, and so on. But it
 /// also has to be implemented for the custom node weight types.
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{
+        BTreeMap,
+        BTreeSet,
+    },
     marker::PhantomData,
 };
 
-use petgraph::Direction::{Incoming, Outgoing};
+use petgraph::Direction::{
+    Incoming,
+    Outgoing,
+};
 use si_split_graph::{
-    CustomEdgeWeight, CustomNodeWeight, EdgeKind, SplitGraph, SplitGraphEdgeWeight,
-    SplitGraphEdgeWeightKind, SplitGraphError, SplitGraphNodeId, SplitGraphNodeWeight, Update,
+    CustomEdgeWeight,
+    CustomNodeWeight,
+    EdgeKind,
+    SplitGraph,
+    SplitGraphEdgeWeight,
+    SplitGraphEdgeWeightKind,
+    SplitGraphError,
+    SplitGraphNodeId,
+    SplitGraphNodeWeight,
+    Update,
     updates::ExternalSourceData,
 };
 use thiserror::Error;
 
 use crate::{
-    EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants, NodeWeightDiscriminants,
+    EdgeWeight,
+    EdgeWeightKind,
+    EdgeWeightKindDiscriminants,
+    NodeWeightDiscriminants,
     workspace_snapshot::node_weight::{
-        NodeWeight, action_node_weight, category_node_weight::CategoryNodeKind,
-        content_node_weight, traits::SiVersionedNodeWeight,
+        NodeWeight,
+        category_node_weight::CategoryNodeKind,
+        traits::SiVersionedNodeWeight,
     },
 };
 
@@ -108,6 +126,8 @@ impl CorrectTransforms<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants> for 
             NodeWeight::Secret(secret_node_weight) => {
                 secret_node_weight.correct_transforms(graph, updates, from_different_change_set)
             }
+            NodeWeight::SchemaVariant(schema_variant_node_weight) => schema_variant_node_weight
+                .correct_transforms(graph, updates, from_different_change_set),
             _ => Ok(updates),
         }
     }

--- a/lib/dal/src/workspace_snapshot/split_snapshot/corrections.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot/corrections.rs
@@ -20,7 +20,8 @@ use thiserror::Error;
 use crate::{
     EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants, NodeWeightDiscriminants,
     workspace_snapshot::node_weight::{
-        NodeWeight, category_node_weight::CategoryNodeKind, traits::SiVersionedNodeWeight,
+        NodeWeight, action_node_weight, category_node_weight::CategoryNodeKind,
+        content_node_weight, traits::SiVersionedNodeWeight,
     },
 };
 
@@ -84,6 +85,15 @@ impl CorrectTransforms<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants> for 
     ) -> CorrectTransformsResult<Vec<Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>>
     {
         match self {
+            NodeWeight::Action(action_node_weight) => {
+                action_node_weight.correct_transforms(graph, updates, from_different_change_set)
+            }
+            NodeWeight::AttributeValue(av_node_weight) => {
+                av_node_weight.correct_transforms(graph, updates, from_different_change_set)
+            }
+            NodeWeight::Content(content_node_weight) => {
+                content_node_weight.correct_transforms(graph, updates, from_different_change_set)
+            }
             NodeWeight::Component(component_node_weight) => {
                 component_node_weight.correct_transforms(graph, updates, from_different_change_set)
             }

--- a/lib/dal/src/workspace_snapshot/split_snapshot/corrections.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot/corrections.rs
@@ -5,40 +5,21 @@
 /// corrections need to know about AttributeValue container objects, and so on. But it
 /// also has to be implemented for the custom node weight types.
 use std::{
-    collections::{
-        BTreeMap,
-        BTreeSet,
-    },
+    collections::{BTreeMap, BTreeSet},
     marker::PhantomData,
 };
 
-use petgraph::Direction::{
-    Incoming,
-    Outgoing,
-};
+use petgraph::Direction::{Incoming, Outgoing};
 use si_split_graph::{
-    CustomEdgeWeight,
-    CustomNodeWeight,
-    EdgeKind,
-    SplitGraph,
-    SplitGraphEdgeWeight,
-    SplitGraphEdgeWeightKind,
-    SplitGraphError,
-    SplitGraphNodeId,
-    SplitGraphNodeWeight,
-    Update,
+    CustomEdgeWeight, CustomNodeWeight, EdgeKind, SplitGraph, SplitGraphEdgeWeight,
+    SplitGraphEdgeWeightKind, SplitGraphError, SplitGraphNodeId, SplitGraphNodeWeight, Update,
     updates::ExternalSourceData,
 };
 use thiserror::Error;
 
 use crate::{
-    EdgeWeight,
-    EdgeWeightKind,
-    EdgeWeightKindDiscriminants,
-    workspace_snapshot::node_weight::{
-        NodeWeight,
-        traits::SiVersionedNodeWeight,
-    },
+    EdgeWeight, EdgeWeightKind, EdgeWeightKindDiscriminants,
+    workspace_snapshot::node_weight::{NodeWeight, traits::SiVersionedNodeWeight},
 };
 
 #[derive(Debug, Error)]
@@ -101,6 +82,9 @@ impl CorrectTransforms<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants> for 
     ) -> CorrectTransformsResult<Vec<Update<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>>>
     {
         match self {
+            NodeWeight::Component(component_node_weight) => {
+                component_node_weight.correct_transforms(graph, updates, from_different_change_set)
+            }
             NodeWeight::DiagramObject(diagram_object_node_weight) => diagram_object_node_weight
                 .correct_transforms(graph, updates, from_different_change_set),
             NodeWeight::Geometry(geometry_node_weight) => {

--- a/lib/dal/tests/integration_test/node_weight.rs
+++ b/lib/dal/tests/integration_test/node_weight.rs
@@ -1,6 +1,7 @@
 mod attribute_prototype;
 mod attribute_value;
 mod component;
+mod diagram_object;
 mod ordering;
 mod schema_variant;
 mod view;

--- a/lib/dal/tests/integration_test/node_weight.rs
+++ b/lib/dal/tests/integration_test/node_weight.rs
@@ -1,7 +1,6 @@
 mod attribute_prototype;
 mod attribute_value;
 mod component;
-mod diagram_object;
 mod ordering;
 mod schema_variant;
 mod view;

--- a/lib/dal/tests/integration_test/node_weight/diagram_object.rs
+++ b/lib/dal/tests/integration_test/node_weight/diagram_object.rs
@@ -1,0 +1,7 @@
+use dal_test::{
+    Result,
+    expected::{self, ExpectView, generate_fake_name},
+    helpers::create_component_for_default_schema_name,
+    prelude::OptionExt,
+    test,
+};

--- a/lib/dal/tests/integration_test/node_weight/diagram_object.rs
+++ b/lib/dal/tests/integration_test/node_weight/diagram_object.rs
@@ -1,7 +1,0 @@
-use dal_test::{
-    Result,
-    expected::{self, ExpectView, generate_fake_name},
-    helpers::create_component_for_default_schema_name,
-    prelude::OptionExt,
-    test,
-};

--- a/lib/dal/tests/integration_test/node_weight/view.rs
+++ b/lib/dal/tests/integration_test/node_weight/view.rs
@@ -1,24 +1,19 @@
 use dal::{
-    Component,
-    DalContext,
-    diagram::{
-        geometry::Geometry,
-        view::View,
-    },
+    Component, DalContext,
+    diagram::{geometry::Geometry, view::View},
+    workspace_snapshot::node_weight::{NodeWeight, category_node_weight::CategoryNodeKind},
 };
 use dal_test::{
     Result,
-    expected::{
-        self,
-        ExpectView,
-        generate_fake_name,
-    },
+    expected::{self, ExpectView, generate_fake_name},
     helpers::create_component_for_default_schema_name,
     prelude::OptionExt,
     test,
 };
+use petgraph::Direction::Outgoing;
 use pretty_assertions_sorted::assert_eq;
 use si_frontend_types::RawGeometry;
+use si_split_graph::SplitGraphNodeId;
 
 #[test]
 async fn correct_transforms_remove_view_all_geometries_removed(ctx: &mut DalContext) {
@@ -192,6 +187,24 @@ async fn correct_transforms_remove_view_not_all_geometries_removed(ctx: &mut Dal
     );
 }
 
+async fn find_diagram_object_category(ctx: &DalContext) -> Option<SplitGraphNodeId> {
+    let snap = ctx.workspace_snapshot().expect("tesco");
+    let root_id = snap.root().await.expect("must have a root");
+    for (_, _, target) in snap
+        .edges_directed(root_id, Outgoing)
+        .await
+        .expect("root node does not exist?")
+    {
+        if let Some(NodeWeight::Category(cat)) = snap.get_node_weight_opt(target).await {
+            if cat.kind() == CategoryNodeKind::DiagramObject {
+                return Some(target);
+            }
+        }
+    }
+
+    None
+}
+
 #[test]
 async fn correct_transforms_remove_view_no_other_views(ctx: &mut DalContext) {
     let new_view = ExpectView::create(ctx).await;
@@ -213,13 +226,26 @@ async fn correct_transforms_remove_view_no_other_views(ctx: &mut DalContext) {
     View::remove(ctx, new_view.id())
         .await
         .expect("Unable to remove View in ChangeSet");
+    find_diagram_object_category(ctx)
+        .await
+        .expect("expected diagram object category");
+
     expected::commit_and_update_snapshot_to_visibility(ctx).await;
 
     expected::fork_from_head_change_set(ctx).await;
-    create_component_for_default_schema_name(ctx, "swifty", generate_fake_name(), new_view.id())
-        .await
-        .expect("Unable to create Component in new View");
+
+    // change set with component, view not removed
+    let component = create_component_for_default_schema_name(
+        ctx,
+        "swifty",
+        generate_fake_name(),
+        new_view.id(),
+    )
+    .await
+    .expect("Unable to create Component in new View");
+
     expected::apply_change_set_to_base(ctx).await;
+
     assert_eq!(
         1,
         Geometry::list_by_view_id(ctx, new_view.id())
@@ -228,9 +254,18 @@ async fn correct_transforms_remove_view_no_other_views(ctx: &mut DalContext) {
             .len(),
     );
 
+    Component::get_by_id(ctx, component.id())
+        .await
+        .expect("component was not there!");
+
     ctx.update_visibility_and_snapshot_to_visibility(view_removal_change_set.id)
         .await
         .expect("Unable to switch to View removal ChangeSet");
+
+    Component::get_by_id(ctx, component.id())
+        .await
+        .expect("component was not there in removal change set!");
+
     assert_eq!(
         1,
         View::list(ctx)
@@ -240,6 +275,9 @@ async fn correct_transforms_remove_view_no_other_views(ctx: &mut DalContext) {
     );
     expected::apply_change_set_to_base(ctx).await;
 
+    Component::get_by_id(ctx, component.id())
+        .await
+        .expect("component was not there in base change set!");
     assert_eq!(
         2,
         View::list(ctx)
@@ -254,6 +292,14 @@ async fn correct_transforms_remove_view_no_other_views(ctx: &mut DalContext) {
             .expect("Unable to list Geometries in new View")
             .len(),
     );
+
+    let default_view_id = View::get_id_for_default(ctx)
+        .await
+        .expect("default view id");
+
+    Geometry::new_for_view(ctx, new_view.id(), default_view_id)
+        .await
+        .expect("create geometry");
 }
 
 #[test]
@@ -386,4 +432,103 @@ async fn correct_transforms_remove_view_components_moved_to_another_view(
     );
 
     Ok(())
+}
+
+/// Creates a view named "test view" and applies it to head. Then, creates two change sets.
+///  In each change set, use Geometry::new_for_view to create a new geometry object in the
+/// "test view" that represents the default view. Confirm no duplicate geometries for the
+/// diagram objects are created.
+///
+/// This is really a correction on the "geometry" node weight, not the "view" node weight.
+#[test]
+async fn correct_transforms_no_duplicate_diagram_object_geometries(ctx: &mut DalContext) {
+    let mut geometry_ids = vec![];
+
+    let default_view_id = View::get_id_for_default(ctx)
+        .await
+        .expect("Unable to get default ViewId");
+
+    // Create a view named "test view"
+    let test_view = ExpectView::create_with_name(ctx, "test view").await;
+    expected::apply_change_set_to_base(ctx).await;
+
+    // Create first change set
+    let first_change_set = expected::fork_from_head_change_set(ctx).await;
+
+    // Create a new geometry in "test view" that represents the default view
+    let geo_id = Geometry::new_for_view(ctx, default_view_id, test_view.id())
+        .await
+        .expect("Unable to create geometry in first change set")
+        .id();
+    geometry_ids.push(geo_id);
+
+    let geometries = Geometry::list_by_view_id(ctx, test_view.id())
+        .await
+        .expect("Unable to list geometries for test view");
+
+    assert_eq!(
+        1,
+        geometries.len(),
+        "Expected only one geometry in test view"
+    );
+
+    expected::commit_and_update_snapshot_to_visibility(ctx).await;
+
+    // Create second change set
+    expected::fork_from_head_change_set(ctx).await;
+
+    // Create another geometry in "test view" that represents the default view
+    let geo_id = Geometry::new_for_view(ctx, default_view_id, test_view.id())
+        .await
+        .expect("Unable to create geometry in second change set")
+        .id();
+    geometry_ids.push(geo_id);
+
+    // Apply second change set to head
+    expected::apply_change_set_to_base(ctx).await;
+
+    // Verify no duplicate geometires
+    let geometries = Geometry::list_by_view_id(ctx, test_view.id())
+        .await
+        .expect("Unable to list geometries for test view");
+
+    assert_eq!(
+        1,
+        geometries.len(),
+        "Expected only one geometry in test view"
+    );
+
+    ctx.update_visibility_and_snapshot_to_visibility(first_change_set.id)
+        .await
+        .expect("Unable to update visibility and snapshot");
+
+    let geometries = Geometry::list_by_view_id(ctx, test_view.id())
+        .await
+        .expect("Unable to list geometries for test view");
+
+    assert_eq!(
+        1,
+        geometries.len(),
+        "Expected only one geometry in test view"
+    );
+
+    let geo_id_on_change_set = geometries.first().expect("No geometry found").id();
+
+    ctx.workspace_snapshot()
+        .expect("hello")
+        .cleanup_and_merkle_tree_hash()
+        .await
+        .expect("hello");
+
+    expected::apply_change_set_to_base(ctx).await;
+
+    let geometries = Geometry::list_by_view_id(ctx, test_view.id())
+        .await
+        .expect("Unable to list geometries for test view");
+
+    assert_eq!(
+        1,
+        geometries.len(),
+        "Expected only one geometry in test view"
+    );
 }

--- a/lib/dal/tests/integration_test/node_weight/view.rs
+++ b/lib/dal/tests/integration_test/node_weight/view.rs
@@ -1,11 +1,22 @@
 use dal::{
-    Component, DalContext,
-    diagram::{geometry::Geometry, view::View},
-    workspace_snapshot::node_weight::{NodeWeight, category_node_weight::CategoryNodeKind},
+    Component,
+    DalContext,
+    diagram::{
+        geometry::Geometry,
+        view::View,
+    },
+    workspace_snapshot::node_weight::{
+        NodeWeight,
+        category_node_weight::CategoryNodeKind,
+    },
 };
 use dal_test::{
     Result,
-    expected::{self, ExpectView, generate_fake_name},
+    expected::{
+        self,
+        ExpectView,
+        generate_fake_name,
+    },
     helpers::create_component_for_default_schema_name,
     prelude::OptionExt,
     test,

--- a/lib/dal/tests/integration_test/node_weight/view.rs
+++ b/lib/dal/tests/integration_test/node_weight/view.rs
@@ -512,8 +512,6 @@ async fn correct_transforms_no_duplicate_diagram_object_geometries(ctx: &mut Dal
         "Expected only one geometry in test view"
     );
 
-    let geo_id_on_change_set = geometries.first().expect("No geometry found").id();
-
     ctx.workspace_snapshot()
         .expect("hello")
         .cleanup_and_merkle_tree_hash()

--- a/lib/si-split-graph/src/lib.rs
+++ b/lib/si-split-graph/src/lib.rs
@@ -1,10 +1,5 @@
 use std::{
-    collections::{
-        BTreeMap,
-        BTreeSet,
-        HashSet,
-        VecDeque,
-    },
+    collections::{BTreeMap, HashSet, VecDeque},
     marker::PhantomData,
     time::Instant,
 };
@@ -13,23 +8,13 @@ use dashmap::DashMap;
 use opt_zip::OptZip;
 use petgraph::prelude::*;
 use petgraph_traits::{
-    RawSplitGraphEdges,
-    SplitGraphEdgeReference,
-    SplitGraphEdges,
-    SplitGraphNeighbors,
+    RawSplitGraphEdges, SplitGraphEdgeReference, SplitGraphEdges, SplitGraphNeighbors,
 };
-use serde::{
-    Deserialize,
-    Serialize,
-    de::DeserializeOwned,
-};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use si_events::{
     ContentHash,
     merkle_tree_hash::MerkleTreeHash,
-    workspace_snapshot::{
-        Change,
-        EntityKind,
-    },
+    workspace_snapshot::{Change, EntityKind},
 };
 use si_id::ulid::Ulid;
 use strum::EnumDiscriminants;
@@ -42,11 +27,7 @@ pub mod subgraph;
 pub mod subgraph_address;
 pub mod updates;
 
-pub use subgraph::{
-    SubGraph,
-    SubGraphEdgeIndex,
-    SubGraphNodeIndex,
-};
+pub use subgraph::{SubGraph, SubGraphEdgeIndex, SubGraphNodeIndex};
 pub use subgraph_address::SubGraphAddress;
 use updates::ExternalSourceData;
 pub use updates::Update;
@@ -1810,9 +1791,9 @@ where
 
         let mut final_changes = vec![];
 
-        // Now that we've detected all the changed nodes in every subgraph, we need to detect all the
-        // parents of these changed nodes, *across* subgraphs, since these will have also changed.
-        // reversed so that parents come before children in the finalized list
+        // Now that we've detected all the changed nodes in every subgraph, we need to detect all
+        // the parents of these changed nodes, *across* subgraphs, since these will have also
+        // changed. reversed so that parents come before children in the finalized list
         for change in &changes {
             // We want to prefer nodes in the updated graph, since those will be the
             // updated version of these nodes, but when the change is a removal,
@@ -1847,12 +1828,11 @@ where
                     | weight @ SplitGraphNodeWeight::Custom(_),
                 ) = graph_to_search.raw_node_weight(parent_id)
                 {
-                    // If we find this node now, that means its merkle tree hash
-                    // hasn't changed since it was in different subgraph than the
-                    // child node which *did* change. This just adds a bit of entropy
-                    // to the changes so that the checksum generated is different.
-                    // May not be necessary since there *will* be at least one
-                    // other changed node?
+                    // If we find this node now, that means its merkle tree hash hasn't changed
+                    // since it was in different subgraph than the child node which *did* change.
+                    // This just adds a bit of entropy to the changes so that the checksum
+                    // generated is different. May not be necessary since there *will* be at least
+                    // one other changed node?
                     let mut hasher = MerkleTreeHash::hasher();
                     hasher.update(change.merkle_tree_hash.as_bytes());
                     hasher.update(weight.merkle_tree_hash().as_bytes());
@@ -1875,7 +1855,6 @@ where
     }
 
     pub fn perform_updates(&mut self, updates: &[Update<N, E, K>]) {
-        let mut removed_node_ids = BTreeSet::new();
         let mut subgraph_id_to_index = BTreeMap::new();
 
         for (subgraph_idx, subgraph) in self.subgraphs.iter().enumerate() {
@@ -1962,7 +1941,6 @@ where
                         continue;
                     };
 
-                    removed_node_ids.insert((*subgraph_index, node_index));
                     subgraph.remove_node(node_index);
                 }
                 Update::ReplaceNode {

--- a/lib/si-split-graph/src/lib.rs
+++ b/lib/si-split-graph/src/lib.rs
@@ -1,5 +1,9 @@
 use std::{
-    collections::{BTreeMap, HashSet, VecDeque},
+    collections::{
+        BTreeMap,
+        HashSet,
+        VecDeque,
+    },
     marker::PhantomData,
     time::Instant,
 };
@@ -8,13 +12,23 @@ use dashmap::DashMap;
 use opt_zip::OptZip;
 use petgraph::prelude::*;
 use petgraph_traits::{
-    RawSplitGraphEdges, SplitGraphEdgeReference, SplitGraphEdges, SplitGraphNeighbors,
+    RawSplitGraphEdges,
+    SplitGraphEdgeReference,
+    SplitGraphEdges,
+    SplitGraphNeighbors,
 };
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{
+    Deserialize,
+    Serialize,
+    de::DeserializeOwned,
+};
 use si_events::{
     ContentHash,
     merkle_tree_hash::MerkleTreeHash,
-    workspace_snapshot::{Change, EntityKind},
+    workspace_snapshot::{
+        Change,
+        EntityKind,
+    },
 };
 use si_id::ulid::Ulid;
 use strum::EnumDiscriminants;
@@ -27,7 +41,11 @@ pub mod subgraph;
 pub mod subgraph_address;
 pub mod updates;
 
-pub use subgraph::{SubGraph, SubGraphEdgeIndex, SubGraphNodeIndex};
+pub use subgraph::{
+    SubGraph,
+    SubGraphEdgeIndex,
+    SubGraphNodeIndex,
+};
 pub use subgraph_address::SubGraphAddress;
 use updates::ExternalSourceData;
 pub use updates::Update;

--- a/lib/si-split-graph/src/lib.rs
+++ b/lib/si-split-graph/src/lib.rs
@@ -1488,7 +1488,7 @@ where
     ) -> SplitGraphResult<impl Iterator<Item = SplitGraphNodeId> + '_> {
         Ok(self
             .incoming_edges(to_id, kind)?
-            .map(|edge_ref| edge_ref.target()))
+            .map(|edge_ref| edge_ref.source()))
     }
 
     pub fn outgoing_edges(

--- a/lib/si-split-graph/src/lib.rs
+++ b/lib/si-split-graph/src/lib.rs
@@ -334,6 +334,13 @@ where
         }
     }
 
+    pub fn custom_kind(&self) -> Option<K> {
+        match self {
+            SplitGraphEdgeWeight::Custom(weight) => Some(weight.kind()),
+            _ => None,
+        }
+    }
+
     pub fn is_default(&self) -> bool {
         match self {
             SplitGraphEdgeWeight::Custom(c) => c.is_default(),
@@ -707,6 +714,11 @@ where
             .find(|subgraph| subgraph.node_id_to_index(node_id).is_some())
     }
 
+    pub fn subgraph_root_id_for_node(&self, node_id: SplitGraphNodeId) -> Option<SplitGraphNodeId> {
+        self.subgraph_for_node(node_id)
+            .and_then(|subgraph| subgraph.root_id())
+    }
+
     pub fn subgraph_mut_for_node(
         &mut self,
         node_id: SplitGraphNodeId,
@@ -816,6 +828,10 @@ where
 
     pub fn node_weight(&self, node_id: SplitGraphNodeId) -> Option<&N> {
         self.raw_node_weight(node_id).and_then(|node| node.custom())
+    }
+
+    pub fn node_exists(&self, node_id: SplitGraphNodeId) -> bool {
+        self.node_weight(node_id).is_some()
     }
 
     pub fn raw_node_weight_mut(

--- a/lib/si-split-graph/src/lib.rs
+++ b/lib/si-split-graph/src/lib.rs
@@ -1473,6 +1473,42 @@ where
         }))
     }
 
+    pub fn incoming_edges(
+        &self,
+        to_id: SplitGraphNodeId,
+        kind: K,
+    ) -> SplitGraphResult<impl Iterator<Item = SplitGraphEdgeReference<'_, E, K>> + '_> {
+        self.edges_directed_for_edge_weight_kind(to_id, Incoming, kind)
+    }
+
+    pub fn incoming_sources(
+        &self,
+        to_id: SplitGraphNodeId,
+        kind: K,
+    ) -> SplitGraphResult<impl Iterator<Item = SplitGraphNodeId> + '_> {
+        Ok(self
+            .incoming_edges(to_id, kind)?
+            .map(|edge_ref| edge_ref.target()))
+    }
+
+    pub fn outgoing_edges(
+        &self,
+        from_id: SplitGraphNodeId,
+        kind: K,
+    ) -> SplitGraphResult<impl Iterator<Item = SplitGraphEdgeReference<'_, E, K>> + '_> {
+        self.edges_directed_for_edge_weight_kind(from_id, Outgoing, kind)
+    }
+
+    pub fn outgoing_targets(
+        &self,
+        from_id: SplitGraphNodeId,
+        kind: K,
+    ) -> SplitGraphResult<impl Iterator<Item = SplitGraphNodeId> + '_> {
+        Ok(self
+            .outgoing_edges(from_id, kind)?
+            .map(|edge_ref| edge_ref.target()))
+    }
+
     pub fn edges_directed_for_edge_weight_kind(
         &self,
         from_id: SplitGraphNodeId,

--- a/lib/si-split-graph/src/petgraph_traits.rs
+++ b/lib/si-split-graph/src/petgraph_traits.rs
@@ -1,14 +1,28 @@
 use std::{
-    collections::{HashSet, btree_map},
+    collections::{
+        HashSet,
+        btree_map,
+    },
     marker::PhantomData,
 };
 
-use petgraph::{prelude::*, stable_graph};
+use petgraph::{
+    prelude::*,
+    stable_graph,
+};
 use telemetry::prelude::*;
 
 use crate::{
-    CustomEdgeWeight, CustomNodeWeight, EdgeKind, SplitGraph, SplitGraphEdgeIndex,
-    SplitGraphEdgeWeight, SplitGraphNodeId, SplitGraphNodeWeight, SubGraph, SubGraphIndex,
+    CustomEdgeWeight,
+    CustomNodeWeight,
+    EdgeKind,
+    SplitGraph,
+    SplitGraphEdgeIndex,
+    SplitGraphEdgeWeight,
+    SplitGraphNodeId,
+    SplitGraphNodeWeight,
+    SubGraph,
+    SubGraphIndex,
     SubGraphNodeIndex,
 };
 

--- a/lib/si-split-graph/src/petgraph_traits.rs
+++ b/lib/si-split-graph/src/petgraph_traits.rs
@@ -1,28 +1,14 @@
 use std::{
-    collections::{
-        HashSet,
-        btree_map,
-    },
+    collections::{HashSet, btree_map},
     marker::PhantomData,
 };
 
-use petgraph::{
-    prelude::*,
-    stable_graph,
-};
+use petgraph::{prelude::*, stable_graph};
 use telemetry::prelude::*;
 
 use crate::{
-    CustomEdgeWeight,
-    CustomNodeWeight,
-    EdgeKind,
-    SplitGraph,
-    SplitGraphEdgeIndex,
-    SplitGraphEdgeWeight,
-    SplitGraphNodeId,
-    SplitGraphNodeWeight,
-    SubGraph,
-    SubGraphIndex,
+    CustomEdgeWeight, CustomNodeWeight, EdgeKind, SplitGraph, SplitGraphEdgeIndex,
+    SplitGraphEdgeWeight, SplitGraphNodeId, SplitGraphNodeWeight, SubGraph, SubGraphIndex,
     SubGraphNodeIndex,
 };
 
@@ -62,6 +48,10 @@ where
 
     pub fn weight(&self) -> &'a E {
         self.weight
+    }
+
+    pub fn triplet(&self) -> (SplitGraphNodeId, K, SplitGraphNodeId) {
+        (self.source(), self.weight().kind(), self.target())
     }
 }
 

--- a/lib/si-split-graph/src/tests/mod.rs
+++ b/lib/si-split-graph/src/tests/mod.rs
@@ -1431,15 +1431,11 @@ fn detect_updates_simple() -> SplitGraphResult<()> {
     assert_eq!(new_node.id(), destination.id);
 
     let inverse_updates = updated_graph.detect_updates(&base_graph);
-    assert_eq!(2, inverse_updates.len());
+    assert_eq!(1, inverse_updates.len());
 
     assert!(matches!(
         inverse_updates.first().unwrap(),
         Update::RemoveEdge { .. }
-    ));
-    assert!(matches!(
-        inverse_updates.get(1).unwrap(),
-        Update::RemoveNode { .. }
     ));
 
     let mut second_updated_graph = updated_graph.clone();

--- a/lib/si-split-graph/src/updates.rs
+++ b/lib/si-split-graph/src/updates.rs
@@ -1,21 +1,44 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{
+        BTreeMap,
+        HashMap,
+        HashSet,
+    },
     marker::PhantomData,
 };
 
 use petgraph::{
     prelude::*,
-    visit::{Control, DfsEvent},
+    visit::{
+        Control,
+        DfsEvent,
+    },
 };
-use serde::{Deserialize, Serialize};
-use si_events::{merkle_tree_hash::MerkleTreeHash, workspace_snapshot::Change};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::{
+    merkle_tree_hash::MerkleTreeHash,
+    workspace_snapshot::Change,
+};
 use strum::EnumDiscriminants;
 
 use crate::{
-    CustomEdgeWeight, CustomNodeWeight, EdgeKind, SplitGraph, SplitGraphEdgeWeight,
-    SplitGraphEdgeWeightKind, SplitGraphNodeId, SplitGraphNodeWeight,
-    SplitGraphNodeWeightDiscriminants, SplitGraphResult,
-    subgraph::{SubGraph, SubGraphNodeIndex},
+    CustomEdgeWeight,
+    CustomNodeWeight,
+    EdgeKind,
+    SplitGraph,
+    SplitGraphEdgeWeight,
+    SplitGraphEdgeWeightKind,
+    SplitGraphNodeId,
+    SplitGraphNodeWeight,
+    SplitGraphNodeWeightDiscriminants,
+    SplitGraphResult,
+    subgraph::{
+        SubGraph,
+        SubGraphNodeIndex,
+    },
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Hash)]


### PR DESCRIPTION
All correction tests pass with this on the split graph, including some new ones.

Includes a working schema variant unlock correction test (just a few tweaks were necessary).