### PR TITLE
feat(web): don't force lobby on new change set

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -348,15 +348,7 @@ onBeforeMount(async () => {
 watch(
   () => props.changeSetId,
   async (newValue, _) => {
-    const exists = await heimdall.changeSetExists(props.workspacePk, newValue);
-    if (!exists) {
-      heimdall.muspelheimStatuses.value[newValue] = false;
-    }
-
-    const result = await heimdall.niflheim(props.workspacePk, newValue, true);
-    if (!result) {
-      heimdall.muspelheimStatuses.value[newValue] = false;
-    }
+    await heimdall.niflheim(props.workspacePk, newValue, true, false);
   },
 );
 

--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -249,7 +249,7 @@ export const useApi = () => {
 
   // You have to run endpoint BEFORE you call setWatchFn or it will break
   let labeledObs: LabeledObs;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
   let apiCall: APICall<any>;
   const endpoint = <Response>(key: routes, args?: Record<string, string>) => {
     let path = _routes[key];
@@ -328,9 +328,6 @@ export const useApi = () => {
         retry += 1;
       }, INTERVAL);
     });
-    if (apiCall.lobbyRequired) {
-      muspelheimStatuses.value[newChangeSetId] = false;
-    }
     await router.push(to);
     reset();
   };

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -361,7 +361,6 @@ export const linkNewChangeset = async (
   changeSetId: string,
   headChangeSetId: string,
 ) => {
-  muspelheimStatuses.value[changeSetId] = false;
   await db.linkNewChangeset(workspaceId, headChangeSetId, changeSetId);
 };
 
@@ -529,7 +528,8 @@ export const muspelheim = async (workspaceId: string, force?: boolean) => {
 export const niflheim = async (
   workspaceId: string,
   changeSetId: ChangeSetId,
-  force?: boolean,
+  force = false,
+  lobbyOnFailure = true,
 ): Promise<boolean> => {
   await waitForInitCompletion();
   const changeSetExists = await db.changeSetExists(workspaceId, changeSetId);
@@ -542,7 +542,11 @@ export const niflheim = async (
 
     // If niflheim returned false (202 response), navigate to lobby
     // Index is being rebuilt and is not ready yet.
-    muspelheimStatuses.value[changeSetId] = success;
+    if (!success && lobbyOnFailure) {
+      muspelheimStatuses.value[changeSetId] = false;
+    } else if (success) {
+      muspelheimStatuses.value[changeSetId] = true;
+    }
     return success;
   }
 


### PR DESCRIPTION
- Wait for a change set to exist before pushing the new change set into the route when a change set is being created by the change set drop down.
- Don't go to the lobby when linking a new change set or getting a ChangeSetCreated.
- Still "cold start" on change set switch, but don't force lobby.