### PR TITLE
feat(web) - better controls for newhotness AttributePanel

### DIFF
--- a/app/web/src/newhotness/CodeEditorModal.vue
+++ b/app/web/src/newhotness/CodeEditorModal.vue
@@ -1,5 +1,26 @@
 <template>
-  <Modal ref="modalRef" :title="title" size="4xl" @close="updateValue">
+  <Modal
+    ref="modalRef"
+    :title="title"
+    size="4xl"
+    hideExitButton
+    @close="updateValue"
+  >
+    <template #titleIcons>
+      <button
+        v-tooltip="'Cancel'"
+        :class="
+          clsx(
+            'modal-close-button',
+            'hover:scale-110 rounded-full opacity-80 hover:opacity-100 -mr-2 -my-2',
+          )
+        "
+        @click="cancel"
+      >
+        <Icon name="x" size="md" />
+      </button>
+    </template>
+
     <div
       :class="
         clsx(
@@ -23,9 +44,9 @@
 </template>
 
 <script setup lang="ts">
-import { Modal, themeClasses, useModal } from "@si/vue-lib/design-system";
+import { Icon, Modal, themeClasses, useModal } from "@si/vue-lib/design-system";
 import clsx from "clsx";
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import CodeEditor from "@/components/CodeEditor.vue";
 
 defineProps({
@@ -34,22 +55,54 @@ defineProps({
 });
 
 const modalRef = ref<InstanceType<typeof Modal>>();
-const { open: openModal, isOpen } = useModal(modalRef);
+const { open: openModal, close: closeModal, isOpen } = useModal(modalRef);
 
 const newValueString = ref<string>("");
+const ignoreValueStringChanges = ref(true);
 
 const open = (startingValue = "") => {
   newValueString.value = startingValue;
+  submit.value = false;
   openModal();
+};
+
+const close = () => {
+  ignoreValueStringChanges.value = true;
+  closeModal();
+};
+
+const submit = ref(true);
+
+const cancel = () => {
+  emit("cancel");
+  submit.value = false;
+  close();
 };
 
 const emit = defineEmits<{
   (e: "submit", value: string): void;
+  (e: "cancel"): void;
 }>();
 
 const updateValue = () => {
-  emit("submit", newValueString.value);
+  if (submit.value) {
+    emit("submit", newValueString.value);
+  }
 };
+
+watch(
+  () => newValueString.value,
+  () => {
+    // Handles the newValueString changing on modal open
+    if (ignoreValueStringChanges.value) {
+      ignoreValueStringChanges.value = false;
+      return;
+    }
+
+    // If you change the string in the modal, then enable submit!
+    submit.value = true;
+  },
+);
 
 defineExpose({
   open,

--- a/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
@@ -36,16 +36,15 @@
           component.schemaName
         }}</TruncateWithTooltip>
       </h3>
+      <Icon v-if="component.toDelete" name="hourglass" size="md" />
       <Icon
-        v-if="canBeUpgraded"
+        v-else-if="canBeUpgraded"
         name="bolt-outline"
         size="md"
         :class="
           clsx(themeClasses('text-success-500', 'text-success-400'), 'mt-[5px]')
         "
       />
-      <!-- TODO(nick): center this vertically with the pill counters -->
-      <Icon v-if="component.toDelete" name="hourglass" size="md" />
     </header>
     <ol
       class="[&>li]:p-xs [&>li]:flex [&>li]:flex-row [&>li]:items-center [&>li]:gap-xs [&>li]:h-9 [&_.pillcounter]:w-5 [&_.pillcounter]:h-5"

--- a/lib/vue-lib/src/design-system/icons/custom-icons/code-pop-right.svg
+++ b/lib/vue-lib/src/design-system/icons/custom-icons/code-pop-right.svg
@@ -1,0 +1,7 @@
+<svg width="28" height="29" viewBox="0 0 28 29" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g transform="scale(-1, 1) translate(-28, 0)">
+<path d="M17.6028 9.58652L22.6937 14.6774L17.6028 19.7683" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.8149 9.58652L5.72404 14.6774L10.8149 19.7683" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.77871 4.15285L0.498413 6.43315L0.498413 0.543049L6.38851 0.543049L4.10822 2.82334L3.75466 3.1769L4.10822 3.53045L7.4707 6.89293L6.8483 7.51534L3.48581 4.15285L3.13226 3.7993L2.77871 4.15285Z" fill="currentColor" stroke="currentColor"/>
+</g>
+</svg>

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -210,6 +210,7 @@ import TildeHexOutline from "./custom-icons/tilde-hex-outline.svg?raw";
 
 import CodeDeployed from "./custom-icons/code-deployed.svg?raw";
 import CodePop from "./custom-icons/code-pop.svg?raw";
+import CodePopRight from "./custom-icons/code-pop-right.svg?raw";
 import LogsPop from "./custom-icons/logs-pop.svg?raw";
 import CodePopSquare from "./custom-icons/code-pop-square.svg?raw";
 import LogsPopSquare from "./custom-icons/logs-pop-square.svg?raw";
@@ -266,6 +267,7 @@ export const ICONS = Object.freeze({
   "code-circle": StreamlineBracesCircleSolid,
   "code-deployed": CodeDeployed,
   "code-pop": CodePop,
+  "code-pop-right": CodePopRight,
   "code-pop-square": CodePopSquare,
   "code-transform": CarbonTransformCode,
   "collapse-row": CollapseAll,


### PR DESCRIPTION
## How does this PR change the system?

New and improved controls for the AttributePanel in the newhotness UI!

- Use tab to navigate and set values intuitively
- If you press tab without changing the input field tab will just move on
- If you touch the input for a value then tab will save your changes
- Unless you navigate up to the field to cancel your edits
- No more losing your place!
- Escape still cancels an edit, Enter still works as well
- I am pretty sure that now all actions can be done with the keyboard!

There are a few other improvements and bug fixes in here as well, will call them out in comments.

#### Jam:

https://jam.dev/c/ec81c4e7-a3e4-485c-9394-06e4cb1425c9

## How was it tested?

I ran through a LOT of manual testing on a wide variety of components (the lego testing component was very helpful!), so hopefully there won't be any bugs left.