### PR TITLE
fix: don't redirect away from new experience until feature flags are loaded

### DIFF
--- a/app/web/src/components/ComponentDetails.vue
+++ b/app/web/src/components/ComponentDetails.vue
@@ -162,8 +162,8 @@
             </template>
             <template
               v-if="
-                ffStore.FRONTEND_ARCH_VIEWS &&
-                ffStore.BIFROST_ACTIONS &&
+                featureFlagsStore.FRONTEND_ARCH_VIEWS &&
+                featureFlagsStore.BIFROST_ACTIONS &&
                 viewStore.selectedComponentId
               "
             >
@@ -243,7 +243,7 @@ const viewStore = useViewsStore();
 const qualificationsStore = useQualificationsStore();
 const changeSetsStore = useChangeSetsStore();
 const funcStore = useFuncStore();
-const ffStore = useFeatureFlagsStore();
+const featureFlagsStore = useFeatureFlagsStore();
 
 const modelingEventBus = componentsStore.eventBus;
 

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -89,6 +89,7 @@ import {
   watch,
   Ref,
   inject,
+  watchEffect,
 } from "vue";
 import * as _ from "lodash-es";
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
@@ -345,13 +346,17 @@ onBeforeMount(async () => {
   }
   // NOTE(nick,wendy): if you do not have the flag enabled, you will be re-directed. This will be
   // true for all of the new hotness routes, provided that they are all children of the parent
-  // route that uses this component. This is wrapped in a "setTimeout" to ensure that the feature
-  // flag loads in time.
-  setTimeout(() => {
-    if (!featureFlagsStore.ENABLE_NEW_EXPERIENCE) {
-      router.push({ name: "workspace-index" });
+  // route that uses this component. We wait until we know the feature flag is false before
+  // redirecting; undefined means the feature flag is still loading.
+  watchEffect(() => {
+    if (featureFlagsStore.ENABLE_NEW_EXPERIENCE === false) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "ENABLE_NEW_EXPERIENCE feature flag is false! Redirecting to old experience.",
+      );
+      window.location.href = `/w/${props.workspacePk}/${props.changeSetId}`;
     }
-  }, 500);
+  });
 
   const thisWorkspacePk = workspacePk.value;
   const workspaceAuthToken = getTokenForWorkspace(thisWorkspacePk);


### PR DESCRIPTION
If it takes more than 500ms to load feature flags (which can happen with posthog hiccups), we currently redirect you away from the new experience. Additionally, the redirect doesn't actually work when this happens.

This PR:
* Initializes all flags to undefined until they are loaded, so that you can tell whether it's false or "not loaded yet"
* Does not redirect until feature flags are loaded (check if featureFlag === false rather than if (!featureFlag))
* Redirects using window.location to make the redirect work
* Redirects to `/w/<workspaceId>/<changeSetId>` instead of `/w` so the link at least goes to the same change set
* Makes the redirect reactive (if the feature flag is removed in posthog while the new ui is loaded, we now redirect to the old ui). This is basically a side effect of watchEffect, and could be changed to happen only on load.
* Avoids "blips": Sets user, workspace, and override flags all at the same time (not async) to ensure there is never a "blip" where posthog sets it to false and then override sets it to true

**Risk Mitigation:** To ensure existing feature flags are still OK, I manually checked all uses of feature flags in the frontend, to ensure there is no behavior change while loading. All uses are inside `if`, `v-if` and `?`, which treat undefined the same as false.

## How was it tested?

- [X] No premature redirect: add delay to posthog, see that I am not redirected
- [X] Redirect works: set feature flag to false, see redirect on load
- [X] Reactivity: set feature flag to false while new ui has been loaded for a while, see redirect
- [X] Backcompat: check that workspace-specific flags are still set and reacted to

## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbnZtczRtdjJodjh6dGpiazF4amxneDdsOXRsemJkc3J0NzB6cXE0aCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/48i1NZcQQB83ucCMdc/giphy.gif)