### PR TITLE
Fix: editing AVs from HEAD work, but need spinner tweaks

### DIFF
--- a/app/web/src/components/layout/navbar/NavbarPanelLeft.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelLeft.vue
@@ -39,10 +39,10 @@
 
     <ChangeSetPanel ref="changeSetPanelRef" />
 
-    <div v-if="rainbowCount > 0" class="mt-xs ml-xs relative">
+    <div v-if="unref(rainbow.count) > 0" class="mt-xs ml-xs relative">
       <span
         class="text-action-400 text-xs font-bold absolute w-[32px] top-[9px] text-center"
-        >{{ rainbowCount }}</span
+        >{{ rainbow.count }}</span
       >
       <Icon size="lg" name="loader" tone="action" />
     </div>
@@ -58,7 +58,7 @@ import {
   DropdownMenuItem,
   Icon,
 } from "@si/vue-lib/design-system";
-import { computed, ref, watch } from "vue";
+import { computed, ref, watch, unref } from "vue";
 import { useWorkspacesStore } from "@/store/workspaces.store";
 import { useRainbow } from "@/newhotness/logic_composables/rainbow_counter";
 import ChangeSetPanel from "./ChangeSetPanel.vue";
@@ -77,7 +77,7 @@ watch(
   { immediate: true },
 );
 
-const { rainbowCount } = useRainbow();
+const rainbow = useRainbow();
 
 const updateRoute = (newWorkspacePk: string) => {
   if (selectedWorkspacePk.value === newWorkspacePk) return;

--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -83,6 +83,7 @@ type Obs = {
   isWatched: boolean;
   span?: Span;
   label?: string;
+  changeSetIdExecutedAgainst?: string;
 };
 
 type LabeledObs = Obs & Required<Pick<Obs, "label">>;
@@ -135,12 +136,13 @@ export class APICall<Response> {
   ) {
     this.obs.inFlight.value = true;
     this.obs.bifrosting.value = true;
-    rainbow.add(this.ctx.changeSetId.value, this.obs.label);
     if (this.obs.isWatched) this.obs.span = tracer.startSpan("watchedApi");
     let newChangeSetId;
     if (!this.canMutateHead && this.ctx.onHead.value) {
       newChangeSetId = await this.makeChangeSet();
     }
+    rainbow.add(this.changeSetId, this.obs.label);
+    this.obs.changeSetIdExecutedAgainst = this.changeSetId;
 
     const req = await sdf<Response>({
       method,
@@ -150,8 +152,7 @@ export class APICall<Response> {
       validateStatus: (_status) => true, // don't throw exception on 4/5xxx
     });
     this.obs.inFlight.value = false;
-    if (!this.obs.isWatched)
-      rainbow.remove(this.ctx.changeSetId.value, this.obs.label);
+    if (!this.obs.isWatched) rainbow.remove(this.changeSetId, this.obs.label);
     return { req, newChangeSetId };
   }
 
@@ -260,7 +261,10 @@ export const useApi = () => {
       fn,
       () => {
         labeledObs.bifrosting.value = false;
-        rainbow.remove(ctx.changeSetId.value, labeledObs.label);
+        rainbow.remove(
+          labeledObs.changeSetIdExecutedAgainst ?? ctx.changeSetId.value,
+          labeledObs.label,
+        );
         if (labeledObs.span) labeledObs.span.end();
       },
       { once: true },

--- a/app/web/src/newhotness/logic_composables/rainbow_counter.ts
+++ b/app/web/src/newhotness/logic_composables/rainbow_counter.ts
@@ -17,18 +17,20 @@ export const remove = (changeSetId: string, desc: string) => {
 };
 
 export const useRainbow = () => {
-  try {
-    const ctx = inject<Context>("CONTEXT");
-    assertIsDefined(ctx);
+  return computed(() => {
+    try {
+      const ctx = inject<Context>("CONTEXT");
+      assertIsDefined(ctx);
 
-    const queue = queueByChangeSet.get(ctx.changeSetId.value);
+      const queue = queueByChangeSet.get(ctx.changeSetId.value);
 
-    /**
-     * This is a global "stuff is happening" counter
-     * When its > 0 the system is waiting for data
-     */
-    return { rainbowCount: computed(() => queue?.size ?? 0) };
-  } catch (err) {
-    return { rainbowCount: 0 };
-  }
+      /**
+       * This is a global "stuff is happening" counter
+       * When its > 0 the system is waiting for data
+       */
+      return { count: computed(() => queue?.size ?? 0) };
+    } catch (err) {
+      return { count: 0 };
+    }
+  });
 };

--- a/app/web/src/newhotness/logic_composables/watched_form.ts
+++ b/app/web/src/newhotness/logic_composables/watched_form.ts
@@ -96,7 +96,8 @@ export const useWatchedForm = <Data>(label: string) => {
           form: label,
         });
         bifrosting.value = true;
-        rainbow.add(ctx.changeSetId.value, label);
+        if (ctx.changeSetId.value !== ctx.headChangeSetId.value)
+          rainbow.add(ctx.changeSetId.value, label);
 
         // Mark submission as complete and remove the rainbow spinner
         const markComplete = () => {


### PR DESCRIPTION
## How does this PR change the system?

1. if you're on head the watched_form never adds a spinner (b/c you can't mutate head)
2. API index adds the label to the queue for the newly created change set
3. the useRainbow needed to return a computed for when change set changes

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNDlpYmhkMnJhNWNvenJ2MjZxNXB5NzV2ZXMzdWl0NDNwNGM3OXN6OCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/dtHz6tzJp3fbmopSwA/giphy-downsized-medium.gif"/>