### PR TITLE
fix(bedrock): allow a generic restore point to be prepared from remote with no associated test

### DIFF
--- a/lib/bedrock-server/src/routes/prepare.rs
+++ b/lib/bedrock-server/src/routes/prepare.rs
@@ -1,4 +1,6 @@
 // src/routes/prepare.rs
+use std::path::PathBuf;
+
 use axum::{
     extract::{
         Json,
@@ -16,6 +18,7 @@ use crate::{
     app_state::AppState,
     artifacts::{
         clear_nats,
+        collect_files,
         prepare_databases,
         resolve_test,
     },
@@ -73,12 +76,39 @@ pub async fn prepare_route(
 
     let duration = start_time.elapsed().as_millis() as u64;
 
-    let response = PrepareResult {
-        success: true,
-        message: format!(
+    let file_paths: Vec<PathBuf> = match collect_files(&recording_id).await {
+        Ok(paths) => paths,
+        Err(e) => {
+            let result = PrepareResult {
+                success: false,
+                message: format!("Failed to collect files: {}", e),
+                recording_id,
+                duration_ms: Some(start_time.elapsed().as_millis() as u64),
+                output: None,
+            };
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, Json(result)));
+        }
+    };
+
+    let has_sequence_file = file_paths
+        .iter()
+        .any(|path| path.extension().is_some_and(|ext| ext == "sequence"));
+
+    let message = if has_sequence_file {
+        format!(
             "Preparation complete for {}, please conduct the test and hit /tests to execute test",
             &recording_id
-        ),
+        )
+    } else {
+        format!(
+            "Preparation complete for {}, no associated NATS sequence with this restore point i.e. no associated test",
+            &recording_id
+        )
+    };
+
+    let response = PrepareResult {
+        success: true,
+        message,
         recording_id,
         duration_ms: Some(duration),
         output: None,


### PR DESCRIPTION
Previously, we Err'ed during preparation when pulling from remote if there were no .sequence files. By not erroring we allow preparing in a remote Postgres state only which can be useful for locally testing a specific state or to test a migration in a new branch. Handy!