### PR TITLE
fix: Mask lobby terminal correctly

### DIFF
--- a/app/web/src/newhotness/Lobby.vue
+++ b/app/web/src/newhotness/Lobby.vue
@@ -148,7 +148,7 @@ watch([visibleSentenceCount], async () => {
     we chose to use this as is.
   */
   animation: borderRotate 9000ms linear infinite forwards;
-  /* border-radius does not interact with border images, so this makes the div's edges a bit more rounded by masking the border */
-  mask-image: radial-gradient(transparent 0, #000 0px);
+  /* border-radius does not interact with border images, so this all black mask that takes the size of the div makes it round again */
+  mask-image: radial-gradient(#000 0, #000 0);
 }
 </style>


### PR DESCRIPTION
Somewhere in our frontend packaging process a number was being stripped out of the mask on the lobby terminal, making it show a black circle in it's middle on tools prod. This PR refactors the mask code so even if we strip out the same number, it's fully opaque always (ask me about content masks if you wanna know more but they're sort of like photoshop layer masks)
 
Here's what the bug looked like:
<img width="843" alt="image" src="https://github.com/user-attachments/assets/a815ad6b-5cd4-44d6-8a77-7cc0ec0848fb" />
