### PR TITLE
feat(sdf): migrate socket connections

### DIFF
--- a/app/web/src/components/AdminDashboard/MigrateConnections.vue
+++ b/app/web/src/components/AdminDashboard/MigrateConnections.vue
@@ -11,29 +11,46 @@
         </div>
       </template>
       <template #success>
-        <div class="flex flex-row gap-xs p-xs w-full">
-          <div>
-            <h2>Migrateable Connections: {{ migrateable.length }}</h2>
+        <Stack class="flex flex-col gap-xs p-xs w-full font-bold text-xs">
+          <Stack>
+            <div class="text-lg">
+              Migrateable Connections: {{ migrateable.length }}
+            </div>
             <div v-for="migration of migrateable" :key="migration.message">
               {{ migration.message }}
             </div>
-          </div>
-          <div v-if="unmigrateableBecause.length > 0">
-            <h2>
+          </Stack>
+          <Stack v-if="unmigrateableBecause.length > 0">
+            <div class="text-lg">
               Unmigrateable Connections:
-              {{ unmigrateableBecause.map((migrations) => migrations.length) }}
-            </h2>
+              {{
+                unmigrateableBecause
+                  .map(([_, migrations]) => migrations.length)
+                  .reduce((a, b) => a + b, 0)
+              }}
+            </div>
             <div
               v-for="[because, migrations] in unmigrateableBecause"
               :key="because"
             >
-              <h3>{{ because }}: {{ migrations.length }}</h3>
+              <div class="text-lg">{{ because }}: {{ migrations.length }}</div>
               <div v-for="migration in migrations" :key="migration.message">
                 {{ migration.message }}
               </div>
             </div>
-          </div>
-        </div>
+          </Stack>
+          <Stack
+            v-if="alreadyMigrated.length > 0"
+            class="flex flex-row gap-xs p-xs w-full"
+          >
+            <div class="text-lg">
+              Already Migrated Connections: {{ alreadyMigrated.length }}
+            </div>
+            <div v-for="migration of alreadyMigrated" :key="migration.message">
+              {{ migration.message }}
+            </div>
+          </Stack>
+        </Stack>
       </template>
     </LoadStatus>
   </Stack>
@@ -43,25 +60,38 @@
 import * as _ from "lodash-es";
 import { computed } from "vue";
 import { Stack, LoadStatus } from "@si/vue-lib/design-system";
-import { useAdminStore } from "@/store/admin.store";
+import {
+  ConnectionMigration,
+  ConnectionUnmigrateableBecause,
+  useAdminStore,
+} from "@/store/admin.store";
 
 const adminStore = useAdminStore();
 const requestStatus = adminStore.getRequestStatus("MIGRATE_CONNECTIONS");
