### PR TITLE
feat(web): use a shared webworker to enable sqlite3 shared access pool

### DIFF
--- a/app/web/src/workers/shared_webworker.ts
+++ b/app/web/src/workers/shared_webworker.ts
@@ -1,0 +1,295 @@
+import * as Comlink from "comlink";
+import {
+  ExecBaseOptions,
+  ExecReturnResultRowsOptions,
+  ExecRowModeArrayOptions,
+  FlexibleString,
+  SqlValue,
+} from "@sqlite.org/sqlite-wasm";
+import { Span } from "@opentelemetry/api";
+import {
+  BustCacheFn,
+  DBInterface,
+  LobbyExitFn,
+  RainbowFn,
+  NOROW,
+  PatchBatch,
+  AtomMessage,
+  AtomDocument,
+} from "./types/dbinterface";
+import { EntityKind } from "./types/entity_kind_types";
+
+declare global {
+  interface Window {
+    onconnect?: (event: MessageEvent) => void;
+  }
+}
+
+const _DEBUG = true; // import.meta.env.VITE_SI_ENV === "local";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function debug(...args: any | any[]) {
+  // eslint-disable-next-line no-console
+  if (_DEBUG) console.debug(args);
+}
+
+let bearerToken: string;
+let currentRemote: Comlink.Remote<DBInterface> | undefined;
+
+const hasRemoteChannel = new MessageChannel();
+
+const getRemote = (): Promise<Comlink.Remote<DBInterface>> => {
+  return new Promise((resolve, reject) => {
+    if (currentRemote) {
+      resolve(currentRemote);
+    }
+    hasRemoteChannel.port1.onmessage = () => {
+      if (currentRemote) {
+        resolve(currentRemote);
+      } else {
+        reject(new Error("Got remote message but no remote set"));
+      }
+    };
+  });
+};
+
+async function withRemote<R>(
+  cb: (remote: Comlink.Remote<DBInterface>) => Promise<R>,
+): Promise<R> {
+  const remote = await getRemote();
+  return cb(remote);
+}
+
+const dbInterface: DBInterface = {
+  async setRemote(newRemote: Comlink.Remote<DBInterface>) {
+    debug("setting remote in shared web worker");
+    currentRemote = newRemote;
+    hasRemoteChannel.port2.postMessage("got remote");
+    if (bearerToken) {
+      currentRemote.setBearer(bearerToken);
+    }
+  },
+
+  async initDB(_testing: boolean) {
+    debug("init db called in shared webworker");
+  },
+
+  async migrate(testing: boolean) {
+    return withRemote(async (remote) => await remote.migrate(testing));
+  },
+
+  setBearer(token: string): void {
+    bearerToken = token;
+    currentRemote?.setBearer(bearerToken);
+  },
+
+  async initSocket(): Promise<void> {
+    await withRemote(async (remote) => await remote.initSocket());
+  },
+
+  async initBifrost(_gotlockPort: MessagePort) {
+    debug("init bifrost in shared worker called");
+  },
+
+  async bifrostClose() {
+    await withRemote(async (remote) => await remote.bifrostClose());
+  },
+
+  async bifrostReconnect() {
+    await withRemote(async (remote) => await remote.bifrostReconnect());
+  },
+
+  async linkNewChangeset(
+    workspaceId: string,
+    headChangeSetId: string,
+    changeSetId: string,
+  ): Promise<void> {
+    await withRemote(
+      async (remote) =>
+        await remote.linkNewChangeset(
+          workspaceId,
+          headChangeSetId,
+          changeSetId,
+        ),
+    );
+  },
+
+  async getOutgoingConnectionsByComponentId(
+    workspaceId: string,
+    changeSetId: string,
+  ) {
+    return await withRemote(
+      async (remote) =>
+        await remote.getOutgoingConnectionsByComponentId(
+          workspaceId,
+          changeSetId,
+        ),
+    );
+  },
+
+  async get(
+    workspaceId: string,
+    changeSetId: string,
+    kind: EntityKind,
+    id: string,
+  ): Promise<typeof NOROW | AtomDocument> {
+    return await withRemote(
+      async (remote) => await remote.get(workspaceId, changeSetId, kind, id),
+    );
+  },
+
+  async getPossibleConnections(
+    workspaceId,
+    changeSetId,
+    destSchemaName,
+    destProp,
+  ) {
+    return await withRemote(
+      async (remote) =>
+        await remote.getPossibleConnections(
+          workspaceId,
+          changeSetId,
+          destSchemaName,
+          destProp,
+        ),
+    );
+  },
+
+  async mjolnirBulk(
+    workspaceId: string,
+    changeSetId: string,
+    objs: Array<{ kind: string; id: string; checksum?: string }>,
+    indexChecksum: string,
+  ) {
+    await withRemote(
+      async (remote) =>
+        await remote.mjolnirBulk(workspaceId, changeSetId, objs, indexChecksum),
+    );
+  },
+
+  async mjolnir(
+    workspaceId: string,
+    changeSetId: string,
+    kind: EntityKind,
+    id: string,
+    checksum?: string,
+  ) {
+    await withRemote(
+      async (remote) =>
+        await remote.mjolnir(workspaceId, changeSetId, kind, id, checksum),
+    );
+  },
+
+  partialKeyFromKindAndId(kind: EntityKind, id: string): string {
+    return `${kind}|${id}`;
+  },
+
+  kindAndIdFromKey(key: string): { kind: EntityKind; id: string } {
+    const pieces = key.split("|", 2);
+    if (pieces.length !== 2) throw new Error(`Bad key ${key} -> ${pieces}`);
+    if (!pieces[0] || !pieces[1])
+      throw new Error(`Missing key ${key} -> ${pieces}`);
+    const kind = pieces[0] as EntityKind;
+    const id = pieces[1];
+    return { kind, id };
+  },
+
+  addListenerBustCache(_fn: BustCacheFn): void {},
+
+  addListenerInFlight(_fn: RainbowFn): void {},
+
+  addListenerReturned(_fn: RainbowFn): void {},
+
+  addListenerLobbyExit(_fn: LobbyExitFn): void {},
+
+  async atomChecksumsFor(changeSetId: string): Promise<Record<string, string>> {
+    return await withRemote(
+      async (remote) => await remote.atomChecksumsFor(changeSetId),
+    );
+  },
+
+  async changeSetExists(
+    workspaceId: string,
+    changeSetId: string,
+  ): Promise<boolean> {
+    return await withRemote(
+      async (remote) => await remote.changeSetExists(workspaceId, changeSetId),
+    );
+  },
+
+  async niflheim(workspaceId: string, changeSetId: string): Promise<boolean> {
+    return await withRemote(
+      async (remote) => await remote.niflheim(workspaceId, changeSetId),
+    );
+  },
+
+  async pruneAtomsForClosedChangeSet(workspaceId: string, changeSetId: string) {
+    return await withRemote(
+      async (remote) =>
+        await remote.pruneAtomsForClosedChangeSet(workspaceId, changeSetId),
+    );
+  },
+
+  oneInOne(rows: SqlValue[][]): SqlValue | typeof NOROW {
+    const first = rows[0];
+    if (first) {
+      const id = first[0];
+      if (id || id === 0) return id;
+    }
+    return NOROW;
+  },
+
+  async encodeDocumentForDB(doc: object): Promise<ArrayBuffer> {
+    return await new Blob([JSON.stringify(doc)]).arrayBuffer();
+  },
+
+  decodeDocumentFromDB(doc: ArrayBuffer): AtomDocument {
+    const s = new TextDecoder().decode(doc);
+    const j = JSON.parse(s);
+    return j;
+  },
+
+  async handlePatchMessage(data: PatchBatch, span?: Span): Promise<void> {
+    await withRemote(
+      async (remote) => await remote.handlePatchMessage(data, span),
+    );
+  },
+
+  async handleHammer(msg: AtomMessage, span?: Span): Promise<void> {
+    await withRemote(async (remote) => await remote.handleHammer(msg, span));
+  },
+
+  async exec(
+    opts: ExecBaseOptions &
+      ExecRowModeArrayOptions &
+      ExecReturnResultRowsOptions & {
+        sql: FlexibleString;
+      },
+  ): Promise<SqlValue[][]> {
+    return await withRemote(async (remote) => await remote.exec(opts));
+  },
+
+  async bobby(): Promise<void> {
+    await withRemote(async (remote) => await remote.bobby());
+  },
+
+  async ragnarok(
+    workspaceId: string,
+    changeSetId: string,
+    noColdStart?: boolean,
+  ): Promise<void> {
+    await withRemote(
+      async (remote) =>
+        await remote.ragnarok(workspaceId, changeSetId, noColdStart),
+    );
+  },
+
+  async odin(changeSetId: string): Promise<object> {
+    return await withRemote(async (remote) => await remote.odin(changeSetId));
+  },
+};
+
+// eslint-disable-next-line no-restricted-globals
+self.onconnect = (event: MessageEvent) => {
+  Comlink.expose(dbInterface, event.ports[0]);
+};

