### PR TITLE
Fix: when switching change sets clear the navigation stack

### DIFF
--- a/app/web/src/components/layout/navbar/ChangeSetPanel.vue
+++ b/app/web/src/components/layout/navbar/ChangeSetPanel.vue
@@ -127,6 +127,7 @@ import {
 import { useChangeSetsStore } from "@/store/change_sets.store";
 import { ChangeSetStatus } from "@/api/sdf/dal/change_set";
 import AbandonChangeSetModal from "@/components/AbandonChangeSetModal.vue";
+import { reset } from "@/newhotness/logic_composables/navigation_stack";
 
 const CHANGE_SET_NAME_REGEX = /^(?!head).*$/i;
 
@@ -198,7 +199,7 @@ const createChangeSetName = ref(changeSetsStore.getGeneratedChangesetName());
 
 const { validationState, validationMethods } = useValidatedInputGroup();
 
-function onSelectChangeSet(newVal: string) {
+async function onSelectChangeSet(newVal: string) {
   if (newVal === "NEW") {
     createModalRef.value?.open();
     return;
@@ -208,7 +209,7 @@ function onSelectChangeSet(newVal: string) {
     // keep everything in the current route except the change set id
     // note - we use push here, so there is a new browser history entry
     const name = route.name;
-    router.push({
+    await router.push({
       name,
       params: {
         ...route.params,
@@ -216,6 +217,7 @@ function onSelectChangeSet(newVal: string) {
       },
       query: route.query,
     });
+    reset();
   }
 }
 

--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -7,6 +7,7 @@ import { changeSetExists } from "@/store/realtime/heimdall";
 import router from "@/router";
 import { assertIsDefined, Context } from "../types";
 import * as rainbow from "../logic_composables/rainbow_counter";
+import { reset } from "../logic_composables/navigation_stack";
 
 export * as componentTypes from "./component";
 export * as funcRunTypes from "./func_run";
@@ -254,7 +255,8 @@ export const useApi = () => {
         retry += 1;
       }, INTERVAL);
     });
-    router.push(to);
+    await router.push(to);
+    reset();
   };
 
   return {

--- a/app/web/src/newhotness/logic_composables/navigation_stack.ts
+++ b/app/web/src/newhotness/logic_composables/navigation_stack.ts
@@ -38,3 +38,7 @@ export const prevPage = () => {
   if (breadcrumbs.length === 1) return undefined; // current page is only page on the stack
   return breadcrumbs[breadcrumbs.length - 2];
 };
+
+export const reset = () => {
+  breadcrumbs.splice(0, Infinity);
+};


### PR DESCRIPTION
Don't follow an in-app "back button" across change sets.

Testing steps:
1. On HEAD
2. Navigate to a component
3. Use change set drop down to switch to a different one
4. Hit back button on component page
5. End up on Explore page *in the change set* (not HEAD)

1. On HEAD
2. Create a new component
3. Makes a new change set
4. Hit back 
5. End up on Explore page *in the change set* (not HEAD)