### PR TITLE
All the hammers at the same time!

### DIFF
--- a/app/web/src/newhotness/logic_composables/rainbow_counter.ts
+++ b/app/web/src/newhotness/logic_composables/rainbow_counter.ts
@@ -2,8 +2,9 @@ import { computed, inject, reactive } from "vue";
 import { DefaultMap } from "@/utils/defaultmap";
 import { assertIsDefined, Context } from "../types";
 
-const q = new DefaultMap<string, Set<string>>(() => new Set<string>());
-const queueByChangeSet = reactive(q);
+const queueByChangeSet = new DefaultMap<string, Set<string>>(() => {
+  return reactive(new Set<string>());
+});
 
 export const add = (changeSetId: string, desc: string) => {
   const queue = queueByChangeSet.get(changeSetId);

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -33,6 +33,12 @@ export type OutgoingConnections = DefaultMap<
 
 export type RainbowFn = (changeSetId: ChangeSetId, label: string) => void;
 export type LobbyExitFn = () => void;
+
+export type MjolnirBulk = Array<{
+  kind: string;
+  id: Id;
+  checksum?: Checksum;
+}>;
 export interface DBInterface {
   initDB: (testing: boolean) => Promise<void>;
   migrate: (testing: boolean) => void;
@@ -65,6 +71,12 @@ export interface DBInterface {
     kind: EntityKind,
     id: Id,
   ): Promise<typeof NOROW | AtomDocument>;
+  mjolnirBulk(
+    workspaceId: string,
+    changeSetId: ChangeSetId,
+    objs: MjolnirBulk,
+    indexChecksum: string,
+  ): void;
   mjolnir(
     workspaceId: string,
     changeSetId: ChangeSetId,


### PR DESCRIPTION
If we are in "true cold start state" where we don't have the data and we need to fetch it, we want to make ONE request. However, while we do a cold start, the app is rendering and making queries, that are missing and firing their own hammers.

So, we need to stick a queue in there, that collects hammers that _would_ fire, and prevent them from firing. Once the cold start is done, if we were successful, drop those hammers and ignore it — we're fully up to date. If something really weird happens, and the bulk fails (honestly, the only thing I could imagine is a timeout, but 🤷 ), let those hammers fly as a backup to get out of a broken situation.

Testing steps:
1. Go to a change set.
2. Clear your network tab
3. Hit the Ragnarok button (which drops only this change set data)
4. Watch your application re-cold start
5. See only `multi_mjolnir` in the network tab. No other hammers

Aside: small fix to the reactive-ness of the rainbow counter. I put reactive on the DefaultMap, which made it stop working entirely. I need to put the reactive on the interior sets, since thats what we're "counting" in the computed (don't need it on the changeSetId key, since that is reactive via injecting context.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbTkxYzh4d29oMWxiNXZyeG5uZzY5MDJ4d2g3ZnduaXZscmJiaGFvYiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/7cTTE2Z1OmrFm/giphy.gif"/>