### PR TITLE
Fix: change watcher to the func call style and immediate

### DIFF
--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -446,22 +446,16 @@ export const getOutgoingConnections = async (args: {
 const waitForInitCompletion = (): Promise<void> => {
   return new Promise((resolve) => {
     if (initCompleted.value) {
-      // eslint-disable-next-line no-console
-      console.debug("init already completed");
       resolve();
       return;
     }
 
-    // eslint-disable-next-line no-console
-    console.debug("waiting for init completion");
-    const unwatch = watch(initCompleted, (newValue) => {
+    const unwatch = watch(() => initCompleted.value, (newValue) => {
       if (newValue) {
-        // eslint-disable-next-line no-console
-        console.debug("init completed in watcher");
         unwatch();
         resolve();
       }
-    });
+    }, { immediate: true });
   });
 };
 


### PR DESCRIPTION
This fixes the giant Explore page spinner on load.

## How does this PR change the system?
This should technically be working regardless of func call or just the computed. But when it was just—the watch wouldn't fire after the initCompleted value did actually change