### PR TITLE
Fix: when performing a no-op patch, we need the atom document for postProcessing

### DIFF
--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -949,6 +949,8 @@ const applyPatch = async (atom: Required<Atom>, indexChecksum: Checksum) => {
         atom.toChecksum,
         upToDateAtomIndexes,
       );
+      // get the doc for post processing
+      doc = atomDocumentForChecksum(atom.kind, atom.id, atom.toChecksum);
       span.addEvent("noop", {
         upToDateAtomIndexes: JSON.stringify(upToDateAtomIndexes),
       });
@@ -1625,6 +1627,7 @@ const niflheim = async (
       const local = localChecksums[key];
       if (!local || local !== checksum) {
         // Attempt to find an existing atom, since it might already exist in the database with this checksum
+        // if !local, this query will find no results...
         const existingDataForChecksum = atomDocumentForChecksum(
           kind,
           id,
@@ -2083,8 +2086,10 @@ const postProcess = (
   } else if (kind === EntityKind.AttributeTree) {
     const conns: Record<string, PossibleConnection> = {};
 
-    if (!removed && !doc)
-      throw new Error("Atom is not removed, but no data for post processing");
+    if (!removed && !doc) {
+      error("Atom is not removed, but no data for post processing", id);
+      return;
+    }
 
     const existing = allPossibleConns.get(changeSetId);
 


### PR DESCRIPTION
This was the cause of the "MVs don't update" most frequently seen with Action List. `Apply Changes` expresses a lot of the "no-op" behavior.. and it was the no-op on an AttributeTree that was causing the exception

## How does this PR change the system?

When performing a no-op patch, we need the atom document for postProcessing. Without the document we ran into a `throw` that stopped a batch of patches from processing.

This _ought_ to prevent the `Atom is not removed, but no data for post processing` case... and changing that to not `throw` to a console error so it doesn't block other atoms