### PR TITLE
Create MV listing all ComponentIds involved in unfinished DVU

### DIFF
--- a/lib/dal-materialized-views/src/dependent_value_component_list.rs
+++ b/lib/dal-materialized-views/src/dependent_value_component_list.rs
@@ -1,0 +1,36 @@
+use std::collections::HashSet;
+
+use dal::{
+    AttributeValue,
+    DalContext,
+    attribute::value::DependentValueGraph,
+    workspace_snapshot::DependentValueRoot,
+};
+use si_frontend_mv_types::dependent_values::DependentValueComponentList as DependentValueComponentListMv;
+use telemetry::prelude::*;
+
+#[instrument(
+    name = "dal_materialized_views.dependent_value_component_list",
+    level = "debug",
+    skip_all
+)]
+pub async fn assemble(ctx: DalContext) -> super::Result<DependentValueComponentListMv> {
+    let ctx = &ctx;
+    let dependent_value_graph = DependentValueGraph::new(
+        ctx,
+        DependentValueRoot::get_dependent_value_roots(ctx).await?,
+    )
+    .await?;
+
+    let mut component_id_set = HashSet::new();
+    for attribute_value_id in dependent_value_graph.all_value_ids() {
+        component_id_set.insert(AttributeValue::component_id(ctx, attribute_value_id).await?);
+    }
+    let mut component_ids: Vec<_> = component_id_set.into_iter().collect();
+    component_ids.sort();
+
+    Ok(DependentValueComponentListMv {
+        id: ctx.workspace_pk()?,
+        component_ids,
+    })
+}

--- a/lib/dal-materialized-views/src/lib.rs
+++ b/lib/dal-materialized-views/src/lib.rs
@@ -54,6 +54,7 @@ pub mod action_prototype_view_list;
 pub mod action_view_list;
 pub mod component;
 pub mod component_list;
+pub mod dependent_value_component_list;
 pub mod incoming_connections;
 pub mod incoming_connections_list;
 pub mod mgmt_prototype_view_list;
@@ -85,6 +86,10 @@ pub enum Error {
     Component(#[from] dal::ComponentError),
     #[error("dal transactions error: {0}")]
     DalTransactions(#[from] dal::TransactionsError),
+    #[error("dependent value root error: {0}")]
+    DependentValueRoot(
+        #[from] dal::workspace_snapshot::dependent_value_root::DependentValueRootError,
+    ),
     #[error("diagram error: {0}")]
     Diagram(#[from] dal::diagram::DiagramError),
     #[error("func error: {0}")]

--- a/lib/edda-server/src/change_set_processor_task/materialized_view.rs
+++ b/lib/edda-server/src/change_set_processor_task/materialized_view.rs
@@ -44,6 +44,7 @@ use si_frontend_mv_types::{
         SchemaMembers,
         attribute_tree::AttributeTree as AttributeTreeMv,
     },
+    dependent_values::DependentValueComponentList as DependentValueComponentListMv,
     incoming_connections::{
         IncomingConnections as IncomingConnectionsMv,
         IncomingConnectionsList as IncomingConnectionsListMv,
@@ -892,7 +893,20 @@ async fn spawn_build_mv_task_for_change_and_mv_kind(
                 change,
                 workspace_mv_id,
                 ComponentListMv,
-                dal_materialized_views::component_list::assemble(ctx.clone(),),
+                dal_materialized_views::component_list::assemble(ctx.clone()),
+            );
+        }
+        ReferenceKind::DependentValueComponentList => {
+            let workspace_mv_id = workspace_pk.to_string();
+
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                workspace_mv_id,
+                DependentValueComponentListMv,
+                dal_materialized_views::dependent_value_component_list::assemble(ctx.clone()),
             );
         }
         ReferenceKind::IncomingConnections => {

--- a/lib/si-frontend-mv-types-rs/src/dependent_values.rs
+++ b/lib/si-frontend-mv-types-rs/src/dependent_values.rs
@@ -1,0 +1,30 @@
+use serde::Serialize;
+use si_events::workspace_snapshot::EntityKind;
+use si_id::{
+    ComponentId,
+    WorkspacePk,
+};
+
+use crate::reference::ReferenceKind;
+
+#[derive(
+    Debug,
+    Serialize,
+    PartialEq,
+    Eq,
+    Clone,
+    si_frontend_mv_types_macros::MV,
+    si_frontend_mv_types_macros::FrontendChecksum,
+    si_frontend_mv_types_macros::FrontendObject,
+    si_frontend_mv_types_macros::Refer,
+)]
+#[serde(rename_all = "camelCase")]
+#[mv(
+    trigger_entity = EntityKind::CategoryDependentValueRoots,
+    reference_kind = ReferenceKind::DependentValueComponentList,
+    build_priority = "List",
+)]
+pub struct DependentValueComponentList {
+    pub id: WorkspacePk,
+    pub component_ids: Vec<ComponentId>,
+}

--- a/lib/si-frontend-mv-types-rs/src/lib.rs
+++ b/lib/si-frontend-mv-types-rs/src/lib.rs
@@ -26,6 +26,7 @@ pub mod action;
 mod change_set;
 pub mod checksum;
 pub mod component;
+pub mod dependent_values;
 pub mod incoming_connections;
 pub mod index;
 pub mod management;

--- a/lib/si-frontend-mv-types-rs/src/reference.rs
+++ b/lib/si-frontend-mv-types-rs/src/reference.rs
@@ -43,6 +43,7 @@ pub enum ReferenceKind {
     Component,
     ComponentInList,
     ComponentList,
+    DependentValueComponentList,
     IncomingConnections,
     IncomingConnectionsList,
     ManagementConnections,


### PR DESCRIPTION
In order to provide feedback in the front end both for "data has not fully propigated yet", and "these are the components that have updates pending, because of their inputs" the `DependentValueComponentList` provides the list of all `ComponentId`s involved in the DVU graph of the current DVU Roots in the snapshot.
