### PR TITLE
fix(sdf): Catch Component Not Found

### DIFF
--- a/lib/sdf-server/src/service/v2/management.rs
+++ b/lib/sdf-server/src/service/v2/management.rs
@@ -127,6 +127,9 @@ impl IntoResponse for ManagementApiError {
             ManagementApiError::ManagementPrototype(
                 dal::management::prototype::ManagementPrototypeError::FuncExecutionFailure(message),
             ) => (StatusCode::BAD_REQUEST, message),
+            ManagementApiError::Component(dal::ComponentError::NotFound(_)) => {
+                (StatusCode::NOT_FOUND, self.to_string())
+            }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
         ApiError::new(status_code, error_message).into_response()


### PR DESCRIPTION
When on a component page and the change set was abandoned then we were throwing a 500 toast

We now catch the 404 and redirect correctly to the grid view