### PR TITLE
chore(edda): demote `edda_updates.publish_patch_batch` to debug

### DIFF
--- a/lib/edda-server/src/updates.rs
+++ b/lib/edda-server/src/updates.rs
@@ -67,7 +67,7 @@ impl EddaUpdates {
 
     #[instrument(
         name = "edda_updates.publish_patch_batch",
-        level = "info",
+        level = "debug",
         skip_all,
         fields()
     )]


### PR DESCRIPTION
This change demotes the `edda_updates.publish_patch_batch` span to `debug`.

This span adds minimal value and was captured over 852K times in production Honeycomb over the last 7 days.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZHpzenVtZXBsZ2lqZDB0M2cyaWwxd3lxbzk0Z2h6Ync4MGM1ZjhxZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/jivGITd768psP80B2i/giphy.gif"/>