### PR TITLE
fix(web, dal): various fixes to listing func runs

### DIFF
--- a/app/web/src/newhotness/FuncRunCard.vue
+++ b/app/web/src/newhotness/FuncRunCard.vue
@@ -56,13 +56,12 @@
             {{ funcRun.functionKind }}
           </span>
 
-          <!-- FIXME why is component name empty? -->
-          <span v-if="funcRun.componentId">
-            {{ funcRun.componentName || "Component" }}
+          <span v-if="funcRun.componentId && funcRun.componentName">
+            {{ funcRun.componentName }}
           </span>
 
           <span
-            v-if="funcRun.actionId || true"
+            v-if="funcRun.actionId"
             class="flex items-center text-action-400"
           >
             <Icon name="bolt" size="xs" />

--- a/app/web/src/newhotness/FuncRunList.vue
+++ b/app/web/src/newhotness/FuncRunList.vue
@@ -102,7 +102,7 @@ const {
   isFetching,
   isLoading,
 } = useInfiniteQuery({
-  queryKey: [ctx.changeSetId.value, "paginatedFuncRuns"],
+  queryKey: [ctx.changeSetId, "paginatedFuncRuns"],
   queryFn: async ({
     pageParam = undefined,
   }): Promise<funcRunTypes.GetFuncRunsPaginatedResponse> => {

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -582,6 +582,7 @@ impl FuncRunner {
             };
 
             let component_id = AttributeValue::component_id(ctx, attribute_value_id).await?;
+            let component_name = Component::name_by_id(ctx, component_id).await?;
 
             let func_run_create_time = Utc::now();
             let func_run_inner = FuncRunBuilder::default()
@@ -598,6 +599,7 @@ impl FuncRunner {
                 .function_code_cas_address(code_cas_hash)
                 .attribute_value_id(Some(attribute_value_id))
                 .component_id(Some(component_id))
+                .component_name(Some(component_name))
                 .created_at(func_run_create_time)
                 .updated_at(func_run_create_time)
                 .build()?;
@@ -719,6 +721,7 @@ impl FuncRunner {
             let function_args: CasValue = args.clone().into();
 
             let component_id = AttributeValue::component_id(ctx, attribute_value_id).await?;
+            let component_name = Component::name_by_id(ctx, component_id).await?;
             let before = FuncRunner::before_funcs(ctx, component_id, &func).await?;
 
             let func_run_create_time = Utc::now();
@@ -736,6 +739,7 @@ impl FuncRunner {
                 .function_link(func.link.clone())
                 .attribute_value_id(Some(attribute_value_id))
                 .component_id(Some(component_id))
+                .component_name(Some(component_name))
                 .created_at(func_run_create_time)
                 .updated_at(func_run_create_time);
 


### PR DESCRIPTION
Few fixes: 
1. Need to use the computed change set Id so tanstack knows to refetch functions when switching change sets
2. Only show the Action icon if the function was an action
3. For some reason we weren't recording the component name when executing attribute functions. Now that we are, the component name can be displayed correctly going forward