### PR TITLE
feat(web): Show the component resource Id when we have it

### DIFF
--- a/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
@@ -55,16 +55,31 @@
         <!-- We need the "grow" here so that the qualification status expands fully. -->
         <ComponentQualificationStatus class="grow" :component="component" />
       </li>
-      <li>
-        <template v-if="component.hasDiff">
+
+      <!-- Rows 2-3: Dynamic content based on priority -->
+      <li v-for="(rowContent, index) in dynamicRows" :key="index">
+        <template v-if="rowContent === 'resource'">
+          <StatusIndicatorIcon
+            v-if="component.resourceId"
+            v-tooltip="'Resource'"
+            type="resource"
+            size="sm"
+            status="exists"
+          />
+          <StatusIndicatorIcon
+            v-else
+            type="resource"
+            size="sm"
+            status="exists"
+          />
+          <div v-if="component.resourceId" class="text-xs opacity-75">
+            {{ component.resourceId }}
+          </div>
+          <div v-else>Resource</div>
+        </template>
+        <template v-else-if="rowContent === 'diff'">
           <Icon name="tilde" class="text-warning-500" size="sm" />
           <div>Diff</div>
-        </template>
-      </li>
-      <li>
-        <template v-if="component.hasResource">
-          <StatusIndicatorIcon type="resource" size="sm" status="exists" />
-          <div>Resource</div>
         </template>
       </li>
       <!-- NOTE: when coming from the Map page we don't have accurate outputCount, hiding this -->
@@ -155,6 +170,21 @@ const outgoing = computed(
 const canBeUpgraded = computed(() =>
   explore.upgradeableComponents.value.has(props.component.id),
 );
+
+const dynamicRows = computed(() => {
+  const rows: (string | null)[] = [];
+
+  // Priority order: resource first, then diff
+  if (props.component.hasResource) rows.push("resource");
+  if (props.component.hasDiff) rows.push("diff");
+
+  // Ensure we always have exactly 2 rows (for rows 2-3)
+  while (rows.length < 2) {
+    rows.push(null);
+  }
+
+  return rows.slice(0, 2);
+});
 
 const toggleSelection = () => {
   if (props.selected) {

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -15,10 +15,25 @@
         <!-- Attribute name -->
         <div class="flex flex-row items-center gap-2xs pl-xs">
           <TruncateWithTooltip>{{ displayName }}</TruncateWithTooltip>
+          <span
+            v-if="showRequiredAsterisk"
+            v-tooltip="`${displayName} is a required value`"
+            :class="
+              clsx(
+                'shrink-0 text-lg font-bold',
+                themeClasses('text-destructive-600', 'text-destructive-300'),
+              )
+            "
+          >
+            *
+          </span>
           <div class="flex flex-row items-center ml-auto gap-2xs">
             <StatusIndicatorIcon
               v-if="
-                validation && validation.status !== 'Success' && !isPendingValue
+                validation &&
+                validation.status !== 'Success' &&
+                !isPendingValue &&
+                !showRequiredAsterisk
               "
               v-tooltip="validation.message"
               type="qualification"
@@ -651,6 +666,14 @@ const isPendingValue = computed(
     props.externalSources &&
     props.externalSources.length > 0 &&
     props.value === "",
+);
+
+const showRequiredAsterisk = computed(
+  () =>
+    props.validation &&
+    props.validation.status !== "Success" &&
+    !isPendingValue.value &&
+    props.validation.message === '"value" is required',
 );
 
 // does not set the actual key, just the string displayed!

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -293,6 +293,7 @@ export interface ComponentInList {
   inputCount: number;
   hasDiff: boolean;
   toDelete: boolean;
+  resourceId: string | null;
 }
 
 export interface BifrostComponentList {

--- a/lib/si-frontend-mv-types-rs/src/component.rs
+++ b/lib/si-frontend-mv-types-rs/src/component.rs
@@ -2,6 +2,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use serde_json::Value;
 use si_events::{
     ComponentId,
     SchemaId,
@@ -114,6 +115,7 @@ pub struct ComponentInList {
     pub schema_variant_name: String,
     pub schema_category: String,
     pub has_resource: bool,
+    pub resource_id: Option<Value>,
     pub qualification_totals: ComponentQualificationStats,
     pub input_count: usize,
     pub has_diff: bool,


### PR DESCRIPTION
We know a component has a resource and we should have a resourceId, so 
we can calculate that in the MV and sendit across to use it

Also ensured that the GridTile showed items correctly and that when we 
have a required field in the AttributePanel that we show it as a 
redAsterix