### PR TITLE
feat: clear down old machines, stablise tiles test

### DIFF
--- a/.ci/delete-stacks.py
+++ b/.ci/delete-stacks.py
@@ -1,0 +1,81 @@
+import os
+import requests
+import time
+
+API_TOKEN = os.environ.get('SI_API_TOKEN')
+WORKSPACE_ID = os.environ.get("SI_WORKSPACE_ID")
+API_URL = "https://api.systeminit.com"
+
+if not API_TOKEN or not WORKSPACE_ID:
+    raise ValueError(
+        "Missing SI_API_TOKEN or SI_WORKSPACE_ID environment variables.")
+
+headers = {
+    'Authorization': f'Bearer {API_TOKEN}',
+    'Content-Type': 'application/json'
+}
+
+
+def create_change_set(name: str):
+    response = requests.post(f"{API_URL}/v1/w/{WORKSPACE_ID}/change-sets",
+                             headers=headers,
+                             json={"changeSetName": name})
+    response.raise_for_status()
+    return response.json()["changeSet"]["id"]
+
+
+def search_ec2_components(change_set_id: str):
+    response = requests.post(
+        f"{API_URL}/v1/w/{WORKSPACE_ID}/change-sets/{change_set_id}/components/search",
+        headers=headers,
+        json={"schemaName": "AWS::EC2::Instance"})
+    response.raise_for_status()
+    return response.json()["components"]  # List of component IDs
+
+
+def delete_component(change_set_id: str, component_id: str):
+    response = requests.delete(
+        f"{API_URL}/v1/w/{WORKSPACE_ID}/change-sets/{change_set_id}/components/{component_id}",
+        headers=headers)
+    response.raise_for_status()
+    return response.json()
+
+
+def force_apply_change_set(change_set_id: str):
+    response = requests.post(
+        f"{API_URL}/v1/w/{WORKSPACE_ID}/change-sets/{change_set_id}/force_apply",
+        headers=headers,
+        data="")
+    response.raise_for_status()
+    return response.json()
+
+
+def main():
+    print("🔍 Creating a change set for deletion...")
+    change_set_id = create_change_set("Delete All EC2 Components")
+    print(f"✅ Change set created: {change_set_id}")
+
+    print("🔍 Searching for EC2 instance components...")
+    ec2_component_ids = search_ec2_components(change_set_id)
+
+    if not ec2_component_ids:
+        print("✅ No EC2 components found. Nothing to delete.")
+        return
+
+    print(f"⚠️ Found {len(ec2_component_ids)} EC2 components. Deleting...")
+    for component_id in ec2_component_ids:
+        print(f"🗑️ Deleting component: {component_id}")
+        delete_component(change_set_id, component_id)
+
+    print("Waiting for DVU")
+    time.sleep(
+        30
+    )  # I really need a method here to detect DVU is complete more elegantly
+
+    print("🚀 Applying change set to execute deletions...")
+    force_apply_change_set(change_set_id)
+    print("✅ All EC2 components scheduled for deletion.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -58,6 +58,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Delete any lingering nodes
+        working-directory: .ci/
+        run: |
+          export SI_API_TOKEN="${{ secrets.SI_API_TOKEN }}"
+          export SI_WORKSPACE_ID="${{ vars.MANAGEMENT_WORKSPACE_ID }}"
+          python3 ./delete-stacks.py
+
       - name: Deploy EC2 node
         working-directory: .ci/
         run: |
@@ -241,6 +248,23 @@ jobs:
       - name: Check Test Results
         if: failure()
         run: exit 1
+
+  cleanup:
+    name: Cleanup EC2 Nodes
+    runs-on: ubuntu-latest
+    needs: cypress-tests
+    environment: ${{ inputs.environment }}
+    if: inputs.environment == 'ec2-node' && always()
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Delete EC2 nodes
+        working-directory: .ci/
+        run: |
+          export SI_API_TOKEN="${{ secrets.SI_API_TOKEN }}"
+          export SI_WORKSPACE_ID="${{ vars.MANAGEMENT_WORKSPACE_ID }}"
+          python3 ./delete-stacks.py
 
   on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-on-main.yml
+++ b/.github/workflows/test-on-main.yml
@@ -28,6 +28,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+
   e2e-validation:
     uses: ./.github/workflows/e2e-validation.yml
     with:
@@ -42,5 +43,6 @@ jobs:
     steps:
       - run: |
           curl -X POST \
-          -H 'Content-type: application/json' \
-          --data "{\"text\": \":si: Validation of mainline failed: <https://github.com/systeminit/si/actions/runs/$GITHUB_RUN_ID|:ship: Link>\"}" ${{ secrets.SLACK_WEBHOOK_URL }}
+          --header 'Content-type: application/json' \
+          --data "{\"text\": \":si: Failed Cypress E2E Test on main: <https://github.com/systeminit/si/actions/runs/$GITHUB_RUN_ID|:test_tube: Link>\"}" \
+          ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/app/web/cypress.config.ts
+++ b/app/web/cypress.config.ts
@@ -4,6 +4,7 @@ import vitePreprocessor from 'cypress-vite'
 
 export default defineConfig({
   e2e: {
+    specPattern: "cypress/**/*.cy.{js,jsx,ts,tsx}",
     setupNodeEvents(on, config) {
       on('file:preprocessor',
         vitePreprocessor(

--- a/app/web/cypress/ux/tile-view/get-tiles.cy.ts
+++ b/app/web/cypress/ux/tile-view/get-tiles.cy.ts
@@ -32,7 +32,7 @@ describe('web', () => {
         failOnStatusCode: false
     });
 
-    cy.wait(30000);
+    cy.wait(60000);
 
     let attempt = 0;
     let maxAttempts = 10;


### PR DESCRIPTION
Tidy up nodes that are spun up and various fixes to the execution of the test variant. Make sure we only try and clean up once, and for the variants that run ec2-node type.

```
🔍 Creating a change set for deletion...
✅ Change set created: 01JZXTQYYPAWTF1DQJHX5WESRH
🔍 Searching for EC2 instance components...
⚠️ Found 1 EC2 components. Deleting...
🗑️ Deleting component: 01JZXSPY4DKEB6YYVE323AXPCH
Waiting for DVU
🚀 Applying change set to execute deletions...
✅ All EC2 components scheduled for deletion.
```

Chore: Extend the wait in the get-tiles test as the lobby is loading slower now with the same test conditions.

**Testing:**
Pass with tools / normal - https://github.com/systeminit/si/actions/runs/16231089952

Pass with ec2-node / new -
https://github.com/systeminit/si/actions/runs/16230918213