### PR TITLE
fix(web): Default subscriptions for computed values

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -92,9 +92,9 @@
                     props.externalSources[0]?.componentName
                   }}</TruncateWithTooltip>
                   <div class="flex-none">/</div>
-                  <TruncateWithTooltip>{{
-                    field.state.value
-                  }}</TruncateWithTooltip>
+                  <TruncateWithTooltip>
+                    {{ field.state.value }}
+                  </TruncateWithTooltip>
                 </div>
               </template>
               <div
@@ -109,7 +109,10 @@
                 <TruncateWithTooltip
                   :class="themeClasses('text-neutral-600', 'text-neutral-400')"
                 >
-                  {{ field.state.value }}
+                  {{
+                    field.state.value ||
+                    `<${props.externalSources[0]?.path?.replace(/^\//, "")}>`
+                  }}
                 </TruncateWithTooltip>
               </div>
             </AttributeValueBox>


### PR DESCRIPTION
If a prop subscription is a computed value we show `component name/` where it’s an empty string

We are going to default to `component name/<prop path>` to make it visible to a user that it’s a variable