### PR TITLE
Fix: getting management edges right, and you can add a mgmt edge when there are zero existing edges

### DIFF
--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -138,7 +138,6 @@
           <ManagementPanel
             :component="component"
             :latestFuncRuns="latestFuncRuns"
-            :connections="componentConnections ?? undefined"
           />
         </CollapsingFlexItem>
       </div>

--- a/app/web/src/newhotness/ManagementConnectionsList.vue
+++ b/app/web/src/newhotness/ManagementConnectionsList.vue
@@ -1,6 +1,5 @@
 <template>
   <ul
-    v-if="edges.length > 0"
     :class="
       clsx(
         'flex flex-col gap-xs rounded border [&>li]:px-xs py-xs',
@@ -9,6 +8,7 @@
     "
   >
     <li
+      v-if="edges.length > 0"
       :class="
         clsx(
           'text-lg font-bold border-b',
@@ -18,17 +18,20 @@
     >
       {{ titleText }}
     </li>
+
     <ManagementConnectionInput
       v-if="selectComponent && parentComponentId"
       :existingEdges="edges"
       :parentComponentName="parentComponentName ?? 'this component'"
       :parentComponentId="parentComponentId"
     />
-    <ManagementConnectionCard
-      v-for="edge in edges"
-      :key="edge.key"
-      :componentId="edge.componentId"
-    />
+    <template v-if="edges.length > 0">
+      <ManagementConnectionCard
+        v-for="edge in edges"
+        :key="edge.key"
+        :componentId="edge.componentId"
+      />
+    </template>
   </ul>
 </template>
 

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -437,6 +437,20 @@ export const getOutgoingConnections = async (args: {
   return new DefaultMap<string, Record<string, Connection>>(() => ({}));
 };
 
+export const getIncomingManagement = async (args: {
+  workspaceId: string;
+  changeSetId: ChangeSetId;
+}) => {
+  if (!initCompleted.value) throw new Error("You must wait for initialization");
+
+  const connectionsById = await db.getIncomingManagementByComponentId(
+    args.workspaceId,
+    args.changeSetId,
+  );
+  if (connectionsById) return reactive(connectionsById);
+  return new DefaultMap<string, Record<string, Connection>>(() => ({}));
+};
+
 const waitForInitCompletion = (): Promise<void> => {
   return new Promise((resolve) => {
     if (initCompleted.value) {

--- a/app/web/src/workers/shared_webworker.ts
+++ b/app/web/src/workers/shared_webworker.ts
@@ -167,6 +167,19 @@ const dbInterface: SharedDBInterface = {
     );
   },
 
+  async getIncomingManagementByComponentId(
+    workspaceId: string,
+    changeSetId: string,
+  ) {
+    return await withRemote(
+      async (remote) =>
+        await remote.getIncomingManagementByComponentId(
+          workspaceId,
+          changeSetId,
+        ),
+    );
+  },
+
   async get(
     workspaceId: string,
     changeSetId: string,

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -36,6 +36,11 @@ export type OutgoingConnections = DefaultMap<
   Record<string, Connection>
 >;
 
+export type IncomingManagementConnections = DefaultMap<
+  string,
+  Record<string, Connection>
+>;
+
 export type UpdateFn = (
   workspaceId: string,
   changeSetId: string,
@@ -135,6 +140,10 @@ export interface SharedDBInterface {
     workspaceId: string,
     changeSetId: ChangeSetId,
   ): Promise<OutgoingConnections | undefined>;
+  getIncomingManagementByComponentId(
+    workspaceId: string,
+    changeSetId: ChangeSetId,
+  ): Promise<IncomingManagementConnections | undefined>;
   getOutgoingConnectionsCounts(
     workspaceId: string,
     changeSetId: ChangeSetId,
@@ -218,6 +227,10 @@ export interface TabDBInterface {
     workspaceId: string,
     changeSetId: ChangeSetId,
   ): OutgoingConnections;
+  getIncomingManagementByComponentId(
+    workspaceId: string,
+    changeSetId: ChangeSetId,
+  ): IncomingManagementConnections;
   getOutgoingConnectionsCounts(
     workspaceId: string,
     changeSetId: ChangeSetId,

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -17,11 +17,13 @@ import { ComponentInfo } from "./dbinterface";
 export enum EntityKind {
   Component = "Component",
   ComponentInList = "ComponentInList",
+  ComponentDetails = "ComponentDetails",
   View = "View",
   ViewList = "ViewList",
   ComponentList = "ComponentList",
   ViewComponentList = "ViewComponentList",
   IncomingConnections = "IncomingConnections",
+  ManagementConnections = "ManagementConnections",
   IncomingConnectionsList = "IncomingConnectionsList",
   SchemaVariantCategories = "SchemaVariantCategories",
   SchemaVariant = "SchemaVariant",
@@ -32,8 +34,8 @@ export enum EntityKind {
   AttributeTree = "AttributeTree",
   PossibleConnections = "PossibleConnections",
   OutgoingConnections = "OutgoingConnections",
+  IncomingManagementConnections = "IncomingManagementConnections",
   OutgoingCounts = "OutgoingCounts",
-  ComponentDetails = "ComponentDetails",
 }
 
 /**
@@ -382,6 +384,12 @@ export interface AttributeTree {
 export interface IncomingConnectionsList {
   id: ChangeSetId;
   componentConnections: WeakReference<EntityKind.IncomingConnections>[];
+}
+
+// NOTE: these are OUTGOING
+export interface ManagementConnections {
+  id: ComponentId;
+  connections: Connection[];
 }
 
 export interface IncomingConnections {

--- a/lib/dal-materialized-views/src/component.rs
+++ b/lib/dal-materialized-views/src/component.rs
@@ -41,7 +41,7 @@ pub async fn assemble_in_list(
     let color = Component::color_by_id(ctx, component_id).await?;
 
     let attribute_tree = attribute_tree::assemble(ctx.to_owned(), component_id).await?;
-    let mut input_count = attribute_tree
+    let input_count = attribute_tree
         .attribute_values
         .values()
         .filter(|value| match value.external_sources.as_ref() {
@@ -49,7 +49,6 @@ pub async fn assemble_in_list(
             None => false,
         })
         .count();
-    input_count += Component::managers_by_id(ctx, component_id).await?.len();
 
     Ok(ComponentInListMv {
         id: component_id,
@@ -102,7 +101,7 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
     // NOTE(nick): I think having both null and empty external sources may lead to a path of pain
     // and despair. Given that we're solely concerned with the input count though, now is not the
     // time to refactor that.
-    let mut input_count = attribute_tree
+    let input_count = attribute_tree
         .attribute_values
         .values()
         .filter(|value| match value.external_sources.as_ref() {
@@ -110,7 +109,6 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
             None => false,
         })
         .count();
-    input_count += Component::managers_by_id(ctx, component_id).await?.len();
 
     Ok(ComponentMv {
         id: component_id,

--- a/lib/dal-materialized-views/src/incoming_connections.rs
+++ b/lib/dal-materialized-views/src/incoming_connections.rs
@@ -14,6 +14,7 @@ use dal::{
 use si_frontend_mv_types::incoming_connections::{
     Connection,
     IncomingConnections as IncomingConnectionsMv,
+    ManagementConnections as ManagementConnectionsMv,
 };
 use si_id::ComponentId;
 use telemetry::prelude::*;
@@ -30,10 +31,30 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> Result<Inco
 
     let mut connections = Vec::new();
     connections.extend(prop_to_prop(ctx, component_id).await?);
-    connections.extend(management(ctx, component_id).await?);
     connections.sort();
 
     Ok(IncomingConnectionsMv {
+        id: component_id,
+        connections,
+    })
+}
+
+#[instrument(
+    name = "dal_materialized_views.outgoing_mgmt_connections",
+    level = "debug",
+    skip_all
+)]
+pub async fn assemble_management(
+    ctx: DalContext,
+    component_id: ComponentId,
+) -> Result<ManagementConnectionsMv> {
+    let ctx = &ctx;
+
+    let mut connections = Vec::new();
+    connections.extend(management(ctx, component_id).await?);
+    connections.sort();
+
+    Ok(ManagementConnectionsMv {
         id: component_id,
         connections,
     })

--- a/lib/edda-server/src/change_set_processor_task/materialized_view.rs
+++ b/lib/edda-server/src/change_set_processor_task/materialized_view.rs
@@ -47,6 +47,7 @@ use si_frontend_mv_types::{
     incoming_connections::{
         IncomingConnections as IncomingConnectionsMv,
         IncomingConnectionsList as IncomingConnectionsListMv,
+        ManagementConnections as ManagementConnectionsMv,
     },
     index::MvIndex,
     materialized_view::{
@@ -905,6 +906,22 @@ async fn spawn_build_mv_task_for_change_and_mv_kind(
                 entity_mv_id,
                 IncomingConnectionsMv,
                 dal_materialized_views::incoming_connections::assemble(
+                    ctx.clone(),
+                    si_events::ulid::Ulid::from(change.entity_id).into(),
+                ),
+            );
+        }
+        ReferenceKind::ManagementConnections => {
+            let entity_mv_id = change.entity_id.to_string();
+
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                entity_mv_id,
+                ManagementConnectionsMv,
+                dal_materialized_views::incoming_connections::assemble_management(
                     ctx.clone(),
                     si_events::ulid::Ulid::from(change.entity_id).into(),
                 ),

--- a/lib/si-frontend-mv-types-rs/src/incoming_connections.rs
+++ b/lib/si-frontend-mv-types-rs/src/incoming_connections.rs
@@ -66,9 +66,22 @@ pub struct IncomingConnections {
 )]
 #[serde(rename_all = "camelCase")]
 #[mv(
-    trigger_entity = EntityKind::CategoryComponent,
-    reference_kind = ReferenceKind::IncomingConnectionsList,
-    build_priority = "List",
+    trigger_entity = EntityKind::Component,
+    reference_kind = ReferenceKind::ManagementConnections,
+)]
+pub struct ManagementConnections {
+    pub id: ComponentId,
+    pub connections: Vec<Connection>,
+}
+
+#[derive(
+    Clone, Debug, Deserialize, Eq, PartialEq, Serialize, FrontendChecksum, FrontendObject, Refer, MV,
+)]
+#[serde(rename_all = "camelCase")]
+#[mv(
+  trigger_entity = EntityKind::CategoryComponent,
+  reference_kind = ReferenceKind::IncomingConnectionsList,
+  build_priority = "List",
 )]
 pub struct IncomingConnectionsList {
     pub id: WorkspacePk,

--- a/lib/si-frontend-mv-types-rs/src/reference.rs
+++ b/lib/si-frontend-mv-types-rs/src/reference.rs
@@ -45,6 +45,7 @@ pub enum ReferenceKind {
     ComponentList,
     IncomingConnections,
     IncomingConnectionsList,
+    ManagementConnections,
     MvIndex,
     SchemaMembers,
     SchemaVariant,


### PR DESCRIPTION
## How does this PR change the system?
MGMT EDGES ARE OUTGOING, NOT INCOMING
1. Don't bundle them in with `IncomingConnections`
2. Give them their own MV, and their own "flipped" global map of `IncomingManagementConnections`.
3. Don't mutate the call to get outgoing connection data inside the useQuery.
4. Take the mgmt connection count off the count since it wont display in that box, its displays in the panel

![image](https://github.com/user-attachments/assets/bb48913d-2186-4790-abc6-f4ad2e58154d)

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYzhqYmF5OG92YWJ0cjludDdjcWpjcDB4cjFtdnJyb3VzMGNmZjlkMCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/kCoIap1RrUqE1f0fKu/giphy.gif"/>