### PR TITLE
Fix typo bug for documentation panel collapse

### DIFF
--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -498,7 +498,7 @@ section.grid.docs-open-without-banner {
   grid-template-rows: 3rem minmax(0, 1fr);
   grid-template-columns: minmax(0, 1fr) minmax(0, 25%) minmax(0, 25%);
 }
-section.grid.docs-closedout-with-banner {
+section.grid.docs-closed-without-banner {
   grid-template-areas:
     "name right"
     "attrs right";


### PR DESCRIPTION
## Description

This change fixes the typo bug when collapsing the documentation panel in component details.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlcmozamF1eDdwMzIzYmgyOXYwNW5qeXdsYTg1YzdwdnZ0YmVmZGIycCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/lALXmzceZjqI1ogAYQ/giphy.gif"/>