### PR TITLE
ViewId doesn't have to be a prop everywhere. We can use provide/inject context instead, which can go to all children

### DIFF
--- a/app/web/src/newhotness/AddComponentModal.vue
+++ b/app/web/src/newhotness/AddComponentModal.vue
@@ -234,7 +234,7 @@ import {
 } from "@/workers/types/entity_kind_types";
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import FilterTile from "./layout_components/FilterTile.vue";
-import { assertIsDefined, Context } from "./types";
+import { assertIsDefined, Context, ExploreContext } from "./types";
 import { componentTypes, routes, useApi } from "./api_composables";
 import PropTreeComponent, {
   PropsAsTree,
@@ -318,11 +318,9 @@ const makePropTree = (
   return tree;
 };
 
-const props = defineProps<{
-  viewId: string;
-}>();
+const explore = inject<ExploreContext>("EXPLORE_CONTEXT");
+assertIsDefined<ExploreContext>(explore);
 
-const viewId = computed(() => props.viewId);
 const selectionIndex = ref<number | undefined>();
 
 const route = useRoute();
@@ -358,7 +356,7 @@ const onEnter = async () => {
     materializedView: EddaComponent;
     schemaVariantMaterializedView: SchemaVariant;
   }>(routes.CreateComponent, {
-    viewId: viewId.value,
+    viewId: explore.viewId.value,
   });
 
   const { req, newChangeSetId } =

--- a/app/web/src/newhotness/ComponentContextMenu.vue
+++ b/app/web/src/newhotness/ComponentContextMenu.vue
@@ -18,7 +18,7 @@ import {
   DropdownMenuItemObjectDef,
 } from "@si/vue-lib/design-system";
 import { useQuery } from "@tanstack/vue-query";
-import { computed, nextTick, ref } from "vue";
+import { computed, inject, nextTick, ref } from "vue";
 import { RouteLocationRaw } from "vue-router";
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import { ComponentId } from "@/api/sdf/dal/component";
@@ -31,6 +31,7 @@ import {
 import { ActionId, ActionPrototypeId } from "@/api/sdf/dal/action";
 import EraseModal from "./EraseModal.vue";
 import { useApi, routes } from "./api_composables";
+import { assertIsDefined, ExploreContext } from "./types";
 
 const contextMenuRef = ref<InstanceType<typeof DropdownMenu>>();
 
@@ -39,9 +40,10 @@ const args = useMakeArgs();
 
 const props = defineProps<{
   componentIds: string[];
-  // TODO this should be a globally accessible variable, otherwise we'll be prop drilling view id everywhere
-  viewId: string;
 }>();
+
+const explore = inject<ExploreContext>("EXPLORE_CONTEXT");
+assertIsDefined<ExploreContext>(explore);
 
 // ================================================================================================
 // This is the location of objects needed to populate menu items.
@@ -210,7 +212,7 @@ const componentsFinishErase = async () => {
 const duplicateActionApi = useApi();
 const componentDuplicate = async () => {
   const call = duplicateActionApi.endpoint(routes.DuplicateComponents, {
-    viewId: props.viewId,
+    viewId: explore.viewId.value,
   });
   await call.post({
     components: props.componentIds,

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -121,7 +121,7 @@
           />
         </footer>
       </template>
-      <Map v-else :viewId="selectedViewOrDefaultId" :active="!showGrid" />
+      <Map v-else :active="!showGrid" />
     </div>
     <!-- Right column -->
     <div
@@ -165,17 +165,13 @@
         <RealtimeStatusPageState />
       </div>
     </div>
-    <AddComponentModal
-      ref="addComponentModalRef"
-      :viewId="selectedViewOrDefaultId"
-    />
+    <AddComponentModal ref="addComponentModalRef" />
     <AddViewModal
       ref="addViewModalRef"
       :views="viewListQuery.data.value?.views"
     />
     <ComponentContextMenu
       ref="componentContextMenuRef"
-      :viewId="selectedViewOrDefaultId"
       :componentIds="
         interactionTargetComponentId ? [interactionTargetComponentId] : []
       "
@@ -229,7 +225,7 @@ import ComponentGridTile from "./ComponentGridTile.vue";
 import Breadcrumbs from "./layout_components/Breadcrumbs.vue";
 import ActionCard from "./ActionCard.vue";
 import FuncRunList from "./FuncRunList.vue";
-import { assertIsDefined, Context } from "./types";
+import { assertIsDefined, Context, ExploreContext } from "./types";
 import { KeyDetails, keyEmitter } from "./logic_composables/emitters";
 import TabGroupToggle from "./layout_components/TabGroupToggle.vue";
 import { SelectionsInQueryString } from "./Workspace.vue";
@@ -298,6 +294,14 @@ const selectedViewOrDefaultId = computed(() => {
   if (!view) return "";
   return view.id;
 });
+
+const exploreContext = computed<ExploreContext>(() => {
+  return {
+    viewId: selectedViewOrDefaultId,
+  };
+});
+
+provide("EXPLORE_CONTEXT", exploreContext.value);
 
 const actionViewListRaw = useQuery<BifrostActionViewList | null>({
   queryKey: key(EntityKind.ActionViewList),

--- a/app/web/src/newhotness/Map.vue
+++ b/app/web/src/newhotness/Map.vue
@@ -78,7 +78,6 @@
 
     <ComponentContextMenu
       ref="componentContextMenuRef"
-      :viewId="viewId"
       :componentIds="selectedComponent ? [selectedComponent.id] : []"
     />
   </section>
@@ -123,7 +122,7 @@ import {
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import { SelectionsInQueryString } from "./Workspace.vue";
 import { KeyDetails, keyEmitter } from "./logic_composables/emitters";
-import { assertIsDefined, Context } from "./types";
+import { assertIsDefined, Context, ExploreContext } from "./types";
 import ComponentGridTile from "./ComponentGridTile.vue";
 import ConnectionsPanel from "./ConnectionsPanel.vue";
 import { getAssetIcon } from "./util";
@@ -131,7 +130,6 @@ import ComponentContextMenu from "./ComponentContextMenu.vue";
 
 const props = defineProps<{
   active: boolean;
-  viewId: string;
 }>();
 
 const componentContextMenuRef =
@@ -141,6 +139,9 @@ const selectedComponent = ref<BifrostComponent | null>(null);
 
 const ctx = inject<Context>("CONTEXT");
 assertIsDefined(ctx);
+
+const explore = inject<ExploreContext>("EXPLORE_CONTEXT");
+assertIsDefined<ExploreContext>(explore);
 
 // don't change this!
 // magic number puts the yellow dot in the middle!

--- a/app/web/src/newhotness/types.ts
+++ b/app/web/src/newhotness/types.ts
@@ -15,6 +15,10 @@ export function assertIsDefined<T>(value: T | undefined): asserts value is T {
   }
 }
 
+export interface ExploreContext {
+  viewId: ComputedRef<string>;
+}
+
 // Define an enum for function kinds
 export enum FunctionKind {
   Action = "action",


### PR DESCRIPTION
<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaXNvbXI1bmtkdjVpOHd3bmE5NTdyOXJocW1iN2gxM2YxZzRrcWtrciZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l36kU80xPf0ojG0Erg/giphy.gif"/>