### PR TITLE
feat(sdf): Adding a v2 endpoint for being able to set what a component can manage

### DIFF
--- a/lib/sdf-server/src/service/v2/component.rs
+++ b/lib/sdf-server/src/service/v2/component.rs
@@ -24,6 +24,7 @@ use crate::app_state::AppState;
 
 pub mod attributes;
 pub mod delete_components;
+pub mod manage;
 pub mod name;
 pub mod restore_components;
 pub mod secrets;
@@ -97,7 +98,8 @@ pub fn v2_routes() -> Router<AppState> {
             Router::new()
                 .nest("/attributes", attributes::v2_routes())
                 .nest("/name", name::v2_routes())
-                .nest("/secret", secrets::v2_routes()),
+                .nest("/secret", secrets::v2_routes())
+                .nest("/manage", manage::v2_routes()),
         )
 }
 

--- a/lib/sdf-server/src/service/v2/component/manage.rs
+++ b/lib/sdf-server/src/service/v2/component/manage.rs
@@ -1,0 +1,59 @@
+use axum::{
+    Json,
+    Router,
+    extract::Path,
+    routing::post,
+};
+use dal::{
+    ChangeSet,
+    Component,
+    ComponentId,
+};
+use sdf_core::force_change_set_response::ForceChangeSetResponse;
+use sdf_extract::{
+    PosthogEventTracker,
+    change_set::ChangeSetDalContext,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use super::{
+    ComponentIdFromPath,
+    Result,
+};
+use crate::app_state::AppState;
+
+pub fn v2_routes() -> Router<AppState> {
+    Router::new().route("/", post(manage_component))
+}
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ManageComponentRequest {
+    pub component_id: ComponentId,
+}
+
+async fn manage_component(
+    ChangeSetDalContext(ref mut ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    Path(ComponentIdFromPath { component_id }): Path<ComponentIdFromPath>,
+    Json(payload): Json<ManageComponentRequest>,
+) -> Result<ForceChangeSetResponse<()>> {
+    let force_change_set_id = ChangeSet::force_new(ctx).await?;
+    Component::manage_component(ctx, component_id, payload.component_id).await?;
+
+    ctx.commit().await?;
+
+    tracker.track(
+        ctx,
+        "manage_component",
+        serde_json::json!({
+            "how": "/component/manage",
+            "manager_component_id": component_id,
+            "managed_component_id": payload.component_id,
+        }),
+    );
+
+    Ok(ForceChangeSetResponse::empty(force_change_set_id))
+}


### PR DESCRIPTION
This allows you to use a componentId and then /manage and a componentId to put under management