### PR TITLE
Add resource values panel

### DIFF
--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -95,7 +95,11 @@
             tabindex="0"
             type="text"
             @blur="blurNameInput"
-            @input="(e: Event) => { handleNameInput(e, field); }"
+            @input="
+              (e: Event) => {
+                handleNameInput(e, field);
+              }
+            "
             @keydown.enter.stop.prevent="blurNameInput"
             @keydown.esc.stop.prevent="resetNameInput"
             @keydown.tab.stop.prevent="onNameInputTab"
@@ -229,8 +233,6 @@ import {
   BifrostComponent,
   EntityKind,
   MgmtFunction,
-  Prop,
-  Secret,
 } from "@/workers/types/entity_kind_types";
 import { PropKind } from "@/api/sdf/dal/prop";
 import { useMakeKey } from "@/store/realtime/heimdall";
@@ -244,6 +246,7 @@ import { useWatchedForm } from "./logic_composables/watched_form";
 import { NameFormData } from "./ComponentDetails.vue";
 import EmptyState from "./EmptyState.vue";
 import { findAttributeValueInTree } from "./util";
+import { AttrTree, makeAvTree } from "./logic_composables/attribute_tree";
 
 const q = ref("");
 
@@ -253,43 +256,6 @@ const props = defineProps<{
   importFunc?: MgmtFunction;
   importFuncRun?: FuncRun;
 }>();
