### PR TITLE
feat(web) - style the ComponentDetails page

### DIFF
--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -113,95 +113,37 @@
       <SiSearch
         ref="searchRef"
         v-model="q"
-        placeholder="filter attributes..."
+        placeholder="Find an attribute"
         :tabIndex="0"
         :borderBottom="false"
+        variant="new"
         @keydown.tab="onSearchInputTab"
       />
     </div>
-    <div
+    <AttributeChildLayout
       v-if="'children' in filtered.tree && filtered.tree.children.length > 0"
+      defaultOpen
     >
-      <h3
-        :class="
-          clsx(
-            'p-xs border-l',
-            themeClasses(
-              'bg-neutral-200 border-neutral-200',
-              'bg-neutral-800 border-neutral-800',
-            ),
-          )
-        "
-      >
-        domain
-      </h3>
-      <!-- this is _really_ a type guard for "i am not an empty object" -->
-      <ul
-        :class="
-          clsx(
-            'border-l border-r',
-            themeClasses('border-neutral-200', 'border-neutral-800'),
-          )
-        "
-      >
-        <ComponentAttribute
-          v-for="child in filtered.tree.children"
-          :key="child.id"
-          :component="component"
-          :attributeTree="child"
-          @save="save"
-          @delete="remove"
-          @remove-subscription="removeSubscription"
-        />
-      </ul>
-      <div
-        :class="
-          clsx(
-            'w-full border-b',
-            themeClasses('border-neutral-200', 'border-neutral-800'),
-          )
-        "
+      <template #header> domain </template>
+      <ComponentAttribute
+        v-for="child in filtered.tree.children"
+        :key="child.id"
+        :component="component"
+        :attributeTree="child"
+        @save="save"
+        @delete="remove"
+        @remove-subscription="removeSubscription"
       />
-    </div>
-    <div v-if="secrets && secrets.children.length > 0">
-      <h3
-        :class="
-          clsx(
-            'p-xs border-l',
-            themeClasses(
-              'bg-neutral-200 border-neutral-200',
-              'bg-neutral-800 border-neutral-800',
-            ),
-          )
-        "
-      >
-        secrets
-      </h3>
-      <ul
-        v-if="'children' in secrets"
-        :class="
-          clsx(
-            'border-l',
-            themeClasses('border-neutral-200', 'border-neutral-800'),
-          )
-        "
-      >
-        <ComponentSecretAttribute
-          v-for="secret in secrets.children"
-          :key="secret.id"
-          :component="component"
-          :attributeTree="secret"
-        />
-      </ul>
-      <div
-        :class="
-          clsx(
-            'w-full border-b',
-            themeClasses('border-neutral-200', 'border-neutral-800'),
-          )
-        "
+    </AttributeChildLayout>
+    <AttributeChildLayout v-if="secrets && secrets.children.length > 0">
+      <template #header> secrets </template>
+      <ComponentSecretAttribute
+        v-for="secret in secrets.children"
+        :key="secret.id"
+        :component="component"
+        :attributeTree="secret"
       />
-    </div>
+    </AttributeChildLayout>
   </div>
   <EmptyState v-else text="No attributes to display" icon="code-circle" />
 </template>
@@ -247,6 +189,7 @@ import { NameFormData } from "./ComponentDetails.vue";
 import EmptyState from "./EmptyState.vue";
 import { findAttributeValueInTree } from "./util";
 import { AttrTree, makeAvTree } from "./logic_composables/attribute_tree";
+import AttributeChildLayout from "./layout_components/AttributeChildLayout.vue";
 
 const q = ref("");
 

--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -61,8 +61,11 @@
       <div
         :class="
           clsx(
-            'name flex flex-row items-center gap-xs p-xs ',
-            themeClasses('bg-neutral-200', 'bg-neutral-800'),
+            'name flex flex-row items-center gap-xs p-xs border',
+            themeClasses(
+              'bg-white border-neutral-300',
+              'bg-neutral-800 border-neutral-600',
+            ),
           )
         "
       >
@@ -90,14 +93,14 @@
               <span>Attributes</span>
               <template v-if="importFunc">
                 <VButton
-                  size="sm"
+                  size="xs"
                   tone="neutral"
                   :label="
                     showResourceInput
                       ? 'Set attributes manually'
                       : 'Import a Resource'
                   "
