### PR TITLE
fix(dev): remove mount option that is only supported on Linux

### DIFF
--- a/dev/docker-compose.platform.yml
+++ b/dev/docker-compose.platform.yml
@@ -93,7 +93,7 @@ services:
       - --path.rootfs=/host
     pid: host
     volumes:
-      - /:/host:ro,rslave
+      - /:/host:ro
 
   otelcol:
     #<<: *loki-logged-service


### PR DESCRIPTION
References: prometheus/node_exporter#1509

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlODZkNmZiY2E4Y3F1ZWd4Nm15cXVmNXgxNWZtaG95cjdqOHBjdzFxNCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/McD0cTjsFuxc7tjseu/giphy.gif"/>