### PR TITLE
Add ability to pin a component

### DIFF
--- a/app/web/src/newhotness/ComponentCard.vue
+++ b/app/web/src/newhotness/ComponentCard.vue
@@ -21,6 +21,14 @@
         component.schemaName
       }}</TruncateWithTooltip>
     </div>
+    <ComponentQualificationStatus :component="component" hideTitle />
+    <StatusIndicatorIcon
+      v-if="component.hasResource"
+      type="resource"
+      size="sm"
+      status="exists"
+    />
+    <slot name="endItems" />
   </div>
 </template>
 
@@ -32,7 +40,9 @@ import {
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { ComponentInList } from "@/workers/types/entity_kind_types";
+import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
 import { getAssetIcon, getAssetColor } from "./util";
+import ComponentQualificationStatus from "./ComponentQualificationStatus.vue";
 
 defineProps<{
   component: ComponentInList;

--- a/app/web/src/newhotness/ComponentContextMenu.vue
+++ b/app/web/src/newhotness/ComponentContextMenu.vue
@@ -44,7 +44,7 @@ import DeleteModal, { DeleteMode } from "./DeleteModal.vue";
 import { useApi, routes } from "./api_composables";
 import { assertIsDefined, ExploreContext } from "./types";
 
-defineProps<{
+const props = defineProps<{
   onGrid?: boolean;
   enableKeyboardControls?: boolean;
 }>();
@@ -177,6 +177,17 @@ const rightClickMenuItems = computed(() => {
     icon: "clipboard-copy",
     onSelect: () => componentDuplicate(components.value.map((c) => c.id)),
   });
+
+  // Only enable pinning if we are working with a single component on the grid.
+  if (props.onGrid && component.value) {
+    const componentId = component.value.id;
+    items.push({
+      label: "Pin",
+      shortcut: "P",
+      icon: "pin",
+      onSelect: () => emit("pin", componentId),
+    });
+  }
 
   const upgradeableComponents = explore.upgradeableComponents.value;
 
@@ -493,6 +504,7 @@ const isOpen = computed(() => contextMenuRef.value?.isOpen);
 
 const emit = defineEmits<{
   (e: "edit"): void;
+  (e: "pin", componentId: ComponentId): void;
 }>();
 
 defineExpose({

--- a/app/web/src/newhotness/ComponentQualificationStatus.vue
+++ b/app/web/src/newhotness/ComponentQualificationStatus.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="flex flex-row justify-between">
+    <div
+      :class="
+        clsx('flex flex-row items-center gap-xs', props.hideTitle && 'mr-xs')
+      "
+    >
+      <StatusIndicatorIcon
+        type="qualification"
+        size="sm"
+        :status="qualificationStatus"
+      />
+      <div v-if="!props.hideTitle">Qualifications</div>
+    </div>
+    <div class="flex flex-row items-center gap-xs">
+      <TextPill
+        v-if="
+          component.qualificationTotals.failed === 0 &&
+          component.qualificationTotals.warned === 0 &&
+          component.qualificationTotals.succeeded === 0
+        "
+        tighter
+        :class="
+          clsx(
+            'text-xs ml-auto',
+            themeClasses(
+              'border-neutral-500 bg-neutral-100 text-black',
+              'border-neutral-600 bg-neutral-900 text-white',
+            ),
+          )
+        "
+      >
+        Unknown
+      </TextPill>
+      <TextPill
+        v-else-if="
+          component.qualificationTotals.failed === 0 &&
+          component.qualificationTotals.warned === 0
+        "
+        tighter
+        :class="
+          clsx(
+            'text-xs ml-auto',
+            themeClasses(
+              'border-success-500 bg-neutral-100 text-black',
+              'border-success-600 bg-neutral-900 text-white',
+            ),
+          )
+        "
+      >
+        All passed
+      </TextPill>
+      <TextPill
+        v-else-if="component.qualificationTotals.failed > 0"
+        tighter
+        :class="
+          clsx(
+            'text-xs ml-auto',
+            themeClasses(
+              'border-destructive-500 bg-destructive-100 text-black',
+              'border-destructive-600 bg-destructive-900 text-white',
+            ),
+          )
+        "
+      >
+        {{ component.qualificationTotals.failed }} Failed
+      </TextPill>
+      <TextPill
+        v-else-if="component.qualificationTotals.warned > 0"
+        tighter
+        :class="
+          clsx(
+            'text-xs ml-auto',
+            themeClasses(
+              'border-warning-500 bg-warning-100 text-black',
+              'border-warning-600 bg-warning-900 text-white',
+            ),
+          )
+        "
+      >
+        {{ component.qualificationTotals.warned }} Warning
+      </TextPill>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { themeClasses, TextPill } from "@si/vue-lib/design-system";
+import clsx from "clsx";
+import { computed } from "vue";
+import {
+  ComponentInList,
+  BifrostComponent,
+} from "@/workers/types/entity_kind_types";
+import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
+
+const props = defineProps<{
+  component: ComponentInList | BifrostComponent;
+  hideTitle?: boolean;
+}>();
+
+const qualificationStatus = computed(() =>
+  getQualificationStatus(props.component),
+);
+</script>
+
+<script lang="ts">
+export function getQualificationStatus(
+  component: BifrostComponent | ComponentInList,
+) {
+  if (component.qualificationTotals.failed > 0) return "failure";
+  if (component.qualificationTotals.warned > 0) return "warning";
+  if (component.qualificationTotals.succeeded > 0) return "success";
+  return "unknown";
+}
+</script>

--- a/app/web/src/newhotness/Map.vue
+++ b/app/web/src/newhotness/Map.vue
@@ -375,6 +375,9 @@ const onD = (e: KeyDetails["d"]) => {
     ]);
   }
 };
+const onP = (_e: KeyDetails["p"]) => {
+  // Do nothing! Pinning is unsupported in the map view.
+};
 const onU = (_e: KeyDetails["u"]) => {
   // if (selectedComponent.value && selectedComponent.value.canBeUpgraded) {
   //   componentContextMenuRef.value?.componentUpgrade([
@@ -836,6 +839,7 @@ defineExpose({
   onEscape,
   onE,
   onD,
+  onP,
   onU,
   onBackspace,
   onR,

--- a/app/web/src/newhotness/QualificationPanel.vue
+++ b/app/web/src/newhotness/QualificationPanel.vue
@@ -21,7 +21,7 @@ import { AttributeValueId } from "@/store/status.store";
 import { ValidationOutputStatus } from "@/api/sdf/dal/property_editor";
 import { findAvsAtPropPath } from "./util";
 
-export type QualificationStatus = "success" | "failure" | "warning";
+export type QualificationStatus = "success" | "failure" | "warning" | "unknown";
 
 export interface Qualification {
   name?: string;

--- a/app/web/src/newhotness/QualificationView.vue
+++ b/app/web/src/newhotness/QualificationView.vue
@@ -19,7 +19,7 @@
           {{ qualification.message }}
         </template>
         <template v-else>
-          The qualification has not yet ran or is actively running. Standby...
+          The qualification has not yet ran or is actively running.
         </template>
       </StatusMessageBox>
 

--- a/app/web/src/newhotness/ShortcutModal.vue
+++ b/app/web/src/newhotness/ShortcutModal.vue
@@ -80,6 +80,15 @@
       </div>
       <div>
         <div class="keys">
+          <div class="key">P</div>
+        </div>
+        <div>
+          Press <TextPill tighter variant="key">P</TextPill> to pin or unpin the
+          selected component.
+        </div>
+      </div>
+      <div>
+        <div class="keys">
           <Icon name="backspace" />
         </div>
         <div>

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -272,6 +272,7 @@ export type SelectionsInQueryString = Partial<{
   c: string;
   groupBy: GroupByUrlQuery;
   sortBy: SortByUrlQuery;
+  pinned: string;
 }>;
 
 const compositionLink = computed(() => {

--- a/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
@@ -15,6 +15,61 @@
     </span>
     <PillCounter :count="row.count" class="text-xs" />
   </div>
+  <div v-else-if="row.type === 'pinnedContentRow'">
+    <!-- We need an outer div because the card uses borders for the asset color. -->
+    <div
+      :class="
+        clsx(
+          'border rounded-sm cursor-pointer',
+          pinnedBorderClasses(row.component.id),
+        )
+      "
+    >
+      <ComponentCard
+        ref="exploreGridPinnedRef"
+        :component="row.component"
+        :data-index="row.dataIndex"
+        @hoverPin="
+          (hovered) =>
+            row.type === 'pinnedContentRow' && hover(row.component.id, !hovered)
+        "
+        @mouseenter="hover(row.component.id, true)"
+        @mouseleave="hover(row.component.id, false)"
+        @unpin="emit('unpin', row.component.id)"
+        @click.stop.left="
+          (e) =>
+            row.type === 'pinnedContentRow' &&
+            emit('childClicked', e, row.component.id, row.dataIndex)
+        "
+        @click.stop.right="
+          (e) =>
+            row.type === 'pinnedContentRow' &&
+            emit('childClicked', e, row.component.id, row.dataIndex)
+        "
+      >
+        <template #endItems>
+          <div
+            :class="
+              clsx(
+                'bg-neutral-600 border border-neutral-600 rounded p-2xs',
+                hoveredPinId === row.component.id &&
+                  themeClasses(
+                    'border-black bg-black',
+                    'border-white bg-white',
+                  ),
+              )
+            "
+            @mouseenter="hoverPin(row.component.id, true)"
+            @mouseleave="hoverPin(row.component.id, false)"
+            @click.stop.left="emit('unpin', row.component.id)"
+            @click.stop.right="emit('unpin', row.component.id)"
+          >
+            <Icon name="pin" size="sm" />
+          </div>
+        </template>
+      </ComponentCard>
+    </div>
+  </div>
   <div
     v-else-if="row.type === 'contentRow'"
     :class="
@@ -28,19 +83,29 @@
       v-for="(component, columnIndex) in row.components"
       ref="exploreGridTileRefs"
       :key="component.id"
-      :data-index="computeIdx(row, columnIndex)"
+      :data-index="dataIndexForTileInRow(row, columnIndex)"
       :component="component"
       class="flex-1"
-      :class="clsx(tileClasses(component.id))"
+      :class="tileBorderClasses(component.id)"
       @mouseenter="hover(component.id, true)"
       @mouseleave="hover(component.id, false)"
       @click.stop.left="
         (e) =>
-          emit('childClicked', e, component.id, computeIdx(row, columnIndex))
+          emit(
+            'childClicked',
+            e,
+            component.id,
+            dataIndexForTileInRow(row, columnIndex),
+          )
       "
       @click.stop.right="
         (e) =>
-          emit('childClicked', e, component.id, computeIdx(row, columnIndex))
+          emit(
+            'childClicked',
+            e,
+            component.id,
+            dataIndexForTileInRow(row, columnIndex),
+          )
       "
     />
     <!--this fills in any extra spots in an unfilled row-->
@@ -65,6 +130,7 @@
       </span>
     </div>
   </div>
+  <!-- This is subtle, but important. We need a div here, even if empty. -->
   <div v-else>
     <!-- footer area -->
   </div>
@@ -84,24 +150,13 @@ import {
 import { tw } from "@si/vue-lib";
 import { ComponentInList } from "@/workers/types/entity_kind_types";
 import { ComponentId } from "@/api/sdf/dal/component";
+import ComponentCard from "../ComponentCard.vue";
 import ExploreGridTile from "./ExploreGridTile.vue";
 
 const props = defineProps<{
   row: ExploreGridRowData;
   lanesCount: number;
   focusedComponentId?: ComponentId;
-}>();
-
-const emit = defineEmits<{
-  (e: "childHover", componentId: ComponentId): void;
-  (e: "childUnhover", componentId: ComponentId): void;
-  (
-    e: "childClicked",
-    event: MouseEvent,
-    componentId: ComponentId,
-    componentIdx: number,
-  ): void;
-  (e: "clickCollapse", title: string, collapsed: boolean): void;
 }>();
 
 interface TitleIcon {
@@ -127,11 +182,6 @@ const titleIcon = computed((): TitleIcon | null => {
       return {
         iconName: "check-hex-outline",
         iconTone: "success",
-      };
-    case "Running qualifications":
-      return {
-        iconName: "loader",
-        iconTone: "neutral",
       };
     case "Unknown qualification status":
       return {
@@ -188,9 +238,14 @@ const emptyAreaData = computed((): EmptyAreaData | null => {
   }
 });
 
+// You can only have one card in a row, but you have can multiple tiles in a row.
+const exploreGridPinnedRef = ref<InstanceType<typeof ComponentCard>>();
 const exploreGridTileRefs = ref<InstanceType<typeof ExploreGridTile>[]>();
+const exploreGridComponentRefs = computed(() =>
+  _.compact([exploreGridPinnedRef.value, ...(exploreGridTileRefs.value ?? [])]),
+);
 
-const computeIdx = (row: ExploreGridRowData, idx: number) => {
+const dataIndexForTileInRow = (row: ExploreGridRowData, idx: number) => {
   if (row.type !== "contentRow") return -1;
 
   return row.chunkInitialId + idx;
@@ -207,7 +262,37 @@ const hover = (componentId: ComponentId, hovered: boolean) => {
   }
 };
 
-const tileClasses = (componentId: string) => {
+// NOTE(nick): at the time of writing, you could only pin one component at a time. However, the
+// hover detection was written to handle multiple pinned components. That is why it works with a
+// "componentId" rather than "boolean" for the pin hovering logic.
+const hoveredPinId = ref<ComponentId | undefined>(undefined);
+const hoverPin = (pinnedComponentId: ComponentId, hovered: boolean) => {
+  if (hovered) {
+    hoveredPinId.value = pinnedComponentId;
+  } else if (hoveredPinId.value === pinnedComponentId) {
+    hoveredPinId.value = undefined;
+  }
+
+  // Invert the hover state for the entire component. If you are hovering the pin, you are not
+  // hovering the component and vice versa.
+  hover(pinnedComponentId, !hovered);
+};
+
+// Provide a background color because we need to fill the empty space between the div's border and
+// the inner border for the asset color.
+const pinnedBorderClasses = (componentId: string) => {
+  const focused = props.focusedComponentId === componentId;
+  if (focused)
+    return themeClasses(
+      tw`border-action-500 bg-action-500`,
+      tw`border-action-300 bg-action-300`,
+    );
+  else if (hoveredId.value === componentId)
+    return themeClasses(tw`border-black bg-black`, tw`border-white bg-white`);
+  else return "border-neutral-600 bg-neutral-600";
+};
+
+const tileBorderClasses = (componentId: string) => {
   const focused = props.focusedComponentId === componentId;
   if (focused)
     return themeClasses(tw`border-action-500`, tw`border-action-300`);
@@ -216,7 +301,20 @@ const tileClasses = (componentId: string) => {
   else return "";
 };
 
-defineExpose({ exploreGridTileRefs });
+const emit = defineEmits<{
+  (e: "unpin", componentId: ComponentId): void;
+  (e: "childHover", componentId: ComponentId): void;
+  (e: "childUnhover", componentId: ComponentId): void;
+  (
+    e: "childClicked",
+    event: MouseEvent,
+    componentId: ComponentId,
+    componentIdx: number,
+  ): void;
+  (e: "clickCollapse", title: string, collapsed: boolean): void;
+}>();
+
+defineExpose({ exploreGridComponentRefs });
 </script>
 
 <script lang="ts">
@@ -226,6 +324,11 @@ export type ExploreGridRowData =
       components: ComponentInList[];
       chunkInitialId: number;
       insideSection: boolean;
+    }
+  | {
+      type: "pinnedContentRow";
+      component: ComponentInList;
+      dataIndex: number;
     }
   | {
       type: "header";

--- a/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
@@ -45,79 +45,8 @@
       class="[&>li]:p-xs [&>li]:flex [&>li]:flex-row [&>li]:items-center [&>li]:gap-xs [&>li]:h-9 [&_.pillcounter]:w-5 [&_.pillcounter]:h-5"
     >
       <li>
-        <StatusIndicatorIcon
-          type="qualification"
-          size="sm"
-          :status="qualificationStatus"
-        />
-        <div>Qualifications</div>
-        <TextPill
-          v-if="
-            component.qualificationTotals.failed === 0 &&
-            component.qualificationTotals.warned === 0 &&
-            component.qualificationTotals.succeeded === 0
-          "
-          tighter
-          :class="
-            clsx(
-              'text-xs ml-auto',
-              themeClasses(
-                'border-neutral-500 bg-neutral-100 text-black',
-                'border-neutral-600 bg-neutral-900 text-white',
-              ),
-            )
-          "
-        >
-          Unknown
-        </TextPill>
-        <TextPill
-          v-else-if="
-            component.qualificationTotals.failed === 0 &&
-            component.qualificationTotals.warned === 0
-          "
-          tighter
-          :class="
-            clsx(
-              'text-xs ml-auto',
-              themeClasses(
-                'border-success-500 bg-neutral-100 text-black',
-                'border-success-600 bg-neutral-900 text-white',
-              ),
-            )
-          "
-        >
-          All passed
-        </TextPill>
-        <TextPill
-          v-else-if="component.qualificationTotals.failed > 0"
-          tighter
-          :class="
-            clsx(
-              'text-xs ml-auto',
-              themeClasses(
-                'border-destructive-500 bg-destructive-100 text-black',
-                'border-destructive-600 bg-destructive-900 text-white',
-              ),
-            )
-          "
-        >
-          {{ component.qualificationTotals.failed }} Failed
-        </TextPill>
-        <TextPill
-          v-else-if="component.qualificationTotals.warned > 0"
-          tighter
-          :class="
-            clsx(
-              'text-xs ml-auto',
-              themeClasses(
-                'border-warning-500 bg-warning-100 text-black',
-                'border-warning-600 bg-warning-900 text-white',
-              ),
-            )
-          "
-        >
-          {{ component.qualificationTotals.warned }} Warning
-        </TextPill>
+        <!-- We need the "grow" here so that the qualification status expands fully. -->
+        <ComponentQualificationStatus class="grow" :component="component" />
       </li>
       <li>
         <template v-if="component.diffCount > 0">
@@ -168,7 +97,6 @@
 import {
   Icon,
   PillCounter,
-  TextPill,
   themeClasses,
   TruncateWithTooltip,
 } from "@si/vue-lib/design-system";
@@ -181,6 +109,7 @@ import {
 import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
 import { getAssetIcon } from "../util";
 import { assertIsDefined, Context, ExploreContext } from "../types";
+import ComponentQualificationStatus from "../ComponentQualificationStatus.vue";
 
 const props = defineProps<{
   component: BifrostComponent | ComponentInList;
@@ -199,10 +128,6 @@ const outgoing = computed(
 
 const canBeUpgraded = computed(() =>
   explore.upgradeableComponents.value.has(props.component.id),
-);
-
-const qualificationStatus = computed(() =>
-  getQualificationStatus(props.component),
 );
 </script>
 

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -169,6 +169,7 @@ import CarbonCompare from "~icons/carbon/compare";
 import CarbonTransformCode from "~icons/carbon/code"; // using this one as a placeholder for now
 import SettingsEdit from "~icons/carbon/settings-edit";
 import CarbonWarningAlt from "~icons/carbon/warning-alt";
+import Pin from "~icons/carbon/pin-filled";
 
 // streamline
 import StreamlineBracesCircleSolid from "~icons/streamline/braces-circle-solid";
@@ -339,6 +340,7 @@ export const ICONS = Object.freeze({
   "output-connection": OutputConnection,
   "output-socket": OutputSocket,
   password: Password,
+  pin: Pin,
   play: Play,
   plug: Plug,
   plus: Plus,


### PR DESCRIPTION
## Introduction

This change adds the ability to pin a component. Pinning a component results in two groups being shown underneath it: its incoming and outgoing connecting components. The pinned component is placed at the top of the grid and can be focused.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdleHFubG94ejh1Nnk4azVtaWlibXU2MW1tZGphdnBuZWplYzE5M2xtbSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/1j9lIbNVlQXlcEkdOK/giphy.gif"/>

## More Information

There are two ways to interact with a pinned component via the keyboard. You can press "ENTER" to navigate to it or you can press "P" to unpin it. Conversely, pinning a component can be done by pressing "P" or using the component context menu. Note: the component context menu is disabled for pinned components and "group by" is disabled when pinning.

As a consequence of the primary change of this commit, component qualification status badging and iconography has been moved into its own Vue component. Not only does it make it reusable for the grid tile and the pinned component card, but it also allows these details to be available in the delete modal.

## Other Changes

- Add unfocusing when using group by, sort by and pinning due to invalid indexing
- Remove "Standby..." from the qualification helper text
- Remove leftover "Running qualifications" switch check from grid row
- Fix qualification status missing "unknown" for qualification view

## Known Missing Feature

We did not add the pin icon on the upper right of the grid tiles themselves.

## Screenshot: Pinned Component

<img width="1035" alt="Screenshot 2025-06-30 at 6 44 26 PM" src="https://github.com/user-attachments/assets/111c8d72-82e6-42b4-8cd4-537beaab48be" />

## Screenshot: Delete Modal with Qualification Status

<img width="495" alt="Screenshot 2025-06-30 at 6 44 40 PM" src="https://github.com/user-attachments/assets/04684d2c-e42d-4a22-a3c1-dd6f4a8e66eb" />

## Screenshot: Pinning in Keyboard Controls

<img width="592" alt="Screenshot 2025-06-30 at 7 38 04 PM" src="https://github.com/user-attachments/assets/75342a35-8fea-455e-9256-1827ffa5d042" />