### PR TITLE
chore(edda): add `CompressingStream` telemetry

### DIFF
--- a/lib/edda-server/src/change_set_processor_task.rs
+++ b/lib/edda-server/src/change_set_processor_task.rs
@@ -398,9 +398,6 @@ mod handlers {
                     frigg,
                     to_snapshot_address,
                 )
-                .instrument(tracing::info_span!(
-                    "edda.change_set_processor_task.new_change_set"
-                ))
                 .await?;
 
                 if index_was_copied {
@@ -420,26 +417,17 @@ mod handlers {
                         ctx,
                         frigg,
                         None,
+                        "explicit rebuild",
                     )
-                    .instrument(tracing::info_span!(
-                        "edda.change_set_processor_task.build_all_mv_for_change_set.explicit_rebuild"
-                    ))
                     .await
                     .map_err(Into::into)
                 }
             }
             CompressedRequest::Rebuild => {
                 // Rebuild
-                materialized_view::build_all_mv_for_change_set(
-                    ctx,
-                    frigg,
-                    None,
-                )
-                .instrument(tracing::info_span!(
-                    "edda.change_set_processor_task.build_all_mv_for_change_set.explicit_rebuild"
-                ))
-                .await
-                .map_err(Into::into)
+                materialized_view::build_all_mv_for_change_set(ctx, frigg, None, "explicit rebuild")
+                    .await
+                    .map_err(Into::into)
             }
             CompressedRequest::Update {
                 from_snapshot_address,
@@ -476,10 +464,8 @@ mod handlers {
                         ctx,
                         frigg,
                         latest_index_checksum,
+                        "snapshot moved",
                     )
-                    .instrument(tracing::info_span!(
-                        "edda.change_set_processor_task.build_all_mv_for_change_set.snapshot_moved"
-                    ))
                     .await
                     .map_err(Into::into)
                 }
@@ -487,10 +473,12 @@ mod handlers {
                 else {
                     // todo: this is where we'd handle reusing an index from another change set if
                     // the snapshots match!
-                    materialized_view::build_all_mv_for_change_set(ctx, frigg, None)
-                    .instrument(tracing::info_span!(
-                        "edda.change_set_processor_task.build_all_mv_for_change_set.initial_build"
-                    ))
+                    materialized_view::build_all_mv_for_change_set(
+                        ctx,
+                        frigg,
+                        None,
+                        "initial build",
+                    )
                     .await
                     .map_err(Into::into)
                 }
@@ -529,9 +517,6 @@ mod handlers {
             to_snapshot_address,
             &changes,
         )
-        .instrument(tracing::info_span!(
-            "edda.change_set_processor_task.build_mv_for_changes_in_change_set"
-        ))
         .await
         .map_err(Into::into)
     }

--- a/lib/edda-server/src/compressed_request.rs
+++ b/lib/edda-server/src/compressed_request.rs
@@ -52,7 +52,7 @@ impl CompressedRequest {
     // it this way with future compat in mind.
     #[instrument(
         name = "edda.compressed_request.from_requests",
-        level = "debug",
+        level = "info",
         skip_all,
         fields(
             si.edda.compressed_request.inputs = Empty,


### PR DESCRIPTION
This change adds a `Span` for each call to `CompressingStream.next()`, which pulls a `CompressedRequest` into a Naxum app.

Note that the time a span is open involves sitting and waiting for NATS messages on its subscription and possibly waiting for the Naxum app to poll the future to pull in the next unit of work (remember that Edda only performs one request at a time per-change set). There's also a quiescent period shutdown for this change set processing task, so some of these spans last for ~60 seconds and then close without yielding work (the task is being shutdown and so this stream is also being dropped and closes any spans in-flight).

chore(edda): remove extra instrument calls producing extra spans
------------------------------------------------------------------------------------------------

This change remove several `.instrument()` combinators that logged at the `info`
level on functions that were already instrumented at the `info` level.
In one case, the `.instrument()` calls added a little more information
as to *why* the function was being called, and so this "reason message"
was added to the function itself for its `#[instrument]` setup.

Additionally, the `materialized_view.build_mv_inner` span was demoted to
`debug` level.

This should reduce at least 2-4 spans for each Edda request processing
activity without much information loss.


<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdleGE2MWU4b2ZyOXZhYzM4N3NsaWV5d2RwNXk3c3huNzhnYWFlM2lhYyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/hWvk9iUU4uBBeyBq0k/giphy.gif"/>