### PR TITLE
Make non-exempt mutation calls handle change sets

### DIFF
--- a/app/web/src/newhotness/ActionCard.vue
+++ b/app/web/src/newhotness/ActionCard.vue
@@ -233,6 +233,8 @@ const hold = () => {
 const holdApi = useApi();
 const finishHold = async () => {
   const call = holdApi.endpoint(routes.ActionHold, { id: props.action.id });
+
+  // This route can mutate head, so we do not need to handle new change set semantics.
   await call.put({});
   confirmRef.value?.close();
 };
@@ -240,12 +242,16 @@ const finishHold = async () => {
 const retryApi = useApi();
 const retry = async () => {
   const call = retryApi.endpoint(routes.ActionRetry, { id: props.action.id });
+
+  // This route can mutate head, so we do not need to handle new change set semantics.
   await call.put({});
 };
 
 const removeApi = useApi();
 const remove = async () => {
   const call = removeApi.endpoint(routes.ActionCancel, { id: props.action.id });
+
+  // This route can mutate head, so we do not need to handle new change set semantics.
   await call.put({});
 };
 </script>

--- a/app/web/src/newhotness/ActionWidget.vue
+++ b/app/web/src/newhotness/ActionWidget.vue
@@ -57,6 +57,8 @@ const clickHandler = async () => {
       id: props.actionId,
     });
     removeApi.setWatchFn(() => props.actionId);
+
+    // This route can mutate head, so we do not need to handle new change set semantics.
     await call.put({});
   } else {
     const call = addApi.endpoint(routes.ActionAdd);

--- a/app/web/src/newhotness/AddViewModal.vue
+++ b/app/web/src/newhotness/AddViewModal.vue
@@ -25,7 +25,9 @@
             :value="field.state.value"
             type="text"
             :disabled="wForm.bifrosting.value"
-            @input="(e) => field.handleChange((e.target as HTMLInputElement).value)"
+            @input="
+              (e) => field.handleChange((e.target as HTMLInputElement).value)
+            "
           />
         </template>
       </nameForm.Field>
@@ -77,7 +79,7 @@ const nameForm = wForm.newForm({
       if (newChangeSetId) {
         api.navigateToNewChangeSet(
           {
-            name: "new-hotness-view",
+            name: "new-hotness",
             params: {
               workspacePk: route.params.workspacePk,
               changeSetId: newChangeSetId,

--- a/app/web/src/newhotness/FuncRunDetails.vue
+++ b/app/web/src/newhotness/FuncRunDetails.vue
@@ -95,6 +95,8 @@ const removeAction = async () => {
     const call = removeApi.endpoint(routes.ActionCancel, {
       id: funcRun.value.actionId,
     });
+
+    // This route can mutate head, so we do not need to handle new change set semantics.
     await call.put({});
     router.push({
       name: "new-hotness",
@@ -112,6 +114,8 @@ const retryAction = async () => {
     const call = retryApi.endpoint(routes.ActionRetry, {
       id: funcRun.value.actionId,
     });
+
+    // This route can mutate head, so we do not need to handle new change set semantics.
     await call.put({});
   }
 };

--- a/app/web/src/newhotness/ManagementFuncCard.vue
+++ b/app/web/src/newhotness/ManagementFuncCard.vue
@@ -70,12 +70,26 @@ const runMgmtFunc = async (funcId: string) => {
     },
   );
 
-  await call.post({});
+  const { req, newChangeSetId } = await call.post({});
 
   dispatchedFunc.value = true;
   setTimeout(() => {
     dispatchedFunc.value = false;
   }, 2000);
+
+  // NOTE(nick): need to make sure this makes sense after the timeout.
+  if (mgmtRunApi.ok(req) && newChangeSetId) {
+    mgmtRunApi.navigateToNewChangeSet(
+      {
+        name: "new-hotness",
+        params: {
+          workspacePk: route.params.workspacePk,
+          changeSetId: newChangeSetId,
+        },
+      },
+      newChangeSetId,
+    );
+  }
 };
 
 const dispatchedFunc = ref(false);

--- a/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
@@ -152,15 +152,14 @@ const secretFormData = computed(() => {
   } else return {};
 });
 
-const api = useApi();
-
+const saveApi = useApi();
 const save = async (
   path: string,
   _id: string,
   value: string,
   connectingComponentId?: string,
 ) => {
-  const call = api.endpoint<{ success: boolean }>(
+  const call = saveApi.endpoint<{ success: boolean }>(
     routes.UpdateComponentAttributes,
     { id: props.component.id },
   );
@@ -172,11 +171,26 @@ const save = async (
       $source: { component: connectingComponentId, path: value },
     };
   }
-  await call.put<componentTypes.UpdateComponentAttributesArgs>(payload);
+  const { req, newChangeSetId } =
+    await call.put<componentTypes.UpdateComponentAttributesArgs>(payload);
+  if (saveApi.ok(req) && newChangeSetId) {
+    saveApi.navigateToNewChangeSet(
+      {
+        name: "new-hotness-component",
+        params: {
+          workspacePk: route.params.workspacePk,
+          changeSetId: newChangeSetId,
+          componentId: props.component.id,
+        },
+      },
+      newChangeSetId,
+    );
+  }
 };
 
+const removeSubscriptionApi = useApi();
 const removeSubscription = async (path: string, _id: string) => {
-  const call = api.endpoint<{ success: boolean }>(
+  const call = removeSubscriptionApi.endpoint<{ success: boolean }>(
     routes.UpdateComponentAttributes,
     { id: props.component.id },
   );
@@ -188,7 +202,21 @@ const removeSubscription = async (path: string, _id: string) => {
     $source: null,
   };
 
-  await call.put<componentTypes.UpdateComponentAttributesArgs>(payload);
+  const { req, newChangeSetId } =
+    await call.put<componentTypes.UpdateComponentAttributesArgs>(payload);
+  if (removeSubscriptionApi.ok(req) && newChangeSetId) {
+    removeSubscriptionApi.navigateToNewChangeSet(
+      {
+        name: "new-hotness-component",
+        params: {
+          workspacePk: route.params.workspacePk,
+          changeSetId: newChangeSetId,
+          componentId: props.component.id,
+        },
+      },
+      newChangeSetId,
+    );
+  }
 };
 
 const route = useRoute();

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -92,12 +92,6 @@ const routes: RouteRecordRaw[] = [
         component: () => import("@/newhotness/Workspace.vue"),
       },
       {
-        name: "new-hotness-view",
-        path: ":secretId/s/edit",
-        props: true,
-        component: () => import("@/newhotness/Workspace.vue"),
-      },
-      {
         name: "new-hotness-component",
         path: ":componentId/c",
         props: true,


### PR DESCRIPTION
## Description

This change makes all non-exempt mutation calls handle new change sets returned from SDF. An exempt mutation call is one that is marked in "CAN_MUTATE_ON_HEAD", which currently only corresponds to three calls related to actions. All exempt locations have been marked with a comment.

This change fixes the issue where mutating on HEAD did not properly move the user to the new change set as well as cements the developer pattern to either handle the new change set with post, put and delete methods, or to indicate that it doesn't need to be handled via a comment.

All calls were found with the following "ripgrep" command in the "newhotness" directory: ```rg 'call\.(put|post|delete)' -B 1```.

## Other Fixes

- The duplicate "new-hotness-view" route has been removed.
  - It is not being used and can cause a bug where the "secretId" would be missing when navigating to the route
- Multiple usages of the same "useApi" have been split up since they should only be used for one route each

## GIF

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMzNwY3JqaXI3bzcwaml3cmxlZ29wbmF6bHN6M2kyYjgzbDNnb2p4cyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l0IynnSD9W3QUZdNm/giphy.gif"/>
