### PR TITLE
Add info about MV build timings to build all & build for changes info spans

### DIFF
--- a/lib/si-frontend-mv-types-rs/src/reference.rs
+++ b/lib/si-frontend-mv-types-rs/src/reference.rs
@@ -31,6 +31,7 @@ pub use weak::WeakReference;
     strum::Display,
     strum::EnumIter,
     strum::EnumString,
+    strum::IntoStaticStr,
 )]
 #[serde(rename_all = "PascalCase")]
 pub enum ReferenceKind {


### PR DESCRIPTION
The build all MVs & build for changes info spans now include the number of MVs built, how long each one took on average, which kind was the slowest to build, and how long the slowest took to build. This information should help when investigating slower than expected MV building, and give us metrics to use to monitor edda's performance over time.

Example screenshot of Jaeger from local testing:

![image](https://github.com/user-attachments/assets/d5ce2e5f-e35c-476d-9976-3b9fef1e7677)

