### PR TITLE
feat(web): Sort suggested prop connections first in UI

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -416,13 +416,13 @@
                 <TruncateWithTooltip v-else>
                   <template
                     v-if="
-                      connection.annotation === 'array' ||
-                      connection.annotation === 'map' ||
-                      connection.annotation === 'object' ||
-                      connection.annotation === 'json'
+                      connection.kind === 'array' ||
+                      connection.kind === 'map' ||
+                      connection.kind === 'object' ||
+                      connection.kind === 'json'
                     "
                   >
-                    {{ connection.annotation }}
+                    {{ connection.kind }}
                   </template>
                   <template v-else> {{ connection.value }} </template>
                 </TruncateWithTooltip>
@@ -651,6 +651,7 @@ attributeEmitter.on("selectedPath", (selectedPath) => {
   }
 });
 
+const focusedProp = ref<Prop>();
 const focus = () => {
   attributeEmitter.emit("selectedPath", path.value);
   attributeEmitter.emit("selectedDocs", {
@@ -658,7 +659,7 @@ const focus = () => {
     docs: props.prop?.documentation ?? "",
   });
   inputOpen.value = true;
-  annotation.value = props.prop?.kind ?? null;
+  focusedProp.value = props.prop;
 };
 
 const selectConnection = (index: number) => {
@@ -929,20 +930,19 @@ const onTab = (e: KeyboardEvent) => {
 };
 
 const connectingComponentId = ref<string | undefined>();
-const annotation = ref<string | null>(null);
 const makeKey = useMakeKey();
 const makeArgs = useMakeArgs();
-const enabled = computed(() => !!annotation.value);
+const enabled = computed(() => !!focusedProp.value?.kind);
 const potentialConnQuery = useQuery({
   queryKey: makeKey(EntityKind.PossibleConnections),
   enabled,
   queryFn: async () => {
-    if (annotation.value) {
-      const conns = await getPossibleConnections({
+    if (focusedProp.value) {
+      return await getPossibleConnections({
         ...makeArgs(EntityKind.PossibleConnections),
-        annotation: annotation.value,
+        destSchemaName: props.component.schemaName,
+        destProp: focusedProp.value,
       });
-      return conns;
     }
   },
 });

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -1,5 +1,13 @@
 import * as Comlink from "comlink";
-import { computed, reactive, Reactive, inject, ComputedRef, unref } from "vue";
+import {
+  computed,
+  reactive,
+  Reactive,
+  inject,
+  ComputedRef,
+  unref,
+  toRaw,
+} from "vue";
 import { QueryClient } from "@tanstack/vue-query";
 import {
   DBInterface,
@@ -10,6 +18,7 @@ import {
 import {
   BifrostConnection,
   EntityKind,
+  Prop,
 } from "@/workers/types/entity_kind_types";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import { Context } from "@/newhotness/types";
@@ -140,16 +149,15 @@ export const bifrost = async <T>(args: {
 export const getPossibleConnections = async (args: {
   workspaceId: string;
   changeSetId: ChangeSetId;
-  annotation: string;
-  _direction?: "output" | "input";
+  destSchemaName: string;
+  destProp: Prop;
 }) => {
-  // If we end up looking for sockets... we need direction
-  // But sockets are gonna die... so... ???
   return reactive(
-    await db.getConnectionByAnnotation(
+    await db.getPossibleConnections(
       args.workspaceId,
       args.changeSetId,
-      args.annotation,
+      toRaw(args.destSchemaName),
+      toRaw(args.destProp), // Can't send reactive stuff across the boundary, silently fails
     ),
   );
 };

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -15,6 +15,7 @@ import {
   BifrostConnection,
   EntityKind,
   PossibleConnection,
+  Prop,
 } from "./entity_kind_types";
 
 export type Column = string;
@@ -52,10 +53,11 @@ export interface DBInterface {
     headChangeSetId: string,
     changeSetId: string,
   ): Promise<void>;
-  getConnectionByAnnotation(
+  getPossibleConnections(
     workspaceId: string,
     changeSetId: string,
-    annotation: string,
+    destSchemaName: string,
+    destProp: Prop,
   ): {
     exactMatches: Array<PossibleConnection>;
     typeMatches: Array<PossibleConnection>;

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -41,9 +41,10 @@ export enum EntityKind {
 export const isEntityKind = (maybeEntityKind: any): EntityKind | null => {
   const k = maybeEntityKind as string; // first cast to string, since enum values are strings
   // if the string-y value is in the enum
-  if (k in EntityKind)
+  if (k in EntityKind) {
     // you can safely cast this
     return k as EntityKind;
+  }
   return null;
 };
 interface Reference<T extends EntityKind> {
@@ -84,7 +85,8 @@ export type PossibleConnection = {
   componentName: string;
   schemaName: string;
   componentId: string;
-  annotation: string;
+  kind: string;
+  suggestAsSourceFor?: PropSuggestion[];
 };
 
 export interface View {
@@ -306,6 +308,13 @@ export interface Prop {
   createOnly: boolean;
   eligibleForConnection: boolean;
   hidden: boolean;
+  suggestSources?: PropSuggestion[];
+  suggestAsSourceFor?: PropSuggestion[];
+}
+
+export interface PropSuggestion {
+  schema: string;
+  prop: string;
 }
 
 export interface AttributeValue {

--- a/lib/dal-materialized-views/src/schema_variant/prop_tree.rs
+++ b/lib/dal-materialized-views/src/schema_variant/prop_tree.rs
@@ -147,6 +147,11 @@ pub async fn assemble_prop(
                 || path.starts_with("root/secrets")
                 || path.starts_with("root/resource_value")
         },
+        ui_optionals: prop
+            .ui_optionals
+            .into_iter()
+            .map(|(key, value)| (key, value.into()))
+            .collect(),
     };
     Ok(prop_mv)
 }

--- a/lib/si-frontend-mv-types-rs/src/schema_variant/prop_tree.rs
+++ b/lib/si-frontend-mv-types-rs/src/schema_variant/prop_tree.rs
@@ -42,6 +42,8 @@ pub struct Prop {
     pub default_can_be_set_by_socket: bool,
     pub is_origin_secret: bool,
     pub secret_definition: Option<SecretDefinition>,
+    #[serde(flatten)]
+    pub ui_optionals: HashMap<String, serde_json::Value>,
 }
 
 #[remain::sorted]


### PR DESCRIPTION
This sorts suggested props *first* in the prop connections UI:

<img width="813" alt="image" src="https://github.com/user-attachments/assets/2edd4ee2-d5ac-49b6-a185-deced73382c0" />

* Sorts suggested schema/props first, both for suggestSource() and suggestAsSourceFor()
* Adds suggestSources and suggestAsSourceFor to PropTree MV (and by extension, the AttributeTree MV)

## Testing

- [X] Integration tests pass
- [X] Manual test: suggestSource sorted first
- [X] Manual test: suggestAsSourceFor sorted first