### PR TITLE
fix(tests): Ensure that we correctly check the qualifications now that it's format changed

### DIFF
--- a/bin/si-sdf-api-test/tests/7-emulate_authoring.ts
+++ b/bin/si-sdf-api-test/tests/7-emulate_authoring.ts
@@ -108,7 +108,7 @@ async function emulate_authoring_inner(sdf: SdfApiClient,
     );
     const componentQual = qualSummary?.components.find((c) => c.componentId === doublerComponentId);
     assert(componentQual, "Expected to find qualification summary for created component");
-    assert(componentQual?.succeeded === 1, "Expected to have one qualification passing");
+    assert(componentQual?.failed === 1, "Expected to have one qualification failed as it doesn't yet have the value set");
     const { values: doublerValues } = await getPropertyEditor(
         sdf,
         changeSetId,


### PR DESCRIPTION
```
~~ FINAL REPORT GENERATED ~~
Test Report:
[
  {
    "test_name": "7-emulate_authoring",
    "start_time": "2025-06-09T14:48:39.581Z",
    "finish_time": "2025-06-09T14:49:04.039Z",
    "test_duration": "24458ms",
    "test_result": "success",
    "message": "",
    "test_execution_sequence": 1,
    "uuid": "b376ef0f-0008-478d-8a39-e93d6de3f726"
  }
]
```