### PR TITLE
chore(dal): demote dependency graph calculating orphaned spans

### DIFF
--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -444,7 +444,7 @@ impl Action {
 
     /// Sort the dependency graph of [`Actions`][Action] topologically, breaking ties by listing
     /// [`Actions`][Action] sorted by their ID (oldest first thanks to ULID sorting).
-    #[instrument(level = "info", skip_all)]
+    #[instrument(level = "debug", skip_all)]
     pub async fn list_topologically(ctx: &DalContext) -> ActionResult<Vec<ActionId>> {
         // TODO: Grab all "running" & "failed" Actions to list first?
         let mut result = Vec::new();

--- a/lib/dal/src/action/dependency_graph.rs
+++ b/lib/dal/src/action/dependency_graph.rs
@@ -61,7 +61,7 @@ impl ActionDependencyGraph {
     /// Construct an [`ActionDependencyGraph`] of all of the queued [`Action`s][crate::action::Action]
     /// for the current [`WorkspaceSnapshot`][crate::WorkspaceSnapshot].
     #[instrument(
-        level = "info",
+        level = "debug",
         name = "action.dependency_graph.for_workspace",
         skip(ctx)
     )]


### PR DESCRIPTION
This change demotes the following spans to `debug`:

- `list_topologically`
- `action.dependency_graph.for_workspace`

The `list_topologically` is currently orphaned an always has a child of `action.dependency_graph.for_workspace` which accounts for 100% of the parent span.

This trace combination was captured over 1.67M times in production Honeycomb over the last 7 days. If future profiling is required in this area we can dial the level back up.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaXRlYWd3MGl3dnJpeGt6ZGJxbmw4bDdiYXhodXY0d3FwM2JtajR2MSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/jIIduCs5nkq2i2emoS/giphy.gif"/>