### PR TITLE
fix(edda): skip processing abandonned change sets

### DIFF
--- a/lib/rebaser-server/src/rebase.rs
+++ b/lib/rebaser-server/src/rebase.rs
@@ -110,7 +110,7 @@ pub async fn perform_rebase(
 
     // if the change set has been abandoned, do not do this work
     if to_rebase_change_set.status == ChangeSetStatus::Abandoned {
-        warn!("Attempted to rebase for abandoned change set. Early returning");
+        debug!("Attempted to rebase for abandoned change set. Early returning");
         return Ok(RebaseStatus::Error {
             message: "Attempted to rebase for an abandoned change set.".to_string(),
         });


### PR DESCRIPTION
Let's not overwork. Skip processing in Edda for abandoned Change Sets.

<div><img src="https://media2.giphy.com/media/TlK63Euc9KArc2a0kEw/giphy.gif?cid=5a38a5a2snxpuc2p91y5wsh8rlm9fixmf15x3s6xx7fy6hdr&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:306px;width:300px"/></div>