### PR TITLE
Small QOL watchedForm change

### DIFF
--- a/app/web/src/newhotness/logic_composables/watched_form.ts
+++ b/app/web/src/newhotness/logic_composables/watched_form.ts
@@ -103,6 +103,7 @@ export const useWatchedForm = <Data>(label: string) => {
         const markComplete = () => {
           bifrosting.value = false;
           rainbow.remove(ctx.changeSetId.value, label);
+          if (!wForm.state.canSubmit) wForm.reset(props.value);
           if (span) {
             span.setAttribute("measured_time", Date.now() - start);
             span.end();


### PR DESCRIPTION
## How does this PR change the system?
In the case of an api submission exception, reset the form so it can be submitted again

### Out of Scope
I was considering how to get a "universal boolean" for "did this submission succeed"... but there isnt a clean way to do it, it would essentially be a one-off check for each API call within the submission fn... not very universal. Note: this is because we've turned off the "anything except a 200 is an exception" behavior from axios, because exception handling is more annoying and detrimental to development and the user experience

