### PR TITLE
fix(dal): Fix "multiple AVs for prop" multiplayer

### DIFF
--- a/lib/dal-test/src/helpers/attribute/value.rs
+++ b/lib/dal-test/src/helpers/attribute/value.rs
@@ -167,7 +167,7 @@ pub async fn get(ctx: &DalContext, av: impl AttributeValueKey) -> Result<serde_j
     let av_id = av.lookup_attribute_value(ctx).await?;
     AttributeValue::view_by_id(ctx, av_id)
         .await?
-        .ok_or(eyre!("Attribute value not found"))
+        .ok_or(eyre!("Attribute missing value"))
 }
 
 /// Check whether the value exists and is set

--- a/lib/dal-test/src/helpers/change_set.rs
+++ b/lib/dal-test/src/helpers/change_set.rs
@@ -31,6 +31,33 @@ pub async fn commit(ctx: &mut DalContext) -> Result<()> {
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await
 }
 
+/// Creates a new fork from head and returns the new `DalContext`. The original context
+pub async fn fork(ctx: &DalContext) -> Result<DalContext> {
+    let mut ctx = ctx.clone();
+    ChangeSetTestHelpers::fork_from_head_change_set(&mut ctx).await?;
+    Ok(ctx)
+}
+
+/// Applies a forked context to head and re-forks so it can be worked on again.
+pub async fn apply_and_refork(ctx: &mut DalContext) -> Result<()> {
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+    ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
+    Ok(())
+}
+
+/// Applies a forked context to head, consuming it.
+pub async fn apply(mut ctx: DalContext) -> Result<()> {
+    ChangeSetTestHelpers::apply_change_set_to_base(&mut ctx).await?;
+    Ok(())
+}
+
+/// Waits for DVU to finish and updates the snapshot
+pub async fn wait_for_dvu(ctx: &mut DalContext) -> Result<()> {
+    ChangeSetTestHelpers::wait_for_dvu(ctx).await?;
+    ctx.update_snapshot_to_visibility().await?;
+    Ok(())
+}
+
 /// This unit struct providers helper functions for working with [`ChangeSets`](ChangeSet). It is
 /// designed to centralize logic for test authors wishing to commit changes, fork, apply, abandon,
 /// etc.

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -819,6 +819,14 @@ impl Prop {
         Ok(Self::assemble(node_weight, inner))
     }
 
+    pub async fn node_weight(ctx: &DalContext, id: PropId) -> PropResult<PropNodeWeight> {
+        Ok(ctx
+            .workspace_snapshot()?
+            .get_node_weight(id)
+            .await?
+            .get_prop_node_weight()?)
+    }
+
     pub async fn element_prop_id(ctx: &DalContext, prop_id: PropId) -> PropResult<PropId> {
         Self::direct_child_prop_ids_unordered(ctx, prop_id)
             .await?


### PR DESCRIPTION
In production, we periodically get "multiple AVs for prop" errors indicating graphs have more then one AV representing the value of an object prop. This PR fixes this:

* Reuses child AVs for object fields, and array and map elements. reuse child AVs when it can (it just blows away and replaces their values).
* This=makes object updates reuse existing AVs, which prevents a multiplayer issue where two object updates both add new AVs for each prop in the object, and then we merge them all into the node. 
* 
### How It Happens
From running the graph validator, the majority of "multiple AVs for prop" errors we see in production occur in qualifications[], code[], and resource_values. This will happen when:

1. You have a long-lived changeset
2. Actions, qualifications or code updates run on main, creating new AVs for objects that already exist in your changest
3. The long-lived changeset merrily adds the new AVs into the object when OTs replay, causing duplicates

This reuses AVs whenever it can, under objects, maps and arrays. I had to rework the way populate_nested_values() works a bit to get it working, but I made a point not to change the actual main loop or descent algorithm, and kept view_stack the same. A good deal more code is being shared, as well: process_nested_values() is now doing the actual set_value() and enqueueing decisions that were previously done inside the array/map/object helpers.

This *also* removes existing duplicates when you update() a value, which should gradually clean up a lot of our graphs even before migration happens.

### CTs: the road not taken

This does **not** fix the issue with a CT: CTs for this are difficult to make safe. Instead, it takes the approach of reusing existing AVs, so that two changesets don't generate conflicting OTs in the first place. There may be a place for CTs here, but when I tried to write them here, I found it difficult to make them safe (like, if we started updating AVs a different way, the CT not only wouldn't fix it, it could actively make some normal cases worse).

The primary remaining issue would be when two people insert the same key into a map (which, again, can happen with long-lived change sets). That actually could be handled reasonably easily with a CT, and we may want to do that!

This also does not reuse the root AV or socket AVs on upgrade--those are still being switched out on upgrade. That would be separate work, but is already covered under a reasonable CT, so isn't a huge priority right now.

## Tests

- [X] Integration Tests
- [X] New tests for multiplayer
- [X] Manual tests: make sure connections and qualifications still work

<IMG SRC="https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExY3V5dXRrMnc1eHlrMnZscGJja2Z2ODQ4YmVncmxrN2F6Z3hlMHB1ZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/zw7TzF0JxLVOZ9bnH6/giphy.gif">