### PR TITLE
Stream patches to the front end from edda; try to reduce nats write load; priority queue for MV builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8407,6 +8407,7 @@ dependencies = [
  "manyhow",
  "proc-macro2",
  "quote",
+ "si-events",
  "syn 2.0.103",
 ]
 

--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -787,6 +787,7 @@ pub async fn edda_server(
         config.instance_id(),
         config.concurrency_limit(),
         config.parallel_build_limit(),
+        config.streaming_patches(),
         services_context,
         config.quiescent_period(),
         shutdown_token,

--- a/lib/edda-server/src/change_set_processor_task/materialized_view.rs
+++ b/lib/edda-server/src/change_set_processor_task/materialized_view.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{
+        BinaryHeap,
         HashSet,
-        VecDeque,
     },
     time::Duration,
 };
@@ -28,10 +28,10 @@ use frigg::{
 };
 use si_events::{
     WorkspaceSnapshotAddress,
+    materialized_view::BuildPriority,
     workspace_snapshot::Change,
 };
 use si_frontend_mv_types::{
-    MaterializedView,
     action::{
         ActionPrototypeViewList as ActionPrototypeViewListMv,
         ActionViewList as ActionViewListMv,
@@ -49,7 +49,10 @@ use si_frontend_mv_types::{
         IncomingConnectionsList as IncomingConnectionsListMv,
     },
     index::MvIndex,
-    materialized_view::materialized_view_definitions_checksum,
+    materialized_view::{
+        MaterializedViewInventoryItem,
+        materialized_view_definitions_checksum,
+    },
     object::{
         FrontendObject,
         patch::{
@@ -79,7 +82,6 @@ use si_id::{
     WorkspacePk,
 };
 use si_layer_cache::LayerDbError;
-use strum::IntoEnumIterator;
 use telemetry::prelude::*;
 use telemetry_utils::metric;
 use thiserror::Error;
@@ -553,24 +555,17 @@ async fn build_mv_inner(
     let mut frontend_objects = Vec::new();
     let mut patches = Vec::new();
     let mut build_tasks = JoinSet::new();
-    let mut queued_mv_builds = VecDeque::new();
+    let mut queued_mv_builds = BinaryHeap::new();
 
-    // We'll spawn up to the first `parallel_build_limit` build tasks, and queue the rest to be spawned
-    // as other build tasks are completed.
+    // Queue everything so we can let the priority queue determine the order everything is built.
     for &change in changes {
-        for mv_kind in ReferenceKind::iter() {
-            if let Some(queued_build) = spawn_build_mv_task_for_change_and_mv_kind(
-                &mut build_tasks,
-                ctx,
-                frigg,
-                parallel_build_limit,
-                change,
-                mv_kind,
-                workspace_pk,
-            )
-            .await?
-            {
-                queued_mv_builds.push_back(queued_build);
+        for mv_inventory_item in ::inventory::iter::<MaterializedViewInventoryItem>() {
+            if mv_inventory_item.should_build_for_change(change) {
+                queued_mv_builds.push(QueuedBuildMvTask {
+                    change,
+                    mv_kind: mv_inventory_item.kind(),
+                    priority: mv_inventory_item.build_priority(),
+                });
             }
         }
     }
@@ -591,26 +586,23 @@ async fn build_mv_inner(
 
         // Spawn as many of the queued build tasks as we can, up to the concurrency limit.
         while !queued_mv_builds.is_empty() && build_tasks.len() < parallel_build_limit {
-            let Some(QueuedBuildMvTask { change, mv_kind }) = queued_mv_builds.pop_front() else {
+            let Some(QueuedBuildMvTask {
+                change, mv_kind, ..
+            }) = queued_mv_builds.pop()
+            else {
                 // This _really_ shouldn't ever return `None` as we just checked that
                 // `queued_mv_builds` is not empty.
                 break;
             };
-            // This _really_ shouldn't ever return `Some`, but better to be paranoid than to
-            // forget about pending work.
-            if let Some(queued_build) = spawn_build_mv_task_for_change_and_mv_kind(
+            spawn_build_mv_task_for_change_and_mv_kind(
                 &mut build_tasks,
                 ctx,
                 frigg,
-                parallel_build_limit,
                 change,
                 mv_kind,
                 workspace_pk,
             )
             .await?
-            {
-                queued_mv_builds.push_back(queued_build);
-            }
         }
 
         if let Some(join_result) = build_tasks.join_next().await {
@@ -775,356 +767,251 @@ where
 /// The [`Change`] of the trigger entity that would have spawned a build task for the
 /// `mv_kind`, if we hadn't already reached the concurrency limit for running build
 /// tasks.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 struct QueuedBuildMvTask {
     pub change: Change,
     pub mv_kind: ReferenceKind,
+    pub priority: BuildPriority,
+}
+
+impl Ord for QueuedBuildMvTask {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.priority.cmp(&other.priority) {
+            std::cmp::Ordering::Equal => {
+                // Within the same priority, items will be ordered by the triggering
+                // entity ID. Doing `self.cmp(other)` means that the newer IDs are
+                // be considered "larger", and items with the same priority will be
+                // processed newest to oldest acording to when their ID was created.
+                self.change.entity_id.cmp(&other.change.entity_id)
+            }
+            ord => ord,
+        }
+    }
+}
+
+impl PartialOrd for QueuedBuildMvTask {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 async fn spawn_build_mv_task_for_change_and_mv_kind(
     build_tasks: &mut JoinSet<BuildMvTaskResult>,
     ctx: &DalContext,
     frigg: &FriggStore,
-    parallel_build_limit: usize,
     change: Change,
     mv_kind: ReferenceKind,
     workspace_pk: si_id::WorkspacePk,
-) -> Result<Option<QueuedBuildMvTask>, MaterializedViewError> {
+) -> Result<(), MaterializedViewError> {
     match mv_kind {
         ReferenceKind::ActionPrototypeViewList => {
             let entity_mv_id = change.entity_id.to_string();
 
-            let trigger_entity = <ActionPrototypeViewListMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    entity_mv_id,
-                    ActionPrototypeViewListMv,
-                    dal_materialized_views::action_prototype_view_list::assemble(
-                        ctx.clone(),
-                        si_events::ulid::Ulid::from(change.entity_id).into()
-                    ),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                entity_mv_id,
+                ActionPrototypeViewListMv,
+                dal_materialized_views::action_prototype_view_list::assemble(
+                    ctx.clone(),
+                    si_events::ulid::Ulid::from(change.entity_id).into()
+                ),
+            );
         }
         ReferenceKind::ActionViewList => {
             let workspace_mv_id = workspace_pk.to_string();
 
-            let trigger_entity = <ActionViewListMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    workspace_mv_id,
-                    ActionViewListMv,
-                    dal_materialized_views::action_view_list::assemble(ctx.clone()),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                workspace_mv_id,
+                ActionViewListMv,
+                dal_materialized_views::action_view_list::assemble(ctx.clone()),
+            );
         }
         ReferenceKind::AttributeTree => {
             let entity_mv_id = change.entity_id.to_string();
 
-            let trigger_entity = <AttributeTreeMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    entity_mv_id,
-                    AttributeTreeMv,
-                    dal_materialized_views::component::attribute_tree::assemble(
-                        ctx.clone(),
-                        si_events::ulid::Ulid::from(change.entity_id).into(),
-                    ),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                entity_mv_id,
+                AttributeTreeMv,
+                dal_materialized_views::component::attribute_tree::assemble(
+                    ctx.clone(),
+                    si_events::ulid::Ulid::from(change.entity_id).into(),
+                ),
+            );
         }
         ReferenceKind::ComponentInList => {
             let entity_mv_id = change.entity_id.to_string();
 
-            let trigger_entity = <ComponentInListMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    entity_mv_id,
-                    ComponentInListMv,
-                    dal_materialized_views::component::assemble_in_list(
-                        ctx.clone(),
-                        si_events::ulid::Ulid::from(change.entity_id).into(),
-                    ),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                entity_mv_id,
+                ComponentInListMv,
+                dal_materialized_views::component::assemble_in_list(
+                    ctx.clone(),
+                    si_events::ulid::Ulid::from(change.entity_id).into(),
+                ),
+            );
         }
         ReferenceKind::Component => {
             let entity_mv_id = change.entity_id.to_string();
 
-            let trigger_entity = <ComponentMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    entity_mv_id,
-                    ComponentMv,
-                    dal_materialized_views::component::assemble(
-                        ctx.clone(),
-                        si_events::ulid::Ulid::from(change.entity_id).into(),
-                    ),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                entity_mv_id,
+                ComponentMv,
+                dal_materialized_views::component::assemble(
+                    ctx.clone(),
+                    si_events::ulid::Ulid::from(change.entity_id).into(),
+                ),
+            );
         }
         ReferenceKind::ComponentList => {
             let workspace_mv_id = workspace_pk.to_string();
 
-            let trigger_entity = <ComponentListMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    workspace_mv_id,
-                    ComponentListMv,
-                    dal_materialized_views::component_list::assemble(ctx.clone(),),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                workspace_mv_id,
+                ComponentListMv,
+                dal_materialized_views::component_list::assemble(ctx.clone(),),
+            );
         }
         ReferenceKind::IncomingConnections => {
             let entity_mv_id = change.entity_id.to_string();
 
-            let trigger_entity = <IncomingConnectionsMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    entity_mv_id,
-                    IncomingConnectionsMv,
-                    dal_materialized_views::incoming_connections::assemble(
-                        ctx.clone(),
-                        si_events::ulid::Ulid::from(change.entity_id).into(),
-                    ),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                entity_mv_id,
+                IncomingConnectionsMv,
+                dal_materialized_views::incoming_connections::assemble(
+                    ctx.clone(),
+                    si_events::ulid::Ulid::from(change.entity_id).into(),
+                ),
+            );
         }
         ReferenceKind::IncomingConnectionsList => {
             let workspace_mv_id = workspace_pk.to_string();
 
-            let trigger_entity = <IncomingConnectionsListMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    workspace_mv_id,
-                    IncomingConnectionsListMv,
-                    dal_materialized_views::incoming_connections_list::assemble(ctx.clone()),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                workspace_mv_id,
+                IncomingConnectionsListMv,
+                dal_materialized_views::incoming_connections_list::assemble(ctx.clone()),
+            );
         }
         ReferenceKind::SchemaMembers => {
             let entity_mv_id = change.entity_id.to_string();
 
-            let trigger_entity = <SchemaMembers as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    entity_mv_id,
-                    SchemaMembers,
-                    dal_materialized_views::component::assemble_schema_members(
-                        ctx.clone(),
-                        si_events::ulid::Ulid::from(change.entity_id).into()
-                    ),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                entity_mv_id,
+                SchemaMembers,
+                dal_materialized_views::component::assemble_schema_members(
+                    ctx.clone(),
+                    si_events::ulid::Ulid::from(change.entity_id).into()
+                ),
+            );
         }
         ReferenceKind::SchemaVariant => {
             let entity_mv_id = change.entity_id.to_string();
 
-            let trigger_entity = <SchemaVariantMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    entity_mv_id,
-                    SchemaVariantMv,
-                    dal_materialized_views::schema_variant::assemble(
-                        ctx.clone(),
-                        si_events::ulid::Ulid::from(change.entity_id).into()
-                    ),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                entity_mv_id,
+                SchemaVariantMv,
+                dal_materialized_views::schema_variant::assemble(
+                    ctx.clone(),
+                    si_events::ulid::Ulid::from(change.entity_id).into()
+                ),
+            );
         }
         ReferenceKind::SchemaVariantCategories => {
             let workspace_mv_id = workspace_pk.to_string();
 
-            let trigger_entity = <SchemaVariantCategoriesMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    workspace_mv_id,
-                    SchemaVariantCategoriesMv,
-                    dal_materialized_views::schema_variant_categories::assemble(ctx.clone()),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                workspace_mv_id,
+                SchemaVariantCategoriesMv,
+                dal_materialized_views::schema_variant_categories::assemble(ctx.clone()),
+            );
         }
         ReferenceKind::View => {
             let entity_mv_id = change.entity_id.to_string();
 
-            let trigger_entity = <ViewMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    entity_mv_id,
-                    ViewMv,
-                    dal_materialized_views::view::assemble(
-                        ctx.clone(),
-                        si_events::ulid::Ulid::from(change.entity_id).into()
-                    )
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                entity_mv_id,
+                ViewMv,
+                dal_materialized_views::view::assemble(
+                    ctx.clone(),
+                    si_events::ulid::Ulid::from(change.entity_id).into()
+                )
+            );
         }
         ReferenceKind::ViewList => {
             let workspace_mv_id = workspace_pk.to_string();
 
-            let trigger_entity = <ViewListMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    workspace_mv_id,
-                    ViewListMv,
-                    dal_materialized_views::view_list::assemble(ctx.clone()),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                workspace_mv_id,
+                ViewListMv,
+                dal_materialized_views::view_list::assemble(ctx.clone()),
+            );
         }
         ReferenceKind::ViewComponentList => {
             let entity_mv_id = change.entity_id.to_string();
 
-            let trigger_entity = <ViewComponentListMv as MaterializedView>::trigger_entity();
-            if change.entity_kind != trigger_entity {
-                return Ok(None);
-            }
-
-            if build_tasks.len() < parallel_build_limit {
-                spawn_build_mv_task!(
-                    build_tasks,
-                    ctx,
-                    frigg,
-                    change,
-                    entity_mv_id,
-                    ViewComponentListMv,
-                    dal_materialized_views::view_component_list::assemble(
-                        ctx.clone(),
-                        si_events::ulid::Ulid::from(change.entity_id).into(),
-                    ),
-                );
-            } else {
-                return Ok(Some(QueuedBuildMvTask { change, mv_kind }));
-            }
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                entity_mv_id,
+                ViewComponentListMv,
+                dal_materialized_views::view_component_list::assemble(
+                    ctx.clone(),
+                    si_events::ulid::Ulid::from(change.entity_id).into(),
+                ),
+            );
         }
 
         // Building the `MvIndex` itself is handled separately as the logic depends
