### PR TITLE
Yielding webworker

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -73,6 +73,7 @@
     "cm6-theme-gruvbox-dark": "^0.2.0",
     "codemirror": "^6.0.1",
     "comlink": "^4.4.2",
+    "comlink-async-generator": "^0.0.1",
     "d3": "^7.9.0",
     "date-fns": "^2.29.2",
     "elkjs": "^0.10.0",

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -70,7 +70,7 @@ export interface DBInterface {
     changeSetId: ChangeSetId,
     kind: EntityKind,
     id: Id,
-  ): Promise<typeof NOROW | AtomDocument>;
+  ): AsyncGenerator<object | -1>;
   mjolnirBulk(
     workspaceId: string,
     changeSetId: ChangeSetId,

--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -2462,7 +2462,13 @@ async function* get (
     }
 
     if (followComputed) {
-      yield await getComputed(docAndRefs, workspaceId, changeSetId, kind, id);
+      const completedData = await getComputed(docAndRefs, workspaceId, changeSetId, kind, id);
+      if (kind === EntityKind.ComponentList) {
+        for (const c of (completedData as BifrostComponentList).components) {
+          yield c;
+        };
+      } else
+        yield completedData;
       return;
     }
     yield docAndRefs;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       comlink:
         specifier: ^4.4.2
         version: 4.4.2
+      comlink-async-generator:
+        specifier: ^0.0.1
+        version: 0.0.1
       d3:
         specifier: ^7.9.0
         version: 7.9.0
@@ -4846,6 +4849,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comlink-async-generator@0.0.1:
+    resolution: {integrity: sha512-RjOPv6Tb7cL9FiIgwanUJuFG9aW4myAFyyzxZoEkEegeDQrZqr92d1Njv2WIgi7nbGpTiyy5GdNTUubDaNgZ6A==}
 
   comlink@4.4.2:
     resolution: {integrity: sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==}
@@ -10442,9 +10448,8 @@ packages:
   tar-fs@2.1.3:
     resolution: {integrity: sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==}
 
-    
   tar-fs@3.0.9:
-    resolution: {integrity: sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==} 
+    resolution: {integrity: sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
@@ -16374,6 +16379,10 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comlink-async-generator@0.0.1:
+    dependencies:
+      comlink: 4.4.2
 
   comlink@4.4.2: {}
 


### PR DESCRIPTION
With 22 components, yielding the 1st component was slightly faster than returning all the components. By the time we get to the end of the components its taken roughly 4x the amount of time to get the full list.

Of course—there are no optimizations under the hood that remove the need to JSON parse, and structuredClone a string or transfer a blob. This work is in anticipation of not having to look up references and perform JSON parse for finding references in the data itself.