### PR TITLE
Fix: stop racing for a bearer token

### DIFF
--- a/app/web/src/store/apis.web.ts
+++ b/app/web/src/store/apis.web.ts
@@ -34,6 +34,8 @@ export function injectBearerTokenAuth(config: InternalAxiosRequestConfig) {
   const authStore = useAuthStore();
   config.headers = config.headers || {};
 
+  // not logged in means zero tokens
+  if (!authStore.userIsLoggedIn) authStore.initTokens();
   const token = authStore.selectedOrDefaultAuthToken;
   if (token) {
     config.headers.authorization = `Bearer ${token}`;

--- a/app/web/src/store/auth.store.ts
+++ b/app/web/src/store/auth.store.ts
@@ -62,8 +62,8 @@ export const useAuthStore = () => {
         !_.isEmpty(state.tokens) && state.user?.pk,
       selectedWorkspaceToken: (state) => {
         const workspacesStore = useWorkspacesStore();
-        if (workspacesStore.selectedWorkspacePk) {
-          return state.tokens[workspacesStore.selectedWorkspacePk];
+        if (workspacesStore.urlSelectedWorkspaceId) {
+          return state.tokens[workspacesStore.urlSelectedWorkspaceId];
         }
       },
       selectedOrDefaultAuthToken(): string | undefined {
@@ -162,9 +162,7 @@ export const useAuthStore = () => {
         });
       },
 
-      // OTHER ACTIONS ///////////////////////////////////////////////////////////////////
-      async initFromStorage() {
-        // check regular user token (we will likely have a different token for admin auth later)
+      initTokens() {
         let tokensByWorkspacePk: Record<string, string> = {};
         try {
           const parsed = JSON.parse(
@@ -186,6 +184,12 @@ export const useAuthStore = () => {
           tokens: tokensByWorkspacePk,
           userPk,
         });
+      },
+
+      // OTHER ACTIONS ///////////////////////////////////////////////////////////////////
+      async initFromStorage() {
+        // check regular user token (we will likely have a different token for admin auth later)
+        this.initTokens();
 
         // this endpoint re-fetches the user and workspace
         // dont think it's 100% necessary at the moment and not quite the right shape, but can fix later


### PR DESCRIPTION
## How does this PR change the system?

1. separate out the loading of tokens from local storage into a non async function
2. because we call that function prior to injection (if we aren't loaded yet) and we can't call an async function in there
3. when looking up the selected workspace token, use the workspace in the URL (don't require a payload from the FETCH WORKSPACES call)

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMGUwZjFiZmJ0dzYya3hlbnl2ZGk4ODRwOTBzbzloMXRmOHZudG1mdyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3xz2BqgtWhZvuwdhUk/giphy.gif"/>