### PR TITLE
feat(admin): Make workspace admin a bit more pleasant

### DIFF
--- a/app/web/src/components/Workspace/WorkspaceAdminDashboard.vue
+++ b/app/web/src/components/Workspace/WorkspaceAdminDashboard.vue
@@ -1,10 +1,10 @@
 <template>
   <div
-    class="w-full h-full flex flex-col items-center relative overflow-scroll dark:bg-neutral-800 dark:text-shade-0 bg-neutral-50 text-neutral-900"
+    class="w-full h-full flex flex-col gap-xs p-lg items-center relative overflow-scroll dark:bg-neutral-800 dark:text-shade-0 bg-neutral-50 text-neutral-900"
   >
-    <span class="flex flex-row mt-10 font-bold text-3xl">Admin Dashboard</span>
-    <div class="flex flex-row w-full">
-      <Stack spacing="md" class="p-10">
+    <span class="font-bold text-3xl">Admin Dashboard</span>
+    <div class="flex flex-row gap-sm w-full">
+      <Stack spacing="md" class="flex-none">
         <Stack class="max-w-xl">
           <h2 class="font-bold text-lg">UPDATE MODULE CACHE</h2>
           <div class="flex flex-row-reverse gap-sm">
@@ -54,7 +54,6 @@
             />
           </div>
         </Stack>
-        <WorkspaceAdmin @showPanel="showPanel" />
         <Stack class="text-xs font-bold" spacing="none">
           <div class="text-lg pb-2xs">Feature Flags:</div>
           <div
@@ -81,8 +80,7 @@
           </div>
         </Stack>
       </Stack>
-      <ValidateSnapshot v-if="mainPanel === 'validate-snapshot'" />
-      <MigrateConnections v-else-if="mainPanel === 'migrate-connections'" />
+      <WorkspaceAdmin class="flex-1 min-w-0 overflow-hidden" />
     </div>
   </div>
 </template>
@@ -101,10 +99,6 @@ import clsx from "clsx";
 import { useAdminStore } from "@/store/admin.store";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import WorkspaceAdmin from "@/components/AdminDashboard/WorkspaceAdmin.vue";
-import ValidateSnapshot from "@/components/AdminDashboard/ValidateSnapshot.vue";
-import MigrateConnections from "@/components/AdminDashboard/MigrateConnections.vue";
-
-export type PanelKind = "validate-snapshot" | "migrate-connections";
 
 const adminStore = useAdminStore();
 const featureFlagsStore = useFeatureFlagsStore();
@@ -137,9 +131,4 @@ const funcRunId = ref<string | null>(null);
 const featureFlags = computed(() => {
   return featureFlagsStore.allFeatureFlags;
 });
-
-const mainPanel = ref<PanelKind>();
-const showPanel = (panel?: PanelKind) => {
-  mainPanel.value = panel;
-};
 </script>

--- a/lib/dal/examples/snapshot-fixer/main.rs
+++ b/lib/dal/examples/snapshot-fixer/main.rs
@@ -10,9 +10,8 @@ use std::{
 use dal::{
     WorkspaceSnapshotGraph,
     workspace_snapshot::graph::validator::{
-        ValidationIssue,
         WithGraph,
-        validate_graph,
+        connections::connection_migrations,
     },
 };
 use si_layer_cache::db::serialize;
@@ -48,13 +47,16 @@ async fn main() -> Result<()> {
     // let node_id = "01JTXGMYKFFPY7H2ZNV7SKFQ9X";
     // remove_node_by_id(&mut graph, node_id)?;
 
-    for issue in validate_graph(&graph)? {
-        println!("{}", WithGraph(&graph, &issue));
-        // Only fix ConnectionToUnknownSocket issues for now
-        if let issue @ ValidationIssue::ConnectionToUnknownSocket { .. } = issue {
-            issue.fix(&mut graph)?
-        }
+    for migration in connection_migrations(&graph, vec![]) {
+        println!("{}", WithGraph(&graph, &migration));
     }
+    // for issue in validate_graph(&graph)? {
+    //     println!("{}", WithGraph(&graph, &issue));
+    //     // Only fix ConnectionToUnknownSocket issues for now
+    //     if let issue @ ValidationIssue::ConnectionToUnknownSocket { .. } = issue {
+    //         issue.fix(&mut graph)?
+    //     }
+    // }
     // for issue in validate_graph(graph)? {
     //     // println!("{}", issue.with_graph(&graph));
     //     // Only fix ConnectionToUnknownSocket issues for now

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1165,6 +1165,11 @@ impl AttributeValue {
                         .get_prop_node_weight()?
                 };
 
+                println!(
+                    "  vivify {attribute_value_id} {} ({})",
+                    prop_node.name(),
+                    prop_node.kind()
+                );
                 prop_node.kind()
             };
 
@@ -1174,6 +1179,7 @@ impl AttributeValue {
             if !prop_kind.is_scalar() {
                 // if value of non-scalar is set, we're done, else set the empty value
                 if attribute_value.value.is_some() {
+                    println!("  has value!!");
                     return Ok(());
                 } else {
                     Self::set_value(ctx, attribute_value_id, prop_kind.empty_value()).await?;
@@ -2163,13 +2169,8 @@ impl AttributeValue {
         subscriptions: Vec<ValueSubscription>,
         func_id: Option<FuncId>,
     ) -> AttributeValueResult<()> {
-        let func_id = if let Some(id) = func_id {
-            let func = Func::get_by_id(ctx, id).await?;
-            if !func.is_transformation && !func.builtin {
-                return Err(AttributeValueError::SubscribingWithInvalidFunction);
-            }
-
-            id
+        let func_id = if let Some(func_id) = func_id {
+            func_id
         } else {
             // TODO(victor) remove this new ui comes around
             // Pick the prototype for the function based on prop type: if it's Array, use

--- a/lib/dal/src/workspace_snapshot/graph/validator.rs
+++ b/lib/dal/src/workspace_snapshot/graph/validator.rs
@@ -375,12 +375,23 @@ pub fn is_identity_func(
     Ok(func_node.func_kind() == FuncKind::Intrinsic && func_node.name() == "si:identity")
 }
 
-pub fn av_for_path(
+pub fn is_normalize_to_array_func(
     graph: &WorkspaceSnapshotGraphVCurrent,
-    root_av_id: AttributeValueId,
+    func_id: FuncId,
+) -> WorkspaceSnapshotGraphResult<bool> {
+    let func_node = graph
+        .get_node_weight_by_id(func_id)?
+        .get_func_node_weight()?;
+    Ok(func_node.func_kind() == FuncKind::Intrinsic && func_node.name() == "si:normalizeToArray")
+}
+
+pub fn resolve_av(
+    graph: &WorkspaceSnapshotGraphVCurrent,
+    component_id: ComponentId,
     path: impl AsRef<jsonptr::Pointer>,
 ) -> WorkspaceSnapshotGraphResult<Option<AttributeValueId>> {
-    let mut av = graph.get_node_index_by_id(root_av_id)?;
+    let component = graph.get_node_index_by_id(component_id)?;
+    let mut av = graph.target(component, EdgeWeightKind::Root)?;
     for segment in path.as_ref() {
         let prop = graph.target(av, EdgeWeightKind::Prop)?;
         let child_av =

--- a/lib/dal/tests/integration_test/attribute_value/subscription.rs
+++ b/lib/dal/tests/integration_test/attribute_value/subscription.rs
@@ -191,6 +191,7 @@ async fn subscribe_to_map_element(ctx: &mut DalContext) -> Result<()> {
     );
 
     // Update the map value and watch the new value come through!
+    value::set(ctx, ("testy", "/domain/ValueMap/B"), "b_2").await?;
     AttributeValue::insert(
         ctx,
         value_map_av_id,

--- a/lib/sdf-server/src/service/v2/change_set.rs
+++ b/lib/sdf-server/src/service/v2/change_set.rs
@@ -52,6 +52,8 @@ mod validate_snapshot;
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("attribute prototype error: {0}")]
+    AttributePrototype(#[from] dal::attribute::prototype::AttributePrototypeError),
     #[error("attribute prototype argument error: {0}")]
     AttributePrototypeArgument(
         #[from] dal::attribute::prototype::argument::AttributePrototypeArgumentError,


### PR DESCRIPTION
This makes the Admin page a bit more pleasant when it comes to workspaces and change sets, now that we're using it a bit more:

* Reduces scrolling:
  - Moves all workspace admin into the (currently unused) main panel
  - Puts more information side by side rather than top to bottom
* Defaults to the current workspace when you load it up
* Selects the HEAD changeset for a workspace by default, so something is loaded up on first load
* Sorts change sets so that open and active changesets come first

![image](https://github.com/user-attachments/assets/52e266da-7ad0-47f7-ac65-a50147a9de5f)

It's definitely not what I'd class as *wonderful*, but it gets the most annoying things out of the way!
