### PR TITLE
chore(edda): record `src_requests.count` in `handle_task` span

### DIFF
--- a/lib/edda-server/src/change_set_processor_task.rs
+++ b/lib/edda-server/src/change_set_processor_task.rs
@@ -407,6 +407,7 @@ mod handlers {
             si.workspace.id = %workspace_id,
             si.change_set.id = %change_set_id,
             si.edda.compressed_request.kind = request.as_ref(),
+            si.edda.src_requests.count = request.src_requests_count(),
         )
     )]
     async fn handle_request(
@@ -418,6 +419,7 @@ mod handlers {
     ) -> Result<()> {
         match request {
             CompressedRequest::NewChangeSet {
+                src_requests_count: _,
                 base_change_set_id: _,
                 new_change_set_id: _,
                 to_snapshot_address,
@@ -453,13 +455,14 @@ mod handlers {
                     .map_err(Into::into)
                 }
             }
-            CompressedRequest::Rebuild => {
+            CompressedRequest::Rebuild { .. } => {
                 // Rebuild
                 materialized_view::build_all_mv_for_change_set(ctx, frigg, None, "explicit rebuild")
                     .await
                     .map_err(Into::into)
             }
             CompressedRequest::Update {
+                src_requests_count: _,
                 from_snapshot_address,
                 to_snapshot_address,
                 change_batch_addresses,


### PR DESCRIPTION
This change adds an `si.edda.src_requests.count` attribute on each `edda.change_set_processor_task.handle_request` span so that it's easier to track how many API requests were compressed.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlcXp3d2FweHRyYzR0M3VjNmR0YXR0cHp3djJ4dnQxamV4YWRvOW80MSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l0XtbC8EniiuwAEOQn/giphy-downsized-medium.gif"/>