### PR TITLE
Use SAH Pool VFS for sqlite DB in webworker

### DIFF
--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -139,15 +139,16 @@ const getDbName = (testing: boolean) => {
 
 const start = async (sqlite3: Sqlite3Static, testing: boolean) => {
   const dbname = getDbName(testing);
-  db =
-    "opfs" in sqlite3
-      ? new sqlite3.oo1.OpfsDb(`/${dbname}`)
-      : new sqlite3.oo1.DB(`/${dbname}`, "c");
-  debug(
-    "opfs" in sqlite3
-      ? `OPFS is available, created persisted database at ${db.filename}`
-      : `OPFS is not available, created transient database ${db.filename}`,
-  );
+
+  if ("opfs" in sqlite3) {
+    const poolUtil = await sqlite3.installOpfsSAHPoolVfs({});
+    db = new poolUtil.OpfsSAHPoolDb(`/${dbname}`);
+    debug(`OPFS is available, created persisted database in SAH Pool VFS at ${db.filename}`);
+  } else {
+    db = new sqlite3.oo1.DB(`/${dbname}`, "c");
+    debug(`OPFS is not available, created transient database ${db.filename}`);
+  }
+
   db.exec({ sql: "PRAGMA foreign_keys = ON;" });
 };
 


### PR DESCRIPTION
The SyncAccessHandle VFS is the highest performance option of the OPFS-backed configurations (currently) described in the SQLite WASM documentation.

https://sqlite.org/wasm/doc/trunk/persistence.md#vfs-opfs-sahpool

In local testing switching to the SAH VFS from the standard OPFS configuration significantly reduces the time from hitting refresh in the browser to having a fully rendered component list in the new UI when all of the necessary data is already loaded into SQLite, as well as reducing the time needed to do the initial import of data into SQLite. In the warm-sqlite-cache case it was reduced from ~60 seconds to ~20 seconds in local testing.