### PR TITLE
fix: Show "Use Old UI" if you are on the new UI

### DIFF
--- a/app/web/src/components/layout/navbar/NavbarPanelRight.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelRight.vue
@@ -76,7 +76,7 @@
       <NavbarButton
         v-if="featureFlagsStore.ENABLE_NEW_EXPERIENCE"
         icon="grid"
-        tooltipText="Use New UI"
+        :tooltipText="useNewUI ? 'Use Old UI' : 'Use New UI'"
         @click="toggleExperience"
       />
 


### PR DESCRIPTION
<img width="515" height="264" alt="image" src="https://github.com/user-attachments/assets/d1031747-c8cd-43f9-a7a6-9d8371726bb8" />