### PR TITLE
fix(dal): Remove subscriber APAs when removing components

### DIFF
--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -852,7 +852,7 @@ impl ExpectAttributeValue {
     }
 
     pub async fn remove(self, ctx: &DalContext) {
-        dal::AttributeValue::remove_by_id(ctx, self.0)
+        dal::AttributeValue::remove(ctx, self.0)
             .await
             .expect("remove prop value by id failed")
     }

--- a/lib/dal/src/attribute/attributes.rs
+++ b/lib/dal/src/attribute/attributes.rs
@@ -267,7 +267,7 @@ pub async fn update_attributes(
                 if let Some(target_av_id) = av_to_set.resolve(ctx, component_id).await? {
                     if parent_prop_is_map_or_array(ctx, target_av_id).await? {
                         // If the parent is a map or array, remove the value
-                        AttributeValue::remove_by_id(ctx, target_av_id).await?;
+                        AttributeValue::remove(ctx, target_av_id).await?;
                     } else {
                         // Otherwise, just set it to its default value
                         if AttributeValue::component_prototype_id(ctx, target_av_id)

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -2771,9 +2771,9 @@ impl Component {
             .await?;
 
         // Deleting the root attribute value will remove all ValueSubscription edges that point to it.
-        ctx.workspace_snapshot()?
-            .remove_node_by_id(root_attribute_value_id)
-            .await?;
+        AttributeValue::remove(ctx, root_attribute_value_id).await?;
+
+        // Remove the component itself
         ctx.workspace_snapshot()?.remove_node_by_id(id).await?;
 
         Ok(())

--- a/lib/dal/src/func/binding/leaf.rs
+++ b/lib/dal/src/func/binding/leaf.rs
@@ -259,7 +259,7 @@ impl LeafBinding {
         for attribute_value_id in
             AttributePrototype::attribute_value_ids(ctx, attribute_prototype_id).await?
         {
-            AttributeValue::remove_by_id(ctx, attribute_value_id).await?;
+            AttributeValue::remove(ctx, attribute_value_id).await?;
         }
         AttributePrototype::remove(ctx, attribute_prototype_id).await?;
 

--- a/lib/dal/src/management/mod.rs
+++ b/lib/dal/src/management/mod.rs
@@ -1861,7 +1861,7 @@ async fn update_component(
                             continue;
                         }
 
-                        AttributeValue::remove_by_id(ctx, *child_id).await?;
+                        AttributeValue::remove(ctx, *child_id).await?;
                     }
                 }
 

--- a/lib/dal/tests/integration_test/attribute_value/subscription.rs
+++ b/lib/dal/tests/integration_test/attribute_value/subscription.rs
@@ -1,4 +1,5 @@
 use dal::{
+    AttributePrototype,
     AttributeValue,
     Component,
     DalContext,
@@ -42,34 +43,30 @@ async fn subscribe_to_name_on_same_component(ctx: &mut DalContext) -> Result<()>
     .await?;
 
     // Create a component with a Value prop and a name
-    let component_id = component::create(ctx, "testy", "my name is testy").await?;
-    let value_av_id =
-        Component::attribute_value_for_prop(ctx, component_id, &["root", "domain", "Value"])
-            .await?;
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
-    assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
+    let component_id = component::create(ctx, "testy", "initial name").await?;
+    change_set::commit(ctx).await?;
+    assert!(!value::has_value(ctx, (component_id, "/domain/Value")).await?);
 
     // Subscribe to the value and see if it flows through!
-    value::subscribe(ctx, value_av_id, [(component_id, "/si/name")]).await?;
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    value::subscribe(
+        ctx,
+        (component_id, "/domain/Value"),
+        [(component_id, "/si/name")],
+    )
+    .await?;
+    change_set::commit(ctx).await?;
     assert_eq!(
-        Some(json!("my name is testy")),
-        AttributeValue::view_by_id(ctx, value_av_id).await?
+        json!("initial name"),
+        value::get(ctx, (component_id, "/domain/Value")).await?
     );
 
     // Update the name and watch the new value flow through!
-    // Update the name and watch the new value flow through!
-    Component::get_by_id(ctx, component_id)
-        .await?
-        .set_name(ctx, "testy_2")
-        .await?;
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    value::set(ctx, (component_id, "/si/name"), "updated name").await?;
+    change_set::commit(ctx).await?;
     assert_eq!(
-        Some(json!("testy_2")),
-        AttributeValue::view_by_id(ctx, value_av_id).await?
+        json!("updated name"),
+        value::get(ctx, (component_id, "/domain/Value")).await?
     );
-
-    // Unset
 
     Ok(())
 }
@@ -80,39 +77,39 @@ async fn subscribe_to_string(ctx: &mut DalContext) -> Result<()> {
     create_testy_variant(ctx).await?;
 
     // Create a component with a Value prop
-    let component_id = component::create(ctx, "testy", "testy").await?;
-    let value_av_id =
-        Component::attribute_value_for_prop(ctx, component_id, &["root", "domain", "Value"])
-            .await?;
+    component::create(ctx, "testy", "subscriber").await?;
     change_set::commit(ctx).await?;
-    assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
+    assert!(!value::has_value(ctx, ("subscriber", "/domain/Value")).await?);
 
     // Create another component
-    let other_component_id = component::create(ctx, "testy", "other").await?;
-
-    Component::attribute_value_for_prop(ctx, component_id, &["root", "domain", "Value"]).await?;
-    value::set(ctx, ("other", "/domain/Value"), "value").await?;
+    component::create(ctx, "testy", "source").await?;
+    value::set(ctx, ("source", "/domain/Value"), "value").await?;
 
     // Subscribe to the value and see if it flows through!
-    value::subscribe(ctx, value_av_id, [(other_component_id, "/domain/Value")]).await?;
+    value::subscribe(
+        ctx,
+        ("subscriber", "/domain/Value"),
+        [("source", "/domain/Value")],
+    )
+    .await?;
     change_set::commit(ctx).await?;
     assert_eq!(
-        Some(json!("value")),
-        AttributeValue::view_by_id(ctx, value_av_id).await?
+        json!("value"),
+        value::get(ctx, ("subscriber", "/domain/Value")).await?
     );
 
     // Update the value and watch the new value flow through!
-    value::set(ctx, ("other", "/domain/Value"), "value_2").await?;
+    value::set(ctx, ("source", "/domain/Value"), "value_2").await?;
     change_set::commit(ctx).await?;
     assert_eq!(
-        Some(json!("value_2")),
-        AttributeValue::view_by_id(ctx, value_av_id).await?
+        json!("value_2"),
+        value::get(ctx, ("subscriber", "/domain/Value")).await?
     );
 
     // Unset the value and watch it flow through!
-    value::unset(ctx, ("other", "/domain/Value")).await?;
+    value::unset(ctx, ("source", "/domain/Value")).await?;
     change_set::commit(ctx).await?;
-    assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
+    assert!(!value::has_value(ctx, ("subscriber", "/domain/Value")).await?);
 
     Ok(())
 }
@@ -123,7 +120,7 @@ async fn subscribe_to_array_element(ctx: &mut DalContext) -> Result<()> {
     create_testy_variant(ctx).await?;
 
     // Create a component with a Value prop
-    let component_id = component::create(ctx, "testy", "testy").await?;
+    let component_id = component::create(ctx, "testy", "subscriber").await?;
     let value_av_id =
         Component::attribute_value_for_prop(ctx, component_id, &["root", "domain", "Value"])
             .await?;
@@ -133,12 +130,12 @@ async fn subscribe_to_array_element(ctx: &mut DalContext) -> Result<()> {
     AttributeValue::insert(ctx, values_av_id, Some(json!("a")), None).await?;
     AttributeValue::insert(ctx, values_av_id, Some(json!("b")), None).await?;
     AttributeValue::insert(ctx, values_av_id, Some(json!("c")), None).await?;
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    change_set::commit(ctx).await?;
     assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
 
     // Subscribe to a specific index and watch the value come through!
     value::subscribe(ctx, value_av_id, [(component_id, "/domain/Values/1")]).await?;
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    change_set::commit(ctx).await?;
     assert_eq!(
         Some(json!("b")),
         AttributeValue::view_by_id(ctx, value_av_id).await?
@@ -149,7 +146,7 @@ async fn subscribe_to_array_element(ctx: &mut DalContext) -> Result<()> {
     AttributeValue::insert(ctx, values_av_id, Some(json!("a_2")), None).await?;
     AttributeValue::insert(ctx, values_av_id, Some(json!("b_2")), None).await?;
     AttributeValue::insert(ctx, values_av_id, Some(json!("c_2")), None).await?;
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    change_set::commit(ctx).await?;
     assert_eq!(
         Some(json!("b_2")),
         AttributeValue::view_by_id(ctx, value_av_id).await?
@@ -157,7 +154,7 @@ async fn subscribe_to_array_element(ctx: &mut DalContext) -> Result<()> {
 
     // // Update the array with fewer values and watch the value disappear!
     // AttributeValue::update(ctx, values_av_id, Some(json!(["a_3"]))).await?;
-    // ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    // change_set::commit(ctx).await?;
     // assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
 
     Ok(())
@@ -169,7 +166,7 @@ async fn subscribe_to_map_element(ctx: &mut DalContext) -> Result<()> {
     create_testy_variant(ctx).await?;
 
     // Create a component with a Value prop
-    let component_id = component::create(ctx, "testy", "testy").await?;
+    let component_id = component::create(ctx, "testy", "subscriber").await?;
     let value_av_id =
         Component::attribute_value_for_prop(ctx, component_id, &["root", "domain", "Value"])
             .await?;
@@ -179,19 +176,19 @@ async fn subscribe_to_map_element(ctx: &mut DalContext) -> Result<()> {
     AttributeValue::insert(ctx, value_map_av_id, Some(json!("a")), Some("A".to_owned())).await?;
     AttributeValue::insert(ctx, value_map_av_id, Some(json!("b")), Some("B".to_owned())).await?;
     AttributeValue::insert(ctx, value_map_av_id, Some(json!("c")), Some("C".to_owned())).await?;
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    change_set::commit(ctx).await?;
     assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
 
     // Subscribe to a specific index and watch the value come through!
     value::subscribe(ctx, value_av_id, [(component_id, "/domain/ValueMap/B")]).await?;
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    change_set::commit(ctx).await?;
     assert_eq!(
         Some(json!("b")),
         AttributeValue::view_by_id(ctx, value_av_id).await?
     );
 
     // Update the map value and watch the new value come through!
-    value::set(ctx, ("testy", "/domain/ValueMap/B"), "b_2").await?;
+    value::set(ctx, ("subscriber", "/domain/ValueMap/B"), "b_2").await?;
     AttributeValue::insert(
         ctx,
         value_map_av_id,
@@ -199,7 +196,7 @@ async fn subscribe_to_map_element(ctx: &mut DalContext) -> Result<()> {
         Some("B".to_owned()),
     )
     .await?;
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    change_set::commit(ctx).await?;
     assert_eq!(
         Some(json!("b_2")),
         AttributeValue::view_by_id(ctx, value_av_id).await?
@@ -207,7 +204,7 @@ async fn subscribe_to_map_element(ctx: &mut DalContext) -> Result<()> {
 
     // // Remove the map value and watch the value disappear!
     // AttributeValue::insert(ctx, value_map_av_id, None, Some("B".to_owned())).await?;
-    // ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    // change_set::commit(ctx).await?;
     // assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
 
     Ok(())
@@ -219,54 +216,58 @@ async fn subscribe_to_two_values(ctx: &mut DalContext) -> Result<()> {
     create_testy_variant(ctx).await?;
 
     // Create a component with a Value prop
-    let component_id = component::create(ctx, "testy", "testy").await?;
-    let value_av_id =
-        Component::attribute_value_for_prop(ctx, component_id, &["root", "domain", "Value"])
-            .await?;
-    let value2_av_id =
-        Component::attribute_value_for_prop(ctx, component_id, &["root", "domain", "Value2"])
-            .await?;
+    component::create(ctx, "testy", "subscriber").await?;
     change_set::commit(ctx).await?;
-    assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
-    assert_eq!(None, AttributeValue::view_by_id(ctx, value2_av_id).await?);
+    assert!(!value::has_value(ctx, ("subscriber", "/domain/Value")).await?);
+    assert!(!value::has_value(ctx, ("subscriber", "/domain/Value2")).await?);
 
     // Create another component
-    let other_component_id = component::create(ctx, "testy", "other").await?;
-    value::set(ctx, ("other", "/domain/Value"), "value").await?;
-    value::set(ctx, ("other", "/domain/Value2"), "value2").await?;
+    component::create(ctx, "testy", "source").await?;
+    value::set(ctx, ("source", "/domain/Value"), "value").await?;
+    value::set(ctx, ("source", "/domain/Value2"), "value2").await?;
 
     // Subscribe to the values and see if it flows through!
-    value::subscribe(ctx, value_av_id, [(other_component_id, "/domain/Value")]).await?;
-    value::subscribe(ctx, value2_av_id, [(other_component_id, "/domain/Value2")]).await?;
+    value::subscribe(
+        ctx,
+        ("subscriber", "/domain/Value"),
+        [("source", "/domain/Value")],
+    )
+    .await?;
+    value::subscribe(
+        ctx,
+        ("subscriber", "/domain/Value2"),
+        [("source", "/domain/Value2")],
+    )
+    .await?;
     change_set::commit(ctx).await?;
     assert_eq!(
-        Some(json!("value")),
-        AttributeValue::view_by_id(ctx, value_av_id).await?
+        json!("value"),
+        value::get(ctx, ("subscriber", "/domain/Value")).await?
     );
     assert_eq!(
-        Some(json!("value2")),
-        AttributeValue::view_by_id(ctx, value2_av_id).await?
+        json!("value2"),
+        value::get(ctx, ("subscriber", "/domain/Value2")).await?
     );
 
     // Update the values and watch them flow through!
-    value::set(ctx, ("other", "/domain/Value"), "value_2").await?;
-    value::set(ctx, ("other", "/domain/Value2"), "value2_2").await?;
+    value::set(ctx, ("source", "/domain/Value"), "value_2").await?;
+    value::set(ctx, ("source", "/domain/Value2"), "value2_2").await?;
     change_set::commit(ctx).await?;
     assert_eq!(
-        Some(json!("value_2")),
-        AttributeValue::view_by_id(ctx, value_av_id).await?
+        json!("value_2"),
+        value::get(ctx, ("subscriber", "/domain/Value")).await?
     );
     assert_eq!(
-        Some(json!("value2_2")),
-        AttributeValue::view_by_id(ctx, value2_av_id).await?
+        json!("value2_2"),
+        value::get(ctx, ("subscriber", "/domain/Value2")).await?
     );
 
     // Unset the values and watch them flow through!
-    value::unset(ctx, ("other", "/domain/Value")).await?;
-    value::unset(ctx, ("other", "/domain/Value2")).await?;
+    value::unset(ctx, ("source", "/domain/Value")).await?;
+    value::unset(ctx, ("source", "/domain/Value2")).await?;
     change_set::commit(ctx).await?;
-    assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
-    assert_eq!(None, AttributeValue::view_by_id(ctx, value2_av_id).await?);
+    assert!(!value::has_value(ctx, ("subscriber", "/domain/Value")).await?);
+    assert!(!value::has_value(ctx, ("subscriber", "/domain/Value2")).await?);
 
     Ok(())
 }
@@ -276,70 +277,54 @@ async fn delete_component_with_subscriptions_correction(ctx: &mut DalContext) ->
     create_testy_variant(ctx).await?;
 
     // Create a component with a Value prop
-    let component_id = component::create(ctx, "testy", "testy").await?;
-    let value_av_id =
-        Component::attribute_value_for_prop(ctx, component_id, &["root", "domain", "Value"])
-            .await?;
-    let value2_av_id =
-        Component::attribute_value_for_prop(ctx, component_id, &["root", "domain", "Value2"])
-            .await?;
+    component::create(ctx, "testy", "subscriber").await?;
 
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
-    assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
+    change_set::commit(ctx).await?;
+    assert!(!value::has_value(ctx, ("subscriber", "/domain/Value")).await?);
 
     // Create another component
-    let other_component_id = component::create(ctx, "testy", "other").await?;
-    let other_value_av_id =
-        Component::attribute_value_for_prop(ctx, component_id, &["root", "domain", "Value"])
-            .await?;
-    AttributeValue::update(ctx, other_value_av_id, Some(json!("value"))).await?;
+    let source_id = component::create(ctx, "testy", "source").await?;
+    value::set(ctx, ("subscriber", "/domain/Value"), "value").await?;
 
     // Subscribe to the values and see if it flows through!
-    value::subscribe(ctx, value_av_id, [(other_component_id, "/domain/Value")]).await?;
+    value::subscribe(
+        ctx,
+        ("subscriber", "/domain/Value"),
+        [("source", "/domain/Value")],
+    )
+    .await?;
 
-    let other_component_root_av_id =
-        Component::root_attribute_value_id(ctx, other_component_id).await?;
+    let source_root_id = Component::root_attribute_value_id(ctx, source_id).await?;
 
     ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
 
     let cs_1 = ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
 
-    value::subscribe(ctx, value2_av_id, [(other_component_id, "/domain/Value2")]).await?;
+    value::subscribe(
+        ctx,
+        ("subscriber", "/domain/Value2"),
+        [("source", "/domain/Value2")],
+    )
+    .await?;
 
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    change_set::commit(ctx).await?;
 
     let _cs_2 = ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
 
-    Component::remove(ctx, other_component_id).await?;
+    Component::remove(ctx, source_id).await?;
 
     ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
 
-    assert!(
-        !ctx.workspace_snapshot()?
-            .node_exists(other_component_id)
-            .await
-    );
+    assert!(!ctx.workspace_snapshot()?.node_exists(source_id).await);
 
-    assert!(
-        !ctx.workspace_snapshot()?
-            .node_exists(other_component_root_av_id)
-            .await
-    );
+    assert!(!ctx.workspace_snapshot()?.node_exists(source_root_id).await);
 
     ctx.update_visibility_and_snapshot_to_visibility(cs_1.id)
         .await?;
 
-    assert!(
-        !ctx.workspace_snapshot()?
-            .node_exists(other_component_id)
-            .await
-    );
+    assert!(!ctx.workspace_snapshot()?.node_exists(source_id).await);
 
-    assert!(
-        !ctx.workspace_snapshot()?
-            .node_exists(other_component_root_av_id)
-            .await
-    );
+    assert!(!ctx.workspace_snapshot()?.node_exists(source_root_id).await);
 
     Ok(())
 }
@@ -558,7 +543,7 @@ async fn delete_subscribed_to_array_item(ctx: &mut DalContext) -> Result<()> {
     );
 
     // Delete source array item and validated that the null value has been propagated
-    AttributeValue::remove_by_id(
+    AttributeValue::remove(
         ctx,
         ("input", "/domain/Values/0")
             .lookup_attribute_value(ctx)
@@ -630,6 +615,52 @@ async fn subscribe_with_custom_function(ctx: &mut DalContext) -> Result<()> {
     assert_eq!(
         json!("test value, but better"),
         value::get(ctx, ("subscriber", "/domain/Value")).await?
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn remove_subscribed_component(ctx: &mut DalContext) -> Result<()> {
+    create_testy_variant(ctx).await?;
+
+    // Create a component with a Value prop
+    component::create(ctx, "testy", "subscriber").await?;
+    change_set::commit(ctx).await?;
+    assert!(!value::has_value(ctx, ("subscriber", "/domain/Value")).await?);
+
+    // Create another component and subscribe to its values
+    let source_id = component::create(ctx, "testy", "source").await?;
+    value::set(ctx, ("source", "/domain/Value"), "value").await?;
+    value::subscribe(
+        ctx,
+        ("subscriber", "/domain/Value"),
+        [("source", "/domain/Value")],
+    )
+    .await?;
+    change_set::commit(ctx).await?;
+    assert_eq!(
+        json!("value"),
+        value::get(ctx, ("subscriber", "/domain/Value")).await?
+    );
+
+    // Remove the source component and make sure the subscriber value is unset
+    Component::remove(ctx, source_id).await?;
+    change_set::commit(ctx).await?;
+    assert!(!value::has_value(ctx, ("subscriber", "/domain/Value")).await?);
+
+    // Make sure the graph looks like what we want: the subscriber has a prototype with zero
+    // arguments.
+    let av_id = ("subscriber", "/domain/Value")
+        .lookup_attribute_value(ctx)
+        .await?;
+    let prototype_id = AttributeValue::component_prototype_id(ctx, av_id)
+        .await?
+        .expect("should still have a prototype after subscription is removed");
+    assert!(
+        AttributePrototype::list_arguments(ctx, prototype_id)
+            .await?
+            .is_empty()
     );
 
     Ok(())

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -188,7 +188,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
     // ======================================================
 
     // Remove an item from the array prop
-    AttributeValue::remove_by_id(ctx, parrot_names_third_item.id())
+    AttributeValue::remove(ctx, parrot_names_third_item.id())
         .await
         .expect("remove the third item in parrot_names array");
     let parrot_names_child_ids =
@@ -240,7 +240,7 @@ async fn array_map_manipulation(ctx: &DalContext) {
     // ======================================================
 
     // Remove an item from the map prop
-    AttributeValue::remove_by_id(ctx, treasure_second_item.id())
+    AttributeValue::remove(ctx, treasure_second_item.id())
         .await
         .expect("remove the second item in treasure map");
     let treasure_child_ids = AttributeValue::get_child_av_ids_in_order(ctx, treasure_map_value_id)

--- a/lib/sdf-server/src/service/v2/change_set/validate_snapshot.rs
+++ b/lib/sdf-server/src/service/v2/change_set/validate_snapshot.rs
@@ -103,7 +103,7 @@ async fn fix_issue(ctx: &DalContext, issue: &ValidationIssue) -> Result<bool> {
         &ValidationIssue::DuplicateAttributeValue { duplicate, .. }
         | &ValidationIssue::DuplicateAttributeValueWithDifferentValues { duplicate, .. } => {
             // These are extra, so we remove them (which will also enqueue subscribers to DVU!)
-            AttributeValue::remove_by_id(ctx, duplicate).await?;
+            AttributeValue::remove(ctx, duplicate).await?;
             true
         }
         ValidationIssue::MultipleValues { .. }

--- a/lib/sdf-v1-routes-component/src/delete_property_editor_value.rs
+++ b/lib/sdf-v1-routes-component/src/delete_property_editor_value.rs
@@ -43,7 +43,7 @@ pub async fn delete_property_editor_value(
 
     let force_change_set_id = ChangeSet::force_new(&mut ctx).await?;
 
-    AttributeValue::remove_by_id(&ctx, request.attribute_value_id).await?;
+    AttributeValue::remove(&ctx, request.attribute_value_id).await?;
 
     let component = Component::get_by_id(&ctx, request.component_id).await?;
     let mut socket_map = HashMap::new();


### PR DESCRIPTION
Right now, when you remove a component, any subscribing components will get into an invalid graph state where the subscription APA has no value edge. This causes downstream errors with some operations that check for this.

This PR fixes this by removing subscriber APAs pointing directly at an AV when that AV is removed. Subscribers should have the same value they would have if the subscription to was to an array element and the array element was removed.

### Factor Budget

A couple of small factors here:

- AttributeValue::remove_by_id -> AttributeValue::remove (it is accepted and often preferred for DAL methods to take IDs instead of self, so more and more _by_id will go away in the coming months). This was a pure rename, no changes to callers or to the function itself.
- subscription tests use idiomatic APIs -- this revealed some test bugs where we weren't really testing what we thought we were (when you have to actually type the word "subscriber" instead of component_id, it makes it clear exactly what you expected to happen).

## How was it tested?

- [X] Integration tests pass
- [X] New integration test for removing a subcribed component
- [x] Manual test: delete subscribed component, then try to duplicate the subscriber. See no errors.

## In short: [:link:](https://giphy.com/)

![subscription cancelled](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2F4ZXNicTM5cjE0cjVrMzZqMDUzZG1rcjZsOGU1M3BkMHN4NWw4dyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l4EoVjdsvoCMsjr7W/giphy.gif)
