### PR TITLE
Add ability to edit and delete views

### DIFF
--- a/app/web/src/newhotness/EditViewModal.vue
+++ b/app/web/src/newhotness/EditViewModal.vue
@@ -1,0 +1,126 @@
+<template>
+  <!-- NOTE: the Modal CSS for height in "max" doesn't work as we might expect -->
+  <Modal
+    ref="modalRef"
+    size="lg"
+    title="Edit View"
+    type="save"
+    saveLabel="Done"
+    @save="() => nameForm.handleSubmit()"
+  >
+    <label class="flex flex-row items-center relative">
+      <span>View Name</span>
+      <nameForm.Field name="name">
+        <template #default="{ field }">
+          <input
+            :class="
+              clsx(
+                'block w-72 ml-auto border',
+                themeClasses(
+                  'text-black bg-white border-neutral-600 disabled:bg-neutral-100',
+                  'text-white bg-black border-neutral-400 disabled:bg-neutral-900',
+                ),
+              )
+            "
+            :value="field.state.value"
+            type="text"
+            :disabled="wForm.bifrosting.value"
+            @input="
+              (e) => field.handleChange((e.target as HTMLInputElement).value)
+            "
+          />
+        </template>
+      </nameForm.Field>
+      <Icon
+        v-if="wForm.bifrosting.value"
+        class="absolute right-2xs"
+        name="loader"
+        size="sm"
+        tone="action"
+      />
+    </label>
+    <template #leftButton>
+      <div
+        v-tooltip="
+          canDeleteView
+            ? undefined
+            : 'Views containing one or more components cannot be deleted. To delete a view, first remove all components from it.'
+        "
+      >
+        <VButton
+          label="Delete View"
+          :disabled="!canDeleteView"
+          :tone="canDeleteView ? 'destructive' : 'neutral'"
+          @click="deleteView"
+        />
+      </div>
+    </template>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { VButton, Modal, Icon, themeClasses } from "@si/vue-lib/design-system";
+import { computed, ref } from "vue";
+import clsx from "clsx";
+import { ViewId } from "@/api/sdf/dal/views";
+import { useApi, routes } from "./api_composables";
+import { useWatchedForm } from "./logic_composables/watched_form";
+
+const viewId = ref<ViewId>("");
+const canDeleteView = ref<boolean>(false);
+
+const modalRef = ref<InstanceType<typeof Modal>>();
+const deleteViewApi = useApi();
+const updateViewApi = useApi();
+
+const deleteView = async () => {
+  const call = deleteViewApi.endpoint<{ id: string }>(routes.DeleteView, {
+    viewId: viewId.value,
+  });
+  const { req } = await call.delete({});
+  if (deleteViewApi.ok(req)) {
+    close();
+    emit("deleted");
+  }
+};
+
+const wForm = useWatchedForm<{ name: string }>("view.update");
+const formData = computed<{ name: string }>(() => {
+  return { name: "" };
+});
+
+const nameForm = wForm.newForm({
+  data: formData,
+  onSubmit: async ({ value }) => {
+    const call = updateViewApi.endpoint<{ id: string }>(routes.UpdateView, {
+      viewId: viewId.value,
+    });
+    const { req } = await call.put<{ name: string }>({
+      name: value.name,
+    });
+    if (updateViewApi.ok(req)) {
+      close();
+    }
+  },
+  validators: {
+    onSubmit: ({ value }) =>
+      value.name.length === 0 ? "Name is required" : undefined,
+  },
+});
+
+const emit = defineEmits<{
+  (e: "deleted"): void;
+}>();
+
+const open = (openViewId: string, openCanDeleteView: boolean) => {
+  viewId.value = openViewId;
+  canDeleteView.value = openCanDeleteView;
+  modalRef.value?.open();
+};
+const close = () => {
+  viewId.value = "";
+  canDeleteView.value = false;
+  modalRef.value?.close();
+};
+defineExpose({ open, close });
+</script>

