### PR TITLE
fix(web): don't redir to 'head', use the head id instead

### DIFF
--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -586,7 +586,7 @@ export function useChangeSetsStore() {
                     name: route.name,
                     params: {
                       ...route.params,
-                      changeSetId: "head",
+                      changeSetId: this.headChangeSetId,
                     },
                   });
                   if (


### PR DESCRIPTION
The new hotness endpoints expect a ulid in the params, not "head". This breaks some requests after applying.