### PR TITLE
Ensure Components in ViewComponentList have stable ordering

### DIFF
--- a/lib/dal-materialized-views/src/view_component_list.rs
+++ b/lib/dal-materialized-views/src/view_component_list.rs
@@ -31,6 +31,7 @@ pub async fn assemble(ctx: DalContext, view_id: ViewId) -> super::Result<ViewCom
             GeometryRepresents::View(_view_id) => {}
         }
     }
+    components.sort_by_key(|c| c.id);
 
     Ok(ViewComponentListMv {
         id: view_id,


### PR DESCRIPTION
The lack of stable ordering of the `Component`s was causing patches to be unnecessarily large, and for there to be unnecessary patches in the first place.