### PR TITLE
feat(si-db, dal, pinga): management func jobs

### DIFF
--- a/lib/dal-test/src/helpers/component.rs
+++ b/lib/dal-test/src/helpers/component.rs
@@ -88,13 +88,25 @@ pub async fn execute_management_func(
     if prototype_ids.next().is_some() {
         return Err(eyre!("multiple prototypes for func"));
     }
-    let mut execution_result = ManagementPrototype::execute_by_id(
+
+    let (geometries, placeholders, run_channel, _) = ManagementPrototype::start_execution(
         ctx,
         prototype_id,
         component_id,
         Some(view_id(ctx, component_id).await?),
     )
     .await?;
+
+    let mut execution_result = ManagementPrototype::finalize_execution(
+        ctx,
+        component_id,
+        prototype_id,
+        geometries,
+        placeholders,
+        run_channel,
+    )
+    .await?;
+
     let result: ManagementFuncReturn = execution_result
         .result
         .take()

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -120,6 +120,7 @@ pub mod test_exclusive_schemas;
 pub use color_eyre::{
     self,
     eyre::{
+        Report,
         Result,
         WrapErr,
         eyre,

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -64,7 +64,12 @@ use si_events::{
     split_snapshot_rebase_batch_address::SplitSnapshotRebaseBatchAddress,
     workspace_snapshot::Change,
 };
-use si_id::ActionId;
+use si_id::{
+    ActionId,
+    ComponentId,
+    ManagementPrototypeId,
+    ViewId,
+};
 use si_layer_cache::{
     LayerDbError,
     activities::ActivityPayloadDiscriminants,
@@ -482,6 +487,10 @@ impl SiDbContext for DalContext {
 
     fn visibility(&self) -> &Visibility {
         self.visibility()
+    }
+
+    fn change_set_id(&self) -> ChangeSetId {
+        self.change_set_id()
     }
 }
 
@@ -1095,6 +1104,29 @@ impl DalContext {
                 self.workspace_pk()?,
                 self.change_set_id(),
                 attribute_value_id,
+            )
+            .await;
+
+        Ok(())
+    }
+
+    pub async fn enqueue_management_func(
+        &self,
+        prototype_id: ManagementPrototypeId,
+        component_id: ComponentId,
+        view_id: ViewId,
+        request_ulid: Option<ulid::Ulid>,
+    ) -> TransactionsResult<()> {
+        self.txns()
+            .await?
+            .job_queue
+            .enqueue_management_func_job(
+                self.workspace_pk()?,
+                self.change_set_id(),
+                prototype_id,
+                component_id,
+                view_id,
+                request_ulid,
             )
             .await;
 

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -865,7 +865,7 @@ impl FuncRunner {
         manager_component_id: ComponentId,
         management_func_id: FuncId,
         args: serde_json::Value,
-    ) -> FuncRunnerResult<FuncRunnerValueChannel> {
+    ) -> FuncRunnerResult<(FuncRunId, FuncRunnerValueChannel)> {
         let span = current_span_for_instrument_at!("debug");
 
         // Prepares the function for execution.
@@ -1007,9 +1007,10 @@ impl FuncRunner {
         .await
         .map_err(|err| span.record_err(err))?;
 
+        let func_run_id = runner.func_run.id();
         let result_channel = runner.execute(ctx.clone(), span).await;
 
-        Ok(result_channel)
+        Ok((func_run_id, result_channel))
     }
 
     pub async fn build_management(

--- a/lib/dal/src/job/definition.rs
+++ b/lib/dal/src/job/definition.rs
@@ -1,6 +1,11 @@
 mod action;
 pub mod compute_validation;
 pub mod dependent_values_update;
+mod management_func;
 
 pub use action::ActionJob;
 pub use dependent_values_update::DependentValuesUpdate;
+pub use management_func::{
+    ManagementFuncJob,
+    ManagementFuncJobError,
+};

--- a/lib/dal/src/job/definition/management_func.rs
+++ b/lib/dal/src/job/definition/management_func.rs
@@ -1,0 +1,375 @@
+use async_trait::async_trait;
+use pinga_core::api_types::job_execution_request::JobArgsVCurrent;
+use si_db::{
+    ManagementFuncExecutionError,
+    ManagementFuncJobState,
+    ManagementState,
+};
+use si_events::audit_log::AuditLogKind;
+use si_id::{
+    ChangeSetId,
+    ComponentId,
+    FuncRunId,
+    ManagementFuncExecutionId,
+    ManagementPrototypeId,
+    ViewId,
+    WorkspacePk,
+};
+use telemetry::prelude::*;
+use thiserror::Error;
+use tokio::{
+    task::JoinError,
+    time::Duration,
+};
+use veritech_client::ManagementFuncStatus;
+
+use crate::{
+    DalContext,
+    Func,
+    FuncError,
+    TransactionsError,
+    WorkspaceSnapshotError,
+    WsEvent,
+    WsEventError,
+    job::consumer::{
+        DalJob,
+        JobCompletionState,
+        JobConsumer,
+        JobConsumerResult,
+    },
+    management::{
+        ManagementError,
+        ManagementFuncReturn,
+        ManagementOperator,
+        prototype::{
+            ManagementPrototype,
+            ManagementPrototypeError,
+            ManagementPrototypeExecution,
+        },
+    },
+    workspace_snapshot::{
+        DependentValueRoot,
+        dependent_value_root::DependentValueRootError,
+    },
+};
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ManagementFuncJobError {
+    #[error("dependent value root error: {0}")]
+    DependentValueRoot(#[from] DependentValueRootError),
+    #[error("func error: {0}")]
+    Func(#[from] FuncError),
+    #[error("management prototype {0} is not valid for component {1}")]
+    InvalidPrototypeForComponent(ManagementPrototypeId, ComponentId),
+    #[error("management error: {0}")]
+    Management(#[from] ManagementError),
+    #[error("management execution state error: {0}")]
+    ManagementFuncExecutionState(#[from] ManagementFuncExecutionError),
+    #[error("management func js execution failed")]
+    ManagementFuncJsExecutionFailed,
+    #[error("management prototype error: {0}")]
+    ManagementPrototype(#[from] ManagementPrototypeError),
+    #[error(
+        "no pending execution for component {0} and management prototype {1} in change set {2}"
+    )]
+    NoPendingExecution(ComponentId, ManagementPrototypeId, ChangeSetId),
+    #[error("serde json error: {0}")]
+    Serde(#[from] serde_json::Error),
+    #[error(transparent)]
+    TokioTask(#[from] JoinError),
+    #[error(transparent)]
+    Transactions(#[from] TransactionsError),
+    #[error(
+        "management func {0} for component {1} waited too long for dependent values to be calculated"
+    )]
+    WaitedTooLongForDependentValueRoots(ManagementPrototypeId, ComponentId),
+    #[error("workspace snapshot error: {0}")]
+    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+    #[error("ws event error: {0}")]
+    WsEvent(#[from] WsEventError),
+}
+
+pub type ManagementFuncJobResult<T> = Result<T, ManagementFuncJobError>;
+
+const WAIT_MS: u64 = 50;
+const MAX_WAITS: u64 = 5_000;
+
+#[derive(Clone, Debug)]
+pub struct ManagementFuncJob {
+    workspace_id: WorkspacePk,
+    change_set_id: ChangeSetId,
+    component_id: ComponentId,
+    prototype_id: ManagementPrototypeId,
+    view_id: ViewId,
+    request_ulid: Option<ulid::Ulid>,
+}
+
+impl ManagementFuncJob {
+    pub fn new(
+        workspace_id: WorkspacePk,
+        change_set_id: ChangeSetId,
+        prototype_id: ManagementPrototypeId,
+        component_id: ComponentId,
+        view_id: ViewId,
+        request_ulid: Option<ulid::Ulid>,
+    ) -> Box<Self> {
+        Self {
+            workspace_id,
+            change_set_id,
+            component_id,
+            prototype_id,
+            view_id,
+            request_ulid,
+        }
+        .into()
+    }
+
+    async fn spin_until_ready(
+        &self,
+        ctx: &mut DalContext,
+        max: u64,
+    ) -> Result<(), ManagementFuncJobError> {
+        let mut count = 0;
+        loop {
+            if count >= max {
+                return Err(ManagementFuncJobError::WaitedTooLongForDependentValueRoots(
+                    self.prototype_id,
+                    self.component_id,
+                ));
+            }
+
+            ctx.update_snapshot_to_visibility().await?;
+            if !DependentValueRoot::roots_exist(ctx).await? {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(WAIT_MS)).await;
+            count += 1;
+        }
+        Ok(())
+    }
+
+    async fn run_inner(
+        &self,
+        ctx: &DalContext,
+        execution_state_id: ManagementFuncExecutionId,
+    ) -> ManagementFuncJobResult<JobCompletionState> {
+        if !ManagementPrototype::is_valid_prototype_for_component(
+            ctx,
+            self.prototype_id,
+            self.component_id,
+        )
+        .await?
+        {
+            return Err(ManagementFuncJobError::InvalidPrototypeForComponent(
+                self.prototype_id,
+                self.component_id,
+            ));
+        }
+
+        let mut ctx_clone = ctx.clone();
+        // Loop for 5_000 * 50 ms (= 250 seconds max) and then mark job as failed if not ready
+        self.spin_until_ready(&mut ctx_clone, MAX_WAITS).await?;
+        // We want to operate on the snapshot that is "ready"
+        let ctx = &ctx_clone;
+
+        let (geometries, placeholders, run_channel, func_run_id) =
+            ManagementPrototype::start_execution(
+                ctx,
+                self.prototype_id,
+                self.component_id,
+                self.view_id.into(),
+            )
+            .await?;
+
+        Self::executing_state(ctx, execution_state_id, func_run_id).await?;
+
+        let execution_result = ManagementPrototype::finalize_execution(
+            ctx,
+            self.component_id,
+            self.prototype_id,
+            geometries,
+            placeholders,
+            run_channel,
+        )
+        .await?;
+
+        self.operate(ctx, execution_state_id, execution_result)
+            .await?;
+
+        Self::success_state(ctx, execution_state_id).await?;
+
+        ctx.commit().await?;
+
+        Ok(JobCompletionState::Done)
+    }
+
+    async fn operate(
+        &self,
+        ctx: &DalContext,
+        execution_state_id: ManagementFuncExecutionId,
+        mut execution_result: ManagementPrototypeExecution,
+    ) -> ManagementFuncJobResult<()> {
+        let result = execution_result
+            .result
+            .take()
+            .ok_or(ManagementFuncJobError::ManagementFuncJsExecutionFailed)?;
+
+        Self::operating_state(ctx, execution_state_id).await?;
+
+        let result: ManagementFuncReturn = result.try_into()?;
+        let mut created_component_ids = None;
+        if result.status == ManagementFuncStatus::Ok {
+            if let Some(operations) = result.operations {
+                created_component_ids = ManagementOperator::new(
+                    ctx,
+                    self.component_id,
+                    operations,
+                    execution_result,
+                    self.view_id.into(),
+                )
+                .await?
+                .operate()
+                .await?;
+            }
+        }
+
+        let func_id = ManagementPrototype::func_id(ctx, self.prototype_id).await?;
+        let func = Func::get_by_id(ctx, func_id).await?;
+
+        WsEvent::management_operations_complete(
+            ctx,
+            self.request_ulid,
+            func.name.clone(),
+            result.message.clone(),
+            result.status,
+            created_component_ids,
+        )
+        .await?
+        .publish_on_commit(ctx)
+        .await?;
+
+        ctx.write_audit_log(
+            AuditLogKind::ManagementOperationsComplete {
+                component_id: self.component_id,
+                prototype_id: self.prototype_id,
+                func_id,
+                func_name: func.name.clone(),
+                status: match result.status {
+                    ManagementFuncStatus::Ok => "ok",
+                    ManagementFuncStatus::Error => "error",
+                }
+                .to_string(),
+                message: result.message.clone(),
+            },
+            func.name,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn run_prototype(
+        &self,
+        ctx: &mut DalContext,
+    ) -> ManagementFuncJobResult<JobCompletionState> {
+        let pending_execution =
+            ManagementFuncJobState::get_pending(ctx, self.component_id, self.prototype_id)
+                .await?
+                .ok_or(ManagementFuncJobError::NoPendingExecution(
+                    self.component_id,
+                    self.prototype_id,
+                    self.change_set_id,
+                ))?;
+        let execution_state_id = pending_execution.id();
+
+        match self.run_inner(ctx, execution_state_id).await {
+            Ok(completion_state) => Ok(completion_state),
+            Err(err) => {
+                Self::fail_state(ctx, execution_state_id).await?;
+                Err(err)
+            }
+        }
+    }
+
+    async fn transition_state(
+        ctx: &DalContext,
+        execution_state_id: ManagementFuncExecutionId,
+        new_state: si_db::ManagementState,
+        func_run_id: Option<FuncRunId>,
+    ) -> ManagementFuncJobResult<()> {
+        let ctx_clone = ctx.clone();
+        if new_state == ManagementState::Failure {
+            if let Ok(snap) = ctx.workspace_snapshot() {
+                snap.revert().await;
+            }
+        }
+        ManagementFuncJobState::transition_state(ctx, execution_state_id, new_state, func_run_id)
+            .await?;
+        ctx_clone.commit_no_rebase().await?;
+
+        Ok(())
+    }
+
+    async fn executing_state(
+        ctx: &DalContext,
+        execution_state_id: ManagementFuncExecutionId,
+        func_run_id: FuncRunId,
+    ) -> ManagementFuncJobResult<()> {
+        Self::transition_state(
+            ctx,
+            execution_state_id,
+            ManagementState::Executing,
+            Some(func_run_id),
+        )
+        .await
+    }
+
+    async fn operating_state(
+        ctx: &DalContext,
+        execution_state_id: ManagementFuncExecutionId,
+    ) -> ManagementFuncJobResult<()> {
+        Self::transition_state(ctx, execution_state_id, ManagementState::Operating, None).await
+    }
+
+    async fn success_state(
+        ctx: &DalContext,
+        execution_state_id: ManagementFuncExecutionId,
+    ) -> ManagementFuncJobResult<()> {
+        Self::transition_state(ctx, execution_state_id, ManagementState::Success, None).await
+    }
+
+    async fn fail_state(
+        ctx: &DalContext,
+        execution_state_id: ManagementFuncExecutionId,
+    ) -> ManagementFuncJobResult<()> {
+        Self::transition_state(ctx, execution_state_id, ManagementState::Failure, None).await
+    }
+}
+
+impl DalJob for ManagementFuncJob {
+    fn args(&self) -> JobArgsVCurrent {
+        JobArgsVCurrent::ManagementFunc {
+            component_id: self.component_id,
+            prototype_id: self.prototype_id,
+            view_id: self.view_id,
+            request_ulid: self.request_ulid,
+        }
+    }
+
+    fn workspace_id(&self) -> WorkspacePk {
+        self.workspace_id
+    }
+
+    fn change_set_id(&self) -> ChangeSetId {
+        self.change_set_id
+    }
+}
+
+#[async_trait]
+impl JobConsumer for ManagementFuncJob {
+    #[instrument(name = "management_func.run", level = "info", skip_all)]
+    async fn run(&self, ctx: &mut DalContext) -> JobConsumerResult<JobCompletionState> {
+        Ok(self.run_prototype(ctx).await?)
+    }
+}

--- a/lib/dal/src/job/processor/nats_processor.rs
+++ b/lib/dal/src/job/processor/nats_processor.rs
@@ -76,6 +76,24 @@ impl NatsProcessor {
                         )
                         .await?;
                 }
+                JobArgsVCurrent::ManagementFunc {
+                    component_id,
+                    prototype_id,
+                    view_id,
+                    request_ulid,
+                } => {
+                    self.pinga
+                        .dispatch_management_job(
+                            job.workspace_id(),
+                            job.change_set_id(),
+                            component_id,
+                            prototype_id,
+                            view_id,
+                            request_ulid,
+                            false,
+                        )
+                        .await?;
+                }
             }
         }
 
@@ -109,6 +127,24 @@ impl JobQueueProcessor for NatsProcessor {
                         job.workspace_id(),
                         job.change_set_id(),
                         attribute_value_ids,
+                        false,
+                    )
+                    .await?
+            }
+            JobArgsVCurrent::ManagementFunc {
+                component_id,
+                prototype_id,
+                view_id,
+                request_ulid,
+            } => {
+                self.pinga
+                    .await_management_job(
+                        job.workspace_id(),
+                        job.change_set_id(),
+                        component_id,
+                        prototype_id,
+                        view_id,
+                        request_ulid,
                         false,
                     )
                     .await?

--- a/lib/dal/tests/integration_test/qualifications.rs
+++ b/lib/dal/tests/integration_test/qualifications.rs
@@ -101,9 +101,9 @@ async fn list_qualifications(ctx: &mut DalContext) {
     // NOTE(nick): at the time of writing this test, we receive the qualifications sorted, so we
     // neither need to perform an additional sort nor use something like a hash set.
     assert_eq!(
-        vec![
-            replace_output_stream_view_line_contents(expected_additional_qualification_view)
-        ], // expected
+        vec![replace_output_stream_view_line_contents(
+            expected_additional_qualification_view
+        )], // expected
         qualifications // actual
     );
 }

--- a/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/update_variant.rs
@@ -827,7 +827,7 @@ async fn update_variant_with_leaf_func(ctx: &mut DalContext) {
     let bindings = FuncBinding::get_qualification_bindings_for_func_id(ctx, created_func_one.id)
         .await
         .expect("could not get bindings");
-    
+
     // Check the qualifications.
     assert_eq!(
         1,                                  // expected

--- a/lib/naxum-api-types/src/lib.rs
+++ b/lib/naxum-api-types/src/lib.rs
@@ -146,7 +146,7 @@ pub trait ApiWrapper: Serialize + strum::VariantNames {
     fn message_version() -> u64 {
         if Self::VARIANTS.len() != 1 {
             panic!(
-                "{} must only have variant; this is a bug!",
+                "{} must only have variant. if you added a new variant, it should be the only one; this is a bug!",
                 Self::MESSAGE_TYPE
             );
         }

--- a/lib/pinga-core/src/api_types/job_execution_request/snapshots-v2/serialized-action.snap
+++ b/lib/pinga-core/src/api_types/job_execution_request/snapshots-v2/serialized-action.snap
@@ -1,0 +1,15 @@
+---
+source: lib/pinga-core/src/api_types/job_execution_request.rs
+description: "\n\n!!!\n!!! System Initiative Developers:\n!!!\n!!! IMPORTANT:\n!!!\n!!!     The contents of this snapshot should *never* be modified as it\n!!!     represents the serialization of a versioned Rust type. If a tests fails\n!!!     with this warning, then something about a Rust type has changed\n!!!     the wire serialization of this type and would represent a potential\n!!!     production outage or data corruption.\n!!!\n!!!     Consider this an erroneous behavioral change of the Rust code and *not*\n!!!     an out-of-date snapshot or fixture!\n!!!\n\n\n"
+---
+{
+  "id": "01JQCVVDHXYX6S9YCV773R13MG",
+  "workspaceId": "01JVRJNMKGRDDSVQ5Y72R0R9F8",
+  "changeSetId": "01JVRJSRHT964D53MWMTXYBXVK",
+  "args": {
+    "action": {
+      "actionId": "01JVX336AZEFB82369PQGMCTM4"
+    }
+  },
+  "isJobBlocking": true
+}

--- a/lib/pinga-core/src/api_types/job_execution_request/snapshots-v2/serialized-dependent-values-update.snap
+++ b/lib/pinga-core/src/api_types/job_execution_request/snapshots-v2/serialized-dependent-values-update.snap
@@ -1,0 +1,11 @@
+---
+source: lib/pinga-core/src/api_types/job_execution_request.rs
+description: "\n\n!!!\n!!! System Initiative Developers:\n!!!\n!!! IMPORTANT:\n!!!\n!!!     The contents of this snapshot should *never* be modified as it\n!!!     represents the serialization of a versioned Rust type. If a tests fails\n!!!     with this warning, then something about a Rust type has changed\n!!!     the wire serialization of this type and would represent a potential\n!!!     production outage or data corruption.\n!!!\n!!!     Consider this an erroneous behavioral change of the Rust code and *not*\n!!!     an out-of-date snapshot or fixture!\n!!!\n\n\n"
+---
+{
+  "id": "01JQCVVDHXYX6S9YCV773R13MG",
+  "workspaceId": "01JVRJNMKGRDDSVQ5Y72R0R9F8",
+  "changeSetId": "01JVRJSRHT964D53MWMTXYBXVK",
+  "args": "dependentValuesUpdate",
+  "isJobBlocking": true
+}

--- a/lib/pinga-core/src/api_types/job_execution_request/snapshots-v2/serialized-management.snap
+++ b/lib/pinga-core/src/api_types/job_execution_request/snapshots-v2/serialized-management.snap
@@ -1,0 +1,18 @@
+---
+source: lib/pinga-core/src/api_types/job_execution_request.rs
+description: "\n\n!!!\n!!! System Initiative Developers:\n!!!\n!!! IMPORTANT:\n!!!\n!!!     The contents of this snapshot should *never* be modified as it\n!!!     represents the serialization of a versioned Rust type. If a tests fails\n!!!     with this warning, then something about a Rust type has changed\n!!!     the wire serialization of this type and would represent a potential\n!!!     production outage or data corruption.\n!!!\n!!!     Consider this an erroneous behavioral change of the Rust code and *not*\n!!!     an out-of-date snapshot or fixture!\n!!!\n\n\n"
+---
+{
+  "id": "01JQCVVDHXYX6S9YCV773R13MG",
+  "workspaceId": "01JVRJNMKGRDDSVQ5Y72R0R9F8",
+  "changeSetId": "01JVRJSRHT964D53MWMTXYBXVK",
+  "args": {
+    "managementFunc": {
+      "componentId": "01JVX3710QXN05Q6QEZ0FRHW5T",
+      "prototypeId": "01JVX37HB74AFWTDGEMTBQY5NM",
+      "viewId": "01JVX37HB74AFWTDGEMTBQY5NM",
+      "requestUlid": null
+    }
+  },
+  "isJobBlocking": true
+}

--- a/lib/pinga-core/src/api_types/job_execution_request/snapshots-v2/serialized-validation.snap
+++ b/lib/pinga-core/src/api_types/job_execution_request/snapshots-v2/serialized-validation.snap
@@ -1,0 +1,18 @@
+---
+source: lib/pinga-core/src/api_types/job_execution_request.rs
+description: "\n\n!!!\n!!! System Initiative Developers:\n!!!\n!!! IMPORTANT:\n!!!\n!!!     The contents of this snapshot should *never* be modified as it\n!!!     represents the serialization of a versioned Rust type. If a tests fails\n!!!     with this warning, then something about a Rust type has changed\n!!!     the wire serialization of this type and would represent a potential\n!!!     production outage or data corruption.\n!!!\n!!!     Consider this an erroneous behavioral change of the Rust code and *not*\n!!!     an out-of-date snapshot or fixture!\n!!!\n\n\n"
+---
+{
+  "id": "01JQCVVDHXYX6S9YCV773R13MG",
+  "workspaceId": "01JVRJNMKGRDDSVQ5Y72R0R9F8",
+  "changeSetId": "01JVRJSRHT964D53MWMTXYBXVK",
+  "args": {
+    "validation": {
+      "attributeValueIds": [
+        "01JVX3710QXN05Q6QEZ0FRHW5T",
+        "01JVX37HB74AFWTDGEMTBQY5NM"
+      ]
+    }
+  },
+  "isJobBlocking": true
+}

--- a/lib/pinga-core/src/api_types/job_execution_request/v2.rs
+++ b/lib/pinga-core/src/api_types/job_execution_request/v2.rs
@@ -1,0 +1,181 @@
+use naxum_api_types::RequestId;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_id::{
+    ActionId,
+    AttributeValueId,
+    ChangeSetId,
+    ComponentId,
+    ManagementPrototypeId,
+    ViewId,
+    WorkspacePk,
+};
+use strum::{
+    AsRefStr,
+    Display,
+    EnumDiscriminants,
+    IntoStaticStr,
+};
+
+#[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+// NOTE: **do not modify this datatype--it represents a historically stable, versioned request**
+pub struct JobExecutionRequestV2 {
+    pub id: RequestId,
+    pub workspace_id: WorkspacePk,
+    pub change_set_id: ChangeSetId,
+    pub args: JobArgsV2,
+    pub is_job_blocking: bool,
+}
+
+#[remain::sorted]
+#[derive(
+    AsRefStr,
+    Clone,
+    Debug,
+    Deserialize,
+    Display,
+    EnumDiscriminants,
+    Eq,
+    Hash,
+    IntoStaticStr,
+    PartialEq,
+    Serialize,
+)]
+#[serde(rename_all = "camelCase")]
+#[strum_discriminants(derive(Hash))]
+// NOTE: **do not modify this datatype--it represents a historically stable, versioned request**
+pub enum JobArgsV2 {
+    #[serde(rename_all = "camelCase")]
+    Action {
+        action_id: ActionId,
+    },
+    DependentValuesUpdate,
+    #[serde(rename_all = "camelCase")]
+    ManagementFunc {
+        component_id: ComponentId,
+        prototype_id: ManagementPrototypeId,
+        view_id: ViewId,
+        request_ulid: Option<ulid::Ulid>,
+    },
+    #[serde(rename_all = "camelCase")]
+    Validation {
+        attribute_value_ids: Vec<AttributeValueId>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::{
+            JobExecutionRequestVersionsDiscriminants,
+            JobExecutionRequestVersionsDiscriminants::*,
+            test::*,
+        },
+        *,
+    };
+
+    const VERSION: JobExecutionRequestVersionsDiscriminants = V2;
+
+    fn msg_action() -> JobExecutionRequestV2 {
+        JobExecutionRequestV2 {
+            id: "01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),
+            workspace_id: "01JVRJNMKGRDDSVQ5Y72R0R9F8".parse().unwrap(),
+            change_set_id: "01JVRJSRHT964D53MWMTXYBXVK".parse().unwrap(),
+            args: JobArgsV2::Action {
+                action_id: "01JVX336AZEFB82369PQGMCTM4".parse().unwrap(),
+            },
+            is_job_blocking: true,
+        }
+    }
+
+    fn msg_dependent_values_update() -> JobExecutionRequestV2 {
+        JobExecutionRequestV2 {
+            id: "01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),
+            workspace_id: "01JVRJNMKGRDDSVQ5Y72R0R9F8".parse().unwrap(),
+            change_set_id: "01JVRJSRHT964D53MWMTXYBXVK".parse().unwrap(),
+            args: JobArgsV2::DependentValuesUpdate,
+            is_job_blocking: true,
+        }
+    }
+
+    fn msg_validation() -> JobExecutionRequestV2 {
+        JobExecutionRequestV2 {
+            id: "01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),
+            workspace_id: "01JVRJNMKGRDDSVQ5Y72R0R9F8".parse().unwrap(),
+            change_set_id: "01JVRJSRHT964D53MWMTXYBXVK".parse().unwrap(),
+            args: JobArgsV2::Validation {
+                attribute_value_ids: vec![
+                    "01JVX3710QXN05Q6QEZ0FRHW5T".parse().unwrap(),
+                    "01JVX37HB74AFWTDGEMTBQY5NM".parse().unwrap(),
+                ],
+            },
+            is_job_blocking: true,
+        }
+    }
+
+    fn msg_management() -> JobExecutionRequestV2 {
+        JobExecutionRequestV2 {
+            id: "01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),
+            workspace_id: "01JVRJNMKGRDDSVQ5Y72R0R9F8".parse().unwrap(),
+            change_set_id: "01JVRJSRHT964D53MWMTXYBXVK".parse().unwrap(),
+            args: JobArgsV2::ManagementFunc {
+                component_id: "01JVX3710QXN05Q6QEZ0FRHW5T".parse().unwrap(),
+                prototype_id: "01JVX37HB74AFWTDGEMTBQY5NM".parse().unwrap(),
+                view_id: "01JVX37HB74AFWTDGEMTBQY5NM".parse().unwrap(),
+                request_ulid: None,
+            },
+            is_job_blocking: true,
+        }
+    }
+
+    #[test]
+    fn serialize_action() {
+        assert_serialize("serialized-action", VERSION, msg_action());
+    }
+
+    #[test]
+    fn serialize_dependent_values_update() {
+        assert_serialize(
+            "serialized-dependent-values-update",
+            VERSION,
+            msg_dependent_values_update(),
+        );
+    }
+
+    #[test]
+    fn serialize_validation() {
+        assert_serialize("serialized-validation", VERSION, msg_validation());
+    }
+
+    #[test]
+    fn serialize_management() {
+        assert_serialize("serialized-management", VERSION, msg_management());
+    }
+
+    #[test]
+    fn deserialize_action() {
+        assert_deserialize("serialized-action", VERSION, msg_action());
+    }
+
+    #[test]
+    fn deserialize_dependent_values_update() {
+        assert_deserialize(
+            "serialized-dependent-values-update",
+            VERSION,
+            msg_dependent_values_update(),
+        );
+    }
+
+    #[test]
+    fn deserialize_validation() {
+        assert_deserialize("serialized-validation", VERSION, msg_validation());
+    }
+
+    #[test]
+    fn deserialize_management() {
+        assert_deserialize("serialized-management", VERSION, msg_management());
+    }
+}

--- a/lib/pinga-server/src/handlers.rs
+++ b/lib/pinga-server/src/handlers.rs
@@ -14,6 +14,7 @@ use dal::{
         definition::{
             ActionJob,
             DependentValuesUpdate,
+            ManagementFuncJob,
             compute_validation::ComputeValidation,
         },
     },
@@ -255,6 +256,19 @@ async fn try_execute_job(
             request.workspace_id,
             request.change_set_id,
             attribute_value_ids.clone(),
+        ) as Box<dyn JobConsumer + Send + Sync>,
+        JobArgsVCurrent::ManagementFunc {
+            component_id,
+            prototype_id,
+            view_id,
+            request_ulid,
+        } => ManagementFuncJob::new(
+            request.workspace_id,
+            request.change_set_id,
+            *prototype_id,
+            *component_id,
+            *view_id,
+            *request_ulid,
         ) as Box<dyn JobConsumer + Send + Sync>,
     };
 

--- a/lib/si-db/src/context.rs
+++ b/lib/si-db/src/context.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use si_id::ChangeSetId;
 use tokio::sync::MappedMutexGuard;
 
 use crate::{
@@ -19,4 +20,5 @@ pub trait SiDbContext {
     -> Result<MappedMutexGuard<'_, Self::Transactions>, SiDbTransactionsError>;
     fn tenancy(&self) -> &Tenancy;
     fn visibility(&self) -> &Visibility;
+    fn change_set_id(&self) -> ChangeSetId;
 }

--- a/lib/si-db/src/history_event.rs
+++ b/lib/si-db/src/history_event.rs
@@ -48,6 +48,13 @@ impl HistoryActor {
         Ok(email_as_lowercase.ends_with(SYSTEMINIT_EMAIL_SUFFIX)
             || email_as_lowercase.ends_with(TEST_SYSTEMINIT_EMAIL_SUFFIX))
     }
+
+    pub fn user_pk(&self) -> Option<UserPk> {
+        match self {
+            HistoryActor::User(pk) => Some(*pk),
+            HistoryActor::SystemInit => None,
+        }
+    }
 }
 
 impl From<UserPk> for HistoryActor {

--- a/lib/si-db/src/lib.rs
+++ b/lib/si-db/src/lib.rs
@@ -7,6 +7,7 @@ pub mod change_set;
 mod context;
 mod history_event;
 pub mod key_pair;
+mod management_func_execution;
 pub mod migrate;
 // TODO remove pub once we move users out of dal
 pub mod standard_accessors;
@@ -22,6 +23,11 @@ pub use history_event::{
     HistoryActor,
     HistoryEvent,
     HistoryEventMetadata,
+};
+pub use management_func_execution::{
+    ManagementFuncExecutionError,
+    ManagementFuncJobState,
+    ManagementState,
 };
 pub use tenancy::Tenancy;
 pub use transactions::{

--- a/lib/si-db/src/management_func_execution.rs
+++ b/lib/si-db/src/management_func_execution.rs
@@ -1,0 +1,242 @@
+use std::str::FromStr;
+
+use chrono::{
+    DateTime,
+    Utc,
+};
+use si_data_pg::PgRow;
+use si_events::Timestamp;
+use si_id::{
+    ChangeSetId,
+    ComponentId,
+    FuncRunId,
+    ManagementFuncExecutionId,
+    ManagementPrototypeId,
+    UserPk,
+    WorkspacePk,
+};
+use strum::EnumString;
+
+use crate::{
+    SiDbContext,
+    SiDbTransactions,
+    getter_copy,
+};
+
+#[remain::sorted]
+#[derive(thiserror::Error, Debug)]
+pub enum ManagementFuncExecutionError {
+    #[error("management function execution could not be created")]
+    CreationFailed,
+    #[error("cannot transition from {0} to {1}")]
+    InvalidTransition(ManagementState, ManagementState),
+    #[error("no execution found with id: {0}")]
+    NotFound(ManagementFuncExecutionId),
+    #[error(
+        "no in progress execution found for workspace {0}, change set {1}, component {2}, management prototype {3}"
+    )]
+    NotFoundInProgress(WorkspacePk, ChangeSetId, ComponentId, ManagementPrototypeId),
+    #[error("pg error: {0}")]
+    Pg(#[from] si_data_pg::PgError),
+    #[error("pg pool error: {0}")]
+    PgPool(#[from] si_data_pg::PgPoolError),
+    #[error("si db error: {0}")]
+    SiDb(#[from] crate::Error),
+    #[error("si db transactions error: {0}")]
+    SiDbTransactions(#[from] crate::transactions::SiDbTransactionsError),
+    #[error("strum parse error: {0}")]
+    StrumParse(#[from] strum::ParseError),
+}
+
+pub type ManagementFuncExecutionResult<T> = std::result::Result<T, ManagementFuncExecutionError>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, strum::Display)]
+pub enum ManagementState {
+    /// Waiting to be executed
+    #[strum(serialize = "pending")]
+    Pending,
+    /// Executing the management function in veritech/cyclone
+    #[strum(serialize = "executing")]
+    Executing,
+    /// Operating on the return value of the management function
+    #[strum(serialize = "operating")]
+    Operating,
+    /// Success
+    #[strum(serialize = "success")]
+    Success,
+    /// Failure
+    #[strum(serialize = "failure")]
+    Failure,
+}
+
+impl ManagementState {
+    pub fn is_valid_transition(&self, next: Self) -> bool {
+        matches!(
+            (self, next),
+            (Self::Pending, Self::Executing)
+                | (Self::Executing, Self::Operating)
+                | (Self::Operating, Self::Success)
+                | (
+                    Self::Pending | Self::Executing | Self::Operating,
+                    Self::Failure
+                )
+        )
+    }
+}
+
+impl TryFrom<PgRow> for ManagementFuncJobState {
+    type Error = ManagementFuncExecutionError;
+
+    fn try_from(row: PgRow) -> std::result::Result<Self, Self::Error> {
+        let id: ManagementFuncExecutionId = row.try_get("id")?;
+        let workspace_id: WorkspacePk = row.try_get("workspace_id")?;
+        let change_set_id: ChangeSetId = row.try_get("change_set_id")?;
+        let component_id: ComponentId = row.try_get("component_id")?;
+        let prototype_id: ManagementPrototypeId = row.try_get("prototype_id")?;
+        let func_run_id: Option<FuncRunId> = row.try_get("func_run_id")?;
+        let user_id: Option<UserPk> = row.try_get("user_id")?;
+        let state_string: String = row.try_get("state")?;
+        let state = ManagementState::from_str(&state_string)?;
+        let created_at: DateTime<Utc> = row.try_get("created_at")?;
+        let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
+
+        Ok(Self {
+            id,
+            workspace_id,
+            change_set_id,
+            component_id,
+            prototype_id,
+            func_run_id,
+            user_id,
+            state,
+            timestamp: Timestamp::new(created_at, updated_at),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagementFuncJobState {
+    id: ManagementFuncExecutionId,
+    workspace_id: WorkspacePk,
+    change_set_id: ChangeSetId,
+    component_id: ComponentId,
+    prototype_id: ManagementPrototypeId,
+    user_id: Option<UserPk>,
+    func_run_id: Option<FuncRunId>,
+    state: ManagementState,
+    timestamp: Timestamp,
+}
+
+impl ManagementFuncJobState {
+    getter_copy!(id, ManagementFuncExecutionId);
+    getter_copy!(workspace_id, WorkspacePk);
+    getter_copy!(change_set_id, ChangeSetId);
+    getter_copy!(component_id, ComponentId);
+    getter_copy!(prototype_id, ManagementPrototypeId);
+    getter_copy!(state, ManagementState);
+    getter_copy!(timestamp, Timestamp);
+    getter_copy!(user_id, Option<UserPk>);
+    getter_copy!(func_run_id, Option<FuncRunId>);
+
+    pub async fn new_pending(
+        ctx: &impl SiDbContext,
+        component_id: ComponentId,
+        prototype_id: ManagementPrototypeId,
+    ) -> ManagementFuncExecutionResult<Self> {
+        let state = ManagementState::Pending;
+        let user_pk = ctx.history_actor().user_pk();
+        let workspace_id = ctx.tenancy().workspace_pk()?;
+        let change_set_id = ctx.change_set_id();
+
+        let row = ctx.txns().await?.pg().query_opt(
+            r#"INSERT INTO management_func_job_states (workspace_id, change_set_id, component_id, prototype_id, user_id, state) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT DO NOTHING RETURNING *"#,
+            &[&workspace_id, &change_set_id, &component_id, &prototype_id, &user_pk, &state.to_string()]
+        ).await?;
+
+        Self::try_from(row.ok_or(ManagementFuncExecutionError::CreationFailed)?)
+    }
+
+    pub async fn get_pending(
+        ctx: &impl SiDbContext,
+        component_id: ComponentId,
+        prototype_id: ManagementPrototypeId,
+    ) -> ManagementFuncExecutionResult<Option<Self>> {
+        let workspace_id = ctx.tenancy().workspace_pk()?;
+        let change_set_id = ctx.change_set_id();
+
+        let row = ctx.txns().await?.pg().query_opt(
+            r#"SELECT * FROM management_func_job_states WHERE workspace_id = $1 AND change_set_id = $2 AND component_id = $3 AND prototype_id = $4 AND state = 'pending' LIMIT 1"#,
+            &[&workspace_id, &change_set_id, &component_id, &prototype_id]
+        ).await?;
+
+        Ok(match row {
+            Some(row) => Some(Self::try_from(row)?),
+            None => None,
+        })
+    }
+
+    pub async fn get_latest_by_keys(
+        ctx: &impl SiDbContext,
+        component_id: ComponentId,
+        prototype_id: ManagementPrototypeId,
+    ) -> ManagementFuncExecutionResult<Option<Self>> {
+        let workspace_id = ctx.tenancy().workspace_pk()?;
+        let change_set_id = ctx.change_set_id();
+
+        let row = ctx.txns().await?.pg().query_opt(
+            r#"SELECT * FROM management_func_job_states WHERE workspace_id = $1 AND change_set_id = $2 AND component_id = $3 AND prototype_id = $4 ORDER BY created_at DESC LIMIT 1"#,
+            &[&workspace_id, &change_set_id, &component_id, &prototype_id]
+        ).await?;
+
+        Ok(match row {
+            Some(row) => Some(Self::try_from(row)?),
+            None => None,
+        })
+    }
+
+    pub async fn transition_state(
+        ctx: &impl SiDbContext,
+        id: ManagementFuncExecutionId,
+        next_state: ManagementState,
+        func_run_id: Option<FuncRunId>,
+    ) -> ManagementFuncExecutionResult<Self> {
+        let row = ctx
+            .txns()
+            .await?
+            .pg()
+            .query_opt(
+                r#"SELECT * FROM management_func_job_states WHERE id = $1 FOR UPDATE"#,
+                &[&id],
+            )
+            .await?;
+
+        let current = Self::try_from(row.ok_or(ManagementFuncExecutionError::NotFound(id))?)?;
+
+        if !current.state().is_valid_transition(next_state) {
+            return Err(ManagementFuncExecutionError::InvalidTransition(
+                current.state(),
+                next_state,
+            ));
+        }
+
+        let updated_row = match next_state {
+            ManagementState::Executing => {
+                ctx.txns().await?.pg().query_one(r#"UPDATE management_func_job_states SET state = $1, func_run_id = $2, updated_at = now() WHERE id = $3 RETURNING *"#,
+                    &[&next_state.to_string(), &func_run_id, &current.id()]
+                ).await?
+            }
+            _ => {
+                ctx.txns()
+                    .await?
+                    .pg()
+                    .query_one(
+                        r#"UPDATE management_func_job_states SET state = $1, updated_at = now() WHERE id = $2 RETURNING *"#,
+                        &[&next_state.to_string(), &current.id()],
+                    )
+                    .await?
+            }
+        };
+
+        Self::try_from(updated_row)
+    }
+}

--- a/lib/si-db/src/migrations/U3910__add_management_func_job_states.sql
+++ b/lib/si-db/src/migrations/U3910__add_management_func_job_states.sql
@@ -1,0 +1,25 @@
+CREATE TABLE management_func_job_states
+(
+    id                      ident primary key default ident_create_v1(),
+    workspace_id            ident not null,
+    change_set_id           ident not null,
+    component_id            ident not null,
+    prototype_id            ident not null,
+    user_id                 ident,
+    func_run_id             ident,
+    state                   text not null default 'pending',
+    created_at              timestamp with time zone not null default now(),
+    updated_at              timestamp with time zone not null default now()
+);
+
+CREATE INDEX idx_management_func_job_states_for_component ON management_func_job_states(change_set_id, component_id);
+
+--- partial unique index ensuring only one pending, executing, or operating management func per workspace, change set, component, and prototype
+CREATE UNIQUE INDEX
+        unique_in_progress_idx ON
+    management_func_job_states (
+        workspace_id,
+        change_set_id,
+        component_id,
+        prototype_id
+    ) WHERE state IN ('pending', 'executing', 'operating');

--- a/lib/si-db/src/standard_accessors.rs
+++ b/lib/si-db/src/standard_accessors.rs
@@ -6,3 +6,12 @@ macro_rules! getter {
         }
     };
 }
+
+#[macro_export]
+macro_rules! getter_copy {
+    ($column:ident, $value_type:ty) => {
+        pub fn $column(&self) -> $value_type {
+            self.$column
+        }
+    };
+}

--- a/lib/si-events-rs/src/timestamp.rs
+++ b/lib/si-events-rs/src/timestamp.rs
@@ -21,4 +21,11 @@ impl Timestamp {
             updated_at: now,
         }
     }
+
+    pub fn new(created_at: DateTime<Utc>, updated_at: DateTime<Utc>) -> Self {
+        Self {
+            created_at,
+            updated_at,
+        }
+    }
 }

--- a/lib/si-id/src/lib.rs
+++ b/lib/si-id/src/lib.rs
@@ -50,7 +50,6 @@ id!(GeometryId);
 id!(HistoryEventPk);
 id!(InputSocketId);
 id!(LayeredEventId);
-id!(ManagementPrototypeId);
 id!(ModuleId);
 id!(NaxumApiTypesRequestId);
 id!(OutputSocketId);
@@ -73,6 +72,8 @@ id_with_pg_types!(ChangeSetApprovalId);
 id_with_pg_types!(ComponentId);
 id_with_pg_types!(FuncId);
 id_with_pg_types!(FuncRunId);
+id_with_pg_types!(ManagementFuncExecutionId);
+id_with_pg_types!(ManagementPrototypeId);
 id_with_pg_types!(UserPk);
 id_with_pg_types!(WorkspaceIntegrationId);
 

--- a/lib/si-id/src/ulid.rs
+++ b/lib/si-id/src/ulid.rs
@@ -1,9 +1,9 @@
 //! Provides a wrapper for [`::ulid::Ulid`] for common visitor and conversion patterns.
 
-use ulid::Ulid as CoreUlid;
 pub use ulid::{
     DecodeError,
     ULID_LEN,
+    Ulid as CoreUlid,
 };
 
 /// Size is the size in bytes, len is the string length


### PR DESCRIPTION
Adds a pinga job for executing management funcs. Adds a tracking table to ensure only one job at time per component and prototype and change set.

Jobs retry until the DVU roots are clear.

The v2 run_prototype route has been changed to spawn the job, but I have not yet updated the public api or luminork api routes, since I'm not sure what the expectation is for the data they return (they cannot return the message and state of the job since it is now dispatched by pinga).