### PR TITLE
fix(web): move to lobby optimistically on new change set

### DIFF
--- a/app/web/src/components/layout/navbar/ChangeSetPanel.vue
+++ b/app/web/src/components/layout/navbar/ChangeSetPanel.vue
@@ -128,6 +128,7 @@ import { useChangeSetsStore } from "@/store/change_sets.store";
 import { ChangeSetStatus } from "@/api/sdf/dal/change_set";
 import AbandonChangeSetModal from "@/components/AbandonChangeSetModal.vue";
 import { reset } from "@/newhotness/logic_composables/navigation_stack";
+import * as heimdall from "../../../store/realtime/heimdall";
 
 const CHANGE_SET_NAME_REGEX = /^(?!head).*$/i;
 
@@ -230,7 +231,9 @@ async function onCreateChangeSet() {
 
   if (createReq.result.success) {
     // reusing above to navigate to new change set... will probably clean this all up later
-    onSelectChangeSet(createReq.result.data.changeSet.id);
+    const newChangeSetId = createReq.result.data.changeSet.id;
+    heimdall.muspelheimStatuses.value[newChangeSetId] = false;
+    onSelectChangeSet(newChangeSetId);
     createModalRef.value?.close();
   }
 }

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -338,10 +338,6 @@ onBeforeMount(async () => {
 watch(
   () => props.changeSetId,
   async (newValue, _) => {
-    if (heimdall.muspelheimStatuses.value[newValue] === false) {
-      return;
-    }
-
     const exists = await heimdall.changeSetExists(props.workspacePk, newValue);
     if (!exists) {
       heimdall.muspelheimStatuses.value[newValue] = false;


### PR DESCRIPTION
When transitioning to a new change set, we have to move to the lobby right away to prevent a failed call for the component mv list when Explore is mounted.