### PR TITLE
Add collapse, empty states and deep linking to group by

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -265,6 +265,7 @@ export type SelectionsInQueryString = Partial<{
   map: string;
   grid: string;
   c: string;
+  groupBy: "diff" | "qual" | "upgr";
 }>;
 
 const compositionLink = computed(() => {

--- a/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
@@ -2,13 +2,15 @@
   <div
     v-if="row.type === 'header'"
     class="flex flex-row items-center bg-neutral-900 px-xs gap-xs"
+    @click="emit('clickCollapse', row.title, !row.collapsed)"
   >
+    <Icon :name="row.collapsed ? 'chevron--right' : 'chevron--down'" />
     <Icon
       v-if="titleIcon"
       :name="titleIcon.iconName"
       :tone="titleIcon.iconTone"
     />
-    <span>
+    <span class="select-none">
       {{ row.title }}
     </span>
     <PillCounter :count="row.count" class="text-xs" />
@@ -48,6 +50,24 @@
       class="flex-1"
     />
   </div>
+  <div
+    v-else-if="row.type === 'emptyRow'"
+    class="flex items-center justify-center bg-neutral-900 pb-xs px-xs"
+  >
+    <div
+      class="flex flex-col items-center justify-center gap-md bg-neutral-800 border border-neutral-600 grow h-full"
+    >
+      <div class="bg-neutral-700 p-sm rounded-full">
+        <Icon name="check-circle-outline" />
+      </div>
+      <span>
+        {{ emptyAreaData?.message ?? "Nothing to see here!" }}
+      </span>
+    </div>
+  </div>
+  <div v-else>
+    <!-- footer area -->
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -81,6 +101,7 @@ const emit = defineEmits<{
     componentId: ComponentId,
     componentIdx: number,
   ): void;
+  (e: "clickCollapse", title: string, collapsed: boolean): void;
 }>();
 
 interface TitleIcon {
@@ -92,15 +113,70 @@ const titleIcon = computed((): TitleIcon | null => {
   if (props.row.type !== "header") return null;
 
   switch (props.row.title) {
-    case "Passed":
+    case "Failed qualifications":
+      return {
+        iconName: "x-hex-outline",
+        iconTone: "destructive",
+      };
+    case "Warnings":
+      return {
+        iconName: "alert-triangle-outline",
+        iconTone: "warning",
+      };
+    case "Passed qualifications":
       return {
         iconName: "check-hex-outline",
         iconTone: "success",
       };
-    case "Failed":
+    case "Running qualifications":
       return {
-        iconName: "x-hex-outline",
-        iconTone: "destructive",
+        iconName: "loader",
+        iconTone: "neutral",
+      };
+    default:
+      return null;
+  }
+});
+
+interface EmptyAreaData {
+  message: string;
+}
+
+const emptyAreaData = computed((): EmptyAreaData | null => {
+  if (props.row.type !== "emptyRow") return null;
+
+  switch (props.row.groupName) {
+    case "Failed qualifications":
+      return {
+        message: "No failed qualifications",
+      };
+    case "Warnings":
+      return {
+        message: "No warnings on qualifications",
+      };
+    case "Passed qualifications":
+      return {
+        message: "No passing qualifications",
+      };
+    case "Running qualifications":
+      return {
+        message: "There are no qualifications running right now",
+      };
+    case "With Diffs":
+      return {
+        message: "No components have been changed so far",
+      };
+    case "Without Diffs":
+      return {
+        message: "All components have been changed!",
+      };
+    case "Upgradable":
+      return {
+        message: "No components ready for an upgrade so far",
+      };
+    case "Up to date":
+      return {
+        message: "All components are upgradable right now",
       };
     default:
       return null;
@@ -150,9 +226,14 @@ export type ExploreGridRowData =
       type: "header";
       title: string;
       count: number;
+      collapsed: boolean;
     }
   | {
       type: "footer";
+    }
+  | {
+      type: "emptyRow";
+      groupName: string;
     };
 </script>
 

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -9,6 +9,7 @@ import SlashForward from "~icons/mdi/slash-forward";
 import BookOpen from "~icons/heroicons/book-open-20-solid";
 import Check from "~icons/heroicons/check-20-solid";
 import CheckCircle from "~icons/heroicons/check-circle-20-solid";
+import CheckCircleOutline from "~icons/carbon/checkmark-outline";
 import CheckSquare from "./custom-icons/check-square.svg?raw";
 import CloudUpload from "~icons/mdi/cloud-upload";
 import CloudDownload from "~icons/mdi/cloud-download";
@@ -167,6 +168,7 @@ import CarbonCompare from "~icons/carbon/compare";
 // import CarbonTransformCode from '~icons/carbon/transform-code';
 import CarbonTransformCode from "~icons/carbon/code"; // using this one as a placeholder for now
 import SettingsEdit from "~icons/carbon/settings-edit";
+import CarbonWarningAlt from "~icons/carbon/warning-alt";
 
 // streamline
 import StreamlineBracesCircleSolid from "~icons/streamline/braces-circle-solid";
@@ -225,6 +227,7 @@ export const ICONS = Object.freeze({
   "alert-circle": AlertCircle,
   "alert-square": AlertSquare,
   "alert-triangle": AlertTriangle,
+  "alert-triangle-outline": CarbonWarningAlt,
   "arrows-out": PhArrowsOutCardinal,
   backspace: MaterialSymbolsBackspaceOutline,
   beaker: Beaker,
@@ -242,6 +245,7 @@ export const ICONS = Object.freeze({
   check: Check,
   "check-badge": CheckBadge,
   "check-circle": CheckCircle,
+  "check-circle-outline": CheckCircleOutline,
   "check-hex": CheckHex,
   "check-hex-outline": CheckHexOutline,
   "check-square": CheckSquare,


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

- Makes component groups collapsible by the user
- Stores the groupby criteria on the URL so a user can link to specific UI states
- Shows empty groups with the new design

#### Screenshots:

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->
![image](https://github.com/user-attachments/assets/443f0a3c-5287-4e0c-adf5-2034bce08fc7)

