### PR TITLE
fix: Update vue to 3.5.13 so we can use the vue-use library

### DIFF
--- a/app/auth-portal/package.json
+++ b/app/auth-portal/package.json
@@ -30,7 +30,7 @@
     "pinia": "^2.2.4",
     "posthog-js": "^1.176.0",
     "vite-ssg": "^0.23.8",
-    "vue": "^3.5.12",
+    "vue": "^3.5.13",
     "vue-router": "^4.4.5"
   },
   "devDependencies": {

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -111,7 +111,7 @@
     "util-browser": "^0.0.2",
     "validator": "^13.7.0",
     "vanilla-picker": "^2.12.1",
-    "vue": "^3.5.12",
+    "vue": "^3.5.13",
     "vue-konva": "^3.0.1",
     "vue-markdown-render": "^2.2.1",
     "vue-router": "^4.4.5",

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -219,7 +219,7 @@
         v-else
         ref="mapRef"
         :active="!showGrid"
-        :components="filteredComponents.value"
+        :components="filteredComponents"
         :componentsWithFailedActions="componentsHaveActionsWithState.failed"
         @deselect="onMapDeselect"
         @help="openShortcutModal"

--- a/lib/vue-lib/package.json
+++ b/lib/vue-lib/package.json
@@ -65,7 +65,7 @@
     "tailwindcss-capsize": "^3.0.3",
     "ulid": "^2.3.0",
     "vanilla-picker": "^2.12.1",
-    "vue": "^3.5.12",
+    "vue": "^3.5.13",
     "vue-router": "^4.4.5",
     "vue-safe-teleport": "^0.1.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: 12.0.0(typescript@5.0.4)
       '@vueuse/head':
         specifier: ^1.3.1
-        version: 1.3.1(vue@3.5.12(typescript@5.0.4))
+        version: 1.3.1(vue@3.5.13(typescript@5.0.4))
       axios:
         specifier: ^1.8.2
         version: 1.8.2
@@ -30,7 +30,7 @@ importers:
         version: 1.2.1
       floating-vue:
         specifier: 2.0.0-beta.20
-        version: 2.0.0-beta.20(vue@3.5.12(typescript@5.0.4))
+        version: 2.0.0-beta.20(vue@3.5.13(typescript@5.0.4))
       highlight.js:
         specifier: ^11.10.0
         version: 11.10.0
@@ -45,19 +45,19 @@ importers:
         version: 4.17.21
       pinia:
         specifier: ^2.2.4
-        version: 2.2.4(typescript@5.0.4)(vue@3.5.12(typescript@5.0.4))
+        version: 2.2.4(typescript@5.0.4)(vue@3.5.13(typescript@5.0.4))
       posthog-js:
         specifier: ^1.176.0
         version: 1.177.0
       vite-ssg:
         specifier: ^0.23.8
-        version: 0.23.8(vite@5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue-router@4.4.5(vue@3.5.12(typescript@5.0.4)))(vue@3.5.12(typescript@5.0.4))
+        version: 0.23.8(vite@5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue-router@4.4.5(vue@3.5.13(typescript@5.0.4)))(vue@3.5.13(typescript@5.0.4))
       vue:
-        specifier: ^3.5.12
-        version: 3.5.12(typescript@5.0.4)
+        specifier: ^3.5.13
+        version: 3.5.13(typescript@5.0.4)
       vue-router:
         specifier: ^4.4.5
-        version: 4.4.5(vue@3.5.12(typescript@5.0.4))
+        version: 4.4.5(vue@3.5.13(typescript@5.0.4))
     devDependencies:
       '@si/eslint-config':
         specifier: workspace:*
@@ -73,7 +73,7 @@ importers:
         version: 18.19.59
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.1.4(vite@5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.12(typescript@5.0.4))
+        version: 5.1.4(vite@5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.13(typescript@5.0.4))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -179,7 +179,7 @@ importers:
         version: 6.7.1
       '@headlessui/vue':
         specifier: ^1.7.10
-        version: 1.7.12(vue@3.5.12(typescript@5.0.4))
+        version: 1.7.12(vue@3.5.13(typescript@5.0.4))
       '@honeycombio/opentelemetry-web':
         specifier: ^0.3.0
         version: 0.3.0
@@ -239,16 +239,16 @@ importers:
         version: 3.48.0-build4
       '@tanstack/vue-form':
         specifier: ^1.9.0
-        version: 1.9.0(vue@3.5.12(typescript@5.0.4))
+        version: 1.9.0(vue@3.5.13(typescript@5.0.4))
       '@tanstack/vue-query':
         specifier: ^5.67.3
-        version: 5.67.3(vue@3.5.12(typescript@5.0.4))
+        version: 5.67.3(vue@3.5.13(typescript@5.0.4))
       '@tanstack/vue-table':
         specifier: ^8.20.5
-        version: 8.20.5(vue@3.5.12(typescript@5.0.4))
+        version: 8.20.5(vue@3.5.13(typescript@5.0.4))
       '@tanstack/vue-virtual':
         specifier: ^3.13.6
-        version: 3.13.6(vue@3.5.12(typescript@5.0.4))
+        version: 3.13.6(vue@3.5.13(typescript@5.0.4))
       '@types/async':
         specifier: ^3.2.15
         version: 3.2.16
@@ -260,7 +260,7 @@ importers:
         version: 12.0.0(typescript@5.0.4)
       '@vueuse/head':
         specifier: ^1.1.15
-        version: 1.1.15(vue@3.5.12(typescript@5.0.4))
+        version: 1.1.15(vue@3.5.13(typescript@5.0.4))
       async:
         specifier: ^3.2.4
         version: 3.2.4
@@ -299,7 +299,7 @@ importers:
         version: 3.1.1
       floating-vue:
         specifier: ^2.0.0-beta.20
-        version: 2.0.0-beta.20(vue@3.5.12(typescript@5.0.4))
+        version: 2.0.0-beta.20(vue@3.5.13(typescript@5.0.4))
       fontfaceobserver:
         specifier: ^2.3.0
         version: 2.3.0
@@ -362,7 +362,7 @@ importers:
         version: 8.1.0
       pinia:
         specifier: ^2.2.4
-        version: 2.2.4(typescript@5.0.4)(vue@3.5.12(typescript@5.0.4))
+        version: 2.2.4(typescript@5.0.4)(vue@3.5.13(typescript@5.0.4))
       plur:
         specifier: ^5.1.0
         version: 5.1.0
@@ -397,23 +397,23 @@ importers:
         specifier: ^2.12.1
         version: 2.12.1
       vue:
-        specifier: ^3.5.12
-        version: 3.5.12(typescript@5.0.4)
+        specifier: ^3.5.13
+        version: 3.5.13(typescript@5.0.4)
       vue-konva:
         specifier: ^3.0.1
         version: 3.0.2(konva@8.3.13)
       vue-markdown-render:
         specifier: ^2.2.1
-        version: 2.2.1(vue@3.5.12(typescript@5.0.4))
+        version: 2.2.1(vue@3.5.13(typescript@5.0.4))
       vue-router:
         specifier: ^4.4.5
-        version: 4.4.5(vue@3.5.12(typescript@5.0.4))
+        version: 4.4.5(vue@3.5.13(typescript@5.0.4))
       vue-safe-teleport:
         specifier: ^0.1.2
-        version: 0.1.2(vue@3.5.12(typescript@5.0.4))
+        version: 0.1.2(vue@3.5.13(typescript@5.0.4))
       vue-toastification:
         specifier: 2.0.0-rc.5
-        version: 2.0.0-rc.5(vue@3.5.12(typescript@5.0.4))
+        version: 2.0.0-rc.5(vue@3.5.13(typescript@5.0.4))
       y-indexeddb:
         specifier: ^9.0.12
         version: 9.0.12(yjs@13.6.8)
@@ -471,7 +471,7 @@ importers:
         version: 2023.10.5
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.1.4(vite@5.4.19(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))(vue@3.5.12(typescript@5.0.4))
+        version: 5.1.4(vite@5.4.19(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))(vue@3.5.13(typescript@5.0.4))
       cypress:
         specifier: ^13.8.1
         version: 13.13.2
@@ -778,7 +778,7 @@ importers:
         version: 0.1.2(tailwindcss@3.2.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.3.36)(@types/node@18.19.59)(typescript@5.0.4)))
       '@headlessui/vue':
         specifier: ^1.7.10
