### PR TITLE
Disallow func run selection for enqueued actions

### DIFF
--- a/app/web/src/newhotness/ActionCard.vue
+++ b/app/web/src/newhotness/ActionCard.vue
@@ -84,7 +84,8 @@
         <DropdownMenuItem
           icon="eye"
           label="View details"
-          @select="navigateToActionDetails"
+          :disabled="!props.action.funcRunId"
+          @select="navigateToActionDetailsProtected"
         />
 
         <!-- Action state controls -->
@@ -155,6 +156,12 @@ const route = useRoute();
 const confirmRef = ref<InstanceType<typeof ConfirmHoldModal> | null>(null);
 const contextMenuRef = ref<InstanceType<typeof DropdownMenu>>();
 
+// Navigate to action details only if the func run ID is populated for the action
+const navigateToActionDetailsProtected = () => {
+  if (!props.action.funcRunId) return;
+  navigateToActionDetails();
+};
+
 // Navigate to action details
 const navigateToActionDetails = () => {
   router.push({
@@ -186,6 +193,8 @@ const navigateToFuncRunDetails = () => {
 
 // Handle click on the card
 const handleClick = () => {
+  if (!props.action.funcRunId) return;
+
   emit("click", props.action);
 
   // Navigate to action details which will show the latest function run


### PR DESCRIPTION
## Description

This change disallows func run selection for enqueued actions without history of there ever being a func run. Specifically, both the click action and the "view details" option will be disabled when there is no func run for the action.

<img width="572" alt="Screenshot 2025-06-04 at 6 34 42 PM" src="https://github.com/user-attachments/assets/cc316ff8-f987-48a1-ad0a-558fba10d4ee" />
