### PR TITLE
feat(web) - better add component modal newhotness

### DIFF
--- a/app/web/src/newhotness/MarkdownRender.vue
+++ b/app/web/src/newhotness/MarkdownRender.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="prose dark:prose-invert">
+  <div ref="divRef" class="prose dark:prose-invert">
     <VueMarkdown
       :source="props.source"
       :options="{ breaks: true, linkify: true, typographer: true }"
@@ -8,7 +8,39 @@
 </template>
 
 <script setup lang="ts">
+import { tw } from "@si/vue-lib";
+import { themeClasses } from "@si/vue-lib/design-system";
+import { onMounted, ref } from "vue";
 import VueMarkdown from "vue-markdown-render";
 
-const props = defineProps<{ source: string }>();
+const props = defineProps<{ source: string; removeMargins?: boolean }>();
+
+const divRef = ref<HTMLDivElement>();
+
+onMounted(() => {
+  if (divRef.value && divRef.value.children[0]) {
+    const root = divRef.value;
+
+    const walkChildren = (el: Element) => {
+      // Use this to add styles to particular elements in the Markdown
+      if (el instanceof HTMLAnchorElement) {
+        el.target = "_blank";
+        el.classList.add(
+          themeClasses(tw`text-action-500`, tw`text-action-300`),
+          tw`no-underline`,
+          tw`hover:underline`,
+          tw`font-bold`,
+        );
+      }
+
+      if (props.removeMargins) {
+        el.classList.add(tw`m-0`);
+      }
+
+      Array.from(el.children).forEach((child) => walkChildren(child));
+    };
+
+    walkChildren(root);
+  }
+});
 </script>

--- a/app/web/src/newhotness/layout_components/FilterTile.vue
+++ b/app/web/src/newhotness/layout_components/FilterTile.vue
@@ -6,8 +6,8 @@
         'flex flex-row gap-xs items-center',
         'p-2xs max-w-24 h-10 text-sm border cursor-pointer',
         themeClasses(
-          'border-neutral-400 hover:border-action-500',
-          'border-neutral-600 hover:border-action-300',
+          'border-neutral-400 hover:border-action-500 active:bg-action-500',
+          'border-neutral-600 hover:border-action-300 active:bg-action-300',
         ),
         selected
           ? themeClasses('bg-action-100', 'bg-action-800')
@@ -23,9 +23,12 @@
     <Icon v-if="icon" :name="icon" class="flex-none" />
     <TruncateWithTooltip
       :class="
-        themeClasses(
-          'group-hover:text-action-500',
-          'group-hover:text-action-300',
+        clsx(
+          'group-active:text-shade-0',
+          themeClasses(
+            'group-hover:text-action-500',
+            'group-hover:text-action-300',
+          ),
         )
       "
     >

--- a/app/web/src/newhotness/logic_composables/fzf.ts
+++ b/app/web/src/newhotness/logic_composables/fzf.ts
@@ -1,0 +1,10 @@
+import { extendedMatch, Fzf } from "fzf";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const useFzf = (list: any, selector: (item: any) => string) => {
+  return new Fzf(list, {
+    casing: "case-insensitive",
+    match: extendedMatch,
+    selector,
+  });
+};

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -156,8 +156,9 @@ import DockerLogo from "~icons/mdi/docker";
 import KubernetesLogo from "~icons/carbon/kubernetes";
 import CarbonLightning from "~icons/carbon/lightning";
 import DiscordLogo from "~icons/carbon/logo-discord";
-import GithubLogo from "~icons/carbon/logo-github";
+import GitHubLogo from "~icons/carbon/logo-github";
 import VimLogo from "~icons/raphael/vim";
+import FastlyLogo from "~icons/simple-icons/fastly";
 
 // carbon
 import Create from "~icons/carbon/intent-request-create";
@@ -418,9 +419,10 @@ export const LOGO_ICONS = Object.freeze({
   "logo-docker": DockerLogo,
   "logo-k8s": KubernetesLogo,
   "logo-si": SiLogo,
+  "logo-fastly": FastlyLogo,
   // others - not used in providers currently
   "logo-discord": DiscordLogo,
-  "logo-github": GithubLogo,
+  "logo-github": GitHubLogo,
   "logo-vim": VimLogo,
 });
 

--- a/lib/vue-lib/src/design-system/utils/color_utils.ts
+++ b/lib/vue-lib/src/design-system/utils/color_utils.ts
@@ -6,19 +6,20 @@ import { useTheme } from "./theme_tools";
 export const COLOR_PALETTE = colorsJson;
 
 export const BRAND_COLOR_FILTER_HEX_CODES = {
-  AWS: "#FF9900",
-  Docker: "#1D63ED",
-  Azure: "#104581",
-  "Google Cloud": "#EF6255",
-  Github: "#9467EC",
-  Netlify: "#05BDBA",
   "Digital Ocean": "#ABF7FF",
-  Posthog: "#F54E00",
-  CoreOS: "#E9659C",
+  "Google Cloud": "#EF6255",
   "Open AI": "#FFBE19",
-  Tailscale: "#A7DAC2",
-  Helpers: "#E1A7FE",
+  AWS: "#FF9900",
+  Azure: "#104581",
+  CoreOS: "#E9659C",
   Custom: "#E5E5E5",
+  Docker: "#1D63ED",
+  Fastly: "#FE272D",
+  GitHub: "#9467EC",
+  Helpers: "#E1A7FE",
+  Netlify: "#05BDBA",
+  Posthog: "#F54E00",
+  Tailscale: "#A7DAC2",
 };
 
 const TONES = {


### PR DESCRIPTION
## How does this PR change the system?

Many small improvements to the add component modal, including -

- Improved fuzzy search!
- It starts with "All" selected and the component categories collapsed
- Reduced the amount of filters to just the useful ones, will add more later
- Better controls, including tab and shift + tab, shift + up or down to jump between categories, and left or right to switch filters
- Cleaner automatic scrolling
- Improved documentation panel with better styles and formatting
- Empty states
- It doesn't randomly change size anymore

#### Screenshots:

<img width="1289" height="450" alt="Screenshot 2025-07-10 at 7 24 27 PM" src="https://github.com/user-attachments/assets/ecdada67-9aa5-452d-b809-026a209f7d55" />

#### Out of Scope:

We will definitely want to virtualize the component list eventually, the small amount of lag sometimes experienced in the panel is 100% due to the large amount of DOM elements and will only get worse with more components.

The improved fuzzy search should be ported to replace fuzzy searching elsewhere in the newhotness UI.

Currently we have the SI logo as the icon for a few categories (All, Templates) and will probably want to come up with specific icons for each of those.

We will definitely be adjusting and adding to the filters list. Might be good to have one called "Other" that has everything not in any other category (ignoring All of course!)

## How was it tested?

Oodles of manual testing!