### PR TITLE
feat(luminork): Add support for setting prop subscriptions

### DIFF
--- a/lib/luminork-server/src/service/v1.rs
+++ b/lib/luminork-server/src/service/v1.rs
@@ -38,6 +38,7 @@ pub use change_sets::{
 };
 pub use components::{
     ComponentPropKey,
+    ComponentReference,
     ComponentV1RequestPath,
     ComponentsError,
     ComponentsResult,
@@ -50,7 +51,6 @@ pub use components::{
         AddActionV1Response,
     },
     connections::{
-        ComponentReference,
         Connection,
         ConnectionPoint,
     },

--- a/lib/luminork-server/src/service/v1/components/connections.rs
+++ b/lib/luminork-server/src/service/v1/components/connections.rs
@@ -136,57 +136,6 @@ pub async fn find_component_output_socket_id(
     find_output_socket_id(ctx, socket_name, variant_id).await
 }
 
-async fn connection_summary(
-    ctx: &dal::DalContext,
-    connection: &Connection,
-    component_list: &[ComponentId],
-) -> Result<serde_json::Value, ComponentsError> {
-    match connection {
-        Connection::Incoming { from, to: _ } => {
-            let source_component_id =
-                resolve_component_reference(ctx, &from.component_ref, component_list).await?;
-
-            Ok(serde_json::json!({
-                "type": "incoming",
-                "from": {
-                    "socketName": from.socket_name,
-                    "componentId": source_component_id.to_string()
-                }
-            }))
-        }
-        Connection::Outgoing { to, from: _ } => {
-            let target_component_id =
-                resolve_component_reference(ctx, &to.component_ref, component_list).await?;
-
-            Ok(serde_json::json!({
-                "type": "outgoing",
-                "to": {
-                    "socketName": to.socket_name,
-                    "componentId": target_component_id.to_string()
-                }
-            }))
-        }
-    }
-}
-
-pub async fn summarise_connections(
-    ctx: &dal::DalContext,
-    connections: &[Connection],
-    component_list: &[ComponentId],
-) -> Result<serde_json::Value, ComponentsError> {
-    if connections.is_empty() {
-        return Ok(serde_json::Value::Null);
-    }
-
-    let mut summary = Vec::new();
-    for connection in connections {
-        let connection_summary = connection_summary(ctx, connection, component_list).await?;
-        summary.push(connection_summary);
-    }
-
-    Ok(serde_json::json!(summary))
-}
-
 pub async fn handle_connection(
     ctx: &dal::DalContext,
     connection: &Connection,

--- a/lib/luminork-server/src/service/v1/components/connections.rs
+++ b/lib/luminork-server/src/service/v1/components/connections.rs
@@ -15,8 +15,10 @@ use serde::{
 use utoipa::ToSchema;
 
 use super::{
+    ComponentReference,
     ComponentsError,
     ComponentsResult,
+    resolve_component_reference,
 };
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -30,22 +32,6 @@ pub struct ConnectionPoint {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
-#[serde(untagged)]
-#[schema(example = json!({"component": "ComponentName"}))]
-#[schema(example = json!({"componentId": "01H9ZQD35JPMBGHH69BT0Q79VY"}))]
-pub enum ComponentReference {
-    ByName {
-        component: String,
-    },
-    #[serde(rename_all = "camelCase")]
-    ById {
-        #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q79VY")]
-        component_id: ComponentId,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(untagged)]
 #[serde(rename_all = "camelCase")]
 pub enum Connection {
@@ -55,38 +41,6 @@ pub enum Connection {
     #[schema(example = json!({"from": "ThisComponentOutputSocketName", "to": {"component": "OtherComponentName", "socketName": "InputSocketName"}}))]
     #[schema(example = json!({"from": "ThisComponentOutputSocketName", "to": {"componentId": "01H9ZQD35JPMBGHH69BT0Q79VY", "socketName": "InputSocketName"}}))]
     Outgoing { from: String, to: ConnectionPoint },
-}
-
-/// Returns the component ID if found, or appropriate error if not found. If a duplicate exists, it
-/// picks the "first" one it sees.
-pub async fn find_component_id_by_name(
-    ctx: &dal::DalContext,
-    component_list: &[ComponentId],
-    component_name: &str,
-) -> Result<ComponentId, ComponentsError> {
-    for component_id in component_list {
-        let name = Component::name_by_id(ctx, *component_id).await?;
-        if name == component_name {
-            return Ok(*component_id);
-        }
-    }
-    Err(ComponentsError::ComponentNotFound(
-        component_name.to_string(),
-    ))
-}
-
-/// Helper function to resolve a component reference to a component ID
-pub async fn resolve_component_reference(
-    ctx: &dal::DalContext,
-    component_ref: &ComponentReference,
-    component_list: &[ComponentId],
-) -> Result<ComponentId, ComponentsError> {
-    match component_ref {
-        ComponentReference::ById { component_id } => Ok(*component_id),
-        ComponentReference::ByName { component } => {
-            find_component_id_by_name(ctx, component_list, component).await
-        }
-    }
 }
 
 /// Helper function to find an input socket ID by name for a given schema variant

--- a/lib/luminork-server/src/service/v1/components/create_component.rs
+++ b/lib/luminork-server/src/service/v1/components/create_component.rs
@@ -63,6 +63,7 @@ use crate::{
         (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
     )
 )]
+#[allow(deprecated)]
 pub async fn create_component(
     ChangeSetDalContext(ref ctx): ChangeSetDalContext,
     tracker: PosthogEventTracker,
@@ -195,7 +196,7 @@ pub async fn create_component(
             component_name: comp_name.clone(),
             before_domain_tree: None,
             after_domain_tree: Some(after_value),
-            added_connections: Some(added_connection_summary),
+            added_connections: None,
             deleted_connections: None,
             added_secrets: payload.secrets.len(),
         },
@@ -246,13 +247,8 @@ pub struct CreateComponentV1Request {
     #[schema(example = "MyView")]
     pub view_name: Option<String>,
 
-    #[schema(example = json!([
-        {"from": {"component": "OtherComponentName", "socketName": "SocketName"}, "to": "ThisComponentInputSocketName"},
-        {"from": {"componentId": "01H9ZQD35JPMBGHH69BT0Q79VY", "socketName": "SocketName"}, "to": "ThisComponentInputSocketName"},
-        {"from": "ThisComponentOutputSocketName", "to": {"component": "OtherComponentName", "socketName": "InputSocketName"}},
-        {"from": "ThisComponentOutputSocketName", "to": {"componentId": "01H9ZQD35JPMBGHH69BT0Q79VY", "socketName": "InputSocketName"}}
-    ]))]
     #[serde(default)]
+    #[deprecated]
     pub connections: Vec<Connection>,
 }
 

--- a/lib/luminork-server/src/service/v1/components/find_component.rs
+++ b/lib/luminork-server/src/service/v1/components/find_component.rs
@@ -20,12 +20,10 @@ use utoipa::{
 };
 
 use super::{
+    ComponentReference,
     ComponentsError,
-    connections::{
-        ComponentReference,
-        resolve_component_reference,
-    },
     get_component::GetComponentV1Response,
+    resolve_component_reference,
 };
 use crate::{
     extract::{

--- a/lib/luminork-server/src/service/v1/components/subscriptions.rs
+++ b/lib/luminork-server/src/service/v1/components/subscriptions.rs
@@ -1,0 +1,174 @@
+use dal::{
+    AttributeValue,
+    AttributeValueId,
+    Component,
+    ComponentId,
+    DalContext,
+    Func,
+    FuncId,
+    attribute::{
+        path::AttributePath,
+        value::subscription::ValueSubscription,
+    },
+    func::intrinsics::IntrinsicFunc,
+    workspace_snapshot::node_weight::NodeWeight,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use utoipa::ToSchema;
+
+use super::{
+    ComponentReference,
+    ComponentsError,
+    ComponentsResult,
+    resolve_component_reference,
+};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Subscription {
+    #[serde(flatten)]
+    pub component_ref: ComponentReference,
+
+    pub prop_path: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = String)]
+    pub function: Option<FuncReference>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keep_existing_subscriptions: Option<bool>,
+}
+
+pub async fn handle_subscription(
+    ctx: &dal::DalContext,
+    av_to_set: AttributeValueIdent,
+    sub: &Subscription,
+    component_id: ComponentId,
+    component_list: &[ComponentId],
+) -> ComponentsResult<()> {
+    let target_av_id = av_to_set.vivify(ctx, component_id).await?;
+
+    let source_component_id =
+        resolve_component_reference(ctx, &sub.component_ref, component_list).await?;
+
+    let subscription = ValueSubscription {
+        attribute_value_id: Component::root_attribute_value_id(ctx, source_component_id).await?,
+        path: AttributePath::from_json_pointer(sub.prop_path.clone()),
+    };
+
+    subscription.validate(ctx).await?;
+
+    let existing_subscriptions = match sub.keep_existing_subscriptions {
+        Some(true) => AttributeValue::subscriptions(ctx, target_av_id).await?,
+        Some(false) | None => None,
+    };
+    let mut subscriptions = existing_subscriptions.unwrap_or(vec![]);
+    if !subscriptions.contains(&subscription) {
+        subscriptions.push(subscription);
+    }
+
+    let maybe_func_id = if let Some(func) = sub.function.clone() {
+        func.resolve(ctx).await?
+    } else {
+        None
+    };
+
+    AttributeValue::set_to_subscriptions(ctx, target_av_id, subscriptions, maybe_func_id).await?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct FuncReference(String);
+
+impl FuncReference {
+    #[allow(unused)]
+    async fn resolve(&self, ctx: &DalContext) -> ComponentsResult<Option<FuncId>> {
+        if let Some(id) = self.resolve_as_id(ctx).await? {
+            return Ok(Some(id));
+        }
+
+        if let Some(func) = IntrinsicFunc::maybe_from_str(&self.0) {
+            return Ok(Some(Func::find_intrinsic(ctx, func).await?));
+        }
+
+        // Otherwise, try to find it by name
+        Ok(None)
+    }
+
+    async fn resolve_as_id(&self, ctx: &DalContext) -> ComponentsResult<Option<FuncId>> {
+        let Ok(id) = self.0.parse() else {
+            return Ok(None);
+        };
+
+        let Some(NodeWeight::Func(_)) = ctx.workspace_snapshot()?.get_node_weight_opt(id).await
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(id))
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributeValueIdent(String);
+
+impl AttributeValueIdent {
+    #[allow(unused)]
+    async fn resolve(
+        self,
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentsResult<Option<AttributeValueId>> {
+        if let Some(id) = self.resolve_as_id(ctx, component_id).await? {
+            return Ok(Some(id));
+        }
+
+        let root_id = Component::root_attribute_value_id(ctx, component_id).await?;
+        let path = AttributePath::from_json_pointer(self.0);
+        Ok(path.resolve(ctx, root_id).await?)
+    }
+
+    async fn vivify(
+        self,
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentsResult<AttributeValueId> {
+        if let Some(id) = self.resolve_as_id(ctx, component_id).await? {
+            return Ok(id);
+        }
+
+        let root_id = Component::root_attribute_value_id(ctx, component_id).await?;
+        let path = AttributePath::from_json_pointer(&self.0);
+        Ok(path.vivify(ctx, root_id).await?)
+    }
+
+    async fn resolve_as_id(
+        &self,
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentsResult<Option<AttributeValueId>> {
+        // If it is not a ulid, we'll try the alternative
+        let Ok(id) = self.0.parse() else {
+            return Ok(None);
+        };
+        // If it doesn't exist, we'll try the alternative
+        if !ctx.workspace_snapshot()?.node_exists(id).await {
+            return Ok(None);
+        }
+        // If it *does* exist but is from a different component or not from a component,
+        // that is a hard error.
+        if AttributeValue::component_id(ctx, id).await? != component_id {
+            return Err(ComponentsError::AttributeValueNotFromComponent(
+                id,
+                component_id,
+            ));
+        }
+        Ok(Some(id))
+    }
+}


### PR DESCRIPTION
This will allow a user to set subscriptions from a prop on a component to another prop. We can do this as follows:

```
{
  "domain": {
    "propId1": "value1",
    "path/to/prop": "value2"
  },
  "name": "MyComponentName",
  "schemaName": "AWS::EC2::Instance",
  "secrets": {
    "secretDefinitionName": "secretName"
  },
  "subscriptions": {
    "/prop/path/on/this/component": {
      "component": "OtherComponentName",
      "propPath": "/prop/path/on/other/component"
    }
  }
}
```

Please Note: I will refactor this to remove the duplication from the new dal constructs - I need this to get out there!