### PR TITLE
Fix: add a loading guard so we dont re-do setup work

### DIFF
--- a/app/web/src/App.vue
+++ b/app/web/src/App.vue
@@ -34,6 +34,7 @@ import {
   onMounted,
   ref,
   onErrorCaptured,
+  provide,
 } from "vue";
 import "floating-vue/dist/style.css";
 
@@ -90,6 +91,11 @@ onMounted(() => {
 });
 onBeforeUnmount(() => {
   window.removeEventListener("resize", windowResizeHandler);
+});
+
+const loadingGuard = ref(false);
+provide("LOADINGGUARD", {
+  loadingGuard,
 });
 
 useHead(

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -84,6 +84,8 @@ import {
   ref,
   provide,
   watch,
+  Ref,
+  inject,
 } from "vue";
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
 import NavbarPanelLeft from "@/components/layout/navbar/NavbarPanelLeft.vue";
@@ -286,7 +288,14 @@ const tokenFail = ref(false);
 const queryClient = useQueryClient();
 queryClient.setDefaultOptions({ queries: { staleTime: Infinity } });
 
+const container = inject<{ loadingGuard: Ref<boolean> }>("LOADINGGUARD");
 onBeforeMount(async () => {
+  if (container && container.loadingGuard.value) {
+    return;
+  }
+  if (container) {
+    container.loadingGuard.value = true;
+  }
   // NOTE(nick,wendy): if you do not have the flag enabled, you will be re-directed. This will be
   // true for all of the new hotness routes, provided that they are all children of the parent
   // route that uses this component. This is wrapped in a "setTimeout" to ensure that the feature


### PR DESCRIPTION
## How does this PR change the system?
Don't do setup work twice

We can't figure out why Vue is loading this component twice in a row. We turned off HMR and local vue plugins. Only final guess is that we're doing async work in onBeforeMount, which we can't avoid at this moment
