### PR TITLE
Fix: ensure the bust queue is always running after we process data

### DIFF
--- a/app/web/src/workers/mjolnir_queue.ts
+++ b/app/web/src/workers/mjolnir_queue.ts
@@ -94,9 +94,13 @@ bustQueue.on("active", () => {
 
 processPatchQueue.on("empty", () => {
   debug("⚙️ patches processed");
+  // the queue may either be paused or running
+  bustQueue.start();
 });
 processMjolnirQueue.on("empty", () => {
   debug("⚙️ mjolnir processed");
+  // the queue may either be paused or running
+  bustQueue.start();
 });
 bustQueue.on("empty", () => {
   debug("🧹 busts processed");


### PR DESCRIPTION
## How does this PR change the system?

1. When making a change on HEAD, patches and cold start are in flight at the same time. 
2. When cold start begins we let things build up in the bust queue
3. If there are no patches in the queue when the cold start ends, we let the bust queue process
4. If there are patches in there, we dont unpause
5. There was nothing in either the hammer or patch queues that turned on the bust queue

This is why the UI wasn't updating in certain circumstances. If cold start finished before any patches were generated, it would work just fine.

After processing we just need to ensure the bust queue is always running (e.g. calling start on a running queue is not a problem)

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlcW0xNzNucTE5MGp1NWhwMnRrOXZzMmZyNGZweW9maHNjbGJndWYxaSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xT5LMzWVNsfgu6srOU/giphy.gif"/>