### PR TITLE
Correctly log change set id index was reused from

### DIFF
--- a/lib/edda-server/src/change_set_processor_task/materialized_view.rs
+++ b/lib/edda-server/src/change_set_processor_task/materialized_view.rs
@@ -188,7 +188,7 @@ pub async fn try_reuse_mv_index_for_new_change_set(
                     pointer.clone(),
                 )
                 .await?;
-            span.record("si.from_change_set.id", change_set_mv_id);
+            span.record("si.from_change_set.id", change_set.id.to_string());
             let meta = UpdateMeta {
                 workspace_id,
                 change_set_id: Some(change_set_id),


### PR DESCRIPTION
Previously, we were incorrectly logging the change set id of the new change set for both the source & target of the index reuse in edda.
