### PR TITLE
Add management functions to status panel

### DIFF
--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -243,6 +243,12 @@ export type WsEventPayloadMap = {
     message?: string;
     createdComponentIds?: ComponentId[];
   };
+  ManagementOperationsFailed: {
+    requestUlid: string;
+  };
+  ManagementOperationsInProgress: {
+    requestUlid: string;
+  };
 
   ModuleImported: SchemaVariant[];
   ModulesUpdated: {

--- a/lib/dal-test/src/helpers/component.rs
+++ b/lib/dal-test/src/helpers/component.rs
@@ -99,10 +99,17 @@ pub async fn execute_management_func(
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, component_id, operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        component_id,
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
     Ok(())
 }
 

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -1115,7 +1115,7 @@ impl DalContext {
         prototype_id: ManagementPrototypeId,
         component_id: ComponentId,
         view_id: ViewId,
-        request_ulid: Option<ulid::Ulid>,
+        request_ulid: ulid::Ulid,
     ) -> TransactionsResult<()> {
         self.txns()
             .await?
@@ -1126,7 +1126,8 @@ impl DalContext {
                 prototype_id,
                 component_id,
                 view_id,
-                request_ulid,
+                // TODO(nick): make this required.
+                Some(request_ulid),
             )
             .await;
 

--- a/lib/dal/src/management/prototype.rs
+++ b/lib/dal/src/management/prototype.rs
@@ -20,7 +20,6 @@ use veritech_client::{
 
 use super::{
     ManagementError,
-    ManagementFuncReturn,
     ManagementGeometry,
     SocketRef,
 };
@@ -32,7 +31,6 @@ use crate::{
     DalContext,
     EdgeWeightKind,
     EdgeWeightKindDiscriminants,
-    Func,
     FuncError,
     FuncId,
     HelperError,
@@ -626,90 +624,6 @@ impl ManagementPrototype {
         })
     }
 
-    /// This is an experimental API for use with our External API
-    /// It will return a FuncRunId that the user can use to triger
-    /// a get-status request for a function
-    /// Upon successful Mgmt Func Run, relevant WSEvents are fired
-    pub async fn dispatch_by_id(
-        ctx: &DalContext,
-        id: ManagementPrototypeId,
-        manager_component_id: ComponentId,
-        view_id: Option<ViewId>,
-    ) -> ManagementPrototypeResult<FuncRunId> {
-        let span = current_span_for_instrument_at!("debug");
-        let views: HashMap<ViewId, String> = View::list(ctx)
-            .await?
-            .into_iter()
-            .map(|view| (view.id(), view.name().to_owned()))
-            .collect();
-
-        let view_id = match view_id {
-            Some(view_id) => view_id,
-            None => View::get_id_for_default(ctx).await?,
-        };
-        let current_view = views.get(&view_id).cloned().unwrap_or(view_id.to_string());
-
-        let management_func_id = ManagementPrototype::func_id(ctx, id).await?;
-        let manager_component = Component::get_by_id(ctx, manager_component_id).await?;
-
-        let mut managed_component_placeholders = HashMap::new();
-        let mut managed_components = HashMap::new();
-        for component_id in manager_component.get_managed(ctx).await? {
-            let schema = Component::schema_for_component_id(ctx, component_id).await?;
-            let managed_component =
-                ManagedComponent::new(ctx, component_id, schema.name(), &views).await?;
-
-            managed_components.insert(component_id, managed_component);
-            let name = Component::name_by_id(ctx, component_id).await?;
-            managed_component_placeholders.insert(name, component_id);
-            managed_component_placeholders.insert(component_id.to_string(), component_id);
-        }
-
-        let this_schema = Component::schema_for_component_id(ctx, manager_component_id)
-            .await?
-            .name()
-            .to_string();
-
-        let manager_component =
-            ManagedComponent::new(ctx, manager_component_id, &this_schema, &views).await?;
-        let manager_component_geometry = manager_component.geometry.to_owned();
-
-        let variant_socket_map = Self::variant_socket_map(ctx).await?;
-
-        let args = serde_json::json!({
-            "current_view": current_view,
-            "this_component": manager_component,
-            "components": managed_components,
-            "variant_socket_map": variant_socket_map,
-        });
-
-        let func_runner =
-            FuncRunner::build_management(ctx, id, manager_component_id, management_func_id, args)
-                .await?;
-
-        let func_runner_id = func_runner.id();
-        let ctx_clone = ctx.clone();
-
-        tokio::task::spawn(async move {
-            if let Err(err) = dispatch_by_id_inner(
-                &ctx_clone,
-                span,
-                func_runner,
-                manager_component_id,
-                id,
-                Some(view_id),
-                manager_component_geometry,
-                managed_component_placeholders,
-            )
-            .await
-            {
-                error!(si.error.message = ?err.to_string(), "Failure in running management function");
-            }
-        });
-
-        Ok(func_runner_id)
-    }
-
     async fn variant_socket_map(
         ctx: &DalContext,
     ) -> ManagementPrototypeResult<HashMap<String, u32>> {
@@ -926,114 +840,6 @@ impl ManagementPrototype {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn dispatch_by_id_inner(
-    ctx: &DalContext,
-    span: Span,
-    func_runner: FuncRunner,
-    component_id: ComponentId,
-    management_prototype_id: ManagementPrototypeId,
-    view_id: Option<ViewId>,
-    manager_component_geometry: HashMap<String, ManagementGeometry>,
-    managed_component_placeholders: HashMap<String, ComponentId>,
-) -> Result<(), ManagementPrototypeError> {
-    let result_channel = func_runner.execute(ctx.clone(), span).await;
-    let run_value = match result_channel.await {
-        Ok(Err(FuncRunnerError::ResultFailure {
-            kind: _,
-            message,
-            backend: _,
-        })) => return Err(ManagementPrototypeError::FuncExecutionFailure(message)),
-        other => other.map_err(|_| ManagementPrototypeError::FuncRunnerRecvError)??,
-    };
-    let func_run_id = run_value.func_run_id();
-    let maybe_value: Option<si_events::CasValue> =
-        run_value.value().cloned().map(|value| value.into());
-    let maybe_value_address = match maybe_value {
-        Some(value) => Some(
-            ctx.layer_db()
-                .cas()
-                .write(
-                    Arc::new(value.into()),
-                    None,
-                    ctx.events_tenancy(),
-                    ctx.events_actor(),
-                )?
-                .0,
-        ),
-        None => None,
-    };
-    let mut maybe_run_result: Option<ManagementResultSuccess> = match run_value.value() {
-        Some(value) => Some(serde_json::from_value(value.clone())?),
-        None => None,
-    };
-    let action_state = maybe_run_result
-        .as_ref()
-        .map(|result| match result.health {
-            veritech_client::ManagementFuncStatus::Ok => si_events::ActionResultState::Success,
-            veritech_client::ManagementFuncStatus::Error => si_events::ActionResultState::Failure,
-        })
-        .unwrap_or(si_events::ActionResultState::Unknown);
-
-    FuncRunner::update_run(ctx, func_run_id, |func_run| {
-        func_run.set_success(None, maybe_value_address);
-        func_run.set_action_result_state(Some(action_state));
-    })
-    .await?;
-
-    // We publish this immediately because the management "operator" could
-    // fail because of a bad function, but we stil want to know that the
-    // function executed
-    WsEvent::management_func_executed(ctx, management_prototype_id, component_id, func_run_id)
-        .await?
-        .publish_immediately(ctx)
-        .await?;
-
-    if let Some(result) = maybe_run_result.take() {
-        let result: ManagementFuncReturn = result.try_into()?;
-
-        let execution_result = ManagementPrototypeExecution {
-            func_run_id,
-            result: maybe_run_result,
-            manager_component_geometry,
-            managed_component_placeholders,
-        };
-        let mut created_component_ids = None;
-
-        if result.status == ManagementFuncStatus::Ok {
-            if let Some(operations) = result.operations {
-                created_component_ids = crate::management::ManagementOperator::new(
-                    ctx,
-                    component_id,
-                    operations,
-                    execution_result,
-                    view_id,
-                )
-                .await?
-                .operate()
-                .await?;
-            }
-        }
-        let func_id = ManagementPrototype::func_id(ctx, management_prototype_id).await?;
-        let func = Func::get_by_id(ctx, func_id).await?;
-
-        WsEvent::management_operations_complete(
-            ctx,
-            None,
-            func.name.clone(),
-            result.message.clone(),
-            result.status,
-            created_component_ids,
-        )
-        .await?
-        .publish_on_commit(ctx)
-        .await?;
-    }
-
-    ctx.commit().await?;
-    Ok(())
-}
-
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ManagementFuncExecutedPayload {
@@ -1050,6 +856,18 @@ pub struct ManagementOperationsCompletePayload {
     status: ManagementFuncStatus,
     message: Option<String>,
     created_component_ids: Option<Vec<ComponentId>>,
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagementOperationsFailedPayload {
+    request_ulid: ulid::Ulid,
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagementOperationsInProgressPayload {
+    request_ulid: ulid::Ulid,
 }
 
 impl WsEvent {
@@ -1086,6 +904,32 @@ impl WsEvent {
                 status,
                 message,
                 created_component_ids,
+            }),
+        )
+        .await
+    }
+
+    pub async fn management_operations_failed(
+        ctx: &DalContext,
+        request_ulid: ulid::Ulid,
+    ) -> WsEventResult<Self> {
+        WsEvent::new(
+            ctx,
+            WsPayload::ManagementOperationsFailed(ManagementOperationsFailedPayload {
+                request_ulid,
+            }),
+        )
+        .await
+    }
+
+    pub async fn management_operations_in_progress(
+        ctx: &DalContext,
+        request_ulid: ulid::Ulid,
+    ) -> WsEventResult<Self> {
+        WsEvent::new(
+            ctx,
+            WsPayload::ManagementOperationsInProgress(ManagementOperationsInProgressPayload {
+                request_ulid,
             }),
         )
         .await

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -63,6 +63,8 @@ use crate::{
     management::prototype::{
         ManagementFuncExecutedPayload,
         ManagementOperationsCompletePayload,
+        ManagementOperationsFailedPayload,
+        ManagementOperationsInProgressPayload,
     },
     module::ModulesUpdatedPayload,
     pkg::{
@@ -161,6 +163,8 @@ pub enum WsPayload {
     InferredEdgeUpsert(InferredEdgeUpsertPayload),
     ManagementFuncExecuted(ManagementFuncExecutedPayload),
     ManagementOperationsComplete(ManagementOperationsCompletePayload),
+    ManagementOperationsFailed(ManagementOperationsFailedPayload),
+    ManagementOperationsInProgress(ManagementOperationsInProgressPayload),
     ModuleImported(Vec<si_frontend_types::SchemaVariant>),
     ModulesUpdated(ModulesUpdatedPayload),
     Online(OnlinePayload),

--- a/lib/dal/tests/integration_test/management.rs
+++ b/lib/dal/tests/integration_test/management.rs
@@ -116,10 +116,17 @@ async fn exec_mgmt_func_and_operate(
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, component_id, operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        component_id,
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     Ok(())
 }
@@ -165,6 +172,7 @@ async fn update_managed_components_in_view(ctx: &DalContext) -> Result<()> {
         operations,
         execution_result,
         Some(new_view_id),
+        ulid::Ulid::new(),
     )
     .await?
     .operate()
@@ -218,10 +226,17 @@ async fn update_managed_components(ctx: &DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, small_odd_lego.id(), operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     let mut new_component = None;
     let components = Component::list(ctx).await?;
@@ -276,10 +291,17 @@ async fn create_component_of_other_schema(ctx: &DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, small_odd_lego.id(), operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     let mut new_component = None;
     let components = Component::list(ctx).await?;
@@ -339,10 +361,17 @@ async fn create_and_connect_to_self_as_children(ctx: &mut DalContext) -> Result<
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, small_odd_lego.id(), operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     let geometry = small_odd_lego
         .geometry(ctx, View::get_id_for_default(ctx).await?)
@@ -430,10 +459,17 @@ async fn create_and_connect_to_self(ctx: &DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, small_odd_lego.id(), operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     let components = Component::list(ctx).await?;
     assert_eq!(4, components.len());
@@ -492,10 +528,17 @@ async fn create_and_connect_from_self(ctx: &DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, small_odd_lego.id(), operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     let components = Component::list(ctx).await?;
     assert_eq!(4, components.len());
@@ -528,10 +571,17 @@ async fn create_component_of_same_schema(ctx: &DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, small_odd_lego.id(), operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     let mut new_component = None;
     let components = Component::list(ctx).await?;
@@ -571,10 +621,17 @@ async fn create_component_of_same_schema(ctx: &DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, small_odd_lego.id(), operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     let mut new_component_2 = None;
 
@@ -617,10 +674,17 @@ async fn execute_management_func(ctx: &DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, small_odd_lego.id(), operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     let av_id =
         Component::attribute_value_for_prop(ctx, small_odd_lego.id(), &["root", "domain", "two"])
@@ -650,10 +714,17 @@ async fn deeply_nested_children(ctx: &DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, small_odd_lego.id(), operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     let mut component_names = vec![];
 
@@ -698,10 +769,17 @@ async fn override_values_set_by_sockets(ctx: &DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, small_odd_lego.id(), operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     let current = small_odd_lego.id();
     let children = Component::get_children_for_id(ctx, current).await?;
@@ -758,14 +836,20 @@ async fn create_in_views(ctx: &DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    let component_id =
-        ManagementOperator::new(ctx, small_odd_lego.id(), operations, execution_result, None)
-            .await?
-            .operate()
-            .await?
-            .expect("should return component ids")
-            .pop()
-            .expect("should have a component id");
+    let component_id = ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?
+    .expect("should return component ids")
+    .pop()
+    .expect("should have a component id");
 
     let geometries = Geometry::by_view_for_component_id(ctx, component_id).await?;
 
@@ -828,14 +912,20 @@ async fn create_view_and_in_view(ctx: &DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    let component_id =
-        ManagementOperator::new(ctx, small_odd_lego.id(), operations, execution_result, None)
-            .await?
-            .operate()
-            .await?
-            .expect("should return component ids")
-            .pop()
-            .expect("should have a component id");
+    let component_id = ManagementOperator::new(
+        ctx,
+        small_odd_lego.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?
+    .expect("should return component ids")
+    .pop()
+    .expect("should have a component id");
 
     let red_room = View::find_by_name(ctx, view_name)
         .await?
@@ -941,10 +1031,17 @@ async fn delete_and_erase_components(ctx: &mut DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, manager.id(), operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        manager.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     assert!(
         Component::try_get_by_id(ctx, component_to_delete.id())
@@ -1036,10 +1133,17 @@ async fn remove_view_and_component_from_view(ctx: &DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, manager.id(), operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        manager.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     assert!(View::find_by_name(ctx, new_view_name).await?.is_none());
 
@@ -1068,10 +1172,17 @@ async fn remove_view_and_component_from_view(ctx: &DalContext) -> Result<()> {
 
     let operations = result.operations.expect("should have operations");
 
-    ManagementOperator::new(ctx, manager.id(), operations, execution_result, None)
-        .await?
-        .operate()
-        .await?;
+    ManagementOperator::new(
+        ctx,
+        manager.id(),
+        operations,
+        execution_result,
+        None,
+        ulid::Ulid::new(),
+    )
+    .await?
+    .operate()
+    .await?;
 
     assert_eq!(default_view_id, View::get_id_for_default(ctx).await?);
 

--- a/lib/sdf-server/src/service/public/management.rs
+++ b/lib/sdf-server/src/service/public/management.rs
@@ -60,6 +60,8 @@ async fn run_prototype(
     }): Path<RunPrototypePath>,
     Json(request): Json<RunPrototypeRequest>,
 ) -> Result<Json<RunPrototypeResponse>> {
+    let request_ulid = request.request_ulid.unwrap_or_default();
+
     // TODO check that this is a valid prototypeId
     let mut execution_result =
         ManagementPrototype::execute_by_id(ctx, prototype_id, component_id, view_id.into()).await?;
@@ -91,6 +93,7 @@ async fn run_prototype(
                     operations,
                     execution_result,
                     Some(view_id),
+                    request_ulid,
                 )
                 .await?
                 .operate()


### PR DESCRIPTION
## Description

This change adds management functions and operations to the status panel. Events are tracked from the first enqueued management function all the way until the downstream job is completed. This uses a simple request ID approach to keep track of every bucket item individually.

This change also removes unused management prototype code that was formerly used by luminork.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOHN1cjVnODV6MWUxYmVqOHZuYmZlZWxoeTFnN2txa2d1eHNsdWR5eSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/fUezj9VsIhEGtErnnb/giphy.gif"/>