### PR TITLE
fix: Makes sure the components list always reflects what's on the search bar

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -1113,11 +1113,17 @@ const filteredComponentsQuery = useQuery({
 // Make filteredComponentsQuery reactive to its inputs (componentList)
 // TODO filteredComponents needs to be a reactive thing, but queryFns aren't reactive.
 const queryClient = useQueryClient();
-watch([componentList, searchString], () => {
-  queryClient.invalidateQueries({
-    queryKey: filteredComponentsQueryKey.value,
-  });
-});
+watch(
+  [componentList, searchString],
+  () => {
+    queryClient.invalidateQueries({
+      queryKey: filteredComponentsQueryKey.value,
+    });
+  },
+  // Invalidating the query when loading in ensures we rerun the empty filter (show everything) when
+  // coming back to this page without a cached search string
+  { immediate: true },
+);
 
 const filteredComponents = computed(
   () => filteredComponentsQuery.data.value ?? [],


### PR DESCRIPTION
invalidate the search query immediately when mounting explore page so we don't render cached component lists that don't match the search terms