### PR TITLE
fix: add query string to webworker urls

### DIFF
--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -67,7 +67,7 @@ lockAcquiredBroadcastChannel.onmessage = (message) => {
 const SHARED_WEB_WORKER_URL =
   import.meta.env.VITE_SI_ENV === "local"
     ? "../../workers/shared_webworker.ts"
-    : "shared_webworker.js";
+    : `shared_webworker.js?v=${__SHARED_WORKER_HASH__}`;
 
 // Shared workers are unique per *name*, not per code URL.
 const spawnSharedWorker = (name: string) =>
@@ -83,10 +83,11 @@ let db: Comlink.Remote<SharedDBInterface> = Comlink.wrap(sharedWorker.port);
 const WORKER_URL =
   import.meta.env.VITE_SI_ENV === "local"
     ? "../../workers/webworker.ts"
-    : "webworker.js";
+    : `webworker.js?v=${__WEBWORKER_HASH__}`;
 
 const tabWorker = new Worker(new URL(WORKER_URL, import.meta.url), {
   type: "module",
+  name: `si-db-${__WEBWORKER_HASH__}`,
 });
 const tabDb: Comlink.Remote<TabDBInterface> = Comlink.wrap(tabWorker);
 

--- a/app/web/src/vite-env.d.ts
+++ b/app/web/src/vite-env.d.ts
@@ -1,2 +1,3 @@
 declare const __COMMIT_HASH__: string;
 declare const __SHARED_WORKER_HASH__: string;
+declare const __WEBWORKER_HASH__: string;

--- a/app/web/vite.config.ts
+++ b/app/web/vite.config.ts
@@ -43,6 +43,8 @@ const gitHashFile = (file: string) => {
   const cmd = `git hash-object '${file}'`;
   return child_process.execSync(cmd).toString().trim();
 }
+const webWorkerPath = path.resolve(__dirname, "src/workers/webworker.ts");
+const webWorkerHash = JSON.stringify(gitHashFile(webWorkerPath));
 
 const sharedWorkerPath = path.resolve(__dirname, "src/workers/shared_webworker.ts");
 const sharedWorkerHash = JSON.stringify(gitHashFile(sharedWorkerPath));
@@ -62,6 +64,7 @@ export default (opts: { mode: string }) => {
     define: {
       __COMMIT_HASH__:  headCommitHash,
       __SHARED_WORKER_HASH__: sharedWorkerHash,
+      __WEBWORKER_HASH__: webWorkerHash,
     },
     plugins: [
       dotPathFixPlugin(),
@@ -137,7 +140,7 @@ export default (opts: { mode: string }) => {
       rollupOptions: {
         input: {
           main: path.resolve(__dirname, "index.html"),
-          worker: path.resolve(__dirname, "src/workers/webworker.ts"), // Add worker as an entry point
+          worker: webWorkerPath,
           sharedWorker: sharedWorkerPath,
         },
         output: {


### PR DESCRIPTION
To prevent caching of old webworker code, fetch them with the hash appended.