### PR TITLE
Add compiling spike of compressing edda messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2608,6 +2608,7 @@ dependencies = [
  "serde_json",
  "si-data-nats",
  "si-events",
+ "si-id",
  "strum",
 ]
 
@@ -2626,6 +2627,7 @@ dependencies = [
  "futures",
  "json-patch",
  "naxum",
+ "pin-project-lite",
  "rebaser-client",
  "remain",
  "serde",

--- a/lib/edda-core/BUCK
+++ b/lib/edda-core/BUCK
@@ -6,6 +6,7 @@ rust_library(
         "//lib/naxum-api-types:naxum-api-types",
         "//lib/si-data-nats:si-data-nats",
         "//lib/si-events-rs:si-events",
+        "//lib/si-id:si-id",
         "//third-party/rust:remain",
         "//third-party/rust:serde",
         "//third-party/rust:strum",

--- a/lib/edda-core/Cargo.toml
+++ b/lib/edda-core/Cargo.toml
@@ -10,10 +10,12 @@ publish.workspace = true
 
 [dependencies]
 naxum-api-types = { path = "../../lib/naxum-api-types" }
+si-data-nats = { path = "../../lib/si-data-nats" }
+si-id = { path = "../../lib/si-id" }
+si-events = { path = "../../lib/si-events-rs" }
+
 remain = { workspace = true }
 serde = { workspace = true }
-si-data-nats = { path = "../../lib/si-data-nats" }
-si-events = { path = "../../lib/si-events-rs" }
 strum = { workspace = true }
 
 [dev-dependencies]

--- a/lib/edda-core/src/api_types.rs
+++ b/lib/edda-core/src/api_types.rs
@@ -1,3 +1,5 @@
+pub mod compressor_rebuild_request;
+pub mod compressor_update_request;
 pub mod rebuild_request;
 pub mod update_request;
 

--- a/lib/edda-core/src/api_types/compressor_rebuild_request.rs
+++ b/lib/edda-core/src/api_types/compressor_rebuild_request.rs
@@ -1,0 +1,238 @@
+mod v1;
+
+use std::{
+    fmt,
+    ops::{
+        Deref,
+        DerefMut,
+    },
+};
+
+use naxum_api_types::{
+    ApiVersionsWrapper,
+    ApiWrapper,
+    RequestId,
+    UpgradeError,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use strum::{
+    AsRefStr,
+    EnumDiscriminants,
+    EnumIs,
+    EnumString,
+    VariantNames,
+};
+
+pub use self::v1::CompressorRebuildRequestV1;
+
+pub type CompressorRebuildRequestVCurrent = CompressorRebuildRequestV1;
+
+#[derive(Clone, Eq, Serialize, PartialEq, VariantNames)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum CompressorRebuildRequest {
+    V1(CompressorRebuildRequestV1),
+}
+
+impl ApiWrapper for CompressorRebuildRequest {
+    type VersionsTarget = CompressorRebuildRequestVersions;
+    type Current = CompressorRebuildRequestVCurrent;
+
+    const MESSAGE_TYPE: &'static str = "CompressorRebuildRequest";
+
+    fn id(&self) -> RequestId {
+        match self {
+            Self::V1(CompressorRebuildRequestVCurrent { id, .. }) => *id,
+        }
+    }
+
+    fn new_current(current: Self::Current) -> Self {
+        Self::V1(current)
+    }
+}
+
+impl fmt::Debug for CompressorRebuildRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::V1(inner) => inner.fmt(f),
+        }
+    }
+}
+
+impl Deref for CompressorRebuildRequest {
+    type Target = CompressorRebuildRequestVCurrent;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::V1(inner) => inner,
+        }
+    }
+}
+
+impl DerefMut for CompressorRebuildRequest {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::V1(inner) => inner,
+        }
+    }
+}
+
+#[remain::sorted]
+#[derive(Clone, Debug, Deserialize, EnumDiscriminants, EnumIs, Eq, PartialEq, VariantNames)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+#[strum_discriminants(strum(serialize_all = "camelCase"), derive(AsRefStr, EnumString))]
+pub enum CompressorRebuildRequestVersions {
+    V1(CompressorRebuildRequestV1),
+}
+
+impl ApiVersionsWrapper for CompressorRebuildRequestVersions {
+    type Target = CompressorRebuildRequest;
+
+    fn id(&self) -> RequestId {
+        match self {
+            Self::V1(CompressorRebuildRequestV1 { id, .. }) => *id,
+        }
+    }
+
+    fn into_current_version(self) -> Result<Self::Target, UpgradeError> {
+        match self {
+            Self::V1(inner) => Ok(Self::Target::V1(inner)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        error::Error,
+        fmt,
+        fs::File,
+        io::{
+            self,
+            BufRead as _,
+            BufReader,
+            Read as _,
+        },
+        path::Path,
+    };
+
+    use serde::{
+        Serialize,
+        de::DeserializeOwned,
+    };
+
+    use super::CompressorRebuildRequestVersionsDiscriminants;
+
+    /// Tests that a versioned object will always serialize to the same representation, no matter
+    /// what future versions or changes to the object.
+    ///
+    /// NOTE: It is imperative that incremental refactorings do not lead to a version-incompatible
+    /// or serialize-incompatible change. If a test fails and it's because there is a diff to the
+    /// commiteed `.snap` file, this should be considered a failed refactoring. The remediation is
+    /// to *not* update the `.snap` file but rather to fix the code so that the `.snap` format is
+    /// 100% preserved.
+    pub fn assert_serialize(
+        name: &str,
+        version: CompressorRebuildRequestVersionsDiscriminants,
+        serialize: impl Serialize,
+    ) {
+        insta::with_settings!({
+            snapshot_path => format!("rebuild_request/snapshots-{}", version.as_ref()),
+            prepend_module_to_snapshot => false,
+            omit_expression => true,
+            description => concat!(
+                "\n",
+                "\n",
+                "!!!\n",
+                "!!! System Initiative Developers:\n",
+                "!!!\n",
+                "!!! IMPORTANT:\n",
+                "!!!\n",
+                "!!!     The contents of this snapshot should *never* be modified as it\n",
+                "!!!     represents the serialization of a versioned Rust type. If a tests fails\n",
+                "!!!     with this warning, then something about a Rust type has changed\n",
+                "!!!     the wire serialization of this type and would represent a potential\n",
+                "!!!     production outage or data corruption.\n",
+                "!!!\n",
+                "!!!     Consider this an erroneous behavioral change of the Rust code and *not*\n",
+                "!!!     an out-of-date snapshot or fixture!\n",
+                "!!!\n",
+                "\n",
+                "\n",
+            ),
+        }, {
+            insta::assert_json_snapshot!(name, serialize);
+        });
+    }
+
+    pub fn assert_deserialize<T>(
+        snapshot_name: &str,
+        version: CompressorRebuildRequestVersionsDiscriminants,
+        expected: T,
+    ) where
+        T: fmt::Debug + DeserializeOwned + PartialEq,
+    {
+        let actual: T = read_from_snapshot(
+            snapshot_name,
+            &format!("rebuild_request/snapshots-{}", version.as_ref()),
+        )
+        .expect("failed to deserialize from snapshot");
+
+        assert_eq!(actual, expected);
+    }
+
+    fn read_from_snapshot<T>(name: &str, path: &str) -> Result<T, Box<dyn Error>>
+    where
+        T: fmt::Debug + DeserializeOwned + PartialEq,
+    {
+        let glob = format!("{path}/{name}.snap");
+
+        let mut maybe_obj_result = None;
+        insta::glob!(&glob, |path| {
+            let bytes = read_snapshot_content(path).unwrap();
+
+            maybe_obj_result = Some(serde_json::from_slice(&bytes).map_err(Into::into));
+        });
+
+        match maybe_obj_result {
+            Some(object_result) => object_result,
+            None => Err(Box::new(io::Error::other(format!(
+                "snapshot not found: {glob}"
+            )))),
+        }
+    }
+
+    // Implementation is adapted from the [`insta::Snapshot::from_file`] function.
+    //
+    // See: <https://github.com/mitsuhiko/insta/blob/62bb0a3/insta/src/snapshot.rs#L339-L421>
+    fn read_snapshot_content(path: &Path) -> Result<Vec<u8>, Box<dyn Error>> {
+        let mut f = BufReader::new(File::open(path)?);
+
+        // Skip through the snapshot metadata, that being the first YAML document, where YAML
+        // documents are delimited with a `"---"` line
+        {
+            let mut buf = String::new();
+            f.read_line(&mut buf)?;
+            if buf.trim_end() == "---" {
+                loop {
+                    let read = f.read_line(&mut buf)?;
+                    if read == 0 {
+                        break;
+                    }
+                    if buf[buf.len() - read..].trim_end() == "---" {
+                        break;
+                    }
+                }
+            }
+        }
+
+        let mut buf = Vec::new();
+        f.read_to_end(&mut buf)?;
+
+        Ok(buf)
+    }
+}

--- a/lib/edda-core/src/api_types/compressor_rebuild_request/v1.rs
+++ b/lib/edda-core/src/api_types/compressor_rebuild_request/v1.rs
@@ -1,0 +1,45 @@
+use naxum_api_types::RequestId;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+#[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+// NOTE: **do not modify this datatype--it represents a historically stable, versioned request**
+pub struct CompressorRebuildRequestV1 {
+    pub id: RequestId,
+    pub previous_ids: Vec<RequestId>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::{
+            CompressorRebuildRequestVersionsDiscriminants,
+            CompressorRebuildRequestVersionsDiscriminants::*,
+            test::*,
+        },
+        *,
+    };
+
+    const SNAPSHOT_NAME: &str = "serialized";
+    const VERSION: CompressorRebuildRequestVersionsDiscriminants = V1;
+
+    fn msg() -> CompressorRebuildRequestV1 {
+        CompressorRebuildRequestV1 {
+            id: "01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),
+            previous_ids: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn serialize() {
+        assert_serialize(SNAPSHOT_NAME, VERSION, msg());
+    }
+
+    #[test]
+    fn deserialize() {
+        assert_deserialize(SNAPSHOT_NAME, VERSION, msg());
+    }
+}

--- a/lib/edda-core/src/api_types/compressor_update_request.rs
+++ b/lib/edda-core/src/api_types/compressor_update_request.rs
@@ -1,0 +1,238 @@
+mod v1;
+
+use std::{
+    fmt,
+    ops::{
+        Deref,
+        DerefMut,
+    },
+};
+
+use naxum_api_types::{
+    ApiVersionsWrapper,
+    ApiWrapper,
+    RequestId,
+    UpgradeError,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use strum::{
+    AsRefStr,
+    EnumDiscriminants,
+    EnumIs,
+    EnumString,
+    VariantNames,
+};
+
+pub use self::v1::CompressorUpdateRequestV1;
+
+pub type CompressorUpdateRequestVCurrent = CompressorUpdateRequestV1;
+
+#[derive(Clone, Eq, Serialize, PartialEq, VariantNames)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+pub enum CompressorUpdateRequest {
+    V1(CompressorUpdateRequestV1),
+}
+
+impl ApiWrapper for CompressorUpdateRequest {
+    type VersionsTarget = CompressorUpdateRequestVersions;
+    type Current = CompressorUpdateRequestVCurrent;
+
+    const MESSAGE_TYPE: &'static str = "CompressorUpdateRequest";
+
+    fn id(&self) -> RequestId {
+        match self {
+            Self::V1(CompressorUpdateRequestVCurrent { id, .. }) => *id,
+        }
+    }
+
+    fn new_current(current: Self::Current) -> Self {
+        Self::V1(current)
+    }
+}
+
+impl fmt::Debug for CompressorUpdateRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::V1(inner) => inner.fmt(f),
+        }
+    }
+}
+
+impl Deref for CompressorUpdateRequest {
+    type Target = CompressorUpdateRequestVCurrent;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::V1(inner) => inner,
+        }
+    }
+}
+
+impl DerefMut for CompressorUpdateRequest {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::V1(inner) => inner,
+        }
+    }
+}
+
+#[remain::sorted]
+#[derive(Clone, Debug, Deserialize, EnumDiscriminants, EnumIs, Eq, PartialEq, VariantNames)]
+#[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
+#[strum_discriminants(strum(serialize_all = "camelCase"), derive(AsRefStr, EnumString))]
+pub enum CompressorUpdateRequestVersions {
+    V1(CompressorUpdateRequestV1),
+}
+
+impl ApiVersionsWrapper for CompressorUpdateRequestVersions {
+    type Target = CompressorUpdateRequest;
+
+    fn id(&self) -> RequestId {
+        match self {
+            Self::V1(CompressorUpdateRequestV1 { id, .. }) => *id,
+        }
+    }
+
+    fn into_current_version(self) -> Result<Self::Target, UpgradeError> {
+        match self {
+            Self::V1(inner) => Ok(Self::Target::V1(inner)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        error::Error,
+        fmt,
+        fs::File,
+        io::{
+            self,
+            BufRead as _,
+            BufReader,
+            Read as _,
+        },
+        path::Path,
+    };
+
+    use serde::{
+        Serialize,
+        de::DeserializeOwned,
+    };
+
+    use super::CompressorUpdateRequestVersionsDiscriminants;
+
+    /// Tests that a versioned object will always serialize to the same representation, no matter
+    /// what future versions or changes to the object.
+    ///
+    /// NOTE: It is imperative that incrementatl refactorings do not lead to a version-incompatible
+    /// or serialize-incompatible change. If a test fails and it's because there is a diff to the
+    /// commiteed `.snap` file, this should be considered a failed refactoring. The remediation is
+    /// to *not* update the `.snap` file but rather to fix the code so that the `.snap` format is
+    /// 100% preserved.
+    pub fn assert_serialize(
+        name: &str,
+        version: CompressorUpdateRequestVersionsDiscriminants,
+        serialize: impl Serialize,
+    ) {
+        insta::with_settings!({
+            snapshot_path => format!("update_request/snapshots-{}", version.as_ref()),
+            prepend_module_to_snapshot => false,
+            omit_expression => true,
+            description => concat!(
+                "\n",
+                "\n",
+                "!!!\n",
+                "!!! System Initiative Developers:\n",
+                "!!!\n",
+                "!!! IMPORTANT:\n",
+                "!!!\n",
+                "!!!     The contents of this snapshot should *never* be modified as it\n",
+                "!!!     represents the serialization of a versioned Rust type. If a tests fails\n",
+                "!!!     with this warning, then something about a Rust type has changed\n",
+                "!!!     the wire serialization of this type and would represent a potential\n",
+                "!!!     production outage or data corruption.\n",
+                "!!!\n",
+                "!!!     Consider this an erroneous behavioral change of the Rust code and *not*\n",
+                "!!!     an out-of-date snapshot or fixture!\n",
+                "!!!\n",
+                "\n",
+                "\n",
+            ),
+        }, {
+            insta::assert_json_snapshot!(name, serialize);
+        });
+    }
+
+    pub fn assert_deserialize<T>(
+        snapshot_name: &str,
+        version: CompressorUpdateRequestVersionsDiscriminants,
+        expected: T,
+    ) where
+        T: fmt::Debug + DeserializeOwned + PartialEq,
+    {
+        let actual: T = read_from_snapshot(
+            snapshot_name,
+            &format!("update_request/snapshots-{}", version.as_ref()),
+        )
+        .expect("failed to deserialize from snapshot");
+
+        assert_eq!(actual, expected);
+    }
+
+    fn read_from_snapshot<T>(name: &str, path: &str) -> Result<T, Box<dyn Error>>
+    where
+        T: fmt::Debug + DeserializeOwned + PartialEq,
+    {
+        let glob = format!("{path}/{name}.snap");
+
+        let mut maybe_obj_result = None;
+        insta::glob!(&glob, |path| {
+            let bytes = read_snapshot_content(path).unwrap();
+
+            maybe_obj_result = Some(serde_json::from_slice(&bytes).map_err(Into::into));
+        });
+
+        match maybe_obj_result {
+            Some(object_result) => object_result,
+            None => Err(Box::new(io::Error::other(format!(
+                "snapshot not found: {glob}"
+            )))),
+        }
+    }
+
+    // Implementation is adapted from the [`insta::Snapshot::from_file`] function.
+    //
+    // See: <https://github.com/mitsuhiko/insta/blob/62bb0a3/insta/src/snapshot.rs#L339-L421>
+    fn read_snapshot_content(path: &Path) -> Result<Vec<u8>, Box<dyn Error>> {
+        let mut f = BufReader::new(File::open(path)?);
+
+        // Skip through the snapshot metadata, that being the first YAML document, where YAML
+        // documents are delimited with a `"---"` line
+        {
+            let mut buf = String::new();
+            f.read_line(&mut buf)?;
+            if buf.trim_end() == "---" {
+                loop {
+                    let read = f.read_line(&mut buf)?;
+                    if read == 0 {
+                        break;
+                    }
+                    if buf[buf.len() - read..].trim_end() == "---" {
+                        break;
+                    }
+                }
+            }
+        }
+
+        let mut buf = Vec::new();
+        f.read_to_end(&mut buf)?;
+
+        Ok(buf)
+    }
+}

--- a/lib/edda-core/src/api_types/compressor_update_request/v1.rs
+++ b/lib/edda-core/src/api_types/compressor_update_request/v1.rs
@@ -1,0 +1,70 @@
+use std::collections::HashMap;
+
+use naxum_api_types::RequestId;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::{
+    WorkspaceSnapshotAddress,
+    workspace_snapshot::Change,
+};
+use si_id::EntityId;
+
+#[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+// NOTE: **do not modify this datatype--it represents a historically stable, versioned request**
+pub struct CompressorUpdateRequestV1 {
+    pub id: RequestId,
+    pub previous_ids: Vec<RequestId>,
+    pub from_snapshot_address: WorkspaceSnapshotAddress,
+    pub to_snapshot_address: WorkspaceSnapshotAddress,
+    pub changes: HashMap<EntityId, Change>,
+}
+
+#[cfg(test)]
+mod tests {
+    use si_events::{
+        merkle_tree_hash::MerkleTreeHash,
+        workspace_snapshot::EntityKind,
+    };
+
+    use super::{
+        super::{
+            CompressorUpdateRequestVersionsDiscriminants,
+            CompressorUpdateRequestVersionsDiscriminants::*,
+            test::*,
+        },
+        *,
+    };
+
+    const SNAPSHOT_NAME: &str = "serialized";
+    const VERSION: CompressorUpdateRequestVersionsDiscriminants = V1;
+
+    fn msg() -> CompressorUpdateRequestV1 {
+        CompressorUpdateRequestV1 {
+            id: "01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),
+            previous_ids: Vec::new(),
+            from_snapshot_address: WorkspaceSnapshotAddress::new(b"super-snapshot"),
+            to_snapshot_address: WorkspaceSnapshotAddress::new(b"super-snapshot"),
+            changes: HashMap::from_iter([(
+                "01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),
+                Change {
+                    entity_id: "01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),
+                    entity_kind: EntityKind::Component,
+                    merkle_tree_hash: MerkleTreeHash::new(b"todd-howard"),
+                },
+            )]),
+        }
+    }
+
+    #[test]
+    fn serialize() {
+        assert_serialize(SNAPSHOT_NAME, VERSION, msg());
+    }
+
+    #[test]
+    fn deserialize() {
+        assert_deserialize(SNAPSHOT_NAME, VERSION, msg());
+    }
+}

--- a/lib/edda-server/BUCK
+++ b/lib/edda-server/BUCK
@@ -29,6 +29,7 @@ rust_library(
         "//third-party/rust:derive_builder",
         "//third-party/rust:futures",
         "//third-party/rust:json-patch",
+        "//third-party/rust:pin-project-lite",
         "//third-party/rust:remain",
         "//third-party/rust:serde",
         "//third-party/rust:serde_json",

--- a/lib/edda-server/Cargo.toml
+++ b/lib/edda-server/Cargo.toml
@@ -36,6 +36,7 @@ bytes = { workspace = true }
 derive_builder = { workspace = true }
 futures = { workspace = true }
 json-patch = { workspace = true }
+pin-project-lite = { workspace = true }
 remain = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/lib/edda-server/src/compressor.rs
+++ b/lib/edda-server/src/compressor.rs
@@ -1,0 +1,422 @@
+use std::{
+    collections::HashMap,
+    task::Poll,
+};
+
+use bytes::Bytes;
+use dal::{
+    ChangeSetId,
+    Component,
+    DalContext,
+    DalContextBuilder,
+    TransactionsError,
+    WorkspacePk,
+    WorkspaceSnapshotAddress,
+    workspace_snapshot::graph::detector::Update,
+};
+use edda_core::api_types::{
+    RequestId,
+    compressor_rebuild_request::{
+        CompressorRebuildRequest,
+        CompressorRebuildRequestVCurrent,
+    },
+    compressor_update_request::{
+        CompressorUpdateRequest,
+        CompressorUpdateRequestV1,
+        CompressorUpdateRequestVCurrent,
+    },
+    rebuild_request,
+};
+use futures::{
+    FutureExt,
+    StreamExt,
+};
+use naxum::{
+    MessageHead,
+    extract::{
+        FromMessage,
+        FromMessageRaw,
+    },
+};
+use pin_project_lite::pin_project;
+use si_data_nats::async_nats::jetstream::{
+    self,
+    Message,
+    consumer::{
+        self,
+        StreamError,
+        push,
+    },
+    stream::ConsumerError,
+};
+use si_events::workspace_snapshot::Change;
+use si_id::EntityId;
+use si_layer_cache::LayerDbError;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+use crate::extract::{
+    ApiTypesNegotiate,
+    EddaRequestKind,
+};
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum CompressorError {
+    #[error("error creating consumer: {0}")]
+    ConsumerCreate(#[source] ConsumerError),
+    #[error("error building dal context: {0}")]
+    DalContextBuild(#[source] TransactionsError),
+    #[error("invalid edda request kind: compressor rebuild")]
+    InvalidEddaRequestKindCompressorRebuild,
+    #[error("invalid edda request kind: compressor update")]
+    InvalidEddaRequestKindCompressorUpdate,
+    #[error("layer db error: {0}")]
+    LayerDb(#[from] LayerDbError),
+    #[error("error while subscribing for messages: {0}")]
+    Subscribe(#[source] StreamError),
+}
+
+type Result<T> = std::result::Result<T, CompressorError>;
+
+#[remain::sorted]
+#[derive(Debug, Clone)]
+enum State {
+    Draining(CompressorUpdateRequestVCurrent),
+    DrainingToRebuild(CompressorRebuildRequestVCurrent),
+    Inactive,
+}
+
+pin_project! {
+    /// A stream that wraps an inner stream with the ability to "compress" requests.
+    pub struct Compressor {
+        incoming: consumer::push::Ordered,
+        state: State,
+        ctx_builder: DalContextBuilder,
+        change_set_id: ChangeSetId,
+        workspace_id: WorkspacePk,
+        ctx: DalContext,
+    }
+}
+
+impl Compressor {
+    pub async fn new(
+        requests_stream: &jetstream::stream::Stream,
+        consumer_config: push::OrderedConfig,
+        ctx_builder: DalContextBuilder,
+        change_set_id: ChangeSetId,
+        workspace_id: WorkspacePk,
+    ) -> Result<Self> {
+        let incoming = requests_stream
+            .create_consumer(consumer_config)
+            .await
+            .map_err(CompressorError::ConsumerCreate)?
+            .messages()
+            .await
+            .map_err(CompressorError::Subscribe)?;
+
+        let ctx = ctx_builder
+            .build_for_change_set_as_system(workspace_id, change_set_id, None)
+            .await
+            .map_err(CompressorError::DalContextBuild)?;
+
+        Ok(Self {
+            incoming,
+            state: State::Inactive,
+            ctx_builder,
+            change_set_id,
+            workspace_id,
+            ctx,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CompressorRequest {
+    CompressorRebuild(CompressorRebuildRequestVCurrent),
+    CompressorUpdate(CompressorUpdateRequestVCurrent),
+}
+
+impl futures::Stream for Compressor {
+    type Item = std::result::Result<Message, consumer::push::MessagesError>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let project = self.project();
+
+        // FIXME(nick): we need to handle timing or max size. What if we have been pending for a long time or have made a massive batch?
+        // We should publish the compressed message at certain limits. We need to first see if there are too many or too few compression
+        // sets happening first though.
+
+        loop {
+            match project.incoming.poll_next_unpin(cx) {
+                Poll::Ready(Some(result)) => {
+                    // First, get the message off the stream and validate it.
+                    let message = match result {
+                        Ok(message) => message,
+                        Err(err) => {
+                            error!(si.error.message = ?err, "error getting info for jetstream message");
+                            continue;
+                        }
+                    };
+
+                    // FIXME(nick): remove later. Only used to make compiler happy to get this into draft PR form.
+                    let cloned_message = message.clone();
+
+                    // Determine if the stream has been drained.
+                    let drained = match message.info() {
+                        Ok(info) => info.pending == 0,
+                        Err(err) => {
+                            error!(si.error.message = ?err, "error getting info for jetstream message");
+                            continue;
+                        }
+                    };
+
+                    // Negotiate the API type. This is for handling streams with  multiple versions
+                    // of messages.
+                    let negotiated = match ApiTypesNegotiate::from_message_raw(message.into()) {
+                        Ok(negotiated) => negotiated,
+                        Err(err) => {
+                            error!(si.error.message = ?err, "rejection or error when negotiating api type");
+                            continue;
+                        }
+                    };
+
+                    // Finally, try to compress the request. We need an inner loop because we need
+                    // to fetch change batches from layer db... which returns a future.
+                    let ctx = (*project.ctx).clone();
+                    'inner: loop {
+                        let locked_state = (*project.state).clone();
+                        match Box::pin(compress(&ctx, negotiated.0.clone(), locked_state))
+                            .poll_unpin(cx)
+                        {
+                            // If everything is drained, let's return the compressed message.
+                            // This is the end of the critical path!
+                            Poll::Ready(Ok(state)) if drained => {
+                                let new_message = match state {
+                                    State::Draining(inner) => {
+                                        CompressorRequest::CompressorUpdate(inner)
+                                    }
+                                    State::DrainingToRebuild(inner) => {
+                                        CompressorRequest::CompressorRebuild(inner)
+                                    }
+                                    // This should be impossible since compressing should always
+                                    // result in an active state.
+                                    State::Inactive => {
+                                        error!("this should be impossible");
+                                        break 'inner;
+                                    }
+                                };
+
+                                // Reset the state and send the compressed message to the naxum handler.
+                                // This is the end of the critical path!
+                                *project.state = State::Inactive;
+
+                                // FIXME(nick): I spent an hour trying to make naxum generic. Basically "Message<R>" is used everywhere
+                                // and "R" must implement "MessageHead". I don't think it is worth pursuing that path. Frankly, I am
+                                // not certain naxum is even the right tool for this. We should probably just double ack every message
+                                // here and switch to more primitive Rust stream management semantics.
+                                // ```
+                                // message.payload =
+                                //     Bytes::from(serde_json::to_value(new_message)?);
+                                // ```
+
+                                // Return the compressed message. This is the critical path!
+                                return Poll::Ready(Some(Ok(cloned_message)));
+                            }
+                            // Everything is not drained so let's update the state and LOOP again!
+                            // This is the critical path!
+                            Poll::Ready(Ok(state)) => {
+                                // FIXME(nick): double ack the message since it has been compressed.
+                                *project.state = state;
+                                break 'inner;
+                            }
+                            Poll::Ready(Err(err)) => {
+                                error!(si.error.message = ?err, "compress error");
+                                break 'inner;
+                            }
+                            // We are waiting for the layer db future.
+                            Poll::Pending => {}
+                        }
+                    }
+                }
+                // FIXME(nick): handle shutdown and publishing what we have compressed in flight on the way out.
+                Poll::Ready(None) => todo!(),
+                // FIXME(nick): handle publishing what we have compressed in flight before returning pending.
+                Poll::Pending => todo!(),
+            }
+        }
+    }
+}
+
+async fn compress(ctx: &DalContext, request: EddaRequestKind, state: State) -> Result<State> {
+    match (request, state) {
+        // We see an update, are in a draining state, and the request's "from" snapshot matches
+        // the current "to" snapshot. This is the critical path!
+        (
+            EddaRequestKind::Update(update_request),
+            State::Draining(CompressorUpdateRequestVCurrent {
+                id,
+                previous_ids,
+                from_snapshot_address: _from_snapshot_address,
+                to_snapshot_address,
+                changes,
+            }),
+        ) if update_request.from_snapshot_address == to_snapshot_address => match ctx
+            .layer_db()
+            .change_batch()
+            .read_wait_for_memory(&update_request.change_batch_address)
+            .await?
+        {
+            // We have found a change batch for the update request. We will update our current
+            // compressed payload accordingly. This is the critical path!
+            Some(change_batch) => {
+                let mut changes = changes;
+                for change in change_batch.changes() {
+                    changes.insert(change.entity_id, change.to_owned());
+                }
+                let from_snapshot_address = update_request.from_snapshot_address;
+                let to_snapshot_address = update_request.to_snapshot_address;
+                let mut previous_ids = previous_ids;
+                previous_ids.push(id);
+                let id = update_request.id;
+                Ok(State::Draining(CompressorUpdateRequestVCurrent {
+                    id,
+                    previous_ids,
+                    from_snapshot_address,
+                    to_snapshot_address,
+                    changes,
+                }))
+            }
+            // We have not found the change batch and are unable to determine what changes need to
+            // be done. Let's go into rebuild mode.
+            None => {
+                let mut previous_ids = previous_ids;
+                previous_ids.push(id);
+                let id = update_request.id;
+                Ok(State::DrainingToRebuild(CompressorRebuildRequestVCurrent {
+                    id,
+                    previous_ids,
+                }))
+            }
+        },
+        // We see an update, are in a draining state, BUT the request's "from" snapshot DOES NOT
+        // match the current "to" snapshot. We are dealing with a non-contiguous chain and must go
+        // into rebuild mode.
+        (
+            EddaRequestKind::Update(update_request),
+            State::Draining(CompressorUpdateRequestVCurrent {
+                id,
+                previous_ids,
+                from_snapshot_address: _from_snapshot_address,
+                to_snapshot_address: _to_snapshot_address,
+                changes: _changes,
+            }),
+        ) => {
+            let mut previous_ids = previous_ids;
+            previous_ids.push(id);
+            let id = update_request.id;
+            Ok(State::DrainingToRebuild(CompressorRebuildRequestVCurrent {
+                id,
+                previous_ids,
+            }))
+        }
+        // We see an update and are in a draining-to-rebuild state. Let's update its fields.
+        (
+            EddaRequestKind::Update(update_request),
+            State::DrainingToRebuild(CompressorRebuildRequestVCurrent { id, previous_ids }),
+        ) => {
+            let mut previous_ids = previous_ids;
+            previous_ids.push(id);
+            let id = update_request.id;
+            Ok(State::DrainingToRebuild(CompressorRebuildRequestVCurrent {
+                id,
+                previous_ids,
+            }))
+        }
+        // We see an update and are in an inactive state. We need to kick off the draining process.
+        // This is start of the critical path!
+        (EddaRequestKind::Update(update_request), State::Inactive) => match ctx
+            .layer_db()
+            .change_batch()
+            .read_wait_for_memory(&update_request.change_batch_address)
+            .await?
+        {
+            // We found a change batch for the update request. Let's initialize the update request.
+            // This is the start of the critical path!
+            Some(change_batch) => {
+                let mut changes = HashMap::new();
+                for change in change_batch.changes() {
+                    changes.insert(change.entity_id, change.to_owned());
+                }
+                Ok(State::Draining(CompressorUpdateRequestVCurrent {
+                    id: update_request.id,
+                    previous_ids: Vec::new(),
+                    from_snapshot_address: update_request.from_snapshot_address,
+                    to_snapshot_address: update_request.to_snapshot_address,
+                    changes,
+                }))
+            }
+            // We have not found the change batch and are unable to determine what changes need to
+            // be done. Let's initialize into rebuild mode.
+            None => Ok(State::DrainingToRebuild(CompressorRebuildRequestVCurrent {
+                id: update_request.id,
+                previous_ids: Vec::new(),
+            })),
+        },
+        // We see a rebuild request and we are currently draining. We need to swap to
+        // draining-to-rebuild mode.
+        (
+            EddaRequestKind::Rebuild(rebuild_request),
+            State::Draining(CompressorUpdateRequestVCurrent {
+                id,
+                previous_ids,
+                from_snapshot_address: _from_snapshot_address,
+                to_snapshot_address: _to_snapshot_address,
+                changes: _changes,
+            }),
+        ) => {
+            let mut previous_ids = previous_ids;
+            previous_ids.push(id);
+            let id = rebuild_request.id;
+            Ok(State::DrainingToRebuild(CompressorRebuildRequestVCurrent {
+                id,
+                previous_ids,
+            }))
+        }
+        // We see a rebuild request and are in a draining-to-rebuild state. Let's update its fields.
+        (
+            EddaRequestKind::Rebuild(rebuild_request),
+            State::DrainingToRebuild(CompressorRebuildRequestVCurrent { id, previous_ids }),
+        ) => {
+            let mut previous_ids = previous_ids;
+            previous_ids.push(id);
+            let id = rebuild_request.id;
+            Ok(State::DrainingToRebuild(CompressorRebuildRequestVCurrent {
+                id,
+                previous_ids,
+            }))
+        }
+        // We see a rebuild request and are in an inactive state. Let's initialize into rebuild mode.
+        (EddaRequestKind::Rebuild(rebuild_request), State::Inactive) => {
+            Ok(State::DrainingToRebuild(CompressorRebuildRequestVCurrent {
+                id: rebuild_request.id,
+                previous_ids: Vec::new(),
+            }))
+        }
+        // We see a compressor update request. This should be impossible as it should only be created
+        // in-memory.
+        (EddaRequestKind::CompressorUpdate(_), _) => {
+            // FIXME(nick): depending on how we handle the naxum streams, we may not need compressor requests to be under this type.
+            Err(CompressorError::InvalidEddaRequestKindCompressorUpdate)
+        }
+        // We see a compressor build request. This should be impossible as it should only be created
+        // in-memory.
+        (EddaRequestKind::CompressorRebuild(_), _) => {
+            // FIXME(nick): depending on how we handle the naxum streams, we may not need compressor requests to be under this type.
+            Err(CompressorError::InvalidEddaRequestKindCompressorRebuild)
+        }
+    }
+}

--- a/lib/edda-server/src/lib.rs
+++ b/lib/edda-server/src/lib.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 mod app_state;
 mod change_set_processor_task;
+mod compressor;
 mod config;
 pub mod extract;
 mod handlers;

--- a/lib/naxum/examples/nats-less-messages/BUCK
+++ b/lib/naxum/examples/nats-less-messages/BUCK
@@ -1,0 +1,23 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "rust_binary",
+)
+
+rust_binary(
+    name = "nats-less-messages",
+    srcs = ["main.rs"],
+    crate_root = "main.rs",
+    deps = [
+        "//lib/naxum:naxum",
+        "//third-party/rust:async-nats",
+        "//third-party/rust:bytes",
+        "//third-party/rust:futures",
+        "//third-party/rust:serde",
+        "//third-party/rust:serde_json",
+        "//third-party/rust:tokio",
+        "//third-party/rust:tokio-util",
+        "//third-party/rust:tower",
+        "//third-party/rust:tracing",
+        "//third-party/rust:tracing-subscriber",
+    ],
+)

--- a/lib/naxum/examples/nats-less-messages/main.rs
+++ b/lib/naxum/examples/nats-less-messages/main.rs
@@ -1,0 +1,319 @@
+use std::{
+    convert::Infallible,
+    error,
+    sync::Arc,
+};
+
+use async_nats::Subject;
+use futures::{
+    StreamExt,
+    stream,
+};
+use naxum::{
+    Head,
+    Json,
+    extract::State,
+    handler::Handler,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use tokio::{
+    signal::unix::{
+        self,
+        SignalKind,
+    },
+    sync::Notify,
+};
+use tokio_util::{
+    sync::CancellationToken,
+    task::TaskTracker,
+};
+use tower::ServiceBuilder;
+use tracing::info;
+use tracing_subscriber::{
+    EnvFilter,
+    Registry,
+    fmt::{
+        self,
+        format::FmtSpan,
+    },
+    layer::SubscriberExt as _,
+    util::SubscriberInitExt as _,
+};
+
+use self::message::LocalMessage;
+
+const TRACING_LOG_ENV_VAR: &str = "SI_LOG";
+const DEFAULT_TRACING_DIRECTIVES: &str = "nats_less_messages=trace,naxum=trace,info";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct MyRequest {
+    id: usize,
+    message: String,
+    is_cool: bool,
+}
+
+#[derive(Clone, Debug)]
+struct AppState {}
+
+async fn default(
+    State(_state): State<AppState>,
+    // [`LoaclMessage`] impls [`MessageHead`] and so [`Head`] info can be extracted
+    head: Head,
+    // Message payload has been JSON-encoded so the default [`Json`] extractor works as-is
+    Json(request): Json<MyRequest>,
+) -> naxum::response::Result<()> {
+    info!(
+        subject = head.subject.as_str(),
+        reply = head.reply.as_deref(),
+        headers_size = head.headers.map(|headers| headers.len()),
+        status = head.status.map(|status| status.as_u16()),
+        description = head.description.as_ref(),
+        length = head.length,
+        extensions_size = head.extensions.len(),
+        request = ?request,
+        "processing message",
+    );
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn error::Error>> {
+    Registry::default()
+        .with(
+            EnvFilter::try_from_env(TRACING_LOG_ENV_VAR)
+                .unwrap_or_else(|_| EnvFilter::new(DEFAULT_TRACING_DIRECTIVES)),
+        )
+        .with(
+            fmt::layer()
+                .with_thread_ids(true)
+                .with_thread_names(true)
+                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+                .pretty(),
+        )
+        .try_init()?;
+
+    // Generate local `impl Stream` of a `Vec` of `LocalMessage` which has an `impl MessageHead`,
+    // thus satisfying Naxum's incoming stream requirements
+    let incoming = stream::iter(messages()?)
+        // The iterator stream is a stream of `Option<LocalMessage>` so we convert this into a
+        // stream of `Option<Result<LocalMessage, Infallible>>`
+        .map(Ok::<_, Infallible>);
+
+    // Setup a Tower `Service` stack with some middleware
+    let app = ServiceBuilder::new().service(default.with_state(AppState {}));
+
+    // Use a Tokio `TaskTracker` and `CancellationToken` to support signal handling and graceful
+    // shutdown
+    let tracker = TaskTracker::new();
+    let token = CancellationToken::new();
+
+    let naxum_terminated = Arc::new(Notify::new());
+    let naxum_exited = naxum_terminated.clone();
+
+    let naxum_token = token.clone();
+    tracker.spawn(async move {
+        info!("ready to receive messages from a locally produced channel",);
+        let result = naxum::serve(incoming, app.into_make_service())
+            .with_graceful_shutdown(naxum::wait_on_cancelled(naxum_token))
+            .await;
+        naxum_terminated.notify_one();
+        result
+    });
+
+    // Create streams of `SIGINT` (i.e. `Ctrl+c`) and `SIGTERM` signals
+    let mut sig_int = unix::signal(SignalKind::interrupt())?;
+    let mut sig_term = unix::signal(SignalKind::terminate())?;
+
+    // Wait until one of the signal streams gets a signal, after which we will close the task
+    // tracker and cancel the token, signaling all holders of the token
+    tokio::select! {
+        _ = sig_int.recv() => {
+            info!("received SIGINT, performing graceful shutdown");
+            tracker.close();
+            token.cancel();
+        }
+        _ = sig_term.recv() => {
+            info!("received SIGTERM, performing graceful shutdown");
+            tracker.close();
+            token.cancel();
+        }
+        _ = naxum_exited.notified() => {
+            info!("naxum app exited, performing graceful shutdown");
+            tracker.close();
+            token.cancel();
+        }
+    }
+
+    // Wait for all tasks to finish
+    tracker.wait().await;
+
+    info!("graceful shutdown complete");
+    Ok(())
+}
+
+fn messages() -> Result<Vec<LocalMessage>, Box<dyn error::Error>> {
+    // Produce a collection of request messages
+    let messages = vec![
+        MyRequest {
+            id: 1,
+            message: "Rush".to_owned(),
+            is_cool: true,
+        },
+        MyRequest {
+            id: 2,
+            message: "Fly by Night".to_owned(),
+            is_cool: false,
+        },
+        MyRequest {
+            id: 3,
+            message: "Caress of Steel".to_owned(),
+            is_cool: true,
+        },
+        MyRequest {
+            id: 4,
+            message: "2112".to_owned(),
+            is_cool: false,
+        },
+        MyRequest {
+            id: 5,
+            message: "A Farewell to Kings".to_owned(),
+            is_cool: true,
+        },
+    ]
+    .into_iter()
+    // Encode each request into a [`LocalMessage`] which implements the [`MessageHead`] trait
+    .map(|request| LocalMessage {
+        subject: Subject::from_utf8(format!("my.requests.{}", request.id))
+            .expect("failed to parse subject"),
+        headers: None,
+        payload: serde_json::to_vec(&request)
+            .expect("failed to serialize")
+            .into(),
+    })
+    .collect();
+
+    Ok(messages)
+}
+
+mod message {
+    use async_nats::{
+        HeaderMap,
+        Subject,
+    };
+    use bytes::Bytes;
+    use naxum::{
+        Extensions,
+        Head,
+        MessageHead,
+    };
+
+    // A local alternative to the core/Jetstream NATS message types
+    #[derive(Clone, Debug)]
+    pub struct LocalMessage {
+        pub subject: Subject,
+        pub headers: Option<HeaderMap>,
+        pub payload: Bytes,
+    }
+
+    // Implementing the [`MessageHead`] trait makes [`LocalMessage`] a valid message type for a
+    // Naxum app
+    impl MessageHead for LocalMessage {
+        // Each message needs a subject, but this can be anything, assuming it operates within the
+        // naming rules of a [`Subject`]
+        fn subject(&self) -> &Subject {
+            &self.subject
+        }
+
+        // This type won't have reply subjects as we don't use NATS with this type
+        fn reply(&self) -> Option<&Subject> {
+            None
+        }
+
+        // Headers might still be useful to propagate OpenTelemetry spans, allow for more complex
+        // message encodings, etc.
+        fn headers(&self) -> Option<&async_nats::HeaderMap> {
+            self.headers.as_ref()
+        }
+
+        // This type won't use a status as we don't use NATS with this type
+        fn status(&self) -> Option<naxum::StatusCode> {
+            None
+        }
+
+        // No need for a description either, so this will always be `None`
+        fn description(&self) -> Option<&str> {
+            None
+        }
+
+        // It's not worth adding the extra size calculations for the message (i.e. it's not going
+        // to be encoded as bytes), so return the payload size as a rough approximation
+        fn length(&self) -> usize {
+            self.payload_length()
+        }
+
+        // Payload is still encoded in [`Bytes`] so use its length as normal
+        fn payload_length(&self) -> usize {
+            self.payload.len()
+        }
+
+        fn from_head_and_payload(
+            head: naxum::Head,
+            payload: bytes::Bytes,
+        ) -> Result<(Self, naxum::Extensions), naxum::FromPartsError>
+        where
+            Self: Sized,
+        {
+            let Head {
+                subject,
+                // Replies aren't tracked with this type
+                reply: _,
+                headers,
+                // Status isn't tracked with this type
+                status: _,
+                // Descriptions aren't used with this type
+                description: _,
+                // Length isn't tracked with this type
+                length: _,
+                extensions,
+            } = head;
+
+            Ok((
+                Self {
+                    subject,
+                    headers,
+                    payload,
+                },
+                extensions,
+            ))
+        }
+
+        fn into_head_and_payload(self) -> (naxum::Head, bytes::Bytes) {
+            let Self {
+                subject,
+                headers,
+                payload,
+            } = self;
+
+            (
+                Head {
+                    subject,
+                    // Replies aren't tracked with this type
+                    reply: None,
+                    headers,
+                    // Status isn't tracked with this type
+                    status: None,
+                    // Descriptions aren't used with this type
+                    description: None,
+                    // Length isn't tracked with this type
+                    length: 0,
+                    extensions: Extensions::new(),
+                },
+                payload,
+            )
+        }
+    }
+}

--- a/lib/naxum/src/extract.rs
+++ b/lib/naxum/src/extract.rs
@@ -38,6 +38,13 @@ pub trait FromMessageHead<S>: Sized {
 }
 
 #[async_trait]
+pub trait FromMessageHeadRaw: Sized {
+    type Rejection: IntoResponse;
+
+    fn from_message_head_raw(head: &mut Head) -> Result<Self, Self::Rejection>;
+}
+
+#[async_trait]
 pub trait FromMessage<S, R, M = private::ViaMessage>: Sized
 where
     R: MessageHead,
@@ -45,6 +52,16 @@ where
     type Rejection: IntoResponse;
 
     async fn from_message(req: Message<R>, state: &S) -> Result<Self, Self::Rejection>;
+}
+
+#[async_trait]
+pub trait FromMessageRaw<R, M = private::ViaMessage>: Sized
+where
+    R: MessageHead,
+{
+    type Rejection: IntoResponse;
+
+    fn from_message_raw(req: Message<R>) -> Result<Self, Self::Rejection>;
 }
 
 #[async_trait]

--- a/lib/naxum/src/generic.rs
+++ b/lib/naxum/src/generic.rs
@@ -1,0 +1,5 @@
+// FIXME(nick): here is an experiment in handling generic messages that only require "Send" and not "Message" or "MessageHead".
+// Lot of pain.
+mod handler;
+mod serve;
+mod service_ext;

--- a/lib/naxum/src/generic/handler.rs
+++ b/lib/naxum/src/generic/handler.rs
@@ -1,0 +1,235 @@
+use core::fmt;
+use std::{
+    convert::Infallible,
+    future::{
+        Future,
+        Ready,
+        ready,
+    },
+    marker::PhantomData,
+    pin::Pin,
+};
+
+use tower::{
+    Layer,
+    Service,
+    ServiceExt,
+};
+
+use crate::{
+    extract::FromMessage,
+    make_service::IntoMakeService,
+    message::Message,
+    response::{
+        IntoResponse,
+        Response,
+    },
+};
+
+pub mod future;
+mod service;
+
+pub use self::service::HandlerService;
+
+pub trait Handler<T, S, R>: Clone + Send + Sized + 'static
+where
+    R: Send,
+{
+    type Future: Future<Output = Response> + Send + 'static;
+
+    fn call(self, req: R, state: S) -> Self::Future;
+
+    fn layer<L>(self, layer: L) -> Layered<L, Self, T, S, R>
+    where
+        L: Layer<HandlerService<Self, T, S, R>> + Clone,
+        L::Service: Service<R>,
+    {
+        Layered {
+            layer,
+            handler: self,
+            _marker: PhantomData,
+            _request_marker: PhantomData,
+        }
+    }
+
+    fn with_state(self, state: S) -> HandlerService<Self, T, S, R> {
+        HandlerService::new(self, state)
+    }
+}
+
+impl<F, Fut, Res, S, R> Handler<((),), S, R> for F
+where
+    F: FnOnce() -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = Res> + Send,
+    Res: IntoResponse,
+    R: Send,
+{
+    type Future = Pin<Box<dyn Future<Output = Response> + Send>>;
+
+    fn call(self, _req: R, _state: S) -> Self::Future {
+        Box::pin(async move { self().await.into_response() })
+    }
+}
+
+// FIXME(nick): this is where the pain begins. You need some of the "Message" and "MessageHead" goodies to make this work well.
+// macro_rules! impl_handler {
+//     (
+//         [$($ty:ident),*], $last:ident
+//     ) => {
+//         #[allow(non_snake_case, unused_mut)]
+//         impl<F, Fut, S, R, Res, M, $($ty,)* $last> Handler<(M, $($ty,)* $last,), S, R> for F
+//         where
+//             F: FnOnce($($ty,)* $last,) -> Fut + Clone + Send + 'static,
+//             Fut: Future<Output = Res> + Send,
+//             S: Send + Sync + 'static,
+//             R: Send + 'static,
+//             Res: IntoResponse,
+//             $( $ty: FromMessageHead<S> + Send, )*
+//             $last: FromMessage<S, R, M> + Send,
+//         {
+//             type Future = Pin<Box<dyn Future<Output = Response> + Send>>;
+
+//             fn call(self, req: R, state: S) -> Self::Future {
+//                 Box::pin(async move {
+//                     let (mut parts, body) = req.into_parts();
+//                     let state = &state;
+
+//                     $(
+//                         let $ty = match $ty::from_message_head(&mut parts, state).await {
+//                             Ok(value) => value,
+//                             Err(rejection) => return rejection.into_response(),
+//                         };
+//                     )*
+
+//                     let req = match Message::from_parts(parts, body) {
+//                         Ok(value) => value,
+//                         Err(rejection) => return rejection.into_response(),
+//                     };
+
+//                     let $last = match $last::from_message(req, state).await {
+//                         Ok(value) => value,
+//                         Err(rejection) => return rejection.into_response(),
+//                     };
+
+//                     let res = self($($ty,)* $last,).await;
+
+//                     res.into_response()
+//                 })
+//             }
+//         }
+//     };
+// }
+
+// all_the_tuples!(impl_handler);
+
+mod private {
+    // Marker type for `impl<T: IntoResponse> Handler for T`
+    #[allow(missing_debug_implementations)]
+    pub enum IntoResponseHandler {}
+}
+
+impl<T, S, R> Handler<private::IntoResponseHandler, S, R> for T
+where
+    T: IntoResponse + Clone + Send + 'static,
+    R: Send,
+{
+    type Future = Ready<Response>;
+
+    fn call(self, _req: R, _state: S) -> Self::Future {
+        #[allow(clippy::unit_arg)]
+        ready(self.into_response())
+    }
+}
+
+pub struct Layered<L, H, T, S, R> {
+    layer: L,
+    handler: H,
+    _marker: PhantomData<fn() -> (T, S)>,
+    _request_marker: PhantomData<R>,
+}
+
+impl<L, H, T, S, R> fmt::Debug for Layered<L, H, T, S, R>
+where
+    L: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Layered")
+            .field("layer", &self.layer)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<L, H, T, S, R> Clone for Layered<L, H, T, S, R>
+where
+    L: Clone,
+    H: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            layer: self.layer.clone(),
+            handler: self.handler.clone(),
+            _marker: PhantomData,
+            _request_marker: PhantomData,
+        }
+    }
+}
+
+impl<L, H, T, S, R> Handler<T, S, R> for Layered<L, H, T, S, R>
+where
+    L: Layer<HandlerService<H, T, S, R>> + Clone + Send + 'static,
+    H: Handler<T, S, R>,
+    L::Service: Service<R, Error = Infallible> + Clone + Send + 'static,
+    <L::Service as Service<R>>::Response: IntoResponse,
+    <L::Service as Service<R>>::Future: Send,
+    T: 'static,
+    S: 'static,
+    R: Send + Send + 'static,
+{
+    type Future = future::LayeredFuture<L::Service, R>;
+
+    fn call(self, req: R, state: S) -> Self::Future {
+        use futures::future::{
+            FutureExt,
+            Map,
+        };
+
+        let svc = self.handler.with_state(state);
+        let svc = self.layer.layer(svc);
+
+        #[allow(clippy::type_complexity)]
+        let future: Map<
+            _,
+            fn(
+                Result<<L::Service as Service<R>>::Response, <L::Service as Service<R>>::Error>,
+            ) -> _,
+        > = svc.oneshot(req).map(|result| match result {
+            Ok(res) => res.into_response(),
+            Err(err) => match err {},
+        });
+
+        future::LayeredFuture::new(future)
+    }
+}
+
+pub trait HandlerWithoutStateExt<T, R>: Handler<T, (), R>
+where
+    R: Send,
+{
+    fn into_service(self) -> HandlerService<Self, T, (), R>;
+
+    fn into_make_service(self) -> IntoMakeService<HandlerService<Self, T, (), R>>;
+}
+
+impl<H, T, R> HandlerWithoutStateExt<T, R> for H
+where
+    H: Handler<T, (), R>,
+    R: Send,
+{
+    fn into_service(self) -> HandlerService<Self, T, (), R> {
+        self.with_state(())
+    }
+
+    fn into_make_service(self) -> IntoMakeService<HandlerService<Self, T, (), R>> {
+        self.into_service().into_make_service()
+    }
+}

--- a/lib/naxum/src/generic/handler/future.rs
+++ b/lib/naxum/src/generic/handler/future.rs
@@ -1,0 +1,99 @@
+//! Handler future types.
+
+#![allow(clippy::type_complexity)] // For `Map<F, fn....>` type
+
+use std::{
+    convert::Infallible,
+    fmt,
+    future::Future,
+    pin::Pin,
+    task::{
+        Context,
+        Poll,
+    },
+};
+
+use futures::future::Map;
+use pin_project_lite::pin_project;
+use tower::{
+    Service,
+    util::Oneshot,
+};
+
+use crate::{
+    message::{
+        Message,
+        MessageHead,
+    },
+    response::Response,
+};
+
+pin_project! {
+    pub struct IntoServiceFuture<F> {
+        #[pin]
+        future: Map<
+            F,
+            fn(Response) -> Result<Response, Infallible>,
+        >,
+    }
+}
+
+impl<F> IntoServiceFuture<F> {
+    pub(crate) fn new(future: Map<F, fn(Response) -> Result<Response, Infallible>>) -> Self {
+        Self { future }
+    }
+}
+
+impl<F> fmt::Debug for IntoServiceFuture<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IntoServiceFuture").finish_non_exhaustive()
+    }
+}
+
+impl<F> Future for IntoServiceFuture<F>
+where
+    Map<F, fn(Response) -> Result<Response, Infallible>>: Future,
+{
+    type Output = <Map<F, fn(Response) -> Result<Response, Infallible>> as Future>::Output;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().future.poll(cx)
+    }
+}
+
+pin_project! {
+    pub struct LayeredFuture<S, R>
+    where
+        S: Service<R>,
+        R: Send
+    {
+        #[pin]
+        inner: Map<Oneshot<S, R>, fn(Result<S::Response, S::Error>) -> Response>,
+    }
+}
+
+impl<S, R> LayeredFuture<S, R>
+where
+    S: Service<R>,
+    R: Send,
+{
+    pub(super) fn new(
+        inner: Map<Oneshot<S, R>, fn(Result<S::Response, S::Error>) -> Response>,
+    ) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S, R> Future for LayeredFuture<S, R>
+where
+    S: Service<R>,
+    R: Send,
+{
+    type Output = Response;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx)
+    }
+}

--- a/lib/naxum/src/generic/handler/service.rs
+++ b/lib/naxum/src/generic/handler/service.rs
@@ -1,0 +1,95 @@
+use std::{
+    convert::Infallible,
+    fmt,
+    marker::PhantomData,
+    task::{
+        Context,
+        Poll,
+    },
+};
+
+use futures::FutureExt;
+use tower::Service;
+
+use super::Handler;
+use crate::{
+    make_service::IntoMakeService,
+    message::{
+        Message,
+        MessageHead,
+    },
+    response::Response,
+};
+
+pub struct HandlerService<H, T, S, R> {
+    handler: H,
+    state: S,
+    _marker: PhantomData<fn() -> T>,
+    _request_marker: PhantomData<R>,
+}
+
+impl<H, T, S, R> HandlerService<H, T, S, R> {
+    pub(super) fn new(handler: H, state: S) -> Self {
+        Self {
+            handler,
+            state,
+            _marker: PhantomData,
+            _request_marker: PhantomData,
+        }
+    }
+
+    pub fn into_make_service(self) -> IntoMakeService<HandlerService<H, T, S, R>> {
+        IntoMakeService::new(self)
+    }
+
+    pub fn state(&self) -> &S {
+        &self.state
+    }
+}
+
+impl<H, T, S, R> fmt::Debug for HandlerService<H, T, S, R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HandlerService").finish_non_exhaustive()
+    }
+}
+
+impl<H, T, S, R> Clone for HandlerService<H, T, S, R>
+where
+    H: Clone,
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            handler: self.handler.clone(),
+            state: self.state.clone(),
+            _marker: PhantomData,
+            _request_marker: PhantomData,
+        }
+    }
+}
+
+impl<H, T, S, R> Service<R> for HandlerService<H, T, S, R>
+where
+    H: Handler<T, S, R> + Clone + Send + 'static,
+    S: Clone + Send + Sync,
+    R: Send,
+{
+    type Response = Response;
+    type Error = Infallible;
+    type Future = super::future::IntoServiceFuture<H::Future>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // `IntoService` can only be constructed from async functions which are always ready, or
+        // from `Layered` which buffers in `<Layered as Handler>::call` and is therefore
+        // also always ready.
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        let handler = self.handler.clone();
+        let future = Handler::call(handler, req, self.state.clone());
+        let future = future.map(Ok as _);
+
+        super::future::IntoServiceFuture::new(future)
+    }
+}

