### PR TITLE
feat(sdf): migrate multiple connections to one array

### DIFF
--- a/lib/dal/examples/snapshot-fixer/main.rs
+++ b/lib/dal/examples/snapshot-fixer/main.rs
@@ -10,9 +10,8 @@ use std::{
 use dal::{
     WorkspaceSnapshotGraph,
     workspace_snapshot::graph::validator::{
-        ValidationIssue,
         WithGraph,
-        validate_graph,
+        connections::connection_migrations,
     },
 };
 use si_layer_cache::db::serialize;
@@ -48,13 +47,16 @@ async fn main() -> Result<()> {
     // let node_id = "01JTXGMYKFFPY7H2ZNV7SKFQ9X";
     // remove_node_by_id(&mut graph, node_id)?;
 
-    for issue in validate_graph(&graph)? {
-        println!("{}", WithGraph(&graph, &issue));
-        // Only fix ConnectionToUnknownSocket issues for now
-        if let issue @ ValidationIssue::ConnectionToUnknownSocket { .. } = issue {
-            issue.fix(&mut graph)?
-        }
+    for migration in connection_migrations(&graph, vec![]) {
+        println!("{}", WithGraph(&graph, &migration));
     }
+    // for issue in validate_graph(&graph)? {
+    //     println!("{}", WithGraph(&graph, &issue));
+    //     // Only fix ConnectionToUnknownSocket issues for now
+    //     if let issue @ ValidationIssue::ConnectionToUnknownSocket { .. } = issue {
+    //         issue.fix(&mut graph)?
+    //     }
+    // }
     // for issue in validate_graph(graph)? {
     //     // println!("{}", issue.with_graph(&graph));
     //     // Only fix ConnectionToUnknownSocket issues for now

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1165,6 +1165,11 @@ impl AttributeValue {
                         .get_prop_node_weight()?
                 };
 
+                println!(
+                    "  vivify {attribute_value_id} {} ({})",
+                    prop_node.name(),
+                    prop_node.kind()
+                );
                 prop_node.kind()
             };
 
@@ -1174,6 +1179,7 @@ impl AttributeValue {
             if !prop_kind.is_scalar() {
                 // if value of non-scalar is set, we're done, else set the empty value
                 if attribute_value.value.is_some() {
+                    println!("  has value!!");
                     return Ok(());
                 } else {
                     Self::set_value(ctx, attribute_value_id, prop_kind.empty_value()).await?;
@@ -2163,13 +2169,8 @@ impl AttributeValue {
         subscriptions: Vec<ValueSubscription>,
         func_id: Option<FuncId>,
     ) -> AttributeValueResult<()> {
-        let func_id = if let Some(id) = func_id {
-            let func = Func::get_by_id(ctx, id).await?;
-            if !func.is_transformation && !func.builtin {
-                return Err(AttributeValueError::SubscribingWithInvalidFunction);
-            }
-
-            id
+        let func_id = if let Some(func_id) = func_id {
+            func_id
         } else {
             // TODO(victor) remove this new ui comes around
             // Pick the prototype for the function based on prop type: if it's Array, use

--- a/lib/dal/src/workspace_snapshot/graph/validator.rs
+++ b/lib/dal/src/workspace_snapshot/graph/validator.rs
@@ -375,12 +375,23 @@ pub fn is_identity_func(
     Ok(func_node.func_kind() == FuncKind::Intrinsic && func_node.name() == "si:identity")
 }
 
-pub fn av_for_path(
+pub fn is_normalize_to_array_func(
     graph: &WorkspaceSnapshotGraphVCurrent,
-    root_av_id: AttributeValueId,
+    func_id: FuncId,
+) -> WorkspaceSnapshotGraphResult<bool> {
+    let func_node = graph
+        .get_node_weight_by_id(func_id)?
+        .get_func_node_weight()?;
+    Ok(func_node.func_kind() == FuncKind::Intrinsic && func_node.name() == "si:normalizeToArray")
+}
+
+pub fn resolve_av(
+    graph: &WorkspaceSnapshotGraphVCurrent,
+    component_id: ComponentId,
     path: impl AsRef<jsonptr::Pointer>,
 ) -> WorkspaceSnapshotGraphResult<Option<AttributeValueId>> {
-    let mut av = graph.get_node_index_by_id(root_av_id)?;
+    let component = graph.get_node_index_by_id(component_id)?;
+    let mut av = graph.target(component, EdgeWeightKind::Root)?;
     for segment in path.as_ref() {
         let prop = graph.target(av, EdgeWeightKind::Prop)?;
         let child_av =

--- a/lib/dal/tests/integration_test/attribute_value/subscription.rs
+++ b/lib/dal/tests/integration_test/attribute_value/subscription.rs
@@ -191,6 +191,7 @@ async fn subscribe_to_map_element(ctx: &mut DalContext) -> Result<()> {
     );
 
     // Update the map value and watch the new value come through!
+    value::set(ctx, ("testy", "/domain/ValueMap/B"), "b_2").await?;
     AttributeValue::insert(
         ctx,
         value_map_av_id,

--- a/lib/sdf-server/src/service/v2/change_set.rs
+++ b/lib/sdf-server/src/service/v2/change_set.rs
@@ -52,6 +52,8 @@ mod validate_snapshot;
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("attribute prototype error: {0}")]
+    AttributePrototype(#[from] dal::attribute::prototype::AttributePrototypeError),
     #[error("attribute prototype argument error: {0}")]
     AttributePrototypeArgument(
         #[from] dal::attribute::prototype::argument::AttributePrototypeArgumentError,


### PR DESCRIPTION
This handles multiple connections to a single array, which was previously a migration error. It also makes the migrated connections to array sockets look more like what you would get from the new UI (with single -> array subscriptions hooking directly to explicit array elements instead of to the parent array).

* scalar -> array: We make the array a manual array, create an array element, and subscribe to the single from the array element using si:identity.
* array -> array: The subscription uses si:identity instead of si:normalizeToArray (since that's what si:normalizeToArray would do in the first place and is also the kind of subscription we create through the UI).

<IMG SRC="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ2RyZ3h4dG1pd3Q5anZ3Z3QxeXJuMXlib2I4anV6c2hpN3B2M3ZwMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l2Je4zlfxF6z0IWZi/giphy.gif">

We refuse to migrate connections if: 
* If there are multiple array -> array connections to the same destination.
* If there are both single -> array and array -> array connections to the same destination.
* If the array socket does not use si:normalizeToArray, and there are multiple connections to the array.
* If the source socket does not use si:identity, we refuse to migrate, because we can't know whether the source produces an array or not (the error produced is "source and destination socket both have functions")

This PR also fixes an issue with where, when an array/object/map was using to a non-empty default value (such as in the case of socket connections), `PUT /attributes { "/domain/MyArray/-": ... }` (assigning directly to a child element) would leave the array itself using the default value, and the child element would get overwritten on the next DVU.

## Testing

- [x] Integration tests pass
- Manual tests:
  - [X] migrate array with multiple scalar connections
  - [ ] migrate array with single array connection
  - [ ] attempt to migrate array with multiple array connections
  - [ ] attempt to migrate array with array and scalar connections