### PR TITLE
Add new validation failure UI

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeInputRequiredProperty.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInputRequiredProperty.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="flex flex-row items-center gap-2xs">
+    <TruncateWithTooltip>{{ text }}</TruncateWithTooltip>
+    <span
+      v-if="showAsterisk"
+      v-tooltip="`${text} is a required value`"
+      :class="
+        clsx(
+          'shrink-0 text-lg font-bold',
+          themeClasses('text-destructive-600', 'text-destructive-300'),
+        )
+      "
+    >
+      *
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import clsx from "clsx";
+import { themeClasses, TruncateWithTooltip } from "@si/vue-lib/design-system";
+
+defineProps<{
+  text: string;
+  showAsterisk?: boolean;
+}>();
+</script>


### PR DESCRIPTION
## Description

This change adds a new UI element for failed validations. When a validation is failing that is not a "requirement" one, we now expand the area around the input box and indicate within the panel why the field is failing. This to make the usability flow for both keyboard and mouse users better. The tooltip has been removed and we will show the full message..

This change also ensures that the asterisk is present when the possible connections box is present.

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlM2F3M3dmeDZ1dTBuYzA1bnhuZmt1ZDR5cmcyNWRwZjl1bXJjczJvaiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/OWtpNt0fbvwLeKbHcB/giphy.gif"/>

## Screenshot: New Validation UI

Standard property:

<img width="690" height="454" alt="Screenshot 2025-07-21 at 10 13 49 AM" src="https://github.com/user-attachments/assets/bf3b9564-bed0-412b-8b92-dd70018f1ca5" />

Array item property:

<img width="671" height="447" alt="Screenshot 2025-07-21 at 10 14 36 AM" src="https://github.com/user-attachments/assets/3a86b775-4c3d-41e1-aca8-55e56e58a6d9" />

## Screenshot: Asterisk in the Possible Connections UI

<img width="543" height="193" alt="Screenshot 2025-07-18 at 5 42 29 PM" src="https://github.com/user-attachments/assets/61c9a238-29ac-4178-8f02-352a0f243353" />
