### PR TITLE
chore(dev): Include Luminork in initial build

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -412,6 +412,7 @@ rust_build_targets = [
     "//bin/rebaser:rebaser",
     "//bin/sdf:sdf",
     "//bin/veritech:veritech",
+    "//bin/luminork:luminork",
 ]
 local_resource(
     "rust-initial-build",


### PR DESCRIPTION
This includes Luminork in the initial "build everything" pass, so that we get everything compiled in parallel and started quicker when we first start Tilte.

When we don't do this, we often have to wait for Luminork to compile *anyway*, because only one of them can run the build at a time, and if Luminork gets the lock before sdf starts (for example), sdf has to wait for it to compile anyway!

## How was it tested?

- [X] Starting up tilt still works fine

## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNnhwcHYwczA4cnF3bXV1NXMxN2h6Ymprb3podGx2dnByaGh0ZG40MiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/DQ94PFPPETZCM/giphy.gif)
