### PR TITLE
Fix: no-op patches may still need to create MTMs 

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -291,6 +291,7 @@ queryClient.setDefaultOptions({ queries: { staleTime: Infinity } });
 const container = inject<{ loadingGuard: Ref<boolean> }>("LOADINGGUARD");
 onBeforeMount(async () => {
   if (container && container.loadingGuard.value) {
+    queriesEnabled.value = true;
     return;
   }
   if (container) {

--- a/app/web/src/workers/mjolnir_queue.ts
+++ b/app/web/src/workers/mjolnir_queue.ts
@@ -55,6 +55,7 @@ export const processMjolnirQueue = new PQueue({
 const bustQueue = new PQueue({ concurrency: 10, autoStart: true });
 
 // de-dupe queue busting!
+// except... we're never waiting to bust, so it doesnt really de-dupe
 const _bustQueue = new Set<string>();
 export const bustQueueAdd = (
   workspaceId: string,


### PR DESCRIPTION
## How does this PR change the system?

When the linking for the expected atom checksum exists, but not with our index checksum, we need to make the MTM link even though we don't need to patch any data, and we need to bust the cache when we add the MTM link.

Second fix, `enabledQueries` was being set to false by the "double mount" issue that we added the guard for.

## Testing
Brit saw the first problem by:
- queue an action
- dequeue an action

The "new" checksum of the now _blank_ actions list exists linked to other changesets/index check sums... but not to this brand new index checksum

I saw the second problem by:
- starting on the modeling screen
- move to authoring
- edit an asset to turn `upgrade` on for existing components
- flip back to modeling
- enabled queries was false b/c the guard didn't let muspelheim run which sets it to true

Both of these fixes should resolve the problem Paul was having by not seeing upgrade (e.g. schema members would be flipping into a state that exists on other change sets and be caught by the first scenario)

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlemc3Y3A0amJma3p2dWZmMTF6b3Zrcjlwejlha2dra2I2YXJnNG5sYiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/NVBR6cLvUjV9C/giphy.gif"/>

