### PR TITLE
Fix: shared web worker initialization needs to be awaited/watched diferently now that its doing the lock dance

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -195,9 +195,9 @@ onBeforeMount(async () => {
   // Activate the norse stack, which is explicitly NOT flagged for the job-specific UI.
   await heimdall.init(workspaceAuthToken, queryClient);
   watch(
-    connectionShouldBeEnabled,
+    [connectionShouldBeEnabled.value, heimdall.initCompleted],
     async () => {
-      if (connectionShouldBeEnabled.value) {
+      if (connectionShouldBeEnabled.value && heimdall.initCompleted.value) {
         // NOTE(nick,wendy): this says "reconnect", but it must run once on startup.
         await heimdall.bifrostReconnect();
       } else {

--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -2841,7 +2841,8 @@ const dbInterface: DBInterface = {
 
   async bifrostReconnect() {
     try {
-      if (socket) socket.reconnect();
+      // don't re-connect if you're already connected!
+      if (socket && socket.readyState !== WebSocket.OPEN) socket.reconnect();
     } catch (err) {
       error(err);
     }


### PR DESCRIPTION
## How does this PR change the system?
`heimdall.init` cannot wait on `tabDb.initBifrost` due to the locking scheme. And the `setRemote` call is asnyc. This introduced a race in the `Workspace.vue` where the `watch` to reconnect the web socket was firing _before_ the web socket was initialized. 

## How was it tested?
- Seeing the bifrost web socket in the dev tool
- Changing component name seeing a patch come through

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOGdwMzF6aDUxdGw4aW1rMmp5cTZ0b295ZTNhM2gyajZqZjJ0cm93NiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Gv4sspliwjUTHsudi3/giphy-downsized-medium.gif"/>