### PR TITLE
fix: Remove old values when migrating subscriptions

### DIFF
--- a/lib/dal/examples/snapshot-surfer/main.rs
+++ b/lib/dal/examples/snapshot-surfer/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
         println!("{}", "=".repeat(ident.len()));
         println!("{}", ident);
         println!();
-        println!("  {:?}", graph.get_node_weight(node_idx)?);
+        println!("{:#?}", graph.get_node_weight(node_idx)?);
         print_edges(&graph, node_idx)?;
     }
     // let output_socket =

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -235,6 +235,14 @@ impl AttributePrototype {
         Ok(Func::get_by_id(ctx, Self::func_id(ctx, prototype_id).await?).await?)
     }
 
+    pub async fn is_dynamic(
+        ctx: &DalContext,
+        prototype_id: AttributePrototypeId,
+    ) -> AttributePrototypeResult<bool> {
+        let func_id = Self::func_id(ctx, prototype_id).await?;
+        Ok(Func::is_dynamic(ctx, func_id).await?)
+    }
+
     pub async fn find_for_prop(
         ctx: &DalContext,
         prop_id: PropId,

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1391,7 +1391,7 @@ impl Component {
             let source_component_id = AttributeValue::component_id(ctx, source_av_id).await?;
             let AttributePath::JsonPointer(path) = path;
             let func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
-            let func = match Func::get_intrinsic_kind_by_id(ctx, func_id).await? {
+            let func = match Func::intrinsic_kind(ctx, func_id).await? {
                 Some(IntrinsicFunc::Identity) => None,
                 _ => Some(func_id.into()),
             };

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -407,21 +407,18 @@ impl Func {
     }
 
     /// If you know the func_id is supposed to be for an [`IntrinsicFunc`], get which one or error
-    pub async fn get_intrinsic_kind_by_id_or_error(
+    pub async fn intrinsic_kind_or_error(
         ctx: &DalContext,
         id: FuncId,
     ) -> FuncResult<IntrinsicFunc> {
         let func = Self::get_by_id(ctx, id).await?;
 
-        Self::get_intrinsic_kind_by_id(ctx, id)
+        Self::intrinsic_kind(ctx, id)
             .await?
             .ok_or(FuncError::IntrinsicFuncNotFound(func.name))
     }
 
-    pub async fn get_intrinsic_kind_by_id(
-        ctx: &DalContext,
-        id: FuncId,
-    ) -> FuncResult<Option<IntrinsicFunc>> {
+    pub async fn intrinsic_kind(ctx: &DalContext, id: FuncId) -> FuncResult<Option<IntrinsicFunc>> {
         let func = Self::get_by_id(ctx, id).await?;
         Ok(IntrinsicFunc::maybe_from_str(func.name.clone()))
     }

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -242,7 +242,7 @@ impl AttributeBinding {
     ) -> FuncBindingResult<Vec<FuncBinding>> {
         let mut bindings = vec![];
         let intrinsic_func_kind: IntrinsicFunc =
-            Func::get_intrinsic_kind_by_id_or_error(ctx, func_id).await?;
+            Func::intrinsic_kind_or_error(ctx, func_id).await?;
 
         for attribute_prototype_id in AttributePrototype::list_ids_for_func_id(ctx, func_id).await?
         {
@@ -581,7 +581,7 @@ impl AttributeBinding {
 
         let func_id = AttributePrototype::func_id(ctx, attribute_prototype_id).await?;
         // if this func is intrinsic, make sure everything looks good
-        if (Func::get_intrinsic_kind_by_id(ctx, func_id).await?).is_some() {
+        if (Func::intrinsic_kind(ctx, func_id).await?).is_some() {
             let output_location = Self::find_output_location(ctx, attribute_prototype_id).await?;
             validate_intrinsic_inputs(
                 ctx,
@@ -854,7 +854,7 @@ async fn validate_intrinsic_inputs(
     output_location: AttributeFuncDestination,
     prototype_arguments: Vec<AttributeArgumentBinding>,
 ) -> FuncBindingResult<()> {
-    let intrinsic_kind = Func::get_intrinsic_kind_by_id_or_error(ctx, func_id).await?;
+    let intrinsic_kind = Func::intrinsic_kind_or_error(ctx, func_id).await?;
     if let EventualParent::Component(component_id) = eventual_parent {
         return Err(FuncBindingError::CannotSetIntrinsicForComponent(
             component_id,

--- a/lib/dal/src/func/intrinsics.rs
+++ b/lib/dal/src/func/intrinsics.rs
@@ -16,12 +16,9 @@ use strum::{
     IntoEnumIterator,
 };
 
-use crate::{
-    PropKind,
-    func::{
-        FuncError,
-        FuncResult,
-    },
+use crate::func::{
+    FuncError,
+    FuncResult,
 };
 
 #[remain::sorted]
@@ -316,20 +313,5 @@ impl IntrinsicFunc {
                 return None;
             }
         })
-    }
-}
-
-impl From<PropKind> for IntrinsicFunc {
-    fn from(value: PropKind) -> Self {
-        match value {
-            PropKind::Array => IntrinsicFunc::SetArray,
-            PropKind::Boolean => IntrinsicFunc::SetBoolean,
-            PropKind::Integer => IntrinsicFunc::SetInteger,
-            PropKind::Float => IntrinsicFunc::SetFloat,
-            PropKind::Json => IntrinsicFunc::SetJson,
-            PropKind::Map => IntrinsicFunc::SetMap,
-            PropKind::Object => IntrinsicFunc::SetObject,
-            PropKind::String => IntrinsicFunc::SetString,
-        }
     }
 }

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -392,6 +392,20 @@ impl PropKind {
             PropKind::String | PropKind::Boolean | PropKind::Integer | PropKind::Float
         )
     }
+
+    /// The intrinsic function used to set a static value for this prop kind.
+    pub fn intrinsic_set_func(&self) -> IntrinsicFunc {
+        match self {
+            PropKind::Array => IntrinsicFunc::SetArray,
+            PropKind::Boolean => IntrinsicFunc::SetBoolean,
+            PropKind::Integer => IntrinsicFunc::SetInteger,
+            PropKind::Float => IntrinsicFunc::SetFloat,
+            PropKind::Json => IntrinsicFunc::SetJson,
+            PropKind::Map => IntrinsicFunc::SetMap,
+            PropKind::Object => IntrinsicFunc::SetObject,
+            PropKind::String => IntrinsicFunc::SetString,
+        }
+    }
 }
 
 impl From<PropKind> for PropSpecKind {
@@ -1119,7 +1133,7 @@ impl Prop {
         }
 
         let prototype_id = Self::prototype_id(ctx, prop_id).await?;
-        let intrinsic: IntrinsicFunc = prop.kind.into();
+        let intrinsic: IntrinsicFunc = prop.kind.intrinsic_set_func();
         let intrinsic_id = Func::find_intrinsic(ctx, intrinsic).await?;
         let func_arg_id = FuncArgument::single_arg_for_func(ctx, intrinsic_id).await?;
 

--- a/lib/dal/tests/integration_test/attributes.rs
+++ b/lib/dal/tests/integration_test/attributes.rs
@@ -369,3 +369,117 @@ async fn update_attribute_child_of_subscription(ctx: &mut DalContext) -> Result<
 
     Ok(())
 }
+
+// Test that updating attributes sets them (and their parents) correctly, but leaves default
+// values and other values alone.
+#[test]
+async fn update_attribute_child_of_connection(ctx: &mut DalContext) -> Result<()> {
+    variant::create(
+        ctx,
+        "source",
+        r#"
+            function main() {
+                return {
+                    props: [
+                        { name: "Obj", kind: "object", children: [
+                            { name: "Field", kind: "string" },
+                        ]},
+                        { name: "Map", kind: "map", entry:
+                            { name: "MapItem", kind: "string" },
+                        },
+                        { name: "Arr", kind: "array", entry:
+                            { name: "ArrayItem", kind: "string" },
+                        },
+                    ],
+                    outputSockets: [
+                        { name: "Obj", arity: "many", valueFrom: { kind: "prop", prop_path: [ "root", "domain", "Obj" ] }, connectionAnnotations: "[\"Obj\"]" },
+                        { name: "Map", arity: "many", valueFrom: { kind: "prop", prop_path: [ "root", "domain", "Map" ] }, connectionAnnotations: "[\"Map\"]" },
+                        { name: "Arr", arity: "many", valueFrom: { kind: "prop", prop_path: [ "root", "domain", "Arr" ] }, connectionAnnotations: "[\"Arr\"]" },
+                    ],
+                };
+            }
+        "#,
+    )
+    .await?;
+
+    variant::create(
+        ctx,
+        "dest",
+        r#"
+        function main() {
+            return {
+                props: [
+                    { name: "Obj", kind: "object", valueFrom: { kind: "inputSocket", socket_name: "Obj" }, children: [
+                        { name: "Field", kind: "string" },
+                    ]},
+                    { name: "Map", kind: "map", valueFrom: { kind: "inputSocket", socket_name: "Map" }, entry:
+                        { name: "MapItem", kind: "string" },
+                    },
+                    { name: "Arr", kind: "array", valueFrom: { kind: "inputSocket", socket_name: "Arr" }, entry:
+                        { name: "ArrayItem", kind: "string" },
+                    },
+                ],
+                inputSockets: [
+                    { name: "Obj", arity: "one", connectionAnnotations: "[\"Obj\"]" },
+                    { name: "Map", arity: "one", connectionAnnotations: "[\"Map\"]" },
+                    { name: "Arr", arity: "one", connectionAnnotations: "[\"Arr\"]" },
+                ],
+            };
+        }
+    "#,
+    )
+    .await?;
+
+    // Subscribe source.Obj -> dest.Obj, source.Arr -> dest.Arr
+    component::create(ctx, "source", "source").await?;
+    value::set(ctx, ("source", "/domain/Obj/Field"), "value").await?;
+    value::set(ctx, ("source", "/domain/Map/a"), "valueA").await?;
+    value::set(ctx, ("source", "/domain/Map/b"), "valueB").await?;
+    value::set(ctx, ("source", "/domain/Arr"), ["a", "b"]).await?;
+    let dest = component::create(ctx, "dest", "dest").await?;
+    component::connect(ctx, ("source", "Obj"), ("dest", "Obj")).await?;
+    component::connect(ctx, ("source", "Map"), ("dest", "Map")).await?;
+    component::connect(ctx, ("source", "Arr"), ("dest", "Arr")).await?;
+    change_set::commit(ctx).await?;
+    assert_eq!(
+        json!({
+            "Obj": {
+                "Field": "value",
+            },
+            "Map": {
+                "a": "valueA",
+                "b": "valueB",
+            },
+            "Arr": ["a", "b"],
+        }),
+        component::domain(ctx, "dest").await?
+    );
+
+    // Check that updating a child value of an object/map/array works (and overrides the connection)
+    attributes::update_attributes(
+        ctx,
+        dest,
+        serde_json::from_value(json!({
+            "/domain/Obj/Field": "new",
+            "/domain/Map/a": "new",
+            "/domain/Arr/-": "new",
+        }))?,
+    )
+    .await?;
+    change_set::commit(ctx).await?;
+
+    assert_eq!(
+        json!({
+            "Obj": {
+                "Field": "new",
+            },
+            "Map": {
+                "a": "new",
+            },
+            "Arr": ["new"],
+        }),
+        component::domain(ctx, "dest").await?
+    );
+
+    Ok(())
+}

--- a/lib/dal/tests/integration_test/func/authoring/binding.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding.rs
@@ -857,7 +857,7 @@ async fn return_the_right_bindings(ctx: &mut DalContext, nw: &WorkspaceSignup) {
         let bindings = FuncBinding::for_func_id(ctx, func.id)
             .await
             .expect("could not get func bindings");
-        let intrinsic = Func::get_intrinsic_kind_by_id_or_error(ctx, func.id).await;
+        let intrinsic = Func::intrinsic_kind_or_error(ctx, func.id).await;
         let maybe_intrinsic = intrinsic.ok();
 
         for binding in bindings {


### PR DESCRIPTION
Migrating array socket connections creates duplicate values right now.

### The Migration Problem

Specifically, when you have a item connected to an array via socket (and si:normalizeToArray), and try to migrate:

1. Initial state: `Foo: /domain/InstanceIds` is connected to `Bar: /resource_value/InstanceId` through a socket.
   a. `/domain/InstanceIds` has no component-specific prototype. It gets its value from the "default" (the prop's prototype).
   b. The prop's prototype is `si:normalizeToArray`, and the socket connection is its argument.
   c. It has 1 child attribute value, created by DVU, representing the value at the other end of the socket connection.
2. Migration: first, we remove the socket connection.
   a. We remove the socket connection argument from the prop's prototype.
   b. This does *not* remove the actual child value from the array. It still has 1 element.
   c. This would happen if DVU ran, but we don't give it time to run here.
3. Migration: next, we create a prop subscription `TaskDef: /domain/ContainerDefinitions/-` <- ContainerDefinition
   a. We override the connection prototype by creating a manual array, setting component-specific prototype `si:setArray([])` so we can add a child.
   b. We do *not* currently remove children from the array. This means it still has 1 element.
   c. We add a new child array element to `/domain/ContainerDefinitions` and put the subscription on it. Now it has 2 elements.

In the end, we end up with 2 elements: the migrated prop subscription, and the "manual" array element that came from the no-longer-existent socket connection. If either 2b or 3b had happened, we would be OK here. We solve this by making 3b happen.

## The Fix

This PR fixes the issue by modifying `vivify_json_pointer()` (used in PUT /attributes, luminork, and migrations) to properly override the pointer. In particular:
* When `/Foo` is driven by a dynamic "default" function from its prop (e.g. si:normalizeToArray, si:identity, socket connections)
* And you want to set `/Foos/-` (or for maps, `/Foos/Bar`)
* The vivify() method currently *overrides* the Foo "default" prototype from the schema using `set_value()`, using `AttributeValue::update([] or {})`.
* This removes any existing array or map values, that may have been set by the schema prototype. Before this, we used `set_value()`, which did not remove children.

## How was it tested?

- [X] Integration tests pass
- [X] New test: migrating a child value of a connection removes the data from that connection (for map/object/array).
- [X] Manual test: migrate TaskDefinition -> ContainerDefinition connection, see only one value

## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbzAzdTVzb3pmYjJrZmd6cmtnZTd1bGR2bmZoaHg1Y3A4ZDN6MmZnZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3ofSBuiJp52jmluklW/giphy.gif)
