### PR TITLE
fix(luminork): Support "HEAD" in luminork URLs

### DIFF
--- a/lib/luminork-server/src/service/v1/workspaces.rs
+++ b/lib/luminork-server/src/service/v1/workspaces.rs
@@ -18,7 +18,7 @@ use super::common::ErrorIntoResponse;
 use crate::{
     AppState,
     extract::{
-        change_set::TargetChangeSetIdFromPath,
+        change_set::TargetChangeSetIdentFromPath,
         workspace::{
             AuthorizedForAutomationRole,
             TargetWorkspaceIdFromPath,
@@ -89,7 +89,9 @@ pub fn routes(state: AppState) -> Router<AppState> {
                                 "/merge_status",
                                 get(super::change_sets::merge_status::merge_status),
                             )
-                            .route_layer(middleware::from_extractor::<TargetChangeSetIdFromPath>()),
+                            .route_layer(
+                                middleware::from_extractor::<TargetChangeSetIdentFromPath>(),
+                            ),
                     ),
             )
             .route_layer(middleware::from_extractor_with_state::<

--- a/lib/sdf-extract/src/change_set.rs
+++ b/lib/sdf-extract/src/change_set.rs
@@ -17,7 +17,10 @@ use derive_more::{
     Into,
 };
 use sdf_core::app_state::AppState;
-use serde::Deserialize;
+use serde::{
+    Deserialize,
+    Serialize,
+};
 
 use super::{
     ErrorResponse,
@@ -51,7 +54,8 @@ impl FromRequestParts<AppState> for ChangeSetDalContext {
         } = parts.extract_with_state(state).await?;
 
         // Validate the change set id is within that workspace
-        let TargetChangeSetId(change_set_id) = parts.extract().await?;
+        let TargetChangeSetIdent(change_set_ident) = parts.extract().await?;
+        let change_set_id = change_set_ident.resolve(&ctx).await?;
         let change_set = ChangeSet::find(&ctx, change_set_id)
             .await
             .map_err(internal_error)?;
@@ -72,46 +76,83 @@ impl FromRequestParts<AppState> for ChangeSetDalContext {
 ///
 /// *Not* checked to ensure it is in the workspace.
 ///
-#[derive(Clone, Debug, Deref, Copy, Into)]
-struct TargetChangeSetId(pub ChangeSetId);
+#[derive(Clone, Debug, Deref, Into)]
+struct TargetChangeSetIdent(pub ChangeSetIdent);
 
-impl TargetChangeSetId {
-    fn set(parts: &mut Parts, change_set_id: ChangeSetId) -> Result<ChangeSetId, ErrorResponse> {
+impl TargetChangeSetIdent {
+    fn set(
+        parts: &mut Parts,
+        change_set_ident: ChangeSetIdent,
+    ) -> Result<ChangeSetIdent, ErrorResponse> {
         // This must not be done twice.
-        if parts.extensions.get::<TargetChangeSetId>().is_some() {
+        if parts.extensions.get::<TargetChangeSetIdent>().is_some() {
             return Err(internal_error("Must only specify workspace ID once"));
         }
 
-        parts.extensions.insert(TargetChangeSetId(change_set_id));
-        Ok(change_set_id)
-    }
-}
-
-#[async_trait]
-impl<S> FromRequestParts<S> for TargetChangeSetId {
-    type Rejection = ErrorResponse;
-
-    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        Ok(*parts
+        parts
             .extensions
-            .get::<TargetChangeSetId>()
-            .ok_or_else(|| internal_error("No changeset ID. Endpoints must call an extractor like TargetChangeSetIdFromPath to get the change set ID."))?)
+            .insert(TargetChangeSetIdent(change_set_ident.clone()));
+        Ok(change_set_ident)
     }
 }
 
-#[derive(Deserialize, Clone, Debug, Deref, Copy, Into)]
-pub struct TargetChangeSetIdFromPath {
-    change_set_id: ChangeSetId,
-}
-
 #[async_trait]
-impl<S> FromRequestParts<S> for TargetChangeSetIdFromPath {
+impl<S> FromRequestParts<S> for TargetChangeSetIdent {
     type Rejection = ErrorResponse;
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        let Path(TargetChangeSetIdFromPath { change_set_id }) =
+        Ok(parts
+            .extensions
+            .get::<TargetChangeSetIdent>()
+            .ok_or_else(|| internal_error("No changeset ID. Endpoints must call an extractor like TargetChangeSetIdentFromPath to get the change set ID."))?
+            .clone())
+    }
+}
+
+#[derive(Deserialize, Clone, Debug, Deref, Into)]
+pub struct TargetChangeSetIdentFromPath {
+    change_set_id: ChangeSetIdent,
+}
+
+#[async_trait]
+impl<S> FromRequestParts<S> for TargetChangeSetIdentFromPath {
+    type Rejection = ErrorResponse;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let Path(TargetChangeSetIdentFromPath { change_set_id }) =
             parts.extract().await.map_err(bad_request)?;
-        TargetChangeSetId::set(parts, change_set_id)?;
-        Ok(TargetChangeSetIdFromPath { change_set_id })
+        TargetChangeSetIdent::set(parts, change_set_id.clone())?;
+        Ok(TargetChangeSetIdentFromPath { change_set_id })
+    }
+}
+
+/// String identifier for a changeset within a workspace.
+/// Supports either ChangeSetId (ULID) or a "HEAD" (case-insensitive).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeSetIdent(String);
+
+impl From<ChangeSetId> for ChangeSetIdent {
+    fn from(id: ChangeSetId) -> Self {
+        Self(id.to_string())
+    }
+}
+
+impl ChangeSetIdent {
+    /// Create a ChangeSetIdent with the string "HEAD"
+    pub fn head() -> Self {
+        Self("HEAD".to_string())
+    }
+
+    /// Get the ChangeSetId for this ChangeSetIdent. If it is HEAD, it will get the HEAD
+    /// changeset from the workspace.
+    pub async fn resolve(&self, ctx: &DalContext) -> Result<ChangeSetId, ErrorResponse> {
+        if self.0.eq_ignore_ascii_case("HEAD") {
+            ctx.get_workspace_default_change_set_id()
+                .await
+                .map_err(internal_error)
+        } else {
+            self.0.parse().map_err(bad_request)
+        }
     }
 }

--- a/lib/sdf-server/src/service/public/change_sets.rs
+++ b/lib/sdf-server/src/service/public/change_sets.rs
@@ -46,7 +46,7 @@ use crate::{
         PosthogEventTracker,
         change_set::{
             ChangeSetDalContext,
-            TargetChangeSetIdFromPath,
+            TargetChangeSetIdentFromPath,
         },
         workspace::{
             WorkspaceAuthorization,
@@ -73,7 +73,7 @@ pub fn routes(state: AppState) -> Router<AppState> {
                 )),
             )
             .route("/merge_status", get(merge_status))
-            .route_layer(middleware::from_extractor::<TargetChangeSetIdFromPath>()),
+            .route_layer(middleware::from_extractor::<TargetChangeSetIdentFromPath>()),
     )
 }
 

--- a/lib/sdf-server/src/service/v2.rs
+++ b/lib/sdf-server/src/service/v2.rs
@@ -11,7 +11,7 @@ use crate::{
     AppState,
     extract::{
         ErrorResponse,
-        change_set::TargetChangeSetIdFromPath,
+        change_set::TargetChangeSetIdentFromPath,
         workspace::{
             TargetWorkspaceIdFromPath,
             WorkspaceAuthorization,
@@ -60,7 +60,7 @@ fn workspace_routes(state: AppState) -> Router<AppState> {
                     "/approval-requirement-definitions",
                     approval_requirement_definition::v2_routes(),
                 )
-                .route_layer(middleware::from_extractor::<TargetChangeSetIdFromPath>()),
+                .route_layer(middleware::from_extractor::<TargetChangeSetIdentFromPath>()),
         )
         .nest("/fs", fs::fs_routes(state.clone()))
         .nest("/integrations", integrations::v2_routes())

--- a/lib/sdf-server/src/service/v2/fs.rs
+++ b/lib/sdf-server/src/service/v2/fs.rs
@@ -102,7 +102,7 @@ use super::{
 use crate::extract::{
     HandlerContext,
     PosthogEventTracker,
-    change_set::TargetChangeSetIdFromPath,
+    change_set::TargetChangeSetIdentFromPath,
     workspace::{
         AuthorizedForAutomationRole,
         TargetWorkspaceIdFromPath,
@@ -1564,7 +1564,7 @@ pub fn fs_routes(state: AppState) -> Router<AppState> {
                 .route("/schemas/:schema_id/funcs/:kind", get(list_variant_funcs))
                 .route("/schemas/:schema_id/funcs/:kind/create", post(create_func))
                 .route("/schemas/:schema_id/install", post(install_schema))
-                .route_layer(middleware::from_extractor::<TargetChangeSetIdFromPath>()),
+                .route_layer(middleware::from_extractor::<TargetChangeSetIdentFromPath>()),
         )
         .route_layer(middleware::from_extractor_with_state::<
             AuthorizedForAutomationRole,


### PR DESCRIPTION
This supports the word "head" in the luminork URL instead of a change set id. e.g. `GET /v1/w/<id>/change-sets/head/components`

It changes `ChangeSetDalContext` extractor; any endpoint that uses that will . The word "head" is matched case-insensitive, so HEAD works too.

#### Out of Scope:

Some SDF endpoints now support head, because it is in a common extractor. Not all do, however, because they don't all use that extractor yet. This does not try to change SDF, but it seems just fine to allow at least some endpoints to support the new pattern.

## How was it tested?

- [X] Integration tests pass
- [X] Manual API test for head, HEAD, <change set id of head>, <other change set id>: get list of components, make sure it is from the right change set
- [X] Manual test: old UI can create and switch change sets, create components and view the workspace
- [X] Manual test: 400 if you use "blah" as change set id

## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMzc4b3dteDllN2Zsd2xmdmQ5Nmx2d2RxanljajdzMGcwM3Nnb2V4OCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/JrTMcO4EjENC7PTQS1/giphy.gif)
