### PR TITLE
feat(web) - revamped management panel in progress

### DIFF
--- a/app/web/src/components/QualificationViewerSingle.vue
+++ b/app/web/src/components/QualificationViewerSingle.vue
@@ -73,7 +73,11 @@
         "
         class="text-right"
       >
-        <button class="underline text-action-400" @click="toggleHidden">
+        <button
+          tabindex="-1"
+          class="underline text-action-400"
+          @click="toggleHidden"
+        >
           {{ showDetails ? "Hide" : "View" }} Details
         </button>
       </div>

--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -61,12 +61,14 @@
             :class="
               clsx(
                 'h-lg p-xs text-sm border font-mono cursor-text',
+                'focus:outline-none focus:ring-0 focus:z-10',
                 themeClasses(
-                  'text-shade-100 bg-white border-neutral-400',
-                  'text-shade-0 bg-black border-neutral-600',
+                  'text-shade-100 bg-white border-neutral-400 focus:border-action-500',
+                  'text-shade-0 bg-black border-neutral-600 focus:border-action-300',
                 ),
               )
             "
+            tabindex="0"
             type="text"
             @blur="blurNameInput"
             @input="
@@ -643,8 +645,10 @@ const required = ({ value }: { value: string | undefined }) => {
 };
 
 const resetNameInput = () => {
-  if (nameForm.state.isSubmitted || nameForm.state.isDirty)
+  if (nameForm.state.isSubmitted || nameForm.state.isDirty) {
     nameForm.reset(nameFormData.value);
+  }
+  nameInputRef.value?.blur();
 };
 
 const blurNameInput = () => {

--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -133,20 +133,11 @@
           />
         </CollapsingFlexItem>
         <CollapsingFlexItem ref="mgmtRef" :expandable="false">
-          <template #header>Management Functions</template>
-          <ul v-if="mgmtFuncs.length > 0" class="p-xs flex flex-col gap-xs">
-            <ManagementFuncCard
-              v-for="func in mgmtFuncs"
-              :key="func.id"
-              :componentId="componentId"
-              :func="func"
-              :funcRun="latestFuncRuns[func.id]"
-            />
-          </ul>
-          <EmptyState
-            v-else
-            text="No management functions available"
-            icon="tools"
+          <template #header>Management</template>
+          <ManagementPanel
+            :component="component"
+            :latestFuncRuns="latestFuncRuns"
+            :connections="componentConnections ?? undefined"
           />
         </CollapsingFlexItem>
       </div>
@@ -268,7 +259,6 @@ import {
 } from "@/workers/types/entity_kind_types";
 import { Context, assertIsDefined } from "@/newhotness/types";
 import { FuncRun } from "@/newhotness/api_composables/func_run";
-import ManagementFuncCard from "@/newhotness/ManagementFuncCard.vue";
 import { useRealtimeStore } from "@/store/realtime/realtime.store";
 import AttributePanel from "./AttributePanel.vue";
 import { attributeEmitter, keyEmitter } from "./logic_composables/emitters";
@@ -285,6 +275,7 @@ import ActionsPanel from "./ActionsPanel.vue";
 import ConnectionsPanel from "./ConnectionsPanel.vue";
 import DocumentationPanel from "./DocumentationPanel.vue";
 import EmptyState from "./EmptyState.vue";
+import ManagementPanel from "./ManagementPanel.vue";
 
 const props = defineProps<{
   componentId: string;

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -105,8 +105,8 @@
               "
               @blur="slotProps.blur"
               @keydown.tab="(e: KeyboardEvent) => onTab(e, true)"
-              @keydown.left="() => previousComponent()"
-              @keydown.right="() => nextComponent()"
+              @keydown.left="onArrowLeft"
+              @keydown.right="onArrowRight"
               @keydown.up="onArrowUp"
               @keydown.down="onArrowDown"
               @keydown.esc="onEscape"
@@ -233,7 +233,12 @@
       <div class="grow grid grid-rows-subgrid" :style="collapsingStyles">
         <CollapsingGridItem ref="actionsRef">
           <template #header>Actions ({{ actionViewList.length }})</template>
-          <ul class="actions list">
+          <EmptyState
+            v-if="actionViewList.length === 0"
+            icon="tools"
+            text="No actions to display"
+          />
+          <ul v-else class="actions list">
             <ActionCard
               v-for="action in actionViewList"
               :key="action.id"
@@ -539,7 +544,11 @@ const updateDebouncedSearch = _.debounce(
 );
 
 // Watch for changes to fuzzySearchString and update the debounced version
-watch(searchString, (newValue) => {
+watch(searchString, (newValue, oldValue) => {
+  if (oldValue === "" && newValue === null) {
+    // this is not a real change in the search string!
+    return;
+  }
   updateDebouncedSearch(newValue);
   mapRef.value?.deselect();
   unfocus();
@@ -711,7 +720,6 @@ const focus = (componentId: ComponentId) => {
 };
 const unfocus = () => {
   focusedComponentId.value = undefined;
-
   selectorGridPosition.value = focusGridPosition.value;
   focusGridPosition.value = -1;
   componentContextMenuRef.value?.close();

--- a/app/web/src/newhotness/FuncRunList.vue
+++ b/app/web/src/newhotness/FuncRunList.vue
@@ -46,12 +46,12 @@
       </div>
 
       <!-- Empty state -->
-      <div
+      <EmptyState
         v-if="funcRuns.length === 0 && !isLoading"
-        class="py-4 text-center text-neutral-500"
-      >
-        No function runs found
-      </div>
+        text="No function runs found"
+        icon="func"
+        class="m-xs"
+      />
     </div>
   </div>
 </template>
@@ -66,6 +66,7 @@ import FuncRunCard from "./FuncRunCard.vue";
 import { funcRunTypes, useApi, routes } from "./api_composables";
 import { assertIsDefined, Context } from "./types";
 import { FuncRun } from "./api_composables/func_run";
+import EmptyState from "./EmptyState.vue";
 
 // Component props
 const props = defineProps<{

--- a/app/web/src/newhotness/ManagementEdgeCard.vue
+++ b/app/web/src/newhotness/ManagementEdgeCard.vue
@@ -1,0 +1,28 @@
+<template>
+  <li
+    :class="
+      clsx(
+        'rounded border p-xs',
+        themeClasses('border-neutral-400', 'border-neutral-600'),
+      )
+    "
+  >
+    <!-- TODO(WENDY) - clean this up to display the data better -->
+    {{ ctx.componentNames.value[edge.componentId] ?? edge.componentId }}
+  </li>
+</template>
+
+<script setup lang="ts">
+import { inject, PropType } from "vue";
+import clsx from "clsx";
+import { themeClasses } from "@si/vue-lib/design-system";
+import { SimpleConnection } from "./layout_components/ConnectionLayout.vue";
+import { assertIsDefined, Context } from "./types";
+
+defineProps({
+  edge: { type: Object as PropType<SimpleConnection>, required: true },
+});
+
+const ctx = inject<Context>("CONTEXT");
+assertIsDefined<Context>(ctx);
+</script>

--- a/app/web/src/newhotness/ManagementFuncCard.vue
+++ b/app/web/src/newhotness/ManagementFuncCard.vue
@@ -1,9 +1,21 @@
 <template>
   <li
     v-if="func.kind !== 'import'"
-    class="rounded border border-neutral-600 flex flex-col"
+    :class="
+      clsx(
+        'rounded border flex flex-col',
+        themeClasses('border-neutral-400', 'border-neutral-600'),
+      )
+    "
   >
-    <div class="border-b border-neutral-600 w-full p-xs">
+    <div
+      :class="
+        clsx(
+          'border-b w-full p-xs',
+          themeClasses('border-neutral-400', 'border-neutral-600'),
+        )
+      "
+    >
       {{ func.name }}
     </div>
     <div class="w-full flex place-content-between items-center p-sm">
@@ -22,7 +34,12 @@
     </div>
     <div
       v-if="funcRun"
-      class="m-sm bg-neutral-600 flex items-center gap-xs px-xs py-sm rounded"
+      :class="
+        clsx(
+          'm-sm flex items-center gap-xs px-xs py-sm rounded',
+          themeClasses('bg-neutral-300', 'bg-neutral-700'),
+        )
+      "
     >
       <Icon :name="getIconNameFromFuncRun(funcRun)" class="shrink-0" />
       <span class="grow">
@@ -40,9 +57,15 @@
 </template>
 
 <script setup lang="ts">
-import { Icon, IconNames, VButton } from "@si/vue-lib/design-system";
+import {
+  Icon,
+  IconNames,
+  themeClasses,
+  VButton,
+} from "@si/vue-lib/design-system";
 import { useRoute, useRouter } from "vue-router";
 import { ref } from "vue";
+import clsx from "clsx";
 import { routes, useApi } from "@/newhotness/api_composables";
 import { FuncRun } from "@/newhotness/api_composables/func_run";
 import { MgmtFunction } from "@/workers/types/entity_kind_types";

--- a/app/web/src/newhotness/ManagementPanel.vue
+++ b/app/web/src/newhotness/ManagementPanel.vue
@@ -1,0 +1,137 @@
+<template>
+  <ul
+    v-if="componentId && latestFuncRuns && managementData"
+    class="p-xs flex flex-col gap-xs"
+  >
+    <li v-if="mgmtFuncs.length > 0" class="text-lg font-bold">Functions:</li>
+    <ManagementFuncCard
+      v-for="func in mgmtFuncs"
+      :key="func.id"
+      :componentId="componentId"
+      :func="func"
+      :funcRun="latestFuncRuns[func.id]"
+    />
+    <li v-if="incoming.length > 0" class="text-lg font-bold">
+      Managed By Components:
+    </li>
+    <ManagementEdgeCard v-for="edge in incoming" :key="edge.key" :edge="edge" />
+    <li v-if="outgoing.length > 0" class="text-lg font-bold">
+      Managing Components:
+    </li>
+    <ManagementEdgeCard v-for="edge in outgoing" :key="edge.key" :edge="edge" />
+  </ul>
+  <EmptyState v-else text="No management information available" icon="tools" />
+</template>
+
+<script setup lang="ts">
+import { computed, PropType } from "vue";
+import { useQuery } from "@tanstack/vue-query";
+import { FuncRun } from "@/newhotness/api_composables/func_run";
+import {
+  IncomingConnections,
+  Connection,
+  EntityKind,
+  BifrostComponent,
+} from "@/workers/types/entity_kind_types";
+import {
+  bifrost,
+  getOutgoingConnections,
+  useMakeArgs,
+  useMakeKey,
+} from "@/store/realtime/heimdall";
+import EmptyState from "./EmptyState.vue";
+import ManagementFuncCard from "./ManagementFuncCard.vue";
+import { SimpleConnection } from "./layout_components/ConnectionLayout.vue";
+import ManagementEdgeCard from "./ManagementEdgeCard.vue";
+
+const props = defineProps({
+  component: { type: Object as PropType<BifrostComponent> },
+  latestFuncRuns: { type: Object as PropType<Record<string, FuncRun>> },
+  connections: { type: Object as PropType<IncomingConnections> },
+});
+
+const mgmtFuncs = computed(
+  () => props.component?.schemaVariant.mgmtFunctions ?? [],
+);
+
+const key = useMakeKey();
+const args = useMakeArgs();
+
+const componentId = computed(() => props.component?.id);
+const enableLookup = computed(
+  () => !(props.connections && "id" in props.connections),
+);
+
+const componentConnectionsQuery = useQuery<IncomingConnections | null>({
+  enabled: enableLookup,
+  queryKey: key(EntityKind.IncomingConnections, componentId.value),
+  queryFn: async () => {
+    const componentConnections = await bifrost<IncomingConnections>(
+      args(EntityKind.IncomingConnections, componentId.value),
+    );
+    return componentConnections;
+  },
+});
+
+const outgoingQuery = useQuery<Connection[]>({
+  queryKey: key(EntityKind.OutgoingConnections),
+  queryFn: async () => {
+    const byComponents = await getOutgoingConnections(
+      args(EntityKind.OutgoingConnections),
+    );
+    if (!componentId.value) return [];
+    const mine = byComponents.get(componentId.value);
+    if (!mine) return [];
+    return Object.values(mine);
+  },
+});
+
+const componentConnections = computed(() => {
+  if (enableLookup.value && componentConnectionsQuery.data.value) {
+    const { connections: incoming } = componentConnectionsQuery.data.value;
+    return { incoming };
+  } else if (props.connections) {
+    const { connections: incoming } = props.connections;
+    return { incoming };
+  } else {
+    return {
+      incoming: [] as Connection[],
+    };
+  }
+});
+
+const incoming = computed(
+  () =>
+    componentConnections.value.incoming
+      .filter((conn) => conn.kind === "management")
+      .map((conn) => {
+        return {
+          key: `mgmt-${conn.toComponentId}-${conn.fromComponentId}`,
+          componentId: conn.fromComponentId,
+          self: "Management",
+          other: "-",
+        };
+      }) ?? ([] as SimpleConnection[]),
+);
+
+const outgoing = computed<SimpleConnection[]>(() => {
+  const outgoing = outgoingQuery.data?.value ?? [];
+  return outgoing
+    .filter((conn) => conn.kind === "management")
+    .map((conn) => {
+      return {
+        key: `mgmt-${conn.toComponentId}-${conn.fromComponentId}`,
+        componentId: conn.fromComponentId,
+        self: "Management",
+        other: "-",
+      };
+    });
+});
+
+const managementData = computed(
+  () =>
+    mgmtFuncs.value.length > 0 ||
+    incoming.value.length > 0 ||
+    outgoing.value.length > 0,
+);
+</script>

--- a/app/web/src/newhotness/QualificationView.vue
+++ b/app/web/src/newhotness/QualificationView.vue
@@ -34,7 +34,11 @@
         v-if="qualification.avId && (qualification.message || output?.length)"
         class="text-right"
       >
-        <button class="underline text-action-400" @click="toggleHidden">
+        <button
+          tabindex="-1"
+          class="underline text-action-400"
+          @click="toggleHidden"
+        >
           {{ showDetails ? "Hide" : "View" }} Details
         </button>
       </div>

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -174,9 +174,10 @@
               :class="
                 clsx(
                   'block w-full h-lg p-xs ml-auto text-sm border font-mono',
+                  'focus:outline-none focus:ring-0 focus:z-10',
                   themeClasses(
-                    'text-shade-100 bg-shade-0 border-neutral-400',
-                    'text-shade-0 bg-shade-100 border-neutral-600',
+                    'text-shade-100 bg-shade-0 border-neutral-400 focus:border-action-500',
+                    'text-shade-0 bg-shade-100 border-neutral-600 focus:border-action-300',
                   ),
                 )
               "

--- a/app/web/src/newhotness/layout_components/FuncRunDetailsLayout.vue
+++ b/app/web/src/newhotness/layout_components/FuncRunDetailsLayout.vue
@@ -15,6 +15,7 @@
     >
       <!-- Back button (smaller with no border) -->
       <button
+        tabindex="-1"
         class="text-neutral-400 hover:text-white mr-xs flex flex-row items-center justify-center"
         aria-label="Back to actions list"
         @click="navigateBack"

--- a/app/web/src/newhotness/layout_components/SecretInput.vue
+++ b/app/web/src/newhotness/layout_components/SecretInput.vue
@@ -2,19 +2,20 @@
   <div
     :class="
       clsx(
-        'flex flex-row items-center border',
+        'flex flex-row items-center border focus-within:z-10',
         themeClasses(
-          'text-black bg-white border-neutral-400',
-          'text-white bg-black border-neutral-600',
+          'text-black bg-white border-neutral-400 focus-within:border-action-500',
+          'text-white bg-black border-neutral-600 focus-within:border-action-300',
         ),
       )
     "
   >
     <input
+      ref="inputRef"
       :class="
         clsx(
           'block h-lg w-full ml-auto font-sm font-mono',
-          'border-transparent focus:outline-none focus:border-transparent focus:ring-0 focus:z-100',
+          'border-transparent focus:outline-none focus:border-transparent focus:ring-0 focus:z-10',
           themeClasses(
             'text-black bg-white disabled:bg-neutral-100',
             'text-white bg-black disabled:bg-neutral-900',
@@ -27,6 +28,7 @@
       tabindex="0"
       :placeholder="placeholder"
       data-1p-ignore
+      @keydown.tab="onTab"
       @input="
       (e) =>
         field.handleChange((e.target as HTMLInputElement).value)
@@ -46,7 +48,7 @@
 <script setup lang="ts">
 import { Icon, themeClasses } from "@si/vue-lib/design-system";
 import clsx from "clsx";
-import { ref } from "vue";
+import { nextTick, ref } from "vue";
 
 defineProps({
   field: { type: Object, required: true },
@@ -70,5 +72,35 @@ const getCurrentFormFieldType = (fieldname: string) => {
 
   if (type === "password" && secretShowing.value) return "text";
   else return type;
+};
+
+const inputRef = ref<HTMLInputElement>();
+const onTab = (e: KeyboardEvent) => {
+  // This allows the user to Tab or Shift+Tab to go through the attribute fields
+  const focusable = Array.from(
+    document.querySelectorAll('[tabindex="0"]'),
+  ) as HTMLElement[];
+  const currentFocus = inputRef.value;
+  if (!currentFocus) return;
+  const index = focusable.indexOf(currentFocus);
+  if (e.shiftKey) {
+    e.preventDefault();
+    nextTick(() => {
+      if (currentFocus && focusable) {
+        if (index > 0) {
+          focusable[index - 1]?.focus();
+        } else {
+          focusable[focusable.length - 1]?.focus();
+        }
+      }
+    });
+  } else if (index === focusable.length - 1) {
+    // When you hit the last attribute, go back to the
+    // fuzzy search instead of searching the document for more things to tab to.
+    e.preventDefault();
+    nextTick(() => {
+      focusable[0]?.focus();
+    });
+  }
 };
 </script>

--- a/lib/vue-lib/src/design-system/general/SiSearch.vue
+++ b/lib/vue-lib/src/design-system/general/SiSearch.vue
@@ -24,12 +24,12 @@
         :placeholder="placeholder"
         :class="
           clsx(
-            'w-full text-xs pl-[32px] py-2xs h-[34px] placeholder:italic outline-offset-[-1px] focus:outline focus:outline-2 focus:outline-action-500',
+            'w-full text-xs pl-[32px] py-2xs h-[34px] placeholder:italic outline-offset-[-1px] focus:outline focus:outline-2',
             dropdownMenuSearch
               ? 'text-white bg-shade-100 placeholder:text-neutral-400 rounded-t-md'
               : themeClasses(
-                  'text-black bg-shade-0 placeholder:text-neutral-500 focus:bg-neutral-50',
-                  'text-white bg-neutral-800 placeholder:text-neutral-400 focus:bg-shade-100',
+                  'text-black bg-shade-0 placeholder:text-neutral-500 focus:bg-neutral-50 focus:outline-action-500',
+                  'text-white bg-neutral-800 placeholder:text-neutral-400 focus:bg-shade-100 focus:outline-action-300',
                 ),
             filtersEnabled ? 'pr-[58px]' : 'pr-[30px]',
           )


### PR DESCRIPTION
## How does this PR change the system?

This is the first piece of revamping the Management panel (previously Management Functions) in the ComponentDetails page in the newhotness. This changes the UI to display management edges within that area of the UI.

This PR also has some bug fixes and UI improvements wrapped in it as well.

#### Screenshots:

![Screenshot 2025-06-20 at 7 01 46 PM](https://github.com/user-attachments/assets/a27639c4-d3c9-4d50-96a0-c2e8acc6c94b)

#### Out of Scope:

The next PR working on this area of the UI will make the list of edges look nicer, allow for clickthrough on components listed, and have a button for adding a management edge.