-const allMigrations = computed(
-  () => adminStore.migrateConnectionsResponse?.migrations ?? [],
+const migrationsByIssue = computed(
+  () =>
+    _.groupBy(
+      adminStore.migrateConnectionsResponse?.migrations ?? [],
+      (migration) => migration.issue?.type ?? "migrateable",
+    ) as Record<
+      ConnectionUnmigrateableBecause["type"] | "migrateable",
+      ConnectionMigration[]
+    >,
 );
-const migrateable = computed(() =>
-  allMigrations.value.filter((migration) => !migration.issue),
+const migrateable = computed(() => migrationsByIssue.value.migrateable ?? []);
+const alreadyMigrated = computed(
+  () => migrationsByIssue.value.destinationPropAlreadyHasValue ?? [],
 );
 const unmigrateableBecause = computed(() =>
   _.sortBy(
-    Object.entries(
-      _.groupBy(
-        allMigrations.value.filter((migration) => !!migration.issue),
-        (migration) => migration.issue?.type,
-      ),
-    ),
+    Object.entries(migrationsByIssue.value),
     ([_, migrations]) => migrations.length,
-  ).reverse(),
+  )
+    .reverse()
+    .filter(
+      ([because, _]) =>
+        because !== "migrateable" &&
+        because !== "destinationPropAlreadyHasValue",
+    ),
 );
 </script>

--- a/app/web/src/components/AdminDashboard/ValidateSnapshot.vue
+++ b/app/web/src/components/AdminDashboard/ValidateSnapshot.vue
@@ -11,10 +11,12 @@
         </div>
       </template>
       <template #success>
-        <div class="flex flex-row gap-xs p-xs w-full">
-          <h2>Validation: {{ allIssues.length }} Issues Found</h2>
+        <div class="flex flex-row gap-xs p-xs w-full text-xs font-bold">
+          <div class="text-lg">
+            Validation: {{ allIssues.length }} Issues Found
+          </div>
           <div v-for="[issueType, issues] in issuesByType" :key="issueType">
-            <h3>{{ issueType }}: {{ issues.length }}</h3>
+            <div class="text-lg">{{ issueType }}: {{ issues.length }}</div>
             <div v-for="issue in issues" :key="issue.message">
               {{ issue.message }}
             </div>

--- a/app/web/src/components/AdminDashboard/WorkspaceAdmin.vue
+++ b/app/web/src/components/AdminDashboard/WorkspaceAdmin.vue
@@ -144,6 +144,16 @@
             "
             >Migrate connections</VButton
           >
+
+          <VButton
+            :requestStatus="migrateConnectionsRequestStatus"
+            @click="
+              migrateConnections(selectedWorkspaceId, selectedChangeSetId, {
+                dryRun: true,
+              })
+            "
+            >Migrate connections (dry run only)</VButton
+          >
         </Stack>
       </Stack>
     </Stack>
@@ -442,8 +452,9 @@ const migrateConnectionsRequestStatus = adminStore.getRequestStatus(
 function migrateConnections(
   workspaceId: WorkspacePk,
   changeSetId: ChangeSetId,
+  options?: { dryRun?: boolean },
 ) {
-  adminStore.MIGRATE_CONNECTIONS(workspaceId, changeSetId);
+  adminStore.MIGRATE_CONNECTIONS(workspaceId, changeSetId, options);
   emit("showPanel", "migrate-connections");
 }
 

--- a/app/web/src/store/admin.store.ts
+++ b/app/web/src/store/admin.store.ts
@@ -185,9 +185,13 @@ export const useAdminStore = () => {
             },
           });
         },
