### PR TITLE
feat: Search for components by attribute

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -64,6 +64,7 @@
     "@tanstack/vue-virtual": "^3.13.6",
     "@types/async": "^3.2.15",
     "@typescript/vfs": "^1.5.3",
+    "@vueuse/core": "^12.0.0",
     "@vueuse/head": "^1.1.15",
     "async": "^3.2.4",
     "axios": "^1.8.4",

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -1,6 +1,6 @@
 <template>
   <DelayedSkeleton
-    v-if="componentListRaw.isLoading.value"
+    v-if="componentListQuery.isLoading.value"
     :skeleton="urlGridOrMap"
   />
   <section v-else :class="clsx('grid h-full', showGrid ? 'explore' : 'map')">
@@ -157,7 +157,9 @@
       </div>
       <template v-if="showGrid">
         <div
-          v-if="componentList.length === 0 && componentListRaw.isSuccess.value"
+          v-if="
+            componentList.length === 0 && componentListQuery.isSuccess.value
+          "
           class="flex-1 overflow-hidden flex flex-row items-center justify-center"
         >
           <EmptyState icon="component" text="No components in view" />
@@ -262,7 +264,7 @@
           class="flex-none rounded p-xs"
           variant="key2"
         >
-          Total: {{ componentListRaw.data.value?.length ?? 0 }}
+          Total: {{ componentList.length }}
         </TextPill>
         <TextPill
           v-if="resourceCount > 0"
@@ -313,6 +315,7 @@
 
 <script lang="ts" setup>
 import * as _ from "lodash-es";
