### PR TITLE
fix(web): Remove expand-logs button on FuncRunDetails

### DIFF
--- a/app/web/src/newhotness/layout_components/GridItemWithLiveHeader.vue
+++ b/app/web/src/newhotness/layout_components/GridItemWithLiveHeader.vue
@@ -11,7 +11,7 @@
     "
   >
     <div class="flex flex-row items-center justify-between px-sm py-2xs">
-      <h2 class="text-sm font-medium">{{ title }}</h2>
+      <h2 class="text-md font-medium pt-xs pb-xs">{{ title }}</h2>
       <!-- Live updating indicator -->
       <div
         v-if="live"
@@ -20,14 +20,6 @@
         <Icon name="loader" size="xs" class="mr-2xs" />
         Live
       </div>
-      <VButton
-        icon="expand-row"
-        tone="neutral"
-        variant="ghost"
-        size="xs"
-        class="text-neutral-400"
-        aria-label="Expand logs"
-      />
     </div>
     <div class="overflow-auto flex-1 text-sm">
       <slot></slot>
@@ -36,7 +28,7 @@
 </template>
 
 <script setup lang="ts">
-import { VButton, Icon, themeClasses } from "@si/vue-lib/design-system";
+import { Icon, themeClasses } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 
 defineProps<{


### PR DESCRIPTION
This button didn’t do anything so I am removing it as it’s misleading

![Screenshot 2025-06-24 at 11 17 14](https://github.com/user-attachments/assets/90c01c00-b13b-4824-99b4-318a7ec19d8e)
