### PR TITLE
fix(web): support multiple workspaces

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -328,6 +328,11 @@ const queryClient = useQueryClient();
 queryClient.setDefaultOptions({ queries: { staleTime: Infinity } });
 
 const container = inject<{ loadingGuard: Ref<boolean> }>("LOADINGGUARD");
+
+const getTokenForWorkspace = (workspaceId: string) => {
+  return tokensByWorkspacePk[workspaceId];
+};
+
 onBeforeMount(async () => {
   if (container && container.loadingGuard.value) {
     return;
@@ -346,20 +351,15 @@ onBeforeMount(async () => {
     }
   }, 500);
 
-  if (!Object.keys(tokensByWorkspacePk).length) {
-    tokenFail.value = true;
-    return;
-  }
-
   const thisWorkspacePk = workspacePk.value;
-  const workspaceAuthToken = tokensByWorkspacePk[thisWorkspacePk];
+  const workspaceAuthToken = getTokenForWorkspace(thisWorkspacePk);
   if (!workspaceAuthToken) {
     tokenFail.value = true;
     return;
   }
 
   // Activate the norse stack, which is explicitly NOT flagged for the job-specific UI.
-  await heimdall.init(workspaceAuthToken, queryClient);
+  await heimdall.init(thisWorkspacePk, workspaceAuthToken, queryClient);
   watch(
     [connectionShouldBeEnabled, heimdall.initCompleted],
     async () => {
@@ -377,9 +377,17 @@ onBeforeMount(async () => {
 });
 
 watch(
-  () => props.changeSetId,
-  async (newValue, _) => {
-    await heimdall.niflheim(props.workspacePk, newValue, true, false);
+  () => [props.workspacePk, props.changeSetId],
+  async ([newWorkspacePk, newChangeSetId], _) => {
+    if (newWorkspacePk && newChangeSetId) {
+      const workspaceToken = getTokenForWorkspace(newWorkspacePk);
+      if (!workspaceToken) {
+        tokenFail.value = true;
+        return;
+      }
+      await heimdall.registerBearerToken(newWorkspacePk, workspaceToken);
+      heimdall.niflheim(newWorkspacePk, newChangeSetId, true, false);
+    }
   },
 );
 

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -44,7 +44,7 @@ import { useWorkspacesStore } from "../workspaces.store";
 // we do not need crypto-secure ulids. We just want every tab to have a different one. Which this will get us.
 const ulid = monotonicFactory(() => Math.random());
 
-const token = ref<string | undefined>(undefined);
+const ranInit = ref<boolean>(false);
 let queryClient: QueryClient;
 const tabDbId = ulid();
 const lockAcquired = ref(false);
@@ -54,12 +54,16 @@ lockAcquiredBroadcastChannel.onmessage = () => {
   lockAcquired.value = true;
 };
 
-export const init = async (bearerToken: string, _queryClient: QueryClient) => {
-  if (!token.value) {
+export const init = async (
+  workspaceId: string,
+  bearerToken: string,
+  _queryClient: QueryClient,
+) => {
+  if (!ranInit.value) {
     // eslint-disable-next-line no-console
     console.log("🌈 initializing bifrost...");
     const start = performance.now();
-    await tabDb.setBearer(bearerToken);
+    await db.setBearer(workspaceId, bearerToken);
 
     const { port1, port2 } = new MessageChannel();
     // This message fires when the lock has been acquired for this tab
@@ -73,7 +77,7 @@ export const init = async (bearerToken: string, _queryClient: QueryClient) => {
     tabDb.initBifrost(Comlink.proxy(port2));
 
     const end = performance.now();
-    token.value = bearerToken;
+    ranInit.value = true;
     queryClient = _queryClient;
     // eslint-disable-next-line no-console
     console.log(`...initialization completed [${end - start}ms] 🌈`);
@@ -93,7 +97,7 @@ export const init = async (bearerToken: string, _queryClient: QueryClient) => {
 };
 
 export const initCompleted = computed(
-  () => !!token.value && lockAcquired.value,
+  () => ranInit.value && lockAcquired.value,
 );
 
 const bustTanStackCache: BustCacheFn = (
@@ -526,6 +530,13 @@ export const muspelheim = async (workspaceId: string, force?: boolean) => {
   // eslint-disable-next-line no-console
   console.log("🔥 DONE 🔥");
   return true;
+};
+
+export const registerBearerToken = async (
+  workspaceId: string,
+  bearerToken: string,
+) => {
+  await db.setBearer(workspaceId, bearerToken);
 };
 
 // cold start

--- a/app/web/src/workers/shared_webworker.ts
+++ b/app/web/src/workers/shared_webworker.ts
@@ -32,10 +32,10 @@ function debug(...args: any | any[]) {
   if (_DEBUG) console.debug(args);
 }
 
-let bearerToken: string;
 let currentRemote: Comlink.Remote<TabDBInterface> | undefined;
 let currentRemoteId: string | undefined;
 const remotes: { [key: string]: Comlink.Remote<TabDBInterface> } = {};
+const bearerTokens: { [key: string]: string } = {};
 
 const hasRemoteChannel = new MessageChannel();
 
@@ -90,24 +90,20 @@ const dbInterface: SharedDBInterface = {
   async setRemote(remoteId: string) {
     debug("setting remote in shared web worker to", remoteId);
 
-    const wasConnected = !!currentRemote;
-
     currentRemote = remotes[remoteId];
     if (!currentRemote) {
       throw new Error(`remote {$remoteId} not registered`);
     }
     currentRemoteId = remoteId;
 
-    // Ensure we reconnect the websocket if we already had a remote
-    // (otherwise we let heimdall decide when to connect the websocket)
-    if (wasConnected) {
-      currentRemote.bifrostReconnect();
+    for (const [workspaceId, workspaceToken] of Object.entries(bearerTokens)) {
+      await currentRemote.setBearer(workspaceId, workspaceToken);
+      await currentRemote.initSocket(workspaceId);
     }
 
+    currentRemote.bifrostReconnect();
+
     hasRemoteChannel.port2.postMessage("got remote");
-    if (bearerToken) {
-      currentRemote.setBearer(bearerToken);
-    }
   },
 
   async initDB(_testing: boolean) {
@@ -118,13 +114,14 @@ const dbInterface: SharedDBInterface = {
     return withRemote(async (remote) => await remote.migrate(testing));
   },
 
-  setBearer(token: string): void {
-    bearerToken = token;
-    currentRemote?.setBearer(bearerToken);
+  setBearer(workspaceId, token): void {
+    bearerTokens[workspaceId] = token;
+    currentRemote?.setBearer(workspaceId, token);
+    currentRemote?.initSocket(workspaceId);
   },
 
-  async initSocket(): Promise<void> {
-    await withRemote(async (remote) => await remote.initSocket());
+  async initSocket(workspaceId: string): Promise<void> {
+    await withRemote(async (remote) => await remote.initSocket(workspaceId));
   },
 
   async initBifrost(_gotlockPort: MessagePort) {

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -114,8 +114,8 @@ export type Gettable = Exclude<EntityKind, Listable>;
 export interface SharedDBInterface {
   initDB: (testing: boolean) => Promise<void>;
   migrate: (testing: boolean) => Promise<Database>;
-  setBearer: (token: string) => void;
-  initSocket(): Promise<void>;
+  setBearer: (workspaceId: string, token: string) => void;
+  initSocket(workspaceId: string): Promise<void>;
   unregisterRemote(id: string): void;
   registerRemote(id: string, remote: Comlink.Remote<TabDBInterface>): void;
   broadcastMessage(message: BroadcastMessage): Promise<void>;
@@ -202,8 +202,8 @@ export interface SharedDBInterface {
 export interface TabDBInterface {
   initDB: (testing: boolean) => Promise<void>;
   migrate: (testing: boolean) => Database;
-  setBearer: (token: string) => void;
-  initSocket(): Promise<void>;
+  setBearer: (workspaceId: string, token: string) => void;
+  initSocket(workspaceId: string): Promise<void>;
   receiveBroadcast(message: BroadcastMessage): Promise<void>;
   setRemote(remoteId: string): Promise<void>;
   initBifrost(gotLockPort: MessagePort): Promise<void>;

--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -126,7 +126,7 @@ function debug(...args: any | any[]) {
  *  INITIALIZATION FNS
  */
 let db: Database;
-let sdf: AxiosInstance;
+const sdfClients: { [key: string]: AxiosInstance } = {};
 
 const getDbName = (testing: boolean) => {
   if (testing) return "sitest.sqlite3";
@@ -1236,6 +1236,12 @@ const mjolnirBulk = async (
   });
 
   await tracer.startActiveSpan(`GET ${desc}`, async (span) => {
+    const sdf = getSdfClientForWorkspace(workspaceId, span);
+    if (!sdf) {
+      span.end();
+      return;
+    }
+
     span.setAttributes({
       workspaceId,
       changeSetId,
@@ -1377,6 +1383,11 @@ const mjolnirJob = async (
   let req: undefined | AxiosResponse<IndexObjectMeta, any>;
 
   await tracer.startActiveSpan(`GET ${desc}`, async (span) => {
+    const sdf = getSdfClientForWorkspace(workspaceId, span);
+    if (!sdf) {
+      span.end();
+      return;
+    }
     span.setAttributes({ workspaceId, changeSetId, kind, id, checksum });
     try {
       req = await sdf<IndexObjectMeta>({
@@ -1645,11 +1656,31 @@ export const CHANGE_SET_INDEX_URL = (
 
 export const STATUS_INDEX_IN_PROGRESS = 202;
 
+const getSdfClientForWorkspace = (workspaceId: string, span?: Span) => {
+  const sdf = sdfClients[workspaceId];
+
+  if (!sdf) {
+    const errorMessage = `SDF client not found for workspace: ${workspaceId}`;
+    error(errorMessage);
+    span?.addEvent("error", {
+      "error.message": errorMessage,
+    });
+  }
+
+  return sdf;
+};
+
 const niflheim = async (
   workspaceId: string,
   changeSetId: ChangeSetId,
 ): Promise<boolean> => {
   return await tracer.startActiveSpan("niflheim", async (span: Span) => {
+    const sdf = getSdfClientForWorkspace(workspaceId, span);
+    if (!sdf) {
+      span.end();
+      return false;
+    }
+
     // build connections list based on data we have in the DB
     // connections list will rebuild as data comes in
     bulkInflight();
@@ -2843,8 +2874,8 @@ const getMany = (
  * INTERFACE DEFINITION
  */
 
-let socket: ReconnectingWebSocket;
-let bearerToken: string;
+const sockets: { [key: string]: ReconnectingWebSocket } = {};
+const bearerTokens: { [key: string]: string } = {};
 
 let bustCacheFn: BustCacheFn;
 let inFlightFn: RainbowFn;
@@ -2909,8 +2940,8 @@ const dbInterface: TabDBInterface = {
         assertNever(message);
     }
   },
-  setBearer(token) {
-    bearerToken = token;
+  setBearer(workspaceId, token) {
+    bearerTokens[workspaceId] = token;
     let apiUrl: string;
     if (import.meta.env.VITE_API_PROXY_PATH) {
       // eslint-disable-next-line no-restricted-globals
@@ -2920,7 +2951,7 @@ const dbInterface: TabDBInterface = {
     } else throw new Error("Invalid API env var config");
     const API_HTTP_URL = apiUrl;
 
-    sdf = Axios.create({
+    sdfClients[workspaceId] = Axios.create({
       headers: {
         "Content-Type": "application/json",
       },
@@ -2936,7 +2967,7 @@ const dbInterface: TabDBInterface = {
       return config;
     }
 
-    sdf.interceptors.request.use(injectBearerTokenAuth);
+    sdfClients[workspaceId]?.interceptors.request.use(injectBearerTokenAuth);
   },
   async initDB(testing: boolean) {
     return initializeSQLite(testing);
@@ -2948,22 +2979,28 @@ const dbInterface: TabDBInterface = {
     return result;
   },
 
-  async initSocket() {
+  async initSocket(workspaceId: string) {
+    if (typeof sockets[workspaceId] !== "undefined") {
+      return;
+    }
+
+    debug("Initializing websocket for workspaceId", workspaceId);
+
     try {
-      socket = new ReconnectingWebSocket(
-        () => `/api/ws/bifrost?token=Bearer+${bearerToken}`,
+      const token = bearerTokens[workspaceId];
+      sockets[workspaceId] = new ReconnectingWebSocket(
+        () => `/api/ws/bifrost?token=Bearer+${token}`,
         [],
         {
           // see options https://www.npmjs.com/package/reconnecting-websocket#available-options
           startClosed: true, // don't start connected - we'll watch auth to trigger
-          // TODO: tweak settings around reconnection behaviour
         },
       );
     } catch (err) {
       error(err);
     }
 
-    socket.addEventListener("message", (messageEvent) => {
+    sockets[workspaceId]?.addEventListener("message", (messageEvent) => {
       tracer.startActiveSpan("handleEvent", async (span) => {
         // we'll either be getting AtomMessages as patches to the data
         // OR we'll be getting mjolnir responses with the Atom as a whole
@@ -3051,7 +3088,7 @@ const dbInterface: TabDBInterface = {
       });
     });
 
-    socket.addEventListener("error", (errorEvent) => {
+    sockets[workspaceId]?.addEventListener("error", (errorEvent) => {
       error("ws error", errorEvent.error, errorEvent.message);
     });
   },
@@ -3073,7 +3110,7 @@ const dbInterface: TabDBInterface = {
       { mode: "exclusive", signal: abortController.signal },
       async () => {
         debug("lock acquired! 🌈 Initializing sqlite3 bifrost for real");
-        await Promise.all([this.initDB(false), this.initSocket()]);
+        await this.initDB(false);
         this.migrate(false);
         debug("🌈 Bifrost initialization complete");
 
@@ -3091,7 +3128,9 @@ const dbInterface: TabDBInterface = {
 
   bifrostClose() {
     try {
-      if (socket) socket.close();
+      for (const workspaceId in sockets) {
+        sockets[workspaceId]?.close();
+      }
     } catch (err) {
       error(err);
     }
@@ -3099,8 +3138,13 @@ const dbInterface: TabDBInterface = {
 
   bifrostReconnect() {
     try {
-      // don't re-connect if you're already connected!
-      if (socket && socket.readyState !== WebSocket.OPEN) socket.reconnect();
+      for (const workspaceId in sockets) {
+        const socket = sockets[workspaceId];
+        // don't re-connect if you're already connected!
+        if (socket && socket.readyState !== WebSocket.OPEN) {
+          socket.reconnect();
+        }
+      }
     } catch (err) {
       error(err);
     }


### PR DESCRIPTION
The bifrost websocket is workspace specific, so we need to connect a new socket for every workspace that the user loads.

The sdf client injects the token when it is created, so we also need an sdf client for every workspace that the user loads.

This pr ensures that we initialize a new socket and sdf client for every workspace that the user loads, and that we re-initialize all the necessary sockets and sdf clients when a new tab grabs the lock for the database.

## How was it tested?

- [X] Manual test: switch workspaces in a single tab. Ensure bifrost events flow.
- [X] Open multiple workspaces in multiple tabs. Test updates by editing component properties.
- [x] Close the tab that holds the lock and ensure websockets are connected in the tab that now has the lock.
