### PR TITLE
Fix: stop axios from throwing exceptions on 4/500s... let the caller deal with it

### DIFF
--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -147,6 +147,7 @@ export class APICall<Response> {
       url: this.url(),
       params,
       data,
+      validateStatus: (_status) => true, // don't throw exception on 4/5xxx
     });
     this.obs.inFlight.value = false;
     if (!this.obs.isWatched)


### PR DESCRIPTION
This fixes the "on api error the spinner doesnt stop spinning" because the exception prevents the =false line.

The component which called the API ought to deal with the failure appropriately in the interface
