### PR TITLE
Feat/add cypress remote envs

### DIFF
--- a/.ci/deploy-stack.py
+++ b/.ci/deploy-stack.py
@@ -1,0 +1,266 @@
+import os
+import uuid
+import requests
+import sys
+import time
+
+API_TOKEN = os.environ.get('SI_API_TOKEN')
+WORKSPACE_ID = os.environ.get("SI_WORKSPACE_ID")
+API_URL = "https://api.systeminit.com"
+
+if not API_TOKEN or not WORKSPACE_ID:
+    raise ValueError(
+        "Missing SI_API_TOKEN or SI_WORKSPACE_ID environment variables.")
+
+headers = {
+    'Authorization': f'Bearer {API_TOKEN}',
+    'Content-Type': 'application/json'
+}
+
+
+def wait_for_merge_success(change_set_id,
+                           timeout_seconds=300,
+                           poll_interval=10):
+    """Waits until all actions are 'Success' or the change set is 'Applied' with no actions."""
+    start_time = time.time()
+    while time.time() - start_time < timeout_seconds:
+        response = requests.get(
+            f'{API_URL}/v1/w/{WORKSPACE_ID}/change-sets/{change_set_id}/merge_status',
+            headers=headers)
+        response.raise_for_status()
+        merge_data = response.json()
+
+        change_set = merge_data.get("changeSet", {})
+        actions = merge_data.get("actions", [])
+
+        if not actions:
+            status = change_set.get("status")
+            if status == "Applied":
+                print("✅ Change set applied with no actions.")
+                return True
+            else:
+                print(
+                    f"⏳ No actions found. Change set status: {status}. Waiting..."
+                )
+
+        else:
+            states = [action["state"] for action in actions]
+            if all(state == "Success" for state in states):
+                print("✅ All actions succeeded.")
+                return True
+            else:
+                print(f"⏳ Action states: {states}. Waiting...")
+
+        time.sleep(poll_interval)
+
+    raise TimeoutError(
+        f"❌ Timeout reached. Merge not successful for ChangeSet {change_set_id}."
+    )
+
+
+def get_public_ip(change_set_id,
+                  component_id,
+                  timeout_seconds=60,
+                  poll_interval=3):
+    url = f"{API_URL}/v1/w/{WORKSPACE_ID}/change-sets/{change_set_id}/components/{component_id}"
+
+    start_time = time.time()
+    while time.time() - start_time < timeout_seconds:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        component = response.json().get("component", {})
+
+        for prop in component.get("resourceProps", []):
+            if prop.get("path") == "root/resource_value/PublicIp":
+                public_ip = prop.get("value")
+                if public_ip:
+                    print(f"✅ Public IP found: {public_ip}")
+                    return public_ip
+
+        print("⏳ Public IP not ready yet, retrying...")
+        time.sleep(poll_interval)
+
+    raise TimeoutError("❌ Public IP not found within timeout window.")
+
+
+def manage_component(change_set_id, component_id, manager_component_id):
+    response = requests.post(
+        f'{API_URL}/v1/w/{WORKSPACE_ID}/change-sets/{change_set_id}/components/{component_id}/manage',
+        headers=headers,
+        json={"componentId": manager_component_id})
+    response.raise_for_status()
+    return response.json()
+
+
+def create_change_set(name):
+    response = requests.post(f'{API_URL}/v1/w/{WORKSPACE_ID}/change-sets',
+                             headers=headers,
+                             json={'changeSetName': name})
+    response.raise_for_status()
+    return response.json()
+
+
+def create_component(change_set_id, schema_name, name, options=None):
+    request_body = {'schemaName': schema_name, 'name': name}
+    if options:
+        request_body.update(options)
+    response = requests.post(
+        f'{API_URL}/v1/w/{WORKSPACE_ID}/change-sets/{change_set_id}/components',
+        headers=headers,
+        json=request_body)
+    response.raise_for_status()
+    return response.json()
+
+
+MANAGER_COMPONENT_ID = "01JY7K7ZBMPHG22RVTNSA6GB0Z"
+
+
+def main():
+    try:
+        print('Starting System Initiative Environment Setup')
+
+        branch_name = "main"
+        environment_uuid = uuid.uuid4()
+        change_set_name = f"Environment {environment_uuid}"
+        print(f'Creating change set: {change_set_name}')
+        change_set_data = create_change_set(change_set_name)
+        change_set_id = change_set_data["changeSet"]["id"]
+        print(f'Created ChangeSet ID: {change_set_id}')
+
+        with open('provision.sh', 'r') as f:
+            userdata_template = f.read()
+        userdata_script = userdata_template.replace('{{BRANCH}}', branch_name)
+
+        userdata_options = {
+            "domain": {
+                "userdataContent": userdata_script
+            },
+            "viewName": "Environments",
+        }
+
+        print('Creating Userdata component...')
+        userdata_data = create_component(change_set_id, "Userdata",
+                                         f'userdata-{str(environment_uuid)}',
+                                         userdata_options)
+        userdata_component_id = userdata_data["component"]["id"]
+        print(f'Userdata component ID: {userdata_component_id}')
+
+        print(
+            f'Setting manager for Userdata component {userdata_component_id}...'
+        )
+        manage_component(change_set_id, userdata_component_id,
+                         MANAGER_COMPONENT_ID)
+        print('Userdata component now managed.')
+
+    except requests.exceptions.HTTPError as err:
+        print(f'HTTP Error: {err}')
+        print(f'Response: {err.response.text}')
+    except Exception as err:
+        print(f'General Error: {err}')
+
+    ec2_properties = {
+        "InstanceType":
+        "c6i.16xlarge",
+        "BlockDeviceMappings": [{
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+                "DeleteOnTermination": True,
+                "VolumeSize": 100,
+                "VolumeType": "gp3"
+            }
+        }],
+        "Tags": [{
+            "Key": "Name",
+            "Value": "frontend-ci-validation-test-machine"
+        }]
+    }
+
+    ec2_options = {
+        "domain": ec2_properties,
+        "subscriptions": {
+            "/domain/SecurityGroupIds/0": {
+                "component": "frontend-ci-validation-sg",
+                "propPath": "/resource_value/GroupId",
+            },
+            "/domain/ImageId": {
+                "component": "Arch Linux",
+                "propPath": "/domain/ImageId",
+            },
+            "/domain/SubnetId": {
+                "component": "frontend-ci-validation-subnet-pub-1",
+                "propPath": "/resource_value/SubnetId",
+            },
+            "/domain/KeyName": {
+                "component": "frontend-ci-validation-kp",
+                "propPath": "/domain/KeyName",
+            },
+            "/domain/extra/Region": {
+                "component": "us-east-1",
+                "propPath": "/domain/region"
+            },
+            "/domain/UserData": {
+                "component": f'userdata-{str(environment_uuid)}',
+                "propPath": "/domain/userdataContentBase64"
+            },
+            "/domain/IamInstanceProfile": {
+                "component": "ci-validation-instance-instance-profile",
+                "propPath": "/domain/InstanceProfileName"
+            },
+            "/secrets/AWS Credential": {
+                "component": "si-tools-sandbox",
+                "propPath": "/secrets/AWS Credential"
+            }
+        },
+        "viewName": "Environments",
+    }
+
+    print("Creating EC2 instance component...")
+    ec2_data = create_component(  # Super annoying it doesn't tell you what a misaligned prop mapping is
+        change_set_id,  # would be so much better if it returned something like the valid schema for the
+        "AWS::EC2::Instance",  # attempted connection. It also breaks copy and paste of the component
+        str(environment_uuid),
+        ec2_options)
+
+    ec2_component_id = ec2_data["component"]["id"]
+    print(f'EC2 component ID: {ec2_component_id}')
+
+    print(f'Setting manager for EC2 component {ec2_component_id}...')
+    manage_component(change_set_id, ec2_component_id, MANAGER_COMPONENT_ID)
+    print('EC2 component now managed.')
+
+    print("Waiting for DVU")
+    time.sleep(
+        30
+    )  # I really need a method here to detect DVU is complete more elegantly
+
+    print(f'Force applying change set {change_set_id}...')
+    force_apply_url = f'{API_URL}/v1/w/{WORKSPACE_ID}/change-sets/{change_set_id}/force_apply'
+    response = requests.post(force_apply_url,
+                             headers={
+                                 'Authorization': f'Bearer {API_TOKEN}',
+                                 'accept': 'application/json'
+                             },
+                             data='')
+    response.raise_for_status()
+    print('Change set applied successfully.')
+
+    print("Waiting for actions to complete...")
+    wait_for_merge_success(change_set_id)
+    print("All actions completed successfully...")
+
+    base_change_set_id = "head"
+    print("Querying for public IP...")
+    ip_output_file = './ip'
+
+    try:
+        public_ip = get_public_ip(base_change_set_id, ec2_component_id, 60, 5)
+        print(f"Instance is reachable at: {public_ip}")
+        with open(ip_output_file, 'w') as f:
+            f.write(f'{public_ip}')
+    except TimeoutError as e:
+        print(str(e))
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/.ci/provision.sh
+++ b/.ci/provision.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euxo pipefail
+
+# 0. Remove broken EC2 repo if it exists
+if grep -q "\[ec2\]" /etc/pacman.conf; then
+  echo "[INFO] Removing broken 'ec2' repo from /etc/pacman.conf"
+  sed -i '/^\[ec2\]/,/^$/d' /etc/pacman.conf
+fi
+
+# 1. Update base packages & generate keychain
+pacman -Sy --noconfirm
+pacman-key --init
+pacman-key --populate archlinux
+
+# 2. Install tools:
+pacman -S --noconfirm base-devel git wget postgresql docker
+
+# 2(a) install yay for aur repo usage for us to grab ssm-agent
+#git clone https://aur.archlinux.org/yay.git
+#makepkg -si --noconfirm -D ./yay/
+#yay -Sy amazon-ssm-agent --noconfirm
+
+# (b) Enable and start SSM Agent
+#systemctl enable --now amazon-ssm-agent
+
+# (c) Enable and start Docker
+systemctl enable --now docker
+
+# 3. Install Docker Compose manually
+echo "🔧 Installing latest Docker Compose..."
+BINARY_PATH="/usr/local/bin/docker-compose"
+curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o "$BINARY_PATH"
+chmod +x "$BINARY_PATH"
+
+if command -v docker-compose &> /dev/null; then
+    docker-compose version
+    echo "🎉 Docker Compose installed successfully."
+else
+    echo "❌ Failed to install docker-compose." >&2
+    exit 1
+fi
+
+# 4. Install Nix (multi-user daemon mode)
+export HOME=/root
+curl -L https://nixos.org/nix/install | sh -s -- --daemon
+
+# 3. Clone the System Initiative repo
+git clone https://github.com/systeminit/si.git
+cd si
+
+# Activate nix in current session
+. /etc/profile.d/nix.sh
+
+# 4. Enter development shell for running the test stack
+. /etc/profile.d/nix.sh
+nix develop --extra-experimental-features nix-command --extra-experimental-features flakes -c bash -c "DEV_HOST=0.0.0.0 TILT_HOST=0.0.0.0 buck2 run dev:up"

