### PR TITLE
fix(web): Hide hidden props from the attributes panel inputs

### DIFF
--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -75,7 +75,7 @@
         </div>
       </AttributeChildLayout>
     </template>
-    <template v-else>
+    <template v-else-if="!props.attributeTree.prop?.hidden">
       <AttributeInput
         :displayName="displayName"
         :attributeValueId="props.attributeTree.attributeValue.id"


### PR DESCRIPTION
Before:
![Screenshot 2025-05-29 at 22 30 31](https://github.com/user-attachments/assets/06d0d9e8-e90f-4a90-8cbd-f5c63b9cd313)

After:
![Screenshot 2025-05-29 at 22 30 13](https://github.com/user-attachments/assets/ec17e2df-c22d-4753-a2fb-cad3cb85c4f6)
