### PR TITLE
Ignore errors retrieving index pointer values when attempting to re-use existing MvIndex for a new change set

### DIFF
--- a/lib/edda-server/src/change_set_processor_task/materialized_view.rs
+++ b/lib/edda-server/src/change_set_processor_task/materialized_view.rs
@@ -171,9 +171,10 @@ pub async fn try_reuse_mv_index_for_new_change_set(
 
     for change_set in change_sets_using_snapshot {
         // found a match, so let's retrieve that MvIndex and put the same object as ours
-        let Some((pointer, _revision)) = frigg
+        // If we're unable to parse the pointer for some reason, don't treat it as a hard error and just move on.
+        let Ok(Some((pointer, _revision))) = frigg
             .get_index_pointer_value(workspace_id, change_set.id)
-            .await?
+            .await
         else {
             // try the next one
             // no need error if this index was never built, it would get rebuilt when necessary


### PR DESCRIPTION
If we're unable to get the index pointer value for an existing index pointer then we should ignore it and move on to trying the next one. The read could fail if we have changed the format of the pointer value, and this should not cause the entire operation to fail. We should move on, and act as though the index pointer didn't exist in the first place to give us a chance of finding an index pointer value that is appropriate for us to reuse.