### PR TITLE
feat(web): Show pending actions for a component on the grid

### DIFF
--- a/app/web/src/newhotness/FuncRunDetails.vue
+++ b/app/web/src/newhotness/FuncRunDetails.vue
@@ -11,6 +11,13 @@
   >
     <template #actions>
       <VButton
+        v-if="funcRun && funcRun.componentId"
+        tone="neutral"
+        label="Go to Component"
+        size="xs"
+        @click="navigateToComponent"
+      />
+      <VButton
         v-if="
           funcRun &&
           funcRun.actionId &&
@@ -103,6 +110,20 @@ const retryAction = async () => {
 
     // This route can mutate head, so we do not need to handle new change set semantics.
     await call.put({});
+  }
+};
+
+const navigateToComponent = () => {
+  if (funcRun.value?.componentId) {
+    const params = { ...router.currentRoute.value.params };
+    params.componentId = funcRun.value.componentId;
+    router.push({
+      name: "new-hotness-component",
+      params,
+      query: preserveExploreState(
+        router.currentRoute.value?.query as SelectionsInQueryString,
+      ),
+    });
   }
 };
 

--- a/app/web/src/newhotness/explore_grid/ExploreGrid.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGrid.vue
@@ -32,6 +32,8 @@
         :focusedComponentId="focusedComponent?.id"
         :selectedComponentIndexes="selectedComponentIndexes"
         :componentsWithFailedActions="componentsWithFailedActions"
+        :componentsWithRunningActions="componentsWithRunningActions"
+        :componentsPendingActionNames="componentsPendingActionNames"
         @childClicked="(e, c, idx) => $emit('childClicked', e, c, idx)"
         @childSelect="(idx) => $emit('childSelect', idx)"
         @childDeselect="(idx) => $emit('childDeselect', idx)"
@@ -61,6 +63,11 @@ const props = defineProps<{
   focusedComponentIdx?: number;
   selectedComponentIndexes: Set<number>;
   componentsWithFailedActions: Set<ComponentId>;
+  componentsWithRunningActions: Set<ComponentId>;
+  componentsPendingActionNames: Map<
+    ComponentId,
+    Record<string, { count: number; hasFailed: boolean }>
+  >;
 }>();
 
 const MIN_GRID_TILE_WIDTH = 250;

--- a/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
@@ -93,6 +93,8 @@
       :focused="focusedComponentId === component.id"
       :hovered="hoveredId === component.id"
       :hasFailedActions="componentsWithFailedActions.has(component.id)"
+      :hasRunningActions="componentsWithRunningActions.has(component.id)"
+      :pendingActionCounts="componentsPendingActionNames.get(component.id)"
       @select="emit('childSelect', dataIndexForTileInRow(row, columnIndex))"
       @deselect="emit('childDeselect', dataIndexForTileInRow(row, columnIndex))"
       @mouseenter="hover(component.id, true)"
@@ -167,6 +169,11 @@ const props = defineProps<{
   selectedComponentIndexes: Set<number>;
   focusedComponentId?: ComponentId;
   componentsWithFailedActions: Set<ComponentId>;
+  componentsWithRunningActions: Set<ComponentId>;
+  componentsPendingActionNames: Map<
+    ComponentId,
+    Record<string, { count: number; hasFailed: boolean }>
+  >;
 }>();
 
 interface TitleIcon {


### PR DESCRIPTION
We want to highlight that there are pending actions and if they have 
failed. Also we highlight which components currently have running 
actions

We lastly want to ensure that we can get to the component that a 
function run is for

https://jam.dev/c/ec68b5bc-e84d-4a0e-8bf9-3cef00a43b94