### PR TITLE
fix(web): Don't early-initialize bifrost with random token

### DIFF
--- a/app/web/src/components/Workspace/WorkspaceModelAndView.vue
+++ b/app/web/src/components/Workspace/WorkspaceModelAndView.vue
@@ -282,10 +282,10 @@ const begin = async () => {
   if (
     changeSetsStore.selectedWorkspacePk &&
     changeSetsStore.selectedChangeSetId &&
-    authStore.selectedOrDefaultAuthToken
+    authStore.selectedWorkspaceToken
   ) {
     if (featureFlagsStore.FRONTEND_ARCH_VIEWS) {
-      await heimdall.init(authStore.selectedOrDefaultAuthToken, queryClient);
+      await heimdall.init(authStore.selectedWorkspaceToken, queryClient);
       watch(
         connectionShouldBeEnabled,
         async () => {

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -174,9 +174,9 @@ onBeforeMount(async () => {
   }, 500);
 
   // Activate the norse stack, which is explicitly NOT flagged for the job-specific UI.
-  if (!authStore.selectedOrDefaultAuthToken)
+  if (!authStore.selectedWorkspaceToken)
     throw new Error("no auth token selected");
-  await heimdall.init(authStore.selectedOrDefaultAuthToken, queryClient);
+  await heimdall.init(authStore.selectedWorkspaceToken, queryClient);
   watch(
     connectionShouldBeEnabled,
     async () => {

--- a/app/web/src/store/apis.web.ts
+++ b/app/web/src/store/apis.web.ts
@@ -35,7 +35,9 @@ export function injectBearerTokenAuth(config: InternalAxiosRequestConfig) {
   const authStore = useAuthStore();
   config.headers = config.headers || {};
 
-  const token = authStore.selectedOrDefaultAuthToken;
+  // TODO we don't have any reason to believe `anyWorkspaceToken` is valid, and no workflow
+  // should require us to use it--but things fail if you remove `anyWorkspaceToken`! Debug.
+  const token = authStore.selectedWorkspaceToken || authStore.anyWorkspaceToken;
   if (token) {
     config.headers.authorization = `Bearer ${token}`;
   }

--- a/app/web/src/store/auth.store.ts
+++ b/app/web/src/store/auth.store.ts
@@ -66,9 +66,9 @@ export const useAuthStore = () => {
           return state.tokens[workspacesStore.selectedWorkspacePk];
         }
       },
-      selectedOrDefaultAuthToken(): string | undefined {
-        return this.selectedWorkspaceToken || _.values(this.tokens)[0];
-      },
+      // Pick a workspace token, any token. Used for global auth endpoints when there is no
+      // selected workspace.
+      anyWorkspaceToken: (state) => _.values(state.tokens)[0],
       workspaceHasOneUser(): boolean {
         return Object.keys(this.workspaceUsers).length === 1;
       },


### PR DESCRIPTION
We're getting some failed requests to bifrost that use entirely the wrong token. I can't make this version of the problem repro precisely in localdev, but this fix will make it so that we will error instead of using a random token when we initialize bifrost, so we can debug it.

## Testing

- [x] Old UI still shows action runs (I can't see or create components locally either way)
- [x] New UI can create components
- [x] Account flows (login / logout / Go To Workspace / reload page) work