--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -18,6 +18,7 @@ on:
           - tools
           - production
           - perf
+          - ec2-node
 
 jobs:
   define-test-matrix:
@@ -29,21 +30,46 @@ jobs:
       - id: tests
         working-directory: app/web/cypress/e2e
         run: |
-            # get the names of all test subdirs with out slashes
-            test_dirs=$(find . -mindepth 1 -maxdepth 1 -type d  | sed 's|^\./||')
-            test_array="[]"
-            # put them into an array
-            for d in $test_dirs; do
-              test_array=$(echo "$test_array" | jq --arg d "$d" '. += [$d]')
-            done
-            test_array=$(echo "$test_array" | jq -c '.')
-            echo "$test_array"
-            echo "tests=$test_array" >> "$GITHUB_OUTPUT"
+          test_dirs=$(find . -mindepth 1 -maxdepth 1 -type d  | sed 's|^\./||')
+          test_array="[]"
+          for d in $test_dirs; do
+            test_array=$(echo "$test_array" | jq --arg d "$d" '. += [$d]')
+          done
+          test_array=$(echo "$test_array" | jq -c '.')
+          echo "$test_array"
+          echo "tests=$test_array" >> "$GITHUB_OUTPUT"
+
+  launch-ec2-node:
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    if: ${{ inputs.environment == 'ec2-node' }}
+    outputs:
+      remote-ip: ${{ steps.get-ip.outputs.remote_ip }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy EC2 node
+        working-directory: .ci/
+        run: |
+          export SI_API_TOKEN="${{ secrets.SI_API_TOKEN }}"
+          export SI_WORKSPACE_ID="${{ vars.MANAGEMENT_WORKSPACE_ID }}"
+          python3 ./deploy-stack.py
+
+      - name: Save IP
+        id: get-ip
+        working-directory: .ci/
+        run: |
+          remote_ip=$(grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' ./ip)
+          echo "Remote IP set to ${remote_ip}"
+          echo "remote_ip=$remote_ip" >> "$GITHUB_OUTPUT"
 
   cypress-tests:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
-    needs: define-test-matrix
+    needs: 
+      - define-test-matrix
+      - launch-ec2-node
     strategy:
       fail-fast: true
       matrix:
@@ -71,9 +97,67 @@ jobs:
           sudo apt update
           sudo apt install uuid -y
 
-      - name: Run Cypress Tests
+      - name: Setup SSH tunnel if ec2-node
+        if: ${{ inputs.environment == 'ec2-node' }}
+        working-directory: .ci/
         run: |
-          cd app/web
+          echo "$SSH_KEY" > ssh-key.pem
+          chmod 600 ssh-key.pem
+
+          remote_ip="${{ needs.launch-ec2-node.outputs.remote-ip }}"
+          echo "Tunneling EC2 node @ $remote_ip"
+
+          # Start SSH tunnel in background for 8080 (Web App) & 3020 (Bedrock)
+          nohup ssh -o StrictHostKeyChecking=no -L 8080:localhost:8080 arch@$remote_ip -i ssh-key.pem -N &
+          nohup ssh -o StrictHostKeyChecking=no -L 3020:localhost:3020 arch@$remote_ip -i ssh-key.pem -N &
+
+          # Wait for Bedrock (EC2 localhost:3020) to be ready
+          echo "Waiting for Bedrock to be ready..."
+          for i in {1..180}; do
+            if curl --fail --silent --max-time 2 http://localhost:3020/; then
+                echo "✅ Bedrock service is up and returned a valid response, preparing db"
+                curl --location 'http://localhost:3020/prepare' \
+                --header 'Content;' \
+                --header 'Content-Type: application/json' \
+                --data '{
+                  "recording_id": "W=01JYPR32SD5RKR3AMG298J7263-CS=01JZ3W5XX6QHQZ6PYSBHK4SB3K (39 components)",
+                  "parameters": {},
+                  "executionParameters": {}
+                }'
+                break
+            fi
+            echo "⏳ Attempt $i/180: Bedrock not responding yet. Retrying in 10s..."
+            sleep 10
+          done
+
+          # Fail if still not up after 30 min
+          if ! nc -z localhost 3020; then
+            echo "❌ Timed out waiting for bedrock service on port 3020"
+            exit 1
+          fi
+
+          # Wait for tunnel Web App (EC2 localhost:8080) to be ready
+          echo "Waiting up to 30 minutes for remote web app to be ready..."
+          for i in {1..180}; do
+            if curl --fail --silent --max-time 2 http://localhost:8080/health; then
+                echo "✅ Remote service is up and returned a valid response!"
+                break
+            fi
+            echo "⏳ Attempt $i/180: Service not responding yet. Retrying in 10s..."
+            sleep 10
+          done
+
+          # Fail if still not up after 30 min
+          if ! nc -z localhost 8080; then
+            echo "❌ Timed out waiting for web app on port 8080"
+            exit 1
+          fi
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+
+      - name: Run Cypress Tests
+        working-directory: app/web
+        run: |
           export VITE_AUTH0_USERNAME="${{ secrets.VITE_AUTH0_USERNAME }}"
           export VITE_AUTH0_PASSWORD="${{ secrets.VITE_AUTH0_PASSWORD }}"
           export VITE_SI_CYPRESS_MULTIPLIER="${{ vars.VITE_SI_CYPRESS_MULTIPLIER }}"
@@ -85,24 +169,16 @@ jobs:
           export VITE_AUTH_API_URL="https://auth-api.systeminit.com"
           export VITE_AUTH_PORTAL_URL="https://auth.systeminit.com"
 
-          # Retry loop with 3 attempts
           n=0
           max_retries=3
           
-          until [ $n -ge $max_retries ]
-          do
-
+          until [ $n -ge $max_retries ]; do
             unset exit_code || echo "exit_code not set"
-
-            # Run the npx task and store exit code in a variable
             npx cypress run --spec "cypress/e2e/${{ matrix.tests }}/**" || exit_code=$?
-
-            # Check the exit code
             if [ -z "$exit_code" ]; then
               echo "Cypress Test task succeeded!"
               break
             fi
-
             n=$((n+1))
             echo "Attempt $n/$max_retries failed with exit code $exit_code! Retrying..."
           done
@@ -136,16 +212,13 @@ jobs:
           path: artifacts
       - run: |     
           has_artifacts=false
-          # Check for marker files
           for marker in artifacts/*/*.mp4; do
             if [ -f "$marker" ]; then
               echo "Artifact detected for failed test: $marker"
-              echo "Setting failure to true and breaking"
               has_artifacts=true
               break
             fi
           done
-          # If at least one valid failure marker is present, then page
           if [ "$has_artifacts" = true ] && [ "${{ github.ref_name }}" = "main" ]; then
             curl --location "${{ secrets.FIREHYDRANT_WEBHOOK_URL }}" \
               --header "Content-Type: application/json" \


### PR DESCRIPTION
Adds the ability to run cypress tests against a remote node in AWS orchestrated via SI, pretty cool!

**This is the workflow:**
- User selects ec2-node as environment in the github workflow (Cypress E2E Tests)
- SI is invoked to create a change set and launch a machine via an apply that will run the SI Stack of main
- The remote machine is SSH tunnelled to present localhost:3020 (bedrock) and localhost:8080 (webapp)
- Bedrock seeds the `CI Remote Execution Environment` workspace via a restore point `W=01JYPR32SD5RKR3AMG298J7263-CS=01JZ3W5XX6QHQZ6PYSBHK4SB3K (39 components)` that has some failed actions and components on HEAD
- Services serve
- CI detects web app and continues to execution the suite of cypress tests against the remote node

**Yep, it's the disclaimer (or bonus information!) section**
- This whole code fork isn't used anywhere, it's currently only manually selected
- Branch-selection isn't supported yet, but the framework is there to support it
- It can only run with a concurrency of one, as we have no way of merging multiple change sets at once (ideally each github pipeline would be able to merge it's own Change Set, but this is fraught with difficulty at the minute)
- Automatic cleanup will come sharpish, this can cost a lot if we aren't careful
- I wish I used tailscale but I got stuck in a `tailscale serve` groove and couldn't get over some "workspace url needs to be static for each test" problems
- SSH key needed is in the Shared Engineering Vault, it's literally only used for these machines, for debugging we can connect directly from local to the execution machines via the same portforwarding or SSH methods
- It's a ~12 minute compile from scratch at the minute with the machine type selected

<div><img src="https://media1.giphy.com/media/KEYEpIngcmXlHetDqz/giphy.gif?cid=5a38a5a2c6ufl4jmoj03splywizbn7ams4cv6ivbuxwjxeuz&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:177px;width:300px"/></div>