### PR TITLE
feat(web,sdf): Initial implementation of a lobby for when the change set has gotten out of date and needs to rebuild

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -50,8 +50,13 @@
     <!-- grow the main body to fit all the space in between the nav and the bottom of the browser window
      min-h-0 prevents the main container from being *larger* than the max it can grow, no matter its contents -->
     <main class="grow min-h-0">
-      <!-- more v-ifs for "am i looking at viewId? secretId? or the list of views or list of secrets?"-->
-      <template v-if="componentId">
+      <div v-if="lobby" class="w-[50svh] mx-auto mt-[15svh]">
+        <h1 class="text-center text-2xl">Welcome!</h1>
+        <h2 class="text-center text-xl">Have a seat in our lobby</h2>
+        <h3 class="text-center text-lg">We are loading your workspace now</h3>
+        <Icon class="mx-auto" name="loader" size="full" />
+      </div>
+      <template v-else-if="componentId">
         <ComponentDetail :componentId="componentId" />
       </template>
       <template v-else-if="funcRunId">
@@ -82,6 +87,7 @@ import {
   provide,
   watch,
 } from "vue";
+import { Icon } from "@si/vue-lib/design-system";
 import { useQueryClient } from "@tanstack/vue-query";
 import NavbarPanelLeft from "@/components/layout/navbar/NavbarPanelLeft.vue";
 import NavbarPanelRight from "@/components/layout/navbar/NavbarPanelRight.vue";
@@ -107,6 +113,8 @@ const props = defineProps<{
   funcRunId?: string;
   actionId?: string;
 }>();
+
+const lobby = computed(() => route.name === "new-hotness-lobby");
 
 const authStore = useAuthStore();
 const featureFlagsStore = useFeatureFlagsStore();

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -47,6 +47,11 @@ const routes: RouteRecordRaw[] = [
     component: () => import("@/newhotness/Workspace.vue"),
     children: [
       {
+        name: "new-hotness-lobby",
+        path: "lobby",
+        component: () => import("@/newhotness/Workspace.vue"),
+      },
+      {
         name: "new-hotness-view",
         path: ":viewId/v/edit",
         props: true,

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -32,6 +32,7 @@ export type OutgoingConnections = DefaultMap<
 >;
 
 export type RainbowFn = (changeSetId: ChangeSetId, label: string) => void;
+export type LobbyExitFn = () => void;
 export interface DBInterface {
   initDB: (testing: boolean) => Promise<void>;
   migrate: (testing: boolean) => void;
@@ -77,6 +78,7 @@ export interface DBInterface {
   addListenerBustCache(fn: BustCacheFn): void;
   addListenerInFlight(fn: RainbowFn): void;
   addListenerReturned(fn: RainbowFn): void;
+  addListenerLobbyExit(fn: LobbyExitFn): void;
   atomChecksumsFor(
     changeSetId: ChangeSetId,
   ): Promise<Record<QueryKey, Checksum>>;
@@ -84,7 +86,7 @@ export interface DBInterface {
     workspaceId: string,
     changeSetId: ChangeSetId,
   ): Promise<boolean>;
-  niflheim(workspaceId: string, changeSetId: ChangeSetId): void;
+  niflheim(workspaceId: string, changeSetId: ChangeSetId): Promise<boolean>;
   pruneAtomsForClosedChangeSet(
     workspaceId: WorkspacePk,
     changeSetId: ChangeSetId,


### PR DESCRIPTION
This PR adds an initial "lobby" for users to be sent to if their front end state is stale or otherwise needs rebuilt, as the rebuild time will be dependent on the size of the workspace, we should no longer block on this and instead, detect and handle accordingly. 

Instead of removing the blocking call entirely, I reduced the wait to 4 seconds (down from 30), thinking if the rebuild is fast enough, no reason to send you to the lobby for a split second. 

Todo: I didn't yet account for this in the create change set flow, tackling that in a follow up.