### PR TITLE
Remove running qualifications from new UI

### DIFF
--- a/app/web/src/api/sdf/dal/property_editor.ts
+++ b/app/web/src/api/sdf/dal/property_editor.ts
@@ -127,8 +127,10 @@ export interface PropertyEditorSchema {
   };
 }
 
+export type ValidationOutputStatus = "Error" | "Failure" | "Success";
+
 export interface ValidationOutput {
-  status: "Error" | "Failure" | "Success";
+  status: ValidationOutputStatus;
   message?: string;
 }
 

--- a/app/web/src/newhotness/QualificationView.vue
+++ b/app/web/src/newhotness/QualificationView.vue
@@ -5,12 +5,22 @@
     </div>
 
     <div class="flex flex-col gap-xs text-sm">
-      <StatusMessageBox :status="qualificationStatus" class="break-all">
+      <StatusMessageBox
+        :status="qualificationStatus ?? 'unknown'"
+        class="break-all"
+      >
         <template v-if="qualificationStatus === 'success'"> Passed! </template>
-        <template v-else-if="qualificationStatus === 'failure'">
+        <template
+          v-else-if="
+            qualificationStatus === 'failure' ||
+            qualificationStatus === 'warning'
+          "
+        >
           {{ qualification.message }}
         </template>
-        <template v-else> Qualification running, standby...</template>
+        <template v-else>
+          The qualification has not yet ran or is actively running. Standby...
+        </template>
       </StatusMessageBox>
 
       <template v-if="showDetails && qualification.avId">
@@ -52,13 +62,13 @@ import * as _ from "lodash-es";
 import { LoadingMessage } from "@si/vue-lib/design-system";
 import StatusMessageBox from "@/components/StatusMessageBox.vue";
 import CodeViewer from "@/components/CodeViewer.vue";
-import { QualItem } from "@/newhotness/QualificationPanel.vue";
+import { Qualification } from "@/newhotness/QualificationPanel.vue";
 import { routes, useApi, funcRunTypes } from "@/newhotness/api_composables";
 
 const api = useApi();
 
 const props = defineProps<{
-  qualification: QualItem;
+  qualification: Qualification;
 }>();
 
 const showDetails = ref(false);
@@ -66,8 +76,8 @@ const showDetails = ref(false);
 const qualification = toRef(props, "qualification");
 
 const qualificationStatus = computed(() => {
-  if (_.isNil(props.qualification.result)) return "running";
-  return props.qualification.result;
+  if (_.isNil(props.qualification.status)) return undefined;
+  return props.qualification.status;
 });
 
 const toggleHidden = async () => {

--- a/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
@@ -158,10 +158,6 @@ const emptyAreaData = computed((): EmptyAreaData | null => {
       return {
         message: "No passing qualifications",
       };
-    case "Running qualifications":
-      return {
-        message: "There are no qualifications running right now",
-      };
     case "With Diffs":
       return {
         message: "No components have been changed so far",

--- a/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
@@ -214,7 +214,6 @@ export function getQualificationStatus(
   component: BifrostComponent | ComponentInList,
 ) {
   if (component.qualificationTotals.failed > 0) return "failure";
-  if (component.qualificationTotals.running > 0) return "running";
   if (component.qualificationTotals.warned > 0) return "warning";
   return "success";
 }

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -141,7 +141,6 @@ export interface ComponentQualificationTotals {
   warned: number;
   succeeded: number;
   failed: number;
-  running: number;
 }
 
 export interface EddaComponent {

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -134,8 +134,7 @@ impl QualificationSummary {
             }
         }
 
-        // TODO(nick): this was ported from the frontend. It is an assumption... but is hasn't been
-        // wrong for us... yet... let's keep an eye on it.
+        // FIXME(nick): delete this when we switch to the new UI.
         let running = total
             .checked_sub(warned)
             .and_then(|v| v.checked_sub(succeeded))

--- a/lib/si-frontend-mv-types-rs/src/component.rs
+++ b/lib/si-frontend-mv-types-rs/src/component.rs
@@ -33,7 +33,6 @@ pub struct ComponentQualificationStats {
     pub warned: u64,
     pub succeeded: u64,
     pub failed: u64,
-    pub running: u64,
 }
 
 #[derive(

--- a/lib/si-frontend-mv-types-rs/src/temporary_conversion_impls.rs
+++ b/lib/si-frontend-mv-types-rs/src/temporary_conversion_impls.rs
@@ -16,12 +16,14 @@ use crate::{
 
 impl From<DeprecatedComponentQualificationStats> for ComponentQualificationStats {
     fn from(value: DeprecatedComponentQualificationStats) -> Self {
+        // NOTE(nick): notice how "value.running" isn't called... we need it in the deprecated type
+        // for the old UI, but we don't need it in the new UI. It actually shouldn't be in either,
+        // but we do not want to regress the old UI by accident.
         Self {
             total: value.total,
             warned: value.warned,
             succeeded: value.succeeded,
             failed: value.failed,
-            running: value.running,
         }
     }
 }


### PR DESCRIPTION
## Description

This change removes running qualifications from the new UI. This is a very old concept that predates qualifications on the prop tree (late 2022!) and has been moved around over the years. DVU is the canonical source of prop tree functions in flight and qualification statuses are reflections of the result of DVU.

As a consequence of this work, the domain naming has been standardized across the newhotness Vue components.

An additional change here is that the two sets for action state for sort by functionality have been combined under one interface to only loop over the action list once.

Finally, there's now a comment clarifying why the "canUpgrade" variable was created in a previous PR for the grid.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlenN4ZG42eHpyazVkcnlpZHBvbjJlZGM4MzF4dHA2NnA3bHM2dWIxaSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/TIcnbw606Yl0UXiILS/giphy-downsized-medium.gif"/>