### PR TITLE
Fix component list and connections in Explore

### DIFF
--- a/app/web/src/newhotness/explore_grid/ExploreGrid.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGrid.vue
@@ -296,6 +296,8 @@ const virtualizerOptions = computed(() => ({
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   getScrollElement: () => scrollRef.value!,
   estimateSize: (i: number) => rowHeights.value[i] ?? 0,
+  // The item key is essential for reactivity and was found by @vbustamante and his valiant
+  // efforts. Without this, the virtualizer will not re-compute, even with new components.
   getItemKey: (i: number) => getItemKey(i),
   overscan: 4,
 }));
@@ -357,7 +359,10 @@ defineEmits<{
   ): void;
 }>();
 
-defineExpose({ getGridComponentByIndex, focusedComponent });
+defineExpose({
+  getGridComponentRefByIndex: getGridComponentByIndex,
+  focusedComponent,
+});
 </script>
 
 <style lang="css" scoped>

--- a/app/web/src/newhotness/logic_composables/connections.ts
+++ b/app/web/src/newhotness/logic_composables/connections.ts
@@ -1,0 +1,124 @@
+import { computed, inject, ref } from "vue";
+import { useQuery } from "@tanstack/vue-query";
+import { ComponentId } from "@/api/sdf/dal/component";
+import {
+  Connection,
+  EntityKind,
+  IncomingConnections,
+} from "@/workers/types/entity_kind_types";
+import {
+  bifrost,
+  getOutgoingConnections,
+  useMakeArgs,
+  useMakeKey,
+} from "@/store/realtime/heimdall";
+import { assertIsDefined, Context } from "../types";
+import { SimpleConnection } from "../layout_components/ConnectionLayout.vue";
+
+export const useConnections = () => {
+  const ctx = inject<Context>("CONTEXT");
+  assertIsDefined<Context>(ctx);
+
+  const key = useMakeKey();
+  const args = useMakeArgs();
+
+  // These refs are needed to react to function input.
+  const incomingConnectionsProvided = ref<boolean>(false);
+  const incomingQueryComponentId = ref<ComponentId>("");
+
+  // These computed values are based on the refs and are needed for query reactivity.
+  const enableLookup = computed(() => !incomingConnectionsProvided.value);
+  const id = computed(() => incomingQueryComponentId.value);
+
+  const incomingQuery = useQuery<IncomingConnections | null>({
+    enabled: () => enableLookup.value && id.value !== "",
+    queryKey: key(EntityKind.IncomingConnections, id),
+    queryFn: async () =>
+      await bifrost<IncomingConnections>(
+        args(EntityKind.IncomingConnections, id.value),
+      ),
+  });
+  const allOutgoingQuery = useQuery({
+    queryKey: key(EntityKind.OutgoingConnections),
+    queryFn: async () =>
+      await getOutgoingConnections(args(EntityKind.OutgoingConnections)),
+  });
+
+  return (componentId: ComponentId, connections?: IncomingConnections) => {
+    return computed(() => {
+      if (connections && "id" in connections) {
+        incomingConnectionsProvided.value = true;
+      } else {
+        incomingQueryComponentId.value = componentId;
+        incomingConnectionsProvided.value = false;
+      }
+
+      // TODO(nick): decide if this needs to be an inner computed or not.
+      const incomingConnections = computed(() => {
+        if (!incomingConnectionsProvided.value && incomingQuery.data.value) {
+          const { connections: incoming } = incomingQuery.data.value;
+          return incoming;
+        } else if (connections) {
+          const { connections: incoming } = connections;
+          return incoming;
+        } else {
+          return [] as Connection[];
+        }
+      });
+
+      // TODO(nick): decide if this needs to be an inner computed or not.
+      const outgoingConnections = computed<Connection[]>(() => {
+        if (!allOutgoingQuery.data.value) return [];
+        const mine = allOutgoingQuery.data.value.get(componentId);
+        if (!mine) return [];
+        return Object.values(mine);
+      });
+
+      const incoming: SimpleConnection[] = incomingConnections.value.map(
+        (conn) => {
+          if (conn.kind === "management") {
+            // FIXME(nick,jobelenus): we should split the connection type into two now that
+            // management connections have their own MV.
+            return {
+              key: `mgmt-${conn.toComponentId}-${conn.fromComponentId}`,
+              componentId: conn.fromComponentId,
+              self: "Management",
+              other: "-",
+            };
+          } else {
+            return {
+              key: `${conn.toAttributeValueId}-${conn.toComponentId}-${conn.fromComponentId}-${conn.fromAttributeValueId}`,
+              componentId: conn.fromComponentId,
+              self: conn.toAttributeValuePath,
+              other: conn.fromAttributeValuePath,
+            };
+          }
+        },
+      );
+
+      const outgoing: SimpleConnection[] = outgoingConnections.value.map(
+        (conn) => {
+          if (conn.kind === "management") {
+            // FIXME(nick,jobelenus): we should split the connection type into two now that
+            // management connections have their own MV.
+            return {
+              key: `mgmt-${conn.toComponentId}-${conn.fromComponentId}`,
+              componentId: conn.fromComponentId,
+              self: "Management",
+              other: "-",
+            };
+          } else {
+            return {
+              key: `${conn.toAttributeValueId}-${conn.toComponentId}-${conn.fromComponentId}-${conn.fromAttributeValueId}`,
+              componentId: conn.fromComponentId,
+              self: conn.toAttributeValuePath,
+              other: conn.fromAttributeValuePath,
+            };
+          }
+        },
+      );
+
+      return { incoming, outgoing };
+    });
+  };
+};

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -402,6 +402,8 @@ export interface BifrostIncomingConnections {
   connections: Connection[];
 }
 
