### PR TITLE
Don't mount other components if you're in the lobby

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -50,7 +50,7 @@
 
     <!-- grow the main body to fit all the space in between the nav and the bottom of the browser window
      min-h-0 prevents the main container from being *larger* than the max it can grow, no matter its contents -->
-    <main class="grow min-h-0">
+    <main v-if="!lobby" class="grow min-h-0">
       <div v-if="tokenFail">Bad Token</div>
       <ComponentPage v-else-if="componentId" :componentId="componentId" />
       <FuncRunDetails v-else-if="funcRunId" :funcRunId="funcRunId" />


### PR DESCRIPTION
## How does this PR change the system?
Don't mount other components if you're in the lobby. We don't want to issue any tan stack queries until the cold start & lobby is over.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZHp1ZjYyZDRtZHR3N2dzYm5iZjY4Y2o3bHFwdGwzemowcWVheWdpeCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/LOVMoi1qYWJyw/giphy.gif"/>