### PR TITLE
feat(luminork): Adding a search endpoint for luminork

### DIFF
--- a/lib/luminork-server/src/service/v1.rs
+++ b/lib/luminork-server/src/service/v1.rs
@@ -69,6 +69,10 @@ pub use components::{
         GetComponentV1ResponseManagementFunction,
     },
     list_components::ListComponentsV1Response,
+    search_components::{
+        SearchComponentsV1Request,
+        SearchComponentsV1Response,
+    },
     update_component::{
         UpdateComponentV1Request,
         UpdateComponentV1Response,
@@ -132,6 +136,7 @@ pub use crate::api_types::{
         components::get_component::get_component,
         components::create_component::create_component,
         components::list_components::list_components,
+        components::search_components::search_components,
         components::find_component::find_component,
         components::update_component::update_component,
         components::delete_component::delete_component,

--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -48,6 +48,7 @@ pub mod execute_management_function;
 pub mod find_component;
 pub mod get_component;
 pub mod list_components;
+pub mod search_components;
 pub mod update_component;
 
 #[remain::sorted]
@@ -342,6 +343,7 @@ pub fn routes() -> Router<AppState> {
         .route("/", post(create_component::create_component))
         .route("/", get(list_components::list_components))
         .route("/find", get(find_component::find_component))
+        .route("/search", post(search_components::search_components))
         .nest(
             "/:component_id",
             Router::new()

--- a/lib/luminork-server/src/service/v1/components/search_components.rs
+++ b/lib/luminork-server/src/service/v1/components/search_components.rs
@@ -1,0 +1,115 @@
+use std::collections::HashSet;
+
+use axum::response::Json;
+use dal::{
+    Component,
+    ComponentId,
+    DalContext,
+    Schema,
+    SchemaVariant,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use serde_json::json;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use super::ComponentsResult;
+use crate::{
+    extract::{
+        PosthogEventTracker,
+        change_set::ChangeSetDalContext,
+    },
+    service::v1::ComponentsError,
+};
+
+#[utoipa::path(
+    post,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/components/search",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+    ),
+    tag = "components",
+    request_body = SearchComponentsV1Request,
+    summary = "Complex search for components",
+    responses(
+        (status = 200, description = "Components retrieved successfully", body = SearchComponentsV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 404, description = "Component not found"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn search_components(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    payload: Result<Json<SearchComponentsV1Request>, axum::extract::rejection::JsonRejection>,
+) -> Result<Json<SearchComponentsV1Response>, ComponentsError> {
+    let Json(payload) = payload?;
+
+    let mut component_ids = Component::list_ids(ctx).await?;
+
+    if let Some(schema_name) = payload.schema_name.clone() {
+        component_ids = apply_schema_filter(ctx, component_ids, schema_name).await?;
+    }
+
+    tracker.track(
+        ctx,
+        "api_search_components",
+        json!({
+            "schema_name": payload.schema_name,
+        }),
+    );
+
+    Ok(Json(SearchComponentsV1Response {
+        components: component_ids,
+    }))
+}
+
+async fn apply_schema_filter(
+    ctx: &DalContext,
+    component_ids: Vec<ComponentId>,
+    schema_name: String,
+) -> ComponentsResult<Vec<ComponentId>> {
+    let schema = Schema::get_by_name(ctx, schema_name.clone())
+        .await
+        .map_err(|_| ComponentsError::SchemaNameNotFound(schema_name))?;
+
+    let current_ids_set: HashSet<_> = component_ids.iter().collect();
+
+    let variant_ids = Schema::list_schema_variant_ids(ctx, schema.id()).await?;
+    let mut schema_filtered_components = Vec::new();
+
+    for variant_id in variant_ids {
+        let matching_comps = SchemaVariant::list_component_ids(ctx, variant_id).await?;
+
+        schema_filtered_components.extend(
+            matching_comps
+                .into_iter()
+                .filter(|comp_id| current_ids_set.contains(comp_id)),
+        );
+    }
+
+    schema_filtered_components.sort();
+    schema_filtered_components.dedup();
+
+    Ok(schema_filtered_components)
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchComponentsV1Request {
+    #[schema(example = "AWS::EC2::Instance", required = false)]
+    pub schema_name: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchComponentsV1Response {
+    #[schema(value_type = Vec<Vec<String>>, example = json!(["01H9ZQD35JPMBGHH69BT0Q79AA", "01H9ZQD35JPMBGHH69BT0Q79BB", "01H9ZQD35JPMBGHH69BT0Q79CC"]))]
+    pub components: Vec<ComponentId>,
+}


### PR DESCRIPTION
This endpoint will take a search payload - the first parameter is schemaName.

We will first find all of the components in the workspace. If we don’t pass a schemaName then we will return the full list of the components, if we pass a schemaName then we will filter the components that match only that schema

Next up will be to return components that can be upgraded!