### PR TITLE
feat(web):Include the number of components in the search placeholder text

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -92,7 +92,7 @@
               autocomplete="off"
               :class="slotProps.class"
               noStyles
-              placeholder="Search components"
+              :placeholder="placeholderSearchText"
               @focus="
                 () => {
                   slotProps.focus();
@@ -485,6 +485,9 @@ const componentListRaw = useQuery<ComponentInList[]>({
   },
 });
 
+const placeholderSearchText = computed(
+  () => `Search across ${componentListRaw.data.value?.length ?? 0} Components`,
+);
 const componentList = computed(() => componentListRaw.data.value ?? []);
 const componentsById = computed(() =>
   Object.fromEntries(componentList.value.map((c) => [c.id, c])),


### PR DESCRIPTION

<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?
This PR adds the component count in the placeholder text of the search bar 

We can decide if we want to keep this here long term, but while testing performance and creating components, it makes it easier to quickly see how many components exist in the grid

<!-- Why: briefly what problem this solves and what the aim is as an overview -->

#### Screenshots:

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->
<img width="887" alt="image" src="https://github.com/user-attachments/assets/3c547ed7-6adf-4057-9196-62637652dbf5" />

<!-- Anything this PR explicitly leaves out? -->

## How was it tested?

Manually tested to ensure it's reactive as components are added to the change set!

<div><img src="https://media1.giphy.com/media/FHzemFzwkyRfq/200.gif?cid=5a38a5a2307597cxvew4w01we6fbzs72m8copndtb85jpmoi&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:168px;width:300px"/><br/>via <a href="https://giphy.com/sesamestreet/">Sesame Street</a> on <a href="https://giphy.com/gifs/sesame-street-count-number-of-the-day-FHzemFzwkyRfq">GIPHY</a></div>