### PR TITLE
feat(web) - newhotness better keyboard controls, UI improvements

### DIFF
--- a/app/web/src/newhotness/Component.vue
+++ b/app/web/src/newhotness/Component.vue
@@ -5,9 +5,9 @@
       This component does not exist on this change set
     </h3>
     <VButton
+      v-tooltip="'Back (Esc)'"
       class="border-0 mr-2em"
       icon="arrow--left"
-      label="Back"
       size="sm"
       tone="shade"
       variant="ghost"
@@ -24,9 +24,9 @@
       "
     >
       <VButton
+        v-tooltip="'Back (Esc)'"
         class="border-0 mr-2em"
         icon="arrow--left"
-        label="Back"
         size="sm"
         tone="shade"
         variant="ghost"
@@ -203,7 +203,7 @@ import {
   IconButton,
   themeClasses,
 } from "@si/vue-lib/design-system";
-import { computed, ref, nextTick } from "vue";
+import { computed, ref, nextTick, onMounted, onBeforeUnmount } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import VueMarkdown from "vue-markdown-render";
 import clsx from "clsx";
@@ -214,7 +214,7 @@ import {
   EntityKind,
 } from "@/workers/types/entity_kind_types";
 import AttributePanel from "./AttributePanel.vue";
-import { attributeEmitter } from "./logic_composables/emitters";
+import { attributeEmitter, keyEmitter } from "./logic_composables/emitters";
 import CollapsingFlexItem from "./layout_components/CollapsingFlexItem.vue";
 import DelayedLoader from "./layout_components/DelayedLoader.vue";
 import EditInPlace from "./layout_components/EditInPlace.vue";
@@ -222,7 +222,6 @@ import { useApi, routes, componentTypes } from "./api_composables";
 import { useWatchedForm } from "./logic_composables/watched_form";
 import QualificationPanel from "./QualificationPanel.vue";
 import ResourcePanel from "./ResourcePanel.vue";
-import { prevPage } from "./logic_composables/navigation_stack";
 import CodePanel from "./CodePanel.vue";
 import DiffPanel from "./DiffPanel.vue";
 import ActionsPanel from "./ActionsPanel.vue";
@@ -292,15 +291,11 @@ const editInPlaceRef = ref<typeof EditInPlace>();
 const router = useRouter();
 
 const back = () => {
-  const last = prevPage();
-  if (last) router.push(last);
-  else {
-    const params = router.currentRoute?.value.params ?? {};
-    router.push({
-      name: "new-hotness",
-      params,
-    });
-  }
+  const params = router.currentRoute?.value.params ?? {};
+  router.push({
+    name: "new-hotness",
+    params,
+  });
 };
 
 const api = useApi();
