### PR TITLE
chore(tilt): add "workspaces" link in `web` service

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -326,6 +326,7 @@ si_buck2_resource(
     ),
     links = [
         link("http://127.0.0.1:8080", "web"),
+        link("https://auth.systeminit.com/workspaces", "workspaces"),
         link("https://auth.systeminit.com", "auth-prod"),
     ],
 )


### PR DESCRIPTION
This change adds a "workspaces" link in the Tilt UI under the `web` service. Prior to this change, navigating to the "web" link for a newly brought up dev stack causes authentication redirects often sending the developer to their default workspace rather than the localhost stack. By having the link to the list of workspaces there's far less navigating around and causing other workspaces to load in production environments, etc.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZG5leWpkazNpbmplczNjanE4czFmOWhkODVmcGpqM2w5cG8wZHI4aCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/0WI1FPTxADzi6pu3Xv/giphy.gif"/>