### PR TITLE
chore(dal): impl a type map cache to speed up head change set id queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,6 +1745,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "concurrent-extensions"
+version = "0.1.0"
+dependencies = [
+ "dashmap",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,6 +2197,7 @@ dependencies = [
  "chrono",
  "ciborium",
  "clap",
+ "concurrent-extensions",
  "convert_case 0.6.0",
  "dal-macros",
  "dal-materialized-views",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "lib/billing-events",
     "lib/buck2-resources",
     "lib/bytes-lines-codec",
+    "lib/concurrent-extensions",
     "lib/config-file",
     "lib/cyclone-client",
     "lib/cyclone-core",

--- a/lib/concurrent-extensions/BUCK
+++ b/lib/concurrent-extensions/BUCK
@@ -1,0 +1,9 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "concurrent-extensions",
+    deps = [
+        "//third-party/rust:dashmap",
+    ],
+    srcs = glob(["src/**/*.rs"]),
+)

--- a/lib/concurrent-extensions/Cargo.toml
+++ b/lib/concurrent-extensions/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "concurrent-extensions"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+dashmap = { workspace = true }

--- a/lib/concurrent-extensions/src/lib.rs
+++ b/lib/concurrent-extensions/src/lib.rs
@@ -1,0 +1,379 @@
+//! A concurrent type map for used for caching and protocol extensions.
+
+// Based on `Extensions` from the `http` create, released under the Apache v2 and MIT licenses
+//
+// Source:
+// https://github.com/hyperium/http/blob/63102bcd29fcd4a094cac6a4afb0af370ef1fcbe/src/extensions.rs
+
+use std::{
+    any::{
+        Any,
+        TypeId,
+    },
+    fmt,
+    hash::{
+        BuildHasherDefault,
+        Hasher,
+    },
+};
+
+use dashmap::{
+    DashMap,
+    mapref::one::{
+        MappedRef,
+        MappedRefMut,
+    },
+};
+
+type Key = TypeId;
+type Value = Box<dyn AnyClone + Send + Sync>;
+type AnyMap = DashMap<Key, Value, BuildHasherDefault<IdHasher>>;
+
+// With TypeIds as keys, there's no need to hash them. They are already hashes themselves, coming
+// from the compiler. The IdHasher just holds the u64 of the TypeId, and then returns it, instead
+// of doing any bit fiddling.
+#[derive(Default)]
+struct IdHasher(u64);
+
+impl Hasher for IdHasher {
+    fn write(&mut self, _: &[u8]) {
+        unreachable!("TypeId calls write_u64");
+    }
+
+    #[inline]
+    fn write_u64(&mut self, id: u64) {
+        self.0 = id;
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+/// A concurrent type map used for caching and protocol extensions.
+#[derive(Clone, Default)]
+pub struct ConcurrentExtensions {
+    map: Box<AnyMap>,
+}
+
+impl ConcurrentExtensions {
+    /// Creates an empty `ConcurrentExtensions`.
+    #[inline]
+    pub fn new() -> ConcurrentExtensions {
+        ConcurrentExtensions {
+            map: Box::default(),
+        }
+    }
+
+    /// Inserts a type into the map.
+    ///
+    /// If a extension of this type already existed, it will be returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use concurrent_extensions::ConcurrentExtensions;
+    /// let mut ext = ConcurrentExtensions::new();
+    /// assert!(ext.insert(5i32).is_none());
+    /// assert!(ext.insert(4u8).is_none());
+    /// assert_eq!(ext.insert(9i32), Some(5i32));
+    /// ```
+    pub fn insert<T: Clone + Send + Sync + 'static>(&self, val: T) -> Option<T> {
+        self.map
+            .insert(TypeId::of::<T>(), Box::new(val))
+            .and_then(|boxed| boxed.into_any().downcast().ok().map(|boxed| *boxed))
+    }
+
+    /// Gets a reference to a type previously inserted in the map.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use concurrent_extensions::ConcurrentExtensions;
+    /// let mut ext = ConcurrentExtensions::new();
+    /// assert!(ext.get::<i32>().is_none());
+    /// ext.insert(5i32);
+    ///
+    /// assert_eq!(ext.get::<i32>().as_deref(), Some(&5i32));
+    /// ```
+    pub fn get<T: Send + Sync + 'static>(&self) -> Option<MappedRef<'_, Key, Value, T>> {
+        self.map.get(&TypeId::of::<T>()).map(|dm_ref| {
+            dm_ref.map(|boxed| (**boxed).as_any().downcast_ref().expect("type should be T"))
+        })
+    }
+
+    /// Gets a mutable reference to a type previously inserted in the map.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use concurrent_extensions::ConcurrentExtensions;
+    /// let mut ext = ConcurrentExtensions::new();
+    /// ext.insert(String::from("Hello"));
+    /// ext.get_mut::<String>().unwrap().push_str(" World");
+    ///
+    /// assert_eq!(ext.get::<String>().as_deref().unwrap(), "Hello World");
+    /// ```
+    pub fn get_mut<T: Send + Sync + 'static>(&self) -> Option<MappedRefMut<'_, Key, Value, T>> {
+        self.map.get_mut(&TypeId::of::<T>()).map(|dm_ref_mut| {
+            dm_ref_mut.map(|boxed| {
+                (**boxed)
+                    .as_any_mut()
+                    .downcast_mut()
+                    .expect("value type should be T")
+            })
+        })
+    }
+
+    /// Gets a mutable reference to a type, inserting `value` if not already present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use concurrent_extensions::ConcurrentExtensions;
+    /// let mut ext = ConcurrentExtensions::new();
+    /// *ext.get_or_insert(1i32) += 2;
+    ///
+    /// assert_eq!(*ext.get::<i32>().unwrap(), 3);
+    /// ```
+    pub fn get_or_insert<T: Clone + Send + Sync + 'static>(
+        &self,
+        value: T,
+    ) -> MappedRefMut<'_, Key, Value, T> {
+        self.get_or_insert_with(|| value)
+    }
+
+    /// Gets a mutable reference to a type, inserting the value created by `f` if not already
+    /// present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use concurrent_extensions::ConcurrentExtensions;
+    /// let mut ext = ConcurrentExtensions::new();
+    /// *ext.get_or_insert_with(|| 1i32) += 2;
+    ///
+    /// assert_eq!(*ext.get::<i32>().unwrap(), 3);
+    /// ```
+    pub fn get_or_insert_with<T: Clone + Send + Sync + 'static, F: FnOnce() -> T>(
+        &self,
+        f: F,
+    ) -> MappedRefMut<'_, Key, Value, T> {
+        self.map
+            .entry(TypeId::of::<T>())
+            .or_insert_with(|| Box::new(f()))
+            .map(|boxed| {
+                (**boxed)
+                    .as_any_mut()
+                    .downcast_mut()
+                    .expect("value type should be T")
+            })
+    }
+
+    /// Gets a mutable reference to a type, inserting the type's default value if not already
+    /// present.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use concurrent_extensions::ConcurrentExtensions;
+    /// let mut ext = ConcurrentExtensions::new();
+    /// *ext.get_or_insert_default::<i32>() += 2;
+    ///
+    /// assert_eq!(*ext.get::<i32>().unwrap(), 2);
+    /// ```
+    pub fn get_or_insert_default<T: Default + Clone + Send + Sync + 'static>(
+        &self,
+    ) -> MappedRefMut<'_, Key, Value, T> {
+        self.get_or_insert_with(T::default)
+    }
+
+    /// Removes a type from the map.
+    ///
+    /// If a extension of this type existed, it will be returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use concurrent_extensions::ConcurrentExtensions;
+    /// let mut ext = ConcurrentExtensions::new();
+    /// ext.insert(5i32);
+    /// assert_eq!(ext.remove::<i32>(), Some(5i32));
+    /// assert!(ext.get::<i32>().is_none());
+    /// ```
+    pub fn remove<T: Send + Sync + 'static>(&self) -> Option<T> {
+        self.map
+            .remove(&TypeId::of::<T>())
+            .and_then(|boxed| boxed.1.into_any().downcast().ok().map(|boxed| *boxed))
+    }
+
+    /// Clears the map of all inserted extensions.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use concurrent_extensions::ConcurrentExtensions;
+    /// let mut ext = ConcurrentExtensions::new();
+    /// ext.insert(5i32);
+    /// ext.clear();
+    ///
+    /// assert!(ext.get::<i32>().is_none());
+    /// ```
+    #[inline]
+    pub fn clear(&self) {
+        self.map.clear();
+    }
+
+    /// Checks whether the map is empty or not.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use concurrent_extensions::ConcurrentExtensions;
+    /// let mut ext = ConcurrentExtensions::new();
+    /// assert!(ext.is_empty());
+    /// ext.insert(5i32);
+    /// assert!(!ext.is_empty());
+    /// ```
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Gets the numer of types available in the map.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use concurrent_extensions::ConcurrentExtensions;
+    /// let mut ext = ConcurrentExtensions::new();
+    /// assert_eq!(ext.len(), 0);
+    /// ext.insert(5i32);
+    /// assert_eq!(ext.len(), 1);
+    /// ```
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+}
+
+impl fmt::Debug for ConcurrentExtensions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConcurrentExtensions").finish()
+    }
+}
+
+pub trait AnyClone: Any {
+    fn clone_box(&self) -> Box<dyn AnyClone + Send + Sync>;
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+}
+
+impl<T: Clone + Send + Sync + 'static> AnyClone for T {
+    fn clone_box(&self) -> Box<dyn AnyClone + Send + Sync> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+}
+
+impl Clone for Box<dyn AnyClone + Send + Sync> {
+    fn clone(&self) -> Self {
+        (**self).clone_box()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::DerefMut;
+
+    use super::*;
+
+    #[test]
+    fn concurrent_extensions() {
+        #[derive(Clone, Debug, PartialEq)]
+        struct MyType(i32);
+
+        #[derive(Clone, Debug, PartialEq)]
+        struct MyMemoizedType(i32);
+
+        #[derive(Clone, Debug, PartialEq)]
+        struct MyMemoizedTypeWith(i32);
+
+        #[derive(Clone, Debug, PartialEq)]
+        struct MyMemoizedTypeDefault(i32);
+
+        impl Default for MyMemoizedTypeDefault {
+            fn default() -> Self {
+                Self(7)
+            }
+        }
+
+        let extensions = ConcurrentExtensions::new();
+
+        extensions.insert(5i32);
+        extensions.insert(MyType(10));
+
+        assert_eq!(extensions.get().as_deref(), Some(&5i32));
+        assert_eq!(extensions.get_mut().as_deref_mut(), Some(&mut 5i32));
+
+        assert_eq!(extensions.get::<MyMemoizedType>().as_deref(), None);
+        assert_eq!(
+            extensions.get_or_insert(MyMemoizedType(10)).deref_mut(),
+            &mut MyMemoizedType(10)
+        );
+        assert_eq!(extensions.get().as_deref(), Some(&MyMemoizedType(10)));
+
+        assert_eq!(extensions.get::<MyMemoizedTypeWith>().as_deref(), None);
+        assert_eq!(
+            extensions
+                .get_or_insert_with(|| MyMemoizedTypeWith(12))
+                .deref_mut(),
+            &mut MyMemoizedTypeWith(12)
+        );
+        assert_eq!(extensions.get().as_deref(), Some(&MyMemoizedTypeWith(12)));
+
+        assert_eq!(extensions.get::<MyMemoizedTypeDefault>().as_deref(), None);
+        assert_eq!(
+            extensions
+                .get_or_insert_default::<MyMemoizedTypeDefault>()
+                .deref_mut(),
+            &mut MyMemoizedTypeDefault(7)
+        );
+        assert_eq!(extensions.get().as_deref(), Some(&MyMemoizedTypeDefault(7)));
+
+        let ext2 = extensions.clone();
+
+        assert_eq!(extensions.remove::<i32>(), Some(5i32));
+        assert!(extensions.get::<i32>().is_none());
+
+        // clone still has it
+        assert_eq!(ext2.get().as_deref(), Some(&5i32));
+        assert_eq!(ext2.get().as_deref(), Some(&MyType(10)));
+
+        assert_eq!(extensions.get::<bool>().as_deref(), None);
+        assert_eq!(extensions.get().as_deref(), Some(&MyType(10)));
+
+        assert!(!extensions.is_empty());
+
+        extensions.clear();
+
+        assert!(extensions.is_empty());
+
+        assert_eq!(extensions.get::<MyType>().as_deref(), None);
+        // clone still has it
+        assert_eq!(ext2.get().as_deref(), Some(&MyType(10)));
+    }
+}

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -10,6 +10,7 @@ rust_library(
         "//lib/audit-database:audit-database",
         "//lib/audit-logs-stream:audit-logs-stream",
         "//lib/billing-events:billing-events",
+        "//lib/concurrent-extensions:concurrent-extensions",
         "//lib/dal-macros:dal-macros",
         "//lib/joi-validator:joi-validator",
         "//lib/module-index-client:module-index-client",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -12,6 +12,7 @@ publish.workspace = true
 audit-database           = { path = "../../lib/audit-database" }
 audit-logs-stream        = { path = "../../lib/audit-logs-stream" }
 billing-events           = { path = "../../lib/billing-events" }
+concurrent-extensions    = { path = "../../lib/concurrent-extensions" }
 dal-macros               = { path = "../../lib/dal-macros" }
 joi-validator            = { path = "../../lib/joi-validator" }
 module-index-client      = { path = "../../lib/module-index-client" }

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -287,7 +287,7 @@ impl Workspace {
 
     pub async fn update_default_change_set_id(
         &mut self,
-        ctx: &DalContext,
+        ctx: &mut DalContext,
         change_set_id: ChangeSetId,
     ) -> WorkspaceResult<()> {
         ctx.txns()
@@ -300,6 +300,8 @@ impl Workspace {
             .await?;
 
         self.default_change_set_id = change_set_id;
+        // Bust the default change set id in `DalContext`
+        ctx.update_tenancy(*ctx.tenancy());
 
         Ok(())
     }
@@ -877,7 +879,7 @@ impl Workspace {
 
     pub async fn import(
         &mut self,
-        ctx: &DalContext,
+        ctx: &mut DalContext,
         workspace_data: WorkspaceExport,
     ) -> WorkspaceResult<()> {
         let WorkspaceExportContentV0 {

--- a/lib/sdf-server/src/service/v2/workspace/install_workspace.rs
+++ b/lib/sdf-server/src/service/v2/workspace/install_workspace.rs
@@ -53,7 +53,7 @@ pub async fn install_workspace(
     Host(host_name): Host,
     Path(req_workspace_pk): Path<WorkspacePk>,
 ) -> WorkspaceAPIResult<Json<InstallWorkspaceResponse>> {
-    let ctx = builder.build_head(request_ctx).await?;
+    let mut ctx = builder.build_head(request_ctx).await?;
 
     let current_workspace = {
         let workspace_pk = ctx
@@ -67,7 +67,7 @@ pub async fn install_workspace(
 
     tokio::task::spawn(async move {
         match install_workspace_inner(
-            &ctx,
+            &mut ctx,
             req_workspace_pk,
             current_workspace,
             &original_uri,
@@ -97,7 +97,7 @@ pub async fn install_workspace(
 }
 
 async fn install_workspace_inner(
-    ctx: &DalContext,
+    ctx: &mut DalContext,
     workspace_pk: WorkspacePk,
     mut current_workspace: Workspace,
     original_uri: &Uri,


### PR DESCRIPTION
This change implements a `lib/concurrent-extensions` crate which is modelled after the `http` crate's `Extensions` data type. It uses DashMap's `DashMap` internally to handle interior mutability and concurrent access.

The `ConcurrentExtensions` type is used in the `DalContext` type as the `cache: ConcurrentExtensions` field. Currently only the workspace's default change set ID is cached, meaning that repeat calls to `ctx.get_workspace_default_change_set_id()` will return a cached value once fetched from the database the first time.

It is assumed that normal business logic will not re-assign the default change set id for a workspace within a single `DalContext` lifetime--a very reasonable assumption as we don't have any code to perform this change presently. Any mutations to `DalContext` which would update the `tenancy.workspace_pk` field have a "cache-busting" operation, ensuring that the next call to `ctx.get_workspace_default_change_set_id()` would re-populate the cache lazily.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbXAxaW5kcDkxZ2EzZHh4eW02a2hzazh4Z3FiYzAzN2NkdHJxeTh2ZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/RLbMLWUApYozvc9TGi/giphy.gif"/>