### PR TITLE
fix(dal): Ensure we only set a qualification check status if there are active validations

### DIFF
--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -299,6 +299,7 @@ impl QualificationView {
         let mut status = QualificationSubCheckStatus::Success;
 
         let mut fail_counter = 0;
+        let mut has_active_validations = false;
 
         // Note(victor): If this is ever the bottleneck, we could pretty easily compute a
         // validations summary for a component and store it on the graph during the
@@ -307,6 +308,8 @@ impl QualificationView {
         for (av_id, validation_output) in
             ValidationOutput::list_for_component(ctx, component_id).await?
         {
+            // We have validations therefore, we need to show the validations in the Qualifications output
+            has_active_validations = true;
             if validation_output.status != ValidationStatus::Success {
                 status = QualificationSubCheckStatus::Failure;
                 fail_counter += 1;
@@ -328,6 +331,10 @@ impl QualificationView {
                     ),
                 });
             }
+        }
+
+        if !has_active_validations {
+            return Ok(None);
         }
 
         let result = Some(QualificationResult {

--- a/lib/dal/tests/integration_test/qualifications.rs
+++ b/lib/dal/tests/integration_test/qualifications.rs
@@ -33,23 +33,6 @@ async fn list_qualifications(ctx: &mut DalContext) {
     .expect("could not create component");
 
     // Prepare expected qualification views.
-    let expected_prop_validations_qualification_view = QualificationView {
-        title: "Prop Validations".to_string(),
-        output: vec![],
-        finalized: true,
-        description: None,
-        link: None,
-        result: Some(QualificationResult {
-            status: QualificationSubCheckStatus::Success,
-            title: None,
-            link: None,
-            sub_checks: vec![QualificationSubCheck {
-                description: "Component has 0 invalid value(s).".to_string(),
-                status: QualificationSubCheckStatus::Success,
-            }],
-        }),
-        qualification_name: "validations".to_string(),
-    };
     let expected_additional_qualification_view_name =
         "test:qualificationDummySecretStringIsTodd".to_string();
     let expected_additional_qualification_view = QualificationView {
@@ -79,10 +62,7 @@ async fn list_qualifications(ctx: &mut DalContext) {
     let qualifications = Component::list_qualifications(ctx, component.id())
         .await
         .expect("could not list qualifications");
-    assert_eq!(
-        vec![expected_prop_validations_qualification_view.clone()], // expected
-        qualifications                                              // actual
-    );
+    assert!(qualifications.is_empty());
 
     // Commit and check qualifications again. We should see the populated map with all
     // qualifications.
@@ -122,7 +102,6 @@ async fn list_qualifications(ctx: &mut DalContext) {
     // neither need to perform an additional sort nor use something like a hash set.
     assert_eq!(
         vec![
-            replace_output_stream_view_line_contents(expected_prop_validations_qualification_view),
             replace_output_stream_view_line_contents(expected_additional_qualification_view)
         ], // expected
         qualifications // actual

--- a/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
@@ -827,14 +827,14 @@ async fn update_variant_with_leaf_func(ctx: &mut DalContext) {
     let bindings = FuncBinding::get_qualification_bindings_for_func_id(ctx, created_func_one.id)
         .await
         .expect("could not get bindings");
-
+    
     // Check the qualifications.
     assert_eq!(
-        2,                                  // expected
+        1,                                  // expected
         component_one_qualifications.len()  // actual
     );
     assert_eq!(
-        2,                                  // expected
+        1,                                  // expected
         component_two_qualifications.len()  // actual
     );
     let component_one_qualification_one_result = component_one_qualifications
@@ -976,11 +976,11 @@ async fn update_variant_with_leaf_func(ctx: &mut DalContext) {
         .expect("could not list qualifications");
 
     assert_eq!(
-        3,                                  // expected
+        2,                                  // expected
         component_one_qualifications.len()  // actual
     );
     assert_eq!(
-        3,                                  // expected
+        2,                                  // expected
         component_two_qualifications.len()  // actual
     );
     let component_one_qualification_one_result = component_one_qualifications
@@ -1079,15 +1079,15 @@ async fn update_variant_with_leaf_func(ctx: &mut DalContext) {
         .await
         .expect("could not list qualifications");
     assert_eq!(
-        3,                                  // expected
+        2,                                  // expected
         component_one_qualifications.len()  // actual
     );
     assert_eq!(
-        3,                                  // expected
+        2,                                  // expected
         component_two_qualifications.len()  // actual
     );
     assert_eq!(
-        3,                                    // expected
+        2,                                    // expected
         component_three_qualifications.len()  // actual
     );
     let component_one_qualification_one_result = component_one_qualifications


### PR DESCRIPTION
Previously, the call to `Qualification::new_for_validations` would ALWAYS retun a top level prop validation even if there were no validations for the component. This now changes the way this works so that we only return a top level prop validation if there are validations - otherwise we skip it!

This now means that Generic frames don’t get a value of 1 beside their qualifications - even though there are none. The same for Credentials!