### PR TITLE
Fix si-fs project on macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,6 +3173,7 @@ dependencies = [
  "memchr",
  "nix 0.29.0",
  "page_size",
+ "pkg-config",
  "smallvec",
  "zerocopy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ fastrace = "0.7.4"
 flate2 = "1.0.35"
 foyer = { version = "0.14.1", features = ["tracing"] }
 fs4 = "0.12.0"
-fuser = { version = "0.15.1", default-features = false }
+fuser = { version = "0.15.1", default-features = false, features = ["libfuse"] }
 futures = "0.3.31"
 futures-lite = "2.5.0"
 glob = "0.3.1"

--- a/bin/si-fs/BUCK
+++ b/bin/si-fs/BUCK
@@ -16,6 +16,10 @@ rust_binary(
     ],
     srcs = glob(["src/**/*.rs"]),
     env = {"CARGO_BIN_NAME": "si-fs"},
+    rustc_flags = select({
+        "config//os:macos": ["-C", "link-arg=-L/usr/local/lib", "-C", "link-arg=-lfuse"],
+        "DEFAULT": [],
+    }),
 )
 
 nix_binary(

--- a/bin/si-fs/README.md
+++ b/bin/si-fs/README.md
@@ -12,7 +12,7 @@ A FUSE filesystem for editing System Initiative assets in your favorite editor.
 2. Mount the filesystem:
 
 ```bash
-buck2 run //bin/si-fs -- --foreground --workspace-id <WORKSPACE_ID> --endpoint <ENDPOINT> /mountpoint
+buck2 run //bin/si-fs -- --foreground --workspace-id <WORKSPACE_ID> [--endpoint <ENDPOINT>] /mountpoint
 ```
 
 At this point, we recommend running in the foreground, so you can see any errors
@@ -125,3 +125,10 @@ The function must be on the same change set as the schema you are attaching to.
 
 Like when creating a new function, Attribute and Action functions will be put
 into a pending state.
+
+## Mac Setup
+
+Ensure you setup macFUSE before attempting above setup
+ https://github.com/macfuse/macfuse/wiki/Getting-Started
+
+You will need to use a mountpoint in your user profile otherwise you will get `std io error: Read-only file system (os error 30)` when trying to write to the filesystem.

--- a/lib/si-filesystem/src/lib.rs
+++ b/lib/si-filesystem/src/lib.rs
@@ -57,7 +57,7 @@ use inode_table::{
 use nix::{
     libc::{
         EACCES,
-        EBADFD,
+        EBADF,
         EINVAL,
         ENODATA,
         ENOENT,
@@ -1686,7 +1686,7 @@ impl SiFileSystem {
             };
 
             let Some(mut open_file) = self.open_files.get_mut(&fh) else {
-                reply.error(EBADFD);
+                reply.error(EBADF);
                 return Ok(());
             };
 

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -6846,6 +6846,10 @@ cargo.rust_library(
     env = {
         "OUT_DIR": "$(location :fuser-0.15.1-build-script-run[out_dir])",
     },
+    features = [
+        "libfuse",
+        "pkg-config",
+    ],
     rustc_flags = ["@$(location :fuser-0.15.1-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
@@ -6865,13 +6869,22 @@ cargo.rust_binary(
     crate = "build_script_build",
     crate_root = "fuser-0.15.1.crate/build.rs",
     edition = "2021",
+    features = [
+        "libfuse",
+        "pkg-config",
+    ],
     visibility = [],
+    deps = [":pkg-config-0.3.32"],
 )
 
 buildscript_run(
     name = "fuser-0.15.1-build-script-run",
     package_name = "fuser",
     buildscript_rule = ":fuser-0.15.1-build-script-build",
+    features = [
+        "libfuse",
+        "pkg-config",
+    ],
     version = "0.15.1",
 )
 

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -2663,6 +2663,7 @@ dependencies = [
  "memchr",
  "nix 0.29.0",
  "page_size",
+ "pkg-config",
  "smallvec",
  "zerocopy",
 ]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -81,7 +81,7 @@ fastrace = "0.7.4"
 flate2 = "1.0.35"
 foyer = { version = "0.14.1", features = ["tracing"] }
 fs4 = "0.12.0"
-fuser = { version = "0.15.1", default-features = false }
+fuser = { version = "0.15.1", default-features = false, features = ["libfuse"] }
 futures = "0.3.31"
 futures-lite = "2.5.0"
 glob = "0.3.1"


### PR DESCRIPTION
Added libfuse to fuser features
Switch EBADFD to EBADF for cross platform bad file descriptor Pass additional link args on mac so the rust binary can link the the macfuse symbols

```
nix:nix-shell-env) MacBookPro:si jake$ buck2 build //bin/si-fs
Starting new buck2 daemon...
Connected to new buck2 daemon.
Build ID: 0655c259-4946-42e3-b5fb-e813fe62a0f3
Network: Up: 0B  Down: 26MiB
Loading targets.   Remaining     0/25     
Analyzing targets. Remaining     0/740    
Executing actions. Remaining     0/3041   
Command: build.    Finished 905 local                                                                   
Time elapsed: 2:17.2s
BUILD SUCCEEDED
(nix:nix-shell-env) MacBookPro:si jake$ 
```

<img width="341" alt="image" src="https://github.com/user-attachments/assets/ef9947ab-1dd1-4e11-8604-4840a58c178f" />
<img width="231" alt="image" src="https://github.com/user-attachments/assets/82eca2ed-0ba2-403c-b7bd-f80dd83949df" />
