### PR TITLE
feat(web): gracefully handle the deployment of a new shared webworker

### DIFF
--- a/app/web/src/components/CachedAppNotification.vue
+++ b/app/web/src/components/CachedAppNotification.vue
@@ -13,10 +13,13 @@
 </template>
 
 <script setup lang="ts">
-import { Modal, RichText, Stack, VButton } from "@si/vue-lib/design-system";
-
 import axios from "axios";
 import { onBeforeUnmount, onMounted, ref } from "vue";
+import { Modal, RichText, Stack, VButton } from "@si/vue-lib/design-system";
+import {
+  cachedAppEmitter,
+  SHOW_CACHED_APP_NOTIFICATION_EVENT,
+} from "@/store/realtime/cached_app_emitter";
 
 // const APP_FILENAME_REGEX = /\/?assets\/index-([0-9a-z]+).js/;
 const getFilenameFromPath = (path: string) => path.split("/").pop();
@@ -24,6 +27,10 @@ const getFilenameFromPath = (path: string) => path.split("/").pop();
 const runningHash = getRunningHash();
 
 const modalRef = ref();
+
+cachedAppEmitter.on(SHOW_CACHED_APP_NOTIFICATION_EVENT, () => {
+  modalRef.value?.open();
+});
 
 async function check() {
   const manifestUrl = `${

--- a/app/web/src/store/realtime/cached_app_emitter.ts
+++ b/app/web/src/store/realtime/cached_app_emitter.ts
@@ -1,0 +1,5 @@
+import mitt from "mitt";
+
+export const SHOW_CACHED_APP_NOTIFICATION_EVENT = "showCachedAppNotification";
+
+export const cachedAppEmitter = mitt();

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -114,10 +114,15 @@ export type Gettable = Exclude<EntityKind, Listable>;
 export interface SharedDBInterface {
   initDB: (testing: boolean) => Promise<void>;
   migrate: (testing: boolean) => Promise<Database>;
-  setBearer: (workspaceId: string, token: string) => void;
+  setBearer: (workspaceId: string, token: string) => Promise<void>;
+  getBearers(): Promise<{ [key: string]: string }>;
+  addBearers(bearers: { [key: string]: string }): Promise<void>;
   initSocket(workspaceId: string): Promise<void>;
   unregisterRemote(id: string): void;
-  registerRemote(id: string, remote: Comlink.Remote<TabDBInterface>): void;
+  registerRemote(
+    id: string,
+    remote: Comlink.Remote<TabDBInterface>,
+  ): Promise<void>;
   broadcastMessage(message: BroadcastMessage): Promise<void>;
   setRemote(remoteId: string): Promise<void>;
   hasRemote(): Promise<boolean>;
@@ -214,6 +219,7 @@ export interface SharedDBInterface {
 
 export interface TabDBInterface {
   initDB: (testing: boolean) => Promise<void>;
+  hasDbLock(): Promise<boolean>;
   migrate: (testing: boolean) => Database;
   setBearer: (workspaceId: string, token: string) => void;
   initSocket(workspaceId: string): Promise<void>;


### PR DESCRIPTION
If a new shared worker is detected, hotswap in our comlink to that worker and update our remotes and bearer tokens.

Note that if the tab-local worker changes in breaking ways, or if the interface contract between the tab and the shared worker changes, a reload will still be required for other tabs to get the latest code. But that should be handled by our CachedAppNotification component already.

To test this, load the app in a few tabs (for a real test, load more than one workspace locally, with at least 3 tabs). Then go into `heimdall.ts` and modify the `sharedWebWorkerName`. Then reload in just *one* tab. Ensure that all tabs work correctly and that updates flow across the websocket(s).

Then open `chrome://inspect/#workers` or
`about:debugging#/runtime/this-firefox`, There should only be one shared webworker. If you see two, reload the inspect page (it is not always immediately reactive).

Note that after this is deployed, every tab will have to be closed to support the new shared worker code, but only one final time. Afterwards, we should gracefully detect new shared workers without requiring all tabs to close.