--- a/lib/naxum/src/generic/serve.rs
+++ b/lib/naxum/src/generic/serve.rs
@@ -1,0 +1,325 @@
+use std::{
+    convert::Infallible,
+    error,
+    fmt,
+    future::{
+        Future,
+        IntoFuture,
+        poll_fn,
+    },
+    io,
+    marker::PhantomData,
+    ops,
+    pin::Pin,
+    sync::Arc,
+    time::Duration,
+};
+
+use futures::{
+    Stream,
+    TryStreamExt,
+};
+use telemetry_utils::metric;
+use tokio::{
+    sync::{
+        OwnedSemaphorePermit,
+        Semaphore,
+    },
+    time,
+};
+use tokio_util::{
+    sync::CancellationToken,
+    task::TaskTracker,
+};
+use tower::{
+    Service,
+    ServiceExt,
+};
+use tracing::{
+    debug,
+    error,
+    info,
+    trace,
+};
+
+use crate::{
+    message::{
+        Message,
+        MessageHead,
+    },
+    response::Response,
+};
+
+pub fn serve_with_incoming_limit<M, S, T, E, R>(
+    stream: T,
+    make_service: M,
+    limit: impl Into<Option<usize>>,
+) -> Serve<M, S, T, E, R>
+where
+    M: for<'a> Service<IncomingMessage<'a, R>, Error = Infallible, Response = S>,
+    S: Service<R, Response = Response, Error = Infallible> + Clone + Send + 'static,
+    S::Future: Send,
+    T: Stream<Item = Result<R, E>>,
+    E: error::Error,
+    R: Send,
+{
+    Serve {
+        stream,
+        make_service,
+        limit: limit.into(),
+        _service_marker: PhantomData,
+        _stream_error_marker: PhantomData,
+        _request_marker: PhantomData,
+    }
+}
+
+#[must_use = "futures must be awaited or polled"]
+pub struct Serve<M, S, T, E, R> {
+    stream: T,
+    make_service: M,
+    limit: Option<usize>,
+    _service_marker: PhantomData<S>,
+    _stream_error_marker: PhantomData<E>,
+    _request_marker: PhantomData<R>,
+}
+
+impl<M, S, T, E, R> fmt::Debug for Serve<M, S, T, E, R>
+where
+    M: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Serve")
+            .field("make_service", &self.make_service)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<M, S, T, E, R> Serve<M, S, T, E, R> {
+    pub fn with_graceful_shutdown<F>(self, signal: F) -> WithGracefulShutdown<M, S, T, E, R, F>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        WithGracefulShutdown {
+            stream: self.stream,
+            make_service: self.make_service,
+            limit: self.limit,
+            signal,
+            _service_marker: PhantomData,
+            _stream_error_marker: PhantomData,
+            _request_marker: PhantomData,
+        }
+    }
+}
+
+/// Serve future with supporting a  graceful shutdown.
+#[must_use = "futures must be awaited or polled"]
+pub struct WithGracefulShutdown<M, S, T, E, R, F> {
+    stream: T,
+    make_service: M,
+    limit: Option<usize>,
+    signal: F,
+    _service_marker: PhantomData<S>,
+    _stream_error_marker: PhantomData<E>,
+    _request_marker: PhantomData<R>,
+}
+
+impl<M, S, T, E, R, F> fmt::Debug for WithGracefulShutdown<M, S, T, E, R, F>
+where
+    M: fmt::Debug,
+    S: fmt::Debug,
+    F: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WithGracefulShutdown")
+            .field("make_service", &self.make_service)
+            .field("signal", &self.signal)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<M, S, T, E, R, F> IntoFuture for WithGracefulShutdown<M, S, T, E, R, F>
+where
+    M: for<'a> Service<IncomingMessage<'a, R>, Error = Infallible, Response = S> + Send + 'static,
+    for<'a> <M as Service<IncomingMessage<'a, R>>>::Future: Send,
+    S: Service<R, Response = Response, Error = Infallible> + Clone + Send + 'static,
+    S::Future: Send,
+    T: Stream<Item = Result<R, E>> + Send + 'static,
+    E: error::Error,
+    R: Send + 'static,
+    F: Future<Output = ()> + Send + 'static,
+{
+    type Output = io::Result<()>;
+    type IntoFuture = private::ServeFuture;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let Self {
+            stream,
+            mut make_service,
+            limit,
+            signal,
+            ..
+        } = self;
+
+        let tracker = TaskTracker::new();
+        let graceful_token = CancellationToken::new();
+
+        let token = graceful_token.clone();
+        tracker.spawn(async move {
+            signal.await;
+            debug!("received graceful shutdown signal, telling tasks to shutdown");
+            token.cancel();
+        });
+
+        let semaphore = limit.map(|limit| Arc::new(Semaphore::new(limit)));
+
+        private::ServeFuture(Box::pin(async move {
+            tokio::pin!(stream);
+
+            metric!(counter.naxum.next_message.processing = 0);
+            metric!(counter.naxum.next_message.failed = 0);
+
+            loop {
+                let (msg, permit) = tokio::select! {
+                    biased;
+
+                    _ = graceful_token.cancelled() => {
+                        debug!("signal received, not accepting new messages");
+                        tracker.close();
+                        break;
+                    }
+                    (msg, permit) = next_message(&mut stream, semaphore.clone()) => {
+                        match msg {
+                            Some(Ok(msg)) => {
+                                metric!(counter.naxum.next_message.failed = 0);
+                                (msg, permit)
+                            },
+                            Some(Err(err)) => {
+                                error!(si.error.message = ?err, "failed to read next message from stream");
+                                metric!(counter.naxum.next_message.failed = 1);
+                                continue;
+                            },
+                            None => {
+                                info!("stream is closed, breaking out of loop");
+                                tracker.close();
+                                break;
+                            },
+                        }
+                    }
+                };
+
+                metric!(counter.naxum.next_message.processing = 1);
+
+                poll_fn(|cx| make_service.poll_ready(cx))
+                    .await
+                    .unwrap_or_else(|err| match err {});
+
+                let tower_svc = make_service
+                    .call(IncomingMessage { msg: &msg })
+                    .await
+                    .unwrap_or_else(|err| match err {});
+
+                tracker.spawn(async move {
+                    let _result = tower_svc.oneshot(msg).await;
+                    metric!(counter.naxum.next_message.processing = -1);
+                    trace!("message processed");
+
+                    drop(permit);
+                });
+            }
+
+            trace!("waiting for {} task(s) to finish", tracker.len());
+            let mut progress_interval = time::interval_at(
+                time::Instant::now() + Duration::from_secs(5),
+                Duration::from_secs(5),
+            );
+            loop {
+                tokio::select! {
+                    _ = tracker.wait() => {
+                        break;
+                    }
+                    _ = progress_interval.tick() => {
+                        debug!("waiting for {} task(s) to finish", tracker.len());
+                    }
+                }
+            }
+
+            Ok(())
+        }))
+    }
+}
+
+async fn next_message<T, E, R>(
+    stream: &mut Pin<&mut T>,
+    semaphore: Option<Arc<Semaphore>>,
+) -> (Option<Result<R, E>>, Option<OwnedSemaphorePermit>)
+where
+    T: Stream<Item = Result<R, E>> + Send + 'static,
+    E: error::Error,
+    R: Send + 'static,
+{
+    let permit = match semaphore {
+        Some(semaphore) => {
+            // Acquire permit before awaitng next message on stream, thereby limiting the number of
+            // spawned processing requests
+            Some(
+                #[allow(clippy::expect_used)]
+                // errors only if semaphore is closed (we never close)
+                semaphore
+                    .acquire_owned()
+                    .await
+                    .expect("semaphore will not be closed"),
+            )
+        }
+        None => None,
+    };
+
+    match stream.try_next().await {
+        Ok(maybe) => (Ok(maybe).transpose(), permit),
+        Err(err) => (Some(Err(err)), permit),
+    }
+}
+
+mod private {
+    use std::{
+        fmt,
+        future::Future,
+        io,
+        pin::Pin,
+        task::{
+            Context,
+            Poll,
+        },
+    };
+
+    pub struct ServeFuture(pub(super) futures::future::BoxFuture<'static, io::Result<()>>);
+
+    impl Future for ServeFuture {
+        type Output = io::Result<()>;
+
+        #[inline]
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            self.0.as_mut().poll(cx)
+        }
+    }
+
+    impl fmt::Debug for ServeFuture {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("ServeFuture").finish_non_exhaustive()
+        }
+    }
+}
+
+pub struct IncomingMessage<'a, R> {
+    msg: &'a R,
+}
+
+impl<R> ops::Deref for IncomingMessage<'_, R>
+where
+    R: Send,
+{
+    type Target = R;
+
+    fn deref(&self) -> &Self::Target {
+        self.msg
+    }
+}

