### PR TITLE
Solidify optimistic AV operation

### DIFF
--- a/app/web/src/newhotness/util.ts
+++ b/app/web/src/newhotness/util.ts
@@ -3,7 +3,11 @@ import {
   IconNames,
   BRAND_COLOR_FILTER_HEX_CODES,
 } from "@si/vue-lib/design-system";
-import { AttributeTree } from "@/workers/types/entity_kind_types";
+import {
+  AttributeTree,
+  AttributeValue,
+} from "@/workers/types/entity_kind_types";
+import { AttributePath } from "@/api/sdf/dal/component";
 import { Toggle } from "./logic_composables/toggle_containers";
 import { SelectionsInQueryString } from "./Workspace.vue";
 
@@ -107,4 +111,18 @@ export const preserveExploreState = (
   if (currentQuery.viewId) preservedQuery.viewId = currentQuery.viewId;
 
   return preservedQuery;
+};
+
+export const findAttributeValueInTree = (
+  tree: AttributeTree,
+  targetPath: AttributePath,
+): { attributeValue: AttributeValue; avId: string } | null => {
+  const pathStr = targetPath.toString();
+
+  for (const [avId, av] of Object.entries(tree.attributeValues)) {
+    if (av.path === pathStr) {
+      return { attributeValue: av, avId };
+    }
+  }
+  return null;
 };


### PR DESCRIPTION
## How does this PR change the system?

1. The data passed back in the arguments to `setQueryData` is a proxy which fails on the `structuredClone`.
2. We don't need to invalidate the cache in onSettled, since the patch operation is going to do that for us.
3. We don't need to track an optimistic value separately from the tan stack data, since we're mutating the tan stack data itself.
4. Re-use the findAV function, and check the AV path not the prop path (the prop path has `root/` on it, so the path was never being found correctly).

### Testing
Comment out the `mutateFn` and set and/or remove the subscription to an EC2 instance Region to a /domain/extra/Region and watch the UI update without POSTing the to the API. This proves that the optimistic does something to the tanstack data and that the patch isn't the one performing the update.

Then of course un-comment and run the API call and watch it work in the full patch loop.