### PR TITLE
Stop assigning outgoing connection counts in the web worker. Create another way to reference component names

### DIFF
--- a/app/web/src/newhotness/ComponentGridTile.vue
+++ b/app/web/src/newhotness/ComponentGridTile.vue
@@ -119,11 +119,7 @@
         <li>
           <Icon name="input-connection" size="sm" />
           <div>Outgoing</div>
-          <PillCounter
-            :count="component.outputCount"
-            size="sm"
-            class="ml-auto"
-          />
+          <PillCounter :count="outgoing" size="sm" class="ml-auto" />
         </li>
       </template>
     </ol>
@@ -149,18 +145,26 @@ import {
   TruncateWithTooltip,
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
-import { computed } from "vue";
+import { computed, inject } from "vue";
 import {
   BifrostComponent,
   BifrostComponentInList,
 } from "@/workers/types/entity_kind_types";
 import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
 import { getAssetIcon } from "./util";
+import { assertIsDefined, Context } from "./types";
 
 const props = defineProps<{
   component: BifrostComponent | BifrostComponentInList;
   hideConnections?: boolean;
 }>();
+
+const ctx = inject<Context>("CONTEXT");
+assertIsDefined(ctx);
+
+const outgoing = computed(
+  () => ctx.outgoingCounts.value[props.component.id] ?? 0,
+);
 
 const qualificationSummary = computed(() => {
   if (props.component.qualificationTotals.failed > 0) return "failure";

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -89,7 +89,7 @@ import {
   watch,
 } from "vue";
 import { Icon } from "@si/vue-lib/design-system";
-import { useQueryClient } from "@tanstack/vue-query";
+import { useQuery, useQueryClient } from "@tanstack/vue-query";
 import NavbarPanelLeft from "@/components/layout/navbar/NavbarPanelLeft.vue";
 import NavbarPanelRight from "@/components/layout/navbar/NavbarPanelRight.vue";
 import NavbarButton from "@/components/layout/navbar/NavbarButton.vue";
@@ -98,6 +98,11 @@ import * as heimdall from "@/store/realtime/heimdall";
 import { useAuthStore } from "@/store/auth.store";
 import { useChangeSetsStore } from "@/store/change_sets.store";
 import { useRealtimeStore } from "@/store/realtime/realtime.store";
+import {
+  ComponentNames,
+  EntityKind,
+  OutgoingCounts,
+} from "@/workers/types/entity_kind_types";
 import Explore from "./Explore.vue";
 import ComponentDetails from "./ComponentDetails.vue";
 import FuncRunDetails from "./FuncRunDetails.vue";
@@ -126,6 +131,54 @@ const realtimeStore = useRealtimeStore();
 const workspacePk = computed(() => props.workspacePk);
 const changeSetId = computed(() => props.changeSetId);
 
+const enabled = ref(false);
+
+const countsQueryKey = computed(() => {
+  return [
+    workspacePk.value,
+    changeSetId.value,
+    EntityKind.OutgoingCounts,
+    workspacePk.value,
+  ];
+});
+const args = computed(() => {
+  return {
+    workspaceId: workspacePk.value,
+    changeSetId: changeSetId.value,
+  };
+});
+const countsQuery = useQuery<OutgoingCounts>({
+  queryKey: countsQueryKey,
+  enabled,
+  queryFn: async () => {
+    return await heimdall.getOutgoingConnectionsCounts(args.value);
+  },
+});
+
+const namesQueryKey = computed(() => {
+  return [
+    workspacePk.value,
+    changeSetId.value,
+    EntityKind.ComponentNames,
+    workspacePk.value,
+  ];
+});
+const namesQuery = useQuery<ComponentNames>({
+  queryKey: namesQueryKey,
+  enabled,
+  queryFn: async () => {
+    return await heimdall.getComponentNames(args.value);
+  },
+});
+
+const outgoingCounts = computed(() => {
+  return countsQuery.data.value ?? {};
+});
+
+const componentNames = computed(() => {
+  return namesQuery.data.value ?? {};
+});
+
 const context = computed<Context>(() => {
   return {
     workspacePk,
@@ -133,6 +186,8 @@ const context = computed<Context>(() => {
     user: authStore.user,
     onHead: computed(() => changeSetsStore.headSelected),
     headChangeSetId: computed(() => changeSetsStore.headChangeSetId ?? ""),
+    outgoingCounts,
+    componentNames,
   };
 });
 
@@ -210,6 +265,7 @@ onBeforeMount(async () => {
     props.changeSetId,
     true,
   );
+  enabled.value = true;
   if (success && lobby.value) {
     router.push({
       name: "new-hotness",

--- a/app/web/src/newhotness/types.ts
+++ b/app/web/src/newhotness/types.ts
@@ -1,5 +1,6 @@
 import { ComputedRef } from "vue";
 import { User } from "@/api/sdf/dal/user";
+import { ComponentId } from "@/api/sdf/dal/component";
 
 export interface Context {
   workspacePk: ComputedRef<string>;
@@ -7,6 +8,8 @@ export interface Context {
   user: User | null;
   onHead: ComputedRef<boolean>;
   headChangeSetId: ComputedRef<string>;
+  outgoingCounts: ComputedRef<Record<ComponentId, number>>;
+  componentNames: ComputedRef<Record<ComponentId, string>>;
 }
 
 export function assertIsDefined<T>(value: T | undefined): asserts value is T {

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -170,6 +170,38 @@ export const linkNewChangeset = async (
   await db.linkNewChangeset(workspaceId, headChangeSetId, changeSetId);
 };
 
+export const getOutgoingConnectionsCounts = async (args: {
+  workspaceId: string;
+  changeSetId: ChangeSetId;
+}) => {
+  if (!initCompleted.value) throw new Error("bifrost not initiated");
+
+  const connectionsCounts = await db.getOutgoingConnectionsCounts(
+    args.workspaceId,
+    args.changeSetId,
+  );
+  if (connectionsCounts) return reactive(connectionsCounts);
+  else return {};
+};
+
+export const getComponentNames = async (args: {
+  workspaceId: string;
+  changeSetId: ChangeSetId;
+}) => {
+  if (!initCompleted.value) throw new Error("bifrost not initiated");
+
+  const start = Date.now();
+  const componentNames = await db.getComponentNames(
+    args.workspaceId,
+    args.changeSetId,
+  );
+  const end = Date.now();
+  // eslint-disable-next-line no-console
+  console.log("🌈 bifrost query componentNames", end - start, "ms");
+  if (componentNames) return reactive(componentNames);
+  else return {};
+};
+
 export const getOutgoingConnections = async (args: {
   workspaceId: string;
   changeSetId: ChangeSetId;

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -11,6 +11,7 @@ import { Span } from "@opentelemetry/api";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import { WorkspacePk } from "@/store/workspaces.store";
 import { DefaultMap } from "@/utils/defaultmap";
+import { ComponentId } from "@/api/sdf/dal/component";
 import {
   BifrostConnection,
   EntityKind,
@@ -63,6 +64,14 @@ export interface DBInterface {
     workspaceId: string,
     changeSetId: ChangeSetId,
   ): OutgoingConnections | undefined;
+  getOutgoingConnectionsCounts(
+    workspaceId: string,
+    changeSetId: ChangeSetId,
+  ): Record<ComponentId, number>;
+  getComponentNames(
+    workspaceId: string,
+    changeSetId: ChangeSetId,
+  ): Record<ComponentId, string>;
   get(
     workspaceId: string,
     changeSetId: ChangeSetId,

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -30,9 +30,11 @@ export enum EntityKind {
   SecretDefinitionList = "SecretDefinitionList",
   Secret = "Secret",
   SecretDefinition = "SecretDefinition",
-  OutgoingConnections = "OutgoingConnections",
-  PossibleConnections = "PossibleConnections",
   AttributeTree = "AttributeTree",
+  PossibleConnections = "PossibleConnections",
+  OutgoingConnections = "OutgoingConnections",
+  OutgoingCounts = "OutgoingCounts",
+  ComponentNames = "ComponentNames",
 }
 /**
  * NOTE, if you want to narrow the type of a variable
@@ -78,6 +80,9 @@ export type OutgoingConnections = DefaultMap<string, BifrostConnection[]>;
  *    (e.g. perform the full translation from Edda to Bifrost)
  * 7. `getReferences` SHALL set default/warning data that `getComputed` will write over
  */
+export type OutgoingCounts = Record<ComponentId, number>;
+export type ComponentNames = Record<ComponentId, string>;
+
 export type PossibleConnection = {
   attributeValueId: string;
   name: string;


### PR DESCRIPTION
In order to prevent unnecessary re-querying and transfer of data across the thread boundaries, bring critical pieces of data over at once:

1. Move the outgoing count of computed out to the main thread via tan stack, and reference it in the tile component.
2. Component names is the biggest cause of References in MVs. Make a global lookup instead.
    - we'll use this when we drop component references in incoming connections