### PR TITLE
chore(dal): Move snapshot validator to dal for use in sdf endpoints

### DIFF
--- a/lib/dal/examples/snapshot-fixer/main.rs
+++ b/lib/dal/examples/snapshot-fixer/main.rs
@@ -1,8 +1,4 @@
 use std::{
-    collections::{
-        HashMap,
-        HashSet,
-    },
     env,
     fs::File,
     io::{
@@ -12,26 +8,12 @@ use std::{
 };
 
 use dal::{
-    AttributeValueId,
-    ComponentId,
-    EdgeWeightKind,
-    EdgeWeightKindDiscriminants,
-    OutputSocketId,
-    PropId,
-    PropKind,
     WorkspaceSnapshotGraph,
-    workspace_snapshot::{
-        content_address::ContentAddressDiscriminants,
-        node_weight::{
-            ArgumentTargets,
-            AttributePrototypeArgumentNodeWeight,
-            NodeWeight,
-        },
+    workspace_snapshot::graph::validator::{
+        ValidationIssue,
+        validate_graph,
     },
 };
-use itertools::Itertools;
-use petgraph::prelude::*;
-use si_id::AttributePrototypeArgumentId;
 use si_layer_cache::db::serialize;
 use tokio::time::Instant;
 
@@ -66,7 +48,7 @@ async fn main() -> Result<()> {
     // remove_node_by_id(&mut graph, node_id)?;
 
     for issue in validate_graph(&graph)? {
-        println!("{}", issue.report(&graph)?);
+        println!("{}", issue.display(&graph));
         // Only fix ConnectionToUnknownSocket issues for now
         if let issue @ ValidationIssue::ConnectionToUnknownSocket { .. } = issue {
             issue.fix(&mut graph)?
@@ -81,248 +63,6 @@ async fn main() -> Result<()> {
 
     // then head back to the admin portal and replace snapshot with this new fixed snapshot
     Ok(())
-}
-
-fn validate_graph(graph: &WorkspaceSnapshotGraph) -> Result<Vec<ValidationIssue>> {
-    Ok(graph
-        .nodes()
-        .flat_map(|(node, node_index)| validate_node(graph, node, node_index).unwrap())
-        .collect())
-}
-
-enum ValidationIssue {
-    /// A child prop of an object has more than one attribute value
-    DuplicateAttributeValue {
-        original: AttributeValueId,
-        duplicate: AttributeValueId,
-        content_matches: bool,
-    },
-    /// One or more child props have no corresponding attribute values
-    MissingChildAttributeValues {
-        object: AttributeValueId,
-        missing_children: HashSet<PropId>,
-    },
-    /// A child attribute value was found under an object, but it was not associated with any
-    /// of the object's child props
-    UnknownChildAttributeValue { child: AttributeValueId },
-    /// APA is connected to a socket that does not exist on the source component
-    ConnectionToUnknownSocket {
-        destination_apa: AttributePrototypeArgumentId,
-        source_component: ComponentId,
-        source_socket: OutputSocketId,
-    },
-}
-
-impl ValidationIssue {
-    fn report(&self, graph: &WorkspaceSnapshotGraph) -> Result<String> {
-        Ok(match self {
-            &ValidationIssue::DuplicateAttributeValue {
-                original,
-                duplicate,
-                content_matches,
-            } => format!(
-                "Duplicate attribute value: {} ({}) and {} ({}){}",
-                graph
-                    .get_node_weight(
-                        graph
-                            .target(graph.get_node_index_by_id(original)?, EdgeWeightKind::Prop)?
-                    )?
-                    .as_prop_node_weight()?
-                    .name(),
-                original,
-                graph
-                    .get_node_weight(
-                        graph
-                            .target(graph.get_node_index_by_id(duplicate)?, EdgeWeightKind::Prop)?
-                    )?
-                    .as_prop_node_weight()?
-                    .name(),
-                duplicate,
-                match content_matches {
-                    true => "",
-                    false => " (CONTENT MISMATCH)",
-                }
-            ),
-            ValidationIssue::MissingChildAttributeValues {
-                object,
-                missing_children,
-            } => format!(
-                "Missing child attribute values for object {} ({}): missing {}",
-                graph
-                    .get_node_weight(
-                        graph.target(graph.get_node_index_by_id(object)?, EdgeWeightKind::Prop)?
-                    )?
-                    .as_prop_node_weight()?
-                    .name(),
-                object,
-                missing_children
-                    .iter()
-                    .map(|&child_prop| format!(
-                        "{} ({})",
-                        graph
-                            .get_node_weight_by_id(child_prop)
-                            .unwrap()
-                            .as_prop_node_weight()
-                            .unwrap()
-                            .name(),
-                        child_prop
-                    ))
-                    .join(", ")
-            ),
-            ValidationIssue::UnknownChildAttributeValue { child } => format!(
-                "Child attribute value has unknown (non-child) prop: {} ({})",
-                graph
-                    .get_node_weight(
-                        graph.target(graph.get_node_index_by_id(child)?, EdgeWeightKind::Prop)?
-                    )?
-                    .as_prop_node_weight()?
-                    .name(),
-                child,
-            ),
-            ValidationIssue::ConnectionToUnknownSocket {
-                destination_apa: destination,
-                source_component,
-                source_socket,
-            } => {
-                format!(
-                    "Connection from APA {} to unknown socket {} on component {}",
-                    destination, source_socket, source_component,
-                )
-            }
-        })
-    }
-
-    fn fix(&self, graph: &mut WorkspaceSnapshotGraph) -> Result<()> {
-        match self {
-            &ValidationIssue::DuplicateAttributeValue { duplicate, .. } => {
-                println!("Removing duplicate attribute value {}", duplicate);
-                let node_index = graph.get_node_index_by_id(duplicate)?;
-                graph.remove_node(node_index);
-            }
-            ValidationIssue::ConnectionToUnknownSocket {
-                destination_apa, ..
-            } => {
-                println!("Removing APA {}", destination_apa);
-                // Remove the APA node (as long as it leads back to an input socket)
-                let destination_apa = graph.get_node_index_by_id(destination_apa)?;
-                let destination_prototype =
-                    graph.source(destination_apa, EdgeWeightKind::PrototypeArgument)?;
-                let destination_socket = graph.source(
-                    destination_prototype,
-                    EdgeWeightKindDiscriminants::Prototype,
-                )?;
-                let NodeWeight::InputSocket(_) = graph.get_node_weight(destination_socket)? else {
-                    // If it's not an input socket, we can't be sure we're fixing what we want to fix
-                    return Ok(());
-                };
-                graph.remove_node(destination_apa);
-            }
-            ValidationIssue::MissingChildAttributeValues { .. }
-            | ValidationIssue::UnknownChildAttributeValue { .. } => {}
-        }
-        Ok(())
-    }
-}
-
-fn validate_node(
-    graph: &WorkspaceSnapshotGraph,
-    node: &NodeWeight,
-    node_index: NodeIndex,
-) -> Result<Vec<ValidationIssue>> {
-    let mut issues = vec![];
-    match node {
-        NodeWeight::AttributeValue(_) => {
-            // If this is an object attribute value, check that it has child attribute values for each child prop
-            let attr = node_index;
-            let Some(prop) = graph.target_opt(attr, EdgeWeightKind::Prop)? else {
-                return Ok(issues);
-            };
-            if graph.get_node_weight(prop)?.as_prop_node_weight()?.kind() == PropKind::Object {
-                // Check our the children we *do* have against the child props we *should* have
-                let child_props: HashSet<_> = graph
-                    .targets(prop, EdgeWeightKindDiscriminants::Use)
-                    .collect();
-
-                // Step through child avs, and record the ones we see (maybe report duplicates)
-                let mut attr_content = HashMap::new();
-                for child_attr in graph.targets(attr, EdgeWeightKindDiscriminants::Contain) {
-                    let child_attr_prop = graph.target(child_attr, EdgeWeightKind::Prop)?;
-                    if !child_props.contains(&child_attr_prop) {
-                        issues.push(ValidationIssue::UnknownChildAttributeValue {
-                            child: graph.node_index_to_id(child_attr).unwrap().into(),
-                        });
-                        continue;
-                    }
-                    let content = graph
-                        .get_node_weight(child_attr)?
-                        .get_attribute_value_node_weight()
-                        .unwrap()
-                        .value();
-                    if let Some(orig_content) = attr_content.insert(child_attr_prop, content) {
-                        issues.push(ValidationIssue::DuplicateAttributeValue {
-                            original: graph.node_index_to_id(child_attr).unwrap().into(),
-                            duplicate: graph.node_index_to_id(child_attr).unwrap().into(),
-                            content_matches: content == orig_content,
-                        });
-                    }
-                }
-
-                // If any child attributes are *not* associated with child props, report those
-                let missing_children: HashSet<_> = child_props
-                    .into_iter()
-                    .filter(|child_prop| !attr_content.contains_key(child_prop))
-                    .map(|child_prop| graph.node_index_to_id(child_prop).unwrap().into())
-                    .collect();
-                if !missing_children.is_empty() {
-                    issues.push(ValidationIssue::MissingChildAttributeValues {
-                        object: graph.node_index_to_id(attr).unwrap().into(),
-                        missing_children,
-                    });
-                }
-            }
-        }
-        NodeWeight::AttributePrototypeArgument(AttributePrototypeArgumentNodeWeight {
-            targets:
-                Some(ArgumentTargets {
-                    source_component_id,
-                    ..
-                }),
-            ..
-        }) => {
-            let destination_apa = node_index;
-            let source_component = graph.get_node_index_by_id(source_component_id)?;
-
-            // If this is a connection to a socket or prop, make sure the component on the other
-            // end has an AV for it
-            let Some(source_socket) =
-                graph.target_opt(destination_apa, EdgeWeightKind::PrototypeArgumentValue)?
-            else {
-                return Ok(issues);
-            };
-            // Make sure the source is an output socket
-            if Some(ContentAddressDiscriminants::OutputSocket)
-                != graph
-                    .get_node_weight(source_socket)?
-                    .content_address_discriminants()
-            {
-                return Ok(issues);
-            };
-            // Run through the sockets on the component, and find the one that matches
-            let mut component_sockets = graph
-                .targets(source_component, EdgeWeightKind::SocketValue)
-                .map(|socket_value| graph.target(socket_value, EdgeWeightKind::Socket).unwrap());
-            if !component_sockets.contains(&source_socket) {
-                issues.push(ValidationIssue::ConnectionToUnknownSocket {
-                    destination_apa: graph.node_index_to_id(destination_apa).unwrap().into(),
-                    source_component: graph.node_index_to_id(source_component).unwrap().into(),
-                    source_socket: graph.node_index_to_id(source_socket).unwrap().into(),
-                })
-            }
-        }
-        _ => {}
-    }
-
-    Ok(issues)
 }
 
 fn write_snapshot_graph(path: &str, graph: &WorkspaceSnapshotGraph) -> Result<()> {

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -52,6 +52,7 @@ mod tests;
 pub mod traits;
 pub mod v3;
 pub mod v4;
+pub mod validator;
 
 pub use traits::{
     approval_requirement::ApprovalRequirementExt,

--- a/lib/dal/src/workspace_snapshot/graph/validator.rs
+++ b/lib/dal/src/workspace_snapshot/graph/validator.rs
@@ -1,0 +1,417 @@
+use std::collections::{
+    HashMap,
+    HashSet,
+};
+
+use itertools::Itertools as _;
+use petgraph::prelude::*;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_id::{
+    AttributePrototypeArgumentId,
+    AttributeValueId,
+    ComponentId,
+    OutputSocketId,
+    PropId,
+    SchemaVariantId,
+};
+
+use crate::{
+    prop::PropKind,
+    workspace_snapshot::{
+        content_address::ContentAddressDiscriminants,
+        edge_weight::{
+            EdgeWeight,
+            EdgeWeightKind,
+            EdgeWeightKindDiscriminants,
+        },
+        graph::{
+            WorkspaceSnapshotGraph,
+            WorkspaceSnapshotGraphResult,
+        },
+        node_weight::{
+            ArgumentTargets,
+            AttributePrototypeArgumentNodeWeight,
+            NodeWeight,
+        },
+    },
+};
+
+pub fn validate_graph(
+    graph: &WorkspaceSnapshotGraph,
+) -> WorkspaceSnapshotGraphResult<Vec<ValidationIssue>> {
+    let mut issues = vec![];
+    for (node_weight, node_index) in graph.nodes() {
+        issues.extend(validate_node(graph, node_weight, node_index)?);
+    }
+    Ok(issues)
+}
+
+pub fn validate_node(
+    graph: &WorkspaceSnapshotGraph,
+    node: &NodeWeight,
+    node_index: NodeIndex,
+) -> WorkspaceSnapshotGraphResult<Vec<ValidationIssue>> {
+    let mut issues = vec![];
+    match node {
+        NodeWeight::AttributeValue(_) => {
+            // If this is an object attribute value, check that it has child attribute values for each child prop
+            let attr = node_index;
+            let Some(prop) = graph.target_opt(attr, EdgeWeightKind::Prop)? else {
+                return Ok(issues);
+            };
+            if PropKind::Object == graph.get_node_weight(prop)?.as_prop_node_weight()?.kind() {
+                // Check our the children we *do* have against the child props we *should* have
+                let child_props: HashSet<_> = graph
+                    .targets(prop, EdgeWeightKindDiscriminants::Use)
+                    .collect();
+
+                // Step through child avs, and record the ones we see (maybe report duplicates)
+                let mut attr_content = HashMap::new();
+                for child_attr in graph.targets(attr, EdgeWeightKindDiscriminants::Contain) {
+                    let child_attr_prop = graph.target(child_attr, EdgeWeightKind::Prop)?;
+                    if !child_props.contains(&child_attr_prop) {
+                        issues.push(ValidationIssue::UnknownChildAttributeValue {
+                            child: graph.get_node_weight(child_attr)?.id().into(),
+                        });
+                        continue;
+                    }
+                    let content = graph
+                        .get_node_weight(child_attr)?
+                        .get_attribute_value_node_weight()?
+                        .value();
+                    if let Some(orig_content) = attr_content.insert(child_attr_prop, content) {
+                        let original = graph.get_node_weight(child_attr)?.id().into();
+                        let duplicate = graph.get_node_weight(child_attr)?.id().into();
+                        if content == orig_content {
+                            issues.push(ValidationIssue::DuplicateAttributeValue {
+                                original,
+                                duplicate,
+                            })
+                        } else {
+                            issues.push(
+                                ValidationIssue::DuplicateAttributeValueWithDifferentValues {
+                                    original,
+                                    duplicate,
+                                },
+                            )
+                        };
+                    }
+                }
+
+                // If any child attributes are *not* associated with child props, report those
+                let mut missing_children = HashSet::new();
+                for child_prop in child_props {
+                    if !attr_content.contains_key(&child_prop) {
+                        missing_children.insert(graph.get_node_weight(child_prop)?.id().into());
+                    }
+                }
+                if !missing_children.is_empty() {
+                    issues.push(ValidationIssue::MissingChildAttributeValues {
+                        object: graph.get_node_weight(attr)?.id().into(),
+                        missing_children,
+                    });
+                }
+            }
+        }
+        NodeWeight::AttributePrototypeArgument(AttributePrototypeArgumentNodeWeight {
+            targets:
+                Some(ArgumentTargets {
+                    source_component_id,
+                    ..
+                }),
+            ..
+        }) => {
+            let destination_apa = node_index;
+            let source_component = graph.get_node_index_by_id(source_component_id)?;
+
+            // If this is a connection to a socket or prop, make sure the component on the other
+            // end has an AV for it
+            let Some(source_socket) =
+                graph.target_opt(destination_apa, EdgeWeightKind::PrototypeArgumentValue)?
+            else {
+                return Ok(issues);
+            };
+            // Make sure the source is an output socket
+            if Some(ContentAddressDiscriminants::OutputSocket)
+                != graph
+                    .get_node_weight(source_socket)?
+                    .content_address_discriminants()
+            {
+                return Ok(issues);
+            };
+            // Run through the sockets on the component, and find the one that matches
+            let mut component_sockets = graph
+                .targets(source_component, EdgeWeightKind::SocketValue)
+                .filter_map(|socket_value| graph.target(socket_value, EdgeWeightKind::Socket).ok());
+            if !component_sockets.contains(&source_socket) {
+                issues.push(ValidationIssue::ConnectionToUnknownSocket {
+                    destination_apa: graph.get_node_weight(destination_apa)?.id().into(),
+                    source_component: graph.get_node_weight(source_component)?.id().into(),
+                    source_socket: graph.get_node_weight(source_socket)?.id().into(),
+                })
+            }
+        }
+        _ => {}
+    }
+
+    Ok(issues)
+}
+
+/// A single validation issue found in the graph
+#[remain::sorted]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, strum::EnumDiscriminants)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ValidationIssue {
+    /// APA is connected to a socket that does not exist on the source component
+    ConnectionToUnknownSocket {
+        destination_apa: AttributePrototypeArgumentId,
+        source_component: ComponentId,
+        source_socket: OutputSocketId,
+    },
+    /// A child prop of an object has more than one attribute value
+    DuplicateAttributeValue {
+        original: AttributeValueId,
+        duplicate: AttributeValueId,
+    },
+    /// A child prop of an object has more than one attribute value, with different values
+    DuplicateAttributeValueWithDifferentValues {
+        original: AttributeValueId,
+        duplicate: AttributeValueId,
+    },
+    /// One or more child props have no corresponding attribute values
+    MissingChildAttributeValues {
+        object: AttributeValueId,
+        missing_children: HashSet<PropId>,
+    },
+    /// A child attribute value was found under an object, but it was not associated with any
+    /// of the object's child props
+    UnknownChildAttributeValue { child: AttributeValueId },
+}
+
+impl ValidationIssue {
+    pub fn display(&self, graph: &WorkspaceSnapshotGraph) -> impl std::fmt::Display {
+        DisplayWith(self, graph)
+    }
+
+    pub fn fix(&self, graph: &mut WorkspaceSnapshotGraph) -> WorkspaceSnapshotGraphResult<()> {
+        match self {
+            &ValidationIssue::DuplicateAttributeValue { duplicate, .. }
+            | &ValidationIssue::DuplicateAttributeValueWithDifferentValues { duplicate, .. } => {
+                println!("Removing duplicate attribute value {duplicate}");
+                let node_index = graph.get_node_index_by_id(duplicate)?;
+                graph.remove_node(node_index);
+            }
+            ValidationIssue::ConnectionToUnknownSocket {
+                destination_apa, ..
+            } => {
+                println!("Removing APA {destination_apa}");
+                // Remove the APA node (as long as it leads back to an input socket)
+                let destination_apa = graph.get_node_index_by_id(destination_apa)?;
+                let destination_prototype =
+                    graph.source(destination_apa, EdgeWeightKind::PrototypeArgument)?;
+                let destination_socket = graph.source(
+                    destination_prototype,
+                    EdgeWeightKindDiscriminants::Prototype,
+                )?;
+                let NodeWeight::InputSocket(_) = graph.get_node_weight(destination_socket)? else {
+                    // If it's not an input socket, we can't be sure we're fixing what we want to fix
+                    return Ok(());
+                };
+                graph.remove_node(destination_apa);
+            }
+            ValidationIssue::MissingChildAttributeValues { .. }
+            | ValidationIssue::UnknownChildAttributeValue { .. } => {}
+        }
+
+        Ok(())
+    }
+}
+
+/// Helper to format values that need extra context when being displayed (such as graphs, lookup tables,
+/// etc).
+struct DisplayWith<T, With>(T, With);
+
+impl std::fmt::Display for DisplayWith<AttributeValueId, &'_ WorkspaceSnapshotGraph> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let &DisplayWith(id, graph) = self;
+        match av_path(id, graph) {
+            Ok((_, path)) => write!(f, "{path} ({id})"),
+            Err(err) => write!(f, "{err} ({id})"),
+        }
+    }
+}
+
+impl std::fmt::Display for DisplayWith<PropId, &'_ WorkspaceSnapshotGraph> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let &DisplayWith(id, graph) = self;
+        match prop_path(id, graph) {
+            Ok((_, path)) => write!(f, "{path} ({id})"),
+            Err(err) => write!(f, "{err} ({id})"),
+        }
+    }
+}
+
+impl std::fmt::Display for DisplayWith<&'_ ValidationIssue, &'_ WorkspaceSnapshotGraph> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let &DisplayWith(issue, graph) = self;
+        match *issue {
+            ValidationIssue::ConnectionToUnknownSocket {
+                destination_apa,
+                source_component,
+                source_socket,
+            } => {
+                write!(
+                    f,
+                    "Connection from APA {destination_apa} to unknown socket {source_socket} on component {source_component}"
+                )
+            }
+            ValidationIssue::DuplicateAttributeValue {
+                original,
+                duplicate,
+            } => {
+                write!(
+                    f,
+                    "Duplicate attribute value: {} and {}",
+                    DisplayWith(original, graph),
+                    DisplayWith(duplicate, graph)
+                )
+            }
+            ValidationIssue::DuplicateAttributeValueWithDifferentValues {
+                original,
+                duplicate,
+            } => {
+                write!(
+                    f,
+                    "Duplicate attribute value (with different value!): {} and {}",
+                    DisplayWith(original, graph),
+                    DisplayWith(duplicate, graph)
+                )
+            }
+            ValidationIssue::MissingChildAttributeValues {
+                object,
+                ref missing_children,
+            } => {
+                write!(
+                    f,
+                    "Missing child attribute values for object {}: missing {}",
+                    DisplayWith(object, graph),
+                    missing_children
+                        .iter()
+                        .map(|&child_prop| format!("{}", DisplayWith(child_prop, graph)))
+                        .join(", ")
+                )
+            }
+            ValidationIssue::UnknownChildAttributeValue { child } => {
+                write!(
+                    f,
+                    "Child attribute value has unknown (non-child) prop: {}",
+                    DisplayWith(child, graph)
+                )
+            }
+        }
+    }
+}
+
+fn av_path_from_root(
+    id: AttributeValueId,
+    graph: &WorkspaceSnapshotGraph,
+) -> WorkspaceSnapshotGraphResult<(AttributeValueId, jsonptr::PointerBuf)> {
+    let mut index = graph.get_node_index_by_id(id)?;
+    let mut path = jsonptr::PointerBuf::new();
+    while let Some((
+        EdgeWeight {
+            kind: EdgeWeightKind::Contain(key),
+        },
+        parent_index,
+        _,
+    )) = graph
+        .edges_directed_for_edge_weight_kind(
+            index,
+            Direction::Incoming,
+            EdgeWeightKindDiscriminants::Contain,
+        )
+        .next()
+    {
+        // If we have a key, use it (must be a map)
+        let parent_prop = graph
+            .get_node_weight(graph.target(parent_index, EdgeWeightKind::Prop)?)?
+            .get_prop_node_weight()?;
+        match (parent_prop.kind(), key) {
+            // Use the key if the parent is a map
+            (PropKind::Map, Some(key)) => path.push_front(key),
+            // Use the prop name if the parent is an object
+            (PropKind::Object, None) => {
+                let prop = graph
+                    .get_node_weight(graph.target(index, EdgeWeightKind::Prop)?)?
+                    .get_prop_node_weight()?;
+                path.push_front(prop.name());
+            }
+            // Use the array index if the parent is an array
+            (PropKind::Array, None) => match graph
+                .ordered_children_for_node(parent_index)?
+                .and_then(|order| order.iter().position(|&child| child == index))
+            {
+                Some(index) => path.push_front(index),
+                // TODO return an error here instead
+                None => path.push_front("<NOT IN ORDERING NODE>"),
+            },
+
+            // These are errors (and if we move this out of printing code, we should return an error)
+            (PropKind::Array | PropKind::Object, Some(_)) => {
+                path.push_front("<MAP KEY SPECIFIED FOR ARRAY/OBJECT>")
+            }
+            (PropKind::Map, None) => path.push_front("<NO MAP KEY>"),
+            (kind, _) => path.push_front(format!("<BAD PARENT KIND {}>", kind)),
+        }
+        index = parent_index;
+    }
+
+    let root_id = graph.get_node_weight(index)?.id().into();
+
+    Ok((root_id, path))
+}
+
+fn av_path(
+    id: AttributeValueId,
+    graph: &WorkspaceSnapshotGraph,
+) -> WorkspaceSnapshotGraphResult<(ComponentId, jsonptr::PointerBuf)> {
+    // index is now either the root of the graph, or a socket node. Just grab its prop or socket name
+    let (root_id, mut path) = av_path_from_root(id, graph)?;
+    let root_index = graph.get_node_index_by_id(root_id)?;
+    let component_index = match graph.source_opt(root_index, EdgeWeightKind::Root)? {
+        Some(component_index) => {
+            path.push_front("root");
+            component_index
+        }
+        None => {
+            let socket_index = graph.target(root_index, EdgeWeightKind::Socket)?;
+            let socket_id = graph.get_node_weight(socket_index)?.id();
+            // TODO get name (which we don't presently have, because it's in content)
+            path.push_front(format!("{}", socket_id));
+            match graph.get_node_weight(socket_index)? {
+                NodeWeight::InputSocket(_) => path.push_front("inputSockets"),
+                _ => path.push_front("outputSockets"),
+            }
+            graph.source(root_index, EdgeWeightKind::SocketValue)?
+        }
+    };
+    let component_id = graph.get_node_weight(component_index)?.id().into();
+    Ok((component_id, path))
+}
+
+fn prop_path(
+    id: PropId,
+    graph: &WorkspaceSnapshotGraph,
+) -> WorkspaceSnapshotGraphResult<(SchemaVariantId, jsonptr::PointerBuf)> {
+    let mut index = graph.get_node_index_by_id(id)?;
+    let mut path = jsonptr::PointerBuf::new();
+    while let NodeWeight::Prop(prop_node) = graph.get_node_weight(index)? {
+        path.push_front(prop_node.name());
+        index = graph.source(index, EdgeWeightKindDiscriminants::Use)?;
+    }
+    let schema_variant_id = graph.get_node_weight(index)?.id().into();
+    Ok((schema_variant_id, path))
+}


### PR DESCRIPTION
This moves the validator from snapshot-fixer to DAL in anticipation of using it for other purposes (including admin endpoints that can run validation and down the road, migrations).

Also improved the display of said attributes, showing the actual AV path rather than prop path.