### PR TITLE
feat: Set custom funcs on prop to prop connections

### DIFF
--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -329,7 +329,20 @@ type EventBusEvents = {
 //         }
 //       }
 //
-//   You may also APPEND a subscription by adding `keepExistingSubscriptions: true` to the
+//
+//      You may specify a function ID to be used in subscription, to transform the value before setting
+//      it to the destination AV.
+//
+//      If no func argument is passed, the func will be si:Identity.
+//
+//       {
+//         "/domain/SubnetId": {
+//           "$source": { "component": "ComponentNameOrId", "path": "/resource/SubnetId", "func": "01JWBMRZAANBHKD2G2S5PZQTMA" }
+//         }
+//       }
+//
+//
+//   SOON TO BE DEPRECATED: You may also APPEND a subscription by adding `keepExistingSubscriptions: true` to the
 //   subscription:
 //
 //       {
@@ -369,6 +382,7 @@ type AttributeSourceSetSubscription = {
     component: ComponentId | ComponentName;
     path: AttributePath;
     keepExistingSubscriptions?: boolean;
+    func?: string;
   };
 };
 const isAttributeSourceSetSubscription = (

--- a/lib/dal-test/src/helpers/attribute/value.rs
+++ b/lib/dal-test/src/helpers/attribute/value.rs
@@ -11,6 +11,7 @@ use dal::{
 use si_id::{
     AttributeValueId,
     ComponentId,
+    FuncId,
 };
 
 use crate::{
@@ -153,14 +154,26 @@ pub async fn subscribe<S: AttributeValueKey>(
     subscriber: impl AttributeValueKey,
     subscriptions: impl IntoIterator<Item = S>,
 ) -> Result<()> {
+    subscribe_with_custom_function(ctx, subscriber, subscriptions, None).await
+}
+
+/// Set the subscriptions on a value
+pub async fn subscribe_with_custom_function<S: AttributeValueKey>(
+    ctx: &DalContext,
+    subscriber: impl AttributeValueKey,
+    subscriptions: impl IntoIterator<Item = S>,
+    func_id: Option<FuncId>,
+) -> Result<()> {
     let subscriber = subscriber.vivify_attribute_value(ctx).await?;
     let mut converted_subscriptions = vec![];
     for subscription in subscriptions {
         converted_subscriptions.push(subscription.to_subscription(ctx).await?);
     }
-    AttributeValue::set_to_subscriptions(ctx, subscriber, converted_subscriptions).await?;
+    AttributeValue::set_to_subscriptions(ctx, subscriber, converted_subscriptions, func_id).await?;
     Ok(())
 }
+
+// TODO add a helper to change subscription funcs easily
 
 /// Get the value
 pub async fn get(ctx: &DalContext, av: impl AttributeValueKey) -> Result<serde_json::Value> {

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -2271,29 +2271,35 @@ impl AttributeValue {
         ctx: &DalContext,
         subscriber_av_id: AttributeValueId,
         subscriptions: Vec<ValueSubscription>,
+        func_id: Option<FuncId>,
     ) -> AttributeValueResult<()> {
-        // Pick the prototype for the function based on prop type: if it's Array, use
-        // si:normalizeToArray, otherwise use si:identity
-        let func = match Self::prop(ctx, subscriber_av_id).await?.kind {
-            PropKind::Array => IntrinsicFunc::NormalizeToArray,
-            kind @ PropKind::Boolean
-            | kind @ PropKind::Integer
-            | kind @ PropKind::Json
-            | kind @ PropKind::Map
-            | kind @ PropKind::Object
-            | kind @ PropKind::String
-            | kind @ PropKind::Float => {
-                if subscriptions.len() != 1 {
-                    return Err(AttributeValueError::SingleValueMustHaveOneSubscription(
-                        subscriber_av_id,
-                        kind,
-                        subscriptions.len(),
-                    ));
+        let func_id = if let Some(id) = func_id {
+            id
+        } else {
+            // Pick the prototype for the function based on prop type: if it's Array, use
+            // si:normalizeToArray, otherwise use si:identity
+            let intrinsic_func = match Self::prop(ctx, subscriber_av_id).await?.kind {
+                PropKind::Array => IntrinsicFunc::NormalizeToArray,
+                kind @ PropKind::Boolean
+                | kind @ PropKind::Integer
+                | kind @ PropKind::Json
+                | kind @ PropKind::Map
+                | kind @ PropKind::Object
+                | kind @ PropKind::String
+                | kind @ PropKind::Float => {
+                    if subscriptions.len() != 1 {
+                        return Err(AttributeValueError::SingleValueMustHaveOneSubscription(
+                            subscriber_av_id,
+                            kind,
+                            subscriptions.len(),
+                        ));
+                    }
+                    IntrinsicFunc::Identity
                 }
-                IntrinsicFunc::Identity
-            }
+            };
+            Func::find_intrinsic(ctx, intrinsic_func).await?
         };
-        let func_id = Func::find_intrinsic(ctx, func).await?;
+
         let prototype_id = AttributePrototype::new(ctx, func_id).await?.id();
         Self::set_component_prototype_id(ctx, subscriber_av_id, prototype_id, None).await?;
 

--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -211,10 +211,29 @@ impl FuncAuthoringClient {
             ctx,
             name,
             eventual_parent,
-            output_location,
+            Some(output_location),
             argument_bindings,
         )
         .await?;
+
+        Ok(func)
+    }
+
+    /// Creates a transformation func and returns it.
+    /// A transformation func is an attribute func with a single argument,
+    /// meant to be used for prop to prop connections.
+    #[instrument(
+        name = "func.authoring.create_new_transformation_func",
+        level = "info",
+        skip(ctx)
+    )]
+    pub async fn create_new_transformation_func(
+        ctx: &DalContext,
+        name: Option<String>,
+    ) -> FuncAuthoringResult<Func> {
+        let func = create::create_attribute_func(ctx, name, None, None, vec![]).await?;
+
+        Self::create_func_argument(ctx, func.id, "input", FuncArgumentKind::Any, None).await?;
 
         Ok(func)
     }

--- a/lib/dal/src/func/authoring/create.rs
+++ b/lib/dal/src/func/authoring/create.rs
@@ -158,7 +158,7 @@ pub(crate) async fn create_attribute_func(
     ctx: &DalContext,
     name: Option<String>,
     eventual_parent: Option<EventualParent>,
-    output_location: AttributeFuncDestination,
+    output_location: Option<AttributeFuncDestination>,
     argument_bindings: Vec<AttributeArgumentBinding>,
 ) -> FuncAuthoringResult<Func> {
     let (code, handler, backend_kind, backend_response_type) = (
@@ -178,14 +178,16 @@ pub(crate) async fn create_attribute_func(
     )
     .await?;
 
-    AttributeBinding::upsert_attribute_binding(
-        ctx,
-        func.id,
-        eventual_parent,
-        output_location,
-        argument_bindings,
-    )
-    .await?;
+    if let Some(output_location) = output_location {
+        AttributeBinding::upsert_attribute_binding(
+            ctx,
+            func.id,
+            eventual_parent,
+            output_location,
+            argument_bindings,
+        )
+        .await?;
+    }
 
     Ok(func)
 }

--- a/lib/sdf-server/src/service/v2/component.rs
+++ b/lib/sdf-server/src/service/v2/component.rs
@@ -9,6 +9,7 @@ use axum::{
 use dal::{
     AttributeValueId,
     KeyPairError,
+    func::authoring::FuncAuthoringError,
     prop::PropError,
 };
 use sdf_core::api_error::ApiError;
@@ -38,6 +39,10 @@ pub enum Error {
     Component(#[from] dal::ComponentError),
     #[error("dal secret error: {0}")]
     DalSecret(#[from] dal::SecretError),
+    #[error("func error: {0}")]
+    Func(#[from] dal::FuncError),
+    #[error("func authoring error: {0}")]
+    FuncAuthoring(#[from] FuncAuthoringError),
     #[error("json pointer parse error: {0}")]
     JsonptrParseError(#[from] jsonptr::ParseError),
     #[error("key pair error: {0}")]


### PR DESCRIPTION
- Allow setting a func ID in the subscriptions API
- feature is partly mocked: If a func ID is passed, we use a hardcoded transformation function, since we don't have a consolidated authoring path for those (they're attribute funcs with single argument and no innate bindings)

Validations: 
-  Added an integration test to validate that we could use the attribute funcs for prop to prop connections
- Live tested with direct API calls, values get set on the UI responsively

<img src="https://media1.tenor.com/m/IlgspMyzkQcAAAAd/jake-peralta-youve-changed.gif" />