### PR TITLE
Add apply change set to new UI

### DIFF
--- a/app/web/src/components/layout/navbar/NavbarPanelRight.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelRight.vue
@@ -64,8 +64,13 @@
             "
             icon="trash"
             label="Ragnarok"
-            @click="() => heimdall.ragnarok(changeSetsStore.selectedWorkspacePk!,
-                changeSetsStore.selectedChangeSetId!)"
+            @click="
+              () =>
+                heimdall.ragnarok(
+                  changeSetsStore.selectedWorkspacePk!,
+                  changeSetsStore.selectedChangeSetId!,
+                )
+            "
           />
 
           <hr
@@ -103,6 +108,8 @@
 
     <ProfileButton :showTopLevelMenuItems="collapse" />
 
+    <ApplyChangeSetButton v-if="useNewUI" />
+
     <Modal ref="modalRef" title="Throw">
       <Stack>
         <VormInput v-model="entityKind" label="Entity Kind" type="text" />
@@ -135,6 +142,7 @@ import { useChangeSetsStore } from "@/store/change_sets.store";
 import { sdfApiInstance } from "@/store/apis.web";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import { EntityKind } from "@/workers/types/entity_kind_types";
+import ApplyChangeSetButton from "@/newhotness/ApplyChangeSetButton.vue";
 import NavbarButton from "./NavbarButton.vue";
 import Collaborators from "./Collaborators.vue";
 import Notifications from "./Notifications.vue";

--- a/app/web/src/newhotness/ApplyChangeSetButton.vue
+++ b/app/web/src/newhotness/ApplyChangeSetButton.vue
@@ -1,0 +1,85 @@
+<template>
+  <section v-if="!changeSetsStore.headSelected">
+    <VButton
+      ref="applyButtonRef"
+      size="sm"
+      tone="action"
+      label="Apply Change Set"
+      class="ml-2xs mr-xs"
+      loadingText="Applying Changes"
+      :requestStatus="applyChangeSetReqStatus"
+      :disabled="disabled"
+      @click="openApprovalFlowModal"
+    >
+      <template #iconRight>
+        <!--
+          NOTE(nick): I wanted this to look like "Add a component", but its concept of a pill 
+          more of a plaintext helper. The pills look a little different and I don't love it, but
+          this will have to do in the meantime.
+        -->
+        <PillCounter
+          :count="actions.length"
+          :paddingX="actions.length > 10 ? '2xs' : 'xs'"
+          noColorStyles
+          class="border border-action-200 ml-2xs py-2xs"
+        />
+      </template>
+    </VButton>
+    <ApprovalFlowModal
+      ref="approvalFlowModalRef"
+      votingKind="merge"
+      :actions="actions"
+    />
+  </section>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from "vue";
+import * as _ from "lodash-es";
+import { VButton, PillCounter } from "@si/vue-lib/design-system";
+import { useQuery } from "@tanstack/vue-query";
+import { useChangeSetsStore } from "@/store/change_sets.store";
+import { useStatusStore } from "@/store/status.store";
+import { ChangeSetStatus } from "@/api/sdf/dal/change_set";
+import {
+  BifrostActionViewList,
+  EntityKind,
+} from "@/workers/types/entity_kind_types";
+import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
+import ApprovalFlowModal from "./ApprovalFlowModal.vue";
+
+const changeSetsStore = useChangeSetsStore();
+const statusStore = useStatusStore();
+
+const applyChangeSetReqStatus =
+  changeSetsStore.getRequestStatus("APPLY_CHANGE_SET");
+
+const approvalFlowModalRef = ref<InstanceType<typeof ApprovalFlowModal>>();
+
+const openApprovalFlowModal = () => {
+  approvalFlowModalRef.value?.open();
+};
+
+const disabled = computed(
+  () =>
+    changeSetsStore.selectedChangeSet?.status !== ChangeSetStatus.Open ||
+    changeSetsStore.headSelected ||
+    statusStoreUpdating.value,
+);
+
+const statusStoreUpdating = computed(() => {
+  if (statusStore.globalStatus) {
+    return statusStore.globalStatus.isUpdating;
+  } else return false;
+});
+
+const key = useMakeKey();
+const args = useMakeArgs();
+
+const actionsRaw = useQuery<BifrostActionViewList | null>({
+  queryKey: key(EntityKind.ActionViewList),
+  queryFn: async () =>
+    await bifrost<BifrostActionViewList>(args(EntityKind.ActionViewList)),
+});
+const actions = computed(() => actionsRaw.data.value?.actions ?? []);
+</script>