--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -23,6 +23,7 @@ export enum routes {
   CreateSecret = "CreateSecret",
   CreateView = "CreateView",
   DeleteComponents = "DeleteComponents",
+  DeleteView = "DeleteView",
   DuplicateComponents = "DuplicateComponents",
   EraseComponentsFromView = "EraseComponentsFromView",
   FuncRun = "FuncRun",
@@ -34,6 +35,7 @@ export enum routes {
   RunMgmtPrototype = "RunMgmtPrototype",
   UpdateComponentAttributes = "UpdateComponentAttributes",
   UpdateComponentName = "UpdateComponentName",
+  UpdateView = "UpdateView",
   UpgradeComponents = "UpgradeComponents",
 }
 
@@ -56,6 +58,7 @@ const _routes: Record<routes, string> = {
   CreateSecret: "/components/<id>/secret",
   CreateView: "/views",
   DeleteComponents: "/components/delete",
+  DeleteView: "/views/<viewId>",
   DuplicateComponents: "/views/<viewId>/duplicate_components",
   EraseComponentsFromView: "/views/<viewId>/erase_components",
   FuncRun: "/funcs/runs/<id>",
@@ -68,6 +71,7 @@ const _routes: Record<routes, string> = {
     "/management/prototype/<prototypeId>/<componentId>/<viewId>",
   UpdateComponentAttributes: "/components/<id>/attributes",
   UpdateComponentName: "/components/<id>/name",
+  UpdateView: "/views/<viewId>",
   UpgradeComponents: "/components/upgrade",
 } as const;
 

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -166,6 +166,7 @@ import CarbonCompare from "~icons/carbon/compare";
 // TODO(Wendy) - for some reason this one specific icon fails to import? Not sure why.
 // import CarbonTransformCode from '~icons/carbon/transform-code';
 import CarbonTransformCode from "~icons/carbon/code"; // using this one as a placeholder for now
+import SettingsEdit from "~icons/carbon/settings-edit";
 
 // streamline
 import StreamlineBracesCircleSolid from "~icons/streamline/braces-circle-solid";
@@ -354,6 +355,7 @@ export const ICONS = Object.freeze({
   search: Search,
   selector: Selector,
   settings: Gear,
+  "settings-edit": SettingsEdit,
   shift: MaterialSymbolsShiftLockOutline,
   show: Eye,
   slash: SlashForward,

--- a/lib/vue-lib/src/design-system/menus/DropdownMenuButton.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenuButton.vue
@@ -73,6 +73,8 @@
         :label="option.label"
         :checkable="checkable"
         :checked="option.value === modelValue"
+        :enableSettingsEdit="props.enableSettingsEdit"
+        @edit="editOption(option)"
         @select="selectOption(option)"
       />
       <slot name="afterOptions" />
@@ -116,6 +118,7 @@ const props = defineProps({
   minWidthToAnchor: { type: Boolean },
   noBorder: { type: Boolean },
   alignRightOnAnchor: { type: Boolean },
+  enableSettingsEdit: { type: Boolean },
 });
 
 const arrayOptionsFromProps = computed((): OptionsAsArray => {
@@ -218,9 +221,13 @@ const selectOption = (option: { value: unknown; label: string }) => {
   emit("select", option.value as string);
   emit("update:modelValue", option.value as string);
 };
+const editOption = (option: { value: unknown; label: string }) => {
+  emit("edit", option.value as string);
+};
 const emit = defineEmits<{
   (e: "select", value: string): void;
   (e: "update:modelValue", value: string): void;
+  (e: "edit", value: string): void;
 }>();
 
 defineExpose({

--- a/lib/vue-lib/src/design-system/menus/DropdownMenuItem.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenuItem.vue
@@ -8,7 +8,7 @@
       clsx(
         'flex gap-xs items-center group select-none',
         noInteract ? 'text-neutral-500' : 'cursor-pointer',
-        !endLinkTo && 'children:pointer-events-none',
+        !endLinkTo && !enableSettingsEdit && 'children:pointer-events-none',
         header
           ? 'font-bold [&:not(:last-child)]:border-b [&:not(:first-child)]:border-t border-neutral-600'
           : 'rounded-sm',
@@ -18,7 +18,10 @@
           editor: [header ? 'p-xs' : 'p-2xs pr-xs', 'h-7'],
           contextmenu: 'p-xs pr-sm',
         }[menuCtx.variant as DropdownMenuVariant],
-        isFocused && !header && !menuCtx.navigatingSubmenu.value && themeClasses('bg-action-300', 'bg-action-500'),
+        isFocused &&
+          !header &&
+          !menuCtx.navigatingSubmenu.value &&
+          themeClasses('bg-action-300', 'bg-action-500'),
         (!menuCtx.isCheckable.value || disableCheckable) &&
           !icon &&
           !$slots.icon &&
@@ -85,7 +88,10 @@
     <div
       v-else-if="!(centerHeader && header)"
       :class="
-        clsx('ml-auto shrink-0', shortcut && !endLinkTo && 'capsize text-xs')
+        clsx(
+          'ml-auto shrink-0',
+          shortcut && !endLinkTo && !enableSettingsEdit && 'capsize text-xs',
+        )
       "
     >
       <template v-if="submenuItems && submenuItems.length > 0">
@@ -123,9 +129,27 @@
           <Icon v-else name="link" />
         </slot>
       </div>
+
       <template v-else-if="shortcut">
         {{ shortcut }}
       </template>
+
+      <div
+        v-else-if="enableSettingsEdit"
+        :class="
+          clsx(
+            themeClasses(
+              'group-hover:hover:text-action-500 group-hover:text-shade-0',
+              'group-hover:hover:text-action-300 group-hover:text-shade-0',
+            ),
+          )
+        "
+        @mousedown="emit('edit')"
+        @mouseenter="onMouseEnterEndLink"
+        @mouseleave="onMouseLeaveEndLink"
+      >
+        <Icon name="settings-edit" size="xs" />
+      </div>
     </div>
   </component>
 </template>
@@ -178,6 +202,8 @@ export interface DropdownMenuItemProps {
   endLinkLabel?: string;
   endLinkTo?: string | RouteLocationRaw;
 
+  enableSettingsEdit?: boolean;
+
   insideSubmenu?: boolean;
   submenuItems?: DropdownMenuItemProps[];
 
@@ -192,7 +218,10 @@ useThemeContainer(props.submenuVariant !== "contextmenu" ? "dark" : undefined);
 
 const noInteract = computed(() => props.disabled || props.header);
 
-const emit = defineEmits<{ (e: "select"): void }>();
+const emit = defineEmits<{
+  (e: "select"): void;
+  (e: "edit"): void;
+}>();
 
 const internalRef = ref<HTMLElement | null>(null);
 const menuCtx = useDropdownMenuContext();

--- a/lib/vue-lib/src/design-system/modals/Modal.vue
+++ b/lib/vue-lib/src/design-system/modals/Modal.vue
@@ -87,6 +87,7 @@
                   v-if="type === 'save' && !noWrapper"
                   class="py-3 flex flex-row justify-between gap-sm"
                 >
+                  <slot name="leftButton" />
                   <VButton
                     buttonRank="tertiary"
                     icon="x"


### PR DESCRIPTION
## Description

This change adds the ability to edit and delete views with protections against non-empty views. The existing "AddViewModal" was used as a frame of reference despite the new approval modal being closer to the desired designs.

Some complications in here included adding the "settings-edit" button, which behaves differently than "endLinkTo" in "DropdownMenuItem" as well as handling "canDeleteView" and query timing. Leveraging the "beforeOptions" and "afterOptions" for the button as well as allowing options to expand past the max width were part of getting here. This one was painful to get close, but we got there.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlc3MydnFxYjF4ajFxenAybnBhZmxucHl5cTA5ZGR0dHh5MTB0YjF3YSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/U4FiRhshiWlk6oruAw/giphy.gif"/>

## View Switcher Example

<img width="143" alt="Screenshot 2025-06-13 at 6 50 16 PM" src="https://github.com/user-attachments/assets/6c47d6c4-4665-4311-be5b-dbe3eba14416" />

## Edit View Modal Example with Deletion

<img width="727" alt="Screenshot 2025-06-13 at 6 50 33 PM" src="https://github.com/user-attachments/assets/cbb4c7ed-9bf1-4256-9370-47e2f4e1fc97" />

## Edit View Modal Example without Deletion

<img width="763" alt="Screenshot 2025-06-13 at 6 50 27 PM" src="https://github.com/user-attachments/assets/7ce8dad3-4409-4306-b2e4-a2e385b37dbe" />
