### PR TITLE
chore(si-layer-cache): skip disk caching in DAL integration tests

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -28,4 +28,5 @@ ignore = \
   node_modules, \
   target, \
   third-party/rust/.cargo/**/BUCK, \
-  third-party/rust/vendor/**/BUCK
+  third-party/rust/vendor/**/BUCK, \
+  tmp

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -489,7 +489,7 @@ impl TestContext {
             self.layer_db_pg_pool.clone(),
             self.nats_conn.clone(),
             self.compute_executor.clone(),
-            CacheConfig::default(),
+            CacheConfig::default().disk_layer(false),
             token,
         )
         .await


### PR DESCRIPTION
This change disables the disk caching layer in Foyer when running the DAL (and SDF) integration tests. The si-layer-cache test suite still enables full disk caching to ensure it continues to operate as before.

Without this configuration update the amount of data written to the `/tmp` filesystem is enourmous, grows with each new `Cache` entry and consumes a high number of open file handles in the process. It makes having the `/tmp` filesystem on `tmpfs` almost unusable (due to disk consumption needs of the test suites) and cleanup on disk-backed `/tmp` filesystems takes an incredibly long time due to the large number of inode records.

Addditonally, the default location for the disk cache was hardcoded to by under `/tmp` which means that no usage of `$TMPDIR` could override this decision. This change also changes the default root directory to use Rust's `std::env::temp_dir()` location which honors the `TMPDIR` environment variable. This means that setting `export TMPDIR=$(pwd)/tmp` would cause all temp files for layer cache to be written under the `./tmp` directory.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdleTJvaHl0c20zanhkdzVydGNwcmJveW9qeXJsdzAzYmdvb3Y3bDBhZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3o6Zt6ML6BklcajjsA/giphy.gif"/>