### PR TITLE
feat(luminork): Add setting who a component is managed by at creation time

### DIFF
--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -389,7 +389,6 @@ impl SecretPropPath {
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
 #[schema(example = json!({"component": "ComponentName"}))]
-#[schema(example = json!({"componentId": "01H9ZQD35JPMBGHH69BT0Q79VY"}))]
 pub enum ComponentReference {
     ByName {
         component: String,
@@ -399,6 +398,23 @@ pub enum ComponentReference {
         #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q79VY")]
         component_id: ComponentId,
     },
+}
+
+impl Default for ComponentReference {
+    fn default() -> Self {
+        ComponentReference::ByName {
+            component: String::new(),
+        }
+    }
+}
+
+impl ComponentReference {
+    pub fn is_empty(&self) -> bool {
+        match self {
+            ComponentReference::ByName { component } => component.is_empty(),
+            ComponentReference::ById { component_id: _ } => false, // IDs are never considered "empty"
+        }
+    }
 }
 
 /// Helper function to resolve a component reference to a component ID


### PR DESCRIPTION
API Usage:

Without managedBy (omit entirely):
```
  {
    "name": "MyComponent",
    "schemaName": "AWS::EC2::Instance"
  }
```

With managedBy:
```
  {
    "name": "MyComponent",
    "schemaName": "AWS::EC2::Instance",
    "managedBy": {"component": "ManagerComponentName"}
  }
```

You can also use componentId rather than component
