### PR TITLE
feat: Duplicate Components on new UI

### DIFF
--- a/app/web/src/newhotness/ComponentContextMenu.vue
+++ b/app/web/src/newhotness/ComponentContextMenu.vue
@@ -2,10 +2,10 @@
   <div>
     <DropdownMenu
       ref="contextMenuRef"
-      :items="rightClickMenuItems"
-      variant="editor"
       :anchorTo="anchor"
+      :items="rightClickMenuItems"
       alignOutsideRightEdge
+      variant="editor"
     />
     <EraseModal ref="eraseModalRef" @confirm="componentsFinishErase" />
   </div>
@@ -36,6 +36,12 @@ const contextMenuRef = ref<InstanceType<typeof DropdownMenu>>();
 
 const key = useMakeKey();
 const args = useMakeArgs();
+
+const props = defineProps<{
+  componentIds: string[];
+  // TODO this should be a globally accessible variable, otherwise we'll be prop drilling view id everywhere
+  viewId: string;
+}>();
 
 // ================================================================================================
 // This is the location of objects needed to populate menu items.
@@ -105,6 +111,13 @@ const rightClickMenuItems = computed(() => {
     shortcut: "⌘E",
     icon: "erase",
     onSelect: () => {},
+  });
+
+  items.push({
+    label: "Duplicate",
+    shortcut: "⌘D",
+    icon: "clipboard-copy",
+    onSelect: componentDuplicate,
   });
 
   // Only enable actions if we are working with a single component.
@@ -185,6 +198,16 @@ const componentsFinishErase = async () => {
   // }
 };
 
+const duplicateActionApi = useApi();
+const componentDuplicate = async () => {
+  const call = duplicateActionApi.endpoint(routes.DuplicateComponents, {
+    viewId: props.viewId,
+  });
+  await call.post({
+    components: props.componentIds,
+  });
+};
+
 // eslint-disable-next-line @typescript-eslint/ban-types
 const anchor = ref<Object | undefined>(undefined);
 
