### PR TITLE
feat(web): Add a minimap to the map view!

### DIFF
--- a/app/web/src/newhotness/Map.vue
+++ b/app/web/src/newhotness/Map.vue
@@ -37,45 +37,69 @@
 
     <div
       id="controls"
-      class="absolute left-0 bottom-0 flex flex-row gap-xs m-sm items-center"
+      class="absolute left-0 bottom-0 flex flex-col gap-xs m-sm items-start"
     >
-      <div
-        v-tooltip="'Zoom Out'"
-        :class="getButtonClasses(zoomLevel >= MAX_ZOOM)"
-        @click="zoomOut"
-      >
-        <Icon name="minus" size="sm" />
-      </div>
-      <div
-        v-tooltip="'Current Zoom'"
-        :class="
-          clsx(
-            'border p-2xs rounded select-none',
-            themeClasses(
-              'text-black border-black bg-white',
-              'text-white border-white bg-black',
-            ),
-          )
-        "
-      >
-        {{ Math.round(zoomLevel * 100) }}%
-      </div>
-      <div
-        v-tooltip="'Zoom In'"
-        :class="getButtonClasses(zoomLevel >= MAX_ZOOM)"
-        @click="zoomIn"
-      >
-        <Icon name="plus" size="sm" />
-      </div>
-      <div v-tooltip="'Reset'" :class="getButtonClasses(false)" @click="reset">
-        <Icon name="empty-square" size="sm" />
-      </div>
-      <div
-        v-tooltip="'Help'"
-        :class="getButtonClasses(false)"
-        @click="emit('help')"
-      >
-        <Icon name="question-circle" size="sm" />
+      <!-- Minimap -->
+      <MiniMap
+        v-show="showMinimap"
+        :layoutData="dataAsGraph"
+        :worldBounds="worldBounds"
+        :viewportCoordinates="viewportCoordinates"
+        :currentScale="transformMatrix[0] ?? 1"
+        @pan="pan"
+      />
+
+      <!-- Control buttons -->
+      <div class="flex flex-row gap-xs items-center">
+        <div
+          v-tooltip="showMinimap ? 'Hide Minimap' : 'Show Minimap'"
+          :class="getButtonClasses(false)"
+          @click="toggleMinimap"
+        >
+          <Icon name="minimap" size="sm" />
+        </div>
+        <div
+          v-tooltip="'Zoom Out'"
+          :class="getButtonClasses(zoomLevel >= MAX_ZOOM)"
+          @click="zoomOut"
+        >
+          <Icon name="minus" size="sm" />
+        </div>
+        <div
+          v-tooltip="'Current Zoom'"
+          :class="
+            clsx(
+              'border p-2xs rounded select-none',
+              themeClasses(
+                'text-black border-black bg-white',
+                'text-white border-white bg-black',
+              ),
+            )
+          "
+        >
+          {{ Math.round(zoomLevel * 100) }}%
+        </div>
+        <div
+          v-tooltip="'Zoom In'"
+          :class="getButtonClasses(zoomLevel >= MAX_ZOOM)"
+          @click="zoomIn"
+        >
+          <Icon name="plus" size="sm" />
+        </div>
+        <div
+          v-tooltip="'Reset'"
+          :class="getButtonClasses(false)"
+          @click="reset"
+        >
+          <Icon name="empty-square" size="sm" />
+        </div>
+        <div
+          v-tooltip="'Help'"
+          :class="getButtonClasses(false)"
+          @click="emit('help')"
+        >
+          <Icon name="question-circle" size="sm" />
+        </div>
       </div>
     </div>
 
