### PR TITLE
Fix: bust single func run too, get CodeViewer to behave

### DIFF
--- a/app/web/src/components/CodeViewer.vue
+++ b/app/web/src/components/CodeViewer.vue
@@ -81,7 +81,15 @@
 
 <script setup lang="ts">
 import * as _ from "lodash-es";
-import { ref, computed, watch, PropType, onMounted, onBeforeMount } from "vue";
+import {
+  ref,
+  computed,
+  watch,
+  PropType,
+  onMounted,
+  onBeforeMount,
+  nextTick,
+} from "vue";
 import { basicSetup, EditorView } from "codemirror";
 import { StreamLanguage } from "@codemirror/language";
 
@@ -193,8 +201,6 @@ const editorExtensionList = computed<Extension[]>(() => {
 });
 
 function initCodeMirrorEditor() {
-  if (numberOfLinesInCode.value < 2) return;
-
   editorView = new EditorView({
     state: EditorState.create({
       doc: props.code,
@@ -214,15 +220,8 @@ function syncEditorConfig() {
 }
 
 function syncEditorCode() {
-  if (!editorView) return;
-  editorView.dispatch({
-    changes: {
-      from: 0,
-      to: editorView.state.doc.length,
-      insert: props.code,
-    },
-    effects: readOnly.reconfigure(EditorState.readOnly.of(true)),
-  });
+  // this is what `CodeEditor` does, on any change it remounts the editor
+  initCodeMirrorEditor();
 }
 
 onMounted(initCodeMirrorEditor);
@@ -231,7 +230,9 @@ watch(editorExtensionList, syncEditorConfig, { immediate: true });
 watch(
   () => props.code,
   () => {
-    syncEditorCode();
+    nextTick(() => {
+      syncEditorCode();
+    });
   },
 );
 

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -449,6 +449,15 @@ onMounted(() => {
   windowResizeEmitter.on("resize", windowResizeHandler);
 });
 
+const invalidateOneFuncRun = _.debounce((funcRunId: string) => {
+  const queryKey = [ctx.value.changeSetId, "funcRunLogs", funcRunId];
+  if (queryClient.isFetching({ queryKey }) > 0) {
+    invalidateOneFuncRun(funcRunId);
+    return;
+  }
+  queryClient.invalidateQueries({ queryKey });
+}, 500);
+
 watch(
   ctx.value.changeSetId,
   () => {
@@ -465,6 +474,7 @@ watch(
           callback: async (payload) => {
             if (payload.funcRunId) {
               invalidatePaginatedFuncRuns();
+              invalidateOneFuncRun(payload.funcRunId);
             }
           },
         },


### PR DESCRIPTION
## How does this PR change the system?
- Workspace.vue is already listening for `FuncRunLogsUpdated`, so just bust query cache from there
- `CodeViewer` needs to re-mount on change, just like `CodeEditor` does
- Stop query polling (we can think of this as a back up) once logs are finalized, show "live" until then (don't stop polling on "Failed" just yet, we don't always have the logs, let the result of logs query "turn it off").


<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMDljdW1uaDM3N2kybW1renNpMWliN2J5cnE1N2lyMWFwajJqNjhqbyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ukoCPj790xDFnNlLuA/giphy.gif"/>