### PR TITLE
feat(sdf): Add inferred connection migration to report

### DIFF
--- a/app/web/src/components/AdminDashboard/MigrateConnections.vue
+++ b/app/web/src/components/AdminDashboard/MigrateConnections.vue
@@ -1,0 +1,67 @@
+<template>
+  <Stack class="p-10 w-full">
+    <h1>Migrate Connections</h1>
+    <LoadStatus :requestStatus="requestStatus">
+      <template #loading>
+        <div class="text-neutral-500">Migrating connections ...</div>
+      </template>
+      <template #error>
+        <div class="text-red-500">
+          Error migrating connections: {{ requestStatus.errorMessage }}
+        </div>
+      </template>
+      <template #success>
+        <div class="flex flex-row gap-xs p-xs w-full">
+          <div>
+            <h2>Migrateable Connections: {{ migrateable.length }}</h2>
+            <div v-for="migration of migrateable" :key="migration.message">
+              {{ migration.message }}
+            </div>
+          </div>
+          <div v-if="unmigrateableBecause.length > 0">
+            <h2>
+              Unmigrateable Connections:
+              {{ unmigrateableBecause.map((migrations) => migrations.length) }}
+            </h2>
+            <div
+              v-for="[because, migrations] in unmigrateableBecause"
+              :key="because"
+            >
+              <h3>{{ because }}: {{ migrations.length }}</h3>
+              <div v-for="migration in migrations" :key="migration.message">
+                {{ migration.message }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+    </LoadStatus>
+  </Stack>
+</template>
+
+<script lang="ts" setup>
+import * as _ from "lodash-es";
+import { computed } from "vue";
+import { Stack, LoadStatus } from "@si/vue-lib/design-system";
+import { useAdminStore } from "@/store/admin.store";
+
+const adminStore = useAdminStore();
+const requestStatus = adminStore.getRequestStatus("MIGRATE_CONNECTIONS");
+const allMigrations = computed(
+  () => adminStore.migrateConnectionsResponse?.migrations ?? [],
+);
+const migrateable = computed(() =>
+  allMigrations.value.filter((migration) => !migration.issue),
+);
+const unmigrateableBecause = computed(() =>
+  _.sortBy(
+    Object.entries(
+      _.groupBy(
+        allMigrations.value.filter((migration) => !!migration.issue),
+        (migration) => migration.issue?.type,
+      ),
+    ),
+    ([_, migrations]) => migrations.length,
+  ).reverse(),
+);
+</script>

--- a/app/web/src/components/AdminDashboard/ValidateSnapshot.vue
+++ b/app/web/src/components/AdminDashboard/ValidateSnapshot.vue
@@ -1,0 +1,50 @@
+<template>
+  <Stack class="p-10 w-full">
+    <h1>Validate Snapshot</h1>
+    <LoadStatus :requestStatus="requestStatus">
+      <template #loading>
+        <div class="text-neutral-500">Validating snapshot ...</div>
+      </template>
+      <template #error>
+        <div class="text-red-500">
+          Error validating snapshot: {{ requestStatus.errorMessage }}
+        </div>
+      </template>
+      <template #success>
+        <div class="flex flex-row gap-xs p-xs w-full">
+          <h2>Validation: {{ allIssues.length }} Issues Found</h2>
+          <div v-for="[issueType, issues] in issuesByType" :key="issueType">
+            <h3>{{ issueType }}: {{ issues.length }}</h3>
+            <div v-for="issue in issues" :key="issue.message">
+              {{ issue.message }}
+            </div>
+          </div>
+        </div>
+      </template>
+    </LoadStatus>
+  </Stack>
+</template>
+
+<script lang="ts" setup>
+import * as _ from "lodash-es";
+import { computed } from "vue";
+import { Stack, LoadStatus } from "@si/vue-lib/design-system";
+import { useAdminStore } from "@/store/admin.store";
+
+const adminStore = useAdminStore();
+const requestStatus = adminStore.getRequestStatus("VALIDATE_SNAPSHOT");
+const allIssues = computed(
+  () => adminStore.validateSnapshotResponse?.issues ?? [],
+);
+const issuesByType = computed(() =>
+  _.sortBy(
+    Object.entries(
+      _.groupBy(
+        adminStore.validateSnapshotResponse?.issues ?? [],
+        (issue) => issue.type,
+      ),
+    ),
+    (migrations) => migrations.length,
+  ).reverse(),
+);
+</script>

--- a/app/web/src/components/AdminDashboard/WorkspaceAdmin.vue
+++ b/app/web/src/components/AdminDashboard/WorkspaceAdmin.vue
@@ -183,6 +183,11 @@ import {
 } from "@/store/admin.store";
 import { WorkspacePk } from "@/store/workspaces.store";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
+import { PanelKind } from "../Workspace/WorkspaceAdminDashboard.vue";
+
+const emit = defineEmits<{
+  showPanel: [PanelKind];
+}>();
 
 const adminStore = useAdminStore();
 
@@ -439,11 +444,14 @@ function migrateConnections(
   changeSetId: ChangeSetId,
 ) {
   adminStore.MIGRATE_CONNECTIONS(workspaceId, changeSetId);
+  emit("showPanel", "migrate-connections");
 }
 
 const validateSnapshotRequestStatus =
   adminStore.getRequestStatus("VALIDATE_SNAPSHOT");
+
 function validateSnapshot(workspaceId: WorkspacePk, changeSetId: ChangeSetId) {
   adminStore.VALIDATE_SNAPSHOT(workspaceId, changeSetId);
+  emit("showPanel", "validate-snapshot");
 }
 </script>

--- a/app/web/src/components/Workspace/WorkspaceAdminDashboard.vue
+++ b/app/web/src/components/Workspace/WorkspaceAdminDashboard.vue
@@ -54,7 +54,7 @@
             />
           </div>
         </Stack>
-        <WorkspaceAdmin />
+        <WorkspaceAdmin @showPanel="showPanel" />
         <Stack class="text-xs font-bold" spacing="none">
           <div class="text-lg pb-2xs">Feature Flags:</div>
           <div
@@ -81,6 +81,8 @@
           </div>
         </Stack>
       </Stack>
+      <ValidateSnapshot v-if="mainPanel === 'validate-snapshot'" />
+      <MigrateConnections v-else-if="mainPanel === 'migrate-connections'" />
     </div>
   </div>
 </template>
@@ -99,6 +101,10 @@ import clsx from "clsx";
 import { useAdminStore } from "@/store/admin.store";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import WorkspaceAdmin from "@/components/AdminDashboard/WorkspaceAdmin.vue";
+import ValidateSnapshot from "@/components/AdminDashboard/ValidateSnapshot.vue";
+import MigrateConnections from "@/components/AdminDashboard/MigrateConnections.vue";
+
+export type PanelKind = "validate-snapshot" | "migrate-connections";
 
 const adminStore = useAdminStore();
 const featureFlagsStore = useFeatureFlagsStore();
@@ -131,4 +137,9 @@ const funcRunId = ref<string | null>(null);
 const featureFlags = computed(() => {
   return featureFlagsStore.allFeatureFlags;
 });
+
+const mainPanel = ref<PanelKind>();
+const showPanel = (panel?: PanelKind) => {
+  mainPanel.value = panel;
+};
 </script>

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -17,6 +17,7 @@ use graph::{
     WorkspaceSnapshotGraph,
     correct_transforms::correct_transforms,
     detector::Update,
+    validator::connections::SocketConnection,
 };
 use node_weight::traits::CorrectTransformsError;
 use petgraph::prelude::*;
@@ -1437,11 +1438,13 @@ impl WorkspaceSnapshot {
     /// Get the connection migrations that are available for this snapshot.
     pub async fn connection_migrations(
         &self,
+        inferred_connections: impl IntoIterator<Item = SocketConnection>,
     ) -> WorkspaceSnapshotResult<Vec<(graph::validator::connections::ConnectionMigration, String)>>
     {
         Ok(
             graph::validator::connections::connection_migrations_with_text(
                 &self.working_copy().await,
+                inferred_connections,
             ),
         )
     }

--- a/lib/sdf-server/src/service/v2/change_set.rs
+++ b/lib/sdf-server/src/service/v2/change_set.rs
@@ -78,6 +78,10 @@ pub enum Error {
     IndexNotFoundAfterFreshBuild(WorkspacePk, ChangeSetId),
     #[error("index not found after rebuild; workspace_pk={0}, change_set_id={1}")]
     IndexNotFoundAfterRebuild(WorkspacePk, ChangeSetId),
+    #[error("inferred connection graph error: {0}")]
+    InferredConnectionGraph(
+        #[from] dal::component::inferred_connection_graph::InferredConnectionGraphError,
+    ),
     #[error("item with checksum not found; workspace_pk={0}, change_set_id={1}, kind={2}")]
     ItemWithChecksumNotFound(WorkspacePk, ChangeSetId, String),
     #[error("latest item not found; workspace_pk={0}, change_set_id={1}, kind={2}")]


### PR DESCRIPTION
This brings inferred connections into the connection migration reporter, and shows the report in the admin dashboard (it is not pretty at all, but it's there).