### PR TITLE
feat(luminork): Change how luminork dispatches management funcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4896,6 +4896,7 @@ dependencies = [
  "si-data-nats",
  "si-data-pg",
  "si-data-spicedb",
+ "si-db",
  "si-events",
  "si-frontend-types",
  "si-id",

--- a/lib/dal/src/job/definition/management_func.rs
+++ b/lib/dal/src/job/definition/management_func.rs
@@ -10,7 +10,7 @@ use si_id::{
     ChangeSetId,
     ComponentId,
     FuncRunId,
-    ManagementFuncExecutionId,
+    ManagementFuncJobStateId,
     ManagementPrototypeId,
     ViewId,
     WorkspacePk,
@@ -152,7 +152,7 @@ impl ManagementFuncJob {
     async fn run_inner(
         &self,
         ctx: &DalContext,
-        execution_state_id: ManagementFuncExecutionId,
+        execution_state_id: ManagementFuncJobStateId,
     ) -> ManagementFuncJobResult<JobCompletionState> {
         if !ManagementPrototype::is_valid_prototype_for_component(
             ctx,
@@ -207,7 +207,7 @@ impl ManagementFuncJob {
     async fn operate(
         &self,
         ctx: &DalContext,
-        execution_state_id: ManagementFuncExecutionId,
+        execution_state_id: ManagementFuncJobStateId,
         mut execution_result: ManagementPrototypeExecution,
     ) -> ManagementFuncJobResult<()> {
         let result = execution_result
@@ -294,7 +294,7 @@ impl ManagementFuncJob {
 
     async fn transition_state(
         ctx: &DalContext,
-        execution_state_id: ManagementFuncExecutionId,
+        execution_state_id: ManagementFuncJobStateId,
         new_state: si_db::ManagementState,
         func_run_id: Option<FuncRunId>,
     ) -> ManagementFuncJobResult<()> {
@@ -313,7 +313,7 @@ impl ManagementFuncJob {
 
     async fn executing_state(
         ctx: &DalContext,
-        execution_state_id: ManagementFuncExecutionId,
+        execution_state_id: ManagementFuncJobStateId,
         func_run_id: FuncRunId,
     ) -> ManagementFuncJobResult<()> {
         Self::transition_state(
@@ -327,21 +327,21 @@ impl ManagementFuncJob {
 
     async fn operating_state(
         ctx: &DalContext,
-        execution_state_id: ManagementFuncExecutionId,
+        execution_state_id: ManagementFuncJobStateId,
     ) -> ManagementFuncJobResult<()> {
         Self::transition_state(ctx, execution_state_id, ManagementState::Operating, None).await
     }
 
     async fn success_state(
         ctx: &DalContext,
-        execution_state_id: ManagementFuncExecutionId,
+        execution_state_id: ManagementFuncJobStateId,
     ) -> ManagementFuncJobResult<()> {
         Self::transition_state(ctx, execution_state_id, ManagementState::Success, None).await
     }
 
     async fn fail_state(
         ctx: &DalContext,
-        execution_state_id: ManagementFuncExecutionId,
+        execution_state_id: ManagementFuncJobStateId,
     ) -> ManagementFuncJobResult<()> {
         Self::transition_state(ctx, execution_state_id, ManagementState::Failure, None).await
     }

--- a/lib/luminork-server/BUCK
+++ b/lib/luminork-server/BUCK
@@ -7,6 +7,7 @@ rust_library(
         "//lib/auth-api-client:auth-api-client",
         "//lib/buck2-resources:buck2-resources",
         "//lib/dal:dal",
+        "//lib/si-db:si-db",
         "//lib/edda-client:edda-client",
         "//lib/frigg:frigg",
         "//lib/module-index-client:module-index-client",

--- a/lib/luminork-server/Cargo.toml
+++ b/lib/luminork-server/Cargo.toml
@@ -13,6 +13,7 @@ audit-database = { path = "../../lib/audit-database" }
 auth-api-client = { path = "../../lib/auth-api-client" }
 buck2-resources = { path = "../../lib/buck2-resources" }
 dal = { path = "../../lib/dal" }
+si-db = { path = "../../lib/si-db" }
 edda-client = { path = "../../lib/edda-client" }
 frigg = { path = "../../lib/frigg" }
 module-index-client = { path = "../../lib/module-index-client" }

--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -90,6 +90,12 @@ pub enum ComponentsError {
     InputSocket(#[from] dal::socket::input::InputSocketError),
     #[error("invalid secret value: {0}")]
     InvalidSecretValue(String),
+    #[error("management func error: {0}")]
+    ManagementFuncExecution(#[from] si_db::ManagementFuncExecutionError),
+    #[error("management function already running for this component")]
+    ManagementFunctionAlreadyRunning,
+    #[error("management function execution error: {0}")]
+    ManagementFunctionExecutionFailed(si_db::ManagementFuncExecutionError),
     #[error("management function not found: {0}")]
     ManagementFunctionNotFound(String),
     #[error("prop error: {0}")]
@@ -206,6 +212,9 @@ impl crate::service::v1::common::ErrorIntoResponse for ComponentsError {
             ComponentsError::ActionFunctionNotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
             ComponentsError::ManagementFunctionNotFound(_) => {
                 (StatusCode::NOT_FOUND, self.to_string())
+            }
+            ComponentsError::ManagementFunctionAlreadyRunning => {
+                (StatusCode::CONFLICT, self.to_string())
             }
             ComponentsError::SecretNotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
             ComponentsError::Secret(dal::SecretError::SecretNotFound(_)) => {

--- a/lib/si-db/src/management_func_execution.rs
+++ b/lib/si-db/src/management_func_execution.rs
@@ -10,7 +10,7 @@ use si_id::{
     ChangeSetId,
     ComponentId,
     FuncRunId,
-    ManagementFuncExecutionId,
+    ManagementFuncJobStateId,
     ManagementPrototypeId,
     UserPk,
     WorkspacePk,
@@ -31,7 +31,7 @@ pub enum ManagementFuncExecutionError {
     #[error("cannot transition from {0} to {1}")]
     InvalidTransition(ManagementState, ManagementState),
     #[error("no execution found with id: {0}")]
-    NotFound(ManagementFuncExecutionId),
+    NotFound(ManagementFuncJobStateId),
     #[error(
         "no in progress execution found for workspace {0}, change set {1}, component {2}, management prototype {3}"
     )]
@@ -88,7 +88,7 @@ impl TryFrom<PgRow> for ManagementFuncJobState {
     type Error = ManagementFuncExecutionError;
 
     fn try_from(row: PgRow) -> std::result::Result<Self, Self::Error> {
-        let id: ManagementFuncExecutionId = row.try_get("id")?;
+        let id: ManagementFuncJobStateId = row.try_get("id")?;
         let workspace_id: WorkspacePk = row.try_get("workspace_id")?;
         let change_set_id: ChangeSetId = row.try_get("change_set_id")?;
         let component_id: ComponentId = row.try_get("component_id")?;
@@ -116,7 +116,7 @@ impl TryFrom<PgRow> for ManagementFuncJobState {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ManagementFuncJobState {
-    id: ManagementFuncExecutionId,
+    id: ManagementFuncJobStateId,
     workspace_id: WorkspacePk,
     change_set_id: ChangeSetId,
     component_id: ComponentId,
@@ -128,7 +128,7 @@ pub struct ManagementFuncJobState {
 }
 
 impl ManagementFuncJobState {
-    getter_copy!(id, ManagementFuncExecutionId);
+    getter_copy!(id, ManagementFuncJobStateId);
     getter_copy!(workspace_id, WorkspacePk);
     getter_copy!(change_set_id, ChangeSetId);
     getter_copy!(component_id, ComponentId);
@@ -196,7 +196,7 @@ impl ManagementFuncJobState {
 
     pub async fn transition_state(
         ctx: &impl SiDbContext,
-        id: ManagementFuncExecutionId,
+        id: ManagementFuncJobStateId,
         next_state: ManagementState,
         func_run_id: Option<FuncRunId>,
     ) -> ManagementFuncExecutionResult<Self> {

--- a/lib/si-id/src/lib.rs
+++ b/lib/si-id/src/lib.rs
@@ -72,7 +72,7 @@ id_with_pg_types!(ChangeSetApprovalId);
 id_with_pg_types!(ComponentId);
 id_with_pg_types!(FuncId);
 id_with_pg_types!(FuncRunId);
-id_with_pg_types!(ManagementFuncExecutionId);
+id_with_pg_types!(ManagementFuncJobStateId);
 id_with_pg_types!(ManagementPrototypeId);
 id_with_pg_types!(UserPk);
 id_with_pg_types!(WorkspaceIntegrationId);


### PR DESCRIPTION
This follows the new work in SDF and now returns a different id that the user can look up!

```
Getting started with the System Initiative Public API
1. Creating change set...
Change set ID: 01JXDSGS9HGRX5VE9KCCXJCCX4
2. Creating AWS Credential
AWS Credential created with ID: 01JXDSGT0YJGVYFQZQY3J1CN2Q
3. Creating Localstack secret
4. Setting Localstack secret to AWS Credential component
5. Creating Region
Region created with ID: 01JXDSGW3NQ1XKZ85ZV4KAPKT0
6. Creating AWS Standard VPC Template
Template Component created with ID: 01JXDSGWTXKBMZJ3N2HV5TEQXJ
7. Waiting for DVU to run...
8. Expanding Template
Template Func running with management func job state ID: 01JXDSH2FTC47Y2M8P3DSBED3Y
9. Trying to enqueue the same management func
HTTP Error: 409 Client Error: Conflict for url: http://localhost:5380/v1/w/01HPJ3K7RC486W9RPR3T0B6HS2/change-sets/01JXDSGS9HGRX5VE9KCCXJCCX4/components/01JXDSGWTXKBMZJ3N2HV5TEQXJ/execute-management-function
Response: {"message":"management function already running for this component","statusCode":409,"code":null}
```

**Next Up: A New endpoint to get the status of a management function job**
