### PR TITLE
fix: Disallow changes to child values under subscriptions

### DIFF
--- a/lib/dal-materialized-views/src/component/attribute_tree.rs
+++ b/lib/dal-materialized-views/src/component/attribute_tree.rs
@@ -137,13 +137,12 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
 
         let prototype_id = AttributeValue::prototype_id(ctx, av_id).await?;
         let func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
-        let func = Func::get_by_id(ctx, func_id).await?;
 
         // FIXME(nick): this is likely incorrect.
         let controlling_func = ControllingFuncData {
             func_id,
             av_id,
-            is_dynamic_func: func.is_dynamic(),
+            is_dynamic_func: Func::is_dynamic(ctx, func_id).await?,
         };
 
         // NOTE(nick): I ported Victor's comment.

--- a/lib/dal/src/attribute/attributes.rs
+++ b/lib/dal/src/attribute/attributes.rs
@@ -55,6 +55,7 @@ pub enum Error {
     WsEvent(#[from] crate::WsEventError),
 }
 
+#[derive(Debug)]
 pub struct AttributeUpdateCounts {
     pub set_count: usize,
     pub unset_count: usize,
@@ -276,6 +277,7 @@ pub async fn update_attributes(
 
                 // Unset or remove the value if it exists
                 if let Some(target_av_id) = av_to_set.resolve(ctx, component_id).await? {
+                    AttributeValue::ensure_updateable(ctx, target_av_id).await?;
                     if parent_prop_is_map_or_array(ctx, target_av_id).await? {
                         // If the parent is a map or array, remove the value
                         AttributeValue::remove(ctx, target_av_id).await?;

--- a/lib/dal/src/job/definition/dependent_values_update.rs
+++ b/lib/dal/src/job/definition/dependent_values_update.rs
@@ -87,6 +87,8 @@ pub enum DependentValueUpdateError {
     DependentValueRoot(#[from] DependentValueRootError),
     #[error("dependent values update audit log error: {0}")]
     DependentValuesUpdateAuditLog(#[from] DependentValueUpdateAuditLogError),
+    #[error("func error: {0}")]
+    FuncError(#[from] crate::FuncError),
     #[error("prop error: {0}")]
     Prop(#[from] PropError),
     #[error("schema variant error: {0}")]
@@ -558,10 +560,12 @@ async fn execution_error_detail(
         .await?
         .debug_info(ctx)
         .await?;
-    let prototype_func = AttributeValue::prototype_func(ctx, id).await?.name;
+    let prototype_func =
+        Func::node_weight(ctx, AttributeValue::prototype_func_id(ctx, id).await?).await?;
 
     Ok(format!(
-        "error executing prototype function \"{prototype_func}\" to set the value of {is_for} ({id})"
+        "error executing prototype function \"{}\" to set the value of {is_for} ({id})",
+        prototype_func.name()
     ))
 }
 

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -1075,11 +1075,7 @@ impl Prop {
     ) -> PropResult<bool> {
         let prototype_id = Self::prototype_id(ctx, prop_id).await?;
         let prototype_func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
-
-        Ok(Func::get_by_id_opt(ctx, prototype_func_id)
-            .await?
-            .map(|f| f.is_dynamic())
-            .unwrap_or(false))
+        Ok(Func::is_dynamic(ctx, prototype_func_id).await?)
     }
 
     pub async fn default_value(
@@ -1087,9 +1083,8 @@ impl Prop {
         prop_id: PropId,
     ) -> PropResult<Option<serde_json::Value>> {
         let prototype_id = Self::prototype_id(ctx, prop_id).await?;
-        let prototype_func =
-            Func::get_by_id(ctx, AttributePrototype::func_id(ctx, prototype_id).await?).await?;
-        if prototype_func.is_dynamic() {
+        let prototype_func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
+        if Func::is_dynamic(ctx, prototype_func_id).await? {
             return Ok(None);
         }
 


### PR DESCRIPTION
Right now, if an object or an array is subscribed to another object or array, we let you edit the child values in the subscriber. We should disallow this at the API level, as manually edited fields under a subscribed object will cause DVU nightmares. This PR:

* Disallows update/insert by making `vivify()` error if your path goes through a subscription (started with `/Path/To/Subscription/...`).
* Disallows remove/unset by making `attributes::update_attributes` check whether the path went through a subscription (started with `/Path/To/Subscription/...` before removing / unsetting it. This only happens if the path you looked for exists; otherwise, we've ensured our invariants fine (you told us the value shouldn't exist, and it doesn't).
* [factor] Changes `func.is_dynamic()` to `Func::is_dynamic(FuncId)` in a continuing effort to reduce LayerDB accesses (forcing callers to do `Func::get_by_id()` to call `is_dynamic()` makes them unnecessarily download the function content from the CAS when all they need is the function name).

## How was it tested?

- [X] Integration tests pass
- [X] New test asserting that we yield the correct error when updating or inserting children of objects, maps and arrays
- [X] New test asserting that we yield the correct error when removing or unsetting children of objects, maps and arrays

## In short

![](https://media1.tenor.com/m/6VG3tvOnl44AAAAC/seriously-let.gif)