### PR TITLE
chore(edda): demote `info` event & span in `CompressingStream`

### DIFF
--- a/lib/edda-server/src/compressing_stream.rs
+++ b/lib/edda-server/src/compressing_stream.rs
@@ -300,7 +300,7 @@ where
 
                 let s = span!(
                     parent: None,
-                    Level::INFO,
+                    Level::DEBUG,
                     "compressing_stream.next",
                     messages.deleted.count = Empty,
                     messaging.destination.name = Empty,
@@ -434,7 +434,7 @@ where
                                 .take()
                                 .expect("extracting owned value only happens once");
 
-                            info!(
+                            debug!(
                                 first_message_info_pending = message
                                     .info()
                                     .map(|info| info.pending as isize)


### PR DESCRIPTION
This change demotes an `info!` line and the span for each compressing process in the `CompressingStream` struct.

Note that this means the `compressing_stream.next` `info` span will no longer be reported by default.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbzk0NjQ3eXo5ajRkM2dkbDBhMzhzNTZ0M2ViZ2NndW05dWFiaTVrNyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/iHskdY9SMLFZuQ2u5c/giphy.gif"/>