### PR TITLE
Remove async_recursion from dal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,7 +2189,6 @@ dependencies = [
 name = "dal"
 version = "0.1.0"
 dependencies = [
- "async-recursion",
  "async-trait",
  "audit-database",
  "audit-logs-stream",

--- a/lib/dal-materialized-views/src/component.rs
+++ b/lib/dal-materialized-views/src/component.rs
@@ -62,8 +62,7 @@ pub async fn assemble_in_list(
         {
             let av_id_for_prop_id =
                 Component::attribute_value_for_prop_id(ctx, component_id, prop_id).await?;
-            let av = dal::AttributeValue::get_by_id(ctx, av_id_for_prop_id).await?;
-            av.view(ctx).await?
+            dal::AttributeValue::view(ctx, av_id_for_prop_id).await?
         } else {
             None
         };

--- a/lib/dal-materialized-views/src/component/attribute_tree.rs
+++ b/lib/dal-materialized-views/src/component/attribute_tree.rs
@@ -8,11 +8,11 @@ use dal::{
     AttributeValue,
     Component,
     DalContext,
-    Func,
     Prop,
     Secret,
     component::ControllingFuncData,
     validation::ValidationOutputNode,
+    workspace_snapshot::traits::func::FuncExt as _,
 };
 use si_frontend_mv_types::component::attribute_tree::{
     self,
@@ -137,12 +137,13 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
 
         let prototype_id = AttributeValue::prototype_id(ctx, av_id).await?;
         let func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
+        let is_dynamic_func = ctx.workspace_snapshot()?.func_is_dynamic(func_id).await?;
 
         // FIXME(nick): this is likely incorrect.
         let controlling_func = ControllingFuncData {
             func_id,
             av_id,
-            is_dynamic_func: Func::is_dynamic(ctx, func_id).await?,
+            is_dynamic_func,
         };
 
         // NOTE(nick): I ported Victor's comment.

--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -801,9 +801,7 @@ impl ExpectAttributeValue {
     }
 
     pub async fn view(self, ctx: &DalContext) -> Option<Value> {
-        self.attribute_value(ctx)
-            .await
-            .view(ctx)
+        dal::AttributeValue::view(ctx, self.attribute_value(ctx).await.id())
             .await
             .expect("attribute value view")
     }

--- a/lib/dal-test/src/helpers.rs
+++ b/lib/dal-test/src/helpers.rs
@@ -288,9 +288,9 @@ pub async fn get_component_input_socket_value(
         .collect_vec()
         .pop()
         .ok_or(eyre!("no input socket match found"))?;
-    let input_socket_av =
-        AttributeValue::get_by_id(ctx, component_input_socket.attribute_value_id).await?;
-    Ok(input_socket_av.view(ctx).await?)
+    AttributeValue::view(ctx, component_input_socket.attribute_value_id)
+        .await
+        .map_err(Into::into)
 }
 /// Gets the [`Value`] for a specific [`Component`]'s [`InputSocket`] by the [`InputSocket`] name
 pub async fn get_component_input_socket_attribute_value(
@@ -333,9 +333,9 @@ pub async fn get_component_output_socket_value(
         .collect_vec()
         .pop()
         .ok_or(eyre!("no input socket match found"))?;
-    let output_socket_av =
-        AttributeValue::get_by_id(ctx, component_output_socket.attribute_value_id).await?;
-    Ok(output_socket_av.view(ctx).await?)
+    AttributeValue::view(ctx, component_output_socket.attribute_value_id)
+        .await
+        .map_err(Into::into)
 }
 
 /// Update the [`Value`] for a specific [`AttributeValue`] for the given [`Component`](ComponentId) by the [`PropPath`]
@@ -381,10 +381,9 @@ pub async fn get_attribute_value_for_component_opt(
         .ok_or(eyre!("unexpected, no attribute values found for prop"))?;
     assert!(attribute_value_ids.is_empty());
 
-    let attribute_value = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
-
-    let value = attribute_value.view(ctx).await?;
-    Ok(value)
+    AttributeValue::view(ctx, attribute_value_id)
+        .await
+        .map_err(Into::into)
 }
 
 /// Encrypts a message with a given [`KeyPairPk`](KeyPair).
@@ -420,11 +419,9 @@ pub async fn fetch_resource_last_synced_value(
         return Err(eyre!("unexpected: more than one attribute value found"));
     }
 
-    let last_synced_value = AttributeValue::get_by_id(ctx, attribute_value_id)
-        .await?
-        .view(ctx)
-        .await?;
-    Ok(last_synced_value)
+    AttributeValue::view(ctx, attribute_value_id)
+        .await
+        .map_err(Into::into)
 }
 
 /// Extracts the value and validation from a raw property edtior value.

--- a/lib/dal-test/src/helpers/attribute/value.rs
+++ b/lib/dal-test/src/helpers/attribute/value.rs
@@ -61,7 +61,7 @@ pub async fn subscribe_with_custom_function<S: AttributeValueKey>(
 /// Get the value
 pub async fn get(ctx: &DalContext, av: impl AttributeValueKey) -> Result<serde_json::Value> {
     let av_id = id(ctx, av).await?;
-    AttributeValue::view_by_id(ctx, av_id)
+    AttributeValue::view(ctx, av_id)
         .await?
         .ok_or(eyre!("Attribute missing value"))
 }
@@ -69,7 +69,7 @@ pub async fn get(ctx: &DalContext, av: impl AttributeValueKey) -> Result<serde_j
 /// Check whether the value exists and is set
 pub async fn has_value(ctx: &DalContext, av: impl AttributeValueKey) -> Result<bool> {
     match AttributeValueKey::resolve(ctx, av).await? {
-        Some(av_id) => Ok(AttributeValue::view_by_id(ctx, av_id).await?.is_some()),
+        Some(av_id) => Ok(AttributeValue::view(ctx, av_id).await?.is_some()),
         None => Ok(false),
     }
 }

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -39,7 +39,6 @@ rust_library(
         "//lib/telemetry-rs:telemetry",
         "//lib/telemetry-utils-rs:telemetry-utils",
         "//lib/veritech-client:veritech-client",
-        "//third-party/rust:async-recursion",
         "//third-party/rust:async-trait",
         "//third-party/rust:base64",
         "//third-party/rust:blake3",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -1,90 +1,89 @@
 [package]
-name = "dal"
-version.workspace = true
-authors.workspace = true
-license.workspace = true
-repository.workspace = true
-edition.workspace = true
+name                   = "dal"
+version.workspace      = true
+authors.workspace      = true
+license.workspace      = true
+repository.workspace   = true
+edition.workspace      = true
 rust-version.workspace = true
-publish.workspace = true
+publish.workspace      = true
 
 [dependencies]
-audit-database           = { path = "../../lib/audit-database" }
-audit-logs-stream        = { path = "../../lib/audit-logs-stream" }
-billing-events           = { path = "../../lib/billing-events" }
-concurrent-extensions    = { path = "../../lib/concurrent-extensions" }
-dal-macros               = { path = "../../lib/dal-macros" }
-joi-validator            = { path = "../../lib/joi-validator" }
-module-index-client      = { path = "../../lib/module-index-client" }
-nats-std                 = { path = "../../lib/nats-std" }
-object-tree              = { path = "../../lib/object-tree" }
-pending-events           = { path = "../../lib/pending-events" }
-pinga-client             = { path = "../../lib/pinga-client" }
-pinga-core               = { path = "../../lib/pinga-core" }
-rebaser-client           = { path = "../../lib/rebaser-client" }
-shuttle-server           = { path = "../../lib/shuttle-server" }
-si-crypto                = { path = "../../lib/si-crypto" }
-si-data-nats             = { path = "../../lib/si-data-nats" }
-si-data-pg               = { path = "../../lib/si-data-pg" }
-si-db                    = { path = "../../lib/si-db" }
-si-events                = { path = "../../lib/si-events-rs" }
-si-frontend-types        = { path = "../../lib/si-frontend-types-rs" }
-si-hash                  = { path = "../../lib/si-hash" }
-si-id                    = { path = "../../lib/si-id" }
-si-layer-cache           = { path = "../../lib/si-layer-cache" }
-si-pkg                   = { path = "../../lib/si-pkg" }
-si-runtime               = { path = "../../lib/si-runtime-rs" }
-si-settings              = { path = "../../lib/si-settings" }
-si-split-graph           = { path = "../../lib/si-split-graph" }
-si-std                   = { path = "../../lib/si-std" }
-telemetry                = { path = "../../lib/telemetry-rs" }
-telemetry-nats           = { path = "../../lib/telemetry-nats-rs" }
-telemetry-utils          = { path = "../../lib/telemetry-utils-rs" }
-veritech-client          = { path = "../../lib/veritech-client" }
+audit-database        = { path = "../../lib/audit-database" }
+audit-logs-stream     = { path = "../../lib/audit-logs-stream" }
+billing-events        = { path = "../../lib/billing-events" }
+concurrent-extensions = { path = "../../lib/concurrent-extensions" }
+dal-macros            = { path = "../../lib/dal-macros" }
+joi-validator         = { path = "../../lib/joi-validator" }
+module-index-client   = { path = "../../lib/module-index-client" }
+nats-std              = { path = "../../lib/nats-std" }
+object-tree           = { path = "../../lib/object-tree" }
+pending-events        = { path = "../../lib/pending-events" }
+pinga-client          = { path = "../../lib/pinga-client" }
+pinga-core            = { path = "../../lib/pinga-core" }
+rebaser-client        = { path = "../../lib/rebaser-client" }
+shuttle-server        = { path = "../../lib/shuttle-server" }
+si-crypto             = { path = "../../lib/si-crypto" }
+si-data-nats          = { path = "../../lib/si-data-nats" }
+si-data-pg            = { path = "../../lib/si-data-pg" }
+si-db                 = { path = "../../lib/si-db" }
+si-events             = { path = "../../lib/si-events-rs" }
+si-frontend-types     = { path = "../../lib/si-frontend-types-rs" }
+si-hash               = { path = "../../lib/si-hash" }
+si-id                 = { path = "../../lib/si-id" }
+si-layer-cache        = { path = "../../lib/si-layer-cache" }
+si-pkg                = { path = "../../lib/si-pkg" }
+si-runtime            = { path = "../../lib/si-runtime-rs" }
+si-settings           = { path = "../../lib/si-settings" }
+si-split-graph        = { path = "../../lib/si-split-graph" }
+si-std                = { path = "../../lib/si-std" }
+telemetry             = { path = "../../lib/telemetry-rs" }
+telemetry-nats        = { path = "../../lib/telemetry-nats-rs" }
+telemetry-utils       = { path = "../../lib/telemetry-utils-rs" }
+veritech-client       = { path = "../../lib/veritech-client" }
 
-async-recursion = { workspace = true }
-async-trait     = { workspace = true }
-base64          = { workspace = true }
-blake3          = { workspace = true }
-chrono          = { workspace = true }
-ciborium        = { workspace = true }
-clap            = { workspace = true }
-convert_case    = { workspace = true }
-derive_more     = { workspace = true }
-diff            = { workspace = true }
-dyn-clone       = { workspace = true }
-futures         = { workspace = true }
-hex             = { workspace = true }
-iftree          = { workspace = true }
-indexmap        = { workspace = true }
-itertools       = { workspace = true }
-json-patch      = { workspace = true }
-jsonptr         = { workspace = true }
-jwt-simple      = { workspace = true }
-lazy_static     = { workspace = true }
-once_cell       = { workspace = true }
-paste           = { workspace = true }
-petgraph        = { workspace = true }
-postcard        = { workspace = true }
-postgres-types  = { workspace = true }
-rand            = { workspace = true }
-refinery        = { workspace = true }
-regex           = { workspace = true }
-remain          = { workspace = true }
-ringmap         = { workspace = true }
-serde           = { workspace = true }
-serde-aux       = { workspace = true }
-serde_json      = { workspace = true }
-serde_with      = { workspace = true }
-sodiumoxide     = { workspace = true }
-strum           = { workspace = true }
-thiserror       = { workspace = true }
-tokio           = { workspace = true }
-tokio-stream    = { workspace = true }
-tokio-util      = { workspace = true }
-tryhard         = { workspace = true }
-ulid            = { workspace = true }
-url             = { workspace = true }
+async-trait    = { workspace = true }
+base64         = { workspace = true }
+blake3         = { workspace = true }
+chrono         = { workspace = true }
+ciborium       = { workspace = true }
+clap           = { workspace = true }
+convert_case   = { workspace = true }
+derive_more    = { workspace = true }
+diff           = { workspace = true }
+dyn-clone      = { workspace = true }
+futures        = { workspace = true }
+hex            = { workspace = true }
+iftree         = { workspace = true }
+indexmap       = { workspace = true }
+itertools      = { workspace = true }
+json-patch     = { workspace = true }
+jsonptr        = { workspace = true }
+jwt-simple     = { workspace = true }
+lazy_static    = { workspace = true }
+once_cell      = { workspace = true }
+paste          = { workspace = true }
+petgraph       = { workspace = true }
+postcard       = { workspace = true }
+postgres-types = { workspace = true }
+rand           = { workspace = true }
+refinery       = { workspace = true }
+regex          = { workspace = true }
+remain         = { workspace = true }
+ringmap        = { workspace = true }
+serde          = { workspace = true }
+serde-aux      = { workspace = true }
+serde_json     = { workspace = true }
+serde_with     = { workspace = true }
+sodiumoxide    = { workspace = true }
+strum          = { workspace = true }
+thiserror      = { workspace = true }
+tokio          = { workspace = true }
+tokio-stream   = { workspace = true }
+tokio-util     = { workspace = true }
+tryhard        = { workspace = true }
+ulid           = { workspace = true }
+url            = { workspace = true }
 
 [dev-dependencies]
 buck2-resources        = { path = "../../lib/buck2-resources" }

--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -168,12 +168,7 @@ impl AttributePrototypeDebugView {
                     ValueSource::ValueSubscription(ref subscription) => {
                         let value_source_id = subscription.attribute_value_id.into();
                         let view = match subscription.resolve(ctx).await? {
-                            Some(av_id) => {
-                                AttributeValue::get_by_id(ctx, av_id)
-                                    .await?
-                                    .view(ctx)
-                                    .await?
-                            }
+                            Some(av_id) => AttributeValue::view(ctx, av_id).await?,
                             None => None,
                         };
                         // TODO add subscription path to FuncArgDebugView (path right now is prop path)
@@ -222,11 +217,11 @@ impl AttributePrototypeDebugView {
                             .attribute_values_for_component_id(ctx, expected_source_component_id)
                             .await?
                         {
-                            let attribute_value =
-                                AttributeValue::get_by_id(ctx, attribute_value_id).await?;
                             let prop_path =
                                 AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
-                            let view = attribute_value.view(ctx).await?.unwrap_or(Value::Null);
+                            let view = AttributeValue::view(ctx, attribute_value_id)
+                                .await?
+                                .unwrap_or(Value::Null);
                             let func_arg_debug = FuncArgDebugView {
                                 value: view,
                                 name: func_arg_name.clone(),
@@ -248,13 +243,12 @@ impl AttributePrototypeDebugView {
                             .attribute_values_for_component_id(ctx, expected_source_component_id)
                             .await?
                         {
-                            let attribute_value =
-                                AttributeValue::get_by_id(ctx, attribute_value_id).await?;
                             let attribute_value_path =
                                 AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
 
-                            let value_view =
-                                attribute_value.view(ctx).await?.unwrap_or(Value::Null);
+                            let value_view = AttributeValue::view(ctx, attribute_value_id)
+                                .await?
+                                .unwrap_or(Value::Null);
                             let func_arg_debug = FuncArgDebugView {
                                 value: value_view,
                                 name: func_arg_name.clone(),
@@ -276,13 +270,12 @@ impl AttributePrototypeDebugView {
                             .attribute_values_for_component_id(ctx, expected_source_component_id)
                             .await?
                         {
-                            let attribute_value =
-                                AttributeValue::get_by_id(ctx, attribute_value_id).await?;
                             let attribute_value_path =
                                 AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
 
-                            let value_view =
-                                attribute_value.view(ctx).await?.unwrap_or(Value::Null);
+                            let value_view = AttributeValue::view(ctx, attribute_value_id)
+                                .await?
+                                .unwrap_or(Value::Null);
                             let func_arg_debug = FuncArgDebugView {
                                 value: value_view,
                                 name: func_arg_name.clone(),
@@ -326,9 +319,9 @@ impl AttributePrototypeDebugView {
                     .await?;
                     let attribute_value_path =
                         AttributeValue::get_path_for_id(ctx, attribute_value_id).await?;
-                    let output_av =
-                        AttributeValue::get_by_id(ctx, output_match.attribute_value_id).await?;
-                    let value_view = output_av.view(ctx).await?.unwrap_or(Value::Null);
+                    let value_view = AttributeValue::view(ctx, output_match.attribute_value_id)
+                        .await?
+                        .unwrap_or(Value::Null);
                     let input_func = AttributePrototype::func_id(ctx, prototype_id).await?;
                     if let Some(func_argument) =
                         FuncArgument::list_for_func(ctx, input_func).await?.pop()

--- a/lib/dal/src/attribute/value/debug.rs
+++ b/lib/dal/src/attribute/value/debug.rs
@@ -114,7 +114,7 @@ impl AttributeDebugView {
         let prop_opt: Option<Prop> = Some(prop);
         let attribute_prototype_debug_view =
             AttributePrototypeDebugView::new(ctx, attribute_value_id).await?;
-        let value_view = attribute_value.view(ctx).await?;
+        let value_view = AttributeValue::view(ctx, attribute_value_id).await?;
         let prop_kind = prop_opt.clone().map(|prop| prop.kind);
         let value = match attribute_value.unprocessed_value(ctx).await? {
             Some(value) => Some(value),

--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -291,7 +291,6 @@ impl DependentValueGraph {
                         &mut controlling_funcs_for_component,
                     )
                     .await?;
-                work_queue.reserve(new_work_queue_values.len());
                 work_queue.extend(new_work_queue_values);
             }
 

--- a/lib/dal/src/code_view.rs
+++ b/lib/dal/src/code_view.rs
@@ -93,7 +93,7 @@ impl CodeView {
             None => return Ok(None),
         };
 
-        let func_execution = match attribute_value.view(ctx).await? {
+        let func_execution = match AttributeValue::view(ctx, attribute_value_id).await? {
             Some(func_execution) => func_execution,
             None => return Ok(None),
         };

--- a/lib/dal/src/component/diff.rs
+++ b/lib/dal/src/component/diff.rs
@@ -148,8 +148,7 @@ impl Component {
         // Now we need serialized, textual versions of the component on this change set and on head
         // in order to calculate a textural diff
         //
-        // NOTE(fnichol): this ported implementation is still way too expensive and relies on
-        // `AttributeValue.view()` which uses `async_recursion`. This needs to change...
+        // NOTE(fnichol): this ported implementation is still way too expensive
 
         let this_component_json_str = {
             let view = Self::view_by_id(ctx, component_id).await?.ok_or(

--- a/lib/dal/src/component/inferred_connection_graph.rs
+++ b/lib/dal/src/component/inferred_connection_graph.rs
@@ -266,7 +266,6 @@ impl InferredConnectionGraph {
         {
             let mut cached_results = Vec::new();
             for input_socket_info in component_cache.get().values() {
-                cached_results.reserve(input_socket_info.len());
                 cached_results.extend(input_socket_info);
             }
 

--- a/lib/dal/src/component/qualification.rs
+++ b/lib/dal/src/component/qualification.rs
@@ -35,6 +35,7 @@ impl Component {
 
         Ok(AttributeValue::get_child_avs_in_order(ctx, qualification_map_value_id).await?)
     }
+
     pub async fn list_qualification_statuses(
         ctx: &DalContext,
         component_id: ComponentId,
@@ -44,7 +45,7 @@ impl Component {
         let qualification_avs = Self::list_qualification_avs(ctx, component_id).await?;
 
         for qualification_av in qualification_avs {
-            let Some(qual_value) = qualification_av.view(ctx).await? else {
+            let Some(qual_value) = AttributeValue::view(ctx, qualification_av.id()).await? else {
                 continue;
             };
 
@@ -74,7 +75,7 @@ impl Component {
         let qualification_avs = Self::list_qualification_avs(ctx, component_id).await?;
 
         for qualification_av in qualification_avs {
-            if let Some(view) = QualificationView::new(ctx, qualification_av).await? {
+            if let Some(view) = QualificationView::new(ctx, qualification_av.id()).await? {
                 qualification_views.push(view);
             }
         }

--- a/lib/dal/src/component/socket.rs
+++ b/lib/dal/src/component/socket.rs
@@ -208,8 +208,8 @@ impl ComponentOutputSocket {
             .await?
             .attribute_value_id;
 
-        let av = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
-        let view = av.view(ctx).await?;
+        let view = AttributeValue::view(ctx, attribute_value_id).await?;
+
         Ok(view)
     }
 }
@@ -454,8 +454,9 @@ impl ComponentInputSocket {
         let attribute_value_id = Self::get_by_ids_or_error(ctx, component_id, input_socket_id)
             .await?
             .attribute_value_id;
-        let av = AttributeValue::get_by_id(ctx, attribute_value_id).await?;
-        let view = av.view(ctx).await?;
+
+        let view = AttributeValue::view(ctx, attribute_value_id).await?;
+
         Ok(view)
     }
 

--- a/lib/dal/src/func/intrinsics.rs
+++ b/lib/dal/src/func/intrinsics.rs
@@ -43,6 +43,26 @@ pub enum IntrinsicFunc {
 }
 
 impl IntrinsicFunc {
+    /// The [`IntrinsicFunc`] variant considered "dynamic" if its value changes based on
+    /// the value of another [`AttributeValue`].
+    pub fn is_dynamic(&self) -> bool {
+        match self {
+            IntrinsicFunc::SetArray
+            | IntrinsicFunc::SetBoolean
+            | IntrinsicFunc::SetInteger
+            | IntrinsicFunc::SetFloat
+            | IntrinsicFunc::SetJson
+            | IntrinsicFunc::SetMap
+            | IntrinsicFunc::SetObject
+            | IntrinsicFunc::SetString
+            | IntrinsicFunc::Unset => false,
+            IntrinsicFunc::Identity
+            | IntrinsicFunc::NormalizeToArray
+            | IntrinsicFunc::ResourcePayloadToValue
+            | IntrinsicFunc::Validation => true,
+        }
+    }
+
     pub fn pkg_spec() -> FuncResult<PkgSpec> {
         let mut builder = PkgSpec::builder();
         builder.name("si-intrinsic-funcs");

--- a/lib/dal/src/management/mod.rs
+++ b/lib/dal/src/management/mod.rs
@@ -1849,10 +1849,7 @@ async fn update_component(
             | PropKind::Float
             | PropKind::Json => {
                 // todo: type check!
-                let view = AttributeValue::get_by_id(ctx, path_attribute_value_id)
-                    .await?
-                    .view(ctx)
-                    .await?;
+                let view = AttributeValue::view(ctx, path_attribute_value_id).await?;
                 if Some(&current_val) != view.as_ref() {
                     AttributeValue::update(ctx, path_attribute_value_id, Some(current_val)).await?;
                 }
@@ -1895,10 +1892,7 @@ async fn update_component(
                             if AttributeValue::is_set_by_dependent_function(ctx, *child_id).await? {
                                 continue;
                             }
-                            let view = AttributeValue::get_by_id(ctx, *child_id)
-                                .await?
-                                .view(ctx)
-                                .await?;
+                            let view = AttributeValue::view(ctx, *child_id).await?;
                             if Some(&value) != view.as_ref() {
                                 AttributeValue::update(ctx, *child_id, Some(value)).await?;
                             }
@@ -1917,10 +1911,7 @@ async fn update_component(
             }
             PropKind::Array => {
                 if matches!(current_val, serde_json::Value::Array(_)) {
-                    let view = AttributeValue::get_by_id(ctx, path_attribute_value_id)
-                        .await?
-                        .view(ctx)
-                        .await?;
+                    let view = AttributeValue::view(ctx, path_attribute_value_id).await?;
 
                     if Some(&current_val) != view.as_ref() {
                         // Just update the entire array whole cloth

--- a/lib/dal/src/management/prototype.rs
+++ b/lib/dal/src/management/prototype.rs
@@ -274,10 +274,7 @@ async fn build_connection(
         .to_owned();
     let av_id =
         OutputSocket::component_attribute_value_id(ctx, from_socket_id, from_component_id).await?;
-    let value = AttributeValue::get_by_id(ctx, av_id)
-        .await?
-        .view(ctx)
-        .await?;
+    let value = AttributeValue::view(ctx, av_id).await?;
     Ok(SocketRefAndValue {
         socket_ref: SocketRef { component, socket },
         value,

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -120,6 +120,8 @@ pub enum PropError {
     MapOrArrayMissingElementProp(PropId),
     #[error("missing prototype for prop {0}")]
     MissingPrototypeForProp(PropId),
+    #[error("Multiple prototypes for Prop {0}")]
+    MultiplePrototypesForProp(PropId),
     #[error("node weight error: {0}")]
     NodeWeight(#[from] NodeWeightError),
     #[error("prop {0} is orphaned")]

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -4,6 +4,7 @@ use serde::{
 };
 use si_data_pg::PgError;
 use si_frontend_types::ComponentQualificationStats;
+use si_id::AttributeValueId;
 use si_layer_cache::LayerDbError;
 use strum::{
     AsRefStr,
@@ -214,20 +215,20 @@ impl Ord for QualificationView {
 impl QualificationView {
     pub async fn new(
         ctx: &DalContext,
-        attribute_value: AttributeValue,
+        attribute_value_id: AttributeValueId,
     ) -> Result<Option<Self>, QualificationError> {
         let maybe_qual_run = ctx
             .layer_db()
             .func_run()
             .get_last_qualification_for_attribute_value_id(
                 ctx.events_tenancy().workspace_pk,
-                attribute_value.id(),
+                attribute_value_id,
             )
             .await?;
         match maybe_qual_run {
             Some(qual_run) => {
                 let qualification_entry: QualificationEntry =
-                    match attribute_value.view(ctx).await? {
+                    match AttributeValue::view(ctx, attribute_value_id).await? {
                         Some(value) => serde_json::from_value(value)?,
                         None => return Ok(None),
                     };

--- a/lib/dal/src/socket/debug.rs
+++ b/lib/dal/src/socket/debug.rs
@@ -102,7 +102,7 @@ impl SocketDebugView {
         let path =
             (AttributeValue::get_path_for_id(ctx, attribute_value_id).await?).unwrap_or_default();
 
-        let view = attribute_value.view(ctx).await?;
+        let view = AttributeValue::view(ctx, attribute_value_id).await?;
         let inferred_connections: Vec<Ulid> =
             AttributeValue::list_input_socket_sources_for_id(ctx, attribute_value_id)
                 .await?
@@ -148,7 +148,7 @@ impl SocketDebugView {
             .collect();
         let path =
             (AttributeValue::get_path_for_id(ctx, attribute_value_id).await?).unwrap_or_default();
-        let value_view = attribute_value.view(ctx).await?;
+        let value_view = AttributeValue::view(ctx, attribute_value_id).await?;
         let inferred_connections = component_input_socket
             .find_inferred_connections(ctx)
             .await?

--- a/lib/dal/src/workspace_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/graph.rs
@@ -103,6 +103,8 @@ pub enum WorkspaceSnapshotGraphError {
     IncompatibleNodeTypes,
     #[error("InputSocket error {0}")]
     InputSocketError(#[from] Box<InputSocketError>),
+    #[error("Invalid edge weight kind: {0}")]
+    InvalidEdgeWeightKind(EdgeWeightKindDiscriminants),
     #[error("Invalid value graph")]
     InvalidValueGraph,
     #[error("layerdb error: {0}")]
@@ -121,6 +123,8 @@ pub enum WorkspaceSnapshotGraphError {
     NodeWeightNotFound,
     #[error("Node with ID {} not found", .0.to_string())]
     NodeWithIdNotFound(Ulid),
+    #[error("Node with index {0:?} not found")]
+    NodeWithIndexNotFound(NodeIndex),
     #[error("No edges of kind {1} found with node index {0:?} as the source")]
     NoEdgesOfKindFound(NodeIndex, EdgeWeightKindDiscriminants),
     #[error("No Prop found for NodeIndex {0:?}")]

--- a/lib/dal/src/workspace_snapshot/graph/traits.rs
+++ b/lib/dal/src/workspace_snapshot/graph/traits.rs
@@ -3,5 +3,6 @@ pub mod attribute_value;
 pub mod component;
 pub mod diagram;
 pub mod entity_kind;
+pub mod prop;
 pub mod schema;
 pub mod socket;

--- a/lib/dal/src/workspace_snapshot/graph/traits/attribute_value.rs
+++ b/lib/dal/src/workspace_snapshot/graph/traits/attribute_value.rs
@@ -1,13 +1,122 @@
+use std::collections::HashMap;
+
 use si_id::{
     AttributePrototypeId,
     AttributeValueId,
+    PropId,
 };
 
-use crate::attribute::value::AttributeValueResult;
+use crate::{
+    PropKind,
+    attribute::value::AttributeValueResult,
+};
 
 pub trait AttributeValueExt {
+    fn attribute_value_tree(
+        &self,
+        root_attribute_value_id: AttributeValueId,
+    ) -> AttributeValueResult<AttributeValueTree>;
+
+    fn child_attribute_values(
+        &self,
+        attribute_value_id: AttributeValueId,
+    ) -> AttributeValueResult<Vec<AttributeValueId>>;
+
+    fn child_attribute_values_in_order(
+        &self,
+        attribute_value_id: AttributeValueId,
+    ) -> AttributeValueResult<Vec<AttributeValueId>>;
+
     fn component_prototype_id(
         &self,
-        id: AttributeValueId,
+        attribute_value_id: AttributeValueId,
     ) -> AttributeValueResult<Option<AttributePrototypeId>>;
+
+    fn key_for_attribute_value_id(
+        &self,
+        attribute_value_id: AttributeValueId,
+    ) -> AttributeValueResult<Option<String>>;
+
+    fn prop_for_attribute_value_id(
+        &self,
+        attribute_value_id: AttributeValueId,
+    ) -> AttributeValueResult<Option<PropId>>;
+}
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub struct AttributeValueTreeEntry {
+    pub attribute_value_id: AttributeValueId,
+    pub prop_id: PropId,
+    pub prop_kind: PropKind,
+}
+
+/// The tree of [`AttributeValueId`] starting from the selected root [`AttributeValueId`].
+#[derive(Debug)]
+pub struct AttributeValueTree {
+    root_av_entry: AttributeValueTreeEntry,
+    children: HashMap<AttributeValueId, Vec<AttributeValueTreeEntry>>,
+}
+
+impl AttributeValueTree {
+    /// Construct a new empty tree with the given root [`AttributeValueId`].
+    pub fn new(
+        root_av_id: AttributeValueId,
+        root_av_prop_id: PropId,
+        root_av_prop_kind: PropKind,
+    ) -> Self {
+        let mut children = HashMap::new();
+        children.insert(root_av_id, Vec::new());
+        let root_av_entry = AttributeValueTreeEntry {
+            attribute_value_id: root_av_id,
+            prop_id: root_av_prop_id,
+            prop_kind: root_av_prop_kind,
+        };
+
+        Self {
+            root_av_entry,
+            children,
+        }
+    }
+
+    /// Add a child [`AttributeValueTreeEntry`] under the given parent [`AttributeValueId`].
+    pub fn add_child(
+        &mut self,
+        parent_av_id: AttributeValueId,
+        child_av_entry: AttributeValueTreeEntry,
+    ) {
+        self.children
+            .entry(parent_av_id)
+            .or_default()
+            .push(child_av_entry);
+    }
+
+    /// Add multiple children [`AttributeValueTreeEntry`] under the given parent [`AttributeValueId`].
+    pub fn add_children(
+        &mut self,
+        parent_av_id: AttributeValueId,
+        mut new_children: Vec<AttributeValueTreeEntry>,
+    ) {
+        self.children
+            .entry(parent_av_id)
+            .and_modify(|children| children.append(&mut new_children))
+            .or_insert(new_children);
+    }
+
+    /// Get the children [`AttributeValueTreeEntry`] of the given parent [`AttributeValueId`].
+    pub fn children_of(&self, av_id: AttributeValueId) -> &[AttributeValueTreeEntry] {
+        self.children
+            .get(&av_id)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    /// The total number of [`AttributeValue`] in the tree, including the root.
+    pub fn count(&self) -> usize {
+        self.children.len()
+    }
+
+    /// Get the root [`AttributeValueTreeEntry`].
+    pub fn root(&self) -> AttributeValueTreeEntry {
+        self.root_av_entry
+    }
 }

--- a/lib/dal/src/workspace_snapshot/graph/traits/prop.rs
+++ b/lib/dal/src/workspace_snapshot/graph/traits/prop.rs
@@ -1,0 +1,7 @@
+use si_id::PropId;
+
+use crate::prop::PropResult;
+
+pub trait PropExt {
+    fn ordered_child_prop_ids(&self, prop_id: PropId) -> PropResult<Vec<PropId>>;
+}

--- a/lib/dal/src/workspace_snapshot/graph/v4.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v4.rs
@@ -77,6 +77,7 @@ pub mod attribute_value;
 pub mod component;
 pub mod diagram;
 pub mod entity_kind;
+pub mod prop;
 pub mod schema;
 pub mod socket;
 

--- a/lib/dal/src/workspace_snapshot/graph/v4/prop.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v4/prop.rs
@@ -1,0 +1,29 @@
+use crate::workspace_snapshot::graph::{
+    WorkspaceSnapshotGraphError,
+    WorkspaceSnapshotGraphV4,
+    traits::prop::PropExt,
+};
+
+impl PropExt for WorkspaceSnapshotGraphV4 {
+    fn ordered_child_prop_ids(
+        &self,
+        prop_id: si_id::PropId,
+    ) -> crate::prop::PropResult<Vec<si_id::PropId>> {
+        let prop_idx = self.get_node_index_by_id(prop_id)?;
+        let child_prop_idxs = self
+            .ordered_children_for_node(prop_idx)?
+            .unwrap_or_default();
+        let mut child_prop_ids = Vec::with_capacity(child_prop_idxs.len());
+        for child_prop_idx in child_prop_idxs {
+            child_prop_ids.push(
+                self.node_index_to_id(child_prop_idx)
+                    .ok_or_else(|| {
+                        WorkspaceSnapshotGraphError::NodeWithIndexNotFound(child_prop_idx)
+                    })?
+                    .into(),
+            );
+        }
+
+        Ok(child_prop_ids)
+    }
+}

--- a/lib/dal/src/workspace_snapshot/selector.rs
+++ b/lib/dal/src/workspace_snapshot/selector.rs
@@ -23,10 +23,12 @@ use si_events::{
 };
 use si_id::{
     ApprovalRequirementDefinitionId,
+    AttributePrototypeArgumentId,
     AttributePrototypeId,
     AttributeValueId,
     ComponentId,
     EntityId,
+    FuncId,
     InputSocketId,
     PropId,
     SchemaId,
@@ -56,13 +58,6 @@ use super::{
         category_node_weight::CategoryNodeKind,
     },
     split_snapshot::SplitSnapshot,
-    traits::{
-        approval_requirement::ApprovalRequirementExt,
-        attribute_value::AttributeValueExt,
-        component::ComponentExt,
-        diagram::view::ViewExt,
-        prop::PropExt,
-    },
 };
 use crate::{
     DalContext,
@@ -74,9 +69,27 @@ use crate::{
         ApprovalRequirementApprover,
         ApprovalRequirementDefinition,
     },
+    attribute::{
+        prototype::{
+            AttributePrototypeResult,
+            argument::AttributePrototypeArgumentResult,
+        },
+        value::AttributeValueResult,
+    },
     component::ComponentResult,
     entity_kind::EntityKindResult,
+    func::FuncResult,
     prop::PropResult,
+    workspace_snapshot::traits::{
+        approval_requirement::ApprovalRequirementExt,
+        attribute_prototype::AttributePrototypeExt,
+        attribute_prototype_argument::AttributePrototypeArgumentExt,
+        attribute_value::AttributeValueExt,
+        component::ComponentExt,
+        diagram::view::ViewExt,
+        func::FuncExt,
+        prop::PropExt,
+    },
 };
 
 /// The `WorkspaceSnapshotSelector` enum acts as a dispatcher for workspace snapshot methods
@@ -1005,6 +1018,24 @@ impl ViewExt for WorkspaceSnapshotSelector {
 
 #[async_trait]
 impl PropExt for WorkspaceSnapshotSelector {
+    async fn prop_default_value(
+        &self,
+        ctx: &DalContext,
+        prop_id: PropId,
+    ) -> PropResult<Option<serde_json::Value>> {
+        match self {
+            Self::LegacySnapshot(snapshot) => snapshot.prop_default_value(ctx, prop_id).await,
+            Self::SplitSnapshot(snapshot) => snapshot.prop_default_value(ctx, prop_id).await,
+        }
+    }
+
+    async fn prop_prototype_id(&self, prop_id: PropId) -> PropResult<AttributePrototypeId> {
+        match self {
+            Self::LegacySnapshot(snapshot) => snapshot.prop_prototype_id(prop_id).await,
+            Self::SplitSnapshot(snapshot) => snapshot.prop_prototype_id(prop_id).await,
+        }
+    }
+
     async fn ts_type(&self, prop_id: PropId) -> PropResult<String> {
         match self {
             Self::LegacySnapshot(snapshot) => snapshot.ts_type(prop_id).await,
@@ -1035,13 +1066,99 @@ impl ComponentExt for WorkspaceSnapshotSelector {
 
 #[async_trait]
 impl AttributeValueExt for WorkspaceSnapshotSelector {
+    async fn attribute_value_view(
+        &self,
+        ctx: &DalContext,
+        attribute_value_id: AttributeValueId,
+    ) -> AttributeValueResult<Option<serde_json::Value>> {
+        match self {
+            Self::LegacySnapshot(snapshot) => {
+                snapshot.attribute_value_view(ctx, attribute_value_id).await
+            }
+            Self::SplitSnapshot(snapshot) => {
+                snapshot.attribute_value_view(ctx, attribute_value_id).await
+            }
+        }
+    }
+
     async fn component_prototype_id(
         &self,
         id: AttributeValueId,
-    ) -> WorkspaceSnapshotResult<Option<AttributePrototypeId>> {
+    ) -> AttributeValueResult<Option<AttributePrototypeId>> {
         match self {
             Self::LegacySnapshot(snapshot) => snapshot.component_prototype_id(id).await,
             Self::SplitSnapshot(snapshot) => snapshot.component_prototype_id(id).await,
+        }
+    }
+}
+
+#[async_trait]
+impl AttributePrototypeExt for WorkspaceSnapshotSelector {
+    async fn attribute_prototype_arguments(
+        &self,
+        attribute_prototype_id: AttributePrototypeId,
+    ) -> AttributePrototypeResult<Vec<AttributePrototypeArgumentId>> {
+        match self {
+            Self::LegacySnapshot(snapshot) => {
+                snapshot
+                    .attribute_prototype_arguments(attribute_prototype_id)
+                    .await
+            }
+            Self::SplitSnapshot(snapshot) => {
+                snapshot
+                    .attribute_prototype_arguments(attribute_prototype_id)
+                    .await
+            }
+        }
+    }
+
+    async fn attribute_prototype_func_id(
+        &self,
+        attribute_prototype_id: AttributePrototypeId,
+    ) -> AttributePrototypeResult<FuncId> {
+        match self {
+            Self::LegacySnapshot(snapshot) => {
+                snapshot
+                    .attribute_prototype_func_id(attribute_prototype_id)
+                    .await
+            }
+            Self::SplitSnapshot(snapshot) => {
+                snapshot
+                    .attribute_prototype_func_id(attribute_prototype_id)
+                    .await
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl AttributePrototypeArgumentExt for WorkspaceSnapshotSelector {
+    async fn attribute_prototype_argument_static_value(
+        &self,
+        ctx: &DalContext,
+        attribute_prototype_argument_id: AttributePrototypeArgumentId,
+    ) -> AttributePrototypeArgumentResult<Option<serde_json::Value>> {
+        match self {
+            Self::LegacySnapshot(snapshot) => {
+                snapshot
+                    .attribute_prototype_argument_static_value(ctx, attribute_prototype_argument_id)
+                    .await
+            }
+            Self::SplitSnapshot(snapshot) => {
+                snapshot
+                    .attribute_prototype_argument_static_value(ctx, attribute_prototype_argument_id)
+                    .await
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl FuncExt for WorkspaceSnapshotSelector {
+    async fn func_is_dynamic(&self, func_id: FuncId) -> FuncResult<bool> {
+        match self {
+            Self::LegacySnapshot(snapshot) => snapshot.func_is_dynamic(func_id).await,
+            Self::SplitSnapshot(snapshot) => snapshot.func_is_dynamic(func_id).await,
         }
     }
 }

--- a/lib/dal/src/workspace_snapshot/split_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot.rs
@@ -33,13 +33,11 @@ use si_events::{
 };
 use si_id::{
     ApprovalRequirementDefinitionId,
-    AttributePrototypeId,
     AttributeValueId,
     ChangeSetId,
     ComponentId,
     EntityId,
     InputSocketId,
-    PropId,
     SchemaId,
     SchemaVariantId,
     UserPk,
@@ -95,7 +93,6 @@ use super::{
     traits::{
         approval_requirement::ApprovalRequirementExt,
         diagram::view::ViewExt,
-        prop::PropExt,
         socket::input::input_socket_from_node_weight,
     },
 };
@@ -125,20 +122,22 @@ use crate::{
         ViewContent,
         ViewContentV1,
     },
-    prop::PropResult,
     slow_rt,
     socket::input::InputSocketError,
     workspace_snapshot::{
         graph::traits::component::ComponentExt as _,
-        traits::{
-            attribute_value::AttributeValueExt,
-            component::ComponentExt,
-        },
+        traits::component::ComponentExt,
     },
 };
 
+pub mod attribute_prototype;
+pub mod attribute_prototype_argument;
+pub mod attribute_value;
 pub mod corrections;
+pub mod func;
 pub mod graph;
+pub mod prop;
+pub mod static_argument_value;
 
 pub type SplitSnapshotGraphV1 = SplitGraph<NodeWeight, EdgeWeight, EdgeWeightKindDiscriminants>;
 pub type SplitSnapshotGraphVCurrent = SplitSnapshotGraphV1;
@@ -1855,13 +1854,6 @@ impl ViewExt for SplitSnapshot {
 }
 
 #[async_trait]
-impl PropExt for SplitSnapshot {
-    async fn ts_type(&self, _prop_id: PropId) -> PropResult<String> {
-        Ok("any".to_string())
-    }
-}
-
-#[async_trait]
 impl ComponentExt for SplitSnapshot {
     async fn root_attribute_value(
         &self,
@@ -1874,17 +1866,5 @@ impl ComponentExt for SplitSnapshot {
         self.working_copy()
             .await
             .external_source_count(component_id)
-    }
-}
-
-#[async_trait]
-impl AttributeValueExt for SplitSnapshot {
-    async fn component_prototype_id(
-        &self,
-        id: AttributeValueId,
-    ) -> WorkspaceSnapshotResult<Option<AttributePrototypeId>> {
-        self.target_opt(id.into(), EdgeWeightKindDiscriminants::Prototype)
-            .await
-            .map(|maybe_ulid| maybe_ulid.map(Into::into))
     }
 }

--- a/lib/dal/src/workspace_snapshot/split_snapshot/attribute_prototype.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot/attribute_prototype.rs
@@ -1,0 +1,67 @@
+use async_trait::async_trait;
+use si_id::{
+    AttributePrototypeArgumentId,
+    AttributePrototypeId,
+    FuncId,
+};
+
+use crate::{
+    EdgeWeightKindDiscriminants,
+    NodeWeightDiscriminants,
+    attribute::prototype::{
+        AttributePrototypeError,
+        AttributePrototypeResult,
+    },
+    workspace_snapshot::{
+        split_snapshot::SplitSnapshot,
+        traits::attribute_prototype::AttributePrototypeExt,
+    },
+};
+
+#[async_trait]
+impl AttributePrototypeExt for SplitSnapshot {
+    async fn attribute_prototype_arguments(
+        &self,
+        attribute_prototype_id: AttributePrototypeId,
+    ) -> AttributePrototypeResult<Vec<AttributePrototypeArgumentId>> {
+        Ok(self
+            .outgoing_targets_for_edge_weight_kind(
+                attribute_prototype_id,
+                EdgeWeightKindDiscriminants::PrototypeArgument,
+            )
+            .await?
+            .iter()
+            .copied()
+            .map(Into::into)
+            .collect())
+    }
+
+    async fn attribute_prototype_func_id(
+        &self,
+        attribute_prototype_id: AttributePrototypeId,
+    ) -> AttributePrototypeResult<FuncId> {
+        let mut funcs = Vec::new();
+        for use_target in self
+            .outgoing_targets_for_edge_weight_kind(
+                attribute_prototype_id,
+                EdgeWeightKindDiscriminants::Use,
+            )
+            .await?
+        {
+            if NodeWeightDiscriminants::Func == self.get_node_weight(use_target).await?.into() {
+                funcs.push(use_target);
+            }
+        }
+
+        match (funcs.pop(), funcs.pop()) {
+            (Some(func_id), None) => Ok(func_id.into()),
+            (None, None) => Err(AttributePrototypeError::MissingFunction(
+                attribute_prototype_id,
+            )),
+            (Some(_), Some(_)) => Err(AttributePrototypeError::MultipleFunctionsFound(
+                attribute_prototype_id,
+            )),
+            (None, Some(_)) => unreachable!("Vec::pop() had None then Some"),
+        }
+    }
+}

--- a/lib/dal/src/workspace_snapshot/split_snapshot/attribute_prototype_argument.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot/attribute_prototype_argument.rs
@@ -1,0 +1,50 @@
+use async_trait::async_trait;
+use si_id::AttributePrototypeArgumentId;
+
+use crate::{
+    DalContext,
+    EdgeWeightKindDiscriminants,
+    attribute::prototype::argument::AttributePrototypeArgumentResult,
+    workspace_snapshot::{
+        content_address::ContentAddressDiscriminants,
+        node_weight::NodeWeight,
+        split_snapshot::SplitSnapshot,
+        traits::{
+            attribute_prototype_argument::AttributePrototypeArgumentExt,
+            static_argument_value::StaticArgumentValueExt as _,
+        },
+    },
+};
+
+#[async_trait]
+impl AttributePrototypeArgumentExt for SplitSnapshot {
+    async fn attribute_prototype_argument_static_value(
+        &self,
+        ctx: &DalContext,
+        attribute_prototype_argument_id: AttributePrototypeArgumentId,
+    ) -> AttributePrototypeArgumentResult<Option<serde_json::Value>> {
+        for arg_id in self
+            .outgoing_targets_for_edge_weight_kind(
+                attribute_prototype_argument_id,
+                EdgeWeightKindDiscriminants::PrototypeArgumentValue,
+            )
+            .await?
+        {
+            match self.get_node_weight(arg_id).await? {
+                NodeWeight::Content(content_node_weight) => {
+                    if content_node_weight.content_address_discriminants()
+                        == ContentAddressDiscriminants::StaticArgumentValue
+                    {
+                        return self
+                            .static_argument_value(ctx, content_node_weight.id().into())
+                            .await
+                            .map(Into::into);
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        Ok(None)
+    }
+}

--- a/lib/dal/src/workspace_snapshot/split_snapshot/func.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot/func.rs
@@ -1,0 +1,27 @@
+use async_trait::async_trait;
+use si_id::FuncId;
+
+use crate::{
+    func::{
+        FuncResult,
+        intrinsics::IntrinsicFunc,
+    },
+    workspace_snapshot::{
+        split_snapshot::SplitSnapshot,
+        traits::func::FuncExt,
+    },
+};
+
+#[async_trait]
+impl FuncExt for SplitSnapshot {
+    async fn func_is_dynamic(&self, func_id: FuncId) -> FuncResult<bool> {
+        let func = self
+            .get_node_weight(func_id)
+            .await?
+            .get_func_node_weight()?;
+        match IntrinsicFunc::maybe_from_str(func.name()) {
+            None => Ok(true),
+            Some(intrinsic_func) => Ok(intrinsic_func.is_dynamic()),
+        }
+    }
+}

--- a/lib/dal/src/workspace_snapshot/split_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot/graph.rs
@@ -7,7 +7,6 @@ use petgraph::{
 };
 use si_events::workspace_snapshot::EntityKind;
 use si_id::{
-    AttributePrototypeId,
     AttributeValueId,
     ComponentId,
     EntityId,
@@ -18,10 +17,6 @@ use crate::{
     ComponentError,
     EdgeWeightKindDiscriminants,
     WorkspaceSnapshotError,
-    attribute::value::{
-        AttributeValueError,
-        AttributeValueResult,
-    },
     component::ComponentResult,
     entity_kind::{
         EntityKindError,
@@ -36,6 +31,9 @@ use crate::{
         split_snapshot::SplitSnapshotGraphV1,
     },
 };
+
+pub mod attribute_value;
+pub mod prop;
 
 impl ComponentExt for SplitSnapshotGraphV1 {
     fn root_attribute_value(&self, component_id: ComponentId) -> ComponentResult<AttributeValueId> {
@@ -73,24 +71,6 @@ impl EntityKindExt for SplitSnapshotGraphV1 {
         self.node_weight(id.into())
             .ok_or(EntityKindError::NodeNotFound(id))
             .map(Into::into)
-    }
-}
-
-impl AttributeValueExt for SplitSnapshotGraphV1 {
-    fn component_prototype_id(
-        &self,
-        id: AttributeValueId,
-    ) -> AttributeValueResult<Option<AttributePrototypeId>> {
-        let mut iter = self
-            .outgoing_targets(id.into(), EdgeWeightKindDiscriminants::Prototype)
-            .map_err(WorkspaceSnapshotError::from)?;
-
-        match (iter.next(), iter.next()) {
-            (None, None) => Ok(None),
-            (Some(ap_id), None) => Ok(Some(ap_id.into())),
-            (Some(_), Some(_)) => Err(AttributeValueError::MultiplePrototypesFound(id)),
-            (None, Some(_)) => unreachable!("iterator had none then some"),
-        }
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/split_snapshot/graph/prop.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot/graph/prop.rs
@@ -1,0 +1,21 @@
+use si_id::PropId;
+
+use crate::{
+    prop::PropResult,
+    workspace_snapshot::{
+        graph::traits::prop::PropExt,
+        split_snapshot::SplitSnapshotGraphV1,
+    },
+};
+
+impl PropExt for SplitSnapshotGraphV1 {
+    fn ordered_child_prop_ids(&self, prop_id: PropId) -> PropResult<Vec<PropId>> {
+        Ok(self
+            .ordered_children(prop_id.into())
+            .unwrap_or_default()
+            .iter()
+            .copied()
+            .map(Into::into)
+            .collect())
+    }
+}

--- a/lib/dal/src/workspace_snapshot/split_snapshot/prop.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot/prop.rs
@@ -1,0 +1,63 @@
+use async_trait::async_trait;
+use si_id::{
+    AttributePrototypeId,
+    PropId,
+};
+
+use crate::{
+    DalContext,
+    EdgeWeightKindDiscriminants,
+    prop::{
+        PropError,
+        PropResult,
+    },
+    workspace_snapshot::{
+        split_snapshot::SplitSnapshot,
+        traits::{
+            attribute_prototype::AttributePrototypeExt as _,
+            attribute_prototype_argument::AttributePrototypeArgumentExt as _,
+            func::FuncExt as _,
+            prop::PropExt,
+        },
+    },
+};
+
+#[async_trait]
+impl PropExt for SplitSnapshot {
+    async fn prop_default_value(
+        &self,
+        ctx: &DalContext,
+        prop_id: PropId,
+    ) -> PropResult<Option<serde_json::Value>> {
+        let prototype_id = self.prop_prototype_id(prop_id).await?;
+        let func_id = self.attribute_prototype_func_id(prototype_id).await?;
+        if self.func_is_dynamic(func_id).await? {
+            return Ok(None);
+        }
+
+        match self
+            .attribute_prototype_arguments(prototype_id)
+            .await?
+            .first()
+        {
+            Some(&apa_id) => self
+                .attribute_prototype_argument_static_value(ctx, apa_id)
+                .await
+                .map_err(Into::into),
+            None => Ok(None),
+        }
+    }
+
+    async fn prop_prototype_id(&self, prop_id: PropId) -> PropResult<AttributePrototypeId> {
+        self.outgoing_targets_for_edge_weight_kind(prop_id, EdgeWeightKindDiscriminants::Prototype)
+            .await?
+            .first()
+            .copied()
+            .map(Into::into)
+            .ok_or_else(|| PropError::MissingPrototypeForProp(prop_id))
+    }
+
+    async fn ts_type(&self, _prop_id: PropId) -> PropResult<String> {
+        Ok("any".to_string())
+    }
+}

--- a/lib/dal/src/workspace_snapshot/split_snapshot/static_argument_value.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot/static_argument_value.rs
@@ -1,0 +1,45 @@
+use async_trait::async_trait;
+use si_id::StaticArgumentValueId;
+
+use crate::{
+    DalContext,
+    WorkspaceSnapshotError,
+    attribute::prototype::argument::AttributePrototypeArgumentResult,
+    layer_db_types::StaticArgumentValueContent,
+    workspace_snapshot::{
+        split_snapshot::SplitSnapshot,
+        traits::static_argument_value::StaticArgumentValueExt,
+    },
+};
+
+#[async_trait]
+impl StaticArgumentValueExt for SplitSnapshot {
+    async fn static_argument(
+        &self,
+        ctx: &DalContext,
+        static_argument_value_id: StaticArgumentValueId,
+    ) -> AttributePrototypeArgumentResult<StaticArgumentValueContent> {
+        let content_hash = self
+            .get_node_weight(static_argument_value_id)
+            .await?
+            .content_hash();
+        ctx.layer_db()
+            .cas()
+            .try_read_as(&content_hash)
+            .await?
+            .ok_or_else(|| {
+                WorkspaceSnapshotError::MissingContentFromStore(static_argument_value_id.into())
+                    .into()
+            })
+    }
+
+    async fn static_argument_value(
+        &self,
+        ctx: &DalContext,
+        static_argument_value_id: StaticArgumentValueId,
+    ) -> AttributePrototypeArgumentResult<serde_json::Value> {
+        let StaticArgumentValueContent::V1(static_argument_content) =
+            self.static_argument(ctx, static_argument_value_id).await?;
+        Ok(static_argument_content.value.into())
+    }
+}

--- a/lib/dal/src/workspace_snapshot/traits.rs
+++ b/lib/dal/src/workspace_snapshot/traits.rs
@@ -3,10 +3,14 @@
 //! implemented.
 
 pub mod approval_requirement;
+pub mod attribute_prototype;
+pub mod attribute_prototype_argument;
 pub mod attribute_value;
 pub mod component;
 pub mod diagram;
 pub mod entity_kind;
+pub mod func;
 pub mod prop;
 pub mod schema;
 pub mod socket;
+pub mod static_argument_value;

--- a/lib/dal/src/workspace_snapshot/traits/attribute_prototype.rs
+++ b/lib/dal/src/workspace_snapshot/traits/attribute_prototype.rs
@@ -1,0 +1,87 @@
+use async_trait::async_trait;
+use si_id::{
+    AttributePrototypeArgumentId,
+    AttributePrototypeId,
+    FuncId,
+};
+
+use crate::{
+    EdgeWeightKindDiscriminants,
+    NodeWeightDiscriminants,
+    WorkspaceSnapshot,
+    attribute::prototype::{
+        AttributePrototypeError,
+        AttributePrototypeResult,
+    },
+};
+
+#[async_trait]
+pub trait AttributePrototypeExt {
+    /// All [`AttributePrototypeArgumentId`] for the given [`AttributePrototypeId`].
+    async fn attribute_prototype_arguments(
+        &self,
+        attribute_prototype_id: AttributePrototypeId,
+    ) -> AttributePrototypeResult<Vec<AttributePrototypeArgumentId>>;
+
+    /// The [`FuncId`] for the given [`AttributePrototypeId`].
+    async fn attribute_prototype_func_id(
+        &self,
+        attribute_prototype_id: AttributePrototypeId,
+    ) -> AttributePrototypeResult<FuncId>;
+}
+
+#[async_trait]
+impl AttributePrototypeExt for WorkspaceSnapshot {
+    async fn attribute_prototype_arguments(
+        &self,
+        attribute_prototype_id: AttributePrototypeId,
+    ) -> AttributePrototypeResult<Vec<AttributePrototypeArgumentId>> {
+        let mut apa_ids: Vec<_> = self
+            .outgoing_targets_for_edge_weight_kind(
+                attribute_prototype_id,
+                EdgeWeightKindDiscriminants::PrototypeArgument,
+            )
+            .await?
+            .iter()
+            .copied()
+            .map(Into::into)
+            .collect();
+        // Whenever we're dealing with the arguments, we always want them to have stable
+        // ordering. For function execution, we want the arguments to have the same relative
+        // order from run to run. For use when generating checksums and other lists we also
+        // want them to have consistent order to avoid unnecessary churn in the data sent to
+        // & used by the front end.
+        apa_ids.sort();
+
+        Ok(apa_ids)
+    }
+
+    async fn attribute_prototype_func_id(
+        &self,
+        attribute_prototype_id: AttributePrototypeId,
+    ) -> AttributePrototypeResult<FuncId> {
+        let mut funcs = Vec::new();
+        for use_target in self
+            .outgoing_targets_for_edge_weight_kind(
+                attribute_prototype_id,
+                EdgeWeightKindDiscriminants::Use,
+            )
+            .await?
+        {
+            if NodeWeightDiscriminants::Func == self.get_node_weight(use_target).await?.into() {
+                funcs.push(use_target);
+            }
+        }
+
+        match (funcs.pop(), funcs.pop()) {
+            (Some(func_id), None) => Ok(func_id.into()),
+            (None, None) => Err(AttributePrototypeError::MissingFunction(
+                attribute_prototype_id,
+            )),
+            (Some(_), Some(_)) => Err(AttributePrototypeError::MultipleFunctionsFound(
+                attribute_prototype_id,
+            )),
+            (None, Some(_)) => unreachable!("Vec::pop() had None then Some"),
+        }
+    }
+}

--- a/lib/dal/src/workspace_snapshot/traits/attribute_prototype_argument.rs
+++ b/lib/dal/src/workspace_snapshot/traits/attribute_prototype_argument.rs
@@ -1,0 +1,58 @@
+use async_trait::async_trait;
+use si_id::AttributePrototypeArgumentId;
+
+use crate::{
+    DalContext,
+    EdgeWeightKindDiscriminants,
+    WorkspaceSnapshot,
+    attribute::prototype::argument::AttributePrototypeArgumentResult,
+    workspace_snapshot::{
+        content_address::ContentAddressDiscriminants,
+        node_weight::NodeWeight,
+        traits::static_argument_value::StaticArgumentValueExt as _,
+    },
+};
+
+#[async_trait]
+pub trait AttributePrototypeArgumentExt {
+    /// Returns the static value of the attribute prototype argument. Or [`None`] if
+    /// the argument is not static.
+    async fn attribute_prototype_argument_static_value(
+        &self,
+        ctx: &DalContext,
+        attribute_prototype_argument_id: AttributePrototypeArgumentId,
+    ) -> AttributePrototypeArgumentResult<Option<serde_json::Value>>;
+}
+
+#[async_trait]
+impl AttributePrototypeArgumentExt for WorkspaceSnapshot {
+    async fn attribute_prototype_argument_static_value(
+        &self,
+        ctx: &DalContext,
+        attribute_prototype_argument_id: AttributePrototypeArgumentId,
+    ) -> AttributePrototypeArgumentResult<Option<serde_json::Value>> {
+        for arg_id in self
+            .outgoing_targets_for_edge_weight_kind(
+                attribute_prototype_argument_id,
+                EdgeWeightKindDiscriminants::PrototypeArgumentValue,
+            )
+            .await?
+        {
+            match self.get_node_weight(arg_id).await? {
+                NodeWeight::Content(content_node_weight) => {
+                    if content_node_weight.content_address_discriminants()
+                        == ContentAddressDiscriminants::StaticArgumentValue
+                    {
+                        return self
+                            .static_argument_value(ctx, content_node_weight.id().into())
+                            .await
+                            .map(Into::into);
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        Ok(None)
+    }
+}

--- a/lib/dal/src/workspace_snapshot/traits/func.rs
+++ b/lib/dal/src/workspace_snapshot/traits/func.rs
@@ -1,0 +1,33 @@
+use async_trait::async_trait;
+use si_id::FuncId;
+
+use crate::{
+    WorkspaceSnapshot,
+    func::{
+        FuncResult,
+        intrinsics::IntrinsicFunc,
+    },
+};
+
+#[async_trait]
+pub trait FuncExt {
+    /// A non-dynamic Func is an Intrinsic func that returns a fixed value, set by a StaticArgumentValue in the graph
+    /// opposingly, a dynamic Func is a func that returns a non statically predictable value, possibly user defined.
+    ///
+    /// It's important to note that not all Intrinsic funcs are non-dynamic. Identity, for instance, is dynamic.
+    async fn func_is_dynamic(&self, func_id: FuncId) -> FuncResult<bool>;
+}
+
+#[async_trait]
+impl FuncExt for WorkspaceSnapshot {
+    async fn func_is_dynamic(&self, func_id: FuncId) -> FuncResult<bool> {
+        let func = self
+            .get_node_weight(func_id)
+            .await?
+            .get_func_node_weight()?;
+        match IntrinsicFunc::maybe_from_str(func.name()) {
+            None => Ok(true),
+            Some(intrinsic_func) => Ok(intrinsic_func.is_dynamic()),
+        }
+    }
+}

--- a/lib/dal/src/workspace_snapshot/traits/static_argument_value.rs
+++ b/lib/dal/src/workspace_snapshot/traits/static_argument_value.rs
@@ -1,0 +1,57 @@
+use async_trait::async_trait;
+use si_id::StaticArgumentValueId;
+
+use crate::{
+    DalContext,
+    WorkspaceSnapshot,
+    WorkspaceSnapshotError,
+    attribute::prototype::argument::AttributePrototypeArgumentResult,
+    layer_db_types::StaticArgumentValueContent,
+};
+
+#[async_trait]
+pub trait StaticArgumentValueExt {
+    async fn static_argument(
+        &self,
+        ctx: &DalContext,
+        static_argument_value_id: StaticArgumentValueId,
+    ) -> AttributePrototypeArgumentResult<StaticArgumentValueContent>;
+
+    async fn static_argument_value(
+        &self,
+        ctx: &DalContext,
+        static_argument_value_id: StaticArgumentValueId,
+    ) -> AttributePrototypeArgumentResult<serde_json::Value>;
+}
+
+#[async_trait]
+impl StaticArgumentValueExt for WorkspaceSnapshot {
+    async fn static_argument(
+        &self,
+        ctx: &DalContext,
+        static_argument_value_id: StaticArgumentValueId,
+    ) -> AttributePrototypeArgumentResult<StaticArgumentValueContent> {
+        let content_hash = self
+            .get_node_weight(static_argument_value_id)
+            .await?
+            .content_hash();
+        ctx.layer_db()
+            .cas()
+            .try_read_as(&content_hash)
+            .await?
+            .ok_or_else(|| {
+                WorkspaceSnapshotError::MissingContentFromStore(static_argument_value_id.into())
+                    .into()
+            })
+    }
+
+    async fn static_argument_value(
+        &self,
+        ctx: &DalContext,
+        static_argument_value_id: StaticArgumentValueId,
+    ) -> AttributePrototypeArgumentResult<serde_json::Value> {
+        let StaticArgumentValueContent::V1(static_argument_content) =
+            self.static_argument(ctx, static_argument_value_id).await?;
+        Ok(static_argument_content.value.into())
+    }
+}

--- a/lib/dal/tests/integration_test/attribute_value/subscription.rs
+++ b/lib/dal/tests/integration_test/attribute_value/subscription.rs
@@ -128,14 +128,14 @@ async fn subscribe_to_array_element(ctx: &mut DalContext) -> Result<()> {
     AttributeValue::insert(ctx, values_av_id, Some(json!("b")), None).await?;
     AttributeValue::insert(ctx, values_av_id, Some(json!("c")), None).await?;
     change_set::commit(ctx).await?;
-    assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
+    assert_eq!(None, AttributeValue::view(ctx, value_av_id).await?);
 
     // Subscribe to a specific index and watch the value come through!
     value::subscribe(ctx, value_av_id, [(component_id, "/domain/Values/1")]).await?;
     change_set::commit(ctx).await?;
     assert_eq!(
         Some(json!("b")),
-        AttributeValue::view_by_id(ctx, value_av_id).await?
+        AttributeValue::view(ctx, value_av_id).await?
     );
 
     // Update the array and watch the new value come through!
@@ -146,13 +146,13 @@ async fn subscribe_to_array_element(ctx: &mut DalContext) -> Result<()> {
     change_set::commit(ctx).await?;
     assert_eq!(
         Some(json!("b_2")),
-        AttributeValue::view_by_id(ctx, value_av_id).await?
+        AttributeValue::view(ctx, value_av_id).await?
     );
 
     // // Update the array with fewer values and watch the value disappear!
     // AttributeValue::update(ctx, values_av_id, Some(json!(["a_3"]))).await?;
     // change_set::commit(ctx).await?;
-    // assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
+    // assert_eq!(None, AttributeValue::view(ctx, value_av_id).await?);
 
     Ok(())
 }
@@ -174,14 +174,14 @@ async fn subscribe_to_map_element(ctx: &mut DalContext) -> Result<()> {
     AttributeValue::insert(ctx, value_map_av_id, Some(json!("b")), Some("B".to_owned())).await?;
     AttributeValue::insert(ctx, value_map_av_id, Some(json!("c")), Some("C".to_owned())).await?;
     change_set::commit(ctx).await?;
-    assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
+    assert_eq!(None, AttributeValue::view(ctx, value_av_id).await?);
 
     // Subscribe to a specific index and watch the value come through!
     value::subscribe(ctx, value_av_id, [(component_id, "/domain/ValueMap/B")]).await?;
     change_set::commit(ctx).await?;
     assert_eq!(
         Some(json!("b")),
-        AttributeValue::view_by_id(ctx, value_av_id).await?
+        AttributeValue::view(ctx, value_av_id).await?
     );
 
     // Update the map value and watch the new value come through!
@@ -196,13 +196,13 @@ async fn subscribe_to_map_element(ctx: &mut DalContext) -> Result<()> {
     change_set::commit(ctx).await?;
     assert_eq!(
         Some(json!("b_2")),
-        AttributeValue::view_by_id(ctx, value_av_id).await?
+        AttributeValue::view(ctx, value_av_id).await?
     );
 
     // // Remove the map value and watch the value disappear!
     // AttributeValue::insert(ctx, value_map_av_id, None, Some("B".to_owned())).await?;
     // change_set::commit(ctx).await?;
-    // assert_eq!(None, AttributeValue::view_by_id(ctx, value_av_id).await?);
+    // assert_eq!(None, AttributeValue::view(ctx, value_av_id).await?);
 
     Ok(())
 }

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -312,9 +312,7 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) -> Result<()> {
     )
     .await?;
 
-    let view = AttributeValue::get_by_id(ctx, rigid_designator_value_id)
-        .await?
-        .view(ctx)
+    let view = AttributeValue::view(ctx, rigid_designator_value_id)
         .await?
         .expect("has a view");
 
@@ -322,9 +320,7 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) -> Result<()> {
 
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
-    let naming_and_necessity_view = AttributeValue::get_by_id(ctx, naming_and_necessity_value_id)
-        .await?
-        .view(ctx)
+    let naming_and_necessity_view = AttributeValue::view(ctx, naming_and_necessity_value_id)
         .await?
         .expect("naming and necessity has a value");
 
@@ -341,10 +337,7 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) -> Result<()> {
         .copied()
         .expect("a value exists for the root prop");
 
-    let root_value = AttributeValue::get_by_id(ctx, root_value_id).await?;
-
-    let root_view = root_value
-        .view(ctx)
+    let root_view = AttributeValue::view(ctx, root_value_id)
         .await?
         .expect("there is a value for the root value view");
 
@@ -467,9 +460,7 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) -> R
     )
     .await?;
 
-    let view = AttributeValue::get_by_id(ctx, possible_world_a_value_id)
-        .await?
-        .view(ctx)
+    let view = AttributeValue::view(ctx, possible_world_a_value_id)
         .await?
         .expect("has a view");
 
@@ -477,9 +468,7 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) -> R
 
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
-    let naming_and_necessity_view = AttributeValue::get_by_id(ctx, naming_and_necessity_value_id)
-        .await?
-        .view(ctx)
+    let naming_and_necessity_view = AttributeValue::view(ctx, naming_and_necessity_value_id)
         .await?
         .expect("naming and necessity has a value");
 
@@ -496,10 +485,7 @@ async fn through_the_wormholes_child_value_reactivity(ctx: &mut DalContext) -> R
         .copied()
         .expect("a value exists for the root prop");
 
-    let root_value = AttributeValue::get_by_id(ctx, root_value_id).await?;
-
-    let root_view = root_value
-        .view(ctx)
+    let root_view = AttributeValue::view(ctx, root_value_id)
         .await?
         .expect("there is a value for the root value view");
 
@@ -628,9 +614,7 @@ async fn set_the_universe(ctx: &mut DalContext) -> Result<()> {
 
     AttributeValue::update(ctx, universe_value_id, Some(universe_json.to_owned())).await?;
 
-    let view = AttributeValue::get_by_id(ctx, universe_value_id)
-        .await?
-        .view(ctx)
+    let view = AttributeValue::view(ctx, universe_value_id)
         .await?
         .expect("has a view");
 
@@ -638,9 +622,7 @@ async fn set_the_universe(ctx: &mut DalContext) -> Result<()> {
 
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
-    let view = AttributeValue::get_by_id(ctx, universe_value_id)
-        .await?
-        .view(ctx)
+    let view = AttributeValue::view(ctx, universe_value_id)
         .await?
         .expect("has a view");
 

--- a/lib/dal/tests/integration_test/component/delete.rs
+++ b/lib/dal/tests/integration_test/component/delete.rs
@@ -313,10 +313,7 @@ async fn delete_updates_downstream_components(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");
@@ -357,10 +354,7 @@ async fn delete_updates_downstream_components(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");
@@ -485,10 +479,7 @@ async fn delete_undo_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");
@@ -532,10 +523,7 @@ async fn delete_undo_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");
@@ -577,10 +565,7 @@ async fn delete_undo_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");
@@ -607,10 +592,7 @@ async fn delete_undo_updates_inputs(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");

--- a/lib/dal/tests/integration_test/connection.rs
+++ b/lib/dal/tests/integration_test/connection.rs
@@ -394,10 +394,7 @@ async fn connect_and_disconnect_components_explicit_connection(ctx: &mut DalCont
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");
@@ -436,10 +433,7 @@ async fn connect_and_disconnect_components_explicit_connection(ctx: &mut DalCont
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");
@@ -478,10 +472,7 @@ async fn connect_and_disconnect_components_explicit_connection(ctx: &mut DalCont
         .await
         .expect("could not commit and update snapshot to visibility");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");
@@ -667,10 +658,7 @@ async fn remove_connection(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");
@@ -704,10 +692,7 @@ async fn remove_connection(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");

--- a/lib/dal/tests/integration_test/dependent_values_update.rs
+++ b/lib/dal/tests/integration_test/dependent_values_update.rs
@@ -157,10 +157,7 @@ async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");
@@ -202,10 +199,7 @@ async fn marked_for_deletion_to_normal_is_blocked(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");
@@ -331,10 +325,7 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");
@@ -374,10 +365,7 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");
@@ -417,10 +405,7 @@ async fn normal_to_marked_for_deletion_flows(ctx: &mut DalContext) {
         .copied()
         .expect("has a value");
 
-    let view = AttributeValue::get_by_id(ctx, units_value_id)
-        .await
-        .expect("value exists")
-        .view(ctx)
+    let view = AttributeValue::view(ctx, units_value_id)
         .await
         .expect("able to get units view")
         .expect("units has a view");

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -598,10 +598,7 @@ async fn output_sockets_can_have_both(ctx: &mut DalContext) {
         .into_iter()
         .next()
         .expect("got av");
-    let odd_component_1_mat_view = AttributeValue::get_by_id(ctx, odd_component_1_av)
-        .await
-        .expect("got av")
-        .view(ctx)
+    let odd_component_1_mat_view = AttributeValue::view(ctx, odd_component_1_av)
         .await
         .expect("got mat view")
         .expect("has value");
@@ -616,10 +613,7 @@ async fn output_sockets_can_have_both(ctx: &mut DalContext) {
         .into_iter()
         .next()
         .expect("got av");
-    let odd_component_2_mat_view = AttributeValue::get_by_id(ctx, odd_component_2_av)
-        .await
-        .expect("got av")
-        .view(ctx)
+    let odd_component_2_mat_view = AttributeValue::view(ctx, odd_component_2_av)
         .await
         .expect("got mat view")
         .expect("has value");

--- a/lib/dal/tests/integration_test/management.rs
+++ b/lib/dal/tests/integration_test/management.rs
@@ -788,8 +788,7 @@ async fn override_values_set_by_sockets(ctx: &DalContext) -> Result<()> {
     let component = Component::get_by_id(ctx, child_id).await?;
 
     let props = component.domain_prop_attribute_value(ctx).await?;
-    let domain = AttributeValue::get_by_id(ctx, props).await?;
-    let view = domain.view(ctx).await?;
+    let view = AttributeValue::view(ctx, props).await?;
     assert!(view.is_some());
 
     let one_av_id =

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -381,7 +381,9 @@ async fn override_value_then_reset(ctx: &mut DalContext) {
     AttributeValue::use_default_prototype(ctx, av_id)
         .await
         .expect("revert back to default prototype");
-    let current_value = AttributeValue::view_by_id(ctx, av_id).await.expect("couldn't get av view");
+    let current_value = AttributeValue::view(ctx, av_id)
+        .await
+        .expect("couldn't get av view");
     assert_eq!(current_value, None);
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
@@ -484,7 +486,9 @@ async fn override_array_then_reset(ctx: &mut DalContext) {
     AttributeValue::use_default_prototype(ctx, av_id)
         .await
         .expect("revert back to default prototype");
-    let current_value = AttributeValue::view_by_id(ctx, av_id).await.expect("couldn't get av view");
+    let current_value = AttributeValue::view(ctx, av_id)
+        .await
+        .expect("couldn't get av view");
     assert_eq!(current_value, None);
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await

--- a/lib/dal/tests/integration_test/resource_metadata.rs
+++ b/lib/dal/tests/integration_test/resource_metadata.rs
@@ -176,10 +176,7 @@ async fn list(ctx: &mut DalContext, nw: &WorkspaceSignup) {
         .expect("should be able to find avs for last synced")
         .pop()
         .expect("should have an av for last synced");
-    let last_synced_value = AttributeValue::get_by_id(ctx, last_synced_av_id)
-        .await
-        .expect("should be able to get last synced av")
-        .view(ctx)
+    let last_synced_value = AttributeValue::view(ctx, last_synced_av_id)
         .await
         .expect("should be able to get value for last synced av");
     assert_eq!(

--- a/lib/dal/tests/integration_test/secret/with_actions.rs
+++ b/lib/dal/tests/integration_test/secret/with_actions.rs
@@ -213,10 +213,7 @@ async fn create_action_using_secret(ctx: &mut DalContext, nw: &WorkspaceSignup) 
         .pop()
         .expect("should have an av for last synced");
 
-    let last_synced_value = AttributeValue::get_by_id(ctx, last_synced_av_id)
-        .await
-        .expect("should be able to get last synced av")
-        .view(ctx)
+    let last_synced_value = AttributeValue::view(ctx, last_synced_av_id)
         .await
         .expect("should be able to get value for last synced av");
 

--- a/lib/luminork-server/src/service/v1/components/create_component.rs
+++ b/lib/luminork-server/src/service/v1/components/create_component.rs
@@ -180,11 +180,9 @@ pub async fn create_component(
     }
 
     let av_id = component.domain_prop_attribute_value(ctx).await?;
-    let after_domain_tree = AttributeValue::get_by_id(ctx, av_id)
+    let after_value = AttributeValue::view(ctx, av_id)
         .await?
-        .view(ctx)
-        .await?;
-    let after_value = serde_json::to_value(after_domain_tree)?;
+        .unwrap_or(serde_json::Value::Null);
 
     if !payload.connections.is_empty() {
         for connection in payload.connections.iter() {

--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -682,14 +682,14 @@ impl ComponentViewV1 {
         let domain_values = AttributeValue::get_child_av_ids_in_order(ctx, domain_root_av).await?;
         work_queue.extend(domain_values);
         while let Some(av) = work_queue.pop_front() {
-            let attribute_value = AttributeValue::get_by_id(ctx, av).await?;
+            let value = AttributeValue::view(ctx, av).await?;
             let prop_id = AttributeValue::prop_id(ctx, av).await?;
             let is_hidden_prop = Prop::get_by_id(ctx, prop_id).await?.hidden;
             if !is_hidden_prop {
                 let view = ComponentPropViewV1 {
                     id: av,
                     prop_id,
-                    value: attribute_value.view(ctx).await?,
+                    value,
                     path: AttributeValue::get_path_for_id(ctx, av)
                         .await?
                         .unwrap_or_else(String::new),
@@ -711,12 +711,12 @@ impl ComponentViewV1 {
             AttributeValue::get_child_av_ids_in_order(ctx, resource_value_root_av).await?;
         work_queue.extend(resource_value_values);
         while let Some(av) = work_queue.pop_front() {
-            let attribute_value = AttributeValue::get_by_id(ctx, av).await?;
+            let value = AttributeValue::view(ctx, av).await?;
 
             let view = ComponentPropViewV1 {
                 id: av,
                 prop_id: AttributeValue::prop_id(ctx, av).await?,
-                value: attribute_value.view(ctx).await?,
+                value,
                 path: AttributeValue::get_path_for_id(ctx, av)
                     .await?
                     .unwrap_or_else(String::new),

--- a/lib/luminork-server/src/service/v1/components/update_component.rs
+++ b/lib/luminork-server/src/service/v1/components/update_component.rs
@@ -115,11 +115,9 @@ pub async fn update_component(
 
     let av_id = component.domain_prop_attribute_value(ctx).await?;
 
-    let before_domain_tree = AttributeValue::get_by_id(ctx, av_id)
+    let before_value = AttributeValue::view(ctx, av_id)
         .await?
-        .view(ctx)
-        .await?;
-    let before_value = serde_json::to_value(before_domain_tree)?;
+        .unwrap_or(serde_json::Value::Null);
 
     for (key, value) in payload.domain.clone().into_iter() {
         let prop_id = key.prop_id(ctx, variant_id).await?;
@@ -170,11 +168,9 @@ pub async fn update_component(
         .await?;
     }
 
-    let after_domain_tree = AttributeValue::get_by_id(ctx, av_id)
+    let after_value = AttributeValue::view(ctx, av_id)
         .await?
-        .view(ctx)
-        .await?;
-    let after_value = serde_json::to_value(after_domain_tree)?;
+        .unwrap_or(serde_json::Value::Null);
 
     let component_list = Component::list_ids(ctx).await?;
     if !payload.connection_changes.add.is_empty() || !payload.connection_changes.remove.is_empty() {

--- a/lib/sdf-server/src/service/public/components.rs
+++ b/lib/sdf-server/src/service/public/components.rs
@@ -231,10 +231,7 @@ async fn get_component(
 ) -> Result<Json<GetComponentResponse>> {
     let component = Component::get_by_id(ctx, component_id).await?;
     let domain_av_id = component.domain_prop_attribute_value(ctx).await?;
-    let domain = AttributeValue::get_by_id(ctx, domain_av_id)
-        .await?
-        .view(ctx)
-        .await?;
+    let domain = AttributeValue::view(ctx, domain_av_id).await?;
 
     let mut view_data = vec![];
     for (view_id, geometry) in Geometry::by_view_for_component_id(ctx, component_id).await? {


### PR DESCRIPTION
While convenient, `async_recursion` introduces a fair amount of overhead, and can end up blowing through the stack size limit much faster than expected. Especially when recursing over user-defined data, as is done in `AttributeValue::view`.
 
In addition to making `AttributeValue::view` iterative, instead of recursive, this moves a lot of "graph level" code out of  the domain objects and down into the graph level traits allowing for more direct usage of the underlying graph, more re-use of code between the graph level trait methods, and minimizing the construction of full domain-objects only to pull specific pieces of information from them and to gain access to the helper methods that require the full domain-object instead of just an ID.