### PR TITLE
Fix: push ComponentInList to correct view

### DIFF
--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -1927,15 +1927,14 @@ const postProcess = (
   // So when we move to streaming patches, we have to do something else
   // to support adding & removing items from lists
   if (LISTABLE_ITEMS.includes(kind)) {
-    // push updates over the thread boundary
     const listIds: string[] = [];
     if (kind === EntityKind.ComponentInList) {
       const sql = `
-      select
+      select distinct
         viewId
       FROM
         (select
-          id as viewId,
+          atoms.args as viewId,
           json_each.value as ref
         from
           atoms,


### PR DESCRIPTION
There are no defined `id` columns, and every table has `WITHOUT ROWID`, so I'm not exactly sure how SQLite was interpreting that `id as viewId`. In any case, it was wrong

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNWpvOG9ocDBxd2MwM3M0MTVibGdvbTNwaHB6cDJkY2pyczBhdWR3ZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/cOiKbCtrbXqVi/giphy.gif"/>