### PR TITLE
fix(web): force leader election, restart queries if leader changed mid query

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -57,7 +57,7 @@
     "@replit/codemirror-vim": "^6.0.11",
     "@si/ts-lib": "workspace:*",
     "@si/vue-lib": "workspace:*",
-    "@sqlite.org/sqlite-wasm": "3.48.0-build4",
+    "@sqlite.org/sqlite-wasm": "3.50.3-build1",
     "@tanstack/vue-form": "^1.9.0",
     "@tanstack/vue-query": "^5.67.3",
     "@tanstack/vue-table": "^8.20.5",

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -155,19 +155,7 @@ const authStore = useAuthStore();
 
 const span = ref<Span | undefined>();
 
-const lobby = computed(() => {
-  const muspelheimStates = heimdall.muspelheimStatuses.value;
-  if (Object.keys(muspelheimStates).length === 0) {
-    return true;
-  }
-
-  for (const changeSetId in muspelheimStates) {
-    if (!muspelheimStates[changeSetId]) {
-      return true;
-    }
-  }
-  return false;
-});
+const lobby = computed(() => heimdall.muspelheimInProgress.value);
 
 watch(
   lobby,

--- a/app/web/src/pages/Hashes.vue
+++ b/app/web/src/pages/Hashes.vue
@@ -2,10 +2,12 @@
   <div>
     <pre>commit: {{ commitHash }}</pre>
     <pre>shared worker: {{ sharedWorkerHash }} </pre>
+    <pre>tab worker: {{ webWorkerHash }} </pre>
   </div>
 </template>
 
 <script lang="ts" setup>
 const commitHash = __COMMIT_HASH__;
 const sharedWorkerHash = __SHARED_WORKER_HASH__;
+const webWorkerHash = __WEBWORKER_HASH__;
 </script>

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -67,6 +67,8 @@ export type MjolnirBulk = Array<{
 }>;
 
 export const SHARED_BROADCAST_CHANNEL_NAME = "SHAREDWORKER_BROADCAST";
+export const FORCE_LEADER_ELECTION = "FORCE_LEADER_ELECTION";
+export const DB_NOT_INIT_ERR = "DB_NOT_INIT";
 
 export type BroadcastMessage =
   | {
@@ -129,9 +131,9 @@ export interface SharedDBInterface {
     remote: Comlink.Remote<TabDBInterface>,
   ): Promise<void>;
   broadcastMessage(message: BroadcastMessage): Promise<void>;
-  setRemote(remoteId: string): Promise<void>;
-  hasRemote(): Promise<boolean>;
-  currentRemoteId(): Promise<string | undefined>;
+  setLeader(remoteId: string): Promise<void>;
+  hasLeader(): Promise<boolean>;
+  currentLeaderId(): Promise<string | undefined>;
   initBifrost(gotLockPort: MessagePort): Promise<void>;
   bifrostClose(): Promise<void>;
   bifrostReconnect(): Promise<void>;
@@ -230,7 +232,7 @@ export interface TabDBInterface {
   setBearer: (workspaceId: string, token: string) => void;
   initSocket(workspaceId: string): Promise<void>;
   receiveBroadcast(message: BroadcastMessage): Promise<void>;
-  initBifrost(gotLockPort: MessagePort): Promise<void>;
+  initBifrost(gotLockPort: MessagePort): Promise<string>;
   bifrostClose(): void;
   bifrostReconnect(): void;
   linkNewChangeset(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,8 +241,8 @@ importers:
         specifier: workspace:*
         version: link:../../lib/vue-lib
       '@sqlite.org/sqlite-wasm':
-        specifier: 3.48.0-build4
-        version: 3.48.0-build4
+        specifier: 3.50.3-build1
+        version: 3.50.3-build1
       '@tanstack/vue-form':
         specifier: ^1.9.0
         version: 1.9.0(vue@3.5.13(typescript@5.0.4))
@@ -2897,8 +2897,8 @@ packages:
   '@sphinxxxx/color-conversion@2.2.2':
     resolution: {integrity: sha512-XExJS3cLqgrmNBIP3bBw6+1oQ1ksGjFh0+oClDKFYpCCqx/hlqwWO5KO/S63fzUo67SxI9dMrF0y5T/Ey7h8Zw==}
 
-  '@sqlite.org/sqlite-wasm@3.48.0-build4':
-    resolution: {integrity: sha512-hI6twvUkzOmyGZhQMza1gpfqErZxXRw6JEsiVjUbo7tFanVD+8Oil0Ih3l2nGzHdxPI41zFmfUQG7GHqhciKZQ==}
+  '@sqlite.org/sqlite-wasm@3.50.3-build1':
+    resolution: {integrity: sha512-NU+I7KJ5kpMZNyZtJ9hOLlhQHJAA3fJhtkE7kf3C0SlGg4ayz6AkqxcaDcR4qOsrz1XP2+yM1yORaLCt55XDQg==}
     hasBin: true
 
   '@swc/core-darwin-arm64@1.3.36':
@@ -13818,7 +13818,7 @@ snapshots:
 
   '@sphinxxxx/color-conversion@2.2.2': {}
 
-  '@sqlite.org/sqlite-wasm@3.48.0-build4': {}
+  '@sqlite.org/sqlite-wasm@3.50.3-build1': {}
 
   '@swc/core-darwin-arm64@1.3.36':
     optional: true


### PR DESCRIPTION
This pr makes three changes that should increase the reliablity of the
multitab experience:

  1. If lock acquisition has not been detected after 5 seconds, attempt
     to force leader election.
  2. If the leader changes in the middle of a request, that request will
     likely hang. So detect this change using Promise.race and retry the
     call in the case that leader election fails.
  3. Additionally, we have given `sqlite` it's correct type (it's possibly undefined). If we run into an undefined sqlite during leader re-election, we will also retry (with a sleep).

Also upgrades sqlite-wasm to 3.50.3-build1, which was required to force
leader election by closing the database and pausing the VFS.

Test this: 

1. Open the same workspace in a lot of tabs, on the new UI.
2. Have the console open on them all. Go into tilt and restart the web service. 
3. Once the tabs are all loaded and in the lobby, figure out which tab has the lock (it will be the one with lots of "busts processed" and "`? sql`" messages). Hit refresh on that tab, preferably in between a NIFLHEIM but before a DONE message on another tab.
4. Ensure all workspaces still load.

You'll want a workspace with a good number of components and change sets, so that it loads slow enough to exercise the restart.