### PR TITLE
chore(frigg): demote index key deserialize `warn` msgs to `debug`

### DIFF
--- a/lib/frigg/src/lib.rs
+++ b/lib/frigg/src/lib.rs
@@ -412,7 +412,7 @@ impl FriggStore {
             match serde_json::from_slice(bytes.as_ref()).map_err(Error::Deserialize) {
                 Ok(value) => value,
                 Err(err) => {
-                    warn!(
+                    debug!(
                         "Unable to deserialize index pointer value at {}: {}",
                         index_pointer_key, err
                     );
@@ -422,7 +422,7 @@ impl FriggStore {
         // If the definition checksum for the current set of MVs is not the same as the one the MvIndex was built for,
         // then the MvIndex is out of date and should not be used at all.
         if index_pointer_value.definition_checksum != materialized_view_definitions_checksum() {
-            warn!(
+            debug!(
                 "Index pointer is out of date: index checksum: {}, expected checksum: {}",
                 index_pointer_value.definition_checksum,
                 materialized_view_definitions_checksum()


### PR DESCRIPTION
If we expect that the `IndexPointerValue` could fail to deserialize, and we remediate this, it isn't a `warn` level. We clearly fire this event way too often which either means we should purge Frigg stores, or live with the "un-deserializable" index value (and therefore it's not an unexpected state).

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYWFqODNvc2J3cXRhY3Fyc3M2c3ZyemUwaWN2emQ0M3B5Ym0wb3I4dSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/efc4G5E7mXYoo/giphy.gif"/>