### PR TITLE
Fix: tear down code viewer on code change in order to re-init it

### DIFF
--- a/app/web/src/components/CodeViewer.vue
+++ b/app/web/src/components/CodeViewer.vue
@@ -221,6 +221,7 @@ function syncEditorConfig() {
 
 function syncEditorCode() {
   // this is what `CodeEditor` does, on any change it remounts the editor
+  teardownCodeMirrorEditor();
   initCodeMirrorEditor();
 }
 


### PR DESCRIPTION
## How does this PR change the system?
This is how the code editor works

### Testing
1. Create an EC2::Subnet
2. add an availability zone and a CIDR block
3. Flip the `MapPublicIpOnLaunch` boolean back and forth
4. Don't see code duplicates

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdldzkwNXdneGFrMHcyMjZ0aWQ5YjgyemlkMW8xZzU1dzRlNnJmcmxtciZlcD12MV9naWZzX3NlYXJjaCZjdD1n/QYRKEyLVVk2PVLFmRp/giphy.gif"/>