### PR TITLE
fix(web): reconnect websocket when new database remote is set

### DIFF
--- a/app/web/src/workers/shared_webworker.ts
+++ b/app/web/src/workers/shared_webworker.ts
@@ -90,12 +90,20 @@ const dbInterface: DBInterface = {
   async setRemote(remoteId: string) {
     debug("setting remote in shared web worker");
 
+    const wasConnected = !!currentRemote;
+
     currentRemote = remotes[remoteId];
     if (!currentRemote) {
       throw new Error(`remote {$remoteId} not registered`);
     }
-
     currentRemoteId = remoteId;
+
+    // Ensure we reconnect the websocket if we already had a remote
+    // (otherwise we let heimdall decide when to connect the websocket)
+    if (wasConnected) {
+      currentRemote.bifrostReconnect();
+    }
+
     hasRemoteChannel.port2.postMessage("got remote");
     if (bearerToken) {
       currentRemote.setBearer(bearerToken);


### PR DESCRIPTION
When a new tab acquired the lock, it was not ensuring that its websocket was connected. This ensures we reconnect the websocket. It may make sense to refactor this so that only the shared webworker owns the websocket, and it emits events on a broadcast channel to all tabs.