### PR TITLE
Fix: watch the change set id in order to keep WsEvent subscription for FuncRunLogUpdated working to invalidate query

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -454,23 +454,33 @@ const invalidatePaginatedFuncRuns = _.debounce(() => {
 onMounted(() => {
   windowResizeHandler();
   windowResizeEmitter.on("resize", windowResizeHandler);
-
-  // Invalidate the paginatedFuncRuns query when FuncRunLogUpdated events are received.
-  realtimeStore.subscribe(
-    funcRunKey,
-    `changeset/${ctx.value.changeSetId.value}`,
-    [
-      {
-        eventType: "FuncRunLogUpdated",
-        callback: async (payload) => {
-          if (payload.funcRunId) {
-            invalidatePaginatedFuncRuns();
-          }
-        },
-      },
-    ],
-  );
 });
+
+watch(
+  ctx.value.changeSetId,
+  () => {
+    // stop listening to old change set
+    realtimeStore.unsubscribe(funcRunKey);
+    // listen to new change set
+    // Invalidate the paginatedFuncRuns query when FuncRunLogUpdated events are received.
+    realtimeStore.subscribe(
+      funcRunKey,
+      `changeset/${ctx.value.changeSetId.value}`,
+      [
+        {
+          eventType: "FuncRunLogUpdated",
+          callback: async (payload) => {
+            if (payload.funcRunId) {
+              invalidatePaginatedFuncRuns();
+            }
+          },
+        },
+      ],
+    );
+  },
+  { immediate: true },
+);
+
 onBeforeUnmount(() => {
   windowResizeEmitter.off("resize", windowResizeHandler);
   realtimeStore.unsubscribe(funcRunKey);


### PR DESCRIPTION
## How does this PR change the system?
Stores are dumb.
Watch the change set id in order to keep `WsEvent` subscription for `FuncRunLogUpdated` working to invalidate query.

![image](https://github.com/user-attachments/assets/aa6a38e9-850e-40e1-9a6d-bd0e2c090894)