@@ -195,6 +219,7 @@ import {
   inject,
   nextTick,
   onMounted,
+  onUnmounted,
   reactive,
   Ref,
   ref,
@@ -226,6 +251,7 @@ import ConnectionsPanel from "./ConnectionsPanel.vue";
 import { getAssetIcon } from "./util";
 import ComponentContextMenu from "./ComponentContextMenu.vue";
 import { truncateString } from "./logic_composables/string_funcs";
+import MiniMap from "./MiniMap.vue";
 
 const MAX_STRING_LENGTH = 18;
 
@@ -246,6 +272,7 @@ const componentContextMenuRef =
   ref<InstanceType<typeof ComponentContextMenu>>();
 
 const selectedComponents = ref<Set<ComponentInList>>(new Set());
+const showMinimap = ref(true);
 
 // Get the primary selected component (first one in the set)
 const selectedComponent = computed<ComponentInList | null>(() => {
@@ -354,6 +381,128 @@ const pan = (dx: number, dy: number) => {
 
 const mouseDown = ref(false);
 
+// Reactive window dimensions for accurate viewport tracking
+const windowDimensions = ref({
+  width: window.innerWidth,
+  height: window.innerHeight,
+});
+
+// Update window dimensions reactively
+const updateWindowDimensions = () => {
+  windowDimensions.value = {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+};
+
+// Calculate world bounds for minimap coordinate system
+const worldBounds = computed(() => {
+  if (!dataAsGraph.value?.children || dataAsGraph.value.children.length === 0) {
+    return {
+      minX: -500,
+      minY: -500,
+      maxX: 500,
+      maxY: 500,
+      width: 1000,
+      height: 1000,
+    };
+  }
+
+  // Calculate bounding box of all nodes
+  let nodeMinX = Infinity;
+  let nodeMinY = Infinity;
+  let nodeMaxX = -Infinity;
+  let nodeMaxY = -Infinity;
+
+  dataAsGraph.value.children.forEach((node: layoutNode) => {
+    nodeMinX = Math.min(nodeMinX, node.x);
+    nodeMinY = Math.min(nodeMinY, node.y);
+    nodeMaxX = Math.max(nodeMaxX, node.x + node.width);
+    nodeMaxY = Math.max(nodeMaxY, node.y + node.height);
+  });
+
+  // Calculate current viewport area
+  const currentScale = transformMatrix[0] ?? 1;
+  const translateX = transformMatrix[4] ?? 0;
+  const translateY = transformMatrix[5] ?? 0;
+  const actualWidth = windowDimensions.value.width;
+  const actualHeight = windowDimensions.value.height;
+
+  const viewportWidth = actualWidth / currentScale;
+  const viewportHeight = actualHeight / currentScale;
+  const viewportX = -translateX / currentScale;
+  const viewportY = -translateY / currentScale;
+
+  // Strategy: minimap should always show all nodes prominently for navigation
+  // The world bounds should be large enough to include both nodes and viewport,
+  // but sized so that nodes remain visible and useful
+
+  // Calculate how much larger the viewport is compared to the node area
+  const nodeWidth = nodeMaxX - nodeMinX;
+  const nodeHeight = nodeMaxY - nodeMinY;
+
+  // Always include the viewport area
+  let finalMinX = Math.min(nodeMinX, viewportX);
+  let finalMinY = Math.min(nodeMinY, viewportY);
+  let finalMaxX = Math.max(nodeMaxX, viewportX + viewportWidth);
+  let finalMaxY = Math.max(nodeMaxY, viewportY + viewportHeight);
+
+  // If the total area is much larger than the node area, constrain it so nodes stay visible
+  const totalWidth = finalMaxX - finalMinX;
+  const totalHeight = finalMaxY - finalMinY;
+  const maxReasonableExpansion = 4; // Don't let the world be more than 4x the node size
+
+  if (totalWidth > nodeWidth * maxReasonableExpansion) {
+    const maxWidth = nodeWidth * maxReasonableExpansion;
+    const centerX = (finalMinX + finalMaxX) / 2;
+    finalMinX = centerX - maxWidth / 2;
+    finalMaxX = centerX + maxWidth / 2;
+  }
+
+  if (totalHeight > nodeHeight * maxReasonableExpansion) {
+    const maxHeight = nodeHeight * maxReasonableExpansion;
+    const centerY = (finalMinY + finalMaxY) / 2;
+    finalMinY = centerY - maxHeight / 2;
+    finalMaxY = centerY + maxHeight / 2;
+  }
+
+  // Add small padding for clean edges
+  const padding = 20;
+
+  return {
+    minX: finalMinX - padding,
+    minY: finalMinY - padding,
+    maxX: finalMaxX + padding,
+    maxY: finalMaxY + padding,
+    width: finalMaxX - finalMinX + padding * 2,
+    height: finalMaxY - finalMinY + padding * 2,
+  };
+});
+
+// Calculate viewport coordinates for minimap
+const viewportCoordinates = computed(() => {
+  const scale = transformMatrix[0] ?? 1;
+  const translateX = transformMatrix[4] ?? 0;
+  const translateY = transformMatrix[5] ?? 0;
+
+  // Use actual window dimensions for accurate viewport representation
+  const actualWidth = windowDimensions.value.width;
+  const actualHeight = windowDimensions.value.height;
+
+  // Calculate the viewport area in the main coordinate space
+  const viewportWidth = actualWidth / scale;
+  const viewportHeight = actualHeight / scale;
+  const viewportX = -translateX / scale;
+  const viewportY = -translateY / scale;
+
+  return {
+    x: viewportX,
+    y: viewportY,
+    width: viewportWidth,
+    height: viewportHeight,
+  };
+});
+
 const zoomIn = () => {
   zoomLevel.value += scaleStep;
   applyZoom();
@@ -382,6 +531,10 @@ const wheel = (event: WheelEvent) => {
 const reset = () => {
   zoomLevel.value = 1;
   transformMatrix.splice(0, 6, 1, 0, 0, 1, 0, 0);
+};
+
+const toggleMinimap = () => {
+  showMinimap.value = !showMinimap.value;
 };
 
 const clickWithNoDrag = ref(false);
@@ -468,6 +621,13 @@ onMounted(() => {
   // if we need to adjust zoom level on load dynamically
   // change it here
   applyZoom();
+
+  // Set up window resize listener for reactive dimensions
+  window.addEventListener("resize", updateWindowDimensions);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("resize", updateWindowDimensions);
 });
 
 const mousemove = (event: MouseEvent) => {
@@ -596,7 +756,7 @@ const mapData = computed(() => {
   return { nodes, edges, components };
 });
 
-type node = {
+export type node = {
   id: string;
   width: number;
   height: number;
@@ -604,22 +764,22 @@ type node = {
   icons: [string | null];
 };
 
-type xy = {
+export type xy = {
   x: number;
   y: number;
 };
 
-type h = {
+export type h = {
   $H: number;
 };
 
-type edge = {
+export type edge = {
   id: string;
   sources: string[];
   targets: string[];
 };
 
-type line = {
+export type line = {
   sections: {
     id: string;
     startPoint: xy;
@@ -631,10 +791,17 @@ type line = {
   container: string;
 };
 
-type layoutNode = node & xy & h;
-type layoutLine = line & edge;
+export type layoutNode = node & xy & h;
+export type layoutLine = line & edge;
 
-const dataAsGraph = ref<unknown>();
+// Type for ELK layout result - simplified to match actual usage
+export type GraphData = {
+  children: layoutNode[];
+  edges: unknown[]; // ELK transforms edges in complex ways
+  [key: string]: unknown; // Allow other ELK properties
+};
+
+const dataAsGraph = ref<GraphData | null>(null);
 
 const WIDTH = 250;
 const HEIGHT = 75;
@@ -990,7 +1157,9 @@ watch(
     };
     const elk = new ELK();
     const layoutedData = await elk.layout(graph);
-    dataAsGraph.value = layoutedData;
+    // typescript gods help me
+    dataAsGraph.value = layoutedData as unknown as GraphData;
+
     nextTick(() => {
       const svg = d3.select("#map > svg g");
       // the viewbox should be based on "how much of the coordinate space is in use"

--- a/app/web/src/newhotness/MiniMap.vue
+++ b/app/web/src/newhotness/MiniMap.vue
@@ -1,0 +1,487 @@
+<template>
+  <div
+    id="minimap"
+    class="w-48 h-32 border-2 rounded mb-xs"
+    :class="
+      themeClasses(
+        'bg-white/90 border-neutral-300',
+        'bg-black/90 border-neutral-600',
+      )
+    "
+  >
+    <svg
+      ref="minimapSvgRef"
+      class="w-full h-full"
+      :viewBox="`0 0 ${MINIMAP_WIDTH} ${MINIMAP_HEIGHT}`"
+      preserveAspectRatio="xMidYMid meet"
+      @click="onMinimapClick"
+      @mousedown="onMinimapMouseDown"
+      @mousemove="onViewportMouseMove"
+      @mouseup="onViewportMouseUp"
+    >
+      <g
+        ref="minimapContentRef"
+        :transform="`translate(${minimapTransform.translateX}, ${minimapTransform.translateY}) scale(${minimapTransform.scale})`"
+      ></g>
+
+      <!-- Viewport indicator - outline box for dragging -->
+      <rect
+        ref="viewportIndicatorRef"
+        :x="viewportBounds?.x ?? 0"
+        :y="viewportBounds?.y ?? 0"
+        :width="viewportBounds?.width ?? 100"
+        :height="viewportBounds?.height ?? 100"
+        fill="transparent"
+        :stroke="themeClasses('#000000', '#ffffff')"
+        stroke-width="1"
+        class="viewport-indicator"
+        style="cursor: move"
+        @mousedown="onViewportMouseDown"
+        @click="preventClick"
+      />
+    </svg>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, onUnmounted, ref, watch } from "vue";
+import * as d3 from "d3";
+import { themeClasses } from "@si/vue-lib/design-system";
+import type { layoutNode, GraphData } from "./Map.vue";
+
+type ClusterType = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  count: number;
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+};
+
+// Props
+const props = defineProps<{
+  layoutData?: GraphData | null;
+  worldBounds: {
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+    width: number;
+    height: number;
+  };
+  viewportCoordinates: { x: number; y: number; width: number; height: number };
+  currentScale: number;
+}>();
+
+// Emits
+const emit = defineEmits<{
+  pan: [dx: number, dy: number];
+}>();
+
+// Refs
+const minimapSvgRef = ref<SVGSVGElement>();
+const minimapContentRef = ref<SVGGElement>();
+const viewportIndicatorRef = ref<SVGRectElement>();
+
+// Reactive data - fixed minimap coordinate system
+const MINIMAP_WIDTH = 192;
+const MINIMAP_HEIGHT = 128;
+
+// Calculate transform to fit world bounds in minimap
+const minimapTransform = computed(() => {
+  const scaleX = MINIMAP_WIDTH / props.worldBounds.width;
+  const scaleY = MINIMAP_HEIGHT / props.worldBounds.height;
+  const scale = Math.min(scaleX, scaleY) * 0.95; // Leave some padding
+
+  // The key insight: viewport center should map to minimap center
+  const viewportCenterX =
+    props.viewportCoordinates.x + props.viewportCoordinates.width / 2;
+  const viewportCenterY =
+    props.viewportCoordinates.y + props.viewportCoordinates.height / 2;
+
+  const minimapCenterX = MINIMAP_WIDTH / 2;
+  const minimapCenterY = MINIMAP_HEIGHT / 2;
+
+  // Calculate translation so that viewport center maps to minimap center
+  const translateX = minimapCenterX - viewportCenterX * scale;
+  const translateY = minimapCenterY - viewportCenterY * scale;
+
+  return {
+    scale,
+    translateX,
+    translateY,
+  };
+});
+
+// Drag state - following Map.vue pattern
+const isDragging = ref(false);
+const hasDraggedBeyondThreshold = ref(false);
+const lastPos = ref<{ x: number; y: number } | null>(null);
+const clickWithNoDrag = ref(false);
+
+// Constants
+const MAX_MINIMAP_NODES = 200;
+
+// Computed properties
+const viewportBounds = computed(() => {
+  const transform = minimapTransform.value;
+
+  // Check if viewport coordinates match world bounds (viewing entire world)
+  const tolerance = 1; // Small tolerance for floating point comparison
+  const viewportMatchesWorld =
+    Math.abs(props.viewportCoordinates.x - props.worldBounds.minX) <
+      tolerance &&
+    Math.abs(props.viewportCoordinates.y - props.worldBounds.minY) <
+      tolerance &&
+    Math.abs(props.viewportCoordinates.width - props.worldBounds.width) <
+      tolerance &&
+    Math.abs(props.viewportCoordinates.height - props.worldBounds.height) <
+      tolerance;
+
+  if (viewportMatchesWorld) {
+    // When viewing the entire world, viewport indicator should cover entire minimap
+    return {
+      x: 0,
+      y: 0,
+      width: MINIMAP_WIDTH,
+      height: MINIMAP_HEIGHT,
+    };
+  }
+
+  // Convert viewport coordinates to minimap coordinate space using transform
+  const minimapX =
+    props.viewportCoordinates.x * transform.scale + transform.translateX;
+  const minimapY =
+    props.viewportCoordinates.y * transform.scale + transform.translateY;
+  const minimapWidth = props.viewportCoordinates.width * transform.scale;
+  const minimapHeight = props.viewportCoordinates.height * transform.scale;
+
+  return {
+    x: minimapX,
+    y: minimapY,
+    width: minimapWidth,
+    height: minimapHeight,
+  };
+});
+
+// Core rendering functions
+const renderMinimap = () => {
+  if (!minimapContentRef.value || !props.layoutData) return;
+
+  const minimapSvg = d3.select(minimapContentRef.value);
+  minimapSvg.selectAll("*").remove();
+
+  const children = props.layoutData.children;
+  if (!children || children.length === 0) return;
+
+  const shouldSimplifyRender = children.length > MAX_MINIMAP_NODES;
+
+  if (shouldSimplifyRender) {
+    renderSimplifiedMinimap(minimapSvg, children);
+  } else {
+    renderDetailedMinimap(minimapSvg, children);
+  }
+};
+
+const renderSimplifiedMinimap = (
+  minimapSvg: d3.Selection<SVGGElement, unknown, null, undefined>,
+  children: layoutNode[],
+) => {
+  // Calculate adaptive cluster size to achieve exactly 200 elements
+  const contentArea = props.worldBounds.width * props.worldBounds.height;
+  const targetClusterArea = contentArea / MAX_MINIMAP_NODES;
+  const adaptiveClusterSize = Math.sqrt(targetClusterArea);
+
+  const clusters = new Map<string, ClusterType>();
+
+  children.forEach((node) => {
+    const clusterX =
+      Math.floor(node.x / adaptiveClusterSize) * adaptiveClusterSize;
+    const clusterY =
+      Math.floor(node.y / adaptiveClusterSize) * adaptiveClusterSize;
+    const key = `${clusterX}-${clusterY}`;
+
+    if (!clusters.has(key)) {
+      clusters.set(key, {
+        x: clusterX,
+        y: clusterY,
+        width: adaptiveClusterSize,
+        height: adaptiveClusterSize,
+        count: 0,
+        minX: node.x,
+        minY: node.y,
+        maxX: node.x + node.width,
+        maxY: node.y + node.height,
+      });
+    }
+
+    const cluster = clusters.get(key);
+    if (!cluster) return;
+    cluster.count++;
+    // Update cluster bounds to fit actual content
+    cluster.minX = Math.min(cluster.minX, node.x);
+    cluster.minY = Math.min(cluster.minY, node.y);
+    cluster.maxX = Math.max(cluster.maxX, node.x + node.width);
+    cluster.maxY = Math.max(cluster.maxY, node.y + node.height);
+  });
+
+  // Render all clusters to get as close to 200 elements as possible
+  const clustersToRender = Array.from(clusters.values());
+  renderClusters(minimapSvg, clustersToRender);
+};
+
+const renderIndividualNodes = (
+  minimapSvg: d3.Selection<SVGGElement, unknown, null, undefined>,
+  children: layoutNode[],
+) => {
+  minimapSvg
+    .selectAll(".minimap-node")
+    .data(children)
+    .enter()
+    .append("rect")
+    .attr("class", "minimap-node")
+    .attr("x", (d: layoutNode) => d.x)
+    .attr("y", (d: layoutNode) => d.y)
+    .attr("width", (d: layoutNode) => Math.max(d.width, 2))
+    .attr("height", (d: layoutNode) => Math.max(d.height, 2))
+    .style("fill", () => {
+      const isDark = document.body.classList.contains("dark");
+      return isDark ? "#4b5563" : "#6b7280";
+    })
+    .style("stroke", "none")
+    .style("opacity", "0.8");
+};
+
+const renderClusters = (
+  minimapSvg: d3.Selection<SVGGElement, unknown, null, undefined>,
+  clusters: ClusterType[],
+) => {
+  const maxCount = Math.max(...clusters.map((c) => c.count));
+
+  minimapSvg
+    .selectAll(".minimap-cluster")
+    .data(clusters)
+    .enter()
+    .append("rect")
+    .attr("class", "minimap-cluster")
+    .attr("x", (d) => d.minX)
+    .attr("y", (d) => d.minY)
+    .attr("width", (d) => Math.max(d.maxX - d.minX, 3))
+    .attr("height", (d) => Math.max(d.maxY - d.minY, 3))
+    .style("fill", (d) => {
+      const isDark = document.body.classList.contains("dark");
+      const opacity = Math.min(0.9, 0.4 + (d.count / maxCount) * 0.5);
+      return isDark
+        ? `rgba(75, 85, 99, ${opacity})`
+        : `rgba(107, 114, 128, ${opacity})`;
+    })
+    .style("stroke", "none");
+};
+
+const renderDetailedMinimap = (
+  minimapSvg: d3.Selection<SVGGElement, unknown, null, undefined>,
+  children: layoutNode[],
+) => {
+  renderIndividualNodes(minimapSvg, children);
+};
+
+// Event handlers
+const onMinimapMouseDown = (event: MouseEvent) => {
+  // Set up click state for potential click (not drag)
+  clickWithNoDrag.value = true;
+
+  // If clicking on viewport indicator, don't handle as general minimap click
+  const target = event.target as SVGElement;
+  if (
+    target?.classList.contains("viewport-indicator") ||
+    target === viewportIndicatorRef.value
+  ) {
+    return;
+  }
+};
+
+const onViewportMouseDown = (event: MouseEvent) => {
+  event.preventDefault();
+  event.stopPropagation();
+
+  isDragging.value = true;
+  hasDraggedBeyondThreshold.value = false;
+  clickWithNoDrag.value = true;
+  lastPos.value = { x: event.clientX, y: event.clientY };
+
+  document.body.style.userSelect = "none";
+};
+
+const onViewportMouseMove = (event: MouseEvent) => {
+  // If we're dragging the viewport, handle that
+  if (isDragging.value && lastPos.value) {
+    clickWithNoDrag.value = false;
+
+    // Calculate movement delta like Map.vue does
+    const current = { x: event.clientX, y: event.clientY };
+    const diff = {
+      x: current.x - lastPos.value.x,
+      y: current.y - lastPos.value.y,
+    };
+    lastPos.value = current;
+
+    // Check if we've moved beyond the drag threshold
+    if (Math.abs(diff.x) > 1 || Math.abs(diff.y) > 1) {
+      hasDraggedBeyondThreshold.value = true;
+    }
+
+    const rect = minimapSvgRef.value?.getBoundingClientRect();
+    if (!rect) return;
+
+    const transform = minimapTransform.value;
+
+    // Calculate movement scale based on minimap dimensions and transform
+    const moveScaleX = MINIMAP_WIDTH / rect.width;
+    const moveScaleY = MINIMAP_HEIGHT / rect.height;
+
+    // Calculate movement in minimap SVG coordinates
+    const deltaX = diff.x * moveScaleX;
+    const deltaY = diff.y * moveScaleY;
+
+    // Convert movement to world coordinates
+    const worldDeltaX = deltaX / transform.scale;
+    const worldDeltaY = deltaY / transform.scale;
+
+    // Convert to map coordinate space delta (negative because we're moving viewport in opposite direction)
+    const mapDx = -worldDeltaX * props.currentScale;
+    const mapDy = -worldDeltaY * props.currentScale;
+
+    emit("pan", mapDx, mapDy);
+  }
+};
+
+const onViewportMouseUp = () => {
+  isDragging.value = false;
+  document.body.style.userSelect = "";
+  lastPos.value = null;
+
+  // Reset drag threshold after a short delay
+  setTimeout(() => {
+    hasDraggedBeyondThreshold.value = false;
+  }, 10);
+};
+
+const preventClick = (event: MouseEvent) => {
+  // Only prevent click if we actually dragged beyond threshold
+  if (hasDraggedBeyondThreshold.value) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+};
+
+const onMinimapClick = (event: MouseEvent) => {
+  if (!clickWithNoDrag.value) return;
+
+  const target = event.target as SVGElement;
+  if (
+    target?.classList.contains("viewport-indicator") ||
+    target === viewportIndicatorRef.value
+  ) {
+    return;
+  }
+
+  const rect = minimapSvgRef.value?.getBoundingClientRect();
+  if (!rect) return;
+
+  const clickX = event.clientX - rect.left;
+  const clickY = event.clientY - rect.top;
+  const minimapSvgX = (clickX / rect.width) * MINIMAP_WIDTH;
+  const minimapSvgY = (clickY / rect.height) * MINIMAP_HEIGHT;
+
+  const transform = minimapTransform.value;
+
+  // Convert minimap coordinates to world coordinates
+  const worldX = (minimapSvgX - transform.translateX) / transform.scale;
+  const worldY = (minimapSvgY - transform.translateY) / transform.scale;
+
+  // Calculate where the viewport center should be to center the clicked point
+  const targetViewportCenterX = worldX;
+  const targetViewportCenterY = worldY;
+
+  // Calculate the delta from current viewport center to target center
+  const currentViewportCenterX =
+    props.viewportCoordinates.x + props.viewportCoordinates.width / 2;
+  const currentViewportCenterY =
+    props.viewportCoordinates.y + props.viewportCoordinates.height / 2;
+
+  const layoutDx = targetViewportCenterX - currentViewportCenterX;
+  const layoutDy = targetViewportCenterY - currentViewportCenterY;
+
+  // Convert to map coordinate space delta (negative because we're moving viewport in opposite direction)
+  const mapDx = -layoutDx * props.currentScale;
+  const mapDy = -layoutDy * props.currentScale;
+
+  emit("pan", mapDx, mapDy);
+};
+
+// Watchers
+watch(
+  () => props.layoutData,
+  () => {
+    renderMinimap();
+  },
+  { immediate: true, deep: true },
+);
+
+// Cleanup on unmount
+onUnmounted(() => {
+  // Clean up any remaining styles
+  document.body.style.userSelect = "";
+});
+
+// Expose methods for parent component
+defineExpose({
+  renderMinimap,
+});
+</script>
+
+<style lang="less" scoped>
+#minimap {
+  backdrop-filter: blur(8px);
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  svg {
+    border-radius: 4px;
+    cursor: pointer;
+
+    .minimap-node {
+      transition: opacity 0.2s ease;
+
+      &:hover {
+        opacity: 1 !important;
+      }
+    }
+
+    .minimap-edge {
+      opacity: 0.6;
+    }
+
+    .viewport-indicator {
+      cursor: move;
+      transition: all 0.2s ease;
+
+      &:hover {
+        stroke-width: 2;
+        opacity: 0.9;
+      }
+
+      &:active {
+        stroke-width: 2;
+        opacity: 1;
+      }
+    }
+  }
+}
+</style>

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -120,6 +120,7 @@ import MdiCursorDefaultClickOutline from "~icons/mdi/cursor-default-click-outlin
 import MaterialSymbolsShiftLockOutline from "~icons/material-symbols/shift-lock-outline";
 import MaterialSymbolsAddLink from "~icons/material-symbols/add-link";
 import MaterialSymbolsLink from "~icons/material-symbols/link";
+import Map from "~icons/heroicons/map";
 
 import TdesignLinkUnlink from "~icons/tdesign/link-unlink";
 import PhTestTubeFill from "~icons/ph/test-tube-fill";
@@ -329,6 +330,7 @@ export const ICONS = Object.freeze({
   "logs-pop-square": LogsPopSquare,
   map: CarbonFlowConnection,
   menu: Menu,
+  minimap: Map,
   minus: Minus,
   "minus-circle": MinusCircle,
   "minus-hex": MinusHex,


### PR DESCRIPTION


<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?
When you've got more than a few tens of components, it can be easy when zoomed in to get lost in the sea of components. This adds a minimap feature to the bottom left of the map view! 

Couple neat things attempted: 
1. When zooming/panning around, ensure that the minimap always contains some portion of the nodes so even if you're zoomed into a blank area, you can easily find where everything is again
2. You can click on the minimap to pan directly to that area of the map
3. You can drag the viewbox on the minimap to pan that way (there's something laggy here that's driving me nuts, but you know, initial spike)
4. When there are more than 200 components on the map, render clusters that represent a group of components, to reduce the amount of dom elements and try and keep responsiveness high
5. Be able to hide/show the minimap with an icon alongside the zoom controls
<!-- Why: briefly what problem this solves and what the aim is as an overview -->

#### Screenshots:

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->
<img width="1918" height="968" alt="image" src="https://github.com/user-attachments/assets/76300700-63f6-4484-a1b4-971da21408fe" />
<img width="1918" height="969" alt="image" src="https://github.com/user-attachments/assets/03e2d68b-f09e-4a6d-bf5d-caba36e1b31f" />
<img width="1916" height="907" alt="image" src="https://github.com/user-attachments/assets/fc511897-fa03-4b8d-bb37-bc80bdefaba7" />

#### Out of Scope:

<!-- Anything this PR explicitly leaves out? -->
Perfection 😄 
Sometimes panning by dragging the viewbox gets a little behind the mouse move for some reason, and I suspect there are other linear algebra improvements to be made to handling pan/zoom better.  

## How was it tested?

Lots of manual testing. Screenshots include a component with 906 components in the map as well as 50 to show both the detailed minimap and the clustered minimap. 

<div><img src="https://media3.giphy.com/media/llmrnMkLqcssM6sYG7/200.gif?cid=5a38a5a2uvr3wu8bcrmj8a821eem5fxubab744lo33snyri3&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:171px;width:300px"/><br/>via <a href="https://giphy.com/nickelodeon/">Nickelodeon</a> on <a href="https://giphy.com/gifs/nickelodeon-nick-cfl-cousins-for-life-llmrnMkLqcssM6sYG7">GIPHY</a></div>
