### PR TITLE
Fix: silly rabbit, bust the cache at the end of all the operations

### DIFF
--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -609,16 +609,6 @@ const handlePatchMessage = async (data: PatchBatch, span?: Span) => {
       }),
   );
 
-  atomsToBust.forEach((atom) => {
-    if (atom)
-      bustCacheAndReferences(
-        atom.workspaceId,
-        atom.changeSetId,
-        atom.kind,
-        atom.id,
-      );
-  });
-
   // connections
   const connAtomsToBust = await Promise.all(
     atoms
@@ -627,15 +617,6 @@ const handlePatchMessage = async (data: PatchBatch, span?: Span) => {
         return await applyPatch(atom, toSnapshotAddress);
       }),
   );
-  connAtomsToBust.forEach((atom) => {
-    if (atom)
-      bustCacheAndReferences(
-        atom.workspaceId,
-        atom.changeSetId,
-        atom.kind,
-        atom.id,
-      );
-  });
 
   // list items
   const listAtomsToBust = await Promise.all(
@@ -646,6 +627,27 @@ const handlePatchMessage = async (data: PatchBatch, span?: Span) => {
       }),
   );
 
+  await updateChangeSetWithNewSnapshot(data.meta);
+  await removeOldSnapshot();
+
+  atomsToBust.forEach((atom) => {
+    if (atom)
+      bustCacheAndReferences(
+        atom.workspaceId,
+        atom.changeSetId,
+        atom.kind,
+        atom.id,
+      );
+  });
+  connAtomsToBust.forEach((atom) => {
+    if (atom)
+      bustCacheAndReferences(
+        atom.workspaceId,
+        atom.changeSetId,
+        atom.kind,
+        atom.id,
+      );
+  });
   listAtomsToBust.forEach((atom) => {
     if (atom)
       bustCacheAndReferences(
@@ -655,9 +657,6 @@ const handlePatchMessage = async (data: PatchBatch, span?: Span) => {
         atom.id,
       );
   });
-
-  await updateChangeSetWithNewSnapshot(data.meta);
-  await removeOldSnapshot();
 };
 
 const applyPatch = async (


### PR DESCRIPTION
Fixes intermittent problems where reads return null

![image](https://github.com/user-attachments/assets/c753a44a-59e4-4b42-bcd6-1864c9de7dc3)
