### PR TITLE
feat(web): Highlight components on the grid with failed actions

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -170,6 +170,7 @@
           :components="sortedAndGroupedComponents"
           :focusedComponentIdx="focusedComponentIdx"
           :selectedComponentIndexes="selectedComponentIndexes"
+          :componentsWithFailedActions="componentsHaveActionsWithState.failed"
           @childClicked="componentClicked"
           @childSelect="selectComponent"
           @childDeselect="deselectComponent"

--- a/app/web/src/newhotness/explore_grid/ExploreGrid.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGrid.vue
@@ -31,6 +31,7 @@
         :row="gridRows[row.index]!"
         :focusedComponentId="focusedComponent?.id"
         :selectedComponentIndexes="selectedComponentIndexes"
+        :componentsWithFailedActions="componentsWithFailedActions"
         @childClicked="(e, c, idx) => $emit('childClicked', e, c, idx)"
         @childSelect="(idx) => $emit('childSelect', idx)"
         @childDeselect="(idx) => $emit('childDeselect', idx)"
@@ -57,6 +58,7 @@ const props = defineProps<{
   components: Record<string, ComponentInList[]>;
   focusedComponentIdx?: number;
   selectedComponentIndexes: Set<number>;
+  componentsWithFailedActions: Set<ComponentId>;
 }>();
 
 const MIN_GRID_TILE_WIDTH = 250;

--- a/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
@@ -92,6 +92,7 @@
       "
       :focused="focusedComponentId === component.id"
       :hovered="hoveredId === component.id"
+      :hasFailedActions="componentsWithFailedActions.has(component.id)"
       @select="emit('childSelect', dataIndexForTileInRow(row, columnIndex))"
       @deselect="emit('childDeselect', dataIndexForTileInRow(row, columnIndex))"
       @mouseenter="hover(component.id, true)"
@@ -165,6 +166,7 @@ const props = defineProps<{
   lanesCount: number;
   selectedComponentIndexes: Set<number>;
   focusedComponentId?: ComponentId;
+  componentsWithFailedActions: Set<ComponentId>;
 }>();
 
 interface TitleIcon {

--- a/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
@@ -6,6 +6,8 @@
         'cursor-pointer border rounded overflow-hidden relative select-none',
         selected || focused
           ? themeClasses('border-action-500', 'border-action-300')
+          : hasFailedActions
+          ? themeClasses('border-destructive-500', 'border-destructive-400')
           : [
               hovered
                 ? themeClasses('border-black', 'border-white')
@@ -141,6 +143,7 @@ const props = defineProps<{
   hovered?: boolean;
   hideConnections?: boolean;
   showSelectionCheckbox?: boolean;
+  hasFailedActions?: boolean;
 }>();
 
 const ctx = inject<Context>("CONTEXT");


### PR DESCRIPTION
https://jam.dev/c/adbc1f5b-2b5e-4cab-b266-b5d73d3824a9

This was in our original plans in Figma and we didn't implement it initially - this brings it back into play so we can easily identify what components need action taken on them