### PR TITLE
Block new change set navigation until we've completed MTM linking

### DIFF
--- a/app/web/src/components/layout/navbar/NavbarPanelLeft.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelLeft.vue
@@ -60,7 +60,7 @@ import {
 } from "@si/vue-lib/design-system";
 import { computed, ref, watch } from "vue";
 import { useWorkspacesStore } from "@/store/workspaces.store";
-import { rainbowCount } from "@/newhotness/logic_composables/rainbow_counter";
+import { useRainbow } from "@/newhotness/logic_composables/rainbow_counter";
 import ChangeSetPanel from "./ChangeSetPanel.vue";
 
 const workspacesStore = useWorkspacesStore();
@@ -75,6 +75,8 @@ watch(
   },
   { immediate: true },
 );
+
+const { rainbowCount } = useRainbow();
 
 const updateRoute = (newWorkspacePk: string) => {
   if (selectedWorkspacePk.value === newWorkspacePk) return;

--- a/app/web/src/newhotness/ActionWidget.vue
+++ b/app/web/src/newhotness/ActionWidget.vue
@@ -33,7 +33,7 @@
 import * as _ from "lodash-es";
 import clsx from "clsx";
 import { Icon, themeClasses, Toggle } from "@si/vue-lib/design-system";
-import { useRoute, useRouter } from "vue-router";
+import { useRoute } from "vue-router";
 import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
 import { ActionId } from "@/api/sdf/dal/action";
 import {
@@ -48,7 +48,6 @@ const props = defineProps<{
   actionId?: ActionId;
 }>();
 
-const router = useRouter();
 const route = useRoute();
 const removeApi = useApi();
 const addApi = useApi();
@@ -70,14 +69,17 @@ const clickHandler = async () => {
       prototypeId: props.actionPrototypeView.id,
     });
     if (newChangeSetId && addApi.ok(req)) {
-      router.push({
-        name: "new-hotness-component",
-        params: {
-          workspacePk: route.params.workspacePk,
-          changeSetId: newChangeSetId,
-          componentId: props.component.id,
+      addApi.navigateToNewChangeSet(
+        {
+          name: "new-hotness-component",
+          params: {
+            workspacePk: route.params.workspacePk,
+            changeSetId: newChangeSetId,
+            componentId: props.component.id,
+          },
         },
-      });
+        newChangeSetId,
+      );
     }
   }
 };

