### PR TITLE
chore(edda): demote `edda.compressed_request.from_requests` to debug

### DIFF
--- a/lib/edda-server/src/compressed_request.rs
+++ b/lib/edda-server/src/compressed_request.rs
@@ -69,7 +69,7 @@ impl CompressedRequest {
     // it this way with future compat in mind.
     #[instrument(
         name = "edda.compressed_request.from_requests",
-        level = "info",
+        level = "debug",
         skip_all,
         fields(
             si.edda.compressed_request.inputs = Empty,


### PR DESCRIPTION
This change demotes the orphaned span
`edda.compressed_request.from_requests` to `debug`.

This single span trace was captured over 856K times in production Honeycomb over the last 7 days.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdleTJoM2RoaDJybjdkaXp1OHh4ODlucjI4dmY5MnpyYXFudDdlb2JhaiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/jquDWJfPUMCiI/giphy.gif"/>