### PR TITLE
feat: Support boolean queries and exact matches

### DIFF
--- a/app/web/src/newhotness/logic_composables/search.ts
+++ b/app/web/src/newhotness/logic_composables/search.ts
@@ -1,0 +1,179 @@
+/**
+ * Search string, split into terms.
+ *
+ *     {
+ *       op: "and",
+ *       conditions: [
+ *          { op: "fuzzy", value: "MyComponent" },
+ *          { op: "known", key: "schema", value: "AWS::EC2::Subnet" },
+ *          { op: "attr", key: "vpcId", value: "vpc-123" },
+ *          { op: "exact", value: "AWS::EC2::Subnet" },
+ *       ]
+ *     }
+ *
+ */
+export type SearchTerms =
+  | {
+      op: "not";
+      condition: SearchTerms;
+    }
+  | {
+      op: "and" | "or";
+      conditions: SearchTerms[];
+    }
+  | { op: "fuzzy" | "exact" | "startsWith"; value: string }
+  | { op: "attr"; key: string; value: string };
+
+export function parseSearch(search: string): SearchTerms | undefined {
+  return new SearchParser(search).parse();
+}
+
+class SearchParser {
+  constructor(private search: string) {}
+  private index = 0;
+
+  parse(): SearchTerms | undefined {
+    // parseCondition() stops at end paren, but will consume anything else.
+    // At the top level, we want to make sure we consume the entire search string. If we find
+    // stray end parens, we explicitly ignore them here and continue parsing more conditions.
+    const conditions: SearchTerms[] = [];
+    do {
+      const condition = this.parseCondition();
+      if (condition) conditions.push(condition);
+    } while (this.consume(")")); // We eat stray end parens for breakfast
+
+    // If we're not at end of string, something is wrong with the parser (it's designed to parse
+    // the entire search string, even if it's malformed).
+    if (!this.eof()) {
+      throw new Error(
+        `Search parse error at ${this.index}: ${this.search.slice(this.index)}`,
+      );
+    }
+
+    // If there were extra parens, we want to honor all the conditions, so stuff them together
+    // in an "&".
+    if (conditions.length > 1) return { op: "and", conditions };
+    else return conditions[0];
+  }
+
+  /**
+   * Parse a full search condition (|, &/space, !, (), "", value, attr:value).
+   *
+   * Stops at ) or end of string.
+   *
+   * @return the condition, or undefined if we're at ) or end of string.
+   */
+  parseCondition(): SearchTerms | undefined {
+    return this.parseOrCondition();
+  }
+
+  /**
+   * Parse an OR expression (|, &/space, !, (), "", value, attr:value)
+   *
+   * @return the condition, or undefined if there is no conditoin and we're at ) or end of string.
+   */
+  parseOrCondition(): SearchTerms | undefined {
+    const conditions: SearchTerms[] = [];
+    do {
+      const condition = this.parseAndCondition();
+      if (condition) conditions.push(condition);
+    } while (this.consume("|"));
+
+    if (conditions.length > 1) return { op: "or", conditions };
+    else return conditions[0];
+  }
+
+  /**
+   * Parse an AND expression (&/space, !, (), "", value, attr:value).
+   *
+   * @return the condition, or undefined if we're at |, ), or end of string.
+   */
+  parseAndCondition(): SearchTerms | undefined {
+    const conditions: SearchTerms[] = [];
+    do {
+      const condition = this.parseTerm();
+      if (condition) conditions.push(condition);
+    } while (this.consume(" ") || this.consume("&"));
+
+    if (conditions.length > 1) return { op: "and", conditions };
+    else return conditions[0];
+  }
+
+  /**
+   * Parse a single term (!, (), "", value, attr:value).
+   *
+   * @return the term, or undefined if we're at |, &, ), space, or end of string.
+   */
+  parseTerm(): SearchTerms | undefined {
+    // Parse parens as a single term (...)
+    if (this.consume("(")) {
+      const condition = this.parseCondition();
+      this.consume(")"); // Don't care if it's actually there; end of string closes all parens.
+      return condition;
+    }
+
+    // Parse !expression
+    if (this.consume("!")) {
+      // Skip whitespace (support ! <term>)
+      // eslint-disable-next-line no-empty
+      while (this.consume(" ")) {}
+      const condition = this.parseTerm();
+      return condition ? { op: "not", condition } : undefined;
+    }
+
+    // Parse quoted term "..."
+    if (this.consume('"')) {
+      const value = this.consumeUntil(['"']);
+      if (this.consume('"')) {
+        return { op: "exact", value };
+      } else {
+        // Unclosed quotes should still show the partial match!
+        return { op: "startsWith", value };
+      }
+    }
+
+    //
+    // Parse value or attr:value
+    //
+
+    // Read everything up to the next special character or : (first word)
+    // If this is attr:value:str, this will only read "attr" and we'll read "value:str" next.
+    const value = this.consumeUntil([" ", "(", ")", "&", "|", "!", '"', ":"]);
+    // If there's no term, we're at a special character; let a parent handle it.
+    if (value === "") return undefined;
+
+    // If there is a ":", parse it as an attribute (take the stuff after the :, which might
+    // have other colons in it).
+    if (this.consume(":")) {
+      return {
+        op: "attr",
+        key: value,
+        value: this.consumeUntil([" ", "(", ")", "&", "|", "!", '"']),
+      };
+    }
+
+    return { op: "fuzzy", value };
+  }
+
+  consume(char: string) {
+    const current = this.search[this.index];
+    if (current === char) {
+      this.index++;
+      return this.search[this.index - 1];
+    }
+    return undefined;
+  }
+
+  consumeUntil(chars: string[]) {
+    const start = this.index;
+    // Stop at end of string or one of the included character.
+    while (!(this.eof() || chars.includes(this.search[this.index] ?? ""))) {
+      this.index++;
+    }
+    return this.search.slice(start, this.index);
+  }
+
+  eof() {
+    return this.index >= this.search.length;
+  }
+}


