### PR TITLE
Replace socket connections with management ones

### DIFF
--- a/app/web/src/newhotness/ConnectionsPanel.vue
+++ b/app/web/src/newhotness/ConnectionsPanel.vue
@@ -85,6 +85,38 @@ const componentConnections = computed(() => {
 const incoming = computed(
   () =>
     componentConnections.value.incoming.map((conn) => {
+      if (conn.kind === "management") {
+        return {
+          key: `mgmt-${conn.toComponent.id}-${conn.fromComponent.id}`,
+          component: conn.fromComponent,
+          componentId: conn.fromComponent.id,
+          self: "Management",
+          other: "-",
+        };
+      } else {
+        return {
+          key: `${conn.toAttributeValueId}-${conn.toComponent.id}-${conn.fromComponent.id}-${conn.fromAttributeValueId}`,
+          component: conn.fromComponent,
+          componentId: conn.fromComponent.id,
+          self: conn.toAttributeValuePath,
+          other: conn.fromAttributeValuePath,
+        };
+      }
+    }) ?? ([] as SimpleConnection[]),
+);
+
+const outgoing = computed<SimpleConnection[]>(() => {
+  const outgoing = outgoingQuery.data?.value ?? [];
+  return outgoing.map((conn) => {
+    if (conn.kind === "management") {
+      return {
+        key: `mgmt-${conn.toComponent.id}-${conn.fromComponent.id}`,
+        component: conn.fromComponent,
+        componentId: conn.fromComponent.id,
+        self: "Management",
+        other: "-",
+      };
+    } else {
       return {
         key: `${conn.toAttributeValueId}-${conn.toComponent.id}-${conn.fromComponent.id}-${conn.fromAttributeValueId}`,
         component: conn.fromComponent,
@@ -92,19 +124,7 @@ const incoming = computed(
         self: conn.toAttributeValuePath,
         other: conn.fromAttributeValuePath,
       };
-    }) ?? ([] as SimpleConnection[]),
-);
-
-const outgoing = computed<SimpleConnection[]>(() => {
-  const outgoing = outgoingQuery.data?.value ?? [];
-  return outgoing.map((conn) => {
-    return {
-      key: `${conn.toAttributeValueId}-${conn.toComponent.id}-${conn.fromComponent.id}-${conn.fromAttributeValueId}`,
-      component: conn.fromComponent,
-      componentId: conn.fromComponent.id,
-      self: conn.toAttributeValuePath,
-      other: conn.fromAttributeValuePath,
-    };
+    }
   });
 });
 </script>

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -1,11 +1,6 @@
 import { ActionProposedView } from "@/store/actions.store";
 import { ComponentId } from "@/api/sdf/dal/component";
-import {
-  InputSocketId,
-  OutputSocketId,
-  SchemaId,
-  SchemaVariantId,
-} from "@/api/sdf/dal/schema";
+import { SchemaId, SchemaVariantId } from "@/api/sdf/dal/schema";
 import { ActionKind, ActionPrototypeId } from "@/api/sdf/dal/action";
 import { FuncId } from "@/api/sdf/dal/func";
 import { AttributeValueId } from "@/store/status.store";
@@ -359,6 +354,11 @@ export interface BifrostComponentConnections {
 
 export type EddaConnection =
   | {
+      kind: "management";
+      fromComponentId: WeakReference<EntityKind.Component>;
+      toComponentId: WeakReference<EntityKind.Component>;
+    }
+  | {
       kind: "prop";
       fromComponentId: WeakReference<EntityKind.Component>;
       fromAttributeValueId: AttributeValueId;
@@ -368,25 +368,17 @@ export type EddaConnection =
       toComponentId: WeakReference<EntityKind.Component>;
       toPropId: PropId;
       toPropPath: string;
-      toAttributeValueId: AttributeValueId;
-      toAttributeValuePath: string;
-    }
-  | {
-      kind: "socket";
-      fromComponentId: WeakReference<EntityKind.Component>;
-      fromAttributeValueId: AttributeValueId;
-      fromAttributeValuePath: string;
-      fromSocketId: OutputSocketId;
-      fromSocketName: string;
-      toComponentId: WeakReference<EntityKind.Component>;
-      toSocketId: InputSocketId;
-      toSocketName: string;
       toAttributeValueId: AttributeValueId;
       toAttributeValuePath: string;
     };
 
 export type BifrostConnection =
   | {
+      kind: "management";
+      fromComponent: BifrostComponent;
+      toComponent: BifrostComponent;
+    }
+  | {
       kind: "prop";
       fromComponent: BifrostComponent;
       fromAttributeValueId: AttributeValueId;
@@ -396,19 +388,6 @@ export type BifrostConnection =
       toComponent: BifrostComponent;
       toPropId: PropId;
       toPropPath: string;
-      toAttributeValueId: AttributeValueId;
-      toAttributeValuePath: string;
-    }
-  | {
-      kind: "socket";
-      fromComponent: BifrostComponent;
-      fromAttributeValueId: AttributeValueId;
-      fromAttributeValuePath: string;
-      fromSocketId: OutputSocketId;
-      fromSocketName: string;
-      toComponent: BifrostComponent;
-      toSocketId: InputSocketId;
-      toSocketName: string;
       toAttributeValueId: AttributeValueId;
       toAttributeValuePath: string;
     };

--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -1630,7 +1630,10 @@ const updateComputed = async (
   if (kind === EntityKind.IncomingConnections) {
     const data = doc as BifrostComponentConnections;
     data.incoming.forEach((incoming) => {
-      const id = `${incoming.toAttributeValueId}-${incoming.fromAttributeValueId}`;
+      const id =
+        incoming.kind === "management"
+          ? `mgmt-${incoming.toComponent.id}-${incoming.fromComponent.id}`
+          : `${incoming.toAttributeValueId}-${incoming.fromAttributeValueId}`;
       const outgoing = flip(incoming);
       const conns = allOutgoingConns
         .get(changeSetId)
@@ -1741,23 +1744,17 @@ const flip = (i: BifrostConnection): BifrostConnection => {
   const o: BifrostConnection = {
     ...i,
     fromComponent: i.toComponent,
-    fromAttributeValueId: i.toAttributeValueId,
-    fromAttributeValuePath: i.toAttributeValuePath,
     toComponent: i.fromComponent,
-    toAttributeValueId: i.fromAttributeValueId,
-    toAttributeValuePath: i.fromAttributeValuePath,
   };
   if ("toPropId" in i && o.kind === "prop") {
     o.fromPropId = i.toPropId;
     o.fromPropPath = i.toPropPath;
     o.toPropId = i.fromPropId;
     o.toPropPath = i.fromPropId;
-  }
-  if ("toSocketId" in i && o.kind === "socket") {
-    o.fromSocketId = i.toSocketId;
-    o.fromSocketName = i.toSocketName;
-    o.toSocketId = i.fromSocketId;
-    o.toSocketName = i.fromSocketName;
+    o.fromAttributeValueId = i.toAttributeValueId;
+    o.fromAttributeValuePath = i.toAttributeValuePath;
+    o.toAttributeValueId = i.fromAttributeValueId;
+    o.toAttributeValuePath = i.fromAttributeValuePath;
   }
   return o;
 };

--- a/lib/dal-materialized-views/src/component/attribute_tree.rs
+++ b/lib/dal-materialized-views/src/component/attribute_tree.rs
@@ -22,10 +22,7 @@ use si_frontend_mv_types::component::attribute_tree::{
     ExternalSource,
     ValidationOutput,
 };
-use si_id::{
-    AttributeValueId,
-    ComponentId,
-};
+use si_id::ComponentId;
 use telemetry::prelude::*;
 
 use crate::{
@@ -51,12 +48,7 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
 
     while let Some(av_id) = work_queue.pop_front() {
         let maybe_parent_av_id = AttributeValue::parent_id(ctx, av_id).await?;
-        let child_av_ids: Vec<AttributeValueId> =
-            AttributeValue::get_child_avs_in_order(ctx, av_id)
-                .await?
-                .iter()
-                .map(|av| av.id())
-                .collect();
+        let child_av_ids = AttributeValue::get_child_av_ids_in_order(ctx, av_id).await?;
         work_queue.extend(&child_av_ids);
         tree_info.insert(
             av_id,

--- a/lib/dal-materialized-views/src/incoming_connections.rs
+++ b/lib/dal-materialized-views/src/incoming_connections.rs
@@ -5,8 +5,6 @@ use dal::{
     AttributeValue,
     Component,
     DalContext,
-    InputSocket,
-    OutputSocket,
     Prop,
     attribute::prototype::argument::{
         AttributePrototypeArgument,
@@ -20,10 +18,7 @@ use si_frontend_mv_types::incoming_connections::{
 use si_id::ComponentId;
 use telemetry::prelude::*;
 
-use crate::{
-    Error,
-    Result,
-};
+use crate::Result;
 
 #[instrument(
     name = "dal_materialized_views.incoming_connections",
@@ -34,89 +29,14 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> Result<Inco
     let ctx = &ctx;
 
     let mut connections = Vec::new();
-    connections.extend(socket_to_socket(ctx, component_id).await?);
     connections.extend(prop_to_prop(ctx, component_id).await?);
+    connections.extend(management(ctx, component_id).await?);
     connections.sort();
 
     Ok(IncomingConnectionsMv {
         id: component_id,
         connections,
     })
-}
-
-async fn socket_to_socket(ctx: &DalContext, component_id: ComponentId) -> Result<Vec<Connection>> {
-    let schema_variant = Component::schema_variant_for_component_id(ctx, component_id).await?;
-    let input_sockets = InputSocket::list(ctx, schema_variant.id()).await?;
-
-    let mut connections = Vec::new();
-    for input_socket in input_sockets {
-        let input_socket_id = input_socket.id();
-        let input_socket_attribute_value_id =
-            InputSocket::component_attribute_value_id(ctx, input_socket_id, component_id).await?;
-        let attribute_prototype_id =
-            AttributeValue::prototype_id(ctx, input_socket_attribute_value_id).await?;
-        let mut attribute_prototype_argument_ids =
-            AttributePrototype::list_arguments(ctx, attribute_prototype_id).await?;
-        attribute_prototype_argument_ids.sort();
-
-        // Don't bother gathering information to cache if there are no prototype arguments.
-        if attribute_prototype_argument_ids.is_empty() {
-            continue;
-        }
-
-        let input_socket_attribute_value_path =
-            AttributeValue::get_path_for_id(ctx, input_socket_attribute_value_id)
-                .await?
-                .unwrap_or_default();
-
-        for attribute_prototype_argument_id in attribute_prototype_argument_ids {
-            let attribute_prototype_argument =
-                AttributePrototypeArgument::get_by_id(ctx, attribute_prototype_argument_id).await?;
-            let value_source =
-                AttributePrototypeArgument::value_source(ctx, attribute_prototype_argument_id)
-                    .await?;
-            let ValueSource::OutputSocket(output_socket_id) = value_source else {
-                return Err(Error::InvalidValueSource(value_source));
-            };
-            let output_socket = OutputSocket::get_by_id(ctx, output_socket_id).await?;
-
-            // We've found the connection if the attribute prototype argument has targets whose
-            // destination component ID for the current component. We also need to ensure that we
-            // do not accidentally collect an outgoing connection.
-            let source_component_id = match attribute_prototype_argument.targets() {
-                Some(targets) if targets.destination_component_id == component_id => {
-                    targets.source_component_id
-                }
-                Some(_) | None => continue,
-            };
-
-            let output_socket_attribute_value_id = OutputSocket::component_attribute_value_id(
-                ctx,
-                output_socket_id,
-                source_component_id,
-            )
-            .await?;
-            let output_socket_attribute_value_path =
-                AttributeValue::get_path_for_id(ctx, output_socket_attribute_value_id)
-                    .await?
-                    .unwrap_or_default();
-
-            connections.push(Connection::Socket {
-                from_component_id: source_component_id.into(),
-                from_attribute_value_id: output_socket_attribute_value_id,
-                from_attribute_value_path: output_socket_attribute_value_path,
-                from_socket_id: output_socket_id,
-                from_socket_name: output_socket.name().to_string(),
-                to_component_id: component_id.into(),
-                to_socket_id: input_socket_id,
-                to_socket_name: input_socket.name().to_string(),
-                to_attribute_value_id: input_socket_attribute_value_id,
-                to_attribute_value_path: input_socket_attribute_value_path.clone(),
-            });
-        }
-    }
-
-    Ok(connections)
 }
 
 async fn prop_to_prop(ctx: &DalContext, component_id: ComponentId) -> Result<Vec<Connection>> {
@@ -196,6 +116,19 @@ async fn prop_to_prop(ctx: &DalContext, component_id: ComponentId) -> Result<Vec
                 })
             }
         }
+    }
+
+    Ok(connections)
+}
+
+async fn management(ctx: &DalContext, component_id: ComponentId) -> Result<Vec<Connection>> {
+    let mut connections = Vec::new();
+
+    for manager_component_id in Component::managers_by_id(ctx, component_id).await? {
+        connections.push(Connection::Management {
+            from_component_id: manager_component_id.into(),
+            to_component_id: component_id.into(),
+        })
     }
 
     Ok(connections)

--- a/lib/dal-materialized-views/src/lib.rs
+++ b/lib/dal-materialized-views/src/lib.rs
@@ -89,14 +89,8 @@ pub enum Error {
     Diagram(#[from] dal::diagram::DiagramError),
     #[error("func error: {0}")]
     Func(#[from] dal::FuncError),
-    #[error("input socket error: {0}")]
-    InputSocket(#[from] dal::socket::input::InputSocketError),
-    #[error("invalid value source: {0:?}")]
-    InvalidValueSource(dal::attribute::prototype::argument::value_source::ValueSource),
     #[error("mgmt prototype error: {0}")]
     ManagementPrototype(#[from] dal::management::prototype::ManagementPrototypeError),
-    #[error("output socket error: {0}")]
-    OutputSocket(#[from] dal::socket::output::OutputSocketError),
     #[error("prop error: {0}")]
     Prop(#[from] dal::prop::PropError),
     #[error("qualification summary error: {0}")]

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -4145,31 +4145,18 @@ impl Component {
         ))
     }
 
-    /// Return the ids of all the components that manage this component
+    /// Return the IDs of all the [`Components`](Component) that manage this [`Component`](Component).
     pub async fn managers(&self, ctx: &DalContext) -> ComponentResult<Vec<ComponentId>> {
-        let mut result = vec![];
-
-        let snapshot = ctx.workspace_snapshot()?;
-
-        for source_idx in snapshot
-            .incoming_sources_for_edge_weight_kind(self.id, EdgeWeightKindDiscriminants::Manages)
-            .await?
-        {
-            let node_weight = snapshot.get_node_weight(source_idx).await?;
-            if let NodeWeight::Component(_) = &node_weight {
-                result.push(node_weight.id().into());
-            }
-        }
-
-        Ok(result)
+        Self::managers_by_id(ctx, self.id).await
     }
 
-    /// Return the ids of all the components that manage this component
+    /// Return the IDs of all the [`Components`](Component) that manage the [`Component`](Component) corresponding
+    /// to the provided ID.
     pub async fn managers_by_id(
         ctx: &DalContext,
         id: ComponentId,
     ) -> ComponentResult<Vec<ComponentId>> {
-        let mut result = vec![];
+        let mut result = Vec::new();
 
         let snapshot = ctx.workspace_snapshot()?;
 

--- a/lib/si-frontend-mv-types-rs/src/incoming_connections.rs
+++ b/lib/si-frontend-mv-types-rs/src/incoming_connections.rs
@@ -12,8 +12,6 @@ use si_frontend_mv_types_macros::{
 use si_id::{
     AttributeValueId,
     ComponentId,
-    InputSocketId,
-    OutputSocketId,
     PropId,
     WorkspacePk,
 };
@@ -32,6 +30,11 @@ use crate::reference::{
 #[serde(rename_all = "camelCase", tag = "kind")]
 pub enum Connection {
     #[serde(rename_all = "camelCase")]
+    Management {
+        from_component_id: WeakReference<ComponentId, weak::markers::Component>,
+        to_component_id: WeakReference<ComponentId, weak::markers::Component>,
+    },
+    #[serde(rename_all = "camelCase")]
     Prop {
         from_component_id: WeakReference<ComponentId, weak::markers::Component>,
         from_attribute_value_id: AttributeValueId,
@@ -41,19 +44,6 @@ pub enum Connection {
         to_component_id: WeakReference<ComponentId, weak::markers::Component>,
         to_prop_id: PropId,
         to_prop_path: String,
-        to_attribute_value_id: AttributeValueId,
-        to_attribute_value_path: String,
-    },
-    #[serde(rename_all = "camelCase")]
-    Socket {
-        from_component_id: WeakReference<ComponentId, weak::markers::Component>,
-        from_attribute_value_id: AttributeValueId,
-        from_attribute_value_path: String,
-        from_socket_id: OutputSocketId,
-        from_socket_name: String,
-        to_component_id: WeakReference<ComponentId, weak::markers::Component>,
-        to_socket_id: InputSocketId,
-        to_socket_name: String,
         to_attribute_value_id: AttributeValueId,
         to_attribute_value_path: String,
     },


### PR DESCRIPTION
## Description

This change replaces socket-to-socket connections with management connections. In addition, the input counts have been fixed for components by evaluating the "emptiness" and existence of external sources. As a result of this change, sockets have been removed from the "dal-materialized-views" crate and from the frontend's known entity types.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaWpkNHAzZHkyMDYwOXk0M2lrNHl6ZDdsOHgyYnhkbHc5MXI3aGI4MiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/gQm37vKLwkUVjOvVmp/giphy-downsized-medium.gif"/>