### PR TITLE
fix(sdf): Log if init complete is cancelled

### DIFF
--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -9,6 +9,8 @@ import {
   toRaw,
   ref,
   watch,
+  onScopeDispose,
+  getCurrentScope,
 } from "vue";
 import { QueryClient } from "@tanstack/vue-query";
 import { monotonicFactory } from "ulid";
@@ -452,6 +454,16 @@ const waitForInitCompletion = (): Promise<void> => {
         resolve();
       }
     });
+    // If this happens in a disposable scope, we want to warn if the scope gets cancelled
+    // (because the watch will be cancelled as well)
+    if (getCurrentScope()) {
+      onScopeDispose(() => {
+        if (!initCompleted.value) {
+          // eslint-disable-next-line no-console
+          console.warn("waiting for init cancelled");
+        }
+      });
+    }
   });
 };
 


### PR DESCRIPTION
Sometimes we are seeing logs that we're waiting for init but never completing; this will warn if the watch gets cancelled before completion so we can see if that's the cause.