### PR TITLE
Add sort by functionality to new UI

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -105,7 +105,7 @@ import {
 } from "@/workers/types/entity_kind_types";
 import { SchemaId } from "@/api/sdf/dal/schema";
 import Lobby from "./Lobby.vue";
-import Explore from "./Explore.vue";
+import Explore, { GroupByUrlQuery, SortByUrlQuery } from "./Explore.vue";
 import FuncRunDetails from "./FuncRunDetails.vue";
 import LatestFuncRunDetails from "./LatestFuncRunDetails.vue";
 import { Context, FunctionKind } from "./types";
@@ -270,7 +270,8 @@ export type SelectionsInQueryString = Partial<{
   map: string;
   grid: string;
   c: string;
-  groupBy: "diff" | "qual" | "upgr";
+  groupBy: GroupByUrlQuery;
+  sortBy: SortByUrlQuery;
 }>;
 
 const compositionLink = computed(() => {


### PR DESCRIPTION
## Introduction

This change adds sort by functionality to the new UI. It uses the guts of the group by functionality to do so, but with some twists.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYzFmd2pibnBkOWRrNnl5N3czbG1oa3V5OGlucWVicmYwdTVqNmFkNiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xUNd9S0VBzX8hooOBy/giphy.gif"/>

## Description

There are three sorts: latest to oldest, failed actions and running actions. By default, we will use latest to oldest, which sorts by each component's approximate creation time and uses their ULID-based IDs for sorting. That sort is performed before performing another sort so that we ensure relative ordering always makes sense.

Both the failed actions sort and the running actions sort leverage the pre-existing "actionViewList" in "Explore.vue". Originally, this change used an elaborate multi-point "component action state" that was summary of a component's actions. Not only was that complex and fragile, but it was nightmarish to read and arguably not essential. Now, there are two simple sets to cover "does this component have at least one failed action?" and "does this component have at least one running action?". These sets are arguably more correct anyway as they aren't opinionated summaries of the components and their actions.

The sort by feature was designed to be used with group by or in isolation. In doing so, it uses the deep linking system from the group by feature and expands deep linking strings for all selections to be full names rather than the first four characters of each selection. This should be easier for readability.

## Screenshot of VPC Template Created via API with Actively Sorting "Running Actions"

<img width="1858" alt="Screenshot 2025-06-27 at 1 16 38 AM" src="https://github.com/user-attachments/assets/b6a73877-f945-465c-988b-65dd3c303b7f" />

## Audits Trail Post Deletion (Just for fun!)

<img width="1858" alt="Screenshot 2025-06-27 at 1 26 47 AM" src="https://github.com/user-attachments/assets/410ce436-f053-4120-8f9b-d028a62a62dd" />