### PR TITLE
fix(web) - no explore context in AttributePanel

### DIFF
--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -180,7 +180,6 @@
 <script lang="ts" setup>
 import {
   computed,
-  inject,
   onBeforeUnmount,
   onMounted,
   reactive,
@@ -206,7 +205,6 @@ import {
 } from "@/workers/types/entity_kind_types";
 import { PropKind } from "@/api/sdf/dal/prop";
 import TextPill from "@/newhotness/layout_components/TextPill.vue";
-import { ExploreContext } from "@/newhotness/types";
 import { componentTypes, routes, useApi } from "./api_composables";
 import ComponentAttribute from "./layout_components/ComponentAttribute.vue";
 import { keyEmitter } from "./logic_composables/emitters";
@@ -221,8 +219,6 @@ const props = defineProps<{
   attributeTree?: AttributeTree;
   showImportArea: boolean;
 }>();
-
-const explore = inject<ExploreContext>("EXPLORE_CONTEXT");
 
 export interface AttrTree {
   id: string;
@@ -525,7 +521,7 @@ const doImport = async () => {
     {
       prototypeId: func.id,
       componentId: props.component.id,
-      viewId: explore?.viewId.value ?? "DEFAULT", // Should get the default view id
+      viewId: "DEFAULT", // Should get the default view id
     },
   );
 


### PR DESCRIPTION
## How does this PR change the system?

Because we do not have access to the Explore context within ComponentDetails, we cannot use a specific ViewId when invoking management functions. Thus, we have simply removed the code that tries to get the Explore context and set management functions run from the AttributePanel to simply use the DEFAULT view.

#### Out of Scope:

In the future we may want to allow users in the AttributePanel to select a view to run their management function in. But for now just running them in DEFAULT is fine.
