### PR TITLE
Cannot use snapshot addresses as markers. Using the checksum of the indexMV instead.

### DIFF
--- a/app/web/src/newhotness/FuncRunList.vue
+++ b/app/web/src/newhotness/FuncRunList.vue
@@ -165,13 +165,14 @@ let executionKey: string | undefined;
 
 // Set up subscription on mount
 onMounted(async () => {
-  realtimeStore.subscribe("paginatedFuncRuns", `changeset/${ctx.changeSetId}`, [
+  executionKey = "paginatedFuncRuns";
+  realtimeStore.subscribe(executionKey, `changeset/${ctx.changeSetId.value}`, [
     {
       eventType: "FuncRunLogUpdated",
       callback: async (payload) => {
         if (payload.funcRunId) {
           queryClient.invalidateQueries({
-            queryKey: [ctx.changeSetId.value, "paginatedFuncRuns"],
+            queryKey: [ctx.changeSetId, "paginatedFuncRuns"],
           });
         }
       },
@@ -182,7 +183,7 @@ onMounted(async () => {
 // Clean up on unmount
 onBeforeUnmount(() => {
   if (executionKey) {
-    // realtimeStore.unsubscribe(executionKey);
+    realtimeStore.unsubscribe(executionKey);
     executionKey = undefined;
   }
 });

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -202,7 +202,7 @@ export const niflheim = async (
           changeSetId,
         },
       });
-    }
+    } else return true;
   }
 };
 

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -117,21 +117,21 @@ export interface DBInterface {
 export class Ragnarok extends Error {
   workspaceId: string;
   changeSetId: string;
-  fromSnapshotAddress: string | undefined;
-  snapshotFromAddress: string | undefined;
+  fromChecksumExpected: string | undefined;
+  currentChecksum: string | undefined;
 
   constructor(
     message: string,
     workspaceId: string,
     changeSetId: string,
-    fromSnapshotAddress: string | undefined,
-    snapshotFromAddress: string | undefined,
+    fromChecksumExpected: string | undefined,
+    currentChecksum: string | undefined,
   ) {
     super(message);
     this.workspaceId = workspaceId;
     this.changeSetId = changeSetId;
-    this.fromSnapshotAddress = fromSnapshotAddress;
-    this.snapshotFromAddress = snapshotFromAddress;
+    this.fromChecksumExpected = fromChecksumExpected;
+    this.currentChecksum = currentChecksum;
   }
 }
 
@@ -174,8 +174,8 @@ export interface AtomOperation extends AbstractAtom {
 export interface AtomMeta {
   workspaceId: WorkspacePk;
   changeSetId: ChangeSetId;
-  snapshotFromAddress?: Checksum;
-  snapshotToAddress: Checksum;
+  fromIndexChecksum: Checksum;
+  toIndexChecksum: Checksum;
 }
 
 export enum MessageKind {
@@ -199,6 +199,7 @@ export interface AtomMessage {
 export interface IndexUpdate {
   kind: MessageKind.INDEXUPDATE;
   meta: AtomMeta;
+  indexChecksum: string;
 }
 
 export interface Atom extends AbstractAtom, AtomMeta {
@@ -219,6 +220,7 @@ export interface IndexObject extends Common {
 export interface IndexObjectMeta {
   workspaceSnapshotAddress: string;
   frontEndObject: IndexObject;
+  indexChecksum: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/frigg/src/lib.rs
+++ b/lib/frigg/src/lib.rs
@@ -277,6 +277,7 @@ impl FriggStore {
             index_object_key: index_object_key.into_string(),
             snapshot_address: object.id.to_owned(),
             definition_checksum: materialized_view_definitions_checksum(),
+            index_checksum: object.checksum.to_owned(),
         };
         let value = serde_json::to_vec(&index_pointer_value).map_err(Error::Serialize)?;
         let new_revision = self.store.create(index_pointer_key, value.into()).await?;
@@ -339,6 +340,7 @@ impl FriggStore {
             index_object_key: index_object_key.into_string(),
             snapshot_address: object.id.to_owned(),
             definition_checksum: materialized_view_definitions_checksum(),
+            index_checksum: object.checksum.to_owned(),
         };
         let value = serde_json::to_vec(&index_pointer_value).map_err(Error::Serialize)?;
 
@@ -378,6 +380,7 @@ impl FriggStore {
             index_object_key: index_object_key.into_string(),
             snapshot_address: object.id.to_owned(),
             definition_checksum: materialized_view_definitions_checksum(),
+            index_checksum: object.checksum.to_owned(),
         };
         let value = serde_json::to_vec(&index_pointer_value).map_err(Error::Serialize)?;
 

--- a/lib/sdf-server/src/service/v2/index.rs
+++ b/lib/sdf-server/src/service/v2/index.rs
@@ -14,7 +14,6 @@ use axum::{
 use dal::{
     ChangeSetId,
     WorkspacePk,
-    WorkspaceSnapshotAddress,
 };
 use futures_lite::StreamExt;
 use hyper::StatusCode;
@@ -93,7 +92,8 @@ pub fn v2_change_set_routes() -> Router<AppState> {
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct FrontEndObjectMeta {
-    workspace_snapshot_address: WorkspaceSnapshotAddress,
+    workspace_snapshot_address: String,
+    index_checksum: String,
     front_end_object: FrontendObject,
 }
 

--- a/lib/sdf-server/src/service/v2/index/get_change_set_index.rs
+++ b/lib/sdf-server/src/service/v2/index/get_change_set_index.rs
@@ -5,7 +5,6 @@ use axum::{
     response::IntoResponse,
 };
 use dal::{
-    ChangeSet,
     ChangeSetId,
     WorkspacePk,
 };
@@ -31,11 +30,9 @@ pub async fn get_change_set_index(
     EddaClient(edda_client): EddaClient,
     Path((workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
 ) -> IndexResult<impl IntoResponse> {
-    let ctx = builder
+    let _ctx = builder
         .build(access_builder.build(change_set_id.into()))
         .await?;
-    let change_set = ChangeSet::get_by_id(&ctx, change_set_id).await?;
-
     let index = match frigg.get_index(workspace_pk, change_set_id).await? {
         Some((index, _kv_revision)) => index,
         None => {
@@ -63,7 +60,9 @@ pub async fn get_change_set_index(
     Ok((
         StatusCode::OK,
         Json(Some(FrontEndObjectMeta {
-            workspace_snapshot_address: change_set.workspace_snapshot_address,
+            workspace_snapshot_address: index.clone().id,
+            index_checksum: index.clone().checksum,
+
             front_end_object: index,
         })),
     ))

--- a/lib/sdf-server/src/service/v2/index/get_front_end_object.rs
+++ b/lib/sdf-server/src/service/v2/index/get_front_end_object.rs
@@ -6,7 +6,6 @@ use axum::{
     },
 };
 use dal::{
-    ChangeSet,
     ChangeSetId,
     WorkspacePk,
 };
@@ -41,11 +40,17 @@ pub async fn get_front_end_object(
     Path((workspace_pk, change_set_id)): Path<(WorkspacePk, ChangeSetId)>,
     Query(request): Query<FrontendObjectRequest>,
 ) -> IndexResult<Json<FrontEndObjectMeta>> {
-    let ctx = builder
+    let _ctx = builder
         .build(access_builder.build(change_set_id.into()))
         .await?;
-    let change_set = ChangeSet::get_by_id(&ctx, change_set_id).await?;
 
+    let (checksum, address) = match frigg
+        .get_index_pointer_value(workspace_pk, change_set_id)
+        .await?
+    {
+        Some((index, _kv_revision)) => (index.index_checksum, index.snapshot_address),
+        None => ("".to_string(), "".to_string()),
+    };
     let obj;
     if let Some(checksum) = request.checksum {
         obj = frigg
@@ -68,7 +73,8 @@ pub async fn get_front_end_object(
     }
 
     Ok(Json(FrontEndObjectMeta {
-        workspace_snapshot_address: change_set.workspace_snapshot_address,
+        workspace_snapshot_address: address,
+        index_checksum: checksum,
         front_end_object: obj,
     }))
 }

--- a/lib/si-frontend-mv-types-rs/src/index.rs
+++ b/lib/si-frontend-mv-types-rs/src/index.rs
@@ -59,4 +59,5 @@ pub struct IndexPointerValue {
     pub index_object_key: String,
     pub snapshot_address: String,
     pub definition_checksum: Checksum,
+    pub index_checksum: String,
 }

--- a/lib/si-frontend-mv-types-rs/src/object/patch.rs
+++ b/lib/si-frontend-mv-types-rs/src/object/patch.rs
@@ -1,10 +1,8 @@
 use serde::Serialize;
-use si_events::WorkspaceSnapshotAddress;
 use si_id::{
     ChangeSetId,
     WorkspacePk,
 };
-
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectPatch {
@@ -27,17 +25,18 @@ pub const INDEX_UPDATE_KIND: &str = "IndexUpdate";
 pub const INDEX_UPDATE_POST_FIX: &str = "index_update";
 pub const DATA_CACHE_SUBJECT_PREFIX: &str = "data_cache";
 
-#[derive(Debug, Clone, Serialize, Copy)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateMeta {
     /// The workspace this patch batch is targeting.
     pub workspace_id: WorkspacePk,
     /// The change set this patch batch is targeting.
     pub change_set_id: Option<ChangeSetId>,
-    /// The snapshot address the patches are being applied to.
-    pub snapshot_from_address: Option<WorkspaceSnapshotAddress>,
-    /// The snapshot address the patches will result in data for.
-    pub snapshot_to_address: Option<WorkspaceSnapshotAddress>,
+    /// The index checksum the patches will result in data for.
+    pub to_index_checksum: String,
+    /// The index checksum the patches the patches are being applied to.
+    /// Or in the case of rebuild or a brand new change set, will match the [`to_index_checksum`]
+    pub from_index_checksum: String,
 }
 
 impl UpdateMeta {
@@ -73,6 +72,8 @@ pub struct IndexUpdate {
     pub meta: UpdateMeta,
     /// The message kind for the front end.
     pub kind: &'static str,
+    /// Checksum
+    pub index_checksum: String,
 }
 
 impl IndexUpdate {


### PR DESCRIPTION
Thats the main fix. This includes update the table structure, updating the PatchBatch and IndexUpdate messages to return the `fromChecksum` and `toChecksum`, updated the `IndexPointer` in Frigg to include the Checksum (so we don't need to fetch the whole `MvIndex` to get this) and updating the responses for mjolnir requests to include the index checksum. 

Other fixes include: 

Fixed Func history reactivity 

Fixed handling deleted MVs by returning the previous checksum for that object

When querying sometimes you want to query the "completed" change set, and sometimes you want the "in progress" checksum we're processing

When we call `updateComputed` within the `applyPatch` process, we need to query data off the indexChecksum. So we need to pipe that through the computed, references, and get() callstacks, and run the correct SQL. When we query from Vue components, we always want to look at the checksum being referenced on the changeset.



