### PR TITLE
Do not coerce value for subscriptions

### DIFF
--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -393,16 +393,21 @@ const save = async (
 
   // TODO - Paul there's a better way to handle this for sure!
   let coercedVal: string | boolean | number | null = value;
-  if (value === "") {
-    // For now we don't allow a user to enter an empty string
-    // passing an empty string is effectively an unset operation
-    coercedVal = null;
-  } else if (propKind === PropKind.Boolean) {
-    coercedVal = value.toLowerCase() === "true" || value === "1";
-  } else if (propKind === PropKind.Integer) {
-    coercedVal = Math.trunc(Number(value));
-  } else if (propKind === PropKind.Float) {
-    coercedVal = Number(value);
+
+  // We don't want to coerce a prop path when connecting via a subscription, so skip it (e.g. prop
+  // kind is "integer", but the value is the prop path, which is a "string").
+  if (!connectingComponentId) {
+    if (value === "") {
+      // For now, we don't allow a user to enter an empty string becuase passing an empty string is
+      // effectively an unset operation.
+      coercedVal = null;
+    } else if (propKind === PropKind.Boolean) {
+      coercedVal = value.toLowerCase() === "true" || value === "1";
+    } else if (propKind === PropKind.Integer) {
+      coercedVal = Math.trunc(Number(value));
+    } else if (propKind === PropKind.Float) {
+      coercedVal = Number(value);
+    }
   }
 
   const payload: componentTypes.UpdateComponentAttributesArgs = {};


### PR DESCRIPTION
## Descriptrion

This change ensures that we do not coerce a value when dealing with subscriptions. This bug was found when trying to subscribe from (to?) a prop with kind "integer", but the value would be the prop path, which is a "string". This would result in "NaN" being the coerced value and then "null" sent to the attributes API. Now, we don't even try to coerce if we are dealing with a subscription.

<img width="548" height="577" alt="Screenshot 2025-07-17 at 3 16 21 PM" src="https://github.com/user-attachments/assets/06edf13e-ef47-4a38-b305-9c2c81d33587" />
