### PR TITLE
Remove cross-MV dependency ordering when building MVs

### DIFF
--- a/lib/dal-materialized-views/src/incoming_connections_list.rs
+++ b/lib/dal-materialized-views/src/incoming_connections_list.rs
@@ -12,17 +12,13 @@ use telemetry::prelude::*;
 )]
 pub async fn assemble(ctx: DalContext) -> super::Result<IncomingConnectionsListMv> {
     let ctx = &ctx;
-    let component_ids = Component::list_ids(ctx).await?;
-    let mut component_connections = Vec::with_capacity(component_ids.len());
+    let mut component_ids = Component::list_ids(ctx).await?;
+    component_ids.sort();
 
-    for component_id in component_ids {
-        component_connections
-            .push(super::incoming_connections::assemble(ctx.clone(), component_id).await?);
-    }
     let workspace_mv_id = ctx.workspace_pk()?;
 
     Ok(IncomingConnectionsListMv {
         id: workspace_mv_id,
-        component_connections: component_connections.iter().map(Into::into).collect(),
+        component_connections: component_ids.iter().copied().map(Into::into).collect(),
     })
 }

--- a/lib/si-frontend-mv-types-rs/src/component.rs
+++ b/lib/si-frontend-mv-types-rs/src/component.rs
@@ -129,6 +129,5 @@ pub struct SchemaMembers {
 )]
 pub struct ComponentList {
     pub id: WorkspacePk,
-    #[mv(reference_kind = ReferenceKind::Component)]
     pub components: Vec<WeakReference<ComponentId, weak::markers::Component>>,
 }

--- a/lib/si-frontend-mv-types-rs/src/incoming_connections.rs
+++ b/lib/si-frontend-mv-types-rs/src/incoming_connections.rs
@@ -72,6 +72,5 @@ pub struct IncomingConnections {
 )]
 pub struct IncomingConnectionsList {
     pub id: WorkspacePk,
-    #[mv(reference_kind = ReferenceKind::IncomingConnections)]
     pub component_connections: Vec<Reference<ComponentId>>,
 }

--- a/lib/si-frontend-mv-types-rs/src/incoming_connections.rs
+++ b/lib/si-frontend-mv-types-rs/src/incoming_connections.rs
@@ -17,7 +17,6 @@ use si_id::{
 };
 
 use crate::reference::{
-    Reference,
     ReferenceKind,
     WeakReference,
     weak,
@@ -72,5 +71,5 @@ pub struct IncomingConnections {
 )]
 pub struct IncomingConnectionsList {
     pub id: WorkspacePk,
-    pub component_connections: Vec<Reference<ComponentId>>,
+    pub component_connections: Vec<WeakReference<ComponentId, weak::markers::IncomingConnections>>,
 }

--- a/lib/si-frontend-mv-types-rs/src/materialized_view.rs
+++ b/lib/si-frontend-mv-types-rs/src/materialized_view.rs
@@ -11,7 +11,6 @@ use crate::{
 
 pub trait MaterializedView {
     fn kind() -> ReferenceKind;
-    fn reference_dependencies() -> &'static [ReferenceKind];
     fn trigger_entity() -> EntityKind;
     fn definition_checksum() -> Checksum;
 }
@@ -19,7 +18,6 @@ pub trait MaterializedView {
 #[derive(Debug, Clone)]
 pub struct MaterializedViewInventoryItem {
     kind: ReferenceKind,
-    reference_dependencies: &'static [ReferenceKind],
     trigger_entity: EntityKind,
     definition_checksum: &'static ::std::sync::LazyLock<Checksum>,
 }
@@ -27,13 +25,11 @@ pub struct MaterializedViewInventoryItem {
 impl MaterializedViewInventoryItem {
     pub const fn new(
         kind: ReferenceKind,
-        reference_dependencies: &'static [ReferenceKind],
         trigger_entity: EntityKind,
         definition_checksum: &'static ::std::sync::LazyLock<Checksum>,
     ) -> Self {
         MaterializedViewInventoryItem {
             kind,
-            reference_dependencies,
             trigger_entity,
             definition_checksum,
         }
@@ -41,10 +37,6 @@ impl MaterializedViewInventoryItem {
 
     pub fn kind(&self) -> ReferenceKind {
         self.kind
-    }
-
-    pub fn reference_dependencies(&self) -> &'static [ReferenceKind] {
-        self.reference_dependencies
     }
 
     pub fn trigger_entity(&self) -> EntityKind {

--- a/lib/si-frontend-mv-types-rs/src/reference/weak.rs
+++ b/lib/si-frontend-mv-types-rs/src/reference/weak.rs
@@ -96,6 +96,14 @@ pub mod markers {
         const REFERENCE_KIND: ReferenceKind = ReferenceKind::Component;
     }
 
+    /// A weak reference marker for [`ReferenceKind::IncomingConnections`].
+    #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+    pub struct IncomingConnections;
+
+    impl ReferenceKindMarker for IncomingConnections {
+        const REFERENCE_KIND: ReferenceKind = ReferenceKind::IncomingConnections;
+    }
+
     /// A weak reference marker for [`ReferenceKind::SchemaVariant`].
     #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
     pub struct SchemaVariant;

--- a/lib/si-frontend-mv-types-rs/src/view.rs
+++ b/lib/si-frontend-mv-types-rs/src/view.rs
@@ -48,7 +48,6 @@ pub struct View {
 )]
 pub struct ViewList {
     pub id: WorkspacePk,
-    #[mv(reference_kind = ReferenceKind::View)]
     pub views: Vec<Reference<ViewId>>,
 }
 


### PR DESCRIPTION
The intent of having strong references determine the build ordering of MVs was that MVs were going to have access to other MVs that had been built earlier within the same batch. This would have allowed them to know the checksum of the other MVs without having to build it for itself, which would duplicate the amount of work performed by edda.

Instead, we have been moving towards using weak references (only the kind & ID, with no checksum), which do not require either having access to MVs that may have been built within the same batch, or to re-built the MV every time it is going to be referenced from another MV.

Rather than limiting which MVs can be built at the same time in preparation for a direction we are moving away from, the only limit to the parallelism is now the `PARALLEL_BUILD_LIMIT`, and all MVs are assumed to be able to build without the output from any other MV being available (which is the current state of all MVs).

This also changes the only remaining `Reference` to be a `WeakReference`, removing the need to build every component's `IncomingConnections` MV an additional time to have the checksum in the ref.