### PR TITLE
fix: close modal on view creation

### DIFF
--- a/app/web/src/newhotness/AddViewModal.vue
+++ b/app/web/src/newhotness/AddViewModal.vue
@@ -8,43 +8,45 @@
     saveLabel="Create"
     @save="() => nameForm.handleSubmit()"
   >
-    <label class="flex flex-row items-center relative">
-      <span>View Name</span>
-      <nameForm.Field name="name">
-        <template #default="{ field }">
-          <input
-            :class="
-              clsx(
-                'block w-72 ml-auto border',
-                themeClasses(
-                  'text-black bg-white border-neutral-600 disabled:bg-neutral-100',
-                  'text-white bg-black border-neutral-400 disabled:bg-neutral-900',
-                ),
-              )
-            "
-            :value="field.state.value"
-            type="text"
-            :disabled="wForm.bifrosting.value"
-            @input="
-              (e) => field.handleChange((e.target as HTMLInputElement).value)
-            "
-          />
-        </template>
-      </nameForm.Field>
-      <Icon
-        v-if="wForm.bifrosting.value"
-        class="absolute right-2xs"
-        name="loader"
-        size="sm"
-        tone="action"
-      />
-    </label>
+    <form @submit.prevent="nameForm.handleSubmit()">
+      <label class="flex flex-row items-center relative">
+        <span>View Name</span>
+        <nameForm.Field name="name">
+          <template #default="{ field }">
+            <input
+              :class="
+                clsx(
+                  'block w-72 ml-auto border',
+                  themeClasses(
+                    'text-black bg-white border-neutral-600 disabled:bg-neutral-100',
+                    'text-white bg-black border-neutral-400 disabled:bg-neutral-900',
+                  ),
+                )
+              "
+              :value="field.state.value"
+              type="text"
+              :disabled="wForm.bifrosting.value"
+              @input="
+                (e) => field.handleChange((e.target as HTMLInputElement).value)
+                "
+            />
+          </template>
+        </nameForm.Field>
+        <Icon
+          v-if="wForm.bifrosting.value"
+          class="absolute right-2xs"
+          name="loader"
+          size="sm"
+          tone="action"
+        />
+      </label>
+    </form>
   </Modal>
 </template>
 
 <script setup lang="ts">
 import { Modal, Icon, themeClasses } from "@si/vue-lib/design-system";
-import { computed, ref, watch } from "vue";
+import { computed, ref } from "vue";
 import { useRoute } from "vue-router";
 import clsx from "clsx";
 import { View } from "@/workers/types/entity_kind_types";
@@ -74,8 +76,7 @@ const nameForm = wForm.newForm({
       name: value.name,
     });
     if (api.ok(req)) {
-      // right now, we don't want to push people to the new view
-      // because they won't see components, and won't be able to add any to the view
+      modalRef.value?.close();
       if (newChangeSetId) {
         api.navigateToNewChangeSet(
           {
@@ -88,13 +89,6 @@ const nameForm = wForm.newForm({
           newChangeSetId,
         );
       }
-      watch(
-        () => wForm.bifrosting,
-        () => {
-          modalRef.value?.close();
-        },
-        { once: true },
-      );
     }
   },
   validators: {
@@ -106,6 +100,7 @@ const nameForm = wForm.newForm({
 
 const open = () => {
   modalRef.value?.open();
+  nameForm.reset();
 };
 defineExpose({ open });
 </script>

--- a/app/web/src/newhotness/EditViewModal.vue
+++ b/app/web/src/newhotness/EditViewModal.vue
@@ -178,10 +178,16 @@ const emit = defineEmits<{
   (e: "deleted"): void;
 }>();
 
-const open = (openViewId: string, openIsDefaultView: boolean) => {
+const open = (
+  openViewId: string,
+  openViewName: string,
+  openIsDefaultView: boolean,
+) => {
   viewId.value = openViewId;
   isDefaultView.value = openIsDefaultView;
   modalRef.value?.open();
+  nameForm.reset();
+  nameForm.setFieldValue("name", openViewName);
 };
 const close = () => {
   viewId.value = "";

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -899,9 +899,11 @@ const openAddViewModal = () => {
 
 const editViewModalRef = ref<InstanceType<typeof EditViewModal>>();
 
-const openEditViewModal = (viewId: string) => {
+const openEditViewModal = (option: { value: string; label: string }) => {
+  const viewId = option.value;
+  const viewName = option.label;
   const isDefaultView = viewId === defaultView.value?.id;
-  editViewModalRef.value?.open(viewId, isDefaultView);
+  editViewModalRef.value?.open(viewId, viewName, isDefaultView);
 };
 
 const onMapDeselect = () => {

--- a/lib/vue-lib/src/design-system/menus/DropdownMenuButton.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenuButton.vue
@@ -232,12 +232,12 @@ const selectOption = (option: { value: unknown; label: string }) => {
   emit("update:modelValue", option.value as string);
 };
 const editOption = (option: { value: unknown; label: string }) => {
-  emit("edit", option.value as string);
+  emit("edit", option as { value: string; label: string });
 };
 const emit = defineEmits<{
   (e: "select", value: string): void;
   (e: "update:modelValue", value: string): void;
-  (e: "edit", value: string): void;
+  (e: "edit", option: { value: string; label: string }): void;
 }>();
 
 defineExpose({


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

- Creating a view closes the modal when clicking the Create button
- Creating a view closes the modal when hitting Enter after entering a value
- Editing a view name pulls in the name of the view to the input

#### Video:

https://jam.dev/c/93a78fec-3a94-4af1-9b2a-133e1105dee1

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] Integration tests pass
- [X] Manual test: new functionality works in UI
- [X] Manual test: (regression check) creating a component still works

## In short: [:link:](https://giphy.com/)

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExamZ5YjkzenZvb3k2bmh4YmMwZHV3aTVlcGZyenJhbHY5OThmMnJjaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/nvoLz81uCJPjy/giphy.gif)
