### PR TITLE
Stable output for IncomingConnectionsList and IncommingConnections MVs

### DIFF
--- a/lib/dal-materialized-views/src/incoming_connections.rs
+++ b/lib/dal-materialized-views/src/incoming_connections.rs
@@ -55,8 +55,9 @@ async fn socket_to_socket(ctx: &DalContext, component_id: ComponentId) -> Result
             InputSocket::component_attribute_value_id(ctx, input_socket_id, component_id).await?;
         let attribute_prototype_id =
             AttributeValue::prototype_id(ctx, input_socket_attribute_value_id).await?;
-        let attribute_prototype_argument_ids =
+        let mut attribute_prototype_argument_ids =
             AttributePrototype::list_arguments(ctx, attribute_prototype_id).await?;
+        attribute_prototype_argument_ids.sort();
 
         // Don't bother gathering information to cache if there are no prototype arguments.
         if attribute_prototype_argument_ids.is_empty() {

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1483,6 +1483,8 @@ impl Component {
                 .get_component_node_weight()?;
             component_ids.push(node_weight.id.into())
         }
+        component_ids.sort();
+
         Ok(component_ids)
     }
 

--- a/lib/dal/src/workspace_snapshot/selector.rs
+++ b/lib/dal/src/workspace_snapshot/selector.rs
@@ -863,14 +863,17 @@ impl InputSocketExt for WorkspaceSnapshotSelector {
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
     ) -> WorkspaceSnapshotResult<Vec<InputSocket>> {
-        match self {
+        let mut result = match self {
             Self::LegacySnapshot(snapshot) => {
                 snapshot.list_input_sockets(ctx, schema_variant_id).await
             }
             Self::SplitSnapshot(snapshot) => {
                 snapshot.list_input_sockets(ctx, schema_variant_id).await
             }
-        }
+        }?;
+        result.sort_by_key(|socket| socket.id());
+
+        Ok(result)
     }
 
     async fn all_attribute_value_ids_everywhere_for_input_socket_id(


### PR DESCRIPTION
Not having the Components & InputSockets handled in consistent ordering was causing unnecessary, and unnecessarily large patches to be generated.