### PR TITLE
Fix: during mounting the ? returns false, which is actually undesirable because it fires the map query, enforce the default/undefined state better

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -299,7 +299,7 @@ const urlGridOrMap = computed(() => {
   if (keys.includes("map")) return "map";
   return "grid";
 });
-const showGrid = computed(() => groupRef.value?.isA);
+const showGrid = computed(() => (groupRef.value ? groupRef.value.isA : true));
 watch(showGrid, () => {
   unfocus();
   unhover();


### PR DESCRIPTION
## How does this PR change the system?
The `Map`'s incoming connection list query was firing when we didn't want it to

## How was it tested?
Refresh grid page, see no incoming connections list query
<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNGQycW9lMjQycmE1MzRvaGRiMHA4djh0d3pnMTg3bHJqd2pwM2hlMCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3bSEh9XWHzYUzTk1OM/giphy.gif"/>
