### PR TITLE
fix(dal): When resetting an attribute value to a default prototype, first clear the existing value

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -1819,6 +1819,7 @@ impl AttributeValue {
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
     ) -> AttributeValueResult<()> {
+        AttributeValue::update(ctx, attribute_value_id, None).await?;
         let prototype_id = AttributeValue::component_prototype_id(ctx, attribute_value_id)
             .await?
             .ok_or(AttributeValueError::NoComponentPrototype(

--- a/lib/dal/tests/integration_test/property_editor.rs
+++ b/lib/dal/tests/integration_test/property_editor.rs
@@ -381,6 +381,8 @@ async fn override_value_then_reset(ctx: &mut DalContext) {
     AttributeValue::use_default_prototype(ctx, av_id)
         .await
         .expect("revert back to default prototype");
+    let current_value = AttributeValue::view_by_id(ctx, av_id).await.expect("couldn't get av view");
+    assert_eq!(current_value, None);
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update snapshot to visibility");
@@ -482,6 +484,8 @@ async fn override_array_then_reset(ctx: &mut DalContext) {
     AttributeValue::use_default_prototype(ctx, av_id)
         .await
         .expect("revert back to default prototype");
+    let current_value = AttributeValue::view_by_id(ctx, av_id).await.expect("couldn't get av view");
+    assert_eq!(current_value, None);
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
         .await
         .expect("could not commit and update snapshot to visibility");


### PR DESCRIPTION


<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?
Whenever an attribute value is set by a subscription, or has any other component specific prototype, upon resetting to the schema variant defined (default) prototype, if the default prototype is a dynamic function, we enqueue it in DVU for it to get updated.  However this means that value is temporarily stale until DVU completes, leading to an unexpected user experience.

So we go from: 
1. Value Set By Subscription and value is "vpc-12345"
2. Subscription is removed but value is still "vpc-12345"
3. DVU Runs and finishes, value is removed (or updated depending on the variant)

To: 
1. Value Set by Subscription and value is "vpc-12345"
2. No subscription, value = unset 
3. DVU Runs and finishes, no change if it stays empty, or is updated.
<!-- Why: briefly what problem this solves and what the aim is as an overview -->

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

Extended existing integration tests to ensure we don't break expected functionality while capturing this new intermediate state

<div><img src="https://media3.giphy.com/media/HIFhP9cM6z8lJtoS3I/200.gif?cid=5a38a5a2nz32pu616jyekkl8a4fk4in1vrm5om9hrt7hw2i2&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:168px;width:300px"/><br/>via <a href="https://giphy.com/parksandrec/">Parks and Recreation</a> on <a href="https://giphy.com/gifs/parksandrec-parks-and-recreation-rec-HIFhP9cM6z8lJtoS3I">GIPHY</a></div>
