### PR TITLE
fix(dal,sdf): Update the new attributes interface to auto enqueue update actions when values are manually set and preconditions are met

### DIFF
--- a/lib/dal/tests/integration_test/attributes.rs
+++ b/lib/dal/tests/integration_test/attributes.rs
@@ -1,5 +1,9 @@
 use dal::{
     DalContext,
+    action::{
+        Action,
+        prototype::ActionPrototype,
+    },
     attribute::attributes,
 };
 use dal_test::{
@@ -11,12 +15,18 @@ use dal_test::{
         component::{
             self,
         },
+        create_component_for_default_schema_name_in_default_view,
         schema::variant,
     },
+    prelude::ChangeSetTestHelpers,
     test,
 };
 use pretty_assertions_sorted::assert_eq;
 use serde_json::json;
+use si_events::{
+    ActionKind,
+    ActionState,
+};
 
 // Test that updating attributes sets them (and their parents) correctly, but leaves default
 // values and other values alone.
@@ -97,6 +107,104 @@ async fn update_attributes(ctx: &DalContext) -> Result<()> {
     assert!(!value::is_set(ctx, ("test", "/domain/Parent/Missing")).await?);
     assert!(!value::is_set(ctx, ("test", "/domain/Parent/Default")).await?);
     assert!(!value::is_set(ctx, ("test", "/domain/Default")).await?);
+
+    Ok(())
+}
+
+// Test that updating an attribute value via the new subscription interface correctly enqueues
+// update actions
+#[test]
+async fn update_attributes_enqueues_update_fn(ctx: &mut DalContext) -> Result<()> {
+    // ======================================================
+    // Creating a component  should enqueue a create action
+    // ======================================================
+    let component_jack =
+        create_component_for_default_schema_name_in_default_view(ctx, "swifty", "jack antonoff")
+            .await?;
+    let component_swift =
+        create_component_for_default_schema_name_in_default_view(ctx, "swifty", "taylor swift")
+            .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Apply changeset so it runs the creation action
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+
+    // wait for actions to run
+    ChangeSetTestHelpers::wait_for_actions_to_run(ctx).await?;
+
+    ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
+    Action::remove_all_for_component_id(ctx, component_jack.id()).await?;
+
+    // ======================================================
+    // Updating values in a component that has a resource should enqueue an update action
+    // ======================================================
+
+    attributes::update_attributes(
+        ctx,
+        component_jack.id(),
+        serde_json::from_value(json!({
+            "/domain/name": "whomever",
+        }))?,
+    )
+    .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    let action_ids = Action::list_topologically(ctx).await?;
+
+    let mut update_action_count = 0;
+
+    for action_id in action_ids {
+        let action = Action::get_by_id(ctx, action_id).await?;
+
+        if action.state() == ActionState::Queued {
+            let prototype_id = Action::prototype_id(ctx, action_id).await?;
+            let prototype = ActionPrototype::get_by_id(ctx, prototype_id).await?;
+            let component_id = Action::component_id(ctx, action_id)
+                .await?
+                .expect("is some");
+            if prototype.kind == ActionKind::Update.into() && component_id == component_jack.id() {
+                update_action_count += 1;
+            };
+        }
+    }
+    assert_eq!(1, update_action_count);
+
+    // ======================================================
+    // Updating values in a component that has a resource should not enqueue an update
+    // action if the value didn't change
+    // ======================================================
+
+    attributes::update_attributes(
+        ctx,
+        component_swift.id(),
+        serde_json::from_value(json!({
+            "/domain/name": "taylor swift",
+        }))?,
+    )
+    .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    Action::remove_all_for_component_id(ctx, component_swift.id()).await?;
+
+    let action_ids = Action::list_topologically(ctx).await?;
+
+    let mut update_action_count = 0;
+
+    for action_id in &action_ids {
+        let action_id = *action_id;
+        let action = Action::get_by_id(ctx, action_id).await?;
+        if action.state() == ActionState::Queued {
+            let prototype_id = Action::prototype_id(ctx, action_id).await?;
+            let prototype = ActionPrototype::get_by_id(ctx, prototype_id).await?;
+            let component_id = Action::component_id(ctx, action_id)
+                .await?
+                .expect("is some");
+            if prototype.kind == ActionKind::Update.into() && component_id == component_swift.id() {
+                update_action_count += 1;
+            };
+        }
+    }
+    // didn't actually change the value, so there should not be an update function for swifty!
+    assert_eq!(0, update_action_count);
 
     Ok(())
 }


### PR DESCRIPTION

<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

<!-- Why: briefly what problem this solves and what the aim is as an overview -->
This restores functionality from the  `update_property_editor` route to the new `attributes` route 

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] Integration tests pass + added a new one!

## In short: [:link:](https://giphy.com/)

<div><img src="https://media3.giphy.com/media/gF8jhb7lTPGzqzfZ0h/giphy.gif?cid=5a38a5a2l61gtrcrachq9gilhn780fzmiecbp8o5wc5s196y&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:305px;width:300px"/><br/>via <a href="https://giphy.com/Siemens_/">Siemens</a> on <a href="https://giphy.com/gifs/cat-updates-business-gF8jhb7lTPGzqzfZ0h">GIPHY</a></div>