### PR TITLE
Update new UI Change Set Applied To Head redirect

### DIFF
--- a/app/web/src/store/change_sets.store.ts
+++ b/app/web/src/store/change_sets.store.ts
@@ -582,13 +582,34 @@ export function useChangeSetsStore() {
                 const route = useRouterStore().currentRoute;
 
                 if (route?.name) {
-                  router.push({
-                    name: route.name,
-                    params: {
-                      ...route.params,
-                      changeSetId: this.headChangeSetId,
-                    },
-                  });
+                  if ((route.name as string).startsWith("new-hotness")) {
+                    let name = route.name as string;
+                    // if you're on a single-item page in the UI while just bring them to explore
+                    if (
+                      ![
+                        "new-hotness",
+                        "new-hotness-workspace-auto",
+                        "new-hotness-head",
+                      ].includes(route.name as string)
+                    )
+                      name = "new-hotness";
+
+                    router.push({
+                      name,
+                      params: {
+                        ...route.query, // this will keep map/grid, search, if its there
+                        changeSetId: this.headChangeSetId,
+                      },
+                    });
+                  } else {
+                    router.push({
+                      name: route.name,
+                      params: {
+                        ...route.params,
+                        changeSetId: this.headChangeSetId,
+                      },
+                    });
+                  }
                   if (
                     this.selectedChangeSet &&
                     this.selectedChangeSet.name !== "HEAD"


### PR DESCRIPTION
## How does this PR change the system?
In the new ui if you're looking at an individual page while youre change set is merged to head we redirect you back to the explore page

## How was it tested?
1. Create a key pair
2. Open a second window that stays on the component page
3. In the first window navigate back to `Explore` and hit `Apply`
4. Watch both windows redirect to HEAD in the explore view

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlejNnZ3V3M2xmdmwwMHZhN3BkYWtvazN1bmV0c2I4eWthZXB4NHdrYyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/llmrnMkLqcssM6sYG7/giphy-downsized-medium.gif"/>