### PR TITLE
feat: Rename changesets

### DIFF
--- a/app/web/src/components/ChangesetRenameModal.vue
+++ b/app/web/src/components/ChangesetRenameModal.vue
@@ -1,0 +1,112 @@
+<template>
+  <Modal
+    ref="modal"
+    title="Rename change set"
+    size="sm"
+    @click="inputRef?.focus()"
+  >
+    <div class="flex flex-col gap-sm">
+      <VormInput
+        ref="inputRef"
+        v-model="changesetName"
+        :disabled="loading"
+        label="Name"
+        noLabel
+        required
+        type="text"
+        @enterPressed="submit"
+      />
+      <ErrorMessage
+        v-if="apiErrorMessage"
+        class="rounded-md text-md px-xs py-xs"
+        icon="x-circle"
+        variant="block"
+      >
+        <b>Error renaming change set:</b> <br />
+        {{ apiErrorMessage }}
+      </ErrorMessage>
+
+      <div class="flex flex-row items-center justify-end w-full gap-xs">
+        <VButton
+          :loading="loading"
+          size="xs"
+          tone="neutral"
+          @click="modal?.close()"
+        >
+          Cancel <TextPill tighter variant="key">Esc</TextPill>
+        </VButton>
+        <VButton :loading="loading" size="xs" @click="submit"> Rename </VButton>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<script lang="ts" setup>
+import { nextTick, ref } from "vue";
+import {
+  ErrorMessage,
+  Modal,
+  TextPill,
+  VButton,
+  VormInput,
+} from "@si/vue-lib/design-system";
+import { routes, useApi } from "@/newhotness/api_composables";
+
+const modal = ref<InstanceType<typeof Modal>>();
+const inputRef = ref<InstanceType<typeof VormInput>>();
+
+const loading = ref(false);
+const changesetName = ref("");
+const changesetIdRef = ref<string | undefined>();
+const apiErrorMessage = ref<string | undefined>();
+
+const renameChangesetApi = useApi();
+
+const submit = async () => {
+  if (
+    inputRef.value?.validationState.isError ||
+    !changesetName.value ||
+    !changesetIdRef.value
+  )
+    return;
+
+  const call = renameChangesetApi.endpoint(routes.ChangeSetRename, {
+    changesetId: changesetIdRef.value,
+  });
+
+  loading.value = true;
+  apiErrorMessage.value = undefined;
+
+  const { req, errorMessage } = await call.post({
+    newName: changesetName.value,
+  });
+
+  loading.value = false;
+  if (req.status !== 200) {
+    apiErrorMessage.value = errorMessage ?? "Unknown error";
+    return;
+  }
+
+  modal.value?.close();
+};
+
+const open = (changesetId: string, initialValue?: string) => {
+  loading.value = false;
+  apiErrorMessage.value = undefined;
+  changesetName.value = initialValue ?? "";
+  changesetIdRef.value = changesetId;
+  inputRef.value?.validationMethods.reset();
+  modal.value?.open();
+
+  nextTick(() => {
+    inputRef.value?.focus();
+  });
+};
+
+defineExpose({
+  open,
+  modal,
+});
+
+const emit = defineEmits(["submit"]);
+</script>

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -14,8 +14,8 @@
           minWidthToAnchor
           placeholder="All Views"
           checkable
-          enableSettingsEdit
-          @edit="openEditViewModal"
+          enableSecondaryAction
+          @secondaryAction="openEditViewModal"
           @update:modelValue="(val) => (selectedView = val)"
         >
           <template #beforeOptions>

--- a/lib/vue-lib/src/design-system/index.ts
+++ b/lib/vue-lib/src/design-system/index.ts
@@ -1,5 +1,6 @@
 // ./forms
 export { default as VormInput } from "./forms/VormInput.vue";
+export type { InputOptions } from "./forms/VormInput.vue";
 export { default as VormInputOption } from "./forms/VormInputOption.vue";
 export { default as ColorPicker } from "./forms/ColorPicker.vue";
 export * from "./forms/helpers/form-disabling";

--- a/lib/vue-lib/src/design-system/menus/DropdownMenuButton.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenuButton.vue
@@ -81,8 +81,9 @@
         :label="option.label"
         :checkable="checkable"
         :checked="option.value === modelValue"
-        :enableSettingsEdit="props.enableSettingsEdit"
-        @edit="editOption(option)"
+        :enableSecondaryAction="enableSecondaryAction"
+        :secondaryActionIcon="secondaryActionIcon"
+        @secondaryAction="secondaryAction(option)"
         @select="selectOption(option)"
       />
       <slot name="afterOptions" />
@@ -100,6 +101,7 @@ import { themeClasses } from "../utils/theme_tools";
 import { Filter } from "../general/SiSearch.vue";
 import { InputOptions, OptionsAsArray } from "../forms/VormInput.vue";
 import DropdownMenuItem from "./DropdownMenuItem.vue";
+import { IconNames } from "../icons/icon_set";
 
 export type DropdownMenuButtonVariant = "standard" | "navbar";
 
@@ -126,7 +128,8 @@ const props = defineProps({
   minWidthToAnchor: { type: Boolean },
   noBorder: { type: Boolean },
   alignRightOnAnchor: { type: Boolean },
-  enableSettingsEdit: { type: Boolean },
+  enableSecondaryAction: { type: Boolean },
+  secondaryActionIcon: { type: String as PropType<IconNames> },
   alwaysShowPlaceholder: { type: Boolean },
   highlightWhenModelValue: { type: Boolean },
 });
@@ -231,13 +234,13 @@ const selectOption = (option: { value: unknown; label: string }) => {
   emit("select", option.value as string);
   emit("update:modelValue", option.value as string);
 };
-const editOption = (option: { value: unknown; label: string }) => {
-  emit("edit", option as { value: string; label: string });
+const secondaryAction = (option: { value: unknown; label: string }) => {
+  emit("secondaryAction", option as { value: string; label: string });
 };
 const emit = defineEmits<{
   (e: "select", value: string): void;
   (e: "update:modelValue", value: string): void;
-  (e: "edit", option: { value: string; label: string }): void;
+  (e: "secondaryAction", option: { value: string; label: string }): void;
 }>();
 
 defineExpose({


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

- Add an option to rename change sets from the changeset dropdown
- Add a changeset rename modal with error checking 
#### Also:
- add helper to extract error message from api calls on the new tooling
- Allow overriding changesetId on any api route
- Refactor dropdown button to allow for a secondary action generically, specifying a custom icon
- Refactor dropdowns to only show the secondary action icon on the active item and the hovered item

<!-- Why: briefly what problem this solves and what the aim is as an overview -->

#### Screenshots:

<img width="360" alt="Screenshot 2025-06-27 at 11 43 20" src="https://github.com/user-attachments/assets/6b97747d-2ff5-4eac-aff2-89bfa4297d2d" />

<img width="491" alt="Screenshot 2025-06-27 at 11 28 02" src="https://github.com/user-attachments/assets/a0f55711-439d-4892-8e70-436ae7353c97" />


