### PR TITLE
fix(edda,web): Refactor Schema Variant Categories to do less work

### DIFF
--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -113,6 +113,17 @@ export interface BifrostSchemaVariantCategories {
   id: string; // change set id
   categories: Categories;
 }
+export interface EddaSchemaVariantCategories {
+  id: string; // change set id
+  categories: Array<{
+    displayName: string;
+    schemaVariants: Array<{
+      type: "uninstalled" | "installed";
+      id: string;
+    }>;
+  }>;
+  uninstalled: Record<string, UninstalledVariant>;
+}
 
 export interface BifrostActionViewList {
   id: ChangeSetId;
@@ -133,7 +144,7 @@ export interface EddaComponent {
   color?: string;
   schemaName: string;
   schemaId: SchemaId;
-  schemaVariantId: Reference<EntityKind.SchemaVariant>;
+  schemaVariantId: WeakReference<EntityKind.SchemaVariant>;
   schemaVariantName: string;
   schemaVariantDescription?: string;
   schemaVariantDocLink?: string;
@@ -165,23 +176,10 @@ export interface UninstalledVariant {
   color: string;
   link: string | null;
   description: string | null;
+  uninstalled: "uninstalled";
 }
 
-export interface CategoryInstalledVariant {
-  type: "installed";
-  id: string;
-  variant: SchemaVariant;
-}
-
-export interface CategoryUninstalledVariant {
-  type: "uninstalled";
-  id: string;
-  variant: UninstalledVariant;
-}
-
-export type CategoryVariant =
-  | CategoryInstalledVariant
-  | CategoryUninstalledVariant;
+export type CategoryVariant = SchemaVariant | UninstalledVariant;
 
 export type Categories = {
   displayName: string;

--- a/lib/dal-materialized-views/src/schema_variant_categories.rs
+++ b/lib/dal-materialized-views/src/schema_variant_categories.rs
@@ -5,17 +5,16 @@ use std::collections::{
 
 use dal::{
     DalContext,
+    SchemaId,
     SchemaVariant,
     cached_module::CachedModule,
 };
 use si_frontend_mv_types::{
-    ComponentType,
     UninstalledVariant,
     schema_variant::{
         DisambiguateVariant,
         SchemaVariantCategories as SchemaVariantCategoriesMv,
         SchemaVariantsByCategory,
-        Variant,
         VariantType,
     },
 };
@@ -38,11 +37,7 @@ pub async fn assemble(ctx: DalContext) -> super::Result<SchemaVariantCategoriesM
         let variants = variant_by_category
             .entry(category.to_owned())
             .or_insert(vec![]);
-        let variant =
-            crate::schema_variant::assemble(ctx.clone(), installed_variant.schema_variant_id)
-                .await?;
         variants.push(DisambiguateVariant {
-            variant: Variant::SchemaVariant(variant),
             variant_type: VariantType::Installed,
             id: installed_variant.schema_variant_id.to_string(),
         });
@@ -53,22 +48,22 @@ pub async fn assemble(ctx: DalContext) -> super::Result<SchemaVariantCategoriesM
 
     let cached_modules: Vec<CachedModule> = CachedModule::latest_modules(ctx).await?;
 
+    let mut uninstalled: HashMap<SchemaId, UninstalledVariant> = HashMap::new();
     // We want to hide uninstalled modules that would create duplicate assets in
     // the AssetPanel in old workspace. We do this just by name + category
     // matching. (We also hide if the schema is installed)
     for module in cached_modules {
         let category = module.category.to_owned();
         let category = category.as_deref().unwrap_or("");
-
+        let schema_id = module.schema_id;
         let schema_name = module.schema_name.as_str();
         if !installed_schema_ids.contains(&module.schema_id)
             && !installed_cat_and_name.contains(&(category, schema_name))
         {
-            let module_id = module.id.to_string();
             let variants = variant_by_category
                 .entry(category.to_owned())
                 .or_insert(Vec::new());
-            let uninstalled = UninstalledVariant {
+            let uninstalled_variant = UninstalledVariant {
                 schema_id: module.schema_id,
                 schema_name: module.schema_name,
                 display_name: module.display_name,
@@ -76,32 +71,19 @@ pub async fn assemble(ctx: DalContext) -> super::Result<SchemaVariantCategoriesM
                 link: module.link,
                 color: module.color,
                 description: module.description,
-                component_type: match module.component_type {
-                    dal::ComponentType::AggregationFrame => ComponentType::AggregationFrame,
-                    dal::ComponentType::Component => ComponentType::Component,
-                    dal::ComponentType::ConfigurationFrameDown => {
-                        ComponentType::ConfigurationFrameDown
-                    }
-                    dal::ComponentType::ConfigurationFrameUp => ComponentType::ConfigurationFrameUp,
-                },
             };
             variants.push(DisambiguateVariant {
-                variant: Variant::UninstalledVariant(uninstalled),
                 variant_type: VariantType::Uninstalled,
-                id: module_id, // is this right? no SV id?
+                id: schema_id.to_string(), // is this right? no SV id? let's try schema id insted of module id
             });
+            uninstalled.insert(schema_id, uninstalled_variant);
         }
     }
 
     let mut categories: Vec<SchemaVariantsByCategory> = vec![];
     for (name, variants) in variant_by_category.iter() {
         let mut variants = variants.to_vec();
-        variants.sort_by_cached_key(|v| match v.variant.to_owned() {
-            Variant::SchemaVariant(schema_variant) => schema_variant.display_name,
-            Variant::UninstalledVariant(uninstalled_variant) => uninstalled_variant
-                .display_name
-                .unwrap_or(uninstalled_variant.schema_name),
-        });
+        variants.sort_by_cached_key(|v| v.id.to_owned());
         categories.push(SchemaVariantsByCategory {
             display_name: name.to_string(),
             schema_variants: variants,
@@ -112,5 +94,6 @@ pub async fn assemble(ctx: DalContext) -> super::Result<SchemaVariantCategoriesM
     Ok(SchemaVariantCategoriesMv {
         id: ctx.change_set_id(),
         categories,
+        uninstalled,
     })
 }

--- a/lib/dal/tests/integration_test/materialized_views.rs
+++ b/lib/dal/tests/integration_test/materialized_views.rs
@@ -205,8 +205,7 @@ async fn component(ctx: &DalContext) -> Result<()> {
     };
 
     let sv_id = created_component.schema_variant(ctx).await?.id();
-    let schema_variant_mv =
-        dal_materialized_views::schema_variant::assemble(ctx.clone(), sv_id).await?;
+   
     let attribute_tree = dal_materialized_views::component::attribute_tree::assemble(
         ctx.clone(),
         created_component.id(),
@@ -220,7 +219,7 @@ async fn component(ctx: &DalContext) -> Result<()> {
             color: created_component.color(ctx).await?.to_owned(),
             schema_name: schema_name.to_owned(),
             schema_id: schema.id(),
-            schema_variant_id: (&schema_variant_mv).into(),
+            schema_variant_id: sv_id.into(),
             schema_variant_name: schema_variant.display_name().to_owned(),
             schema_category: schema_variant.category().to_owned(),
             schema_variant_description: schema_variant.description().to_owned(),

--- a/lib/si-frontend-mv-types-rs/src/component.rs
+++ b/lib/si-frontend-mv-types-rs/src/component.rs
@@ -14,6 +14,8 @@ use si_events::{
 use crate::reference::{
     Reference,
     ReferenceKind,
+    WeakReference,
+    weak,
 };
 
 pub mod attribute_tree;
@@ -74,8 +76,7 @@ pub struct Component {
     pub color: Option<String>,
     pub schema_name: String,
     pub schema_id: SchemaId,
-    #[mv(reference_kind = ReferenceKind::SchemaVariant)]
-    pub schema_variant_id: Reference<SchemaVariantId>,
+    pub schema_variant_id: WeakReference<SchemaVariantId, weak::markers::SchemaVariant>,
     pub schema_variant_name: String,
     pub schema_variant_description: Option<String>,
     pub schema_variant_doc_link: Option<String>,

--- a/lib/si-frontend-mv-types-rs/src/lib.rs
+++ b/lib/si-frontend-mv-types-rs/src/lib.rs
@@ -40,7 +40,6 @@ pub mod view;
 pub use crate::{
     materialized_view::MaterializedView,
     schema_variant::{
-        ComponentType,
         SchemaVariant,
         UninstalledVariant,
     },

--- a/lib/si-frontend-mv-types-rs/src/reference/weak.rs
+++ b/lib/si-frontend-mv-types-rs/src/reference/weak.rs
@@ -96,6 +96,14 @@ pub mod markers {
         const REFERENCE_KIND: ReferenceKind = ReferenceKind::Component;
     }
 
+    /// A weak reference marker for [`ReferenceKind::SchemaVariant`].
+    #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+    pub struct SchemaVariant;
+
+    impl ReferenceKindMarker for SchemaVariant {
+        const REFERENCE_KIND: ReferenceKind = ReferenceKind::SchemaVariant;
+    }
+
     /// A weak reference marker for [`ReferenceKind::SecretDefinition`].
     #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
     pub struct SecretDefinition;

--- a/lib/si-frontend-mv-types-rs/src/schema_variant.rs
+++ b/lib/si-frontend-mv-types-rs/src/schema_variant.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use prop_tree::PropTree;
 use serde::{
     Deserialize,
@@ -19,7 +21,11 @@ use strum::{
 
 use crate::{
     management::MgmtPrototypeView,
-    reference::ReferenceKind,
+    reference::{
+        ReferenceKind,
+        WeakReference,
+        weak,
+    },
 };
 
 pub mod prop_tree;
@@ -72,6 +78,21 @@ pub struct SchemaVariant {
     si_frontend_mv_types_macros::FrontendChecksum,
 )]
 #[serde(rename_all = "camelCase")]
+pub struct InstalledVariant {
+    pub id: SchemaVariantId,
+    pub schema_variant: WeakReference<SchemaVariantId, weak::markers::SchemaVariant>,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Deserialize,
+    Eq,
+    Serialize,
+    PartialEq,
+    si_frontend_mv_types_macros::FrontendChecksum,
+)]
+#[serde(rename_all = "camelCase")]
 pub struct UninstalledVariant {
     pub schema_id: SchemaId,
     pub schema_name: String,
@@ -80,32 +101,6 @@ pub struct UninstalledVariant {
     pub link: Option<String>,
     pub color: Option<String>,
     pub description: Option<String>,
-    pub component_type: ComponentType,
-}
-
-#[remain::sorted]
-#[derive(
-    AsRefStr,
-    Clone,
-    Copy,
-    Debug,
-    Deserialize,
-    EnumString,
-    Eq,
-    Serialize,
-    Display,
-    EnumIter,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    si_frontend_mv_types_macros::FrontendChecksum,
-)]
-#[serde(rename_all = "camelCase")]
-pub enum ComponentType {
-    AggregationFrame,
-    Component,
-    ConfigurationFrameDown,
-    ConfigurationFrameUp,
 }
 
 #[derive(
@@ -121,7 +116,7 @@ pub enum ComponentType {
 #[serde(untagged, rename_all = "camelCase")]
 #[allow(clippy::large_enum_variant)]
 pub enum Variant {
-    SchemaVariant(SchemaVariant),
+    InstalledSchemaVariant(InstalledVariant),
     UninstalledVariant(UninstalledVariant),
 }
 
@@ -159,7 +154,6 @@ pub struct DisambiguateVariant {
     #[serde(rename = "type")]
     pub variant_type: VariantType,
     pub id: String,
-    pub variant: Variant,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -188,4 +182,5 @@ pub struct SchemaVariantsByCategory {
 pub struct SchemaVariantCategories {
     pub id: ChangeSetId,
     pub categories: Vec<SchemaVariantsByCategory>,
+    pub uninstalled: HashMap<SchemaId, UninstalledVariant>,
 }

--- a/lib/si-frontend-mv-types-rs/src/temporary_conversion_impls.rs
+++ b/lib/si-frontend-mv-types-rs/src/temporary_conversion_impls.rs
@@ -6,12 +6,10 @@
 
 use si_frontend_types::{
     ComponentQualificationStats as DeprecatedComponentQualificationStats,
-    ComponentType as DeprecatedComponentType,
     PropKind as DeprecatedPropKind,
 };
 
 use crate::{
-    ComponentType,
     component::ComponentQualificationStats,
     schema_variant::prop_tree::PropKind,
 };
@@ -24,20 +22,6 @@ impl From<DeprecatedComponentQualificationStats> for ComponentQualificationStats
             succeeded: value.succeeded,
             failed: value.failed,
             running: value.running,
-        }
-    }
-}
-
-// NOTE(nick): why are we converting component type if it is dead in the new UI? Baggage from the
-// old type in the new MV. For now, let's convert it but the concept of "component type" will also
-// die alongside this module.
-impl From<DeprecatedComponentType> for ComponentType {
-    fn from(value: DeprecatedComponentType) -> Self {
-        match value {
-            DeprecatedComponentType::AggregationFrame => Self::AggregationFrame,
-            DeprecatedComponentType::Component => Self::Component,
-            DeprecatedComponentType::ConfigurationFrameDown => Self::ConfigurationFrameDown,
-            DeprecatedComponentType::ConfigurationFrameUp => Self::ConfigurationFrameUp,
         }
     }
 }


### PR DESCRIPTION
This PR refactors the `SchemaVariantCategories` MV to have a `WeakReference` via the `SchemaVariantId` in line with the new pattern we're starting to follow where if MV A --- references --> MV B, but both MVs share a trigger ancestor (in this case, the Schema Category node), we can use WeakRefs and not need to build MV B twice (once when MV A is triggered, then again when MV B is triggered). 