### PR TITLE
feat(web) - newhotness read only toDelete ComponentAttributes page

### DIFF
--- a/app/web/src/components/layout/navbar/ChangeSetPanel.vue
+++ b/app/web/src/components/layout/navbar/ChangeSetPanel.vue
@@ -17,6 +17,7 @@
         checkable
         variant="navbar"
         :enableSecondaryAction="calculateShowSecondaryAction"
+        :sizeClass="tw`h-[28px]`"
         secondaryActionIcon="edit2"
         @select="onSelectChangeSet"
         @secondaryAction="openRenameModal"
@@ -128,6 +129,7 @@ import {
   DropdownMenuItem,
   DEFAULT_DROPDOWN_SEARCH_THRESHOLD,
 } from "@si/vue-lib/design-system";
+import { tw } from "@si/vue-lib";
 import { useChangeSetsStore } from "@/store/change_sets.store";
 import { ChangeSetStatus } from "@/api/sdf/dal/change_set";
 import AbandonChangeSetModal from "@/components/AbandonChangeSetModal.vue";

--- a/app/web/src/newhotness/ActionsPanel.vue
+++ b/app/web/src/newhotness/ActionsPanel.vue
@@ -1,8 +1,16 @@
 <template>
   <EmptyState
-    v-if="actionPrototypeViews.length === 0"
+    v-if="component.toDelete"
+    text="Marked for deletion"
+    secondaryText="Can't run actions on a component which has been marked for deletion"
+    icon="tools"
+    class="p-sm"
+  />
+  <EmptyState
+    v-else-if="actionPrototypeViews.length === 0"
     text="No actions available"
     icon="tools"
+    class="p-sm"
   />
   <div v-else class="flex flex-col">
     <div

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -26,7 +26,7 @@
               label="All Views"
               value="''"
               checkable
-              sizeClass="h-lg px-xs pr-xs"
+              :sizeClass="tw`px-xs pr-xs h-[28px]`"
               :checked="selectedViewId === ''"
               @select="() => (selectedViewId = '')"
             />
@@ -36,7 +36,7 @@
               class="border-t"
               label="Add a View"
               icon="plus"
-              sizeClass="h-lg px-xs pr-xs"
+              :sizeClass="tw`px-xs pr-xs h-[28px]`"
               disableCheckable
               @select="openAddViewModal"
             />
@@ -345,6 +345,7 @@ import {
 import clsx from "clsx";
 import { useQuery } from "@tanstack/vue-query";
 import { Fzf } from "fzf";
+import { tw } from "@si/vue-lib";
 import {
   bifrost,
   bifrostList,

--- a/app/web/src/newhotness/ManagementPanel.vue
+++ b/app/web/src/newhotness/ManagementPanel.vue
@@ -1,6 +1,13 @@
 <template>
+  <EmptyState
+    v-if="component?.toDelete"
+    text="Marked for deletion"
+    secondaryText="Can't adjust management on a component which has been marked for deletion"
+    icon="tools"
+    class="p-sm"
+  />
   <div
-    v-if="component && componentId && latestFuncRuns && managementData"
+    v-else-if="component && componentId && latestFuncRuns && managementData"
     class="p-xs flex flex-col gap-xs"
   >
     <ul class="flex flex-col gap-xs">
@@ -25,7 +32,12 @@
       :parentComponentId="componentId"
     />
   </div>
-  <EmptyState v-else text="No management information available" icon="tools" />
+  <EmptyState
+    v-else
+    text="No management information available"
+    icon="tools"
+    class="p-sm"
+  />
 </template>
 
 <script setup lang="ts">

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -26,7 +26,7 @@
               class="w-8 mr-2 shrink-0"
             />
             <IconButton
-              v-if="canDelete"
+              v-if="canDelete && !component.toDelete"
               tooltip="Delete"
               tooltipPlacement="top"
               icon="trash"
@@ -149,7 +149,11 @@
           <Icon v-if="isArray" name="chevron--down" />
           <!-- NOTE(nick): you need "click.stop" here to prevent the outer click -->
           <Icon
-            v-if="props.externalSources && props.externalSources.length > 0"
+            v-if="
+              props.externalSources &&
+              props.externalSources.length > 0 &&
+              !component.toDelete
+            "
             v-tooltip="
               props.isSecret
                 ? 'Remove connection to Secret'
@@ -192,7 +196,7 @@
             <div class="flex flex-row items-center gap-2xs">
               <TruncateWithTooltip>{{ displayName }}</TruncateWithTooltip>
               <IconButton
-                v-if="canDelete"
+                v-if="canDelete && !component.toDelete"
                 tooltip="Delete (⌘⌫)"
                 tooltipPlacement="top"
                 icon="trash"
@@ -223,7 +227,10 @@
               "
               :type="inputHtmlTag === 'input' ? 'text' : null"
               :rows="inputHtmlTag === 'textarea' ? 4 : null"
+              data-lpignore="true"
               data-1p-ignore
+              data-bwignore
+              data-form-type="other"
               :value="isMap ? mapKey : field.state.value"
               :disabled="wForm.bifrosting.value || bifrostingTrash"
               @input="(e: Event) => onInputChange(e)"
@@ -1263,7 +1270,9 @@ const selectedConnection = computed(
 );
 
 const readOnly = computed(
-  () => !!(props.prop?.createOnly && props.component.hasResource),
+  () =>
+    !!(props.prop?.createOnly && props.component.hasResource) ||
+    props.component.toDelete,
 );
 
 const kindAsString = computed(() => `${props.prop?.widgetKind}`.toLowerCase());

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -15,14 +15,16 @@
                   'focus:outline-none group/attributeheader',
               )
             "
-            :tabindex="attributeTree.isBuildable ? 0 : undefined"
+            :tabindex="
+              attributeTree.isBuildable && !component.toDelete ? 0 : undefined
+            "
             @keydown.tab.stop.prevent="onHeaderTab"
             @keydown.enter.stop.prevent="remove"
             @keydown.delete.stop.prevent="remove"
           >
             <div>{{ displayName }}</div>
             <IconButton
-              v-if="attributeTree.isBuildable"
+              v-if="attributeTree.isBuildable && !component.toDelete"
               v-tooltip="'Delete'"
               icon="trash"
               size="sm"
@@ -118,7 +120,7 @@
         :validation="attributeTree.attributeValue.validation"
         :component="component"
         :value="attributeTree.attributeValue.value?.toString() ?? ''"
-        :canDelete="attributeTree.isBuildable"
+        :canDelete="attributeTree.isBuildable && !component.toDelete"
         :externalSources="attributeTree.attributeValue.externalSources"
         :isArray="attributeTree.prop?.kind === 'array'"
         :isMap="attributeTree.prop?.kind === 'map'"
@@ -162,8 +164,10 @@ const hasChildren = computed(() => {
   }
 });
 