@@ -399,6 +394,15 @@ const blur = () => {
 // );
 
 // provide("ComponentPageContext", context);
+
+onMounted(() => {
+  keyEmitter.on("Escape", () => {
+    back();
+  });
+});
+onBeforeUnmount(() => {
+  keyEmitter.off("Escape");
+});
 </script>
 
 <style lang="less" scoped>

--- a/app/web/src/newhotness/ComponentGridTile.vue
+++ b/app/web/src/newhotness/ComponentGridTile.vue
@@ -24,7 +24,7 @@
       </h3>
     </header>
     <ol
-      class="[&>li]:p-xs [&>li]:flex [&>li]:flex-row [&>li]:items-center [&>li]:gap-xs [&_.pillcounter]:w-5 [&_.pillcounter]:h-5"
+      class="[&>li]:p-xs [&>li]:flex [&>li]:flex-row [&>li]:items-center [&>li]:gap-xs [&>li]:h-9 [&_.pillcounter]:w-5 [&_.pillcounter]:h-5"
     >
       <li>
         <StatusIndicatorIcon
@@ -45,12 +45,10 @@
         <PillCounter :count="component.diffCount" size="sm" class="ml-auto" />
       </li>
       <li>
-        <StatusIndicatorIcon
-          type="resource"
-          size="sm"
-          :status="component.hasResource ? 'exists' : 'notexists'"
-        />
-        <div>Resource</div>
+        <template v-if="component.hasResource">
+          <StatusIndicatorIcon type="resource" size="sm" status="exists" />
+          <div>Resource</div>
+        </template>
       </li>
       <!-- NOTE: when coming from the Map page we don't have accurate outputCount, hiding this -->
       <template v-if="!props.hideConnections">

--- a/app/web/src/newhotness/Map.vue
+++ b/app/web/src/newhotness/Map.vue
@@ -93,6 +93,7 @@ import {
   ComputedRef,
   inject,
   nextTick,
+  onBeforeUnmount,
   onMounted,
   reactive,
   ref,
@@ -245,31 +246,43 @@ const mouseup = () => {
 const active = computed(() => props.active);
 
 const KEYSTEP = 10;
-keyEmitter.on("ArrowDown", () => {
+const onArrowDown = () => {
   if (!active.value) return;
   pan(0, KEYSTEP);
-});
-keyEmitter.on("ArrowUp", () => {
+};
+const onArrowUp = () => {
   if (!active.value) return;
   pan(0, -KEYSTEP);
-});
-keyEmitter.on("ArrowLeft", () => {
+};
+const onArrowLeft = () => {
   if (!active.value) return;
   pan(-KEYSTEP, 0);
-});
-keyEmitter.on("ArrowRight", () => {
+};
+const onArrowRight = () => {
   if (!active.value) return;
   pan(KEYSTEP, 0);
-});
-keyEmitter.on("Esc", () => {
+};
+const onEscape = () => {
   if (!active.value) return;
   selectedComponent.value = null;
-});
-
+};
 onMounted(() => {
   // if we need to adjust zoom level on load dynamically
   // change it here
   applyZoom();
+
+  keyEmitter.on("ArrowDown", onArrowDown);
+  keyEmitter.on("ArrowUp", onArrowUp);
+  keyEmitter.on("ArrowLeft", onArrowLeft);
+  keyEmitter.on("ArrowRight", onArrowRight);
+  keyEmitter.on("Escape", onEscape);
+});
+onBeforeUnmount(() => {
+  keyEmitter.off("ArrowDown", onArrowDown);
+  keyEmitter.off("ArrowUp", onArrowUp);
+  keyEmitter.off("ArrowLeft", onArrowLeft);
+  keyEmitter.off("ArrowRight", onArrowRight);
+  keyEmitter.off("Escape", onEscape);
 });
 
 const mousemove = (event: MouseEvent) => {

--- a/lib/vue-lib/src/design-system/forms/VormInput.vue
+++ b/lib/vue-lib/src/design-system/forms/VormInput.vue
@@ -870,6 +870,15 @@ function focus() {
   }
 }
 
+function blur() {
+  if (["multi-checkbox", "radio"].includes(props.type)) {
+    const inputEls = wrapperRef?.value?.getElementsByTagName("input");
+    inputEls?.item(0)?.blur();
+  } else {
+    if (inputRef.value?.blur) inputRef.value.blur();
+  }
+}
+
 const error_set = ref<string | null>(null);
 function setError(msg: string) {
   error_set.value = msg;
@@ -877,6 +886,8 @@ function setError(msg: string) {
 
 defineExpose({
   focus,
+  blur,
+  isFocus,
 
   // expose some props for child `VormInputOption` instances to use
   // as these components are tightly coupled and meant to be used together


### PR DESCRIPTION
* Back button keyboard shortcut - Esc
* Revamp the keyboard controls on the Explore page - open a component with just the keyboard by pressing Enter
* Back button bugginess with the history stack, don't use breadcrumbs for that button
* If the domain tree is empty, don't show it
* If a component has no resource, don't show the resource line at all, no red X ever