### PR TITLE
fix(web): fix scrolling on tile view

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -80,7 +80,7 @@
         </InstructiveVormInput>
       </div>
       <template v-if="showGrid">
-        <div ref="scrollRef" class="scrollable tilegrid grow">
+        <div ref="scrollRef" class="scrollable tilegrid grow overflow-y-auto">
           <ComponentGridTile
             v-for="component in componentVirtualItemsList"
             ref="componentGridTileRefs"


### PR DESCRIPTION
**Changes Made**

Fixed scroll container behavior by explicitly adding overflow-y-auto to the .tilegrid container. This ensures the grid properly scrolls when rendering many ComponentGridTile items.

Left the `v-for="component in componentVirtualItemsList"` structure intact for compatibility with @tanstack/vue-virtual.

**Context**
Previously, the scroll behavior was broken due to missing overflow constraints on the tile container. Adding overflow-y-auto ensures the scrollable region behaves as expected while preserving virtualized performance.

**What I checked:**
Load the grid view with a large number of components.
Verify that all tiles render.
Confirm smooth vertical scrolling behavior within the tile container.