### PR TITLE
feat(sdf): Migrate ARN connections with multiple props

### DIFF
--- a/app/web/src/store/admin.store.ts
+++ b/app/web/src/store/admin.store.ts
@@ -241,29 +241,34 @@ export type ValidationIssue =
       source_component: ComponentId;
       source_socket: OutputSocketId;
       message: string;
+      fixed: boolean;
     }
   | {
       type: "duplicateAttributeValue";
       original: AttributeValueId;
       duplicate: AttributeValueId;
       message: string;
+      fixed: boolean;
     }
   | {
       type: "duplicateAttributeValueWithDifferentValues";
       original: AttributeValueId;
       duplicate: AttributeValueId;
       message: string;
+      fixed: boolean;
     }
   | {
       type: "missingChildAttributeValues";
       object: AttributeValueId;
       missing_children: PropId[];
       message: string;
+      fixed: boolean;
     }
   | {
       type: "unknownChildAttributeValue";
       child: AttributeValueId;
       message: string;
+      fixed: boolean;
     };
 
 export interface MigrateConnectionsResponse {
@@ -276,17 +281,17 @@ export type ConnectionMigration =
       issue?: undefined;
       explicitConnectionId?: AttributePrototypeArgumentId;
       socketConnection: ConnectionMigrationSocketConnection;
-      propConnection: ConnectionMigrationPropConnection;
+      propConnections: ConnectionMigrationPropConnection[];
       message: string;
       migrated: boolean;
     }
-  // If there is an issue with an explicit connection, socket and prop connections may be undefined
+  // If there is an issue with an explicit connection, socket connections may be undefined
   // (because we may have identified the connection but been unable to completely build them out).
   | {
       issue: ConnectionUnmigrateableBecause;
       explicitConnectionId: AttributePrototypeArgumentId;
       socketConnection?: ConnectionMigrationSocketConnection;
-      propConnection?: ConnectionMigrationPropConnection;
+      propConnections: ConnectionMigrationPropConnection[];
       message: string;
       migrated: boolean;
     }
@@ -295,7 +300,7 @@ export type ConnectionMigration =
       issue: ConnectionUnmigrateableBecause;
       explicitConnectionId?: undefined;
       socketConnection: ConnectionMigrationSocketConnection;
-      propConnection?: ConnectionMigrationPropConnection;
+      propConnections: ConnectionMigrationPropConnection[];
       message: string;
       migrated: boolean;
     };


### PR DESCRIPTION
This adds the ability to migrate a single socket connection to multiple prop subscriptions, if the input socket is bound to multiple props. AWS ARN in particular uses this: you hook an ARN to its input socket, and 5 attribute functions run, splitting it up into pieces and putting it into five input props. This will create a subscription for each such prop, to the same target ARN, each one using its own attribute function.

<IMG SRC="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdjhzemRmc3dhOWE0ZmR4NW9ua216MWQ3M3p3NDdiZDR4cHo4amNiciZlcD12MV9naWZzX3NlYXJjaCZjdD1n/YBbiSlb0IzC24/giphy.gif">