-                  class="ml-2xs mr-xs font-normal"
+                  class="font-normal p-0 h-md mt-[1px] [&>div]:top-[-2px]"
                   @click.stop="
                     () => {
                       showResourceInput = !showResourceInput;
@@ -172,11 +175,12 @@
 
       <div class="right flex flex-col">
         <CollapsingFlexItem>
-          <template #header>
+          <template #header> Connections </template>
+          <template #headerIcons>
             <PillCounter
               :count="(component.inputCount ?? 0) + (outgoing ?? 0)"
+              size="sm"
             />
-            Connections
           </template>
           <ConnectionsPanel
             v-if="componentConnections && component"
@@ -185,9 +189,12 @@
           />
         </CollapsingFlexItem>
         <CollapsingFlexItem open>
-          <template #header>
-            <PillCounter :count="component.qualificationTotals.total" />
-            Qualifications
+          <template #header> Qualifications </template>
+          <template #headerIcons>
+            <PillCounter
+              :count="component.qualificationTotals.total"
+              size="sm"
+            />
           </template>
           <QualificationPanel
             :component="component"
@@ -195,7 +202,8 @@
           />
         </CollapsingFlexItem>
         <CollapsingFlexItem>
-          <template #header>
+          <template #header> Resource </template>
+          <template #headerIcons>
             <Icon
               v-if="component.hasResource"
               name="check-hex"
@@ -203,7 +211,6 @@
               tone="success"
             />
             <Icon v-else name="refresh-hex-outline" size="sm" tone="shade" />
-            Resource
           </template>
           <ResourcePanel
             :component="component"
@@ -211,10 +218,7 @@
           />
         </CollapsingFlexItem>
         <CollapsingFlexItem>
-          <template #header>
-            <Icon name="brackets-curly" size="sm" />
-            Generated Code
-          </template>
+          <template #header> Generated Code </template>
           <CodePanel
             v-if="attributeTree"
             :component="component"
@@ -222,10 +226,7 @@
           />
         </CollapsingFlexItem>
         <CollapsingFlexItem>
-          <template #header>
-            <Icon name="tilde" size="sm" />
-            Diff
-          </template>
+          <template #header> Diff </template>
           <DiffPanel :component="component" />
         </CollapsingFlexItem>
         <DocumentationPanel
@@ -378,13 +379,6 @@ const attrRef = ref<typeof CollapsingFlexItem>();
 const resourceRef = ref<typeof CollapsingFlexItem>();
 const actionRef = ref<typeof CollapsingFlexItem>();
 const mgmtRef = ref<typeof CollapsingFlexItem>();
-
-// TODO(Wendy) - this code is for if we want the AttributeInput to float again
-// const scrollAttributePanel = (value: number) => {
-//   if (attrRef.value) {
-//     attrRef.value.setScroll(value);
-//   }
-// };
 
 const router = useRouter();
 
@@ -556,31 +550,31 @@ const gridStateClass = computed(() => {
 section.grid.docs-open-with-banner {
   grid-template-areas:
     "banner banner banner"
-    "name docs right"
+    "name name name"
     "attrs docs right";
-  grid-template-rows: 2.5rem 3rem minmax(0, 1fr);
+  grid-template-rows: 2.5rem 2.5rem minmax(0, 1fr);
   grid-template-columns: minmax(0, 1fr) minmax(0, 25%) minmax(0, 25%);
 }
 section.grid.docs-closed-with-banner {
   grid-template-areas:
     "banner banner"
-    "name right"
+    "name name"
     "attrs right";
-  grid-template-rows: 2.5rem 3rem minmax(0, 1fr);
+  grid-template-rows: 2.5rem 2.5rem minmax(0, 1fr);
   grid-template-columns: minmax(0, 1fr) minmax(0, 33%);
 }
 section.grid.docs-open-without-banner {
   grid-template-areas:
-    "name docs right"
+    "name name name"
     "attrs docs right";
-  grid-template-rows: 3rem minmax(0, 1fr);
+  grid-template-rows: 2.5rem minmax(0, 1fr);
   grid-template-columns: minmax(0, 1fr) minmax(0, 25%) minmax(0, 25%);
 }
 section.grid.docs-closed-without-banner {
   grid-template-areas:
-    "name right"
+    "name name"
     "attrs right";
-  grid-template-rows: 3rem minmax(0, 1fr);
+  grid-template-rows: 2.5rem minmax(0, 1fr);
   grid-template-columns: minmax(0, 1fr) minmax(0, 33%);
 }
 .docs {

--- a/app/web/src/newhotness/ResourceValuesPanel.vue
+++ b/app/web/src/newhotness/ResourceValuesPanel.vue
@@ -21,7 +21,7 @@
         :class="
           clsx(
             'border-l border-r border-t',
-            themeClasses('border-neutral-200', 'border-neutral-800'),
+            themeClasses('border-neutral-300', 'border-neutral-800'),
           )
         "
       >
@@ -37,7 +37,7 @@
         :class="
           clsx(
             'w-full border-b',
-            themeClasses('border-neutral-200', 'border-neutral-800'),
+            themeClasses('border-neutral-300', 'border-neutral-800'),
           )
         "
       />

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -1,11 +1,17 @@
 <template>
-  <div id="app-layout" class="h-screen flex flex-col">
+  <div
+    id="app-layout"
+    :class="
+      clsx('h-screen flex flex-col', themeClasses('bg-white', 'bg-neutral-900'))
+    "
+  >
     <!-- nav itself is fixed at 60 px-->
     <nav
       :class="
         clsx(
-          'navbar bg-neutral-900 text-white relative shadow-[0_4px_4px_0_rgba(0,0,0,0.15)]',
+          'navbar relative shadow-[0_4px_4px_0_rgba(0,0,0,0.15)] border-b',
           'z-90 h-[60px] overflow-hidden shrink-0 flex flex-row justify-between select-none',
+          'bg-neutral-800 border-neutral-600 text-white',
           windowWidth > 740 && 'gap-sm',
         )
       "
@@ -98,6 +104,7 @@ import {
 import * as _ from "lodash-es";
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
 import { Span, trace } from "@opentelemetry/api";
+import { themeClasses } from "@si/vue-lib/design-system";
 import NavbarButton from "@/components/layout/navbar/NavbarButton.vue";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import * as heimdall from "@/store/realtime/heimdall";

--- a/app/web/src/newhotness/layout_components/AttributeChildLayout.vue
+++ b/app/web/src/newhotness/layout_components/AttributeChildLayout.vue
@@ -3,8 +3,8 @@
   <dl
     :class="
       clsx(
-        'ml-xs border-l border-b my-xs',
-        themeClasses('border-neutral-200', 'border-neutral-800'),
+        'border my-2xs',
+        themeClasses('border-neutral-300', 'border-neutral-600'),
       )
     "
   >
@@ -12,19 +12,24 @@
     <dt
       :class="
         clsx(
-          'px-2xs py-xs flex flex-row items-center gap-2xs cursor-pointer',
+          'group/header',
+          'px-2xs py-xs flex flex-row items-center gap-2xs cursor-pointer h-lg',
+          open && 'border-b',
           themeClasses(
-            'bg-neutral-200 hover:bg-neutral-300',
-            'bg-neutral-800 hover:bg-neutral-700',
+            'bg-white border-neutral-300 hover:bg-neutral-100',
+            'bg-neutral-800 border-neutral-600 hover:bg-neutral-700',
           ),
         )
       "
       @click="() => (open = !open)"
     >
-      <Icon :name="open ? 'chevron--down' : 'chevron--right'" />
+      <Icon
+        :name="open ? 'chevron--down' : 'chevron--right'"
+        class="group-hover/header:scale-125"
+      />
       <slot name="header" />
     </dt>
-    <dd v-if="open">
+    <dd v-if="open" class="p-2xs">
       <slot />
       <!-- the children are, so far, another list or a button that would create a list -->
     </dd>

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -371,7 +371,7 @@
               "
             >
               <template v-if="isArray && !isSetByConnection">
-                + Add a "{{ displayName }}" item
+                + Add "{{ displayName }}" item
               </template>
               <template v-else-if="isMap && !mapKey && !isSetByConnection">
                 You must enter a key

--- a/lib/vue-lib/src/design-system/general/SiSearch.vue
+++ b/lib/vue-lib/src/design-system/general/SiSearch.vue
@@ -3,7 +3,7 @@
     :class="
       clsx(
         'siSearchRoot',
-        dropdownMenuSearch
+        variant === 'dropdownmenu'
           ? 'rounded-t-md'
           : borderBottom && 'dark:border-neutral-600 border-b',
       )
@@ -13,7 +13,7 @@
       :class="
         clsx(
           'relative text-neutral-400 focus-within:text-neutral-600 block h-[34px]',
-          dropdownMenuSearch && 'rounded-t-md',
+          variant === 'dropdownmenu' && 'rounded-t-md',
         )
       "
     >
@@ -24,13 +24,24 @@
         :placeholder="placeholder"
         :class="
           clsx(
-            'w-full text-xs pl-[32px] py-2xs h-[34px] placeholder:italic outline-offset-[-1px] focus:outline focus:outline-2',
-            dropdownMenuSearch
-              ? 'text-white bg-shade-100 placeholder:text-neutral-400 rounded-t-md'
-              : themeClasses(
-                  'text-black bg-shade-0 placeholder:text-neutral-500 focus:bg-neutral-50 focus:outline-action-500',
-                  'text-white bg-neutral-800 placeholder:text-neutral-400 focus:bg-shade-100 focus:outline-action-300',
+            'w-full text-xs pl-[32px] py-2xs h-[34px] placeholder:italic',
+            variant !== 'new' &&
+              'outline-offset-[-1px] focus:outline focus:outline-2',
+            {
+              dropdownmenu:
+                'text-white bg-shade-100 placeholder:text-neutral-400 rounded-t-md',
+              standard: themeClasses(
+                'text-black bg-shade-0 placeholder:text-neutral-500 focus:bg-neutral-50 focus:outline-action-500',
+                'text-white bg-neutral-800 placeholder:text-neutral-400 focus:bg-shade-100 focus:outline-action-300',
+              ),
+              new: [
+                'border outline-none focus:outline-none',
+                themeClasses(
+                  'text-black bg-shade-0 placeholder:text-neutral-500 border-neutral-400 focus:border-action-500',
+                  'text-white bg-shade-100 placeholder:text-neutral-400 border-neutral-600 focus:border-action-300',
                 ),
+              ],
+            }[variant],
             filtersEnabled ? 'pr-[58px]' : 'pr-[30px]',
           )
         "
@@ -48,7 +59,9 @@
         :class="
           clsx(
             'absolute left-2xs top-[6px]',
-            dropdownMenuSearch ? 'text-neutral-600' : 'dark:text-neutral-600',
+            variant === 'dropdownmenu'
+              ? 'text-neutral-600'
+              : 'dark:text-neutral-600',
           )
         "
       />
@@ -148,6 +161,8 @@ export type Filter = {
   count?: number;
 };
 
+export type SearchVariant = "standard" | "dropdownmenu" | "new";
+
 const emit = defineEmits<{
   (e: "search", searchTerm: string): void;
   (e: "clearSearch"): void;
@@ -162,7 +177,7 @@ const props = defineProps({
   modelValue: { type: String },
   filters: { type: Array<Filter> },
   disableFilters: { type: Boolean },
-  dropdownMenuSearch: { type: Boolean },
+  variant: { type: String as PropType<SearchVariant>, default: "standard" },
   borderBottom: { type: Boolean, default: true },
   allFilter: { type: Object as PropType<Filter> },
   tabIndex: { type: Number },

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -166,6 +166,7 @@ import Create from "~icons/carbon/intent-request-create";
 import CarbonEdit from "~icons/carbon/edit";
 import Hourglass from "~icons/carbon/hourglass";
 import CarbonCompare from "~icons/carbon/compare";
+import CarbonMaximize from "~icons/carbon/maximize";
 // TODO(Wendy) - for some reason this one specific icon fails to import? Not sure why.
 // import CarbonTransformCode from '~icons/carbon/transform-code';
 import CarbonTransformCode from "~icons/carbon/code"; // using this one as a placeholder for now
@@ -330,6 +331,7 @@ export const ICONS = Object.freeze({
   "logs-pop": LogsPop,
   "logs-pop-square": LogsPopSquare,
   map: CarbonFlowConnection,
+  maximize: CarbonMaximize,
   menu: Menu,
   minimap: Map,
   minus: Minus,

--- a/lib/vue-lib/src/design-system/menus/DropdownMenu.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenu.vue
@@ -36,7 +36,7 @@
         v-if="search"
         ref="siSearchRef"
         class="w-full flex-none"
-        dropdownMenuSearch
+        variant="dropdownmenu"
         :allFilter="{ name: 'All Views' }"
         :filters="searchFilters"
         @click.stop="selectSearch"


### PR DESCRIPTION
Fixes and improvements to the ComponentDetails page to more closely match designs in Figma.

<img width="1906" height="639" alt="Screenshot 2025-07-18 at 5 24 26 PM" src="https://github.com/user-attachments/assets/fb733f25-233a-490d-8045-c82b27d97abe" />
