### PR TITLE
feat(web): Add the ability to be able to connect components with failed actions and the actions

### DIFF
--- a/app/web/src/mead-hall/ActionCardLayout.vue
+++ b/app/web/src/mead-hall/ActionCardLayout.vue
@@ -6,8 +6,13 @@
         !noInteraction
           ? 'cursor-pointer hover:border-action-500 dark:hover:border-action-300 group/actioncard'
           : '',
-        selected
-          ? 'dark:bg-action-900 bg-action-100 border-action-500 dark:border-action-300'
+        // Background color for selected state
+        selected ? 'dark:bg-action-900 bg-action-100' : '',
+        // Border color priority: red for highlighted failed, blue for selected, default for others
+        highlightedFailed
+          ? 'border-destructive-500 dark:border-destructive-400'
+          : selected
+          ? 'border-action-500 dark:border-action-300'
           : 'dark:border-neutral-800',
         actionFailed ? 'action-failed' : '',
       )
@@ -54,6 +59,7 @@ defineProps<{
   noInteraction?: boolean;
   selected?: boolean;
   actionFailed: boolean;
+  highlightedFailed?: boolean;
   componentId: string | null | undefined;
   componentSchemaName?: string;
   componentName?: string;

--- a/app/web/src/newhotness/ActionCard.vue
+++ b/app/web/src/newhotness/ActionCard.vue
@@ -3,6 +3,7 @@
     :noInteraction="noInteraction"
     :selected="selected"
     :actionFailed="actionFailed"
+    :highlightedFailed="failed"
     :abbr="actionKindToAbbreviation(action.kind)"
     :description="action.kind === ActionKind.Manual ? action.description : ''"
     :componentSchemaName="action.componentSchemaName"
@@ -153,6 +154,7 @@ const props = defineProps<{
   action: ActionProposedView;
   slim?: boolean;
   selected?: boolean;
+  failed?: boolean;
   noInteraction?: boolean;
 }>();
 

--- a/app/web/src/newhotness/ActionQueueList.vue
+++ b/app/web/src/newhotness/ActionQueueList.vue
@@ -20,25 +20,130 @@
     <ActionCard
       v-for="action in actionViewList"
       :key="action.id"
+      :ref="(el) => setActionCardRef(action.id, el)"
       :action="action"
-      :selected="false"
+      :selected="highlightedActionIds.has(action.id)"
+      :failed="highlightedActionIds.has(action.id)"
       :noInteraction="false"
     />
   </ul>
 </template>
 
 <script lang="ts" setup>
-import { PropType } from "vue";
+import { PropType, ref, watch, nextTick } from "vue";
 import { themeClasses } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { ActionProposedView } from "@/store/actions.store";
 import ActionCard from "./ActionCard.vue";
 import EmptyState from "./EmptyState.vue";
 
-defineProps({
+const props = defineProps({
   actionViewList: {
     type: Array as PropType<ActionProposedView[]>,
     required: true,
   },
+  highlightedActionIds: {
+    type: Object as PropType<Set<string>>,
+    default: () => new Set(),
+  },
 });
+
+// Track refs to ActionCard components by action ID
+const actionCardRefs = ref<Map<string, InstanceType<typeof ActionCard>>>(
+  new Map(),
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const setActionCardRef = (actionId: string, el: any) => {
+  if (el) {
+    actionCardRefs.value.set(actionId, el);
+  } else {
+    actionCardRefs.value.delete(actionId);
+  }
+};
+
+// Watch for changes in highlighted actions and scroll to show as many as possible
+watch(
+  () => props.highlightedActionIds,
+  async (newHighlightedIds) => {
+    if (newHighlightedIds.size === 0) return;
+
+    // Wait for DOM to update
+    await nextTick();
+
+    // Find all highlighted actions and their positions
+    const highlightedActions = props.actionViewList.filter((action) =>
+      newHighlightedIds.has(action.id),
+    );
+
+    if (highlightedActions.length === 0) return;
+
+    if (highlightedActions.length === 1) {
+      // Single action: scroll to center it
+      const firstAction = highlightedActions[0];
+      if (firstAction) {
+        const actionCardRef = actionCardRefs.value.get(firstAction.id);
+        if (actionCardRef && actionCardRef.$el) {
+          actionCardRef.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+            inline: "nearest",
+          });
+        }
+      }
+    } else {
+      // Multiple actions: try to show all or scroll to the middle one
+      const firstAction = highlightedActions[0];
+      const lastAction = highlightedActions[highlightedActions.length - 1];
+
+      if (firstAction && lastAction) {
+        const firstActionRef = actionCardRefs.value.get(firstAction.id);
+        const lastActionRef = actionCardRefs.value.get(lastAction.id);
+
+        if (firstActionRef?.$el && lastActionRef?.$el) {
+          // Get the container element (scrollable parent)
+          const container = firstActionRef.$el.closest(".scrollable");
+          if (container) {
+            const firstRect = firstActionRef.$el.getBoundingClientRect();
+            const lastRect = lastActionRef.$el.getBoundingClientRect();
+            const containerRect = container.getBoundingClientRect();
+
+            const totalHeight = lastRect.bottom - firstRect.top;
+            const containerHeight = containerRect.height;
+
+            if (totalHeight <= containerHeight) {
+              // All actions can fit in view, scroll to show them all
+              const middleY = (firstRect.top + lastRect.bottom) / 2;
+              const containerMiddleY =
+                containerRect.top + containerRect.height / 2;
+              const scrollOffset = middleY - containerMiddleY;
+
+              container.scrollBy({
+                top: scrollOffset,
+                behavior: "smooth",
+              });
+            } else {
+              // Actions don't all fit, scroll to the middle action
+              const middleIndex = Math.floor(highlightedActions.length / 2);
+              const middleAction = highlightedActions[middleIndex];
+              if (middleAction) {
+                const middleActionRef = actionCardRefs.value.get(
+                  middleAction.id,
+                );
+                if (middleActionRef?.$el) {
+                  middleActionRef.$el.scrollIntoView({
+                    behavior: "smooth",
+                    block: "center",
+                    inline: "nearest",
+                  });
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  { deep: true, flush: "post" },
+);
 </script>

--- a/app/web/src/newhotness/explore_grid/ExploreGrid.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGrid.vue
@@ -35,6 +35,8 @@
         @childClicked="(e, c, idx) => $emit('childClicked', e, c, idx)"
         @childSelect="(idx) => $emit('childSelect', idx)"
         @childDeselect="(idx) => $emit('childDeselect', idx)"
+        @childHover="(componentId) => $emit('childHover', componentId)"
+        @childUnhover="(componentId) => $emit('childUnhover', componentId)"
         @clickCollapse="clickCollapse"
         @unpin="(componentId) => $emit('unpin', componentId)"
       />
@@ -373,6 +375,8 @@ defineEmits<{
   (e: "unpin", componentId: ComponentId): void;
   (e: "childSelect", componentIdx: number): void;
   (e: "childDeselect", componentIdx: number): void;
+  (e: "childHover", componentId: ComponentId): void;
+  (e: "childUnhover", componentId: ComponentId): void;
   (
     e: "childClicked",
     event: MouseEvent,

--- a/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
@@ -265,10 +265,10 @@ const hoveredId = ref<ComponentId | undefined>(undefined);
 const hover = (componentId: ComponentId, hovered: boolean) => {
   if (hovered) {
     hoveredId.value = componentId;
-    emit("childUnhover", componentId);
+    emit("childHover", componentId);
   } else {
     hoveredId.value = undefined;
-    emit("childHover", componentId);
+    emit("childUnhover", componentId);
   }
 };
 


### PR DESCRIPTION
This will introduce a new way that if rolling over the component, the ActionList will pan the associated failed action(s) into view

https://jam.dev/c/495ceb74-9589-4cd2-add0-c9a6735a4e2c