### PR TITLE
feat: Move validations to show as icons on the prop editor

### DIFF
--- a/app/web/src/newhotness/QualificationPanel.vue
+++ b/app/web/src/newhotness/QualificationPanel.vue
@@ -12,13 +12,10 @@
 import { computed } from "vue";
 import {
   AttributeTree,
-  AttributeValue,
   BifrostComponent,
-  Prop,
 } from "@/workers/types/entity_kind_types";
 import QualificationView from "@/newhotness/QualificationView.vue";
 import { AttributeValueId } from "@/store/status.store";
-import { ValidationOutputStatus } from "@/api/sdf/dal/property_editor";
 import { findAvsAtPropPath } from "./util";
 
 export type QualificationStatus = "success" | "failure" | "warning" | "unknown";
@@ -37,7 +34,7 @@ const props = defineProps<{
 
 const root = computed(() => props.attributeTree);
 
-const qualificationsWithoutValidations = computed<Qualification[]>(() => {
+const qualifications = computed<Qualification[]>(() => {
   const items: Qualification[] = [];
   if (!root.value) return items;
   const r = root.value;
@@ -67,51 +64,5 @@ const qualificationsWithoutValidations = computed<Qualification[]>(() => {
     });
   });
   return items;
-});
-
-const validations = computed(() => {
-  const avsWithValidation: {
-    prop?: Prop;
-    attributeValue: AttributeValue;
-  }[] = [];
-  if (!root.value) return avsWithValidation;
-  Object.values(root.value.attributeValues).forEach((attributeValue) => {
-    if (attributeValue.validation !== null) {
-      const prop = root.value?.props[attributeValue.propId ?? ""];
-      avsWithValidation.push({ attributeValue, prop });
-    }
-  });
-  return avsWithValidation;
-});
-
-const convertValidationStatusToQualificationStatus = (
-  status: ValidationOutputStatus,
-): QualificationStatus => {
-  switch (status) {
-    case "Failure":
-      return "failure";
-    case "Error":
-      return "failure";
-    default:
-      return "success";
-  }
-};
-
-const qualifications = computed<Qualification[]>(() => {
-  const results = [...qualificationsWithoutValidations.value];
-
-  validations.value.forEach(({ attributeValue, prop }) => {
-    if (attributeValue.validation && prop) {
-      results.push({
-        name: prop.name,
-        message: attributeValue.validation.message || "",
-        status: convertValidationStatusToQualificationStatus(
-          attributeValue.validation.status,
-        ),
-      });
-    }
-  });
-
-  return results;
 });
 </script>

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -6,7 +6,7 @@
         ref="anchorRef"
         :class="
           clsx(
-            'grid grid-cols-2 items-center gap-xs relative text-sm font-normal',
+            'grid grid-cols-2 items-center gap-2xs relative text-sm font-normal',
             inputOpen && 'hidden',
             isSecret && 'mb-[-1px]',
           )
@@ -16,6 +16,13 @@
         <div class="flex flex-row items-center gap-2xs pl-xs">
           <TruncateWithTooltip>{{ displayName }}</TruncateWithTooltip>
           <div class="flex flex-row items-center ml-auto gap-2xs">
+            <StatusIndicatorIcon
+              v-if="validation"
+              v-tooltip="validation.message"
+              type="qualification"
+              :status="validation.status === 'Success' ? 'success' : 'failure'"
+              class="w-8 mr-2 shrink-0"
+            />
             <IconButton
               v-if="canDelete"
               tooltip="Delete"
@@ -567,6 +574,7 @@ import {
   PropertyEditorPropWidgetKindComboBox,
   PropertyEditorPropWidgetKindSecret,
   PropertyEditorPropWidgetKindSelect,
+  ValidationOutput,
 } from "@/api/sdf/dal/property_editor";
 import { LabelEntry, LabelList } from "@/api/sdf/dal/label_list";
 import {
@@ -585,6 +593,7 @@ import {
 import CodeViewer from "@/components/CodeViewer.vue";
 import { PropKind } from "@/api/sdf/dal/prop";
 import { CategorizedPossibleConnections } from "@/workers/types/dbinterface";
+import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
 import {
   attributeEmitter,
   MouseDetails,
@@ -604,6 +613,7 @@ const props = defineProps<{
   value: string;
   kind?: PropertyEditorPropWidgetKind | string;
   prop?: Prop;
+  validation?: ValidationOutput;
   component: BifrostComponent;
   displayName: string;
   canDelete?: boolean;

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -118,6 +118,7 @@
         :path="attributeTree.attributeValue.path ?? ''"
         :kind="attributeTree.prop?.widgetKind"
         :prop="attributeTree.prop"
+        :validation="attributeTree.attributeValue.validation"
         :component="component"
         :value="attributeTree.attributeValue.value?.toString() ?? ''"
         :canDelete="attributeTree.isBuildable"

--- a/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="props.attributeTree.prop?.isOriginSecret && showSecretForm"
+    v-if="attributeTree.prop?.isOriginSecret && showSecretForm"
     ref="secretFormRef"
   >
     <AttributeChildLayout>
@@ -67,9 +67,7 @@
           </li>
           <!-- TODO(Wendy) - figure out tabbing for buttons -->
           <VButton
-            :label="
-              props.attributeTree.secret ? 'Replace Secret' : 'Add Secret'
-            "
+            :label="attributeTree.secret ? 'Replace Secret' : 'Add Secret'"
             :loading="wForm.bifrosting.value"
             loadingText="Saving Secret"
             tone="action"
@@ -84,16 +82,17 @@
   <!-- TODO(nick): add the ability to remove a subscription -->
   <AttributeInput
     v-else
-    :displayName="props.attributeTree.prop?.name ?? 'Secret Value'"
-    :attributeValueId="props.attributeTree.attributeValue.id"
-    :path="props.attributeTree.attributeValue.path ?? ''"
-    :kind="props.attributeTree.prop?.widgetKind"
-    :prop="props.attributeTree.prop"
+    :displayName="attributeTree.prop?.name ?? 'Secret Value'"
+    :attributeValueId="attributeTree.attributeValue.id"
+    :path="attributeTree.attributeValue.path ?? ''"
+    :kind="attributeTree.prop?.widgetKind"
+    :prop="attributeTree.prop"
+    :validation="attributeTree.attributeValue.validation"
     :component="component"
-    :externalSources="props.attributeTree.attributeValue.externalSources"
-    :value="props.attributeTree.secret?.name?.toString() ?? ''"
+    :externalSources="attributeTree.attributeValue.externalSources"
+    :value="attributeTree.secret?.name?.toString() ?? ''"
     :canDelete="false"
-    :disableInputWindow="props.attributeTree.prop?.isOriginSecret"
+    :disableInputWindow="attributeTree.prop?.isOriginSecret"
     isSecret
     @selected="openSecretForm"
     @save="


### PR DESCRIPTION
- Removes individual validations from qualifications list
- Shows validations status icons besides the prop editor
- On fail, hovering over the validation icons shows the error


<img width="1245" alt="Screenshot 2025-07-04 at 18 56 45" src="https://github.com/user-attachments/assets/146fbeb3-4d9b-4ac1-84bd-0f4846e39c1a" />
