### PR TITLE
fix(web): Allow insertion of array items under array items

### DIFF
--- a/app/web/src/api/sdf/dal/component.ts
+++ b/app/web/src/api/sdf/dal/component.ts
@@ -14,6 +14,7 @@ import {
   DiagramSocketDirection,
   Size2D,
 } from "@/components/ModelingDiagram/diagram_types";
+import { TopLevelProp } from "./prop";
 
 export interface Component extends StandardModel {
   name: string;
@@ -140,5 +141,11 @@ export interface PotentialMatch {
   value: any | null;
 }
 
-// JSON pointer to an attribute, relative to the component root (e.g. /domain/IpAddresses/0 or /si/name)
-export type AttributePath = string;
+/** JSON pointer to an attribute, relative to the component root (e.g. /domain/IpAddresses/0 or /si/name) */
+// NOTE: This three-alternative type is used to ensure it is either the root (/), or a path under
+// domain/resource/si, etc. Specifying it this way gives us nice autocompletions for "/domain"
+// and friends under IDEs, too.
+export type AttributePath =
+  | "/"
+  | `/${TopLevelProp}`
+  | `/${TopLevelProp}/${string}`;

--- a/app/web/src/api/sdf/dal/prop.ts
+++ b/app/web/src/api/sdf/dal/prop.ts
@@ -22,3 +22,16 @@ export interface Prop {
   eligibleToSendData: boolean;
   hidden: boolean;
 }
+
+/**
+ * Valid top-level props of a component.
+ */
+export type TopLevelProp =
+  | "code"
+  | "domain"
+  | "resource_value"
+  | "resource"
+  | "qualification"
+  | "secret_definition"
+  | "secrets"
+  | "si";

--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -209,6 +209,7 @@ import {
 } from "@/workers/types/entity_kind_types";
 import { PropKind } from "@/api/sdf/dal/prop";
 import { FuncRun } from "@/newhotness/api_composables/func_run";
+import { AttributePath, ComponentId } from "@/api/sdf/dal/component";
 import { componentTypes, routes, useApi } from "./api_composables";
 import ComponentAttribute from "./layout_components/ComponentAttribute.vue";
 import { keyEmitter } from "./logic_composables/emitters";
@@ -386,11 +387,10 @@ const route = useRoute();
 const saveApi = useApi();
 
 const save = async (
-  path: string,
-  _id: string,
+  path: AttributePath,
   value: string,
   propKind: PropKind,
-  connectingComponentId?: string,
+  connectingComponentId?: ComponentId,
 ) => {
   const call = saveApi.endpoint<{ success: boolean }>(
     routes.UpdateComponentAttributes,
@@ -408,7 +408,6 @@ const save = async (
   }
 
   const payload: componentTypes.UpdateComponentAttributesArgs = {};
-  path = path.replace("root", ""); // endpoint doesn't want it
   payload[path] = coercedVal;
   if (connectingComponentId) {
     payload[path] = {
@@ -435,13 +434,12 @@ const save = async (
 
 const removeApi = useApi();
 
-const remove = async (path: string, _id: string) => {
+const remove = async (path: AttributePath) => {
   const call = removeApi.endpoint<{ success: boolean }>(
     routes.UpdateComponentAttributes,
     { id: props.component.id },
   );
   const payload: componentTypes.UpdateComponentAttributesArgs = {};
-  path = path.replace("root", ""); // endpoint doesn't want it
   payload[path] = { $source: null };
   const { req, newChangeSetId } =
     await call.put<componentTypes.UpdateComponentAttributesArgs>(payload);
@@ -462,14 +460,13 @@ const remove = async (path: string, _id: string) => {
 
 const removeSubscriptionApi = useApi();
 
-const removeSubscription = async (path: string, _id: string) => {
+const removeSubscription = async (path: AttributePath) => {
   const call = removeSubscriptionApi.endpoint<{ success: boolean }>(
     routes.UpdateComponentAttributes,
     { id: props.component.id },
   );
 
   const payload: componentTypes.UpdateComponentAttributesArgs = {};
-  path = path.replace("root", ""); // endpoint doesn't want it
 
   payload[path] = {
     $source: null,
@@ -517,7 +514,7 @@ const saveResourceId = async () => {
 
   bifrostingResourceId.value = true;
 
-  await save("/si/resourceId", "", resourceIdFormValue.value, PropKind.String);
+  await save("/si/resourceId", resourceIdFormValue.value, PropKind.String);
 };
 
 watch(

--- a/app/web/src/newhotness/api_composables/component.ts
+++ b/app/web/src/newhotness/api_composables/component.ts
@@ -1,9 +1,8 @@
-import { ComponentId } from "@/api/sdf/dal/component";
+import { AttributePath, ComponentId } from "@/api/sdf/dal/component";
 
-export type UpdateComponentAttributesArgs = Record<
-  AttributeJsonPointer,
-  SetAttributeTo
->;
+export type UpdateComponentAttributesArgs = {
+  [K in AttributePath]?: SetAttributeTo;
+};
 
 export type ComponentIdType =
   | {
@@ -47,15 +46,12 @@ export type SetAttributeTo =
   | {
       $source: "subscription";
       component: ComponentId | string;
-      path: AttributeJsonPointer;
+      path: AttributePath;
     }
   // Unset the value by not passing "value" field
   | { $source: "value"; value?: undefined }
   // Set attribute to a static JS value (use this to safely set object values that could have "$source" property in them)
   | { $source: "value"; value: unknown };
-
-// JSON pointer to the attribute, relative to the component root (e.g. /domain/IpAddresses/0 or /si/name)
-export type AttributeJsonPointer = string;
 
 export type UpdateComponentNameArgs = {
   name: string;

--- a/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
@@ -96,8 +96,8 @@
     isSecret
     @selected="openSecretForm"
     @save="
-      (path, id, value, _kind, connectingComponentId) =>
-        save(path, id, value, connectingComponentId)
+      (path, value, _kind, connectingComponentId) =>
+        save(path, value, connectingComponentId)
     "
     @remove-subscription="removeSubscription"
   />
@@ -114,6 +114,7 @@ import { useRoute } from "vue-router";
 import clsx from "clsx";
 import { BifrostComponent } from "@/workers/types/entity_kind_types";
 import { encryptMessage } from "@/utils/messageEncryption";
+import { AttributePath, ComponentId } from "@/api/sdf/dal/component";
 import AttributeChildLayout from "./AttributeChildLayout.vue";
 import AttributeInput from "./AttributeInput.vue";
 import { AttrTree } from "../AttributePanel.vue";
@@ -154,17 +155,15 @@ const secretFormData = computed(() => {
 
 const saveApi = useApi();
 const save = async (
-  path: string,
-  _id: string,
+  path: AttributePath,
   value: string,
-  connectingComponentId?: string,
+  connectingComponentId?: ComponentId,
 ) => {
   const call = saveApi.endpoint<{ success: boolean }>(
     routes.UpdateComponentAttributes,
     { id: props.component.id },
   );
   const payload: componentTypes.UpdateComponentAttributesArgs = {};
-  path = path.replace("root", ""); // endpoint doesn't want it
   payload[path] = value;
   if (connectingComponentId) {
     payload[path] = {
@@ -189,15 +188,13 @@ const save = async (
 };
 
 const removeSubscriptionApi = useApi();
-const removeSubscription = async (path: string, _id: string) => {
+const removeSubscription = async (path: AttributePath) => {
   const call = removeSubscriptionApi.endpoint<{ success: boolean }>(
     routes.UpdateComponentAttributes,
     { id: props.component.id },
   );
 
   const payload: componentTypes.UpdateComponentAttributesArgs = {};
-  path = path.replace("root", ""); // endpoint doesn't want it
-
   payload[path] = {
     $source: null,
   };

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -371,10 +371,9 @@ type EventBusEvents = {
 //         }
 //       }
 //
-export type UpdateComponentAttributesArgs = Record<
-  AttributePath,
-  AttributeSource
->;
+export type UpdateComponentAttributesArgs = {
+  [K in AttributePath]?: AttributeSource;
+};
 
 // Set attribute to a subscription (another component's value feeds it)
 type AttributeSourceSetSubscription = {
@@ -1394,7 +1393,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
               passRequestUlidInHeadersOnly: true,
               optimistic: () => {
                 for (const toPath in payload) {
-                  const update = payload[toPath];
+                  const update = payload[toPath as AttributePath];
                   if (!update) continue;
 
                   if (isAttributeSourceSetSubscription(update)) {
@@ -1402,7 +1401,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
                       fromComponentId: update.$source.component,
                       fromAttributePath: update.$source.path,
                       toComponentId: componentId,
-                      toAttributePath: toPath,
+                      toAttributePath: toPath as AttributePath,
                       toDelete: false,
                       changeStatus: "added",
                     });

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -1,5 +1,5 @@
 import { ActionProposedView } from "@/store/actions.store";
-import { ComponentId } from "@/api/sdf/dal/component";
+import { AttributePath, ComponentId } from "@/api/sdf/dal/component";
 import { SchemaId, SchemaVariantId } from "@/api/sdf/dal/schema";
 import { ActionKind, ActionPrototypeId } from "@/api/sdf/dal/action";
 import { FuncId } from "@/api/sdf/dal/func";
@@ -351,8 +351,8 @@ export interface PropSuggestion {
 export interface AttributeValue {
   id: AttributeValueId;
   key?: string;
-  path?: string;
-  propId?: string;
+  path: AttributePath;
+  propId?: PropId;
   value: string | null;
   canBeSetBySocket: boolean;
   externalSources?: ExternalSource[];

--- a/lib/dal-materialized-views/src/component/attribute_tree.rs
+++ b/lib/dal-materialized-views/src/component/attribute_tree.rs
@@ -184,7 +184,7 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
             id: av_id,
             prop_id: maybe_prop.as_ref().map(|p| p.id),
             key,
-            path: Some(av_path),
+            path: av_path,
             value,
             can_be_set_by_socket,
             external_sources,

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -213,10 +213,10 @@ pub enum AttributeValueError {
     InputSocket(#[from] InputSocketError),
     #[error("cannot insert for prop kind: {0}")]
     InsertionForInvalidPropKind(PropKind),
-    #[error("jsonptr parse error: {0}")]
-    JsonptrParseError(#[from] jsonptr::ParseError),
-    #[error("jsonptr parse index error: {0}")]
-    JsonptrParseIndexError(#[from] jsonptr::index::ParseIndexError),
+    #[error("jsonptr parse error parsing {0}: {1}")]
+    JsonptrParseError(String, jsonptr::ParseError),
+    #[error("jsonptr parse index error parsing {0}: {1}")]
+    JsonptrParseIndexError(String, jsonptr::index::ParseIndexError),
     #[error("layer db error: {0}")]
     LayerDb(#[from] si_layer_cache::LayerDbError),
     #[error("missing attribute value with id: {0}")]

--- a/lib/si-frontend-mv-types-rs/src/component/attribute_tree.rs
+++ b/lib/si-frontend-mv-types-rs/src/component/attribute_tree.rs
@@ -69,7 +69,7 @@ pub struct ExternalSource {
 pub struct AttributeValue {
     pub id: AttributeValueId,
     pub key: Option<String>,
-    pub path: Option<String>,
+    pub path: String,
     pub prop_id: Option<PropId>,
     pub value: serde_json::Value,
     pub can_be_set_by_socket: bool, // true if this prop value is currently driven by a socket, even if the socket isn't in use


### PR DESCRIPTION
Presently, when you try to insert an array item underneath an array item, it fails with a 400 error.

The source of this bug was that we were using the prop path (munged to remove the initial "root") instead of the attribute path; because of this, we send the parent array item prop name instead of the actual array index.

## How does this PR change the system?

This makes the frontend always use AttributePath instead of munging PropPath when editing / inserting / removing attributes.

It also fixes a bug where you can't insert map items when the map item is an array/object/map.

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbTVheGlmNWhhNjlra3Npbm94ZDFzcDhodTN4N29kZXlmYjljaG5oeCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/To2g552KoqHlbMbCb9/giphy.gif)

### Factor Budget

* Made AttributeTree.AttributeValue.path non-optional (which it already is)
* Stopped passing AttributeValueId around in the attribute panel; use path everywhere (which we mostly already were)
* Require "/" at the beginning of AttributePath. This gives nice autocomplete, but more importantly, makes it so you can't pass a prop path to something expecting an AttributePath.

#### Screenshots:

![image](https://github.com/user-attachments/assets/7ce35d35-fed8-4621-ae66-c48af1c77617)

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: inserting and deleting deep children of array and map items works
- [x] Manual test: updating deep children of array items works
- [x] Manual test: insert and delete of top-level array and map items works
