### PR TITLE
fix(edda): impl a liveness-aware quiescent period for compressing stream

### DIFF
--- a/lib/edda-server/src/config.rs
+++ b/lib/edda-server/src/config.rs
@@ -28,7 +28,7 @@ use ulid::Ulid;
 
 const DEFAULT_CONCURRENCY_LIMIT: Option<usize> = None;
 
-const DEFAULT_QUIESCENT_PERIOD_SECS: u64 = 60;
+const DEFAULT_QUIESCENT_PERIOD_SECS: u64 = 60 * 10;
 const DEFAULT_QUIESCENT_PERIOD: Duration = Duration::from_secs(DEFAULT_QUIESCENT_PERIOD_SECS);
 
 #[remain::sorted]


### PR DESCRIPTION
This change alters the "quiescent_period" timeout on
`ChangeSetProcessorTask`s by basing the quiet period on the last time
the `CompressingStream`'s state machine was updated. This way, if there
is still work to be done inside the compressing stream, a quiet period
will *not* be detected until we are waiting for another "first message"
(or if it stalls on another intermediate state).

Additionally, the current value of the stream's `State` is recorded as
a `task.state` attribute on the `compressing_stream.next` span. This
would allow us to alert on the compressing stream closing in unexpected
states.


chore(edda): increase default quiescent period to `10m`
------------------------

Yep, we're upping this for now!

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYzJ3OWx5c3dqcHA0aTAwZTlwa2NoMjFscmNvczBhOXo5YXo2NnI1aSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/nhklNniaxTXoI/giphy.gif"/>