@@ -205,5 +228,5 @@ function close() {
 
 const isOpen = computed(() => contextMenuRef.value?.isOpen);
 
-defineExpose({ open, close, isOpen, componentsStartErase });
+defineExpose({ open, close, isOpen, componentsStartErase, componentDuplicate });
 </script>

--- a/app/web/src/newhotness/Map.vue
+++ b/app/web/src/newhotness/Map.vue
@@ -76,7 +76,11 @@
       <circle :cx="origCenter" :cy="origCenter" r="5" fill="yellow" />
     </svg>
 
-    <ComponentContextMenu ref="componentContextMenuRef" />
+    <ComponentContextMenu
+      ref="componentContextMenuRef"
+      :viewId="viewId"
+      :componentIds="selectedComponent ? [selectedComponent.id] : []"
+    />
   </section>
 </template>
 
@@ -125,7 +129,10 @@ import ConnectionsPanel from "./ConnectionsPanel.vue";
 import { getAssetIcon } from "./util";
 import ComponentContextMenu from "./ComponentContextMenu.vue";
 
-const props = defineProps<{ active: boolean }>();
+const props = defineProps<{
+  active: boolean;
+  viewId: string;
+}>();
 
 const componentContextMenuRef =
   ref<InstanceType<typeof ComponentContextMenu>>();

--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -30,6 +30,7 @@ export enum routes {
   ActionHold = "ActionHold",
   ActionRetry = "ActionRetry",
   DeleteComponents = "DeleteComponents",
+  DuplicateComponents = "DuplicateComponents",
 }
 
 /**
@@ -51,6 +52,7 @@ const _routes: Record<routes, string> = {
   UpdateComponentAttributes: "/components/<id>/attributes",
   UpdateComponentName: "/components/<id>/name",
   CreateComponent: "/views/<viewId>/component",
+  DuplicateComponents: "/views/<viewId>/duplicate_components",
   CreateView: "/views",
   CreateSecret: "/components/<id>/secret",
   GetPublicKey: "/components/<id>/secret/public_key",
@@ -77,6 +79,7 @@ const setLabel = (obs: Obs, label: string): LabeledObs => {
     label,
   };
 };
+
 export class APICall<Response> {
   workspaceId: string;
   changeSetId: string;

--- a/app/web/src/newhotness/logic_composables/emitters.ts
+++ b/app/web/src/newhotness/logic_composables/emitters.ts
@@ -17,7 +17,13 @@ export interface KeyDetails {
 
 export const keyEmitter: Emitter<KeyDetails> = mitt<KeyDetails>();
 
+// Make sure we don't start the emitter more than once.
+// This happens often when developing the system and causes redundant keydown evs
+let keyEmitterStarted = false;
+
 export const startKeyEmitter = (document: Document) => {
+  if (keyEmitterStarted) return;
+  keyEmitterStarted = true;
   document.addEventListener("keydown", (event: KeyboardEvent) => {
     const fromInput = ["INPUT", "TEXTAREA", "SELECT"].includes(
       (event.target as HTMLBodyElement)?.tagName,

--- a/app/web/src/store/views.store.ts
+++ b/app/web/src/store/views.store.ts
@@ -1541,7 +1541,7 @@ export const useViewsStore = (forceChangeSetId?: ChangeSetId) => {
             method: "post",
             url: API_PREFIX.concat([
               { viewId: this.selectedViewId },
-              "duplicate_components",
+              "paste_components",
             ]),
             keyRequestStatusBy: components.map((c) => c.id),
             params: {

--- a/lib/dal/tests/integration_test/component/paste.rs
+++ b/lib/dal/tests/integration_test/component/paste.rs
@@ -43,7 +43,7 @@ async fn paste_component_with_value(ctx: &mut DalContext) -> Result<()> {
         component
             .component(ctx)
             .await
-            .copy_without_connections(
+            .duplicate_without_connections(
                 ctx,
                 default_view_id,
                 component.geometry_for_default(ctx).await,
@@ -96,7 +96,7 @@ async fn paste_component_with_dependent_value(ctx: &mut DalContext) -> Result<()
         downstream
             .component(ctx)
             .await
-            .copy_without_connections(
+            .duplicate_without_connections(
                 ctx,
                 default_view_id,
                 downstream.geometry_for_default(ctx).await,

--- a/lib/dal/tests/integration_test/component/property_order.rs
+++ b/lib/dal/tests/integration_test/component/property_order.rs
@@ -347,7 +347,7 @@ async fn child_property_value_remains_after_update_and_paste(
         component
             .component(ctx)
             .await
-            .copy_without_connections(
+            .duplicate_without_connections(
                 ctx,
                 default_view_id,
                 component.geometry_for_default(ctx).await,

--- a/lib/dal/tests/integration_test/secret.rs
+++ b/lib/dal/tests/integration_test/secret.rs
@@ -334,7 +334,7 @@ async fn copy_paste_component_with_secrets_being_used(ctx: &mut DalContext, nw: 
             .expect("couldn't get geometry");
 
         component
-            .copy_without_connections(
+            .duplicate_without_connections(
                 ctx,
                 default_view_id,
                 RawGeometry {
@@ -360,7 +360,7 @@ async fn copy_paste_component_with_secrets_being_used(ctx: &mut DalContext, nw: 
     user_component
         .component(ctx)
         .await
-        .copy_without_connections(
+        .duplicate_without_connections(
             ctx,
             default_view_id,
             RawGeometry {

--- a/lib/sdf-server/src/service/v2/view.rs
+++ b/lib/sdf-server/src/service/v2/view.rs
@@ -54,6 +54,7 @@ mod erase_components;
 mod erase_view_object;
 pub mod get_diagram;
 pub mod list_views;
+mod paste_component;
 mod remove_view;
 mod set_component_parent;
 mod set_geometry;
@@ -168,6 +169,10 @@ pub fn v2_routes() -> Router<AppState> {
         .route(
             "/:view_id/component",
             post(create_component::create_component),
+        )
+        .route(
+            "/:view_id/paste_components",
+            post(paste_component::paste_component),
         )
         .route(
             "/:view_id/duplicate_components",

--- a/lib/sdf-server/src/service/v2/view/duplicate_components.rs
+++ b/lib/sdf-server/src/service/v2/view/duplicate_components.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use axum::{
     Json,
     extract::Path,
@@ -8,20 +6,11 @@ use dal::{
     ChangeSet,
     Component,
     ComponentId,
-    WsEvent,
-    change_status::ChangeStatus,
-    diagram::{
-        SummaryDiagramEdge,
-        SummaryDiagramInferredEdge,
-        SummaryDiagramManagementEdge,
-    },
 };
-use itertools::Itertools;
 use serde::{
     Deserialize,
     Serialize,
 };
-use si_frontend_types::StringGeometry;
 
 use super::{
     ViewParam,
@@ -37,19 +26,11 @@ use crate::{
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct PasteSingleComponentPayload {
-    id: ComponentId,
-    component_geometry: StringGeometry,
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(rename_all = "camelCase")]
 pub struct PasteComponentsRequest {
-    pub components: Vec<PasteSingleComponentPayload>,
-    pub new_parent_node_id: Option<ComponentId>,
+    pub components: Vec<ComponentId>,
 }
 
-/// Duplicate a set of [`Component`](dal::Component)s via their componentId. Creates change-set if on head
+/// Duplicate a set of [`Component`](Component)s via their componentIds. Creates change-set if on head
 pub async fn duplicate_components(
     ChangeSetDalContext(ref mut ctx): ChangeSetDalContext,
     tracker: PosthogEventTracker,
@@ -58,21 +39,10 @@ pub async fn duplicate_components(
 ) -> ViewResult<ForceChangeSetResponse<()>> {
     let force_change_set_id = ChangeSet::force_new(ctx).await?;
 
-    let pasted_component_ids = Component::batch_copy(
-        ctx,
-        view_id,
-        request.new_parent_node_id,
-        request
-            .components
-            .into_iter()
-            .map(|p| p.component_geometry.try_into().map(|geo| (p.id, geo)))
-            .try_collect()?,
-    )
-    .await?;
+    let pasted_component_ids = Component::duplicate(ctx, view_id, request.components).await?;
 
-    // Emit WsEvents and posthog events
+    // Emit  posthog events
     for pasted_component_id in pasted_component_ids {
-        // posthog paste component event
         let schema = Component::schema_for_component_id(ctx, pasted_component_id).await?;
         tracker.track(
             ctx,
@@ -83,72 +53,6 @@ pub async fn duplicate_components(
                 "component_schema_name": schema.name(),
             }),
         );
-
-        // Component created event
-        {
-            let pasted = Component::get_by_id(ctx, pasted_component_id).await?;
-            let mut diagram_sockets = HashMap::new();
-            let geo = pasted.geometry(ctx, view_id).await?;
-            let payload = pasted
-                .into_frontend_type(ctx, Some(&geo), ChangeStatus::Added, &mut diagram_sockets)
-                .await?;
-
-            // Inferred connections (parent-child)
-            let inferred_connections =
-                Component::inferred_incoming_connections(ctx, pasted_component_id).await?;
-            let inferred_edges = if !inferred_connections.is_empty() {
-                Some(
-                    inferred_connections
-                        .into_iter()
-                        .map(SummaryDiagramInferredEdge::assemble)
-                        .collect(),
-                )
-            } else {
-                None
-            };
-
-            WsEvent::component_created_with_inferred_edges(ctx, payload, inferred_edges)
-                .await?
-                .publish_on_commit(ctx)
-                .await?;
-        }
-
-        // Manager connections
-        for manager_component_id in Component::managers_by_id(ctx, pasted_component_id).await? {
-            let manager_schema =
-                Component::schema_for_component_id(ctx, manager_component_id).await?;
-            let pasted_schema =
-                Component::schema_for_component_id(ctx, pasted_component_id).await?;
-            let edge = SummaryDiagramManagementEdge::new(
-                manager_schema.id(),
-                pasted_schema.id(),
-                manager_component_id,
-                pasted_component_id,
-            );
-            WsEvent::connection_upserted(ctx, edge.into())
-                .await?
-                .publish_on_commit(ctx)
-                .await?;
-        }
-
-        // Incoming socket connections
-        for connection in Component::incoming_connections_for_id(ctx, pasted_component_id).await? {
-            let edge = SummaryDiagramEdge {
-                from_component_id: connection.from_component_id,
-                from_socket_id: connection.from_output_socket_id,
-                to_component_id: pasted_component_id,
-                to_socket_id: connection.to_input_socket_id,
-                change_status: ChangeStatus::Added,
-                created_info: serde_json::to_value(connection.created_info)?,
-                deleted_info: serde_json::to_value(connection.deleted_info)?,
-                to_delete: false,
-                from_base_change_set: false,
-            };
-            WsEvent::connection_upserted(ctx, edge.into())
-                .await?
-                .publish_on_commit(ctx)
-                .await?;
-        }
     }
 
     ctx.commit().await?;

--- a/lib/sdf-server/src/service/v2/view/paste_component.rs
+++ b/lib/sdf-server/src/service/v2/view/paste_component.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+
+use axum::{
+    Json,
+    extract::Path,
+};
+use dal::{
+    ChangeSet,
+    Component,
+    ComponentId,
+    WsEvent,
+    change_status::ChangeStatus,
+    diagram::{
+        SummaryDiagramEdge,
+        SummaryDiagramInferredEdge,
+        SummaryDiagramManagementEdge,
+    },
+};
+use itertools::Itertools;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_frontend_types::StringGeometry;
+
+use super::{
+    ViewParam,
+    ViewResult,
+};
+use crate::{
+    extract::{
+        PosthogEventTracker,
+        change_set::ChangeSetDalContext,
+    },
+    service::force_change_set_response::ForceChangeSetResponse,
+};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PasteSingleComponentPayload {
+    id: ComponentId,
+    component_geometry: StringGeometry,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PasteComponentsRequest {
+    pub components: Vec<PasteSingleComponentPayload>,
+    pub new_parent_node_id: Option<ComponentId>,
+}
+
+/// Paste a set of [`Component`](dal::Component)s via their componentId. Creates change-set if on head
+pub async fn paste_component(
+    ChangeSetDalContext(ref mut ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    Path(ViewParam { view_id }): Path<ViewParam>,
+    Json(request): Json<PasteComponentsRequest>,
+) -> ViewResult<ForceChangeSetResponse<()>> {
+    let force_change_set_id = ChangeSet::force_new(ctx).await?;
+
+    let pasted_component_ids = Component::batch_copy(
+        ctx,
+        view_id,
+        request.new_parent_node_id,
+        request
+            .components
+            .into_iter()
+            .map(|p| p.component_geometry.try_into().map(|geo| (p.id, geo)))
+            .try_collect()?,
+    )
+    .await?;
+
+    // Emit WsEvents and posthog events
+    for pasted_component_id in pasted_component_ids {
+        // posthog paste component event
+        let schema = Component::schema_for_component_id(ctx, pasted_component_id).await?;
+        tracker.track(
+            ctx,
+            "paste_component",
+            serde_json::json!({
+                "how": "/v2/view/paste_component",
+                "component_id": pasted_component_id,
+                "component_schema_name": schema.name(),
+            }),
+        );
+
+        // Component created event
+        {
+            let pasted = Component::get_by_id(ctx, pasted_component_id).await?;
+            let mut diagram_sockets = HashMap::new();
+            let geo = pasted.geometry(ctx, view_id).await?;
+            let payload = pasted
+                .into_frontend_type(ctx, Some(&geo), ChangeStatus::Added, &mut diagram_sockets)
+                .await?;
+
+            // Inferred connections (parent-child)
+            let inferred_connections =
+                Component::inferred_incoming_connections(ctx, pasted_component_id).await?;
+            let inferred_edges = if !inferred_connections.is_empty() {
+                Some(
+                    inferred_connections
+                        .into_iter()
+                        .map(SummaryDiagramInferredEdge::assemble)
+                        .collect(),
+                )
+            } else {
+                None
+            };
+
+            WsEvent::component_created_with_inferred_edges(ctx, payload, inferred_edges)
+                .await?
+                .publish_on_commit(ctx)
+                .await?;
+        }
+
+        // Manager connections
+        for manager_component_id in Component::managers_by_id(ctx, pasted_component_id).await? {
+            let manager_schema =
+                Component::schema_for_component_id(ctx, manager_component_id).await?;
+            let pasted_schema =
+                Component::schema_for_component_id(ctx, pasted_component_id).await?;
+            let edge = SummaryDiagramManagementEdge::new(
+                manager_schema.id(),
+                pasted_schema.id(),
+                manager_component_id,
+                pasted_component_id,
+            );
+            WsEvent::connection_upserted(ctx, edge.into())
+                .await?
+                .publish_on_commit(ctx)
+                .await?;
+        }
+
+        // Incoming socket connections
+        for connection in Component::incoming_connections_for_id(ctx, pasted_component_id).await? {
+            let edge = SummaryDiagramEdge {
+                from_component_id: connection.from_component_id,
+                from_socket_id: connection.from_output_socket_id,
+                to_component_id: pasted_component_id,
+                to_socket_id: connection.to_input_socket_id,
+                change_status: ChangeStatus::Added,
+                created_info: serde_json::to_value(connection.created_info)?,
+                deleted_info: serde_json::to_value(connection.deleted_info)?,
+                to_delete: false,
+                from_base_change_set: false,
+            };
+            WsEvent::connection_upserted(ctx, edge.into())
+                .await?
+                .publish_on_commit(ctx)
+                .await?;
+        }
+    }
+
+    ctx.commit().await?;
+
+    Ok(ForceChangeSetResponse::empty(force_change_set_id))
+}


### PR DESCRIPTION
- Changes the old paste endpoint back to paste
- Implements a duplicate sdf endpoint that takes in multiple component ids, clones them and retains subscriptions and mgmt relationships
- Adds and option to the component context menu and a keyboard shortcut (cmd/ctrl+d) to duplicate
- Adds a flag to avoid us creating multiple keydown listeners
- Doesn't implement optimistic creation of copies (and feels somewhat slow, but it's reactive)

![image](https://github.com/user-attachments/assets/8081868e-183e-4c4d-9e52-733de797bb20)
