### PR TITLE
fix(web): Couple of fixes for action func run reactivity

### DIFF
--- a/app/web/src/newhotness/ActionCard.vue
+++ b/app/web/src/newhotness/ActionCard.vue
@@ -84,8 +84,7 @@
         <DropdownMenuItem
           icon="eye"
           label="View details"
-          :disabled="!props.action.funcRunId"
-          @select="navigateToActionDetailsProtected"
+          @select="navigateToActionDetails"
         />
 
         <!-- Go to component -->
@@ -166,12 +165,6 @@ const route = useRoute();
 const confirmRef = ref<InstanceType<typeof ConfirmHoldModal> | null>(null);
 const contextMenuRef = ref<InstanceType<typeof DropdownMenu>>();
 
-// Navigate to action details only if the func run ID is populated for the action
-const navigateToActionDetailsProtected = () => {
-  if (!props.action.funcRunId) return;
-  navigateToActionDetails();
-};
-
 // Navigate to action details
 const navigateToActionDetails = () => {
   router.push({
@@ -204,29 +197,9 @@ const navigateToComponent = () => {
   });
 };
 
-// Note: This function is commented out but kept for future use
-// when we might want to navigate directly to function run details
-/*
-const navigateToFuncRunDetails = () => {
-  if (props.action.funcRunId) {
-    router.push({
-      name: "new-hotness-func-run",
-      params: {
-        workspacePk: route.params.workspacePk,
-        changeSetId: route.params.changeSetId,
-        funcRunId: props.action.funcRunId,
-      },
-    });
-  }
-};
-*/
-
 // Handle click on the card
 const handleClick = () => {
-  if (!props.action.funcRunId) return;
-
   emit("click", props.action);
-
   // Navigate to action details which will show the latest function run
   navigateToActionDetails();
 };

--- a/app/web/src/newhotness/FuncRunDetails.vue
+++ b/app/web/src/newhotness/FuncRunDetails.vue
@@ -13,6 +13,7 @@
       <VButton
         v-if="
           funcRun &&
+          funcRun.actionId &&
           ['Failure', 'ActionFailure', 'Running'].includes(
             funcRunStatus(funcRun) || '',
           )
@@ -25,6 +26,7 @@
       <VButton
         v-if="
           funcRun &&
+          funcRun.actionId &&
           ['Failure', 'ActionFailure'].includes(funcRunStatus(funcRun) || '')
         "
         tone="action"
@@ -108,7 +110,7 @@ const api = useApi();
 const pollInterval = ref<number | false>(0); // initial calls
 
 const { data: funcRunQuery } = useQuery<Omit<FuncRun, "logs"> | undefined>({
-  queryKey: [ctx.changeSetId.value, "funcRun", props.funcRunId],
+  queryKey: computed(() => [ctx.changeSetId.value, "funcRun", props.funcRunId]),
   queryFn: async () => {
     const call = api.endpoint<funcRunTypes.FuncRunResponse>(routes.FuncRun, {
       id: props.funcRunId,

--- a/app/web/src/newhotness/layout_components/FuncRunDetailsLayout.vue
+++ b/app/web/src/newhotness/layout_components/FuncRunDetailsLayout.vue
@@ -52,10 +52,6 @@
             <dt><Icon name="play" size="xs" /></dt>
             <dd>{{ funcRun.actionKind }}</dd>
           </template>
-
-          <!-- ID and Status -->
-          <dt class="text-xs">ID:</dt>
-          <dd class="text-xs">{{ funcRun.id }}</dd>
         </dl>
         <FuncRunStatusBadge v-if="funcRun && status" :status="status" />
       </div>


### PR DESCRIPTION


<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

<!-- Why: briefly what problem this solves and what the aim is as an overview -->
1. Restore the ability to view the latest func run details for an action (note: as the `FuncRunId` for an action is not on the graph, and no longer in the MV, we're lazily loading it when a user clicks the action. This means we're back to letting you click an action and it might have a func run yet. We should consider if want to invest more in preventing this, or I recommend we surface information about the action that's about to run instead)
2. When a user hits retry, and the new func run starts, we will show the newest run including logs
3. Removed `FuncRunId` from the top
4. Only show the remove/retry buttons if the func run is for an action

#### Out of Scope:

<!-- Anything this PR explicitly leaves out? -->
No improvements to the experience when clicking an action that hasn't yet run. We can follow on with that after some discussion
## How was it tested?

Manual tests: 
1. On head with a failed action, hit retry, see that the new func run starts streaming in and the retry button is removed
2. On head with a queued (or failed/running/etc.) action, hit remove, see the action is removed and the user lands back on the grid
3. Check the network tab, notice we're only fetching the func run after clicking an action. Notice when hitting retry, we refetch the func run id, and when it is different, we also begin fetching logs
4. See that as the function finishes, when it's still a failure, the retry button reappears and the func status is correct

<div><img src="https://media3.giphy.com/media/7rf2Bd3bnlJHMa4sVj/200.gif?cid=5a38a5a2f1ngn7ptfq7epp12p7ezu18jfoskgxjwaxtctzva&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:165px;width:300px"/><br/>via <a href="https://giphy.com/cbs/">CBS</a> on <a href="https://giphy.com/gifs/cbs-ghosts-ghostscbs-cbs-7rf2Bd3bnlJHMa4sVj">GIPHY</a></div>