### PR TITLE
fix(web): Wait for bifrost to initialize before fetching the action view list from sqlite

### DIFF
--- a/app/web/src/newhotness/ApplyChangeSetButton.vue
+++ b/app/web/src/newhotness/ApplyChangeSetButton.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from "vue";
+import { computed, inject, ref } from "vue";
 import * as _ from "lodash-es";
 import { VButton, PillCounter } from "@si/vue-lib/design-system";
 import { useQuery } from "@tanstack/vue-query";
@@ -47,9 +47,12 @@ import {
 } from "@/workers/types/entity_kind_types";
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import ApprovalFlowModal from "./ApprovalFlowModal.vue";
+import { assertIsDefined, Context } from "./types";
 
 const changeSetsStore = useChangeSetsStore();
 const statusStore = useStatusStore();
+const ctx = inject<Context>("CONTEXT");
+assertIsDefined(ctx);
 
 const applyChangeSetReqStatus =
   changeSetsStore.getRequestStatus("APPLY_CHANGE_SET");
@@ -80,6 +83,7 @@ const actionsRaw = useQuery<BifrostActionViewList | null>({
   queryKey: key(EntityKind.ActionViewList),
   queryFn: async () =>
     await bifrost<BifrostActionViewList>(args(EntityKind.ActionViewList)),
+  enabled: ctx.queriesEnabled,
 });
 const actions = computed(() => actionsRaw.data.value?.actions ?? []);
 </script>

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -229,6 +229,7 @@ const ctx = computed<Context>(() => {
     outgoingCounts,
     componentNames,
     schemaMembers,
+    queriesEnabled,
   };
 });
 

--- a/app/web/src/newhotness/types.ts
+++ b/app/web/src/newhotness/types.ts
@@ -1,4 +1,4 @@
-import { ComputedRef } from "vue";
+import { ComputedRef, Ref } from "vue";
 import { User } from "@/api/sdf/dal/user";
 import { ComponentId } from "@/api/sdf/dal/component";
 import { SchemaMembers } from "@/workers/types/entity_kind_types";
@@ -13,6 +13,7 @@ export interface Context {
   outgoingCounts: ComputedRef<Record<ComponentId, number>>;
   componentNames: ComputedRef<Record<ComponentId, string>>;
   schemaMembers: ComputedRef<Record<SchemaId, SchemaMembers>>;
+  queriesEnabled: Ref<boolean>;
 }
 
 export function assertIsDefined<T>(value: T | undefined): asserts value is T {


### PR DESCRIPTION


<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

This is the one case where we're rendering data before bifrost is initialized and before cold start finishes, which was causing a whole host of strange issues. Adding this flag to the context, allows the Apply button to render with a default 0 action count, and the action count updates when the query can finally run.
<!-- Why: briefly what problem this solves and what the aim is as an overview -->

## How was it tested?

Manually tested to ensure that loading an empty change set succeeds, loading a change set with actions shows 0 actions initially and the correct count after cold start completes, and flipping between change sets shows the accurate count as well. 

<div><img src="https://media2.giphy.com/media/6rdMX8uL9NaawLhX96/200.gif?cid=5a38a5a29qr3z1jqhgo6hr8g773ans82tpjownh1ioi96maw&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:171px;width:300px"/><br/>via <a href="https://giphy.com/dreamstage/">DREAMSTAGE</a> on <a href="https://giphy.com/gifs/dreamstage-live-show-saintmotel-fames-orchestra-6rdMX8uL9NaawLhX96">GIPHY</a></div>