--- a/app/web/src/newhotness/ApprovalFlowModal.vue
+++ b/app/web/src/newhotness/ApprovalFlowModal.vue
@@ -1,0 +1,223 @@
+<template>
+  <div>
+    <Modal ref="modalRef" hideExitButton title="Changes To Be Applied">
+      <div class="max-h-[70vh] overflow-hidden flex flex-col">
+        <div class="text-sm mb-xs pb-sm">
+          Applying this change set may create, modify, or destroy real resources
+          in the cloud. These actions will be applied to the real world:
+        </div>
+        <div
+          class="flex-grow overflow-y-auto mb-sm border border-neutral-100 dark:border-neutral-700"
+        >
+          <div class="flex flex-row py-xs">
+            <span class="ml-xs text-md">{{ actionsTitle }}</span>
+
+            <!-- NOTE(nick): these are right-aligned pill counters for each action kind. -->
+            <div class="ml-auto mr-xs flex flex-row">
+              <PillCounter hideIfZero class="ml-2xs" :count="counts.create">
+                <Icon name="plus" tone="success" size="xs" />
+              </PillCounter>
+              <PillCounter hideIfZero class="ml-2xs" :count="counts.destroy">
+                <Icon name="x" tone="destructive" size="xs" />
+              </PillCounter>
+              <PillCounter hideIfZero class="ml-2xs" :count="counts.refresh">
+                <Icon name="refresh" tone="action" size="xs" />
+              </PillCounter>
+              <PillCounter hideIfZero class="ml-2xs" :count="counts.other">
+                <Icon name="play" tone="warning" size="xs" />
+              </PillCounter>
+            </div>
+          </div>
+          <ul class="actions list">
+            <!-- NOTE(nick): we are re-using the action cards, but are disallowing interaction. -->
+            <ActionCard
+              v-for="action in props.actions"
+              :key="action.id"
+              :action="action"
+              :selected="false"
+              noInteraction
+            />
+          </ul>
+        </div>
+        <div
+          class="flex flex-row w-full items-center justify-center gap-sm mt-xs"
+        >
+          <VButton
+            label="Cancel"
+            tone="neutral"
+            pill="Esc"
+            @click="closeModalHandler"
+          />
+          <!--
+            TODO(nick): restore the dynamic label when approvals are re-introduced.
+            ```
+            :label="
+              workspaceHasOneUser || !workspacesStore.workspaceApprovalsEnabled
+              ? 'Apply Change Set'
+              : 'Request Approval'
+            "
+            ```
+          -->
+          <VButton
+            tone="action"
+            label="Apply Change Set"
+            class="grow"
+            pill="Cmd + Enter"
+            @click="applyButtonHandler"
+          />
+        </div>
+      </div>
+    </Modal>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import * as _ from "lodash-es";
+import { PillCounter, Icon, VButton, Modal } from "@si/vue-lib/design-system";
+import { useToast } from "vue-toastification";
+import { useRouter, useRoute } from "vue-router";
+import { computed, inject, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { ChangeSetStatus } from "@/api/sdf/dal/change_set";
+import { useAuthStore } from "@/store/auth.store";
+import { useChangeSetsStore } from "@/store/change_sets.store";
+import ApprovalFlowCancelled from "@/components/toasts/ApprovalFlowCancelled.vue";
+import { ActionProposedView } from "@/store/actions.store";
+import { ActionKind } from "@/api/sdf/dal/action";
+import { keyEmitter } from "./logic_composables/emitters";
+import ActionCard from "./ActionCard.vue";
+import { Context } from "./types";
+import { reset } from "./logic_composables/navigation_stack";
+
+const props = defineProps<{
+  actions: ActionProposedView[];
+}>();
+
+const changeSetsStore = useChangeSetsStore();
+const authStore = useAuthStore();
+const toast = useToast();
+
+const modalRef = ref<InstanceType<typeof Modal> | null>(null);
+const changeSet = computed(() => changeSetsStore.selectedChangeSet);
+
+const ctx: Context | undefined = inject("CONTEXT");
+const router = useRouter();
+const route = useRoute();
+
+const actionsTitle = computed(() =>
+  props.actions.length === 1
+    ? `${props.actions.length} Action`
+    : `${props.actions.length} Actions`,
+);
+
+const counts = computed(() => {
+  const results: Record<string, number> = {
+    create: 0,
+    destroy: 0,
+    refresh: 0,
+    other: 0, // NOTE(nick): "manual" and "other" are grouped together
+  };
+  for (const action of props.actions) {
+    if (action.kind === ActionKind.Create) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      results.create! += 1;
+    } else if (action.kind === ActionKind.Destroy) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      results.destroy! += 1;
+    } else if (action.kind === ActionKind.Refresh) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      results.refresh! += 1;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      results.other! += 1;
+    }
+  }
+  return results;
+});
+
+const clearKeyEmitters = () => {
+  keyEmitter.off("Enter");
+};
+onMounted(() => {
+  clearKeyEmitters();
+
+  keyEmitter.on("Enter", (e) => {
+    if (e.metaKey || e.ctrlKey) {
+      applyButtonHandler();
+    }
+  });
+});
+onBeforeUnmount(() => {
+  clearKeyEmitters();
+});
+
+async function openModalHandler() {
+  if (changeSet?.value?.name === "HEAD") return;
+
+  modalRef.value?.open();
+}
+
+function closeModalHandler() {
+  modalRef.value?.close();
+}
+
+function applyButtonHandler() {
+  // TODO(nick): restore approvals in the new UI.
+  // if (!workspacesStore.workspaceApprovalsEnabled && authStore.user) {
+  //   changeSetsStore.APPLY_CHANGE_SET(authStore.user.name);
+  // } else {
+  //   if (workspaceHasOneUser.value && authStore.user) {
+  //     changeSetsStore.APPLY_CHANGE_SET(authStore.user.name);
+  //   } else {
+  //     changeSetsStore.REQUEST_CHANGE_SET_APPROVAL();
+  //
+  //     // TODO(nick): we should remove this in favor of only the WsEvent fetching. It appears that
+  //     // requesting the approval itself is insufficient for getting the latest approval status at
+  //     // the time of writing and the reason appears to be that the change set is "open" by the
+  //     // time the inset modal opens. Fortunately, this will work since we are the requester.
+  //     if (changeSet.value) {
+  //       changeSetsStore.FETCH_APPROVAL_STATUS(changeSet.value.id);
+  //     }
+  //
+  //     presenceStore.leftDrawerOpen = false; // close the left draw for the InsetModal
+  //   }
+  // }
+
+  // TODO(nick): we should make sure this isn't possible...
+  if (!ctx || !authStore.user) return;
+
+  changeSetsStore.APPLY_CHANGE_SET(authStore.user.name);
+  const name = route.name;
+  router.push({
+    name,
+    params: {
+      ...route.params,
+      changeSetId: ctx.headChangeSetId.value,
+    },
+    query: route.query,
+  });
+  reset();
+  closeModalHandler();
+}
+
+watch(
+  () => changeSetsStore.selectedChangeSet?.status,
+  (newVal, oldVal) => {
+    if (
+      newVal === ChangeSetStatus.Open &&
+      (oldVal === ChangeSetStatus.NeedsApproval ||
+        oldVal === ChangeSetStatus.Approved ||
+        oldVal === ChangeSetStatus.Rejected)
+    ) {
+      if (!changeSetsStore.headSelected) {
+        toast({
+          component: ApprovalFlowCancelled,
+          props: {
+            action: "applying",
+          },
+        });
+      }
+    }
+  },
+);
+defineExpose({ open: openModalHandler });
+</script>

