### PR TITLE
chore: Allow any host for web, on dev

### DIFF
--- a/app/web/vite.config.ts
+++ b/app/web/vite.config.ts
@@ -1,6 +1,6 @@
 import path from "path";
-import { existsSync, readFileSync } from "fs";
-import { loadEnv, defineConfig } from "vite";
+import {existsSync, readFileSync} from "fs";
+import {loadEnv, defineConfig} from "vite";
 import vue from "@vitejs/plugin-vue";
 import checkerPlugin from "vite-plugin-checker";
 import svgLoaderPlugin from "vite-svg-loader";
@@ -52,7 +52,7 @@ export default (opts: { mode: string }) => {
 
       // using "raw" as icon compiler (rather than `vue3`) because we need raw svgs for use in konva
       // our Icon component knows how to deal with raw SVGs
-      IconsPlugin({ compiler: "raw" }),
+      IconsPlugin({compiler: "raw"}),
 
       process.env.NODE_ENV !== "production" &&
       checkerPlugin({
@@ -61,7 +61,7 @@ export default (opts: { mode: string }) => {
           lintCommand: packageJson.scripts.lint,
           // I _think_ we only want to pop up an error on the screen for proper errors
           // otherwise we can get a lot of unused var errors when you comment something out temporarily
-          dev: { logLevel: ["error"] },
+          dev: {logLevel: ["error"]},
         },
       }),
 
@@ -70,11 +70,12 @@ export default (opts: { mode: string }) => {
     css: {
       postcss,
       preprocessorOptions: {
-        less: { additionalData: lessVars },
+        less: {additionalData: lessVars},
       },
     },
     server: {
       host: config.DEV_HOST,
+      allowedHosts: true,
       port: parseInt(config.DEV_PORT),
       strictPort: true,
       fs: {
@@ -108,7 +109,7 @@ export default (opts: { mode: string }) => {
           find: "@",
           replacement: path.resolve(__dirname, "src"),
         },
-        { find: "util", replacement: "util-browser" },
+        {find: "util", replacement: "util-browser"},
       ],
     },
     build: {


### PR DESCRIPTION
When developing from a machine that is not running the system, one needs to add the external host to the Vite config. This makes sense for production systems, but since we only use vite for development, it's kind of a hassle to have to do it for every external host.

This change allows us use any host to access a web system running with vite

<img src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExbDdjenh0dWN4ZjVydnRlcHdkdmpnNG1mZTZ2d2hldzhzZWxmcWhtNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/5bdgmjtAkC00xgo1mo/giphy.gif">