### PR TITLE
fix(clover): Ensure we don't try to return a resource that doesn't exist

### DIFF
--- a/bin/clover/src/cloud-control-funcs/actions/awsCloudControlDelete.ts
+++ b/bin/clover/src/cloud-control-funcs/actions/awsCloudControlDelete.ts
@@ -3,8 +3,7 @@ async function main(component: Input): Promise<Output> {
   if (!component.properties.resource?.payload) {
     return {
       status: "error",
-      message: "Resource must exist",
-      payload: component.properties.resource.payload,
+      message: "Unable to queue a delete action on a component without a resource",
     };
   }
   const child = await siExec.waitUntilEnd("aws", [

--- a/bin/clover/src/cloud-control-funcs/actions/awsCloudControlUpdate.ts
+++ b/bin/clover/src/cloud-control-funcs/actions/awsCloudControlUpdate.ts
@@ -2,8 +2,7 @@ async function main(component: Input): Promise<Output> {
   if (!component.properties.resource?.payload) {
     return {
       status: "error",
-      message: "Resource must exist to be updated",
-      payload: component.properties.resource.payload,
+      message: "Unable to queue an update action on a component without a resource",
     };
   }
 


### PR DESCRIPTION
If a user tries to queue an update or delete action when a resource 
doesn’t exist. This caused an error trying to get the value of payload:

```
Cannot read properties of undefined (reading 'payload')
```

This protects against using these actions and getting an unrecognisable 
Error