### PR TITLE
fix(web): Only show proposed actions

### DIFF
--- a/app/web/src/newhotness/ApplyChangeSetButton.vue
+++ b/app/web/src/newhotness/ApplyChangeSetButton.vue
@@ -18,8 +18,8 @@
         this will have to do in the meantime.
         -->
         <PillCounter
-          :count="actions.length"
-          :paddingX="actions.length > 10 ? '2xs' : 'xs'"
+          :count="proposedActions.length"
+          :paddingX="proposedActions.length > 10 ? '2xs' : 'xs'"
           noColorStyles
           class="border border-action-200 ml-2xs py-2xs"
         />
@@ -28,7 +28,7 @@
     <ApprovalFlowModal
       ref="approvalFlowModalRef"
       votingKind="merge"
-      :actions="actions"
+      :actions="proposedActions"
     />
   </section>
 </template>
@@ -68,4 +68,9 @@ const actionsRaw = useQuery<BifrostActionViewList | null>({
   enabled: ctx.queriesEnabled,
 });
 const actions = computed(() => actionsRaw.data.value?.actions ?? []);
+const proposedActions = computed(() =>
+  actions.value.filter(
+    (action) => action.originatingChangeSetId === ctx.changeSetId.value,
+  ),
+);
 </script>


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?
Filter out actions that were enqueued in other change sets so the count in the Apply Button and the list of actions displayed on Apply are reflected
<!-- Why: briefly what problem this solves and what the aim is as an overview -->

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->


- [X] Manual test: new functionality works in UI


## In short: [:link:](https://giphy.com/)
<div><img src="https://media2.giphy.com/media/eFEmFLvVfvCFxyAG0Q/200w.gif?cid=5a38a5a2bmf30dlbqnlztu3ycf97dnpr19gjz69wtyfipomp&amp;ep=v1_gifs_trending&amp;tid=a487431853f7a6b0307f59f86930d46d637fdafdede5783dd8372561ebecf972&amp;rid=200w.gif&amp;ct=g&amp;ap=1" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/sanpellegrino/">Sanpellegrino</a> on <a href="https://giphy.com/gifs/sanpellegrino-eFEmFLvVfvCFxyAG0Q">GIPHY</a></div>