### PR TITLE
feat(web): fetch all change sets on load, wait in the lobby

### DIFF
--- a/app/web/src/components/layout/navbar/NavbarPanelRight.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelRight.vue
@@ -16,11 +16,7 @@
             icon="niflheim"
             label="Re-do Cold Start"
             @click="
-              heimdall.niflheim(
-                changeSetsStore.selectedWorkspacePk,
-                changeSetsStore.selectedChangeSetId,
-                true,
-              )
+              heimdall.muspelheim(changeSetsStore.selectedWorkspacePk, true)
             "
           />
           <DropdownMenuItem

--- a/app/web/src/newhotness/Lobby.vue
+++ b/app/web/src/newhotness/Lobby.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="w-[50svh] mx-auto mt-[15svh]">
+    <h1 class="text-center text-2xl">Welcome!</h1>
+    <h2 class="text-center text-xl">Take a load off</h2>
+    <h3 v-if="niflheimTotal > 0" class="text-center text-lg">
+      {{ niflheimComplete }} change set(s) loaded of {{ niflheimTotal }}
+    </h3>
+    <Icon class="mx-auto" name="loader" size="full" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { Icon } from "@si/vue-lib/design-system";
+import { computed } from "vue";
+import { muspelheimStatuses } from "@/store/realtime/heimdall";
+
+const niflheimTotal = computed(
+  () => Object.keys(muspelheimStatuses.value).length,
+);
+const niflheimComplete = computed(
+  () =>
+    Object.values(muspelheimStatuses.value).filter((status) => status === true)
+      .length,
+);
+</script>

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -51,12 +51,9 @@
      min-h-0 prevents the main container from being *larger* than the max it can grow, no matter its contents -->
     <main class="grow min-h-0">
       <div v-if="tokenFail">Bad Token</div>
-      <div v-else-if="lobby" class="w-[50svh] mx-auto mt-[15svh]">
-        <h1 class="text-center text-2xl">Welcome!</h1>
-        <h2 class="text-center text-xl">Have a seat in our lobby</h2>
-        <h3 class="text-center text-lg">We are loading your workspace now</h3>
-        <Icon class="mx-auto" name="loader" size="full" />
-      </div>
+      <template v-else-if="lobby">
+        <Lobby />
+      </template>
       <template v-else-if="componentId">
         <ComponentDetails :componentId="componentId" />
       </template>
@@ -88,7 +85,6 @@ import {
   provide,
   watch,
 } from "vue";
-import { Icon } from "@si/vue-lib/design-system";
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
 import NavbarPanelLeft from "@/components/layout/navbar/NavbarPanelLeft.vue";
 import NavbarPanelRight from "@/components/layout/navbar/NavbarPanelRight.vue";
@@ -105,6 +101,7 @@ import {
   SchemaMembers,
 } from "@/workers/types/entity_kind_types";
 import { SchemaId } from "@/api/sdf/dal/schema";
+import Lobby from "./Lobby.vue";
 import Explore from "./Explore.vue";
 import ComponentDetails from "./ComponentDetails.vue";
 import FuncRunDetails from "./FuncRunDetails.vue";
@@ -128,7 +125,19 @@ const props = defineProps<{
   actionId?: string;
 }>();
 
-const lobby = computed(() => route.name === "new-hotness-lobby");
+const lobby = computed(() => {
+  const muspelheimStates = heimdall.muspelheimStatuses.value;
+  if (Object.keys(muspelheimStates).length === 0) {
+    return true;
+  }
+
+  for (const changeSetId in muspelheimStates) {
+    if (!muspelheimStates[changeSetId]) {
+      return true;
+    }
+  }
+  return false;
+});
 
 const authStore = useAuthStore();
 const featureFlagsStore = useFeatureFlagsStore();