--- a/app/web/src/newhotness/AddComponentModal.vue
+++ b/app/web/src/newhotness/AddComponentModal.vue
@@ -344,16 +344,16 @@ const onEnter = async () => {
   const { req, newChangeSetId } =
     await call.post<componentTypes.CreateComponentPayload>(payload);
   if (api.ok(req)) {
-    const params = {
-      workspacePk: route.params.workspacePk,
-      changeSetId: newChangeSetId || route.params.changeSetId,
-      componentId: req.data.componentId,
-    };
-    router.push({
+    const to = {
       name: "new-hotness-component",
-      params,
-      // TODO querystring for "was i on head?"
-    });
+      params: {
+        workspacePk: route.params.workspacePk,
+        changeSetId: newChangeSetId || route.params.changeSetId,
+        componentId: req.data.componentId,
+      },
+    };
+    if (newChangeSetId) api.navigateToNewChangeSet(to, newChangeSetId);
+    else router.push(to);
   }
 };
 const onUp = () => {

--- a/app/web/src/newhotness/AddViewModal.vue
+++ b/app/web/src/newhotness/AddViewModal.vue
@@ -35,7 +35,7 @@
 <script setup lang="ts">
 import { Modal, Icon } from "@si/vue-lib/design-system";
 import { computed, ref, watch } from "vue";
-import { useRoute, useRouter } from "vue-router";
+import { useRoute } from "vue-router";
 import { View } from "@/workers/types/entity_kind_types";
 import { useApi, routes } from "./api_composables";
 import { useWatchedForm } from "./logic_composables/watched_form";
@@ -49,7 +49,6 @@ const modalRef = ref<InstanceType<typeof Modal>>();
 const api = useApi();
 
 const route = useRoute();
-const router = useRouter();
 
 const wForm = useWatchedForm<{ name: string }>("view.add");
 const formData = computed<{ name: string }>(() => {
@@ -67,13 +66,16 @@ const nameForm = wForm.newForm({
       // right now, we don't want to push people to the new view
       // because they won't see components, and won't be able to add any to the view
       if (newChangeSetId) {
-        router.push({
-          name: "new-hotness-view",
-          params: {
-            workspacePk: route.params.workspacePk,
-            changeSetId: newChangeSetId,
+        api.navigateToNewChangeSet(
+          {
+            name: "new-hotness-view",
+            params: {
+              workspacePk: route.params.workspacePk,
+              changeSetId: newChangeSetId,
+            },
           },
-        });
+          newChangeSetId,
+        );
       }
       watch(
         () => wForm.bifrosting,

--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -88,7 +88,7 @@
 <script lang="ts" setup>
 import { computed, reactive, ref, watch } from "vue";
 import { Fzf } from "fzf";
-import { useRoute, useRouter } from "vue-router";
+import { useRoute } from "vue-router";
 import { SiSearch, themeClasses, VButton } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { useQuery } from "@tanstack/vue-query";
@@ -264,14 +264,17 @@ const secretForm = wForm.newForm({
     const { req, newChangeSetId } =
       await newSecret.post<componentTypes.CreateSecret>(payload);
     if (secretApi.ok(req) && newChangeSetId) {
-      router.push({
-        name: "new-hotness-component",
-        params: {
-          workspacePk: route.params.workspacePk,
-          changeSetId: newChangeSetId,
-          componentId: props.component.id,
+      secretApi.navigateToNewChangeSet(
+        {
+          name: "new-hotness-component",
+          params: {
+            workspacePk: route.params.workspacePk,
+            changeSetId: newChangeSetId,
+            componentId: props.component.id,
+          },
         },
-      });
+        newChangeSetId,
+      );
     }
   },
   validators: {
@@ -397,7 +400,6 @@ const save = async (
   await call.put<componentTypes.UpdateComponentAttributesArgs>(payload);
 };
 
-const router = useRouter();
 const route = useRoute();
 const remove = async (path: string, _id: string) => {
   const call = api.endpoint<{ success: boolean }>(
@@ -410,14 +412,17 @@ const remove = async (path: string, _id: string) => {
   const { req, newChangeSetId } =
     await call.put<componentTypes.UpdateComponentAttributesArgs>(payload);
   if (newChangeSetId && api.ok(req)) {
-    router.push({
-      name: "new-hotness-component",
-      params: {
-        workspacePk: route.params.workspacePk,
-        changeSetId: newChangeSetId,
-        componentId: props.component.id,
+    api.navigateToNewChangeSet(
+      {
+        name: "new-hotness-component",
+        params: {
+          workspacePk: route.params.workspacePk,
+          changeSetId: newChangeSetId,
+          componentId: props.component.id,
+        },
       },
-    });
+      newChangeSetId,
+    );
   }
 };
 

--- a/app/web/src/newhotness/Component.vue
+++ b/app/web/src/newhotness/Component.vue
@@ -323,14 +323,17 @@ const nameForm = wForm.newForm({
           name,
         });
       if (newChangeSetId && api.ok(req)) {
-        router.push({
-          name: "new-hotness-component",
-          params: {
-            workspacePk: route.params.workspacePk,
-            changeSetId: newChangeSetId,
-            componentId: props.componentId,
+        api.navigateToNewChangeSet(
+          {
+            name: "new-hotness-component",
+            params: {
+              workspacePk: route.params.workspacePk,
+              changeSetId: newChangeSetId,
+              componentId: props.componentId,
+            },
           },
-        });
+          newChangeSetId,
+        );
       }
     }
   },

--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -131,7 +131,7 @@ export class APICall<Response> {
   async put<D = Record<string, unknown>>(data: D, params?: URLSearchParams) {
     this.obs.inFlight.value = true;
     this.obs.bifrosting.value = true;
-    rainbow.add(this.obs.label);
+    rainbow.add(this.ctx.changeSetId.value, this.obs.label);
     if (this.obs.isWatched) this.obs.span = tracer.startSpan("watchedApi");
     let newChangeSetId;
     if (!this.canMutateHead && this.ctx.onHead.value) {
@@ -151,7 +151,7 @@ export class APICall<Response> {
   async post<D = Record<string, unknown>>(data: D, params?: URLSearchParams) {
     this.obs.inFlight.value = true;
     this.obs.bifrosting.value = true;
-    rainbow.add(this.obs.label);
+    rainbow.add(this.ctx.changeSetId.value, this.obs.label);
     if (this.obs.isWatched) this.obs.span = tracer.startSpan("watchedApi");
     let newChangeSetId;
     if (!this.canMutateHead && this.ctx.onHead.value) {
@@ -219,7 +219,7 @@ export const useApi = () => {
       fn,
       () => {
         labeledObs.bifrosting.value = false;
-        rainbow.remove(labeledObs.label);
+        rainbow.remove(ctx.changeSetId.value, labeledObs.label);
         if (labeledObs.span) labeledObs.span.end();
       },
       { once: true },

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -93,7 +93,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { VButton, IconButton, Icon } from "@si/vue-lib/design-system";
-import { useRoute, useRouter } from "vue-router";
+import { useRoute } from "vue-router";
 import clsx from "clsx";
 import { BifrostComponent } from "@/workers/types/entity_kind_types";
 import AttributeChildLayout from "./AttributeChildLayout.vue";
@@ -164,18 +164,20 @@ const add = async () => {
   const { req, newChangeSetId } =
     await call.put<componentTypes.UpdateComponentAttributesArgs>(payload);
   if (addApi.ok(req) && newChangeSetId) {
-    router.push({
-      name: "new-hotness-component",
-      params: {
-        workspacePk: route.params.workspacePk,
-        changeSetId: newChangeSetId,
-        componentId: props.component.id,
+    addApi.navigateToNewChangeSet(
+      {
+        name: "new-hotness-component",
+        params: {
+          workspacePk: route.params.workspacePk,
+          changeSetId: newChangeSetId,
+          componentId: props.component.id,
+        },
       },
-    });
+      newChangeSetId,
+    );
   }
 };
 
-const router = useRouter();
 const route = useRoute();
 const showKey = ref(false);
 const wForm = useWatchedForm<{ key: string }>(
@@ -199,14 +201,17 @@ const keyForm = wForm.newForm({
     const { req, newChangeSetId } =
       await call.put<componentTypes.UpdateComponentAttributesArgs>(payload);
     if (newChangeSetId && keyApi.ok(req)) {
-      router.push({
-        name: "new-hotness-component",
-        params: {
-          workspacePk: route.params.workspacePk,
-          changeSetId: newChangeSetId,
-          componentId: props.component.id,
+      keyApi.navigateToNewChangeSet(
+        {
+          name: "new-hotness-component",
+          params: {
+            workspacePk: route.params.workspacePk,
+            changeSetId: newChangeSetId,
+            componentId: props.component.id,
+          },
         },
-      });
+        newChangeSetId,
+      );
     }
   },
 });

--- a/app/web/src/newhotness/logic_composables/rainbow_counter.ts
+++ b/app/web/src/newhotness/logic_composables/rainbow_counter.ts
@@ -1,12 +1,29 @@
-import { computed, reactive } from "vue";
+import { computed, inject, reactive } from "vue";
+import { DefaultMap } from "@/utils/defaultmap";
+import { assertIsDefined, Context } from "../types";
 
-const queue = reactive(new Set<string>());
+const q = new DefaultMap<string, Set<string>>(() => new Set<string>());
+const queueByChangeSet = reactive(q);
 
-/**
- * This is a global "stuff is happening" counter
- * When its > 0 the system is waiting for data
- */
-export const rainbowCount = computed(() => queue.size);
+export const add = (changeSetId: string, desc: string) => {
+  const queue = queueByChangeSet.get(changeSetId);
+  if (queue) queue.add(desc);
+};
 
-export const add = (desc: string) => queue.add(desc);
-export const remove = (desc: string) => queue.delete(desc);
+export const remove = (changeSetId: string, desc: string) => {
+  const queue = queueByChangeSet.get(changeSetId);
+  if (queue) queue.delete(desc);
+};
+
+export const useRainbow = () => {
+  const ctx = inject<Context>("CONTEXT");
+  assertIsDefined(ctx);
+
+  const queue = queueByChangeSet.get(ctx.changeSetId.value);
+
+  /**
+   * This is a global "stuff is happening" counter
+   * When its > 0 the system is waiting for data
+   */
+  return { rainbowCount: computed(() => queue?.size ?? 0) };
+};

--- a/app/web/src/newhotness/logic_composables/watched_form.ts
+++ b/app/web/src/newhotness/logic_composables/watched_form.ts
@@ -92,7 +92,7 @@ export const useWatchedForm = <Data>(label: string) => {
         start = Date.now();
         onSubmit(props);
         bifrosting.value = true;
-        rainbow.add(label);
+        rainbow.add(ctx.changeSetId.value, label);
       },
       validators,
     });
@@ -110,7 +110,7 @@ export const useWatchedForm = <Data>(label: string) => {
     if (watchFn) {
       watch(watchFn, () => {
         bifrosting.value = false;
-        rainbow.remove(label);
+        rainbow.remove(ctx.changeSetId.value, label);
         const end = Date.now();
         observe(end - start);
         wForm.reset(unref(data));
@@ -118,7 +118,7 @@ export const useWatchedForm = <Data>(label: string) => {
     } else {
       watch(data, () => {
         bifrosting.value = false;
-        rainbow.remove(label);
+        rainbow.remove(ctx.changeSetId.value, label);
         const end = Date.now();
         observe(end - start);
         wForm.reset(unref(data));

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -212,6 +212,11 @@ export const useMakeArgs = () => {
   };
 };
 
+export const changeSetExists = async (
+  workspaceId: string,
+  changeSetId: string,
+) => await db.changeSetExists(workspaceId, changeSetId);
+
 export const useMakeKey = () => {
   const ctx: Context | undefined = inject("CONTEXT");
 

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -60,14 +60,12 @@ const db: Comlink.Remote<DBInterface> = Comlink.wrap(worker);
 db.addListenerBustCache(Comlink.proxy(bustTanStackCache));
 
 const inFlight = (changeSetId: ChangeSetId, label: string) => {
-  const ctx: Context | undefined = inject("CONTEXT");
-  if (ctx?.changeSetId.value === changeSetId) rainbow.add(label);
+  rainbow.add(changeSetId, label);
 };
 db.addListenerInFlight(Comlink.proxy(inFlight));
 
 const returned = (changeSetId: ChangeSetId, label: string) => {
-  const ctx: Context | undefined = inject("CONTEXT");
-  if (ctx?.changeSetId.value === changeSetId) rainbow.remove(label);
+  rainbow.remove(changeSetId, label);
 };
 db.addListenerReturned(Comlink.proxy(returned));
 


### PR DESCRIPTION
Add-on: fix the inject warnings from the counter I added.

I am seeing more "create MTM" failures with this approach because MTM linking exists while patch info comes over the wire. Notably the patch info is sending `fromChecksum=0`on a component that _absolutely exists_ on HEAD. There's no way it should be "from zero" indicating we need to create it.

I believe the in-flight work will fix that problem... but we need to check.