### PR TITLE
feat(web): Ensuring we store the viewId in the queryString

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -273,6 +273,7 @@ export type SelectionsInQueryString = Partial<{
   groupBy: GroupByUrlQuery;
   sortBy: SortByUrlQuery;
   pinned: string;
+  viewId: string;
 }>;
 
 const compositionLink = computed(() => {


### PR DESCRIPTION
We will not store the viewId if it’s default or all views - but we will if it’s a custom view and we will load the correct view from that queryString on deep linking