-        async MIGRATE_CONNECTIONS(workspaceId: string, changeSetId: string) {
+        async MIGRATE_CONNECTIONS(
+          workspaceId: string,
+          changeSetId: string,
+          options?: { dryRun?: boolean },
+        ) {
           return new ApiRequest<MigrateConnectionsResponse>({
-            method: "get",
+            method: options?.dryRun ? "get" : "post",
             url: `v2/workspaces/${workspaceId}/change-sets/${changeSetId}/migrate_connections`,
             onSuccess: (response) => {
               this.migrateConnectionsResponse = response;
@@ -269,6 +273,7 @@ export type ConnectionMigration =
       socketConnection: ConnectionMigrationSocketConnection;
       propConnection: ConnectionMigrationPropConnection;
       message: string;
+      migrated: boolean;
     }
   // If there is an issue with an explicit connection, socket and prop connections may be undefined
   // (because we may have identified the connection but been unable to completely build them out).
@@ -278,6 +283,7 @@ export type ConnectionMigration =
       socketConnection?: ConnectionMigrationSocketConnection;
       propConnection?: ConnectionMigrationPropConnection;
       message: string;
+      migrated: boolean;
     }
   // If there is an issue with an inferred connection, socketConnection is still always defined.
   | {
@@ -286,6 +292,7 @@ export type ConnectionMigration =
       socketConnection: ConnectionMigrationSocketConnection;
       propConnection?: ConnectionMigrationPropConnection;
       message: string;
+      migrated: boolean;
     };
 
 export interface ConnectionMigrationSocketConnection {
@@ -304,6 +311,7 @@ export interface ConnectionMigrationPropConnection {
 export type ConnectionUnmigrateableBecause =
   | { type: "connectionPrototypeHasMultipleArgs" }
   | { type: "destinationIsNotInputSocket" }
+  | { type: "destinationPropAlreadyHasValue" }
   | { type: "destinationSocketArgumentNotBoundToProp" }
   | { type: "destinationSocketBoundToPropWithNoValue"; destPropId: PropId }
   | { type: "destinationSocketHasMultipleBindings" }

--- a/lib/sdf-server/src/service/v2/change_set.rs
+++ b/lib/sdf-server/src/service/v2/change_set.rs
@@ -52,12 +52,20 @@ mod validate_snapshot;
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("attribute prototype argument error: {0}")]
+    AttributePrototypeArgument(
+        #[from] dal::attribute::prototype::argument::AttributePrototypeArgumentError,
+    ),
+    #[error("attribute value error: {0}")]
+    AttributeValue(#[from] dal::attribute::value::AttributeValueError),
     #[error("change set error: {0}")]
     ChangeSet(#[from] dal::ChangeSetError),
     #[error("change set apply error: {0}")]
     ChangeSetApply(#[from] dal::ChangeSetApplyError),
     #[error("change set approval error: {0}")]
     ChangeSetApproval(#[from] dal::change_set::approval::ChangeSetApprovalError),
+    #[error("component error: {0}")]
+    Component(#[from] dal::component::ComponentError),
     #[error("dal wrapper error: {0}")]
     DalWrapper(#[from] sdf_core::dal_wrapper::DalWrapperError),
     #[error("dependent value root error: {0}")]
@@ -207,9 +215,10 @@ pub fn change_set_routes(state: AppState) -> Router<AppState> {
                 permissions::Permission::Approve,
             )),
         )
+        .route("/migrate_connections", get(migrate_connections::dry_run))
         .route(
             "/migrate_connections",
-            get(migrate_connections::migrate_connections),
+            post(migrate_connections::migrate_connections),
         )
         .route("/rename", post(rename::rename))
         // Consider how we make it editable again after it's been rejected

--- a/lib/sdf-server/src/service/v2/change_set/migrate_connections.rs
+++ b/lib/sdf-server/src/service/v2/change_set/migrate_connections.rs
@@ -1,8 +1,27 @@
-use axum::Json;
-use dal::workspace_snapshot::graph::validator::connections::{
-    ConnectionMigration,
-    SocketConnection,
+use std::collections::{
+    HashMap,
+    HashSet,
 };
+
+use axum::Json;
+use dal::{
+    AttributeValue,
+    ChangeSet,
+    Component,
+    DalContext,
+    WsEvent,
+    attribute::{
+        path::AttributePath,
+        prototype::argument::AttributePrototypeArgument,
+        value::subscription::ValueSubscription,
+    },
+    workspace_snapshot::graph::validator::connections::{
+        ConnectionMigration,
+        PropConnection,
+        SocketConnection,
+    },
+};
+use sdf_core::force_change_set_response::ForceChangeSetResponse;
 use sdf_extract::change_set::ChangeSetDalContext;
 
 use super::Result;
@@ -19,11 +38,70 @@ pub struct ConnectionMigrationWithMessage {
     #[serde(flatten)]
     pub migration: ConnectionMigration,
     pub message: String,
+    pub migrated: bool,
 }
 
+// Migrates all connections, and reports the unmigrateable ones as well.
 pub async fn migrate_connections(
     ChangeSetDalContext(ref mut ctx): ChangeSetDalContext,
-) -> Result<Json<Response>> {
+) -> Result<ForceChangeSetResponse<Response>> {
+    let force_change_set_id = ChangeSet::force_new(ctx).await?;
+
+    // Migrate
+    let mut migrations = get_connection_migrations(ctx).await?;
+    for migration in &mut migrations {
+        migration.migrated = migrate_connection(ctx, &migration.migration).await?;
+    }
+
+    // Send WsEvents for components we migrated
+    let mut components = HashSet::new();
+    for migration in &migrations {
+        if !migration.migrated {
+            continue;
+        }
+        let Some(ref socket_connection) = migration.migration.socket_connection else {
+            continue;
+        };
+
+        if components.insert(socket_connection.destination.0) {
+            let component = Component::get_by_id(ctx, socket_connection.destination.0).await?;
+
+            let mut socket_map = HashMap::new();
+            let payload = component
+                .into_frontend_type(
+                    ctx,
+                    None,
+                    component.change_status(ctx).await?,
+                    &mut socket_map,
+                )
+                .await?;
+            WsEvent::component_updated(ctx, payload)
+                .await?
+                .publish_on_commit(ctx)
+                .await?;
+        }
+    }
+
+    ctx.commit().await?;
+
+    Ok(ForceChangeSetResponse::new(
+        force_change_set_id,
+        Response { migrations },
+    ))
+}
+
+/// Does the migrations, but doesn't commit them--just lets you see what would have happened.
+pub async fn dry_run(ChangeSetDalContext(ref ctx): ChangeSetDalContext) -> Result<Json<Response>> {
+    let migrations = get_connection_migrations(ctx).await?;
+    for migration in &migrations {
+        migrate_connection(ctx, &migration.migration).await?;
+    }
+    Ok(Json(Response { migrations }))
+}
+
+async fn get_connection_migrations(
+    ctx: &DalContext,
+) -> Result<Vec<ConnectionMigrationWithMessage>> {
     let snapshot = ctx.workspace_snapshot()?.as_legacy_snapshot()?;
 
     let inferred_connections = snapshot
@@ -40,12 +118,69 @@ pub async fn migrate_connections(
             ),
         });
 
-    let migrations = snapshot
+    Ok(snapshot
         .connection_migrations(inferred_connections)
         .await?
         .into_iter()
-        .map(|(migration, message)| ConnectionMigrationWithMessage { migration, message })
-        .collect();
+        .map(|(migration, message)| ConnectionMigrationWithMessage {
+            migration,
+            message,
+            migrated: false,
+        })
+        .collect())
+}
 
-    Ok(Json(Response { migrations }))
+// Returns true if migrated, false if we didn't migrate
+async fn migrate_connection(ctx: &DalContext, migration: &ConnectionMigration) -> Result<bool> {
+    // Make sure it's migrateable (no issues and has all the data we need)
+    let &ConnectionMigration {
+        issue: None,
+        explicit_connection_id,
+        prop_connection:
+            Some(PropConnection {
+                dest_av_id,
+                source_root_av_id,
+                ref source_path,
+                func_id,
+                func_arg_id: _, // TODO handle funcs with multiple args but only get passed one
+            }),
+        socket_connection:
+            Some(SocketConnection {
+                source: (from_component_id, from_socket_id),
+                destination: (to_component_id, to_socket_id),
+            }),
+    } = migration
+    else {
+        return Ok(false);
+    };
+
+    // Add the prop connection
+    AttributeValue::set_to_subscriptions(
+        ctx,
+        dest_av_id,
+        vec![ValueSubscription {
+            attribute_value_id: source_root_av_id,
+            path: AttributePath::from_json_pointer(source_path.to_string()),
+        }],
+        Some(func_id),
+    )
+    .await?;
+
+    // Remove the existing socket connection (unless it was inferred, in which case there isn't one)
+    if let Some(explicit_connection_id) = explicit_connection_id {
+        AttributePrototypeArgument::remove(ctx, explicit_connection_id).await?;
+        // Send the WsEvent
+        WsEvent::connection_deleted(
+            ctx,
+            from_component_id,
+            to_component_id,
+            from_socket_id,
+            to_socket_id,
+        )
+        .await?
+        .publish_on_commit(ctx)
+        .await?;
+    };
+
+    Ok(true)
 }


### PR DESCRIPTION
This flips the socket connection migration endpoint to actually perform the migration. In this PR:

* Adds POST endpoint that does the migration: forces changeset, removes socket connections, creates equivalent prop connections and sends WsEvents, then returns a report of what was migrated and what was not
* Anything that *can* be migrated, *will* (even if there were some we couldn't)
* Only does this for migrateable connections where it is safe--where we didn't detect an issue
* Displays already-migrated inferred connections as "already has a value" so they don't continuously get re-migrated
* Adds a "Dry Run" button with a GET request that tells you what would have been migrated, without migrating
* Groups the displayed issues better and makes them a tiny bit easier on the eyes (still not great though)

## What's Left

This gets us around 80-90% of sockets on our prod workspace and one of the other bigger ones. To get the last 10-20%, next we will want to:

- handle array sockets with multiple connections by creating array elements (gets us to 90-95%)
- figure out what to do with IAM double-transforming connections (gets us to 99%)