### PR TITLE
fix(edda): Improve handling of rebuild requests

### DIFF
--- a/lib/edda-server/src/change_set_processor_task.rs
+++ b/lib/edda-server/src/change_set_processor_task.rs
@@ -505,18 +505,23 @@ mod handlers {
                 if !span.is_disabled() {
                     span.record("si.edda_request.id", update_request.id.to_string());
                 }
-                materialized_view::build_all_mv_for_change_set(ctx, frigg)
-                    .instrument(tracing::info_span!(
-                        "edda.change_set_processor_task.build_all_mv_for_change_set.snapshot_moved"
-                    ))
-                    .await
-                    .map_err(Into::into)
+                materialized_view::build_all_mv_for_change_set(
+                    ctx,
+                    frigg,
+                    Some(update_request.from_snapshot_address),
+                )
+                .instrument(tracing::info_span!(
+                    "edda.change_set_processor_task.build_all_mv_for_change_set.snapshot_moved"
+                ))
+                .await
+                .map_err(Into::into)
             }
             EddaRequestKind::Update(update_request) => {
                 if !span.is_disabled() {
                     span.record("si.edda_request.id", update_request.id.to_string());
                 }
-                materialized_view::build_all_mv_for_change_set(ctx, frigg)
+                // todo: this is where we'd handle reusing an index from another change set if the snapshots match!
+                materialized_view::build_all_mv_for_change_set(ctx, frigg, None)
                     .instrument(tracing::info_span!(
                         "edda.change_set_processor_task.build_all_mv_for_change_set.initial_build"
                     ))
@@ -527,7 +532,7 @@ mod handlers {
                 if !span.is_disabled() {
                     span.record("si.edda_request.id", rebuild_request.id.to_string());
                 }
-                materialized_view::build_all_mv_for_change_set(ctx, frigg)
+                materialized_view::build_all_mv_for_change_set(ctx, frigg, None)
                     .instrument(tracing::info_span!(
                         "edda.change_set_processor_task.build_all_mv_for_change_set.explicit_rebuild"
                     ))


### PR DESCRIPTION
This change does two things and is a small turn forward. 
1. If the rebuild request is a reaction to Edda getting out of date, we will propagate the `fromSnapshotAddress` on the update request, as until we're compressing these, the front end can better serially handle the patches even if it took a rebuild to generate them
2. If the rebuild request was triggered manually (via SDF `/rebuild` or as a reaction to fetching an index and detecting it needed to be rebuilt, fromSnapshot will be the same as the toSnapshot. This allows the front end to determine if it's seen this snapshot before in the first place, if it has, it'll accept the patches as normal. If it hasn't, it can refetch what it needs.

<div><img src="https://media2.giphy.com/media/m9MaXtasxTu82sCrYW/giphy.gif?cid=5a38a5a2mv2vcjprlqdrhugxmfed0u5l7t4xnl7nvao6l60e&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/mollybalint/">Molly Balint</a> on <a href="https://giphy.com/gifs/the-social-circle-molly-balint-intagram-fam-m9MaXtasxTu82sCrYW">GIPHY</a></div>