### PR TITLE
fix: endpoint needs specified on newer versions of otelcol

### DIFF
--- a/bin/innitctl/configs/config.yaml.template
+++ b/bin/innitctl/configs/config.yaml.template
@@ -3,6 +3,7 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
 
 processors:
   batch:


### PR DESCRIPTION
It would help if this red box was slightly bigger (or correct)
![Screenshot 2025-06-27 at 20 47 32](https://github.com/user-attachments/assets/c32298f9-94f0-463b-b0c8-ebe3b0659c27)

ref: https://opentelemetry.io/docs/collector/configuration/

It happened. We got stung. This fixes our metrics and spans publishing in Production.