### PR TITLE
fix: Make migrate connections endpoint async (communicates via WsEvent)

### DIFF
--- a/app/web/src/components/AdminDashboard/MigrateConnections.vue
+++ b/app/web/src/components/AdminDashboard/MigrateConnections.vue
@@ -1,65 +1,68 @@
 <template>
   <Stack class="p-10 w-full">
-    <h1>Migrate Connections</h1>
-    <LoadStatus :requestStatus="requestStatus">
-      <template #loading>
-        <div class="text-neutral-500">Migrating connections ...</div>
-      </template>
-      <template #error>
-        <div class="text-red-500">
-          Error migrating connections: {{ requestStatus.errorMessage }}
+    <h1>Migrate Connections {{ migrationRun?.dryRun ? "(dry run)" : "" }}</h1>
+
+    <!-- Show status -->
+    <div v-if="!migrationRun">Waiting for migrationRun to start ...</div>
+    <div v-else-if="!migrationRun.summary" class="text-neutral-500">
+      Migrating connections ... ({{ elapsed }})
+    </div>
+    <div v-else-if="migrationRun.summary.error" class="text-red-500">
+      Error migrating after {{ elapsed }}: {{ migrationRun.summary.error }}
+    </div>
+    <div v-else>
+      Migrated {{ migrationRun?.dryRun ? "(dry run)" : "" }} in {{ elapsed }}!
+    </div>
+
+    <!-- Show migrations -->
+    <Stack class="flex flex-col gap-xs p-xs w-full font-bold text-xs">
+      <Stack>
+        <div class="text-lg">
+          Migrateable Connections: {{ migrateable.length }}
         </div>
-      </template>
-      <template #success>
-        <Stack class="flex flex-col gap-xs p-xs w-full font-bold text-xs">
-          <Stack>
-            <div class="text-lg">
-              Migrateable Connections: {{ migrateable.length }}
-            </div>
-            <div v-for="migration of migrateable" :key="migration.message">
-              {{ migration.message }}
-            </div>
-          </Stack>
-          <Stack v-if="unmigrateableBecause.length > 0">
-            <div class="text-lg">
-              Unmigrateable Connections:
-              {{
-                unmigrateableBecause
-                  .map(([_, migrations]) => migrations.length)
-                  .reduce((a, b) => a + b, 0)
-              }}
-            </div>
-            <div
-              v-for="[because, migrations] in unmigrateableBecause"
-              :key="because"
-            >
-              <div class="text-lg">{{ because }}: {{ migrations.length }}</div>
-              <div v-for="migration in migrations" :key="migration.message">
-                {{ migration.message }}
-              </div>
-            </div>
-          </Stack>
-          <Stack
-            v-if="alreadyMigrated.length > 0"
-            class="flex flex-row gap-xs p-xs w-full"
-          >
-            <div class="text-lg">
-              Already Migrated Connections: {{ alreadyMigrated.length }}
-            </div>
-            <div v-for="migration of alreadyMigrated" :key="migration.message">
-              {{ migration.message }}
-            </div>
-          </Stack>
-        </Stack>
-      </template>
-    </LoadStatus>
+        <div v-for="migration of migrateable" :key="migration.message">
+          {{ migration.message }}
+        </div>
+      </Stack>
+      <Stack v-if="unmigrateableBecause.length > 0">
+        <div class="text-lg">
+          Unmigrateable Connections:
+          {{
+            unmigrateableBecause
+              .map(([_, migrations]) => migrations.length)
+              .reduce((a, b) => a + b, 0)
+          }}
+        </div>
+        <div
+          v-for="[because, migrations] in unmigrateableBecause"
+          :key="because"
+        >
+          <div class="text-lg">{{ because }}: {{ migrations.length }}</div>
+          <div v-for="migration in migrations" :key="migration.message">
+            {{ migration.message }}
+          </div>
+        </div>
+      </Stack>
+      <Stack
+        v-if="alreadyMigrated.length > 0"
+        class="flex flex-row gap-xs p-xs w-full"
+      >
+        <div class="text-lg">
+          Already Migrated Connections: {{ alreadyMigrated.length }}
+        </div>
+        <div v-for="migration of alreadyMigrated" :key="migration.message">
+          {{ migration.message }}
+        </div>
+      </Stack>
+    </Stack>
   </Stack>
 </template>
 
 <script lang="ts" setup>
 import * as _ from "lodash-es";
 import { computed } from "vue";
