### PR TITLE
fix(web): Ensure that we are reactive to selected components for mgmt functions

### DIFF
--- a/app/web/src/newhotness/ComponentContextMenu.vue
+++ b/app/web/src/newhotness/ComponentContextMenu.vue
@@ -116,14 +116,12 @@ const actionByPrototype = computed(() => {
 });
 const schemaVariantQuery = useQuery<SchemaVariant | null>({
   enabled: () => singleComponent.value !== undefined,
-  queryKey: key(
-    EntityKind.SchemaVariant,
-    singleComponent.value?.schemaVariantId,
-  ),
-  queryFn: async () =>
-    await bifrost<SchemaVariant>(
+  queryKey: key(EntityKind.SchemaVariant, schemaVariantId),
+  queryFn: async () => {
+    return await bifrost<SchemaVariant>(
       args(EntityKind.SchemaVariant, singleComponent.value?.schemaVariantId),
-    ),
+    );
+  },
 });
 const managementFunctions = computed(
   () => schemaVariantQuery.data.value?.mgmtFunctions ?? [],


### PR DESCRIPTION
The fix ensures that:
  1. . When you right-click on different components, the schema variant 
   ery executes with the correct schema variant ID
  2. The query cache is properly keyed by the schema variant ID, preventing stale data from being returned
  3. Each component shows its correct management functions (or no management functions if none are defined for that schema variant)