### PR TITLE
Fix: possible connections invalidations

### DIFF
--- a/app/web/src/workers/shared_webworker.ts
+++ b/app/web/src/workers/shared_webworker.ts
@@ -203,20 +203,10 @@ const dbInterface: SharedDBInterface = {
     );
   },
 
-  async getPossibleConnections(
-    workspaceId,
-    changeSetId,
-    destSchemaName,
-    destProp,
-  ) {
+  async getPossibleConnections(workspaceId, changeSetId) {
     return await withRemote(
       async (remote) =>
-        await remote.getPossibleConnections(
-          workspaceId,
-          changeSetId,
-          destSchemaName,
-          destProp,
-        ),
+        await remote.getPossibleConnections(workspaceId, changeSetId),
     );
   },
 

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -18,7 +18,6 @@ import {
   Connection,
   EntityKind,
   PossibleConnection,
-  Prop,
 } from "./entity_kind_types";
 
 export type Column = string;
@@ -133,9 +132,7 @@ export interface SharedDBInterface {
   getPossibleConnections(
     workspaceId: string,
     changeSetId: string,
-    destSchemaName: string,
-    dest: Prop,
-  ): Promise<CategorizedPossibleConnections>;
+  ): Promise<PossibleConnection[]>;
   getOutgoingConnectionsByComponentId(
     workspaceId: string,
     changeSetId: ChangeSetId,
@@ -220,9 +217,7 @@ export interface TabDBInterface {
   getPossibleConnections(
     workspaceId: string,
     changeSetId: string,
-    destSchemaName: string,
-    dest: Prop,
-  ): CategorizedPossibleConnections;
+  ): PossibleConnection[];
   getOutgoingConnectionsByComponentId(
     workspaceId: string,
     changeSetId: ChangeSetId,

--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -41,7 +41,6 @@ import {
   AtomMeta,
   BroadcastMessage,
   BustCacheFn,
-  CategorizedPossibleConnections,
   Checksum,
   ComponentInfo,
   Gettable,
@@ -70,7 +69,6 @@ import {
   EddaSchemaVariantCategories,
   EntityKind,
   PossibleConnection,
-  Prop,
   SchemaMembers,
   SchemaVariant,
   UninstalledVariant,
@@ -2119,60 +2117,14 @@ const postProcess = (
         workspaceId,
         changeSetId,
         EntityKind.PossibleConnections,
-        changeSetId,
+        workspaceId,
       );
     }
   }
 };
 
-const getPossibleConnections = (
-  _workspaceId: string,
-  changeSetId: string,
-  destSchemaName: string,
-  dest: Prop,
-) => {
-  const possible = Object.values(allPossibleConns.get(changeSetId));
-
-  const categories: CategorizedPossibleConnections = {
-    suggestedMatches: [],
-    typeAndNameMatches: [],
-    typeMatches: [],
-    nonMatches: [],
-  };
-
-  for (const source of possible) {
-    const isSuggested =
-      dest.suggestSources?.some(
-        (s) => s.schema === source.schemaName && s.prop === source.path,
-      ) ||
-      source.suggestAsSourceFor?.some(
-        (d) => d.schema === destSchemaName && `root${d.prop}` === dest.path,
-      );
-    if (isSuggested) {
-      categories.suggestedMatches.push(source);
-    } else if (
-      source.kind === dest.kind ||
-      (source.kind === "string" &&
-        !["string", "boolean", "object", "map", "integer"].includes(dest.kind))
-    ) {
-      // If the types match, sort name matches first
-      if (source.name === dest.name && source.schemaName !== destSchemaName) {
-        categories.typeAndNameMatches.push(source);
-      } else {
-        categories.typeMatches.push(source);
-      }
-    } else {
-      categories.nonMatches.push(source);
-    }
-  }
-
-  const cmp = (a: PossibleConnection, b: PossibleConnection) =>
-    `${a.name} ${a.path}`.localeCompare(`${b.name} ${b.path}`);
-  categories.suggestedMatches.sort(cmp);
-  categories.typeAndNameMatches.sort(cmp);
-  categories.typeMatches.sort(cmp);
-  categories.nonMatches.sort(cmp);
-  return categories;
+const getPossibleConnections = (_workspaceId: string, changeSetId: string) => {
+  return Object.values(allPossibleConns.get(changeSetId));
 };
 
 const getOutgoingConnectionsByComponentId = (


### PR DESCRIPTION
## How does this PR change the system?
- First, we can't add "extras" to `queryKey`—because the web worker has no way of knowing how to bust it
- Because we can't add extras, we cannot account for the last 2 arguments of "what do i want a suggestion for???"...
    - send the full possible list over the boundary
    - do the "what order ought things to be in" based on the prop, within the component itself.
- Third, we missed the web worker cache bust on the `PossibleConnections`, it was set to bust on `ChangeSetId`, needed to be `WorkspaceId`.

I screwed up what goes on what side of the boundary in my first WIP on this one... which led to folks adding "extras" to force it to work—which means busting fails.

### Testing steps
1. On HEAD, I have Cred, Region, and EC2::Instance w/ resource all linked together
2. Create a change set
3. Make another EC2::Instance
4. Name it `Deleted`
5. Navigate to the first EC2::Instance
6. Open `AttributeInput`, see `Deleted` in the list of options
7. Back to `Explore`
8. Right Click & Erase the `Deleted` EC2::Instance
9. Go back to the first EC2::Instance
10. Open `AttributeInput`, no more `Deleted`!!

To ensure that the "suggested props" are ordered correctly... I compare the order of the list on any input vs the `Region` input which always puts the region first.