### PR TITLE
A handful of fixes

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -239,7 +239,6 @@ realtimeStore.subscribe(
             props.workspacePk,
             data.changeSetId,
             context.value.headChangeSetId.value,
-            data.workspaceSnapshotAddress,
           );
         }
       },

--- a/app/web/src/newhotness/logic_composables/watched_form.ts
+++ b/app/web/src/newhotness/logic_composables/watched_form.ts
@@ -91,7 +91,7 @@ export const useWatchedForm = <Data>(label: string) => {
         });
         start = Date.now();
         onSubmit(props);
-        if (watchFn) bifrosting.value = true;
+        bifrosting.value = true;
         rainbow.add(ctx.changeSetId.value, label);
       },
       validators,

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -75,7 +75,7 @@ const returned = (changeSetId: ChangeSetId, label: string) => {
 };
 db.addListenerReturned(Comlink.proxy(returned));
 
-const lobbyExit: LobbyExitFn = () => {
+const lobbyExit: LobbyExitFn = async () => {
   // Only navigate away from lobby if user is currently in the lobby
   if (router.currentRoute.value.name !== "new-hotness-lobby") {
     return;
@@ -88,6 +88,7 @@ const lobbyExit: LobbyExitFn = () => {
   // find the current workspace or change set?
 
   if (workspacePk && changeSetId) {
+    await niflheim(workspacePk, changeSetId, true);
     router.push({
       name: "new-hotness",
       params: {
@@ -153,14 +154,8 @@ export const linkNewChangeset = async (
   workspaceId: string,
   changeSetId: string,
   headChangeSetId: string,
-  workspaceSnapshotAddress: string,
 ) => {
-  await db.linkNewChangeset(
-    workspaceId,
-    headChangeSetId,
-    changeSetId,
-    workspaceSnapshotAddress,
-  );
+  await db.linkNewChangeset(workspaceId, headChangeSetId, changeSetId);
 };
 
 export const getOutgoingConnections = async (args: {

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -45,7 +45,6 @@ export interface DBInterface {
     workspaceId: string,
     headChangeSetId: string,
     changeSetId: string,
-    workspaceSnapshotAddress: string,
   ): Promise<void>;
   getConnectionByAnnotation(
     workspaceId: string,

--- a/lib/edda-server/src/data_cache.rs
+++ b/lib/edda-server/src/data_cache.rs
@@ -22,10 +22,6 @@ pub(crate) struct DataCache;
 impl DataCache {
     #[instrument(name = "data_cache.publish_patch_batch", level = "info", skip_all)]
     pub async fn publish_patch_batch(ctx: &DalContext, patch_batch: PatchBatch) -> Result<()> {
-        if patch_batch.patches.is_empty() {
-            return Ok(());
-        }
-
         ctx.txns()
             .await?
             .nats()


### PR DESCRIPTION
- Fix: don't need a checksum (dont send a snapshot!) for linking new change set, and cold start within the lobby
- Fix: not completing a hammer when we have the atom, but need the mtm
- Fix form bifrosting
- Don't ragnarok, just warn. Log deletes
- send empty patches because the patches contain index checksums we need
   - the patch is empty correctly, the index checksum changes because the snapshot address is in the body of the index payload that is computed for the checksum

- And a cold start in the lobby after we get the index notifcation