--- a/lib/vue-lib/src/design-system/general/PillCounter.vue
+++ b/lib/vue-lib/src/design-system/general/PillCounter.vue
@@ -7,6 +7,7 @@
         paddingX !== 'none' && `px-${paddingX}`,
         paddingY !== 'none' && `py-${paddingY}`,
         'inline-block rounded text-center',
+        'flex flex-row items-center', // NOTE(nick): this is for the slot
         !noColorStyles &&
           (toneToBg
             ? getToneBgColorClass(tone)
@@ -20,6 +21,7 @@
       )
     "
   >
+    <slot />
     {{ count }}
   </div>
 </template>


### PR DESCRIPTION
## Description

This change adds the ability to apply change sets in the new UI. This does not include approvals, but leaves the door open to them. The apply button follows the same design style as "Add a component".

The modal supports keyboard input, including "ESC" for exiting the modal and "CMD + ENTER" for applying the change set. The modal also follows a similar style to the rest of the new UI, trading icons for keyboard shortcut suggestions.

The actions list within the modal is now driven by props and contains pill counters for each kind of action seen in the list. The pill counter building block component has been extended to allow slotted-in icons.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlb3I3aTF3djEzbHN1bTUwZ2xsN2pvczZsdW9uNzY4dXpmaWl0bTV3NiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/tF5F1Eh4a2UILG2xjD/giphy.gif"/>