### PR TITLE
fix: otelcol updated exporter name to debug

### DIFF
--- a/bin/innitctl/configs/config.yaml.template
+++ b/bin/innitctl/configs/config.yaml.template
@@ -8,7 +8,7 @@ processors:
   batch:
 
 exporters:
-  logging:
+  debug:
     verbosity: normal
   otlp:
     endpoint: "api.honeycomb.io:443"
@@ -25,7 +25,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp]
+      exporters: [debug, otlp]
     metrics:
       receivers: [otlp]
       processors: [batch]


### PR DESCRIPTION
logging is deprecated as an exporter name in favour of "debug". This fixes all otel config deployments (including local)

ref: https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.111.0

