### PR TITLE
First pass at minimizing Vec (re)allocations

### DIFF
--- a/lib/dal-materialized-views/src/action_prototype_view_list.rs
+++ b/lib/dal-materialized-views/src/action_prototype_view_list.rs
@@ -20,13 +20,16 @@ pub async fn assemble(
     schema_variant_id: SchemaVariantId,
 ) -> super::Result<ActionPrototypeViewListMv> {
     let ctx = &ctx;
-    let mut views = Vec::new();
 
-    for action_prototype in ActionPrototype::for_variant(ctx, schema_variant_id).await? {
+    let action_prototypes_for_variant =
+        ActionPrototype::for_variant(ctx, schema_variant_id).await?;
+    let mut action_prototypes = Vec::with_capacity(action_prototypes_for_variant.len());
+
+    for action_prototype in action_prototypes_for_variant {
         let func_id = ActionPrototype::func_id(ctx, action_prototype.id).await?;
         let func = Func::get_by_id(ctx, func_id).await?;
 
-        views.push(ActionPrototypeView {
+        action_prototypes.push(ActionPrototypeView {
             id: action_prototype.id,
             func_id,
             kind: action_prototype.kind.into(),
@@ -37,6 +40,6 @@ pub async fn assemble(
 
     Ok(ActionPrototypeViewListMv {
         id: schema_variant_id,
-        action_prototypes: views,
+        action_prototypes,
     })
 }

--- a/lib/dal-materialized-views/src/action_view_list.rs
+++ b/lib/dal-materialized-views/src/action_view_list.rs
@@ -23,7 +23,7 @@ pub async fn assemble(ctx: DalContext) -> super::Result<ActionViewListMv> {
     let ctx = &ctx;
     let action_ids = Action::list_topologically(ctx).await?;
 
-    let mut views = Vec::new();
+    let mut actions = Vec::with_capacity(action_ids.len());
 
     let action_graph = ActionDependencyGraph::for_workspace(ctx).await?;
     if !action_graph.is_acyclic() {
@@ -55,7 +55,7 @@ pub async fn assemble(ctx: DalContext) -> super::Result<ActionViewListMv> {
         let mut hold_status_influenced_by =
             Action::get_hold_status_influenced_by(ctx, &action_graph, action_id).await?;
         hold_status_influenced_by.sort();
-        views.push(ActionView {
+        actions.push(ActionView {
             id: action_id,
             prototype_id: prototype.id(),
             name: prototype.name().clone(),
@@ -72,9 +72,6 @@ pub async fn assemble(ctx: DalContext) -> super::Result<ActionViewListMv> {
             hold_status_influenced_by,
         })
     }
-    let workspace_mv_id = ctx.workspace_pk()?;
-    Ok(ActionViewListMv {
-        id: workspace_mv_id,
-        actions: views,
-    })
+    let id = ctx.workspace_pk()?;
+    Ok(ActionViewListMv { id, actions })
 }

--- a/lib/dal-materialized-views/src/component/attribute_tree.rs
+++ b/lib/dal-materialized-views/src/component/attribute_tree.rs
@@ -120,7 +120,7 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
         let subscriptions = AttributeValue::subscriptions(ctx, av_id).await?;
 
         let external_sources: Option<Vec<ExternalSource>> = if let Some(subs) = subscriptions {
-            let mut sources = vec![];
+            let mut sources = Vec::with_capacity(subs.len());
             for sub in subs {
                 let comp_id = AttributeValue::component_id(ctx, sub.attribute_value_id).await?;
                 let comp_name = Component::name_by_id(ctx, comp_id).await?;

--- a/lib/dal-materialized-views/src/mgmt_prototype_view_list.rs
+++ b/lib/dal-materialized-views/src/mgmt_prototype_view_list.rs
@@ -20,9 +20,12 @@ pub async fn assemble(
     schema_variant_id: SchemaVariantId,
 ) -> super::Result<Vec<MgmtPrototypeView>> {
     let ctx = &ctx;
-    let mut views = Vec::new();
 
-    for p in ManagementPrototype::list_for_variant_id(ctx, schema_variant_id).await? {
+    let management_prototypes_for_variant =
+        ManagementPrototype::list_for_variant_id(ctx, schema_variant_id).await?;
+    let mut views = Vec::with_capacity(management_prototypes_for_variant.len());
+
+    for p in management_prototypes_for_variant {
         let func_id = ManagementPrototype::func_id(ctx, p.id).await?;
         let func = Func::get_by_id(ctx, func_id).await?;
         // TODO: Make Management Func Kinds a real thing

--- a/lib/dal-materialized-views/src/secret.rs
+++ b/lib/dal-materialized-views/src/secret.rs
@@ -68,7 +68,7 @@ pub async fn find_definition(
                 Prop::direct_child_props_ordered(ctx, secret_definition_prop_id).await?;
 
             // Assemble the form data views.
-            let mut form_data_views = Vec::new();
+            let mut form_data_views = Vec::with_capacity(field_props.len());
             for field_prop in field_props {
                 let widget_options = field_prop.widget_options.clone().map(|options| {
                     options

--- a/lib/dal-materialized-views/src/view_component_list.rs
+++ b/lib/dal-materialized-views/src/view_component_list.rs
@@ -16,9 +16,10 @@ use telemetry::prelude::*;
 )]
 pub async fn assemble(ctx: DalContext, view_id: ViewId) -> super::Result<ViewComponentListMv> {
     // Logic comes from the /get_geometry endpoint
-    let mut components = vec![];
+    let geometries = Geometry::list_by_view_id(&ctx, view_id).await?;
+    let mut components = Vec::with_capacity(geometries.len());
 
-    for geometry in Geometry::list_by_view_id(&ctx, view_id).await? {
+    for geometry in geometries {
         let geo_represents = match Geometry::represented_id(&ctx, geometry.id()).await? {
             Some(id) => id,
             None => continue,

--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -446,11 +446,10 @@ impl Action {
     /// [`Actions`][Action] sorted by their ID (oldest first thanks to ULID sorting).
     #[instrument(level = "debug", skip_all)]
     pub async fn list_topologically(ctx: &DalContext) -> ActionResult<Vec<ActionId>> {
-        // TODO: Grab all "running" & "failed" Actions to list first?
-        let mut result = Vec::new();
-
         let mut action_dependency_graph = ActionDependencyGraph::for_workspace(ctx).await?;
+        let mut result = Vec::with_capacity(action_dependency_graph.remaining_actions().len());
 
+        // TODO: Grab all "running" & "failed" Actions to list first?
         loop {
             let mut independent_actions = action_dependency_graph.independent_actions();
             if independent_actions.is_empty() {
@@ -617,7 +616,7 @@ impl Action {
     ///     [`Component`](crate::Component) as the [`Action`].
     pub async fn eligible_to_dispatch(ctx: &DalContext) -> ActionResult<Vec<ActionId>> {
         let action_dependency_graph = ActionDependencyGraph::for_workspace(ctx).await?;
-        let mut result = Vec::new();
+        let mut result = Vec::with_capacity(action_dependency_graph.remaining_actions().len());
         let dependent_value_graph = DependentValueGraph::new(
             ctx,
             DependentValueRoot::get_dependent_value_roots(ctx).await?,

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -750,8 +750,6 @@ impl ChangeSet {
         ctx: &DalContext,
         workspace_pk: WorkspacePk,
     ) -> ChangeSetResult<Vec<Self>> {
-        let mut result = Vec::new();
-
         let rows = ctx
             .txns()
             .await?
@@ -762,6 +760,7 @@ impl ChangeSet {
             )
             .await?;
 
+        let mut result = Vec::with_capacity(rows.len());
         for row in rows {
             result.push(Self::try_from(row)?);
         }


### PR DESCRIPTION
As we learned in 7084431ffa, extra allocations are a death by a thousand cuts for performance.

This focuses on the MV creation methods, specifically on uses `Vec::new()`, and `vec![]` to pre-allocate (at least) the required space, whenever possible using `Vec::with_capacity(final_entry_count)`.

In the case where we don't have a reasonable estimate of the final size of the `Vec`, and we do know how many entries we're about to add, reserve space for the batch before inserting using `vec.reserve(new_item_count)`. This reduces the number of allocations necessary to have space for all of the new entries down to a maximum of one, instead of possibly having multiple re-allocations.
