### PR TITLE
fix(web): allow direct linking to map

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -496,9 +496,7 @@ watch([selectedViewId], () => {
   const query: SelectionsInQueryString = {
     ...router.currentRoute.value?.query,
   };
-  delete query.map;
   delete query.viewId;
-  query.grid = "1";
   if (
     selectedViewId.value !== "" &&
     selectedViewId.value !== defaultView.value?.id


### PR DESCRIPTION
The view selection watcher was deleting the map=1 from the query and forcing the grid. Unless there was a good reason for this, we should allow the user to navigate directly to the map