### PR TITLE
feat(web): Automatically suggest props with the same name and type

### DIFF
--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -57,12 +57,8 @@ export interface DBInterface {
     workspaceId: string,
     changeSetId: string,
     destSchemaName: string,
-    destProp: Prop,
-  ): {
-    exactMatches: Array<PossibleConnection>;
-    typeMatches: Array<PossibleConnection>;
-    nonMatches: Array<PossibleConnection>;
-  };
+    dest: Prop,
+  ): CategorizedPossibleConnections;
   getOutgoingConnectionsByComponentId(
     workspaceId: string,
     changeSetId: ChangeSetId,
@@ -153,6 +149,13 @@ export type RowWithColumns = Record<Column, SqlValue>;
 export type RowID = Record<"id", number>;
 export type RowWithColumnsAndId = RowID & RowWithColumns;
 export type Records = (RowWithColumns | RowWithColumnsAndId)[];
+
+export interface CategorizedPossibleConnections {
+  suggestedMatches: Array<PossibleConnection>;
+  typeAndNameMatches: Array<PossibleConnection>;
+  typeMatches: Array<PossibleConnection>;
+  nonMatches: Array<PossibleConnection>;
+}
 
 export const interpolate = (columns: Columns, rows: SqlValue[][]): Records => {
   const results: Records = [];


### PR DESCRIPTION
This makes the frontend automatically suggest props with the same name as possible sources, making many suggestions unnecessary to add.

![image](https://github.com/user-attachments/assets/392b8a74-662c-420e-810e-12210f2705a0)

The sort order is now:
* Explicit suggestions first
* Name+type matches next (except if they come from the same schema)
* Type matches next

This PR also makes the useQuery reactive, and fixes a performance issue introduced in the last round where we were preloading suggestions for all props even if you never selected any.

### Out of Scope

Reactivity and stability issues that appear to already exist. PotentialConnections doesn't seem to get updated when component names update; and when I switch from component to component, they don't always load until I hit reload. Doesn't seem to be new to this PR, though.

## Testing

- [X] Props with suggestions still sort first even if there are also name matches
- [X] Props with name and type matches sort first
- [X] Props without suggestions still sort type matches alphabetically