### PR TITLE
feat(web): Show new components instantly

### DIFF
--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -305,29 +305,26 @@ const outgoing = computed(
   () => ctx.outgoingCounts.value[props.componentId] ?? 0,
 );
 
-const componentQuery = useQuery<BifrostComponent | null>({
+const componentQuery = useQuery<BifrostComponent | undefined>({
   queryKey: key(EntityKind.Component, componentId),
-  queryFn: async (queryContext) => {
-    const component = await bifrost<BifrostComponent>(
+  queryFn: async (queryContext) =>
+    (await bifrost<BifrostComponent>(
       args(EntityKind.Component, componentId.value),
-    );
-    if (!component) {
-      return queryContext.client.getQueryData(
-        key(EntityKind.Component, componentId).value,
-      ) as BifrostComponent | null;
-    }
-    return component;
-  },
+    )) ??
+    queryContext.client.getQueryData(
+      key(EntityKind.Component, componentId).value,
+    ),
 });
 
-const attributeTreeQuery = useQuery<AttributeTree | null>({
+const attributeTreeQuery = useQuery<AttributeTree | undefined>({
   queryKey: key(EntityKind.AttributeTree, componentId.value),
-  queryFn: async () => {
-    const attributeTree = await bifrost<AttributeTree>(
+  queryFn: async (queryContext) =>
+    (await bifrost<AttributeTree>(
       args(EntityKind.AttributeTree, componentId.value),
-    );
-    return attributeTree;
-  },
+    )) ??
+    queryContext.client.getQueryData(
+      key(EntityKind.AttributeTree, componentId).value,
+    ),
 });
 const attributeTree = computed(() => attributeTreeQuery.data.value);
 

--- a/lib/sdf-server/src/service/v2/view.rs
+++ b/lib/sdf-server/src/service/v2/view.rs
@@ -139,6 +139,12 @@ impl IntoResponse for ViewError {
     }
 }
 
+impl From<dal_materialized_views::Error> for ViewError {
+    fn from(error: dal_materialized_views::Error) -> Self {
+        Box::new(error).into()
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ViewNodeGeometry {


### PR DESCRIPTION
Right now, we wait for edda to finish indexing new components before we show their attributes. With this change, we display new components as soon as they are created.

This PR:

* Adds the attribute tree to the create_component response
* Caches the attribute tree MV from the response so that it can be used in the absence of a true updated index
* Uses the cached attribute tree MV when the index has not yet been updated
* Switches to use the real attribute tree MV when it becomes available

#### Out of Scope:

* This does not speed up the actual creation of the component (if anything, it slows it down, because it adds data to the response). This means that when you double click, there is still a long, perceptible pause (with no feedback) before the component is created and the new page opens.
* This will not add a "skeleton" component to the main screen, so if you hit escape because the component is taking too long to create, you won't see it show up in the screen.

## How was it tested?

- [x] Created a new component, verified the attribute tree shows right away
- [x] Temporarily disabled the active query (locally) to ensure the attribute tree looks correct and it wasn't just the MV being created quickly

## In Short

![instant noodles](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExOXRkZHpsMTBkeGUyMGVhbDl0ajhrYXhqZnhwNmJnenBndXZmbXBtYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fnsmqj9f0a13OvWSf1/giphy.gif)
