### PR TITLE
feat: Implement the lobby with messages

### DIFF
--- a/app/web/src/newhotness/Lobby.vue
+++ b/app/web/src/newhotness/Lobby.vue
@@ -1,37 +1,108 @@
 <template>
-  <div class="w-[50svh] mx-auto mt-[15svh]">
-    <template v-if="show">
-      <h1 class="text-center text-2xl">Welcome!</h1>
-      <h2 class="text-center text-xl">Take a load off</h2>
-      <h3 v-if="niflheimTotal > 0" class="text-center text-lg">
-        {{ niflheimComplete }} change set(s) loaded of {{ niflheimTotal }}
-      </h3>
-      <Icon class="mx-auto" name="loader" size="full" />
-    </template>
+  <div
+    class="absolute w-screen h-screen bg-neutral-900 z-100 flex flex-col items-center justify-center"
+  >
+    <!-- Floating panel (to hold future animated border  -->
+    <div
+      :class="
+        clsx(
+          'w-[720px] max-w-[70vw] h-[400px] rounded shadow-[0_0_8px_0_rgba(255,255,255,0.08)]',
+          'transition-opacity',
+          showPanel ? 'opacity-100' : 'opacity-0',
+        )
+      "
+    >
+      <!-- Inner section of panel -->
+      <div
+        :class="
+          clsx(
+            'w-full h-full rounded font-mono text-sm',
+            'flex flex-col justify-end gap-xs',
+            // Note(Victor): We need borders, since padding does not hide overflow
+            'overflow-hidden border-[16px] border-b-[64px]',
+            'bg-neutral-800 border-neutral-800',
+          )
+        "
+      >
+        <LobbyTerminalOutputLine
+          v-for="(data, index) in visibleSentences"
+          :key="index"
+          :message="data.sentence"
+          :isActive="index === visibleSentences.length - 1"
+          :isLoader="data.isLoader"
+        />
+      </div>
+    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { Icon } from "@si/vue-lib/design-system";
-import { computed, onMounted, ref } from "vue";
-import { muspelheimStatuses } from "@/store/realtime/heimdall";
+import { computed, onMounted, ref, watch } from "vue";
+import clsx from "clsx";
+import { sleep } from "@si/ts-lib/src/async-sleep";
+import LobbyTerminalOutputLine from "@/newhotness/LobbyTerminalOutputLine.vue";
 
-const DELAY_MS = 400;
+const sentences = [
+  { sentence: "Welcome to System Initiative!" },
+  { sentence: "Unpacking your workspace... it’s been through a lot" },
+  { sentence: "We'll need a few minutes to reconstruct the state of things" },
+  {
+    sentence: "_______————***————_______".repeat(3), // There
+    isLoader: true,
+  },
+  { sentence: "Loading change sets and parsing intent" },
+  {
+    sentence:
+      "Scanning your workspace to see what's real... and what wants to be",
+  },
+  { sentence: "Populating attributes from source of truth" },
+  { sentence: "Preparing views with just the right perspective" },
+  { sentence: "Warming up the data so everything connects on the first try" },
+  {
+    sentence: "Filling in component attributes, thoughtfully and declaratively",
+  },
+  { sentence: "Views loading... perfect clarity takes a second" },
+  {
+    sentence:
+      "Describing infrastructure so well, it might describe itself back",
+  },
+  { sentence: "Locating intent in a sea of configuration" },
+  { sentence: "Applying structure without limiting flexibility" },
+  { sentence: "Bringing your workspace to you — clean, clear, and traceable" },
+  { sentence: "Finalizing..." },
+];
 
-const show = ref(false);
+const showPanel = ref(false);
+const visibleSentenceCount = ref<number>(0);
+const visibleSentences = computed(() =>
+  sentences.slice(0, visibleSentenceCount.value),
+);
 
-onMounted(() => {
-  setTimeout(() => {
-    show.value = true;
-  }, DELAY_MS);
+// Delay before opening, so we don't blink the screen
+const BLINK_DELAY_MS = 500;
+// Delay so we complete the fade in before starting to show log lines
+const TRANSITION_DELAY_MS = 200;
+
+const kickOffTerminalLogs = async () => {
+  await sleep(BLINK_DELAY_MS);
+  showPanel.value = true;
+  await sleep(TRANSITION_DELAY_MS);
+  visibleSentenceCount.value = 1;
+};
+
+onMounted(kickOffTerminalLogs);
+
+// Every time we show a sentence, enqueue showing the next sentence after a delay
+const LOG_MIN_DELAY_MS = 4000;
+const logDelayVariable = () =>
+  LOG_MIN_DELAY_MS + Math.floor(Math.random() * 1000);
+watch([visibleSentenceCount], async () => {
+  if (!showPanel.value) return;
+
+  if (visibleSentenceCount.value >= sentences.length) return;
+
+  await sleep(logDelayVariable());
+
+  visibleSentenceCount.value += 1;
 });
-
-const niflheimTotal = computed(
-  () => Object.keys(muspelheimStatuses.value).length,
-);
-const niflheimComplete = computed(
-  () =>
-    Object.values(muspelheimStatuses.value).filter((status) => status === true)
-      .length,
-);
 </script>

--- a/app/web/src/newhotness/LobbyTerminalOutputLine.vue
+++ b/app/web/src/newhotness/LobbyTerminalOutputLine.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="flex flex-row items-center">
+    <Icon
+      name="logo-si"
+      size="sm"
+      :class="clsx('mr-xs self-start', !isActive && 'opacity-0')"
+    />
+    <div class="leading-[1.5rem] tracking-tight">
+      <span
+        :class="
+          clsx(!isLoader && isActive ? 'text-neutral-100' : 'text-neutral-400')
+        "
+      >
+        {{ croppedSentence }}
+      </span>
+      <div
+        v-if="isActive"
+        :class="
+          clsx(
+            // Since this is an inline cursor like element, there's some finicky positioning required to make it look good
+            'w-xs h-sm inline-block relative top-0.5 left-0.5',
+            'bg-white animate-pulse [animation-duration:_1s]',
+          )
+        "
+      ></div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { Icon } from "@si/vue-lib/design-system";
+import { computed, onMounted, ref, watch } from "vue";
+import clsx from "clsx";
+import { sleep } from "@si/ts-lib/src/async-sleep";
+
+const props = defineProps({
+  message: { type: String, required: true },
+  /// Shows SI logo on the left side of line and in active colors, if false color will be greyer
+  isActive: { type: Boolean },
+  /// When loader, will be shown in secondary greyer color, and without the initial delay
+  isLoader: { type: Boolean },
+});
+
+const visibleCharCount = ref(-1);
+const croppedSentence = computed(() =>
+  props.message.slice(0, Math.max(visibleCharCount.value, 0)),
+);
+
+// Kick-off line animation
+const startWritingSentence = async () => {
+  visibleCharCount.value = 0;
+};
+onMounted(startWritingSentence);
+
+// Write character one at a time, enqueuing the next change with a watch that sleeps
+const INITIAL_DELAY_MS = 800;
+const CHAR_DELAY_MS = 35;
+const BASE_ELLIPSIS_DELAY_MS = 300;
+const ellipsisDelay = () =>
+  BASE_ELLIPSIS_DELAY_MS + Math.floor(Math.random() * 200);
+watch([visibleCharCount], async () => {
+  const message = props.message ?? "";
+  if (visibleCharCount.value >= message.length) return;
+
+  const latestChar = message[visibleCharCount.value - 1] ?? "";
+
+  let delay = CHAR_DELAY_MS;
+
+  // Add some extra delay on the initial character, except if the line is a loader
+  if (!props.isLoader && visibleCharCount.value === 0) {
+    delay = INITIAL_DELAY_MS;
+  } else if (latestChar === ".") {
+    delay = ellipsisDelay();
+  }
+
+  await sleep(delay);
+
+  visibleCharCount.value += 1;
+});
+</script>

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -15,6 +15,7 @@
 
       <!-- Center -->
       <div
+        v-if="!lobby"
         class="flex flex-row flex-none items-center h-full justify-center place-items-center mx-auto overflow-hidden"
       >
         <NavbarButton
@@ -51,25 +52,27 @@
      min-h-0 prevents the main container from being *larger* than the max it can grow, no matter its contents -->
     <main class="grow min-h-0">
       <div v-if="tokenFail">Bad Token</div>
-      <template v-else-if="lobby">
-        <Lobby />
-      </template>
-      <template v-else-if="componentId">
-        <ComponentPage :componentId="componentId" />
-      </template>
-      <template v-else-if="funcRunId">
-        <FuncRunDetails :funcRunId="funcRunId" />
-      </template>
-      <template v-else-if="actionId">
-        <LatestFuncRunDetails
-          :functionKind="FunctionKind.Action"
-          :actionId="actionId"
-        />
-      </template>
-      <template v-else>
-        <Explore @openChangesetModal="openChangesetModal" />
-      </template>
+      <ComponentPage v-else-if="componentId" :componentId="componentId" />
+      <FuncRunDetails v-else-if="funcRunId" :funcRunId="funcRunId" />
+      <LatestFuncRunDetails
+        v-else-if="actionId"
+        :functionKind="FunctionKind.Action"
+        :actionId="actionId"
+      />
+      <Explore v-else @openChangesetModal="openChangesetModal" />
     </main>
+
+    <!-- Since lobby hides away the navbar, it's more of an overlay and stays apart from all else -->
+    <Transition
+      enterActiveClass="duration-300 ease-out"
+      enterFromClass="transform opacity-0"
+      enterToClass="opacity-100"
+      leaveActiveClass="delay-1000 duration-200 ease-in"
+      leaveFromClass="opacity-100"
+      leaveToClass="transform opacity-0"
+    >
+      <Lobby v-if="!tokenFail && lobby" />
+    </Transition>
   </div>
 </template>
 

--- a/lib/ts-lib/src/async-sleep.ts
+++ b/lib/ts-lib/src/async-sleep.ts
@@ -1,0 +1,6 @@
+export async function sleep(ms: number) {
+  const positive_ms = Math.max(0, Math.floor(ms));
+  return new Promise((resolve) => {
+    setTimeout(resolve, positive_ms);
+  });
+}


### PR DESCRIPTION
Changes lobby to overlay whole screen, fade in and out and show messages terminal style

<img width="831" alt="Screenshot 2025-07-03 at 16 06 40" src="https://github.com/user-attachments/assets/045d5cc6-131d-4b3b-a45c-46048df30cfc" />