@@ -306,8 +315,6 @@ onBeforeMount(async () => {
       if (connectionShouldBeEnabled.value && heimdall.initCompleted.value) {
         // NOTE(nick,wendy): this says "reconnect", but it must run once on startup.
         await heimdall.bifrostReconnect();
-      } else {
-        await heimdall.bifrostClose();
       }
     },
     { immediate: true },
@@ -315,42 +322,29 @@ onBeforeMount(async () => {
 
   // NOTE: onBeforeMount doesn't wait on promises
   // the page will load before execution finishes
-  const success = await heimdall.niflheim(
-    props.workspacePk,
-    props.changeSetId,
-    true,
-  );
+  await heimdall.muspelheim(props.workspacePk, true);
   queriesEnabled.value = true;
-  if (success && lobby.value) {
-    router.push({
-      name: "new-hotness",
-      params: {
-        workspacePk: props.workspacePk,
-        changeSetId: props.changeSetId,
-      },
-    });
-  }
 });
 
 watch(
   () => props.changeSetId,
-  async () => {
-    const success = await heimdall.niflheim(
-      props.workspacePk,
-      props.changeSetId,
-      true,
-    );
-    if (success && lobby.value) {
-      router.push({
-        name: "new-hotness",
-        params: {
-          workspacePk: props.workspacePk,
-          changeSetId: props.changeSetId,
-        },
-      });
+  async (newValue, _) => {
+    if (heimdall.muspelheimStatuses.value[newValue] === false) {
+      return;
+    }
+
+    const exists = await heimdall.changeSetExists(props.workspacePk, newValue);
+    if (!exists) {
+      heimdall.muspelheimStatuses.value[newValue] = false;
+    }
+
+    const success = await heimdall.niflheim(props.workspacePk, newValue, true);
+    if (!success) {
+      heimdall.muspelheimStatuses.value[newValue] = false;
     }
   },
 );
+
 realtimeStore.subscribe(
   "TOP_LEVEL_WORKSPACE",
   `workspace/${props.workspacePk}`,

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -345,6 +345,32 @@ watch(
   },
 );
 
+const hiddenAt = ref<Date | undefined>(undefined);
+
+// Force muspelheim if the window has been hidden for 12 hours
+const FORCE_MUSPELHEIM_AFTER_MS = 12 * 60 * 60 * 1000;
+
+// We have put this in a watch, instead of in the event
+// listener, in order to ensure we are reactive to the prop
+watch(hiddenAt, (newValue, oldValue) => {
+  if (!newValue && oldValue) {
+    const now = new Date();
+    const timeDiff = now.getTime() - oldValue.getTime();
+
+    if (timeDiff >= FORCE_MUSPELHEIM_AFTER_MS) {
+      heimdall.muspelheim(props.workspacePk, true);
+    }
+  }
+});
+
+document.addEventListener("visibilitychange", () => {
+  if (document.hidden) {
+    hiddenAt.value = new Date();
+  } else {
+    hiddenAt.value = undefined;
+  }
+});
+
 realtimeStore.subscribe(
   "TOP_LEVEL_WORKSPACE",
   `workspace/${props.workspacePk}`,

--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -3,7 +3,7 @@ import { AxiosResponse } from "axios";
 import { trace, Span } from "@opentelemetry/api";
 import { RouteLocationRaw } from "vue-router";
 import { sdfApiInstance as sdf } from "@/store/apis.web";
-import { changeSetExists } from "@/store/realtime/heimdall";
+import { changeSetExists, muspelheimStatuses } from "@/store/realtime/heimdall";
 import router from "@/router";
 import { assertIsDefined, Context } from "../types";
 import * as rainbow from "../logic_composables/rainbow_counter";
@@ -237,7 +237,7 @@ export const useApi = () => {
         path = path.replace(`<${k}>`, v);
       });
     const canMutateHead = CAN_MUTATE_ON_HEAD.includes(key);
-    const argList = args ? [...Object.entries(args)].flatMap((m) => m) : [];
+    const argList = args ? Object.entries(args).flatMap((m) => m) : [];
     const desc = `${key} ${argList.join(": ")} by ${
       ctx.user?.name
     } on ${new Date().toLocaleDateString()}`;
@@ -287,15 +287,14 @@ export const useApi = () => {
         );
         if (exists) {
           clearInterval(interval);
+          muspelheimStatuses.value[newChangeSetId] = true;
           resolve();
         }
         retry += 1;
       }, INTERVAL);
     });
     if (apiCall.lobbyRequired) {
-      if (typeof to === "string") to = "new-hotness-lobby";
-      else if ("name" in to) to.name = "new-hotness-lobby";
-      else throw new Error("Thanks, router");
+      muspelheimStatuses.value[newChangeSetId] = false;
     }
     await router.push(to);
     reset();

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -74,11 +74,11 @@ const routes: RouteRecordRaw[] = [
     props: true,
     component: () => import("@/newhotness/Workspace.vue"),
     children: [
-      {
-        name: "new-hotness-lobby",
-        path: "lobby",
-        component: () => import("@/newhotness/Workspace.vue"),
-      },
+      // {
+      //   name: "new-hotness-lobby",
+      //   path: "lobby",
+      //   component: () => import("@/newhotness/Workspace.vue"),
+      // },
       {
         name: "new-hotness-view",
         path: ":viewId/v/edit",

--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -108,6 +108,9 @@ export function useChangeSetsStore() {
         changeSetsApprovalData: {} as Record<ChangeSetId, ApprovalData>,
       }),
       getters: {
+        openChangeSetIds(): ChangeSetId[] {
+          return this.openChangeSets.map((changeSet) => changeSet.id);
+        },
         currentUserIsDefaultApprover(): boolean {
           const userPk = authStore.user?.pk;
           if (!userPk) return false;
@@ -256,7 +259,7 @@ export function useChangeSetsStore() {
               const headkey = `${this.headChangeSetId}_selected_component`;
               window.localStorage.removeItem(headkey);
             },
-            onSuccess: (response) => {
+            onSuccess: (_response) => {
               // this.changeSetsById[response.changeSet.pk] = response.changeSet;
               const statusStore = useStatusStore();
               statusStore.resetWhenChangingChangeset();


### PR DESCRIPTION
Starts the user in the lobby, and runs "muspelheim", which runs niflheim against every open change set. Only then does it exit the lobby.

Lobby is controlled by the status of the niflheim queries, not the route.

Also sends the user to the lobby / muspelheims if the tab has been idle for 12 hours+.