-
-export interface AttrTree {
-  id: string;
-  children: AttrTree[];
-  parent?: string;
-  prop?: Prop;
-  secret?: Secret;
-  attributeValue: AttributeValue;
-  isBuildable: boolean; // is my parent an array or map?
-}
-
-const makeAvTree = (
-  data: AttributeTree,
-  avId: string,
-  isBuildable: boolean,
-  parent?: string,
-): AttrTree => {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const av = data.attributeValues[avId]!;
-  const prop = av.propId ? data.props[av.propId] : undefined;
-  const secret = av.secret ?? undefined;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const childrenIds = data.treeInfo[avId]!.children;
-  const children = childrenIds.map((id) =>
-    makeAvTree(data, id, ["array", "map"].includes(prop?.kind ?? ""), avId),
-  );
-  const tree: AttrTree = {
-    id: avId,
-    children,
-    parent,
-    attributeValue: av,
-    prop,
-    secret,
-    isBuildable,
-  };
-  return tree;
-};
 
 const root = computed<AttrTree>(() => {
   const empty = {

--- a/app/web/src/newhotness/ResourcePanel.vue
+++ b/app/web/src/newhotness/ResourcePanel.vue
@@ -4,7 +4,12 @@
       v-if="resourcePayload"
       :code="JSON.stringify(resourcePayload, null, 2)"
     />
-    <EmptyState v-else icon="check-hex" text="This component has no resource" />
+    <EmptyState
+      v-else
+      icon="check-hex"
+      text="No resource"
+      secondaryText="This component hasn’t been applied to HEAD, so its resource (the real-world object it represents) hasn’t been created yet."
+    />
   </ul>
 </template>
 

--- a/app/web/src/newhotness/ResourceValuesPanel.vue
+++ b/app/web/src/newhotness/ResourceValuesPanel.vue
@@ -1,0 +1,225 @@
+<template>
+  <div
+    v-if="root && component && attributeTree && component.hasResource"
+    class="p-xs flex flex-col gap-xs"
+  >
+    <div>
+      <SiSearch
+        ref="searchRef"
+        v-model="q"
+        placeholder="filter resource values..."
+        :tabIndex="0"
+        :borderBottom="false"
+        @keydown.tab="onSearchInputTab"
+      />
+    </div>
+    <div
+      v-if="'children' in filtered.tree && filtered.tree.children.length > 0"
+    >
+      <!-- this is _really_ a type guard for "i am not an empty object" -->
+      <ul
+        :class="
+          clsx(
+            'border-l border-r border-t',
+            themeClasses('border-neutral-200', 'border-neutral-800'),
+          )
+        "
+      >
+        <ComponentAttribute
+          v-for="child in filtered.tree.children"
+          :key="child.id"
+          :component="component"
+          :attributeTree="child"
+          forceReadOnly
+        />
+      </ul>
+      <div
+        :class="
+          clsx(
+            'w-full border-b',
+            themeClasses('border-neutral-200', 'border-neutral-800'),
+          )
+        "
+      />
+    </div>
+  </div>
+  <EmptyState
+    v-else
+    icon="check-hex"
+    text="No resource"
+    secondaryText="This component hasn’t been applied to HEAD, so its resource (the real-world object it represents) hasn’t been created yet."
+  />
+</template>
+
+<script lang="ts" setup>
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  reactive,
+  ref,
+  watch,
+} from "vue";
+import { Fzf } from "fzf";
+import { themeClasses, SiSearch } from "@si/vue-lib/design-system";
+import clsx from "clsx";
+import * as _ from "lodash-es";
+import {
+  AttributeTree,
+  AttributeValue,
+  BifrostComponent,
+} from "@/workers/types/entity_kind_types";
+import ComponentAttribute from "./layout_components/ComponentAttribute.vue";
+import { keyEmitter } from "./logic_composables/emitters";
+import { AttrTree, makeAvTree } from "./logic_composables/attribute_tree";
+import EmptyState from "./EmptyState.vue";
+
+const q = ref("");
+
+const props = defineProps<{
+  component?: BifrostComponent;
+  attributeTree?: AttributeTree;
+}>();
+
+// TODO(nick): move the root computation to a shared location since this is a copy from "AttributePanel".
+const root = computed<AttrTree>(() => {
+  const empty = {
+    id: "",
+    children: [] as AttrTree[],
+    attributeValue: {} as AttributeValue,
+    isBuildable: false,
+  };
+  const raw = props.attributeTree;
+  if (!raw) return empty;
+
+  // find the root node in the tree, the only one with parent null
+  const rootId = Object.keys(raw.treeInfo).find((avId) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const av = raw.treeInfo[avId]!;
+    if (!av.parent) return true;
+    return false;
+  });
+  if (!rootId) return empty;
+
+  const tree = makeAvTree(raw, rootId, false);
+  return tree;
+});
+
+const resourceValue = computed(() =>
+  root.value?.children.find((c) => c.prop?.name === "resource_value"),
+);
+
+const filtered = reactive<{ tree: AttrTree | object }>({
+  tree: {},
+});
+
+// TODO(nick): move the root computation to a shared location since this is a copy from "AttributePanel".
+watch(
+  () => [q.value, resourceValue.value],
+  () => {
+    if (!q.value) {
+      filtered.tree = resourceValue.value ?? {};
+      return;
+    }
+    if (!resourceValue.value) {
+      filtered.tree = {};
+      return;
+    }
+
+    // we need to access attrs by id
+    const map: Record<string, AttrTree> = {};
+    map[resourceValue.value.id] = resourceValue.value;
+    const walking = [...resourceValue.value.children];
+    // walk all the children and find if they match
+    while (walking.length > 0) {
+      const attr = walking.shift();
+      if (!attr) break;
+      map[attr.id] = attr;
+      walking.push(...attr.children);
+    }
+
+    const fzf = new Fzf(Object.values(map), {
+      casing: "case-insensitive",
+      selector: (p) =>
+        `${p.id} ${p.prop?.name} ${p.prop?.path} ${p.attributeValue.key} ${p.attributeValue.value}`,
+    });
+
+    const results = fzf.find(q.value);
+    // Maybe we want to get rid of low scoring options (via std dev)?
+    const matches: AttrTree[] = results.map((fz) => fz.item);
+
+    // get new instances of all the objects with empty children arrays
+    const parentsWithoutChildren = Object.values(map)
+      .map((attr) => {
+        return {
+          ...attr,
+          children: [],
+        };
+      })
+      .reduce((map, attr) => {
+        map[attr.id] = attr;
+        return map;
+      }, {} as Record<string, AttrTree>);
+
+    const matchesAsTree: Record<string, AttrTree> = {};
+    // work backwards from the leaf node, filling in their parents children arrays
+    // make sure there are no dupes b/c matches will give us dupes
+    matches.forEach((attr) => {
+      const parents = [attr.parent];
+      let prevPid: string | undefined;
+      while (parents.length > 0) {
+        const pId = parents.shift();
+        if (!pId) throw new Error("no pid");
+        let p: AttrTree | undefined;
+        p = matchesAsTree[pId];
+        if (!p) p = parentsWithoutChildren[pId];
+        if (p) {
+          if (prevPid) {
+            const lastParent = matchesAsTree[prevPid];
+            if (lastParent && !p.children.some((c) => c.id === lastParent.id))
+              p.children.push(lastParent);
+          } else if (!p.children.some((c) => c.id === attr.id))
+            p.children.push(attr);
+
+          matchesAsTree[p.id] = p;
+
+          if (p.parent && p.id !== resourceValue.value?.id)
+            // dont traverse past "resource_value"
+            parents.push(p.parent);
+        }
+        prevPid = pId;
+      }
+    });
+
+    // all roads lead back to resource value
+    const newResourceValue = matchesAsTree[resourceValue.value.id];
+    filtered.tree = newResourceValue ?? {};
+  },
+  { immediate: true },
+);
+
+const searchRef = ref<InstanceType<typeof SiSearch>>();
+
+onMounted(() => {
+  keyEmitter.on("Tab", (e) => {
+    e.preventDefault();
+    focusSearch();
+  });
+  focusSearch();
+});
+
+const focusSearch = () => {
+  searchRef.value?.focusSearch();
+};
+
+onBeforeUnmount(() => {
+  keyEmitter.off("Tab");
+});
+
+const onSearchInputTab = (e: KeyboardEvent) => {
+  if (e.shiftKey) {
+    e.preventDefault();
+    focusSearch();
+  }
+};
+</script>

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -640,6 +640,7 @@ const props = defineProps<{
   isMap?: boolean;
   isSecret?: boolean;
   disableInputWindow?: boolean;
+  forceReadOnly?: boolean;
 }>();
 
 const isSetByConnection = computed(
@@ -1364,7 +1365,8 @@ const selectedConnection = computed(
 const readOnly = computed(
   () =>
     !!(props.prop?.createOnly && props.component.hasResource) ||
-    props.component.toDelete,
+    props.component.toDelete ||
+    props.forceReadOnly,
 );
 
 const kindAsString = computed(() => `${props.prop?.widgetKind}`.toLowerCase());

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -124,6 +124,7 @@
         :externalSources="attributeTree.attributeValue.externalSources"
         :isArray="attributeTree.prop?.kind === 'array'"
         :isMap="attributeTree.prop?.kind === 'map'"
+        :forceReadOnly="props.forceReadOnly"
         @save="(...args) => emit('save', ...args)"
         @delete="(...args) => emit('delete', ...args)"
         @remove-subscription="(...args) => emit('removeSubscription', ...args)"
@@ -143,13 +144,14 @@ import { PropKind } from "@/api/sdf/dal/prop";
 import { AttributePath, ComponentId } from "@/api/sdf/dal/component";
 import AttributeChildLayout from "./AttributeChildLayout.vue";
 import AttributeInput from "./AttributeInput.vue";
-import { AttrTree } from "../AttributePanel.vue";
+import { AttrTree } from "../logic_composables/attribute_tree";
 import { useApi, routes, componentTypes } from "../api_composables";
 import { useWatchedForm } from "../logic_composables/watched_form";
 
 const props = defineProps<{
   component: BifrostComponent;
   attributeTree: AttrTree;
+  forceReadOnly?: boolean;
 }>();
 
 const hasChildren = computed(() => {

--- a/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
@@ -117,7 +117,7 @@ import { encryptMessage } from "@/utils/messageEncryption";
 import { AttributePath, ComponentId } from "@/api/sdf/dal/component";
 import AttributeChildLayout from "./AttributeChildLayout.vue";
 import AttributeInput from "./AttributeInput.vue";
-import { AttrTree } from "../AttributePanel.vue";
+import { AttrTree } from "../logic_composables/attribute_tree";
 import { useApi, routes, componentTypes } from "../api_composables";
 import { useWatchedForm } from "../logic_composables/watched_form";
 import SecretInput from "./SecretInput.vue";

--- a/app/web/src/newhotness/logic_composables/attribute_tree.ts
+++ b/app/web/src/newhotness/logic_composables/attribute_tree.ts
@@ -1,0 +1,43 @@
+import {
+  AttributeTree,
+  AttributeValue,
+  Prop,
+  Secret,
+} from "@/workers/types/entity_kind_types";
+
+export interface AttrTree {
+  id: string;
+  children: AttrTree[];
+  parent?: string;
+  prop?: Prop;
+  secret?: Secret;
+  attributeValue: AttributeValue;
+  isBuildable: boolean; // is my parent an array or map?
+}
+
+export const makeAvTree = (
+  data: AttributeTree,
+  avId: string,
+  isBuildable: boolean,
+  parent?: string,
+): AttrTree => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const av = data.attributeValues[avId]!;
+  const prop = av.propId ? data.props[av.propId] : undefined;
+  const secret = av.secret ?? undefined;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const childrenIds = data.treeInfo[avId]!.children;
+  const children = childrenIds.map((id) =>
+    makeAvTree(data, id, ["array", "map"].includes(prop?.kind ?? ""), avId),
+  );
+  const tree: AttrTree = {
+    id: avId,
+    children,
+    parent,
+    attributeValue: av,
+    prop,
+    secret,
+    isBuildable,
+  };
+  return tree;
+};


### PR DESCRIPTION
## Description

This change adds the "ResourceValuesPanel" for looking at a read-only tree of values corresponding resource of a given component. There are three states for this panel: non-existence (the component will not have a resource), empty state (the component does not have a resource) and populated (the component has a resource). The empty state design is copied from "ResourcePanel".

At a nuts and bolts level, the new panel is a stripped down version of the "AttributePanel". In fact, so much has been re-used that some logic has been moved into a new composable library and likely more logic can be moved there in the near future.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlb2Nqd2kwNzU3cW9zYmM3OTc5Ymt1cHNuNGh0OTMzanE0eGtqb2p0MiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/GMpBFo01C4OdYhMVI2/giphy.gif"/>

## Screenshot: "Will Not Have a Resource"

<img width="1849" height="900" alt="Screenshot 2025-07-15 at 8 40 23 PM" src="https://github.com/user-attachments/assets/b95c83bd-2732-4928-abde-0abb3f5b740d" />

## Screenshot: "Does Not Have a Resource"

Note: the empty state text has changed since this screenshot was taken!

<img width="1850" height="905" alt="Screenshot 2025-07-15 at 8 40 38 PM" src="https://github.com/user-attachments/assets/3af94fd7-5bef-4476-b7bb-7d141643550e" />

## Screenshot: "Has a Resource"

<img width="1843" height="895" alt="Screenshot 2025-07-15 at 8 39 34 PM" src="https://github.com/user-attachments/assets/3da004b1-1ebc-47e7-b435-363cde9e96e8" />
