### PR TITLE
fix(edda): Ensure new management edges propagate to the front end

### DIFF
--- a/lib/dal-materialized-views/src/incoming_connections.rs
+++ b/lib/dal-materialized-views/src/incoming_connections.rs
@@ -124,10 +124,10 @@ async fn prop_to_prop(ctx: &DalContext, component_id: ComponentId) -> Result<Vec
 async fn management(ctx: &DalContext, component_id: ComponentId) -> Result<Vec<Connection>> {
     let mut connections = Vec::new();
 
-    for manager_component_id in Component::managers_by_id(ctx, component_id).await? {
+    for managed_component_id in Component::get_managed_by_id(ctx, component_id).await? {
         connections.push(Connection::Management {
-            from_component_id: manager_component_id,
-            to_component_id: component_id,
+            from_component_id: component_id,
+            to_component_id: managed_component_id,
         })
     }
 

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -4264,12 +4264,23 @@ impl Component {
 
     /// Return the ids of all the components managed by this component
     pub async fn get_managed(&self, ctx: &DalContext) -> ComponentResult<Vec<ComponentId>> {
+        Self::get_managed_by_id(ctx, self.id()).await
+    }
+
+    /// Return the ids of all the components managed by this component
+    pub async fn get_managed_by_id(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<Vec<ComponentId>> {
         let mut result = vec![];
 
         let snapshot = ctx.workspace_snapshot()?;
 
         for target_idx in snapshot
-            .outgoing_targets_for_edge_weight_kind(self.id, EdgeWeightKindDiscriminants::Manages)
+            .outgoing_targets_for_edge_weight_kind(
+                component_id,
+                EdgeWeightKindDiscriminants::Manages,
+            )
             .await?
         {
             let node_weight = snapshot.get_node_weight(target_idx).await?;


### PR DESCRIPTION
The IncomingConnections MV currently includes both management connections and prop to prop connections.  The management edges were backwards in this MV, which meant that when a new management edge was created (Component A -> Manages -> Component B), the component that gets triggered to rebuild is the one newly under management (Component B), only when building this MV, we're asking about the managed components (Component B -> Manages -> GO FIND THEM, SORRY NO NEW ONES SO NO PATCH), not the managing components (GO FIND THEM BECAUSE THERE IS A NEW ONE NOW -> Manages -> Component B).

<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?
After this change, when a new management connection (Component A -> Manages -> Component B) is created, when Component B is triggered to rebuild, the new management connection is included and a patch is sent!
<!-- Why: briefly what problem this solves and what the aim is as an overview -->


## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->

- Manually tested by creating a new management connection, and seeing that a patch is sent (whereas before, when adding a new management connection, no patch is sent), as well as seeing the front end update to reflect this new data!

<div><img src="https://media4.giphy.com/media/6vzwF4HgszGBLiOvdq/giphy.gif?cid=5a38a5a2ka88fme7miwucbe4tkihchu491db8uo88vcdf4wu&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/channel/DudeDad/">Dude Dad</a> on <a href="https://giphy.com/gifs/karen-dude-dad-let-me-talk-to-your-manager-6vzwF4HgszGBLiOvdq">GIPHY</a></div>
