### PR TITLE
fix(module-index-client): re-use `reqwest::Client` across calls

### DIFF
--- a/bin/hoist/src/main.rs
+++ b/bin/hoist/src/main.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
 
     let endpoint = &args.endpoint;
     let token = &args.token;
-    let client = ModuleIndexClient::new(Url::parse(endpoint)?, token);
+    let client = ModuleIndexClient::new(Url::parse(endpoint)?, token)?;
 
     match args.command {
         Some(Commands::AnonymizeSpecs(args)) => anonymize_specs(args.target_dir, args.out).await?,

--- a/lib/dal/src/cached_module.rs
+++ b/lib/dal/src/cached_module.rs
@@ -271,7 +271,7 @@ impl CachedModule {
                 .module_index_url()
                 .ok_or(CachedModuleError::ModuleIndexUrlNotSet)?;
 
-            ModuleIndexClient::unauthenticated_client(module_index_url.try_into()?)
+            ModuleIndexClient::unauthenticated_client(module_index_url.try_into()?)?
         };
 
         let modules: HashMap<_, _> = module_index_client

--- a/lib/sdf-server/src/migrations.rs
+++ b/lib/sdf-server/src/migrations.rs
@@ -223,7 +223,7 @@ impl Migrator {
                     info!("Module cache updated successfully");
                 }
                 Err(err) => {
-                    error!("Error updating module cache: {}", err);
+                    error!("Error updating module cache: {:?}", err);
                 }
             }
         });

--- a/lib/sdf-server/src/service/v2/module/builtins.rs
+++ b/lib/sdf-server/src/service/v2/module/builtins.rs
@@ -72,7 +72,7 @@ pub async fn promote(
         ));
 
     let module_index_client =
-        ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token);
+        ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token)?;
 
     module_index_client
         .promote_to_builtin(module_id.into(), created_by_email.clone())
@@ -132,7 +132,7 @@ pub async fn reject(
         ));
 
     let module_index_client =
-        ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token);
+        ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token)?;
 
     module_index_client
         .reject_module(module_id.into(), created_by_email.clone())

--- a/lib/sdf-server/src/service/v2/module/contribute.rs
+++ b/lib/sdf-server/src/service/v2/module/contribute.rs
@@ -48,7 +48,7 @@ pub async fn contribute(
         Some(url) => url,
         None => return Err(ModulesAPIError::ModuleIndexNotConfigured),
     };
-    let index_client = ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token);
+    let index_client = ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token)?;
 
     let (
         name,

--- a/lib/sdf-server/src/service/v2/module/module_by_id.rs
+++ b/lib/sdf-server/src/service/v2/module/module_by_id.rs
@@ -62,7 +62,7 @@ pub async fn remote_module_by_id(
     };
 
     let module_index_client =
-        ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token);
+        ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token)?;
     let pkg_data = module_index_client.download_module(request.id).await?;
 
     let pkg = SiPkg::load_from_bytes(&pkg_data)?;

--- a/lib/sdf-server/src/service/v2/workspace/install_workspace.rs
+++ b/lib/sdf-server/src/service/v2/workspace/install_workspace.rs
@@ -112,7 +112,7 @@ async fn install_workspace_inner(
             None => return Err(WorkspaceAPIError::ModuleIndexUrlNotSet),
         };
         let module_index_client =
-            ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token);
+            ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token)?;
         module_index_client
             .download_workspace(workspace_pk.into())
             .await?

--- a/lib/sdf-v1-routes-module/src/approval_process.rs
+++ b/lib/sdf-v1-routes-module/src/approval_process.rs
@@ -52,7 +52,7 @@ pub async fn begin_approval_process(
     };
 
     let module_index_client =
-        ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token);
+        ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token)?;
     let pkg_data = module_index_client.download_workspace(request.id).await?;
 
     let metadata = pkg_data.into_latest().metadata;

--- a/lib/sdf-v1-routes-module/src/install_module.rs
+++ b/lib/sdf-v1-routes-module/src/install_module.rs
@@ -68,7 +68,7 @@ pub async fn install_module(
     let mut variants = Vec::new();
 
     let module_index_client =
-        ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token);
+        ModuleIndexClient::new(module_index_url.try_into()?, &raw_access_token)?;
 
     // Before we install the module(s), ensure that there are no unlocked variants.
     let mut ids_with_details = Vec::with_capacity(request.ids.len());


### PR DESCRIPTION
This change forces the `ModuleIndexClient` to re-use a once-built `reqwest::Client` to reuse underlying connection pooling, DNS lookups, etc. The bearer auth is replicated using the underlying associated header and is marked as `sensitive` so that any debug logging doesn't accidentally leak credentials (which is what that
`RequestBuilder.bearer_auth` does in its impl).

Prior to this change, every fresh `reqwest::Client` is forced to DNS-resolve its URLs, re-establish any persistent TCP connections, etc.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlempqa2gydHU1MHMzeGZ0N3Y5dGE0anI1MDI3Z3Jzc2kzeWF4b2tqayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ZI4owdgI8ob1LtkFjt/giphy.gif"/>