-        version: 1.7.12(vue@3.5.12(typescript@5.0.4))
+        version: 1.7.12(vue@3.5.13(typescript@5.0.4))
       '@opentelemetry/api':
         specifier: ^1.8.0
         version: 1.8.0
@@ -793,13 +793,13 @@ importers:
         version: 0.4.2(tailwindcss@3.2.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.3.36)(@types/node@18.19.59)(typescript@5.0.4)))
       '@tanstack/vue-table':
         specifier: ^8.20.5
-        version: 8.20.5(vue@3.5.12(typescript@5.0.4))
+        version: 8.20.5(vue@3.5.13(typescript@5.0.4))
       '@vueuse/core':
         specifier: ^12.0.0
         version: 12.0.0(typescript@5.0.4)
       '@vueuse/head':
         specifier: ^1.1.23
-        version: 1.1.23(vue@3.5.12(typescript@5.0.4))
+        version: 1.1.23(vue@3.5.13(typescript@5.0.4))
       axios:
         specifier: ^1.8.2
         version: 1.8.2
@@ -811,7 +811,7 @@ importers:
         version: 2.29.3
       floating-vue:
         specifier: 2.0.0-beta.20
-        version: 2.0.0-beta.20(vue@3.5.12(typescript@5.0.4))
+        version: 2.0.0-beta.20(vue@3.5.13(typescript@5.0.4))
       highlight.js:
         specifier: ^11.10.0
         version: 11.10.0
@@ -835,7 +835,7 @@ importers:
         version: 2.0.0
       pinia:
         specifier: ^2.2.4
-        version: 2.2.4(typescript@5.0.4)(vue@3.5.12(typescript@5.0.4))
+        version: 2.2.4(typescript@5.0.4)(vue@3.5.13(typescript@5.0.4))
       posthog-js:
         specifier: ^1.57.2
         version: 1.177.0
@@ -849,14 +849,14 @@ importers:
         specifier: ^2.12.1
         version: 2.12.1
       vue:
-        specifier: ^3.5.12
-        version: 3.5.12(typescript@5.0.4)
+        specifier: ^3.5.13
+        version: 3.5.13(typescript@5.0.4)
       vue-router:
         specifier: ^4.4.5
-        version: 4.4.5(vue@3.5.12(typescript@5.0.4))
+        version: 4.4.5(vue@3.5.13(typescript@5.0.4))
       vue-safe-teleport:
         specifier: ^0.1.2
-        version: 0.1.2(vue@3.5.12(typescript@5.0.4))
+        version: 0.1.2(vue@3.5.13(typescript@5.0.4))
     devDependencies:
       '@iconify/json':
         specifier: ^2.2.166
@@ -1081,20 +1081,12 @@ packages:
     resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.22.5':
