### PR TITLE
fix(web): Skip initializing bifrost in modeling diagram to prevent multiple cold starts when switching between old and new experience

### DIFF
--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -450,7 +450,7 @@ export function useChangeSetsStore() {
                 ].includes(data.changeSet.status) &&
                 data.changeSet.id !== this.headChangeSetId
               ) {
-                if (featureFlagsStore.FRONTEND_ARCH_VIEWS)
+                if (featureFlagsStore.NEW_HOTNESS)
                   heimdall.prune(workspacePk, data.changeSet.id);
               }
               // If I'm the one who requested this change set - toast that it's been approved/rejected/etc.
@@ -488,7 +488,7 @@ export function useChangeSetsStore() {
             eventType: "ChangeSetAbandoned",
             callback: async (data) => {
               if (data.changeSetId !== this.headChangeSetId) {
-                if (featureFlagsStore.FRONTEND_ARCH_VIEWS)
+                if (featureFlagsStore.NEW_HOTNESS)
                   heimdall.prune(workspacePk, data.changeSetId);
               }
 
@@ -556,7 +556,7 @@ export function useChangeSetsStore() {
                 if (changeSet.id !== this.headChangeSetId) {
                   // never set HEAD to Applied
                   changeSet.status = ChangeSetStatus.Applied;
-                  if (featureFlagsStore.FRONTEND_ARCH_VIEWS)
+                  if (featureFlagsStore.NEW_HOTNESS)
                     heimdall.prune(workspacePk, changeSet.id);
                 }
                 if (this.selectedChangeSet?.id === changeSetId) {

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -62,7 +62,6 @@ export function useFeatureFlagsStore() {
       actions: {
         setDependentFlags() {
           if (this.NEW_HOTNESS) {
-            this.FRONTEND_ARCH_VIEWS = true;
             this.FLOATING_CONNECTION_MENU = true;
             this.SIMPLE_SOCKET_UI = true;
             this.PROPS_TO_PROPS_CONNECTIONS = true;


### PR DESCRIPTION
## How does this PR change the system?

We had previously exposed some data to the existing user experience using the new architectural pattern, behind feature flags. The flags have since been disabled with no intention of reenabling them, but they're a bit coupled, so when navigating from the diagram to the grid view, it was causing bifrost to initialize twice (and multiple cold starts) - one is enough!

I also removed the dependency between `NEW_HOTNESS` and `FRONTEND_ARCH_VIEWS` feature flags, as mixed mode was causing issues with views in the old UI when `NEW_HOTNESS` was flagged on. 

#### Out of Scope:

I am not going as far as ripping out _all_ of the unexercised code behind those flags - not worth it right now. Also, I think we need to move where bifrost is initialized, but that can come with future improvements. 

## How was it tested?

Manually Tested Old UI: 
- Create, modify, delete views all works
- Interacting with actions in old UI works
- Applying change set works in old UI 

New UI: 
- Abandon change set still garbage collects abandoned data
- Bifrost initializes (once!) 
- Switching between old and new, I don't see multiple bifrost initializations (aside from each time we navigate to the new UI, but again, for later)

## In short: [:link:](https://giphy.com/)

<div><img src="https://media2.giphy.com/media/dXoVlat19IED3jySHk/giphy.gif?cid=5a38a5a2bhr4nz5h9cn9pgzr694fjlv3k8dyvzlcga4rbnlb&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/tvland/">TV Land</a> on <a href="https://giphy.com/gifs/tvland-tv-land-romano-rayromano-dXoVlat19IED3jySHk">GIPHY</a></div>