+import { computedAsync } from "@vueuse/core";
 import {
   computed,
   inject,
@@ -339,6 +342,7 @@ import { Fzf } from "fzf";
 import {
   bifrost,
   bifrostList,
+  bifrostQueryAttributes,
   useMakeArgs,
   useMakeKey,
 } from "@/store/realtime/heimdall";
@@ -438,14 +442,13 @@ watch(showGrid, () => {
 
 // ================================================================================================
 // SETUP THE FILTERED COMPONENTS REACTIVE AND UPGRADEABLES
-const filteredComponents = reactive<ComponentInList[]>([]);
 const upgrade = useUpgrade();
 const upgradeableComponentIds = computed(() => {
   const set: Set<ComponentId> = new Set();
 
   // TODO(nick): try to swap this with the component list to see if we recompute this less
   // frequently. This is not a problem today, but could be tomorrow.
-  for (const component of filteredComponents) {
+  for (const component of filteredComponents.value) {
     // This needs to be split out into a variable for reactivity. Keep this here or drown in
     // sorrow and suffering. Relevant pull request: https://github.com/systeminit/si/pull/6483
     const canUpgrade = upgrade(
@@ -614,7 +617,7 @@ const componentListQueryId = computed(() =>
   selectedViewId.value ? selectedViewId.value : ctx.workspacePk.value,
 );
 const componentQueryKey = key(componentListQueryKind, componentListQueryId);
-const componentListRaw = useQuery<ComponentInList[]>({
+const componentListQuery = useQuery<ComponentInList[]>({
   queryKey: componentQueryKey,
   queryFn: async () => {
     const arg = selectedViewId.value
@@ -625,13 +628,12 @@ const componentListRaw = useQuery<ComponentInList[]>({
   },
 });
 const placeholderSearchText = computed(
-  () => `Search across ${componentListRaw.data.value?.length ?? 0} Components`,
+  () =>
+    `Search across ${componentListQuery.data.value?.length ?? 0} Components`,
 );
-const componentListUnchecked = computed(
-  () => componentListRaw.data.value ?? [],
-);
+const componentList = computed(() => componentListQuery.data.value ?? []);
 const pinnedComponent = computed(() =>
-  componentListUnchecked.value.find((c) => c.id === pinnedComponentId.value),
+  componentList.value.find((c) => c.id === pinnedComponentId.value),
 );
 const connectionsGetter = useConnections();
 const pinnedComponentConnections = computed(() =>
@@ -654,18 +656,9 @@ const pinnedComponentConnectionSets = computed(() => {
     outgoing,
   };
 });
-const componentList = computed(() => {
-  // If we aren't dealing with pinning, return the standard list.
-  if (!pinnedComponent.value || !pinnedComponentConnections.value)
-    return componentListUnchecked.value;
-
-  // When pinning, include all components so they can be properly grouped
-  // into connected and unconnected sections
-  return componentListUnchecked.value;
-});
 
 const resourceCount = computed(
-  () => componentListUnchecked.value.filter((c) => c.hasResource).length ?? 0,
+  () => componentList.value.filter((c) => c.hasResource).length ?? 0,
 );
 const resourceCountTooltip = "Components with resources";
 const componentCountTooltip = "Total components in selected view";
@@ -683,7 +676,7 @@ const sortedAndGroupedComponents = computed(() => {
   let groups: Record<string, ComponentInList[]> = {};
 
   // First, always sort by latest to oldest. This relies on the fact ULIDs are time-based.
-  let components = filteredComponents;
+  let components = filteredComponents.value;
   components.sort((a, b) => b.id.localeCompare(a.id));
 
   // Second, perform any secondary sorts, if applicable. This relies on the fact that the
@@ -802,49 +795,122 @@ const sortedAndGroupedComponents = computed(() => {
 // THE SEARCH BAR AND FILTERING
 const searchString = ref<string>("");
 const debouncedSearchString = ref<string>("");
-const computedSearchString = computed(() => debouncedSearchString.value);
 
 // send this down to any components that might use it
-provide("SEARCH", computedSearchString);
+provide("SEARCH", debouncedSearchString);
 
-watch(
-  () => [debouncedSearchString.value, componentList.value],
-  () => {
-    if (!debouncedSearchString.value) {
-      filteredComponents.splice(0, Infinity, ...componentList.value);
-      return;
-    }
-
-    const searchTerm = debouncedSearchString.value.trim();
-
-    // Check if the search term contains "schema:" queries
-    const schemaMatches = searchTerm.match(/schema:([^\s]+)/gi);
-    if (schemaMatches) {
-      const schemaNames = schemaMatches.map((match) =>
-        match.substring(7).trim().toLowerCase(),
-      );
-
-      if (schemaNames.length === 0 || schemaNames.some((name) => name === "")) {
-        filteredComponents.splice(0, Infinity, ...componentList.value);
-        return;
+/**
+ * Search string, split into terms.
+ *
+ * MyComponent vpcId:vpc-123 AWS::EC2::Subnet parses to:
+ *
+ *     {
+ *       attrSearchTerms: [ { key: "vpcId", value: "vpc-123" } ],
+ *       knownSearchTerms: [ { key: "schema", value: "AWS::EC2::Subnet" } ],
+ *       fuzzyTerms: [ "MyComponent", "AWS::EC2::Subnet" ]
+ *     }
+ */
+const debouncedSearchTerms = computed(() => {
+  const attrSearchTerms = new Array<{ key: string; value: string }>();
+  const knownSearchTerms = new Array<{ key: "schema"; value: string }>();
+  const fuzzyTerms = new Array<string>();
+  for (const term of debouncedSearchString.value.split(/\s+/g)) {
+    // Treat a:b as a key-value pair
+    const colon = term.indexOf(":");
+    if (colon >= 0 && term[colon + 1] !== ":") {
+      // Don't treat :: as a key-value pair
+      const key = term.slice(0, colon);
+      const value = term.slice(colon + 1);
+      if (key === "schema") {
+        knownSearchTerms.push({ key, value });
+      } else {
+        attrSearchTerms.push({ key, value });
       }
-
-      const results = componentList.value.filter((c) =>
-        schemaNames.includes(c.schemaName.toLowerCase()),
-      );
-      filteredComponents.splice(0, Infinity, ...results);
     } else {
-      // Regular fuzzy search across all fields
-      const fzf = new Fzf(componentList.value, {
-        casing: "case-insensitive",
-        selector: (c) =>
-          `${c.name} ${c.schemaVariantName} ${c.schemaName} ${c.schemaCategory} ${c.schemaId} ${c.id}`,
-      });
-
-      const results = fzf.find(searchTerm);
-      filteredComponents.splice(0, Infinity, ...results.map((fz) => fz.item));
+      fuzzyTerms.push(term);
     }
+  }
+  return { attrSearchTerms, knownSearchTerms, fuzzyTerms };
+});
 
+/**
+ * Components list filtered by the advanced search terms (by querying bifrost).
+ *
+ * Should only be used by filteredComponents.
+ */
+const attrSearchedComponentIds = computedAsync(async () => {
+  const { attrSearchTerms } = debouncedSearchTerms.value;
+  if (attrSearchTerms.length === 0) {
+    return undefined;
+  }
+
+  const result = await bifrostQueryAttributes({
+    workspaceId: ctx.workspacePk.value,
+    changeSetId: ctx.changeSetId.value,
+    terms: attrSearchTerms,
+  });
+  return result;
+});
+
+/**
+ * Components list filtered by all search terms.
+ */
+const filteredComponents = computed(() => {
+  let components = componentList.value;
+  const { attrSearchTerms, knownSearchTerms, fuzzyTerms } =
+    debouncedSearchTerms.value;
+
+  // Handle attribute search terms
+  if (attrSearchTerms.length > 0) {
+    components = components.filter((component) =>
+      attrSearchedComponentIds.value?.includes(component.id),
+    );
+  }
+
+  // Handle special-cased keys (e.g. schema)
+  for (const term of knownSearchTerms) {
+    // Search specifically for matching schemas
+    switch (term.key) {
+      case "schema":
+        components = components.filter((c) => {
+          let schemaName: string | undefined = c.schemaName.toLowerCase();
+          const termLowerCase = term.value.toLowerCase();
+          // Support matching "VPC", "EC2::VPC" or "AWS::EC2::VPC" by checking against each one
+          // in succession
+          while (schemaName) {
+            if (schemaName.startsWith(termLowerCase)) {
+              return true;
+            }
+            // Remove the first part of the schema name ("AWS::EC2::VPC" -> "EC2::VPC") and try again
+            const doubleColon = schemaName.indexOf("::");
+            if (doubleColon >= 0) {
+              schemaName = schemaName.slice(doubleColon + 2);
+            } else {
+              // No more "::" to remove, break out of the loop
+              schemaName = undefined;
+            }
+          }
+          return false;
+        });
+        break;
+      default:
+        break;
+    }
+  }
+
+  // Regular fuzzy search across all fields
+  const fzf = new Fzf(components, {
+    casing: "case-insensitive",
+    selector: (c) => `${c.name} ${c.schemaName} ${c.schemaCategory} ${c.id}`,
+  });
+  return fzf.find(fuzzyTerms.join(" ")).map((fz) => fz.item);
+});
+
+// Clear the selection when the filter changes
+// TODO leave the selection as long as it is still one of the filtered components?
+watch(
+  filteredComponents,
+  () => {
     mapRef.value?.deselect();
     clearSelection();
   },

--- a/app/web/src/newhotness/Map.vue
+++ b/app/web/src/newhotness/Map.vue
@@ -192,11 +192,11 @@ import {
 } from "@si/vue-lib/design-system";
 import {
   computed,
-  ComputedRef,
   inject,
   nextTick,
   onMounted,
   reactive,
+  Ref,
   ref,
   watch,
 } from "vue";
@@ -814,7 +814,7 @@ watch(selectedComponent, () => {
   router.push({ query });
 });
 
-const searchString = inject<ComputedRef<string>>("SEARCH");
+const searchString = inject<Ref<string>>("SEARCH");
 
 const connectedComponentIds = computed(() => {
   const connectedIds = new Set<string>();

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -346,6 +346,33 @@ export const bifrostList = async <T>(args: {
   return reactive(JSON.parse(maybeAtomDoc));
 };
 
+/**
+ * Query AttributeTree MVs in a changeset, looking for components that match the given terms.
+ *
+ * @param workspaceId The workspace ID to query.
+ * @param changeSetId The changeset ID to query.
+ * @param terms The key/value pairs to match. e.g. { key: "vpcId", value: "vpc-123" } or { key: "/domain/vpcId", value: "vpc-123" }
+ * @returns the list of component IDs that match the given terms.
+ */
+export const bifrostQueryAttributes = async (args: {
+  workspaceId: string;
+  changeSetId: ChangeSetId;
+  terms: { key: string; value: string }[];
+}) => {
+  if (!initCompleted.value) throw new Error("You must wait for initialization");
+
+  const start = performance.now();
+  const components = await db.queryAttributes(
+    args.workspaceId,
+    args.changeSetId,
+    args.terms,
+  );
+  const end = performance.now();
+  // eslint-disable-next-line no-console
+  console.log("🌈 bifrost queryAttributes", end - start, "ms");
+  return reactive(components);
+};
+
 export const getPossibleConnections = async (args: {
   workspaceId: string;
   changeSetId: ChangeSetId;

--- a/app/web/src/workers/shared_webworker.ts
+++ b/app/web/src/workers/shared_webworker.ts
@@ -6,6 +6,10 @@ import {
   FlexibleString,
   SqlValue,
 } from "@sqlite.org/sqlite-wasm";
+import { ChangeSetId } from "@/api/sdf/dal/change_set";
+import { WorkspacePk } from "@/store/workspaces.store";
+import { ComponentId } from "@/api/sdf/dal/component";
+import { EntityKind } from "./types/entity_kind_types";
 import {
   SharedDBInterface,
   TabDBInterface,
@@ -16,7 +20,6 @@ import {
   Gettable,
   Listable,
 } from "./types/dbinterface";
-import { EntityKind } from "./types/entity_kind_types";
 
 declare global {
   interface Window {
@@ -200,6 +203,17 @@ const dbInterface: SharedDBInterface = {
     return await withRemote(
       async (remote) =>
         await remote.getList(workspaceId, changeSetId, kind, id),
+    );
+  },
+
+  async queryAttributes(
+    workspaceId: WorkspacePk,
+    changeSetId: ChangeSetId,
+    terms: { key: string; value: string }[],
+  ): Promise<ComponentId[]> {
+    return await withRemote(
+      async (remote) =>
+        await remote.queryAttributes(workspaceId, changeSetId, terms),
     );
   },
 

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -165,6 +165,19 @@ export interface SharedDBInterface {
     kind: Listable,
     id: Id,
   ): Promise<string>;
+  /**
+   * Query AttributeTree MVs in a changeset, looking for components that match the given terms.
+   *
+   * @param workspaceId The workspace ID to query.
+   * @param changeSetId The changeset ID to query.
+   * @param terms The key/value pairs to match. e.g. { key: "vpcId", value: "vpc-123" } or { key: "/domain/vpcId", value: "vpc-123" }
+   * @returns the list of component IDs that match the given terms.
+   */
+  queryAttributes(
+    workspaceId: WorkspacePk,
+    changeSetId: ChangeSetId,
+    terms: { key: string; value: string }[],
+  ): Promise<ComponentId[]>;
   mjolnir(
     workspaceId: string,
     changeSetId: ChangeSetId,
@@ -247,6 +260,19 @@ export interface TabDBInterface {
     kind: Listable,
     id: Id,
   ): string;
+  /**
+   * Query AttributeTree MVs in a changeset, looking for components that match the given terms.
+   *
+   * @param workspaceId The workspace ID to query.
+   * @param changeSetId The changeset ID to query.
+   * @param terms The key/value pairs to match. e.g. { key: "vpcId", value: "vpc-123" } or { key: "/domain/vpcId", value: "vpc-123" }
+   * @returns the list of component IDs that match the given terms.
+   */
+  queryAttributes(
+    workspaceId: WorkspacePk,
+    changeSetId: ChangeSetId,
+    terms: { key: string; value: string }[],
+  ): ComponentId[];
   mjolnirBulk(
     workspaceId: string,
     changeSetId: ChangeSetId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       '@typescript/vfs':
         specifier: ^1.5.3
         version: 1.5.3(typescript@5.0.4)
+      '@vueuse/core':
+        specifier: ^12.0.0
+        version: 12.0.0(typescript@5.0.4)
       '@vueuse/head':
         specifier: ^1.1.15
         version: 1.1.15(vue@3.5.12(typescript@5.0.4))
@@ -4461,7 +4464,7 @@ packages:
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
-    
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -10442,9 +10445,8 @@ packages:
   tar-fs@2.1.3:
     resolution: {integrity: sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==}
 
-    
   tar-fs@3.0.9:
-    resolution: {integrity: sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==} 
+    resolution: {integrity: sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}


### PR DESCRIPTION
This adds `vpcId:vpc-1234` syntax to the search bar, allowing you to refine a search based on arbitrary attributes in a component.

## How does this PR change the system?

* **Attribute matching:** `/domain/Foo/Bar:val` matches components where /domain/Foo/Bar = val
* **Partial attribute matching:** `Bar:val` and `Foo/Bar:val` will all match components where /domain/Foo/Bar = val.
  * Partial matches will match partial *paths*, not partial attribute names: `Bar:val` will not match /domain/BarMaid or /domain/OpenBar.
* **Exact matches:** Bar:val will not match /domain/Bar = "evaluation"
* **Progressive matches:** Bar:val will match /domain/Bar = "valuation" so that it progressively refines the set of components as you continue typing each letter the word "Bar:valuation"
  * Empty value does not match attributes with no value: `SecondaryIp:` will match every instance with a SecondaryIp defined, but will not match instances where SecondaryIp: has no value (was never filled in). Yes, I know SecondaryIp is not a thing, I had to make up something that sounded optional.
* **Wildcards matches**: `InstanceType:*.large` will match any large instance type.

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcGNqdWxjNWtxNmg4a3N6NTNycm12MXI0cWNoeDRweGUycjM3d3NjYSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l0HlTlUJ8lEPryCf6/giphy.gif)

#### Screenshots:

![image](https://github.com/user-attachments/assets/6b301188-59a9-4c9f-80ab-5ad4b6ca9b75)

#### Out of Scope:

* Can't search for boolean and int values. This sucks!
* Default value searches. Not sure if we want x:y to match unset values if the default value of x is y; we should consider.

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: fuzzy search, schema:AWS::EC2::VPC, schema::VPC, InstanceType:, /domain/InstanceType: