### PR TITLE
feat(newhotness): return materialized views from create_component to …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7411,6 +7411,7 @@ dependencies = [
  "clap",
  "convert_case 0.6.0",
  "dal",
+ "dal-materialized-views",
  "dal-test",
  "derive_builder",
  "derive_more",

--- a/app/web/src/newhotness/Component.vue
+++ b/app/web/src/newhotness/Component.vue
@@ -231,10 +231,15 @@ const componentId = computed(() => props.componentId);
 
 const componentQuery = useQuery<BifrostComponent | null>({
   queryKey: key(EntityKind.Component, componentId),
-  queryFn: async () => {
+  queryFn: async (queryContext) => {
     const component = await bifrost<BifrostComponent>(
       args(EntityKind.Component, componentId.value),
     );
+    if (!component) {
+      return queryContext.client.getQueryData(
+        key(EntityKind.Component, componentId).value,
+      ) as BifrostComponent | null;
+    }
     return component;
   },
 });

--- a/lib/sdf-server/BUCK
+++ b/lib/sdf-server/BUCK
@@ -7,6 +7,7 @@ rust_library(
         "//lib/auth-api-client:auth-api-client",
         "//lib/buck2-resources:buck2-resources",
         "//lib/dal:dal",
+        "//lib/dal-materialized-views:dal-materialized-views",
         "//lib/si-db:si-db",
         "//lib/edda-client:edda-client",
         "//lib/innit-client:innit-client",

--- a/lib/sdf-server/Cargo.toml
+++ b/lib/sdf-server/Cargo.toml
@@ -13,6 +13,7 @@ audit-database = { path = "../../lib/audit-database" }
 auth-api-client = { path = "../../lib/auth-api-client" }
 buck2-resources = { path = "../../lib/buck2-resources" }
 dal = { path = "../../lib/dal" }
+dal-materialized-views = { path = "../../lib/dal-materialized-views" }
 si-db = { path = "../../lib/si-db" }
 edda-client = { path = "../../lib/edda-client" }
 innit-client = { path = "../../lib/innit-client" }

--- a/lib/sdf-server/src/service/v2/view.rs
+++ b/lib/sdf-server/src/service/v2/view.rs
@@ -84,6 +84,8 @@ pub enum ViewError {
     InvalidRequest(String),
     #[error("join error: {0}")]
     Join(#[from] JoinError),
+    #[error("materialized view error: {0}")]
+    MaterializedView(#[from] Box<dal_materialized_views::Error>),
     #[error("there is already a view called {0}")]
     NameAlreadyInUse(String),
     #[error(transparent)]


### PR DESCRIPTION
Constructs the "materialized view" of the component and its schema variant on create component, so that the frontend can insert it optimistically into the tanstack.