-import { Stack, LoadStatus } from "@si/vue-lib/design-system";
+import { Stack, durationString } from "@si/vue-lib/design-system";
+import { useNow } from "@vueuse/core";
 import {
   ConnectionMigration,
   ConnectionUnmigrateableBecause,
@@ -67,12 +70,20 @@ import {
 } from "@/store/admin.store";
 
 const adminStore = useAdminStore();
-const requestStatus = adminStore.getRequestStatus("MIGRATE_CONNECTIONS");
+const migrationRun = computed(() => adminStore.connectionMigrationRun);
+const now = useNow();
+const elapsed = computed(() => {
+  if (!migrationRun.value) return "<error: not started>";
+  const start = migrationRun.value.startedAt;
+  const end = migrationRun.value.summary?.finishedAt ?? now.value;
+  return durationString(end.getTime() - start.getTime());
+});
+
 const migrationsByIssue = computed(
   () =>
     _.groupBy(
-      adminStore.migrateConnectionsResponse?.migrations ?? [],
-      (migration) => migration.issue?.type ?? "migrateable",
+      migrationRun.value?.migrations ?? [],
+      (migrationRun) => migrationRun.issue?.type ?? "migrateable",
     ) as Record<
       ConnectionUnmigrateableBecause["type"] | "migrateable",
       ConnectionMigration[]

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -33,6 +33,7 @@ import { UserId } from "../auth.store";
 import { SecretId } from "../secrets.store";
 import { FuncRunId } from "../actions.store";
 import { FuncRunLogId } from "../func_runs.store";
+import { ConnectionMigration } from "../admin.store";
 
 export type WebsocketRequest =
   | CursorRequest
@@ -230,6 +231,17 @@ export type WsEventPayloadMap = {
         toComponentId: string;
       };
 
+  ConnectionMigrationStarted: {
+    dryRun: boolean;
+  };
+  ConnectionMigrationFinished: {
+    dryRun: boolean;
+    connections: number;
+    migrated: number;
+    unmigrateable: number;
+    error?: string;
+  };
+  ConnectionMigrated: ConnectionMigration;
   ManagementFuncExecuted: {
     managerComponentId: string;
     prototypeId: string;

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -88,6 +88,11 @@ use crate::{
         CursorPayload,
         OnlinePayload,
     },
+    workspace_snapshot::graph::validator::connections::{
+        ConnectionMigratedPayload,
+        ConnectionMigrationFinishedPayload,
+        ConnectionMigrationStartedPayload,
+    },
 };
 
 #[remain::sorted]
@@ -109,11 +114,19 @@ pub enum WsEventError {
     SchemaVariant(#[from] SchemaVariantError),
     #[error("error serializing/deserializing json: {0}")]
     SerdeJson(#[from] serde_json::Error),
-    #[error(transparent)]
+    #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),
+    #[error("workspace snapshot: {0}")]
+    WorkspaceSnapshot(#[from] crate::WorkspaceSnapshotError),
 }
 
 pub type WsEventResult<T> = Result<T, WsEventError>;
+
+impl From<FuncError> for WsEventError {
+    fn from(err: FuncError) -> Self {
+        Box::new(err).into()
+    }
+}
 
 #[remain::sorted]
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
@@ -148,6 +161,9 @@ pub enum WsPayload {
     ComponentUpdated(ComponentUpdatedPayload),
     ComponentUpgraded(ComponentUpgradedPayload),
     ConnectionDeleted(ConnectionDeletedPayload),
+    ConnectionMigrated(ConnectionMigratedPayload),
+    ConnectionMigrationFinished(ConnectionMigrationFinishedPayload),
+    ConnectionMigrationStarted(ConnectionMigrationStartedPayload),
     ConnectionUpserted(ConnectionUpsertedPayload),
     Cursor(CursorPayload),
     FuncArgumentsSaved(FuncWsEventPayload),

--- a/lib/sdf-server/src/service/v2/change_set.rs
+++ b/lib/sdf-server/src/service/v2/change_set.rs
@@ -100,6 +100,8 @@ pub enum Error {
     Request(#[from] reqwest::Error),
     #[error("si db error: {0}")]
     SiDb(#[from] si_db::Error),
+    #[error("slow runtime error: {0}")]
+    SlowRuntime(#[from] dal::slow_rt::SlowRuntimeError),
     #[error("spice db error: {0}")]
     SpiceDB(#[from] SpiceDbError),
     #[error("spicedb client not found")]
@@ -220,7 +222,10 @@ pub fn change_set_routes(state: AppState) -> Router<AppState> {
                 permissions::Permission::Approve,
             )),
         )
-        .route("/migrate_connections", get(migrate_connections::dry_run))
+        .route(
+            "/migrate_connections",
+            get(migrate_connections::migrate_connections_dry_run),
+        )
         .route(
             "/migrate_connections",
             post(migrate_connections::migrate_connections),

--- a/lib/vue-lib/src/design-system/utils/timestamp.ts
+++ b/lib/vue-lib/src/design-system/utils/timestamp.ts
@@ -80,3 +80,18 @@ export function dateString(
   }
   return `${dateClassesSpan}${format(d, "MMMM d, y")}${dateClassesCloseSpan}`;
 }
+
+export function durationString(ms: number): string {
+  if (ms < 0) ms = -ms;
+  const time = {
+    day: Math.floor(ms / 86400000),
+    hour: Math.floor(ms / 3600000) % 24,
+    minute: Math.floor(ms / 60000) % 60,
+    second: Math.floor(ms / 1000) % 60,
+    millisecond: Math.floor(ms) % 1000,
+  };
+  return Object.entries(time)
+    .filter((val) => val[1] !== 0)
+    .map(([key, val]) => `${val} ${key}${val !== 1 ? "s" : ""}`)
+    .join(", ");
+}


### PR DESCRIPTION
When migrations take longer than 60 seconds, we currently time out and don't complete the migration. This PR makes the migrate_connections endpoint kick off a background migration task, and sends WsEvents to communicate status to the Admin UI.

## How was it tested?

- [X] Run dry run and non-dry run migrations with actual migrateable connections; make sure non-dry run commits
- [X] Run multiple migrations in a row and make sure they show up

## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbms4MjlxcmM4NTdjc3cybWpibWlwdWgwOXliMnU0NWtscjFqdWE3dyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/SWVzkIlHdEckF81gnA/giphy.gif)