@@ -1136,5 +1023,5 @@ async fn spawn_build_mv_task_for_change_and_mv_kind(
         ReferenceKind::ChangeSetList | ReferenceKind::ChangeSetRecord => {}
     }
 
-    Ok(None)
+    Ok(())
 }

--- a/lib/edda-server/src/config.rs
+++ b/lib/edda-server/src/config.rs
@@ -67,6 +67,9 @@ pub struct Config {
     #[builder(default = "default_parallel_build_limit()")]
     parallel_build_limit: usize,
 
+    #[builder(default = "default_streaming_patches()")]
+    streaming_patches: bool,
+
     #[builder(default = "PgPoolConfig::default()")]
     pg_pool: PgPoolConfig,
 
@@ -99,6 +102,11 @@ impl Config {
     /// Gets the config's parallel build limit.
     pub fn parallel_build_limit(&self) -> usize {
         self.parallel_build_limit
+    }
+
+    /// Gets whether edda should stream patches, or send as a single batch.
+    pub fn streaming_patches(&self) -> bool {
+        self.streaming_patches
     }
 
     /// Gets the config's instance ID.
@@ -157,6 +165,8 @@ pub struct ConfigFile {
     edda_concurrency_limit: Option<usize>,
     #[serde(default = "default_parallel_build_limit")]
     edda_parallel_build_limit: usize,
+    #[serde(default = "default_streaming_patches")]
+    streaming_patches: bool,
     #[serde(default)]
     pg: PgPoolConfig,
     #[serde(default)]
@@ -177,6 +187,7 @@ impl Default for ConfigFile {
             instance_id: random_instance_id(),
             edda_concurrency_limit: default_concurrency_limit(),
             edda_parallel_build_limit: default_parallel_build_limit(),
+            streaming_patches: default_streaming_patches(),
             pg: Default::default(),
             nats: Default::default(),
             crypto: Default::default(),
@@ -204,6 +215,7 @@ impl TryFrom<ConfigFile> for Config {
         config.symmetric_crypto_service(value.symmetric_crypto_service.try_into()?);
         config.layer_db_config(value.layer_db_config);
         config.concurrency_limit(value.edda_concurrency_limit);
+        config.streaming_patches(value.streaming_patches);
         config.parallel_build_limit(value.edda_parallel_build_limit);
         config.instance_id(value.instance_id);
         config.quiescent_period(Duration::from_secs(value.quiescent_period_secs));
@@ -221,6 +233,10 @@ fn default_concurrency_limit() -> Option<usize> {
 
 fn default_parallel_build_limit() -> usize {
     DEFAULT_PARALLEL_BUILD_LIMIT
+}
+
+fn default_streaming_patches() -> bool {
+    false
 }
 
 fn default_symmetric_crypto_config() -> SymmetricCryptoServiceConfigFile {

--- a/lib/edda-server/src/server.rs
+++ b/lib/edda-server/src/server.rs
@@ -161,6 +161,7 @@ impl Server {
             config.instance_id().to_string(),
             config.concurrency_limit(),
             config.parallel_build_limit(),
+            config.streaming_patches(),
             services_context,
             config.quiescent_period(),
             shutdown_token,
@@ -174,6 +175,7 @@ impl Server {
         instance_id: impl Into<String>,
         concurrency_limit: Option<usize>,
         parallel_build_limit: usize,
+        streaming_patches: bool,
         services_context: ServicesContext,
         quiescent_period: Duration,
         shutdown_token: CancellationToken,
@@ -200,8 +202,11 @@ impl Server {
 
         let frigg = FriggStore::new(nats.clone(), frigg_kv(&context, prefix.as_deref()).await?);
 
-        let edda_updates =
-            EddaUpdates::new(nats.clone(), services_context.compute_executor().clone());
+        let edda_updates = EddaUpdates::new(
+            nats.clone(),
+            services_context.compute_executor().clone(),
+            streaming_patches,
+        );
 
         let ctx_builder = DalContext::builder(services_context, false);
 

--- a/lib/edda-server/src/updates.rs
+++ b/lib/edda-server/src/updates.rs
@@ -15,6 +15,7 @@ use si_data_nats::{
 use si_frontend_mv_types::object::patch::{
     IndexUpdate,
     PatchBatch,
+    StreamingPatch,
 };
 use si_id::WorkspacePk;
 use telemetry::prelude::*;
@@ -74,6 +75,30 @@ impl EddaUpdates {
                 patch_batch.kind(),
             ),
             patch_batch,
+            true,
+        )
+        .await
+    }
+
+    #[instrument(
+        name = "edda_updates.publish_streaming_patch",
+        level = "debug",
+        skip_all,
+        fields()
+    )]
+    pub(crate) async fn publish_streaming_patch(
+        &self,
+        streaming_patch: StreamingPatch,
+    ) -> Result<()> {
+        let mut id_buf = WorkspacePk::array_to_str_buf();
+
+        self.serialize_compress_publish(
+            subject::update_for(
+                self.subject_prefix.as_deref(),
+                streaming_patch.workspace_id.array_to_str(&mut id_buf),
+                streaming_patch.message_kind(),
+            ),
+            streaming_patch,
             true,
         )
         .await

--- a/lib/si-events-rs/src/lib.rs
+++ b/lib/si-events-rs/src/lib.rs
@@ -28,6 +28,7 @@ mod func;
 mod func_execution;
 mod func_run;
 mod func_run_log;
+pub mod materialized_view;
 mod resource_metadata;
 mod schema;
 mod schema_variant;

--- a/lib/si-events-rs/src/materialized_view.rs
+++ b/lib/si-events-rs/src/materialized_view.rs
@@ -1,0 +1,14 @@
+#[remain::sorted]
+#[derive(
+    Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Default, strum::Display, strum::EnumString,
+)]
+/// The build priority for MVs is:
+///   * List
+///   * Detail
+///
+/// The order of the priorities is determined by the descriminant, largest to smallest.
+pub enum BuildPriority {
+    #[default]
+    Detail = 5,
+    List = 10,
+}

--- a/lib/si-events-rs/src/workspace_snapshot.rs
+++ b/lib/si-events-rs/src/workspace_snapshot.rs
@@ -12,7 +12,7 @@ use crate::{
 
 create_xxhash_type!(Checksum);
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Change {
     pub entity_id: EntityId,
     pub entity_kind: EntityKind,

--- a/lib/si-frontend-mv-types-macros/BUCK
+++ b/lib/si-frontend-mv-types-macros/BUCK
@@ -10,6 +10,7 @@ cargo_test(
 rust_library(
     name = "si-frontend-mv-types-macros",
     deps = [
+        "//lib/si-events-rs:si-events",
         "//third-party/rust:darling",
         "//third-party/rust:manyhow",
         "//third-party/rust:proc-macro2",

--- a/lib/si-frontend-mv-types-macros/Cargo.toml
+++ b/lib/si-frontend-mv-types-macros/Cargo.toml
@@ -12,6 +12,8 @@ publish.workspace = true
 proc-macro = true
 
 [dependencies]
+si-events = { path = "../../lib/si-events-rs" }
+
 darling     = { workspace = true }
 manyhow     = { workspace = true }
 proc-macro2 = { workspace = true }

--- a/lib/si-frontend-mv-types-rs/src/action.rs
+++ b/lib/si-frontend-mv-types-rs/src/action.rs
@@ -71,6 +71,7 @@ pub struct ActionView {
 #[mv(
     trigger_entity = EntityKind::CategoryAction,
     reference_kind = ReferenceKind::ActionViewList,
+    build_priority = "List",
 )]
 pub struct ActionViewList {
     pub id: WorkspacePk,

--- a/lib/si-frontend-mv-types-rs/src/component.rs
+++ b/lib/si-frontend-mv-types-rs/src/component.rs
@@ -160,6 +160,7 @@ pub struct SchemaMembers {
 #[mv(
   trigger_entity = EntityKind::CategoryComponent,
   reference_kind = ReferenceKind::ComponentList,
+  build_priority = "List",
 )]
 pub struct ComponentList {
     pub id: WorkspacePk,

--- a/lib/si-frontend-mv-types-rs/src/incoming_connections.rs
+++ b/lib/si-frontend-mv-types-rs/src/incoming_connections.rs
@@ -66,8 +66,9 @@ pub struct IncomingConnections {
 )]
 #[serde(rename_all = "camelCase")]
 #[mv(
-  trigger_entity = EntityKind::CategoryComponent,
-  reference_kind = ReferenceKind::IncomingConnectionsList,
+    trigger_entity = EntityKind::CategoryComponent,
+    reference_kind = ReferenceKind::IncomingConnectionsList,
+    build_priority = "List",
 )]
 pub struct IncomingConnectionsList {
     pub id: WorkspacePk,

--- a/lib/si-frontend-mv-types-rs/src/materialized_view.rs
+++ b/lib/si-frontend-mv-types-rs/src/materialized_view.rs
@@ -1,7 +1,11 @@
-use si_events::workspace_snapshot::{
-    Checksum,
-    ChecksumHasher,
-    EntityKind,
+use si_events::{
+    materialized_view::BuildPriority,
+    workspace_snapshot::{
+        Change,
+        Checksum,
+        ChecksumHasher,
+        EntityKind,
+    },
 };
 
 use crate::{
@@ -13,12 +17,14 @@ pub trait MaterializedView {
     fn kind() -> ReferenceKind;
     fn trigger_entity() -> EntityKind;
     fn definition_checksum() -> Checksum;
+    fn build_priority() -> BuildPriority;
 }
 
 #[derive(Debug, Clone)]
 pub struct MaterializedViewInventoryItem {
     kind: ReferenceKind,
     trigger_entity: EntityKind,
+    build_priority: BuildPriority,
     definition_checksum: &'static ::std::sync::LazyLock<Checksum>,
 }
 
@@ -26,11 +32,13 @@ impl MaterializedViewInventoryItem {
     pub const fn new(
         kind: ReferenceKind,
         trigger_entity: EntityKind,
+        build_priority: BuildPriority,
         definition_checksum: &'static ::std::sync::LazyLock<Checksum>,
     ) -> Self {
         MaterializedViewInventoryItem {
             kind,
             trigger_entity,
+            build_priority,
             definition_checksum,
         }
     }
@@ -42,8 +50,17 @@ impl MaterializedViewInventoryItem {
     pub fn trigger_entity(&self) -> EntityKind {
         self.trigger_entity
     }
+
+    pub fn build_priority(&self) -> BuildPriority {
+        self.build_priority
+    }
+
     pub fn definition_checksum(&self) -> Checksum {
         **self.definition_checksum
+    }
+
+    pub fn should_build_for_change(&self, change: Change) -> bool {
+        change.entity_kind == self.trigger_entity
     }
 }
 

--- a/lib/si-frontend-mv-types-rs/src/object/patch.rs
+++ b/lib/si-frontend-mv-types-rs/src/object/patch.rs
@@ -4,8 +4,11 @@ use si_id::{
     WorkspacePk,
 };
 
-const PATCH_BATCH_KIND: &str = "PatchMessage";
+use crate::reference::ReferenceKind;
+
 const INDEX_UPDATE_KIND: &str = "IndexUpdate";
+const PATCH_BATCH_KIND: &str = "PatchMessage";
+const STREAMING_PATCH_MESSAGE_KIND: &str = "StreamingPatch";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -19,6 +22,63 @@ pub struct UpdateMeta {
     /// The index checksum the patches the patches are being applied to.
     /// Or in the case of rebuild or a brand new change set, will match the [`to_index_checksum`]
     pub from_index_checksum: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StreamingPatch {
+    /// The workspace this patch is targeting.
+    pub workspace_id: WorkspacePk,
+    /// The change set this patch is targeting.
+    pub change_set_id: ChangeSetId,
+    /// The MV kind this patch is targeting.
+    pub kind: String,
+    /// The ID of the object this patch is targeting.
+    pub id: String,
+    /// The original checksum of the object before this patch.
+    ///
+    /// Checksum of `"0"` means this is a new object that must be created.
+    pub from_checksum: String,
+    /// The new checksum of the object after this patch.
+    ///
+    /// Checksum of `"0"` means this is an existing object that must be removed
+    pub to_checksum: String,
+    /// The JSON patch to apply to the object.
+    ///
+    /// If neither of `from_checksum`, and `to_checksum` are all `0`, this field
+    /// contains the JSON Patch document to apply to the version of the object with
+    /// a checksum matching `from_checksum` that will result in a version with the
+    /// checksum matching `to_checksum`.
+    pub patch: json_patch::Patch,
+    /// The message kind for the front end.
+    message_kind: &'static str,
+}
+
+impl StreamingPatch {
+    pub fn new(
+        workspace_id: WorkspacePk,
+        change_set_id: ChangeSetId,
+        kind: ReferenceKind,
+        id: String,
+        from_checksum: String,
+        to_checksum: String,
+        patch: json_patch::Patch,
+    ) -> Self {
+        Self {
+            workspace_id,
+            change_set_id,
+            kind: kind.to_string(),
+            id,
+            from_checksum,
+            to_checksum,
+            patch,
+            message_kind: STREAMING_PATCH_MESSAGE_KIND,
+        }
+    }
+
+    pub fn message_kind(&self) -> &'static str {
+        self.message_kind
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/lib/si-frontend-mv-types-rs/src/schema_variant.rs
+++ b/lib/si-frontend-mv-types-rs/src/schema_variant.rs
@@ -179,6 +179,7 @@ pub struct SchemaVariantsByCategory {
 #[mv(
     trigger_entity = EntityKind::CategorySchema,
     reference_kind = ReferenceKind::SchemaVariantCategories,
+    build_priority = "List",
 )]
 pub struct SchemaVariantCategories {
     pub id: WorkspacePk,

--- a/lib/si-frontend-mv-types-rs/src/view.rs
+++ b/lib/si-frontend-mv-types-rs/src/view.rs
@@ -45,6 +45,7 @@ pub struct View {
 #[mv(
     trigger_entity = EntityKind::CategoryView,
     reference_kind = ReferenceKind::ViewList,
+    build_priority = "List",
 )]
 pub struct ViewList {
     pub id: WorkspacePk,
@@ -65,6 +66,7 @@ pub struct ViewList {
 #[mv(
     trigger_entity = EntityKind::View,
     reference_kind = ReferenceKind::ViewComponentList,
+    build_priority = "List",
 )]
 pub struct ViewComponentList {
     pub id: ViewId,


### PR DESCRIPTION
# Initial sketch of streaming patches to the front end from edda

The idea with streaming patches to the front end is that it will be able to start using the new MVs as soon as they are generated, before _all_ of the data is ready, and there will be a message with the MvIndex patch (message not created/sent yet) that will let the front end know that the stream of patches has finished, and which objects it should have by the end (fetching any it missed the patch for).

Right now, these streaming patches are sent in addition to the existing patch batches, but once we start using the streamed patches in the front end, we'll want to stop creating & sending the batched patches as it will be purely redundant from the streamed patches.

We will also want to figure out if the existing `IndexUpdate` message should be augmented to include both the from-checksum & patch for the MvIndex, or if we want an entirely new message to handle this.

# Try to reduce nats load by only inserting FrontEndObjects if they're not already in the KV store

This doesn't reduce the amount of information sent over the wrire to nats on an insert, but nats should be able to short-circuit and avoid doing any write in the case where the object has already been generated for any reason.

With the interface provided by the nats KV store, our options for only inserting if the key doesn't already exist looked to be:

* Send the (potentially) new thing over the wire and watching for a failure (`create` behaves this way).
* Try to get first (and receive the full value).
* Iterate over all of the keys to see if the key is already there.

Trying the insert using `create` and ignoring the "already exists" error kind seems to be the least-bad of the options.

# Use a priority queue to determine order of MV builds in edda

When streaming patches out to the front end, it would be helpful for the front end's reactivity to be able to send lists early so it can display skeletons for individual items it hasn't gotten the patch information for yet.

Right now, there are two "priorities":
  * Lists
  * Details (everything else)

By default an MV will use the "Details" priority. If the `build_priority` annotation is provided for the MV struct definition, then it will use whatever is specified in the annotation.

This also re-structures how MV build tasks are spawned so that we can get everything queued before letting the priority queue handle things from there, to ensure the higher-priority items are always built first. Rather than having to explicitly check if the Change's `entity_kind` is the same as the MV's `trigger_entity`, this check has been abstracted away into the `MaterializedViewInventoryItem` and is checked during the initial queue population. This means that whenever we go to spawn an MV build task, we already know that the change is relevant for that specific MV kind.

# Make streamed patches from edda a config setting instead of always on

Rather than always sending the patches for the front end both as individual patches when each is built, and as a single batch after all have been built, there is now a `SI_EDDA__STREAMING_PATCHES` setting to toggle between the two behaviors. The default behavior is to send the patches as a single batch, making the newer streaming behavior opt-in for development & testing.