### PR TITLE
fix(dal): Fix normalize to array migration

### DIFF
--- a/lib/dal/src/workspace_snapshot/graph/validator/connections.rs
+++ b/lib/dal/src/workspace_snapshot/graph/validator/connections.rs
@@ -387,13 +387,15 @@ impl PropConnection {
                     .kind;
             match func_produces_array(graph, source_func_id, source_is_array)? {
                 // If the source function already produces an array, we can use it as is
-                Some(false) => source_func_id,
+                Some(true) => source_func_id,
+
                 // If the source function produces a single value, we append a new element to the
                 // array and set the subscription on the new element.
-                Some(true) => {
-                    destination_path.push_back("");
+                Some(false) => {
+                    destination_path.push_back("-");
                     source_func_id
                 }
+
                 // If we don't know whether the source func yields an array or not, we can't
                 // migrate a normalizeToArray connection!
                 None => {


### PR DESCRIPTION
I may have switched a sign on that last PR, making multi-arity connections not migrate. This is why we have dry run, I guess :)

<IMG SRC="https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3OXppZTVwM2ZscDlvbTY3YW5wemNuZXl2NDYzNzFwMjltMjMyMjc2ayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/M8cGrJFXyJMKTEfam2/giphy.gif">