### PR TITLE
feat(web): add hashes to the frontend build

### DIFF
--- a/app/web/src/components/Workspace/WorkspaceAdminDashboard.vue
+++ b/app/web/src/components/Workspace/WorkspaceAdminDashboard.vue
@@ -3,6 +3,8 @@
     class="w-full h-full flex flex-col gap-xs p-lg items-center relative overflow-scroll dark:bg-neutral-800 dark:text-shade-0 bg-neutral-50 text-neutral-900"
   >
     <span class="font-bold text-3xl">Admin Dashboard</span>
+    <span class="text-xs">commit hash: {{ commitHash }}</span>
+    <span class="text-xs">shared worker hash: {{ sharedWorkerHash }}</span>
     <div class="flex flex-row gap-sm w-full">
       <Stack spacing="md" class="flex-none">
         <Stack class="max-w-xl">
@@ -127,6 +129,9 @@ const killExecution = () => {
 };
 
 const funcRunId = ref<string | null>(null);
+
+const commitHash = __COMMIT_HASH__;
+const sharedWorkerHash = __SHARED_WORKER_HASH__;
 
 const featureFlags = computed(() => {
   return featureFlagsStore.allFeatureFlags;

--- a/app/web/src/pages/Hashes.vue
+++ b/app/web/src/pages/Hashes.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <pre>commit: {{ commitHash }}</pre>
+    <pre>shared worker: {{ sharedWorkerHash }} </pre>
+  </div>
+</template>
+
+<script lang="ts" setup>
+const commitHash = __COMMIT_HASH__;
+const sharedWorkerHash = __SHARED_WORKER_HASH__;
+</script>

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -22,6 +22,12 @@ const routes: RouteRecordRaw[] = [
     component: () => import("@/pages/HomePage.vue"),
   },
   {
+    path: "/hashes",
+    name: "hashes",
+    meta: { public: true },
+    component: () => import("@/pages/Hashes.vue"),
+  },
+  {
     path: "/w",
     name: "workspace-index",
     redirect: { name: "home" },

--- a/app/web/src/vite-env.d.ts
+++ b/app/web/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+declare const __COMMIT_HASH__: string;
+declare const __SHARED_WORKER_HASH__: string;


### PR DESCRIPTION
Adds two hashes to the frontend build:

`__COMMIT_HASH__`, the hash of HEAD when the frontend is built, and `__SHARED_WORKER_HASH__`, the git sha of the shared_webworker.js file when the frontend is built.

We can use the commit hash to confirm that a user is on the latest version of the frontend (they can go to `/hashes`) to see the hashes, and we will use the `__SHARED_WORKER_HASH__` to detect when the shared webworker that is resident in the browser is out of sync with the frontend code running in a tab.