-    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.25.9':
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.22.20':
-    resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.25.9':
@@ -1115,26 +1107,6 @@ packages:
 
   '@babel/parser@7.22.11':
     resolution: {integrity: sha512-R5zb8eJIBPJriQtbH/htEQy4k7E2dHWlD2Y2VT07JCzwYZHBxV5ZYtM0UhXSNMT74LyxuM+b1jdL7pSesXbC/g==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.23.6':
-    resolution: {integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.24.7':
-    resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.26.1':
-    resolution: {integrity: sha512-reoQYNiAJreZNsJzyrDNzFQ+IQ5JFiIzAHJg9bn94S3l+4++J7RsIhNMoB+lgP/9tpmiAQqspv+xfdxTSzREOw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.27.0':
-    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1230,20 +1202,8 @@ packages:
     resolution: {integrity: sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.22.11':
-    resolution: {integrity: sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.26.0':
-    resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/types@7.26.10':
     resolution: {integrity: sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.27.0':
-    resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.27.1':
@@ -3752,23 +3712,11 @@ packages:
   '@vue/compiler-core@3.2.47':
     resolution: {integrity: sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==}
 
-  '@vue/compiler-core@3.3.12':
-    resolution: {integrity: sha512-qAtjyG3GBLG0chzp5xGCyRLLe6wFCHmjI82aGzwuGKyznNP+GJJMxjc0wOYWDB2YKfho7niJFdoFpo0CZZQg9w==}
-
-  '@vue/compiler-core@3.5.12':
-    resolution: {integrity: sha512-ISyBTRMmMYagUxhcpyEH0hpXRd/KqDU4ymofPgl2XAkY9ZhQ+h0ovEZJIiPop13UmR/54oA2cgMDjgroRelaEw==}
-
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
 
   '@vue/compiler-dom@3.2.47':
     resolution: {integrity: sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==}
-
-  '@vue/compiler-dom@3.3.12':
-    resolution: {integrity: sha512-RdJU9oEYaoPKUdGXCy0l+i4clesdDeLmbvRlszoc9iagsnBnMmQtYfCPVQ5BHB6o7K4SCucDdJM2Dh3oXB0D6g==}
-
-  '@vue/compiler-dom@3.5.12':
-    resolution: {integrity: sha512-9G6PbJ03uwxLHKQ3P42cMTi85lDRvGLB2rSGOiQqtXELat6uI4n8cNz9yjfVHRPIu+MsK6TE418Giruvgptckg==}
 
   '@vue/compiler-dom@3.5.13':
     resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
@@ -3776,17 +3724,11 @@ packages:
   '@vue/compiler-sfc@3.2.47':
     resolution: {integrity: sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==}
 
-  '@vue/compiler-sfc@3.5.12':
-    resolution: {integrity: sha512-2k973OGo2JuAa5+ZlekuQJtitI5CgLMOwgl94BzMCsKZCX/xiqzJYzapl4opFogKHqwJk34vfsaKpfEhd1k5nw==}
-
   '@vue/compiler-sfc@3.5.13':
     resolution: {integrity: sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==}
 
   '@vue/compiler-ssr@3.2.47':
     resolution: {integrity: sha512-wVXC+gszhulcMD8wpxMsqSOpvDZ6xKXSVWkf50Guf/S+28hTAXPDYRTbLQ3EDkOP5Xz/+SY37YiwDquKbJOgZw==}
-
-  '@vue/compiler-ssr@3.5.12':
-    resolution: {integrity: sha512-eLwc7v6bfGBSM7wZOGPmRavSWzNFF6+PdRhE+VFJhNCgHiF8AM7ccoqcv5kBXA2eWUfigD7byekvf/JsOfKvPA==}
 
   '@vue/compiler-ssr@3.5.13':
     resolution: {integrity: sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==}
@@ -3831,28 +3773,14 @@ packages:
   '@vue/reactivity-transform@3.2.47':
     resolution: {integrity: sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==}
 
-  '@vue/reactivity@3.5.12':
-    resolution: {integrity: sha512-UzaN3Da7xnJXdz4Okb/BGbAaomRHc3RdoWqTzlvd9+WBR5m3J39J1fGcHes7U3za0ruYn/iYy/a1euhMEHvTAg==}
-
   '@vue/reactivity@3.5.13':
     resolution: {integrity: sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==}
-
-  '@vue/runtime-core@3.5.12':
-    resolution: {integrity: sha512-hrMUYV6tpocr3TL3Ad8DqxOdpDe4zuQY4HPY3X/VRh+L2myQO8MFXPAMarIOSGNu0bFAjh1yBkMPXZBqCk62Uw==}
 
   '@vue/runtime-core@3.5.13':
     resolution: {integrity: sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==}
 
-  '@vue/runtime-dom@3.5.12':
-    resolution: {integrity: sha512-q8VFxR9A2MRfBr6/55Q3umyoN7ya836FzRXajPB6/Vvuv0zOPL+qltd9rIMzG/DbRLAIlREmnLsplEF/kotXKA==}
-
   '@vue/runtime-dom@3.5.13':
     resolution: {integrity: sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==}
-
-  '@vue/server-renderer@3.5.12':
-    resolution: {integrity: sha512-I3QoeDDeEPZm8yR28JtY+rk880Oqmj43hreIBVTicisFTx/Dl7JpG72g/X7YF8hnQD3IFhkky5i2bPonwrTVPg==}
-    peerDependencies:
-      vue: 3.5.12
 
   '@vue/server-renderer@3.5.13':
     resolution: {integrity: sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==}
@@ -3861,12 +3789,6 @@ packages:
 
   '@vue/shared@3.2.47':
     resolution: {integrity: sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==}
-
-  '@vue/shared@3.3.12':
-    resolution: {integrity: sha512-6p0Yin0pclvnER7BLNOQuod9Z+cxSYh8pSh7CzHnWNjAIP6zrTlCdHRvSCb1aYEx6i3Q3kvfuWU7nG16CgG1ag==}
-
-  '@vue/shared@3.5.12':
-    resolution: {integrity: sha512-L2RPSAwUFbgZH20etwrXyVyCBu9OxRSi8T/38QsvnkJyvq2LufW2lDCOzm7t/U9C1mkhJGWYfCuFBCmIuNivrg==}
 
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
@@ -5095,9 +5017,6 @@ packages:
   cssstyle@4.1.0:
     resolution: {integrity: sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==}
     engines: {node: '>=18'}
-
-  csstype@3.1.1:
-    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -8103,9 +8022,6 @@ packages:
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
 
-  magic-string@0.30.12:
-    resolution: {integrity: sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==}
-
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -10528,10 +10444,6 @@ packages:
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
-  to-fast-properties@2.0.0:
-    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
-    engines: {node: '>=4'}
-
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -11231,14 +11143,6 @@ packages:
     peerDependencies:
       typescript: '*'
 
-  vue@3.5.12:
-    resolution: {integrity: sha512-CLVZtXtn2ItBIi/zHZ0Sg1Xkb7+PU32bJJ8Bmy7ts3jxXTcbfsEfBivFYYWz1Hur+lalqGAh65Coin0r+HRUfg==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   vue@3.5.13:
     resolution: {integrity: sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==}
     peerDependencies:
@@ -11787,10 +11691,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
       '@babel/helpers': 7.26.10
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.27.1
       '@babel/template': 7.25.9
       '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/types': 7.27.1
       convert-source-map: 2.0.0
       debug: 4.4.0
       gensync: 1.0.0-beta.2
@@ -11801,14 +11705,14 @@ snapshots:
 
   '@babel/generator@7.20.4':
     dependencies:
-      '@babel/types': 7.22.11
+      '@babel/types': 7.27.1
       '@jridgewell/gen-mapping': 0.3.5
       jsesc: 2.5.2
 
   '@babel/generator@7.26.0':
     dependencies:
-      '@babel/parser': 7.26.1
-      '@babel/types': 7.26.0
+      '@babel/parser': 7.27.1
+      '@babel/types': 7.27.1
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.0.2
@@ -11824,7 +11728,7 @@ snapshots:
   '@babel/helper-module-imports@7.25.9':
     dependencies:
       '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/types': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -11839,13 +11743,9 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.20.2': {}
 
-  '@babel/helper-string-parser@7.22.5': {}
-
   '@babel/helper-string-parser@7.25.9': {}
 
   '@babel/helper-string-parser@7.27.1': {}
-
-  '@babel/helper-validator-identifier@7.22.20': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
 
@@ -11856,27 +11756,11 @@ snapshots:
   '@babel/helpers@7.26.10':
     dependencies:
       '@babel/template': 7.27.0
-      '@babel/types': 7.26.10
+      '@babel/types': 7.27.1
 
   '@babel/parser@7.22.11':
     dependencies:
-      '@babel/types': 7.22.11
-
-  '@babel/parser@7.23.6':
-    dependencies:
-      '@babel/types': 7.22.11
-
-  '@babel/parser@7.24.7':
-    dependencies:
-      '@babel/types': 7.22.11
-
-  '@babel/parser@7.26.1':
-    dependencies:
-      '@babel/types': 7.26.0
-
-  '@babel/parser@7.27.0':
-    dependencies:
-      '@babel/types': 7.27.0
+      '@babel/types': 7.27.1
 
   '@babel/parser@7.27.1':
     dependencies:
@@ -11952,53 +11836,37 @@ snapshots:
   '@babel/template@7.18.10':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.22.11
+      '@babel/parser': 7.27.1
+      '@babel/types': 7.27.1
 
   '@babel/template@7.25.9':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.26.1
-      '@babel/types': 7.26.0
+      '@babel/parser': 7.27.1
+      '@babel/types': 7.27.1
 
   '@babel/template@7.27.0':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/parser': 7.27.1
+      '@babel/types': 7.27.1
 
   '@babel/traverse@7.25.9':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/generator': 7.26.0
-      '@babel/parser': 7.26.1
+      '@babel/parser': 7.27.1
       '@babel/template': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/types': 7.27.1
       debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.22.11':
-    dependencies:
-      '@babel/helper-string-parser': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.20
-      to-fast-properties: 2.0.0
-
-  '@babel/types@7.26.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
-
   '@babel/types@7.26.10':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
-
-  '@babel/types@7.27.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.27.1
 
   '@babel/types@7.27.1':
     dependencies:
@@ -12041,7 +11909,7 @@ snapshots:
 
   '@capsizecss/core@3.1.0':
     dependencies:
-      csstype: 3.1.1
+      csstype: 3.1.3
 
   '@codemirror/autocomplete@6.4.2(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)(@lezer/common@1.0.1)':
     dependencies:
@@ -12488,9 +12356,9 @@ snapshots:
     dependencies:
       tailwindcss: 3.2.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.3.36)(@types/node@18.19.59)(typescript@5.0.4))
 
-  '@headlessui/vue@1.7.12(vue@3.5.12(typescript@5.0.4))':
+  '@headlessui/vue@1.7.12(vue@3.5.13(typescript@5.0.4))':
     dependencies:
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
   '@honeycombio/opentelemetry-web@0.3.0':
     dependencies:
@@ -14019,37 +13887,37 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.6': {}
 
-  '@tanstack/vue-form@1.9.0(vue@3.5.12(typescript@5.0.4))':
+  '@tanstack/vue-form@1.9.0(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       '@tanstack/form-core': 1.9.0
-      '@tanstack/vue-store': 0.7.0(vue@3.5.12(typescript@5.0.4))
-      vue: 3.5.12(typescript@5.0.4)
+      '@tanstack/vue-store': 0.7.0(vue@3.5.13(typescript@5.0.4))
+      vue: 3.5.13(typescript@5.0.4)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  '@tanstack/vue-query@5.67.3(vue@3.5.12(typescript@5.0.4))':
+  '@tanstack/vue-query@5.67.3(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       '@tanstack/match-sorter-utils': 8.19.4
       '@tanstack/query-core': 5.67.3
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.12(typescript@5.0.4)
-      vue-demi: 0.14.10(vue@3.5.12(typescript@5.0.4))
+      vue: 3.5.13(typescript@5.0.4)
+      vue-demi: 0.14.10(vue@3.5.13(typescript@5.0.4))
 
-  '@tanstack/vue-store@0.7.0(vue@3.5.12(typescript@5.0.4))':
+  '@tanstack/vue-store@0.7.0(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       '@tanstack/store': 0.7.0
-      vue: 3.5.12(typescript@5.0.4)
-      vue-demi: 0.14.10(vue@3.5.12(typescript@5.0.4))
+      vue: 3.5.13(typescript@5.0.4)
+      vue-demi: 0.14.10(vue@3.5.13(typescript@5.0.4))
 
-  '@tanstack/vue-table@8.20.5(vue@3.5.12(typescript@5.0.4))':
+  '@tanstack/vue-table@8.20.5(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       '@tanstack/table-core': 8.20.5
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
-  '@tanstack/vue-virtual@3.13.6(vue@3.5.12(typescript@5.0.4))':
+  '@tanstack/vue-virtual@3.13.6(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       '@tanstack/virtual-core': 3.13.6
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
   '@tapjs/after-each@1.1.17(@tapjs/core@1.4.6(@swc/core@1.3.36)(@types/node@18.16.20)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))':
     dependencies:
@@ -14339,24 +14207,24 @@ snapshots:
 
   '@types/babel__core@7.1.20':
     dependencies:
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.22.11
+      '@babel/parser': 7.27.1
+      '@babel/types': 7.27.1
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.2
 
   '@types/babel__generator@7.6.4':
     dependencies:
-      '@babel/types': 7.22.11
+      '@babel/types': 7.27.1
 
   '@types/babel__template@7.4.1':
     dependencies:
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.22.11
+      '@babel/parser': 7.27.1
+      '@babel/types': 7.27.1
 
   '@types/babel__traverse@7.18.2':
     dependencies:
-      '@babel/types': 7.22.11
+      '@babel/types': 7.27.1
 
   '@types/body-parser@1.19.2':
     dependencies:
@@ -14910,38 +14778,38 @@ snapshots:
       '@unhead/schema': 1.11.10
       '@unhead/shared': 1.11.10
 
-  '@unhead/vue@1.1.15(vue@3.5.12(typescript@5.0.4))':
+  '@unhead/vue@1.1.15(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       '@unhead/schema': 1.1.15
       '@unhead/shared': 1.1.15
       hookable: 5.4.2
       unhead: 1.1.15
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
-  '@unhead/vue@1.1.25(vue@3.5.12(typescript@5.0.4))':
+  '@unhead/vue@1.1.25(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       '@unhead/schema': 1.1.25
       '@unhead/shared': 1.1.25
       hookable: 5.5.3
       unhead: 1.1.25
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
-  '@unhead/vue@1.11.10(vue@3.5.12(typescript@5.0.4))':
+  '@unhead/vue@1.11.10(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       '@unhead/schema': 1.11.10
       '@unhead/shared': 1.11.10
       defu: 6.1.4
       hookable: 5.5.3
       unhead: 1.11.10
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
-  '@unhead/vue@1.8.9(vue@3.5.12(typescript@5.0.4))':
+  '@unhead/vue@1.8.9(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       '@unhead/schema': 1.8.9
       '@unhead/shared': 1.8.9
       hookable: 5.5.3
       unhead: 1.8.9
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
   '@vercel/nft@0.27.7(encoding@0.1.13)(rollup@4.24.2)':
     dependencies:
@@ -14981,20 +14849,20 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue@5.1.4(vite@5.4.19(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))(vue@3.5.12(typescript@5.0.4))':
+  '@vitejs/plugin-vue@5.1.4(vite@5.4.19(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0))(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       vite: 5.4.19(@types/node@18.19.59)(less@4.1.3)(terser@5.24.0)
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
-  '@vitejs/plugin-vue@5.1.4(vite@5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.12(typescript@4.9.5))':
+  '@vitejs/plugin-vue@5.1.4(vite@5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.13(typescript@4.9.5))':
     dependencies:
       vite: 5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
-      vue: 3.5.12(typescript@4.9.5)
+      vue: 3.5.13(typescript@4.9.5)
 
-  '@vitejs/plugin-vue@5.1.4(vite@5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.12(typescript@5.0.4))':
+  '@vitejs/plugin-vue@5.1.4(vite@5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       vite: 5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
   '@volar/language-core@1.11.1':
     dependencies:
@@ -15011,25 +14879,10 @@ snapshots:
 
   '@vue/compiler-core@3.2.47':
     dependencies:
-      '@babel/parser': 7.22.11
+      '@babel/parser': 7.27.1
       '@vue/shared': 3.2.47
       estree-walker: 2.0.2
       source-map: 0.6.1
-
-  '@vue/compiler-core@3.3.12':
-    dependencies:
-      '@babel/parser': 7.23.6
-      '@vue/shared': 3.3.12
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
-
-  '@vue/compiler-core@3.5.12':
-    dependencies:
-      '@babel/parser': 7.26.1
-      '@vue/shared': 3.5.12
-      entities: 4.5.0
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
 
   '@vue/compiler-core@3.5.13':
     dependencies:
@@ -15043,16 +14896,6 @@ snapshots:
     dependencies:
       '@vue/compiler-core': 3.2.47
       '@vue/shared': 3.2.47
-
-  '@vue/compiler-dom@3.3.12':
-    dependencies:
-      '@vue/compiler-core': 3.3.12
-      '@vue/shared': 3.3.12
-
-  '@vue/compiler-dom@3.5.12':
-    dependencies:
-      '@vue/compiler-core': 3.5.12
-      '@vue/shared': 3.5.12
 
   '@vue/compiler-dom@3.5.13':
     dependencies:
@@ -15072,18 +14915,6 @@ snapshots:
       postcss: 8.5.3
       source-map: 0.6.1
 
-  '@vue/compiler-sfc@3.5.12':
-    dependencies:
-      '@babel/parser': 7.26.1
-      '@vue/compiler-core': 3.5.12
-      '@vue/compiler-dom': 3.5.12
-      '@vue/compiler-ssr': 3.5.12
-      '@vue/shared': 3.5.12
-      estree-walker: 2.0.2
-      magic-string: 0.30.12
-      postcss: 8.5.3
-      source-map-js: 1.2.1
-
   '@vue/compiler-sfc@3.5.13':
     dependencies:
       '@babel/parser': 7.27.1
@@ -15100,11 +14931,6 @@ snapshots:
     dependencies:
       '@vue/compiler-dom': 3.2.47
       '@vue/shared': 3.2.47
-
-  '@vue/compiler-ssr@3.5.12':
-    dependencies:
-      '@vue/compiler-dom': 3.5.12
-      '@vue/shared': 3.5.12
 
   '@vue/compiler-ssr@3.5.13':
     dependencies:
@@ -15154,8 +14980,8 @@ snapshots:
     dependencies:
       '@volar/language-core': 1.11.1
       '@volar/source-map': 1.11.1
-      '@vue/compiler-dom': 3.3.12
-      '@vue/shared': 3.3.12
+      '@vue/compiler-dom': 3.5.13
+      '@vue/shared': 3.5.13
       computeds: 0.0.1
       minimatch: 9.0.3
       muggle-string: 0.3.1
@@ -15166,36 +14992,20 @@ snapshots:
 
   '@vue/reactivity-transform@3.2.47':
     dependencies:
-      '@babel/parser': 7.22.11
+      '@babel/parser': 7.27.1
       '@vue/compiler-core': 3.2.47
       '@vue/shared': 3.2.47
       estree-walker: 2.0.2
       magic-string: 0.25.9
 
-  '@vue/reactivity@3.5.12':
-    dependencies:
-      '@vue/shared': 3.5.12
-
   '@vue/reactivity@3.5.13':
     dependencies:
       '@vue/shared': 3.5.13
-
-  '@vue/runtime-core@3.5.12':
-    dependencies:
-      '@vue/reactivity': 3.5.12
-      '@vue/shared': 3.5.12
 
   '@vue/runtime-core@3.5.13':
     dependencies:
       '@vue/reactivity': 3.5.13
       '@vue/shared': 3.5.13
-
-  '@vue/runtime-dom@3.5.12':
-    dependencies:
-      '@vue/reactivity': 3.5.12
-      '@vue/runtime-core': 3.5.12
-      '@vue/shared': 3.5.12
-      csstype: 3.1.3
 
   '@vue/runtime-dom@3.5.13':
     dependencies:
@@ -15204,17 +15014,11 @@ snapshots:
       '@vue/shared': 3.5.13
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.12(vue@3.5.12(typescript@4.9.5))':
+  '@vue/server-renderer@3.5.13(vue@3.5.13(typescript@4.9.5))':
     dependencies:
-      '@vue/compiler-ssr': 3.5.12
-      '@vue/shared': 3.5.12
-      vue: 3.5.12(typescript@4.9.5)
-
-  '@vue/server-renderer@3.5.12(vue@3.5.12(typescript@5.0.4))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.12
-      '@vue/shared': 3.5.12
-      vue: 3.5.12(typescript@5.0.4)
+      '@vue/compiler-ssr': 3.5.13
+      '@vue/shared': 3.5.13
+      vue: 3.5.13(typescript@4.9.5)
 
   '@vue/server-renderer@3.5.13(vue@3.5.13(typescript@5.0.4))':
     dependencies:
@@ -15224,18 +15028,14 @@ snapshots:
 
   '@vue/shared@3.2.47': {}
 
-  '@vue/shared@3.3.12': {}
-
-  '@vue/shared@3.5.12': {}
-
   '@vue/shared@3.5.13': {}
 
-  '@vueuse/core@10.11.0(vue@3.5.12(typescript@4.9.5))':
+  '@vueuse/core@10.11.0(vue@3.5.13(typescript@4.9.5))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.0
-      '@vueuse/shared': 10.11.0(vue@3.5.12(typescript@4.9.5))
-      vue-demi: 0.14.8(vue@3.5.12(typescript@4.9.5))
+      '@vueuse/shared': 10.11.0(vue@3.5.13(typescript@4.9.5))
+      vue-demi: 0.14.8(vue@3.5.13(typescript@4.9.5))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -15249,35 +15049,35 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/head@1.1.15(vue@3.5.12(typescript@5.0.4))':
+  '@vueuse/head@1.1.15(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       '@unhead/dom': 1.1.15
       '@unhead/schema': 1.1.15
       '@unhead/ssr': 1.1.15
-      '@unhead/vue': 1.1.15(vue@3.5.12(typescript@5.0.4))
-      vue: 3.5.12(typescript@5.0.4)
+      '@unhead/vue': 1.1.15(vue@3.5.13(typescript@5.0.4))
+      vue: 3.5.13(typescript@5.0.4)
 
-  '@vueuse/head@1.1.23(vue@3.5.12(typescript@5.0.4))':
+  '@vueuse/head@1.1.23(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       '@unhead/dom': 1.1.25
       '@unhead/schema': 1.1.25
       '@unhead/ssr': 1.1.25
-      '@unhead/vue': 1.1.25(vue@3.5.12(typescript@5.0.4))
-      vue: 3.5.12(typescript@5.0.4)
+      '@unhead/vue': 1.1.25(vue@3.5.13(typescript@5.0.4))
+      vue: 3.5.13(typescript@5.0.4)
 
-  '@vueuse/head@1.3.1(vue@3.5.12(typescript@5.0.4))':
+  '@vueuse/head@1.3.1(vue@3.5.13(typescript@5.0.4))':
     dependencies:
       '@unhead/dom': 1.8.9
       '@unhead/schema': 1.8.9
       '@unhead/ssr': 1.11.10
-      '@unhead/vue': 1.8.9(vue@3.5.12(typescript@5.0.4))
-      vue: 3.5.12(typescript@5.0.4)
+      '@unhead/vue': 1.8.9(vue@3.5.13(typescript@5.0.4))
+      vue: 3.5.13(typescript@5.0.4)
 
-  '@vueuse/integrations@10.11.0(axios@1.8.4)(focus-trap@7.5.4)(jwt-decode@3.1.2)(vue@3.5.12(typescript@4.9.5))':
+  '@vueuse/integrations@10.11.0(axios@1.8.4)(focus-trap@7.5.4)(jwt-decode@3.1.2)(vue@3.5.13(typescript@4.9.5))':
     dependencies:
-      '@vueuse/core': 10.11.0(vue@3.5.12(typescript@4.9.5))
-      '@vueuse/shared': 10.11.0(vue@3.5.12(typescript@4.9.5))
-      vue-demi: 0.14.8(vue@3.5.12(typescript@4.9.5))
+      '@vueuse/core': 10.11.0(vue@3.5.13(typescript@4.9.5))
+      '@vueuse/shared': 10.11.0(vue@3.5.13(typescript@4.9.5))
+      vue-demi: 0.14.8(vue@3.5.13(typescript@4.9.5))
     optionalDependencies:
       axios: 1.8.4
       focus-trap: 7.5.4
@@ -15290,9 +15090,9 @@ snapshots:
 
   '@vueuse/metadata@12.0.0': {}
 
-  '@vueuse/shared@10.11.0(vue@3.5.12(typescript@4.9.5))':
+  '@vueuse/shared@10.11.0(vue@3.5.13(typescript@4.9.5))':
     dependencies:
-      vue-demi: 0.14.8(vue@3.5.12(typescript@4.9.5))
+      vue-demi: 0.14.8(vue@3.5.13(typescript@4.9.5))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -15807,7 +15607,7 @@ snapshots:
   babel-plugin-jest-hoist@27.5.1:
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/types': 7.22.11
+      '@babel/types': 7.27.1
       '@types/babel__core': 7.1.20
       '@types/babel__traverse': 7.18.2
 
@@ -16614,8 +16414,6 @@ snapshots:
   cssstyle@4.1.0:
     dependencies:
       rrweb-cssom: 0.7.1
-
-  csstype@3.1.1: {}
 
   csstype@3.1.3: {}
 
@@ -18276,11 +18074,11 @@ snapshots:
 
   flatted@3.2.7: {}
 
-  floating-vue@2.0.0-beta.20(vue@3.5.12(typescript@5.0.4)):
+  floating-vue@2.0.0-beta.20(vue@3.5.13(typescript@5.0.4)):
     dependencies:
       '@floating-ui/dom': 0.1.10
-      vue: 3.5.12(typescript@5.0.4)
-      vue-resize: 2.0.0-alpha.1(vue@3.5.12(typescript@5.0.4))
+      vue: 3.5.13(typescript@5.0.4)
+      vue-resize: 2.0.0-alpha.1(vue@3.5.13(typescript@5.0.4))
 
   fn.name@1.1.0: {}
 
@@ -19439,7 +19237,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/parser': 7.24.7
+      '@babel/parser': 7.27.1
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
@@ -19790,7 +19588,7 @@ snapshots:
       '@babel/generator': 7.20.4
       '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.26.0)
       '@babel/traverse': 7.25.9
-      '@babel/types': 7.22.11
+      '@babel/types': 7.27.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__traverse': 7.18.2
@@ -20487,10 +20285,6 @@ snapshots:
   magic-string@0.25.9:
     dependencies:
       sourcemap-codec: 1.4.8
-
-  magic-string@0.30.12:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.17:
     dependencies:
@@ -21612,11 +21406,11 @@ snapshots:
 
   pify@4.0.1: {}
 
-  pinia@2.2.4(typescript@5.0.4)(vue@3.5.12(typescript@5.0.4)):
+  pinia@2.2.4(typescript@5.0.4)(vue@3.5.13(typescript@5.0.4)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.12(typescript@5.0.4)
-      vue-demi: 0.14.10(vue@3.5.12(typescript@5.0.4))
+      vue: 3.5.13(typescript@5.0.4)
+      vue-demi: 0.14.10(vue@3.5.13(typescript@5.0.4))
     optionalDependencies:
       typescript: 5.0.4
 
@@ -23282,8 +23076,6 @@ snapshots:
 
   tmpl@1.0.5: {}
 
-  to-fast-properties@2.0.0: {}
-
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -23846,10 +23638,10 @@ snapshots:
       markdown-it: 12.3.2
       vite: 5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
 
-  vite-ssg@0.23.8(vite@5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue-router@4.4.5(vue@3.5.12(typescript@5.0.4)))(vue@3.5.12(typescript@5.0.4)):
+  vite-ssg@0.23.8(vite@5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue-router@4.4.5(vue@3.5.13(typescript@5.0.4)))(vue@3.5.13(typescript@5.0.4)):
     dependencies:
       '@unhead/dom': 1.11.10
-      '@unhead/vue': 1.11.10(vue@3.5.12(typescript@5.0.4))
+      '@unhead/vue': 1.11.10(vue@3.5.13(typescript@5.0.4))
       fs-extra: 11.2.0
       html-minifier-terser: 7.2.0
       html5parser: 2.0.2
@@ -23857,10 +23649,10 @@ snapshots:
       kolorist: 1.8.0
       prettier: 3.3.3
       vite: 5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
       yargs: 17.7.2
     optionalDependencies:
-      vue-router: 4.4.5(vue@3.5.12(typescript@5.0.4))
+      vue-router: 4.4.5(vue@3.5.13(typescript@5.0.4))
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -23906,16 +23698,16 @@ snapshots:
       '@shikijs/core': 1.10.1
       '@shikijs/transformers': 1.10.1
       '@types/markdown-it': 13.0.8
-      '@vitejs/plugin-vue': 5.1.4(vite@5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.12(typescript@4.9.5))
+      '@vitejs/plugin-vue': 5.1.4(vite@5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0))(vue@3.5.13(typescript@4.9.5))
       '@vue/devtools-api': 7.3.5
-      '@vueuse/core': 10.11.0(vue@3.5.12(typescript@4.9.5))
-      '@vueuse/integrations': 10.11.0(axios@1.8.4)(focus-trap@7.5.4)(jwt-decode@3.1.2)(vue@3.5.12(typescript@4.9.5))
+      '@vueuse/core': 10.11.0(vue@3.5.13(typescript@4.9.5))
+      '@vueuse/integrations': 10.11.0(axios@1.8.4)(focus-trap@7.5.4)(jwt-decode@3.1.2)(vue@3.5.13(typescript@4.9.5))
       focus-trap: 7.5.4
       mark.js: 8.11.1
       minisearch: 6.3.0
       shiki: 1.10.1
       vite: 5.4.19(@types/node@18.19.59)(less@4.2.0)(terser@5.24.0)
-      vue: 3.5.12(typescript@4.9.5)
+      vue: 3.5.13(typescript@4.9.5)
     optionalDependencies:
       postcss: 8.5.3
     transitivePeerDependencies:
@@ -23969,13 +23761,13 @@ snapshots:
 
   vscode-uri@3.0.6: {}
 
-  vue-demi@0.14.10(vue@3.5.12(typescript@5.0.4)):
+  vue-demi@0.14.10(vue@3.5.13(typescript@5.0.4)):
     dependencies:
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
-  vue-demi@0.14.8(vue@3.5.12(typescript@4.9.5)):
+  vue-demi@0.14.8(vue@3.5.13(typescript@4.9.5)):
     dependencies:
-      vue: 3.5.12(typescript@4.9.5)
+      vue: 3.5.13(typescript@4.9.5)
 
   vue-eslint-parser@9.1.0(eslint@8.57.1):
     dependencies:
@@ -24007,32 +23799,32 @@ snapshots:
     dependencies:
       konva: 8.3.13
 
-  vue-markdown-render@2.2.1(vue@3.5.12(typescript@5.0.4)):
+  vue-markdown-render@2.2.1(vue@3.5.13(typescript@5.0.4)):
     dependencies:
       markdown-it: 13.0.2
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
-  vue-resize@2.0.0-alpha.1(vue@3.5.12(typescript@5.0.4)):
+  vue-resize@2.0.0-alpha.1(vue@3.5.13(typescript@5.0.4)):
     dependencies:
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
-  vue-router@4.4.5(vue@3.5.12(typescript@5.0.4)):
+  vue-router@4.4.5(vue@3.5.13(typescript@5.0.4)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
-  vue-safe-teleport@0.1.2(vue@3.5.12(typescript@5.0.4)):
+  vue-safe-teleport@0.1.2(vue@3.5.13(typescript@5.0.4)):
     dependencies:
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
   vue-template-compiler@2.7.14:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
 
-  vue-toastification@2.0.0-rc.5(vue@3.5.12(typescript@5.0.4)):
+  vue-toastification@2.0.0-rc.5(vue@3.5.13(typescript@5.0.4)):
     dependencies:
-      vue: 3.5.12(typescript@5.0.4)
+      vue: 3.5.13(typescript@5.0.4)
 
   vue-tsc@1.8.27(typescript@5.0.4):
     dependencies:
@@ -24041,25 +23833,15 @@ snapshots:
       semver: 7.5.4
       typescript: 5.0.4
 
-  vue@3.5.12(typescript@4.9.5):
+  vue@3.5.13(typescript@4.9.5):
     dependencies:
-      '@vue/compiler-dom': 3.5.12
-      '@vue/compiler-sfc': 3.5.12
-      '@vue/runtime-dom': 3.5.12
-      '@vue/server-renderer': 3.5.12(vue@3.5.12(typescript@4.9.5))
-      '@vue/shared': 3.5.12
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-sfc': 3.5.13
+      '@vue/runtime-dom': 3.5.13
+      '@vue/server-renderer': 3.5.13(vue@3.5.13(typescript@4.9.5))
+      '@vue/shared': 3.5.13
     optionalDependencies:
       typescript: 4.9.5
-
-  vue@3.5.12(typescript@5.0.4):
-    dependencies:
-      '@vue/compiler-dom': 3.5.12
-      '@vue/compiler-sfc': 3.5.12
-      '@vue/runtime-dom': 3.5.12
-      '@vue/server-renderer': 3.5.12(vue@3.5.12(typescript@5.0.4))
-      '@vue/shared': 3.5.12
-    optionalDependencies:
-      typescript: 5.0.4
 
   vue@3.5.13(typescript@5.0.4):
     dependencies:


### PR DESCRIPTION
The library that we were using for the computedAsync filteredComponents depended on the vue version 13.5.13, and we're using vue 13.5.12. This caused typescript to get confused and not know vue would unwrap refs, giving a linting error on the Eplore.vue change we fixed here. This pr updates vue by a minor version, which didn't seem to cause any functional changes. 

We tested it manually, but had to run pnpm install on our system to get the correct linting 