### PR TITLE
chore(edda): demote "quiesced notified" log event to debug

### DIFF
--- a/lib/edda-server/src/handlers.rs
+++ b/lib/edda-server/src/handlers.rs
@@ -193,7 +193,7 @@ pub(crate) async fn default(State(state): State<AppState>, subject: Subject) -> 
         }
         // The processor tasks has signaled to shutdown from a quiet period
         _ = quiesced_notify.notified() => {
-            info!(
+            debug!(
                 service.instance.id = metadata.instance_id(),
                 si.workspace.id = %workspace.str,
                 si.change_set.id = %change_set.str,


### PR DESCRIPTION
This change demotes a log event when the `ChangeSetProcessorTask` begins shutting down after detecting a quiescent period. This logic appears much more trustworthy than when it was initially implemented and can be safely demoted to a `debug` level.

This event was captured over 201K times in production Honeycomb over the last 7 days.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMThhYjV3a3RnZGRwc2k3d2lpcm04d2NjZ2pvYzhpeWNubmt5Y2gxaCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/9rjKLsynBodhiIovdD/giphy.gif"/>