--- a/lib/naxum/src/generic/service_ext.rs
+++ b/lib/naxum/src/generic/service_ext.rs
@@ -1,0 +1,24 @@
+use tower::Service;
+
+use crate::{
+    error_handling::HandleError,
+    make_service::IntoMakeService,
+    message::Message,
+};
+
+pub trait GenericServiceExt<R>: Service<R> + Sized {
+    fn into_make_service(self) -> IntoMakeService<Self>;
+
+    fn handle_error<F, T>(self, f: F) -> HandleError<Self, F, T> {
+        HandleError::new(self, f)
+    }
+}
+
+impl<S, R> GenericServiceExt<R> for S
+where
+    S: Service<R> + Sized,
+{
+    fn into_make_service(self) -> IntoMakeService<Self> {
+        IntoMakeService::new(self)
+    }
+}

--- a/lib/naxum/src/lib.rs
+++ b/lib/naxum/src/lib.rs
@@ -32,6 +32,7 @@ pub use self::{
     make_service::IntoMakeService,
     message::{
         Extensions,
+        FromPartsError,
         Head,
         HeadRef,
         Message,

--- a/lib/naxum/src/lib.rs
+++ b/lib/naxum/src/lib.rs
@@ -15,6 +15,9 @@ pub mod response;
 pub mod serve;
 mod service_ext;
 
+// FIXME(nick): experimentation in not requiring "R: MessageHead" and "Message<R>".
+mod generic;
+
 pub use async_nats::StatusCode;
 pub use async_trait::async_trait;
 pub use tower::{

--- a/lib/si-events-rs/src/workspace_snapshot.rs
+++ b/lib/si-events-rs/src/workspace_snapshot.rs
@@ -12,7 +12,7 @@ use crate::{
 
 create_xxhash_type!(Checksum);
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Change {
     pub entity_id: EntityId,
     pub entity_kind: EntityKind,


### PR DESCRIPTION
## Description

This change adds a compiling spike of compressing edda messages. It is not functional nor should be merged, but it is a compiling base for processing "compressed" NATS JetStream messages and distributing work to handlers accordingly.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlcm53MnYzcWJ3eHhpcDdhMml2aXV3YTJibWZodm1icWJrZ3lsOG0ybyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Dqt6eEDO1b6uRoe9tl/giphy-downsized-medium.gif"/>

## Details

It contains a "spike within a spike" to see if we can make naxum generic to non-NATS messages. Unfortunately, the juice is likely not worth the squeeze and it may be easier to 1) make a fake NATS message or modify the last processed one or 2) do not use a naxum server for the change set processor task and spawn MV builds via a task tracker.

The good news is that the core logic in "compressor.rs" is mostly close. The idea is that if you see a continguous stream of messages (i.e. the new "from" snapshot was the last "to" snapshot) that are all "update" messages, we should try to compress them. The compressed message contains de-duped changes (WHICH ARE OKAY BECAUSE THEY ARE NOT UPDATES) that can be used for MV builds accordingly.

There's excess code in this commit that we can likely trash. For instance, the API types additions in "edda-core" can likely get thrown out if we decide to not go through NATS because the request type is entirely in-memory.

My 0.02 cents from this spike: we have to decide what is easier and better for the system from two options. The options are 1) get naxum to work with non-NATS messages (or fake it) or 2) do not use naxum for the change set processor task and use traditional streams. Yes, this is written similarly to my message earlier about the "spike within a spike", but you can see that I was contending with this problem. The hacker in me leans towards cutting out naxum for the change set processor task and just double acking every message that was successfully compressed. I fear that the lift to make naxum generic is not worth it when we already have control over the stream.

At any rate, this change should at least help move the needle forward for this effort. Follow the "FIXME" comments in this change for more details.