### PR TITLE
chore: re-enable mjolnir test

### DIFF
--- a/bin/si-sdf-api-test/tests/8-check_mjolnir.ts
+++ b/bin/si-sdf-api-test/tests/8-check_mjolnir.ts
@@ -15,15 +15,14 @@ export default async function check_mjolnir(
   sdfApiClient: SdfApiClient,
   changeSetId: string,
 ) {
-  console.log("test temporarily disabled");
-  // if (changeSetId) {
-  //   return await check_mjolnir_inner(sdfApiClient, changeSetId);
-  // } else {
-  //   return runWithTemporaryChangeset(
-  //     sdfApiClient,
-  //     check_mjolnir_inner,
-  //   );
-  // }
+  if (changeSetId) {
+    return await check_mjolnir_inner(sdfApiClient, changeSetId);
+  } else {
+    return runWithTemporaryChangeset(
+      sdfApiClient,
+      check_mjolnir_inner,
+    );
+  }
 }
 
 async function check_mjolnir_inner(


### PR DESCRIPTION
Re-enables this now Edda is back and active in Prod.

Working test run here:
https://github.com/systeminit/si/actions/runs/15174109790/job/42670827693