### PR TITLE
feat(clover): Add specific prop suggestion for region pros

### DIFF
--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -39,6 +39,7 @@ import {
 import { removeBadDocLinks } from "../pipeline-steps/removeBadDocLinks.ts";
 import { reorderProps } from "../pipeline-steps/reorderProps.ts";
 import { createSuggestionsForPrimaryIdentifiers } from "../pipeline-steps/createSuggestionsAcrossAssets.ts";
+import { createAwsRegionSpecificSuggestion } from "../pipeline-steps/awsRegionSpecificSuggestions.ts";
 
 const logger = _logger.ns("siSpecs").seal();
 const SI_SPEC_DIR = "si-specs";
@@ -102,6 +103,7 @@ export async function generateSiSpecs(
   // this step will eventually replace all the socket stuff. Must come before
   // overrides so it can be... overriden
   specs = createSuggestionsForPrimaryIdentifiers(specs);
+  specs = createAwsRegionSpecificSuggestion(specs);
 
   // Our overrides right now only run after the prop tree and the sockets are generated
   specs = assetSpecificOverrides(specs);

--- a/bin/clover/src/pipeline-steps/awsRegionSpecificSuggestions.ts
+++ b/bin/clover/src/pipeline-steps/awsRegionSpecificSuggestions.ts
@@ -1,0 +1,42 @@
+import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+import { addPropSuggestSource, ExpandedPropSpecFor, findPropByName } from "../spec/props.ts";
+
+// We want to ensure that the first suggestion for any region
+// prop in the generated assets have a suggestion of a Region schema
+// and prop /domain/region
+// This ensures that we can keep things easy to compose using the new
+// suggestions format
+export function createAwsRegionSpecificSuggestion(
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const newSpecs = [] as ExpandedPkgSpec[];
+  for (const spec of specs) {
+    const [schema] = spec.schemas;
+    const [schemaVariant] = schema.variants;
+
+    const domainProp = schemaVariant.domain;
+    const extraProp = findPropByName(domainProp, "extra");
+    if (!extraProp) {
+      newSpecs.push(spec);
+      continue;
+    }
+
+    let regionProp = findPropByName(
+      extraProp as ExpandedPropSpecFor["object"],
+      "Region",
+    );
+    if (!regionProp) {
+      newSpecs.push(spec);
+      continue;
+    }
+    
+    regionProp = addPropSuggestSource(regionProp, {
+      schema: "Region",
+      prop: "/domain/region"
+    })
+    
+    newSpecs.push(spec)
+  }
+
+  return newSpecs;
+}


### PR DESCRIPTION
We are adding a specific prop suggestion for `domain/extra/Region` to point to `Region:/domain/region`

The VPC Component has no suggestion yet EC2 Instance does and you can see the suggestion sorting in the tree

![Screenshot 2025-06-19 at 17 28 47](https://github.com/user-attachments/assets/6a752b5a-56e6-4b3c-abf4-1c3ee28d128b)

![Screenshot 2025-06-19 at 17 28 30](https://github.com/user-attachments/assets/5e894aea-5eb8-42b6-b6e2-4344cea0b42e)
