### PR TITLE
fix(sdf,web):Decrease risk of race condition, handle removed nodes, and reactive func runs

### DIFF
--- a/app/web/src/newhotness/FuncRunList.vue
+++ b/app/web/src/newhotness/FuncRunList.vue
@@ -165,13 +165,14 @@ let executionKey: string | undefined;
 
 // Set up subscription on mount
 onMounted(async () => {
-  realtimeStore.subscribe("paginatedFuncRuns", `changeset/${ctx.changeSetId}`, [
+  executionKey = "paginatedFuncRuns";
+  realtimeStore.subscribe(executionKey, `changeset/${ctx.changeSetId.value}`, [
     {
       eventType: "FuncRunLogUpdated",
       callback: async (payload) => {
         if (payload.funcRunId) {
           queryClient.invalidateQueries({
-            queryKey: [ctx.changeSetId.value, "paginatedFuncRuns"],
+            queryKey: [ctx.changeSetId, "paginatedFuncRuns"],
           });
         }
       },
@@ -182,7 +183,7 @@ onMounted(async () => {
 // Clean up on unmount
 onBeforeUnmount(() => {
   if (executionKey) {
-    // realtimeStore.unsubscribe(executionKey);
+    realtimeStore.unsubscribe(executionKey);
     executionKey = undefined;
   }
 });

--- a/lib/sdf-server/src/service/v2/index.rs
+++ b/lib/sdf-server/src/service/v2/index.rs
@@ -93,7 +93,7 @@ pub fn v2_change_set_routes() -> Router<AppState> {
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct FrontEndObjectMeta {
-    workspace_snapshot_address: WorkspaceSnapshotAddress,
+    workspace_snapshot_address: String,
     front_end_object: FrontendObject,
 }
 

--- a/lib/sdf-server/src/service/v2/index/get_change_set_index.rs
+++ b/lib/sdf-server/src/service/v2/index/get_change_set_index.rs
@@ -63,7 +63,7 @@ pub async fn get_change_set_index(
     Ok((
         StatusCode::OK,
         Json(Some(FrontEndObjectMeta {
-            workspace_snapshot_address: change_set.workspace_snapshot_address,
+            workspace_snapshot_address: index.clone().id,
             front_end_object: index,
         })),
     ))


### PR DESCRIPTION
This doesn't solve it completely, but by returning the current index's snapshot address, we *slightly* reduce the risk that the front end has a newer snapshot than the patches it is receiving.  I tend to see `Ragnarok` a bit less with this, but more work is needed. 

When nodes are removed, we try to look up the previous object in Frigg to get the last checksum. This was causing patches with deletes to not land as the `fromChecksum` was incorrect.  

Func Run list is now reactive to Func Runs in the grid view!

<div><img src="https://media4.giphy.com/media/YYht2UTV41u1vxHTss/200w.gif?cid=5a38a5a2xqmfi0cz9dmn5ucg5y593n7kexpjrk4m8edghd6s&amp;ep=v1_gifs_search&amp;rid=200w.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/tennistv/">Tennis TV</a> on <a href="https://giphy.com/gifs/tennistv-tennis-rublev-andrey-rubleb-YYht2UTV41u1vxHTss">GIPHY</a></div>