### PR TITLE
fix(web): Remove incorrect default of all passing for qualifications

### DIFF
--- a/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
@@ -54,6 +54,25 @@
         <TextPill
           v-if="
             component.qualificationTotals.failed === 0 &&
+            component.qualificationTotals.warned === 0 &&
+            component.qualificationTotals.succeeded === 0
+          "
+          tighter
+          :class="
+            clsx(
+              'text-xs ml-auto',
+              themeClasses(
+                'border-neutral-500 bg-neutral-100 text-black',
+                'border-neutral-600 bg-neutral-900 text-white',
+              ),
+            )
+          "
+        >
+          Unknown
+        </TextPill>
+        <TextPill
+          v-else-if="
+            component.qualificationTotals.failed === 0 &&
             component.qualificationTotals.warned === 0
           "
           tighter
@@ -70,7 +89,7 @@
           All passed
         </TextPill>
         <TextPill
-          v-if="component.qualificationTotals.failed > 0"
+          v-else-if="component.qualificationTotals.failed > 0"
           tighter
           :class="
             clsx(
@@ -85,7 +104,7 @@
           {{ component.qualificationTotals.failed }} Failed
         </TextPill>
         <TextPill
-          v-if="component.qualificationTotals.warned > 0"
+          v-else-if="component.qualificationTotals.warned > 0"
           tighter
           :class="
             clsx(


### PR DESCRIPTION
When we created a component in the new UI, we checked for failing or warning qualifications and if not found then we defaulted to `all passed`.

For new components, there will be no passing, no failing and no warning. So if we find that seet of groups then we default to `unknown` as the status is actually calculating the results.

This makes the flow that when you create a component that te qualifications show unknown until they work as expected

https://jam.dev/c/d382da8c-b166-4508-bbbc-449c69966b0c