### PR TITLE
fix(web): ensure we set lockAcquired = true on other tabs

### DIFF
--- a/app/web/src/workers/shared_webworker.ts
+++ b/app/web/src/workers/shared_webworker.ts
@@ -79,11 +79,16 @@ const dbInterface: SharedDBInterface = {
     delete remotes[id];
   },
   registerRemote(id: string, remote: Comlink.Remote<TabDBInterface>) {
-    debug("register remote in shared", id);
-    remotes[id] = remote;
+    if (!remotes[id]) {
+      debug("register remote in shared", id);
+      remotes[id] = remote;
+    }
+  },
+  async hasRemote() {
+    return !!currentRemote;
   },
   async setRemote(remoteId: string) {
-    debug("setting remote in shared web worker");
+    debug("setting remote in shared web worker to", remoteId);
 
     const wasConnected = !!currentRemote;
 

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -116,6 +116,7 @@ export interface SharedDBInterface {
   registerRemote(id: string, remote: Comlink.Remote<TabDBInterface>): void;
   broadcastMessage(message: BroadcastMessage): Promise<void>;
   setRemote(remoteId: string): Promise<void>;
+  hasRemote(): Promise<boolean>;
   initBifrost(gotLockPort: MessagePort): Promise<void>;
   bifrostClose(): Promise<void>;
   bifrostReconnect(): Promise<void>;


### PR DESCRIPTION
Ensures that if the database lock is acquired by one tab, every tab knows about it.

Tested by opening lots of tabs and seeing that they all render the change set eventually.