### PR TITLE
feat: Add search query to URL

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -305,6 +305,7 @@ export type SelectionsInQueryString = Partial<{
   sortBy: SortByUrlQuery;
   pinned: string;
   viewId: string;
+  searchQuery: string;
 }>;
 
 const compositionLink = computed(() => {

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -349,9 +349,9 @@ export const bifrostList = async <T>(args: {
 /**
  * Query AttributeTree MVs in a changeset, looking for components that match the given terms.
  *
- * @param workspaceId The workspace ID to query.
- * @param changeSetId The changeset ID to query.
- * @param terms The key/value pairs to match. e.g. { key: "vpcId", value: "vpc-123" } or { key: "/domain/vpcId", value: "vpc-123" }
+ * @param args.workspaceId The workspace ID to query.
+ * @param args.changeSetId The changeset ID to query.
+ * @param args.terms The key/value pairs to match. e.g. { key: "vpcId", value: "vpc-123" } or { key: "/domain/vpcId", value: "vpc-123" }
  * @returns the list of component IDs that match the given terms.
  */
 export const bifrostQueryAttributes = async (args: {


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExajNnenh3czEweGJ2YTY4enE5dmRyNHB6cmZuem1xanhzcnhmb3k1aSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/WSy0SI6qipEDJogaGD/giphy.gif)


## How does this PR change the system?

- Adds search string to URL, without adding each change to history
- Fix a watcher on explore that was trying to access data too quickly and throwing exceptions

#### Screenshots:
<img width="961" alt="image" src="https://github.com/user-attachments/assets/858cb373-2cab-4145-8db6-cef2dc824f81" />

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->


## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] Manual test: Change search string, see it on the URL
- [X] Manual test: navigate away fro search, press back button, search is still there
- [X] Manual test: Copy link, open in another tab, search is still there



