### PR TITLE
build(deps): upgrade to NATS server 2.11.4

### DIFF
--- a/component/nats/BUCK
+++ b/component/nats/BUCK
@@ -9,7 +9,7 @@ docker_image(
         "nats-server.conf": "component/nats",
     },
     build_args = {
-        "BASE_VERSION": "2.10.26",
+        "BASE_VERSION": "2.11.4",
     },
     run_docker_args = [
         "--publish",


### PR DESCRIPTION
Update to track environment deployments.

See: https://github.com/nats-io/nats-server/releases/tag/v2.11.4