### PR TITLE
fix: add launchtemplateid socket to ec2 instance

### DIFF
--- a/bin/clover/doc-link-cache.json
+++ b/bin/clover/doc-link-cache.json
@@ -9630,5 +9630,14 @@
   "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ssmcontacts-contact-tag.html": 200,
   "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-synthetics-canary-retryconfig.html": 200,
   "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-verifiedpermissions-policystore-deletionprotection.html": 200,
-  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-workspaces-workspacespool-runningmode.html": 302
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-workspaces-workspacespool-runningmode.html": 302,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-datasync-locationazureblob-customsecretconfig.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-datasync-locationazureblob-cmksecretconfig.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-datasync-locationazureblob-managedsecretconfig.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-datasync-locationobjectstorage-customsecretconfig.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-datasync-locationobjectstorage-cmksecretconfig.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-datasync-locationobjectstorage-managedsecretconfig.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-metadataoptions.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-pcs-cluster-accounting.html": 200,
+  "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ses-mailmanagerruleset-snsaction.html": 200
 }

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -136,6 +136,23 @@ const overrides = new Map<string, OverrideFn>([
     );
     variant.sockets.push(launchTemplateNameSocket);
 
+    const launchTemplateIdProp = propForOverride(
+      launchTemplateProp,
+      "LaunchTemplateId"
+    );
+    if (!launchTemplateIdProp) return;
+
+    const launchTemplateIdSocket = createInputSocketFromProp(
+      launchTemplateIdProp,
+      [
+        { tokens: ["LaunchTemplateId"] },
+        { tokens: ["LaunchTemplateId<string<scalar>>"] },
+        { tokens: ["Launch Template Id"] },
+      ],
+      "Launch Template Id"
+    );
+    variant.sockets.push(launchTemplateIdSocket);
+
     const iamInstanceProfileProp = propForOverride(variant.domain, "IamInstanceProfile");
     if (!iamInstanceProfileProp) return;
 


### PR DESCRIPTION
User reported issue where Launch Template Id from AWS::EC2::LaunchTemplate component could not connect to AWS::EC2::Instance (no input socket)

<img width="723" alt="Screenshot 2025-05-23 at 19 13 49" src="https://github.com/user-attachments/assets/837d29b3-8493-4a4c-9442-09500a3eb08a" />
