### PR TITLE
chore: put mjolnir behind a p-queue

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -97,6 +97,7 @@
     "local-storage-fallback": "^4.1.3",
     "lodash-es": "^4.17.21",
     "mitt": "^3.0.1",
+    "p-queue": "^8.1.0",
     "pinia": "^2.2.4",
     "plur": "^5.1.0",
     "posthog-js": "^1.155.0",

--- a/app/web/src/workers/mjolnir_queue.ts
+++ b/app/web/src/workers/mjolnir_queue.ts
@@ -1,0 +1,3 @@
+import PQueue from "p-queue";
+
+export const mjolnirQueue = new PQueue({ concurrency: 10, autoStart: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,6 +354,9 @@ importers:
       mitt:
         specifier: ^3.0.1
         version: 3.0.1
+      p-queue:
+        specifier: ^8.1.0
+        version: 8.1.0
       pinia:
         specifier: ^2.2.4
         version: 2.2.4(typescript@5.0.4)(vue@3.5.12(typescript@5.0.4))
@@ -6043,6 +6046,9 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
   events-to-array@2.0.3:
     resolution: {integrity: sha512-f/qE2gImHRa4Cp2y1stEOSgw8wTFyUdVJX7G//bMwbaV9JqISFxg99NbmVQeP7YLnDUZ2un851jlaDrlpmGehQ==}
     engines: {node: '>=12'}
@@ -8866,6 +8872,10 @@ packages:
 
   p-map@7.0.3:
     resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
+    engines: {node: '>=18'}
+
+  p-queue@8.1.0:
+    resolution: {integrity: sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==}
     engines: {node: '>=18'}
 
   p-reduce@3.0.0:
@@ -17833,6 +17843,8 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
+  eventemitter3@5.0.1: {}
+
   events-to-array@2.0.3: {}
 
   events@3.3.0: {}
@@ -21373,6 +21385,11 @@ snapshots:
       aggregate-error: 4.0.1
 
   p-map@7.0.3: {}
+
+  p-queue@8.1.0:
+    dependencies:
+      eventemitter3: 5.0.1
+      p-timeout: 6.1.4
 
   p-reduce@3.0.0: {}
 


### PR DESCRIPTION
This PR puts mjolnir calls behind a p-queue with a concurrency limit of
10. This helps mjolnir not overwhelm the browser with pending requests.

P-queue has many options, and we're using very little of them right now. We can extend things later if we need more advanced functionality.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdld2k1ZzJvZXo1Z2F2dWN3Mjd3bjgwbWMxMjhqcHh3MXN2NmFhazFiOSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/MF1aaZpwtmqUa2FoCa/giphy.gif"/>