### PR TITLE
feat: add ci to docker group

### DIFF
--- a/component/ci-base/Dockerfile
+++ b/component/ci-base/Dockerfile
@@ -32,6 +32,7 @@ RUN set -eux; \
         containerd.io \
         docker-buildx-plugin \
         docker-compose-plugin \
+        wget \
     ; \
     rm -rf /var/lib/apt/lists/*
 
@@ -62,17 +63,13 @@ RUN apt-get update; \
     ; \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable libxss1 \
-      --no-install-recommends \
-
 RUN set -eux; \
     useradd --create-home --shell /bin/bash --uid "${USER_UID}" ci; \
     echo 'ci ALL=(ALL:ALL) NOPASSWD: ALL' >/etc/sudoers.d/ci; \
     mkdir -p /workdir; \
     chown -R ci:ci /workdir
+
+RUN groupadd -f docker && usermod -aG docker ci
 
 ENV USER=ci
 USER ci:ci


### PR DESCRIPTION
Adds the ci user to the docker group so the user in buildkite CI can use the docker daemon directly

**_NB:_** I had to remove some of the google chrome deps but I'm fairly certain we aren't even using them as they were added for cypress in buildkite, which we don't do at the minute (I'm trying to add this back in as part of my normal work + will come back to it if I need it)