### PR TITLE
fix(web): use interval ms in ChangeSetPanel waitForChangeSetExists

### DIFF
--- a/app/web/src/components/layout/navbar/ChangeSetPanel.vue
+++ b/app/web/src/components/layout/navbar/ChangeSetPanel.vue
@@ -243,7 +243,7 @@ const waitForChangeSetExists = (
         resolve();
       }
       retry += 1;
-    });
+    }, INTERVAL_MS);
   });
 };
 


### PR DESCRIPTION
Actually uses the sleep time in the interval that waits for a change set to be ready in the new UI