### PR TITLE
Protect the default view from deletion

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -277,6 +277,10 @@ TILT_HOST=0.0.0.0 DEV_HOST=0.0.0.0 buck2 run dev:up
 > [!CAUTION]
 > _The user is responsible for maintaining secure access (local, remote, etc.) to their local instance._
 
+> [!NOTE]
+> Unless you are using "localhost", your remote workspace must be accessible using SSL.
+> For example, if you are using [Tailscale](https://tailscale.com/) and running SI on a remote instance without SSL, you may want to port foward over SSH and use a local development workspace instead.
+
 # Using LocalStack for Secrets and Credentials
 
 This section contains information related to using [LocalStack](https://github.com/localstack/localstack) when working on the System Initiative software.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ buck2 run dev:stop
 
 ### (7) Logging into the Stack
 
-To log into System Initiative locally, you need to create a new Workspace of type `Local Dev Instance` and select it at https://auth.systeminit.com/workspaces/
+To log into SI locally, you need to create a new Workspace of type `Local Dev Instance` and select it at `https://auth.systeminit.com/workspaces`.
 
 ## Where Do I Learn More?
 

--- a/app/web/src/newhotness/EditViewModal.vue
+++ b/app/web/src/newhotness/EditViewModal.vue
@@ -40,13 +40,7 @@
       />
     </label>
     <template #leftButton>
-      <div
-        v-tooltip="
-          canDeleteView
-            ? undefined
-            : 'Views containing one or more components cannot be deleted. To delete a view, first remove all components from it.'
-        "
-      >
+      <div v-tooltip="tooltipText">
         <VButton
           label="Delete View"
           :disabled="!canDeleteView"
@@ -68,6 +62,17 @@ import { useWatchedForm } from "./logic_composables/watched_form";
 
 const viewId = ref<ViewId>("");
 const canDeleteView = ref<boolean>(false);
+const isDefaultView = ref<boolean>(false);
+
+const tooltipText = computed(() => {
+  if (isDefaultView.value) {
+    return "Cannot delete the default View.";
+  }
+  if (canDeleteView.value) {
+    return undefined;
+  }
+  return "Views containing one or more components cannot be deleted. To delete a view, first remove all components from it.";
+});
 
 const modalRef = ref<InstanceType<typeof Modal>>();
 const deleteViewApi = useApi();
@@ -112,14 +117,20 @@ const emit = defineEmits<{
   (e: "deleted"): void;
 }>();
 
-const open = (openViewId: string, openCanDeleteView: boolean) => {
+const open = (
+  openViewId: string,
+  openCanDeleteView: boolean,
+  openIsDefaultView: boolean,
+) => {
   viewId.value = openViewId;
   canDeleteView.value = openCanDeleteView;
+  isDefaultView.value = openIsDefaultView;
   modalRef.value?.open();
 };
 const close = () => {
   viewId.value = "";
   canDeleteView.value = false;
+  isDefaultView.value = false;
   modalRef.value?.close();
 };
 defineExpose({ open, close });

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -357,12 +357,13 @@ const viewListOptions = computed(() => {
   });
 });
 
+const defaultView = computed(() =>
+  viewListQuery.data.value?.views.find((v) => v.isDefault),
+);
 const selectedViewOrDefaultId = computed(() => {
   if (selectedView.value) return selectedView.value;
-  if (!viewListQuery.data.value) return "";
-  const view = viewListQuery.data.value.views.find((v) => v.isDefault);
-  if (!view) return "";
-  return view.id;
+  if (!defaultView.value) return "";
+  return defaultView.value.id;
 });
 
 const exploreContext = computed<ExploreContext>(() => {
@@ -962,10 +963,16 @@ const openEditViewModal = (viewId: string) => {
   // calls), but I scrapped it since the query would never load properly. Ideally, you should be able to
   // delete a view or edit it without switching to it. For now, we will survive.
   selectedView.value = viewId;
-  const canDeleteView = componentListRaw.data.value
-    ? componentListRaw.data.value.components.length < 1
-    : false;
-  editViewModalRef.value?.open(viewId, canDeleteView);
+
+  // Handle if we are dealing with the default view first.
+  if (viewId === defaultView.value?.id) {
+    editViewModalRef.value?.open(viewId, false, true);
+  } else {
+    const canDeleteView = componentListRaw.data.value
+      ? componentListRaw.data.value.components.length < 1
+      : false;
+    editViewModalRef.value?.open(viewId, canDeleteView, false);
+  }
 };
 
 const componentContextMenuRef =

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -161,6 +161,8 @@ pub enum WorkspaceSnapshotError {
     CorrectTransformsSplit(#[from] split_snapshot::corrections::CorrectTransformsError),
     #[error("Action would create a graph cycle")]
     CreateGraphCycle,
+    #[error("cannot delete the default view")]
+    DefaultViewDeletionAttempt,
     #[error("InferredConnectionGraph error: {0}")]
     InferredConnectionGraph(#[from] Box<InferredConnectionGraphError>),
     #[error("InputSocket error: {0}")]

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -81,6 +81,8 @@ pub enum WorkspaceSnapshotGraphError {
     ContentMissingForContentHash,
     #[error("Action would create a graph cycle")]
     CreateGraphCycle,
+    #[error("cannot delete the default view")]
+    DefaultViewDeletionAttempt,
     #[error("could not find the newly imported subgraph when performing updates")]
     DestinationNotUpdatedWhenImportingSubgraph,
     #[error("Edge does not exist for EdgeIndex: {0:?}")]

--- a/lib/dal/src/workspace_snapshot/split_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot.rs
@@ -1691,6 +1691,19 @@ impl ViewExt for SplitSnapshot {
 
         let view_id: Ulid = view_id.into();
 
+        // Do not allow deletion of the default view. We will likely need to get rid of this when
+        // we change what views do.
+        for edge_ref in working_copy.edges_directed_for_edge_weight_kind(
+            view_id,
+            Incoming,
+            EdgeWeightKindDiscriminants::Use,
+        )? {
+            let edge_weight = edge_ref.weight();
+            if *edge_weight.kind() == EdgeWeightKind::new_use_default() {
+                return Err(WorkspaceSnapshotError::DefaultViewDeletionAttempt);
+            }
+        }
+
         // Find all geometries used by this view
         for view_use_edge_ref in working_copy.edges_directed_for_edge_weight_kind(
             view_id,


### PR DESCRIPTION
## Description

This change protects the default view from deletion at the graph level as well as provides tooltip text for default views in the edit modal in the new UI.

In addition to that change, the local development docs have been edited to mention the SSL requirement when not using localhost. This was already recommended, but is now required with the recent webworker changes and its lock acquisition code.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlcHB4dWZ3ZnQ1Y2ljbDV0c3p2eHRsdjRpcmRreDhhZnFqMnh1ZzdteCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3oEduLzte7jSNmq4z6/giphy.gif"/>
