### PR TITLE
fix(web): ensure we always register the remote before setting it

### DIFF
--- a/app/web/src/workers/shared_webworker.ts
+++ b/app/web/src/workers/shared_webworker.ts
@@ -83,6 +83,10 @@ const dbInterface: SharedDBInterface = {
 
   unregisterRemote(id: string) {
     debug("unregister remote in shared", id);
+    if (currentRemoteId === id) {
+      debug("tab with lock unregistered. no remote set");
+      currentRemote = undefined;
+    }
     delete remotes[id];
 
     if (Object.keys(remotes).length === 0) {
@@ -100,20 +104,23 @@ const dbInterface: SharedDBInterface = {
     if (!remotes[id]) {
       debug("register remote in shared", id);
       remotes[id] = remote;
-      if (!currentRemote && (await remote.hasDbLock())) {
-        await this.setRemote(id);
-      }
+    }
+    if (await remote.hasDbLock()) {
+      await this.setRemote(id);
     }
   },
   async hasRemote() {
     return !!currentRemote;
+  },
+  async currentRemoteId() {
+    return currentRemoteId;
   },
   async setRemote(remoteId: string) {
     debug("setting remote in shared web worker to", remoteId);
 
     currentRemote = remotes[remoteId];
     if (!currentRemote) {
-      throw new Error(`remote {$remoteId} not registered`);
+      throw new Error(`remote ${remoteId} not registered`);
     }
     currentRemoteId = remoteId;
 

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -132,6 +132,7 @@ export interface SharedDBInterface {
   broadcastMessage(message: BroadcastMessage): Promise<void>;
   setRemote(remoteId: string): Promise<void>;
   hasRemote(): Promise<boolean>;
+  currentRemoteId(): Promise<string | undefined>;
   initBifrost(gotLockPort: MessagePort): Promise<void>;
   bifrostClose(): Promise<void>;
   bifrostReconnect(): Promise<void>;
@@ -230,7 +231,6 @@ export interface TabDBInterface {
   setBearer: (workspaceId: string, token: string) => void;
   initSocket(workspaceId: string): Promise<void>;
   receiveBroadcast(message: BroadcastMessage): Promise<void>;
-  setRemote(remoteId: string): Promise<void>;
   initBifrost(gotLockPort: MessagePort): Promise<void>;
   bifrostClose(): void;
   bifrostReconnect(): void;

--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -3238,10 +3238,6 @@ const dbInterface: TabDBInterface = {
     });
   },
 
-  async setRemote(_remote: string) {
-    debug("this should only be called on the shared webworker");
-  },
-
   async hasDbLock(): Promise<boolean> {
     return hasTheLock;
   },


### PR DESCRIPTION
We've seen a race condition in some circumstances where setRemote is being fired before the remote is registered. This will ensure that is impossible.