### PR TITLE
Remove N+1 from bifrost get calls

### DIFF
--- a/app/web/src/components/layout/navbar/NavbarPanelCenter.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelCenter.vue
@@ -37,6 +37,7 @@
 import { useRoute } from "vue-router";
 import { useViewsStore } from "@/store/views.store";
 import { useChangeSetsStore } from "@/store/change_sets.store";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import NavbarButton from "./NavbarButton.vue";
 
 const route = useRoute();
@@ -44,10 +45,12 @@ const route = useRoute();
 const modelingLink = () => {
   const viewsStore = useViewsStore();
   const changeSetStore = useChangeSetsStore();
+  const ffStore = useFeatureFlagsStore();
+  const prefix = ffStore.NEW_HOTNESS ? "new-hotness" : "workspace-compose";
   if (changeSetStore.selectedChangeSetId) {
     if (viewsStore.selectedViewId) {
       return {
-        name: "workspace-compose-view",
+        name: `${prefix}-view`,
         params: {
           changeSetId: changeSetStore.selectedChangeSetId,
           viewId: viewsStore.selectedViewId,
@@ -55,13 +58,13 @@ const modelingLink = () => {
       };
     } else {
       return {
-        name: "workspace-compose",
+        name: prefix,
         params: { changeSetId: changeSetStore.selectedChangeSetId },
       };
     }
   }
   return {
-    name: "workspace-compose",
+    name: prefix,
     params: { changeSetId: "auto" },
   };
 };

--- a/app/web/src/newhotness/ComponentGridTile.vue
+++ b/app/web/src/newhotness/ComponentGridTile.vue
@@ -104,12 +104,15 @@ import {
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { computed } from "vue";
-import { BifrostComponent } from "@/workers/types/entity_kind_types";
+import {
+  BifrostComponent,
+  BifrostComponentInList,
+} from "@/workers/types/entity_kind_types";
 import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
 import { getAssetIcon } from "./util";
 
 const props = defineProps<{
-  component: BifrostComponent;
+  component: BifrostComponent | BifrostComponentInList;
   hideConnections?: boolean;
 }>();
 

--- a/app/web/src/newhotness/ConnectionsPanel.vue
+++ b/app/web/src/newhotness/ConnectionsPanel.vue
@@ -23,8 +23,8 @@ import { useQuery } from "@tanstack/vue-query";
 import clsx from "clsx";
 import { themeClasses } from "@si/vue-lib/design-system";
 import {
-  BifrostComponent,
   BifrostComponentConnections,
+  BifrostComponentInList,
   BifrostConnection,
   EntityKind,
 } from "@/workers/types/entity_kind_types";
@@ -39,7 +39,7 @@ import ConnectionLayout, {
 } from "./layout_components/ConnectionLayout.vue";
 
 const props = defineProps<{
-  component: BifrostComponent;
+  component: BifrostComponentInList;
   connections?: BifrostComponentConnections;
 }>();
 

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -1,5 +1,6 @@
 <template>
-  <section :class="clsx('grid h-full', showGrid ? 'explore' : 'map')">
+  <DelayedLoader v-if="componentListRaw.isLoading.value" :size="'full'" />
+  <section v-else :class="clsx('grid h-full', showGrid ? 'explore' : 'map')">
     <!-- Left column -->
     <!-- 12 pixel padding to align with the SI logo -->
     <div
@@ -212,11 +213,11 @@ import { tw } from "@si/vue-lib";
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import {
   BifrostActionViewList,
-  BifrostComponent,
   BifrostComponentList,
   BifrostViewList,
   ViewComponentList,
   EntityKind,
+  BifrostComponentInList,
 } from "@/workers/types/entity_kind_types";
 import RealtimeStatusPageState from "@/components/RealtimeStatusPageState.vue";
 import { ComponentId } from "@/api/sdf/dal/component";
@@ -229,6 +230,7 @@ import Breadcrumbs from "./layout_components/Breadcrumbs.vue";
 import ActionCard from "./ActionCard.vue";
 import FuncRunList from "./FuncRunList.vue";
 import { assertIsDefined, Context, ExploreContext } from "./types";
+import DelayedLoader from "./layout_components/DelayedLoader.vue";
 import { KeyDetails, keyEmitter } from "./logic_composables/emitters";
 import TabGroupToggle from "./layout_components/TabGroupToggle.vue";
 import { SelectionsInQueryString } from "./Workspace.vue";
@@ -341,7 +343,7 @@ const componentList = computed(
 
 const scrollRef = ref<HTMLDivElement>();
 
-const filteredComponents = reactive<BifrostComponent[]>([]);
+const filteredComponents = reactive<BifrostComponentInList[]>([]);
 
 const searchString = ref("");
 const computedSearchString = computed(() => searchString.value);

--- a/app/web/src/newhotness/Map.vue
+++ b/app/web/src/newhotness/Map.vue
@@ -118,8 +118,8 @@ import * as _ from "lodash-es";
 import { Fzf } from "fzf";
 import { ComponentId } from "@/api/sdf/dal/component";
 import {
-  BifrostComponent,
   BifrostComponentConnections,
+  BifrostComponentInList,
   BifrostIncomingConnectionsList,
   EntityKind,
 } from "@/workers/types/entity_kind_types";
@@ -139,7 +139,7 @@ const props = defineProps<{
 const componentContextMenuRef =
   ref<InstanceType<typeof ComponentContextMenu>>();
 
-const selectedComponent = ref<BifrostComponent | null>(null);
+const selectedComponent = ref<BifrostComponentInList | null>(null);
 
 const ctx = inject<Context>("CONTEXT");
 assertIsDefined(ctx);
@@ -358,6 +358,7 @@ const tones = reactive<Tones[]>(["success", "destructive"]);
 
 const connections = useQuery<BifrostIncomingConnectionsList>({
   queryKey,
+  enabled: () => active.value, // Only run query when map view is active
   queryFn: async () => {
     const d = await bifrost<BifrostIncomingConnectionsList | null>(
       args(EntityKind.IncomingConnectionsList),
@@ -387,14 +388,14 @@ const connections = useQuery<BifrostIncomingConnectionsList>({
 const mapData = computed(() => {
   const nodes = new Set<string>();
   const edges = new Set<string>();
-  const components: Record<string, BifrostComponent> = {};
+  const components: Record<string, BifrostComponentInList> = {};
   if (!connections.data.value) {
     return { nodes, edges, components };
   }
 
   const matchingIds: string[] = [];
   if (searchString?.value && searchString.value.trim().length > 0) {
-    const componentsMap: Record<string, BifrostComponent> = {};
+    const componentsMap: Record<string, BifrostComponentInList> = {};
     connections.data.value.componentConnections.forEach((c) => {
       componentsMap[c.id] = c.component;
     });
@@ -443,7 +444,7 @@ type node = {
   id: string;
   width: number;
   height: number;
-  component: BifrostComponent;
+  component: BifrostComponentInList;
   icons: [string | null];
 };
 

--- a/app/web/src/newhotness/layout_components/ConnectionLayout.vue
+++ b/app/web/src/newhotness/layout_components/ConnectionLayout.vue
@@ -23,12 +23,12 @@
 
 <script setup lang="ts">
 import { useRoute, useRouter } from "vue-router";
-import { BifrostComponent } from "@/workers/types/entity_kind_types";
+import { BifrostComponentInList } from "@/workers/types/entity_kind_types";
 
 export interface SimpleConnection {
   key: string;
   componentId: string;
-  component: BifrostComponent;
+  component: BifrostComponentInList;
   self: string;
   other: string;
 }

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -123,14 +123,16 @@ export const bifrost = async <T>(args: {
   id: Id;
 }): Promise<Reactive<T> | null> => {
   if (!initCompleted.value) throw new Error("bifrost not initiated");
-  // eslint-disable-next-line no-console
-  console.log("🌈 bifrost query", args.kind, args.id);
+  const start = Date.now();
   const maybeAtomDoc = await db.get(
     args.workspaceId,
     args.changeSetId,
     args.kind,
     args.id,
   );
+  const end = Date.now();
+  // eslint-disable-next-line no-console
+  console.log("🌈 bifrost query", args.kind, args.id, end - start, "ms");
   if (maybeAtomDoc === -1) return null;
   return reactive(maybeAtomDoc);
 };
@@ -220,7 +222,7 @@ export const makeKey = (kind: string, id?: string) => {
     workspaceId.value,
     changeSetId.value,
     kind as EntityKind,
-    id ?? changeSetId.value,
+    id ?? workspaceId.value,
   ];
 };
 

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -106,11 +106,11 @@ export interface RawViewList {
 }
 
 export interface BifrostSchemaVariantCategories {
-  id: string; // change set id
+  id: string; // workspace id
   categories: Categories;
 }
 export interface EddaSchemaVariantCategories {
-  id: string; // change set id
+  id: string; // workspace id
   categories: Array<{
     displayName: string;
     schemaVariants: Array<{
@@ -259,19 +259,23 @@ export interface BifrostComponent {
   attributeTree: AttributeTree;
 }
 
+// NOTE: when using `getMany` you don't end up with a BifrostComponent (b/c it doesnt have SchemaVariant)
+// You end up with a BifrostComponentInList
+export type BifrostComponentInList = Omit<BifrostComponent, "schemaVariant">;
+
 export interface BifrostComponentList {
   id: ChangeSetId;
-  components: BifrostComponent[];
+  components: BifrostComponentInList[];
 }
 
 export interface ViewComponentList {
   id: ViewId;
-  components: BifrostComponent[];
+  components: BifrostComponentInList[];
 }
 
 export interface EddaComponentList {
   id: ChangeSetId;
-  components: Reference<EntityKind.Component>[];
+  components: WeakReference<EntityKind.Component>[];
 }
 
 export interface ActionPrototypeView {
@@ -356,7 +360,7 @@ export interface BifrostIncomingConnectionsList {
 // EntityKind.IncomingConnections
 export interface BifrostComponentConnections {
   id: ComponentId;
-  component: BifrostComponent;
+  component: BifrostComponentInList;
   incoming: BifrostConnection[];
   // note: outgoing connections cannot be computed right now
 }
@@ -384,23 +388,40 @@ export type EddaConnection =
 export type BifrostConnection =
   | {
       kind: "management";
-      fromComponent: BifrostComponent;
-      toComponent: BifrostComponent;
+      fromComponentId: WeakReference<EntityKind.Component>;
+      fromComponent: BifrostComponentInList;
+      toComponent: BifrostComponentInList;
     }
   | {
       kind: "prop";
-      fromComponent: BifrostComponent;
+      fromComponentId: WeakReference<EntityKind.Component>;
+      fromComponent: BifrostComponentInList;
       fromAttributeValueId: AttributeValueId;
       fromAttributeValuePath: string;
       fromPropId: PropId;
       fromPropPath: string;
-      toComponent: BifrostComponent;
+      toComponent: BifrostComponentInList;
       toPropId: PropId;
       toPropPath: string;
       toAttributeValueId: AttributeValueId;
       toAttributeValuePath: string;
     };
 
+export type MaybeBifrostConnection = Omit<
+  BifrostConnection,
+  "toComponent" | "fromComponent"
+> & {
+  toComponent: BifrostComponentInList | -1;
+  fromComponent: BifrostComponentInList | -1;
+};
+
+export type MaybeBifrostComponentConnections = Omit<
+  BifrostComponentConnections,
+  "component" | "incoming"
+> & {
+  component: BifrostComponentInList | -1;
+  incoming: MaybeBifrostConnection[];
+};
 export interface SecretFormDataView {
   name: string;
   kind: string;

--- a/lib/dal-materialized-views/src/component_list.rs
+++ b/lib/dal-materialized-views/src/component_list.rs
@@ -14,14 +14,10 @@ pub async fn assemble(ctx: DalContext) -> super::Result<ComponentListMv> {
     let ctx = &ctx;
     let mut component_ids = Component::list_ids(ctx).await?;
     component_ids.sort();
-    let mut components = Vec::with_capacity(component_ids.len());
 
-    for component_id in component_ids {
-        components.push(super::component::assemble(ctx.clone(), component_id).await?);
-    }
     let workspace_mv_id = ctx.workspace_pk()?;
     Ok(ComponentListMv {
         id: workspace_mv_id,
-        components: components.iter().map(Into::into).collect(),
+        components: component_ids.iter().map(|&id| id.into()).collect(),
     })
 }

--- a/lib/dal-materialized-views/src/view_component_list.rs
+++ b/lib/dal-materialized-views/src/view_component_list.rs
@@ -26,15 +26,15 @@ pub async fn assemble(ctx: DalContext, view_id: ViewId) -> super::Result<ViewCom
 
         match geo_represents {
             GeometryRepresents::Component(component_id) => {
-                components.push(super::component::assemble(ctx.clone(), component_id).await?);
+                components.push(component_id);
             }
             GeometryRepresents::View(_view_id) => {}
         }
     }
-    components.sort_by_key(|c| c.id);
+    components.sort();
 
     Ok(ViewComponentListMv {
         id: view_id,
-        components: components.iter().map(Into::into).collect(),
+        components: components.iter().map(|&id| id.into()).collect(),
     })
 }

--- a/lib/si-frontend-mv-types-rs/src/component.rs
+++ b/lib/si-frontend-mv-types-rs/src/component.rs
@@ -12,7 +12,6 @@ use si_events::{
 use si_id::WorkspacePk;
 
 use crate::reference::{
-    Reference,
     ReferenceKind,
     WeakReference,
     weak,
@@ -133,5 +132,5 @@ pub struct SchemaMembers {
 pub struct ComponentList {
     pub id: WorkspacePk,
     #[mv(reference_kind = ReferenceKind::Component)]
-    pub components: Vec<Reference<ComponentId>>,
+    pub components: Vec<WeakReference<ComponentId, weak::markers::Component>>,
 }

--- a/lib/si-frontend-mv-types-rs/src/view.rs
+++ b/lib/si-frontend-mv-types-rs/src/view.rs
@@ -21,6 +21,8 @@ use si_id::{
 use crate::reference::{
     Reference,
     ReferenceKind,
+    WeakReference,
+    weak,
 };
 
 #[derive(
@@ -67,6 +69,5 @@ pub struct ViewList {
 )]
 pub struct ViewComponentList {
     pub id: ViewId,
-    #[mv(reference_kind = ReferenceKind::Component)]
-    pub components: Vec<Reference<ComponentId>>,
+    pub components: Vec<WeakReference<ComponentId, weak::markers::Component>>,
 }


### PR DESCRIPTION
### What We Did
When looking up an EntityKind that is a List of References, call `getMany`. This does not perform a recursive "getReferences", it only looks for the single reference from the list.

This covers off our functionality for all but ONE thing: `IncomingConnectionsList`. We need the "second level" reference from the connection itself to the components. So we special case that and call `getMany` again.

### About the implementation
- a lot of the changes here are making sure that the right types are being sent back. For example the "BifrostComponent" that is in the "ComponentList" doesn't have "SchemaVariant" b/c we don't do that "second level" reference lookup. While looking that component up directly WILL have that data. So we need different types.
- we need to massage the types in the one-off getMany call for `IncomingConnectionsList` too because of the next point
- don't call hammer from within getMany because we cannot establish the weak reference from that spot. We need the weak reference so that when data updates, the UI re-renders with the correct data.

### Testing steps
- Have a region connected to another component
- cold start should show region outgoing connection 1
- navigate to region, see the connection panel
- connect a second component
- show region with 2 outgoing connections in the grid
- navigate, see connection panel