### PR TITLE
Refactoring: watchedForm should now be much more readable

### DIFF
--- a/app/web/src/newhotness/AddViewModal.vue
+++ b/app/web/src/newhotness/AddViewModal.vue
@@ -51,15 +51,14 @@ const api = useApi();
 const route = useRoute();
 const router = useRouter();
 
-const wForm = useWatchedForm<{ name: string }>();
+const wForm = useWatchedForm<{ name: string }>("view.add");
 const formData = computed<{ name: string }>(() => {
   return { name: "" };
 });
 
-const nameForm = wForm.newForm(
-  "view.add",
-  formData,
-  async ({ value }) => {
+const nameForm = wForm.newForm({
+  data: formData,
+  onSubmit: async ({ value }) => {
     const call = api.endpoint<{ id: string }>(routes.CreateView);
     const { req, newChangeSetId } = await call.post<{ name: string }>({
       name: value.name,
@@ -85,9 +84,12 @@ const nameForm = wForm.newForm(
       );
     }
   },
-  ({ value }) => (value.name.length === 0 ? "Name is required" : undefined),
-  () => props.views?.length ?? 0,
-);
+  validators: {
+    onSubmit: ({ value }) =>
+      value.name.length === 0 ? "Name is required" : undefined,
+  },
+  watchFn: () => props.views?.length ?? 0,
+});
 
 const open = () => {
   modalRef.value?.open();

--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -222,11 +222,10 @@ const secret = computed(
 const keyApi = useApi();
 const secretApi = useApi();
 
-const wForm = useWatchedForm<Record<string, string>>();
-const secretForm = wForm.newForm(
-  "component.secret",
-  secretFormData,
-  async ({ value }) => {
+const wForm = useWatchedForm<Record<string, string>>("component.secret");
+const secretForm = wForm.newForm({
+  data: secretFormData,
+  onSubmit: async ({ value }) => {
     const definition = secretQuery.data.value?.label;
     if (!definition) throw new Error("Secret Definition Required");
     if (!secret.value) throw new Error("Secret AV Required");
@@ -269,15 +268,17 @@ const secretForm = wForm.newForm(
       });
     }
   },
-  ({ value }) => {
-    return {
-      fields: {
-        Name: !value.Name ? "Name required" : undefined,
-      },
-    };
+  validators: {
+    onSubmit: ({ value }) => {
+      return {
+        fields: {
+          Name: !value.Name ? "Name required" : undefined,
+        },
+      };
+    },
   },
-  () => secret.value?.secret,
-);
+  watchFn: () => secret.value?.secret,
+});
 
 const filtered = reactive<{ tree: AttrTree | object }>({
   tree: {},

--- a/app/web/src/newhotness/Component.vue
+++ b/app/web/src/newhotness/Component.vue
@@ -300,14 +300,13 @@ const nameFormData = computed<NameFormData>(() => {
   return { name: component.value?.name ?? "" };
 });
 
-const wForm = useWatchedForm<NameFormData>();
+const wForm = useWatchedForm<NameFormData>("component.name");
 
 const route = useRoute();
 
-const nameForm = wForm.newForm(
-  "component.name",
-  nameFormData,
-  async ({ value }) => {
+const nameForm = wForm.newForm({
+  data: nameFormData,
+  onSubmit: async ({ value }) => {
     const name = value.name;
     // i wish the validator narrowed this type to always be a string
     if (name) {
@@ -330,7 +329,7 @@ const nameForm = wForm.newForm(
       }
     }
   },
-);
+});
 
 const required = ({ value }: { value: string | undefined }) => {
   const len = value?.trim().length ?? 0;

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -232,18 +232,17 @@ const path = computed(() => {
 });
 
 type AttrData = { value: string };
-const wForm = useWatchedForm<AttrData>();
+const wForm = useWatchedForm<AttrData>("component.av.prop");
 const attrData = computed<AttrData>(() => {
   return { value: props.value };
 });
 
-const valueForm = wForm.newForm(
-  "component.av.prop",
-  attrData,
-  async ({ value }) => {
+const valueForm = wForm.newForm({
+  data: attrData,
+  onSubmit: async ({ value }) => {
     emit("save", path.value, props.attributeValueId, value.value);
   },
-);
+});
 
 // i assume more things than comboboxes have a list of options
 type AttrOption = string | number;

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -165,13 +165,12 @@ const add = async () => {
 const router = useRouter();
 const route = useRoute();
 const showKey = ref(false);
-const wForm = useWatchedForm<{ key: string }>();
+const wForm = useWatchedForm<{ key: string }>("component.av.key");
 const keyData = ref({ key: "" });
 const keyApi = useApi();
-const keyForm = wForm.newForm(
-  "component.av.key",
-  keyData,
-  async ({ value }) => {
+const keyForm = wForm.newForm({
+  data: keyData,
+  onSubmit: async ({ value }) => {
     const call = keyApi.endpoint<{ success: boolean }>(
       routes.UpdateComponentAttributes,
       { id: props.component.id },
@@ -195,7 +194,7 @@ const keyForm = wForm.newForm(
       });
     }
   },
-);
+});
 
 const saveKey = async () => {
   if (keyForm.fieldInfo.key.instance?.state.meta.isDirty) {


### PR DESCRIPTION
Form code ends up being large blocks of logic and the ergonomics of putting them all in one place was making it really hard to find which function arg you wanted.

1. Move the form label (e.g. "what is this form") for observability purposes to the `useWatchedForm()` call.
2. Changed the args to `newForm` from positional to be an object with key names.
3. I changed the validation to match the tanstack style, so we dont need an arg per validation fn, just pass them all at once.