### PR TITLE
feat(web): on cold start, do database operations in bulk

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -102,6 +102,7 @@
     "pinia": "^2.2.4",
     "plur": "^5.1.0",
     "posthog-js": "^1.155.0",
+    "quick-lru": "^7.0.1",
     "reconnecting-websocket": "^4.4.0",
     "sigma": "3.0.0-beta.5",
     "sourcemapped-stacktrace": "^1.1.11",

--- a/app/web/src/newhotness/ActionsPanel.vue
+++ b/app/web/src/newhotness/ActionsPanel.vue
@@ -30,7 +30,7 @@
 
 <script lang="ts" setup>
 import { useQuery } from "@tanstack/vue-query";
-import { computed } from "vue";
+import { computed, inject } from "vue";
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import {
   ActionPrototypeViewList,
@@ -41,6 +41,7 @@ import {
 import { ActionId, ActionPrototypeId } from "@/api/sdf/dal/action";
 import ActionWidget from "./ActionWidget.vue";
 import EmptyState from "./EmptyState.vue";
+import { assertIsDefined, Context } from "./types";
 
 const props = defineProps<{
   component: BifrostComponent;
@@ -53,11 +54,15 @@ const props = defineProps<{
 const makeKey = useMakeKey();
 const makeArgs = useMakeArgs();
 
+const ctx = inject<Context>("CONTEXT");
+assertIsDefined(ctx);
+
 const queryKeyForActionPrototypeViews = makeKey(
   EntityKind.ActionPrototypeViewList,
   props.component.schemaVariant.id,
 );
 const actionPrototypeViewsRaw = useQuery<ActionPrototypeViewList | null>({
+  enabled: ctx.queriesEnabled,
   queryKey: queryKeyForActionPrototypeViews,
   queryFn: async () =>
     await bifrost<ActionPrototypeViewList>(

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -781,6 +781,7 @@ const componentListQueryId = computed(() =>
 const componentQueryKey = key(componentListQueryKind, componentListQueryId);
 const componentListQuery = useQuery<ComponentInList[]>({
   queryKey: componentQueryKey,
+  enabled: ctx.queriesEnabled,
   queryFn: async () => {
     const arg = selectedViewId.value
       ? args<Listable>(EntityKind.ViewComponentList, selectedViewId.value)

--- a/app/web/src/newhotness/StatusPanel.vue
+++ b/app/web/src/newhotness/StatusPanel.vue
@@ -44,6 +44,7 @@ const args = useMakeArgs();
 
 const dependentValueComponentListQuery =
   useQuery<DependentValueComponentList | null>({
+    enabled: ctx.queriesEnabled,
     queryKey: key(EntityKind.DependentValueComponentList),
     queryFn: async () =>
       await bifrost<DependentValueComponentList>(

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -184,8 +184,6 @@ const bustTanStackCache: BustCacheFn = (
   noBroadcast?: boolean,
 ) => {
   const queryKey = [workspaceId, changeSetId, kind, id];
-  // eslint-disable-next-line no-console
-  console.log("💥 bust tanstack cache for", queryKey);
   queryClient.invalidateQueries({ queryKey });
   if (!noBroadcast) {
     db.broadcastMessage({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,6 +369,9 @@ importers:
       posthog-js:
         specifier: ^1.155.0
         version: 1.155.0
+      quick-lru:
+        specifier: ^7.0.1
+        version: 7.0.1
       reconnecting-websocket:
         specifier: ^4.4.0
         version: 4.4.0
@@ -9388,6 +9391,10 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  quick-lru@7.0.1:
+    resolution: {integrity: sha512-kLjThirJMkWKutUKbZ8ViqFc09tDQhlbQo2MNuVeLWbRauqYP96Sm6nzlQ24F0HFjUNZ4i9+AgldJ9H6DZXi7g==}
+    engines: {node: '>=18'}
 
   quote-unquote@1.0.0:
     resolution: {integrity: sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==}
@@ -21789,6 +21796,8 @@ snapshots:
   quick-format-unescaped@4.0.4: {}
 
   quick-lru@5.1.1: {}
+
+  quick-lru@7.0.1: {}
 
   quote-unquote@1.0.0: {}
 


### PR DESCRIPTION
Insert atoms, mtms, and do cleanup in single SQL queries to improve frontend performance.

Removes `coldStartComputed`. Handling of atoms is now entirely in `postProcess`.
    
Use QuickLRU for the decodedAtomCache to prevent runaway atom cache sizes.

Also included: use queriesEnabled from the context in more places to ensure we do not query before the database is ready

## Testing this PR

Load a big workspace. Ensure everything is as expected :).

Confirm management edges and possible connections are correct. 