### PR TITLE
chore: improve performance of component create in luminork

### DIFF
--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -372,6 +372,8 @@ impl DependentValueGraph {
             // Find the values that are set by the prototype for the relevant
             // AttributePrototypeArguments, and declare that these values depend
             // on the value of the current value
+            //
+            // TODO: This code is very expensive, especially as the graph grows.
             for apa in relevant_apas {
                 let prototype_id =
                     AttributePrototypeArgument::prototype_id(ctx, apa.id().into()).await?;

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -933,6 +933,21 @@ impl Prop {
         }
     }
 
+    // Return all the parent prop ids from a given prop id
+    pub async fn all_parent_prop_ids_from_prop_id(
+        ctx: &DalContext,
+        prop_id: PropId,
+    ) -> PropResult<Vec<PropId>> {
+        let mut cursor = prop_id;
+        let mut result = vec![];
+
+        while let Some(parent) = Self::parent_prop_id_by_id(ctx, cursor).await? {
+            result.push(parent);
+            cursor = parent;
+        }
+        Ok(result)
+    }
+
     /// Walk the prop tree up, finding the root prop for the passed in `prop_id`
     pub async fn root_prop_for_prop_id(ctx: &DalContext, prop_id: PropId) -> PropResult<PropId> {
         let mut cursor = prop_id;

--- a/lib/luminork-server/src/service/v1/components/connections.rs
+++ b/lib/luminork-server/src/service/v1/components/connections.rs
@@ -57,30 +57,22 @@ pub enum Connection {
     Outgoing { from: String, to: ConnectionPoint },
 }
 
-/// Returns the component ID if found, or appropriate error if not found or if duplicate names exist
+/// Returns the component ID if found, or appropriate error if not found. If a duplicate exists, it
+/// picks the "first" one it sees.
 pub async fn find_component_id_by_name(
     ctx: &dal::DalContext,
     component_list: &[ComponentId],
     component_name: &str,
 ) -> Result<ComponentId, ComponentsError> {
-    let mut matching_components = Vec::new();
-
     for component_id in component_list {
         let name = Component::name_by_id(ctx, *component_id).await?;
         if name == component_name {
-            matching_components.push(*component_id);
+            return Ok(*component_id);
         }
     }
-
-    match matching_components.len() {
-        0 => Err(ComponentsError::ComponentNotFound(
-            component_name.to_string(),
-        )),
-        1 => Ok(matching_components[0]),
-        _ => Err(ComponentsError::DuplicateComponentName(
-            component_name.to_string(),
-        )),
-    }
+    Err(ComponentsError::ComponentNotFound(
+        component_name.to_string(),
+    ))
 }
 
 /// Helper function to resolve a component reference to a component ID

--- a/lib/luminork-server/src/service/v1/components/create_component.rs
+++ b/lib/luminork-server/src/service/v1/components/create_component.rs
@@ -170,6 +170,7 @@ pub async fn create_component(
     let after_value = serde_json::to_value(after_domain_tree)?;
 
     let component_list = Component::list_ids(ctx).await?;
+
     let added_connection_summary =
         super::connections::summarise_connections(ctx, &payload.connections, &component_list)
             .await?;


### PR DESCRIPTION
This PR makes some chanes that improve performance of component create specifically in luminork, but likely across the board. It does the following:

* Removes the extra DVU Graph calculation in component.rs, as it is no longer needed
* Updates the input_socket_attribute_values function so that it no  longer is linear with the number of components of a given schema  variant that are present in the graph. 
* Updates the 'connections' code in luminork to no longer error if  a connection is proposed but there are multiple components whose names match. It instead returns the first match. If the user wants to disambiguate, they can use the component id.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbW40MmQzeDczZmFhYXBuNGoyZXZ6bjJ5OHh0ZzRneW5pMGdrYjI0YiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/SdJkJ7DEtQN8240b98/giphy.gif"/>