### PR TITLE
feat: fix markdown rendering in new hotness

### DIFF
--- a/app/web/src/newhotness/DocumentationPanel.vue
+++ b/app/web/src/newhotness/DocumentationPanel.vue
@@ -31,7 +31,7 @@
         >
       </p>
       <p>
-        <VueMarkdown :source="component.schemaVariantDescription ?? ''" />
+        <MarkdownRender :source="component.schemaVariantDescription ?? ''" />
       </p>
     </template>
     <template v-else>
@@ -47,7 +47,7 @@
       <p v-if="docLink">
         <a :href="docLink" target="_blank">{{ component.schemaVariantName }}</a>
       </p>
-      <p>{{ docs }}</p>
+      <MarkdownRender :source="docs" />
     </template>
   </CollapsingFlexItem>
 </template>
@@ -56,9 +56,9 @@
 import { Icon, themeClasses, VButton } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { PropType } from "vue";
-import VueMarkdown from "vue-markdown-render";
 import { BifrostComponent } from "@/workers/types/entity_kind_types";
 import CollapsingFlexItem from "./layout_components/CollapsingFlexItem.vue";
+import MarkdownRender from "./MarkdownRender.vue";
 
 defineProps({
   component: { type: Object as PropType<BifrostComponent>, required: true },

--- a/app/web/src/newhotness/MarkdownRender.vue
+++ b/app/web/src/newhotness/MarkdownRender.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="prose dark:prose-invert">
+    <VueMarkdown
+      :source="props.source"
+      :options="{ breaks: true, linkify: true, typographer: true }"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import VueMarkdown from "vue-markdown-render";
+
+const props = defineProps<{ source: string }>();
+</script>

--- a/lib/vue-lib/package.json
+++ b/lib/vue-lib/package.json
@@ -73,6 +73,7 @@
     "@iconify/json": "^2.2.166",
     "@si/eslint-config": "workspace:*",
     "@si/tsconfig": "workspace:*",
+    "@tailwindcss/typography": "^0.5.16",
     "@types/lodash-es": "^4.17.12",
     "autoprefixer": "^10.4.8",
     "eslint": "^8.57.1",

--- a/lib/vue-lib/src/tailwind/tailwind.config.cjs
+++ b/lib/vue-lib/src/tailwind/tailwind.config.cjs
@@ -4,9 +4,10 @@ const colors = require("tailwindcss/colors");
 const capsizePlugin = require("tailwindcss-capsize");
 const lineClampPlugin = require("@tailwindcss/line-clamp");
 const headlessUiPlugin = require("@headlessui/tailwindcss");
+const typographyPlugin = require("@tailwindcss/typography");
 
 const themeValues = require("./tailwind_customization/tailwind_theme_values.cjs");
-const typographyPlugin = require("./tailwind_customization/typography_plugin.cjs");
+const customTypographyPlugin = require("./tailwind_customization/typography_plugin.cjs");
 const childrenVariantPlugin = require("./tailwind_customization/children_variant_plugin.cjs");
 
 /** @type {import('tailwindcss').Config} */
@@ -89,10 +90,11 @@ module.exports = {
   plugins: [
     capsizePlugin,
     formsPlugin,
-    typographyPlugin,
+    customTypographyPlugin,
     lineClampPlugin,
     childrenVariantPlugin,
     headlessUiPlugin,
+    typographyPlugin,
   ],
   safelist: [
     "text-2xs", // TODO - this can be removed when we use 'text-2xs' somewhere that isn't generated

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -864,6 +864,9 @@ importers:
       '@si/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@tailwindcss/typography':
+        specifier: ^0.5.16
+        version: 0.5.16(tailwindcss@3.2.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.3.36)(@types/node@18.19.59)(typescript@5.0.4)))
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -2993,6 +2996,11 @@ packages:
     resolution: {integrity: sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==}
     peerDependencies:
       tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
+
+  '@tailwindcss/typography@0.5.16':
+    resolution: {integrity: sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
   '@tanstack/form-core@1.9.0':
     resolution: {integrity: sha512-lEXXQdIMW7PcybwnzJ+6VaEC65tWV/ZCgYfR5nC+lApXSlLPN+bp1fJanIclsw5U4dnx3DOxeOy/uzXwJ02wDQ==}
@@ -7967,6 +7975,9 @@ packages:
 
   lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+
+  lodash.castarray@4.4.0:
+    resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -13979,6 +13990,14 @@ snapshots:
 
   '@tailwindcss/line-clamp@0.4.2(tailwindcss@3.2.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.3.36)(@types/node@18.19.59)(typescript@5.0.4)))':
     dependencies:
+      tailwindcss: 3.2.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.3.36)(@types/node@18.19.59)(typescript@5.0.4))
+
+  '@tailwindcss/typography@0.5.16(tailwindcss@3.2.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.3.36)(@types/node@18.19.59)(typescript@5.0.4)))':
+    dependencies:
+      lodash.castarray: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      postcss-selector-parser: 6.0.10
       tailwindcss: 3.2.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.3.36)(@types/node@18.19.59)(typescript@5.0.4))
 
   '@tanstack/form-core@1.9.0':
@@ -20349,6 +20368,8 @@ snapshots:
       p-locate: 6.0.0
 
   lodash-es@4.17.21: {}
+
+  lodash.castarray@4.4.0: {}
 
   lodash.debounce@4.0.8: {}
 


### PR DESCRIPTION
Adds the tailwind prose plugin, so that we can render our markdown in a way that's easily tweakable with tailwind. Adds the MarkdownRender component, which takes the source to render, wraps it in the prose declaration, and passes it off to VueMarkdown.

Future additions would customize the prose styling from within the markdownrender component itself - for now, it's left as-is.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbzd5MG5ycXc1ZWs1Njdyanl3cnNpYXVyc3U0cWdtcWt6OGJtNTRudiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/oveqQA2LxpwYg/giphy.gif"/>