-const isBuildable = computed(() =>
-  ["array", "map"].includes(props.attributeTree.prop?.kind ?? ""),
+const isBuildable = computed(
+  () =>
+    ["array", "map"].includes(props.attributeTree.prop?.kind ?? "") &&
+    !props.component.toDelete,
 );
 
 const displayName = computed(() => {
@@ -195,6 +199,8 @@ const emptyChildValue = () => {
 };
 
 const add = async (key?: string) => {
+  if (props.component.toDelete) return;
+
   if (props.attributeTree.prop?.kind === "map") {
     if (!key) {
       saveKeyIfFormValid();

--- a/app/web/src/newhotness/layout_components/SecretInput.vue
+++ b/app/web/src/newhotness/layout_components/SecretInput.vue
@@ -32,7 +32,10 @@
       :value="field.state.value"
       tabindex="0"
       :placeholder="placeholder"
+      data-lpignore="true"
       data-1p-ignore
+      data-bwignore
+      data-form-type="other"
       @keydown.tab="onTab"
       @input="
       (e: Event) =>

--- a/lib/vue-lib/src/design-system/general/SiSearch.vue
+++ b/lib/vue-lib/src/design-system/general/SiSearch.vue
@@ -34,7 +34,10 @@
             filtersEnabled ? 'pr-[58px]' : 'pr-[30px]',
           )
         "
+        data-lpignore="true"
         data-1p-ignore
+        data-bwignore
+        data-form-type="other"
         :tabindex="tabIndex"
         @input="onChange"
         @keydown="onKeyDown"

--- a/lib/vue-lib/src/design-system/menus/DropdownMenuButton.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenuButton.vue
@@ -85,6 +85,7 @@
           enableSecondaryAction && enableSecondaryAction(option)
         "
         :secondaryActionIcon="secondaryActionIcon"
+        :sizeClass="sizeClass"
         @secondaryAction="secondaryAction(option)"
         @select="selectOption(option)"
       />
@@ -134,6 +135,7 @@ const props = defineProps({
   secondaryActionIcon: { type: String as PropType<IconNames> },
   alwaysShowPlaceholder: { type: Boolean },
   highlightWhenModelValue: { type: Boolean },
+  sizeClass: { type: String },
 });
 
 const arrayOptionsFromProps = computed((): OptionsAsArray => {

--- a/lib/vue-lib/src/design-system/menus/DropdownMenuItem.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenuItem.vue
@@ -136,7 +136,7 @@
         v-else-if="enableSecondaryAction"
         :class="
           clsx(
-            'h-full flex items-center p-2xs px-xs',
+            'h-full flex items-center px-xs',
             themeClasses(
               'group-hover:hover:bg-action-300 group-hover:text-shade-0',
               'group-hover:hover:bg-action-500 group-hover:text-shade-0',
@@ -259,7 +259,7 @@ const showSecondaryAction = computed(
 // the class option pile for the component attribute. Please forgive me.
 const sizeClass = computed(() => {
   if (props.sizeClass) return props.sizeClass;
-  if (props.enableSecondaryAction) return tw`h-lg`;
+  if (props.enableSecondaryAction) return tw`h-[28px]`;
   return {
     classic: tw`p-xs pr-sm`,
     compact: tw`px-xs py-2xs pr-xs`,


### PR DESCRIPTION
## How does this PR change the system?

Completes ENG-3117 - now users of the newhotness UI can see a read only ComponentDetails page for components marked for deletion.

#### Screenshots:

<img width="929" height="576" alt="Screenshot 2025-07-12 at 5 42 42 PM" src="https://github.com/user-attachments/assets/98cd670c-6740-469f-8187-9f0f19aee2c6" />

#### Out of Scope:

There is a commented out restore button in the UI which we can wire up later.

## How was it tested?

Plenty of manual testing, aggressive blocking of any functions within ComponentDetails which should not run if a component has `toDelete` set to true.