### PR TITLE
No more hot reload

### DIFF
--- a/app/web/vite.config.ts
+++ b/app/web/vite.config.ts
@@ -74,6 +74,7 @@ export default (opts: { mode: string }) => {
       },
     },
     server: {
+      hmr: false,
       host: config.DEV_HOST,
       allowedHosts: true,
       port: parseInt(config.DEV_PORT),


### PR DESCRIPTION
Hot reload is generally unreliable during development. And has the potential to exacerbate "double mounting" of the `Workspace.vue` (which we still see even with this off, but now handle somewhat gracefully). I vote to just remove it. (This has zero effect on the deployed application)