### PR TITLE
feat: add cache control specification to s3 upload for web

### DIFF
--- a/.github/workflows/upgrade-web.yml
+++ b/.github/workflows/upgrade-web.yml
@@ -67,6 +67,12 @@ jobs:
         with:
           dir-path: app/web/dist
           s3-bucket: ${{ vars.WEB_HOSTING_BUCKET }}
+          cache-control-merge-policy: replace
+          cache-control: >
+            {
+              "assets/webworker.js": "public,max-age=60,stale-while-revalidate=2592000",
+              "assets/shared_webworker.js": "public,max-age=60,stale-while-revalidate=2592000"
+            }
 
       - name: Invalidate web cache
         run: |


### PR DESCRIPTION
We were pushing up the default cache policy onto every object in S3 for web.

`Uploading s3://si-tools-web/assets/webworker.js | content-type=application/javascript; charset=utf-8 | cache-control=public,max-age=31536000,immutable`

We need the two webworker files to have a different caching strategy. This adds a custom cache policy to those two files at point of time of upload into S3, which should then be respected through the CDN.