### PR TITLE
fix: ensure key commands work with caps lock

### DIFF
--- a/app/web/src/newhotness/logic_composables/emitters.ts
+++ b/app/web/src/newhotness/logic_composables/emitters.ts
@@ -30,7 +30,13 @@ export const startKeyEmitter = (document: Document) => {
     );
 
     if (!fromInput) {
-      keyEmitter.emit(event.key, event);
+      const isUpperCaseLetter = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".includes(
+        event.key,
+      );
+      keyEmitter.emit(
+        isUpperCaseLetter ? event.key.toLowerCase() : event.key,
+        event,
+      );
     }
   });
 };


### PR DESCRIPTION
This change ensures that when on Grid view the cmd + a, k, e and d shortcuts work with caps lock on.


![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2J2dXB4NWZ2ZHNkcjJsbWNldTh6b2Y4b2s4c2t4b3ppcmExa2k0OSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/nB7k4jFiy2iUJdA914/giphy.gif)