### PR TITLE
fix(web): Don't show caution-tape or passing validatons

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -17,10 +17,10 @@
           <TruncateWithTooltip>{{ displayName }}</TruncateWithTooltip>
           <div class="flex flex-row items-center ml-auto gap-2xs">
             <StatusIndicatorIcon
-              v-if="validation"
+              v-if="validation && validation.status !== 'Success'"
               v-tooltip="validation.message"
               type="qualification"
-              :status="validation.status === 'Success' ? 'success' : 'failure'"
+              status="failure"
               class="w-8 mr-2 shrink-0"
             />
             <IconButton
@@ -58,8 +58,8 @@
                 ? [
                     'cursor-not-allowed focus:outline-none focus:z-10',
                     themeClasses(
-                      'bg-caution-lines-light text-neutral-600 focus:border-action-500',
-                      'bg-caution-lines-dark text-neutral-400 focus:border-action-300',
+                      'bg-neutral-100 text-neutral-600 focus:border-action-500',
+                      'bg-neutral-900 text-neutral-400 focus:border-action-300',
                     ),
                   ]
                 : [themeClasses('bg-shade-0', 'bg-shade-100'), 'cursor-text'],


### PR DESCRIPTION
We should only show failing validations to avoid noise. We also need to ensure that we show a readonly input that isn’t caution tape