### PR DESCRIPTION
This adds |, !, parens (), and "exact match" syntax to search.

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExanJnZWNlamhwbDE2NXp5MGVyeWtnbjhydnJrcXNsMHZrNzc0d2c4dCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3oipPTHYlTpCw8oBBy/giphy.gif)

## How does this PR change the system?

* New `parseSearch()` reads the search string into individual terms and operators (an AST)
* `filteredComponents` recursively evaluates the search, doing individual searches for each term and then doing set operations (union for |, negate for ! ...) to figure out the results
* The order of results is preserved; for fuzzy searches, the result order is honored (though it doesn't show up yet due to Out of Scope).
* Search is *tolerant to partially-typed queries*: the goal is that as you type each character of a query, the results get closer and closer to what you want. Not having typed the end ) of a paren, or the close quote in a "exact match", should still show results matching the partial paren expression / exact match. (We have specific code to do a "starts with" match if you start an exact match like `"AWS::EC2::I` but haven't typed the " yet, so it will progressively filter results as you type.)
* Makes searches happen up to 5 times per second instead of 2, to reduce latency

#### Screenshots:

<img width="811" height="430" alt="image" src="https://github.com/user-attachments/assets/ad09147a-dd15-45c6-b48f-5566b51234c5" />

#### Out of Scope:

* fzf result order is not honored because we sort the results *after* filtering, but that's out of scope here. Preexisting.
* `InstanceType:*.large|*.medium` and `InstanceType:"m8g.large"` (right now we don't support alternatives or exact matches in attr searches)

## How was it tested?

- [X] Manual test: Instance (InstanceType:*.large | InstanceType:*.medium)
- [X] Manual test: empty query returns all results (as does (), 
- [X] Manual tests: tolerant of partial queries: don't show errors just because you haven't finished typing, and make the results get closer and closer to the final result as you type more and more of the query (typing one more character of a word should make the results smaller)
  - [X] trailing (empty) |, & or ! do not change the results
  - [X] unclosed paren is ignored (we figure you will eventually type it)
  - [X] unclosed quote means the whole rest of the string is the literal
- [X] Manual tests: error tolerant: no errors ever happen, we always try to render something
  - [X] unopened parens (stray close paren) are ignored