### PR TITLE
fix(sdf): send NewChangeSet edda request in v1 change set route

### DIFF
--- a/lib/sdf-core/src/lib.rs
+++ b/lib/sdf-core/src/lib.rs
@@ -16,6 +16,11 @@ pub mod nats_multiplexer;
 pub mod tracking;
 pub mod workspace_permissions;
 
+pub use edda_client::{
+    ClientError as EddaClientError,
+    EddaClient,
+};
+
 /// CRDT broadcast group type, moved here because it's used in AppState
 pub type BroadcastGroups = Arc<Mutex<HashMap<String, Arc<y_sync::net::BroadcastGroup>>>>;
 

--- a/lib/sdf-server/src/service/v2/change_set.rs
+++ b/lib/sdf-server/src/service/v2/change_set.rs
@@ -280,7 +280,7 @@ pub async fn create_index_for_new_change_set_and_watch(
 
 #[instrument(
     level = "info",
-    name = "sdf.change_set.create_index_for_new_change_set_and_watch",
+    name = "sdf.change_set.create_index_for_new_change_set",
     skip_all,
     fields(
         si.edda_request.id = Empty

--- a/lib/sdf-v1-routes-change-sets/src/create_change_set.rs
+++ b/lib/sdf-v1-routes-change-sets/src/create_change_set.rs
@@ -6,11 +6,18 @@ use axum::{
     },
 };
 use dal::{
+    ChangeSetId,
+    WorkspacePk,
+    WorkspaceSnapshotAddress,
     WsEvent,
     change_set::ChangeSet,
 };
-use sdf_core::tracking::track;
+use sdf_core::{
+    EddaClient,
+    tracking::track,
+};
 use sdf_extract::{
+    EddaClient as EddaClientExtractor,
     HandlerContext,
     PosthogClient,
     v1::AccessBuilder,
@@ -20,6 +27,7 @@ use si_frontend_types::{
     CreateChangeSetRequest,
     CreateChangeSetResponse,
 };
+use telemetry::prelude::*;
 
 use super::ChangeSetResult;
 
@@ -29,9 +37,12 @@ pub async fn create_change_set(
     PosthogClient(posthog_client): PosthogClient,
     OriginalUri(original_uri): OriginalUri,
     Host(host_name): Host,
+    EddaClientExtractor(edda_client): EddaClientExtractor,
     Json(request): Json<CreateChangeSetRequest>,
 ) -> ChangeSetResult<Json<CreateChangeSetResponse>> {
     let ctx = builder.build_head(access_builder).await?;
+
+    let workspace_pk = ctx.workspace_pk()?;
 
     let change_set_name = &request.change_set_name;
 
@@ -56,8 +67,46 @@ pub async fn create_change_set(
         .publish_on_commit(&ctx)
         .await?;
 
+    create_index_for_new_change_set(
+        &edda_client,
+        workspace_pk,
+        change_set.id,
+        ctx.change_set_id(),
+        change_set.workspace_snapshot_address,
+    )
+    .await?;
+
     let change_set = change_set.into_frontend_type(&ctx).await?;
     ctx.commit_no_rebase().await?;
 
     Ok(Json(CreateChangeSetResponse { change_set }))
+}
+
+#[instrument(
+    level = "info",
+    name = "sdf.change_set.v1.create_index_for_new_change_set",
+    skip_all,
+    fields(
+        si.edda_request.id = Empty
+    )
+)]
+pub async fn create_index_for_new_change_set(
+    edda_client: &EddaClient,
+    workspace_pk: WorkspacePk,
+    change_set_id: ChangeSetId,
+    base_change_set_id: ChangeSetId,
+    to_snapshot_address: WorkspaceSnapshotAddress,
+) -> ChangeSetResult<()> {
+    let span = Span::current();
+    let request_id = edda_client
+        .new_change_set(
+            workspace_pk,
+            change_set_id,
+            base_change_set_id,
+            to_snapshot_address,
+        )
+        .await?;
+    span.record("si.edda_request.id", request_id.to_string());
+
+    Ok(())
 }

--- a/lib/sdf-v1-routes-change-sets/src/lib.rs
+++ b/lib/sdf-v1-routes-change-sets/src/lib.rs
@@ -26,6 +26,7 @@ use dal::{
     },
 };
 use sdf_core::{
+    EddaClientError,
     api_error::ApiError,
     app_state::AppState,
 };
@@ -56,6 +57,8 @@ pub enum ChangeSetError {
     DalChangeSetApply(#[from] DalChangeSetApplyError),
     #[error("dvu roots are not empty for change set: {0}")]
     DvuRootsNotEmpty(ChangeSetId),
+    #[error("edda client error: {0}")]
+    EddaClient(#[from] EddaClientError),
     #[error("func error: {0}")]
     Func(#[from] FuncError),
     #[error("invalid header name {0}")]


### PR DESCRIPTION
This will ensure we start calculating the index quickly when creating a new change set via the navbar.