--- a/app/web/vite.config.ts
+++ b/app/web/vite.config.ts
@@ -1,6 +1,6 @@
 import path from "path";
-import {existsSync, readFileSync} from "fs";
-import {loadEnv, defineConfig} from "vite";
+import { existsSync, readFileSync } from "fs";
+import { loadEnv, defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import checkerPlugin from "vite-plugin-checker";
 import svgLoaderPlugin from "vite-svg-loader";
@@ -55,22 +55,22 @@ export default (opts: { mode: string }) => {
       IconsPlugin({compiler: "raw"}),
 
       process.env.NODE_ENV !== "production" &&
-      checkerPlugin({
-        vueTsc: true,
-        eslint: {
-          lintCommand: packageJson.scripts.lint,
-          // I _think_ we only want to pop up an error on the screen for proper errors
-          // otherwise we can get a lot of unused var errors when you comment something out temporarily
-          dev: {logLevel: ["error"]},
-        },
-      }),
+        checkerPlugin({
+          vueTsc: true,
+          eslint: {
+            lintCommand: packageJson.scripts.lint,
+            // I _think_ we only want to pop up an error on the screen for proper errors
+            // otherwise we can get a lot of unused var errors when you comment something out temporarily
+            dev: { logLevel: ["error"] },
+          },
+        }),
 
       ViteGitRevisionPlugin({}),
     ],
     css: {
       postcss,
       preprocessorOptions: {
-        less: {additionalData: lessVars},
+        less: { additionalData: lessVars },
       },
     },
     server: {
@@ -88,12 +88,12 @@ export default (opts: { mode: string }) => {
         },
       },
       headers: {
-        'Cross-Origin-Opener-Policy': 'same-origin',
-        'Cross-Origin-Embedder-Policy': 'credentialless',
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "Cross-Origin-Embedder-Policy": "credentialless",
       },
     },
     optimizeDeps: {
-      exclude: ['@sqlite.org/sqlite-wasm'],
+      exclude: ["@sqlite.org/sqlite-wasm"],
     },
     preview: {
       proxy: {
@@ -109,7 +109,7 @@ export default (opts: { mode: string }) => {
           find: "@",
           replacement: path.resolve(__dirname, "src"),
         },
-        {find: "util", replacement: "util-browser"},
+        { find: "util", replacement: "util-browser" },
       ],
     },
     build: {
@@ -118,11 +118,18 @@ export default (opts: { mode: string }) => {
         input: {
           main: path.resolve(__dirname, "index.html"),
           worker: path.resolve(__dirname, "src/workers/webworker.ts"), // Add worker as an entry point
+          sharedWorker: path.resolve(
+            __dirname,
+            "src/workers/shared_webworker.ts",
+          ),
         },
         output: {
           entryFileNames: (chunk) => {
             if (chunk.name === "worker") {
               return "assets/webworker.js"; // Specify output path for web worker
+            }
+            if (chunk.name === "sharedWorker") {
+              return "assets/shared_webworker.js";
             }
             return "assets/[name]-[hash].js";
           },


### PR DESCRIPTION
Uses weblocks to ensure that only one tab's worker task has access to the sqlite3 database at a time. Proxies requests through a SharedWorker to the worker that holds the lock. As soon as a tab closes, all tabs will race for the lock, and the one that acquires it first will send a proxy of itself to the SharedWorker.

Requires all DBInterface methods that hit the database to be async (so they can wait for a tab remote to be ready)