+// FIXME(nick,jobelenus): we should split the connection type into two now that management
+// connections have their own MV.
 export type Connection =
   | {
       kind: "management";

--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -1855,6 +1855,14 @@ const coldStartComputed = async (workspaceId: string, changeSetId: string) => {
     true,
     true,
   );
+  bustCacheAndReferences(
+    workspaceId,
+    changeSetId,
+    EntityKind.OutgoingCounts,
+    workspaceId,
+    true,
+    true,
+  );
 
   const mgmtSql = `
     select


### PR DESCRIPTION
## Introduction

Welcome. This is "one of those" changes. Buckle up.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdleHN1aG9sMmx5ZWg0NnJiYnN1NnN2bnpkYnQxdGoyMmR1Mmplb2g1dCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/84BjZMVEX3aRG/giphy.gif"/>

## Description

Here's the deal: I originally set out to just fix connections for pinning. As I clawed at every little bug fix, the rabbit hole got deeper. I fixed the connections when pinning! Wait, now the indexes are messed up. I fixed the indexes sometimes. Wait, it still happens. Okay those look better, but... oh DEAR GOD THE COMPONENT CONTEXT MENU IS FLYING OFF THE SCREEN.

There turned out to be something evil lurking within...the component list, filtered component list, and grouped component list all did not account for pinning. Sure, they accounted for views, but not pinning. For indices, tabbing, component context menu and general ease of use, you need your component list to be absolute. You cannot just drop components from that list when grouping.

I combed all of Explore and now my brain is fried. It is happy, but fried. Each section is now titled in the file and there is a clear split between determining the absolute component list and performing filtering, sorting and grouping of that list. More stuff in the logic composables directory in the future? Likely yes.

Now, the original guts of this change are still here, despite all the drama. That change fixes connections for pinning and makes connections reusable for multiple contexts. Now, the connections panel and pinned connections use the same underlying logic. Alongside that work, we now bust the output count alongside the outgoing connections to ensure both are working in tandem with one another.

All of these changes result in grid that is much more trustworthy and reliable when working with pinning and connections.