### PR TITLE
feat(web): load head first muspelheim

### DIFF
--- a/app/web/src/api/sdf/dal/change_set.ts
+++ b/app/web/src/api/sdf/dal/change_set.ts
@@ -22,7 +22,7 @@ export interface ChangeSet {
   mergeRequestedAt?: IsoDateString;
   mergeRequestedByUserId?: UserId;
   mergeRequestedByUser?: string;
-  baseChangeSetId: ChangeSetId;
+  baseChangeSetId: ChangeSetId | null;
   reviewedByUserId?: UserId;
   reviewedByUser?: string;
   reviewedAt?: IsoDateString;

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -346,8 +346,8 @@ watch(
       heimdall.muspelheimStatuses.value[newValue] = false;
     }
 
-    const success = await heimdall.niflheim(props.workspacePk, newValue, true);
-    if (!success) {
+    const result = await heimdall.niflheim(props.workspacePk, newValue, true);
+    if (!result) {
       heimdall.muspelheimStatuses.value[newValue] = false;
     }
   },


### PR DESCRIPTION
Load the HEAD snapshot first, which is likely to contain almost all the atoms for the other snapshots.

Also reduces concurrency in "muspelheim" to 1