### PR TITLE
fix(web): fix sourcemap

### DIFF
--- a/app/web/vite.config.ts
+++ b/app/web/vite.config.ts
@@ -115,6 +115,7 @@ export default (opts: { mode: string }) => {
     },
     build: {
       manifest: "manifest.json",
+      sourcemap: "inline",
       rollupOptions: {
         input: {
           main: path.resolve(__dirname, "index.html"),
@@ -134,7 +135,6 @@ export default (opts: { mode: string }) => {
             }
             return "assets/[name]-[hash].js";
           },
-          sourcemap: "inline",
           format: "es",
           globals: {
             react: "React",


### PR DESCRIPTION
sourcemap is part of the build object in vite.config.js, not the rollupOptions. This fixed sourcemapping for me in local production builds.