### PR TITLE
Reduce Vec (re)allocations

### DIFF
--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -281,11 +281,11 @@ impl ActionPrototype {
     ) -> ActionPrototypeResult<Vec<ActionPrototypeId>> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        let mut action_prototype_ids = Vec::new();
-        for node_index in workspace_snapshot
+        let action_prototype_nodes = workspace_snapshot
             .incoming_sources_for_edge_weight_kind(func_id, EdgeWeightKindDiscriminants::Use)
-            .await?
-        {
+            .await?;
+        let mut action_prototype_ids = Vec::with_capacity(action_prototype_nodes.len());
+        for node_index in action_prototype_nodes {
             if let NodeWeight::ActionPrototype(node_weight) =
                 workspace_snapshot.get_node_weight(node_index).await?
             {
@@ -423,16 +423,16 @@ impl ActionPrototype {
         ctx: &DalContext,
         schema_variant_id: SchemaVariantId,
     ) -> ActionPrototypeResult<Vec<Self>> {
-        let mut prototypes = Vec::new();
-        for (_, _tail_node_idx, head_node_idx) in ctx
+        let prototype_edges = ctx
             .workspace_snapshot()?
             .edges_directed_for_edge_weight_kind(
                 schema_variant_id,
                 Outgoing,
                 EdgeWeightKindDiscriminants::ActionPrototype,
             )
-            .await?
-        {
+            .await?;
+        let mut prototypes = Vec::with_capacity(prototype_edges.len());
+        for (_, _tail_node_idx, head_node_idx) in prototype_edges {
             if let NodeWeight::ActionPrototype(node_weight) = ctx
                 .workspace_snapshot()?
                 .get_node_weight(head_node_idx)

--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -101,7 +101,7 @@ impl DependentValueGraph {
     ) -> AttributeValueResult<Vec<WorkQueueValue>> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        let mut values = Vec::new();
+        let mut values = Vec::with_capacity(roots.len());
         for root in roots {
             let root_ulid: Ulid = root.into();
             // It's possible that one or more of the initial ids provided by the enqueued

--- a/lib/dal/src/component/diff.rs
+++ b/lib/dal/src/component/diff.rs
@@ -53,8 +53,9 @@ impl Component {
                 });
             };
 
-        let mut lines = Vec::new();
-        for diff_object in diff::lines(&head_json, &curr_json) {
+        let diff_lines = diff::lines(&head_json, &curr_json);
+        let mut lines = Vec::with_capacity(diff_lines.len());
+        for diff_object in diff_lines {
             let line = match diff_object {
                 diff::Result::Left(left) => format!("-{left}"),
                 diff::Result::Both(unchanged, _) => format!(" {unchanged}"),

--- a/lib/dal/src/component/inferred_connection_graph.rs
+++ b/lib/dal/src/component/inferred_connection_graph.rs
@@ -187,8 +187,9 @@ impl InferredConnectionGraph {
     ) -> InferredConnectionGraphResult<Vec<InferredConnection>> {
         let mut results = Vec::new();
         for component_id in Component::list_ids(ctx).await.map_err(Box::new)? {
-            results.extend(
-                self.inferred_incoming_connections_for_component(ctx, component_id)
+            results.append(
+                &mut self
+                    .inferred_incoming_connections_for_component(ctx, component_id)
                     .await?,
             );
         }
@@ -265,6 +266,7 @@ impl InferredConnectionGraph {
         {
             let mut cached_results = Vec::new();
             for input_socket_info in component_cache.get().values() {
+                cached_results.reserve(input_socket_info.len());
                 cached_results.extend(input_socket_info);
             }
 

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -694,8 +694,8 @@ impl Func {
             )
             .await?;
 
-        let mut func_node_weights = Vec::new();
-        let mut func_content_hashes = Vec::new();
+        let mut func_node_weights = Vec::with_capacity(func_node_indexes.len());
+        let mut func_content_hashes = Vec::with_capacity(func_node_indexes.len());
         for index in func_node_indexes {
             let node_weight = workspace_snapshot
                 .get_node_weight(index)
@@ -743,8 +743,8 @@ impl Func {
     pub async fn list_from_ids(ctx: &DalContext, func_ids: &[FuncId]) -> FuncResult<Vec<Self>> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        let mut func_node_weights = Vec::new();
-        let mut func_content_hashes = Vec::new();
+        let mut func_node_weights = Vec::with_capacity(func_ids.len());
+        let mut func_content_hashes = Vec::with_capacity(func_ids.len());
         for id in func_ids {
             let node_weight = workspace_snapshot
                 .get_node_weight(id)
@@ -768,7 +768,7 @@ impl Func {
             .try_read_many_as(func_content_hashes.as_slice())
             .await?;
 
-        let mut funcs = Vec::new();
+        let mut funcs = Vec::with_capacity(func_node_weights.len());
         for node_weight in func_node_weights {
             match func_contents.get(&node_weight.content_hash()) {
                 Some(func_content) => {

--- a/lib/dal/src/label_list.rs
+++ b/lib/dal/src/label_list.rs
@@ -62,7 +62,7 @@ where
     V: Debug + DeserializeOwned + Serialize + postgres_types::FromSqlOwned,
 {
     pub fn from_rows(rows: Vec<PgRow>) -> LabelListResult<LabelList<V>> {
-        let mut results = Vec::new();
+        let mut results = Vec::with_capacity(rows.len());
         for row in rows.into_iter() {
             let name: String = row.try_get("name")?;
             let value: V = row.try_get("value")?;

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -1165,7 +1165,7 @@ impl Prop {
             .try_read_many_as(content_hashes.as_slice())
             .await?;
 
-        let mut props = Vec::new();
+        let mut props = Vec::with_capacity(node_weights.len());
         for node_weight in node_weights {
             match content_map.get(&node_weight.content_hash()) {
                 Some(content) => {

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -293,8 +293,6 @@ impl QualificationView {
         ctx: &DalContext,
         component_id: ComponentId,
     ) -> Result<Option<Self>, QualificationError> {
-        let mut output = Vec::new();
-
         let mut status = QualificationSubCheckStatus::Success;
 
         let mut fail_counter = 0;
@@ -304,9 +302,10 @@ impl QualificationView {
         // validations summary for a component and store it on the graph during the
         // compute_validations job.
         // Then we'd just load it here and convert to the view struct
-        for (av_id, validation_output) in
-            ValidationOutput::list_for_component(ctx, component_id).await?
-        {
+        let component_validation_outputs =
+            ValidationOutput::list_for_component(ctx, component_id).await?;
+        let mut output = Vec::with_capacity(component_validation_outputs.len());
+        for (av_id, validation_output) in component_validation_outputs {
             // We have validations therefore, we need to show the validations in the Qualifications output
             has_active_validations = true;
             if validation_output.status != ValidationStatus::Success {

--- a/lib/dal/src/resource_metadata.rs
+++ b/lib/dal/src/resource_metadata.rs
@@ -50,8 +50,9 @@ type ResourceMetadataResult<T> = Result<T, ResourceMetadataError>;
 /// Collect [`ResourceMetadata`] for every [`Component`] in the workspace.
 #[instrument(name = "resource_metadata.list", level = "debug", skip(ctx))]
 pub async fn list(ctx: &DalContext) -> ResourceMetadataResult<Vec<si_events::ResourceMetadata>> {
-    let mut results = Vec::new();
-    for component_id in Component::list_ids(ctx).await? {
+    let component_ids = Component::list_ids(ctx).await?;
+    let mut results = Vec::with_capacity(component_ids.len());
+    for component_id in component_ids {
         if let Some(data) = Component::resource_by_id(ctx, component_id).await? {
             results.push(assemble_metadata(component_id, data));
         }

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -272,11 +272,11 @@ impl Schema {
     ) -> SchemaResult<Vec<SchemaVariantId>> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
-        let mut schema_variant_ids = Vec::new();
-        for (edge_weight, _, target_index) in workspace_snapshot
+        let schema_variant_edges = workspace_snapshot
             .edges_directed(schema_id, Outgoing)
-            .await?
-        {
+            .await?;
+        let mut schema_variant_ids = Vec::with_capacity(schema_variant_edges.len());
+        for (edge_weight, _, target_index) in schema_variant_edges {
             if EdgeWeightKindDiscriminants::Use == edge_weight.kind().into() {
                 schema_variant_ids.push(
                     workspace_snapshot
@@ -493,7 +493,7 @@ impl Schema {
             )
             .await?;
 
-        let mut schema_ids = Vec::new();
+        let mut schema_ids = Vec::with_capacity(schema_node_indices.len());
         for index in schema_node_indices {
             let raw_id = workspace_snapshot.get_node_weight(index).await?.id();
             schema_ids.push(raw_id.into());

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -538,7 +538,8 @@ impl Secret {
             )
             .await?;
 
-        let mut attribute_value_ids = Vec::new();
+        let mut attribute_value_ids =
+            Vec::with_capacity(attribute_prototype_argument_indices.len());
         for attribute_prototype_argument_index in attribute_prototype_argument_indices {
             let attribute_prototype_argument_node_weight = workspace_snapshot
                 .get_node_weight(attribute_prototype_argument_index)

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -443,7 +443,7 @@ impl Workspace {
             .query(WORKSPACE_LIST_FOR_USER, &[&user_pk])
             .await?;
 
-        let mut result = Vec::new();
+        let mut result = Vec::with_capacity(rows.len());
 
         for row in rows {
             result.push(Self::try_from(row)?);
@@ -489,7 +489,7 @@ impl Workspace {
                 .await?
         };
 
-        let mut result = Vec::new();
+        let mut result = Vec::with_capacity(rows.len());
         for row in rows.into_iter() {
             result.push(Self::try_from(row)?);
         }


### PR DESCRIPTION
This is another pass at reducing the number of times `Vec`s are potentially (re)allocated due to growth, similarly as was done in 52719a4277.

Whenever possible:
* Create the `Vec` using `Vec::with_capacity`.
* Use `Vec::append` when adding items from another `Vec` that is also never used again.
* Use `Vec::reserve` when adding items from an iterator that we can determine the size of ahead of time. This applies to both using `Vec::extend` and `Vec::push` to add the items.
